### PR TITLE
[P1] fix(checks): stop skipped and manual checks reporting as failures

### DIFF
--- a/config/scripts/smoke-packaged-cli.mjs
+++ b/config/scripts/smoke-packaged-cli.mjs
@@ -74,5 +74,8 @@ try {
   assert.equal(update.executed, false)
   console.log(`[packaged-cli-smoke] help and skills commands passed via ${cliPath}`)
 } finally {
-  await rm(tempRoot, { recursive: true, force: true })
+  // Why: Windows AV/indexers keep a handle on the freshly copied Orca.exe, so the cleanup of a
+  // temp copy can hit EBUSY after every assertion already passed and fail the whole package job.
+  // Same retry treatment as removeHostTree(); a lock that never clears still throws.
+  await rm(tempRoot, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
 }

--- a/config/scripts/smoke-packaged-cli.mjs
+++ b/config/scripts/smoke-packaged-cli.mjs
@@ -35,6 +35,7 @@ const appDir = resolve(readAppDirArg(process.argv.slice(2)))
 const tempRoot = await mkdtemp(join(tmpdir(), 'orca-packaged-cli-smoke-'))
 const copiedAppDir = join(tempRoot, basename(appDir))
 
+let smokeFailure = null
 try {
   await cp(appDir, copiedAppDir, { recursive: true, verbatimSymlinks: true })
   const cliPath = getPackagedCliPath(copiedAppDir)
@@ -73,10 +74,31 @@ try {
   assert.equal(install.executed, false)
   assert.equal(update.executed, false)
   console.log(`[packaged-cli-smoke] help and skills commands passed via ${cliPath}`)
-} finally {
-  // Why: on Windows the launcher above spawns the copied Orca.exe (and its crashpad/utility
-  // children) once per command; those handles can outlive execFile's exit by a few ms, so this
-  // cleanup hits EBUSY on our own just-exited process after every assertion already passed.
-  // Same retry treatment as removeHostTree(); a lock that never clears still throws.
-  await rm(tempRoot, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
+} catch (error) {
+  smokeFailure = error
+}
+
+// Why: on Windows the launcher above spawns the copied Orca.exe (and its crashpad/utility children)
+// once per command; those handles can outlive execFile's exit by a few ms, so this cleanup hits
+// EBUSY on our own just-exited process after every assertion already passed. Same retry treatment
+// as removeHostTree(); a lock that never clears still throws — unless the smoke run itself failed,
+// in which case surfacing EBUSY instead of the real assertion would hide the actual regression.
+const cleanupFailure = await rm(tempRoot, {
+  recursive: true,
+  force: true,
+  maxRetries: 20,
+  retryDelay: 250
+}).then(
+  () => null,
+  (error) => error
+)
+
+if (smokeFailure) {
+  if (cleanupFailure) {
+    console.warn(`[packaged-cli-smoke] temp cleanup failed: ${cleanupFailure.message}`)
+  }
+  throw smokeFailure
+}
+if (cleanupFailure) {
+  throw cleanupFailure
 }

--- a/config/scripts/smoke-packaged-cli.mjs
+++ b/config/scripts/smoke-packaged-cli.mjs
@@ -74,8 +74,9 @@ try {
   assert.equal(update.executed, false)
   console.log(`[packaged-cli-smoke] help and skills commands passed via ${cliPath}`)
 } finally {
-  // Why: Windows AV/indexers keep a handle on the freshly copied Orca.exe, so the cleanup of a
-  // temp copy can hit EBUSY after every assertion already passed and fail the whole package job.
+  // Why: on Windows the launcher above spawns the copied Orca.exe (and its crashpad/utility
+  // children) once per command; those handles can outlive execFile's exit by a few ms, so this
+  // cleanup hits EBUSY on our own just-exited process after every assertion already passed.
   // Same retry treatment as removeHostTree(); a lock that never clears still throws.
   await rm(tempRoot, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
 }

--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -6,6 +6,7 @@
     "../src/renderer/src/**/*.tsx",
     "../src/preload/api-types.ts",
     "../src/shared/**/*",
+    "../src/main/gitlab/mappers.ts",
     "../src/main/ipc/worktree-branch-name.ts",
     "../src/main/ipc/worktree-logic.ts",
     "../src/main/ipc/worktree-linked-work-item-metadata.ts",

--- a/mobile/src/tasks/github-check-summary.test.ts
+++ b/mobile/src/tasks/github-check-summary.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { buildGitHubCheckSummary } from './github-check-summary'
+import { buildGitHubCheckSummary, type GitHubCheckLike } from './github-check-summary'
 import { buildGitLabCheckSummary } from './gitlab-check-summary'
+import { summarizeProviderChecks } from '../../../src/shared/provider-check-summary'
+import type { ProviderCheckSummary } from '../../../src/shared/types'
 
 describe('buildGitHubCheckSummary', () => {
   it('returns none for empty check lists', () => {
@@ -31,14 +33,14 @@ describe('buildGitHubCheckSummary', () => {
     })
   })
 
-  it('keeps neutral and unknown terminal conclusions out of passed', () => {
+  it('keeps neutral and unknown terminal conclusions out of passed without demoting the PR', () => {
     expect(
       buildGitHubCheckSummary([
         { status: 'completed', conclusion: 'success' },
         { status: 'completed', conclusion: 'neutral' }
       ])
     ).toEqual({
-      state: 'neutral',
+      state: 'success',
       total: 2,
       passed: 1,
       failed: 0,
@@ -49,12 +51,93 @@ describe('buildGitHubCheckSummary', () => {
 
   it('rolls up GitLab jobs with unknown terminal statuses as neutral', () => {
     expect(buildGitLabCheckSummary([{ status: 'success' }, { status: 'future_status' }])).toEqual({
-      state: 'neutral',
+      state: 'success',
       total: 2,
       passed: 1,
       failed: 0,
       pending: 0,
       neutral: 1
+    })
+  })
+})
+
+type ParityCase = {
+  name: string
+  checks: GitHubCheckLike[]
+  expected: Omit<ProviderCheckSummary, 'total'>
+}
+
+const completed = (conclusion: string): GitHubCheckLike => ({ status: 'completed', conclusion })
+
+const PARITY_CASES: ParityCase[] = [
+  {
+    name: 'all success',
+    checks: [completed('success'), completed('success')],
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'success plus skipped',
+    checks: [completed('success'), completed('skipped')],
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'all skipped',
+    checks: [completed('skipped'), completed('skipped')],
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'success plus neutral',
+    checks: [completed('success'), completed('neutral')],
+    expected: { state: 'success', passed: 1, failed: 0, pending: 0, neutral: 1 }
+  },
+  {
+    name: 'all neutral',
+    checks: [completed('neutral')],
+    expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 }
+  },
+  {
+    name: 'success plus failure',
+    checks: [completed('success'), completed('failure')],
+    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'success plus running',
+    checks: [completed('success'), { status: 'in_progress', conclusion: null }],
+    expected: { state: 'pending', passed: 1, failed: 0, pending: 1, neutral: 0 }
+  },
+  {
+    name: 'genuine action_required',
+    checks: [completed('success'), completed('action_required')],
+    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+  }
+]
+
+describe('mobile / desktop check classification parity', () => {
+  it.each(PARITY_CASES)('$name matches the shared desktop classifier', ({ checks, expected }) => {
+    const summary = { ...expected, total: checks.length }
+    expect(buildGitHubCheckSummary(checks)).toEqual(summary)
+    expect(summarizeProviderChecks(checks)).toEqual(summary)
+  })
+
+  it.each([
+    {
+      name: 'GitLab manual gate only',
+      statuses: ['manual'],
+      expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 }
+    },
+    {
+      name: 'GitLab manual gate alongside a green pipeline',
+      statuses: ['manual', 'success'],
+      expected: { state: 'success', passed: 1, failed: 0, pending: 0, neutral: 1 }
+    }
+  ] satisfies {
+    name: string
+    statuses: string[]
+    expected: Omit<ProviderCheckSummary, 'total'>
+  }[])('$name never reads as failing', ({ statuses, expected }) => {
+    expect(buildGitLabCheckSummary(statuses.map((status) => ({ status })))).toEqual({
+      ...expected,
+      total: statuses.length
     })
   })
 })

--- a/mobile/src/tasks/github-check-summary.ts
+++ b/mobile/src/tasks/github-check-summary.ts
@@ -1,60 +1,15 @@
+import { summarizeProviderChecks } from '../../../src/shared/provider-check-summary'
+import type { ProviderCheckSummary } from '../../../src/shared/types'
+
 export type GitHubCheckLike = {
   status: string
   conclusion?: string | null
 }
 
-export type GitHubCheckSummary = {
-  state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
-  total: number
-  passed: number
-  failed: number
-  pending: number
-  neutral: number
-}
+export type GitHubCheckSummary = ProviderCheckSummary
 
-function isFailedCheck(check: GitHubCheckLike): boolean {
-  return (
-    check.conclusion === 'failure' ||
-    check.conclusion === 'timed_out' ||
-    check.conclusion === 'cancelled'
-  )
-}
-
-function isPendingCheck(check: GitHubCheckLike): boolean {
-  return (
-    check.status === 'queued' || check.status === 'in_progress' || check.conclusion === 'pending'
-  )
-}
-
+// Why: reuse the desktop classifier verbatim — a second copy is what let mobile call `skipped`
+// unresolved while desktop called the same PR green.
 export function buildGitHubCheckSummary(checks: GitHubCheckLike[]): GitHubCheckSummary {
-  let failed = 0
-  let pending = 0
-  let neutral = 0
-
-  for (const check of checks) {
-    if (isFailedCheck(check) || check.conclusion === 'action_required') {
-      failed += 1
-    } else if (isPendingCheck(check)) {
-      pending += 1
-    } else if (check.conclusion === 'success') {
-      continue
-    } else {
-      neutral += 1
-    }
-  }
-
-  const total = checks.length
-  const passed = total - failed - pending - neutral
-  const state =
-    total === 0
-      ? 'none'
-      : failed > 0
-        ? 'failure'
-        : pending > 0
-          ? 'pending'
-          : neutral > 0
-            ? 'neutral'
-            : 'success'
-
-  return { state, total, passed, failed, pending, neutral }
+  return summarizeProviderChecks(checks)
 }

--- a/mobile/src/tasks/gitlab-check-summary.ts
+++ b/mobile/src/tasks/gitlab-check-summary.ts
@@ -1,37 +1,17 @@
-import { buildGitHubCheckSummary, type GitHubCheckLike } from './github-check-summary'
+import {
+  mapGitLabPipelineJobStatusToCheckStatus,
+  mapGitLabPipelineJobStatusToConclusion
+} from '../../../src/shared/gitlab-pipeline-checks'
+import { summarizeProviderChecks } from '../../../src/shared/provider-check-summary'
 import type { ProviderCheckSummary } from '../../../src/shared/types'
 
 type GitLabPipelineJobLike = { status: string }
 
 export function buildGitLabCheckSummary(jobs: GitLabPipelineJobLike[]): ProviderCheckSummary {
-  return buildGitHubCheckSummary(
-    jobs.map((job): GitHubCheckLike => {
-      const status = job.status.toLowerCase()
-      const nonterminal = [
-        'created',
-        'pending',
-        'scheduled',
-        'waiting_for_callback',
-        'waiting_for_resource',
-        'preparing'
-      ].includes(status)
-      return {
-        status: status === 'running' ? 'in_progress' : nonterminal ? 'queued' : 'completed',
-        conclusion:
-          status === 'success'
-            ? 'success'
-            : status === 'failed'
-              ? 'failure'
-              : ['canceled', 'canceling'].includes(status)
-                ? 'cancelled'
-                : status === 'skipped'
-                  ? 'skipped'
-                  : ['manual', 'action_required'].includes(status)
-                    ? 'action_required'
-                    : status === 'running' || nonterminal
-                      ? 'pending'
-                      : null
-      }
-    })
+  return summarizeProviderChecks(
+    jobs.map((job) => ({
+      status: mapGitLabPipelineJobStatusToCheckStatus(job.status),
+      conclusion: mapGitLabPipelineJobStatusToConclusion(job.status)
+    }))
   )
 }

--- a/mobile/src/tasks/mobile-hosted-check-status.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.ts
@@ -1,4 +1,5 @@
 import type { ProviderCheckSummary, PRMergeableState } from '../../../src/shared/types'
+import { getProviderChecksLabel } from '../../../src/shared/provider-check-summary'
 
 export type MobileHostedReviewStatus = {
   checksSummary?: ProviderCheckSummary
@@ -39,22 +40,7 @@ export function getHostedMergeLabel(item: MobileHostedReviewStatus): string {
 }
 
 export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummary }): string {
-  const summary = item.checksSummary
-  if (!summary) {
-    return 'Checks'
-  }
-  if (summary.total === 0) {
-    return 'No checks'
-  }
-  if (summary.failed > 0) {
-    return `${summary.failed} failing`
-  }
-  if (summary.pending > 0) {
-    return `${summary.pending} pending`
-  }
-  return summary.state === 'neutral'
-    ? 'Unresolved checks'
-    : `${summary.passed}/${summary.total} passed`
+  return getProviderChecksLabel(item.checksSummary)
 }
 
 export function getHostedReviewSignalTone(

--- a/src/main/github/client-work-item-check-summary.test.ts
+++ b/src/main/github/client-work-item-check-summary.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock, getOwnerRepoMock, rateLimitGuardMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  getOwnerRepoMock: vi.fn(),
+  rateLimitGuardMock: vi.fn(() => ({ blocked: false }))
+}))
+
+vi.mock('./gh-utils', () => ({
+  execFileAsync: vi.fn(),
+  ghExecFileAsync: ghExecFileAsyncMock,
+  githubRepoContext: (repoPath: string, connectionId?: string | null) => ({
+    repoPath,
+    connectionId: connectionId ?? null
+  }),
+  ghRepoExecOptions: (context: { repoPath: string }) => ({ cwd: context.repoPath }),
+  getOwnerRepo: getOwnerRepoMock,
+  getIssueOwnerRepo: vi.fn(),
+  getOwnerRepoForRemote: (
+    repoPath: string,
+    remoteName: string,
+    connectionId?: string | null,
+    localGitOptions?: unknown
+  ) =>
+    remoteName === 'origin'
+      ? getOwnerRepoMock(repoPath, connectionId, localGitOptions)
+      : Promise.resolve(null),
+  resolveIssueSource: vi.fn(),
+  extractExecError: vi.fn((err: unknown) => ({ stderr: String(err), stdout: '' })),
+  acquire: vi.fn(),
+  release: vi.fn(),
+  _resetOwnerRepoCache: vi.fn(),
+  classifyGhError: (stderr: string) => ({ type: 'unknown', message: stderr }),
+  classifyListIssuesError: (stderr: string) => ({ type: 'unknown', message: stderr })
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: vi.fn()
+}))
+
+vi.mock('./rate-limit', () => ({
+  rateLimitGuard: rateLimitGuardMock,
+  noteRateLimitSpend: vi.fn(),
+  getRateLimit: vi.fn(async () => ({ ok: false, error: 'not probed in tests' })),
+  repositoryRateLimitGuard: vi.fn(() => ({ blocked: false })),
+  noteRepositoryRateLimitSpend: vi.fn(),
+  spendsSharedGitHubComQuota: vi.fn(() => true)
+}))
+
+import { getWorkItem, _resetMergeQueueCacheForTests, _resetOwnerRepoCache } from './client'
+import { _resetOriginGitHubApiRepositoryCache } from './github-api-repository'
+
+// Why: only `pr view` is fixtured; the merge-metadata fan-out is best-effort and must not mask the summary.
+function mockPullRequestDetail(payload: Record<string, unknown>): void {
+  ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] !== 'pr' || args[1] !== 'view') {
+      throw new Error('unexpected gh call')
+    }
+    return { stdout: JSON.stringify(payload) }
+  })
+}
+
+describe('work item checksSummary', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    getOwnerRepoMock.mockReset()
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
+    _resetOwnerRepoCache()
+    _resetOriginGitHubApiRepositoryCache()
+    _resetMergeQueueCacheForTests()
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+  })
+
+  it('counts a skipped run as passing and reads a StatusContext state as its conclusion', async () => {
+    mockPullRequestDetail({
+      number: 42,
+      title: 'Add feature',
+      state: 'OPEN',
+      url: 'https://github.com/acme/widgets/pull/42',
+      updatedAt: '2026-04-01T00:00:00Z',
+      statusCheckRollup: [
+        { __typename: 'CheckRun', status: 'COMPLETED', conclusion: 'SKIPPED' },
+        // Why: StatusContext carries no status/conclusion — only `state`.
+        { __typename: 'StatusContext', state: 'SUCCESS' },
+        { __typename: 'CheckRun', status: 'COMPLETED', conclusion: 'NEUTRAL' }
+      ]
+    })
+
+    const item = await getWorkItem('/repo-root', 42, 'pr', null, {}, 'origin')
+
+    expect(item?.checksSummary).toEqual({
+      state: 'success',
+      total: 3,
+      passed: 2,
+      failed: 0,
+      pending: 0,
+      neutral: 1
+    })
+  })
+
+  it('reports a still-running check as pending', async () => {
+    mockPullRequestDetail({
+      number: 43,
+      title: 'Add feature',
+      state: 'OPEN',
+      url: 'https://github.com/acme/widgets/pull/43',
+      updatedAt: '2026-04-01T00:00:00Z',
+      statusCheckRollup: [
+        { __typename: 'CheckRun', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { __typename: 'CheckRun', status: 'IN_PROGRESS', conclusion: null }
+      ]
+    })
+
+    const item = await getWorkItem('/repo-root', 43, 'pr', null, {}, 'origin')
+
+    expect(item?.checksSummary).toEqual({
+      state: 'pending',
+      total: 2,
+      passed: 1,
+      failed: 0,
+      pending: 1,
+      neutral: 0
+    })
+  })
+
+  it('fails the summary on a failing run and leaves an empty rollup with no state', async () => {
+    mockPullRequestDetail({
+      number: 44,
+      title: 'Add feature',
+      state: 'OPEN',
+      url: 'https://github.com/acme/widgets/pull/44',
+      updatedAt: '2026-04-01T00:00:00Z',
+      statusCheckRollup: [
+        { __typename: 'CheckRun', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        { __typename: 'CheckRun', status: 'COMPLETED', conclusion: 'FAILURE' }
+      ]
+    })
+    await expect(getWorkItem('/repo-root', 44, 'pr', null, {}, 'origin')).resolves.toMatchObject({
+      checksSummary: { state: 'failure', total: 2, passed: 1, failed: 1, pending: 0, neutral: 0 }
+    })
+
+    mockPullRequestDetail({
+      number: 45,
+      title: 'Add feature',
+      state: 'OPEN',
+      url: 'https://github.com/acme/widgets/pull/45',
+      updatedAt: '2026-04-01T00:00:00Z',
+      statusCheckRollup: []
+    })
+    await expect(getWorkItem('/repo-root', 45, 'pr', null, {}, 'origin')).resolves.toMatchObject({
+      checksSummary: { state: 'none', total: 0, passed: 0, failed: 0, pending: 0, neutral: 0 }
+    })
+  })
+})

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -27,6 +27,7 @@ import {
   normalizeHostedReviewHeadRef
 } from '../../shared/hosted-review-refs'
 import { normalizeGitHubPRMergeMethodSettings } from '../../shared/github-pr-merge-methods'
+import { summarizeProviderChecks } from '../../shared/provider-check-summary'
 import { isGitHubWorkItemsQueryTooLarge } from '../../shared/github-work-items-query-bounds'
 import { classifyGitHubUnavailable } from '../../shared/github-api-availability'
 import { parseTaskQuery, type ParsedTaskQuery } from '../../shared/task-query'
@@ -656,44 +657,19 @@ function checkRollupEntries(value: unknown): unknown[] {
 }
 
 function deriveWorkItemCheckSummary(value: unknown): GitHubWorkItem['checksSummary'] {
-  const entries = checkRollupEntries(value)
-  if (entries.length === 0) {
-    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0, neutral: 0 }
-  }
-  let passed = 0
-  let failed = 0
-  let pending = 0
-  let neutral = 0
-  for (const entry of entries) {
-    if (typeof entry !== 'object' || entry === null) {
-      pending += 1
-      continue
-    }
-    const raw = entry as Record<string, unknown>
-    const conclusion = String(raw.conclusion ?? raw.state ?? '').toUpperCase()
-    const status = String(raw.status ?? '').toUpperCase()
-    if (['SUCCESS', 'SKIPPED'].includes(conclusion)) {
-      passed += 1
-    } else if (
-      ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE'].includes(
-        conclusion
-      )
-    ) {
-      failed += 1
-    } else if (status === 'COMPLETED') {
-      neutral += 1
-    } else {
-      pending += 1
-    }
-  }
-  return {
-    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : neutral > 0 ? 'neutral' : 'success',
-    total: entries.length,
-    passed,
-    failed,
-    pending,
-    neutral
-  }
+  return summarizeProviderChecks(
+    checkRollupEntries(value).map((entry) => {
+      if (typeof entry !== 'object' || entry === null) {
+        return { status: '', conclusion: '' }
+      }
+      const raw = entry as Record<string, unknown>
+      // Why: StatusContext reports `state` and carries no `status`; CheckRun reports both.
+      return {
+        status: String(raw.status ?? ''),
+        conclusion: String(raw.conclusion ?? raw.state ?? '')
+      }
+    })
+  )
 }
 
 function mapPullRequestWorkItem(

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -249,6 +249,15 @@ describe('derivePipelineStatus', () => {
     expect(derivePipelineStatus([{ status: 'manual' }, { status: 'success' }])).toBe('success')
   })
 
+  it('leaves a manual-only pipeline unresolved rather than green', () => {
+    expect(derivePipelineStatus([{ status: 'manual' }])).toBe('neutral')
+    expect(derivePipelineStatus([{ status: 'manual' }, { status: 'manual' }])).toBe('neutral')
+  })
+
+  it('counts skipped jobs as passing', () => {
+    expect(derivePipelineStatus([{ status: 'skipped' }, { status: 'skipped' }])).toBe('success')
+  })
+
   it('handles a single object with status', () => {
     expect(derivePipelineStatus({ status: 'success' })).toBe('success')
   })
@@ -256,8 +265,13 @@ describe('derivePipelineStatus', () => {
   it('keeps malformed and unknown array jobs neutral', () => {
     expect(derivePipelineStatus([{ status: 'future_status' }])).toBe('neutral')
     expect(derivePipelineStatus([{}])).toBe('neutral')
+  })
+
+  // Why: matches the shared rollup rule — one unresolved job must not demote a pipeline that has
+  // a passing job, or the same MR reads green in the Checks tab and grey on the card.
+  it('lets a passing job outweigh an unknown one', () => {
     expect(derivePipelineStatus([{ status: 'success' }, { status: 'future_status' }])).toBe(
-      'neutral'
+      'success'
     )
   })
 })

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -232,6 +232,23 @@ describe('derivePipelineStatus', () => {
     expect(derivePipelineStatus('manual')).toBe('neutral')
   })
 
+  // Why: `head_pipeline.status` is the only production entry point (client.ts passes objects, not
+  // job arrays), so it must land where the Checks tab lands for the same jobs — an all-skipped
+  // pipeline read grey on the card and green in the tab, flipping tone purely on hydration order.
+  it('counts a skipped pipeline string as passing, matching the Checks tab', () => {
+    expect(derivePipelineStatus('skipped')).toBe('success')
+    expect(derivePipelineStatus({ status: 'skipped' })).toBe('success')
+  })
+
+  // Why: pins the one remaining string/array divergence. A canceled *job* rolls up to 'failure',
+  // but the card stays neutral until the grey→red tone change is signed off separately; this
+  // assertion exists so that flip cannot land silently.
+  it('keeps a canceled pipeline string neutral (deferred tone change)', () => {
+    expect(derivePipelineStatus('canceled')).toBe('neutral')
+    expect(derivePipelineStatus('canceling')).toBe('neutral')
+    expect(derivePipelineStatus([{ status: 'canceled' }])).toBe('failure')
+  })
+
   it('rolls up an array of jobs', () => {
     expect(derivePipelineStatus([{ status: 'success' }, { status: 'success' }])).toBe('success')
     expect(derivePipelineStatus([{ status: 'success' }, { status: 'failed' }])).toBe('failure')

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -228,22 +228,20 @@ describe('derivePipelineStatus', () => {
     expect(derivePipelineStatus('success')).toBe('success')
     expect(derivePipelineStatus('failed')).toBe('failure')
     expect(derivePipelineStatus('running')).toBe('pending')
-    // Why: a blocked pipeline is waiting on a human trigger, not broken.
-    expect(derivePipelineStatus('manual')).toBe('neutral')
+    // Why: pipeline-level `manual` means GitLab blocked the pipeline on a human trigger — it is
+    // outstanding, not broken (red) and not resolved (which would paint the MR card green while
+    // "Pipelines must succeed" still refuses the merge).
+    expect(derivePipelineStatus('manual')).toBe('pending')
+    expect(derivePipelineStatus({ status: 'manual' })).toBe('pending')
   })
 
-  // Why: `head_pipeline.status` is the only production entry point (client.ts passes objects, not
-  // job arrays), so it must land where the Checks tab lands for the same jobs — an all-skipped
-  // pipeline read grey on the card and green in the tab, flipping tone purely on hydration order.
-  it('counts a skipped pipeline string as passing, matching the Checks tab', () => {
-    expect(derivePipelineStatus('skipped')).toBe('success')
-    expect(derivePipelineStatus({ status: 'skipped' })).toBe('success')
-  })
-
-  // Why: pins the one remaining string/array divergence. A canceled *job* rolls up to 'failure',
-  // but the card stays neutral until the grey→red tone change is signed off separately; this
-  // assertion exists so that flip cannot land silently.
-  it('keeps a canceled pipeline string neutral (deferred tone change)', () => {
+  // Why: pins the two remaining string/array divergences. The job rollup calls skipped jobs
+  // passing and canceled jobs failing, but `head_pipeline.status` is the only production entry
+  // point and GitLab paints both pipeline states grey — flipping either card tone needs product
+  // sign-off, so these assertions exist so neither flip can land silently.
+  it('keeps skipped and canceled pipeline strings neutral (deferred tone changes)', () => {
+    expect(derivePipelineStatus('skipped')).toBe('neutral')
+    expect(derivePipelineStatus({ status: 'skipped' })).toBe('neutral')
     expect(derivePipelineStatus('canceled')).toBe('neutral')
     expect(derivePipelineStatus('canceling')).toBe('neutral')
     expect(derivePipelineStatus([{ status: 'canceled' }])).toBe('failure')

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -38,8 +38,8 @@ describe('mapPipelineJobStatusToConclusion', () => {
     expect(mapPipelineJobStatusToConclusion('skipped')).toBe('skipped')
   })
 
-  it('maps manual and action-required jobs to an actionable conclusion', () => {
-    expect(mapPipelineJobStatusToConclusion('manual')).toBe('action_required')
+  it('keeps manual gates neutral while action-required stays actionable', () => {
+    expect(mapPipelineJobStatusToConclusion('manual')).toBe('neutral')
     expect(mapPipelineJobStatusToConclusion('action_required')).toBe('action_required')
   })
 
@@ -228,7 +228,8 @@ describe('derivePipelineStatus', () => {
     expect(derivePipelineStatus('success')).toBe('success')
     expect(derivePipelineStatus('failed')).toBe('failure')
     expect(derivePipelineStatus('running')).toBe('pending')
-    expect(derivePipelineStatus('manual')).toBe('failure')
+    // Why: a blocked pipeline is waiting on a human trigger, not broken.
+    expect(derivePipelineStatus('manual')).toBe('neutral')
   })
 
   it('rolls up an array of jobs', () => {
@@ -239,7 +240,13 @@ describe('derivePipelineStatus', () => {
 
   it('failure beats pending in the rollup', () => {
     expect(derivePipelineStatus([{ status: 'failed' }, { status: 'running' }])).toBe('failure')
-    expect(derivePipelineStatus([{ status: 'manual' }, { status: 'success' }])).toBe('failure')
+    expect(derivePipelineStatus([{ status: 'action_required' }, { status: 'success' }])).toBe(
+      'failure'
+    )
+  })
+
+  it('keeps a manual deploy gate from failing an otherwise green pipeline', () => {
+    expect(derivePipelineStatus([{ status: 'manual' }, { status: 'success' }])).toBe('success')
   })
 
   it('handles a single object with status', () => {

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -9,6 +9,7 @@ import {
   mapGitLabPipelineJobStatusToCheckStatus,
   mapGitLabPipelineJobStatusToConclusion
 } from '../../shared/gitlab-pipeline-checks'
+import { summarizeProviderChecks } from '../../shared/provider-check-summary'
 
 // ── Pipeline job mapping (GitLab REST `/pipelines/:id/jobs`) ────────
 // Why: GitLab pipeline jobs roughly map to GitHub check-runs, but use a
@@ -156,34 +157,20 @@ export function derivePipelineStatus(
   if (!Array.isArray(rollup)) {
     return classifyPipelineString(rollup.status ?? '')
   }
-  if (rollup.length === 0) {
-    return 'neutral'
-  }
-  let hasFailure = false
-  let hasPending = false
-  let hasUnknown = false
-  for (const job of rollup) {
-    const s = job.status?.toLowerCase() ?? ''
-    const conclusion = mapPipelineJobStatusToConclusion(s)
-    if (
-      conclusion === 'failure' ||
-      conclusion === 'cancelled' ||
-      conclusion === 'action_required'
-    ) {
-      hasFailure = true
-    } else if (conclusion === 'pending') {
-      hasPending = true
-    } else if (conclusion !== 'success' && conclusion !== 'skipped' && conclusion !== 'neutral') {
-      hasUnknown = true
-    }
-  }
-  if (hasFailure) {
-    return 'failure'
-  }
-  if (hasPending) {
-    return 'pending'
-  }
-  return hasUnknown ? 'neutral' : 'success'
+  // Why: a job array is just a check list, so route it through the shared classifier instead of
+  // re-deriving the rules here — a local copy drifted (manual-only read green, an unrecognized
+  // status demoted a passing pipeline to neutral).
+  const { state } = summarizeProviderChecks(
+    rollup.map((job) => {
+      const s = job.status?.toLowerCase() ?? ''
+      return {
+        status: mapPipelineJobStatusToCheckStatus(s),
+        conclusion: mapPipelineJobStatusToConclusion(s)
+      }
+    })
+  )
+  // Why: CheckStatus has no 'none'; an empty job list carries the same "nothing to report" meaning.
+  return state === 'none' ? 'neutral' : state
 }
 
 // ── Raw → GitLabWorkItem mapping ────────────────────────────────────

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -279,22 +279,18 @@ function classifyPipelineString(status: string): CheckStatus {
   if (s === 'failed' || s === 'action_required') {
     return 'failure'
   }
-  // Why: a skipped pipeline is a deliberate "not applicable" (every job filtered out by `rules:`),
-  // which classifyCheckOutcome counts as passing — leaving it neutral here made the MR card read
-  // grey while the Checks tab, fed by the same jobs, read green.
-  if (s === 'skipped') {
-    return 'success'
-  }
-  // Why: a `manual` pipeline is blocked on a human trigger, not broken — never paint the card red.
+  // Why: GitLab only reports pipeline-level `manual` when the pipeline is *blocked* on a human
+  // trigger (a manual job with allow_failure: false), so it is outstanding rather than broken or
+  // done. Red overstated it; neutral would drop the cue entirely and paint the worktree card's MR
+  // icon green (worktree-review-helpers.tsx defaults `open` to emerald), which is worse — with
+  // "Pipelines must succeed" on, GitLab rejects this merge.
   if (s === 'manual') {
-    return 'neutral'
+    return 'pending'
   }
-  // Why: deliberate, product-sign-off-pending divergence — a canceled *job* is 'failed' on every
-  // check surface (provider-check-summary.ts FAILED_CONCLUSIONS), but flipping canceled MR cards
-  // from grey to red is a visible tone change that belongs in its own change, not this one.
-  if (s === 'canceled' || s === 'canceling') {
-    return 'neutral'
-  }
+  // Why: `skipped` and `canceled` pipelines stay neutral (the fall-through below) even though the
+  // job rollup calls the same jobs passing/failing. GitLab's own MR widget paints both grey, and
+  // `allow_merge_on_skipped_pipeline` defaults to false, so a skipped pipeline still blocks merge —
+  // flipping either tone is a product decision that belongs in its own change, not this one.
   if (
     s === 'created' ||
     s === 'pending' ||

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -289,8 +289,12 @@ function classifyPipelineString(status: string): CheckStatus {
   if (s === 'success') {
     return 'success'
   }
-  if (s === 'failed' || s === 'manual' || s === 'action_required') {
+  if (s === 'failed' || s === 'action_required') {
     return 'failure'
+  }
+  // Why: a `manual` pipeline is blocked on a human trigger, not broken — never paint the card red.
+  if (s === 'manual') {
+    return 'neutral'
   }
   if (
     s === 'created' ||

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -279,8 +279,20 @@ function classifyPipelineString(status: string): CheckStatus {
   if (s === 'failed' || s === 'action_required') {
     return 'failure'
   }
+  // Why: a skipped pipeline is a deliberate "not applicable" (every job filtered out by `rules:`),
+  // which classifyCheckOutcome counts as passing — leaving it neutral here made the MR card read
+  // grey while the Checks tab, fed by the same jobs, read green.
+  if (s === 'skipped') {
+    return 'success'
+  }
   // Why: a `manual` pipeline is blocked on a human trigger, not broken — never paint the card red.
   if (s === 'manual') {
+    return 'neutral'
+  }
+  // Why: deliberate, product-sign-off-pending divergence — a canceled *job* is 'failed' on every
+  // check surface (provider-check-summary.ts FAILED_CONCLUSIONS), but flipping canceled MR cards
+  // from grey to red is a visible tone change that belongs in its own change, not this one.
+  if (s === 'canceled' || s === 'canceling') {
     return 'neutral'
   }
   if (

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -232,6 +232,11 @@ import {
   type TaskPageGitHubCloseAction
 } from '@/components/task-page-github-status-actions'
 import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
+import {
+  getCheckConclusion,
+  getCheckCounts,
+  getChecksSummaryLabel
+} from '@/components/pr-check-counts'
 
 // Why: the dialog lacks repository context, so recover its host-aware identity from the canonical item URL.
 function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
@@ -4321,10 +4326,6 @@ function CommentReplyForm({
   )
 }
 
-function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
-  return check.conclusion ?? 'pending'
-}
-
 function getCheckStatusLabel(check: PRCheckDetail): string {
   const conclusion = getCheckConclusion(check)
   if (conclusion === 'success') {
@@ -4355,57 +4356,6 @@ function getCheckStatusLabel(check: PRCheckDetail): string {
     return 'In progress'
   }
   return 'Pending'
-}
-
-function getCheckCounts(checks: PRCheckDetail[]): {
-  passing: number
-  failing: number
-  needsAction: number
-  pending: number
-  skipped: number
-  neutral: number
-} {
-  return checks.reduce(
-    (counts, check) => {
-      const conclusion = getCheckConclusion(check)
-      if (conclusion === 'success') {
-        counts.passing += 1
-      } else if (conclusion === 'action_required') {
-        counts.needsAction += 1
-      } else if (['failure', 'cancelled', 'timed_out'].includes(conclusion)) {
-        counts.failing += 1
-      } else if (conclusion === 'skipped') {
-        counts.skipped += 1
-      } else if (conclusion === 'neutral') {
-        counts.neutral += 1
-      } else {
-        counts.pending += 1
-      }
-      return counts
-    },
-    { passing: 0, failing: 0, needsAction: 0, pending: 0, skipped: 0, neutral: 0 }
-  )
-}
-
-function getChecksSummaryLabel(checks: PRCheckDetail[]): string {
-  const counts = getCheckCounts(checks)
-  if (checks.length === 0) {
-    return 'No checks found'
-  }
-  if (counts.failing > 0) {
-    return `${counts.failing} ${counts.failing === 1 ? 'check' : 'checks'} failing`
-  }
-  // Why: action_required blocks merge but isn't a failure; surface it distinctly so users know a manual step is needed.
-  if (counts.needsAction > 0) {
-    return `${counts.needsAction} ${counts.needsAction === 1 ? 'check needs' : 'checks need'} action`
-  }
-  if (counts.pending > 0) {
-    return `${counts.pending} ${counts.pending === 1 ? 'check' : 'checks'} pending`
-  }
-  if (counts.passing === checks.length) {
-    return 'All checks passing'
-  }
-  return `${counts.passing} of ${checks.length} checks passing`
 }
 
 function getCheckDetailsKey(check: PRCheckDetail): string {
@@ -4468,6 +4418,8 @@ function ChecksTab({
   const failedChecks = getBrokenChecks(list)
   const counts = getCheckCounts(list)
   const summaryLabel = getChecksSummaryLabel(list)
+  // Why: keying the green tick off `list.length` painted an all-neutral PR green above the words
+  // "0 of N checks passing"; nothing passed, so it reads unresolved like the checks pill does.
   const SummaryIcon =
     counts.failing > 0
       ? CHECK_ICON.failure
@@ -4475,7 +4427,7 @@ function ChecksTab({
         ? CHECK_ICON.action_required
         : counts.pending > 0
           ? CHECK_ICON.pending
-          : list.length > 0
+          : counts.passing > 0
             ? CHECK_ICON.success
             : CircleDashed
   const summaryColor =
@@ -4485,7 +4437,7 @@ function ChecksTab({
         ? CHECK_COLOR.action_required
         : counts.pending > 0
           ? CHECK_COLOR.pending
-          : list.length > 0
+          : counts.passing > 0
             ? CHECK_COLOR.success
             : 'text-muted-foreground'
   const canFixBrokenChecks = Boolean((repoId ?? item.repoId) && failedChecks.length > 0)
@@ -5208,10 +5160,10 @@ function ChecksTab({
         className: CHECK_COLOR.pending
       })
     }
-    if (counts.skipped + counts.neutral > 0) {
+    if (counts.neutral > 0) {
       countChips.push({
         label: translate('auto.components.GitHubItemDialog.d23bbb6416', '{{value0}} skipped', {
-          value0: counts.skipped + counts.neutral
+          value0: counts.neutral
         }),
         className: 'text-muted-foreground'
       })

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -228,6 +228,11 @@ import {
 import { translate } from '@/i18n/i18n'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
+import {
+  getCheckConclusion,
+  getCheckCounts,
+  getChecksSummaryLabel
+} from '@/components/pr-check-counts'
 
 // Why: the item URL is the only host-aware repository identity present on every work item across IPC.
 function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
@@ -4330,10 +4335,6 @@ function CommentReplyForm({
   )
 }
 
-function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
-  return check.conclusion ?? 'pending'
-}
-
 function getCheckStatusLabel(check: PRCheckDetail): string {
   const conclusion = getCheckConclusion(check)
   if (conclusion === 'success') {
@@ -4364,57 +4365,6 @@ function getCheckStatusLabel(check: PRCheckDetail): string {
     return 'In progress'
   }
   return 'Pending'
-}
-
-function getCheckCounts(checks: PRCheckDetail[]): {
-  passing: number
-  failing: number
-  needsAction: number
-  pending: number
-  skipped: number
-  neutral: number
-} {
-  return checks.reduce(
-    (counts, check) => {
-      const conclusion = getCheckConclusion(check)
-      if (conclusion === 'success') {
-        counts.passing += 1
-      } else if (conclusion === 'action_required') {
-        counts.needsAction += 1
-      } else if (['failure', 'cancelled', 'timed_out'].includes(conclusion)) {
-        counts.failing += 1
-      } else if (conclusion === 'skipped') {
-        counts.skipped += 1
-      } else if (conclusion === 'neutral') {
-        counts.neutral += 1
-      } else {
-        counts.pending += 1
-      }
-      return counts
-    },
-    { passing: 0, failing: 0, needsAction: 0, pending: 0, skipped: 0, neutral: 0 }
-  )
-}
-
-function getChecksSummaryLabel(checks: PRCheckDetail[]): string {
-  const counts = getCheckCounts(checks)
-  if (checks.length === 0) {
-    return 'No checks found'
-  }
-  if (counts.failing > 0) {
-    return `${counts.failing} ${counts.failing === 1 ? 'check' : 'checks'} failing`
-  }
-  // Why: action_required (e.g. workflow awaiting approval) blocks merge but isn't a failure, so surface it distinctly.
-  if (counts.needsAction > 0) {
-    return `${counts.needsAction} ${counts.needsAction === 1 ? 'check needs' : 'checks need'} action`
-  }
-  if (counts.pending > 0) {
-    return `${counts.pending} ${counts.pending === 1 ? 'check' : 'checks'} pending`
-  }
-  if (counts.passing === checks.length) {
-    return 'All checks passing'
-  }
-  return `${counts.passing} of ${checks.length} checks passing`
 }
 
 function getCheckDetailsKey(check: PRCheckDetail): string {
@@ -4572,6 +4522,8 @@ function ChecksTab({
   const failedChecks = getBrokenChecks(list)
   const counts = getCheckCounts(list)
   const summaryLabel = getChecksSummaryLabel(list)
+  // Why: keying the green tick off `list.length` painted an all-neutral PR green above the words
+  // "0 of N checks passing"; nothing passed, so it reads unresolved like the checks pill does.
   const SummaryIcon =
     counts.failing > 0
       ? CHECK_ICON.failure
@@ -4579,7 +4531,7 @@ function ChecksTab({
         ? CHECK_ICON.action_required
         : counts.pending > 0
           ? CHECK_ICON.pending
-          : list.length > 0
+          : counts.passing > 0
             ? CHECK_ICON.success
             : CircleDashed
   const summaryColor =
@@ -4589,7 +4541,7 @@ function ChecksTab({
         ? CHECK_COLOR.action_required
         : counts.pending > 0
           ? CHECK_COLOR.pending
-          : list.length > 0
+          : counts.passing > 0
             ? CHECK_COLOR.success
             : 'text-muted-foreground'
   const canFixBrokenChecks = Boolean((repoId ?? item.repoId) && failedChecks.length > 0)
@@ -5342,10 +5294,10 @@ function ChecksTab({
         className: CHECK_COLOR.pending
       })
     }
-    if (counts.skipped + counts.neutral > 0) {
+    if (counts.neutral > 0) {
       countChips.push({
         label: translate('auto.components.PullRequestPage.e6ad0a8d06', '{{value0}} skipped', {
-          value0: counts.skipped + counts.neutral
+          value0: counts.neutral
         }),
         className: 'text-muted-foreground'
       })

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -209,7 +209,7 @@ import {
   taskPageToGitHubApiPage
 } from '@/components/task-page-work-item-pagination'
 import { sortWorkItemsByNumber } from '../../../shared/work-items'
-import { getProviderChecksLabel } from '../../../shared/provider-check-summary'
+import { getChecksLabel, getChecksPillTone } from '@/components/task-page-checks-pill'
 import LinearIssueAttributeFilterDropdowns from '@/components/linear-issue-attribute-filter-dropdowns'
 import { resolveLinearIssueAttributeFilterPrimaryTeam } from '@/components/linear-issue-attribute-filter-primary-team'
 import {
@@ -2011,24 +2011,6 @@ function GHAssigneesCell({
       </PopoverContent>
     </Popover>
   )
-}
-
-function getChecksLabel(item: GitHubWorkItem): string {
-  return getProviderChecksLabel(item.checksSummary)
-}
-
-function getChecksPillTone(item: GitHubWorkItem): string {
-  const state = item.checksSummary?.state
-  if (state === 'success') {
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
-  }
-  if (state === 'failure') {
-    return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200'
-  }
-  if (state === 'pending') {
-    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200'
-  }
-  return 'border-border/60 bg-background/70 text-muted-foreground'
 }
 
 function sameOptionalGitHubOwnerRepo(

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -209,6 +209,7 @@ import {
   taskPageToGitHubApiPage
 } from '@/components/task-page-work-item-pagination'
 import { sortWorkItemsByNumber } from '../../../shared/work-items'
+import { getProviderChecksLabel } from '../../../shared/provider-check-summary'
 import LinearIssueAttributeFilterDropdowns from '@/components/linear-issue-attribute-filter-dropdowns'
 import { resolveLinearIssueAttributeFilterPrimaryTeam } from '@/components/linear-issue-attribute-filter-primary-team'
 import {
@@ -2013,23 +2014,7 @@ function GHAssigneesCell({
 }
 
 function getChecksLabel(item: GitHubWorkItem): string {
-  const summary = item.checksSummary
-  if (!summary) {
-    return 'Checks'
-  }
-  if (summary.total === 0) {
-    return 'No checks'
-  }
-  if (summary.failed > 0) {
-    return `${summary.failed} failing`
-  }
-  if (summary.pending > 0) {
-    return `${summary.pending} pending`
-  }
-  if (summary.neutral > 0) {
-    return `${summary.neutral} unresolved`
-  }
-  return `${summary.passed}/${summary.total} passed`
+  return getProviderChecksLabel(item.checksSummary)
 }
 
 function getChecksPillTone(item: GitHubWorkItem): string {

--- a/src/renderer/src/components/github-enterprise-slug-routing-boundary.test.ts
+++ b/src/renderer/src/components/github-enterprise-slug-routing-boundary.test.ts
@@ -18,10 +18,12 @@ describe('GitHub Enterprise slug routing boundaries', () => {
   it('keeps work-item URL hosts on TaskPage metadata and issue mutations', () => {
     const source = componentSource('TaskPage.tsx')
     const statusSection = sourceBetween(source, 'function GHStatusCell', 'function formatPRDelta')
+    // Why: the end sentinel just bounds GHAssigneesCell's body — getChecksLabel moved out to
+    // task-page-checks-pill.ts, so the next declaration is the boundary now.
     const assigneeSection = sourceBetween(
       source,
       'function GHAssigneesCell',
-      'function getChecksLabel'
+      'function sameOptionalGitHubOwnerRepo'
     )
 
     expect(statusSection).toContain('host: githubProjectHost(parsedOwnerRepo.host)')

--- a/src/renderer/src/components/pr-check-counts.test.ts
+++ b/src/renderer/src/components/pr-check-counts.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { getCheckCounts, getChecksSummaryLabel } from './pr-check-counts'
+import {
+  getProviderChecksLabel,
+  summarizeProviderChecks
+} from '../../../shared/provider-check-summary'
+import type { PRCheckDetail } from '../../../shared/types'
+
+function check(conclusion: PRCheckDetail['conclusion'], name = String(conclusion)): PRCheckDetail {
+  return { name, status: 'completed', conclusion, url: null }
+}
+
+describe('getCheckCounts', () => {
+  // Why: the PR page, the work-item dialog and the sidebar Checks panel all count this same list;
+  // a 2-success/3-skipped PR used to read "2 passing · 3 skipped" here and "5 passing" there.
+  it('counts skipped checks as passing, matching the sidebar header and the checks pill', () => {
+    const checks = [
+      check('success', 'build'),
+      check('success', 'test'),
+      check('skipped', 'deploy'),
+      check('skipped', 'docs'),
+      check('skipped', 'e2e')
+    ]
+
+    expect(getCheckCounts(checks)).toEqual({
+      passing: 5,
+      failing: 0,
+      needsAction: 0,
+      pending: 0,
+      neutral: 0
+    })
+    expect(getChecksSummaryLabel(checks)).toBe('All checks passing')
+    expect(summarizeProviderChecks(checks).passed).toBe(5)
+    expect(getProviderChecksLabel(summarizeProviderChecks(checks))).toBe('5/5 passed')
+  })
+
+  // Why: action_required blocks merge but is not a red failure, so it keeps its own amber bucket
+  // even though the shared rollup treats it as failing.
+  it('keeps action_required separate from failures', () => {
+    expect(getCheckCounts([check('action_required'), check('failure')])).toEqual({
+      passing: 0,
+      failing: 1,
+      needsAction: 1,
+      pending: 0,
+      neutral: 0
+    })
+    expect(getChecksSummaryLabel([check('action_required')])).toBe('1 check needs action')
+  })
+
+  it('buckets neutral and still-running checks apart', () => {
+    const checks: PRCheckDetail[] = [
+      check('neutral'),
+      { name: 'ci', status: 'in_progress', conclusion: null, url: null }
+    ]
+
+    expect(getCheckCounts(checks)).toEqual({
+      passing: 0,
+      failing: 0,
+      needsAction: 0,
+      pending: 1,
+      neutral: 1
+    })
+    expect(getChecksSummaryLabel(checks)).toBe('1 check pending')
+  })
+
+  it('reports no checks for an empty list', () => {
+    expect(getChecksSummaryLabel([])).toBe('No checks found')
+  })
+})

--- a/src/renderer/src/components/pr-check-counts.test.ts
+++ b/src/renderer/src/components/pr-check-counts.test.ts
@@ -63,6 +63,21 @@ describe('getCheckCounts', () => {
     expect(getChecksSummaryLabel(checks)).toBe('1 check pending')
   })
 
+  it('keeps a completed check without a conclusion unresolved', () => {
+    const checks: PRCheckDetail[] = [
+      { name: 'external', status: 'completed', conclusion: null, url: null }
+    ]
+
+    expect(getCheckCounts(checks)).toEqual({
+      passing: 0,
+      failing: 0,
+      needsAction: 0,
+      pending: 0,
+      neutral: 1
+    })
+    expect(getChecksSummaryLabel(checks)).toBe('0 of 1 checks passing')
+  })
+
   it('reports no checks for an empty list', () => {
     expect(getChecksSummaryLabel([])).toBe('No checks found')
   })

--- a/src/renderer/src/components/pr-check-counts.ts
+++ b/src/renderer/src/components/pr-check-counts.ts
@@ -10,7 +10,10 @@ export type PRCheckCounts = {
 }
 
 export function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
-  return check.conclusion ?? 'pending'
+  if (check.conclusion) {
+    return check.conclusion
+  }
+  return check.status === 'completed' ? 'neutral' : 'pending'
 }
 
 /**

--- a/src/renderer/src/components/pr-check-counts.ts
+++ b/src/renderer/src/components/pr-check-counts.ts
@@ -1,0 +1,63 @@
+import { classifyCheckOutcome } from '../../../shared/provider-check-summary'
+import type { PRCheckDetail } from '../../../shared/types'
+
+export type PRCheckCounts = {
+  passing: number
+  failing: number
+  needsAction: number
+  pending: number
+  neutral: number
+}
+
+export function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
+  return check.conclusion ?? 'pending'
+}
+
+/**
+ * The check-tab breakdown shared by the PR page and the work-item dialog. Both panes used to keep
+ * private copies, which is how one drifted from the Checks panel's own header.
+ */
+export function getCheckCounts(checks: readonly PRCheckDetail[]): PRCheckCounts {
+  return checks.reduce<PRCheckCounts>(
+    (counts, check) => {
+      const conclusion = getCheckConclusion(check)
+      // Why: the shared classifier counts a skipped check as passing, so bucketing it separately
+      // made this pane say "2 passing" for the same list the Checks panel called "5 passing".
+      // action_required stays its own bucket: it blocks merge but is not a red failure.
+      if (classifyCheckOutcome(check) === 'passed') {
+        counts.passing += 1
+      } else if (conclusion === 'action_required') {
+        counts.needsAction += 1
+      } else if (['failure', 'cancelled', 'timed_out'].includes(conclusion)) {
+        counts.failing += 1
+      } else if (conclusion === 'neutral') {
+        counts.neutral += 1
+      } else {
+        counts.pending += 1
+      }
+      return counts
+    },
+    { passing: 0, failing: 0, needsAction: 0, pending: 0, neutral: 0 }
+  )
+}
+
+export function getChecksSummaryLabel(checks: readonly PRCheckDetail[]): string {
+  const counts = getCheckCounts(checks)
+  if (checks.length === 0) {
+    return 'No checks found'
+  }
+  if (counts.failing > 0) {
+    return `${counts.failing} ${counts.failing === 1 ? 'check' : 'checks'} failing`
+  }
+  // Why: action_required (e.g. workflow awaiting approval) blocks merge but isn't a failure, so surface it distinctly.
+  if (counts.needsAction > 0) {
+    return `${counts.needsAction} ${counts.needsAction === 1 ? 'check needs' : 'checks need'} action`
+  }
+  if (counts.pending > 0) {
+    return `${counts.pending} ${counts.pending === 1 ? 'check' : 'checks'} pending`
+  }
+  if (counts.passing === checks.length) {
+    return 'All checks passing'
+  }
+  return `${counts.passing} of ${checks.length} checks passing`
+}

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { deriveTaskPagePRCheckSummary } from './task-page-pr-check-summary'
+import { derivePipelineStatus } from '../../../main/gitlab/mappers'
 import { gitLabPipelineJobsToPRChecks } from '../../../shared/gitlab-pipeline-checks'
 import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from '../../../shared/pr-check-status'
 import {
@@ -42,10 +43,18 @@ function toGraphQLRollup(check: PRCheckDetail): { status: string; conclusion: st
   }
 }
 
+type ParityExpectation = Omit<ProviderCheckSummary, 'total'>
+
 type ParityCase = {
   name: string
   checks: PRCheckDetail[]
-  expected: Omit<ProviderCheckSummary, 'total'>
+  /** Set when the case also pins the main-process job-array rollup for the same jobs. */
+  gitLabJobStatuses?: string[]
+  expected: ParityExpectation
+}
+
+function gitLabCase(name: string, statuses: string[], expected: ParityExpectation): ParityCase {
+  return { name, checks: gitLabJobs(...statuses), gitLabJobStatuses: statuses, expected }
 }
 
 const PARITY_CASES: ParityCase[] = [
@@ -87,16 +96,48 @@ const PARITY_CASES: ParityCase[] = [
     ],
     expected: { state: 'pending', passed: 1, failed: 0, pending: 1, neutral: 0 }
   },
-  {
-    name: 'GitLab manual gate only',
-    checks: gitLabJobs('manual'),
-    expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 }
-  },
-  {
-    name: 'GitLab manual gate alongside a green pipeline',
-    checks: gitLabJobs('manual', 'success'),
-    expected: { state: 'success', passed: 1, failed: 0, pending: 0, neutral: 1 }
-  },
+  gitLabCase('GitLab manual gate only', ['manual'], {
+    state: 'neutral',
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    neutral: 1
+  }),
+  gitLabCase('GitLab manual gate alongside a green pipeline', ['manual', 'success'], {
+    state: 'success',
+    passed: 1,
+    failed: 0,
+    pending: 0,
+    neutral: 1
+  }),
+  gitLabCase('GitLab skipped-only pipeline', ['skipped', 'skipped'], {
+    state: 'success',
+    passed: 2,
+    failed: 0,
+    pending: 0,
+    neutral: 0
+  }),
+  gitLabCase('GitLab success alongside an unrecognized job status', ['success', 'wat'], {
+    state: 'success',
+    passed: 1,
+    failed: 0,
+    pending: 0,
+    neutral: 1
+  }),
+  gitLabCase('GitLab canceled job', ['success', 'canceled'], {
+    state: 'failure',
+    passed: 1,
+    failed: 1,
+    pending: 0,
+    neutral: 0
+  }),
+  gitLabCase('GitLab manual gate alongside a running job', ['manual', 'running'], {
+    state: 'pending',
+    passed: 0,
+    failed: 0,
+    pending: 1,
+    neutral: 1
+  }),
   {
     name: 'genuine action_required',
     checks: [completed('success'), completed('action_required')],
@@ -107,12 +148,18 @@ const PARITY_CASES: ParityCase[] = [
 describe('provider check classification parity', () => {
   it.each(PARITY_CASES)(
     '$name resolves identically on every desktop surface',
-    ({ checks, expected }) => {
+    ({ checks, expected, gitLabJobStatuses }) => {
       const summary = { ...expected, total: checks.length }
       expect(summarizeProviderChecks(checks)).toEqual(summary)
       expect(deriveTaskPagePRCheckSummary(checks)).toEqual(summary)
       expect(derivePRCheckStatus(checks)).toBe(expected.state)
       expect(derivePRCheckStatusFromRollup(checks.map(toGraphQLRollup))).toBe(expected.state)
+      if (gitLabJobStatuses) {
+        // Why: the main-process job-array rollup is a fourth surface for the same jobs.
+        expect(derivePipelineStatus(gitLabJobStatuses.map((status) => ({ status })))).toBe(
+          expected.state
+        )
+      }
       // Why: the pill's label, tone and icon all read this one summary, so a green pill must never say "unresolved".
       expect(getProviderChecksLabel(summary).includes('Unresolved')).toBe(
         expected.state === 'neutral'

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -50,11 +50,28 @@ type ParityCase = {
   checks: PRCheckDetail[]
   /** Set when the case also pins the main-process job-array rollup for the same jobs. */
   gitLabJobStatuses?: string[]
+  /**
+   * The `head_pipeline.status` GitLab reports for this same job set. This is the only GitLab path
+   * with production callers (client.ts passes pipeline objects, never job arrays), so it is the
+   * surface that decides the MR card's tone.
+   */
+  gitLabPipelineStatus?: string
   expected: ParityExpectation
 }
 
-function gitLabCase(name: string, statuses: string[], expected: ParityExpectation): ParityCase {
-  return { name, checks: gitLabJobs(...statuses), gitLabJobStatuses: statuses, expected }
+function gitLabCase(
+  name: string,
+  statuses: string[],
+  expected: ParityExpectation,
+  pipelineStatus?: string
+): ParityCase {
+  return {
+    name,
+    checks: gitLabJobs(...statuses),
+    gitLabJobStatuses: statuses,
+    ...(pipelineStatus ? { gitLabPipelineStatus: pipelineStatus } : {}),
+    expected
+  }
 }
 
 const PARITY_CASES: ParityCase[] = [
@@ -96,13 +113,12 @@ const PARITY_CASES: ParityCase[] = [
     ],
     expected: { state: 'pending', passed: 1, failed: 0, pending: 1, neutral: 0 }
   },
-  gitLabCase('GitLab manual gate only', ['manual'], {
-    state: 'neutral',
-    passed: 0,
-    failed: 0,
-    pending: 0,
-    neutral: 1
-  }),
+  gitLabCase(
+    'GitLab manual gate only',
+    ['manual'],
+    { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 },
+    'manual'
+  ),
   gitLabCase('GitLab manual gate alongside a green pipeline', ['manual', 'success'], {
     state: 'success',
     passed: 1,
@@ -110,13 +126,12 @@ const PARITY_CASES: ParityCase[] = [
     pending: 0,
     neutral: 1
   }),
-  gitLabCase('GitLab skipped-only pipeline', ['skipped', 'skipped'], {
-    state: 'success',
-    passed: 2,
-    failed: 0,
-    pending: 0,
-    neutral: 0
-  }),
+  gitLabCase(
+    'GitLab skipped-only pipeline',
+    ['skipped', 'skipped'],
+    { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 },
+    'skipped'
+  ),
   gitLabCase('GitLab success alongside an unrecognized job status', ['success', 'wat'], {
     state: 'success',
     passed: 1,
@@ -131,13 +146,12 @@ const PARITY_CASES: ParityCase[] = [
     pending: 0,
     neutral: 0
   }),
-  gitLabCase('GitLab manual gate alongside a running job', ['manual', 'running'], {
-    state: 'pending',
-    passed: 0,
-    failed: 0,
-    pending: 1,
-    neutral: 1
-  }),
+  gitLabCase(
+    'GitLab manual gate alongside a running job',
+    ['manual', 'running'],
+    { state: 'pending', passed: 0, failed: 0, pending: 1, neutral: 1 },
+    'running'
+  ),
   {
     name: 'genuine action_required',
     checks: [completed('success'), completed('action_required')],
@@ -148,17 +162,24 @@ const PARITY_CASES: ParityCase[] = [
 describe('provider check classification parity', () => {
   it.each(PARITY_CASES)(
     '$name resolves identically on every desktop surface',
-    ({ checks, expected, gitLabJobStatuses }) => {
+    ({ checks, expected, gitLabJobStatuses, gitLabPipelineStatus }) => {
       const summary = { ...expected, total: checks.length }
       expect(summarizeProviderChecks(checks)).toEqual(summary)
       expect(deriveTaskPagePRCheckSummary(checks)).toEqual(summary)
       expect(derivePRCheckStatus(checks)).toBe(expected.state)
       expect(derivePRCheckStatusFromRollup(checks.map(toGraphQLRollup))).toBe(expected.state)
       if (gitLabJobStatuses) {
-        // Why: the main-process job-array rollup is a fourth surface for the same jobs.
+        // Why: the job-array rollup has no production caller today (client.ts only ever passes
+        // pipeline objects) — it is pinned so a future caller cannot inherit a drifted copy.
         expect(derivePipelineStatus(gitLabJobStatuses.map((status) => ({ status })))).toBe(
           expected.state
         )
+      }
+      if (gitLabPipelineStatus) {
+        // Why: this *is* the production GitLab entry point — the MR card and the hosted-review
+        // queue read it, so it must not disagree with the Checks tab for the same jobs.
+        expect(derivePipelineStatus(gitLabPipelineStatus)).toBe(expected.state)
+        expect(derivePipelineStatus({ status: gitLabPipelineStatus })).toBe(expected.state)
       }
       // Why: the pill's label, tone and icon all read this one summary, so a green pill must never say "unresolved".
       expect(getProviderChecksLabel(summary).includes('Unresolved')).toBe(

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { deriveTaskPagePRCheckSummary } from './task-page-pr-check-summary'
 import { gitLabPipelineJobsToPRChecks } from '../../../shared/gitlab-pipeline-checks'
 import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from '../../../shared/pr-check-status'
-import { summarizeProviderChecks } from '../../../shared/provider-check-summary'
+import {
+  getProviderChecksLabel,
+  summarizeProviderChecks
+} from '../../../shared/provider-check-summary'
 import type { GitLabPipelineJob } from '../../../shared/gitlab-types'
 import type { PRCheckDetail, ProviderCheckSummary } from '../../../shared/types'
 
@@ -110,6 +113,15 @@ describe('provider check classification parity', () => {
       expect(deriveTaskPagePRCheckSummary(checks)).toEqual(summary)
       expect(derivePRCheckStatus(checks)).toBe(expected.state)
       expect(derivePRCheckStatusFromRollup(checks.map(toGraphQLRollup))).toBe(expected.state)
+      // Why: the pill's label, tone and icon all read this one summary, so a green pill must never say "unresolved".
+      expect(getProviderChecksLabel(summary).includes('Unresolved')).toBe(
+        expected.state === 'neutral'
+      )
     }
   )
+
+  it('labels a green PR carrying one neutral check as passing', () => {
+    const checks = [...Array.from({ length: 19 }, () => completed('success')), completed('neutral')]
+    expect(getProviderChecksLabel(summarizeProviderChecks(checks))).toBe('19/20 passed')
+  })
 })

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -53,7 +53,10 @@ type ParityCase = {
   /**
    * The `head_pipeline.status` GitLab reports for this same job set. This is the only GitLab path
    * with production callers (client.ts passes pipeline objects, never job arrays), so it is the
-   * surface that decides the MR card's tone.
+   * surface that decides the MR card's tone. Left unset for the shapes where the pipeline string
+   * knowingly disagrees with the job rollup — a `manual`/`skipped`/`canceled` pipeline is grey on
+   * the card but its jobs roll up green/red in the Checks tab. Those are the deferred tone changes
+   * documented in `classifyPipelineString`; pinning them here would just freeze the disagreement.
    */
   gitLabPipelineStatus?: string
   expected: ParityExpectation
@@ -113,12 +116,13 @@ const PARITY_CASES: ParityCase[] = [
     ],
     expected: { state: 'pending', passed: 1, failed: 0, pending: 1, neutral: 0 }
   },
-  gitLabCase(
-    'GitLab manual gate only',
-    ['manual'],
-    { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 },
-    'manual'
-  ),
+  gitLabCase('GitLab manual gate only', ['manual'], {
+    state: 'neutral',
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    neutral: 1
+  }),
   gitLabCase('GitLab manual gate alongside a green pipeline', ['manual', 'success'], {
     state: 'success',
     passed: 1,
@@ -126,12 +130,13 @@ const PARITY_CASES: ParityCase[] = [
     pending: 0,
     neutral: 1
   }),
-  gitLabCase(
-    'GitLab skipped-only pipeline',
-    ['skipped', 'skipped'],
-    { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 },
-    'skipped'
-  ),
+  gitLabCase('GitLab skipped-only pipeline', ['skipped', 'skipped'], {
+    state: 'success',
+    passed: 2,
+    failed: 0,
+    pending: 0,
+    neutral: 0
+  }),
   gitLabCase('GitLab success alongside an unrecognized job status', ['success', 'wat'], {
     state: 'success',
     passed: 1,
@@ -177,7 +182,8 @@ describe('provider check classification parity', () => {
       }
       if (gitLabPipelineStatus) {
         // Why: this *is* the production GitLab entry point — the MR card and the hosted-review
-        // queue read it, so it must not disagree with the Checks tab for the same jobs.
+        // queue read it, so where it is pinned it must not disagree with the Checks tab for the
+        // same jobs.
         expect(derivePipelineStatus(gitLabPipelineStatus)).toBe(expected.state)
         expect(derivePipelineStatus({ status: gitLabPipelineStatus })).toBe(expected.state)
       }

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { deriveTaskPagePRCheckSummary } from '../renderer/src/components/task-page-pr-check-summary'
-import { gitLabPipelineJobsToPRChecks } from './gitlab-pipeline-checks'
-import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from './pr-check-status'
-import { summarizeProviderChecks } from './provider-check-summary'
-import type { GitLabPipelineJob } from './gitlab-types'
-import type { PRCheckDetail, ProviderCheckSummary } from './types'
+import { deriveTaskPagePRCheckSummary } from './task-page-pr-check-summary'
+import { gitLabPipelineJobsToPRChecks } from '../../../shared/gitlab-pipeline-checks'
+import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from '../../../shared/pr-check-status'
+import { summarizeProviderChecks } from '../../../shared/provider-check-summary'
+import type { GitLabPipelineJob } from '../../../shared/gitlab-types'
+import type { PRCheckDetail, ProviderCheckSummary } from '../../../shared/types'
 
 function completed(conclusion: string): PRCheckDetail {
   return {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -210,6 +210,31 @@ describe('ChecksList', () => {
     expect(markup).not.toContain('opacity-0')
     expect(markup).not.toContain('Open details')
   })
+
+  // Why: the pill above this list already calls skipped checks passing; a "2 passing" header on the
+  // same 2-success/3-skipped PR contradicts its own "5/5 passed" pill.
+  it('counts skipped checks in the passing header, matching the checks pill', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(ChecksList, {
+          checks: [
+            { name: 'build', status: 'completed', conclusion: 'success', url: null },
+            { name: 'test', status: 'completed', conclusion: 'success', url: null },
+            { name: 'deploy', status: 'completed', conclusion: 'skipped', url: null },
+            { name: 'docs', status: 'completed', conclusion: 'skipped', url: null },
+            { name: 'e2e', status: 'completed', conclusion: 'skipped', url: null }
+          ],
+          checksLoading: false,
+          checkDetailsContextKey: 'repo:43'
+        })
+      )
+    )
+
+    expect(markup).toContain('5 passing')
+    expect(markup).not.toContain('2 passing')
+  })
 })
 
 describe('isMutablePRConversationComment', () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -235,6 +235,70 @@ describe('ChecksList', () => {
     expect(markup).toContain('5 passing')
     expect(markup).not.toContain('2 passing')
   })
+
+  // Why: a completed check with no conclusion will never resolve, so calling it pending kept an
+  // amber spinner next to a grey "Unresolved checks" pill reading the same list.
+  it('reports a completed check with no conclusion as unresolved, not pending', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(ChecksList, {
+          checks: [{ name: 'legacy', status: 'completed', conclusion: null, url: null }],
+          checksLoading: false,
+          checkDetailsContextKey: 'repo:44'
+        })
+      )
+    )
+
+    expect(markup).toContain('1 unresolved')
+    expect(markup).not.toContain('1 pending')
+  })
+})
+
+describe('PRTriageStrip check counts', () => {
+  function renderStrip(checks: PRCheckDetail[]): string {
+    return renderToStaticMarkup(
+      React.createElement(PRTriageStrip, {
+        pr: makePR({ mergeable: 'MERGEABLE' }),
+        checks,
+        isResolvingConflictsWithAI: false,
+        onResolveConflictsWithAI: () => {},
+        isFixingChecksWithAI: false,
+        onFixChecksWithAI: () => {}
+      })
+    )
+  }
+
+  // Why: the strip and the checks pill read the same list, so a check that completed without a
+  // verdict must not spin here as pending while the pill calls it unresolved.
+  it('shows a completed check with no conclusion as unresolved instead of pending', () => {
+    const markup = renderStrip([
+      { name: 'legacy', status: 'completed', conclusion: null, url: null }
+    ])
+
+    expect(markup).toContain('1 check unresolved')
+    expect(markup).not.toContain('1 check pending')
+    expect(markup).not.toContain('No blocking PR action')
+  })
+
+  it('still reports a running check as pending', () => {
+    const markup = renderStrip([{ name: 'ci', status: 'in_progress', conclusion: null, url: null }])
+
+    expect(markup).toContain('1 check pending')
+  })
+
+  // Why: one unresolved check must not demote a PR that has a passing one — that is the same
+  // rollup rule the pill uses, so both keep saying the PR is green.
+  it('keeps a passing check green even when another check is unresolved', () => {
+    const markup = renderStrip([
+      { name: 'build', status: 'completed', conclusion: 'success', url: null },
+      { name: 'legacy', status: 'completed', conclusion: 'neutral', url: null }
+    ])
+
+    expect(markup).toContain('No blocking PR action')
+    expect(markup).not.toContain('unresolved')
+  })
 })
 
 describe('isMutablePRConversationComment', () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -100,7 +100,7 @@ import { translate } from '@/i18n/i18n'
 import { useActiveWorktree } from '@/store/selectors'
 import { useAppStore } from '@/store'
 import { sortChecksBySeverity } from '../../../../shared/pr-check-severity-order'
-import { classifyCheckOutcome } from '../../../../shared/provider-check-summary'
+import { summarizeProviderChecks } from '../../../../shared/provider-check-summary'
 
 export const PullRequestIcon = GitPullRequest
 
@@ -346,10 +346,12 @@ export function PRTriageStrip({
   fixChecksDisabledReason?: string
 }): React.JSX.Element {
   const resolvedReview = review ?? pr
-  const failingCount = checks.filter((check) => isFailedCheck(check)).length
-  const pendingCount = checks.filter(
-    (check) => check.conclusion === 'pending' || check.conclusion === null
-  ).length
+  // Why: the whole strip reads one shared summary so it cannot contradict the checks pill — a
+  // `{status: completed, conclusion: null}` check used to spin here as "1 pending" forever while
+  // the pill two panes away called it unresolved.
+  const summary = summarizeProviderChecks(checks)
+  const failingCount = summary.failed
+  const pendingCount = summary.pending
 
   if (resolvedReview?.mergeable === 'CONFLICTING') {
     return (
@@ -423,6 +425,35 @@ export function PRTriageStrip({
               {translate(
                 'auto.components.right.sidebar.checks.panel.content.5856874b59',
                 'Orca will refresh checks while this panel stays open.'
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Why: nothing passed, failed or is still running — a green tick here would contradict the grey
+  // "Unresolved checks" pill reading the same list.
+  if (summary.state === 'neutral') {
+    return (
+      <div className="border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <CircleDashed className="size-3.5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[11px] font-medium text-foreground">
+              {summary.neutral}{' '}
+              {translate('auto.components.right.sidebar.checks.panel.content.5341023167', 'check')}
+              {summary.neutral === 1 ? '' : 's'}{' '}
+              {translate(
+                'auto.components.right.sidebar.checks.panel.content.checksUnresolvedChip',
+                'unresolved'
+              )}
+            </div>
+            <div className="truncate text-[10px] text-muted-foreground">
+              {translate(
+                'auto.components.right.sidebar.checks.panel.content.checksUnresolvedStripHint',
+                'These checks finished without a pass or fail verdict.'
               )}
             </div>
           </div>
@@ -970,13 +1001,15 @@ export function ChecksList({
       })),
     [checkDetailsContextKey, sorted]
   )
-  // Why: the header count must agree with the checks pill, which reads the shared classifier —
-  // counting only `success` made a 2-success/3-skipped PR say "2 passing" next to "5/5 passed".
-  const passingCount = checks.filter((c) => classifyCheckOutcome(c) === 'passed').length
-  const failingCount = checks.filter((c) => isFailedCheck(c)).length
-  const pendingCount = checks.filter(
-    (c) => c.conclusion === 'pending' || c.conclusion === null
-  ).length
+  // Why: every header count comes from the same classifier the checks pill uses — counting only
+  // `success` made a 2-success/3-skipped PR say "2 passing" next to "5/5 passed", and treating a
+  // null conclusion as pending kept a completed-but-unresolved check spinning forever.
+  const {
+    passed: passingCount,
+    failed: failingCount,
+    pending: pendingCount,
+    neutral: neutralCount
+  } = summarizeProviderChecks(checks)
 
   useEffect(() => {
     const validKeys = new Set(rows.map((row) => row.key))
@@ -1185,6 +1218,18 @@ export function ChecksList({
               {translate(
                 'auto.components.right.sidebar.checks.panel.content.9ad98f2a17',
                 'pending'
+              )}
+            </span>
+          )}
+          {/* Why: without this chip a list of only unresolved checks rendered a header with no
+              counts at all, so nothing said why the pill was grey. */}
+          {neutralCount > 0 && (
+            <span className="flex items-center gap-1">
+              <CircleDashed className="size-3 text-muted-foreground" />
+              {neutralCount}{' '}
+              {translate(
+                'auto.components.right.sidebar.checks.panel.content.checksUnresolvedChip',
+                'unresolved'
               )}
             </span>
           )}
@@ -1993,7 +2038,9 @@ function PRCommentGroupView({
     ) : null
   const startReply = onStartReply ? (comment: PRComment) => onStartReply(comment.id) : undefined
   const surfaceClassName = cn(
-    getPRCommentGroupSurfaceClasses(presentation, actionState, { queued: isQueued }),
+    getPRCommentGroupSurfaceClasses(presentation, actionState, {
+      queued: isQueued
+    }),
     group.kind === 'standalone' ? presentation.groupStandalone : presentation.groupThread
   )
   const sharedRowProps = {

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -100,6 +100,7 @@ import { translate } from '@/i18n/i18n'
 import { useActiveWorktree } from '@/store/selectors'
 import { useAppStore } from '@/store'
 import { sortChecksBySeverity } from '../../../../shared/pr-check-severity-order'
+import { classifyCheckOutcome } from '../../../../shared/provider-check-summary'
 
 export const PullRequestIcon = GitPullRequest
 
@@ -969,7 +970,9 @@ export function ChecksList({
       })),
     [checkDetailsContextKey, sorted]
   )
-  const passingCount = checks.filter((c) => c.conclusion === 'success').length
+  // Why: the header count must agree with the checks pill, which reads the shared classifier —
+  // counting only `success` made a 2-success/3-skipped PR say "2 passing" next to "5/5 passed".
+  const passingCount = checks.filter((c) => classifyCheckOutcome(c) === 'passed').length
   const failingCount = checks.filter((c) => isFailedCheck(c)).length
   const pendingCount = checks.filter(
     (c) => c.conclusion === 'pending' || c.conclusion === null

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import { ReviewIcon } from './worktree-review-helpers'
+import { derivePipelineStatus } from '../../../../main/gitlab/mappers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 
 const gitlabReview: WorktreeCardPrDisplay = {
@@ -25,5 +26,22 @@ describe('ReviewIcon', () => {
 
     expect(markup).toContain('viewBox="0 0 16 16"')
     expect(markup).not.toContain('lucide-git-merge')
+  })
+
+  // Why: an open MR with no explicit check tone falls through to the emerald "open" colour, so a
+  // GitLab pipeline blocked on a manual gate must not resolve to a tone-less status — the card
+  // would read exactly like a passing pipeline while GitLab still refuses the merge.
+  it('does not paint a manual-blocked GitLab pipeline like a passing one', () => {
+    const status = derivePipelineStatus({ status: 'manual' })
+    const blocked = renderToStaticMarkup(
+      <ReviewIcon review={{ ...gitlabReview, status }} className="size-3" />
+    )
+    const passing = renderToStaticMarkup(
+      <ReviewIcon review={{ ...gitlabReview, status: 'success' }} className="size-3" />
+    )
+
+    expect(blocked).toContain('text-amber-500/85')
+    expect(blocked).not.toContain('text-emerald-500/80')
+    expect(blocked).not.toBe(passing)
   })
 })

--- a/src/renderer/src/components/task-page-checks-pill.test.ts
+++ b/src/renderer/src/components/task-page-checks-pill.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { getChecksLabel, getChecksPillTone } from './task-page-checks-pill'
+
+describe('task page checks pill', () => {
+  // Why: the pill's tone reads `state`, so a label branch keyed off `neutral > 0` painted a green
+  // pill that said "1 unresolved" for a PR the same summary called successful.
+  it('labels a green summary carrying one neutral check as passing', () => {
+    const item = {
+      checksSummary: {
+        state: 'success' as const,
+        total: 2,
+        passed: 1,
+        failed: 0,
+        pending: 0,
+        neutral: 1
+      }
+    }
+
+    expect(getChecksLabel(item)).toBe('1/2 passed')
+    expect(getChecksPillTone(item)).toContain('emerald')
+  })
+
+  it('only says unresolved when nothing passed, failed or is running', () => {
+    const item = {
+      checksSummary: {
+        state: 'neutral' as const,
+        total: 1,
+        passed: 0,
+        failed: 0,
+        pending: 0,
+        neutral: 1
+      }
+    }
+
+    expect(getChecksLabel(item)).toBe('Unresolved checks')
+    expect(getChecksPillTone(item)).toContain('text-muted-foreground')
+  })
+
+  it('falls back while the summary is unknown or empty', () => {
+    expect(getChecksLabel({})).toBe('Checks')
+    expect(
+      getChecksLabel({
+        checksSummary: {
+          state: 'none',
+          total: 0,
+          passed: 0,
+          failed: 0,
+          pending: 0,
+          neutral: 0
+        }
+      })
+    ).toBe('No checks')
+  })
+})

--- a/src/renderer/src/components/task-page-checks-pill.ts
+++ b/src/renderer/src/components/task-page-checks-pill.ts
@@ -1,0 +1,26 @@
+import { getProviderChecksLabel } from '../../../shared/provider-check-summary'
+import type { ProviderCheckSummary } from '../../../shared/types'
+
+type ChecksPillItem = { checksSummary?: ProviderCheckSummary }
+
+/**
+ * The Tasks-grid checks pill. Label and tone both read the one shared summary so the pill can never
+ * contradict its own colour — a green pill used to read "1 unresolved" whenever neutral > 0.
+ */
+export function getChecksLabel(item: ChecksPillItem): string {
+  return getProviderChecksLabel(item.checksSummary)
+}
+
+export function getChecksPillTone(item: ChecksPillItem): string {
+  const state = item.checksSummary?.state
+  if (state === 'success') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+  }
+  if (state === 'failure') {
+    return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200'
+  }
+  if (state === 'pending') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+  }
+  return 'border-border/60 bg-background/70 text-muted-foreground'
+}

--- a/src/renderer/src/components/task-page-pr-check-summary.test.ts
+++ b/src/renderer/src/components/task-page-pr-check-summary.test.ts
@@ -50,7 +50,7 @@ describe('deriveTaskPagePRCheckSummary', () => {
         check({ conclusion: 'skipped' })
       ])
     ).toEqual({
-      state: 'neutral',
+      state: 'success',
       total: 3,
       passed: 2,
       failed: 0,

--- a/src/renderer/src/components/task-page-pr-check-summary.ts
+++ b/src/renderer/src/components/task-page-pr-check-summary.ts
@@ -1,55 +1,6 @@
+import { summarizeProviderChecks } from '../../../shared/provider-check-summary'
 import type { PRCheckDetail, ProviderCheckSummary } from '../../../shared/types'
 
-function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
-  return check.conclusion ?? 'pending'
-}
-
-function isPendingCheck(check: PRCheckDetail): boolean {
-  return (
-    check.status === 'queued' ||
-    check.status === 'in_progress' ||
-    getCheckConclusion(check) === 'pending'
-  )
-}
-
 export function deriveTaskPagePRCheckSummary(checks: PRCheckDetail[]): ProviderCheckSummary {
-  if (checks.length === 0) {
-    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0, neutral: 0 }
-  }
-
-  let passed = 0
-  let failed = 0
-  let pending = 0
-  let neutral = 0
-
-  for (const check of checks) {
-    const conclusion = getCheckConclusion(check)
-    if (conclusion === 'success' || conclusion === 'skipped') {
-      passed += 1
-    } else if (conclusion === 'neutral') {
-      neutral += 1
-    } else if (
-      conclusion === 'failure' ||
-      conclusion === 'timed_out' ||
-      conclusion === 'cancelled' ||
-      // Why: action_required (e.g. a workflow awaiting approval) blocks merge; it
-      // must count as failed so the summary never reads "passing" while blocked.
-      conclusion === 'action_required'
-    ) {
-      failed += 1
-    } else if (isPendingCheck(check)) {
-      pending += 1
-    } else {
-      neutral += 1
-    }
-  }
-
-  return {
-    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : neutral > 0 ? 'neutral' : 'success',
-    total: checks.length,
-    passed,
-    failed,
-    pending,
-    neutral
-  }
+  return summarizeProviderChecks(checks)
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10660,6 +10660,8 @@
                 "9ad98f2a17": "pending",
                 "5e52f4ef7f": "failing",
                 "02ca4f9074": "passing",
+                "checksUnresolvedChip": "unresolved",
+                "checksUnresolvedStripHint": "These checks finished without a pass or fail verdict.",
                 "e15a8b77ef": "No inline details are available for this check.",
                 "679bf2093c": "Copy log excerpt",
                 "d713f500b2": "Log excerpt",

--- a/src/shared/gitlab-pipeline-checks.test.ts
+++ b/src/shared/gitlab-pipeline-checks.test.ts
@@ -49,7 +49,7 @@ describe('gitLabPipelineJobsToPRChecks', () => {
       {
         name: 'deploy: deploy',
         status: 'completed',
-        conclusion: 'action_required',
+        conclusion: 'neutral',
         url: null
       },
       {

--- a/src/shared/gitlab-pipeline-checks.ts
+++ b/src/shared/gitlab-pipeline-checks.ts
@@ -35,7 +35,12 @@ export function mapGitLabPipelineJobStatusToConclusion(
   if (s === 'skipped') {
     return 'skipped'
   }
-  if (s === 'manual' || s === 'action_required') {
+  // Why: manual GitLab jobs are intentionally waiting for a human trigger; calling them pending
+  // would make the Checks tab look stuck forever, and action_required flags green MRs as failing.
+  if (s === 'manual') {
+    return 'neutral'
+  }
+  if (s === 'action_required') {
     return 'action_required'
   }
   if (

--- a/src/shared/pr-check-severity-order.test.ts
+++ b/src/shared/pr-check-severity-order.test.ts
@@ -116,10 +116,11 @@ describe('PR check severity order', () => {
       check('pass-b', 'success')
     ]
 
+    // A manual GitLab gate is neutral, so it sinks below the passing checks a reviewer reads first.
     expect(sortChecksBySeverity(checks).map((item) => item.name)).toEqual([
-      'manual',
       'pass-a',
       'pass-b',
+      'manual',
       'future'
     ])
   })

--- a/src/shared/pr-check-status.ts
+++ b/src/shared/pr-check-status.ts
@@ -1,38 +1,11 @@
+import { summarizeProviderChecks } from './provider-check-summary'
 import type { CheckStatus, PRCheckDetail } from './types'
 
 /** Derives the review status from the normalized check contract. */
 export function derivePRCheckStatus(checks: readonly PRCheckDetail[]): CheckStatus {
-  if (checks.length === 0) {
-    return 'neutral'
-  }
-
-  let hasPending = false
-  let hasSuccess = false
-  for (const check of checks) {
-    if (
-      check.conclusion === 'failure' ||
-      check.conclusion === 'timed_out' ||
-      check.conclusion === 'cancelled' ||
-      check.conclusion === 'action_required'
-    ) {
-      return 'failure'
-    }
-    if (
-      check.status === 'queued' ||
-      check.status === 'in_progress' ||
-      check.conclusion === 'pending'
-    ) {
-      hasPending = true
-    }
-    if (check.conclusion === 'success') {
-      hasSuccess = true
-    }
-  }
-
-  if (hasPending) {
-    return 'pending'
-  }
-  return hasSuccess ? 'success' : 'neutral'
+  const { state } = summarizeProviderChecks(checks)
+  // Why: CheckStatus has no 'none'; an empty rollup carries the same "nothing to report" meaning.
+  return state === 'none' ? 'neutral' : state
 }
 
 type RawCheckRollup = { status?: unknown; conclusion?: unknown; state?: unknown }

--- a/src/shared/provider-check-summary.test.ts
+++ b/src/shared/provider-check-summary.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { deriveTaskPagePRCheckSummary } from '../renderer/src/components/task-page-pr-check-summary'
+import { gitLabPipelineJobsToPRChecks } from './gitlab-pipeline-checks'
+import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from './pr-check-status'
+import { summarizeProviderChecks } from './provider-check-summary'
+import type { GitLabPipelineJob } from './gitlab-types'
+import type { PRCheckDetail, ProviderCheckSummary } from './types'
+
+function completed(conclusion: string): PRCheckDetail {
+  return {
+    name: conclusion,
+    status: 'completed',
+    conclusion: conclusion as PRCheckDetail['conclusion'],
+    url: null
+  }
+}
+
+function gitLabJobs(...statuses: string[]): PRCheckDetail[] {
+  return gitLabPipelineJobsToPRChecks(
+    statuses.map(
+      (status, index): GitLabPipelineJob => ({
+        id: index,
+        name: status,
+        stage: 'deploy',
+        status,
+        webUrl: '',
+        duration: null
+      })
+    )
+  )
+}
+
+// Why: GraphQL rollups arrive upper-cased and status-first; the main process must land on the
+// same verdict as the renderer for the same checks.
+function toGraphQLRollup(check: PRCheckDetail): { status: string; conclusion: string | null } {
+  return {
+    status: check.status.toUpperCase(),
+    conclusion: check.conclusion ? check.conclusion.toUpperCase() : null
+  }
+}
+
+type ParityCase = {
+  name: string
+  checks: PRCheckDetail[]
+  expected: Omit<ProviderCheckSummary, 'total'>
+}
+
+const PARITY_CASES: ParityCase[] = [
+  {
+    name: 'all success',
+    checks: [completed('success'), completed('success')],
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'success plus skipped',
+    checks: [completed('success'), completed('skipped')],
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'all skipped',
+    checks: [completed('skipped'), completed('skipped')],
+    expected: { state: 'success', passed: 2, failed: 0, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'success plus neutral',
+    checks: [completed('success'), completed('neutral')],
+    expected: { state: 'success', passed: 1, failed: 0, pending: 0, neutral: 1 }
+  },
+  {
+    name: 'all neutral',
+    checks: [completed('neutral')],
+    expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 }
+  },
+  {
+    name: 'success plus failure',
+    checks: [completed('success'), completed('failure')],
+    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+  },
+  {
+    name: 'success plus running',
+    checks: [
+      completed('success'),
+      { name: 'ci', status: 'in_progress', conclusion: null, url: null }
+    ],
+    expected: { state: 'pending', passed: 1, failed: 0, pending: 1, neutral: 0 }
+  },
+  {
+    name: 'GitLab manual gate only',
+    checks: gitLabJobs('manual'),
+    expected: { state: 'neutral', passed: 0, failed: 0, pending: 0, neutral: 1 }
+  },
+  {
+    name: 'GitLab manual gate alongside a green pipeline',
+    checks: gitLabJobs('manual', 'success'),
+    expected: { state: 'success', passed: 1, failed: 0, pending: 0, neutral: 1 }
+  },
+  {
+    name: 'genuine action_required',
+    checks: [completed('success'), completed('action_required')],
+    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+  }
+]
+
+describe('provider check classification parity', () => {
+  it.each(PARITY_CASES)(
+    '$name resolves identically on every desktop surface',
+    ({ checks, expected }) => {
+      const summary = { ...expected, total: checks.length }
+      expect(summarizeProviderChecks(checks)).toEqual(summary)
+      expect(deriveTaskPagePRCheckSummary(checks)).toEqual(summary)
+      expect(derivePRCheckStatus(checks)).toBe(expected.state)
+      expect(derivePRCheckStatusFromRollup(checks.map(toGraphQLRollup))).toBe(expected.state)
+    }
+  )
+})

--- a/src/shared/provider-check-summary.ts
+++ b/src/shared/provider-check-summary.ts
@@ -1,0 +1,82 @@
+import type { ProviderCheckSummary } from './types'
+
+export type CheckOutcome = 'passed' | 'failed' | 'pending' | 'neutral'
+
+export type CheckOutcomeInput = { status?: string | null; conclusion?: string | null }
+
+// Why: a skipped job is a deliberate "not applicable", not an unresolved signal — every surface
+// must count it as passing or the same PR reads green on desktop and grey on mobile.
+const PASSED_CONCLUSIONS = new Set(['success', 'skipped'])
+
+// Why: these block the merge. GitLab `manual` is deliberately absent — it waits on a human.
+const FAILED_CONCLUSIONS = new Set([
+  'failure',
+  'error',
+  'startup_failure',
+  'timed_out',
+  'cancelled',
+  'action_required'
+])
+
+/** The single provider-neutral verdict for one check; every check surface must route through it. */
+export function classifyCheckOutcome(check: CheckOutcomeInput): CheckOutcome {
+  const conclusion = (check.conclusion ?? '').toLowerCase()
+  const status = (check.status ?? '').toLowerCase()
+  if (FAILED_CONCLUSIONS.has(conclusion)) {
+    return 'failed'
+  }
+  if (PASSED_CONCLUSIONS.has(conclusion)) {
+    return 'passed'
+  }
+  // Why: anything that has not reached a terminal status is still running, whatever it calls itself.
+  if (conclusion === 'pending' || status !== 'completed') {
+    return 'pending'
+  }
+  return 'neutral'
+}
+
+/** Rolls up counted outcomes; passing checks win over neutral ones so one neutral cannot demote a green PR. */
+export function resolveProviderCheckState(
+  counts: Pick<ProviderCheckSummary, 'total' | 'passed' | 'failed' | 'pending'>
+): ProviderCheckSummary['state'] {
+  if (counts.total === 0) {
+    return 'none'
+  }
+  if (counts.failed > 0) {
+    return 'failure'
+  }
+  if (counts.pending > 0) {
+    return 'pending'
+  }
+  return counts.passed > 0 ? 'success' : 'neutral'
+}
+
+export function summarizeProviderChecks(
+  checks: readonly CheckOutcomeInput[]
+): ProviderCheckSummary {
+  let passed = 0
+  let failed = 0
+  let pending = 0
+  let neutral = 0
+  for (const check of checks) {
+    const outcome = classifyCheckOutcome(check)
+    if (outcome === 'passed') {
+      passed += 1
+    } else if (outcome === 'failed') {
+      failed += 1
+    } else if (outcome === 'pending') {
+      pending += 1
+    } else {
+      neutral += 1
+    }
+  }
+  const total = checks.length
+  return {
+    state: resolveProviderCheckState({ total, passed, failed, pending }),
+    total,
+    passed,
+    failed,
+    pending,
+    neutral
+  }
+}

--- a/src/shared/provider-check-summary.ts
+++ b/src/shared/provider-check-summary.ts
@@ -80,3 +80,22 @@ export function summarizeProviderChecks(
     neutral
   }
 }
+
+/** The one checks-pill label; it keys off `state` so the text can never contradict the pill's tone or icon. */
+export function getProviderChecksLabel(summary: ProviderCheckSummary | undefined): string {
+  if (!summary) {
+    return 'Checks'
+  }
+  if (summary.total === 0) {
+    return 'No checks'
+  }
+  if (summary.failed > 0) {
+    return `${summary.failed} failing`
+  }
+  if (summary.pending > 0) {
+    return `${summary.pending} pending`
+  }
+  return summary.state === 'neutral'
+    ? 'Unresolved checks'
+    : `${summary.passed}/${summary.total} passed`
+}


### PR DESCRIPTION
## ELI5

Imagine a checklist on your pull request. Some items say "passed", some say "skipped, not needed here", and on GitLab some say "waiting for a human to click Deploy". Recently Orca started reading two of those as "broken".

- GitLab's "waiting for a human" deploy gate got filed under "action required", which Orca treats as a hard failure — so perfectly green, mergeable MRs showed red failing checks.
- On mobile, "skipped" items got filed under "unresolved" — so a PR that read "20/20 passed" in green flipped to grey "Unresolved checks" the moment you pulled to refresh. Same PR, same data, opposite answer.
- And a single harmless "neutral" item dragged the whole PR down, greying out the checks pill and disabling the Merge button.

This PR gives all three surfaces (desktop sidebar, desktop Tasks grid, mobile) one shared rulebook: skipped means passed, a GitLab manual gate means waiting-on-a-human, and one neutral item can't outvote the checks that actually passed.

## Summary

- Added `src/shared/provider-check-summary.ts:21` — a single `classifyCheckOutcome` / `summarizeProviderChecks` pair that is now the only place a provider conclusion becomes passed/failed/pending/neutral. `skipped` is bucketed with `success`; `action_required` stays a failure.
- `src/shared/provider-check-summary.ts:39` — `resolveProviderCheckState` ranks `passed > 0` above `neutral > 0`, so one neutral (or unknown) conclusion can no longer demote a PR that has passing checks. Fixes the Tasks-grid Merge button (`github-pr-merge-state.ts:50` `checksPassed`) and the sidebar checks dot (`activity-bar-buttons.tsx:58`, which hides on `'neutral'`).
- `src/shared/gitlab-pipeline-checks.ts:38` — GitLab `manual` maps back to `neutral` instead of `action_required`, restoring the intent (and comment) that #11337 deleted; `action_required` keeps its own branch. `src/main/gitlab/mappers.ts:292` gets the same treatment for pipeline-level `head_pipeline.status`, so a blocked pipeline no longer paints the worktree card red.
- `mobile/src/tasks/github-check-summary.ts:13` and `mobile/src/tasks/gitlab-check-summary.ts:10` now delegate to the shared helper (and to the shared GitLab job mappers) instead of keeping a third divergent copy of the rules.
- `src/shared/pr-check-status.ts:6`, `src/renderer/src/components/task-page-pr-check-summary.ts:5` and `src/main/github/client.ts:659` (`deriveWorkItemCheckSummary`) all re-express themselves in terms of the shared helper, so `checksStatus` and `checksSummary` can no longer disagree about the same PR.
- `src/shared/provider-check-summary.ts:84` — `getProviderChecksLabel` is now the single checks-pill label, keyed off `state` rather than the raw `neutral` counter, with `TaskPage.tsx:2016` and `mobile/src/tasks/mobile-hosted-check-status.ts:42` both delegating to it. This keeps the label consistent with the corrected `state` on every surface: now that one neutral check no longer demotes an otherwise-green summary, a label derived from the raw `neutral` counter would still have said "1 unresolved" for a PR whose state is `success`. Deriving it from `state` removes that second source of truth.
- #11337's actual intent is preserved: `src/shared/pr-check-severity-order.ts` still ranks successful checks above skipped/neutral in the checks list ordering. This change is about classification, not ordering.

## Regression source

All four regressions were introduced by #11337 (`6f3845baa4`) — "fix(checks): rank successful checks above skipped and neutral". Alongside its ordering change it reclassified GitLab `manual` as `action_required`, added neutral buckets that demote a whole summary, and made mobile count `skipped` as unresolved.

_Not_ #11071 (`554892b184`, "fix(github): classify all blocking check conclusions"). An earlier draft of this PR body named it as a contributing cause; that was wrong on two counts, and the correction is recorded here rather than silently dropped:
- **Ordering:** #11337 is an *ancestor* of #11071 (`git merge-base --is-ancestor 6f3845baa4 554892b184` succeeds), so #11071 cannot have established a path #11337 fell into.
- **Scope:** #11071 changed only `src/shared/pr-check-status.ts` (+6/−2) plus its test, mapping `error` and `startup_failure` conclusions to `failure`. It never touched `gitlab-pipeline-checks.ts`, `mobile/src/tasks/github-check-summary.ts`, or `task-page-pr-check-summary.ts`, and it did not introduce the `action_required`-is-blocking treatment.

## Test plan

- New `src/renderer/src/components/provider-check-classification-parity.test.ts`: table-driven parity across the desktop surfaces (`summarizeProviderChecks`, `deriveTaskPagePRCheckSummary`, `derivePRCheckStatus`, `derivePRCheckStatusFromRollup`) for all success; success+skipped; all skipped; success+neutral; all neutral; success+failure; success+running; GitLab manual-only; GitLab manual+success; genuine `action_required`.
- New parity block in `mobile/src/tasks/github-check-summary.test.ts`: same table asserted against `buildGitHubCheckSummary` / `buildGitLabCheckSummary` and pinned to the shared classifier.
- Verified failing-then-passing: with the production files reverted to `origin/main` (shared test module kept), `npx vitest run --config config/vitest.config.ts src/renderer/src/components/provider-check-classification-parity.test.ts` fails 4/10 —
  - `'all skipped' resolves identically on every desktop surface` → `AssertionError: expected 'neutral' to be 'success'`
  - `'GitLab manual gate only' ...` → `expected { state: 'failure', total: 1, ... } to deeply equal { state: 'neutral', passed: +0, ... }`
  - `'GitLab manual gate alongside a green pipeline' ...` → `expected { state: 'failure', total: 2, ... } to deeply equal { state: 'success', passed: 1, ... }`
  - `'success plus neutral' ...` → `expected { state: 'neutral', total: 2, ... } to deeply equal { state: 'success', passed: 1, ... }`
  and the mobile file fails 7 tests, including `'success plus skipped' matches the shared desktop classifier` → `expected { state: 'neutral', ... } to deeply equal { state: 'success', passed: 2, ... }`. Both pass after restoring the fix.
- New `src/main/github/client-work-item-check-summary.test.ts`: drives `getWorkItem(..., 'pr', ...)` with real `statusCheckRollup` fixtures so `deriveWorkItemCheckSummary` — the desktop-main producer of the `checksSummary` that reaches the Tasks grid and the relay-paired mobile client — is covered directly rather than by proxy through `derivePRCheckStatusFromRollup` (a different normalizer). Asserts a CheckRun `SKIPPED` + StatusContext `SUCCESS` + CheckRun `NEUTRAL` rollup resolves to `{state:'success', total:3, passed:2, neutral:1}`, plus a pending, a failing and an empty rollup. Confirmed failing-then-passing: deleting the `?? raw.state` StatusContext fallback fails the first case (`expected 'success' to be 'pending'`) and nothing else in the suite notices.
- The parity table now also asserts `getProviderChecksLabel` for every row: only a `'neutral'` state may produce an "Unresolved" label, plus an explicit 19-success + 1-neutral case: `state` is `success` after this change, so the label must read `19/20 passed` rather than "1 unresolved".
- Updated the existing tests that had pinned the regressed behavior (`src/main/gitlab/mappers.test.ts`, `src/shared/gitlab-pipeline-checks.test.ts`, `src/renderer/src/components/task-page-pr-check-summary.test.ts`, `src/shared/pr-check-severity-order.test.ts`); each was confirmed failing against the unfixed code first, e.g. `mapPipelineJobStatusToConclusion('manual')` → `expected 'action_required' to be 'neutral'`.
- Full desktop suite: `npx vitest run --config config/vitest.config.ts` → 3975 files passed, 42085 tests passed; the only failures are the 2 known `GIT_CONFIG_COUNT` environment assertions in `src/relay/agent-exec-handler.test.ts`.
- Mobile: all 27 files / 175 tests under `mobile/src/tasks` pass.
- `npx oxlint` on every changed file: clean. All three `pnpm typecheck` projects (`config/tsconfig.node.json`, `config/tsconfig.tc.cli.json`, `config/tsconfig.tc.web.json`) are clean. The parity table lives in the renderer tree rather than `src/shared` because the node and cli projects are `composite` and include `src/shared` without the renderer components directory, so a shared test importing `task-page-pr-check-summary` fails them with TS6307.

Found by the production release scan of v1.4.163-rc.0..origin/main.

Made with [Orca](https://github.com/stablyai/orca) 🐋




---

## Review follow-up (`dd72c9bfaf`) — user-visible tone changes, disclosed

Two GitLab presentation changes ship here and are worth calling out explicitly, because both alter what a user sees on a card they did not previously have to think about.

**1. A `manual` (blocked) GitLab pipeline now reads amber "pending" instead of red "failed".**
GitLab reports pipeline-level `manual` only when the pipeline is genuinely blocked on a human trigger (a manual job with `allow_failure: false`); optional `when: manual` deploy buttons leave the pipeline at `success`. Before this PR that blocked state resolved to `failure`, so the worktree card's MR icon was rose and `ReviewChecksBadge` read "Checks: Failed" for a pipeline that had not failed. It is now `pending`: amber icon, "Checks: Pending" badge. Nothing is gated on the value — the merge button's enabled state and label are unchanged (`HostedReviewActions.tsx:147-149` reads the merge-method label whenever `directMergeAvailable`, which GitLab always sets `true` for an open non-conflicting MR).

Resolving it to `neutral` was considered and rejected: `worktree-review-helpers.tsx:35-41` gives `neutral` no check tone and then falls through to the emerald `open` default, so a blocked MR would have rendered identically to a passing one, with `ReviewChecksBadge` suppressed entirely — a false green in place of a false red.

**2. The per-job "Action required" cue for GitLab `manual` jobs is dropped.**
`mapGitLabPipelineJobStatusToConclusion('manual')` moves from `action_required` to `neutral`, so in the Checks tab a manual job's row goes from an amber `AlertTriangle` + "Action required" + "Needs a manual action … to unblock merging" to a grey `CircleDashed` + "Neutral". This is deliberate. A job's `manual` status cannot distinguish a blocking gate from an optional deploy button, and `action_required` is in `FAILED_CONCLUSIONS` — which is precisely why a green pipeline carrying one optional manual job rolled up to `failure` and painted the whole MR red. Recovering the cue without the false red requires a first-class `manual` conclusion in `PRCheckDetail`, plumbed through every check surface; that is a separate change.

**Explicitly not changed:** `classifyPipelineString` still resolves both `skipped` and `canceled` pipelines to `neutral`, even though the job rollup calls the same jobs passing and failing respectively. GitLab's own MR widget paints both grey, and `allow_merge_on_skipped_pipeline` defaults to `false`, so a skipped pipeline still blocks merging — painting that card green would be the optimistic direction. Both string-vs-array divergences are pinned by a test so neither can flip silently, and both remain product decisions for their own PR.
