### PR TITLE
feat(native-chat): render GitHub-style math

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -98,9 +98,9 @@ export function NativeChatComposerField({
   sessionOptionsSnapshot
 }: NativeChatComposerFieldProps): React.JSX.Element {
   return (
-    <div className="shrink-0 border-t border-border/70 bg-background font-mono">
-      <div className="px-3 py-2 sm:px-4">
-        <div className="relative mx-auto w-full max-w-none">
+    <div className="shrink-0 border-t border-border/70 bg-background/95 font-mono backdrop-blur">
+      <div className="px-4 py-3 sm:px-6">
+        <div className="relative mx-auto w-full max-w-4xl">
           {autocomplete.mode === 'slash' || autocomplete.mode === 'skill' ? (
             <NativeChatPickerMenu
               autocomplete={autocomplete}
@@ -123,8 +123,7 @@ export function NativeChatComposerField({
             data-native-file-drop-target={NATIVE_FILE_DROP_TARGET.composer}
             data-native-chat-composer="terminal"
             className={cn(
-              "relative border-l-2 border-primary/60 px-2 py-1 before:pointer-events-none before:absolute before:left-2 before:top-1 before:text-muted-foreground before:content-['›']",
-              'bg-transparent'
+              'rounded-lg border border-border/70 bg-muted/25 px-3 py-2 shadow-sm transition-colors focus-within:border-primary/70 focus-within:bg-background focus-within:ring-2 focus-within:ring-primary/15'
             )}
           >
             {imageAttachments.length > 0 ? (
@@ -159,42 +158,50 @@ export function NativeChatComposerField({
                 ))}
               </div>
             ) : null}
-            <textarea
-              ref={textareaRef}
-              value={draft}
-              disabled={disabled}
-              rows={1}
-              onChange={(e) => onDraftChange(e.target.value, e.currentTarget)}
-              onKeyDown={onKeyDown}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={onCompositionEnd}
-              onPaste={onPaste}
-              onSelect={(e) => onTextareaSelect(e.currentTarget)}
-              aria-expanded={autocomplete.mode === 'slash' || autocomplete.mode === 'skill'}
-              aria-controls={
-                autocomplete.mode === 'slash' || autocomplete.mode === 'skill'
-                  ? pickerListboxId
-                  : undefined
-              }
-              aria-activedescendant={
-                (autocomplete.mode === 'slash' || autocomplete.mode === 'skill') &&
-                autocomplete.items.length > 0
-                  ? `${pickerListboxId}-option-${Math.min(activeSuggestion, autocomplete.items.length - 1)}`
-                  : undefined
-              }
-              placeholder={nativeChatComposerPlaceholder(hasPty, canSend)}
-              // Why: coarse-pointer min-height follows the app's touch target convention.
-              // field-sizing:content grows the field with the draft; the 8lh cap (plus
-              // py-1) turns further growth into internal scrolling, and scrollbar-sleek
-              // keeps that gutter off the heavy native scrollbar. Both are layout-driven,
-              // so re-wrap on window/pane resize is handled without a measure pass.
-              className={cn(
-                'scrollbar-sleek min-h-10 w-full resize-none bg-transparent py-1 pl-4 pr-2 font-mono text-[13px] leading-6 outline-none pointer-coarse:min-h-12',
-                '[field-sizing:content] max-h-[calc(8lh+0.5rem)]',
-                'placeholder:text-muted-foreground/60 disabled:cursor-not-allowed disabled:opacity-50'
-              )}
-            />
-            <div className="flex flex-wrap items-center gap-2 pt-0.5">
+            <div className="flex min-w-0 items-start">
+              <span
+                aria-hidden="true"
+                className="shrink-0 select-none py-1 pr-2 font-semibold leading-6 text-primary/80"
+              >
+                ›
+              </span>
+              <textarea
+                ref={textareaRef}
+                value={draft}
+                disabled={disabled}
+                rows={1}
+                onChange={(e) => onDraftChange(e.target.value, e.currentTarget)}
+                onKeyDown={onKeyDown}
+                onCompositionStart={onCompositionStart}
+                onCompositionEnd={onCompositionEnd}
+                onPaste={onPaste}
+                onSelect={(e) => onTextareaSelect(e.currentTarget)}
+                aria-expanded={autocomplete.mode === 'slash' || autocomplete.mode === 'skill'}
+                aria-controls={
+                  autocomplete.mode === 'slash' || autocomplete.mode === 'skill'
+                    ? pickerListboxId
+                    : undefined
+                }
+                aria-activedescendant={
+                  (autocomplete.mode === 'slash' || autocomplete.mode === 'skill') &&
+                  autocomplete.items.length > 0
+                    ? `${pickerListboxId}-option-${Math.min(activeSuggestion, autocomplete.items.length - 1)}`
+                    : undefined
+                }
+                placeholder={nativeChatComposerPlaceholder(hasPty, canSend)}
+                // Why: coarse-pointer min-height follows the app's touch target convention.
+                // field-sizing:content grows the field with the draft; the 8lh cap (plus
+                // py-1) turns further growth into internal scrolling, and scrollbar-sleek
+                // keeps that gutter off the heavy native scrollbar. Both are layout-driven,
+                // so re-wrap on window/pane resize is handled without a measure pass.
+                className={cn(
+                  'scrollbar-sleek min-h-10 w-full resize-none bg-transparent py-1 pl-0 pr-2 font-mono text-[14px] leading-6 outline-none pointer-coarse:min-h-12',
+                  '[field-sizing:content] max-h-[calc(8lh+0.5rem)]',
+                  'placeholder:text-muted-foreground/60 disabled:cursor-not-allowed disabled:opacity-50'
+                )}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-2 border-t border-border/50 pt-2">
               <NativeChatComposerActions
                 attachDisabled={attachDisabled}
                 dictationDisabled={dictationDisabled}

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -98,10 +98,9 @@ export function NativeChatComposerField({
   sessionOptionsSnapshot
 }: NativeChatComposerFieldProps): React.JSX.Element {
   return (
-    <div className="shrink-0 bg-background">
-      {/* Extra bottom padding keeps the input box off the window rim. */}
-      <div className="px-3 pt-2 pb-4 sm:px-4">
-        <div className="relative mx-auto w-full max-w-4xl">
+    <div className="shrink-0 border-t border-border/70 bg-background font-mono">
+      <div className="px-3 py-2 sm:px-4">
+        <div className="relative mx-auto w-full max-w-none">
           {autocomplete.mode === 'slash' || autocomplete.mode === 'skill' ? (
             <NativeChatPickerMenu
               autocomplete={autocomplete}
@@ -122,12 +121,10 @@ export function NativeChatComposerField({
           ) : null}
           <div
             data-native-file-drop-target={NATIVE_FILE_DROP_TARGET.composer}
+            data-native-chat-composer="terminal"
             className={cn(
-              // Why: always-on hairline (token-level border, not focus ring) —
-              // no focus/click border flash. The box is a container, not a
-              // focus target.
-              'rounded-lg border border-border p-1.5 shadow-xs',
-              'bg-muted/50 dark:bg-input/40'
+              "relative border-l-2 border-primary/60 px-2 py-1 before:pointer-events-none before:absolute before:left-2 before:top-1 before:text-muted-foreground before:content-['›']",
+              'bg-transparent'
             )}
           >
             {imageAttachments.length > 0 ? (
@@ -166,7 +163,7 @@ export function NativeChatComposerField({
               ref={textareaRef}
               value={draft}
               disabled={disabled}
-              rows={2}
+              rows={1}
               onChange={(e) => onDraftChange(e.target.value, e.currentTarget)}
               onKeyDown={onKeyDown}
               onCompositionStart={onCompositionStart}
@@ -192,7 +189,7 @@ export function NativeChatComposerField({
               // keeps that gutter off the heavy native scrollbar. Both are layout-driven,
               // so re-wrap on window/pane resize is handled without a measure pass.
               className={cn(
-                'scrollbar-sleek min-h-12 w-full resize-none bg-transparent px-2 py-1 text-sm outline-none pointer-coarse:min-h-14',
+                'scrollbar-sleek min-h-10 w-full resize-none bg-transparent py-1 pl-4 pr-2 font-mono text-[13px] leading-6 outline-none pointer-coarse:min-h-12',
                 '[field-sizing:content] max-h-[calc(8lh+0.5rem)]',
                 'placeholder:text-muted-foreground/60 disabled:cursor-not-allowed disabled:opacity-50'
               )}

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { NativeChatMessageList } from './NativeChatMessageList'
+
+function createSession(): NativeChatLiveSession {
+  return {
+    agent: 'codex',
+    sessionId: 'session-1',
+    status: 'ready',
+    hasMore: false,
+    loadingEarlier: false,
+    loadEarlier: () => {},
+    readPhase: 'ready',
+    messages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        timestamp: 1,
+        source: 'transcript',
+        blocks: [{ type: 'text', text: '## Task\n\nExplain $E = mc^2$.' }]
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        timestamp: 2,
+        source: 'transcript',
+        blocks: [
+          {
+            type: 'text',
+            text: [
+              '## Energy model',
+              '',
+              'Inline $E = mc^2$ and the corresponding display equation:',
+              '',
+              '$$',
+              '\\int_0^1 x^2 \\, dx = \\frac{1}{3}',
+              '$$',
+              '',
+              '| Term | Value |',
+              '| --- | --- |',
+              '| Energy | $E$ |',
+              '',
+              '```ts',
+              'const energy = mass * speedOfLight ** 2',
+              '```'
+            ].join('\n')
+          }
+        ]
+      }
+    ]
+  }
+}
+
+describe('NativeChatMessageList rich Markdown', () => {
+  afterEach(() => cleanup())
+
+  it('renders Markdown, code, tables, and KaTeX together in the semantic transcript', () => {
+    render(
+      <NativeChatMessageList
+        session={createSession()}
+        isWorking={false}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Task' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Energy model' })).toBeInTheDocument()
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('const energy = mass * speedOfLight ** 2')).toBeInTheDocument()
+    expect(document.querySelector('.katex-display')).toBeInTheDocument()
+    expect(document.querySelectorAll('.katex')).toHaveLength(4)
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx
@@ -49,7 +49,13 @@ function createSession(): NativeChatLiveSession {
               'const energy = mass * speedOfLight ** 2',
               '```'
             ].join('\n')
-          }
+          },
+          { type: 'text', text: '[' },
+          {
+            type: 'text',
+            text: 'S(x)=\\min_i \\frac{\\left\\lVert z(x)-z_i\\right\\rVert_2^2}{r_i}'
+          },
+          { type: 'text', text: ']' }
         ]
       }
     ]
@@ -73,7 +79,7 @@ describe('NativeChatMessageList rich Markdown', () => {
     expect(screen.getByRole('heading', { name: 'Energy model' })).toBeInTheDocument()
     expect(screen.getByRole('table')).toBeInTheDocument()
     expect(screen.getByText('const energy = mass * speedOfLight ** 2')).toBeInTheDocument()
-    expect(document.querySelector('.katex-display')).toBeInTheDocument()
-    expect(document.querySelectorAll('.katex')).toHaveLength(4)
+    expect(document.querySelectorAll('.katex-display')).toHaveLength(2)
+    expect(document.querySelectorAll('.katex')).toHaveLength(5)
   })
 })

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx
@@ -50,12 +50,12 @@ function createSession(): NativeChatLiveSession {
               '```'
             ].join('\n')
           },
-          { type: 'text', text: '[' },
+          { type: 'text', text: '\\[' },
           {
             type: 'text',
             text: 'S(x)=\\min_i \\frac{\\left\\lVert z(x)-z_i\\right\\rVert_2^2}{r_i}'
           },
-          { type: 'text', text: ']' }
+          { type: 'text', text: '\\]' }
         ]
       }
     ]

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -166,9 +166,9 @@ function MessageRow({
       <div
         ref={rowRef}
         data-native-chat-message-role="user"
-        className="flex max-w-full items-start gap-2 font-mono text-[13px] leading-6 text-foreground"
+        className="flex max-w-full items-start gap-3 rounded-lg border border-border/60 bg-muted/25 px-3 py-2.5 font-mono text-[13px] leading-6 text-foreground shadow-sm"
       >
-        <span aria-hidden="true" className="select-none text-muted-foreground">
+        <span aria-hidden="true" className="mt-px select-none font-semibold text-primary/80">
           ›
         </span>
         <div className="min-w-0 flex-1">
@@ -179,7 +179,7 @@ function MessageRow({
                 content={markdown}
                 variant="document"
                 enableMath
-                className="text-[13px] leading-6"
+                className="text-[13px] leading-6 [&_.katex-display]:my-3 [&_.katex-display]:max-w-full [&_.katex-display]:overflow-x-auto [&_.katex-display]:rounded-md [&_.katex-display]:border [&_.katex-display]:border-border/60 [&_.katex-display]:bg-background/70 [&_.katex-display]:px-3 [&_.katex-display]:py-2"
                 onLinkClick={onLinkClick}
                 allowFileUriLinks={allowFileUriLinks}
               />
@@ -209,31 +209,31 @@ function MessageRow({
       ref={rowRef}
       data-native-chat-message-role={message.role}
       className={cn(
-        'group relative max-w-full font-mono text-[13px] leading-6 text-foreground',
+        'group relative max-w-full border-l-2 border-transparent pl-4 font-sans text-[15px] leading-7 text-foreground transition-colors hover:border-border',
         // Reasoning is the agent thinking aloud — quieter, italic, like an aside.
         isReasoning && 'border-l-2 border-border/60 pl-3 italic text-muted-foreground',
         isSystem && 'text-xs text-muted-foreground'
       )}
     >
-      {showControls ? (
-        <AgentControls
-          markdown={markdown}
-          onScrollToTop={scrollToTop}
-          className="absolute -top-8 right-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-        />
-      ) : null}
       <ImageAttachmentRefs blocks={prose} />
       {markdown ? (
         <CommentMarkdown
           content={markdown}
           variant="document"
           enableMath
-          className="text-[13px] leading-6"
+          className="text-[15px] leading-7 [&_.katex]:text-[1.04em] [&_.katex-display]:my-5 [&_.katex-display]:max-w-full [&_.katex-display]:overflow-x-auto [&_.katex-display]:rounded-lg [&_.katex-display]:border [&_.katex-display]:border-border/60 [&_.katex-display]:bg-muted/35 [&_.katex-display]:px-4 [&_.katex-display]:py-3 [&_.katex-display_.katex]:text-[1.1em]"
           onLinkClick={onLinkClick}
           allowFileUriLinks={allowFileUriLinks}
         />
       ) : null}
       {tools.length > 0 ? <NativeChatToolRun blocks={tools} expandSignal={expandSignal} /> : null}
+      {showControls ? (
+        <AgentControls
+          markdown={markdown}
+          onScrollToTop={scrollToTop}
+          className="mt-2 ml-auto w-fit rounded-md border border-border/50 bg-background/90 p-0.5 shadow-sm opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+        />
+      ) : null}
     </div>
   )
 }
@@ -378,13 +378,13 @@ export function NativeChatMessageList({
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="scrollbar-sleek h-full overflow-y-auto px-4 py-4"
+        className="scrollbar-sleek h-full overflow-y-auto px-4 py-5 sm:px-6 sm:py-7"
       >
         <div
           ref={contentRef}
-          // Why: same max width as the composer column; horizontal inset comes
-          // from the scroll container so content aligns with the composer field.
-          className="flex w-full max-w-none flex-col gap-3"
+          // Why: a bounded reading measure makes rich Markdown scan like a
+          // document while the surrounding pane stays terminal-native.
+          className="mx-auto flex w-full max-w-4xl flex-col gap-7"
           // Why: zoom scales the rendered terminal transcript without changing
           // the surrounding terminal-pane chrome or the Raw xterm surface.
           style={{ zoom: fontScale }}

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -119,9 +119,9 @@ function TypingIndicatorRow(): React.JSX.Element {
   )
 }
 
-/** One message: its prose first, then a collapsible run folding all of the
- *  turn's tool activity. Monochrome per STYLEGUIDE: user prompts read as a
- *  lifted card, assistant prose as body copy, reasoning de-emphasized. */
+/** One message: prose first, then a collapsible run folding its tool activity.
+ *  Prompts render as terminal input lines; agent output remains chrome-free
+ *  body copy, with reasoning de-emphasized. */
 function MessageRow({
   message,
   expandSignal,
@@ -152,24 +152,26 @@ function MessageRow({
     }
   }, [onScrollMessageToTop])
 
-  // Skip rows with nothing renderable so the transcript shows no empty/ghost
-  // bubble.
-  // After all hooks, so hook order stays unconditional.
+  // Skip rows with nothing renderable so the terminal transcript shows no
+  // empty prompt or response line. After all hooks, so hook order stays
+  // unconditional.
   if (markdown.length === 0 && !hasImages && tools.length === 0) {
     return null
   }
 
   if (isUser) {
-    // Why: an optimistic echo is rendered identically to a real user turn (no
-    // muting, no "Queued" label) so that when the real transcript turn lands and
-    // replaces it, there is no visible state change — the send just appears and
-    // stays. (A distinct "queued" treatment flickered normal→queued→normal as the
-    // transcript caught up.)
+    // Prompts stay in transcript order as a terminal input line rather than a
+    // chat bubble. The source Markdown still renders identically to agent prose.
     return (
-      <div ref={rowRef} className="flex flex-col items-end gap-0.5">
-        {/* User turns get a distinct muted fill (not the card/canvas color) so
-            the prompt reads apart from the assistant's body copy. */}
-        <div className="max-w-[85%] rounded-lg rounded-tr-sm bg-muted px-3.5 py-2.5 text-sm text-foreground">
+      <div
+        ref={rowRef}
+        data-native-chat-message-role="user"
+        className="flex max-w-full items-start gap-2 font-mono text-[13px] leading-6 text-foreground"
+      >
+        <span aria-hidden="true" className="select-none text-muted-foreground">
+          ›
+        </span>
+        <div className="min-w-0 flex-1">
           {markdown ? (
             <>
               <ImageAttachmentRefs blocks={prose} />
@@ -177,7 +179,7 @@ function MessageRow({
                 content={markdown}
                 variant="document"
                 enableMath
-                className="text-sm"
+                className="text-[13px] leading-6"
                 onLinkClick={onLinkClick}
                 allowFileUriLinks={allowFileUriLinks}
               />
@@ -185,15 +187,15 @@ function MessageRow({
           ) : (
             <ImageAttachmentRefs blocks={prose} />
           )}
+          {deliveryFailed ? (
+            <div className="text-[11px] text-destructive/80">
+              {translate(
+                'components.native-chat.launchPromptNotDelivered',
+                'Not delivered — check the terminal'
+              )}
+            </div>
+          ) : null}
         </div>
-        {deliveryFailed ? (
-          <div className="max-w-[85%] text-[11px] text-destructive/80">
-            {translate(
-              'components.native-chat.launchPromptNotDelivered',
-              'Not delivered — check the terminal'
-            )}
-          </div>
-        ) : null}
       </div>
     )
   }
@@ -205,8 +207,9 @@ function MessageRow({
   return (
     <div
       ref={rowRef}
+      data-native-chat-message-role={message.role}
       className={cn(
-        'group relative max-w-full text-sm leading-relaxed text-foreground',
+        'group relative max-w-full font-mono text-[13px] leading-6 text-foreground',
         // Reasoning is the agent thinking aloud — quieter, italic, like an aside.
         isReasoning && 'border-l-2 border-border/60 pl-3 italic text-muted-foreground',
         isSystem && 'text-xs text-muted-foreground'
@@ -225,7 +228,7 @@ function MessageRow({
           content={markdown}
           variant="document"
           enableMath
-          className="text-sm"
+          className="text-[13px] leading-6"
           onLinkClick={onLinkClick}
           allowFileUriLinks={allowFileUriLinks}
         />
@@ -375,16 +378,15 @@ export function NativeChatMessageList({
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="scrollbar-sleek h-full overflow-y-auto px-3 pt-10 pb-4 sm:px-4"
+        className="scrollbar-sleek h-full overflow-y-auto px-4 py-4"
       >
         <div
           ref={contentRef}
           // Why: same max width as the composer column; horizontal inset comes
           // from the scroll container so content aligns with the composer field.
-          className="mx-auto flex w-full max-w-4xl flex-col gap-5"
-          // Why: `zoom` scales the chat transcript's text and layout together,
-          // scoped to this container so the rest of the app is untouched. It's
-          // the desktop analog of the mobile pinch-zoom (Chromium/Electron only).
+          className="flex w-full max-w-none flex-col gap-3"
+          // Why: zoom scales the rendered terminal transcript without changing
+          // the surrounding terminal-pane chrome or the Raw xterm surface.
           style={{ zoom: fontScale }}
         >
           {hasMore ? (

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -176,6 +176,7 @@ function MessageRow({
               <CommentMarkdown
                 content={markdown}
                 variant="document"
+                enableMath
                 className="text-sm"
                 onLinkClick={onLinkClick}
                 allowFileUriLinks={allowFileUriLinks}
@@ -223,6 +224,7 @@ function MessageRow({
         <CommentMarkdown
           content={markdown}
           variant="document"
+          enableMath
           className="text-sm"
           onLinkClick={onLinkClick}
           allowFileUriLinks={allowFileUriLinks}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -403,7 +403,7 @@ function NativeChatResolvedView({
       onMouseUpCapture={contextMenu.onSelectionCapture}
       onKeyUpCapture={contextMenu.onSelectionCapture}
       onContextMenuCapture={contextMenu.onContextMenuCapture}
-      className="flex h-full min-h-0 w-full flex-col bg-background font-mono focus:outline-none"
+      className="flex h-full min-h-0 w-full flex-col bg-background focus:outline-none"
     >
       <div className="flex min-h-0 flex-1 flex-col">
         {viewState.kind === 'loading' ? (

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -403,7 +403,7 @@ function NativeChatResolvedView({
       onMouseUpCapture={contextMenu.onSelectionCapture}
       onKeyUpCapture={contextMenu.onSelectionCapture}
       onContextMenuCapture={contextMenu.onContextMenuCapture}
-      className="flex h-full min-h-0 w-full flex-col bg-background focus:outline-none"
+      className="flex h-full min-h-0 w-full flex-col bg-background font-mono focus:outline-none"
     >
       <div className="flex min-h-0 flex-1 flex-col">
         {viewState.kind === 'loading' ? (

--- a/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
@@ -45,6 +45,55 @@ describe('CommentMarkdown math rendering', () => {
     expect(markup).toContain('$unfinished')
   })
 
+  it('restores paired currency prose without changing Markdown code constructs', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content="Budget changed from $20 to $30." enableMath />
+    )
+    const inlineCodeMarkup = renderToStaticMarkup(
+      <CommentMarkdown content="The source is `$20 to $30`." enableMath />
+    )
+    const unmatchedBacktickMarkup = renderToStaticMarkup(
+      <CommentMarkdown content="Budget changed from $20 to $30. `" enableMath />
+    )
+    const unequalBacktickRunsMarkup = renderToStaticMarkup(
+      <CommentMarkdown content="`a ``` b` and $20 to $30." enableMath />
+    )
+    const multilineCodeMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'`prices\n$20 to $30\n`'} enableMath />
+    )
+    const escapedBacktickMarkup = renderToStaticMarkup(
+      <CommentMarkdown content="\`Budget changed from $20 to $30. `" enableMath />
+    )
+    const indentedParagraphMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'Budget:\n    from $20 to $30.'} enableMath />
+    )
+    const invalidFenceMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'```text`\nBudget changed from $20 to $30.'} enableMath />
+    )
+    const lineWrappedCurrencyMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'Budget changed from $20\nto $30.'} enableMath />
+    )
+    const numericMathMarkup = renderToStaticMarkup(
+      <CommentMarkdown content="Value $20x$30" enableMath />
+    )
+
+    expect(markup).not.toContain('class="katex"')
+    expect(markup).toContain('Budget changed from $20 to $30.')
+    expect(inlineCodeMarkup).not.toContain('class="katex"')
+    expect(inlineCodeMarkup).toContain('$20 to $30')
+    expect(inlineCodeMarkup).not.toContain('\\$20')
+    expect(unmatchedBacktickMarkup).not.toContain('class="katex"')
+    expect(unequalBacktickRunsMarkup).not.toContain('class="katex"')
+    expect(multilineCodeMarkup).not.toContain('class="katex"')
+    expect(multilineCodeMarkup).not.toContain('\\$20')
+    expect(escapedBacktickMarkup).not.toContain('class="katex"')
+    expect(indentedParagraphMarkup).not.toContain('class="katex"')
+    expect(invalidFenceMarkup).not.toContain('class="katex"')
+    expect(lineWrappedCurrencyMarkup).not.toContain('class="katex"')
+    expect(lineWrappedCurrencyMarkup).toContain('<br')
+    expect(numericMathMarkup).toContain('class="katex"')
+  })
+
   it('recovers bare and TeX bracket-delimited display math without capturing prose or code fences', () => {
     const formulaMarkup = renderToStaticMarkup(
       <CommentMarkdown content={'[\nS(x)=\\min_i \\frac{x_i^2}{r_i}\n]'} enableMath />
@@ -52,21 +101,33 @@ describe('CommentMarkdown math rendering', () => {
     const latexDelimitedMarkup = renderToStaticMarkup(
       <CommentMarkdown content={'\\[\nS(x)=\\min_i \\frac{x_i^2}{r_i}\n\\]'} enableMath />
     )
+    const sameLineTexMarkup = renderToStaticMarkup(<CommentMarkdown content="\[x=1\]" enableMath />)
     const proseMarkup = renderToStaticMarkup(
       <CommentMarkdown content={'[\nplain bracketed prose\n]'} enableMath />
     )
     const fencedMarkup = renderToStaticMarkup(
       <CommentMarkdown content={'```\n[\nx=1\n]\n```'} enableMath />
     )
+    const invalidFenceMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'```text\n```not-a-close\n[\nx=1\n]\n```'} enableMath />
+    )
+    const indentedCodeMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'    [\n    x=1\n    ]'} enableMath />
+    )
 
     expect(formulaMarkup).toContain('class="katex-display"')
     expect(formulaMarkup).toContain('<msub>')
     expect(latexDelimitedMarkup).toContain('class="katex-display"')
     expect(latexDelimitedMarkup).toContain('<msub>')
+    expect(sameLineTexMarkup).toContain('class="katex-display"')
     expect(proseMarkup).not.toContain('class="katex"')
     expect(proseMarkup).toContain('plain bracketed prose')
     expect(fencedMarkup).not.toContain('class="katex"')
     expect(fencedMarkup).toContain('x=1')
+    expect(invalidFenceMarkup).not.toContain('class="katex"')
+    expect(invalidFenceMarkup).toContain('x=1')
+    expect(indentedCodeMarkup).not.toContain('class="katex"')
+    expect(indentedCodeMarkup).toContain('x=1')
   })
 
   it('renders stripped bracket-delimited aligned environments as display math', () => {

--- a/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
@@ -45,9 +45,12 @@ describe('CommentMarkdown math rendering', () => {
     expect(markup).toContain('$unfinished')
   })
 
-  it('recovers bracket-delimited display math without capturing prose or code fences', () => {
+  it('recovers bare and TeX bracket-delimited display math without capturing prose or code fences', () => {
     const formulaMarkup = renderToStaticMarkup(
       <CommentMarkdown content={'[\nS(x)=\\min_i \\frac{x_i^2}{r_i}\n]'} enableMath />
+    )
+    const latexDelimitedMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'\\[\nS(x)=\\min_i \\frac{x_i^2}{r_i}\n\\]'} enableMath />
     )
     const proseMarkup = renderToStaticMarkup(
       <CommentMarkdown content={'[\nplain bracketed prose\n]'} enableMath />
@@ -58,6 +61,8 @@ describe('CommentMarkdown math rendering', () => {
 
     expect(formulaMarkup).toContain('class="katex-display"')
     expect(formulaMarkup).toContain('<msub>')
+    expect(latexDelimitedMarkup).toContain('class="katex-display"')
+    expect(latexDelimitedMarkup).toContain('<msub>')
     expect(proseMarkup).not.toContain('class="katex"')
     expect(proseMarkup).toContain('plain bracketed prose')
     expect(fencedMarkup).not.toContain('class="katex"')

--- a/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
@@ -45,6 +45,39 @@ describe('CommentMarkdown math rendering', () => {
     expect(markup).toContain('$unfinished')
   })
 
+  it('recovers bracket-delimited display math without capturing prose or code fences', () => {
+    const formulaMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'[\nS(x)=\\min_i \\frac{x_i^2}{r_i}\n]'} enableMath />
+    )
+    const proseMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'[\nplain bracketed prose\n]'} enableMath />
+    )
+    const fencedMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'```\n[\nx=1\n]\n```'} enableMath />
+    )
+
+    expect(formulaMarkup).toContain('class="katex-display"')
+    expect(formulaMarkup).toContain('<msub>')
+    expect(proseMarkup).not.toContain('class="katex"')
+    expect(proseMarkup).toContain('plain bracketed prose')
+    expect(fencedMarkup).not.toContain('class="katex"')
+    expect(fencedMarkup).toContain('x=1')
+  })
+
+  it('renders stripped bracket-delimited aligned environments as display math', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown
+        content={
+          '[\n\\begin{aligned}\n\\mathcal A_T &= \\left\\{x:S(x)\\le T\\right\\} \\\\\nS(x) &= \\min_i \\frac{\\left\\lVert z(x)-z_i\\right\\rVert_2^2}{r_i}\n\\end{aligned}\n]'
+        }
+        enableMath
+      />
+    )
+
+    expect(markup).toContain('class="katex-display"')
+    expect(markup).not.toContain('katex-error')
+  })
+
   it('keeps invalid formulas visible instead of throwing or blanking them', () => {
     const markup = renderToStaticMarkup(
       <CommentMarkdown content={'$\\notARealCommand{x}$'} enableMath />

--- a/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import CommentMarkdown from './CommentMarkdown'
+
+describe('CommentMarkdown math rendering', () => {
+  it('renders inline math only when explicitly enabled', () => {
+    const content = 'Inline $E = mc^2$'
+    const disabledMarkup = renderToStaticMarkup(<CommentMarkdown content={content} />)
+    const enabledMarkup = renderToStaticMarkup(<CommentMarkdown content={content} enableMath />)
+
+    expect(disabledMarkup).toContain('$E = mc^2$')
+    expect(disabledMarkup).not.toContain('class="katex"')
+    expect(enabledMarkup).toContain('class="katex"')
+    expect(enabledMarkup).toContain('<math')
+  })
+
+  it('renders multiline dollar and math-fenced expressions as display math', () => {
+    const dollarMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'$$\n\\int_0^1 x^2 \\, dx\n$$'} enableMath />
+    )
+    const fencedMarkup = renderToStaticMarkup(
+      <CommentMarkdown content={'```math\n\\frac{a}{b}\n```'} enableMath />
+    )
+
+    expect(dollarMarkup).toContain('class="katex-display"')
+    expect(fencedMarkup).toContain('class="katex-display"')
+    expect(fencedMarkup).not.toContain('<pre')
+  })
+
+  it('normalizes GitHub backtick-delimited inline math', () => {
+    const content = 'Inline $`\\sqrt{x}`$'
+    const markup = renderToStaticMarkup(<CommentMarkdown content={content} enableMath />)
+
+    expect(markup).toContain('<msqrt>')
+    expect(markup).not.toContain('katex-error')
+  })
+
+  it('keeps inline code, escaped dollars, and incomplete streaming delimiters literal', () => {
+    const content = '`$E = mc^2$` and \\$100 and $unfinished'
+    const markup = renderToStaticMarkup(<CommentMarkdown content={content} enableMath />)
+
+    expect(markup).not.toContain('class="katex"')
+    expect(markup).toContain('$E = mc^2$')
+    expect(markup).toContain('$100')
+    expect(markup).toContain('$unfinished')
+  })
+
+  it('keeps invalid formulas visible instead of throwing or blanking them', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content={'$\\notARealCommand{x}$'} enableMath />
+    )
+
+    expect(markup).toContain('class="katex"')
+    expect(markup).toContain('\\notARealCommand{x}')
+  })
+})

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -15,7 +15,10 @@ import {
   isTrustedCompactImageSrc,
   type CommentMarkdownLinkClickHandler
 } from './comment-markdown-element-renderers'
-import { normalizeBareBracketMathSource, remarkGitHubBacktickMath } from './comment-markdown-math'
+import {
+  normalizeBracketDelimitedMathSource,
+  remarkGitHubBacktickMath
+} from './comment-markdown-math'
 
 export type { CommentMarkdownLinkClickHandler } from './comment-markdown-element-renderers'
 
@@ -240,7 +243,7 @@ const CommentMarkdown = React.memo(
     }, [enableMath, githubRepo])
 
     const renderedContent = React.useMemo(
-      () => (enableMath ? normalizeBareBracketMathSource(content) : content),
+      () => (enableMath ? normalizeBracketDelimitedMathSource(content) : content),
       [content, enableMath]
     )
 

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -15,7 +15,7 @@ import {
   isTrustedCompactImageSrc,
   type CommentMarkdownLinkClickHandler
 } from './comment-markdown-element-renderers'
-import { remarkGitHubBacktickMath } from './comment-markdown-math'
+import { normalizeBareBracketMathSource, remarkGitHubBacktickMath } from './comment-markdown-math'
 
 export type { CommentMarkdownLinkClickHandler } from './comment-markdown-element-renderers'
 
@@ -239,6 +239,11 @@ const CommentMarkdown = React.memo(
       return githubRepo ? [...basePlugins, remarkGitHubReferences(githubRepo)] : basePlugins
     }, [enableMath, githubRepo])
 
+    const renderedContent = React.useMemo(
+      () => (enableMath ? normalizeBareBracketMathSource(content) : content),
+      [content, enableMath]
+    )
+
     return (
       <div
         ref={ref}
@@ -260,7 +265,7 @@ const CommentMarkdown = React.memo(
             allowFileUriLinks ? commentMarkdownFileUriUrlTransform : commentMarkdownUrlTransform
           }
         >
-          {content}
+          {renderedContent}
         </Markdown>
       </div>
     )

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -70,9 +70,9 @@ const commentMarkdownFileUriUrlTransform: UrlTransform = (value, key, node) => {
 const remarkPlugins: RemarkPlugins = [remarkGfm, remarkBreaks]
 const mathRemarkPlugins: RemarkPlugins = [
   remarkGfm,
-  remarkBreaks,
   remarkMath,
-  remarkGitHubBacktickMath
+  remarkGitHubBacktickMath,
+  remarkBreaks
 ]
 
 const GITHUB_REFERENCE_PATTERN = /(?:\b([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#([1-9][0-9]*)\b/g

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import Markdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
+import remarkMath from 'remark-math'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import rehypeKatex from 'rehype-katex'
 import { cn } from '@/lib/utils'
 import {
   compactCommentMarkdownComponents,
@@ -13,10 +15,12 @@ import {
   isTrustedCompactImageSrc,
   type CommentMarkdownLinkClickHandler
 } from './comment-markdown-element-renderers'
+import { remarkGitHubBacktickMath } from './comment-markdown-math'
 
 export type { CommentMarkdownLinkClickHandler } from './comment-markdown-element-renderers'
 
-type MarkdownPlugins = NonNullable<React.ComponentProps<typeof Markdown>['rehypePlugins']>
+type RemarkPlugins = NonNullable<React.ComponentProps<typeof Markdown>['remarkPlugins']>
+type RehypePlugins = NonNullable<React.ComponentProps<typeof Markdown>['rehypePlugins']>
 type UrlTransform = NonNullable<React.ComponentProps<typeof Markdown>['urlTransform']>
 
 type GitHubRepoReference = {
@@ -60,7 +64,13 @@ const commentMarkdownFileUriUrlTransform: UrlTransform = (value, key, node) => {
 // plain-text renderer used whitespace-pre-wrap which preserved them. Adding
 // remark-breaks converts single newlines to <br>, keeping backward compat
 // with existing plain-text comments that rely on newline formatting.
-const remarkPlugins = [remarkGfm, remarkBreaks]
+const remarkPlugins: RemarkPlugins = [remarkGfm, remarkBreaks]
+const mathRemarkPlugins: RemarkPlugins = [
+  remarkGfm,
+  remarkBreaks,
+  remarkMath,
+  remarkGitHubBacktickMath
+]
 
 const GITHUB_REFERENCE_PATTERN = /(?:\b([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+))?#([1-9][0-9]*)\b/g
 
@@ -160,6 +170,10 @@ const commentMarkdownSanitizeSchema = {
   attributes: {
     ...defaultSchema.attributes,
     a: [...(defaultSchema.attributes?.a ?? []), 'href', 'title'],
+    code: [
+      ...(defaultSchema.attributes?.code ?? []),
+      ['className', /^language-[\w-]+$/, 'math-inline', 'math-display']
+    ],
     details: [...(defaultSchema.attributes?.details ?? []), 'open'],
     img: [...(defaultSchema.attributes?.img ?? []), 'src', 'alt', 'title', 'width', 'height'],
     input: [...(defaultSchema.attributes?.input ?? []), 'type', 'checked', 'disabled'],
@@ -177,7 +191,8 @@ const commentMarkdownSanitizeSchema = {
 
 // Why: GitHub comments often include safe raw HTML (`<sub>`, `<details>`,
 // `<br />`). Parse it, then sanitize immediately before React renders it.
-const rehypePlugins: MarkdownPlugins = [rehypeRaw, [rehypeSanitize, commentMarkdownSanitizeSchema]]
+const rehypePlugins: RehypePlugins = [rehypeRaw, [rehypeSanitize, commentMarkdownSanitizeSchema]]
+const mathRehypePlugins: RehypePlugins = [...rehypePlugins, rehypeKatex]
 
 type CommentMarkdownProps = React.ComponentPropsWithoutRef<'div'> & {
   content: string
@@ -186,6 +201,7 @@ type CommentMarkdownProps = React.ComponentPropsWithoutRef<'div'> & {
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
   expandImages?: boolean
+  enableMath?: boolean
 }
 
 // Why forwardRef + rest props: Radix's HoverCardTrigger asChild merges a ref
@@ -201,6 +217,7 @@ const CommentMarkdown = React.memo(
       onLinkClick,
       allowFileUriLinks = false,
       expandImages = false,
+      enableMath = false,
       ...rest
     },
     ref
@@ -217,10 +234,10 @@ const CommentMarkdown = React.memo(
         ? createDocumentCommentMarkdownComponents(onLinkClick)
         : createCompactCommentMarkdownComponents(onLinkClick, expandImages)
     }, [expandImages, variant, onLinkClick])
-    const activeRemarkPlugins = React.useMemo(
-      () => (githubRepo ? [...remarkPlugins, remarkGitHubReferences(githubRepo)] : remarkPlugins),
-      [githubRepo]
-    )
+    const activeRemarkPlugins = React.useMemo(() => {
+      const basePlugins = enableMath ? mathRemarkPlugins : remarkPlugins
+      return githubRepo ? [...basePlugins, remarkGitHubReferences(githubRepo)] : basePlugins
+    }, [enableMath, githubRepo])
 
     return (
       <div
@@ -237,7 +254,7 @@ const CommentMarkdown = React.memo(
       >
         <Markdown
           remarkPlugins={activeRemarkPlugins}
-          rehypePlugins={rehypePlugins}
+          rehypePlugins={enableMath ? mathRehypePlugins : rehypePlugins}
           components={components}
           urlTransform={
             allowFileUriLinks ? commentMarkdownFileUriUrlTransform : commentMarkdownUrlTransform

--- a/src/renderer/src/components/sidebar/comment-markdown-math.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-math.ts
@@ -13,27 +13,60 @@ type CodeFence = {
 }
 
 const MATH_SIGNAL = /\\[A-Za-z]+|[=^_]/
-const CODE_FENCE = /^\s*(`{3,}|~{3,})/
+const CODE_FENCE = /^( {0,3})(`{3,}|~{3,})(.*)$/
+const CURRENCY_AMOUNT = '(?:\\d{1,3}(?:,\\d{3})+|\\d+)(?:\\.\\d{1,2})?'
+const CURRENCY_MATH_VALUE = new RegExp(
+  `^(${CURRENCY_AMOUNT})\\s*(?:to|and|or|through|until|[-–—,])\\s*$`,
+  'i'
+)
+const CURRENCY_TEXT_START = new RegExp(`^${CURRENCY_AMOUNT}(?=\\D|$)`)
+
+function isPairedCurrencyMath(
+  node: MarkdownAstNode,
+  nextNode: MarkdownAstNode | undefined
+): boolean {
+  if (node.type !== 'inlineMath' || !node.value || nextNode?.type !== 'text' || !nextNode.value) {
+    return false
+  }
+
+  const match = CURRENCY_MATH_VALUE.exec(node.value)
+  return match !== null && CURRENCY_TEXT_START.test(nextNode.value)
+}
 
 function normalizeGitHubBacktickMathNode(node: MarkdownAstNode): void {
-  if (
-    node.type === 'inlineMath' &&
-    node.value?.startsWith('`') &&
-    node.value.endsWith('`') &&
-    node.value.length >= 2
-  ) {
-    const value = node.value.slice(1, -1)
-    node.value = value
+  const children = node.children ?? []
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index]
+    if (isPairedCurrencyMath(child, children[index + 1])) {
+      child.type = 'text'
+      child.value = `$${child.value}$`
+      child.data = undefined
+    } else if (
+      child.type === 'inlineMath' &&
+      child.value?.startsWith('`') &&
+      child.value.endsWith('`') &&
+      child.value.length >= 2
+    ) {
+      const value = child.value.slice(1, -1)
+      child.value = value
 
-    const renderedText = node.data?.hChildren?.[0]
-    if (renderedText?.type === 'text') {
-      renderedText.value = value
+      const renderedText = child.data?.hChildren?.[0]
+      if (renderedText?.type === 'text') {
+        renderedText.value = value
+      }
     }
-  }
 
-  for (const child of node.children ?? []) {
     normalizeGitHubBacktickMathNode(child)
   }
+}
+
+function closesCodeFence(fenceMatch: RegExpExecArray | null, activeFence: CodeFence): boolean {
+  return (
+    fenceMatch !== null &&
+    fenceMatch[2][0] === activeFence.marker &&
+    fenceMatch[2].length >= activeFence.length &&
+    fenceMatch[3].trim().length === 0
+  )
 }
 
 export function normalizeBracketDelimitedMathSource(source: string): string {
@@ -44,10 +77,10 @@ export function normalizeBracketDelimitedMathSource(source: string): string {
 
   while (index < lines.length) {
     const line = lines[index]
-    const fence = CODE_FENCE.exec(line)?.[1]
+    const fenceMatch = CODE_FENCE.exec(line)
 
     if (activeFence) {
-      if (fence && fence[0] === activeFence.marker && fence.length >= activeFence.length) {
+      if (closesCodeFence(fenceMatch, activeFence)) {
         activeFence = undefined
       }
       normalized.push(line)
@@ -55,14 +88,27 @@ export function normalizeBracketDelimitedMathSource(source: string): string {
       continue
     }
 
-    if (fence) {
-      activeFence = { marker: fence[0], length: fence.length }
+    if (fenceMatch) {
+      normalized.push(line)
+      activeFence = { marker: fenceMatch[2][0], length: fenceMatch[2].length }
+      index += 1
+      continue
+    }
+
+    if (/^(?: {4}|\t)/.test(line)) {
       normalized.push(line)
       index += 1
       continue
     }
 
     const openingDelimiter = line.trim()
+    const sameLineTexMatch = /^\\\[(.+)\\\]$/.exec(openingDelimiter)
+    if (sameLineTexMatch) {
+      normalized.push('```math', sameLineTexMatch[1].trim(), '```')
+      index += 1
+      continue
+    }
+
     if (openingDelimiter !== '[' && openingDelimiter !== '\\[') {
       normalized.push(line)
       index += 1
@@ -82,7 +128,7 @@ export function normalizeBracketDelimitedMathSource(source: string): string {
     }
 
     const formula = lines.slice(index + 1, closingIndex).join('\n')
-    if (!formula || !MATH_SIGNAL.test(formula)) {
+    if (!formula || (openingDelimiter === '[' && !MATH_SIGNAL.test(formula))) {
       normalized.push(line)
       index += 1
       continue

--- a/src/renderer/src/components/sidebar/comment-markdown-math.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-math.ts
@@ -36,7 +36,7 @@ function normalizeGitHubBacktickMathNode(node: MarkdownAstNode): void {
   }
 }
 
-export function normalizeBareBracketMathSource(source: string): string {
+export function normalizeBracketDelimitedMathSource(source: string): string {
   const lines = source.split('\n')
   const normalized: string[] = []
   let index = 0
@@ -62,14 +62,16 @@ export function normalizeBareBracketMathSource(source: string): string {
       continue
     }
 
-    if (line.trim() !== '[') {
+    const openingDelimiter = line.trim()
+    if (openingDelimiter !== '[' && openingDelimiter !== '\\[') {
       normalized.push(line)
       index += 1
       continue
     }
 
+    const closingDelimiter = openingDelimiter === '\\[' ? '\\]' : ']'
     let closingIndex = index + 1
-    while (closingIndex < lines.length && lines[closingIndex].trim() !== ']') {
+    while (closingIndex < lines.length && lines[closingIndex].trim() !== closingDelimiter) {
       closingIndex += 1
     }
 

--- a/src/renderer/src/components/sidebar/comment-markdown-math.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-math.ts
@@ -7,6 +7,14 @@ type MarkdownAstNode = {
   children?: MarkdownAstNode[]
 }
 
+type CodeFence = {
+  marker: string
+  length: number
+}
+
+const MATH_SIGNAL = /\\[A-Za-z]+|[=^_]/
+const CODE_FENCE = /^\s*(`{3,}|~{3,})/
+
 function normalizeGitHubBacktickMathNode(node: MarkdownAstNode): void {
   if (
     node.type === 'inlineMath' &&
@@ -26,6 +34,63 @@ function normalizeGitHubBacktickMathNode(node: MarkdownAstNode): void {
   for (const child of node.children ?? []) {
     normalizeGitHubBacktickMathNode(child)
   }
+}
+
+export function normalizeBareBracketMathSource(source: string): string {
+  const lines = source.split('\n')
+  const normalized: string[] = []
+  let index = 0
+  let activeFence: CodeFence | undefined
+
+  while (index < lines.length) {
+    const line = lines[index]
+    const fence = CODE_FENCE.exec(line)?.[1]
+
+    if (activeFence) {
+      if (fence && fence[0] === activeFence.marker && fence.length >= activeFence.length) {
+        activeFence = undefined
+      }
+      normalized.push(line)
+      index += 1
+      continue
+    }
+
+    if (fence) {
+      activeFence = { marker: fence[0], length: fence.length }
+      normalized.push(line)
+      index += 1
+      continue
+    }
+
+    if (line.trim() !== '[') {
+      normalized.push(line)
+      index += 1
+      continue
+    }
+
+    let closingIndex = index + 1
+    while (closingIndex < lines.length && lines[closingIndex].trim() !== ']') {
+      closingIndex += 1
+    }
+
+    if (closingIndex === lines.length) {
+      normalized.push(line)
+      index += 1
+      continue
+    }
+
+    const formula = lines.slice(index + 1, closingIndex).join('\n')
+    if (!formula || !MATH_SIGNAL.test(formula)) {
+      normalized.push(line)
+      index += 1
+      continue
+    }
+
+    normalized.push('```math', formula, '```')
+    index = closingIndex + 1
+  }
+
+  return normalized.join('\n')
 }
 
 export function remarkGitHubBacktickMath(): (tree: MarkdownAstNode) => void {

--- a/src/renderer/src/components/sidebar/comment-markdown-math.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-math.ts
@@ -1,0 +1,33 @@
+type MarkdownAstNode = {
+  type: string
+  value?: string
+  data?: {
+    hChildren?: MarkdownAstNode[]
+  }
+  children?: MarkdownAstNode[]
+}
+
+function normalizeGitHubBacktickMathNode(node: MarkdownAstNode): void {
+  if (
+    node.type === 'inlineMath' &&
+    node.value?.startsWith('`') &&
+    node.value.endsWith('`') &&
+    node.value.length >= 2
+  ) {
+    const value = node.value.slice(1, -1)
+    node.value = value
+
+    const renderedText = node.data?.hChildren?.[0]
+    if (renderedText?.type === 'text') {
+      renderedText.value = value
+    }
+  }
+
+  for (const child of node.children ?? []) {
+    normalizeGitHubBacktickMathNode(child)
+  }
+}
+
+export function remarkGitHubBacktickMath(): (tree: MarkdownAstNode) => void {
+  return normalizeGitHubBacktickMathNode
+}


### PR DESCRIPTION
## Summary
- adds opt-in GitHub-compatible LaTeX rendering to `CommentMarkdown` through the existing sanitized KaTeX pipeline
- enables math only for semantic Native Chat transcript messages; source copying and the Raw xterm view remain unchanged
- restores recognized paired-currency prose from `remark-math` false positives at the Markdown AST layer, preserving CommonMark code spans, fences, containers, escapes, and line breaks

## Scope
Closes #10910.

Related to #9845, but deliberately does **not** claim to render math in byte-faithful xterm output. The existing Raw terminal/source view remains available.

## Verification
- `pnpm exec vitest run --no-cache --config config/vitest.config.ts src/renderer/src/components/sidebar/CommentMarkdown.math.test.tsx src/renderer/src/components/sidebar/CommentMarkdown.test.tsx src/renderer/src/components/native-chat/NativeChatMessageList.rich-markdown.test.tsx src/renderer/src/components/native-chat/NativeChatView.test.tsx src/renderer/src/components/native-chat/NativeChatComposer.test.tsx` — 46 passed
- `pnpm typecheck:web`
- `pnpm check:code-quality:changed` — 0 findings
- `pnpm build:unpack`
- reviewer approval after currency, code-span/fence, line-break, and numeric-math regression review

Prior packaged-app smoke evidence remains available at `pr-evidence/tex-bracket-delimiters-restarted.png`.