### PR TITLE
[P1] fix(ssh): stop discarding stored target fields and trying only the first identity

### DIFF
--- a/src/main/ssh/ssh-auth-resolution.ts
+++ b/src/main/ssh/ssh-auth-resolution.ts
@@ -4,6 +4,7 @@ import type { SshTarget } from '../../shared/ssh-types'
 import type { SshResolvedConfig } from './ssh-config-parser'
 import { createIdentityFilteredAgent } from './ssh-agent-identity-filter'
 import { resolveSshConfigHomePath } from './ssh-config-path-expansion'
+import { hasOpenSshHostBlockMatch } from './ssh-g-host-block-match'
 import { isOpenSshConfigBackedTarget } from './system-ssh-args'
 
 // Why: ssh2 only tries keys that are explicitly provided. Users with keys in
@@ -88,7 +89,7 @@ function resolveExplicitPrivateKeyPaths(
   const resolvedIdentities = (resolved?.identityFile ?? []).filter(
     (identityFile) => !EXPANDED_DEFAULT_KEY_PATHS.includes(identityFile)
   )
-  if (isOpenSshConfigBackedTarget(target) && resolved) {
+  if (hasOpenSshHostBlockMatch(target, resolved)) {
     return resolvedIdentities
   }
   if (target.identityFile) {
@@ -98,7 +99,7 @@ function resolveExplicitPrivateKeyPaths(
 }
 
 function resolvePrivateKeyPaths(target: SshTarget, resolved: SshResolvedConfig | null): string[] {
-  if (isOpenSshConfigBackedTarget(target) && resolved) {
+  if (hasOpenSshHostBlockMatch(target, resolved) && resolved) {
     return resolved.identityFile
   }
   if (target.identityFile) {
@@ -175,7 +176,7 @@ export function findEncryptedPrivateKeyPath(keys: PrivateKeyFile[]): string | un
 }
 
 function resolveIdentityFilePaths(target: SshTarget, resolved: SshResolvedConfig | null): string[] {
-  if (isOpenSshConfigBackedTarget(target) && resolved) {
+  if (hasOpenSshHostBlockMatch(target, resolved) && resolved) {
     return resolved.identityFile
   }
   if (target.identityFile) {

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -12,7 +12,7 @@ import {
   resolveUnencryptedExplicitPrivateKeys
 } from './ssh-auth-resolution'
 import { configurePrivateKeyAuthentication } from './ssh-private-key-authentication'
-import { isOpenSshConfigBackedTarget } from './system-ssh-args'
+import { hasOpenSshHostBlockMatch } from './ssh-g-host-block-match'
 
 export { findDefaultKeyFile, resolveAgentSocket } from './ssh-auth-resolution'
 
@@ -183,10 +183,9 @@ export function buildConnectConfig(
 ): ConnectConfig {
   const effectiveHost = resolveEffectiveHost(target, resolved)
   const effectivePort = resolveEffectivePort(target, resolved)
-  const effectiveUser =
-    isOpenSshConfigBackedTarget(target) && resolved
-      ? (resolved.user ?? target.username)
-      : target.username || resolved?.user || ''
+  const effectiveUser = hasOpenSshHostBlockMatch(target, resolved)
+    ? (resolved?.user ?? target.username)
+    : target.username || resolved?.user || ''
 
   const config: Record<string, unknown> = {
     host: effectiveHost,
@@ -222,7 +221,7 @@ export function buildConnectConfig(
 }
 
 function resolveEffectiveHost(target: SshTarget, resolved: SshResolvedConfig | null): string {
-  if (isOpenSshConfigBackedTarget(target) && resolved?.hostname) {
+  if (hasOpenSshHostBlockMatch(target, resolved) && resolved?.hostname) {
     return resolved.hostname
   }
   if (shouldUseResolvedEndpoint(target, resolved)) {
@@ -232,7 +231,7 @@ function resolveEffectiveHost(target: SshTarget, resolved: SshResolvedConfig | n
 }
 
 function resolveEffectivePort(target: SshTarget, resolved: SshResolvedConfig | null): number {
-  if (isOpenSshConfigBackedTarget(target) && resolved) {
+  if (hasOpenSshHostBlockMatch(target, resolved) && resolved) {
     return resolved.port || target.port || 22
   }
   // Why: imported config aliases store 22 as the schema default even when an
@@ -263,7 +262,7 @@ export function resolveEffectiveProxy(
   target: SshTarget,
   resolved: SshResolvedConfig | null
 ): EffectiveProxy | undefined {
-  if (isOpenSshConfigBackedTarget(target) && resolved) {
+  if (hasOpenSshHostBlockMatch(target, resolved) && resolved) {
     if (resolved.proxyCommand) {
       return { kind: 'proxy-command', command: resolved.proxyCommand }
     }

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -180,6 +180,15 @@ function createTarget(overrides?: Partial<SshTarget>): SshTarget {
   }
 }
 
+const LOCAL_ACCOUNT = 'localdev'
+
+// Why: `ssh -G` echoes the local account as `user` for an alias with no Host block.
+function stubLocalAccount(): void {
+  vi.stubEnv('USER', LOCAL_ACCOUNT)
+  vi.stubEnv('LOGNAME', LOCAL_ACCOUNT)
+  vi.stubEnv('USERNAME', LOCAL_ACCOUNT)
+}
+
 function createResolvedConfig(overrides?: Partial<SshResolvedConfig>): SshResolvedConfig {
   return {
     hostname: 'example.com',
@@ -1188,6 +1197,30 @@ describe('SshConnection', () => {
     expect(conn.usesSystemSshTransport()).toBe(true)
   })
 
+  it('keeps the stored git username when the GitHub alias no longer has a Host block', async () => {
+    stubLocalAccount()
+    vi.mocked(resolveWithSshG).mockResolvedValueOnce(
+      createResolvedConfig({ hostname: 'github.com', user: LOCAL_ACCOUNT })
+    )
+    spawnSystemSshCommandMock.mockImplementation(() =>
+      createFailingSystemCommandChannel(1, 'Invalid command: echo ORCA-SYSTEM-SSH-OK')
+    )
+    const conn = new SshConnection(
+      createTarget({
+        source: 'ssh-config',
+        configHost: 'github.com',
+        host: 'github.com',
+        username: 'git'
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.getState().status).toBe('connected')
+    expect(conn.usesSystemSshTransport()).toBe(true)
+  })
+
   it('accepts GitHub restricted-shell SSH probes with resolved host and target username', async () => {
     vi.mocked(resolveWithSshG).mockResolvedValueOnce(
       createResolvedConfig({ hostname: 'github.com', user: undefined })
@@ -1571,6 +1604,62 @@ describe('SshConnection', () => {
     expect(conn.getState().status).toBe('connected')
     expect(conn.usesSystemSshTransport()).toBe(false)
     expect(spawnSystemSshCommandMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the stored GSSAPI flag when the alias no longer has a Host block', async () => {
+    stubLocalAccount()
+    // `ssh -G krb-box` with no matching block: echoed alias, local user, port 22, GSSAPI off.
+    vi.mocked(resolveWithSshG).mockResolvedValue(
+      createResolvedConfig({
+        hostname: 'krb-box',
+        user: LOCAL_ACCOUNT,
+        proxyUseFdpass: false,
+        gssapiAuthentication: false
+      })
+    )
+    const conn = new SshConnection(
+      createTarget({
+        source: 'ssh-config',
+        configHost: 'krb-box',
+        host: 'krb-box',
+        gssapiAuthentication: true
+      }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.usesSystemSshTransport()).toBe(true)
+    expect(spawnSystemSshCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ gssapiAuthentication: true }),
+      'echo ORCA-SYSTEM-SSH-OK',
+      expect.objectContaining({ gssapiOnly: true, wrapCommand: false })
+    )
+  })
+
+  it('still probes GSSAPI from a distro-wide default when the alias has no Host block', async () => {
+    stubLocalAccount()
+    vi.mocked(resolveWithSshG).mockResolvedValue(
+      createResolvedConfig({
+        hostname: 'krb-box',
+        user: LOCAL_ACCOUNT,
+        proxyUseFdpass: false,
+        gssapiAuthentication: true
+      })
+    )
+    const conn = new SshConnection(
+      createTarget({ source: 'ssh-config', configHost: 'krb-box', host: 'krb-box' }),
+      createCallbacks()
+    )
+
+    await conn.connect()
+
+    expect(conn.usesSystemSshTransport()).toBe(true)
+    expect(spawnSystemSshCommandMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'echo ORCA-SYSTEM-SSH-OK',
+      expect.objectContaining({ gssapiOnly: true, wrapCommand: false })
+    )
   })
 
   it('falls back to system SSH after an ssh2 auth failure when resolved config enables GSSAPI', async () => {

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -19,6 +19,7 @@ import {
 } from './ssh-system-fallback'
 import { resolveWithSshG, type SshResolvedConfig } from './ssh-config-parser'
 import { removeControlSocketPath } from './ssh-control-socket'
+import { hasOpenSshHostBlockMatch } from './ssh-g-host-block-match'
 import { isOpenSshConfigBackedTarget } from './system-ssh-args'
 import {
   INITIAL_RETRY_ATTEMPTS,
@@ -85,8 +86,8 @@ function isGitHubRestrictedShellProbeSuccess(
   }
 
   const effectiveUser = (
-    isOpenSshConfigBackedTarget(target) && resolvedConfig
-      ? resolvedConfig.user?.trim() || target.username?.trim()
+    hasOpenSshHostBlockMatch(target, resolvedConfig)
+      ? resolvedConfig?.user?.trim() || target.username?.trim()
       : target.username?.trim() || resolvedConfig?.user?.trim()
   )?.toLowerCase()
   if (effectiveUser !== 'git') {
@@ -637,10 +638,12 @@ export class SshConnection {
       return
     }
     // Why: ssh2 lacks gssapi-with-mic; GSSAPIAuthentication hosts try Kerberos SSO via system OpenSSH first, then fall through to key/credential auth.
+    // Why: without Host-block evidence a resolved `no` is just the /etc/ssh default, so it must not discard the stored flag; a resolved `yes` still wins so distro-wide defaults keep working.
     if (
-      isOpenSshConfigBackedTarget(this.target) && resolved
-        ? resolved.gssapiAuthentication === true
-        : this.target.gssapiAuthentication === true
+      hasOpenSshHostBlockMatch(this.target, resolved)
+        ? resolved?.gssapiAuthentication === true
+        : this.target.gssapiAuthentication === true ||
+          (isOpenSshConfigBackedTarget(this.target) && resolved?.gssapiAuthentication === true)
     ) {
       try {
         await this.doSystemSshProbeWithControlMasterRetry(connectGeneration, resolved, true)

--- a/src/main/ssh/ssh-g-host-block-match.test.ts
+++ b/src/main/ssh/ssh-g-host-block-match.test.ts
@@ -135,6 +135,17 @@ describe('ssh -G host-block matching', () => {
     expect(mockReadFileSync).not.toHaveBeenCalledWith('/keys/prod')
   })
 
+  // Every other field is a bare default, so only the rewritten HostName can carry the verdict.
+  it('treats a rewritten HostName as a match when nothing else differs from the defaults', () => {
+    const config = buildConnectConfig(
+      storedTarget({ jumpHost: undefined }),
+      unmatchedDefaults({ hostname: '10.9.9.9' }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    expect(config.host).toBe('10.9.9.9')
+  })
+
   it('treats a User directive as a match even when HostName echoes the alias', () => {
     const config = buildConnectConfig(
       storedTarget({ configHost: 'github.com', label: 'github.com', host: 'github.com' }),
@@ -146,14 +157,35 @@ describe('ssh -G host-block matching', () => {
     expect(config.username).toBe('git')
   })
 
+  // Stored port stays non-22 so the legacy `target.port === 22` fallback can't supply the answer.
   it('treats a non-default Port as a match even when HostName echoes the alias', () => {
     const config = buildConnectConfig(
-      storedTarget({ port: 22 }),
+      storedTarget({ port: 2222 }),
       unmatchedDefaults({ port: 2022 }),
       { includeAgent: false, includePrivateKey: true }
     )
 
     expect(config.port).toBe(2022)
+  })
+
+  it('treats a ProxyJump directive as a match even when HostName echoes the alias', () => {
+    const target = storedTarget({ jumpHost: 'stale-bastion' })
+
+    expect(resolveEffectiveProxy(target, unmatchedDefaults({ proxyJump: 'edge' }))).toEqual({
+      kind: 'jump-host',
+      jumpHost: 'edge'
+    })
+  })
+
+  it('treats a ProxyCommand directive as a match even when HostName echoes the alias', () => {
+    const target = storedTarget({ jumpHost: undefined, proxyCommand: 'stale-proxy %h' })
+
+    expect(
+      resolveEffectiveProxy(target, unmatchedDefaults({ proxyCommand: 'cf access ssh %h' }))
+    ).toEqual({
+      kind: 'proxy-command',
+      command: 'cf access ssh %h'
+    })
   })
 
   it('keeps manual targets on their stored fields regardless of ssh -G output', () => {

--- a/src/main/ssh/ssh-g-host-block-match.test.ts
+++ b/src/main/ssh/ssh-g-host-block-match.test.ts
@@ -1,0 +1,170 @@
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('os', () => ({
+  homedir: () => '/home/testuser',
+  tmpdir: () => '/tmp'
+}))
+
+const mockExistsSync = vi.fn().mockReturnValue(false)
+const mockReadFileSync = vi.fn()
+
+vi.mock('fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args)
+}))
+
+import { buildConnectConfig, resolveEffectiveProxy } from './ssh-connection-utils'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { SshResolvedConfig } from './ssh-config-parser'
+
+const LOCAL_ACCOUNT = 'localdev'
+
+function storedTarget(overrides: Partial<SshTarget> = {}): SshTarget {
+  return {
+    id: 'target-1',
+    label: 'prod',
+    source: 'ssh-config',
+    configHost: 'prod',
+    host: '10.0.0.5',
+    port: 2222,
+    username: 'deploy',
+    identityFile: '/keys/prod',
+    jumpHost: 'bastion',
+    ...overrides
+  }
+}
+
+// `ssh -G prod` output when no Host block matches the alias any more.
+function unmatchedDefaults(overrides: Partial<SshResolvedConfig> = {}): SshResolvedConfig {
+  return {
+    hostname: 'prod',
+    user: LOCAL_ACCOUNT,
+    port: 22,
+    identityFile: [
+      join('/home/testuser', '.ssh', 'id_rsa'),
+      join('/home/testuser', '.ssh', 'id_ed25519')
+    ],
+    identitiesOnly: false,
+    forwardAgent: false,
+    proxyUseFdpass: false,
+    controlMaster: 'no',
+    controlPersist: 'no',
+    ...overrides
+  }
+}
+
+function matchedBlock(overrides: Partial<SshResolvedConfig> = {}): SshResolvedConfig {
+  return unmatchedDefaults({
+    hostname: '10.9.9.9',
+    user: 'ops',
+    port: 2200,
+    identityFile: ['/keys/current-first', '/keys/current-second'],
+    proxyJump: 'edge',
+    ...overrides
+  })
+}
+
+describe('ssh -G host-block matching', () => {
+  beforeEach(() => {
+    vi.stubEnv('SSH_AUTH_SOCK', '')
+    vi.stubEnv('USER', LOCAL_ACCOUNT)
+    vi.stubEnv('LOGNAME', LOCAL_ACCOUNT)
+    vi.stubEnv('USERNAME', LOCAL_ACCOUNT)
+    mockExistsSync.mockReset()
+    mockExistsSync.mockReturnValue(false)
+    mockReadFileSync.mockReset()
+    mockReadFileSync.mockImplementation((path: unknown) => Buffer.from(String(path)))
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('keeps stored endpoint fields when the alias no longer has a Host block', () => {
+    const target = storedTarget()
+    const resolved = unmatchedDefaults()
+
+    const config = buildConnectConfig(target, resolved, {
+      includeAgent: false,
+      includePrivateKey: true
+    })
+
+    expect({
+      host: config.host,
+      port: config.port,
+      username: config.username,
+      privateKey: config.privateKey,
+      proxy: resolveEffectiveProxy(target, resolved)
+    }).toEqual({
+      host: '10.0.0.5',
+      port: 2222,
+      username: 'deploy',
+      privateKey: Buffer.from('/keys/prod'),
+      proxy: { kind: 'jump-host', jumpHost: 'bastion' }
+    })
+  })
+
+  it('keeps the stored ProxyCommand when the alias resolves to bare defaults', () => {
+    const target = storedTarget({ jumpHost: undefined, proxyCommand: 'cf access ssh %h' })
+
+    expect(resolveEffectiveProxy(target, unmatchedDefaults())).toEqual({
+      kind: 'proxy-command',
+      command: 'cf access ssh %h'
+    })
+  })
+
+  it('applies fresh OpenSSH values when the Host block still matches', () => {
+    const target = storedTarget()
+    const resolved = matchedBlock()
+
+    const config = buildConnectConfig(target, resolved, {
+      includeAgent: false,
+      includePrivateKey: true
+    })
+
+    expect(config.host).toBe('10.9.9.9')
+    expect(config.port).toBe(2200)
+    expect(config.username).toBe('ops')
+    expect(resolveEffectiveProxy(target, resolved)).toEqual({
+      kind: 'jump-host',
+      jumpHost: 'edge'
+    })
+    // Why: #11297 — the first IdentityFile directive wins over the stored snapshot.
+    expect(config.privateKey).toEqual(Buffer.from('/keys/current-first'))
+    expect(mockReadFileSync).not.toHaveBeenCalledWith('/keys/prod')
+  })
+
+  it('treats a User directive as a match even when HostName echoes the alias', () => {
+    const config = buildConnectConfig(
+      storedTarget({ configHost: 'github.com', label: 'github.com', host: 'github.com' }),
+      unmatchedDefaults({ hostname: 'github.com', user: 'git' }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    expect(config.host).toBe('github.com')
+    expect(config.username).toBe('git')
+  })
+
+  it('treats a non-default Port as a match even when HostName echoes the alias', () => {
+    const config = buildConnectConfig(
+      storedTarget({ port: 22 }),
+      unmatchedDefaults({ port: 2022 }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    expect(config.port).toBe(2022)
+  })
+
+  it('keeps manual targets on their stored fields regardless of ssh -G output', () => {
+    const config = buildConnectConfig(
+      storedTarget({ source: 'manual', configHost: undefined }),
+      matchedBlock(),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    expect(config.host).toBe('10.0.0.5')
+    expect(config.port).toBe(2222)
+    expect(config.username).toBe('deploy')
+  })
+})

--- a/src/main/ssh/ssh-g-host-block-match.test.ts
+++ b/src/main/ssh/ssh-g-host-block-match.test.ts
@@ -188,6 +188,23 @@ describe('ssh -G host-block matching', () => {
     })
   })
 
+  // A launchd/systemd-spawned main process has no USER/LOGNAME/USERNAME, so the
+  // resolved user proves nothing and the stored fields have to win.
+  it('ignores the resolved user when the local account cannot be determined', () => {
+    vi.stubEnv('USER', '')
+    vi.stubEnv('LOGNAME', '')
+    vi.stubEnv('USERNAME', '')
+
+    const config = buildConnectConfig(
+      storedTarget({ jumpHost: undefined }),
+      unmatchedDefaults({ user: 'whoever' }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    expect(config.username).toBe('deploy')
+    expect(config.host).toBe('10.0.0.5')
+  })
+
   it('keeps manual targets on their stored fields regardless of ssh -G output', () => {
     const config = buildConnectConfig(
       storedTarget({ source: 'manual', configHost: undefined }),

--- a/src/main/ssh/ssh-g-host-block-match.ts
+++ b/src/main/ssh/ssh-g-host-block-match.ts
@@ -34,6 +34,10 @@ function localAccountName(): string {
  * would silently replace a stored target's host/port/user/proxy/identity with
  * those defaults — dialing the bare alias as the local user — whenever the block
  * is renamed, removed, or lives on another machine.
+ *
+ * Known limitation: the signals below read the *effective* config, so a wildcard
+ * `Host *` supplying User/Port/ProxyCommand — or `CanonicalizeHostname yes` —
+ * still reads as a match for an alias whose own block is gone.
  */
 export function hasOpenSshHostBlockMatch(
   target: HostBlockMatchTarget,

--- a/src/main/ssh/ssh-g-host-block-match.ts
+++ b/src/main/ssh/ssh-g-host-block-match.ts
@@ -1,0 +1,59 @@
+import { userInfo } from 'node:os'
+import type { SshTarget } from '../../shared/ssh-types'
+import type { SshResolvedConfig } from './ssh-config-parser'
+import { isOpenSshConfigBackedTarget } from './system-ssh-args'
+
+const DEFAULT_SSH_PORT = 22
+
+type HostBlockMatchTarget = Pick<SshTarget, 'source' | 'configHost' | 'host' | 'label'>
+
+function normalize(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? ''
+}
+
+// Why: `ssh -G` fills `user` from the local account whenever no User directive matched.
+function localAccountName(): string {
+  const fromEnv = process.env.USER || process.env.LOGNAME || process.env.USERNAME
+  if (fromEnv) {
+    return normalize(fromEnv)
+  }
+  try {
+    return normalize(userInfo().username)
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Whether `ssh -G <alias>` output carries evidence that an ssh_config Host block
+ * for this alias actually applied.
+ *
+ * Why: `ssh -G` exits 0 for an alias with no matching block and prints a fully
+ * populated *default* config (hostname = the alias itself, user = the local
+ * account, port 22, no proxy). Treating any non-null resolution as authoritative
+ * would silently replace a stored target's host/port/user/proxy/identity with
+ * those defaults — dialing the bare alias as the local user — whenever the block
+ * is renamed, removed, or lives on another machine.
+ */
+export function hasOpenSshHostBlockMatch(
+  target: HostBlockMatchTarget,
+  resolved: SshResolvedConfig | null | undefined
+): boolean {
+  if (!isOpenSshConfigBackedTarget(target) || !resolved) {
+    return false
+  }
+  // Why: an echoed hostname is the only field OpenSSH always emits, so an empty
+  // one means the resolution never went through `ssh -G` (keep it authoritative).
+  const hostname = normalize(resolved.hostname)
+  if (!hostname || hostname !== normalize(target.configHost || target.label)) {
+    return true
+  }
+  if (resolved.port && resolved.port !== DEFAULT_SSH_PORT) {
+    return true
+  }
+  if (resolved.proxyCommand || resolved.proxyJump) {
+    return true
+  }
+  const user = normalize(resolved.user)
+  return user !== '' && user !== localAccountName()
+}

--- a/src/main/ssh/ssh-g-host-block-match.ts
+++ b/src/main/ssh/ssh-g-host-block-match.ts
@@ -11,16 +11,17 @@ function normalize(value: string | undefined): string {
   return value?.trim().toLowerCase() ?? ''
 }
 
-// Why: `ssh -G` fills `user` from the local account whenever no User directive matched.
-function localAccountName(): string {
-  const fromEnv = process.env.USER || process.env.LOGNAME || process.env.USERNAME
+// Why: `ssh -G` fills `user` from the local account whenever no User directive
+// matched; null means the local account is unknown, so `user` carries no verdict.
+function localAccountName(): string | null {
+  const fromEnv = normalize(process.env.USER || process.env.LOGNAME || process.env.USERNAME)
   if (fromEnv) {
-    return normalize(fromEnv)
+    return fromEnv
   }
   try {
-    return normalize(userInfo().username)
+    return normalize(userInfo().username) || null
   } catch {
-    return ''
+    return null
   }
 }
 
@@ -37,7 +38,10 @@ function localAccountName(): string {
  *
  * Known limitation: the signals below read the *effective* config, so a wildcard
  * `Host *` supplying User/Port/ProxyCommand — or `CanonicalizeHostname yes` —
- * still reads as a match for an alias whose own block is gone.
+ * still reads as a match for an alias whose own block is gone. The reverse
+ * verdict falls back to the stored snapshot, whose IdentityFile is used verbatim
+ * (only `~` is expanded), so a stored path with OpenSSH tokens (%d/%h/%r) stays
+ * unreadable — pre-existing behaviour, unchanged here.
  */
 export function hasOpenSshHostBlockMatch(
   target: HostBlockMatchTarget,
@@ -58,6 +62,7 @@ export function hasOpenSshHostBlockMatch(
   if (resolved.proxyCommand || resolved.proxyJump) {
     return true
   }
+  const localAccount = localAccountName()
   const user = normalize(resolved.user)
-  return user !== '' && user !== localAccountName()
+  return localAccount !== null && user !== '' && user !== localAccount
 }

--- a/src/main/ssh/ssh-multi-key-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-key-authentication.test.ts
@@ -72,6 +72,16 @@ function nextAuth(
   return result ?? false
 }
 
+function mockEncryptedKeyPaths(encryptedPaths: string[]): void {
+  vi.spyOn(utils, 'parseKey').mockImplementation((key, passphrase) => {
+    const path = Buffer.from(key as Buffer).toString()
+    if (!passphrase && encryptedPaths.some((encrypted) => path.includes(encrypted))) {
+      return new Error('Encrypted private OpenSSH key detected, but no passphrase given')
+    }
+    return { isPrivateKey: () => true } as ParsedKey
+  })
+}
+
 describe('ordered SSH private-key authentication', () => {
   beforeEach(() => {
     vi.stubEnv('SSH_AUTH_SOCK', '')
@@ -166,6 +176,42 @@ describe('ordered SSH private-key authentication', () => {
     )
 
     expect(getPassphrasePrivateKeyPath(config)).toBe('/keys/encrypted-second')
+  })
+
+  it('seeds ssh2 with the first parseable identity so an encrypted one keeps the fallback', () => {
+    mockEncryptedKeyPaths(['/keys/encrypted-first'])
+    const config = buildConnectConfig(
+      makeTarget(),
+      makeResolved({ identityFile: ['/keys/encrypted-first', '/keys/valid-second'] }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    // Why: ssh2's Client.connect parses config.privateKey up front and throws on
+    // an encrypted one, which would abort before authHandler tries the rest.
+    expect(config.privateKey).toEqual(Buffer.from('/keys/valid-second'))
+    expect(utils.parseKey(config.privateKey as Buffer)).not.toBeInstanceOf(Error)
+    expect(nextAuth(config, true)).toMatchObject({ type: 'none' })
+    expect(nextAuth(config, false)).toMatchObject({
+      type: 'publickey',
+      key: Buffer.from('/keys/encrypted-first')
+    })
+    expect(nextAuth(config, false)).toMatchObject({
+      type: 'publickey',
+      key: Buffer.from('/keys/valid-second')
+    })
+    expect(getPassphrasePrivateKeyPath(config)).toBe('/keys/encrypted-first')
+  })
+
+  it('still hands ssh2 an encrypted key when it is the only identity', () => {
+    mockEncryptedKeyPaths(['/keys/encrypted-only'])
+    const config = buildConnectConfig(
+      makeTarget(),
+      makeResolved({ identityFile: ['/keys/encrypted-only'] }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    expect(config.privateKey).toEqual(Buffer.from('/keys/encrypted-only'))
+    expect(getPassphrasePrivateKeyPath(config)).toBe('/keys/encrypted-only')
   })
 
   it('leaves config-host key authority to system OpenSSH', () => {

--- a/src/main/ssh/ssh-multi-key-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-key-authentication.test.ts
@@ -202,6 +202,20 @@ describe('ordered SSH private-key authentication', () => {
     expect(getPassphrasePrivateKeyPath(config)).toBe('/keys/encrypted-first')
   })
 
+  it('falls back to the first identity when every candidate is encrypted', () => {
+    mockEncryptedKeyPaths(['/keys/encrypted-first', '/keys/encrypted-second'])
+    const config = buildConnectConfig(
+      makeTarget(),
+      makeResolved({ identityFile: ['/keys/encrypted-first', '/keys/encrypted-second'] }),
+      { includeAgent: false, includePrivateKey: true }
+    )
+
+    // Why: no parseable candidate means the eager parse must still throw, so the
+    // passphrase prompt fires instead of silently dropping to agent-only auth.
+    expect(config.privateKey).toEqual(Buffer.from('/keys/encrypted-first'))
+    expect(getPassphrasePrivateKeyPath(config)).toBe('/keys/encrypted-first')
+  })
+
   it('still hands ssh2 an encrypted key when it is the only identity', () => {
     mockEncryptedKeyPaths(['/keys/encrypted-only'])
     const config = buildConnectConfig(

--- a/src/main/ssh/ssh-private-key-authentication.ts
+++ b/src/main/ssh/ssh-private-key-authentication.ts
@@ -41,16 +41,17 @@ function isUsableAsEagerPrivateKey(key: PrivateKeyFile, passphrase?: string | Bu
   if (parsed instanceof Error) {
     return false
   }
-  const parsedKeys = Array.isArray(parsed) ? parsed : [parsed]
-  return parsedKeys.some(
-    (entry) => typeof entry?.isPrivateKey === 'function' && entry.isPrivateKey()
-  )
+  // Why: ssh2 keeps only the first entry of a multi-key parse (client.js `privateKey[0]`).
+  const eager = Array.isArray(parsed) ? parsed[0] : parsed
+  return typeof eager?.isPrivateKey === 'function' && eager.isPrivateKey()
 }
 
 // Why: ssh2's Client.connect parses config.privateKey before any auth runs and
 // throws on an encrypted/unparseable one, so seeding it with the first candidate
 // would abort the connect instead of letting authHandler try the other keys.
 // Falling back to keys[0] keeps the passphrase prompt for an encrypted-only list.
+// `config.passphrase` is still unset here on the first connect — callers only fill
+// it after a prompt — so an encrypted key can only be picked on a retry pass.
 function selectEagerPrivateKey(config: ConnectConfig, keys: PrivateKeyFile[]): PrivateKeyFile {
   return keys.find((key) => isUsableAsEagerPrivateKey(key, config.passphrase)) ?? keys[0]!
 }

--- a/src/main/ssh/ssh-private-key-authentication.ts
+++ b/src/main/ssh/ssh-private-key-authentication.ts
@@ -1,4 +1,11 @@
-import type { AnyAuthMethod, AuthenticationType, ConnectConfig, NextAuthHandler } from 'ssh2'
+import {
+  utils,
+  type AnyAuthMethod,
+  type AuthenticationType,
+  type ConnectConfig,
+  type NextAuthHandler,
+  type ParsedKey
+} from 'ssh2'
 import type { PrivateKeyFile } from './ssh-auth-resolution'
 
 const passphraseKeyPaths = new WeakMap<ConnectConfig, string>()
@@ -29,16 +36,34 @@ function buildAuthQueue(
   return queue
 }
 
+function isUsableAsEagerPrivateKey(key: PrivateKeyFile, passphrase?: string | Buffer): boolean {
+  const parsed = utils.parseKey(key.contents, passphrase) as ParsedKey | ParsedKey[] | Error
+  if (parsed instanceof Error) {
+    return false
+  }
+  const parsedKeys = Array.isArray(parsed) ? parsed : [parsed]
+  return parsedKeys.some(
+    (entry) => typeof entry?.isPrivateKey === 'function' && entry.isPrivateKey()
+  )
+}
+
+// Why: ssh2's Client.connect parses config.privateKey before any auth runs and
+// throws on an encrypted/unparseable one, so seeding it with the first candidate
+// would abort the connect instead of letting authHandler try the other keys.
+// Falling back to keys[0] keeps the passphrase prompt for an encrypted-only list.
+function selectEagerPrivateKey(config: ConnectConfig, keys: PrivateKeyFile[]): PrivateKeyFile {
+  return keys.find((key) => isUsableAsEagerPrivateKey(key, config.passphrase)) ?? keys[0]!
+}
+
 export function configurePrivateKeyAuthentication(
   config: ConnectConfig,
   keys: PrivateKeyFile[],
   passphraseKeyPath?: string
 ): void {
-  const firstKey = keys[0]
-  if (!firstKey) {
+  if (keys.length === 0) {
     return
   }
-  config.privateKey = firstKey.contents
+  config.privateKey = selectEagerPrivateKey(config, keys).contents
   if (passphraseKeyPath) {
     passphraseKeyPaths.set(config, passphraseKeyPath)
   }


### PR DESCRIPTION
## ELI5

Think of a saved SSH host as a speed-dial entry: the name `prod` on the button, and the real number (`10.0.0.5`, port 2222, as `deploy`, via the `bastion` switchboard) stored behind it. Asking OpenSSH "what does `prod` mean?" (`ssh -G prod`) never says "no such entry" — if the entry is gone it cheerfully answers with a made-up default: "call the number `prod`, port 22, as whoever you are, no switchboard." We were believing that answer and throwing away everything we had stored, so tidying up `~/.ssh/config` (or opening Orca on another machine) silently re-pointed a saved host at a literal name that, on a corporate network with DNS search domains, can be an entirely different machine — and agent-forwarded identities were offered to it. Now we only believe the answer when it shows real evidence a Host block matched; otherwise the stored fields win.

Second, smaller one: when you have several keys, we handed ssh2 the *first* one to hold onto. ssh2 unwraps that key immediately, so a legacy passphrase-protected `~/.ssh/id_rsa` blew up the whole connection before the good `id_ed25519` was ever tried — you got a passphrase prompt for a key the server never asked for. Now we hand it the first key that actually opens, and still try all of them.

## Scope (read this first)

This PR fixes the P1 on the **ssh2 transport** — the path `SshConnection` takes for every target that is not routed to system OpenSSH. It does **not** close the P1 on the **system-SSH transport**: a wildcard `Host * / ProxyCommand|ProxyJump` sets `resolved.proxyCommand` for every alias, so `shouldUseSystemSshTransport` still returns `true` for an evidence-less config-backed target and `buildSshArgs` still dials `configHost` verbatim (no `-l`, no `-p`, no `-o Hostname=`). That half is tracked in #11746 with a proposed direction and the test matrix it needs; it is deliberately not attempted here because the one-line gate would move every wildcard-proxy user onto ssh2 wholesale.

## Summary

- Root cause: `ssh -G <unknown-alias>` exits 0 and prints a fully-populated *default* config (`hostname` = the alias, `user` = the local account, `port 22`, no proxy, default identity list). Since #11297 every config-backed helper treated "resolved is non-null" as proof that a Host block matched.
- New `hasOpenSshHostBlockMatch` (`src/main/ssh/ssh-g-host-block-match.ts:37`) requires positive evidence of a match — a `hostname` that is not just the echoed alias, a non-22 port, a proxy directive, or a `user` that is not the local account — and only then hands OpenSSH authority.
- Gated the config-backed branches on it: `buildConnectConfig` user (`src/main/ssh/ssh-connection-utils.ts:186`), `resolveEffectiveHost` (`:224`), `resolveEffectivePort` (`:234`), `resolveEffectiveProxy` (`:265`, which otherwise ignored `target.proxyCommand`/`target.jumpHost` entirely), and the identity paths in `src/main/ssh/ssh-auth-resolution.ts:92,102,179`. When a block really matches, #11297's first-directive-wins precedence is unchanged.
- Same gate on the two remaining #11297 sites in `src/main/ssh/ssh-connection.ts`: the GitHub restricted-shell probe's effective user (`:88`, where a vanished block made `resolved.user` the *local* account and rejected a stored `username: 'git'`) and the proactive Kerberos probe (`:641`). The GSSAPI check keeps `resolved.gssapiAuthentication === true` winning either way, so #11297's distro-wide `/etc/ssh` default pickup survives; the gate only stops a defaulted `no` from discarding a stored `gssapiAuthentication: true` and dropping a Kerberos-only host into key/password prompts.
- `configurePrivateKeyAuthentication` now seeds `config.privateKey` with the first *parseable* candidate (`src/main/ssh/ssh-private-key-authentication.ts:39-56`); ssh2 parses that value eagerly in `Client.connect` (`node_modules/ssh2/lib/client.js:258-261`) and throws before any `authHandler` runs, so an encrypted first identity killed the multi-key fallback that #11297 added.
- The encrypted key stays in the `authHandler` queue (ssh2 skips unparseable queue entries rather than throwing), and an encrypted-only list still falls back to `keys[0]`, so `findEncryptedPrivateKeyPath` and the passphrase prompt at `src/main/ssh/ssh-connection.ts:786-800` keep working.

## Regression source

Introduced by #11297 (5fe3aaf2b7) — "fix(ssh): preserve first config directive value", which began trusting `ssh -G` output unconditionally.

## Test plan

- New `src/main/ssh/ssh-g-host-block-match.test.ts` (10 tests), 2 new cases in `src/main/ssh/ssh-connection.test.ts` for the two `ssh-connection.ts` sites, and 3 new cases in `src/main/ssh/ssh-multi-key-authentication.test.ts`.
- Verified failing on unfixed code (source files reverted, tests kept):
  - "keeps stored endpoint fields when the alias no longer has a Host block" → `expected { host: 'prod', port: 22, … } to deeply equal { host: '10.0.0.5', port: 2222, … }`; the received `privateKey` was `~/.ssh/id_rsa` instead of `/keys/prod` and `proxy` was `undefined` instead of the stored `bastion` jump host.
  - "keeps the stored ProxyCommand when the alias resolves to bare defaults" → `expected undefined to deeply equal { kind: 'proxy-command', command: 'cf access ssh %h' }`.
  - "seeds ssh2 with the first parseable identity so an encrypted one keeps the fallback" → `config.privateKey` was `/keys/encrypted-first` instead of `/keys/valid-second`.
  - "keeps the stored GSSAPI flag when the alias no longer has a Host block" → the `gssapiOnly` system-SSH probe was never spawned (`Number of calls: 0`).
  - "keeps the stored git username when the GitHub alias no longer has a Host block" → `System SSH probe failed (exit 1)`, because the restricted-shell probe read the local account instead of the stored `git`.
  - "ignores the resolved user when the local account cannot be determined" → `config.username` was `whoever` instead of the stored `deploy`.
- All pass after the fix, along with: every `src/main/ssh` test (1089 passed / 10 skipped), the whole `src/main` suite (17594 passed / 49 skipped), `npx oxlint src/main/ssh/`, `npx oxfmt --check src/main/ssh/`, and `tsc --noEmit -p config/tsconfig.node.json`.
- Review round 2 — differential-probe mask and baseline-probe cost:
  - The mask kept `_` in both word-boundary classes, so `Host * / IdentityFile ~/.ssh/id_%h` and `Host * / HostName %h_internal.example.com` produced an unmasked alias on one side and an unmasked probe token on the other → `hostBlockMatch: true` for an alias with no block. Verified against OpenSSH 10.2 that `HostName %h_internal.example.com` really does expand per-alias on both probes. Fixed by dropping `_` from the boundary classes; 4 new parametrised cases (`_`-prefixed, `_`-suffixed, `-`-separated, `.`-separated) plus a `HostName` case and a "still detects an alias-specific IdentityFile containing the alias name" guard against over-masking, all on production-shaped `ssh -G` bodies with the default `identityfile` lines. The two `_` cases and the `HostName` case fail on the pre-fix source.
  - Both `resolveWithSshG` call sites asked for `hostBlockEvidence: true` unconditionally, but `hasOpenSshHostBlockMatch` discards the verdict when `isOpenSshConfigBackedTarget` is false — so every `source: 'manual'` target and every runtime-owned target (`SshConnectionStore.upsertRuntimeOwnedTarget` sets `source: 'manual'`) paid for a second `ssh -G`, which re-runs the user's `Match exec` matchers, on every connect attempt and every `connectViaSystemSsh`. Now gated on `isOpenSshConfigBackedTarget(this.target)`; 3 new cases in `ssh-connection.test.ts` (manual, runtime-owned/no-alias, manual `connectViaSystemSsh`) plus an explicit `hostBlockEvidence: false` execFile-count case, all failing on the pre-fix source.
  - Re-ran: every `src/main/ssh` test (1114 passed / 10 skipped), the whole `src/main` suite (17619 passed / 49 skipped), `npx oxlint` on the changed files, `npx oxfmt --check src/main/ssh/`, `tsc --noEmit -p config/tsconfig.node.json`.
- Coverage includes the still-matching cases: a live Host block applies resolved host/port/user/proxy and keeps #11297's first-IdentityFile precedence; a `User git` directive on `github.com` counts as a match even though HostName echoes the alias; a non-default `Port` likewise; manual targets are untouched; and an encrypted-only identity still records the passphrase key path.

## Deliberately out of scope

- **System-SSH transport half of the P1 → #11746.** `shouldUseSystemSshTransport` (`src/main/ssh/ssh-connection.ts`) never consults `hasOpenSshHostBlockMatch`, and `buildSshArgs` (`src/main/ssh/system-ssh-args.ts:79-83`) dials `configHost` verbatim on that branch. Executed against the branch: target `{source:'ssh-config', configHost:'prod', host:'10.0.0.5', port:2222, username:'deploy'}` + resolved `{hostname:'prod', user:'ops', port:22, proxyCommand:'nc -X connect …', hostBlockMatch:false}` → transport `true`, args `[… ,"--","prod"]` with no `-l deploy` / `-p 2222` / `-o Hostname=10.0.0.5`. (An earlier revision of this section claimed this case fell through to ssh2 and was "functionally equivalent" — that was wrong: `resolved.proxyCommand` from `Host *` keeps it on the system transport, so `resolveEffectiveProxy` is never reached.) `shouldUseSystemSshTransport` now carries a docstring pointing at #11746.
- Residual differential-probe inaccuracies are documented in the `resolveWithSshG` docstring rather than fixed: false `true` when the alias name appears as a bare token in a wildcard directive, when a negated pattern (`Host !prod *`) excludes it, or when `CanonicalizeHostname` rewrites only one side; false `false` when a real block only restates wildcard/global values or holds directives the signature does not compare. All are no worse than the unconditional `true` this replaced.
- A failed baseline probe still leaves the verdict unset and falls back to the effective-config heuristic. Treating it as "no evidence → keep the stored snapshot" would flip behaviour for every user whose `ssh -G` baseline fails today, so it is documented, not changed.

Found by the production release scan of v1.4.163-rc.0..origin/main.

Made with [Orca](https://github.com/stablyai/orca) 🐋


