### PR TITLE
fix(worktrees): make agent-scratch worktrees importable (#10324)

### DIFF
--- a/src/renderer/src/components/sidebar/new-external-worktrees-inbox-candidates.test.ts
+++ b/src/renderer/src/components/sidebar/new-external-worktrees-inbox-candidates.test.ts
@@ -88,6 +88,26 @@ describe('buildNewExternalWorktreesInboxCandidates', () => {
     ).toBe(0)
   })
 
+  it('builds inbox candidates for agent scratch even when visibility already shows externals', () => {
+    const scratch = detectedWorktree({
+      id: 'repo-1::/repo/.claude/worktrees/agent-1',
+      path: '/repo/.claude/worktrees/agent-1',
+      displayName: 'agent-1',
+      ownership: 'agent-scratch'
+    })
+
+    expect(
+      buildNewExternalWorktreesInboxCandidates({
+        repos: [{ ...repo, externalWorktreeVisibility: 'show' }],
+        visibleWorktrees: [visibleWorktree],
+        detectedWorktreesByRepo: { [repo.id]: detectedResult([scratch]) }
+      }).get(repo.id)
+    ).toMatchObject({
+      repo: { id: repo.id },
+      inboxWorktrees: [{ id: 'repo-1::/repo/.claude/worktrees/agent-1' }]
+    })
+  })
+
   it('suppresses inbox candidates when discovery is permanently hidden or visibility is show', () => {
     const detectedWorktreesByRepo = { [repo.id]: detectedResult([detectedWorktree()]) }
 

--- a/src/shared/external-worktree-inbox.test.ts
+++ b/src/shared/external-worktree-inbox.test.ts
@@ -9,6 +9,7 @@ import type {
 } from './types'
 import {
   getHiddenExternalWorktrees,
+  getHiddenImportableExternalWorktrees,
   getNewExternalWorktreeInboxWorktrees,
   getVisibleExternalWorktrees,
   mergeExternalWorktreeInboxPaths,
@@ -191,6 +192,96 @@ describe('external worktree inbox', () => {
     expect(manual.ownership).toBe('external')
     expect(manual.visible).toBe(false)
     expect(getNewExternalWorktreeInboxWorktrees(detectedResult([manual]), repo)).toEqual([manual])
+  })
+
+  it('offers agent scratch for import in both hide and show visibility modes', () => {
+    const scratch = detectedWorktree({
+      id: 'agent-scratch',
+      path: '/repo/.claude/worktrees/agent-1',
+      ownership: 'agent-scratch'
+    })
+    const detected = detectedResult([scratch])
+
+    expect(getNewExternalWorktreeInboxWorktrees(detected, repo)).toEqual([scratch])
+    expect(
+      getNewExternalWorktreeInboxWorktrees(detected, {
+        ...repo,
+        externalWorktreeVisibility: 'show'
+      })
+    ).toEqual([scratch])
+  })
+
+  it('offers agent scratch before the initial import prompt is dismissed', () => {
+    // Why: the prompt is only dismissable from the card, which never renders for
+    // a scratch-only repo, so gating scratch on it would strand the import.
+    const scratch = detectedWorktree({
+      id: 'agent-scratch',
+      path: '/repo/.claude/worktrees/agent-1',
+      ownership: 'agent-scratch'
+    })
+
+    expect(
+      getNewExternalWorktreeInboxWorktrees(detectedResult([scratch]), {
+        ...repo,
+        externalWorktreeVisibilityPromptDismissedAt: undefined
+      })
+    ).toEqual([scratch])
+  })
+
+  it('keeps suppression and the inbox baseline authoritative over agent scratch', () => {
+    const scratch = detectedWorktree({
+      id: 'agent-scratch',
+      path: '/repo/.claude/worktrees/agent-1',
+      ownership: 'agent-scratch'
+    })
+    const detected = detectedResult([scratch])
+
+    expect(
+      getNewExternalWorktreeInboxWorktrees(detected, {
+        ...repo,
+        externalWorktreeDiscoverySuppressedAt: 1
+      })
+    ).toEqual([])
+    expect(
+      getNewExternalWorktreeInboxWorktrees(detected, {
+        ...repo,
+        externalWorktreeInboxBaselinePaths: ['/repo/.claude/worktrees/agent-1']
+      })
+    ).toEqual([])
+  })
+
+  it('keeps non-scratch externals out of the inbox while visibility already shows them', () => {
+    const external = detectedWorktree({ id: 'external', path: '/scratch/new-one' })
+    const scratch = detectedWorktree({
+      id: 'agent-scratch',
+      path: '/repo/.claude/worktrees/agent-1',
+      ownership: 'agent-scratch'
+    })
+
+    expect(
+      getNewExternalWorktreeInboxWorktrees(detectedResult([external, scratch]), {
+        ...repo,
+        externalWorktreeVisibility: 'show'
+      })
+    ).toEqual([scratch])
+  })
+
+  it('separates importable hidden worktrees from user-facing ones', () => {
+    const external = detectedWorktree({ id: 'external', path: '/scratch/new-one' })
+    const scratch = detectedWorktree({
+      id: 'agent-scratch',
+      path: '/repo/.claude/worktrees/agent-1',
+      ownership: 'agent-scratch'
+    })
+    const detected = detectedResult([
+      external,
+      scratch,
+      detectedWorktree({ id: 'orca-managed', ownership: 'orca-managed' }),
+      detectedWorktree({ id: 'selected', selectedCheckout: true })
+    ])
+
+    expect(getHiddenImportableExternalWorktrees(detected)).toEqual([external, scratch])
+    expect(getHiddenExternalWorktrees(detected)).toEqual([external])
   })
 
   it('suppresses non-authoritative detected results', () => {

--- a/src/shared/external-worktree-inbox.ts
+++ b/src/shared/external-worktree-inbox.ts
@@ -43,6 +43,17 @@ export function getHiddenExternalWorktrees(
   )
 }
 
+export function getHiddenImportableExternalWorktrees(
+  detected: DetectedWorktreeListResult | undefined
+): DetectedWorktree[] {
+  if (detected?.authoritative !== true) {
+    return []
+  }
+  return detected.worktrees.filter(
+    (worktree) => !worktree.visible && isImportableExternalWorktree(worktree)
+  )
+}
+
 export function getVisibleExternalWorktrees(
   detected: DetectedWorktreeListResult | undefined
 ): DetectedWorktree[] {
@@ -62,6 +73,12 @@ function isUserFacingExternalWorktree(worktree: DetectedWorktree): boolean {
     worktree.ownership !== 'orca-managed' &&
     worktree.ownership !== 'agent-scratch'
   )
+}
+
+function isImportableExternalWorktree(worktree: DetectedWorktree): boolean {
+  // Why: scratch is not user-facing, but the visibility toggle can never reveal
+  // it, so explicit import is its only reachable path back (#10324).
+  return !worktree.selectedCheckout && worktree.ownership !== 'orca-managed'
 }
 
 export function isExternalWorktreeDiscoverySuppressed(
@@ -93,16 +110,21 @@ export function getNewExternalWorktreeInboxWorktrees(
   detected: DetectedWorktreeListResult | undefined,
   repo: Repo
 ): DetectedWorktree[] {
-  if (!shouldOfferNewExternalWorktreeInbox(repo)) {
+  if (isExternalWorktreeDiscoverySuppressed(repo)) {
     return []
   }
+  // Why: the visibility toggle and its first-run prompt only govern non-Orca
+  // worktrees, so gating scratch on either leaves it unreachable (#10324).
+  const offersNonScratch = shouldOfferNewExternalWorktreeInbox(repo)
   const baseline = new Set(
     (repo.externalWorktreeInboxBaselinePaths ?? []).map((path) =>
       normalizeExternalWorktreeInboxPath(path)
     )
   )
-  return getHiddenExternalWorktrees(detected).filter(
-    (worktree) => !baseline.has(normalizeExternalWorktreeInboxPath(worktree.path))
+  return getHiddenImportableExternalWorktrees(detected).filter(
+    (worktree) =>
+      (offersNonScratch || worktree.ownership === 'agent-scratch') &&
+      !baseline.has(normalizeExternalWorktreeInboxPath(worktree.path))
   )
 }
 


### PR DESCRIPTION
## Summary

Worktrees created by Claude Code under `<repo>/.claude/worktrees/` became impossible to reveal from the sidebar. They are classified `agent-scratch`, and `shouldShowWorktree` hides that ownership *before* the visibility branch, so the "Show non-Orca worktrees" toggle cannot reveal them. That hide is intentional (#9388): scratch is agent plumbing, and the design is that it is revealed only by an explicit import or by being the selected checkout.

The defect is that the explicit-import path was unreachable. `isUserFacingExternalWorktree` excluded `agent-scratch`, so scratch was never offered as an import candidate, and the only mechanism that can reveal it (`importedExternalWorktreePaths`, which `shouldShowWorktree` already honors) could never be populated.

This keeps the #9388 policy intact and makes the import path reachable instead:

- adds `isImportableExternalWorktree` (excludes only `orca-managed` and the selected checkout, so it *includes* `agent-scratch`) plus `getHiddenImportableExternalWorktrees`
- `getNewExternalWorktreeInboxWorktrees` uses them, and lets scratch through regardless of visibility mode and regardless of the first-run prompt gate
- `externalWorktreeDiscoverySuppressedAt` and `externalWorktreeInboxBaselinePaths` still apply

Two gates had to be bypassed *for scratch only*, because neither governs it:

1. **Visibility mode.** The inbox was gated on `'hide'`, so in a repo set to `'show'` no import affordance rendered at all.
2. **First-run prompt.** `externalWorktreeVisibilityPromptDismissedAt` is written in exactly one place, `keepImportedWorktreesHiddenCard`. That card never renders for a scratch-only repo, so the flag could never become true and the gate would have stranded the import permanently.

`getHiddenExternalWorktrees`, the import card and the visibility dialog are deliberately **untouched**. The card's only positive action is `showImportedWorktreesCard`, which flips `externalWorktreeVisibility` — by design that can never reveal scratch, so routing scratch through the card would render a button that provably does nothing. Its "Keep hidden" action also seeds the inbox baseline from that same selector, so widening it would have baselined scratch out of the inbox on dismissal: a second dead end.

Fixes #10324.

## Screenshots

`No visual change` — logic and candidate-builder level only. No JSX, styling or copy touched. The existing inbox row now has candidates to render where it previously always had none.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — blocked locally by an unrelated pre-existing bug, see note
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Six new tests covering: scratch offered in both `'show'` and `'hide'`; offered before the first-run prompt is dismissed; still blocked by discovery suppression and by the inbox baseline; not leaking into `getHiddenExternalWorktrees`; and the candidate builder producing a real inbox row for a scratch-only repo in `'show'`. The pre-existing assertions that scratch is *not* a "visible other", that the card builds no candidate for scratch-only, and that `shouldOfferNewExternalWorktreeInbox` is false in `'show'` all remain green and unmodified.

These tests were checked against the obvious failure mode of restating the implementation: reverting only `src/shared/external-worktree-inbox.ts` to `origin/main` and re-running them fails 5 of the new cases, so they pin the fixed behavior rather than describing it.

Note on how these were run: `pnpm test` and `pnpm typecheck` could not complete through their package scripts in this environment — `ensure-native-runtime` cannot rebuild node-pty for Node 24.18.1, and `tsc` cannot write `tsbuildinfo`. Both were run directly instead (`vitest run --config config/vitest.config.ts`, `tsc --noEmit --composite false` across all three projects) with equivalent coverage. All `src/shared/` and `src/renderer/` tests pass; the remaining failures are `src/main/**` integration tests failing on missing native modules, and nothing in `src/main`, `src/cli` or `src/relay` calls the functions this PR changes.

`pnpm build` could not be completed either, for a reason that has nothing to do with this change: `build:native` dies before ever reaching this PR's code, because `config/scripts/build-native-for-platform.mjs` hands a native `@pnpm/exe` binary to Node. That is pre-existing on `main` and is fixed separately in #11738. The other five build steps (`typecheck`, `build:relay`, `build:cli`, `build:electron-vite`, `build:web-from-renderer`) were each run individually and all pass, and CI runs the full build regardless. This is explanatory only — this PR does not depend on #11738 and shares no files with it.

## AI Review Report

Reviewed for correctness, minimality and end-to-end reachability. The main risk checked was whether the fix actually reaches the user or just moves a predicate, so the consumer chain was traced explicitly: `getNewExternalWorktreeInboxWorktrees` → `buildNewExternalWorktreesInboxCandidates` (gates only on `filterRepoIds` / `isGitRepoKind`) → `worktree-list-groups.ts:1156,1303` → `buildNewExternalWorktreesInboxRow` → `handleImportNewExternalWorktree` → `importNewExternalWorktreeInboxPaths` → `importedExternalWorktreePaths` → `shouldShowWorktree`. No separate visibility gate sits in the render path, so widening the selector is sufficient.

The review flagged and rejected a broader variant that also widened `getHiddenExternalWorktrees` and the import card, for the two dead ends described in Summary; the narrower change was taken instead.

**Cross-platform (macOS, Linux, Windows):** explicitly checked. No new path handling — path comparison flows through the existing `normalizeRuntimePathForComparison`, and `createAgentScratchWorktreePathMatcher` already handles Windows drive roots. No keyboard shortcuts, shortcut labels, shell behavior or Electron platform APIs are touched by this PR.

**SSH / remote / local:** the change is shared-layer predicate logic over already-detected worktrees, with no filesystem, process or network access, so it behaves identically for local, SSH and remote hosts.

**Agent / integration / git-provider compatibility:** no provider-specific or agent-specific branching added. The scratch path prefixes (`.claude/worktrees`, `.gsd-workspaces`) are pre-existing and untouched.

**Performance:** no new traversal. One extra `ownership` comparison per already-iterated worktree, inside a selector that was already filtering the same list.

**UI quality:** not applicable — no JSX, styling, tokens or copy are touched, so there is nothing to verify against `docs/STYLEGUIDE.md`, light/dark mode or SSH latency. The change only supplies candidates to an inbox row that already exists and already renders.

**Folder workspaces:** unaffected — `buildNewExternalWorktreesInboxCandidates` still short-circuits on `isGitRepoKind`.

## Security Audit

Low risk, no new attack surface. No input handling, command execution, IPC, auth, secrets or dependency changes. Path handling is comparison-only and reuses existing normalization; no path is constructed, resolved or written.

The one security-relevant property reviewed is that this **widens what can become visible**, so it was verified that visibility still requires an explicit user action: the predicate only makes scratch an import *candidate*, and revealing it still requires the user to click import, which writes `importedExternalWorktreePaths`. Two user opt-outs remain authoritative and are covered by tests — `externalWorktreeDiscoverySuppressedAt` and the inbox baseline. Nothing becomes visible automatically.

No follow-up security work needed.

## Notes

No platform-specific behavior in this change.

**Behavior change worth calling out explicitly.** Agent scratch worktrees are offered to the inbox with no quiescence filter, so a worktree an agent created seconds ago and is still using will surface a row, not only an abandoned one. This also now happens in `'show'` mode, where the inbox previously never rendered at all. That is the direct consequence of making the import path reachable — the persistent, orphaned case is exactly what #10324 asks for, and there is no signal available here to distinguish "abandoned" from "in use". The two opt-outs are honest but coarse: "keep hidden" baselines individual paths, which is repetitive against uniquely-named scratch directories, and `externalWorktreeDiscoverySuppressedAt` disables discovery wholesale. If maintainers would rather trade recoverability for quiet, the natural knob is an age or activity threshold on scratch candidates in `getNewExternalWorktreeInboxWorktrees`; that is deliberately not in this PR, which fixes reachability only.

**Reach limitation, pre-existing and not addressed here.** The inbox row is only built under `groupBy === 'repo'` (`worktree-list-groups.ts:1155-1172` and `:1302-1306`). The imported-worktrees card has a pinned-group fallback for other grouping modes (`:487-489`, `:507-515`); the inbox row has none. So a user grouping the sidebar by PR status still cannot reach the import affordance, and orphaned scratch stays as unrecoverable for them as before. The default grouping is `'repo'` (`src/renderer/src/store/slices/ui.ts:1991`), so this affects a minority of users. It is an inherited limitation of the inbox feature as a whole rather than anything this change introduces, which is why it is flagged rather than fixed here.
