### PR TITLE
fix(codex): prevent transient managed-auth onboarding

### DIFF
--- a/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
+import { waitForManagedCodexAuthReady } from './managed-codex-auth-readiness'
+
+const roots: string[] = []
+const testIdToken = 'e30.eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ.sig'
+const testChatGptAuth = {
+  tokens: {
+    access_token: 'access',
+    id_token: testIdToken,
+    refresh_token: 'refresh',
+    account_id: 'account'
+  },
+  last_refresh: '2026-07-31T00:00:00Z'
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('waitForManagedCodexAuthReady', () => {
+  it('accepts a readable managed ChatGPT credential', async () => {
+    const fixture = createFixture()
+    writeAuth(fixture.home, testChatGptAuth)
+
+    await waitForManagedCodexAuthReady(fixture.args)
+  })
+
+  it('waits for a missing managed credential to be restored', async () => {
+    vi.useFakeTimers()
+    const fixture = createFixture()
+    const readiness = waitForManagedCodexAuthReady(fixture.args)
+
+    await vi.advanceTimersByTimeAsync(50)
+    writeAuth(fixture.home, { OPENAI_API_KEY: 'sk-test' })
+    await vi.runAllTimersAsync()
+
+    await expect(readiness).resolves.toBeUndefined()
+  })
+
+  it('waits for a partial managed ChatGPT credential to become complete', async () => {
+    vi.useFakeTimers()
+    const fixture = createFixture()
+    writeAuth(fixture.home, {
+      tokens: { access_token: 'access', id_token: testIdToken }
+    })
+    let resolved = false
+    const readiness = waitForManagedCodexAuthReady(fixture.args)?.then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(resolved).toBe(false)
+    writeAuth(fixture.home, testChatGptAuth)
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(readiness).resolves.toBeUndefined()
+  })
+
+  it('waits for an empty managed ChatGPT refresh token to be restored', async () => {
+    vi.useFakeTimers()
+    const fixture = createFixture()
+    writeAuth(fixture.home, {
+      ...testChatGptAuth,
+      tokens: { ...testChatGptAuth.tokens, refresh_token: '' }
+    })
+    let resolved = false
+    const readiness = waitForManagedCodexAuthReady(fixture.args)?.then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(resolved).toBe(false)
+    writeAuth(fixture.home, testChatGptAuth)
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(readiness).resolves.toBeUndefined()
+  })
+
+  it('rejects an unreadable managed credential without switching accounts', async () => {
+    vi.useFakeTimers()
+    const fixture = createFixture()
+    writeFileSync(join(fixture.home, 'auth.json'), '{', 'utf8')
+
+    const readiness = waitForManagedCodexAuthReady(fixture.args)
+    const rejection = expect(readiness).rejects.toThrow(
+      'The selected Codex account credentials are temporarily unavailable'
+    )
+    await vi.advanceTimersByTimeAsync(2_000)
+    await rejection
+  })
+
+  it('does not gate system, WSL, or unmanaged custom homes', async () => {
+    const fixture = createFixture()
+    await waitForManagedCodexAuthReady({
+      ...fixture.args,
+      codexHomePath: join(fixture.root, 'custom-home')
+    })
+    await waitForManagedCodexAuthReady({
+      ...fixture.args,
+      target: { runtime: 'wsl', wslDistro: 'Ubuntu' }
+    })
+    await waitForManagedCodexAuthReady({
+      ...fixture.args,
+      codexHomePath: null
+    })
+  })
+})
+
+function createFixture(): {
+  root: string
+  home: string
+  args: Parameters<typeof waitForManagedCodexAuthReady>[0]
+} {
+  const root = mkdtempSync(join(tmpdir(), 'orca-managed-codex-auth-'))
+  roots.push(root)
+  const home = join(root, 'account', 'home')
+  mkdirSync(home, { recursive: true })
+  const account = {
+    id: 'account-1',
+    managedHomePath: home,
+    managedHomeRuntime: 'host'
+  } as CodexManagedAccount
+  return {
+    root,
+    home,
+    args: {
+      codexHomePath: home,
+      settings: { codexManagedAccounts: [account] } as GlobalSettings,
+      target: { runtime: 'host' }
+    }
+  }
+}
+
+function writeAuth(home: string, auth: object): void {
+  writeFileSync(join(home, 'auth.json'), JSON.stringify(auth), { mode: 0o600 })
+}

--- a/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
@@ -9,6 +9,7 @@ import { waitForManagedCodexAuthReady } from './managed-codex-auth-readiness'
 const roots: string[] = []
 const testIdToken = 'e30.eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ.sig'
 const testChatGptAuth = {
+  auth_mode: 'chatgpt',
   tokens: {
     access_token: 'access',
     id_token: testIdToken,
@@ -26,11 +27,46 @@ afterEach(() => {
 })
 
 describe('waitForManagedCodexAuthReady', () => {
-  it('accepts a readable managed ChatGPT credential', async () => {
+  it.each([
+    ['ChatGPT', testChatGptAuth],
+    ['ChatGPT auth tokens', { ...testChatGptAuth, auth_mode: 'chatgptAuthTokens' }],
+    ['API key', { auth_mode: 'apikey', OPENAI_API_KEY: 'sk-test' }],
+    [
+      'agent identity',
+      {
+        auth_mode: 'agentIdentity',
+        agent_identity: { agent_runtime_id: 'runtime', agent_private_key: 'private-key' }
+      }
+    ],
+    [
+      'future agent identity storage',
+      { auth_mode: 'agentIdentity', agent_identity: { future_material: 'opaque' } }
+    ],
+    [
+      'personal access token',
+      { auth_mode: 'personalAccessToken', personal_access_token: 'pat-test' }
+    ],
+    [
+      'Bedrock API key',
+      {
+        auth_mode: 'bedrockApiKey',
+        bedrock_api_key: { api_key: 'bedrock-key', region: 'us-east-1' }
+      }
+    ],
+    ['future auth mode', { auth_mode: 'futureAuthMode', future_credential: { value: 'opaque' } }],
+    ['future auth shape', { future_credential: { value: 'opaque' } }],
+    [
+      'ChatGPT with agent identity metadata',
+      {
+        ...testChatGptAuth,
+        agent_identity: { agent_runtime_id: 'runtime', agent_private_key: 'private-key' }
+      }
+    ]
+  ])('accepts a readable managed %s credential', (_label, auth) => {
     const fixture = createFixture()
-    writeAuth(fixture.home, testChatGptAuth)
+    writeAuth(fixture.home, auth)
 
-    await waitForManagedCodexAuthReady(fixture.args)
+    expect(waitForManagedCodexAuthReady(fixture.args)).toBeUndefined()
   })
 
   it('waits for a missing managed credential to be restored', async () => {
@@ -42,7 +78,7 @@ describe('waitForManagedCodexAuthReady', () => {
     writeAuth(fixture.home, { OPENAI_API_KEY: 'sk-test' })
     await vi.runAllTimersAsync()
 
-    await expect(readiness).resolves.toBeUndefined()
+    await expect(readiness).resolves.toBe(true)
   })
 
   it('waits for a partial managed ChatGPT credential to become complete', async () => {
@@ -52,7 +88,8 @@ describe('waitForManagedCodexAuthReady', () => {
       tokens: { access_token: 'access', id_token: testIdToken }
     })
     let resolved = false
-    const readiness = waitForManagedCodexAuthReady(fixture.args)?.then(() => {
+    const readiness = waitForManagedCodexAuthReady(fixture.args)
+    void readiness?.then(() => {
       resolved = true
     })
 
@@ -61,7 +98,7 @@ describe('waitForManagedCodexAuthReady', () => {
     writeAuth(fixture.home, testChatGptAuth)
     await vi.advanceTimersByTimeAsync(25)
 
-    await expect(readiness).resolves.toBeUndefined()
+    await expect(readiness).resolves.toBe(true)
   })
 
   it('waits for an empty managed ChatGPT refresh token to be restored', async () => {
@@ -72,7 +109,8 @@ describe('waitForManagedCodexAuthReady', () => {
       tokens: { ...testChatGptAuth.tokens, refresh_token: '' }
     })
     let resolved = false
-    const readiness = waitForManagedCodexAuthReady(fixture.args)?.then(() => {
+    const readiness = waitForManagedCodexAuthReady(fixture.args)
+    void readiness?.then(() => {
       resolved = true
     })
 
@@ -81,20 +119,79 @@ describe('waitForManagedCodexAuthReady', () => {
     writeAuth(fixture.home, testChatGptAuth)
     await vi.advanceTimersByTimeAsync(25)
 
-    await expect(readiness).resolves.toBeUndefined()
+    await expect(readiness).resolves.toBe(true)
   })
 
-  it('rejects an unreadable managed credential without switching accounts', async () => {
+  it.each([
+    [
+      'empty agent identity record',
+      { auth_mode: 'agentIdentity', agent_identity: {} },
+      {
+        auth_mode: 'agentIdentity',
+        agent_identity: { agent_runtime_id: 'runtime', agent_private_key: 'private-key' }
+      }
+    ],
+    [
+      'agent identity missing its private key',
+      {
+        auth_mode: 'agentIdentity',
+        agent_identity: { agent_runtime_id: 'runtime', plan_type: 'team' }
+      },
+      {
+        auth_mode: 'agentIdentity',
+        agent_identity: { agent_runtime_id: 'runtime', agent_private_key: 'private-key' }
+      }
+    ],
+    [
+      'agent identity with an empty runtime id',
+      {
+        auth_mode: 'agentIdentity',
+        agent_identity: { agent_runtime_id: '', agent_private_key: 'private-key' }
+      },
+      {
+        auth_mode: 'agentIdentity',
+        agent_identity: { agent_runtime_id: 'runtime', agent_private_key: 'private-key' }
+      }
+    ],
+    [
+      'object-valued personal access token',
+      { auth_mode: 'personalAccessToken', personal_access_token: { token_id: 'pat' } },
+      { auth_mode: 'personalAccessToken', personal_access_token: 'pat-test' }
+    ],
+    [
+      'Bedrock metadata without an API key',
+      { auth_mode: 'bedrockApiKey', bedrock_api_key: { region: 'us-east-1' } },
+      {
+        auth_mode: 'bedrockApiKey',
+        bedrock_api_key: { api_key: 'bedrock-key', region: 'us-east-1' }
+      }
+    ]
+  ])('waits for %s to become complete', async (_label, partial, complete) => {
     vi.useFakeTimers()
     const fixture = createFixture()
+    writeAuth(fixture.home, partial)
+
+    const readiness = waitForManagedCodexAuthReady(fixture.args)
+    await vi.advanceTimersByTimeAsync(50)
+    writeAuth(fixture.home, complete)
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(readiness).resolves.toBe(true)
+  })
+
+  it('reports an unreadable managed credential after the retry window', async () => {
+    vi.useFakeTimers()
+    const fixture = createFixture()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     writeFileSync(join(fixture.home, 'auth.json'), '{', 'utf8')
 
     const readiness = waitForManagedCodexAuthReady(fixture.args)
-    const rejection = expect(readiness).rejects.toThrow(
-      'The selected Codex account credentials are temporarily unavailable'
-    )
     await vi.advanceTimersByTimeAsync(2_000)
-    await rejection
+
+    await expect(readiness).resolves.toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[codex-auth-readiness] Managed credential remained unavailable after 1500ms'
+    )
   })
 
   it('does not gate system, WSL, or unmanaged custom homes', async () => {

--- a/src/main/codex-accounts/managed-codex-auth-readiness.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.ts
@@ -12,47 +12,63 @@ type StoredCodexAuth = {
   auth_mode?: unknown
   OPENAI_API_KEY?: unknown
   agent_identity?: unknown
+  personal_access_token?: unknown
+  bedrock_api_key?: unknown
   last_refresh?: unknown
-  tokens?: {
-    access_token?: unknown
-    id_token?: unknown
-    refresh_token?: unknown
-    account_id?: unknown
-  } | null
+  tokens?: unknown
 }
+
+const KNOWN_CREDENTIAL_KEYS = [
+  'OPENAI_API_KEY',
+  'tokens',
+  'agent_identity',
+  'personal_access_token',
+  'bedrock_api_key'
+] as const
+const KNOWN_AGENT_IDENTITY_RECORD_KEYS = [
+  'agent_runtime_id',
+  'agent_private_key',
+  'plan_type',
+  'task_id'
+] as const
 
 export function waitForManagedCodexAuthReady(args: {
   codexHomePath: string | null
   settings: GlobalSettings | undefined
   target: CodexAccountSelectionTarget
-}): Promise<void> | undefined {
-  if (
-    args.target.runtime !== 'host' ||
-    !args.codexHomePath ||
-    !isManagedHostCodexHome(args.codexHomePath, args.settings)
-  ) {
+}): Promise<boolean> | undefined {
+  if (isCodexHomeAuthReadyForLaunch(args)) {
     return
   }
-
-  const authPath = join(args.codexHomePath, 'auth.json')
-  if (hasStoredCodexCredential(authPath)) {
-    return
-  }
-  return waitForStoredCodexCredential(authPath)
+  return waitForStoredCodexCredential(join(args.codexHomePath!, 'auth.json'))
 }
 
-async function waitForStoredCodexCredential(authPath: string): Promise<void> {
+export function isCodexHomeAuthReadyForLaunch(args: {
+  codexHomePath: string | null
+  settings: GlobalSettings | undefined
+  target: CodexAccountSelectionTarget
+}): boolean {
+  return (
+    args.target.runtime !== 'host' ||
+    !args.codexHomePath ||
+    !isManagedHostCodexHome(args.codexHomePath, args.settings) ||
+    hasStoredCodexCredential(join(args.codexHomePath, 'auth.json'))
+  )
+}
+
+async function waitForStoredCodexCredential(authPath: string): Promise<boolean> {
   const deadline = Date.now() + AUTH_READY_TIMEOUT_MS
   do {
     await delay(AUTH_READY_RETRY_MS)
     if (hasStoredCodexCredential(authPath)) {
-      return
+      return true
     }
   } while (Date.now() < deadline)
 
-  throw new Error(
-    'The selected Codex account credentials are temporarily unavailable. Try opening the terminal again.'
+  console.warn(
+    `[codex-auth-readiness] Managed credential remained unavailable after ${AUTH_READY_TIMEOUT_MS}ms`
   )
+  return false
 }
 
 function isManagedHostCodexHome(
@@ -69,72 +85,89 @@ function isManagedHostCodexHome(
   )
 }
 
-function hasStoredCodexCredential(authPath: string): boolean {
+export function hasStoredCodexCredential(authPath: string): boolean {
   try {
-    const auth = JSON.parse(readFileSync(authPath, 'utf8')) as StoredCodexAuth
-    if (!hasValidStoredAuthShape(auth)) {
+    const parsed: unknown = JSON.parse(readFileSync(authPath, 'utf8'))
+    if (!isRecord(parsed) || Object.keys(parsed).length === 0) {
       return false
     }
-    if (auth.auth_mode === 'apikey' || (!auth.auth_mode && auth.OPENAI_API_KEY != null)) {
-      return isNonEmptyString(auth.OPENAI_API_KEY)
-    }
-    if (auth.auth_mode === 'agentIdentity') {
-      return isNonEmptyString(auth.agent_identity)
-    }
-    return hasChatGptCredential(auth)
+    const auth = parsed as StoredCodexAuth
+    return auth.auth_mode == null
+      ? hasCredentialWithoutDeclaredMode(auth)
+      : hasCredentialForDeclaredMode(auth)
   } catch {
     return false
   }
 }
 
-function hasValidStoredAuthShape(auth: StoredCodexAuth): boolean {
-  if (!auth || typeof auth !== 'object' || Array.isArray(auth)) {
+function hasCredentialForDeclaredMode(auth: StoredCodexAuth): boolean {
+  if (!isNonEmptyString(auth.auth_mode)) {
     return false
   }
-  if (
-    !isOptionalString(auth.OPENAI_API_KEY) ||
-    !isOptionalString(auth.agent_identity) ||
-    !isOptionalString(auth.last_refresh) ||
-    !isValidAuthMode(auth.auth_mode)
-  ) {
-    return false
+  switch (auth.auth_mode) {
+    case 'apikey':
+      return isNonEmptyString(auth.OPENAI_API_KEY)
+    case 'chatgpt':
+    case 'chatgptAuthTokens':
+      return hasChatGptCredential(auth.tokens)
+    case 'agentIdentity':
+      return hasAgentIdentityCredential(auth.agent_identity)
+    case 'personalAccessToken':
+      return isNonEmptyString(auth.personal_access_token)
+    case 'bedrockApiKey':
+      return hasBedrockApiKey(auth.bedrock_api_key)
+    default:
+      return true
   }
-  const tokens = auth.tokens
-  return (
-    tokens == null ||
-    (typeof tokens === 'object' &&
-      !Array.isArray(tokens) &&
-      typeof tokens.access_token === 'string' &&
-      typeof tokens.id_token === 'string' &&
-      typeof tokens.refresh_token === 'string' &&
-      isOptionalString(tokens.account_id))
-  )
 }
 
-function isValidAuthMode(value: unknown): boolean {
-  return (
-    value == null ||
-    value === 'apikey' ||
-    value === 'chatgpt' ||
-    value === 'chatgptAuthTokens' ||
-    value === 'agentIdentity'
-  )
-}
-
-function hasChatGptCredential(auth: StoredCodexAuth): boolean {
-  return (
-    isNonEmptyString(auth.tokens?.access_token) &&
-    isNonEmptyString(auth.tokens?.id_token) &&
-    isNonEmptyString(auth.tokens?.refresh_token)
-  )
-}
-
-function isOptionalString(value: unknown): boolean {
-  return value == null || typeof value === 'string'
+function hasCredentialWithoutDeclaredMode(auth: StoredCodexAuth): boolean {
+  const knownCredentialPresent = KNOWN_CREDENTIAL_KEYS.some((key) => key in auth)
+  if (knownCredentialPresent) {
+    return (
+      isNonEmptyString(auth.OPENAI_API_KEY) ||
+      hasChatGptCredential(auth.tokens) ||
+      hasAgentIdentityCredential(auth.agent_identity) ||
+      isNonEmptyString(auth.personal_access_token) ||
+      hasBedrockApiKey(auth.bedrock_api_key)
+    )
+  }
+  return Object.keys(auth).some((key) => key !== 'auth_mode' && key !== 'last_refresh')
 }
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
+}
+
+function hasChatGptCredential(tokens: unknown): boolean {
+  if (!isRecord(tokens)) {
+    return false
+  }
+  return (
+    isNonEmptyString(tokens.access_token) &&
+    isNonEmptyString(tokens.id_token) &&
+    isNonEmptyString(tokens.refresh_token)
+  )
+}
+
+function hasAgentIdentityCredential(value: unknown): boolean {
+  if (isNonEmptyString(value)) {
+    return true
+  }
+  if (!isRecord(value) || Object.keys(value).length === 0) {
+    return false
+  }
+  return KNOWN_AGENT_IDENTITY_RECORD_KEYS.some((key) => key in value)
+    ? isNonEmptyString(value.agent_runtime_id) && isNonEmptyString(value.agent_private_key)
+    : true
+}
+
+function hasBedrockApiKey(value: unknown): boolean {
+  return isRecord(value) && isNonEmptyString(value.api_key)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/main/codex-accounts/managed-codex-auth-readiness.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import type { GlobalSettings } from '../../shared/types'
+import type { CodexAccountSelectionTarget } from './runtime-selection'
+
+const AUTH_READY_TIMEOUT_MS = 1_500
+const AUTH_READY_RETRY_MS = 25
+
+type StoredCodexAuth = {
+  auth_mode?: unknown
+  OPENAI_API_KEY?: unknown
+  agent_identity?: unknown
+  last_refresh?: unknown
+  tokens?: {
+    access_token?: unknown
+    id_token?: unknown
+    refresh_token?: unknown
+    account_id?: unknown
+  } | null
+}
+
+export function waitForManagedCodexAuthReady(args: {
+  codexHomePath: string | null
+  settings: GlobalSettings | undefined
+  target: CodexAccountSelectionTarget
+}): Promise<void> | undefined {
+  if (
+    args.target.runtime !== 'host' ||
+    !args.codexHomePath ||
+    !isManagedHostCodexHome(args.codexHomePath, args.settings)
+  ) {
+    return
+  }
+
+  const authPath = join(args.codexHomePath, 'auth.json')
+  if (hasStoredCodexCredential(authPath)) {
+    return
+  }
+  return waitForStoredCodexCredential(authPath)
+}
+
+async function waitForStoredCodexCredential(authPath: string): Promise<void> {
+  const deadline = Date.now() + AUTH_READY_TIMEOUT_MS
+  do {
+    await delay(AUTH_READY_RETRY_MS)
+    if (hasStoredCodexCredential(authPath)) {
+      return
+    }
+  } while (Date.now() < deadline)
+
+  throw new Error(
+    'The selected Codex account credentials are temporarily unavailable. Try opening the terminal again.'
+  )
+}
+
+function isManagedHostCodexHome(
+  codexHomePath: string,
+  settings: GlobalSettings | undefined
+): boolean {
+  const expected = normalizeRuntimePathForComparison(codexHomePath)
+  return (
+    settings?.codexManagedAccounts?.some(
+      (account) =>
+        account.managedHomeRuntime !== 'wsl' &&
+        normalizeRuntimePathForComparison(account.managedHomePath) === expected
+    ) === true
+  )
+}
+
+function hasStoredCodexCredential(authPath: string): boolean {
+  try {
+    const auth = JSON.parse(readFileSync(authPath, 'utf8')) as StoredCodexAuth
+    if (!hasValidStoredAuthShape(auth)) {
+      return false
+    }
+    if (auth.auth_mode === 'apikey' || (!auth.auth_mode && auth.OPENAI_API_KEY != null)) {
+      return isNonEmptyString(auth.OPENAI_API_KEY)
+    }
+    if (auth.auth_mode === 'agentIdentity') {
+      return isNonEmptyString(auth.agent_identity)
+    }
+    return hasChatGptCredential(auth)
+  } catch {
+    return false
+  }
+}
+
+function hasValidStoredAuthShape(auth: StoredCodexAuth): boolean {
+  if (!auth || typeof auth !== 'object' || Array.isArray(auth)) {
+    return false
+  }
+  if (
+    !isOptionalString(auth.OPENAI_API_KEY) ||
+    !isOptionalString(auth.agent_identity) ||
+    !isOptionalString(auth.last_refresh) ||
+    !isValidAuthMode(auth.auth_mode)
+  ) {
+    return false
+  }
+  const tokens = auth.tokens
+  return (
+    tokens == null ||
+    (typeof tokens === 'object' &&
+      !Array.isArray(tokens) &&
+      typeof tokens.access_token === 'string' &&
+      typeof tokens.id_token === 'string' &&
+      typeof tokens.refresh_token === 'string' &&
+      isOptionalString(tokens.account_id))
+  )
+}
+
+function isValidAuthMode(value: unknown): boolean {
+  return (
+    value == null ||
+    value === 'apikey' ||
+    value === 'chatgpt' ||
+    value === 'chatgptAuthTokens' ||
+    value === 'agentIdentity'
+  )
+}
+
+function hasChatGptCredential(auth: StoredCodexAuth): boolean {
+  return (
+    isNonEmptyString(auth.tokens?.access_token) &&
+    isNonEmptyString(auth.tokens?.id_token) &&
+    isNonEmptyString(auth.tokens?.refresh_token)
+  )
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value == null || typeof value === 'string'
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/main/codex-accounts/runtime-home-service-per-account-migration.test.ts
+++ b/src/main/codex-accounts/runtime-home-service-per-account-migration.test.ts
@@ -179,9 +179,10 @@ describe('CodexRuntimeHomeService per-account takeover composition', () => {
     rmSync(accountAuthPath)
     writeFileSync(sharedAuthPath(), laterShared, 'utf-8')
 
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBe(account.managedHomePath)
+    expect(service.prepareForRateLimitFetch()).toBe(account.managedHomePath)
     expect(existsSync(accountAuthPath)).toBe(false)
-    expect(settings.activeCodexManagedAccountId).toBeNull()
+    expect(settings.activeCodexManagedAccountId).toBe(account.id)
     expect(readFileSync(sharedAuthPath(), 'utf-8')).toBe(laterShared)
     expect(readFileSync(systemAuthPath(), 'utf-8')).toBe('system auth sentinel\n')
   })

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1275,7 +1275,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.prepareForRateLimitFetch()).toBe(home1)
   })
 
-  it('drops a managed selection whose auth.json vanished and resolves the real home (flag ON)', async () => {
+  it('preserves a managed selection whose auth.json is temporarily missing (flag ON)', async () => {
     writeFileSync(getSystemCodexAuthPath(), '{"account":"system"}\n', 'utf-8')
     // A managed home that has lost its auth.json (only the marker remains).
     const brokenHome = join(testState.userDataDir, 'codex-accounts', 'account-1', 'home')
@@ -1303,9 +1303,9 @@ describe('CodexRuntimeHomeService', () => {
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
 
-    // The broken account is dropped and the launch resolves to the real home.
-    expect(service.prepareForCodexLaunch()).toBeNull()
-    expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBe(brokenHome)
+    expect(service.prepareForRateLimitFetch()).toBe(brokenHome)
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
   })
 
   it('keeps the shared runtime home + auth hot-swap for managed accounts when the flag is OFF', async () => {
@@ -1636,7 +1636,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(syncSpy).not.toHaveBeenCalled()
   })
 
-  it('fails closed when per-account auth disappears before a real-home fallback', async () => {
+  it('preserves selected identity when per-account auth disappears before launch', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
     const account1Auth = createCodexAuthJson('one@example.com', 'acct-1', 'one', 1)
@@ -1669,27 +1669,25 @@ describe('CodexRuntimeHomeService', () => {
     // A stale pre-E process leaves a matching refresh in the shared runtime home.
     writeFileSync(runtimeAuthPath, account1Refreshed, 'utf-8')
 
-    // The active account's canonical auth disappears before launch. This is the
-    // same-account auto-deselect path, where no ordinary outgoing switch runs.
+    // The active account's canonical auth disappears before launch.
     rmSync(join(managedHomePath1, 'auth.json'), { force: true })
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBe(managedHomePath1)
 
-    // Missing canonical auth clears selection without reviving shared bytes.
+    // Missing canonical auth preserves selection without reviving shared bytes.
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
     expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(account1Refreshed)
-    expect(store.updateSettings).toHaveBeenCalledWith(
-      expect.objectContaining({ activeCodexManagedAccountId: null })
-    )
-    expect(warnSpy).toHaveBeenCalled()
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+    expect(store.updateSettings).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
 
-    // The follow-up launch takes the real-home lane and remains fail-closed.
-    expect(service.isHostSystemDefaultRealHome()).toBe(true)
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.isHostSystemDefaultRealHome()).toBe(false)
+    expect(service.prepareForRateLimitFetch()).toBe(managedHomePath1)
+    expect(service.prepareForCodexLaunch()).toBe(managedHomePath1)
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
   })
 
-  it('refuses mismatched runtime auth when the active managed auth is missing', async () => {
+  it('ignores mismatched runtime auth when the active managed auth is missing', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
     const managedAuth = createCodexAuthJson('user@example.com', 'acct-user', 'managed', 1)
@@ -1721,12 +1719,13 @@ describe('CodexRuntimeHomeService', () => {
 
     writeFileSync(runtimeAuthPath, mismatchedAuth, 'utf-8')
     rmSync(join(managedHomePath, 'auth.json'), { force: true })
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBe(managedHomePath)
 
     expect(existsSync(join(managedHomePath, 'auth.json'))).toBe(false)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
     expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(mismatchedAuth)
-    expect(warnSpy).toHaveBeenCalled()
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 
   it('ignores shared auth on an explicit managed-to-real-home deselect', async () => {

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -267,7 +267,9 @@ function createCodexAuthJson(
   ].join('.')
 
   return `${JSON.stringify({
+    auth_mode: 'chatgpt',
     tokens: {
+      access_token: `access-${accountId}`,
       id_token: idToken,
       account_id: accountId,
       ...(expiresAt === undefined ? {} : { expires_at: expiresAt }),
@@ -1189,6 +1191,12 @@ describe('CodexRuntimeHomeService', () => {
     settings.activeCodexManagedAccountId = 'account-2'
     settings.activeCodexManagedAccountIdsByRuntime = { host: 'account-2', wsl: {} }
     expect(service.prepareForCodexLaunch()).toBe(home2)
+    expect(
+      service.prepareForCodexLaunch(undefined, undefined, {
+        unavailableManagedHomePath: home1
+      })
+    ).toBe(home2)
+    expect(store.updateSettings).not.toHaveBeenCalled()
 
     // Nothing is hot-swapped, so the still-running account-1 pane keeps seeing
     // account-1's credentials — the single-auth.json race (GAP-5) is gone.
@@ -1643,6 +1651,11 @@ describe('CodexRuntimeHomeService', () => {
     const account1Refreshed = createCodexAuthJson('one@example.com', 'acct-1', 'one-refreshed', 2)
     writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
     const managedHomePath1 = createManagedAuth(testState.userDataDir, 'account-1', account1Auth)
+    const wslManagedHomePath = createManagedAuth(
+      testState.userDataDir,
+      'wsl-account',
+      createCodexAuthJson('wsl@example.com', 'acct-wsl', 'wsl')
+    )
     const settings = createSettings({
       codexSystemDefaultRealHomeEnabled: true,
       codexManagedAccounts: [
@@ -1656,10 +1669,24 @@ describe('CodexRuntimeHomeService', () => {
           createdAt: 1,
           updatedAt: 1,
           lastAuthenticatedAt: 1
+        },
+        {
+          id: 'wsl-account',
+          email: 'wsl@example.com',
+          managedHomePath: wslManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/wsl-account/home',
+          createdAt: 2,
+          updatedAt: 2,
+          lastAuthenticatedAt: 2
         }
       ],
       activeCodexManagedAccountId: 'account-1',
-      activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      activeCodexManagedAccountIdsByRuntime: {
+        host: 'account-1',
+        wsl: { Ubuntu: 'wsl-account' }
+      }
     })
     const store = createStore(settings)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -1685,6 +1712,33 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.prepareForRateLimitFetch()).toBe(managedHomePath1)
     expect(service.prepareForCodexLaunch()).toBe(managedHomePath1)
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
+
+    writeFileSync(join(managedHomePath1, 'auth.json'), account1Auth, 'utf-8')
+    expect(
+      service.prepareForCodexLaunch(undefined, undefined, {
+        unavailableManagedHomePath: managedHomePath1
+      })
+    ).toBe(managedHomePath1)
+    expect(store.updateSettings).not.toHaveBeenCalled()
+
+    rmSync(join(managedHomePath1, 'auth.json'), { force: true })
+    expect(
+      service.prepareForCodexLaunch(undefined, undefined, {
+        unavailableManagedHomePath: managedHomePath1
+      })
+    ).toBeNull()
+    expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime).toEqual({
+      host: null,
+      wsl: { Ubuntu: 'wsl-account' }
+    })
+    expect(store.getSettings().codexManagedAccounts).toHaveLength(2)
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ activeCodexManagedAccountId: null })
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[codex-runtime-home] Active managed account credential remained unavailable, clearing selection'
+    )
   })
 
   it('ignores mismatched runtime auth when the active managed auth is missing', async () => {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -29,6 +29,7 @@ import {
 } from 'node:path'
 import { app } from 'electron'
 import type { CodexManagedAccount } from '../../shared/types'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import type { Store } from '../persistence'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import { writeFileAtomically } from './fs-utils'
@@ -72,6 +73,7 @@ import {
   codexAuthMatchesSystemDefaultIdentity
 } from './codex-auth-identity'
 import { migrateLegacySharedAuthToPerAccountHome } from './legacy-shared-auth-migration'
+import { hasStoredCodexCredential } from './managed-codex-auth-readiness'
 
 type CodexSystemDefaultSnapshot = {
   authJson: string | null
@@ -153,7 +155,8 @@ export class CodexRuntimeHomeService {
    */
   prepareForCodexLaunch(
     target?: CodexAccountSelectionTarget,
-    launchEnv?: NodeJS.ProcessEnv
+    launchEnv?: NodeJS.ProcessEnv,
+    options?: { unavailableManagedHomePath?: string }
   ): string | null {
     if (target?.runtime === 'wsl') {
       const wslTarget = this.resolveWslDefaultTarget(target)
@@ -165,7 +168,10 @@ export class CodexRuntimeHomeService {
     }
     const selfContainedAccount = this.getSelfContainedManagedHostAccount()
     if (selfContainedAccount) {
-      const perAccountHome = this.prepareSelfContainedManagedHomeForLaunch(selfContainedAccount)
+      const perAccountHome = this.prepareSelfContainedManagedHomeForLaunch(
+        selfContainedAccount,
+        options?.unavailableManagedHomePath
+      )
       if (perAccountHome) {
         return perAccountHome
       }
@@ -235,10 +241,22 @@ export class CodexRuntimeHomeService {
     return homes
   }
 
-  private prepareSelfContainedManagedHomeForLaunch(account: CodexManagedAccount): string | null {
+  private prepareSelfContainedManagedHomeForLaunch(
+    account: CodexManagedAccount,
+    unavailableManagedHomePath?: string
+  ): string | null {
     const perAccountHome = this.getTrustedSelfContainedManagedHomePath(account)
     if (!perAccountHome) {
       this.clearSelfContainedManagedSelection(account)
+      return null
+    }
+    if (
+      unavailableManagedHomePath &&
+      normalizeRuntimePathForComparison(unavailableManagedHomePath) ===
+        normalizeRuntimePathForComparison(perAccountHome) &&
+      !hasStoredCodexCredential(join(perAccountHome, 'auth.json'))
+    ) {
+      this.clearSelfContainedManagedSelection(account, 'credential remained unavailable')
       return null
     }
     // Why: link the user's real ~/.codex resources and mirror config into THIS
@@ -312,8 +330,11 @@ export class CodexRuntimeHomeService {
     }
   }
 
-  private clearSelfContainedManagedSelection(account: CodexManagedAccount): void {
-    console.warn('[codex-runtime-home] Active managed account home is invalid, clearing selection')
+  private clearSelfContainedManagedSelection(
+    account: CodexManagedAccount,
+    reason = 'home is invalid'
+  ): void {
+    console.warn(`[codex-runtime-home] Active managed account ${reason}, clearing selection`)
     const settings = this.store.getSettings()
     if (normalizeCodexRuntimeSelection(settings).host !== account.id) {
       return
@@ -511,8 +532,7 @@ export class CodexRuntimeHomeService {
       : null
     if (selfContainedAccount && selfContainedHome) {
       // Why: the quota fetch reads the account's own auth.json in place; no
-      // shared-home hot-swap, and no per-poll resource relink (that is launch
-      // prep). Its auth-presence gate suppresses probes during replacement.
+      // shared-home hot-swap or per-poll resource relink (that is launch prep).
       return selfContainedHome
     }
     if (selfContainedAccount) {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -169,8 +169,8 @@ export class CodexRuntimeHomeService {
       if (perAccountHome) {
         return perAccountHome
       }
-      // Why: the account's home lost its auth.json, so the selection was just
-      // dropped. Fall through and resolve this launch as the system default.
+      // Why: only an untrusted home clears the selection; fall through to the
+      // system default without injecting a path Orca cannot prove it owns.
     }
     if (this.isHostSystemDefaultRealHome(launchEnv)) {
       // Why (flag ON, system default): run Codex on the user's own ~/.codex.
@@ -237,9 +237,7 @@ export class CodexRuntimeHomeService {
 
   private prepareSelfContainedManagedHomeForLaunch(account: CodexManagedAccount): string | null {
     const perAccountHome = this.getTrustedSelfContainedManagedHomePath(account)
-    if (!perAccountHome || !existsSync(join(perAccountHome, 'auth.json'))) {
-      // Why: drop the selection so this and future launches resolve to the
-      // system default rather than a home codex cannot authenticate against.
+    if (!perAccountHome) {
       this.clearSelfContainedManagedSelection(account)
       return null
     }
@@ -282,11 +280,11 @@ export class CodexRuntimeHomeService {
 
   // Why: the per-account home is both the launch CODEX_HOME and the credential
   // store, so codex reads/refreshes auth.json in place — there is no shared-home
-  // hot-swap or token read-back to reconcile. Only validate the credential
-  // survives; a vanished auth.json drops the selection to the system default.
+  // hot-swap or token read-back to reconcile. A trusted home remains selected
+  // while Codex atomically replaces auth.json.
   private syncSelfContainedManagedSelection(account: CodexManagedAccount): void {
     const perAccountHome = this.getTrustedSelfContainedManagedHomePath(account)
-    if (perAccountHome && existsSync(join(perAccountHome, 'auth.json'))) {
+    if (perAccountHome) {
       this.lastSyncedAccountId = account.id
       this.lastHostAccountUsedSelfContainedHome = true
       // Why: selection runs well before the user restarts a pane, so history is
@@ -315,9 +313,7 @@ export class CodexRuntimeHomeService {
   }
 
   private clearSelfContainedManagedSelection(account: CodexManagedAccount): void {
-    console.warn(
-      '[codex-runtime-home] Active managed account home is invalid or missing auth.json, clearing selection'
-    )
+    console.warn('[codex-runtime-home] Active managed account home is invalid, clearing selection')
     const settings = this.store.getSettings()
     if (normalizeCodexRuntimeSelection(settings).host !== account.id) {
       return
@@ -513,14 +509,10 @@ export class CodexRuntimeHomeService {
     const selfContainedHome = selfContainedAccount
       ? this.getTrustedSelfContainedManagedHomePath(selfContainedAccount)
       : null
-    if (
-      selfContainedAccount &&
-      selfContainedHome &&
-      existsSync(join(selfContainedHome, 'auth.json'))
-    ) {
+    if (selfContainedAccount && selfContainedHome) {
       // Why: the quota fetch reads the account's own auth.json in place; no
       // shared-home hot-swap, and no per-poll resource relink (that is launch
-      // prep). Config was mirrored on add/select and refreshed at launch.
+      // prep). Its auth-presence gate suppresses probes during replacement.
       return selfContainedHome
     }
     if (selfContainedAccount) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,7 +28,8 @@ import {
   registerPaneKeyTeardownListener,
   getLocalPtyProvider,
   getSshPtyProvider,
-  registerHeadlessPtyRuntime
+  registerHeadlessPtyRuntime,
+  type CodexHomeLaunchContext
 } from './ipc/pty'
 import {
   initDaemonPtyProvider,
@@ -97,7 +98,7 @@ import {
   resolveUpdateInstallMode
 } from './updater'
 import { configureRemoteServerUpdater } from './runtime/remote-server-updater'
-import type { TuiAgent, UpdateCheckOptions } from '../shared/types'
+import type { UpdateCheckOptions } from '../shared/types'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
 import {
   installServeSupervisorDisconnectQuit,
@@ -869,7 +870,7 @@ function startTerminalRuntimeStartupServices(): Promise<void> {
 function prepareCodexRuntimeHomeForLaunch(
   target?: CodexAccountSelectionTarget,
   launchEnv?: NodeJS.ProcessEnv,
-  launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
+  launchContext?: CodexHomeLaunchContext
 ): string | null {
   if (
     target?.runtime !== 'wsl' &&
@@ -901,14 +902,18 @@ function prepareCodexRuntimeHomeForLaunch(
     return true
   }
   let realHomeHooksPrepared = ensureRealHomeHooksIfSelected()
-  let runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv)
+  let runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv, {
+    unavailableManagedHomePath: launchContext?.unavailableManagedHomePath
+  })
   if (runtimeHomePath === null && !realHomeHooksPrepared) {
     // Why: launch prep can reject an untrusted managed home and clear its
     // selection. Establish hook capability for that newly selected lane, then
     // re-resolve if the capability gate rejects it.
     realHomeHooksPrepared = ensureRealHomeHooksIfSelected()
     if (realHomeHooksPrepared) {
-      runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv)
+      runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv, {
+        unavailableManagedHomePath: launchContext?.unavailableManagedHomePath
+      })
     }
   }
   if (runtimeHomePath === null && target?.runtime !== 'wsl') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -903,9 +903,9 @@ function prepareCodexRuntimeHomeForLaunch(
   let realHomeHooksPrepared = ensureRealHomeHooksIfSelected()
   let runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv)
   if (runtimeHomePath === null && !realHomeHooksPrepared) {
-    // Why: a managed home can lose auth during launch prep, which clears its
-    // selection and falls through to real home. Establish hook capability for
-    // that newly selected lane, then re-resolve if the capability gate rejects it.
+    // Why: launch prep can reject an untrusted managed home and clear its
+    // selection. Establish hook capability for that newly selected lane, then
+    // re-resolve if the capability gate rejects it.
     realHomeHooksPrepared = ensureRealHomeHooksIfSelected()
     if (realHomeHooksPrepared) {
       runtimeHomePath = codexRuntimeHome!.prepareForCodexLaunch(target, launchEnv)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -226,6 +226,7 @@ import {
   setPtyOwnership,
   setLocalPtyProvider,
   rebindLocalProviderListeners,
+  resolveCodexHomeAfterManagedAuthReadiness,
   unregisterSshPtyProvider,
   getLocalPtyProvider,
   isCurrentPtyExit,
@@ -2800,7 +2801,11 @@ describe('registerPtyHandlers', () => {
         ]
       })) as never)
 
-      const spawnPromise = handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+      const spawnPromise = handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        launchAgent: 'codex'
+      })
       await vi.advanceTimersByTimeAsync(0)
       expect(spawnMock).not.toHaveBeenCalled()
 
@@ -2812,6 +2817,29 @@ describe('registerPtyHandlers', () => {
         CODEX_HOME: TEST_CODEX_HOME,
         ORCA_CODEX_HOME: TEST_CODEX_HOME
       })
+    })
+
+    it('does not gate a bare local shell on managed Codex auth', async () => {
+      readFileSyncMock.mockImplementation((filePath: string) => {
+        if (filePath.endsWith('auth.json')) {
+          throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+        }
+        return ''
+      })
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, undefined, () => TEST_CODEX_HOME, (() => ({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            managedHomePath: TEST_CODEX_HOME,
+            managedHomeRuntime: 'host'
+          }
+        ]
+      })) as never)
+
+      await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+      expect(spawnMock).toHaveBeenCalledOnce()
     })
 
     it('leaves an inherited CODEX_HOME untouched for system default when the flag is OFF', async () => {
@@ -3086,7 +3114,11 @@ describe('registerPtyHandlers', () => {
           ]
         })) as never)
 
-        const spawnPromise = handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+        const spawnPromise = handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          launchAgent: 'codex'
+        })
         await vi.advanceTimersByTimeAsync(0)
         expect(daemonSpawn).not.toHaveBeenCalled()
 
@@ -3100,8 +3132,77 @@ describe('registerPtyHandlers', () => {
         })
       })
 
-      it('fails closed when managed Codex auth stays unavailable', async () => {
+      it('resolves valid managed Codex auth synchronously', () => {
+        readFileSyncMock.mockReturnValue(TEST_CODEX_AUTH_JSON)
+        const resolveCurrent = vi.fn(() => TEST_CODEX_HOME)
+        const resolveAfterUnavailable = vi.fn(() => null)
+        const settings = {
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        }
+
+        const resolution = resolveCodexHomeAfterManagedAuthReadiness({
+          selectedCodexHomePath: TEST_CODEX_HOME,
+          getSettings: () => settings as never,
+          target: { runtime: 'host' },
+          resolveCurrent,
+          resolveAfterUnavailable
+        })
+
+        expect(resolution).toBe(TEST_CODEX_HOME)
+        expect(resolveCurrent).not.toHaveBeenCalled()
+        expect(resolveAfterUnavailable).not.toHaveBeenCalled()
+      })
+
+      it('uses the current account when the original auth recovers after a switch', async () => {
         vi.useFakeTimers()
+        const nextHome = '/managed/next/home'
+        let originalAuthReady = false
+        let selectedHome = TEST_CODEX_HOME
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath === join(TEST_CODEX_HOME, 'auth.json') && !originalAuthReady) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          if (filePath.endsWith('auth.json')) {
+            return TEST_CODEX_AUTH_JSON
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        const resolveHome = vi.fn(() => selectedHome)
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, undefined, resolveHome, (() => ({
+          codexManagedAccounts: [TEST_CODEX_HOME, nextHome].map((managedHomePath, index) => ({
+            id: `account-${index + 1}`,
+            managedHomePath,
+            managedHomeRuntime: 'host'
+          }))
+        })) as never)
+
+        const spawnPromise = handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          launchAgent: 'codex'
+        })
+        await vi.advanceTimersByTimeAsync(0)
+        selectedHome = nextHome
+        originalAuthReady = true
+        await vi.advanceTimersByTimeAsync(25)
+        await spawnPromise
+
+        expect(resolveHome).toHaveBeenCalledTimes(2)
+        expect(daemonSpawn.mock.calls[0]?.[0].env).toMatchObject({
+          CODEX_HOME: nextHome,
+          ORCA_CODEX_HOME: nextHome
+        })
+      })
+
+      it('does not gate a non-Codex daemon PTY on managed Codex auth', async () => {
         readFileSyncMock.mockImplementation((filePath: string) => {
           if (filePath.endsWith('auth.json')) {
             throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
@@ -3120,14 +3221,238 @@ describe('registerPtyHandlers', () => {
           ]
         })) as never)
 
-        const spawnPromise = handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
-        const rejection = expect(spawnPromise).rejects.toThrow(
-          'The selected Codex account credentials are temporarily unavailable'
-        )
-        await vi.advanceTimersByTimeAsync(2_000)
+        await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          launchAgent: 'claude'
+        })
 
+        expect(daemonSpawn).toHaveBeenCalledOnce()
+      })
+
+      it('does not gate a Codex daemon reattach on current managed auth', async () => {
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath.endsWith('auth.json')) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, undefined, () => TEST_CODEX_HOME, (() => ({
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        })) as never)
+
+        await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          launchAgent: 'codex',
+          sessionId: 'retained-codex'
+        })
+
+        expect(daemonSpawn).toHaveBeenCalledOnce()
+      })
+
+      it('does not gate a runtime-created Codex reattach on current managed auth', async () => {
+        type RuntimeSpawnController = {
+          spawn(args: {
+            cols: number
+            rows: number
+            launchAgent: 'codex'
+            sessionId: string
+          }): Promise<{ id: string }>
+        }
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath.endsWith('auth.json')) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        const runtime = {
+          setPtyController: vi.fn(),
+          registerPty: vi.fn(),
+          noteTerminalSpawnCommand: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyExit: vi.fn(),
+          onPtyData: vi.fn()
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never, () => TEST_CODEX_HOME, (() => ({
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        })) as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+        await controller.spawn({
+          cols: 80,
+          rows: 24,
+          launchAgent: 'codex',
+          sessionId: 'retained-runtime-codex'
+        })
+
+        expect(daemonSpawn).toHaveBeenCalledOnce()
+      })
+
+      it('falls back when managed Codex auth stays unavailable', async () => {
+        vi.useFakeTimers()
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath.endsWith('auth.json')) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        const resolveHome = vi.fn(
+          (
+            _target?: unknown,
+            _env?: NodeJS.ProcessEnv,
+            context?: { unavailableManagedHomePath?: string }
+          ) => (context?.unavailableManagedHomePath ? null : TEST_CODEX_HOME)
+        )
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, undefined, resolveHome, (() => ({
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        })) as never)
+
+        const spawnPromise = handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          launchAgent: 'codex'
+        })
+        await vi.advanceTimersByTimeAsync(2_000)
+        await spawnPromise
+
+        expect(resolveHome).toHaveBeenCalledTimes(2)
+        expect(resolveHome.mock.calls[1]?.[2]).toMatchObject({
+          unavailableManagedHomePath: TEST_CODEX_HOME
+        })
+        expect(daemonSpawn).toHaveBeenCalledOnce()
+        expect(daemonSpawn.mock.calls[0]?.[0].env).not.toHaveProperty('CODEX_HOME')
+      })
+
+      it('rejects when account changes keep resolving unavailable managed homes', async () => {
+        vi.useFakeTimers()
+        const secondHome = '/managed/second/home'
+        const thirdHome = '/managed/third/home'
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath.endsWith('auth.json')) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        const resolveHome = vi.fn(
+          (
+            _target?: unknown,
+            _env?: NodeJS.ProcessEnv,
+            context?: { unavailableManagedHomePath?: string }
+          ) =>
+            !context?.unavailableManagedHomePath
+              ? TEST_CODEX_HOME
+              : context.unavailableManagedHomePath === TEST_CODEX_HOME
+                ? secondHome
+                : thirdHome
+        )
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, undefined, resolveHome, (() => ({
+          codexManagedAccounts: [TEST_CODEX_HOME, secondHome, thirdHome].map(
+            (managedHomePath, index) => ({
+              id: `account-${index + 1}`,
+              managedHomePath,
+              managedHomeRuntime: 'host'
+            })
+          )
+        })) as never)
+
+        const spawnPromise = handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          launchAgent: 'codex'
+        })
+        const rejection = expect(spawnPromise).rejects.toThrow(
+          'The selected Codex account credentials are temporarily unavailable. Try opening the terminal again.'
+        )
+        await vi.advanceTimersByTimeAsync(4_000)
         await rejection
+
+        expect(resolveHome.mock.calls.map((call) => call[2]?.unavailableManagedHomePath)).toEqual([
+          undefined,
+          TEST_CODEX_HOME,
+          secondHome
+        ])
+        expect(vi.getTimerCount()).toBe(0)
         expect(daemonSpawn).not.toHaveBeenCalled()
+      })
+
+      it('falls back for a runtime-created Codex launch when auth stays unavailable', async () => {
+        type RuntimeSpawnController = {
+          spawn(args: { cols: number; rows: number; launchAgent: 'codex' }): Promise<{ id: string }>
+        }
+        vi.useFakeTimers()
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath.endsWith('auth.json')) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        const resolveHome = vi.fn(
+          (
+            _target?: unknown,
+            _env?: NodeJS.ProcessEnv,
+            context?: { unavailableManagedHomePath?: string }
+          ) => (context?.unavailableManagedHomePath ? null : TEST_CODEX_HOME)
+        )
+        const runtime = {
+          setPtyController: vi.fn(),
+          registerPty: vi.fn(),
+          noteTerminalSpawnCommand: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyExit: vi.fn(),
+          onPtyData: vi.fn()
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never, resolveHome, (() => ({
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        })) as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+        const spawnPromise = controller.spawn({ cols: 80, rows: 24, launchAgent: 'codex' })
+        await vi.advanceTimersByTimeAsync(0)
+        expect(daemonSpawn).not.toHaveBeenCalled()
+        await vi.advanceTimersByTimeAsync(2_000)
+        await spawnPromise
+
+        expect(resolveHome).toHaveBeenCalledTimes(2)
+        expect(resolveHome.mock.calls[1]?.[2]).toMatchObject({
+          unavailableManagedHomePath: TEST_CODEX_HOME
+        })
+        expect(daemonSpawn).toHaveBeenCalledOnce()
+        expect(daemonSpawn.mock.calls[0]?.[0].env).not.toHaveProperty('CODEX_HOME')
       })
 
       it('injects OpenCode plugin env (OPENCODE_CONFIG_DIR) on the daemon path', async () => {
@@ -14686,6 +15011,70 @@ describe('registerPtyHandlers', () => {
     expect(recordCodexPaneAccountMock.mock.calls).toEqual([
       ['pty-fresh', { selectionKey: 'host', accountId: 'account-a' }]
     ])
+  })
+
+  it('does not resume under another account when the origin auth stays unavailable', async () => {
+    vi.useFakeTimers()
+    const spawn = vi.fn(async () => ({ id: 'pty-must-not-spawn' }))
+    setLocalPtyProvider({
+      spawn,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    readFileSyncMock.mockImplementation((filePath: string) => {
+      if (filePath.endsWith('auth.json')) {
+        throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+      }
+      return ''
+    })
+    const resolveHome = vi.fn(() => '/managed/current/home')
+    registerPtyHandlers(
+      mainWindow as never,
+      undefined,
+      resolveHome,
+      (() => ({
+        codexManagedAccounts: [
+          { id: 'account-a', managedHomePath: '/managed/origin/home' },
+          { id: 'account-b', managedHomePath: '/managed/current/home' }
+        ]
+      })) as never,
+      undefined,
+      undefined,
+      {
+        prepareCodexSessionResume: async () => ({
+          outcome: 'resume' as const,
+          codexHomePath: '/managed/origin/home'
+        })
+      }
+    )
+
+    const launch = handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      command: 'codex resume session-a',
+      envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME'],
+      launchAgent: 'codex',
+      resumeProviderSession: {
+        key: 'session_id',
+        id: 'session-a',
+        transcriptPath: '/managed/origin/home/sessions/2026/07/20/rollout-a.jsonl'
+      }
+    })
+    const rejection = expect(launch).rejects.toThrow(
+      'The Codex account credentials for this session are temporarily unavailable. Try opening the terminal again.'
+    )
+    await vi.advanceTimersByTimeAsync(2_000)
+    await rejection
+
+    expect(resolveHome).not.toHaveBeenCalled()
+    expect(spawn).not.toHaveBeenCalled()
+    expect(recordCodexPaneAccountMock).not.toHaveBeenCalled()
   })
 
   it('records the origin account a resumed Codex pane is pinned to', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -269,6 +269,15 @@ const TEST_CODEX_HOME =
   process.platform === 'win32'
     ? 'C:\\Users\\test\\AppData\\Roaming\\orca\\codex-runtime-home\\home'
     : '/tmp/orca-codex-home'
+const TEST_CODEX_AUTH_JSON = JSON.stringify({
+  tokens: {
+    access_token: 'access',
+    id_token: 'e30.eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ.sig',
+    refresh_token: 'refresh',
+    account_id: 'account'
+  },
+  last_refresh: '2026-07-31T00:00:00Z'
+})
 
 function makeDisposable() {
   return { dispose: vi.fn() }
@@ -2768,6 +2777,43 @@ describe('registerPtyHandlers', () => {
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
     })
 
+    it('waits for managed Codex auth before spawning a local PTY', async () => {
+      vi.useFakeTimers()
+      let authReady = false
+      readFileSyncMock.mockImplementation((filePath: string) => {
+        if (!filePath.endsWith('auth.json')) {
+          return ''
+        }
+        if (!authReady) {
+          throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+        }
+        return TEST_CODEX_AUTH_JSON
+      })
+      handlers.clear()
+      registerPtyHandlers(mainWindow as never, undefined, () => TEST_CODEX_HOME, (() => ({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            managedHomePath: TEST_CODEX_HOME,
+            managedHomeRuntime: 'host'
+          }
+        ]
+      })) as never)
+
+      const spawnPromise = handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(spawnMock).not.toHaveBeenCalled()
+
+      authReady = true
+      await vi.advanceTimersByTimeAsync(25)
+      await spawnPromise
+
+      expect(spawnMock.mock.calls.at(-1)?.[2].env).toMatchObject({
+        CODEX_HOME: TEST_CODEX_HOME,
+        ORCA_CODEX_HOME: TEST_CODEX_HOME
+      })
+    })
+
     it('leaves an inherited CODEX_HOME untouched for system default when the flag is OFF', async () => {
       // Why: flag OFF must stay byte-identical to today. With no managed home
       // selected (resolver null) and the real-home flag off, no CODEX_HOME
@@ -3015,6 +3061,74 @@ describe('registerPtyHandlers', () => {
           )
         ).env
       }
+
+      it('waits for managed Codex auth before spawning a daemon PTY', async () => {
+        vi.useFakeTimers()
+        let authReady = false
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (!filePath.endsWith('auth.json')) {
+            return ''
+          }
+          if (!authReady) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return TEST_CODEX_AUTH_JSON
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, undefined, () => TEST_CODEX_HOME, (() => ({
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        })) as never)
+
+        const spawnPromise = handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+        await vi.advanceTimersByTimeAsync(0)
+        expect(daemonSpawn).not.toHaveBeenCalled()
+
+        authReady = true
+        await vi.advanceTimersByTimeAsync(25)
+        await spawnPromise
+
+        expect(daemonSpawn.mock.calls.at(-1)?.[0].env).toMatchObject({
+          CODEX_HOME: TEST_CODEX_HOME,
+          ORCA_CODEX_HOME: TEST_CODEX_HOME
+        })
+      })
+
+      it('fails closed when managed Codex auth stays unavailable', async () => {
+        vi.useFakeTimers()
+        readFileSyncMock.mockImplementation((filePath: string) => {
+          if (filePath.endsWith('auth.json')) {
+            throw Object.assign(new Error('missing auth'), { code: 'ENOENT' })
+          }
+          return ''
+        })
+        const daemonSpawn = setupDaemonAdapter()
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, undefined, () => TEST_CODEX_HOME, (() => ({
+          codexManagedAccounts: [
+            {
+              id: 'account-1',
+              managedHomePath: TEST_CODEX_HOME,
+              managedHomeRuntime: 'host'
+            }
+          ]
+        })) as never)
+
+        const spawnPromise = handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+        const rejection = expect(spawnPromise).rejects.toThrow(
+          'The selected Codex account credentials are temporarily unavailable'
+        )
+        await vi.advanceTimersByTimeAsync(2_000)
+
+        await rejection
+        expect(daemonSpawn).not.toHaveBeenCalled()
+      })
 
       it('injects OpenCode plugin env (OPENCODE_CONFIG_DIR) on the daemon path', async () => {
         const env = await daemonSpawnAndGetEnv({}, undefined, undefined, {
@@ -14607,6 +14721,7 @@ describe('registerPtyHandlers', () => {
         })
       }
     )
+    readFileSyncMock.mockReturnValue(TEST_CODEX_AUTH_JSON)
 
     await handlers.get('pty:spawn')!(null, {
       cols: 80,
@@ -14625,6 +14740,7 @@ describe('registerPtyHandlers', () => {
     expect(recordCodexPaneAccountMock.mock.calls).toEqual([
       ['pty-resumed', { selectionKey: 'host', accountId: 'account-a' }]
     ])
+    expect(readFileSyncMock).toHaveBeenCalledWith('/managed/origin/home/auth.json', 'utf8')
     expect(forgetCodexPaneAccountMock).not.toHaveBeenCalled()
   })
 
@@ -14726,6 +14842,7 @@ describe('registerPtyHandlers', () => {
       }
     )
     const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+    readFileSyncMock.mockReturnValue(TEST_CODEX_AUTH_JSON)
 
     await controller.spawn({
       cols: 80,
@@ -14743,6 +14860,7 @@ describe('registerPtyHandlers', () => {
     expect(recordCodexPaneAccountMock.mock.calls).toEqual([
       ['pty-runtime-resumed', { selectionKey: 'host', accountId: 'account-a' }]
     ])
+    expect(readFileSyncMock).toHaveBeenCalledWith('/managed/origin/home/auth.json', 'utf8')
     expect(forgetCodexPaneAccountMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -187,6 +187,7 @@ import { setTerminalViewAttributes } from '../runtime/terminal-view-attribute-st
 import { validateTerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyModelRestoreReason } from '../../shared/pty-model-restore-marker'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
+import { waitForManagedCodexAuthReady } from '../codex-accounts/managed-codex-auth-readiness'
 import {
   forgetCodexPaneAccount,
   recordCodexPaneAccount
@@ -3775,7 +3776,7 @@ export function registerPtyHandlers(
       if (args.preAllocatedHandle) {
         env = { ...env, ORCA_TERMINAL_HANDLE: args.preAllocatedHandle }
       }
-      const selectedCodexHomePath = isDaemonHostSpawn
+      const selectedCodexHomePath = !args.connectionId
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
             codexResumeHome
@@ -3786,6 +3787,14 @@ export function registerPtyHandlers(
                 }) ?? null)
           )
         : null
+      const codexAuthReadiness = waitForManagedCodexAuthReady({
+        codexHomePath: selectedCodexHomePath,
+        settings: getSettings?.(),
+        target: codexSelectionTarget
+      })
+      if (codexAuthReadiness) {
+        await codexAuthReadiness
+      }
       const skipCodexHomeEnv =
         isDaemonHostSpawn &&
         shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, cwd) &&
@@ -3836,8 +3845,8 @@ export function registerPtyHandlers(
         env,
         ...(isMintedSessionId ? { isNewSession: true } : {})
       }
-      if (!isDaemonHostSpawn && codexResumeHome) {
-        spawnOptions.codexHomePathOverride = { value: codexResumeHome.codexHomePath }
+      if (!args.connectionId && !isDaemonHostSpawn) {
+        spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }
       }
       const startupTerminalColorQueryReplyColors = getStartupTerminalColorQueryReplyColors(args)
       if (startupTerminalColorQueryReplyColors) {
@@ -4953,7 +4962,7 @@ export function registerPtyHandlers(
       // Why: declared after the strip so a local-provider spawn cannot capture the
       // pre-strip env — only the daemon branch below re-derives this from baseEnv.
       let env: Record<string, string> | undefined = baseEnv
-      const selectedCodexHomePath = isDaemonHostSpawn
+      const selectedCodexHomePath = !args.connectionId
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
             codexResumeHome
@@ -4964,6 +4973,14 @@ export function registerPtyHandlers(
                 }) ?? null)
           )
         : null
+      const codexAuthReadiness = waitForManagedCodexAuthReady({
+        codexHomePath: selectedCodexHomePath,
+        settings: getSettings?.(),
+        target: codexSelectionTarget
+      })
+      if (codexAuthReadiness) {
+        await codexAuthReadiness
+      }
       const skipCodexHomeEnv =
         isDaemonHostSpawn &&
         shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, cwd) &&
@@ -5050,8 +5067,8 @@ export function registerPtyHandlers(
         env: spawnEnv,
         ...(isMintedSessionId ? { isNewSession: true } : {})
       }
-      if (!isDaemonHostSpawn && codexResumeHome) {
-        spawnOptions.codexHomePathOverride = { value: codexResumeHome.codexHomePath }
+      if (!args.connectionId && !isDaemonHostSpawn) {
+        spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }
       }
       if (combinedEnvToDelete) {
         spawnOptions.envToDelete = combinedEnvToDelete

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -187,7 +187,10 @@ import { setTerminalViewAttributes } from '../runtime/terminal-view-attribute-st
 import { validateTerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyModelRestoreReason } from '../../shared/pty-model-restore-marker'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
-import { waitForManagedCodexAuthReady } from '../codex-accounts/managed-codex-auth-readiness'
+import {
+  isCodexHomeAuthReadyForLaunch,
+  waitForManagedCodexAuthReady
+} from '../codex-accounts/managed-codex-auth-readiness'
 import {
   forgetCodexPaneAccount,
   recordCodexPaneAccount
@@ -824,10 +827,16 @@ function getLocalOrcaCodexHomeEnvKeysToDelete(env: Record<string, string>): stri
   return keysToDelete
 }
 
+export type CodexHomeLaunchContext = {
+  workspacePath?: string
+  launchAgent?: TuiAgent
+  unavailableManagedHomePath?: string
+}
+
 export type GetSelectedCodexHomePath = (
   target?: CodexAccountSelectionTarget,
   launchEnv?: NodeJS.ProcessEnv,
-  launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
+  launchContext?: CodexHomeLaunchContext
 ) => string | null
 export type PrepareCodexSessionResume = (args: {
   providerSession: AgentProviderSessionMetadata
@@ -865,6 +874,113 @@ function getCompatibleSelectedCodexHomePath(
   return wslInfo || (process.platform === 'win32' && isWslCodexHomeForHost(selectedCodexHomePath))
     ? null
     : selectedCodexHomePath
+}
+
+const MANAGED_CODEX_AUTH_UNAVAILABLE_MESSAGE =
+  'The selected Codex account credentials are temporarily unavailable. Try opening the terminal again.'
+const CODEX_RESUME_AUTH_UNAVAILABLE_MESSAGE =
+  'The Codex account credentials for this session are temporarily unavailable. Try opening the terminal again.'
+
+type ManagedCodexAuthResolutionArgs = {
+  selectedCodexHomePath: string | null
+  getSettings: () => GlobalSettings | undefined
+  requiredCodexHomePath?: string
+  target: CodexAccountSelectionTarget
+  resolveCurrent: () => string | null
+  resolveAfterUnavailable: (unavailableManagedHomePath: string) => string | null
+}
+
+export function resolveCodexHomeAfterManagedAuthReadiness(
+  args: ManagedCodexAuthResolutionArgs
+): string | null | Promise<string | null> {
+  const selectedCodexHomePath = args.selectedCodexHomePath
+  if (
+    args.requiredCodexHomePath &&
+    !codexHomePathsEqual(selectedCodexHomePath, args.requiredCodexHomePath)
+  ) {
+    throw new Error(CODEX_RESUME_AUTH_UNAVAILABLE_MESSAGE)
+  }
+  const readiness = waitForManagedCodexAuthReady({
+    codexHomePath: selectedCodexHomePath,
+    settings: args.getSettings(),
+    target: args.target
+  })
+  return readiness
+    ? continueCodexHomeAfterManagedAuthWait(args, selectedCodexHomePath, readiness)
+    : selectedCodexHomePath
+}
+
+async function continueCodexHomeAfterManagedAuthWait(
+  args: ManagedCodexAuthResolutionArgs,
+  initialCodexHomePath: string | null,
+  initialReadiness: Promise<boolean>
+): Promise<string | null> {
+  let selectedCodexHomePath = initialCodexHomePath
+  let readiness = initialReadiness
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (await readiness) {
+      if (args.requiredCodexHomePath) {
+        return selectedCodexHomePath
+      }
+      const currentCodexHomePath = args.resolveCurrent()
+      if (codexHomeSelectionsEqual(selectedCodexHomePath, currentCodexHomePath)) {
+        return selectedCodexHomePath
+      }
+      selectedCodexHomePath = currentCodexHomePath
+      if (attempt === 1) {
+        break
+      }
+      const nextReadiness = waitForManagedCodexAuthReady({
+        codexHomePath: selectedCodexHomePath,
+        settings: args.getSettings(),
+        target: args.target
+      })
+      if (!nextReadiness) {
+        return selectedCodexHomePath
+      }
+      readiness = nextReadiness
+      continue
+    }
+    if (args.requiredCodexHomePath) {
+      throw new Error(CODEX_RESUME_AUTH_UNAVAILABLE_MESSAGE)
+    }
+    selectedCodexHomePath = args.resolveAfterUnavailable(selectedCodexHomePath!)
+    if (attempt === 1) {
+      break
+    }
+    const nextReadiness = waitForManagedCodexAuthReady({
+      codexHomePath: selectedCodexHomePath,
+      settings: args.getSettings(),
+      target: args.target
+    })
+    if (!nextReadiness) {
+      return selectedCodexHomePath
+    }
+    readiness = nextReadiness
+  }
+  if (
+    isCodexHomeAuthReadyForLaunch({
+      codexHomePath: selectedCodexHomePath,
+      settings: args.getSettings(),
+      target: args.target
+    })
+  ) {
+    return selectedCodexHomePath
+  }
+  throw new Error(MANAGED_CODEX_AUTH_UNAVAILABLE_MESSAGE)
+}
+
+function codexHomeSelectionsEqual(left: string | null, right: string | null): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      normalizeRuntimePathForComparison(left) === normalizeRuntimePathForComparison(right))
+  )
+}
+
+function codexHomePathsEqual(left: string | null, right: string): boolean {
+  return codexHomeSelectionsEqual(left, right)
 }
 
 // Why: CODEX_HOME is fixed in a shell's environment at spawn and the daemon
@@ -3776,7 +3892,7 @@ export function registerPtyHandlers(
       if (args.preAllocatedHandle) {
         env = { ...env, ORCA_TERMINAL_HANDLE: args.preAllocatedHandle }
       }
-      const selectedCodexHomePath = !args.connectionId
+      let selectedCodexHomePath = !args.connectionId
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
             codexResumeHome
@@ -3787,14 +3903,35 @@ export function registerPtyHandlers(
                 }) ?? null)
           )
         : null
-      const codexAuthReadiness = waitForManagedCodexAuthReady({
-        codexHomePath: selectedCodexHomePath,
-        settings: getSettings?.(),
-        target: codexSelectionTarget
-      })
-      if (codexAuthReadiness) {
-        await codexAuthReadiness
+      if (args.launchAgent === 'codex' && callerRequestedSessionId === undefined) {
+        const resolution = resolveCodexHomeAfterManagedAuthReadiness({
+          selectedCodexHomePath,
+          getSettings: () => getSettings?.(),
+          requiredCodexHomePath: codexResumeHome?.codexHomePath,
+          target: codexSelectionTarget,
+          resolveCurrent: () =>
+            getCompatibleSelectedCodexHomePath(
+              codexSelectionTarget,
+              getSelectedCodexHomePath?.(codexSelectionTarget, env, {
+                workspacePath: cwd,
+                launchAgent: 'codex'
+              }) ?? null
+            ),
+          resolveAfterUnavailable: (unavailableManagedHomePath) =>
+            getCompatibleSelectedCodexHomePath(
+              codexSelectionTarget,
+              getSelectedCodexHomePath?.(codexSelectionTarget, env, {
+                workspacePath: cwd,
+                launchAgent: 'codex',
+                unavailableManagedHomePath
+              }) ?? null
+            )
+        })
+        selectedCodexHomePath = resolution instanceof Promise ? await resolution : resolution
       }
+      const codexResumeHomeSelected = Boolean(
+        codexResumeHome && codexHomePathsEqual(selectedCodexHomePath, codexResumeHome.codexHomePath)
+      )
       const skipCodexHomeEnv =
         isDaemonHostSpawn &&
         shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, cwd) &&
@@ -3882,7 +4019,7 @@ export function registerPtyHandlers(
           'ORCA_CODEX_HOME'
         ])
       }
-      if (codexResumeHome?.codexHomePath) {
+      if (codexResumeHomeSelected) {
         spawnOptions.envToDelete = removeCodexHomeDeletionRequests(spawnOptions.envToDelete)
       }
       deleteRequestedEnvKeys(env, spawnOptions.envToDelete)
@@ -4222,7 +4359,7 @@ export function registerPtyHandlers(
           ptyId: result.id,
           isDaemonHostSpawn,
           isReattach: result.isReattach === true,
-          pinnedByResume: Boolean(codexResumeHome),
+          pinnedByResume: codexResumeHomeSelected,
           launchCodexHomePath: selectedCodexHomePath,
           target: codexSelectionTarget,
           settings: getSettings?.()
@@ -4962,7 +5099,7 @@ export function registerPtyHandlers(
       // Why: declared after the strip so a local-provider spawn cannot capture the
       // pre-strip env — only the daemon branch below re-derives this from baseEnv.
       let env: Record<string, string> | undefined = baseEnv
-      const selectedCodexHomePath = !args.connectionId
+      let selectedCodexHomePath = !args.connectionId
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
             codexResumeHome
@@ -4973,14 +5110,35 @@ export function registerPtyHandlers(
                 }) ?? null)
           )
         : null
-      const codexAuthReadiness = waitForManagedCodexAuthReady({
-        codexHomePath: selectedCodexHomePath,
-        settings: getSettings?.(),
-        target: codexSelectionTarget
-      })
-      if (codexAuthReadiness) {
-        await codexAuthReadiness
+      if (args.launchAgent === 'codex' && args.sessionId === undefined) {
+        const resolution = resolveCodexHomeAfterManagedAuthReadiness({
+          selectedCodexHomePath,
+          getSettings: () => getSettings?.(),
+          requiredCodexHomePath: codexResumeHome?.codexHomePath,
+          target: codexSelectionTarget,
+          resolveCurrent: () =>
+            getCompatibleSelectedCodexHomePath(
+              codexSelectionTarget,
+              getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
+                workspacePath: cwd,
+                launchAgent: 'codex'
+              }) ?? null
+            ),
+          resolveAfterUnavailable: (unavailableManagedHomePath) =>
+            getCompatibleSelectedCodexHomePath(
+              codexSelectionTarget,
+              getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
+                workspacePath: cwd,
+                launchAgent: 'codex',
+                unavailableManagedHomePath
+              }) ?? null
+            )
+        })
+        selectedCodexHomePath = resolution instanceof Promise ? await resolution : resolution
       }
+      const codexResumeHomeSelected = Boolean(
+        codexResumeHome && codexHomePathsEqual(selectedCodexHomePath, codexResumeHome.codexHomePath)
+      )
       const skipCodexHomeEnv =
         isDaemonHostSpawn &&
         shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, cwd) &&
@@ -5055,7 +5213,7 @@ export function registerPtyHandlers(
         // main cannot safely decide ownership for a process it may not parent.
         stripInheritedOrcaCodexHome ? ['ORCA_CODEX_HOME'] : []
       )
-      if (codexResumeHome?.codexHomePath) {
+      if (codexResumeHomeSelected) {
         combinedEnvToDelete = removeCodexHomeDeletionRequests(combinedEnvToDelete)
       }
       deleteRequestedEnvKeys(spawnEnv, combinedEnvToDelete)
@@ -5285,7 +5443,7 @@ export function registerPtyHandlers(
           ptyId: result.id,
           isDaemonHostSpawn,
           isReattach: result.isReattach === true,
-          pinnedByResume: Boolean(codexResumeHome),
+          pinnedByResume: codexResumeHomeSelected,
           launchCodexHomePath: selectedCodexHomePath,
           target: codexSelectionTarget,
           settings: getSettings?.()

--- a/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
+++ b/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
@@ -177,4 +177,37 @@ describe('fetchCodexRateLimits auth errors', () => {
       error: authError
     })
   })
+
+  it('stops a PTY probe when Codex renders its sign-in screen', async () => {
+    const ptyHandlers: { onData?: (data: string) => void } = {}
+    const ptyWrite = vi.fn()
+    const ptyKill = vi.fn()
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn((callback) => {
+        ptyHandlers.onData = callback
+        return makeDisposable()
+      }),
+      onExit: vi.fn(() => makeDisposable()),
+      write: ptyWrite,
+      kill: ptyKill
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(0)
+    ptyHandlers.onData?.('\u001b[2JSign in with ChatGPT\r\n')
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      status: 'error',
+      error: 'Sign in with ChatGPT'
+    })
+    expect(ptyWrite).not.toHaveBeenCalled()
+    expect(ptyKill).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -1035,6 +1035,29 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         output = output.slice(-MAX_DIAGNOSTIC_OUTPUT_LENGTH)
       }
 
+      const authError = extractCodexAuthError(output)
+      if (authError) {
+        resolved = true
+        if (timeout) {
+          clearTimeout(timeout)
+          timeout = null
+        }
+        if (settleTimer) {
+          clearTimeout(settleTimer)
+          settleTimer = null
+        }
+        cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
+        resolve({
+          provider: 'codex',
+          session: null,
+          weekly: null,
+          updatedAt: Date.now(),
+          error: authError,
+          status: 'error'
+        })
+        return
+      }
+
       armStatusNudge()
 
       // Wait for prompt, then send /status

--- a/src/shared/codex-auth-errors.test.ts
+++ b/src/shared/codex-auth-errors.test.ts
@@ -8,6 +8,7 @@ afterEach(() => {
 describe('isCodexAuthError', () => {
   it('matches Codex authentication refresh failures', () => {
     expect(isCodexAuthError('Access token could not be refreshed')).toBe(true)
+    expect(isCodexAuthError('Sign in with ChatGPT')).toBe(true)
     expect(isCodexAuthError('plain provider error')).toBe(false)
     expect(isCodexAuthError(null)).toBe(false)
   })

--- a/src/shared/codex-auth-errors.ts
+++ b/src/shared/codex-auth-errors.ts
@@ -6,6 +6,7 @@ const CODEX_AUTH_ERROR_PATTERNS = [
   /please (?:log out and )?sign in again/i,
   /please reauthenticate/i,
   /not logged in/i,
+  /sign in with chatgpt/i,
   /token data is not available/i,
   /auth (?:is missing|tokens are missing|does not expose)/i,
   // Why: app-server rejects account/rateLimits/read with this when auth.json


### PR DESCRIPTION
## Summary

Prevent a fresh Orca-launched Codex session from latching unauthenticated state while a selected managed account's `auth.json` is temporarily missing or incomplete.

This revision keeps the fix at the Codex launch boundary and avoids turning a credential problem into a terminal-wide outage:

- fresh host-local Codex launches wait up to 1.5 seconds for a known incomplete credential to recover;
- a credential that is valid on the first read stays on a synchronous, timer-free path;
- if auth remains unavailable, Orca clears only the still-selected host account and falls back through the existing system-default launch path;
- selection changes during the wait are re-resolved and fenced, so a recovered old account cannot launch after the user selects another account;
- resumed/pinned Codex sessions never switch identities; unavailable origin auth rejects the resume;
- bare shells, other agents, SSH, WSL, daemon reattaches, system-default homes, and unmanaged homes bypass this gate;
- hidden Codex quota probes still stop immediately if Codex renders `Sign in with ChatGPT`.

## User symptom and evidence

With an authenticated managed account selected, a newly opened Codex tab could intermittently show onboarding, while an immediate retry opened the authenticated composer.

A deterministic real-Codex reproduction established the latch behavior: start Codex while a valid copied `auth.json` is temporarily absent, restore the file before reading the account, and that process remains unauthenticated while a new process against the restored home is authenticated. This proves the startup-latch failure mode. The exact production writer and timing for each historical occurrence were not captured, so this PR does not claim more specific causality.

The Orca regression surface dates to #9501 (`e58de71f5e`, 2026-07-20), which made managed account homes live self-contained `CODEX_HOME` directories and treated a missing `auth.json` as a reason to abandon the selected account at launch. #9451 is similar by symptom but is not treated as a confirmed duplicate.

## Implementation

### Credential readiness

Known complete Codex credential forms are accepted:

- `chatgpt` / `chatgptAuthTokens` token records;
- `apikey`;
- `personalAccessToken`;
- `bedrockApiKey`;
- object-backed `agentIdentity` records with the required runtime ID and private key.

Known partial records retry. Genuinely unknown future modes or parseable object shapes fail open so a new Codex schema cannot strand terminal creation. Missing, malformed, or unreadable files use the bounded retry/fallback path.

### Identity and availability safety

The readiness decision is scoped to fresh Codex launches. After the wait, Orca re-checks the selected account before it creates a PTY. A permanent credential failure restores the previous safe system-default behavior instead of rejecting every terminal indefinitely. Resume-pinned sessions remain pinned and reject if their original managed credential is unavailable.

The same rules are enforced for renderer-to-daemon, renderer local fallback, and runtime-controller Codex launches. Trusted managed-home ownership checks remain in place.

## No-regression and performance evidence

| Lane/state | Result |
| --- | --- |
| Valid managed auth on first read | Synchronous return; no Promise tick or polling timer |
| Transient missing/partial auth | Bounded wait, then spawn with the still-selected managed home |
| Permanently unavailable auth | Clear only the still-selected host account and use normal fallback |
| Selection changes during wait | Re-resolve/fence; never launch the stale account |
| Resume-pinned Codex session | Keep original account; reject rather than switch identity |
| Bare shell or another agent | No Codex readiness read or wait |
| Codex daemon reattach | No current-account gate |
| SSH / WSL | Existing remote and distro-local behavior unchanged |
| Folder workspace / Git worktree | Shared PTY boundary; no worktree-only assumption |
| Hidden quota PTY shows onboarding | Stop immediately; never send `/status` |

The healthy path is covered by an explicit synchronous-return test, and the PTY suite verifies that non-Codex launches and reattaches do not gain the readiness wait.

## Verification

Final candidate `1017c2589630e4aa2d55c6f727df0d0a2572585e`:

- focused Vitest suite: **6 files, 549 tests passed**;
- `pnpm typecheck`: node, CLI, and web passed;
- `pnpm lint`: passed, including 56 reliability gates, max-lines ratchet, bundled-skill checks, and localization checks;
- `pnpm exec oxfmt --check` on changed files: passed;
- `git diff --check`: passed;
- pre-commit oxlint, react-doctor, and formatting hooks: passed.

A same-model review loop continued until a fresh reviewer returned **CLEAN**. Earlier completed iterations found and drove fixes for real Codex credential shapes, permanent-auth terminal lockout, over-broad terminal gating, selection races, the healthy-path Promise tick, and partial Agent Identity records. The final review found no remaining correctness, availability, identity, scope, platform, or performance issue.

### Electron validation

An isolated source build was launched from this exact worktree with a disposable user-data profile. Settings showed the disposable managed Codex account active; **New tab → Codex** opened Codex 0.146.0 directly at the authenticated composer, not onboarding. Process inspection confirmed that the launched Codex process received the disposable managed account's `CODEX_HOME`; no credential values were displayed or captured.

![Fresh Codex launch opens the authenticated composer](https://github.com/user-attachments/assets/4388eed0-8c46-457f-87c2-891974984207)

## Deliberate boundary

This guards Orca's fresh Codex launch action. If a user opens a bare shell and manually types `codex` much later, Orca cannot intercept that future shell command at PTY-spawn time; that path remains outside this launch-scoped fix.
