### PR TITLE
fix(git): resolve branch-prefix Git Username from user.name fallback

### DIFF
--- a/src/main/git/git-username.ts
+++ b/src/main/git/git-username.ts
@@ -326,7 +326,18 @@ export async function resolveLocalGitUsernameDetailed(
   }
   if (await localRepoHasEffectiveGitHubRemote(repoPath)) {
     const outcome = await getGhLoginOutcome()
-    return { username: outcome.login, authoritative: !outcome.timedOut }
+    if (outcome.login || outcome.timedOut) {
+      return { username: outcome.login, authoritative: !outcome.timedOut }
+    }
+  }
+  // Why: branch-prefix "Git Username" was unreachable when only `user.name` was
+  // set (common when github.user / gh login are absent). Accept branch-safe
+  // tokens only — free-form author names with spaces stay out of branch names
+  // (issue #11590). git config --get already walks local → global → system.
+  const authorName = await readGitStdout(repoPath, ['config', '--get', 'user.name'])
+  const fromAuthor = normalizeConfiguredLogin(authorName)
+  if (fromAuthor) {
+    return { username: fromAuthor, authoritative: true }
   }
   return { username: '', authoritative: true }
 }

--- a/src/main/git/repo-username.test.ts
+++ b/src/main/git/repo-username.test.ts
@@ -166,13 +166,32 @@ describe('resolveLocalGitUsername', () => {
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
-  it('does not derive GitHub username prefixes from non-GitHub remotes', async () => {
+  it('does not derive GitHub username prefixes from free-form author names on non-GitHub remotes', async () => {
     originRemoteUrl = 'https://gitlab.com/stablyai/orca.git'
     gitConfig['user.email'] = 'demo@example.com'
     gitConfig['user.name'] = 'Demo User'
     ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'gh-demo\n', stderr: '' })
 
+    // Spaces make "Demo User" branch-unsafe; free-form author identity stays out of prefixes.
     await expect(resolveLocalGitUsername('/repo')).resolves.toBe('')
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to branch-safe user.name when github.user and gh login are absent', async () => {
+    // Issue #11590: only `user.name = lorengroves` is configured; branch prefix was empty.
+    originRemoteUrl = 'https://github.com/stablyai/orca.git'
+    gitConfig['user.name'] = 'lorengroves'
+    ghExecFileAsyncMock.mockRejectedValue(makeExecError('gh unavailable'))
+
+    await expect(resolveLocalGitUsername('/repo')).resolves.toBe('lorengroves')
+  })
+
+  it('uses branch-safe user.name on non-GitHub remotes when no explicit username keys exist', async () => {
+    originRemoteUrl = 'https://gitlab.com/stablyai/orca.git'
+    gitConfig['user.name'] = 'lorengroves'
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'gh-demo\n', stderr: '' })
+
+    await expect(resolveLocalGitUsername('/repo')).resolves.toBe('lorengroves')
     expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -713,7 +713,11 @@ function Settings(): React.JSX.Element {
     applyDocumentTheme(theme)
   }, [])
 
-  const displayedGitUsername = repos[0]?.gitUsername ?? ''
+  // Why: repos[0] alone left the Git Username branch-prefix blank when only a
+  // later project had been enriched (issue #11590). Prefer the first resolved
+  // non-empty username across projects so Settings reflects any known identity.
+  const displayedGitUsername =
+    repos.map((repo) => repo.gitUsername?.trim() ?? '').find((name) => name.length > 0) ?? ''
   const baseNavSections = useSettingsNavigationMetadata()
   const { installed: orchestrationSkillInstalled, loading: orchestrationSkillLoading } =
     orchestrationSkill


### PR DESCRIPTION
## Summary

Fixes #11590 — **Branch Prefix → Git Username** stayed empty when only `git config user.name` was set, and Settings always read `repos[0].gitUsername`.

### User-visible change
- Branch-safe `user.name` (e.g. `lorengroves`) is used as a last-resort username for branch prefixes after `github.user` / `user.username` / `gh` login.
- Free-form author names with spaces still never become branch components.
- Settings shows the first non-empty resolved username across projects (not only project index 0).

### Tests
- Extended `src/main/git/repo-username.test.ts` (34 tests, all passing locally).

### Platform / SSH
- Local resolution still uses local `git`/`gh` only; SSH repos remain on the existing SSH username path (not this change).
- Cross-platform: path-agnostic git config reads.

### AI review notes
- Cross-platform: yes (git config semantics).
- SSH/remote: SSH path unchanged; only local resolution gains `user.name` fallback.
- Agents/integrations: provider-neutral.
- Performance: one extra `git config --get user.name` only when earlier probes yield nothing.
- UI: Settings display only; no visual layout change.
- Security: only branch-safe tokens accepted via existing normalizers.

X: n/a