### PR TITLE
Fix duplicate terminal renderers after layout restore

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -238,12 +238,11 @@ export function replayTerminalLayout(
 ): Map<string, number> {
   const paneByLeafId = new Map<string, number>()
 
-  const inputSnapshot = snapshot
   const normalized = normalizeTerminalLayoutSnapshot(snapshot)
   snapshot = normalized.snapshot
   const initialLeafId = snapshot.root
     ? getLeftmostLeafId(snapshot.root)
-    : (resolveRootlessTerminalLayoutLeafId(inputSnapshot ?? snapshot) ?? undefined)
+    : (resolveRootlessTerminalLayoutLeafId(snapshot) ?? undefined)
   const initialPane = manager.createInitialPane({ focus: focusInitialPane, leafId: initialLeafId })
   if (!snapshot?.root) {
     paneByLeafId.set(initialPane.leafId, initialPane.id)

--- a/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
@@ -65,4 +65,34 @@ describe('duplicate PTY layout replay', () => {
     expect(manager.splitPane).not.toHaveBeenCalled()
     expect([...restored]).toEqual([[LEAF_1, 1]])
   })
+
+  it('reattaches one PTY when the split repeats its bound leaf id', () => {
+    const manager = {
+      createInitialPane: vi.fn((opts?: { leafId?: string }) => ({
+        id: 1,
+        leafId: opts?.leafId ?? LEAF_2
+      })),
+      splitPane: vi.fn()
+    }
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: LEAF_1 },
+          second: { type: 'leaf', leafId: LEAF_1 }
+        },
+        activeLeafId: LEAF_1,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
+      },
+      true
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_1 })
+    expect(manager.splitPane).not.toHaveBeenCalled()
+    expect([...restored]).toEqual([[LEAF_1, 1]])
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { replayTerminalLayout } from './layout-serialization'
+
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+
+describe('duplicate PTY layout replay', () => {
+  it('replays one surface when restored leaves point to the same PTY', () => {
+    const manager = {
+      createInitialPane: vi.fn((opts?: { leafId?: string }) => ({
+        id: 1,
+        leafId: opts?.leafId ?? LEAF_1
+      })),
+      splitPane: vi.fn()
+    }
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: LEAF_1 },
+          second: { type: 'leaf', leafId: LEAF_2 }
+        },
+        activeLeafId: LEAF_2,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_1]: 'pty-agent',
+          [LEAF_2]: 'pty-agent'
+        }
+      },
+      true
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_2 })
+    expect(manager.splitPane).not.toHaveBeenCalled()
+    expect([...restored]).toEqual([[LEAF_2, 1]])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
@@ -66,6 +66,34 @@ describe('duplicate PTY layout replay', () => {
     expect([...restored]).toEqual([[LEAF_1, 1]])
   })
 
