### PR TITLE
fix(browser): recover embedded guests after lifecycle loss

### DIFF
--- a/src/main/ipc/browser.test.ts
+++ b/src/main/ipc/browser.test.ts
@@ -4,6 +4,7 @@ const {
   removeHandlerMock,
   handleMock,
   registerGuestMock,
+  attachGuestPoliciesMock,
   unregisterGuestMock,
   getGuestWebContentsIdMock,
   getWebContentsIdByTabIdMock,
@@ -20,6 +21,7 @@ const {
   removeHandlerMock: vi.fn(),
   handleMock: vi.fn(),
   registerGuestMock: vi.fn(),
+  attachGuestPoliciesMock: vi.fn(),
   unregisterGuestMock: vi.fn(),
   getGuestWebContentsIdMock: vi.fn(),
   getWebContentsIdByTabIdMock: vi.fn(() => new Map()),
@@ -53,6 +55,7 @@ vi.mock('../browser/browser-manager', () => ({
   },
   browserManager: {
     registerGuest: registerGuestMock,
+    attachGuestPolicies: attachGuestPoliciesMock,
     unregisterGuest: unregisterGuestMock,
     getGuestWebContentsId: getGuestWebContentsIdMock,
     getWebContentsIdByTabId: getWebContentsIdByTabIdMock,
@@ -80,6 +83,7 @@ describe('registerBrowserHandlers', () => {
     handleMock.mockReset()
     registerGuestMock.mockReset()
     registerGuestMock.mockReturnValue(true)
+    attachGuestPoliciesMock.mockReset()
     unregisterGuestMock.mockReset()
     getGuestWebContentsIdMock.mockReset()
     getWebContentsIdByTabIdMock.mockReset()
@@ -160,6 +164,93 @@ describe('registerBrowserHandlers', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('validates exact live guest registration only for the trusted renderer', () => {
+    getGuestWebContentsIdMock.mockReturnValue(123)
+    registerBrowserHandlers()
+    const validateHandler = handleMock.mock.calls.find(
+      ([channel]) => channel === 'browser:isGuestRegistered'
+    )?.[1] as (event: { sender: Electron.WebContents }, args: unknown) => boolean
+    const trustedSender = {
+      id: 91,
+      isDestroyed: () => false,
+      getType: () => 'window',
+      getURL: () => 'file:///renderer/index.html'
+    } as Electron.WebContents
+
+    expect(
+      validateHandler({ sender: trustedSender }, { browserPageId: 'page-1', webContentsId: 123 })
+    ).toBe(true)
+    expect(
+      validateHandler({ sender: trustedSender }, { browserPageId: 'page-1', webContentsId: 124 })
+    ).toBe(false)
+
+    webContentsFromIdMock.mockReturnValue({ isDestroyed: () => true })
+    expect(
+      validateHandler({ sender: trustedSender }, { browserPageId: 'page-1', webContentsId: 123 })
+    ).toBe(false)
+    expect(
+      validateHandler(
+        {
+          sender: {
+            id: 92,
+            isDestroyed: () => false,
+            getType: () => 'webview',
+            getURL: () => 'https://example.com'
+          } as Electron.WebContents
+        },
+        { browserPageId: 'page-1', webContentsId: 123 }
+      )
+    ).toBe(false)
+  })
+
+  it('repairs only a live webview owned by the trusted renderer', () => {
+    registerBrowserHandlers()
+    const repairHandler = handleMock.mock.calls.find(
+      ([channel]) => channel === 'browser:repairGuestRegistration'
+    )?.[1] as (
+      event: { sender: Electron.WebContents },
+      args: {
+        browserPageId: string
+        workspaceId: string
+        worktreeId: string
+        webContentsId: number
+      }
+    ) => boolean
+    const trustedSender = {
+      id: 91,
+      isDestroyed: () => false,
+      getType: () => 'window',
+      getURL: () => 'file:///renderer/index.html'
+    } as Electron.WebContents
+    const guest = {
+      id: 123,
+      hostWebContents: trustedSender,
+      isDestroyed: () => false,
+      getType: () => 'webview'
+    } as Electron.WebContents
+    webContentsFromIdMock.mockReturnValue(guest)
+    const args = {
+      browserPageId: 'page-1',
+      workspaceId: 'workspace-1',
+      worktreeId: 'worktree-1',
+      webContentsId: 123
+    }
+
+    expect(repairHandler({ sender: trustedSender }, args)).toBe(true)
+    expect(attachGuestPoliciesMock).toHaveBeenCalledWith(guest)
+    expect(registerGuestMock).toHaveBeenCalledWith({
+      ...args,
+      rendererWebContentsId: trustedSender.id
+    })
+
+    webContentsFromIdMock.mockReturnValue({
+      ...guest,
+      hostWebContents: { id: 92 }
+    })
+    expect(repairHandler({ sender: trustedSender }, args)).toBe(false)
+    expect(registerGuestMock).toHaveBeenCalledTimes(1)
   })
 
   it('authorizes browser download cancellation through the owning renderer', () => {

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -87,6 +87,14 @@ function isLiveBrowserWebContentsId(webContentsId: number | null | undefined): b
   return Boolean(guest && !guest.isDestroyed())
 }
 
+type BrowserGuestRegistrationArgs = {
+  browserPageId: string
+  workspaceId: string
+  worktreeId: string
+  sessionProfileId?: string | null
+  webContentsId: number
+}
+
 function hasRegisteredTabForWorktree(worktreeId: string): boolean {
   for (const [browserPageId, webContentsId] of browserManager.getWebContentsIdByTabId()) {
     if (
@@ -197,6 +205,8 @@ export function registerBrowserHandlers(): void {
   // Why: a stale in-flight chain from a prior registration would block new operations forever.
   grabModeOperationByPageId.clear()
   ipcMain.removeHandler('browser:registerGuest')
+  ipcMain.removeHandler('browser:isGuestRegistered')
+  ipcMain.removeHandler('browser:repairGuestRegistration')
   ipcMain.removeHandler('browser:unregisterGuest')
   ipcMain.removeHandler('browser:openDevTools')
   ipcMain.removeHandler('browser:setViewportOverride')
@@ -211,46 +221,84 @@ export function registerBrowserHandlers(): void {
   ipcMain.removeHandler('browser:activeTabChanged')
   ipcMain.removeHandler('browser:proceedCertificate')
 
+  const registerGuest = (
+    event: Electron.IpcMainInvokeEvent,
+    args: BrowserGuestRegistrationArgs,
+    repairPolicies: boolean
+  ): boolean => {
+    if (!isTrustedBrowserRenderer(event.sender)) {
+      return false
+    }
+    if (
+      !args ||
+      typeof args.browserPageId !== 'string' ||
+      typeof args.workspaceId !== 'string' ||
+      typeof args.worktreeId !== 'string' ||
+      typeof args.webContentsId !== 'number'
+    ) {
+      return false
+    }
+    if (repairPolicies) {
+      const guest = webContents.fromId(args.webContentsId)
+      if (
+        !guest ||
+        guest.isDestroyed() ||
+        guest.getType() !== 'webview' ||
+        guest.hostWebContents?.id !== event.sender.id
+      ) {
+        return false
+      }
+      browserManager.attachGuestPolicies(guest)
+    }
+    // Why: when Chromium swaps a guest's renderer process (navigation,
+    // crash recovery), the renderer re-registers the same browserPageId
+    // with a new webContentsId. The bridge must destroy the old session's
+    // proxy (its webContents is gone) and let the next command recreate it.
+    const previousWcId = browserManager.getGuestWebContentsId(args.browserPageId)
+    const registered = browserManager.registerGuest({
+      ...args,
+      rendererWebContentsId: event.sender.id
+    })
+    if (!registered) {
+      return false
+    }
+    if (agentBrowserBridgeRef && previousWcId !== null && previousWcId !== args.webContentsId) {
+      agentBrowserBridgeRef.onProcessSwap(args.browserPageId, args.webContentsId, previousWcId)
+    }
+    const pendingResolves = pendingTabRegistrations.get(args.browserPageId)
+    pendingTabRegistrations.delete(args.browserPageId)
+    resolvePendingRegistrations(pendingResolves)
+    const pendingWorktreeResolves = pendingWorktreeTabRegistrations.get(args.worktreeId)
+    pendingWorktreeTabRegistrations.delete(args.worktreeId)
+    resolvePendingRegistrations(pendingWorktreeResolves)
+    const pendingAnyResolves = new Set(pendingAnyTabRegistrations)
+    pendingAnyTabRegistrations.clear()
+    resolvePendingRegistrations(pendingAnyResolves)
+    return true
+  }
+
+  ipcMain.handle('browser:registerGuest', (event, args: BrowserGuestRegistrationArgs) =>
+    registerGuest(event, args, false)
+  )
+
+  ipcMain.handle('browser:repairGuestRegistration', (event, args: BrowserGuestRegistrationArgs) =>
+    registerGuest(event, args, true)
+  )
+
   ipcMain.handle(
-    'browser:registerGuest',
-    (
-      event,
-      args: {
-        browserPageId: string
-        workspaceId: string
-        worktreeId: string
-        sessionProfileId?: string | null
-        webContentsId: number
-      }
-    ) => {
-      if (!isTrustedBrowserRenderer(event.sender)) {
+    'browser:isGuestRegistered',
+    (event, args: { browserPageId?: unknown; webContentsId?: unknown }): boolean => {
+      if (
+        !isTrustedBrowserRenderer(event.sender) ||
+        typeof args?.browserPageId !== 'string' ||
+        typeof args.webContentsId !== 'number'
+      ) {
         return false
       }
-      // Why: when Chromium swaps a guest's renderer process (navigation,
-      // crash recovery), the renderer re-registers the same browserPageId
-      // with a new webContentsId. The bridge must destroy the old session's
-      // proxy (its webContents is gone) and let the next command recreate it.
-      const previousWcId = browserManager.getGuestWebContentsId(args.browserPageId)
-      const registered = browserManager.registerGuest({
-        ...args,
-        rendererWebContentsId: event.sender.id
-      })
-      if (!registered) {
-        return false
-      }
-      if (agentBrowserBridgeRef && previousWcId !== null && previousWcId !== args.webContentsId) {
-        agentBrowserBridgeRef.onProcessSwap(args.browserPageId, args.webContentsId, previousWcId)
-      }
-      const pendingResolves = pendingTabRegistrations.get(args.browserPageId)
-      pendingTabRegistrations.delete(args.browserPageId)
-      resolvePendingRegistrations(pendingResolves)
-      const pendingWorktreeResolves = pendingWorktreeTabRegistrations.get(args.worktreeId)
-      pendingWorktreeTabRegistrations.delete(args.worktreeId)
-      resolvePendingRegistrations(pendingWorktreeResolves)
-      const pendingAnyResolves = new Set(pendingAnyTabRegistrations)
-      pendingAnyTabRegistrations.clear()
-      resolvePendingRegistrations(pendingAnyResolves)
-      return true
+      return (
+        browserManager.getGuestWebContentsId(args.browserPageId) === args.webContentsId &&
+        isLiveBrowserWebContentsId(args.webContentsId)
+      )
     }
   )
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -552,6 +552,14 @@ export type BrowserApi = {
     sessionProfileId?: string | null
     webContentsId: number
   }) => Promise<boolean>
+  isGuestRegistered: (args: { browserPageId: string; webContentsId: number }) => Promise<boolean>
+  repairGuestRegistration: (args: {
+    browserPageId: string
+    workspaceId: string
+    worktreeId: string
+    sessionProfileId?: string | null
+    webContentsId: number
+  }) => Promise<boolean>
   unregisterGuest: (args: { browserPageId: string }) => Promise<void>
   openDevTools: (args: { browserPageId: string }) => Promise<boolean>
   setViewportOverride: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2436,6 +2436,17 @@ const api = {
       webContentsId: number
     }): Promise<boolean> => ipcRenderer.invoke('browser:registerGuest', args),
 
+    isGuestRegistered: (args: { browserPageId: string; webContentsId: number }): Promise<boolean> =>
+      ipcRenderer.invoke('browser:isGuestRegistered', args),
+
+    repairGuestRegistration: (args: {
+      browserPageId: string
+      workspaceId: string
+      worktreeId: string
+      sessionProfileId?: string | null
+      webContentsId: number
+    }): Promise<boolean> => ipcRenderer.invoke('browser:repairGuestRegistration', args),
+
     unregisterGuest: (args: { browserPageId: string }): Promise<void> =>
       ipcRenderer.invoke('browser:unregisterGuest', args),
 

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -203,6 +203,12 @@ type BrowserTabPageState = Partial<
   >
 >
 
+type BrowserPageUrlSetter = (
+  tabId: string,
+  url: string,
+  options?: { preserveLoadError?: boolean }
+) => void
+
 type BrowserDownloadState = Omit<BrowserDownloadRequestedEvent, 'status' | 'savePath'> & {
   receivedBytes: number
   status: 'downloading' | 'completed' | 'failed' | 'canceled'
@@ -910,7 +916,7 @@ function RemoteBrowserPagePane({
   worktreeId: string
   isActive: boolean
   onUpdatePageState: (tabId: string, updates: BrowserTabPageState) => void
-  onSetUrl: (tabId: string, url: string) => void
+  onSetUrl: BrowserPageUrlSetter
 }): React.JSX.Element {
   const activeRuntimeEnvironmentId = runtimeEnvironmentId
   const addressBarInputRef = useRef<HTMLInputElement | null>(null)
@@ -2801,7 +2807,7 @@ function BrowserPagePane({
   isMobileDriven: boolean
   inputLocked: boolean
   onUpdatePageState: (tabId: string, updates: BrowserTabPageState) => void
-  onSetUrl: (tabId: string, url: string) => void
+  onSetUrl: BrowserPageUrlSetter
 }): React.JSX.Element {
   const isPaintable = isBrowserPagePanePaintable({
     isActive,
@@ -2877,6 +2883,11 @@ function BrowserPagePane({
   const initialBrowserUrlRef = useRef(browserTab.url)
   const browserTabUrlRef = useRef(browserTab.url)
   const activeLoadFailureRef = useRef<BrowserLoadError | null>(browserTab.loadError)
+  const recoveryNavigationValidationRef = useRef<{
+    committed: boolean
+    started: boolean
+    targetUrl: string
+  } | null>(null)
   // Why: CDP viewport emulation doesn't survive renderer process swaps, so reapply the preset from this ref on every dom-ready.
   const viewportPresetIdRef = useRef(browserTab.viewportPresetId ?? null)
   viewportPresetIdRef.current = browserTab.viewportPresetId ?? null
@@ -3853,24 +3864,33 @@ function BrowserPagePane({
     }
 
     const handleDomReady = (): void => {
+      const validateRecoveryAfterNavigation =
+        recoveryNavigationValidationRef.current?.committed === true
+      if (validateRecoveryAfterNavigation) {
+        recoveryNavigationValidationRef.current = null
+      }
+      let liveWebContentsId: number | null = null
+      try {
+        liveWebContentsId = webview.getWebContentsId()
+      } catch {
+        // Why: the guest can detach between dom-ready and registration.
+      }
       const queuedAnnotationViewportBridgeSync =
-        registeredWebContentsIds.get(browserTab.id) !== webview.getWebContentsId()
+        liveWebContentsId === null ||
+        registeredWebContentsIds.get(browserTab.id) !== liveWebContentsId
       if (queuedAnnotationViewportBridgeSync) {
         void registerGuest().then((registered) => {
           if (registered) {
             clearGuestRecoveryError()
-            if (guestRecoveryPendingRef.current) {
-              guestRecovery.finish()
-            }
+            guestRecovery.finish()
+          } else {
+            guestRecovery.recoverRenderer()
           }
           syncBrowserAnnotationViewportBridge()
         })
       } else {
-        const recoveryWasPending = guestRecoveryPendingRef.current
-        const recoveryErrorVisible =
-          activeLoadFailureRef.current?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
-        guestRecovery.finish()
-        if (recoveryWasPending || recoveryErrorVisible) {
+        const completedRecovery = guestRecovery.finish()
+        if (completedRecovery || validateRecoveryAfterNavigation) {
           guestRecovery.validateAfterResume()
         }
       }
@@ -3992,7 +4012,23 @@ function BrowserPagePane({
       })
     }
 
-    const handleDidNavigate = (event: { url?: string; isMainFrame?: boolean }): void => {
+    const handleDidStartNavigation = (event: Electron.DidStartNavigationEvent): void => {
+      if (!event.isMainFrame || event.isInPlace || !event.url) {
+        return
+      }
+      const pendingRecoveryNavigation = recoveryNavigationValidationRef.current
+      const browserStartedUrl = redactKagiSessionToken(event.url)
+      const startedUrl = normalizeBrowserNavigationUrl(browserStartedUrl) ?? browserStartedUrl
+      if (pendingRecoveryNavigation?.targetUrl === startedUrl) {
+        pendingRecoveryNavigation.started = true
+      }
+    }
+
+    const handleDidNavigate = (
+      event: { url?: string; isMainFrame?: boolean },
+      persistUrl = true,
+      preserveLoadError = false
+    ): void => {
       if (event.isMainFrame === false) {
         return
       }
@@ -4001,19 +4037,38 @@ function BrowserPagePane({
         return
       }
       const browserModelUrl = redactKagiSessionToken(currentUrl)
-      lastKnownWebviewUrlRef.current =
+      const normalizedBrowserModelUrl =
         normalizeBrowserNavigationUrl(browserModelUrl) ?? browserModelUrl
+      lastKnownWebviewUrlRef.current = normalizedBrowserModelUrl
       rememberLiveBrowserUrl(browserTab.id, browserModelUrl)
       // Why: don't overwrite in-progress typing (see above).
       if (document.activeElement !== addressBarInputRef.current) {
         setAddressBarValue(toDisplayUrl(browserModelUrl))
       }
-      onSetUrlRef.current(browserTab.id, browserModelUrl)
+      if (persistUrl) {
+        onSetUrlRef.current(browserTab.id, browserModelUrl, { preserveLoadError })
+      }
       onUpdatePageStateRef.current(browserTab.id, {
         title: webview.getTitle() || browserModelUrl,
         canGoBack: webview.canGoBack(),
         canGoForward: webview.canGoForward()
       })
+    }
+
+    const handleFullDidNavigate = (event: { url?: string; isMainFrame?: boolean }): void => {
+      const pendingRecoveryNavigation = recoveryNavigationValidationRef.current
+      if (event.isMainFrame !== false && pendingRecoveryNavigation?.started) {
+        pendingRecoveryNavigation.committed = true
+      }
+      const preserveRecoveryError =
+        activeLoadFailureRef.current?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
+      handleDidNavigate(event, true, preserveRecoveryError)
+    }
+
+    const handleDidNavigateInPage = (event: { url?: string; isMainFrame?: boolean }): void => {
+      const preserveRecoveryError =
+        activeLoadFailureRef.current?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
+      handleDidNavigate(event, !preserveRecoveryError)
     }
 
     const handleTitleUpdate = (event: { title?: string }): void => {
@@ -4054,6 +4109,10 @@ function BrowserPagePane({
         return
       }
       trackNextLoadingEventRef.current = false
+      const pendingRecoveryNavigation = recoveryNavigationValidationRef.current
+      if (pendingRecoveryNavigation?.started) {
+        recoveryNavigationValidationRef.current = null
+      }
       const loadError = buildLoadError(event)
       activeLoadFailureRef.current = loadError
       onUpdatePageStateRef.current(browserTab.id, {
@@ -4097,15 +4156,16 @@ function BrowserPagePane({
     webview.addEventListener('render-process-gone', guestRecovery.recoverRenderer)
     webview.addEventListener('focus', dismissAddressBarSuggestions)
     webview.addEventListener('did-start-loading', handleDidStartLoading)
+    webview.addEventListener('did-start-navigation', handleDidStartNavigation)
     webview.addEventListener('did-stop-loading', handleDidStopLoading)
     // Why: close find only on full 'did-navigate', not the shared handler, which also fires on SPA in-page hash/pushState changes.
     const handleFindCloseOnNavigate = (): void => {
       setFindOpen(false)
     }
 
-    webview.addEventListener('did-navigate', handleDidNavigate)
+    webview.addEventListener('did-navigate', handleFullDidNavigate)
     webview.addEventListener('did-navigate', handleFindCloseOnNavigate)
-    webview.addEventListener('did-navigate-in-page', handleDidNavigate)
+    webview.addEventListener('did-navigate-in-page', handleDidNavigateInPage)
     webview.addEventListener('page-title-updated', handleTitleUpdate)
     webview.addEventListener('page-favicon-updated', handleFaviconUpdate)
     webview.addEventListener('did-fail-load', handleFailLoad)
@@ -4132,10 +4192,11 @@ function BrowserPagePane({
       webview.removeEventListener('render-process-gone', guestRecovery.recoverRenderer)
       webview.removeEventListener('focus', dismissAddressBarSuggestions)
       webview.removeEventListener('did-start-loading', handleDidStartLoading)
+      webview.removeEventListener('did-start-navigation', handleDidStartNavigation)
       webview.removeEventListener('did-stop-loading', handleDidStopLoading)
-      webview.removeEventListener('did-navigate', handleDidNavigate)
+      webview.removeEventListener('did-navigate', handleFullDidNavigate)
       webview.removeEventListener('did-navigate', handleFindCloseOnNavigate)
-      webview.removeEventListener('did-navigate-in-page', handleDidNavigate)
+      webview.removeEventListener('did-navigate-in-page', handleDidNavigateInPage)
       webview.removeEventListener('page-title-updated', handleTitleUpdate)
       webview.removeEventListener('page-favicon-updated', handleFaviconUpdate)
       webview.removeEventListener('did-fail-load', handleFailLoad)
@@ -4665,6 +4726,8 @@ function BrowserPagePane({
     (url: string): void => {
       const navigateBrowserUrl = (targetUrl: string): void => {
         const browserModelUrl = redactKagiSessionToken(targetUrl)
+        const normalizedBrowserModelUrl =
+          normalizeBrowserNavigationUrl(browserModelUrl) ?? browserModelUrl
         const recoveryLoadError =
           activeLoadFailureRef.current?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
             ? activeLoadFailureRef.current
@@ -4683,8 +4746,10 @@ function BrowserPagePane({
           return
         }
         trackNextLoadingEventRef.current = targetUrl !== ORCA_BROWSER_BLANK_URL
-        lastKnownWebviewUrlRef.current =
-          normalizeBrowserNavigationUrl(browserModelUrl) ?? browserModelUrl
+        lastKnownWebviewUrlRef.current = normalizedBrowserModelUrl
+        recoveryNavigationValidationRef.current = recoveryLoadError
+          ? { committed: false, started: false, targetUrl: normalizedBrowserModelUrl }
+          : null
         webview.src = targetUrl
         if (targetUrl !== ORCA_BROWSER_BLANK_URL) {
           focusWebviewNow()

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -86,7 +86,9 @@ import { rememberLiveBrowserUrl } from './browser-runtime'
 import { ensureBrowserPageWebview } from './browser-page-webview'
 import {
   destroyPersistentWebview,
+  isBrowserPageRendererRecoveryPending,
   moveFocusToRendererBeforeWebviewDetach,
+  replacePersistentWebview,
   registeredWebContentsIds
 } from './webview-registry'
 import {
@@ -188,6 +190,11 @@ import { MarkupOverlay } from './markup/MarkupOverlay'
 import { MarkupDrawButton } from './markup/MarkupDrawButton'
 import { deliverMarkupToClipboard } from './markup/markup-clipboard-delivery'
 import { BrowserLoadFailureOverlay } from './browser-load-failure-overlay'
+import {
+  BROWSER_GUEST_RECOVERY_ERROR_CODE,
+  createBrowserPageGuestRecovery
+} from './browser-page-guest-recovery'
+import { subscribeBrowserSystemResume } from './browser-system-resume'
 
 type BrowserTabPageState = Partial<
   Pick<
@@ -2818,6 +2825,10 @@ function BrowserPagePane({
   const [slotViewportReady, setSlotViewportReady] = useState(
     () => getBrowserOverlaySlotViewport(workspaceId) !== null
   )
+  const [guestRecoveryGeneration, setGuestRecoveryGeneration] = useState(0)
+  const guestRecoveryPendingRef = useRef(false)
+  const validateVisibleGuestRegistrationRef = useRef<() => void>(() => {})
+  const wasPaintableForGuestValidationRef = useRef(isPaintable)
   useLayoutEffect(() => {
     if (getBrowserOverlaySlotViewport(workspaceId)) {
       setSlotViewportReady(true)
@@ -2927,6 +2938,8 @@ function BrowserPagePane({
   })
   const isActiveRef = useRef(isActive)
   isActiveRef.current = isActive
+  const isPaintableRef = useRef(isPaintable)
+  isPaintableRef.current = isPaintable
   const annotationViewportBridgeTokenRef = useRef(createBrowserUuid().replaceAll('-', ''))
   const browserAnnotations = useAppStore(
     (s) => s.browserAnnotationsByPageId[browserTab.id] ?? EMPTY_BROWSER_ANNOTATIONS
@@ -3731,7 +3744,12 @@ function BrowserPagePane({
 
     let registrationInFlight: { webContentsId: number; promise: Promise<boolean> } | null = null
     const registerGuest = (): Promise<boolean> => {
-      const webContentsId = webview.getWebContentsId()
+      let webContentsId: number
+      try {
+        webContentsId = webview.getWebContentsId()
+      } catch {
+        return Promise.resolve(false)
+      }
       if (registeredWebContentsIds.get(browserTab.id) === webContentsId) {
         return Promise.resolve(true)
       }
@@ -3763,16 +3781,84 @@ function BrowserPagePane({
       return promise
     }
 
+    const guestRecovery = createBrowserPageGuestRecovery({
+      webview,
+      browserPageExists: () => browserPageExists(browserTab.id),
+      shouldValidate: () => isPaintableRef.current,
+      isCurrentWebview: () => webviewRef.current === webview,
+      isPending: () => guestRecoveryPendingRef.current,
+      setPending: (pending) => {
+        guestRecoveryPendingRef.current = pending
+      },
+      validateRegistration: async () => {
+        let webContentsId: number
+        try {
+          webContentsId = webview.getWebContentsId()
+        } catch {
+          return false
+        }
+        if (registeredWebContentsIds.get(browserTab.id) !== webContentsId) {
+          return registerGuest()
+        }
+        const registered = await window.api.browser.isGuestRegistered({
+          browserPageId: browserTab.id,
+          webContentsId
+        })
+        if (registered) {
+          return true
+        }
+        return window.api.browser.repairGuestRegistration({
+          browserPageId: browserTab.id,
+          workspaceId,
+          worktreeId,
+          sessionProfileId,
+          webContentsId
+        })
+      },
+      replaceGuest: () => replacePersistentWebview(browserTab.id),
+      onReplacementReady: () => setGuestRecoveryGeneration((generation) => generation + 1),
+      onRecoveryFailed: () => {
+        const loadError = {
+          code: BROWSER_GUEST_RECOVERY_ERROR_CODE,
+          description: translate(
+            'browser.guestRecovery.failed',
+            'The browser page stopped unexpectedly. Retry to restore it.'
+          ),
+          validatedUrl: redactKagiSessionToken(
+            browserTabUrlRef.current || addressBarValueRef.current || 'about:blank'
+          )
+        }
+        activeLoadFailureRef.current = loadError
+        onUpdatePageStateRef.current(browserTab.id, { loading: false, loadError })
+      }
+    })
+
     const handleDidAttach = (): void => {
       // Why: register at attach since cert failures can precede dom-ready; the dom-ready path stays an idempotent fallback.
-      void registerGuest().finally(() => syncBrowserAnnotationViewportBridge())
+      void registerGuest().then((registered) => {
+        if (registered && guestRecoveryPendingRef.current) {
+          guestRecovery.finish()
+        }
+        syncBrowserAnnotationViewportBridge()
+      })
     }
 
     const handleDomReady = (): void => {
       const queuedAnnotationViewportBridgeSync =
         registeredWebContentsIds.get(browserTab.id) !== webview.getWebContentsId()
       if (queuedAnnotationViewportBridgeSync) {
-        void registerGuest().finally(() => syncBrowserAnnotationViewportBridge())
+        void registerGuest().then((registered) => {
+          if (registered && guestRecoveryPendingRef.current) {
+            guestRecovery.finish()
+          }
+          syncBrowserAnnotationViewportBridge()
+        })
+      } else {
+        const recoveryWasPending = guestRecoveryPendingRef.current
+        guestRecovery.finish()
+        if (recoveryWasPending) {
+          guestRecovery.validateAfterResume()
+        }
       }
       syncNavigationState(webview)
       if (keepAddressBarFocusRef.current) {
@@ -3836,7 +3922,9 @@ function BrowserPagePane({
         })
         return
       }
-      if (activeLoadFailure) {
+      if (activeLoadFailure?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE) {
+        activeLoadFailureRef.current = null
+      } else if (activeLoadFailure) {
         const normalizedAttemptedUrl =
           normalizeBrowserNavigationUrl(activeLoadFailure.validatedUrl) ??
           activeLoadFailure.validatedUrl
@@ -3977,8 +4065,12 @@ function BrowserPagePane({
       }
     }
 
+    const unsubscribeSystemResumed = subscribeBrowserSystemResume(guestRecovery.validateAfterResume)
+    validateVisibleGuestRegistrationRef.current = guestRecovery.validateAfterResume
+
     webview.addEventListener('did-attach', handleDidAttach)
     webview.addEventListener('dom-ready', handleDomReady)
+    webview.addEventListener('render-process-gone', guestRecovery.recoverRenderer)
     webview.addEventListener('focus', dismissAddressBarSuggestions)
     webview.addEventListener('did-start-loading', handleDidStartLoading)
     webview.addEventListener('did-stop-loading', handleDidStopLoading)
@@ -4002,11 +4094,18 @@ function BrowserPagePane({
       trackNextLoadingEventRef.current = initialUrl !== ORCA_BROWSER_BLANK_URL
       lastKnownWebviewUrlRef.current = initialUrl
       webview.src = initialUrl
+    } else if (isPaintableRef.current) {
+      if (isBrowserPageRendererRecoveryPending(browserTab.id)) {
+        guestRecovery.recoverRenderer()
+      } else {
+        guestRecovery.validateAfterResume()
+      }
     }
 
     return () => {
       webview.removeEventListener('did-attach', handleDidAttach)
       webview.removeEventListener('dom-ready', handleDomReady)
+      webview.removeEventListener('render-process-gone', guestRecovery.recoverRenderer)
       webview.removeEventListener('focus', dismissAddressBarSuggestions)
       webview.removeEventListener('did-start-loading', handleDidStartLoading)
       webview.removeEventListener('did-stop-loading', handleDidStopLoading)
@@ -4019,6 +4118,11 @@ function BrowserPagePane({
       webview.removeEventListener('console-message', handleAnnotationViewportMessage)
       container.removeEventListener('dragover', onContainerDragOver)
       container.removeEventListener('drop', onContainerDrop)
+      unsubscribeSystemResumed()
+      guestRecovery.dispose()
+      if (validateVisibleGuestRegistrationRef.current === guestRecovery.validateAfterResume) {
+        validateVisibleGuestRegistrationRef.current = () => {}
+      }
 
       if (webviewRef.current === webview) {
         webviewRef.current = null
@@ -4033,6 +4137,7 @@ function BrowserPagePane({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     browserTab.id,
+    guestRecoveryGeneration,
     workspaceId,
     slotViewportReady,
     webviewPartition,
@@ -4043,6 +4148,14 @@ function BrowserPagePane({
     syncNavigationState,
     syncBrowserAnnotationViewportBridge
   ])
+
+  useEffect(() => {
+    const becamePaintable = isPaintable && !wasPaintableForGuestValidationRef.current
+    wasPaintableForGuestValidationRef.current = isPaintable
+    if (becamePaintable) {
+      validateVisibleGuestRegistrationRef.current()
+    }
+  }, [isPaintable])
 
   useLayoutEffect(() => {
     applyBrowserPageViewportLayout(browserTab.id, { paintable: isPaintable, active: isActive })
@@ -4768,6 +4881,7 @@ function BrowserPagePane({
 
   return (
     <div
+      data-browser-page-pane-id={browserTab.id}
       className={cn(
         'absolute inset-0 flex min-h-0 flex-1 flex-col',
         isActive

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -3756,16 +3756,16 @@ function BrowserPagePane({
       dismissAddressBarSuggestionsRef.current?.()
     }
 
-    let registrationInFlight: { webContentsId: number; promise: Promise<boolean> } | null = null
-    const registerGuest = (): Promise<boolean> => {
+    let registrationInFlight: {
+      webContentsId: number
+      promise: Promise<boolean | null>
+    } | null = null
+    const registerGuest = (): Promise<boolean | null> => {
       let webContentsId: number
       try {
         webContentsId = webview.getWebContentsId()
       } catch {
-        return Promise.resolve(false)
-      }
-      if (registeredWebContentsIds.get(browserTab.id) === webContentsId) {
-        return Promise.resolve(true)
+        return Promise.resolve(null)
       }
       if (registrationInFlight?.webContentsId === webContentsId) {
         return registrationInFlight.promise
@@ -3781,11 +3781,12 @@ function BrowserPagePane({
         .then((registered) => {
           if (registered) {
             registeredWebContentsIds.set(browserTab.id, webContentsId)
+            return true
           }
-          return registered
+          return null
         })
-        // Why: normalize IPC rejection to false so the dom-ready fallback can retry attach-policy races.
-        .catch(() => false)
+        // Why: registration rejection can be an attach-policy race; only validation of an identified guest proves loss.
+        .catch(() => null)
         .finally(() => {
           if (registrationInFlight?.promise === promise) {
             registrationInFlight = null
@@ -3817,7 +3818,8 @@ function BrowserPagePane({
         try {
           webContentsId = webview.getWebContentsId()
         } catch {
-          return false
+          // Why: a reused webview can remount before dom-ready; only an identified guest can be declared missing.
+          return null
         }
         if (registeredWebContentsIds.get(browserTab.id) !== webContentsId) {
           return registerGuest()
@@ -3858,7 +3860,10 @@ function BrowserPagePane({
 
     const handleDidAttach = (): void => {
       // Why: register at attach since cert failures can precede dom-ready; the dom-ready path stays an idempotent fallback.
-      void registerGuest().then(() => {
+      void registerGuest().then((registered) => {
+        if (registered === true) {
+          guestRecovery.confirmRegistration()
+        }
         syncBrowserAnnotationViewportBridge()
       })
     }
@@ -3880,11 +3885,13 @@ function BrowserPagePane({
         registeredWebContentsIds.get(browserTab.id) !== liveWebContentsId
       if (queuedAnnotationViewportBridgeSync) {
         void registerGuest().then((registered) => {
-          if (registered) {
+          const completedRecovery = guestRecovery.finish()
+          if (registered === true) {
+            guestRecovery.confirmRegistration()
             clearGuestRecoveryError()
-            guestRecovery.finish()
-          } else {
-            guestRecovery.recoverRenderer()
+          }
+          if (registered === null || completedRecovery || validateRecoveryAfterNavigation) {
+            guestRecovery.validateAfterResume()
           }
           syncBrowserAnnotationViewportBridge()
         })

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2828,6 +2828,7 @@ function BrowserPagePane({
   const [guestRecoveryGeneration, setGuestRecoveryGeneration] = useState(0)
   const guestRecoveryPendingRef = useRef(false)
   const validateVisibleGuestRegistrationRef = useRef<() => void>(() => {})
+  const retryGuestRecoveryRef = useRef<() => void>(() => {})
   const wasPaintableForGuestValidationRef = useRef(isPaintable)
   useLayoutEffect(() => {
     if (getBrowserOverlaySlotViewport(workspaceId)) {
@@ -2939,7 +2940,9 @@ function BrowserPagePane({
   const isActiveRef = useRef(isActive)
   isActiveRef.current = isActive
   const isPaintableRef = useRef(isPaintable)
-  isPaintableRef.current = isPaintable
+  useLayoutEffect(() => {
+    isPaintableRef.current = isPaintable
+  }, [isPaintable])
   const annotationViewportBridgeTokenRef = useRef(createBrowserUuid().replaceAll('-', ''))
   const browserAnnotations = useAppStore(
     (s) => s.browserAnnotationsByPageId[browserTab.id] ?? EMPTY_BROWSER_ANNOTATIONS
@@ -3781,6 +3784,14 @@ function BrowserPagePane({
       return promise
     }
 
+    const clearGuestRecoveryError = (): void => {
+      if (activeLoadFailureRef.current?.code !== BROWSER_GUEST_RECOVERY_ERROR_CODE) {
+        return
+      }
+      activeLoadFailureRef.current = null
+      onUpdatePageStateRef.current(browserTab.id, { loading: false, loadError: null })
+    }
+
     const guestRecovery = createBrowserPageGuestRecovery({
       webview,
       browserPageExists: () => browserPageExists(browserTab.id),
@@ -3830,15 +3841,13 @@ function BrowserPagePane({
         }
         activeLoadFailureRef.current = loadError
         onUpdatePageStateRef.current(browserTab.id, { loading: false, loadError })
-      }
+      },
+      onRecoverySucceeded: clearGuestRecoveryError
     })
 
     const handleDidAttach = (): void => {
       // Why: register at attach since cert failures can precede dom-ready; the dom-ready path stays an idempotent fallback.
-      void registerGuest().then((registered) => {
-        if (registered && guestRecoveryPendingRef.current) {
-          guestRecovery.finish()
-        }
+      void registerGuest().then(() => {
         syncBrowserAnnotationViewportBridge()
       })
     }
@@ -3848,15 +3857,20 @@ function BrowserPagePane({
         registeredWebContentsIds.get(browserTab.id) !== webview.getWebContentsId()
       if (queuedAnnotationViewportBridgeSync) {
         void registerGuest().then((registered) => {
-          if (registered && guestRecoveryPendingRef.current) {
-            guestRecovery.finish()
+          if (registered) {
+            clearGuestRecoveryError()
+            if (guestRecoveryPendingRef.current) {
+              guestRecovery.finish()
+            }
           }
           syncBrowserAnnotationViewportBridge()
         })
       } else {
         const recoveryWasPending = guestRecoveryPendingRef.current
+        const recoveryErrorVisible =
+          activeLoadFailureRef.current?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
         guestRecovery.finish()
-        if (recoveryWasPending) {
+        if (recoveryWasPending || recoveryErrorVisible) {
           guestRecovery.validateAfterResume()
         }
       }
@@ -3923,7 +3937,16 @@ function BrowserPagePane({
         return
       }
       if (activeLoadFailure?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE) {
-        activeLoadFailureRef.current = null
+        trackNextLoadingEventRef.current = false
+        onUpdatePageStateRef.current(browserTab.id, {
+          loading: false,
+          title: getBrowserDisplayTitle(webview.getTitle(), browserModelUrl),
+          faviconUrl: faviconUrlRef.current,
+          canGoBack: webview.canGoBack(),
+          canGoForward: webview.canGoForward(),
+          loadError: activeLoadFailure
+        })
+        return
       } else if (activeLoadFailure) {
         const normalizedAttemptedUrl =
           normalizeBrowserNavigationUrl(activeLoadFailure.validatedUrl) ??
@@ -4067,6 +4090,7 @@ function BrowserPagePane({
 
     const unsubscribeSystemResumed = subscribeBrowserSystemResume(guestRecovery.validateAfterResume)
     validateVisibleGuestRegistrationRef.current = guestRecovery.validateAfterResume
+    retryGuestRecoveryRef.current = guestRecovery.retryRecovery
 
     webview.addEventListener('did-attach', handleDidAttach)
     webview.addEventListener('dom-ready', handleDomReady)
@@ -4122,6 +4146,9 @@ function BrowserPagePane({
       guestRecovery.dispose()
       if (validateVisibleGuestRegistrationRef.current === guestRecovery.validateAfterResume) {
         validateVisibleGuestRegistrationRef.current = () => {}
+      }
+      if (retryGuestRecoveryRef.current === guestRecovery.retryRecovery) {
+        retryGuestRecoveryRef.current = () => {}
       }
 
       if (webviewRef.current === webview) {
@@ -4638,11 +4665,15 @@ function BrowserPagePane({
     (url: string): void => {
       const navigateBrowserUrl = (targetUrl: string): void => {
         const browserModelUrl = redactKagiSessionToken(targetUrl)
+        const recoveryLoadError =
+          activeLoadFailureRef.current?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
+            ? activeLoadFailureRef.current
+            : null
         setAddressBarValue(toDisplayUrl(browserModelUrl))
         onSetUrlRef.current(browserTab.id, browserModelUrl)
         onUpdatePageStateRef.current(browserTab.id, {
           loading: true,
-          loadError: null,
+          loadError: recoveryLoadError,
           title: getBrowserDisplayTitle(browserModelUrl, browserModelUrl)
         })
         setResourceNotice(null)
@@ -5084,7 +5115,12 @@ function BrowserPagePane({
               if (browserTab.loading) {
                 webview.stop()
               } else if (browserTab.loadError) {
-                retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
+                if (browserTab.loadError.code === BROWSER_GUEST_RECOVERY_ERROR_CODE) {
+                  onUpdatePageStateRef.current(browserTab.id, { loading: true })
+                  retryGuestRecoveryRef.current()
+                } else {
+                  retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
+                }
               } else {
                 webview.reload()
               }
@@ -5551,6 +5587,10 @@ function BrowserPagePane({
                       return
                     }
                     onUpdatePageStateRef.current(browserTab.id, { loading: true })
+                    if (browserTab.loadError?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE) {
+                      retryGuestRecoveryRef.current()
+                      return
+                    }
                     retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
                   }}
                   onTryHttps={navigateToUrl}

--- a/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
+++ b/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
@@ -5,12 +5,14 @@ import { ORCA_BROWSER_GUEST_WEB_PREFERENCES_ATTRIBUTE } from '../../../../shared
 const registryMocks = vi.hoisted(() => ({
   destroyPersistentWebview: vi.fn(),
   registerPersistentWebview: vi.fn(),
+  replacePersistentWebview: vi.fn(),
   webviewRegistry: new Map<string, Electron.WebviewTag>()
 }))
 
 vi.mock('./webview-registry', () => ({
   destroyPersistentWebview: registryMocks.destroyPersistentWebview,
   registerPersistentWebview: registryMocks.registerPersistentWebview,
+  replacePersistentWebview: registryMocks.replacePersistentWebview,
   webviewRegistry: registryMocks.webviewRegistry
 }))
 
@@ -27,6 +29,7 @@ describe('BrowserPane webview preferences', () => {
   beforeEach(() => {
     registryMocks.destroyPersistentWebview.mockReset()
     registryMocks.registerPersistentWebview.mockReset()
+    registryMocks.replacePersistentWebview.mockReset()
     registryMocks.webviewRegistry.clear()
     document.body.innerHTML = ''
   })
@@ -113,7 +116,7 @@ describe('BrowserPane webview preferences', () => {
     const requestedContainer = createContainer('requested')
     const replacementContainer = createContainer('replacement')
     const resolveContainer = vi.fn(() => replacementContainer)
-    registryMocks.destroyPersistentWebview.mockImplementation(() => {
+    registryMocks.replacePersistentWebview.mockImplementation(() => {
       staleWebview.remove()
       staleContainer.remove()
       registryMocks.webviewRegistry.delete('browser-page-1')
@@ -127,7 +130,7 @@ describe('BrowserPane webview preferences', () => {
       resolveContainer
     })
 
-    expect(registryMocks.destroyPersistentWebview).toHaveBeenCalledWith('browser-page-1', {
+    expect(registryMocks.replacePersistentWebview).toHaveBeenCalledWith('browser-page-1', {
       preserveViewport: true
     })
     expect(resolveContainer).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
+++ b/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
@@ -110,6 +110,7 @@ describe('BrowserPane webview preferences', () => {
     staleWebview.setAttribute('partition', 'persist:orca-browser')
     staleContainer.appendChild(staleWebview)
     registryMocks.webviewRegistry.set('browser-page-1', staleWebview)
+    const requestedContainer = createContainer('requested')
     const replacementContainer = createContainer('replacement')
     const resolveContainer = vi.fn(() => replacementContainer)
     registryMocks.destroyPersistentWebview.mockImplementation(() => {
@@ -120,7 +121,7 @@ describe('BrowserPane webview preferences', () => {
 
     const ensuredWebview = ensureBrowserPageWebview({
       browserTabId: 'browser-page-1',
-      container: replacementContainer,
+      container: requestedContainer,
       inputLocked: false,
       webviewPartition: 'persist:orca-browser',
       resolveContainer
@@ -129,6 +130,7 @@ describe('BrowserPane webview preferences', () => {
     expect(registryMocks.destroyPersistentWebview).toHaveBeenCalledWith('browser-page-1', {
       preserveViewport: true
     })
+    expect(resolveContainer).toHaveBeenCalledTimes(1)
     expect(ensuredWebview?.container).toBe(replacementContainer)
     expect(replacementContainer.isConnected).toBe(true)
     expect(replacementContainer.lastElementChild).toBe(

--- a/src/renderer/src/components/browser-pane/browser-load-failure-overlay.test.tsx
+++ b/src/renderer/src/components/browser-pane/browser-load-failure-overlay.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { BrowserLoadFailureOverlay } from './browser-load-failure-overlay'
+import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from './browser-page-guest-recovery'
 
 const callbacks = {
   onRetry: vi.fn(),
@@ -109,6 +110,30 @@ describe('BrowserLoadFailureOverlay', () => {
       />
     )
     expect(screen.queryByRole('button', { name: 'Try HTTPS' })).toBeNull()
+  })
+
+  it('presents guest recovery failures without network troubleshooting', () => {
+    render(
+      <BrowserLoadFailureOverlay
+        loadError={{
+          code: BROWSER_GUEST_RECOVERY_ERROR_CODE,
+          description: 'The browser page stopped unexpectedly. Retry to restore it.',
+          validatedUrl: 'http://localhost:3000/app'
+        }}
+        externalUrl="http://localhost:3000/app"
+        currentUrl="http://localhost:3000/app"
+        httpsRecoveryUrl="https://localhost:3000/app"
+        {...callbacks}
+      />
+    )
+
+    expect(screen.getByText('Browser page stopped')).toBeInTheDocument()
+    expect(
+      screen.getByText('The browser page stopped unexpectedly. Retry to restore it.')
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/make sure the server is running/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Try HTTPS' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled()
   })
 
   it('hides Open Externally and works without an external handler', () => {

--- a/src/renderer/src/components/browser-pane/browser-load-failure-overlay.tsx
+++ b/src/renderer/src/components/browser-pane/browser-load-failure-overlay.tsx
@@ -17,6 +17,7 @@ import {
   isCertificateLoadError,
   type LoadFailureMeta
 } from './browser-notices'
+import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from './browser-page-guest-recovery'
 
 type BrowserLoadFailureOverlayProps = {
   loadError: BrowserLoadError
@@ -148,6 +149,7 @@ export function BrowserLoadFailureOverlay({
       : loadError
   const meta = getLoadErrorMetadata(presentationLoadError)
   const certificateError = isCertificateLoadError(presentationLoadError)
+  const guestRecoveryError = presentationLoadError.code === BROWSER_GUEST_RECOVERY_ERROR_CODE
   const recoveryHint = formatLoadFailureRecoveryHint(meta, presentationLoadError)
   const activeProceedAttempt =
     proceedAttempt?.challengeId === matchingCertificateFailure?.challengeId ? proceedAttempt : null
@@ -261,11 +263,13 @@ export function BrowserLoadFailureOverlay({
         <h2 className="text-base font-semibold text-foreground">
           {certificateError
             ? translate('browser.loadFailure.connectionNotSecure', "Connection isn't secure")
-            : meta.host
-              ? translate('browser.loadFailure.cantReachHost', "Can't reach {{value0}}", {
-                  value0: meta.host
-                })
-              : translate('browser.loadFailure.cantLoadPage', "Can't load this page")}
+            : guestRecoveryError
+              ? translate('browser.guestRecovery.title', 'Browser page stopped')
+              : meta.host
+                ? translate('browser.loadFailure.cantReachHost', "Can't reach {{value0}}", {
+                    value0: meta.host
+                  })
+                : translate('browser.loadFailure.cantLoadPage', "Can't load this page")}
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
           {formatLoadFailureDescription(presentationLoadError, meta)}
@@ -312,7 +316,7 @@ export function BrowserLoadFailureOverlay({
             </>
           ) : (
             <>
-              {httpsRecoveryUrl ? (
+              {httpsRecoveryUrl && !guestRecoveryError ? (
                 <Button
                   size="sm"
                   className="h-9 gap-2 px-3"

--- a/src/renderer/src/components/browser-pane/browser-notices.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-notices.test.ts
@@ -118,16 +118,17 @@ describe('browser notice formatting', () => {
   })
 
   it('preserves the explicit guest recovery failure copy', () => {
+    const loadError = {
+      code: BROWSER_GUEST_RECOVERY_ERROR_CODE,
+      description: 'The browser page stopped unexpectedly. Retry to restore it.',
+      validatedUrl: 'http://localhost:3000'
+    }
     expect(
-      formatLoadFailureDescription(
-        {
-          code: BROWSER_GUEST_RECOVERY_ERROR_CODE,
-          description: 'The browser page stopped unexpectedly. Retry to restore it.',
-          validatedUrl: 'https://example.com'
-        },
-        { host: 'example.com', isLocalhostLike: false }
-      )
+      formatLoadFailureDescription(loadError, { host: 'localhost:3000', isLocalhostLike: true })
     ).toBe('The browser page stopped unexpectedly. Retry to restore it.')
+    expect(
+      formatLoadFailureRecoveryHint({ host: 'localhost:3000', isLocalhostLike: true }, loadError)
+    ).toBeNull()
   })
 
   it('formats certificate failures without local-server recovery advice', () => {

--- a/src/renderer/src/components/browser-pane/browser-notices.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-notices.test.ts
@@ -8,6 +8,7 @@ import {
   formatPopupNotice,
   isCertificateLoadError
 } from './browser-notices'
+import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from './browser-page-guest-recovery'
 
 describe('browser notice formatting', () => {
   it('formats denied permissions with safe copy', () => {
@@ -114,6 +115,19 @@ describe('browser notice formatting', () => {
         isLocalhostLike: false
       })
     ).toBeNull()
+  })
+
+  it('preserves the explicit guest recovery failure copy', () => {
+    expect(
+      formatLoadFailureDescription(
+        {
+          code: BROWSER_GUEST_RECOVERY_ERROR_CODE,
+          description: 'The browser page stopped unexpectedly. Retry to restore it.',
+          validatedUrl: 'https://example.com'
+        },
+        { host: 'example.com', isLocalhostLike: false }
+      )
+    ).toBe('The browser page stopped unexpectedly. Retry to restore it.')
   })
 
   it('formats certificate failures without local-server recovery advice', () => {

--- a/src/renderer/src/components/browser-pane/browser-notices.ts
+++ b/src/renderer/src/components/browser-pane/browser-notices.ts
@@ -6,6 +6,7 @@ import type {
 import type { BrowserLoadError } from '../../../../shared/types'
 import { isChromiumCertificateErrorCode } from '../../../../shared/browser-certificate-errors'
 import { translate } from '@/i18n/i18n'
+import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from './browser-page-guest-recovery'
 
 export type LoadFailureMeta = {
   host: string | null
@@ -74,6 +75,9 @@ export function formatLoadFailureDescription(
 ): string {
   if (!loadError) {
     return 'The page did not respond.'
+  }
+  if (loadError.code === BROWSER_GUEST_RECOVERY_ERROR_CODE) {
+    return loadError.description
   }
   if (isChromiumCertificateErrorCode(loadError.code)) {
     const host = meta.host ?? 'this address'

--- a/src/renderer/src/components/browser-pane/browser-notices.ts
+++ b/src/renderer/src/components/browser-pane/browser-notices.ts
@@ -121,7 +121,11 @@ export function formatLoadFailureRecoveryHint(
   meta: LoadFailureMeta,
   loadError?: BrowserLoadErrorLike
 ): string | null {
-  if (!meta.isLocalhostLike || (loadError && isChromiumCertificateErrorCode(loadError.code))) {
+  if (
+    !meta.isLocalhostLike ||
+    loadError?.code === BROWSER_GUEST_RECOVERY_ERROR_CODE ||
+    (loadError && isChromiumCertificateErrorCode(loadError.code))
+  ) {
     return null
   }
   return 'If this should be a local app, make sure the server is running and listening on the expected port.'

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
@@ -74,6 +74,17 @@ describe('browser page guest recovery', () => {
     expect(state.onRecoveryFailed).not.toHaveBeenCalled()
   })
 
+  it('reports whether document readiness completed a recovery cycle', () => {
+    const normal = createRecovery()
+    const resumed = createRecovery({ pending: true })
+
+    expect(normal.recovery.finish()).toBe(false)
+    expect(resumed.recovery.finish()).toBe(true)
+
+    normal.recovery.recoverRenderer()
+    expect(normal.recovery.finish()).toBe(true)
+  })
+
   it('recreates a guest when in-place reload is unavailable', async () => {
     const state = createRecovery({
       reload: () => {
@@ -147,7 +158,10 @@ describe('browser page guest recovery', () => {
     expect(state.validateRegistration).toHaveBeenCalledOnce()
 
     resolveValidation?.(true)
-    await vi.waitFor(() => expect(state.pending()).toBe(false))
+    await vi.waitFor(() => {
+      state.recovery.validateAfterResume()
+      expect(state.validateRegistration).toHaveBeenCalledTimes(2)
+    })
   })
 
   it('does not validate while renderer recovery is pending', async () => {

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  BROWSER_GUEST_RECOVERY_TIMEOUT_MS,
+  createBrowserPageGuestRecovery
+} from './browser-page-guest-recovery'
+
+function createRecovery(
+  overrides: {
+    active?: boolean
+    current?: boolean
+    exists?: boolean
+    pending?: boolean
+    registered?: boolean
+    reload?: () => void
+  } = {}
+) {
+  let pending = overrides.pending ?? false
+  const reload = vi.fn(overrides.reload ?? (() => {}))
+  const replaceGuest = vi.fn(() => Promise.resolve())
+  const onReplacementReady = vi.fn()
+  const onRecoveryFailed = vi.fn()
+  const validateRegistration = vi.fn(() => Promise.resolve(overrides.registered ?? true))
+  const recovery = createBrowserPageGuestRecovery({
+    webview: { reload } as unknown as Electron.WebviewTag,
+    browserPageExists: () => overrides.exists ?? true,
+    shouldValidate: () => overrides.active ?? true,
+    isCurrentWebview: () => overrides.current ?? true,
+    isPending: () => pending,
+    setPending: (next) => {
+      pending = next
+    },
+    validateRegistration,
+    replaceGuest,
+    onReplacementReady,
+    onRecoveryFailed
+  })
+  return {
+    recovery,
+    reload,
+    replaceGuest,
+    onReplacementReady,
+    onRecoveryFailed,
+    validateRegistration,
+    pending: () => pending
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('browser page guest recovery', () => {
+  it('reloads a lost renderer in place and cancels the failure surface after recovery', () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+
+    state.recovery.recoverRenderer()
+
+    expect(state.reload).toHaveBeenCalledOnce()
+    expect(state.pending()).toBe(true)
+
+    state.recovery.finish()
+    vi.advanceTimersByTime(BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+
+    expect(state.pending()).toBe(false)
+    expect(state.onRecoveryFailed).not.toHaveBeenCalled()
+  })
+
+  it('recreates a guest when in-place reload is unavailable', async () => {
+    const state = createRecovery({
+      reload: () => {
+        throw new Error('guest destroyed')
+      }
+    })
+
+    state.recovery.recoverRenderer()
+    await vi.waitFor(() => expect(state.onReplacementReady).toHaveBeenCalledOnce())
+
+    expect(state.replaceGuest).toHaveBeenCalledOnce()
+    expect(state.pending()).toBe(true)
+  })
+
+  it('recreates an active guest missing from the authoritative registry after resume', async () => {
+    const state = createRecovery({ registered: false })
+
+    state.recovery.validateAfterResume()
+    await vi.waitFor(() => expect(state.onReplacementReady).toHaveBeenCalledOnce())
+
+    expect(state.validateRegistration).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).toHaveBeenCalledOnce()
+  })
+
+  it('does not probe inactive guests on resume', async () => {
+    const state = createRecovery({ active: false, registered: false })
+
+    state.recovery.validateAfterResume()
+    await Promise.resolve()
+
+    expect(state.validateRegistration).not.toHaveBeenCalled()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an explicit recovery failure instead of leaving a permanent blank page', () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+
+    state.recovery.recoverRenderer()
+    vi.advanceTimersByTime(BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+
+    expect(state.pending()).toBe(false)
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the original recovery deadline across repeated renderer loss events', () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+
+    state.recovery.recoverRenderer()
+    vi.advanceTimersByTime(BROWSER_GUEST_RECOVERY_TIMEOUT_MS - 1)
+    state.recovery.recoverRenderer()
+    vi.advanceTimersByTime(1)
+
+    expect(state.reload).toHaveBeenCalledOnce()
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+  })
+
+  it('deduplicates concurrent registration validation', async () => {
+    let resolveValidation: ((registered: boolean) => void) | undefined
+    const state = createRecovery()
+    state.validateRegistration.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveValidation = resolve
+        })
+    )
+
+    state.recovery.validateAfterResume()
+    state.recovery.validateAfterResume()
+    expect(state.validateRegistration).toHaveBeenCalledOnce()
+
+    resolveValidation?.(true)
+    await vi.waitFor(() => expect(state.pending()).toBe(false))
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
@@ -3,6 +3,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   BROWSER_GUEST_RECOVERY_TIMEOUT_MS,
+  BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS,
+  BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS,
   createBrowserPageGuestRecovery
 } from './browser-page-guest-recovery'
 
@@ -21,6 +23,7 @@ function createRecovery(
   const replaceGuest = vi.fn(() => Promise.resolve())
   const onReplacementReady = vi.fn()
   const onRecoveryFailed = vi.fn()
+  const onRecoverySucceeded = vi.fn()
   const validateRegistration = vi.fn(() => Promise.resolve(overrides.registered ?? true))
   const recovery = createBrowserPageGuestRecovery({
     webview: { reload } as unknown as Electron.WebviewTag,
@@ -34,7 +37,8 @@ function createRecovery(
     validateRegistration,
     replaceGuest,
     onReplacementReady,
-    onRecoveryFailed
+    onRecoveryFailed,
+    onRecoverySucceeded
   })
   return {
     recovery,
@@ -42,6 +46,7 @@ function createRecovery(
     replaceGuest,
     onReplacementReady,
     onRecoveryFailed,
+    onRecoverySucceeded,
     validateRegistration,
     pending: () => pending
   }
@@ -49,6 +54,7 @@ function createRecovery(
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('browser page guest recovery', () => {
@@ -142,5 +148,147 @@ describe('browser page guest recovery', () => {
 
     resolveValidation?.(true)
     await vi.waitFor(() => expect(state.pending()).toBe(false))
+  })
+
+  it('does not validate while renderer recovery is pending', async () => {
+    const state = createRecovery()
+
+    state.recovery.recoverRenderer()
+    state.recovery.validateAfterResume()
+    await Promise.resolve()
+
+    expect(state.validateRegistration).not.toHaveBeenCalled()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+    state.recovery.finish()
+  })
+
+  it('reports validation IPC failures without replacing a healthy guest', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    const error = new Error('ipc unavailable')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    state.validateRegistration.mockRejectedValueOnce(error)
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(warn).toHaveBeenCalledWith('[browser] guest registration validation failed:', error)
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+    state.recovery.dispose()
+  })
+
+  it('ignores a stale validation result when renderer recovery starts', async () => {
+    let resolveValidation: ((registered: boolean) => void) | undefined
+    const state = createRecovery()
+    state.validateRegistration
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveValidation = resolve
+          })
+      )
+      .mockResolvedValue(true)
+
+    state.recovery.validateAfterResume()
+    state.recovery.recoverRenderer()
+    state.recovery.finish()
+    resolveValidation?.(false)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(state.pending()).toBe(false)
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(state.validateRegistration).toHaveBeenCalledTimes(2))
+    expect(state.onRecoverySucceeded).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces repeated validation failures after bounded retries', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    state.validateRegistration.mockRejectedValue(new Error('ipc unavailable'))
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+    for (let attempt = 1; attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
+      state.recovery.finish()
+      await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+    }
+
+    expect(state.validateRegistration).toHaveBeenCalledTimes(BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS)
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('cancels a pending validation retry when disposed', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    state.validateRegistration.mockRejectedValue(new Error('ipc unavailable'))
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+    state.recovery.dispose()
+    await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+
+    expect(state.validateRegistration).toHaveBeenCalledOnce()
+    expect(state.onRecoveryFailed).not.toHaveBeenCalled()
+  })
+
+  it('retries a failed recovery until registration ownership converges', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    state.validateRegistration.mockRejectedValue(new Error('ipc unavailable'))
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+    for (let attempt = 1; attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+    }
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+
+    state.validateRegistration.mockResolvedValue(true)
+    state.recovery.retryRecovery()
+    expect(state.reload).toHaveBeenCalledOnce()
+    state.recovery.finish()
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(state.onRecoverySucceeded).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('keeps a renderer timeout visible until document readiness', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+
+    state.recovery.recoverRenderer()
+    await vi.advanceTimersByTimeAsync(BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+    expect(state.validateRegistration).not.toHaveBeenCalled()
+    expect(state.onRecoverySucceeded).not.toHaveBeenCalled()
+
+    state.recovery.retryRecovery()
+    state.recovery.finish()
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(state.onRecoverySucceeded).toHaveBeenCalledOnce()
+  })
+
+  it('deduplicates manual retry while recovery is pending', () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+
+    state.recovery.retryRecovery()
+    state.recovery.retryRecovery()
+    vi.advanceTimersByTime(BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+
+    expect(state.reload).toHaveBeenCalledOnce()
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
@@ -121,6 +121,35 @@ describe('browser page guest recovery', () => {
     expect(state.pending()).toBe(false)
   })
 
+  it('surfaces a hung replacement and retries replacement directly', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let replacementAttempt = 0
+    const state = createRecovery({
+      reload: () => {
+        throw new Error('guest destroyed')
+      },
+      replaceGuest: () => {
+        replacementAttempt += 1
+        return replacementAttempt === 1 ? new Promise<void>(() => {}) : Promise.resolve()
+      }
+    })
+
+    state.recovery.recoverRenderer()
+    await vi.advanceTimersByTimeAsync(BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+    expect(state.onReplacementReady).not.toHaveBeenCalled()
+    expect(state.pending()).toBe(false)
+
+    state.recovery.retryRecovery()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(state.reload).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).toHaveBeenCalledTimes(2)
+    expect(state.onReplacementReady).toHaveBeenCalledOnce()
+  })
+
   it('recreates an active guest missing from the authoritative registry after resume', async () => {
     const state = createRecovery({ registered: false })
 

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
@@ -5,6 +5,7 @@ import {
   BROWSER_GUEST_RECOVERY_TIMEOUT_MS,
   BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS,
   BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS,
+  BROWSER_GUEST_VALIDATION_TIMEOUT_MS,
   createBrowserPageGuestRecovery
 } from './browser-page-guest-recovery'
 
@@ -16,11 +17,12 @@ function createRecovery(
     pending?: boolean
     registered?: boolean
     reload?: () => void
+    replaceGuest?: () => Promise<void>
   } = {}
 ) {
   let pending = overrides.pending ?? false
   const reload = vi.fn(overrides.reload ?? (() => {}))
-  const replaceGuest = vi.fn(() => Promise.resolve())
+  const replaceGuest = vi.fn(overrides.replaceGuest ?? (() => Promise.resolve()))
   const onReplacementReady = vi.fn()
   const onRecoveryFailed = vi.fn()
   const onRecoverySucceeded = vi.fn()
@@ -97,6 +99,24 @@ describe('browser page guest recovery', () => {
 
     expect(state.replaceGuest).toHaveBeenCalledOnce()
     expect(state.pending()).toBe(true)
+  })
+
+  it('surfaces guest replacement rejection without marking it ready', async () => {
+    const replacementError = new Error('replacement failed')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const state = createRecovery({
+      reload: () => {
+        throw new Error('guest destroyed')
+      },
+      replaceGuest: () => Promise.reject(replacementError)
+    })
+
+    state.recovery.recoverRenderer()
+    await vi.waitFor(() => expect(state.onRecoveryFailed).toHaveBeenCalledOnce())
+
+    expect(warn).toHaveBeenCalledWith('[browser] guest replacement failed:', replacementError)
+    expect(state.onReplacementReady).not.toHaveBeenCalled()
+    expect(state.pending()).toBe(false)
   })
 
   it('recreates an active guest missing from the authoritative registry after resume', async () => {
@@ -227,6 +247,25 @@ describe('browser page guest recovery', () => {
     for (let attempt = 1; attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
       state.recovery.finish()
       await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+    }
+
+    expect(state.validateRegistration).toHaveBeenCalledTimes(BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS)
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('surfaces hung validation IPC after bounded deadlines', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    state.validateRegistration.mockImplementation(() => new Promise<boolean>(() => {}))
+
+    state.recovery.validateAfterResume()
+    for (let attempt = 0; attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_TIMEOUT_MS)
+      if (attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS - 1) {
+        await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+      }
     }
 
     expect(state.validateRegistration).toHaveBeenCalledTimes(BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS)

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.test.ts
@@ -26,7 +26,9 @@ function createRecovery(
   const onReplacementReady = vi.fn()
   const onRecoveryFailed = vi.fn()
   const onRecoverySucceeded = vi.fn()
-  const validateRegistration = vi.fn(() => Promise.resolve(overrides.registered ?? true))
+  const validateRegistration = vi.fn<() => Promise<boolean | null>>(() =>
+    Promise.resolve(overrides.registered ?? true)
+  )
   const recovery = createBrowserPageGuestRecovery({
     webview: { reload } as unknown as Electron.WebviewTag,
     browserPageExists: () => overrides.exists ?? true,
@@ -127,6 +129,108 @@ describe('browser page guest recovery', () => {
 
     expect(state.validateRegistration).toHaveBeenCalledOnce()
     expect(state.replaceGuest).toHaveBeenCalledOnce()
+  })
+
+  it('waits for an attaching guest instead of replacing it as missing', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    state.validateRegistration.mockResolvedValueOnce(null).mockResolvedValueOnce(true)
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+
+    expect(state.validateRegistration).toHaveBeenCalledTimes(2)
+    expect(state.onRecoverySucceeded).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an attaching guest that never becomes identifiable', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    state.validateRegistration.mockResolvedValue(null)
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+    for (let attempt = 1; attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+    }
+
+    expect(state.validateRegistration).toHaveBeenCalledTimes(BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS)
+    expect(state.onRecoveryFailed).toHaveBeenCalledOnce()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('keeps validation active after document readiness until registration converges', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    state.validateRegistration.mockResolvedValueOnce(null).mockResolvedValueOnce(true)
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+    state.recovery.finish()
+    await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+
+    expect(state.validateRegistration).toHaveBeenCalledTimes(2)
+    expect(state.onRecoverySucceeded).toHaveBeenCalledOnce()
+    expect(state.onRecoveryFailed).not.toHaveBeenCalled()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('cancels attaching retries after authoritative registration succeeds', async () => {
+    vi.useFakeTimers()
+    const state = createRecovery()
+    state.validateRegistration.mockResolvedValue(null)
+
+    state.recovery.validateAfterResume()
+    await vi.advanceTimersByTimeAsync(0)
+    state.recovery.confirmRegistration()
+    await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+
+    expect(state.validateRegistration).toHaveBeenCalledOnce()
+    expect(state.onRecoveryFailed).not.toHaveBeenCalled()
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+  })
+
+  it('ignores an older missing result after authoritative registration succeeds', async () => {
+    let resolveValidation: ((registered: boolean | null) => void) | undefined
+    const state = createRecovery()
+    state.validateRegistration.mockImplementation(
+      () =>
+        new Promise<boolean | null>((resolve) => {
+          resolveValidation = resolve
+        })
+    )
+
+    state.recovery.validateAfterResume()
+    state.recovery.confirmRegistration()
+    resolveValidation?.(false)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(state.replaceGuest).not.toHaveBeenCalled()
+    expect(state.onRecoveryFailed).not.toHaveBeenCalled()
+  })
+
+  it('uses an authoritative missing result that settles after document readiness', async () => {
+    let resolveValidation: ((registered: boolean | null) => void) | undefined
+    const state = createRecovery()
+    state.validateRegistration.mockImplementation(
+      () =>
+        new Promise<boolean | null>((resolve) => {
+          resolveValidation = resolve
+        })
+    )
+
+    state.recovery.validateAfterResume()
+    state.recovery.finish()
+    resolveValidation?.(false)
+    await vi.waitFor(() => expect(state.replaceGuest).toHaveBeenCalledOnce())
+
+    expect(state.validateRegistration).toHaveBeenCalledOnce()
+    expect(state.onRecoveryFailed).not.toHaveBeenCalled()
   })
 
   it('does not probe inactive guests on resume', async () => {
@@ -232,8 +336,8 @@ describe('browser page guest recovery', () => {
 
     expect(state.pending()).toBe(false)
     expect(state.replaceGuest).not.toHaveBeenCalled()
-    await vi.waitFor(() => expect(state.validateRegistration).toHaveBeenCalledTimes(2))
-    expect(state.onRecoverySucceeded).toHaveBeenCalledOnce()
+    await vi.waitFor(() => expect(state.onRecoverySucceeded).toHaveBeenCalledOnce())
+    expect(state.validateRegistration).toHaveBeenCalledTimes(2)
   })
 
   it('surfaces repeated validation failures after bounded retries', async () => {
@@ -245,7 +349,6 @@ describe('browser page guest recovery', () => {
     state.recovery.validateAfterResume()
     await vi.advanceTimersByTimeAsync(0)
     for (let attempt = 1; attempt < BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS; attempt += 1) {
-      state.recovery.finish()
       await vi.advanceTimersByTimeAsync(BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
     }
 

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
@@ -19,7 +19,7 @@ type BrowserPageGuestRecoveryOptions = {
 
 export type BrowserPageGuestRecovery = {
   dispose: () => void
-  finish: () => void
+  finish: () => boolean
   recoverRenderer: () => void
   retryRecovery: () => void
   validateAfterResume: () => void
@@ -30,7 +30,7 @@ export function createBrowserPageGuestRecovery(
 ): BrowserPageGuestRecovery {
   let recoveryTimer: number | null = null
   let disposed = false
-  let recoveryStarted = false
+  let recoveryStarted = options.isPending()
   let replacementRequested = false
   let validationInFlight = false
   let validationFailureCount = 0
@@ -49,10 +49,12 @@ export function createBrowserPageGuestRecovery(
       validationRetryTimer = null
     }
   }
-  const finish = (): void => {
+  const finish = (): boolean => {
+    const completedRecovery = recoveryStarted
     recoveryStarted = false
     options.setPending(false)
     clearRecoveryTimer()
+    return completedRecovery
   }
   const showRecoveryFailure = (): void => {
     if (disposed || !options.browserPageExists()) {

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
@@ -11,7 +11,7 @@ type BrowserPageGuestRecoveryOptions = {
   isCurrentWebview: () => boolean
   isPending: () => boolean
   setPending: (pending: boolean) => void
-  validateRegistration: () => Promise<boolean>
+  validateRegistration: () => Promise<boolean | null>
   replaceGuest: () => Promise<void>
   onReplacementReady: () => void
   onRecoveryFailed: () => void
@@ -19,6 +19,7 @@ type BrowserPageGuestRecoveryOptions = {
 }
 
 export type BrowserPageGuestRecovery = {
+  confirmRegistration: () => void
   dispose: () => void
   finish: () => boolean
   recoverRenderer: () => void
@@ -38,6 +39,7 @@ export function createBrowserPageGuestRecovery(
   let validationRetryTimer: number | null = null
   let validationTimeoutTimer: number | null = null
   let lifecycleGeneration = 0
+  let registrationConfirmedGeneration = -1
 
   const clearRecoveryTimer = (): void => {
     if (recoveryTimer !== null) {
@@ -134,7 +136,7 @@ export function createBrowserPageGuestRecovery(
       validateAfterResume()
     }, BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
   }
-  const validateRegistrationWithTimeout = (): Promise<boolean> => {
+  const validateRegistrationWithTimeout = (): Promise<boolean | null> => {
     const deadline = new Promise<never>((_resolve, reject) => {
       validationTimeoutTimer = window.setTimeout(() => {
         validationTimeoutTimer = null
@@ -163,11 +165,28 @@ export function createBrowserPageGuestRecovery(
         if (validationGeneration !== lifecycleGeneration) {
           return
         }
-        validationFailureCount = 0
-        if (registered) {
+        if (registered === true) {
+          validationFailureCount = 0
           options.onRecoverySucceeded()
-        } else if (!options.isPending() && options.isCurrentWebview()) {
-          replaceGuest()
+        } else if (registered === false) {
+          validationFailureCount = 0
+          if (!options.isPending() && options.isCurrentWebview()) {
+            replaceGuest()
+          }
+        } else if (
+          !disposed &&
+          !options.isPending() &&
+          options.browserPageExists() &&
+          options.shouldValidate() &&
+          options.isCurrentWebview()
+        ) {
+          validationFailureCount += 1
+          if (validationFailureCount >= BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS) {
+            validationFailureCount = 0
+            options.onRecoveryFailed()
+          } else {
+            retryValidation = true
+          }
         }
       })
       .catch((error: unknown) => {
@@ -196,6 +215,7 @@ export function createBrowserPageGuestRecovery(
         validationInFlight = false
         if (
           validationGeneration !== lifecycleGeneration &&
+          registrationConfirmedGeneration !== lifecycleGeneration &&
           !disposed &&
           !options.isPending() &&
           options.shouldValidate() &&
@@ -213,6 +233,12 @@ export function createBrowserPageGuestRecovery(
   }
 
   return {
+    confirmRegistration: () => {
+      lifecycleGeneration += 1
+      registrationConfirmedGeneration = lifecycleGeneration
+      validationFailureCount = 0
+      clearValidationRetry()
+    },
     dispose: () => {
       disposed = true
       lifecycleGeneration += 1

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
@@ -33,6 +33,7 @@ export function createBrowserPageGuestRecovery(
   let recoveryTimer: number | null = null
   let disposed = false
   let recoveryStarted = options.isPending()
+  let replacementRequired = false
   let replacementRequested = false
   let validationInFlight = false
   let validationFailureCount = 0
@@ -78,18 +79,34 @@ export function createBrowserPageGuestRecovery(
     clearRecoveryTimer()
     recoveryTimer = window.setTimeout(showRecoveryFailure, BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
   }
+  const replaceGuestWithTimeout = (): Promise<void> => {
+    let timeoutTimer: number | null = null
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timeoutTimer = window.setTimeout(() => {
+        reject(new Error('Guest replacement timed out'))
+      }, BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+    })
+    const replacement = Promise.resolve().then(() => options.replaceGuest())
+    return Promise.race([replacement, deadline]).finally(() => {
+      if (timeoutTimer !== null) {
+        window.clearTimeout(timeoutTimer)
+      }
+    })
+  }
   const replaceGuest = (): void => {
     if (disposed || replacementRequested || !options.browserPageExists()) {
       return
     }
+    replacementRequired = true
     replacementRequested = true
     lifecycleGeneration += 1
     validationFailureCount = 0
     options.setPending(true)
     clearRecoveryTimer()
     clearValidationRetry()
-    void options.replaceGuest().then(
+    void replaceGuestWithTimeout().then(
       () => {
+        replacementRequired = false
         if (disposed || !options.browserPageExists()) {
           options.setPending(false)
           return
@@ -259,6 +276,11 @@ export function createBrowserPageGuestRecovery(
       }
       recoveryStarted = false
       options.setPending(false)
+      if (replacementRequired) {
+        recoveryStarted = true
+        replaceGuest()
+        return
+      }
       recoverRenderer()
     },
     validateAfterResume

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
@@ -1,5 +1,7 @@
 export const BROWSER_GUEST_RECOVERY_ERROR_CODE = -10_000
 export const BROWSER_GUEST_RECOVERY_TIMEOUT_MS = 8_000
+export const BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS = 1_000
+export const BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS = 3
 
 type BrowserPageGuestRecoveryOptions = {
   webview: Electron.WebviewTag
@@ -12,12 +14,14 @@ type BrowserPageGuestRecoveryOptions = {
   replaceGuest: () => Promise<void>
   onReplacementReady: () => void
   onRecoveryFailed: () => void
+  onRecoverySucceeded: () => void
 }
 
 export type BrowserPageGuestRecovery = {
   dispose: () => void
   finish: () => void
   recoverRenderer: () => void
+  retryRecovery: () => void
   validateAfterResume: () => void
 }
 
@@ -29,11 +33,20 @@ export function createBrowserPageGuestRecovery(
   let recoveryStarted = false
   let replacementRequested = false
   let validationInFlight = false
+  let validationFailureCount = 0
+  let validationRetryTimer: number | null = null
+  let lifecycleGeneration = 0
 
   const clearRecoveryTimer = (): void => {
     if (recoveryTimer !== null) {
       window.clearTimeout(recoveryTimer)
       recoveryTimer = null
+    }
+  }
+  const clearValidationRetry = (): void => {
+    if (validationRetryTimer !== null) {
+      window.clearTimeout(validationRetryTimer)
+      validationRetryTimer = null
     }
   }
   const finish = (): void => {
@@ -58,8 +71,11 @@ export function createBrowserPageGuestRecovery(
       return
     }
     replacementRequested = true
+    lifecycleGeneration += 1
+    validationFailureCount = 0
     options.setPending(true)
     clearRecoveryTimer()
+    clearValidationRetry()
     void options.replaceGuest().finally(() => {
       if (disposed || !options.browserPageExists()) {
         options.setPending(false)
@@ -69,11 +85,19 @@ export function createBrowserPageGuestRecovery(
     })
   }
   const recoverRenderer = (): void => {
-    if (recoveryStarted || !options.isCurrentWebview() || !options.browserPageExists()) {
+    if (
+      disposed ||
+      recoveryStarted ||
+      !options.isCurrentWebview() ||
+      !options.browserPageExists()
+    ) {
       return
     }
     recoveryStarted = true
+    lifecycleGeneration += 1
+    validationFailureCount = 0
     options.setPending(true)
+    clearValidationRetry()
     watchRecovery()
     try {
       // Why: reload keeps Chromium history and guest identity while starting a fresh renderer.
@@ -82,21 +106,76 @@ export function createBrowserPageGuestRecovery(
       replaceGuest()
     }
   }
-  const validateAfterResume = (): void => {
-    if (validationInFlight || !options.shouldValidate() || !options.isCurrentWebview()) {
+  const scheduleValidationRetry = (): void => {
+    clearValidationRetry()
+    validationRetryTimer = window.setTimeout(() => {
+      validationRetryTimer = null
+      validateAfterResume()
+    }, BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
+  }
+  function validateAfterResume(): void {
+    if (
+      disposed ||
+      recoveryStarted ||
+      validationInFlight ||
+      options.isPending() ||
+      !options.shouldValidate() ||
+      !options.isCurrentWebview()
+    ) {
       return
     }
     validationInFlight = true
+    clearValidationRetry()
+    const validationGeneration = lifecycleGeneration
+    let retryValidation = false
     void options
       .validateRegistration()
       .then((registered) => {
-        if (!registered && options.isCurrentWebview()) {
+        if (validationGeneration !== lifecycleGeneration) {
+          return
+        }
+        validationFailureCount = 0
+        if (registered) {
+          options.onRecoverySucceeded()
+        } else if (!options.isPending() && options.isCurrentWebview()) {
           replaceGuest()
         }
       })
-      .catch(() => {})
+      .catch((error: unknown) => {
+        if (validationGeneration !== lifecycleGeneration) {
+          return
+        }
+        console.warn('[browser] guest registration validation failed:', error)
+        if (
+          disposed ||
+          options.isPending() ||
+          !options.browserPageExists() ||
+          !options.shouldValidate() ||
+          !options.isCurrentWebview()
+        ) {
+          return
+        }
+        validationFailureCount += 1
+        if (validationFailureCount >= BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS) {
+          validationFailureCount = 0
+          options.onRecoveryFailed()
+          return
+        }
+        retryValidation = true
+      })
       .finally(() => {
         validationInFlight = false
+        if (
+          validationGeneration !== lifecycleGeneration &&
+          !disposed &&
+          !options.isPending() &&
+          options.shouldValidate() &&
+          options.isCurrentWebview()
+        ) {
+          validateAfterResume()
+        } else if (retryValidation) {
+          scheduleValidationRetry()
+        }
       })
   }
 
@@ -107,10 +186,25 @@ export function createBrowserPageGuestRecovery(
   return {
     dispose: () => {
       disposed = true
+      lifecycleGeneration += 1
       clearRecoveryTimer()
+      clearValidationRetry()
     },
     finish,
     recoverRenderer,
+    retryRecovery: () => {
+      if (
+        disposed ||
+        options.isPending() ||
+        !options.isCurrentWebview() ||
+        !options.browserPageExists()
+      ) {
+        return
+      }
+      recoveryStarted = false
+      options.setPending(false)
+      recoverRenderer()
+    },
     validateAfterResume
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
@@ -1,6 +1,7 @@
 export const BROWSER_GUEST_RECOVERY_ERROR_CODE = -10_000
 export const BROWSER_GUEST_RECOVERY_TIMEOUT_MS = 8_000
 export const BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS = 1_000
+export const BROWSER_GUEST_VALIDATION_TIMEOUT_MS = 3_000
 export const BROWSER_GUEST_VALIDATION_MAX_ATTEMPTS = 3
 
 type BrowserPageGuestRecoveryOptions = {
@@ -35,6 +36,7 @@ export function createBrowserPageGuestRecovery(
   let validationInFlight = false
   let validationFailureCount = 0
   let validationRetryTimer: number | null = null
+  let validationTimeoutTimer: number | null = null
   let lifecycleGeneration = 0
 
   const clearRecoveryTimer = (): void => {
@@ -47,6 +49,12 @@ export function createBrowserPageGuestRecovery(
     if (validationRetryTimer !== null) {
       window.clearTimeout(validationRetryTimer)
       validationRetryTimer = null
+    }
+  }
+  const clearValidationTimeout = (): void => {
+    if (validationTimeoutTimer !== null) {
+      window.clearTimeout(validationTimeoutTimer)
+      validationTimeoutTimer = null
     }
   }
   const finish = (): boolean => {
@@ -78,13 +86,24 @@ export function createBrowserPageGuestRecovery(
     options.setPending(true)
     clearRecoveryTimer()
     clearValidationRetry()
-    void options.replaceGuest().finally(() => {
-      if (disposed || !options.browserPageExists()) {
+    void options.replaceGuest().then(
+      () => {
+        if (disposed || !options.browserPageExists()) {
+          options.setPending(false)
+          return
+        }
+        options.onReplacementReady()
+      },
+      (error: unknown) => {
         options.setPending(false)
-        return
+        replacementRequested = false
+        if (disposed || !options.browserPageExists()) {
+          return
+        }
+        console.warn('[browser] guest replacement failed:', error)
+        options.onRecoveryFailed()
       }
-      options.onReplacementReady()
-    })
+    )
   }
   const recoverRenderer = (): void => {
     if (
@@ -115,6 +134,15 @@ export function createBrowserPageGuestRecovery(
       validateAfterResume()
     }, BROWSER_GUEST_VALIDATION_RETRY_DELAY_MS)
   }
+  const validateRegistrationWithTimeout = (): Promise<boolean> => {
+    const deadline = new Promise<never>((_resolve, reject) => {
+      validationTimeoutTimer = window.setTimeout(() => {
+        validationTimeoutTimer = null
+        reject(new Error('Guest registration validation timed out'))
+      }, BROWSER_GUEST_VALIDATION_TIMEOUT_MS)
+    })
+    return Promise.race([options.validateRegistration(), deadline]).finally(clearValidationTimeout)
+  }
   function validateAfterResume(): void {
     if (
       disposed ||
@@ -130,8 +158,7 @@ export function createBrowserPageGuestRecovery(
     clearValidationRetry()
     const validationGeneration = lifecycleGeneration
     let retryValidation = false
-    void options
-      .validateRegistration()
+    void validateRegistrationWithTimeout()
       .then((registered) => {
         if (validationGeneration !== lifecycleGeneration) {
           return
@@ -191,6 +218,7 @@ export function createBrowserPageGuestRecovery(
       lifecycleGeneration += 1
       clearRecoveryTimer()
       clearValidationRetry()
+      clearValidationTimeout()
     },
     finish,
     recoverRenderer,

--- a/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-guest-recovery.ts
@@ -1,0 +1,116 @@
+export const BROWSER_GUEST_RECOVERY_ERROR_CODE = -10_000
+export const BROWSER_GUEST_RECOVERY_TIMEOUT_MS = 8_000
+
+type BrowserPageGuestRecoveryOptions = {
+  webview: Electron.WebviewTag
+  browserPageExists: () => boolean
+  shouldValidate: () => boolean
+  isCurrentWebview: () => boolean
+  isPending: () => boolean
+  setPending: (pending: boolean) => void
+  validateRegistration: () => Promise<boolean>
+  replaceGuest: () => Promise<void>
+  onReplacementReady: () => void
+  onRecoveryFailed: () => void
+}
+
+export type BrowserPageGuestRecovery = {
+  dispose: () => void
+  finish: () => void
+  recoverRenderer: () => void
+  validateAfterResume: () => void
+}
+
+export function createBrowserPageGuestRecovery(
+  options: BrowserPageGuestRecoveryOptions
+): BrowserPageGuestRecovery {
+  let recoveryTimer: number | null = null
+  let disposed = false
+  let recoveryStarted = false
+  let replacementRequested = false
+  let validationInFlight = false
+
+  const clearRecoveryTimer = (): void => {
+    if (recoveryTimer !== null) {
+      window.clearTimeout(recoveryTimer)
+      recoveryTimer = null
+    }
+  }
+  const finish = (): void => {
+    recoveryStarted = false
+    options.setPending(false)
+    clearRecoveryTimer()
+  }
+  const showRecoveryFailure = (): void => {
+    if (disposed || !options.browserPageExists()) {
+      return
+    }
+    recoveryTimer = null
+    options.setPending(false)
+    options.onRecoveryFailed()
+  }
+  const watchRecovery = (): void => {
+    clearRecoveryTimer()
+    recoveryTimer = window.setTimeout(showRecoveryFailure, BROWSER_GUEST_RECOVERY_TIMEOUT_MS)
+  }
+  const replaceGuest = (): void => {
+    if (disposed || replacementRequested || !options.browserPageExists()) {
+      return
+    }
+    replacementRequested = true
+    options.setPending(true)
+    clearRecoveryTimer()
+    void options.replaceGuest().finally(() => {
+      if (disposed || !options.browserPageExists()) {
+        options.setPending(false)
+        return
+      }
+      options.onReplacementReady()
+    })
+  }
+  const recoverRenderer = (): void => {
+    if (recoveryStarted || !options.isCurrentWebview() || !options.browserPageExists()) {
+      return
+    }
+    recoveryStarted = true
+    options.setPending(true)
+    watchRecovery()
+    try {
+      // Why: reload keeps Chromium history and guest identity while starting a fresh renderer.
+      options.webview.reload()
+    } catch {
+      replaceGuest()
+    }
+  }
+  const validateAfterResume = (): void => {
+    if (validationInFlight || !options.shouldValidate() || !options.isCurrentWebview()) {
+      return
+    }
+    validationInFlight = true
+    void options
+      .validateRegistration()
+      .then((registered) => {
+        if (!registered && options.isCurrentWebview()) {
+          replaceGuest()
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        validationInFlight = false
+      })
+  }
+
+  if (options.isPending()) {
+    watchRecovery()
+  }
+
+  return {
+    dispose: () => {
+      disposed = true
+      clearRecoveryTimer()
+    },
+    finish,
+    recoverRenderer,
+    validateAfterResume
+  }
+}

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
@@ -98,6 +98,18 @@ describe('ensureBrowserPageViewport', () => {
     expect(evicted.shell.isConnected).toBe(false)
     expect(getBrowserPageViewportContainer('page-1')).toBe(rebuilt!.container)
   })
+
+  it('removes the stale shell when a connected slot root is replaced', () => {
+    const oldRoot = mountSlotViewport('workspace-1')
+    const stale = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    const newRoot = mountSlotViewport('workspace-1')
+    expect(oldRoot.contains(stale.shell)).toBe(true)
+
+    const rebuilt = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    expect(oldRoot.contains(stale.shell)).toBe(false)
+    expect(rebuilt.shell.parentElement).toBe(newRoot)
+  })
 })
 
 describe('syncBrowserPageChromeInset', () => {

--- a/src/renderer/src/components/browser-pane/browser-page-webview.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-webview.ts
@@ -2,6 +2,7 @@ import { ORCA_BROWSER_GUEST_WEB_PREFERENCES_ATTRIBUTE } from '../../../../shared
 import {
   destroyPersistentWebview,
   registerPersistentWebview,
+  replacePersistentWebview,
   webviewRegistry
 } from './webview-registry'
 
@@ -30,9 +31,9 @@ export function ensureBrowserPageWebview({
   // preserves the newly replaced viewport; always verify the resolved container.
   if (webview && (parentDrifted || webview.getAttribute('partition') !== webviewPartition)) {
     if (parentDrifted) {
-      destroyPersistentWebview(browserTabId, { preserveViewport: true })
+      void replacePersistentWebview(browserTabId, { preserveViewport: true })
     } else {
-      destroyPersistentWebview(browserTabId)
+      void destroyPersistentWebview(browserTabId)
     }
     webview = undefined
     const refreshedContainer = resolveContainer()

--- a/src/renderer/src/components/browser-pane/browser-system-resume.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-system-resume.test.ts
@@ -34,3 +34,27 @@ it('shares one system resume IPC listener across browser pages and releases it',
   unsubscribeSecond()
   expect(unsubscribeIpc).toHaveBeenCalledOnce()
 })
+
+it('continues dispatching when a system resume listener throws', async () => {
+  let dispatchResume: (() => void) | undefined
+  onSystemResumed.mockImplementation((listener: () => void) => {
+    dispatchResume = listener
+    return vi.fn()
+  })
+  const { subscribeBrowserSystemResume } = await import('./browser-system-resume')
+  const listenerError = new Error('pane failed')
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const second = vi.fn()
+
+  subscribeBrowserSystemResume(() => {
+    throw listenerError
+  })
+  subscribeBrowserSystemResume(second)
+  dispatchResume?.()
+
+  expect(consoleError).toHaveBeenCalledWith(
+    '[browser] system resume listener failed:',
+    listenerError
+  )
+  expect(second).toHaveBeenCalledOnce()
+})

--- a/src/renderer/src/components/browser-pane/browser-system-resume.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-system-resume.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const onSystemResumed = vi.fn()
+
+beforeEach(() => {
+  vi.resetModules()
+  onSystemResumed.mockReset()
+  ;(window as unknown as { api: unknown }).api = { ui: { onSystemResumed } }
+})
+
+it('shares one system resume IPC listener across browser pages and releases it', async () => {
+  const unsubscribeIpc = vi.fn()
+  let dispatchResume: (() => void) | undefined
+  onSystemResumed.mockImplementation((listener: () => void) => {
+    dispatchResume = listener
+    return unsubscribeIpc
+  })
+  const { subscribeBrowserSystemResume } = await import('./browser-system-resume')
+  const first = vi.fn()
+  const second = vi.fn()
+
+  const unsubscribeFirst = subscribeBrowserSystemResume(first)
+  const unsubscribeSecond = subscribeBrowserSystemResume(second)
+  dispatchResume?.()
+
+  expect(onSystemResumed).toHaveBeenCalledOnce()
+  expect(first).toHaveBeenCalledOnce()
+  expect(second).toHaveBeenCalledOnce()
+
+  unsubscribeFirst()
+  expect(unsubscribeIpc).not.toHaveBeenCalled()
+  unsubscribeSecond()
+  expect(unsubscribeIpc).toHaveBeenCalledOnce()
+})

--- a/src/renderer/src/components/browser-pane/browser-system-resume.ts
+++ b/src/renderer/src/components/browser-pane/browser-system-resume.ts
@@ -1,0 +1,21 @@
+const resumeListeners = new Set<() => void>()
+let unsubscribeSystemResumed: (() => void) | null = null
+
+function dispatchBrowserSystemResume(): void {
+  for (const listener of resumeListeners) {
+    listener()
+  }
+}
+
+export function subscribeBrowserSystemResume(listener: () => void): () => void {
+  resumeListeners.add(listener)
+  unsubscribeSystemResumed ??= window.api.ui.onSystemResumed(dispatchBrowserSystemResume)
+
+  return () => {
+    resumeListeners.delete(listener)
+    if (resumeListeners.size === 0) {
+      unsubscribeSystemResumed?.()
+      unsubscribeSystemResumed = null
+    }
+  }
+}

--- a/src/renderer/src/components/browser-pane/browser-system-resume.ts
+++ b/src/renderer/src/components/browser-pane/browser-system-resume.ts
@@ -3,7 +3,11 @@ let unsubscribeSystemResumed: (() => void) | null = null
 
 function dispatchBrowserSystemResume(): void {
   for (const listener of resumeListeners) {
-    listener()
+    try {
+      listener()
+    } catch (error) {
+      console.error('[browser] system resume listener failed:', error)
+    }
   }
 }
 

--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -227,8 +227,8 @@ describe('webview registry drag listeners', () => {
     expect(webview.style.pointerEvents).toBe('auto')
   })
 
-  it('preserves explicit zoom across a parent-drift rebuild (preserveViewport)', async () => {
-    const { destroyPersistentWebview, registerPersistentWebview } =
+  it('preserves explicit zoom across a parent-drift replacement', async () => {
+    const { registerPersistentWebview, replacePersistentWebview } =
       await import('./webview-registry')
     const { getExplicitBrowserPageZoomLevel, rememberExplicitBrowserPageZoomLevel } =
       await import('./browser-page-zoom')
@@ -236,7 +236,7 @@ describe('webview registry drag listeners', () => {
     registerPersistentWebview('page-1', createWebview())
     rememberExplicitBrowserPageZoomLevel('page-1', 1.5)
 
-    destroyPersistentWebview('page-1', { preserveViewport: true })
+    await replacePersistentWebview('page-1', { preserveViewport: true })
 
     expect(getExplicitBrowserPageZoomLevel('page-1')).toBe(1.5)
   })

--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -7,13 +7,13 @@ type ListenerRecord = {
 }
 
 function createWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.WebviewTag {
-  return {
+  return Object.assign(new EventTarget(), {
     style: {},
     blur: vi.fn(),
     remove: vi.fn(),
     contains: vi.fn(() => false),
     ...overrides
-  } as unknown as Electron.WebviewTag
+  }) as unknown as Electron.WebviewTag
 }
 
 describe('webview registry drag listeners', () => {
@@ -136,6 +136,42 @@ describe('webview registry drag listeners', () => {
       browserWebviewCount: 2,
       registeredBrowserGuestCount: 1
     })
+  })
+
+  it('retains renderer loss across pane unmount until the persistent guest is ready', async () => {
+    const {
+      isBrowserPageRendererRecoveryPending,
+      registerPersistentWebview,
+      unregisterPersistentWebview
+    } = await import('./webview-registry')
+    const webview = createWebview()
+    registerPersistentWebview('page-1', webview)
+
+    webview.dispatchEvent(new Event('render-process-gone'))
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(true)
+
+    webview.dispatchEvent(new Event('dom-ready'))
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
+
+    webview.dispatchEvent(new Event('render-process-gone'))
+    unregisterPersistentWebview('page-1')
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
+  })
+
+  it('preserves explicit page zoom only when replacing a failed guest', async () => {
+    const { destroyPersistentWebview, registerPersistentWebview, replacePersistentWebview } =
+      await import('./webview-registry')
+    const { getExplicitBrowserPageZoomLevel, rememberExplicitBrowserPageZoomLevel } =
+      await import('./browser-page-zoom')
+
+    registerPersistentWebview('page-1', createWebview())
+    rememberExplicitBrowserPageZoomLevel('page-1', 1.5)
+    await replacePersistentWebview('page-1')
+    expect(getExplicitBrowserPageZoomLevel('page-1')).toBe(1.5)
+
+    registerPersistentWebview('page-1', createWebview())
+    await destroyPersistentWebview('page-1')
+    expect(getExplicitBrowserPageZoomLevel('page-1')).toBeNull()
   })
 
   it('keeps webviews in passthrough until every renderer drag releases', async () => {

--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const viewportMocks = vi.hoisted(() => ({
+  removeBrowserPageViewport: vi.fn()
+}))
+
+vi.mock('./browser-page-viewport', () => viewportMocks)
+
 type ListenerRecord = {
   type: string
   listener: EventListenerOrEventListenerObject
@@ -26,6 +32,7 @@ describe('webview registry drag listeners', () => {
     addedListeners = []
     removedListeners = []
     unregisterGuestMock = vi.fn()
+    viewportMocks.removeBrowserPageViewport.mockReset()
 
     vi.stubGlobal('window', {
       addEventListener: vi.fn(
@@ -158,7 +165,7 @@ describe('webview registry drag listeners', () => {
     expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
   })
 
-  it('preserves explicit page zoom only when replacing a failed guest', async () => {
+  it('preserves the viewport and zoom only while replacing a guest', async () => {
     const { destroyPersistentWebview, registerPersistentWebview, replacePersistentWebview } =
       await import('./webview-registry')
     const { getExplicitBrowserPageZoomLevel, rememberExplicitBrowserPageZoomLevel } =
@@ -166,12 +173,14 @@ describe('webview registry drag listeners', () => {
 
     registerPersistentWebview('page-1', createWebview())
     rememberExplicitBrowserPageZoomLevel('page-1', 1.5)
-    await replacePersistentWebview('page-1')
+    await replacePersistentWebview('page-1', { preserveViewport: true })
     expect(getExplicitBrowserPageZoomLevel('page-1')).toBe(1.5)
+    expect(viewportMocks.removeBrowserPageViewport).not.toHaveBeenCalled()
 
     registerPersistentWebview('page-1', createWebview())
     await destroyPersistentWebview('page-1')
     expect(getExplicitBrowserPageZoomLevel('page-1')).toBeNull()
+    expect(viewportMocks.removeBrowserPageViewport).toHaveBeenCalledWith('page-1')
   })
 
   it('keeps webviews in passthrough until every renderer drag releases', async () => {

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -20,6 +20,15 @@ let dragListenersAttached = false
 let nativeDragPassthroughRelease: (() => void) | null = null
 const dragPassthroughTokens = new Set<symbol>()
 const dragPassthroughPreviousPointerEvents = new Map<Electron.WebviewTag, string>()
+const rendererRecoveryPendingPageIds = new Set<string>()
+const webviewLifecycleListeners = new Map<
+  string,
+  {
+    webview: Electron.WebviewTag
+    onRendererGone: EventListener
+    onRendererReady: EventListener
+  }
+>()
 
 type DragListenerRegistry = {
   dragstart: () => void
@@ -147,6 +156,23 @@ export function registerPersistentWebview(
   browserTabId: string,
   webview: Electron.WebviewTag
 ): void {
+  const previousListeners = webviewLifecycleListeners.get(browserTabId)
+  if (previousListeners) {
+    previousListeners.webview.removeEventListener(
+      'render-process-gone',
+      previousListeners.onRendererGone
+    )
+    previousListeners.webview.removeEventListener('dom-ready', previousListeners.onRendererReady)
+  }
+  const onRendererGone = (): void => {
+    rendererRecoveryPendingPageIds.add(browserTabId)
+  }
+  const onRendererReady = (): void => {
+    rendererRecoveryPendingPageIds.delete(browserTabId)
+  }
+  webview.addEventListener('render-process-gone', onRendererGone)
+  webview.addEventListener('dom-ready', onRendererReady)
+  webviewLifecycleListeners.set(browserTabId, { webview, onRendererGone, onRendererReady })
   webviewRegistry.set(browserTabId, webview)
   applyCurrentDragPassthroughToWebview(webview)
   ensureDragListeners()
@@ -154,6 +180,16 @@ export function registerPersistentWebview(
 
 export function unregisterPersistentWebview(browserTabId: string): void {
   const webview = webviewRegistry.get(browserTabId)
+  const lifecycleListeners = webviewLifecycleListeners.get(browserTabId)
+  if (lifecycleListeners) {
+    lifecycleListeners.webview.removeEventListener(
+      'render-process-gone',
+      lifecycleListeners.onRendererGone
+    )
+    lifecycleListeners.webview.removeEventListener('dom-ready', lifecycleListeners.onRendererReady)
+    webviewLifecycleListeners.delete(browserTabId)
+  }
+  rendererRecoveryPendingPageIds.delete(browserTabId)
   if (webview) {
     dragPassthroughPreviousPointerEvents.delete(webview)
   }
@@ -161,6 +197,10 @@ export function unregisterPersistentWebview(browserTabId: string): void {
   if (webviewRegistry.size === 0) {
     removeDragListeners()
   }
+}
+
+export function isBrowserPageRendererRecoveryPending(browserTabId: string): boolean {
+  return rendererRecoveryPendingPageIds.has(browserTabId)
 }
 
 function moveFocusToRendererIfWebviewOwnsFocus(webview: Electron.WebviewTag): boolean {
@@ -193,14 +233,13 @@ export function moveFocusToRendererBeforeWebviewDetach(webview: Electron.Webview
   moveFocusToRendererIfWebviewOwnsFocus(webview)
 }
 
-export function destroyPersistentWebview(
+function removePersistentWebview(
   browserTabId: string,
-  { preserveViewport = false }: { preserveViewport?: boolean } = {}
-): void {
+  { preserveViewport, preserveZoom }: { preserveViewport: boolean; preserveZoom: boolean }
+): Promise<void> {
   const webview = webviewRegistry.get(browserTabId)
-  // Why: only a real close forgets user zoom; preserveViewport marks a
-  // same-tab rebuild (parent-drift repair) whose zoom must survive.
-  if (!preserveViewport) {
+  if (!preserveZoom) {
+    // The guest is gone, so its user-applied zoom must not be inherited by a later tab that reuses the id.
     forgetExplicitBrowserPageZoomLevel(browserTabId)
   }
   if (!webview) {
@@ -211,9 +250,11 @@ export function destroyPersistentWebview(
     }
     registeredWebContentsIds.delete(browserTabId)
     clearLiveBrowserUrl(browserTabId)
-    return
+    return Promise.resolve()
   }
-  void window.api.browser.unregisterGuest({ browserPageId: browserTabId })
+  const unregisterGuest = Promise.resolve(
+    window.api.browser.unregisterGuest({ browserPageId: browserTabId })
+  ).catch(() => {})
   moveFocusToRendererBeforeWebviewDetach(webview)
   webview.remove()
   unregisterPersistentWebview(browserTabId)
@@ -222,4 +263,19 @@ export function destroyPersistentWebview(
   }
   registeredWebContentsIds.delete(browserTabId)
   clearLiveBrowserUrl(browserTabId)
+  return unregisterGuest
+}
+
+export function destroyPersistentWebview(browserTabId: string): Promise<void> {
+  return removePersistentWebview(browserTabId, {
+    preserveViewport: false,
+    preserveZoom: false
+  })
+}
+
+export function replacePersistentWebview(
+  browserTabId: string,
+  { preserveViewport = false }: { preserveViewport?: boolean } = {}
+): Promise<void> {
+  return removePersistentWebview(browserTabId, { preserveViewport, preserveZoom: true })
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -28,6 +28,9 @@
       "certificateChallengeChanged": "The certificate request changed. Retry the page and review the new warning.",
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
+    },
+    "guestRecovery": {
+      "failed": "The browser page stopped unexpectedly. Retry to restore it."
     }
   },
   "settings": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -30,6 +30,7 @@
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
     },
     "guestRecovery": {
+      "title": "Browser page stopped",
       "failed": "The browser page stopped unexpectedly. Retry to restore it."
     }
   },

--- a/src/renderer/src/store/slices/browser-webview-cleanup.test.ts
+++ b/src/renderer/src/store/slices/browser-webview-cleanup.test.ts
@@ -143,6 +143,7 @@ describe('destroyWorktreeBrowserGuests', () => {
     // Mirror the real registry contract: a plain destroy forgets explicit zoom.
     vi.mocked(destroyPersistentWebview).mockImplementation((browserTabId: string) => {
       forgetExplicitBrowserPageZoomLevel(browserTabId)
+      return Promise.resolve()
     })
     rememberExplicitBrowserPageZoomLevel('page-1', 1.5)
     rememberExplicitBrowserPageZoomLevel('legacy-workspace', 0.5)

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -180,6 +180,31 @@ describe('createBrowserSlice annotations', () => {
     expect(store.getState().browserAnnotationsByPageId[pageId]).toBeUndefined()
   })
 
+  it('can commit a navigation URL without hiding an active recovery error', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+    const recoveryError = {
+      code: -720,
+      description: 'Recovery is still pending',
+      validatedUrl: 'https://example.com'
+    }
+
+    store.getState().updateBrowserPageState(pageId, { loadError: recoveryError })
+    store
+      .getState()
+      .setBrowserPageUrl(pageId, 'https://example.com/committed', { preserveLoadError: true })
+
+    const page = store.getState().browserPagesByWorkspace[tab.id]?.find(({ id }) => id === pageId)
+    expect(page).toMatchObject({
+      url: 'https://example.com/committed',
+      loadError: recoveryError
+    })
+  })
+
   it('keeps certificate challenges transient across navigation, success, and close', () => {
     const store = createTestStore()
     const tab = store.getState().createBrowserTab('wt-1', 'https://localhost:3443/')

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -86,6 +86,10 @@ type BrowserTabPageState = {
   loadError?: BrowserLoadError | null
 }
 
+type SetBrowserPageUrlOptions = {
+  preserveLoadError?: boolean
+}
+
 type ClosedBrowserWorkspaceSnapshot = {
   workspace: BrowserWorkspace
   pages: BrowserPage[]
@@ -156,7 +160,7 @@ export type BrowserSlice = {
     failure: BrowserCertificateFailure | null
   ) => void
   setBrowserTabUrl: (pageId: string, url: string) => void
-  setBrowserPageUrl: (pageId: string, url: string) => void
+  setBrowserPageUrl: (pageId: string, url: string, options?: SetBrowserPageUrlOptions) => void
   setRemoteBrowserPageHandle: (pageId: string, handle: RemoteBrowserPageHandle) => void
   removeRemoteBrowserPageHandle: (
     pageId: string,
@@ -1452,7 +1456,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
 
   setBrowserTabUrl: (pageId, url) => get().setBrowserPageUrl(pageId, url),
 
-  setBrowserPageUrl: (pageId, url) => {
+  setBrowserPageUrl: (pageId, url, options) => {
     const nextUrl = normalizeUrl(url)
     if (nextUrl !== 'about:blank' && nextUrl !== ORCA_BROWSER_BLANK_URL) {
       const currentPage = findPage(get().browserPagesByWorkspace, pageId)
@@ -1478,7 +1482,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
               url: nextUrl,
               title: normalizeBrowserTitle(entry.title, nextUrl),
               loading: true,
-              loadError: null
+              loadError: options?.preserveLoadError ? entry.loadError : null
             }
           : entry
       )

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -285,13 +285,13 @@ function makeTerminalTab(overrides: Partial<TerminalTab> & { id: string; worktre
 }
 
 function createWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.WebviewTag {
-  return {
+  return Object.assign(new EventTarget(), {
     style: {},
     blur: vi.fn(),
     remove: vi.fn(),
     contains: vi.fn(() => false),
     ...overrides
-  } as unknown as Electron.WebviewTag
+  }) as unknown as Electron.WebviewTag
 }
 
 function makeLineage(overrides: Partial<WorktreeLineage> = {}): WorktreeLineage {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2196,6 +2196,8 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
 function createBrowserApi(): NonNullable<Partial<PreloadApi>['browser']> {
   return {
     registerGuest: () => Promise.resolve(false),
+    isGuestRegistered: () => Promise.resolve(false),
+    repairGuestRegistration: () => Promise.resolve(false),
     unregisterGuest: () => Promise.resolve(),
     openDevTools: () => Promise.resolve(false),
     setViewportOverride: () => Promise.resolve(false),

--- a/tests/e2e/browser-guest-attachment-validation.spec.ts
+++ b/tests/e2e/browser-guest-attachment-validation.spec.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, getActiveWorktreeId, waitForActiveWorktree } from './helpers/store'
+
+type BrowserFixture = {
+  browserTab: { activePageId: string; id: string }
+  fixtureUrl: string
+}
+
+async function createBrowserFixture(
+  page: Page,
+  registerCleanup: (cleanup: () => Promise<void>) => void
+): Promise<BrowserFixture> {
+  const fixtureDir = mkdtempSync(path.join(os.tmpdir(), 'orca-browser-attachment-'))
+  registerCleanup(async () => {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  })
+  const fixturePath = path.join(fixtureDir, 'attachment.html')
+  writeFileSync(
+    fixturePath,
+    '<!doctype html><html><body style="background:#fff"><h1 id="attachment-marker">painted-attachment-guest</h1></body></html>'
+  )
+  const fixtureUrl = pathToFileURL(fixturePath).href
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  const worktreeId = await getActiveWorktreeId(page)
+  if (!worktreeId) {
+    throw new Error('Expected an active worktree')
+  }
+  const browserTab = await page.evaluate(
+    ({ targetWorktreeId, targetUrl }) =>
+      window.__store?.getState().createBrowserTab(targetWorktreeId, targetUrl, {
+        title: 'Attachment fixture',
+        activate: true
+      }),
+    { targetWorktreeId: worktreeId, targetUrl: fixtureUrl }
+  )
+  if (!browserTab?.activePageId) {
+    throw new Error('Failed to create browser attachment fixture tab')
+  }
+  return {
+    browserTab: { activePageId: browserTab.activePageId, id: browserTab.id },
+    fixtureUrl
+  }
+}
+
+async function readGuestState(page: Page, browserTabId: string) {
+  return page.evaluate(async (targetBrowserTabId) => {
+    const chromePresent = Boolean(document.querySelector(`[data-tab-id="${targetBrowserTabId}"]`))
+    const webview = document.querySelector(
+      `[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`
+    ) as Electron.WebviewTag | null
+    if (!webview) {
+      return { chromePresent, marker: null, url: null, webContentsId: null }
+    }
+    try {
+      const webContentsId = webview.getWebContentsId()
+      const guest = (await webview.executeJavaScript(`({
+        marker: document.querySelector('#attachment-marker')?.textContent ?? null,
+        url: location.href
+      })`)) as { marker: string | null; url: string }
+      return { chromePresent, ...guest, webContentsId }
+    } catch {
+      return { chromePresent, marker: null, url: null, webContentsId: null }
+    }
+  }, browserTabId)
+}
+
+test('resume validation waits for an attaching guest without replacing it', async ({
+  electronApp,
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  const { browserTab, fixtureUrl } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+  await expect
+    .poll(() => readGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ marker: 'painted-attachment-guest', url: fixtureUrl })
+  const before = await readGuestState(orcaPage, browserTab.id)
+  expect(before.webContentsId).not.toBeNull()
+
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    const webview = document.querySelector(
+      `[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`
+    ) as Electron.WebviewTag
+    const getWebContentsId = webview.getWebContentsId.bind(webview)
+    let failedReads = 1
+    webview.dataset.attachingGuestIdentity = 'original'
+    Object.defineProperty(webview, 'getWebContentsId', {
+      configurable: true,
+      value: () => {
+        if (failedReads > 0) {
+          failedReads -= 1
+          webview.dataset.attachingGuestForcedRead = 'true'
+          throw new Error('guest still attaching')
+        }
+        webview.dataset.attachingGuestSuccessfulRead = 'true'
+        return getWebContentsId()
+      }
+    })
+  }, browserTab.id)
+
+  await orcaPage.evaluate(
+    (browserPageId) => window.api.browser.unregisterGuest({ browserPageId }),
+    browserTab.activePageId
+  )
+
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.webContents.send('system:resumed')
+  })
+  await expect
+    .poll(() =>
+      orcaPage.evaluate(
+        (targetBrowserTabId) =>
+          document
+            .querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`)
+            ?.getAttribute('data-attaching-guest-forced-read') ?? null,
+        browserTab.id
+      )
+    )
+    .toBe('true')
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    document
+      .querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`)
+      ?.dispatchEvent(new Event('dom-ready'))
+  }, browserTab.id)
+  await expect
+    .poll(() =>
+      orcaPage.evaluate((targetBrowserTabId) => {
+        const webview = document.querySelector(
+          `[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`
+        ) as Electron.WebviewTag | null
+        return {
+          forcedRead: webview?.dataset.attachingGuestForcedRead ?? null,
+          identity: webview?.dataset.attachingGuestIdentity ?? null,
+          successfulRead: webview?.dataset.attachingGuestSuccessfulRead ?? null
+        }
+      }, browserTab.id)
+    )
+    .toEqual({ forcedRead: 'true', identity: 'original', successfulRead: 'true' })
+
+  await expect
+    .poll(() => readGuestState(orcaPage, browserTab.id))
+    .toMatchObject({
+      chromePresent: true,
+      marker: 'painted-attachment-guest',
+      url: fixtureUrl,
+      webContentsId: before.webContentsId
+    })
+  await expect
+    .poll(() =>
+      orcaPage.evaluate(
+        ({ browserPageId, webContentsId }) =>
+          window.api.browser.isGuestRegistered({ browserPageId, webContentsId }),
+        { browserPageId: browserTab.activePageId, webContentsId: before.webContentsId! }
+      )
+    )
+    .toBe(true)
+  await expect
+    .poll(() =>
+      orcaPage.evaluate(
+        ({ workspaceId, browserPageId }) =>
+          window.__store
+            ?.getState()
+            .browserPagesByWorkspace[workspaceId]?.find((page) => page.id === browserPageId)
+            ?.loadError?.code ?? null,
+        { workspaceId: browserTab.id, browserPageId: browserTab.activePageId }
+      )
+    )
+    .toBeNull()
+})

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -4,10 +4,17 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
-import { ensureTerminalVisible, getActiveWorktreeId, waitForActiveWorktree } from './helpers/store'
+import {
+  ensureTerminalVisible,
+  getActiveWorktreeId,
+  switchToOtherWorktree,
+  switchToWorktree,
+  waitForActiveWorktree
+} from './helpers/store'
 
 type BrowserGuestState = {
   chromePresent: boolean
+  formValue: string | null
   marker: string | null
   url: string | null
   webContentsId: number | null
@@ -45,7 +52,7 @@ async function createBrowserFixture(
   const fixturePath = path.join(fixtureDir, 'recovery.html')
   writeFileSync(
     fixturePath,
-    '<!doctype html><html><head><title>Recovery fixture</title></head><body style="background:#fff"><h1 id="recovery-marker">painted-file-guest</h1></body></html>'
+    '<!doctype html><html><head><title>Recovery fixture</title></head><body style="background:#fff"><h1 id="recovery-marker">painted-file-guest</h1><input id="recovery-state"></body></html>'
   )
   const fixtureUrl = pathToFileURL(fixturePath).href
   await waitForActiveWorktree(page)
@@ -78,19 +85,55 @@ async function readBrowserGuestState(page: Page, browserTabId: string): Promise<
     const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
     const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
     if (!webview) {
-      return { chromePresent, marker: null, url: null, webContentsId: null }
+      return {
+        chromePresent,
+        formValue: null,
+        marker: null,
+        url: null,
+        webContentsId: null
+      }
     }
     try {
       const webContentsId = webview.getWebContentsId()
       const guest = (await webview.executeJavaScript(`({
+        formValue: document.querySelector('#recovery-state')?.value ?? null,
         marker: document.querySelector('#recovery-marker')?.textContent ?? null,
         url: location.href
-      })`)) as { marker: string | null; url: string }
-      return { chromePresent, marker: guest.marker, url: guest.url, webContentsId }
+      })`)) as { formValue: string | null; marker: string | null; url: string }
+      return { chromePresent, ...guest, webContentsId }
     } catch {
-      return { chromePresent, marker: null, url: null, webContentsId: null }
+      return {
+        chromePresent,
+        formValue: null,
+        marker: null,
+        url: null,
+        webContentsId: null
+      }
     }
   }, browserTabId)
+}
+
+async function isBrowserPagePaneMounted(page: Page, browserPageId: string): Promise<boolean> {
+  return page.evaluate(
+    (targetBrowserPageId) =>
+      Boolean(document.querySelector(`[data-browser-page-pane-id="${targetBrowserPageId}"]`)),
+    browserPageId
+  )
+}
+
+async function setGuestFormValue(page: Page, browserTabId: string, value: string): Promise<void> {
+  await page.evaluate(
+    async ({ targetBrowserTabId, targetValue }) => {
+      const overlay = document.querySelector(
+        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+      )
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag
+      await webview.executeJavaScript(
+        `document.querySelector('#recovery-state').value = ${JSON.stringify(targetValue)}`
+      )
+    },
+    { targetBrowserTabId: browserTabId, targetValue: value }
+  )
 }
 
 async function listRegisteredBrowserPages(
@@ -172,6 +215,7 @@ test('browser chrome recovers a live registered file guest after renderer loss',
       result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
     })
 
+  await setGuestFormValue(orcaPage, browserTab.id, 'unsaved-form-state')
   const backgroundTab = await orcaPage.evaluate(
     ({ targetWorktreeId }) =>
       window.__store?.getState().createBrowserTab(targetWorktreeId, 'about:blank', {
@@ -211,7 +255,8 @@ test('browser chrome recovers a live registered file guest after renderer loss',
     .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
     .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
   const resumeRecovered = await readBrowserGuestState(orcaPage, browserTab.id)
-  expect(resumeRecovered.webContentsId).not.toBe(recovered.webContentsId)
+  expect(resumeRecovered.webContentsId).toBe(recovered.webContentsId)
+  expect(resumeRecovered.formValue).toBe('unsaved-form-state')
   await expect
     .poll(async () =>
       (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.find(
@@ -246,6 +291,27 @@ test('browser chrome recovers a live registered file guest after renderer loss',
   await expect
     .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
     .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+
+  const parkedBefore = await readBrowserGuestState(orcaPage, browserTab.id)
+  const parkedProcessId = await readGuestProcessId(electronApp, parkedBefore.webContentsId!)
+  await expect.poll(() => isBrowserPagePaneMounted(orcaPage, browserTab.activePageId)).toBe(true)
+  const otherWorktreeId = await switchToOtherWorktree(orcaPage, worktreeId)
+  expect(otherWorktreeId).not.toBeNull()
+  await expect.poll(() => isBrowserPagePaneMounted(orcaPage, browserTab.activePageId)).toBe(false)
+  await crashGuestRenderer(electronApp, parkedBefore.webContentsId!)
+  await switchToWorktree(orcaPage, worktreeId)
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    window.__store?.getState().setActiveBrowserTab(targetBrowserTabId)
+  }, browserTab.id)
+  await expect.poll(() => isBrowserPagePaneMounted(orcaPage, browserTab.activePageId)).toBe(true)
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  const parkedRecovered = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(parkedRecovered.webContentsId).toBe(parkedBefore.webContentsId)
+  await expect
+    .poll(() => readGuestProcessId(electronApp, parkedRecovered.webContentsId!))
+    .not.toBe(parkedProcessId)
 })
 
 test('minimized browser guest stays painted and registered after restore @headful', async ({

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -3,39 +3,17 @@ import { createServer } from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
-import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import type { Page } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
-import {
-  ensureTerminalVisible,
-  getActiveWorktreeId,
-  switchToOtherWorktree,
-  switchToWorktree,
-  waitForActiveWorktree
-} from './helpers/store'
+import { ensureTerminalVisible, getActiveWorktreeId, waitForActiveWorktree } from './helpers/store'
 import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from '../../src/renderer/src/components/browser-pane/browser-page-guest-recovery'
-
-type BrowserGuestState = {
-  chromePresent: boolean
-  formValue: string | null
-  marker: string | null
-  url: string | null
-  webContentsId: number | null
-}
-
-async function readGuestProcessId(
-  electronApp: ElectronApplication,
-  webContentsId: number
-): Promise<number | null> {
-  return electronApp.evaluate(({ webContents }, targetId) => {
-    const guest = webContents.fromId(targetId)
-    return guest && !guest.isDestroyed() ? guest.getOSProcessId() : null
-  }, webContentsId)
-}
-
-type RuntimeResponse = {
-  ok: boolean
-  result?: { tabs?: { browserPageId: string; url: string }[] }
-}
+import {
+  crashGuestRenderer,
+  listRegisteredBrowserPages,
+  readBrowserGuestState,
+  readGuestProcessId,
+  verifyBrowserWorktreeRetentionAndRecovery
+} from './browser-guest-runtime-oracle'
 
 type BrowserFixture = {
   browserTab: { id: string; activePageId: string }
@@ -81,40 +59,6 @@ async function createBrowserFixture(
   }
 }
 
-async function readBrowserGuestState(page: Page, browserTabId: string): Promise<BrowserGuestState> {
-  return page.evaluate(async (targetBrowserTabId) => {
-    const chromePresent = Boolean(document.querySelector(`[data-tab-id="${targetBrowserTabId}"]`))
-    const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
-    const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
-    if (!webview) {
-      return {
-        chromePresent,
-        formValue: null,
-        marker: null,
-        url: null,
-        webContentsId: null
-      }
-    }
-    try {
-      const webContentsId = webview.getWebContentsId()
-      const guest = (await webview.executeJavaScript(`({
-        formValue: document.querySelector('#recovery-state')?.value ?? null,
-        marker: document.querySelector('#recovery-marker')?.textContent ?? null,
-        url: location.href
-      })`)) as { formValue: string | null; marker: string | null; url: string }
-      return { chromePresent, ...guest, webContentsId }
-    } catch {
-      return {
-        chromePresent,
-        formValue: null,
-        marker: null,
-        url: null,
-        webContentsId: null
-      }
-    }
-  }, browserTabId)
-}
-
 async function readBrowserPageRecoveryState(
   page: Page,
   workspaceId: string,
@@ -134,59 +78,6 @@ async function readBrowserPageRecoveryState(
     },
     { targetWorkspaceId: workspaceId, targetBrowserPageId: browserPageId }
   )
-}
-
-async function isBrowserPagePaneMounted(page: Page, browserPageId: string): Promise<boolean> {
-  return page.evaluate(
-    (targetBrowserPageId) =>
-      Boolean(document.querySelector(`[data-browser-page-pane-id="${targetBrowserPageId}"]`)),
-    browserPageId
-  )
-}
-
-async function setGuestFormValue(page: Page, browserTabId: string, value: string): Promise<void> {
-  await page.evaluate(
-    async ({ targetBrowserTabId, targetValue }) => {
-      const overlay = document.querySelector(
-        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
-      )
-      const webview = overlay?.querySelector('webview') as Electron.WebviewTag
-      await webview.executeJavaScript(
-        `document.querySelector('#recovery-state').value = ${JSON.stringify(targetValue)}`
-      )
-    },
-    { targetBrowserTabId: browserTabId, targetValue: value }
-  )
-}
-
-async function listRegisteredBrowserPages(
-  page: Page,
-  worktreeId: string
-): Promise<RuntimeResponse> {
-  return page.evaluate(
-    (targetWorktreeId) =>
-      window.api.runtime.call({
-        method: 'browser.tabList',
-        params: { worktree: `id:${targetWorktreeId}` }
-      }),
-    worktreeId
-  ) as Promise<RuntimeResponse>
-}
-
-async function crashGuestRenderer(
-  electronApp: ElectronApplication,
-  webContentsId: number
-): Promise<Electron.RenderProcessGoneDetails> {
-  return electronApp.evaluate(async ({ webContents }, targetId) => {
-    const guest = webContents.fromId(targetId)
-    if (!guest) {
-      throw new Error(`Missing guest webContents ${targetId}`)
-    }
-    return new Promise<Electron.RenderProcessGoneDetails>((resolve) => {
-      guest.once('render-process-gone', (_event, details) => resolve(details))
-      guest.forcefullyCrashRenderer()
-    })
-  }, webContentsId)
 }
 
 test('browser chrome recovers a live registered file guest after renderer loss', async ({
@@ -210,11 +101,14 @@ test('browser chrome recovers a live registered file guest after renderer loss',
   expect(before.webContentsId).not.toBeNull()
   const beforeProcessId = await readGuestProcessId(electronApp, before.webContentsId!)
   await expect
-    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId), { timeout: 10_000 })
-    .toMatchObject({
-      ok: true,
-      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
-    })
+    .poll(
+      async () =>
+        (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.find(
+          (tab) => tab.browserPageId === browserTab.activePageId
+        ),
+      { timeout: 10_000 }
+    )
+    .toMatchObject({ browserPageId: browserTab.activePageId, url: fixtureUrl })
 
   const crashDetails = await crashGuestRenderer(electronApp, before.webContentsId!)
   expect(['crashed', 'killed']).toContain(crashDetails.reason)
@@ -238,7 +132,18 @@ test('browser chrome recovers a live registered file guest after renderer loss',
       result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
     })
 
-  await setGuestFormValue(orcaPage, browserTab.id, 'unsaved-form-state')
+  await orcaPage.evaluate(
+    async ({ targetBrowserTabId, targetValue }) => {
+      const overlay = document.querySelector(
+        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+      )
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag
+      await webview.executeJavaScript(
+        `document.querySelector('#recovery-state').value = ${JSON.stringify(targetValue)}`
+      )
+    },
+    { targetBrowserTabId: browserTab.id, targetValue: 'unsaved-form-state' }
+  )
   await orcaPage.evaluate((browserPageId) => {
     return window.api.browser.unregisterGuest({ browserPageId })
   }, browserTab.activePageId)
@@ -307,26 +212,13 @@ test('browser chrome recovers a live registered file guest after renderer loss',
     .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
     .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
 
-  const parkedBefore = await readBrowserGuestState(orcaPage, browserTab.id)
-  const parkedProcessId = await readGuestProcessId(electronApp, parkedBefore.webContentsId!)
-  await expect.poll(() => isBrowserPagePaneMounted(orcaPage, browserTab.activePageId)).toBe(true)
-  const otherWorktreeId = await switchToOtherWorktree(orcaPage, worktreeId)
-  expect(otherWorktreeId).not.toBeNull()
-  await expect.poll(() => isBrowserPagePaneMounted(orcaPage, browserTab.activePageId)).toBe(false)
-  await crashGuestRenderer(electronApp, parkedBefore.webContentsId!)
-  await switchToWorktree(orcaPage, worktreeId)
-  await orcaPage.evaluate((targetBrowserTabId) => {
-    window.__store?.getState().setActiveBrowserTab(targetBrowserTabId)
-  }, browserTab.id)
-  await expect.poll(() => isBrowserPagePaneMounted(orcaPage, browserTab.activePageId)).toBe(true)
-  await expect
-    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
-    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
-  const parkedRecovered = await readBrowserGuestState(orcaPage, browserTab.id)
-  expect(parkedRecovered.webContentsId).toBe(parkedBefore.webContentsId)
-  await expect
-    .poll(() => readGuestProcessId(electronApp, parkedRecovered.webContentsId!))
-    .not.toBe(parkedProcessId)
+  await verifyBrowserWorktreeRetentionAndRecovery({
+    browserTab,
+    electronApp,
+    fixtureUrl,
+    page: orcaPage,
+    worktreeId
+  })
 })
 
 test('dom-ready ID loss waits for validation without reloading the guest', async ({

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -467,7 +467,24 @@ test('explicit navigation repairs a recovery error without dom-ready churn', asy
   const committedRequest = new Promise<void>((resolve) => {
     resolveCommittedRequest = resolve
   })
+  let resolveRedirectedRequest: (() => void) | null = null
+  const redirectedRequest = new Promise<void>((resolve) => {
+    resolveRedirectedRequest = resolve
+  })
   const stalledServer = createServer((request, response) => {
+    if (request.url === '/redirect') {
+      response.writeHead(302, { Location: '/redirected' })
+      response.end()
+      return
+    }
+    if (request.url === '/redirected') {
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      response.end(
+        '<!doctype html><html><body><h1 id="recovery-marker">painted-redirected-guest</h1></body></html>'
+      )
+      resolveRedirectedRequest?.()
+      return
+    }
     if (request.url === '/committed') {
       response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
       response.write('<!doctype html><html><head><title>Committed stall</title></head><body>')
@@ -563,6 +580,67 @@ test('explicit navigation repairs a recovery error without dom-ready churn', asy
     .toMatchObject({
       ok: true,
       result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+  expect(
+    await electronApp.evaluate(() => {
+      const testState = globalThis as typeof globalThis & {
+        browserRecoveryValidationCalls?: number
+      }
+      return testState.browserRecoveryValidationCalls ?? 0
+    })
+  ).toBe(1)
+
+  await orcaPage.evaluate(
+    (browserPageId) => window.api.browser.unregisterGuest({ browserPageId }),
+    browserTab.activePageId
+  )
+  await orcaPage.evaluate(
+    ({ browserPageId, validatedUrl, recoveryErrorCode }) => {
+      window.__store?.getState().updateBrowserPageState(browserPageId, {
+        loading: false,
+        loadError: {
+          code: recoveryErrorCode,
+          description: 'Recovery redirect fixture error',
+          validatedUrl
+        }
+      })
+    },
+    {
+      browserPageId: browserTab.activePageId,
+      validatedUrl: fixtureUrl,
+      recoveryErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE
+    }
+  )
+  await expect
+    .poll(() => readBrowserPageRecoveryState(orcaPage, browserTab.id, browserTab.activePageId))
+    .toMatchObject({ loadErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE })
+  await electronApp.evaluate(() => {
+    const testState = globalThis as typeof globalThis & {
+      browserRecoveryValidationCalls?: number
+    }
+    testState.browserRecoveryValidationCalls = 0
+  })
+
+  const redirectedUrl = `${stalledOrigin}/redirected`
+  await addressBar.fill(`${stalledOrigin}/redirect`)
+  await addressBar.press('Enter')
+  await redirectedRequest
+
+  await expect
+    .poll(() => readBrowserPageRecoveryState(orcaPage, browserTab.id, browserTab.activePageId))
+    .toMatchObject({ loadErrorCode: null, url: redirectedUrl })
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId))
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: redirectedUrl }] }
+    })
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({
+      chromePresent: true,
+      marker: 'painted-redirected-guest',
+      url: redirectedUrl
     })
   expect(
     await electronApp.evaluate(() => {

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -329,7 +329,7 @@ test('browser chrome recovers a live registered file guest after renderer loss',
     .not.toBe(parkedProcessId)
 })
 
-test('dom-ready ID loss enters bounded renderer recovery', async ({
+test('dom-ready ID loss waits for validation without reloading the guest', async ({
   orcaPage,
   registerPostElectronShutdownCleanup
 }) => {
@@ -355,6 +355,7 @@ test('dom-ready ID loss enters bounded renderer recovery', async ({
           failedReads -= 1
           throw new Error('guest detached')
         }
+        webview.dataset.domReadyIdRestored = 'true'
         return getWebContentsId()
       }
     })
@@ -374,11 +375,16 @@ test('dom-ready ID loss enters bounded renderer recovery', async ({
         (targetBrowserTabId) =>
           document
             .querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`)
-            ?.getAttribute('data-recovery-reload-attempted') ?? null,
+            ?.getAttribute('data-dom-ready-id-restored') ?? null,
         browserTab.id
       )
     )
     .toBe('true')
+  await expect(
+    orcaPage.locator(
+      `[data-browser-overlay-tab-id="${browserTab.id}"] webview[data-recovery-reload-attempted]`
+    )
+  ).toHaveCount(0)
   await expect
     .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
     .toMatchObject({

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -114,6 +115,27 @@ async function readBrowserGuestState(page: Page, browserTabId: string): Promise<
   }, browserTabId)
 }
 
+async function readBrowserPageRecoveryState(
+  page: Page,
+  workspaceId: string,
+  browserPageId: string
+): Promise<{ loadErrorCode: number | null; url: string | null }> {
+  return page.evaluate(
+    ({ targetWorkspaceId, targetBrowserPageId }) => {
+      const browserPage = window.__store
+        ?.getState()
+        .browserPagesByWorkspace[targetWorkspaceId]?.find(
+          (entry) => entry.id === targetBrowserPageId
+        )
+      return {
+        loadErrorCode: browserPage?.loadError?.code ?? null,
+        url: browserPage?.url ?? null
+      }
+    },
+    { targetWorkspaceId: workspaceId, targetBrowserPageId: browserPageId }
+  )
+}
+
 async function isBrowserPagePaneMounted(page: Page, browserPageId: string): Promise<boolean> {
   return page.evaluate(
     (targetBrowserPageId) =>
@@ -217,19 +239,6 @@ test('browser chrome recovers a live registered file guest after renderer loss',
     })
 
   await setGuestFormValue(orcaPage, browserTab.id, 'unsaved-form-state')
-  const backgroundTab = await orcaPage.evaluate(
-    ({ targetWorktreeId }) =>
-      window.__store?.getState().createBrowserTab(targetWorktreeId, 'about:blank', {
-        title: 'Background control',
-        activate: true
-      }),
-    { targetWorktreeId: worktreeId }
-  )
-  expect(backgroundTab?.id).toBeTruthy()
-  await expect
-    .poll(() => readBrowserGuestState(orcaPage, backgroundTab!.id), { timeout: 10_000 })
-    .toMatchObject({ chromePresent: true })
-
   await orcaPage.evaluate((browserPageId) => {
     return window.api.browser.unregisterGuest({ browserPageId })
   }, browserTab.activePageId)
@@ -244,20 +253,6 @@ test('browser chrome recovers a live registered file guest after renderer loss',
   await electronApp.evaluate(({ BrowserWindow }) => {
     BrowserWindow.getAllWindows()[0]?.webContents.send('system:resumed')
   })
-  await orcaPage.evaluate(
-    ({ targetWorktreeId, targetBrowserTabId }) => {
-      const state = window.__store?.getState()
-      state?.setActiveWorktree(targetWorktreeId)
-      state?.setActiveBrowserTab(targetBrowserTabId)
-    },
-    { targetWorktreeId: worktreeId, targetBrowserTabId: browserTab.id }
-  )
-  await expect
-    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
-    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
-  const resumeRecovered = await readBrowserGuestState(orcaPage, browserTab.id)
-  expect(resumeRecovered.webContentsId).toBe(recovered.webContentsId)
-  expect(resumeRecovered.formValue).toBe('unsaved-form-state')
   await expect
     .poll(async () =>
       (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.find(
@@ -265,6 +260,25 @@ test('browser chrome recovers a live registered file guest after renderer loss',
       )
     )
     .toMatchObject({ browserPageId: browserTab.activePageId, url: fixtureUrl })
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  const resumeRecovered = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(resumeRecovered.webContentsId).toBe(recovered.webContentsId)
+  expect(resumeRecovered.formValue).toBe('unsaved-form-state')
+
+  const backgroundTab = await orcaPage.evaluate(
+    ({ targetWorktreeId }) =>
+      window.__store?.getState().createBrowserTab(targetWorktreeId, 'about:blank', {
+        title: 'Background control',
+        activate: false
+      }),
+    { targetWorktreeId: worktreeId }
+  )
+  expect(backgroundTab?.id).toBeTruthy()
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, backgroundTab!.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true })
 
   const beforeRendererReloadId = resumeRecovered.webContentsId
   await orcaPage.reload()
@@ -313,6 +327,251 @@ test('browser chrome recovers a live registered file guest after renderer loss',
   await expect
     .poll(() => readGuestProcessId(electronApp, parkedRecovered.webContentsId!))
     .not.toBe(parkedProcessId)
+})
+
+test('dom-ready ID loss enters bounded renderer recovery', async ({
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  const { browserTab, fixtureUrl, worktreeId } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ marker: 'painted-file-guest', url: fixtureUrl })
+  const before = await readBrowserGuestState(orcaPage, browserTab.id)
+
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
+    const webview = overlay?.querySelector('webview') as Electron.WebviewTag
+    const getWebContentsId = webview.getWebContentsId.bind(webview)
+    const reload = webview.reload.bind(webview)
+    let failedReads = 2
+    Object.defineProperty(webview, 'getWebContentsId', {
+      configurable: true,
+      value: () => {
+        if (failedReads > 0) {
+          failedReads -= 1
+          throw new Error('guest detached')
+        }
+        return getWebContentsId()
+      }
+    })
+    Object.defineProperty(webview, 'reload', {
+      configurable: true,
+      value: () => {
+        webview.dataset.recoveryReloadAttempted = 'true'
+        reload()
+      }
+    })
+    webview.dispatchEvent(new Event('dom-ready'))
+  }, browserTab.id)
+
+  await expect
+    .poll(() =>
+      orcaPage.evaluate(
+        (targetBrowserTabId) =>
+          document
+            .querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"] webview`)
+            ?.getAttribute('data-recovery-reload-attempted') ?? null,
+        browserTab.id
+      )
+    )
+    .toBe('true')
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({
+      chromePresent: true,
+      marker: 'painted-file-guest',
+      url: fixtureUrl,
+      webContentsId: before.webContentsId
+    })
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId))
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+})
+
+test('explicit navigation repairs a recovery error without dom-ready churn', async ({
+  electronApp,
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  const { browserTab, fixtureUrl, worktreeId } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ marker: 'painted-file-guest', url: fixtureUrl })
+
+  await orcaPage.evaluate(
+    (browserPageId) => window.api.browser.unregisterGuest({ browserPageId }),
+    browserTab.activePageId
+  )
+  await orcaPage.evaluate(
+    ({ browserPageId, validatedUrl, recoveryErrorCode }) => {
+      window.__store?.getState().updateBrowserPageState(browserPageId, {
+        loading: false,
+        loadError: {
+          code: recoveryErrorCode,
+          description: 'Recovery fixture error',
+          validatedUrl
+        }
+      })
+    },
+    {
+      browserPageId: browserTab.activePageId,
+      validatedUrl: fixtureUrl,
+      recoveryErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE
+    }
+  )
+  await expect
+    .poll(() => readBrowserPageRecoveryState(orcaPage, browserTab.id, browserTab.activePageId))
+    .toMatchObject({ loadErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE })
+
+  await electronApp.evaluate(({ ipcMain }) => {
+    const testState = globalThis as typeof globalThis & {
+      browserRecoveryValidationCalls?: number
+    }
+    testState.browserRecoveryValidationCalls = 0
+    ipcMain.removeHandler('browser:isGuestRegistered')
+    ipcMain.handle('browser:isGuestRegistered', () => {
+      testState.browserRecoveryValidationCalls = (testState.browserRecoveryValidationCalls ?? 0) + 1
+      return false
+    })
+  })
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
+    overlay?.querySelector('webview')?.dispatchEvent(new Event('dom-ready'))
+  }, browserTab.id)
+  await expect
+    .poll(async () =>
+      (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.some(
+        (tab) => tab.browserPageId === browserTab.activePageId
+      )
+    )
+    .toBe(false)
+
+  const addressBar = orcaPage.locator(
+    `[data-browser-overlay-tab-id="${browserTab.id}"] [data-orca-browser-address-bar="true"]`
+  )
+  let resolvePrecommitRequest: (() => void) | null = null
+  const precommitRequest = new Promise<void>((resolve) => {
+    resolvePrecommitRequest = resolve
+  })
+  let resolveCommittedRequest: (() => void) | null = null
+  const committedRequest = new Promise<void>((resolve) => {
+    resolveCommittedRequest = resolve
+  })
+  const stalledServer = createServer((request, response) => {
+    if (request.url === '/committed') {
+      response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+      response.write('<!doctype html><html><head><title>Committed stall</title></head><body>')
+      resolveCommittedRequest?.()
+      return
+    }
+    resolvePrecommitRequest?.()
+  })
+  await new Promise<void>((resolve, reject) => {
+    stalledServer.once('error', reject)
+    stalledServer.listen(0, '127.0.0.1', resolve)
+  })
+  registerPostElectronShutdownCleanup(async () => {
+    stalledServer.closeAllConnections()
+    await new Promise<void>((resolve) => {
+      stalledServer.close(() => resolve())
+    })
+  })
+  const stalledAddress = stalledServer.address()
+  if (!stalledAddress || typeof stalledAddress === 'string') {
+    throw new Error('Expected a local stalled server address')
+  }
+  const stalledOrigin = `http://127.0.0.1:${stalledAddress.port}`
+  await addressBar.fill(`${stalledOrigin}/precommit`)
+  await addressBar.press('Enter')
+  await precommitRequest
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
+    const webview = overlay?.querySelector('webview')
+    const inPageNavigation = Object.assign(new Event('did-navigate-in-page'), {
+      isMainFrame: true,
+      url: `${webview?.getAttribute('src') ?? 'about:blank'}#stale`
+    })
+    webview?.dispatchEvent(inPageNavigation)
+    webview?.dispatchEvent(new Event('dom-ready'))
+  }, browserTab.id)
+  await orcaPage.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      })
+  )
+  expect(
+    await electronApp.evaluate(() => {
+      const testState = globalThis as typeof globalThis & {
+        browserRecoveryValidationCalls?: number
+      }
+      return testState.browserRecoveryValidationCalls ?? 0
+    })
+  ).toBe(0)
+  await expect
+    .poll(async () =>
+      (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.some(
+        (tab) => tab.browserPageId === browserTab.activePageId
+      )
+    )
+    .toBe(false)
+  await expect
+    .poll(() => readBrowserPageRecoveryState(orcaPage, browserTab.id, browserTab.activePageId))
+    .toMatchObject({ loadErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE })
+
+  const committedStallUrl = `${stalledOrigin}/committed`
+  await addressBar.fill(committedStallUrl)
+  await addressBar.press('Enter')
+  await committedRequest
+  await expect
+    .poll(() => readBrowserPageRecoveryState(orcaPage, browserTab.id, browserTab.activePageId))
+    .toEqual({ loadErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE, url: committedStallUrl })
+  await expect(orcaPage.getByText('Recovery fixture error', { exact: true })).toBeVisible()
+  expect(
+    await electronApp.evaluate(() => {
+      const testState = globalThis as typeof globalThis & {
+        browserRecoveryValidationCalls?: number
+      }
+      return testState.browserRecoveryValidationCalls ?? 0
+    })
+  ).toBe(0)
+  await expect
+    .poll(async () =>
+      (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.some(
+        (tab) => tab.browserPageId === browserTab.activePageId
+      )
+    )
+    .toBe(false)
+  await addressBar.fill(fixtureUrl)
+  await addressBar.press('Enter')
+
+  await expect
+    .poll(() => readBrowserPageRecoveryState(orcaPage, browserTab.id, browserTab.activePageId))
+    .toMatchObject({ loadErrorCode: null, url: fixtureUrl })
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId))
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+  expect(
+    await electronApp.evaluate(() => {
+      const testState = globalThis as typeof globalThis & {
+        browserRecoveryValidationCalls?: number
+      }
+      return testState.browserRecoveryValidationCalls ?? 0
+    })
+  ).toBe(1)
 })
 
 test('recovery error stays visible until toolbar retry repairs registration', async ({

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -11,6 +11,7 @@ import {
   switchToWorktree,
   waitForActiveWorktree
 } from './helpers/store'
+import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from '../../src/renderer/src/components/browser-pane/browser-page-guest-recovery'
 
 type BrowserGuestState = {
   chromePresent: boolean
@@ -312,6 +313,135 @@ test('browser chrome recovers a live registered file guest after renderer loss',
   await expect
     .poll(() => readGuestProcessId(electronApp, parkedRecovered.webContentsId!))
     .not.toBe(parkedProcessId)
+})
+
+test('recovery error stays visible until toolbar retry repairs registration', async ({
+  electronApp,
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  const { browserTab, fixtureUrl, worktreeId } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ marker: 'painted-file-guest', url: fixtureUrl })
+
+  await orcaPage.evaluate(
+    (browserPageId) => window.api.browser.unregisterGuest({ browserPageId }),
+    browserTab.activePageId
+  )
+  await electronApp.evaluate(({ BrowserWindow, ipcMain }) => {
+    ipcMain.removeHandler('browser:isGuestRegistered')
+    BrowserWindow.getAllWindows()[0]?.webContents.send('system:resumed')
+  })
+
+  await expect
+    .poll(
+      () =>
+        orcaPage.evaluate(
+          ({ workspaceId, browserPageId }) =>
+            window.__store
+              ?.getState()
+              .browserPagesByWorkspace[workspaceId]?.find((page) => page.id === browserPageId)
+              ?.loadError?.code ?? null,
+          { workspaceId: browserTab.id, browserPageId: browserTab.activePageId }
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(BROWSER_GUEST_RECOVERY_ERROR_CODE)
+
+  await electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.handle('browser:isGuestRegistered', () => false)
+  })
+  await orcaPage
+    .locator('[data-contextual-tour-target="browser-toolbar"]')
+    .locator('button')
+    .nth(2)
+    .click()
+
+  await expect
+    .poll(
+      () =>
+        orcaPage.evaluate(
+          ({ workspaceId, browserPageId }) =>
+            window.__store
+              ?.getState()
+              .browserPagesByWorkspace[workspaceId]?.find((page) => page.id === browserPageId)
+              ?.loadError?.code ?? null,
+          { workspaceId: browserTab.id, browserPageId: browserTab.activePageId }
+        ),
+      { timeout: 10_000 }
+    )
+    .toBeNull()
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId))
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+})
+
+test('attachment keeps recovery error until document readiness', async ({
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  const { browserTab, fixtureUrl } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ marker: 'painted-file-guest', url: fixtureUrl })
+
+  await orcaPage.evaluate(
+    ({ workspaceId, browserPageId, validatedUrl, recoveryErrorCode }) => {
+      window.__store?.getState().updateBrowserPageState(browserPageId, {
+        loading: false,
+        loadError: {
+          code: recoveryErrorCode,
+          description: 'Recovery fixture error',
+          validatedUrl
+        }
+      })
+      const overlay = document.querySelector(`[data-browser-overlay-tab-id="${workspaceId}"]`)
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag
+      Object.defineProperty(webview, 'reload', {
+        configurable: true,
+        value: () => webview.dispatchEvent(new Event('did-attach'))
+      })
+    },
+    {
+      workspaceId: browserTab.id,
+      browserPageId: browserTab.activePageId,
+      validatedUrl: fixtureUrl,
+      recoveryErrorCode: BROWSER_GUEST_RECOVERY_ERROR_CODE
+    }
+  )
+  await orcaPage
+    .locator('[data-contextual-tour-target="browser-toolbar"]')
+    .locator('button')
+    .nth(2)
+    .click()
+  const recoveryErrorCode = await orcaPage.evaluate(
+    ({ workspaceId, browserPageId }) =>
+      new Promise<number | null>((resolve) => {
+        requestAnimationFrame(() => {
+          resolve(
+            window.__store
+              ?.getState()
+              .browserPagesByWorkspace[workspaceId]?.find((page) => page.id === browserPageId)
+              ?.loadError?.code ?? null
+          )
+        })
+      }),
+    { workspaceId: browserTab.id, browserPageId: browserTab.activePageId }
+  )
+  expect(recoveryErrorCode).toBe(BROWSER_GUEST_RECOVERY_ERROR_CODE)
 })
 
 test('minimized browser guest stays painted and registered after restore @headful', async ({

--- a/tests/e2e/browser-guest-crash-recovery.spec.ts
+++ b/tests/e2e/browser-guest-crash-recovery.spec.ts
@@ -1,0 +1,298 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, getActiveWorktreeId, waitForActiveWorktree } from './helpers/store'
+
+type BrowserGuestState = {
+  chromePresent: boolean
+  marker: string | null
+  url: string | null
+  webContentsId: number | null
+}
+
+async function readGuestProcessId(
+  electronApp: ElectronApplication,
+  webContentsId: number
+): Promise<number | null> {
+  return electronApp.evaluate(({ webContents }, targetId) => {
+    const guest = webContents.fromId(targetId)
+    return guest && !guest.isDestroyed() ? guest.getOSProcessId() : null
+  }, webContentsId)
+}
+
+type RuntimeResponse = {
+  ok: boolean
+  result?: { tabs?: { browserPageId: string; url: string }[] }
+}
+
+type BrowserFixture = {
+  browserTab: { id: string; activePageId: string }
+  fixtureUrl: string
+  worktreeId: string
+}
+
+async function createBrowserFixture(
+  page: Page,
+  registerCleanup: (cleanup: () => Promise<void>) => void
+): Promise<BrowserFixture> {
+  const fixtureDir = mkdtempSync(path.join(os.tmpdir(), 'orca-browser-recovery-'))
+  registerCleanup(async () => {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  })
+  const fixturePath = path.join(fixtureDir, 'recovery.html')
+  writeFileSync(
+    fixturePath,
+    '<!doctype html><html><head><title>Recovery fixture</title></head><body style="background:#fff"><h1 id="recovery-marker">painted-file-guest</h1></body></html>'
+  )
+  const fixtureUrl = pathToFileURL(fixturePath).href
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  const worktreeId = await getActiveWorktreeId(page)
+  if (!worktreeId) {
+    throw new Error('Expected an active worktree')
+  }
+  const browserTab = await page.evaluate(
+    ({ targetWorktreeId, targetUrl }) =>
+      window.__store?.getState().createBrowserTab(targetWorktreeId, targetUrl, {
+        title: 'Recovery fixture',
+        activate: true
+      }),
+    { targetWorktreeId: worktreeId, targetUrl: fixtureUrl }
+  )
+  if (!browserTab?.activePageId) {
+    throw new Error('Failed to create browser recovery fixture tab')
+  }
+  return {
+    browserTab: { id: browserTab.id, activePageId: browserTab.activePageId },
+    fixtureUrl,
+    worktreeId
+  }
+}
+
+async function readBrowserGuestState(page: Page, browserTabId: string): Promise<BrowserGuestState> {
+  return page.evaluate(async (targetBrowserTabId) => {
+    const chromePresent = Boolean(document.querySelector(`[data-tab-id="${targetBrowserTabId}"]`))
+    const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
+    const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+    if (!webview) {
+      return { chromePresent, marker: null, url: null, webContentsId: null }
+    }
+    try {
+      const webContentsId = webview.getWebContentsId()
+      const guest = (await webview.executeJavaScript(`({
+        marker: document.querySelector('#recovery-marker')?.textContent ?? null,
+        url: location.href
+      })`)) as { marker: string | null; url: string }
+      return { chromePresent, marker: guest.marker, url: guest.url, webContentsId }
+    } catch {
+      return { chromePresent, marker: null, url: null, webContentsId: null }
+    }
+  }, browserTabId)
+}
+
+async function listRegisteredBrowserPages(
+  page: Page,
+  worktreeId: string
+): Promise<RuntimeResponse> {
+  return page.evaluate(
+    (targetWorktreeId) =>
+      window.api.runtime.call({
+        method: 'browser.tabList',
+        params: { worktree: `id:${targetWorktreeId}` }
+      }),
+    worktreeId
+  ) as Promise<RuntimeResponse>
+}
+
+async function crashGuestRenderer(
+  electronApp: ElectronApplication,
+  webContentsId: number
+): Promise<Electron.RenderProcessGoneDetails> {
+  return electronApp.evaluate(async ({ webContents }, targetId) => {
+    const guest = webContents.fromId(targetId)
+    if (!guest) {
+      throw new Error(`Missing guest webContents ${targetId}`)
+    }
+    return new Promise<Electron.RenderProcessGoneDetails>((resolve) => {
+      guest.once('render-process-gone', (_event, details) => resolve(details))
+      guest.forcefullyCrashRenderer()
+    })
+  }, webContentsId)
+}
+
+test('browser chrome recovers a live registered file guest after renderer loss', async ({
+  electronApp,
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
+  const { browserTab, fixtureUrl, worktreeId } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({
+      chromePresent: true,
+      marker: 'painted-file-guest',
+      url: fixtureUrl
+    })
+  const before = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(before.webContentsId).not.toBeNull()
+  const beforeProcessId = await readGuestProcessId(electronApp, before.webContentsId!)
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId), { timeout: 10_000 })
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+
+  const crashDetails = await crashGuestRenderer(electronApp, before.webContentsId!)
+  expect(['crashed', 'killed']).toContain(crashDetails.reason)
+
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({
+      chromePresent: true,
+      marker: 'painted-file-guest',
+      url: fixtureUrl
+    })
+  const recovered = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(recovered.webContentsId).toBe(before.webContentsId)
+  await expect
+    .poll(() => readGuestProcessId(electronApp, recovered.webContentsId!), { timeout: 10_000 })
+    .not.toBe(beforeProcessId)
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId), { timeout: 10_000 })
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+
+  const backgroundTab = await orcaPage.evaluate(
+    ({ targetWorktreeId }) =>
+      window.__store?.getState().createBrowserTab(targetWorktreeId, 'about:blank', {
+        title: 'Background control',
+        activate: true
+      }),
+    { targetWorktreeId: worktreeId }
+  )
+  expect(backgroundTab?.id).toBeTruthy()
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, backgroundTab!.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true })
+
+  await orcaPage.evaluate((browserPageId) => {
+    return window.api.browser.unregisterGuest({ browserPageId })
+  }, browserTab.activePageId)
+  await expect
+    .poll(
+      async () =>
+        (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.some(
+          (tab) => tab.browserPageId === browserTab.activePageId
+        ) ?? false
+    )
+    .toBe(false)
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.webContents.send('system:resumed')
+  })
+  await orcaPage.evaluate(
+    ({ targetWorktreeId, targetBrowserTabId }) => {
+      const state = window.__store?.getState()
+      state?.setActiveWorktree(targetWorktreeId)
+      state?.setActiveBrowserTab(targetBrowserTabId)
+    },
+    { targetWorktreeId: worktreeId, targetBrowserTabId: browserTab.id }
+  )
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  const resumeRecovered = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(resumeRecovered.webContentsId).not.toBe(recovered.webContentsId)
+  await expect
+    .poll(async () =>
+      (await listRegisteredBrowserPages(orcaPage, worktreeId)).result?.tabs?.find(
+        (tab) => tab.browserPageId === browserTab.activePageId
+      )
+    )
+    .toMatchObject({ browserPageId: browserTab.activePageId, url: fixtureUrl })
+
+  const beforeRendererReloadId = resumeRecovered.webContentsId
+  await orcaPage.reload()
+  await waitForActiveWorktree(orcaPage)
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  const rendererReloaded = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(rendererReloaded.webContentsId).not.toBe(beforeRendererReloadId)
+
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    window.__store?.getState().setActiveBrowserTab(targetBrowserTabId)
+  }, backgroundTab!.id)
+  const hiddenBefore = await readBrowserGuestState(orcaPage, browserTab.id)
+  const hiddenProcessId = await readGuestProcessId(electronApp, hiddenBefore.webContentsId!)
+  await crashGuestRenderer(electronApp, hiddenBefore.webContentsId!)
+  await expect
+    .poll(() => readGuestProcessId(electronApp, hiddenBefore.webContentsId!), {
+      timeout: 10_000
+    })
+    .not.toBe(hiddenProcessId)
+  await orcaPage.evaluate((targetBrowserTabId) => {
+    window.__store?.getState().setActiveBrowserTab(targetBrowserTabId)
+  }, browserTab.id)
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+})
+
+test('minimized browser guest stays painted and registered after restore @headful', async ({
+  electronApp,
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}, testInfo) => {
+  const { browserTab, fixtureUrl, worktreeId } = await createBrowserFixture(
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  )
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ marker: 'painted-file-guest', url: fixtureUrl })
+  const before = await readBrowserGuestState(orcaPage, browserTab.id)
+
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.minimize()
+  })
+  await expect
+    .poll(() =>
+      electronApp.evaluate(({ BrowserWindow }) =>
+        Boolean(BrowserWindow.getAllWindows()[0]?.isMinimized())
+      )
+    )
+    .toBe(true)
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+    window?.restore()
+    window?.show()
+  })
+
+  await expect
+    .poll(() => readBrowserGuestState(orcaPage, browserTab.id))
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  const restored = await readBrowserGuestState(orcaPage, browserTab.id)
+  expect(restored.webContentsId).toBe(before.webContentsId)
+  await expect
+    .poll(() => listRegisteredBrowserPages(orcaPage, worktreeId))
+    .toMatchObject({
+      ok: true,
+      result: { tabs: [{ browserPageId: browserTab.activePageId, url: fixtureUrl }] }
+    })
+  const screenshotPath = testInfo.outputPath('browser-minimize-restore.png')
+  await orcaPage.screenshot({ path: screenshotPath, fullPage: true })
+  await testInfo.attach('browser-minimize-restore', {
+    path: screenshotPath,
+    contentType: 'image/png'
+  })
+})

--- a/tests/e2e/browser-guest-runtime-oracle.ts
+++ b/tests/e2e/browser-guest-runtime-oracle.ts
@@ -1,0 +1,186 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { expect } from './helpers/orca-app'
+import { switchToOtherWorktree, switchToWorktree } from './helpers/store'
+
+export type BrowserGuestState = {
+  chromePresent: boolean
+  formValue: string | null
+  marker: string | null
+  url: string | null
+  webContentsId: number | null
+}
+
+type RuntimeResponse = {
+  ok: boolean
+  result?: { tabs?: { browserPageId: string; url: string }[] }
+}
+
+export async function readGuestProcessId(
+  electronApp: ElectronApplication,
+  webContentsId: number
+): Promise<number | null> {
+  return electronApp.evaluate(({ webContents }, targetId) => {
+    const guest = webContents.fromId(targetId)
+    return guest && !guest.isDestroyed() ? guest.getOSProcessId() : null
+  }, webContentsId)
+}
+
+export async function readBrowserGuestState(
+  page: Page,
+  browserTabId: string
+): Promise<BrowserGuestState> {
+  return page.evaluate(async (targetBrowserTabId) => {
+    const chromePresent = Boolean(document.querySelector(`[data-tab-id="${targetBrowserTabId}"]`))
+    const overlay = document.querySelector(`[data-browser-overlay-tab-id="${targetBrowserTabId}"]`)
+    const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+    if (!webview) {
+      return {
+        chromePresent,
+        formValue: null,
+        marker: null,
+        url: null,
+        webContentsId: null
+      }
+    }
+    try {
+      const webContentsId = webview.getWebContentsId()
+      const guest = (await webview.executeJavaScript(`({
+        formValue: document.querySelector('#recovery-state')?.value ?? null,
+        marker: document.querySelector('#recovery-marker')?.textContent ?? null,
+        url: location.href
+      })`)) as { formValue: string | null; marker: string | null; url: string }
+      return { chromePresent, ...guest, webContentsId }
+    } catch {
+      return {
+        chromePresent,
+        formValue: null,
+        marker: null,
+        url: null,
+        webContentsId: null
+      }
+    }
+  }, browserTabId)
+}
+
+export async function listRegisteredBrowserPages(
+  page: Page,
+  worktreeId: string
+): Promise<RuntimeResponse> {
+  return page.evaluate(
+    (targetWorktreeId) =>
+      window.api.runtime.call({
+        method: 'browser.tabList',
+        params: { worktree: `id:${targetWorktreeId}` }
+      }),
+    worktreeId
+  ) as Promise<RuntimeResponse>
+}
+
+export async function crashGuestRenderer(
+  electronApp: ElectronApplication,
+  webContentsId: number
+): Promise<Electron.RenderProcessGoneDetails> {
+  return electronApp.evaluate(async ({ webContents }, targetId) => {
+    const guest = webContents.fromId(targetId)
+    if (!guest) {
+      throw new Error(`Missing guest webContents ${targetId}`)
+    }
+    return new Promise<Electron.RenderProcessGoneDetails>((resolve) => {
+      guest.once('render-process-gone', (_event, details) => resolve(details))
+      guest.forcefullyCrashRenderer()
+    })
+  }, webContentsId)
+}
+
+export async function verifyBrowserWorktreeRetentionAndRecovery({
+  browserTab,
+  electronApp,
+  fixtureUrl,
+  page,
+  worktreeId
+}: {
+  browserTab: { id: string; activePageId: string }
+  electronApp: ElectronApplication
+  fixtureUrl: string
+  page: Page
+  worktreeId: string
+}): Promise<void> {
+  await page.evaluate(
+    async ({ targetBrowserTabId, targetValue }) => {
+      const overlay = document.querySelector(
+        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+      )
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag
+      await webview.executeJavaScript(
+        `document.querySelector('#recovery-state').value = ${JSON.stringify(targetValue)}`
+      )
+    },
+    {
+      targetBrowserTabId: browserTab.id,
+      targetValue: 'retained-across-worktree-switch'
+    }
+  )
+  const parkedBefore = await readBrowserGuestState(page, browserTab.id)
+  const parkedProcessId = await readGuestProcessId(electronApp, parkedBefore.webContentsId!)
+  await expect.poll(() => isBrowserPagePaneMounted(page, browserTab.activePageId)).toBe(true)
+  const otherWorktreeId = await switchToOtherWorktree(page, worktreeId)
+  expect(otherWorktreeId).not.toBeNull()
+  await expect.poll(() => isBrowserPagePaneMounted(page, browserTab.activePageId)).toBe(false)
+  await expect
+    .poll(() => readBrowserGuestState(page, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({
+      formValue: 'retained-across-worktree-switch',
+      marker: 'painted-file-guest',
+      url: fixtureUrl,
+      webContentsId: parkedBefore.webContentsId
+    })
+  await expect
+    .poll(
+      async () =>
+        (await listRegisteredBrowserPages(page, worktreeId)).result?.tabs?.find(
+          (tab) => tab.browserPageId === browserTab.activePageId
+        ),
+      { timeout: 10_000 }
+    )
+    .toMatchObject({ browserPageId: browserTab.activePageId, url: fixtureUrl })
+  expect(await readGuestProcessId(electronApp, parkedBefore.webContentsId!)).toBe(parkedProcessId)
+
+  await switchToWorktree(page, worktreeId)
+  await page.evaluate((targetBrowserTabId) => {
+    window.__store?.getState().setActiveBrowserTab(targetBrowserTabId)
+  }, browserTab.id)
+  await expect.poll(() => isBrowserPagePaneMounted(page, browserTab.activePageId)).toBe(true)
+  await expect
+    .poll(() => readBrowserGuestState(page, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({
+      formValue: 'retained-across-worktree-switch',
+      marker: 'painted-file-guest',
+      url: fixtureUrl,
+      webContentsId: parkedBefore.webContentsId
+    })
+
+  await switchToWorktree(page, otherWorktreeId!)
+  await expect.poll(() => isBrowserPagePaneMounted(page, browserTab.activePageId)).toBe(false)
+  await crashGuestRenderer(electronApp, parkedBefore.webContentsId!)
+  await switchToWorktree(page, worktreeId)
+  await page.evaluate((targetBrowserTabId) => {
+    window.__store?.getState().setActiveBrowserTab(targetBrowserTabId)
+  }, browserTab.id)
+  await expect.poll(() => isBrowserPagePaneMounted(page, browserTab.activePageId)).toBe(true)
+  await expect
+    .poll(() => readBrowserGuestState(page, browserTab.id), { timeout: 10_000 })
+    .toMatchObject({ chromePresent: true, marker: 'painted-file-guest', url: fixtureUrl })
+  const parkedRecovered = await readBrowserGuestState(page, browserTab.id)
+  expect(parkedRecovered.webContentsId).toBe(parkedBefore.webContentsId)
+  await expect
+    .poll(() => readGuestProcessId(electronApp, parkedRecovered.webContentsId!))
+    .not.toBe(parkedProcessId)
+}
+
+async function isBrowserPagePaneMounted(page: Page, browserPageId: string): Promise<boolean> {
+  return page.evaluate(
+    (targetBrowserPageId) =>
+      Boolean(document.querySelector(`[data-browser-page-pane-id="${targetBrowserPageId}"]`)),
+    browserPageId
+  )
+}

--- a/tests/e2e/browser-split-find-shortcut.spec.ts
+++ b/tests/e2e/browser-split-find-shortcut.spec.ts
@@ -12,6 +12,7 @@ type SplitFindFixture = {
 }
 
 type BrowserSplitFixture = {
+  firstBrowserPageId: string
   firstBrowserTabId: string
   secondBrowserTabId: string
 }
@@ -76,6 +77,7 @@ async function createBrowserSplit(page: Page): Promise<BrowserSplitFixture> {
       targetGroupId: secondBrowserGroupId
     })
     return {
+      firstBrowserPageId: firstBrowserTab.activePageId,
       firstBrowserTabId: firstBrowserTab.id,
       secondBrowserTabId: secondBrowserTab.id
     }
@@ -113,42 +115,55 @@ function browserSplitFindInput(page: Page, browserTabId: string) {
     .getByPlaceholder('Find in page...')
 }
 
-async function pressFindInBrowserGuest(page: Page, browserTabId: string): Promise<void> {
+async function pressFindInBrowserGuest(
+  page: Page,
+  browserTabId: string,
+  browserPageId: string
+): Promise<void> {
   await expect
     .poll(() =>
-      page.evaluate((targetBrowserTabId) => {
-        const overlay = document.querySelector(
-          `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
-        )
-        const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
-        return webview?.getWebContentsId() ?? null
-      }, browserTabId)
-    )
-    .not.toBeNull()
-
-  await page.evaluate(
-    async ({ targetBrowserTabId, inputModifier }) => {
-      const overlay = document.querySelector(
-        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+      page.evaluate(
+        async ({ targetBrowserPageId, targetBrowserTabId, inputModifier }) => {
+          const overlay = document.querySelector(
+            `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+          )
+          const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+          try {
+            if (!webview) {
+              return false
+            }
+            const webContentsId = webview.getWebContentsId()
+            const registered = await window.api.browser.isGuestRegistered({
+              browserPageId: targetBrowserPageId,
+              webContentsId
+            })
+            if (!registered) {
+              return false
+            }
+            webview.focus()
+            await webview.sendInputEvent({
+              type: 'keyDown',
+              keyCode: 'F',
+              modifiers: [inputModifier]
+            })
+            await webview.sendInputEvent({
+              type: 'keyUp',
+              keyCode: 'F',
+              modifiers: [inputModifier]
+            })
+            return true
+          } catch {
+            return false
+          }
+        },
+        {
+          targetBrowserPageId: browserPageId,
+          targetBrowserTabId: browserTabId,
+          inputModifier: modifier.toLowerCase()
+        }
       )
-      const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
-      if (!webview) {
-        throw new Error(`Missing webview for browser tab ${targetBrowserTabId}`)
-      }
-      webview.focus()
-      await webview.sendInputEvent({
-        type: 'keyDown',
-        keyCode: 'F',
-        modifiers: [inputModifier]
-      })
-      await webview.sendInputEvent({
-        type: 'keyUp',
-        keyCode: 'F',
-        modifiers: [inputModifier]
-      })
-    },
-    { targetBrowserTabId: browserTabId, inputModifier: modifier.toLowerCase() }
-  )
+    )
+    .toBe(true)
 }
 
 function terminalFindInput(page: Page) {
@@ -240,10 +255,25 @@ test.describe('browser split Find shortcut', () => {
   }) => {
     const fixture = await createBrowserSplit(orcaPage)
 
-    await pressFindInBrowserGuest(orcaPage, fixture.firstBrowserTabId)
+    await pressFindInBrowserGuest(orcaPage, fixture.firstBrowserTabId, fixture.firstBrowserPageId)
 
     await expect(browserSplitFindInput(orcaPage, fixture.firstBrowserTabId)).toBeVisible()
     await expect(browserSplitFindInput(orcaPage, fixture.secondBrowserTabId)).toBeHidden()
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          ({ browserPageId, browserTabId }) =>
+            window.__store
+              ?.getState()
+              .browserPagesByWorkspace[browserTabId]?.find((page) => page.id === browserPageId)
+              ?.loadError?.code ?? null,
+          {
+            browserPageId: fixture.firstBrowserPageId,
+            browserTabId: fixture.firstBrowserTabId
+          }
+        )
+      )
+      .toBeNull()
   })
 
   test('keeps browser Find available when split focus state is temporarily missing', async ({


### PR DESCRIPTION
## Summary

Builds on the host-retention fix merged in #12137 and closes the remaining embedded-browser lifecycle gap: when tab chrome/model survives but its Electron guest is crashed, detached, or missing from the runtime registry, Orca now converges to a live registered guest or a truthful retryable error surface instead of a permanent blank viewport.

- Repairs healthy guests with missing registry ownership in place, preserving live DOM and unsaved page state.
- Reloads crashed renderers in place, preserving `webContents` identity while requiring a new renderer process and repainted DOM.
- Uses bounded guest replacement only as the final fallback, preserving URL/history, profile/partition, zoom, and the replacement viewport without duplicate guests or reload loops.
- Bounds replacement handoff at 8 seconds; a stalled teardown becomes a retryable error, and Retry starts a fresh replacement instead of waiting forever.
- Covers system resume, renderer reload/hydration, hidden tabs, parked worktrees, local `file://` pages, registry disagreement, redirects, and explicit recovery failure/retry.

## Relationship to #12137 / STA-3228

#12137 fixed the worktree-switch trigger by retaining browser overlay hosts and repairing stranded viewport shells. It merged while this combined candidate was being prepared, so this PR is rebased on that fix rather than duplicating it. This is the single remaining follow-up: it handles guest/process/registry loss after the host survives and adds an integrated worktree-retention + guest-recovery oracle.

## Deterministic reproduction

The byte-identical Electron oracle (SHA-256 `5f8272e96a7041d42db14de57744d939006a9d7cbb9c8b5aecc3e8eaa2d5329d`) force-crashes a real local `file://` guest while keeping tab chrome/model alive, then checks two independent signal groups:

1. guest DOM paint plus URL/form state;
2. runtime registry membership plus `webContents` and renderer-process identity.

- Current `main` `cd68a8b00c`: **fails** after 10 seconds because chrome survives but the guest DOM never repaints.
- Candidate `4958840738`: **passes** with the same `webContents` ID, a new renderer PID, restored DOM paint, and a live registry entry.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] 13 focused Vitest files: 417/417 passed
- [x] Full local Vitest sweep: 4,076 files and 43,548 tests passed; two relay tests pass with Codex-injected `GIT_CONFIG_*` variables removed, and three root-directory guard tests require Bash associative arrays unavailable in macOS Bash 3.2
- [x] Fresh Electron E2E build and recovery suite: 6/6 passed, repeated twice after the final integration fix
- [x] Headed minimize/restore: 1/1 passed with painted pixels and registry identity
- [x] Forced-headed combined worktree-switch/park/crash/recovery oracle: 1/1 passed

## AI Review Report

Fresh independent correctness/security, adversarial architecture, and performance/resource reviewers ended **CLEAN** on the final patch. Review covered parent-drift replacement, unregister/re-register ordering, bounded retries, duplicate-guest prevention, URL/history/profile/partition/zoom preservation, focus, multiple tabs/workspaces, local versus remote panes, resume scaling, listener/timer cleanup, and viewport/webContents retention.

The final rebase integrated newer main browser-retention and zoom work. Conflict resolution preserved explicit `preserveZoom` behavior plus guest-budget eviction and connected-root replacement coverage, and updated the parent-drift and async-destroy test contracts.

## Security Audit

The repair IPC accepts only trusted Orca renderers, validates argument shapes, resolves an existing live Electron `webview`, and requires its `hostWebContents` to be the invoking renderer before reattaching policies and registering the exact `webContents` ID. No command execution, dependency, credential, secret, or new path-interpretation surface is added.

## Gaps / risks

- Actual macOS sleep was not automated because it could sever the shared development session; minimize/restore, resume delivery, renderer loss, and worktree parking are covered separately.
- No native-Windows validation claim; CI provides Windows packaging/type/test coverage once this head runs remotely.
- GPU/compositor-only blanking with a healthy renderer and healthy registry is outside this deterministic failure oracle.
- Remote/paired browser pages use a separate lifecycle and are intentionally unchanged.

