### PR TITLE
fix: stabilize new worktree task source tabs

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
@@ -113,4 +113,8 @@ describe('SmartWorkspaceNameField repo-backed source boundaries', () => {
     expect(FIELD_SOURCE).toContain('onPointerDown={() => {')
     expect(FIELD_SOURCE).toContain('markSourcePopoverUserEngaged()')
   })
+
+  it('confines source-mode overflow to the source strip', () => {
+    expect(FIELD_SOURCE).toContain('overflow-x-auto overflow-y-hidden px-0 scrollbar-sleek')
+  })
 })

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -394,11 +394,10 @@ export default function SmartWorkspaceNameField({
     link: NonNullable<ReturnType<typeof parseGitHubIssueOrPRLink>>
     matchingRepo: RepoOption | null
   } | null>(null)
-  // Why: Jira status is read lazily — mounting the composer must not cost an IPC/RPC round-trip,
-  // so only reach for it once the user opens the source picker, picks Jira, or pastes an issue URL.
+  // Why: read Jira status when the composer mounts so an already-configured source is available
+  // before users start typing, without showing Jira for hosts where it is not configured.
   const jiraConnection = useJiraSourceConnection({
-    enabled:
-      !disabled && !textOnly && (open || mode === 'jira' || isBlockingJiraUrlIntent(mode, value)),
+    enabled: !disabled && !textOnly && jiraSourceContext !== null,
     sourceContext: jiraSourceContext
   })
   const jiraConnectionStatus = jiraConnection.status
@@ -1624,7 +1623,7 @@ export default function SmartWorkspaceNameField({
             <TabsList
               ref={tabsListRef}
               variant="line"
-              className="h-7 w-full justify-start gap-4 px-0"
+              className="h-7 w-full justify-start gap-4 overflow-x-auto overflow-y-hidden px-0 scrollbar-sleek"
               onFocusCapture={(event) => {
                 // Why: Radix Tabs roving focus re-applies tabindex=0 to the active trigger (races React commits), so forward Tab to the input.
                 const previous = event.relatedTarget as HTMLElement | null


### PR DESCRIPTION
## Description

Starts the Jira connection check when the create-worktree dialog opens, so configured Jira sources are ready before users start typing. Jira remains hidden for hosts where it is not configured. The task-source strip now owns horizontal overflow and explicitly hides vertical overflow, so a long source list cannot widen or scroll the name input/dialog.

## ELI5

Previously, the dialog did not ask whether Jira was available until you interacted with the name field. That made the Jira button appear in the middle of typing. Now it checks when the dialog opens: people with Jira configured see it up front, and people without Jira never see it.

## Proof of fix

- `pnpm run typecheck:web`
- `pnpm run check:code-quality:changed`
- `pnpm exec vitest run src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts` — 6 passed
- Electron dev build launched from this worktree; the real create-worktree dialog was opened through the app store and captured through CDP.

## Screenshot

Fresh Electron capture after the scrollbar fix: Jira is visible for the configured local target before typing, the source strip has no vertical scrollbar, and the modal and name input remain at their normal widths.

![Create-worktree dialog after scrollbar fix](https://github.com/user-attachments/assets/b54c8c84-1ad8-4792-862f-0d7753a1edd2)