### PR TITLE
fix(skills): treat outdated independent-copy as routine freshness

### DIFF
--- a/src/shared/skill-freshness.attention.test.ts
+++ b/src/shared/skill-freshness.attention.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSkillCopyNeedingAttention,
+  type SkillFreshnessInstallation
+} from './skill-freshness'
+
+function installation(
+  overrides: Partial<SkillFreshnessInstallation> &
+    Pick<SkillFreshnessInstallation, 'topology' | 'status'>
+): SkillFreshnessInstallation {
+  return {
+    id: 'i1',
+    name: 'orca-cli',
+    rootId: 'home-claude',
+    providers: [],
+    sourceKind: 'home',
+    sourceLabel: 'test',
+    unresolvedPath: '/tmp/skill',
+    resolvedPath: '/tmp/skill',
+    physicalIdentity: 'abc',
+    installedReleaseRevision: 1,
+    installedAppVersion: '1.0.0',
+    currentReleaseRevision: 2,
+    currentPackageDigest: 'digest',
+    currentAppVersion: '1.1.0',
+    observedPackageDigest: 'old',
+    errorCategory: null,
+    ...overrides
+  }
+}
+
+describe('isSkillCopyNeedingAttention', () => {
+  it('treats outdated independent-copy as routine (not attention)', () => {
+    // Issue #11455: Windows skill installs are independent-copy; outdated must
+    // match the "Update available" pill, not the amber warning triangle.
+    expect(
+      isSkillCopyNeedingAttention(
+        installation({ topology: 'independent-copy', status: 'outdated' })
+      )
+    ).toBe(false)
+  })
+
+  it('still treats outdated canonical-copy and provider-alias as routine', () => {
+    expect(
+      isSkillCopyNeedingAttention(
+        installation({ topology: 'canonical-copy', status: 'outdated' })
+      )
+    ).toBe(false)
+    expect(
+      isSkillCopyNeedingAttention(
+        installation({ topology: 'provider-alias', status: 'outdated' })
+      )
+    ).toBe(false)
+  })
+
+  it('flags unrecognized independent-copy as needing attention', () => {
+    expect(
+      isSkillCopyNeedingAttention(
+        installation({ topology: 'independent-copy', status: 'unrecognized' })
+      )
+    ).toBe(true)
+  })
+
+  it('does not flag current independent-copy', () => {
+    expect(
+      isSkillCopyNeedingAttention(
+        installation({ topology: 'independent-copy', status: 'current' })
+      )
+    ).toBe(false)
+  })
+})

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -63,11 +63,7 @@ export const SUPPORTED_GLOBAL_SKILL_TOPOLOGIES: ReadonlySet<SkillInstallationTop
   'provider-alias'
 ])
 
-// Why: outdated copies the update command can converge are ordinary work, not
-// amber attention. On Windows, skills installs fall back to real file copies
-// (`independent-copy`) instead of symlinks (`provider-alias`); excluding only
-// the symlink-friendly topologies left every outdated Windows install showing
-// a warning triangle while the pill said "Update available" (issue #11455).
+// Why: include independent-copy - Windows skill installs use file copies, not symlinks (#11455).
 export const ROUTINE_OUTDATED_SKILL_TOPOLOGIES: ReadonlySet<SkillInstallationTopology> = new Set([
   ...SUPPORTED_GLOBAL_SKILL_TOPOLOGIES,
   'independent-copy'

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -63,6 +63,16 @@ export const SUPPORTED_GLOBAL_SKILL_TOPOLOGIES: ReadonlySet<SkillInstallationTop
   'provider-alias'
 ])
 
+// Why: outdated copies the update command can converge are ordinary work, not
+// amber attention. On Windows, skills installs fall back to real file copies
+// (`independent-copy`) instead of symlinks (`provider-alias`); excluding only
+// the symlink-friendly topologies left every outdated Windows install showing
+// a warning triangle while the pill said "Update available" (issue #11455).
+export const ROUTINE_OUTDATED_SKILL_TOPOLOGIES: ReadonlySet<SkillInstallationTopology> = new Set([
+  ...SUPPORTED_GLOBAL_SKILL_TOPOLOGIES,
+  'independent-copy'
+])
+
 export type SkillFreshnessInstallation = {
   id: string
   name: string
@@ -131,7 +141,7 @@ export function isSkillCopyNeedingAttention(installation: SkillFreshnessInstalla
     installation.status !== 'newer-known' &&
     !(installation.status === 'unrecognized' && installation.topology === 'plugin-cache') &&
     !(
-      SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(installation.topology) &&
+      ROUTINE_OUTDATED_SKILL_TOPOLOGIES.has(installation.topology) &&
       installation.status === 'outdated'
     )
   )


### PR DESCRIPTION
## Summary

Fixes #11455 — outdated **independent-copy** skill installs (common on Windows where skills cannot symlink) showed an amber warning triangle while the pill/dialog said a routine update was available.

### User-visible change
- Outdated `independent-copy` placements no longer count as \"needs attention\".
- They match `canonical-copy` / `provider-alias` as ordinary update work.
- Unrecognized independent copies still need attention.

### Tests
- `src/shared/skill-freshness.attention.test.ts` (4 tests, passing).

### Platform / SSH
- Especially fixes Windows installs that fall back to real file copies.
- Topology classification is path-agnostic; no SSH-specific change.

### AI review notes
- Cross-platform: yes (Windows-focused bug, logic shared).
- SSH/remote: no path assumptions.
- Performance: set membership only.
- UI: status glyph alignment only; no layout change.
- Security: no path writes; classification only.

X: n/a