+  it('ignores dangling rootless focus when choosing the retained PTY leaf', () => {
+    const manager = {
+      createInitialPane: vi.fn((opts?: { leafId?: string }) => ({
+        id: 1,
+        leafId: opts?.leafId ?? LEAF_2
+      })),
+      splitPane: vi.fn()
+    }
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: null,
+        activeLeafId: '33333333-3333-4333-8333-333333333333',
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_1]: 'pty-agent',
+          [LEAF_2]: 'pty-agent'
+        }
+      },
+      true
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_1 })
+    expect(manager.splitPane).not.toHaveBeenCalled()
+    expect([...restored]).toEqual([[LEAF_1, 1]])
+  })
+
   it('reattaches one PTY when the split repeats its bound leaf id', () => {
     const manager = {
       createInitialPane: vi.fn((opts?: { leafId?: string }) => ({

--- a/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
@@ -3,6 +3,7 @@ import { replayTerminalLayout } from './layout-serialization'
 
 const LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+const LEAF_3 = '33333333-3333-4333-8333-333333333333'
 
 describe('duplicate PTY layout replay', () => {
   it('replays one surface when restored leaves point to the same PTY', () => {
@@ -66,7 +67,7 @@ describe('duplicate PTY layout replay', () => {
     expect([...restored]).toEqual([[LEAF_1, 1]])
   })
 
-  it('ignores dangling rootless focus when choosing the retained PTY leaf', () => {
+  it('preserves a rootless pending leaf while pruning duplicate PTY ownership', () => {
     const manager = {
       createInitialPane: vi.fn((opts?: { leafId?: string }) => ({
         id: 1,
@@ -79,7 +80,7 @@ describe('duplicate PTY layout replay', () => {
       manager as unknown as Parameters<typeof replayTerminalLayout>[0],
       {
         root: null,
-        activeLeafId: '33333333-3333-4333-8333-333333333333',
+        activeLeafId: LEAF_3,
         expandedLeafId: null,
         ptyIdsByLeafId: {
           [LEAF_1]: 'pty-agent',
@@ -89,9 +90,9 @@ describe('duplicate PTY layout replay', () => {
       true
     )
 
-    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_1 })
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_3 })
     expect(manager.splitPane).not.toHaveBeenCalled()
-    expect([...restored]).toEqual([[LEAF_1, 1]])
+    expect([...restored]).toEqual([[LEAF_3, 1]])
   })
 
   it('reattaches one PTY when the split repeats its bound leaf id', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-duplicate-pty-replay.test.ts
@@ -37,4 +37,32 @@ describe('duplicate PTY layout replay', () => {
     expect(manager.splitPane).not.toHaveBeenCalled()
     expect([...restored]).toEqual([[LEAF_2, 1]])
   })
+
+  it('reattaches the retained PTY leaf from rootless duplicate state', () => {
+    const manager = {
+      createInitialPane: vi.fn((opts?: { leafId?: string }) => ({
+        id: 1,
+        leafId: opts?.leafId ?? LEAF_2
+      })),
+      splitPane: vi.fn()
+    }
+
+    const restored = replayTerminalLayout(
+      manager as unknown as Parameters<typeof replayTerminalLayout>[0],
+      {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_1]: 'pty-agent',
+          [LEAF_2]: 'pty-agent'
+        }
+      },
+      true
+    )
+
+    expect(manager.createInitialPane).toHaveBeenCalledWith({ focus: true, leafId: LEAF_1 })
+    expect(manager.splitPane).not.toHaveBeenCalled()
+    expect([...restored]).toEqual([[LEAF_1, 1]])
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -214,9 +214,16 @@ export function normalizeTerminalLayoutSnapshot(
 ): { snapshot: TerminalLayoutSnapshot; changed: boolean } {
   const leafIds = normalizeTerminalLayoutLeafIds(snapshot)
   const ptyOwnership = normalizeTerminalLayoutPtyOwnership(leafIds.snapshot)
+  const activeLeafId = ptyOwnership.snapshot.root
+    ? ptyOwnership.snapshot.activeLeafId
+    : resolveRootlessTerminalLayoutLeafId(ptyOwnership.snapshot)
   return {
-    snapshot: ptyOwnership.snapshot,
-    changed: leafIds.changed || ptyOwnership.changed
+    snapshot:
+      activeLeafId === ptyOwnership.snapshot.activeLeafId
+        ? ptyOwnership.snapshot
+        : { ...ptyOwnership.snapshot, activeLeafId },
+    changed:
+      leafIds.changed || ptyOwnership.changed || activeLeafId !== ptyOwnership.snapshot.activeLeafId
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -212,18 +212,18 @@ function normalizeTerminalLayoutLeafIds(snapshot: TerminalLayoutSnapshot | null 
 export function normalizeTerminalLayoutSnapshot(
   snapshot: TerminalLayoutSnapshot | null | undefined
 ): { snapshot: TerminalLayoutSnapshot; changed: boolean } {
-  const leafIds = normalizeTerminalLayoutLeafIds(snapshot)
-  const ptyOwnership = normalizeTerminalLayoutPtyOwnership(leafIds.snapshot)
-  const activeLeafId = ptyOwnership.snapshot.root
-    ? ptyOwnership.snapshot.activeLeafId
-    : resolveRootlessTerminalLayoutLeafId(ptyOwnership.snapshot)
+  const ptyOwnership = normalizeTerminalLayoutPtyOwnership(snapshot ?? EMPTY_TERMINAL_LAYOUT)
+  const leafIds = normalizeTerminalLayoutLeafIds(ptyOwnership.snapshot)
+  const activeLeafId = leafIds.snapshot.root
+    ? leafIds.snapshot.activeLeafId
+    : resolveRootlessTerminalLayoutLeafId(leafIds.snapshot)
   return {
     snapshot:
-      activeLeafId === ptyOwnership.snapshot.activeLeafId
-        ? ptyOwnership.snapshot
-        : { ...ptyOwnership.snapshot, activeLeafId },
+      activeLeafId === leafIds.snapshot.activeLeafId
+        ? leafIds.snapshot
+        : { ...leafIds.snapshot, activeLeafId },
     changed:
-      leafIds.changed || ptyOwnership.changed || activeLeafId !== ptyOwnership.snapshot.activeLeafId
+      ptyOwnership.changed || leafIds.changed || activeLeafId !== leafIds.snapshot.activeLeafId
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -1,6 +1,7 @@
 import type { TerminalLayoutSnapshot, TerminalPaneLayoutNode } from '../../../../shared/types'
 import { isTerminalLeafId, type TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { mintStablePaneId } from '@/lib/pane-manager/mint-stable-pane-id'
+import { normalizeTerminalLayoutPtyOwnership } from './terminal-layout-pty-ownership'
 
 const EMPTY_TERMINAL_LAYOUT: TerminalLayoutSnapshot = {
   root: null,
@@ -124,9 +125,10 @@ function getRemappedLeafId(
   return rewrite.nextLeafIdByInputLeafId.get(leafId) ?? null
 }
 
-export function normalizeTerminalLayoutSnapshot(
-  snapshot: TerminalLayoutSnapshot | null | undefined
-): { snapshot: TerminalLayoutSnapshot; changed: boolean } {
+function normalizeTerminalLayoutLeafIds(snapshot: TerminalLayoutSnapshot | null | undefined): {
+  snapshot: TerminalLayoutSnapshot
+  changed: boolean
+} {
   if (!snapshot?.root) {
     const nextSnapshot = snapshot ?? EMPTY_TERMINAL_LAYOUT
     const activeLeafId = resolveRootlessTerminalLayoutLeafId(nextSnapshot)
@@ -204,6 +206,17 @@ export function normalizeTerminalLayoutSnapshot(
       ...(titlesByLeafId ? { titlesByLeafId } : {})
     },
     changed: true
+  }
+}
+
+export function normalizeTerminalLayoutSnapshot(
+  snapshot: TerminalLayoutSnapshot | null | undefined
+): { snapshot: TerminalLayoutSnapshot; changed: boolean } {
+  const leafIds = normalizeTerminalLayoutLeafIds(snapshot)
+  const ptyOwnership = normalizeTerminalLayoutPtyOwnership(leafIds.snapshot)
+  return {
+    snapshot: ptyOwnership.snapshot,
+    changed: leafIds.changed || ptyOwnership.changed
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership-depth.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership-depth.test.ts
@@ -1,0 +1,30 @@
+import { expect, it } from 'vitest'
+import type { TerminalPaneLayoutNode } from '../../../../shared/types'
+import { normalizeTerminalLayoutPtyOwnership } from './terminal-layout-pty-ownership'
+
+it('prunes deeply nested duplicate ownership without recursive stack growth', () => {
+  const leafCount = 12_000
+  let root: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-0' }
+  const ptyIdsByLeafId: Record<string, string> = { 'leaf-0': 'pty-agent' }
+  for (let index = 1; index < leafCount; index += 1) {
+    const leafId = `leaf-${index}`
+    root = {
+      type: 'split',
+      direction: 'vertical',
+      first: root,
+      second: { type: 'leaf', leafId }
+    }
+    ptyIdsByLeafId[leafId] = 'pty-agent'
+  }
+
+  const retainedLeafId = `leaf-${leafCount - 1}`
+  const normalized = normalizeTerminalLayoutPtyOwnership({
+    root,
+    activeLeafId: retainedLeafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId
+  }).snapshot
+
+  expect(normalized.root).toEqual({ type: 'leaf', leafId: retainedLeafId })
+  expect(normalized.ptyIdsByLeafId).toEqual({ [retainedLeafId]: 'pty-agent' })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -163,6 +163,25 @@ describe('terminal layout PTY ownership normalization', () => {
     })
   })
 
+  it('keeps rooted ownership when stale focus names a dangling duplicate leaf', () => {
+    const normalized = normalizeTerminalLayoutPtyOwnership({
+      root: { type: 'leaf', leafId: LEAF_1 },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: { type: 'leaf', leafId: LEAF_1 },
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
+    })
+  })
+
   it('repairs rootless duplicate ownership in one idempotent pass', () => {
     const normalized = normalizeTerminalLayoutSnapshot({
       root: null,
@@ -201,15 +220,79 @@ describe('terminal layout PTY ownership normalization', () => {
     })
 
     expect(normalized.snapshot).toEqual({
-      root: null,
+      root: { type: 'leaf', leafId: LEAF_1 },
       activeLeafId: LEAF_1,
-      expandedLeafId: null,
+      expandedLeafId: LEAF_1,
       ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' },
       buffersByLeafId: { [LEAF_1]: 'cached buffer' }
     })
     expect(normalizeTerminalLayoutPtyOwnership(normalized.snapshot)).toEqual({
       snapshot: normalized.snapshot,
       changed: false
+    })
+  })
+
+  it('preserves PTY ownership while collapsing repeated live leaf ids', () => {
+    const normalized = normalizeTerminalLayoutSnapshot({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_1 }
+      },
+      activeLeafId: LEAF_1,
+      expandedLeafId: LEAF_1,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' },
+      buffersByLeafId: { [LEAF_1]: 'cached buffer' }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: { type: 'leaf', leafId: LEAF_1 },
+      activeLeafId: LEAF_1,
+      expandedLeafId: LEAF_1,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' },
+      buffersByLeafId: { [LEAF_1]: 'cached buffer' }
+    })
+    expect(normalizeTerminalLayoutSnapshot(normalized.snapshot)).toEqual({
+      snapshot: normalized.snapshot,
+      changed: false
+    })
+  })
+
+  it('retains one repeated PTY leaf alongside distinct sibling ownership', () => {
+    const normalized = normalizeTerminalLayoutSnapshot({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: LEAF_1 },
+          second: { type: 'leaf', leafId: LEAF_1 }
+        },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      activeLeafId: LEAF_1,
+      expandedLeafId: LEAF_1,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-shell'
+      }
+    }).snapshot
+
+    expect(normalized).toEqual({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      activeLeafId: LEAF_1,
+      expandedLeafId: LEAF_1,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-shell'
+      }
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -121,6 +121,17 @@ describe('terminal layout PTY ownership normalization', () => {
     expect(normalized.titlesByLeafId).toEqual({ [LEAF_2]: 'only cached title' })
   })
 
+  it('does not combine a retained buffer with a stale duplicate scrollback ref', () => {
+    const layout = duplicatePtyLayout()
+    layout.buffersByLeafId = { [LEAF_2]: 'active buffer' }
+    layout.scrollbackRefsByLeafId = { [LEAF_1]: 'stale-scrollback-ref' }
+
+    const normalized = normalizeTerminalLayoutPtyOwnership(layout).snapshot
+
+    expect(normalized.buffersByLeafId).toEqual({ [LEAF_2]: 'active buffer' })
+    expect(normalized.scrollbackRefsByLeafId).toBeUndefined()
+  })
+
   it('coalesces chained duplicate metadata in layout order', () => {
     const layout = duplicatePtyLayout()
     layout.activeLeafId = LEAF_3
@@ -133,6 +144,7 @@ describe('terminal layout PTY ownership normalization', () => {
       [LEAF_1]: 'first cached buffer',
       [LEAF_2]: 'second cached buffer'
     }
+    layout.scrollbackRefsByLeafId = undefined
 
     const normalized = normalizeTerminalLayoutSnapshot(layout).snapshot
 
@@ -248,6 +260,40 @@ describe('terminal layout PTY ownership normalization', () => {
     })
   })
 
+  it('keeps a valid active unbound leaf while repairing duplicate sibling ownership', () => {
+    const normalized = normalizeTerminalLayoutPtyOwnership({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: LEAF_1 },
+          second: { type: 'leaf', leafId: LEAF_2 }
+        },
+        second: { type: 'leaf', leafId: LEAF_3 }
+      },
+      activeLeafId: LEAF_3,
+      expandedLeafId: LEAF_3,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_3 }
+      },
+      activeLeafId: LEAF_3,
+      expandedLeafId: LEAF_3,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
+    })
+  })
+
   it('collapses repeated live leaf ids without looping during direct normalization', () => {
     const normalized = normalizeTerminalLayoutPtyOwnership({
       root: {
@@ -272,6 +318,45 @@ describe('terminal layout PTY ownership normalization', () => {
     expect(normalizeTerminalLayoutPtyOwnership(normalized.snapshot)).toEqual({
       snapshot: normalized.snapshot,
       changed: false
+    })
+  })
+
+  it('keeps active metadata when its retained leaf id also repeats', () => {
+    const normalized = normalizeTerminalLayoutPtyOwnership({
+      root: {
+        type: 'split',
+        direction: 'horizontal',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: LEAF_2 },
+          second: { type: 'leaf', leafId: LEAF_2 }
+        }
+      },
+      activeLeafId: LEAF_2,
+      expandedLeafId: LEAF_2,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      },
+      buffersByLeafId: {
+        [LEAF_1]: 'stale buffer',
+        [LEAF_2]: 'active buffer'
+      },
+      titlesByLeafId: {
+        [LEAF_1]: 'stale title',
+        [LEAF_2]: 'active title'
+      }
+    }).snapshot
+
+    expect(normalized).toEqual({
+      root: { type: 'leaf', leafId: LEAF_2 },
+      activeLeafId: LEAF_2,
+      expandedLeafId: LEAF_2,
+      ptyIdsByLeafId: { [LEAF_2]: 'pty-agent' },
+      buffersByLeafId: { [LEAF_2]: 'active buffer' },
+      titlesByLeafId: { [LEAF_2]: 'active title' }
     })
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 import { normalizeTerminalLayoutSnapshot } from './terminal-layout-leaf-ids'
+import { normalizeTerminalLayoutPtyOwnership } from './terminal-layout-pty-ownership'
 
 const LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const LEAF_2 = '22222222-2222-4222-8222-222222222222'
@@ -180,6 +181,33 @@ describe('terminal layout PTY ownership normalization', () => {
       ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
     })
     expect(normalizeTerminalLayoutSnapshot(normalized.snapshot)).toEqual({
+      snapshot: normalized.snapshot,
+      changed: false
+    })
+  })
+
+  it('collapses repeated live leaf ids without looping during direct normalization', () => {
+    const normalized = normalizeTerminalLayoutPtyOwnership({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_1 }
+      },
+      activeLeafId: LEAF_1,
+      expandedLeafId: LEAF_1,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' },
+      buffersByLeafId: { [LEAF_1]: 'cached buffer' }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: null,
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' },
+      buffersByLeafId: { [LEAF_1]: 'cached buffer' }
+    })
+    expect(normalizeTerminalLayoutPtyOwnership(normalized.snapshot)).toEqual({
       snapshot: normalized.snapshot,
       changed: false
     })

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+import { normalizeTerminalLayoutSnapshot } from './terminal-layout-leaf-ids'
+
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+const LEAF_3 = '33333333-3333-4333-8333-333333333333'
+
+function collectRootLeafIds(layout: TerminalLayoutSnapshot): string[] {
+  const visit = (node: NonNullable<TerminalLayoutSnapshot['root']>): string[] =>
+    node.type === 'leaf' ? [node.leafId] : [...visit(node.first), ...visit(node.second)]
+  return layout.root ? visit(layout.root) : []
+}
+
+function duplicatePtyLayout(): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      ratio: 0.4,
+      first: {
+        type: 'split',
+        direction: 'horizontal',
+        ratio: 0.25,
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      second: { type: 'leaf', leafId: LEAF_3 }
+    },
+    activeLeafId: LEAF_2,
+    expandedLeafId: LEAF_1,
+    ptyIdsByLeafId: {
+      [LEAF_1]: 'pty-agent',
+      [LEAF_2]: 'pty-agent',
+      [LEAF_3]: 'remote:env-1@@term_setup'
+    },
+    buffersByLeafId: {
+      [LEAF_1]: 'stale agent buffer',
+      [LEAF_2]: 'active agent buffer',
+      [LEAF_3]: 'setup buffer'
+    },
+    scrollbackRefsByLeafId: {
+      [LEAF_1]: 'stale-agent-scrollback',
+      [LEAF_2]: 'active-agent-scrollback',
+      [LEAF_3]: 'setup-scrollback'
+    },
+    titlesByLeafId: {
+      [LEAF_1]: 'stale agent',
+      [LEAF_2]: 'active agent',
+      [LEAF_3]: 'setup'
+    }
+  }
+}
+
+describe('terminal layout PTY ownership normalization', () => {
+  it('keeps the active leaf and prunes the stale surface plus its metadata', () => {
+    const normalized = normalizeTerminalLayoutSnapshot(duplicatePtyLayout())
+
+    expect(normalized.changed).toBe(true)
+    expect(normalized.snapshot).toEqual({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        ratio: 0.4,
+        first: { type: 'leaf', leafId: LEAF_2 },
+        second: { type: 'leaf', leafId: LEAF_3 }
+      },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_2]: 'pty-agent',
+        [LEAF_3]: 'remote:env-1@@term_setup'
+      },
+      buffersByLeafId: {
+        [LEAF_2]: 'active agent buffer',
+        [LEAF_3]: 'setup buffer'
+      },
+      scrollbackRefsByLeafId: {
+        [LEAF_2]: 'active-agent-scrollback',
+        [LEAF_3]: 'setup-scrollback'
+      },
+      titlesByLeafId: {
+        [LEAF_2]: 'active agent',
+        [LEAF_3]: 'setup'
+      }
+    })
+  })
+
+  it('keeps the first layout leaf when focus belongs to another PTY', () => {
+    const layout = duplicatePtyLayout()
+    layout.activeLeafId = LEAF_3
+    layout.expandedLeafId = null
+
+    const normalized = normalizeTerminalLayoutSnapshot(layout)
+
+    expect(normalized.snapshot.root).toEqual({
+      type: 'split',
+      direction: 'vertical',
+      ratio: 0.4,
+      first: { type: 'leaf', leafId: LEAF_1 },
+      second: { type: 'leaf', leafId: LEAF_3 }
+    })
+    expect(normalized.snapshot.activeLeafId).toBe(LEAF_3)
+    expect(normalized.snapshot.ptyIdsByLeafId).toEqual({
+      [LEAF_1]: 'pty-agent',
+      [LEAF_3]: 'remote:env-1@@term_setup'
+    })
+  })
+
+  it('carries missing scrollback metadata onto the surviving leaf', () => {
+    const layout = duplicatePtyLayout()
+    layout.buffersByLeafId = { [LEAF_1]: 'only cached buffer' }
+    layout.scrollbackRefsByLeafId = { [LEAF_1]: 'only-scrollback-ref' }
+    layout.titlesByLeafId = { [LEAF_1]: 'only cached title' }
+
+    const normalized = normalizeTerminalLayoutSnapshot(layout).snapshot
+
+    expect(normalized.buffersByLeafId).toEqual({ [LEAF_2]: 'only cached buffer' })
+    expect(normalized.scrollbackRefsByLeafId).toEqual({ [LEAF_2]: 'only-scrollback-ref' })
+    expect(normalized.titlesByLeafId).toEqual({ [LEAF_2]: 'only cached title' })
+  })
+
+  it('coalesces chained duplicate metadata in layout order', () => {
+    const layout = duplicatePtyLayout()
+    layout.activeLeafId = LEAF_3
+    layout.ptyIdsByLeafId = {
+      [LEAF_1]: 'pty-agent',
+      [LEAF_2]: 'pty-agent',
+      [LEAF_3]: 'pty-agent'
+    }
+    layout.buffersByLeafId = {
+      [LEAF_1]: 'first cached buffer',
+      [LEAF_2]: 'second cached buffer'
+    }
+
+    const normalized = normalizeTerminalLayoutSnapshot(layout).snapshot
+
+    expect(normalized.root).toEqual({ type: 'leaf', leafId: LEAF_3 })
+    expect(normalized.buffersByLeafId).toEqual({ [LEAF_3]: 'first cached buffer' })
+  })
+
+  it('deduplicates rootless remount state without guessing among distinct PTYs', () => {
+    const normalized = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent',
+        [LEAF_3]: 'pty-setup'
+      }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: null,
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_2]: 'pty-agent',
+        [LEAF_3]: 'pty-setup'
+      }
+    })
+  })
+
+  it('preserves valid split layouts by identity', () => {
+    const layout = duplicatePtyLayout()
+    layout.ptyIdsByLeafId = {
+      [LEAF_1]: 'pty-1',
+      [LEAF_2]: 'pty-2',
+      [LEAF_3]: 'remote:env-1@@term_setup'
+    }
+
+    const normalized = normalizeTerminalLayoutSnapshot(layout)
+
+    expect(normalized).toEqual({ snapshot: layout, changed: false })
+    expect(normalized.snapshot).toBe(layout)
+  })
+
+  it('is idempotent and preserves one owner across PTY and focus permutations', () => {
+    const ptyOptions = [undefined, 'pty-a', 'remote:env-1@@term_b'] as const
+    for (const firstPtyId of ptyOptions) {
+      for (const secondPtyId of ptyOptions) {
+        for (const thirdPtyId of ptyOptions) {
+          for (const activeLeafId of [LEAF_1, LEAF_2, LEAF_3]) {
+            const ptyIdsByLeafId = Object.fromEntries(
+              [
+                [LEAF_1, firstPtyId],
+                [LEAF_2, secondPtyId],
+                [LEAF_3, thirdPtyId]
+              ].filter((entry): entry is [string, string] => entry[1] !== undefined)
+            )
+            const layout = duplicatePtyLayout()
+            layout.activeLeafId = activeLeafId
+            layout.expandedLeafId = activeLeafId
+            layout.ptyIdsByLeafId = ptyIdsByLeafId
+            const before = structuredClone(layout)
+
+            const normalized = normalizeTerminalLayoutSnapshot(layout).snapshot
+            const normalizedPtyIds = Object.values(normalized.ptyIdsByLeafId ?? {})
+            const rootLeafIds = new Set(collectRootLeafIds(normalized))
+
+            expect(new Set(normalizedPtyIds).size).toBe(normalizedPtyIds.length)
+            expect(
+              Object.keys(normalized.ptyIdsByLeafId ?? {}).every((id) => rootLeafIds.has(id))
+            ).toBe(true)
+            expect(normalized.activeLeafId && rootLeafIds.has(normalized.activeLeafId)).toBe(true)
+            expect(normalizeTerminalLayoutSnapshot(normalized)).toEqual({
+              snapshot: normalized,
+              changed: false
+            })
+            expect(layout).toEqual(before)
+          }
+        }
+      }
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -205,6 +205,49 @@ describe('terminal layout PTY ownership normalization', () => {
     })
   })
 
+  it('repairs dangling rootless focus onto the sole retained PTY owner', () => {
+    const normalized = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: LEAF_3,
+      expandedLeafId: LEAF_3,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: null,
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
+    })
+  })
+
+  it('repairs dangling rooted selection during direct ownership normalization', () => {
+    const normalized = normalizeTerminalLayoutPtyOwnership({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      activeLeafId: LEAF_3,
+      expandedLeafId: LEAF_3,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: { type: 'leaf', leafId: LEAF_1 },
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
+    })
+  })
+
   it('collapses repeated live leaf ids without looping during direct normalization', () => {
     const normalized = normalizeTerminalLayoutPtyOwnership({
       root: {

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -217,7 +217,7 @@ describe('terminal layout PTY ownership normalization', () => {
     })
   })
 
-  it('repairs dangling rootless focus onto the sole retained PTY owner', () => {
+  it('preserves rootless pending focus while repairing duplicate ownership', () => {
     const normalized = normalizeTerminalLayoutSnapshot({
       root: null,
       activeLeafId: LEAF_3,
@@ -230,7 +230,7 @@ describe('terminal layout PTY ownership normalization', () => {
 
     expect(normalized.snapshot).toEqual({
       root: null,
-      activeLeafId: LEAF_1,
+      activeLeafId: LEAF_3,
       expandedLeafId: null,
       ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
     })

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.test.ts
@@ -162,6 +162,29 @@ describe('terminal layout PTY ownership normalization', () => {
     })
   })
 
+  it('repairs rootless duplicate ownership in one idempotent pass', () => {
+    const normalized = normalizeTerminalLayoutSnapshot({
+      root: null,
+      activeLeafId: null,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(normalized.snapshot).toEqual({
+      root: null,
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-agent' }
+    })
+    expect(normalizeTerminalLayoutSnapshot(normalized.snapshot)).toEqual({
+      snapshot: normalized.snapshot,
+      changed: false
+    })
+  })
+
   it('preserves valid split layouts by identity', () => {
     const layout = duplicatePtyLayout()
     layout.ptyIdsByLeafId = {

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -32,24 +32,44 @@ function pruneLeaves(
   retainedLeafIdByRemovedLeafId: ReadonlyMap<string, string>,
   retainedSelfLeafIds: Set<string>
 ): TerminalPaneLayoutNode | null {
-  if (node.type === 'leaf') {
-    const retainedLeafId = retainedLeafIdByRemovedLeafId.get(node.leafId)
-    if (!retainedLeafId) {
-      return node
+  const pending: { node: TerminalPaneLayoutNode; visited: boolean }[] = [{ node, visited: false }]
+  const pruned: (TerminalPaneLayoutNode | null)[] = []
+  while (pending.length > 0) {
+    const current = pending.pop()!
+    if (current.node.type === 'leaf') {
+      const retainedLeafId = retainedLeafIdByRemovedLeafId.get(current.node.leafId)
+      if (!retainedLeafId) {
+        pruned.push(current.node)
+      } else if (
+        retainedLeafId === current.node.leafId &&
+        !retainedSelfLeafIds.has(current.node.leafId)
+      ) {
+        retainedSelfLeafIds.add(current.node.leafId)
+        pruned.push(current.node)
+      } else {
+        pruned.push(null)
+      }
+      continue
     }
-    if (retainedLeafId === node.leafId && !retainedSelfLeafIds.has(node.leafId)) {
-      retainedSelfLeafIds.add(node.leafId)
-      return node
+    if (!current.visited) {
+      pending.push({ node: current.node, visited: true })
+      pending.push({ node: current.node.second, visited: false })
+      pending.push({ node: current.node.first, visited: false })
+      continue
     }
-    return null
+    const second = pruned.pop() ?? null
+    const first = pruned.pop() ?? null
+    if (first && second) {
+      pruned.push(
+        first === current.node.first && second === current.node.second
+          ? current.node
+          : { ...current.node, first, second }
+      )
+    } else {
+      pruned.push(first ?? second)
+    }
   }
-
-  const first = pruneLeaves(node.first, retainedLeafIdByRemovedLeafId, retainedSelfLeafIds)
-  const second = pruneLeaves(node.second, retainedLeafIdByRemovedLeafId, retainedSelfLeafIds)
-  if (first && second) {
-    return first === node.first && second === node.second ? node : { ...node, first, second }
-  }
-  return first ?? second
+  return pruned[0] ?? null
 }
 
 function resolveRetainedLeafId(

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -17,14 +17,23 @@ function collectLeafIds(node: TerminalPaneLayoutNode | null | undefined): string
 
 function pruneLeaves(
   node: TerminalPaneLayoutNode,
-  removedLeafIds: ReadonlySet<string>
+  retainedLeafIdByRemovedLeafId: ReadonlyMap<string, string>,
+  retainedSelfLeafIds: Set<string>
 ): TerminalPaneLayoutNode | null {
   if (node.type === 'leaf') {
-    return removedLeafIds.has(node.leafId) ? null : node
+    const retainedLeafId = retainedLeafIdByRemovedLeafId.get(node.leafId)
+    if (!retainedLeafId) {
+      return node
+    }
+    if (retainedLeafId === node.leafId && !retainedSelfLeafIds.has(node.leafId)) {
+      retainedSelfLeafIds.add(node.leafId)
+      return node
+    }
+    return null
   }
 
-  const first = pruneLeaves(node.first, removedLeafIds)
-  const second = pruneLeaves(node.second, removedLeafIds)
+  const first = pruneLeaves(node.first, retainedLeafIdByRemovedLeafId, retainedSelfLeafIds)
+  const second = pruneLeaves(node.second, retainedLeafIdByRemovedLeafId, retainedSelfLeafIds)
   if (first && second) {
     return first === node.first && second === node.second ? node : { ...node, first, second }
   }
@@ -72,6 +81,10 @@ function findDuplicatePtyLeafReplacements(snapshot: TerminalLayoutSnapshot): Map
   const ptyIdsByLeafId = snapshot.ptyIdsByLeafId ?? {}
   const rootLeafIds = collectLeafIds(snapshot.root)
   const rootLeafIdSet = new Set(rootLeafIds)
+  const activeLeafId =
+    !snapshot.root || (snapshot.activeLeafId && rootLeafIdSet.has(snapshot.activeLeafId))
+      ? snapshot.activeLeafId
+      : null
   const orderedLeafIds = [
     ...rootLeafIds,
     ...Object.keys(ptyIdsByLeafId).filter((leafId) => !rootLeafIdSet.has(leafId))
@@ -89,7 +102,7 @@ function findDuplicatePtyLeafReplacements(snapshot: TerminalLayoutSnapshot): Map
       retainedLeafIdByPtyId.set(ptyId, leafId)
       continue
     }
-    if (leafId === snapshot.activeLeafId) {
+    if (leafId === activeLeafId) {
       retainedLeafIdByRemovedLeafId.set(retainedLeafId, leafId)
       retainedLeafIdByPtyId.set(ptyId, leafId)
       continue
@@ -109,8 +122,18 @@ export function normalizeTerminalLayoutPtyOwnership(
   }
 
   // Why: one live PTY has one renderer surface; retaining both leaves races input, resize, and teardown.
-  const removedLeafIds = new Set(retainedLeafIdByRemovedLeafId.keys())
-  const root = snapshot.root ? pruneLeaves(snapshot.root, removedLeafIds) : null
+  const removedLeafIds = new Set<string>()
+  for (const [removedLeafId, retainedLeafId] of retainedLeafIdByRemovedLeafId) {
+    if (removedLeafId !== retainedLeafId) {
+      removedLeafIds.add(removedLeafId)
+    }
+  }
+  const root = snapshot.root
+    ? pruneLeaves(snapshot.root, retainedLeafIdByRemovedLeafId, new Set())
+    : null
+  const activeLeafId = snapshot.activeLeafId
+    ? resolveRetainedLeafId(snapshot.activeLeafId, retainedLeafIdByRemovedLeafId)
+    : snapshot.activeLeafId
   const ptyIdsByLeafId = coalesceLeafRecord(snapshot.ptyIdsByLeafId, retainedLeafIdByRemovedLeafId)
   const buffersByLeafId = coalesceLeafRecord(
     snapshot.buffersByLeafId,
@@ -133,6 +156,7 @@ export function normalizeTerminalLayoutPtyOwnership(
     snapshot: {
       ...snapshotWithoutLeafRecords,
       root,
+      activeLeafId,
       expandedLeafId:
         snapshot.expandedLeafId && removedLeafIds.has(snapshot.expandedLeafId)
           ? null

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -208,7 +208,7 @@ function resolveOwnedActiveLeafId(
     Boolean(ptyIdsByLeafId && Object.prototype.hasOwnProperty.call(ptyIdsByLeafId, leafId))
   if (rootLeafIds.length === 0) {
     const boundLeafIds = Object.keys(ptyIdsByLeafId ?? {})
-    if (activeLeafId && hasBinding(activeLeafId)) {
+    if (activeLeafId) {
       return activeLeafId
     }
     return boundLeafIds.length === 1 ? boundLeafIds[0] : null

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -9,10 +9,17 @@ function collectLeafIds(node: TerminalPaneLayoutNode | null | undefined): string
   if (!node) {
     return []
   }
-  if (node.type === 'leaf') {
-    return [node.leafId]
+  const leafIds: string[] = []
+  const pending = [node]
+  while (pending.length > 0) {
+    const current = pending.pop()!
+    if (current.type === 'leaf') {
+      leafIds.push(current.leafId)
+      continue
+    }
+    pending.push(current.second, current.first)
   }
-  return [...collectLeafIds(node.first), ...collectLeafIds(node.second)]
+  return leafIds
 }
 
 function pruneLeaves(
@@ -113,6 +120,32 @@ function findDuplicatePtyLeafReplacements(snapshot: TerminalLayoutSnapshot): Map
   return retainedLeafIdByRemovedLeafId
 }
 
+function resolveOwnedActiveLeafId(
+  rootLeafIds: readonly string[],
+  activeLeafId: string | null,
+  ptyIdsByLeafId: Record<string, string> | undefined
+): string | null {
+  const hasBinding = (leafId: string): boolean =>
+    Boolean(ptyIdsByLeafId && Object.prototype.hasOwnProperty.call(ptyIdsByLeafId, leafId))
+  if (rootLeafIds.length === 0) {
+    const boundLeafIds = Object.keys(ptyIdsByLeafId ?? {})
+    if (activeLeafId && hasBinding(activeLeafId)) {
+      return activeLeafId
+    }
+    return boundLeafIds.length === 1 ? boundLeafIds[0] : null
+  }
+
+  const hasBoundRootLeaf = rootLeafIds.some(hasBinding)
+  if (
+    activeLeafId &&
+    rootLeafIds.includes(activeLeafId) &&
+    (!hasBoundRootLeaf || hasBinding(activeLeafId))
+  ) {
+    return activeLeafId
+  }
+  return hasBoundRootLeaf ? (rootLeafIds.find(hasBinding) ?? null) : (rootLeafIds[0] ?? null)
+}
+
 export function normalizeTerminalLayoutPtyOwnership(
   snapshot: TerminalLayoutSnapshot
 ): TerminalLayoutPtyOwnershipNormalization {
@@ -131,10 +164,12 @@ export function normalizeTerminalLayoutPtyOwnership(
   const root = snapshot.root
     ? pruneLeaves(snapshot.root, retainedLeafIdByRemovedLeafId, new Set())
     : null
-  const activeLeafId = snapshot.activeLeafId
+  const mappedActiveLeafId = snapshot.activeLeafId
     ? resolveRetainedLeafId(snapshot.activeLeafId, retainedLeafIdByRemovedLeafId)
     : snapshot.activeLeafId
   const ptyIdsByLeafId = coalesceLeafRecord(snapshot.ptyIdsByLeafId, retainedLeafIdByRemovedLeafId)
+  const rootLeafIds = collectLeafIds(root)
+  const activeLeafId = resolveOwnedActiveLeafId(rootLeafIds, mappedActiveLeafId, ptyIdsByLeafId)
   const buffersByLeafId = coalesceLeafRecord(
     snapshot.buffersByLeafId,
     retainedLeafIdByRemovedLeafId
@@ -158,9 +193,11 @@ export function normalizeTerminalLayoutPtyOwnership(
       root,
       activeLeafId,
       expandedLeafId:
-        snapshot.expandedLeafId && removedLeafIds.has(snapshot.expandedLeafId)
-          ? null
-          : snapshot.expandedLeafId,
+        snapshot.expandedLeafId &&
+        !removedLeafIds.has(snapshot.expandedLeafId) &&
+        rootLeafIds.includes(snapshot.expandedLeafId)
+          ? snapshot.expandedLeafId
+          : null,
       ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
       ...(buffersByLeafId ? { buffersByLeafId } : {}),
       ...(scrollbackRefsByLeafId ? { scrollbackRefsByLeafId } : {}),

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -5,6 +5,11 @@ type TerminalLayoutPtyOwnershipNormalization = {
   changed: boolean
 }
 
+type DuplicatePtyLeafReplacements = {
+  orderedLeafIds: string[]
+  retainedLeafIdByRemovedLeafId: Map<string, string>
+}
+
 function collectLeafIds(node: TerminalPaneLayoutNode | null | undefined): string[] {
   if (!node) {
     return []
@@ -70,7 +75,10 @@ function coalesceLeafRecord(
     return undefined
   }
   const retained = Object.fromEntries(
-    Object.entries(source).filter(([leafId]) => !retainedLeafIdByRemovedLeafId.has(leafId))
+    Object.entries(source).filter(([leafId]) => {
+      const retainedLeafId = retainedLeafIdByRemovedLeafId.get(leafId)
+      return retainedLeafId === undefined || retainedLeafId === leafId
+    })
   )
   for (const [removedLeafId, value] of Object.entries(source)) {
     if (!retainedLeafIdByRemovedLeafId.has(removedLeafId)) {
@@ -84,7 +92,78 @@ function coalesceLeafRecord(
   return Object.keys(retained).length > 0 ? retained : undefined
 }
 
-function findDuplicatePtyLeafReplacements(snapshot: TerminalLayoutSnapshot): Map<string, string> {
+function hasLeafRecordValue(source: Record<string, string> | undefined, leafId: string): boolean {
+  return Boolean(source && Object.prototype.hasOwnProperty.call(source, leafId))
+}
+
+function coalesceScrollbackRecords(
+  buffersByLeafId: Record<string, string> | undefined,
+  scrollbackRefsByLeafId: Record<string, string> | undefined,
+  retainedLeafIdByRemovedLeafId: ReadonlyMap<string, string>,
+  orderedLeafIds: readonly string[]
+): {
+  buffersByLeafId: Record<string, string> | undefined
+  scrollbackRefsByLeafId: Record<string, string> | undefined
+} {
+  const affectedRetainedLeafIds = new Set<string>()
+  for (const removedLeafId of retainedLeafIdByRemovedLeafId.keys()) {
+    affectedRetainedLeafIds.add(resolveRetainedLeafId(removedLeafId, retainedLeafIdByRemovedLeafId))
+  }
+
+  const sourceLeafIdByRetainedLeafId = new Map<string, string>()
+  for (const retainedLeafId of affectedRetainedLeafIds) {
+    if (
+      hasLeafRecordValue(buffersByLeafId, retainedLeafId) ||
+      hasLeafRecordValue(scrollbackRefsByLeafId, retainedLeafId)
+    ) {
+      sourceLeafIdByRetainedLeafId.set(retainedLeafId, retainedLeafId)
+    }
+  }
+  for (const leafId of orderedLeafIds) {
+    const retainedLeafId = resolveRetainedLeafId(leafId, retainedLeafIdByRemovedLeafId)
+    if (
+      !affectedRetainedLeafIds.has(retainedLeafId) ||
+      sourceLeafIdByRetainedLeafId.has(retainedLeafId)
+    ) {
+      continue
+    }
+    if (
+      hasLeafRecordValue(buffersByLeafId, leafId) ||
+      hasLeafRecordValue(scrollbackRefsByLeafId, leafId)
+    ) {
+      sourceLeafIdByRetainedLeafId.set(retainedLeafId, leafId)
+    }
+  }
+
+  const coalesce = (
+    source: Record<string, string> | undefined
+  ): Record<string, string> | undefined => {
+    if (!source) {
+      return undefined
+    }
+    const retained = Object.fromEntries(
+      Object.entries(source).filter(([leafId]) => {
+        const retainedLeafId = resolveRetainedLeafId(leafId, retainedLeafIdByRemovedLeafId)
+        return !affectedRetainedLeafIds.has(retainedLeafId)
+      })
+    )
+    for (const [retainedLeafId, sourceLeafId] of sourceLeafIdByRetainedLeafId) {
+      if (hasLeafRecordValue(source, sourceLeafId)) {
+        retained[retainedLeafId] = source[sourceLeafId]!
+      }
+    }
+    return Object.keys(retained).length > 0 ? retained : undefined
+  }
+
+  return {
+    buffersByLeafId: coalesce(buffersByLeafId),
+    scrollbackRefsByLeafId: coalesce(scrollbackRefsByLeafId)
+  }
+}
+
+function findDuplicatePtyLeafReplacements(
+  snapshot: TerminalLayoutSnapshot
+): DuplicatePtyLeafReplacements {
   const ptyIdsByLeafId = snapshot.ptyIdsByLeafId ?? {}
   const rootLeafIds = collectLeafIds(snapshot.root)
   const rootLeafIdSet = new Set(rootLeafIds)
@@ -117,7 +196,7 @@ function findDuplicatePtyLeafReplacements(snapshot: TerminalLayoutSnapshot): Map
     retainedLeafIdByRemovedLeafId.set(leafId, retainedLeafId)
   }
 
-  return retainedLeafIdByRemovedLeafId
+  return { orderedLeafIds, retainedLeafIdByRemovedLeafId }
 }
 
 function resolveOwnedActiveLeafId(
@@ -135,21 +214,18 @@ function resolveOwnedActiveLeafId(
     return boundLeafIds.length === 1 ? boundLeafIds[0] : null
   }
 
-  const hasBoundRootLeaf = rootLeafIds.some(hasBinding)
-  if (
-    activeLeafId &&
-    rootLeafIds.includes(activeLeafId) &&
-    (!hasBoundRootLeaf || hasBinding(activeLeafId))
-  ) {
+  if (activeLeafId && rootLeafIds.includes(activeLeafId)) {
     return activeLeafId
   }
+  const hasBoundRootLeaf = rootLeafIds.some(hasBinding)
   return hasBoundRootLeaf ? (rootLeafIds.find(hasBinding) ?? null) : (rootLeafIds[0] ?? null)
 }
 
 export function normalizeTerminalLayoutPtyOwnership(
   snapshot: TerminalLayoutSnapshot
 ): TerminalLayoutPtyOwnershipNormalization {
-  const retainedLeafIdByRemovedLeafId = findDuplicatePtyLeafReplacements(snapshot)
+  const { orderedLeafIds, retainedLeafIdByRemovedLeafId } =
+    findDuplicatePtyLeafReplacements(snapshot)
   if (retainedLeafIdByRemovedLeafId.size === 0) {
     return { snapshot, changed: false }
   }
@@ -170,13 +246,11 @@ export function normalizeTerminalLayoutPtyOwnership(
   const ptyIdsByLeafId = coalesceLeafRecord(snapshot.ptyIdsByLeafId, retainedLeafIdByRemovedLeafId)
   const rootLeafIds = collectLeafIds(root)
   const activeLeafId = resolveOwnedActiveLeafId(rootLeafIds, mappedActiveLeafId, ptyIdsByLeafId)
-  const buffersByLeafId = coalesceLeafRecord(
+  const { buffersByLeafId, scrollbackRefsByLeafId } = coalesceScrollbackRecords(
     snapshot.buffersByLeafId,
-    retainedLeafIdByRemovedLeafId
-  )
-  const scrollbackRefsByLeafId = coalesceLeafRecord(
     snapshot.scrollbackRefsByLeafId,
-    retainedLeafIdByRemovedLeafId
+    retainedLeafIdByRemovedLeafId,
+    orderedLeafIds
   )
   const titlesByLeafId = coalesceLeafRecord(snapshot.titlesByLeafId, retainedLeafIdByRemovedLeafId)
   const {

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -37,7 +37,11 @@ function resolveRetainedLeafId(
 ): string {
   let retainedLeafId = leafId
   while (retainedLeafIdByRemovedLeafId.has(retainedLeafId)) {
-    retainedLeafId = retainedLeafIdByRemovedLeafId.get(retainedLeafId) ?? retainedLeafId
+    const nextLeafId = retainedLeafIdByRemovedLeafId.get(retainedLeafId)
+    if (!nextLeafId || nextLeafId === retainedLeafId) {
+      return retainedLeafId
+    }
+    retainedLeafId = nextLeafId
   }
   return retainedLeafId
 }

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -300,3 +300,20 @@ export function normalizeTerminalLayoutPtyOwnership(
     changed: true
   }
 }
+
+export function resolveTerminalLayoutPtyOwnershipTransfers(
+  source: TerminalLayoutSnapshot,
+  normalized: TerminalLayoutSnapshot
+): { removedLeafId: string; retainedLeafId: string; ptyId: string }[] {
+  const retainedLeafIdByPtyId = new Map(
+    Object.entries(normalized.ptyIdsByLeafId ?? {}).map(([leafId, ptyId]) => [ptyId, leafId])
+  )
+  const transfers: { removedLeafId: string; retainedLeafId: string; ptyId: string }[] = []
+  for (const [removedLeafId, ptyId] of Object.entries(source.ptyIdsByLeafId ?? {})) {
+    const retainedLeafId = retainedLeafIdByPtyId.get(ptyId)
+    if (retainedLeafId && retainedLeafId !== removedLeafId) {
+      transfers.push({ removedLeafId, retainedLeafId, ptyId })
+    }
+  }
+  return transfers
+}

--- a/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-pty-ownership.ts
@@ -1,0 +1,143 @@
+import type { TerminalLayoutSnapshot, TerminalPaneLayoutNode } from '../../../../shared/types'
+
+type TerminalLayoutPtyOwnershipNormalization = {
+  snapshot: TerminalLayoutSnapshot
+  changed: boolean
+}
+
+function collectLeafIds(node: TerminalPaneLayoutNode | null | undefined): string[] {
+  if (!node) {
+    return []
+  }
+  if (node.type === 'leaf') {
+    return [node.leafId]
+  }
+  return [...collectLeafIds(node.first), ...collectLeafIds(node.second)]
+}
+
+function pruneLeaves(
+  node: TerminalPaneLayoutNode,
+  removedLeafIds: ReadonlySet<string>
+): TerminalPaneLayoutNode | null {
+  if (node.type === 'leaf') {
+    return removedLeafIds.has(node.leafId) ? null : node
+  }
+
+  const first = pruneLeaves(node.first, removedLeafIds)
+  const second = pruneLeaves(node.second, removedLeafIds)
+  if (first && second) {
+    return first === node.first && second === node.second ? node : { ...node, first, second }
+  }
+  return first ?? second
+}
+
+function resolveRetainedLeafId(
+  leafId: string,
+  retainedLeafIdByRemovedLeafId: ReadonlyMap<string, string>
+): string {
+  let retainedLeafId = leafId
+  while (retainedLeafIdByRemovedLeafId.has(retainedLeafId)) {
+    retainedLeafId = retainedLeafIdByRemovedLeafId.get(retainedLeafId) ?? retainedLeafId
+  }
+  return retainedLeafId
+}
+
+function coalesceLeafRecord(
+  source: Record<string, string> | undefined,
+  retainedLeafIdByRemovedLeafId: ReadonlyMap<string, string>
+): Record<string, string> | undefined {
+  if (!source) {
+    return undefined
+  }
+  const retained = Object.fromEntries(
+    Object.entries(source).filter(([leafId]) => !retainedLeafIdByRemovedLeafId.has(leafId))
+  )
+  for (const [removedLeafId, value] of Object.entries(source)) {
+    if (!retainedLeafIdByRemovedLeafId.has(removedLeafId)) {
+      continue
+    }
+    const retainedLeafId = resolveRetainedLeafId(removedLeafId, retainedLeafIdByRemovedLeafId)
+    if (!Object.prototype.hasOwnProperty.call(retained, retainedLeafId)) {
+      retained[retainedLeafId] = value
+    }
+  }
+  return Object.keys(retained).length > 0 ? retained : undefined
+}
+
+function findDuplicatePtyLeafReplacements(snapshot: TerminalLayoutSnapshot): Map<string, string> {
+  const ptyIdsByLeafId = snapshot.ptyIdsByLeafId ?? {}
+  const rootLeafIds = collectLeafIds(snapshot.root)
+  const rootLeafIdSet = new Set(rootLeafIds)
+  const orderedLeafIds = [
+    ...rootLeafIds,
+    ...Object.keys(ptyIdsByLeafId).filter((leafId) => !rootLeafIdSet.has(leafId))
+  ]
+  const retainedLeafIdByPtyId = new Map<string, string>()
+  const retainedLeafIdByRemovedLeafId = new Map<string, string>()
+
+  for (const leafId of orderedLeafIds) {
+    const ptyId = ptyIdsByLeafId[leafId]
+    if (!ptyId) {
+      continue
+    }
+    const retainedLeafId = retainedLeafIdByPtyId.get(ptyId)
+    if (!retainedLeafId) {
+      retainedLeafIdByPtyId.set(ptyId, leafId)
+      continue
+    }
+    if (leafId === snapshot.activeLeafId) {
+      retainedLeafIdByRemovedLeafId.set(retainedLeafId, leafId)
+      retainedLeafIdByPtyId.set(ptyId, leafId)
+      continue
+    }
+    retainedLeafIdByRemovedLeafId.set(leafId, retainedLeafId)
+  }
+
+  return retainedLeafIdByRemovedLeafId
+}
+
+export function normalizeTerminalLayoutPtyOwnership(
+  snapshot: TerminalLayoutSnapshot
+): TerminalLayoutPtyOwnershipNormalization {
+  const retainedLeafIdByRemovedLeafId = findDuplicatePtyLeafReplacements(snapshot)
+  if (retainedLeafIdByRemovedLeafId.size === 0) {
+    return { snapshot, changed: false }
+  }
+
+  // Why: one live PTY has one renderer surface; retaining both leaves races input, resize, and teardown.
+  const removedLeafIds = new Set(retainedLeafIdByRemovedLeafId.keys())
+  const root = snapshot.root ? pruneLeaves(snapshot.root, removedLeafIds) : null
+  const ptyIdsByLeafId = coalesceLeafRecord(snapshot.ptyIdsByLeafId, retainedLeafIdByRemovedLeafId)
+  const buffersByLeafId = coalesceLeafRecord(
+    snapshot.buffersByLeafId,
+    retainedLeafIdByRemovedLeafId
+  )
+  const scrollbackRefsByLeafId = coalesceLeafRecord(
+    snapshot.scrollbackRefsByLeafId,
+    retainedLeafIdByRemovedLeafId
+  )
+  const titlesByLeafId = coalesceLeafRecord(snapshot.titlesByLeafId, retainedLeafIdByRemovedLeafId)
+  const {
+    ptyIdsByLeafId: _oldPtyIdsByLeafId,
+    buffersByLeafId: _oldBuffersByLeafId,
+    scrollbackRefsByLeafId: _oldScrollbackRefsByLeafId,
+    titlesByLeafId: _oldTitlesByLeafId,
+    ...snapshotWithoutLeafRecords
+  } = snapshot
+
+  return {
+    snapshot: {
+      ...snapshotWithoutLeafRecords,
+      root,
+      expandedLeafId:
+        snapshot.expandedLeafId && removedLeafIds.has(snapshot.expandedLeafId)
+          ? null
+          : snapshot.expandedLeafId,
+      ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
+      ...(buffersByLeafId ? { buffersByLeafId } : {}),
+      ...(scrollbackRefsByLeafId ? { scrollbackRefsByLeafId } : {}),
+      ...(titlesByLeafId ? { titlesByLeafId } : {})
+    },
+    changed: true
+  }
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2361,7 +2361,16 @@ describe('applyWebSessionTabsSnapshot', () => {
           parentLayout,
           isActive: false,
           status: 'ready',
-          terminal: 'terminal-1'
+          terminal: 'terminal-1',
+          agentStatus: {
+            state: 'working',
+            prompt: 'stale duplicate',
+            updatedAt: NOW - 100,
+            stateStartedAt: NOW - 1_000,
+            agentType: 'codex',
+            paneKey: makePaneKey('host-tab-1', LEAF_ID),
+            stateHistory: []
+          }
         },
         {
           type: 'terminal',
@@ -2388,6 +2397,13 @@ describe('applyWebSessionTabsSnapshot', () => {
       ptyIdsByLeafId: {
         [SECOND_LEAF_ID]: 'remote:web-env-1@@terminal-1'
       }
+    })
+    expect(Object.keys(patch.agentStatusByPaneKey ?? {})).toEqual([
+      makePaneKey(mirroredId!, SECOND_LEAF_ID)
+    ])
+    expect(patch.agentStatusByPaneKey?.[makePaneKey(mirroredId!, SECOND_LEAF_ID)]).toMatchObject({
+      prompt: 'stale duplicate',
+      paneKey: makePaneKey(mirroredId!, SECOND_LEAF_ID)
     })
   })
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -55,6 +55,7 @@ const ENV = 'web-env-1'
 const NOW = 1_700_000_000_000
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const THIRD_LEAF_ID = '33333333-3333-4333-8333-333333333333'
 const HOST_SURFACE_ID = `host-tab-1::${LEAF_ID}`
 
 function makeState(overrides: Partial<WebSessionTabsSyncState> = {}): WebSessionTabsSyncState {
@@ -2367,21 +2368,23 @@ describe('applyWebSessionTabsSnapshot', () => {
             prompt: 'stale duplicate',
             updatedAt: NOW - 100,
             stateStartedAt: NOW - 1_000,
-            agentType: 'codex',
+            agentType: 'pi',
             paneKey: makePaneKey('host-tab-1', LEAF_ID),
+            terminalTitle: 'Pi ready',
             stateHistory: []
           }
         },
         {
           type: 'terminal',
           id: `host-tab-1::${SECOND_LEAF_ID}`,
-          title: 'active mirror',
+          title: 'Pi ready',
           parentTabId: 'host-tab-1',
           leafId: SECOND_LEAF_ID,
           parentLayout,
           isActive: true,
           status: 'ready',
-          terminal: 'terminal-1'
+          terminal: 'terminal-1',
+          launchAgent: 'omp'
         }
       ]),
       ENV,
@@ -2403,7 +2406,9 @@ describe('applyWebSessionTabsSnapshot', () => {
     ])
     expect(patch.agentStatusByPaneKey?.[makePaneKey(mirroredId!, SECOND_LEAF_ID)]).toMatchObject({
       prompt: 'stale duplicate',
-      paneKey: makePaneKey(mirroredId!, SECOND_LEAF_ID)
+      paneKey: makePaneKey(mirroredId!, SECOND_LEAF_ID),
+      agentType: 'omp',
+      terminalTitle: 'OMP ready'
     })
   })
 
@@ -3815,9 +3820,19 @@ describe('applyWebSessionTabsSnapshot', () => {
         {
           type: 'terminal',
           id: `host-tab-1::${SECOND_LEAF_ID}`,
-          title: 'pending shell',
+          title: 'duplicate ready shell',
           parentTabId: 'host-tab-1',
           leafId: SECOND_LEAF_ID,
+          isActive: false,
+          status: 'ready',
+          terminal: 'terminal-1'
+        },
+        {
+          type: 'terminal',
+          id: `host-tab-1::${THIRD_LEAF_ID}`,
+          title: 'pending shell',
+          parentTabId: 'host-tab-1',
+          leafId: THIRD_LEAF_ID,
           isActive: true,
           status: 'pending-handle',
           terminal: null
@@ -3839,7 +3854,12 @@ describe('applyWebSessionTabsSnapshot', () => {
     ])
     expect(patch.ptyIdsByTabId?.[mirroredId!]).toEqual(['remote:web-env-1@@terminal-1'])
     expect(patch.terminalLayoutsByTabId?.[mirroredId!]).toMatchObject({
-      activeLeafId: SECOND_LEAF_ID,
+      root: {
+        type: 'split',
+        first: { type: 'leaf', leafId: LEAF_ID },
+        second: { type: 'leaf', leafId: THIRD_LEAF_ID }
+      },
+      activeLeafId: THIRD_LEAF_ID,
       ptyIdsByLeafId: {
         [LEAF_ID]: 'remote:web-env-1@@terminal-1'
       }

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2338,6 +2338,59 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.activeTabIdByWorktree?.[WT]).toBe(mirroredId)
   })
 
+  it('deduplicates mirrored leaves that claim the same remote PTY', () => {
+    const parentLayout = {
+      root: {
+        type: 'split' as const,
+        direction: 'horizontal' as const,
+        first: { type: 'leaf' as const, leafId: LEAF_ID },
+        second: { type: 'leaf' as const, leafId: SECOND_LEAF_ID }
+      },
+      activeLeafId: SECOND_LEAF_ID,
+      expandedLeafId: null
+    }
+    const patch = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'stale mirror',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          parentLayout,
+          isActive: false,
+          status: 'ready',
+          terminal: 'terminal-1'
+        },
+        {
+          type: 'terminal',
+          id: `host-tab-1::${SECOND_LEAF_ID}`,
+          title: 'active mirror',
+          parentTabId: 'host-tab-1',
+          leafId: SECOND_LEAF_ID,
+          parentLayout,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const mirroredId = patch.tabsByWorktree?.[WT]?.[0]?.id
+    expect(patch.ptyIdsByTabId?.[mirroredId!]).toEqual(['remote:web-env-1@@terminal-1'])
+    expect(patch.terminalLayoutsByTabId?.[mirroredId!]).toEqual({
+      root: { type: 'leaf', leafId: SECOND_LEAF_ID },
+      activeLeafId: SECOND_LEAF_ID,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [SECOND_LEAF_ID]: 'remote:web-env-1@@terminal-1'
+      }
+    })
+  })
+
   it('does not let repeated remote terminal status snapshots steal local tab focus', () => {
     const agentTabId = toWebTerminalSurfaceTabId('host-tab-1')
     const shellTabId = toWebTerminalSurfaceTabId('host-tab-2')

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -117,6 +117,7 @@ type MirroredTerminalTab = {
   hostTabId: string
   ptyIds: string[]
   layout: TerminalLayoutSnapshot
+  retainedLeafIdByPrunedLeafId?: ReadonlyMap<string, string>
 }
 
 type MirroredBrowserTab = {
@@ -590,7 +591,21 @@ function buildMirroredTerminalTabs(
     const layout = normalizeTerminalLayoutPtyOwnership(
       chooseRemoteTerminalLayout(surfaces, ptyIdsByLeafId, existingLayout, requestedActiveLeafId)
     ).snapshot
-    const ptyIds = Object.values(layout.ptyIdsByLeafId ?? {})
+    const layoutPtyEntries = Object.entries(layout.ptyIdsByLeafId ?? {})
+    const ptyIds = layoutPtyEntries.map(([, ptyId]) => ptyId)
+    let retainedLeafIdByPrunedLeafId: Map<string, string> | undefined
+    if (layoutPtyEntries.length < Object.keys(ptyIdsByLeafId).length) {
+      const retainedLeafIdByPtyId = new Map(
+        layoutPtyEntries.map(([leafId, ptyId]) => [ptyId, leafId])
+      )
+      retainedLeafIdByPrunedLeafId = new Map()
+      for (const [leafId, ptyId] of Object.entries(ptyIdsByLeafId)) {
+        const retainedLeafId = retainedLeafIdByPtyId.get(ptyId)
+        if (retainedLeafId && retainedLeafId !== leafId) {
+          retainedLeafIdByPrunedLeafId.set(leafId, retainedLeafId)
+        }
+      }
+    }
     const launchAgent =
       activeSurface.launchAgent ?? surfaces.find((surface) => surface.launchAgent)?.launchAgent
     const ownerAgent = resolvePaneAgentOwner({
@@ -645,24 +660,28 @@ function buildMirroredTerminalTabs(
       },
       hostTabId: parentTabId,
       ptyIds,
-      layout
+      layout,
+      ...(retainedLeafIdByPrunedLeafId ? { retainedLeafIdByPrunedLeafId } : {})
     }
   })
 }
 
-function toMirroredPaneKey(surface: TerminalSurface): string | null {
-  if (!isTerminalLeafId(surface.leafId)) {
+function toMirroredPaneKey(surface: TerminalSurface, leafId = surface.leafId): string | null {
+  if (!isTerminalLeafId(leafId)) {
     return null
   }
-  return makePaneKey(toWebTerminalSurfaceTabId(surface.parentTabId), surface.leafId)
+  return makePaneKey(toWebTerminalSurfaceTabId(surface.parentTabId), leafId)
 }
 
 /** Normalises and mirrors agent status updates from the host payload, preserving ownership metadata. */
-function remapHostAgentStatus(surface: TerminalSurface): AgentStatusEntry | null {
+function remapHostAgentStatus(
+  surface: TerminalSurface,
+  retainedLeafId?: string
+): AgentStatusEntry | null {
   if (!surface.agentStatus) {
     return null
   }
-  const paneKey = toMirroredPaneKey(surface)
+  const paneKey = toMirroredPaneKey(surface, retainedLeafId)
   if (!paneKey) {
     return null
   }
@@ -687,6 +706,7 @@ function buildMirroredAgentStatusPatch(
   state: WebSessionTabsSyncState,
   currentTerminalTabs: readonly TerminalTab[],
   terminalSurfaceTabs: readonly TerminalSurface[],
+  mirroredTerminalTabs: readonly MirroredTerminalTab[],
   now: number
 ): Pick<WebSessionTabsSyncState, 'agentStatusByPaneKey' | 'agentStatusEpoch' | 'sortEpoch'> | null {
   const mirroredTabIds = new Set<string>()
@@ -703,13 +723,26 @@ function buildMirroredAgentStatusPatch(
     return null
   }
 
+  let retainedLeafIdByHostTabAndPrunedLeafId: Map<string, ReadonlyMap<string, string>> | undefined
+  for (const entry of mirroredTerminalTabs) {
+    if (entry.retainedLeafIdByPrunedLeafId) {
+      retainedLeafIdByHostTabAndPrunedLeafId ??= new Map()
+      retainedLeafIdByHostTabAndPrunedLeafId.set(
+        entry.hostTabId,
+        entry.retainedLeafIdByPrunedLeafId
+      )
+    }
+  }
   const nextByPaneKey = new Map<string, AgentStatusEntry>()
   for (const surface of terminalSurfaceTabs) {
-    const entry = remapHostAgentStatus(surface)
+    const retainedLeafId = retainedLeafIdByHostTabAndPrunedLeafId
+      ?.get(surface.parentTabId)
+      ?.get(surface.leafId)
+    const entry = remapHostAgentStatus(surface, retainedLeafId)
     if (!entry) {
       continue
     }
-    const existing = state.agentStatusByPaneKey[entry.paneKey]
+    const existing = nextByPaneKey.get(entry.paneKey) ?? state.agentStatusByPaneKey[entry.paneKey]
     // Why: keep fresher OSC state while taking remapped ownership metadata from the authoritative host snapshot.
     const hostIdentityPredatesCurrentTurn =
       existing !== undefined &&
@@ -2520,6 +2553,7 @@ export function applyWebSessionTabsSnapshot(
     state,
     currentTerminalTabs,
     terminalSurfaceTabs,
+    mirroredTerminalTabs,
     now
   )
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -117,7 +117,7 @@ type MirroredTerminalTab = {
   hostTabId: string
   ptyIds: string[]
   layout: TerminalLayoutSnapshot
-  retainedLeafIdByPrunedLeafId?: ReadonlyMap<string, string>
+  retainedSurfaceByPrunedLeafId?: ReadonlyMap<string, TerminalSurface>
 }
 
 type MirroredBrowserTab = {
@@ -593,16 +593,20 @@ function buildMirroredTerminalTabs(
     ).snapshot
     const layoutPtyEntries = Object.entries(layout.ptyIdsByLeafId ?? {})
     const ptyIds = layoutPtyEntries.map(([, ptyId]) => ptyId)
-    let retainedLeafIdByPrunedLeafId: Map<string, string> | undefined
+    let retainedSurfaceByPrunedLeafId: Map<string, TerminalSurface> | undefined
     if (layoutPtyEntries.length < Object.keys(ptyIdsByLeafId).length) {
       const retainedLeafIdByPtyId = new Map(
         layoutPtyEntries.map(([leafId, ptyId]) => [ptyId, leafId])
       )
-      retainedLeafIdByPrunedLeafId = new Map()
+      const surfaceByLeafId = new Map(surfaces.map((surface) => [surface.leafId, surface]))
+      retainedSurfaceByPrunedLeafId = new Map()
       for (const [leafId, ptyId] of Object.entries(ptyIdsByLeafId)) {
         const retainedLeafId = retainedLeafIdByPtyId.get(ptyId)
         if (retainedLeafId && retainedLeafId !== leafId) {
-          retainedLeafIdByPrunedLeafId.set(leafId, retainedLeafId)
+          const retainedSurface = surfaceByLeafId.get(retainedLeafId)
+          if (retainedSurface) {
+            retainedSurfaceByPrunedLeafId.set(leafId, retainedSurface)
+          }
         }
       }
     }
@@ -661,7 +665,7 @@ function buildMirroredTerminalTabs(
       hostTabId: parentTabId,
       ptyIds,
       layout,
-      ...(retainedLeafIdByPrunedLeafId ? { retainedLeafIdByPrunedLeafId } : {})
+      ...(retainedSurfaceByPrunedLeafId ? { retainedSurfaceByPrunedLeafId } : {})
     }
   })
 }
@@ -676,17 +680,17 @@ function toMirroredPaneKey(surface: TerminalSurface, leafId = surface.leafId): s
 /** Normalises and mirrors agent status updates from the host payload, preserving ownership metadata. */
 function remapHostAgentStatus(
   surface: TerminalSurface,
-  retainedLeafId?: string
+  retainedSurface?: TerminalSurface
 ): AgentStatusEntry | null {
   if (!surface.agentStatus) {
     return null
   }
-  const paneKey = toMirroredPaneKey(surface, retainedLeafId)
+  const paneKey = toMirroredPaneKey(surface, retainedSurface?.leafId)
   if (!paneKey) {
     return null
   }
   const ownerAgent = resolvePaneAgentOwner({
-    launchAgent: surface.launchAgent,
+    launchAgent: retainedSurface?.launchAgent ?? surface.launchAgent,
     hookAgent: surface.agentStatus.agentType
   })
   return {
@@ -723,22 +727,24 @@ function buildMirroredAgentStatusPatch(
     return null
   }
 
-  let retainedLeafIdByHostTabAndPrunedLeafId: Map<string, ReadonlyMap<string, string>> | undefined
+  let retainedSurfaceByHostTabAndPrunedLeafId:
+    | Map<string, ReadonlyMap<string, TerminalSurface>>
+    | undefined
   for (const entry of mirroredTerminalTabs) {
-    if (entry.retainedLeafIdByPrunedLeafId) {
-      retainedLeafIdByHostTabAndPrunedLeafId ??= new Map()
-      retainedLeafIdByHostTabAndPrunedLeafId.set(
+    if (entry.retainedSurfaceByPrunedLeafId) {
+      retainedSurfaceByHostTabAndPrunedLeafId ??= new Map()
+      retainedSurfaceByHostTabAndPrunedLeafId.set(
         entry.hostTabId,
-        entry.retainedLeafIdByPrunedLeafId
+        entry.retainedSurfaceByPrunedLeafId
       )
     }
   }
   const nextByPaneKey = new Map<string, AgentStatusEntry>()
   for (const surface of terminalSurfaceTabs) {
-    const retainedLeafId = retainedLeafIdByHostTabAndPrunedLeafId
+    const retainedSurface = retainedSurfaceByHostTabAndPrunedLeafId
       ?.get(surface.parentTabId)
       ?.get(surface.leafId)
-    const entry = remapHostAgentStatus(surface, retainedLeafId)
+    const entry = remapHostAgentStatus(surface, retainedSurface)
     if (!entry) {
       continue
     }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -32,6 +32,7 @@ import type { OpenFile } from '../store/slices/editor'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
+import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import {
   getExplicitRuntimeEnvironmentIdForWorktree,
   getRuntimeSessionMirrorEnvironmentIds
@@ -586,9 +587,10 @@ function buildMirroredTerminalTabs(
         .filter((surface): surface is ReadyTerminalSurface => surface.status === 'ready')
         .map((surface) => [surface.leafId, toRemoteRuntimePtyId(surface.terminal, environmentId)])
     )
-    const ptyIds = surfaces
-      .map((surface) => ptyIdsByLeafId[surface.leafId]!)
-      .filter((ptyId): ptyId is string => typeof ptyId === 'string' && ptyId.length > 0)
+    const layout = normalizeTerminalLayoutPtyOwnership(
+      chooseRemoteTerminalLayout(surfaces, ptyIdsByLeafId, existingLayout, requestedActiveLeafId)
+    ).snapshot
+    const ptyIds = Object.values(layout.ptyIdsByLeafId ?? {})
     const launchAgent =
       activeSurface.launchAgent ?? surfaces.find((surface) => surface.launchAgent)?.launchAgent
     const ownerAgent = resolvePaneAgentOwner({
@@ -643,12 +645,7 @@ function buildMirroredTerminalTabs(
       },
       hostTabId: parentTabId,
       ptyIds,
-      layout: chooseRemoteTerminalLayout(
-        surfaces,
-        ptyIdsByLeafId,
-        existingLayout,
-        requestedActiveLeafId
-      )
+      layout
     }
   })
 }

--- a/src/renderer/src/store/slices/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/store/slices/terminal-layout-pty-ownership.test.ts
@@ -1,10 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  resetAgentPaneAuthorityAliasesForTests,
+  resolveAgentPaneAuthorityKey
+} from './agent-pane-authority'
 import { createTestStore } from './store-test-helpers'
 
 const LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const LEAF_2 = '22222222-2222-4222-8222-222222222222'
 
 describe('setTabLayout PTY ownership', () => {
+  beforeEach(() => {
+    resetAgentPaneAuthorityAliasesForTests()
+  })
+
   it('normalizes duplicate PTY surfaces at the renderer state boundary', () => {
     const store = createTestStore()
 
@@ -51,6 +60,43 @@ describe('setTabLayout PTY ownership', () => {
     store.getState().setTabLayout('tab-1', layout)
 
     expect(store.getState().terminalLayoutsByTabId['tab-1']).toBe(layout)
+  })
+
+  it('moves live and future pane authority onto the retained PTY leaf', () => {
+    const store = createTestStore()
+    const removedPaneKey = makePaneKey('tab-1', LEAF_1)
+    const retainedPaneKey = makePaneKey('tab-1', LEAF_2)
+    store.getState().setAgentStatus(removedPaneKey, {
+      state: 'working',
+      prompt: 'before repair',
+      agentType: 'codex'
+    })
+
+    store.getState().setTabLayout('tab-1', {
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(store.getState().agentStatusByPaneKey[removedPaneKey]).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[retainedPaneKey]?.prompt).toBe('before repair')
+    expect(resolveAgentPaneAuthorityKey(removedPaneKey)).toBe(retainedPaneKey)
+
+    store.getState().setAgentStatus(removedPaneKey, {
+      state: 'working',
+      prompt: 'after repair',
+      agentType: 'codex'
+    })
+    expect(store.getState().agentStatusByPaneKey[retainedPaneKey]?.prompt).toBe('after repair')
   })
 
   it('scopes ownership to a tab so detach handoffs can share a PTY across tabs', () => {

--- a/src/renderer/src/store/slices/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/store/slices/terminal-layout-pty-ownership.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+
+describe('setTabLayout PTY ownership', () => {
+  it('normalizes duplicate PTY surfaces at the renderer state boundary', () => {
+    const store = createTestStore()
+
+    store.getState().setTabLayout('tab-1', {
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-agent',
+        [LEAF_2]: 'pty-agent'
+      }
+    })
+
+    expect(store.getState().terminalLayoutsByTabId['tab-1']).toEqual({
+      root: { type: 'leaf', leafId: LEAF_2 },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_2]: 'pty-agent' }
+    })
+  })
+
+  it('preserves valid live layouts and legacy leaf ids by identity', () => {
+    const store = createTestStore()
+    const layout = {
+      root: {
+        type: 'split' as const,
+        direction: 'horizontal' as const,
+        first: { type: 'leaf' as const, leafId: 'pane:1' },
+        second: { type: 'leaf' as const, leafId: 'pane:2' }
+      },
+      activeLeafId: 'pane:2',
+      expandedLeafId: 'pane:1',
+      ptyIdsByLeafId: {
+        'pane:1': 'pty-local',
+        'pane:2': 'remote:env-1@@term_remote'
+      }
+    }
+
+    store.getState().setTabLayout('tab-1', layout)
+
+    expect(store.getState().terminalLayoutsByTabId['tab-1']).toBe(layout)
+  })
+
+  it('scopes ownership to a tab so detach handoffs can share a PTY across tabs', () => {
+    const store = createTestStore()
+    const sourceLayout = {
+      root: { type: 'leaf' as const, leafId: LEAF_1 },
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-detached' }
+    }
+    const targetLayout = {
+      root: { type: 'leaf' as const, leafId: LEAF_2 },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_2]: 'pty-detached' }
+    }
+
+    store.getState().setTabLayout('source-tab', sourceLayout)
+    store.getState().setTabLayout('target-tab', targetLayout)
+
+    expect(store.getState().terminalLayoutsByTabId['source-tab']).toBe(sourceLayout)
+    expect(store.getState().terminalLayoutsByTabId['target-tab']).toBe(targetLayout)
+  })
+})

--- a/src/renderer/src/store/slices/terminal-layout-pty-ownership.test.ts
+++ b/src/renderer/src/store/slices/terminal-layout-pty-ownership.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { getDefaultWorkspaceSession } from '../../../../shared/constants'
 import {
   resetAgentPaneAuthorityAliasesForTests,
   resolveAgentPaneAuthorityKey
 } from './agent-pane-authority'
-import { createTestStore } from './store-test-helpers'
+import { createTestStore, makeTab, makeWorktree, seedStore } from './store-test-helpers'
 
 const LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const LEAF_2 = '22222222-2222-4222-8222-222222222222'
@@ -97,6 +98,117 @@ describe('setTabLayout PTY ownership', () => {
       agentType: 'codex'
     })
     expect(store.getState().agentStatusByPaneKey[retainedPaneKey]?.prompt).toBe('after repair')
+  })
+
+  it('moves hydrated pane authority onto the retained PTY leaf', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/wt-1'
+    const removedPaneKey = makePaneKey('tab-1', LEAF_1)
+    const retainedPaneKey = makePaneKey('tab-1', LEAF_2)
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: worktreeId, repoId: 'repo1', path: '/wt-1' })]
+      }
+    })
+    store.getState().setAgentStatus(removedPaneKey, {
+      state: 'working',
+      prompt: 'before hydration',
+      agentType: 'codex'
+    })
+
+    store.getState().hydrateWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: 'repo1',
+      activeWorktreeId: worktreeId,
+      activeTabId: 'tab-1',
+      tabsByWorktree: {
+        [worktreeId]: [makeTab({ id: 'tab-1', worktreeId, ptyId: 'pty-agent' })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'vertical',
+            first: { type: 'leaf', leafId: LEAF_1 },
+            second: { type: 'leaf', leafId: LEAF_2 }
+          },
+          activeLeafId: LEAF_2,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {
+            [LEAF_1]: 'pty-agent',
+            [LEAF_2]: 'pty-agent'
+          }
+        }
+      }
+    })
+
+    expect(store.getState().agentStatusByPaneKey[removedPaneKey]).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[retainedPaneKey]?.prompt).toBe('before hydration')
+    expect(resolveAgentPaneAuthorityKey(removedPaneKey)).toBe(retainedPaneKey)
+  })
+
+  it('does not steal authority from a pane that was already detached to another tab', () => {
+    const store = createTestStore()
+    const removedPaneKey = makePaneKey('source-tab', LEAF_1)
+    const retainedPaneKey = makePaneKey('source-tab', LEAF_2)
+    const detachedPaneKey = makePaneKey('target-tab', LEAF_1)
+    store.getState().setTabLayout('target-tab', {
+      root: { type: 'leaf', leafId: LEAF_1 },
+      activeLeafId: LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_1]: 'pty-detached' }
+    })
+    store.getState().transferAgentPaneAuthority({
+      fromPaneKey: removedPaneKey,
+      toPaneKey: detachedPaneKey,
+      ptyId: 'pty-detached'
+    })
+
+    store.getState().setTabLayout('source-tab', {
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_1 },
+        second: { type: 'leaf', leafId: LEAF_2 }
+      },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        [LEAF_1]: 'pty-detached',
+        [LEAF_2]: 'pty-detached'
+      }
+    })
+
+    expect(resolveAgentPaneAuthorityKey(removedPaneKey)).toBe(detachedPaneKey)
+    expect(resolveAgentPaneAuthorityKey(detachedPaneKey)).toBe(detachedPaneKey)
+    expect(resolveAgentPaneAuthorityKey(retainedPaneKey)).toBe(retainedPaneKey)
+  })
+
+  it('repairs duplicate legacy leaf ownership without throwing', () => {
+    const store = createTestStore()
+
+    expect(() =>
+      store.getState().setTabLayout('tab-1', {
+        root: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: 'pane:1' },
+          second: { type: 'leaf', leafId: 'pane:2' }
+        },
+        activeLeafId: 'pane:2',
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          'pane:1': 'pty-agent',
+          'pane:2': 'pty-agent'
+        }
+      })
+    ).not.toThrow()
+    expect(store.getState().terminalLayoutsByTabId['tab-1']).toEqual({
+      root: { type: 'leaf', leafId: 'pane:2' },
+      activeLeafId: 'pane:2',
+      expandedLeafId: null,
+      ptyIdsByLeafId: { 'pane:2': 'pty-agent' }
+    })
   })
 
   it('scopes ownership to a tab so detach handoffs can share a PTY across tabs', () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -87,7 +87,10 @@ import {
   normalizeTerminalLayoutSnapshot,
   resolvePtyBoundActiveLeafId
 } from '@/components/terminal-pane/terminal-layout-leaf-ids'
-import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
+import {
+  normalizeTerminalLayoutPtyOwnership,
+  resolveTerminalLayoutPtyOwnershipTransfers
+} from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { parseRemoteRuntimePtyId, toRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
@@ -3511,15 +3514,30 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   setTabLayout: (tabId, layout) => {
+    let ownershipTransfers: ReturnType<typeof resolveTerminalLayoutPtyOwnershipTransfers> = []
     set((s) => {
       const next = { ...s.terminalLayoutsByTabId }
       if (layout) {
-        next[tabId] = normalizeTerminalLayoutPtyOwnership(layout).snapshot
+        const normalized = normalizeTerminalLayoutPtyOwnership(layout)
+        next[tabId] = normalized.snapshot
+        if (normalized.changed) {
+          ownershipTransfers = resolveTerminalLayoutPtyOwnershipTransfers(
+            layout,
+            normalized.snapshot
+          )
+        }
       } else {
         delete next[tabId]
       }
       return { terminalLayoutsByTabId: next }
     })
+    for (const { removedLeafId, retainedLeafId, ptyId } of ownershipTransfers) {
+      get().transferAgentPaneAuthority({
+        fromPaneKey: makePaneKey(tabId, removedLeafId),
+        toPaneKey: makePaneKey(tabId, retainedLeafId),
+        ptyId
+      })
+    }
   },
 
   syncPaneDetachPtyOwnership: ({

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -87,6 +87,7 @@ import {
   normalizeTerminalLayoutSnapshot,
   resolvePtyBoundActiveLeafId
 } from '@/components/terminal-pane/terminal-layout-leaf-ids'
+import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { parseRemoteRuntimePtyId, toRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
@@ -3513,7 +3514,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     set((s) => {
       const next = { ...s.terminalLayoutsByTabId }
       if (layout) {
-        next[tabId] = layout
+        next[tabId] = normalizeTerminalLayoutPtyOwnership(layout).snapshot
       } else {
         delete next[tabId]
       }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -31,6 +31,7 @@ import {
 import { deriveGeneratedTabTitle } from '../../../../shared/agent-tab-title'
 import { isDecorativeAgentTitleFrameChange } from '../../../../shared/agent-decorative-title-signature'
 import {
+  isTerminalLeafId,
   makePaneKey,
   parseLegacyNumericPaneKey,
   parsePaneKey
@@ -125,6 +126,7 @@ import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-route'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import type { NativeChatLaunchDraft, NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
+import { resolveAgentPaneAuthorityKey } from './agent-pane-authority'
 import {
   addAdditionalValidWorkspaceKeys,
   type WorkspaceSessionHydrationOptions
@@ -869,6 +871,48 @@ function replaceHydratedRecordKeys<T>(
   return {
     ...Object.fromEntries(Object.entries(current).filter(([key]) => !replaceKeys.has(key))),
     ...Object.fromEntries(Object.entries(hydrated).filter(([key]) => replaceKeys.has(key)))
+  }
+}
+
+type TerminalLayoutPtyOwnershipTransfer = ReturnType<
+  typeof resolveTerminalLayoutPtyOwnershipTransfers
+>[number]
+
+function transferNormalizedTerminalLayoutPtyOwnership(
+  state: Pick<AppState, 'terminalLayoutsByTabId' | 'transferAgentPaneAuthority'>,
+  tabId: string,
+  transfers: readonly TerminalLayoutPtyOwnershipTransfer[]
+): void {
+  if (transfers.length === 0) {
+    return
+  }
+  const ptyIdsOwnedByOtherTabs = new Set<string>()
+  for (const [candidateTabId, layout] of Object.entries(state.terminalLayoutsByTabId)) {
+    if (candidateTabId === tabId) {
+      continue
+    }
+    for (const ptyId of Object.values(layout.ptyIdsByLeafId ?? {})) {
+      ptyIdsOwnedByOtherTabs.add(ptyId)
+    }
+  }
+  for (const { removedLeafId, retainedLeafId, ptyId } of transfers) {
+    if (
+      !isTerminalLeafId(removedLeafId) ||
+      !isTerminalLeafId(retainedLeafId) ||
+      ptyIdsOwnedByOtherTabs.has(ptyId)
+    ) {
+      continue
+    }
+    const fromPaneKey = makePaneKey(tabId, removedLeafId)
+    const currentOwner = parsePaneKey(resolveAgentPaneAuthorityKey(fromPaneKey))
+    if (currentOwner && currentOwner.tabId !== tabId) {
+      continue
+    }
+    state.transferAgentPaneAuthority({
+      fromPaneKey,
+      toPaneKey: makePaneKey(tabId, retainedLeafId),
+      ptyId
+    })
   }
 }
 
@@ -3531,13 +3575,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       }
       return { terminalLayoutsByTabId: next }
     })
-    for (const { removedLeafId, retainedLeafId, ptyId } of ownershipTransfers) {
-      get().transferAgentPaneAuthority({
-        fromPaneKey: makePaneKey(tabId, removedLeafId),
-        toPaneKey: makePaneKey(tabId, retainedLeafId),
-        ptyId
-      })
-    }
+    transferNormalizedTerminalLayoutPtyOwnership(get(), tabId, ownershipTransfers)
   },
 
   syncPaneDetachPtyOwnership: ({
@@ -3737,6 +3775,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   },
 
   hydrateWorkspaceSession: (session, options) => {
+    const ownershipTransferTabIds = options?.replaceWorkspaceKeys
+      ? new Set(
+          options.replaceWorkspaceKeys.flatMap((workspaceKey) =>
+            (session.tabsByWorktree[workspaceKey] ?? []).map((tab) => tab.id)
+          )
+        )
+      : null
+    const ownershipTransfersByTabId = new Map<string, TerminalLayoutPtyOwnershipTransfer[]>()
     set((s) => {
       const runtimeSessionPlaceholders = buildRuntimeSessionPlaceholders({
         repos: s.repos,
@@ -3987,7 +4033,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             .filter(([tabId]) => validTabIds.has(tabId))
             .map(([tabId, layout]) => {
               // Why: old sessions can contain renderer-local pane:1-style leaf ids; normalize before runtime/mobile surfaces read them.
-              const normalized = normalizeTerminalLayoutSnapshot(layout).snapshot
+              const normalization = normalizeTerminalLayoutSnapshot(layout)
+              const normalized = normalization.snapshot
+              if (
+                normalization.changed &&
+                (!ownershipTransferTabIds || ownershipTransferTabIds.has(tabId))
+              ) {
+                ownershipTransfersByTabId.set(
+                  tabId,
+                  resolveTerminalLayoutPtyOwnershipTransfers(layout, normalized)
+                )
+              }
               const tab = tabById.get(tabId)
               const sanitized = tab ? sanitizeTerminalLayoutPaneTitles(normalized, tab) : normalized
               const activeLeafId = sanitized.root
@@ -4005,6 +4061,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ? targetScopedWorkspaceHydrationPatch(s, hydrated, session, options)
         : hydrated
     })
+    for (const [tabId, transfers] of ownershipTransfersByTabId) {
+      transferNormalizedTerminalLayoutPtyOwnership(get(), tabId, transfers)
+    }
   },
 
   reconnectPersistedTerminals: async (signal, options) => {


### PR DESCRIPTION
## Summary

- enforce one renderer leaf per PTY within each terminal tab
- repair duplicate ownership across hydration, replay, live writes, and mirrored remote snapshots
- preserve active/pending focus, pane authority, status aliases, and coherent buffer/scrollback/title metadata
- retain valid legacy and distinct-PTY layouts by identity
- bound malformed deep-layout repair with iterative linear traversal

## Regression coverage

- duplicate and repeated-leaf replay creates one terminal surface without losing the retained PTY
- rooted/rootless, active/pending/dangling selection, split-tree, metadata-source, and idempotence permutations
- live store, persisted hydration, pane-authority alias, late status, mirrored web/mobile snapshot, and cross-tab detach coverage
- valid legacy IDs and distinct-PTY layouts remain unchanged
- 12,000-leaf deterministic depth regression plus an independent 100,000-leaf review probe

## Reliability contract

- **Invariant (`terminal-session.layout-pty-ownership`)**: within one terminal tab, one PTY identity has at most one renderer leaf; repair preserves the surviving focus, restore metadata, and pane authority without changing valid layouts.
- **Failure source**: stale persisted or mirrored layouts can map one PTY to multiple leaves, repeat a leaf ID, retain dangling selection, or leave status/authority under a pruned pane key.
- **Oracle**: pure normalization/replay tests, live store and hydration tests, mirrored snapshot/status tests, pane-authority late-event tests, deep-layout stress tests, and a visible Electron duplicate-restore/control scenario.
- **Gate**: no exact manifest gate exists yet; accepted gap. The adjacent `terminal-session.explicit-close-retirement` deterministic gate passed 512 tests, and the full PR matrix passed.
- **Provider/platform coverage**: normalization treats PTY IDs and workspace kinds as opaque. Deterministic coverage includes local, daemon, SSH-shaped, WSL-shaped, remote/mirrored, folder-workspace, and detach contracts. macOS Electron visible behavior and Windows CI terminal/package paths passed. Live Linux, Windows, WSL, SSH, remote-runtime, and mobile-provider journeys remain gaps.
- **Performance budget**: ownership repair is iterative and linear in one layout plus its leaf metadata. A 100,000-leaf review probe completed without stack overflow. No polling, provider inventory, subprocess, global session scan, startup await, or render loop was added; unchanged valid layouts retain object identity.
- **Diagnostics**: deterministic red/green artifacts and the Electron evidence comments identify input/output leaf and PTY ownership. No new runtime logging was added for deterministic repair.
- **Residual gaps**: live Linux, Windows, WSL, SSH, remote-runtime, and mobile-provider journeys remain unproved.

## Validation

- final same-model review pass returned clean at `5cb86539b8`
- final focused review: 120 ownership/replay/mirror tests passed
- authority reliability gate: 512 tests passed
- parent Node 24 verification: 108 focused tests passed
- web typecheck, changed-file lint, max-lines, reliability manifest, formatting, and diff checks passed
- full PR CI passed across Node 24/26 tests, static analysis, typecheck, packaging, Windows terminal restart, Windows crash survival, verify, and Greptile
- Electron: duplicate ownership of a real live PTY repaired to one visible/backing pane with post-repair I/O; the real split control created two panes backed by distinct PTYs with live I/O in the new pane
- screenshots and exact runtime evidence: [initial deterministic run](https://github.com/stablyai/orca/pull/11726#issuecomment-5141572797), [live PTY retry](https://github.com/stablyai/orca/pull/11726#issuecomment-5146001870)
