### PR TITLE
fix(browser): stop agent browser input from stealing the user's focus

### DIFF
--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -177,8 +177,26 @@ describe('orca cli browser page targeting', () => {
       {
         url: 'https://example.com',
         worktree: undefined,
-        profileId: 'work'
+        profileId: 'work',
+        // Why: agent opens stay in the background unless --focus asks otherwise.
+        activate: false
       },
+      { timeoutMs: 60_000 }
+    )
+  })
+
+  it('asks tab create to focus the new tab only with --focus', async () => {
+    queueFixtures(callMock, okFixture('req_create', { browserPageId: 'page-4' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'create', '--url', 'https://example.com', '--worktree', 'all', '--focus', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'browser.tabCreate',
+      expect.objectContaining({ activate: true }),
       { timeoutMs: 60_000 }
     )
   })

--- a/src/cli/handlers/browser-tab.ts
+++ b/src/cli/handlers/browser-tab.ts
@@ -60,9 +60,12 @@ export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
     const url = getOptionalStringFlag(flags, 'url')
     const profileId = getOptionalStringFlag(flags, 'profile')
     const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
+    // Why: TabCreate documents "agent/automation opens stay background", but the CLI
+    // never sent `activate`, so every agent-created tab surfaced the browser pane and
+    // took focus from whatever the user was working in. Mirror `tab switch`: opt-in.
     const result = await client.call<{ browserPageId: string }>(
       'browser.tabCreate',
-      { url, worktree, profileId },
+      { url, worktree, profileId, activate: flags.has('focus') },
       { timeoutMs: 60_000 }
     )
     printResult(result, json, (v) => `Created tab ${v.browserPageId}`)

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -178,8 +178,9 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['tab', 'create'],
     summary: 'Create a new browser tab in the current worktree',
-    usage: 'orca tab create [--url <url>] [--worktree <selector>] [--profile <id>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree', 'profile']
+    usage:
+      'orca tab create [--url <url>] [--worktree <selector>] [--profile <id>] [--focus] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree', 'profile', 'focus']
   },
   {
     path: ['tab', 'profile', 'list'],

--- a/src/main/browser/cdp-ws-proxy-focus-borrow.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-borrow.test.ts
@@ -118,9 +118,10 @@ describe('CdpWsProxy agent input focus borrow', () => {
     client.close()
   })
 
-  // Why: no pane hosts this guest, so nobody answers. Dropping the input there would
-  // break offscreen and not-yet-mounted guests that worked before the handoff existed.
-  it('forwards input when no pane answers the borrow', async () => {
+  // Why: the host renderer took the begin, so silence means no pane is holding this
+  // guest — it cannot have focus, and forwarding anyway puts the keystroke in the
+  // user's window. Only a guest with no host renderer at all keeps the old path.
+  it('fails input when no pane answers the borrow', async () => {
     mock.webContents.hostWebContents.send.mockImplementation(() => {})
     const client = await connect(endpoint)
 
@@ -130,8 +131,8 @@ describe('CdpWsProxy agent input focus borrow', () => {
       params: { type: 'keyDown', key: 'a' }
     })
 
-    expect(response.error).toBeUndefined()
-    expect(getSendCommandMethods(mock)).toContain('Input.dispatchKeyEvent')
+    expect((response.error as { message: string }).message).toContain('keyboard focus')
+    expect(getSendCommandMethods(mock)).not.toContain('Input.dispatchKeyEvent')
     client.close()
   })
 

--- a/src/main/browser/cdp-ws-proxy-focus-borrow.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-borrow.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { CdpWsProxy } from './cdp-ws-proxy'
+import {
+  connect,
+  createMockWebContents,
+  getSendCommandMethods,
+  sendAndReceive,
+  type MockWebContents
+} from './cdp-ws-proxy-test-harness'
+
+const electronMock = vi.hoisted(() => {
+  const focusReplyListeners = new Set<(...args: unknown[]) => void>()
+  return {
+    replyFocusBorrow: (borrowId: number, focused: boolean): void => {
+      for (const listener of focusReplyListeners) {
+        listener({}, { borrowId, focused })
+      }
+    },
+    ipcMain: {
+      on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+        if (channel === 'browser:agentInputFocusReply') {
+          focusReplyListeners.add(listener)
+        }
+      }),
+      removeListener: vi.fn((_channel: string, listener: (...args: unknown[]) => void) => {
+        focusReplyListeners.delete(listener)
+      })
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  webContents: { fromId: vi.fn() },
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => null),
+    fromWebContents: vi.fn(() => null)
+  },
+  ipcMain: electronMock.ipcMain
+}))
+
+// Why: main cannot see whether the guest took focus — only the pane hosting it can.
+// These tests pin what main does with each answer, because forwarding an input the
+// guest never focused is exactly how agent keystrokes reach the user's window.
+describe('CdpWsProxy agent input focus borrow', () => {
+  let mock: MockWebContents
+  let proxy: CdpWsProxy
+  let endpoint: string
+
+  function answerBorrowWith(focused: boolean): void {
+    mock.webContents.hostWebContents.send.mockImplementation((_channel, detail) => {
+      if (detail.phase === 'begin') {
+        electronMock.replyFocusBorrow(detail.borrowId, focused)
+      }
+    })
+  }
+
+  beforeEach(async () => {
+    mock = createMockWebContents()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    proxy = new CdpWsProxy(mock.webContents as any)
+    endpoint = await proxy.start()
+  })
+
+  afterEach(async () => {
+    await proxy.stop()
+  })
+
+  it('forwards a key event once the pane grants focus', async () => {
+    answerBorrowWith(true)
+    const client = await connect(endpoint)
+
+    const response = await sendAndReceive(client, {
+      id: 90,
+      method: 'Input.dispatchKeyEvent',
+      params: { type: 'keyDown', key: 'a' }
+    })
+
+    expect(response.error).toBeUndefined()
+    expect(getSendCommandMethods(mock)).toContain('Input.dispatchKeyEvent')
+    client.close()
+  })
+
+  // Why: a guest can refuse focus while staying alive — a hidden or detached pane still
+  // answers CDP. Forwarding then puts the keystroke wherever the user is typing, so the
+  // command has to fail instead of reporting a success that landed somewhere else.
+  it('fails a key event the pane could not focus', async () => {
+    answerBorrowWith(false)
+    const client = await connect(endpoint)
+
+    const response = await sendAndReceive(client, {
+      id: 91,
+      method: 'Input.dispatchKeyEvent',
+      params: { type: 'keyDown', key: 'a' }
+    })
+
+    expect((response.error as { message: string }).message).toContain('keyboard focus')
+    expect(getSendCommandMethods(mock)).not.toContain('Input.dispatchKeyEvent')
+    // Why: the pane counted the begin, so it still needs the end to unwind it.
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'end' })
+    )
+    client.close()
+  })
+
+  it('fails Input.insertText the pane could not focus', async () => {
+    answerBorrowWith(false)
+    const client = await connect(endpoint)
+
+    const response = await sendAndReceive(client, {
+      id: 92,
+      method: 'Input.insertText',
+      params: { text: 'hello' }
+    })
+
+    expect((response.error as { message: string }).message).toContain('keyboard focus')
+    expect(getSendCommandMethods(mock)).not.toContain('Input.insertText')
+    client.close()
+  })
+
+  // Why: no pane hosts this guest, so nobody answers. Dropping the input there would
+  // break offscreen and not-yet-mounted guests that worked before the handoff existed.
+  it('forwards input when no pane answers the borrow', async () => {
+    mock.webContents.hostWebContents.send.mockImplementation(() => {})
+    const client = await connect(endpoint)
+
+    const response = await sendAndReceive(client, {
+      id: 93,
+      method: 'Input.dispatchKeyEvent',
+      params: { type: 'keyDown', key: 'a' }
+    })
+
+    expect(response.error).toBeUndefined()
+    expect(getSendCommandMethods(mock)).toContain('Input.dispatchKeyEvent')
+    client.close()
+  })
+
+  it('forwards input without asking when the guest has no host renderer', async () => {
+    mock.webContents.hostWebContents.isDestroyed.mockReturnValue(true)
+    const client = await connect(endpoint)
+
+    const response = await sendAndReceive(client, {
+      id: 94,
+      method: 'Input.dispatchKeyEvent',
+      params: { type: 'keyDown', key: 'a' }
+    })
+
+    expect(response.error).toBeUndefined()
+    expect(mock.webContents.hostWebContents.send).not.toHaveBeenCalled()
+    expect(getSendCommandMethods(mock)).toContain('Input.dispatchKeyEvent')
+    client.close()
+  })
+})

--- a/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
@@ -10,7 +10,13 @@ import {
 } from './cdp-ws-proxy-test-harness'
 
 vi.mock('electron', () => ({
-  webContents: { fromId: vi.fn() }
+  webContents: { fromId: vi.fn() },
+  // Why: input forwarding borrows native focus and hands it back, so it asks the
+  // window layer who held focus. No window in tests means nothing to restore.
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => null),
+    fromWebContents: vi.fn(() => null)
+  }
 }))
 
 // Why: the proxy focuses the guest webContents natively before Input.insertText,
@@ -49,7 +55,10 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(focusResponse.id).toBe(14)
     expect(insertResponse.id).toBe(15)
     expect(insertResponse.result).toEqual({})
-    expect(mock.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
@@ -109,7 +118,10 @@ describe('CdpWsProxy DOM.focus replay', () => {
 
     expect(insertResponse.id).toBe(20)
     expect(insertResponse.result).toEqual({})
-    expect(mock.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
@@ -152,7 +164,10 @@ describe('CdpWsProxy DOM.focus replay', () => {
     })
     expect(insertResponse.id).toBe(22)
     expect(insertResponse.result).toEqual({})
-    expect(mock.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
@@ -194,7 +209,10 @@ describe('CdpWsProxy DOM.focus replay', () => {
       id: 24,
       error: { code: -32000, message: 'Focus target went stale' }
     })
-    expect(mock.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
@@ -269,7 +287,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(insertResponse.result).toEqual({})
     // Why: both Page.bringToFront and Input.insertText natively call focus(),
     // independent of the (now-cleared) DOM.focus replay.
-    expect(mock.webContents.focus).toHaveBeenCalledTimes(2)
+    expect(mock.webContents.focus).toHaveBeenCalledTimes(1)
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',

--- a/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
@@ -9,6 +9,27 @@ import {
   type MockWebContents
 } from './cdp-ws-proxy-test-harness'
 
+const electronMock = vi.hoisted(() => {
+  const focusReplyListeners = new Set<(...args: unknown[]) => void>()
+  return {
+    replyFocusBorrow: (borrowId: number, focused: boolean): void => {
+      for (const listener of focusReplyListeners) {
+        listener({}, { borrowId, focused })
+      }
+    },
+    ipcMain: {
+      on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+        if (channel === 'browser:agentInputFocusReply') {
+          focusReplyListeners.add(listener)
+        }
+      }),
+      removeListener: vi.fn((_channel: string, listener: (...args: unknown[]) => void) => {
+        focusReplyListeners.delete(listener)
+      })
+    }
+  }
+})
+
 vi.mock('electron', () => ({
   webContents: { fromId: vi.fn() },
   // Why: input forwarding borrows native focus and hands it back, so it asks the
@@ -16,7 +37,8 @@ vi.mock('electron', () => ({
   BrowserWindow: {
     getFocusedWindow: vi.fn(() => null),
     fromWebContents: vi.fn(() => null)
-  }
+  },
+  ipcMain: electronMock.ipcMain
 }))
 
 // Why: the proxy focuses the guest webContents natively before Input.insertText,
@@ -28,7 +50,15 @@ describe('CdpWsProxy DOM.focus replay', () => {
   let endpoint: string
 
   beforeEach(async () => {
-    mock = createMockWebContents()
+    // Why: stand in for a mounted pane that grants every borrow, so input tests exercise
+    // the granted path instead of falling through the no-answer timeout.
+    mock = createMockWebContents({
+      onAgentInput: ({ phase, borrowId }) => {
+        if (phase === 'begin') {
+          electronMock.replyFocusBorrow(borrowId, true)
+        }
+      }
+    })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     proxy = new CdpWsProxy(mock.webContents as any)
     endpoint = await proxy.start()

--- a/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
@@ -409,4 +409,47 @@ describe('CdpWsProxy DOM.focus replay', () => {
 
     expect(getSendCommandMethods(mock)).not.toContain('Input.insertText')
   })
+
+  // Why: ending the borrow on queueing would hand focus back before Chromium
+  // processed the insert.
+  it('does not end the focus borrow before Input.insertText resolves', async () => {
+    let resolveInsert: ((value: Record<string, unknown>) => void) | undefined
+    const insertInFlight = new Promise<Record<string, unknown>>((resolve) => {
+      resolveInsert = resolve
+    })
+    mock.webContents.debugger.sendCommand.mockImplementation(async (...args: unknown[]) => {
+      const [method] = args as [string]
+      if (method === 'Input.insertText') {
+        return insertInFlight
+      }
+      return {}
+    })
+
+    const client = await connect(endpoint)
+    const pending = sendAndReceive(client, {
+      id: 40,
+      method: 'Input.insertText',
+      params: { text: 'slow insert' }
+    })
+
+    await vi.waitFor(() => {
+      expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+        'ui:browserAgentInput',
+        expect.objectContaining({ phase: 'begin' })
+      )
+    })
+    expect(mock.webContents.hostWebContents.send).not.toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'end' })
+    )
+
+    resolveInsert?.({})
+    await pending
+
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'end' })
+    )
+    client.close()
+  })
 })

--- a/src/main/browser/cdp-ws-proxy-test-harness.ts
+++ b/src/main/browser/cdp-ws-proxy-test-harness.ts
@@ -29,7 +29,7 @@ export type MockWebContents = {
     focus: Mock<() => void>
     hostWebContents: {
       isDestroyed: Mock<() => boolean>
-      send: Mock<(channel: string, phase: string) => void>
+      send: Mock<(channel: string, detail: { phase: 'begin' | 'end'; guestId: number }) => void>
     }
     printToPDF: Mock<() => Promise<Buffer>>
     reload: Mock<() => void>

--- a/src/main/browser/cdp-ws-proxy-test-harness.ts
+++ b/src/main/browser/cdp-ws-proxy-test-harness.ts
@@ -25,7 +25,12 @@ export type MockWebContents = {
   webContents: {
     debugger: MockDebugger
     isDestroyed: () => boolean
+    id: number
     focus: Mock<() => void>
+    hostWebContents: {
+      isDestroyed: Mock<() => boolean>
+      send: Mock<(channel: string, phase: string) => void>
+    }
     printToPDF: Mock<() => Promise<Buffer>>
     reload: Mock<() => void>
     reloadIgnoringCache: Mock<() => void>
@@ -71,7 +76,10 @@ export function createMockWebContents(): MockWebContents {
     webContents: {
       debugger: debuggerObj,
       isDestroyed: () => destroyed,
+      id: 1,
       focus: vi.fn(),
+      // Why: the proxy lends DOM focus to the guest by messaging its host renderer.
+      hostWebContents: { isDestroyed: vi.fn(() => false), send: vi.fn() },
       printToPDF: vi.fn(async () => Buffer.from('%PDF-test')),
       reload: vi.fn(),
       reloadIgnoringCache: vi.fn(),

--- a/src/main/browser/cdp-ws-proxy-test-harness.ts
+++ b/src/main/browser/cdp-ws-proxy-test-harness.ts
@@ -21,6 +21,12 @@ type MockDebugger = {
 // Why: annotate the return explicitly so the exported inferred type stays nameable under
 // composite declaration emit — otherwise the vi.fn() mocks leak @vitest/spy's Procedure
 // and tsgo reports TS2883.
+export type AgentInputDetail = {
+  phase: 'begin' | 'end'
+  guestId: number
+  borrowId: number
+}
+
 export type MockWebContents = {
   webContents: {
     debugger: MockDebugger
@@ -29,7 +35,7 @@ export type MockWebContents = {
     focus: Mock<() => void>
     hostWebContents: {
       isDestroyed: Mock<() => boolean>
-      send: Mock<(channel: string, detail: { phase: 'begin' | 'end'; guestId: number }) => void>
+      send: Mock<(channel: string, detail: AgentInputDetail) => void>
     }
     printToPDF: Mock<() => Promise<Buffer>>
     reload: Mock<() => void>
@@ -42,7 +48,10 @@ export type MockWebContents = {
   emit: (event: string, ...args: unknown[]) => void
 }
 
-export function createMockWebContents(): MockWebContents {
+export function createMockWebContents(options?: {
+  /** Stands in for the host renderer answering a focus borrow. */
+  onAgentInput?: (detail: AgentInputDetail) => void
+}): MockWebContents {
   const listeners = new Map<string, DebuggerListener[]>()
   let debuggerAttached = false
   let destroyed = false
@@ -79,7 +88,12 @@ export function createMockWebContents(): MockWebContents {
       id: 1,
       focus: vi.fn(),
       // Why: the proxy lends DOM focus to the guest by messaging its host renderer.
-      hostWebContents: { isDestroyed: vi.fn(() => false), send: vi.fn() },
+      hostWebContents: {
+        isDestroyed: vi.fn(() => false),
+        send: vi.fn((_channel: string, detail: AgentInputDetail) => {
+          options?.onAgentInput?.(detail)
+        })
+      },
       printToPDF: vi.fn(async () => Buffer.from('%PDF-test')),
       reload: vi.fn(),
       reloadIgnoringCache: vi.fn(),

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -11,7 +11,13 @@ import {
 } from './cdp-ws-proxy-test-harness'
 
 vi.mock('electron', () => ({
-  webContents: { fromId: vi.fn() }
+  webContents: { fromId: vi.fn() },
+  // Why: input forwarding borrows native focus and hands it back, so it asks the
+  // window layer who held focus. No window in tests means nothing to restore.
+  BrowserWindow: {
+    getFocusedWindow: vi.fn(() => null),
+    fromWebContents: vi.fn(() => null)
+  }
 }))
 
 describe('CdpWsProxy', () => {
@@ -399,7 +405,10 @@ describe('CdpWsProxy', () => {
       params: { text: 'hello' }
     })
 
-    expect(mock.webContents.focus).toHaveBeenCalledTimes(1)
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -841,4 +841,62 @@ describe('CdpWsProxy', () => {
     resolveCommand!({})
     client.close()
   })
+
+  it('announces a focus borrow around Input.dispatchKeyEvent', async () => {
+    const client = await connect(endpoint)
+
+    await sendAndReceive(client, {
+      id: 90,
+      method: 'Input.dispatchKeyEvent',
+      params: { type: 'keyDown', key: 'a' }
+    })
+
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'end' })
+    )
+    expect(getSendCommandMethods(mock)).toContain('Input.dispatchKeyEvent')
+    client.close()
+  })
+
+  it('borrows focus for a mouse press', async () => {
+    const client = await connect(endpoint)
+
+    await sendAndReceive(client, {
+      id: 91,
+      method: 'Input.dispatchMouseEvent',
+      params: { type: 'mousePressed', x: 1, y: 1 }
+    })
+
+    expect(mock.webContents.hostWebContents.send).toHaveBeenCalledWith(
+      'ui:browserAgentInput',
+      expect.objectContaining({ phase: 'begin' })
+    )
+    client.close()
+  })
+
+  // Why: only the press takes focus. Borrowing for the release would add a frame of
+  // latency to every click for nothing.
+  it('does not borrow focus for a mouse release or move', async () => {
+    const client = await connect(endpoint)
+
+    await sendAndReceive(client, {
+      id: 92,
+      method: 'Input.dispatchMouseEvent',
+      params: { type: 'mouseReleased', x: 1, y: 1 }
+    })
+    await sendAndReceive(client, {
+      id: 93,
+      method: 'Input.dispatchMouseEvent',
+      params: { type: 'mouseMoved', x: 2, y: 2 }
+    })
+
+    expect(mock.webContents.hostWebContents.send).not.toHaveBeenCalled()
+    expect(getSendCommandMethods(mock)).toContain('Input.dispatchMouseEvent')
+    client.close()
+  })
 })

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -10,6 +10,27 @@ import {
   type MockWebContents
 } from './cdp-ws-proxy-test-harness'
 
+const electronMock = vi.hoisted(() => {
+  const focusReplyListeners = new Set<(...args: unknown[]) => void>()
+  return {
+    replyFocusBorrow: (borrowId: number, focused: boolean): void => {
+      for (const listener of focusReplyListeners) {
+        listener({}, { borrowId, focused })
+      }
+    },
+    ipcMain: {
+      on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+        if (channel === 'browser:agentInputFocusReply') {
+          focusReplyListeners.add(listener)
+        }
+      }),
+      removeListener: vi.fn((_channel: string, listener: (...args: unknown[]) => void) => {
+        focusReplyListeners.delete(listener)
+      })
+    }
+  }
+})
+
 vi.mock('electron', () => ({
   webContents: { fromId: vi.fn() },
   // Why: input forwarding borrows native focus and hands it back, so it asks the
@@ -17,7 +38,8 @@ vi.mock('electron', () => ({
   BrowserWindow: {
     getFocusedWindow: vi.fn(() => null),
     fromWebContents: vi.fn(() => null)
-  }
+  },
+  ipcMain: electronMock.ipcMain
 }))
 
 describe('CdpWsProxy', () => {
@@ -26,7 +48,15 @@ describe('CdpWsProxy', () => {
   let endpoint: string
 
   beforeEach(async () => {
-    mock = createMockWebContents()
+    // Why: stand in for a mounted pane that grants every borrow, so input tests exercise
+    // the granted path instead of falling through the no-answer timeout.
+    mock = createMockWebContents({
+      onAgentInput: ({ phase, borrowId }) => {
+        if (phase === 'begin') {
+          electronMock.replyFocusBorrow(borrowId, true)
+        }
+      }
+    })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     proxy = new CdpWsProxy(mock.webContents as any)
     endpoint = await proxy.start()

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -8,9 +8,10 @@ import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 
 const LIFECYCLE_PRIMING_TIMEOUT_MS = 1_000
-// Why: the renderer answers within a frame; this only bounds the wait for a host
-// that never will, so the input falls through instead of hanging on it.
-const FOCUS_ACK_TIMEOUT_MS = 64
+// Why: a mounted pane answers within a frame, so this is slack for a busy renderer
+// rather than an expected wait — silence past it means no pane is holding the guest.
+// Generous because overrunning it fails the command; the granted path never waits.
+const FOCUS_ACK_TIMEOUT_MS = 250
 
 // Why: borrows are matched by id across every proxy instance, so the counter cannot
 // live on one of them.
@@ -556,9 +557,10 @@ export class CdpWsProxy {
         this.pendingFocusBorrows.delete(borrowId)
         resolve(focused)
       }
-      // Why: no pane hosts this guest yet, so nobody will answer. Treat silence as the
-      // pre-handoff behaviour — forward the input — rather than dropping it.
-      timer = setTimeout(() => settle(true), FOCUS_ACK_TIMEOUT_MS)
+      // Why: the host renderer took the begin, so silence means no pane holds this
+      // guest — mounting, unmounting, or swapping the guest out. None of those can be
+      // focused, and forwarding regardless is the leak this path exists to close.
+      timer = setTimeout(() => settle(false), FOCUS_ACK_TIMEOUT_MS)
       this.pendingFocusBorrows.set(borrowId, settle)
     })
   }

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -1,16 +1,20 @@
 /* eslint-disable max-lines -- Why: this proxy owns HTTP discovery, websocket client lifecycle, and CDP debugger forwarding together. */
 import { WebSocketServer, WebSocket } from 'ws'
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http'
-import type { WebContents } from 'electron'
+import { ipcMain, type WebContents } from 'electron'
 import { captureScreenshot } from './cdp-screenshot'
 import { buildPrintToPdfOptions, CdpPdfStreamStore } from './cdp-print-to-pdf'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 
 const LIFECYCLE_PRIMING_TIMEOUT_MS = 1_000
-// Why: one animation frame is enough for the renderer to move DOM focus onto the
-// guest; longer stalls every agent keystroke, shorter races the focus handoff.
-const FOCUS_HANDOFF_FRAME_MS = 16
+// Why: the renderer answers within a frame; this only bounds the wait for a host
+// that never will, so the input falls through instead of hanging on it.
+const FOCUS_ACK_TIMEOUT_MS = 64
+
+// Why: borrows are matched by id across every proxy instance, so the counter cannot
+// live on one of them.
+let nextFocusBorrowId = 0
 
 export class CdpWsProxy {
   // Why: holds each session's last DOM.focus params to replay right before the next
@@ -36,6 +40,8 @@ export class CdpWsProxy {
   private nextClientSessionOrdinal = 0
   private nextClientBrowserSessionOrdinal = 0
   private readonly pdfStreams = new CdpPdfStreamStore()
+  private readonly pendingFocusBorrows = new Map<number, (focused: boolean) => void>()
+  private focusReplyHandler: ((...args: unknown[]) => void) | null = null
 
   constructor(private readonly webContents: WebContents) {}
 
@@ -99,6 +105,13 @@ export class CdpWsProxy {
   async stop(): Promise<void> {
     this.detachDebugger()
     this.closeClient()
+    if (this.focusReplyHandler) {
+      ipcMain.removeListener('browser:agentInputFocusReply', this.focusReplyHandler)
+      this.focusReplyHandler = null
+    }
+    // Why: any borrow still in flight is settled by its own timeout, so dropping the
+    // entries here only stops late replies from resolving a stopped proxy.
+    this.pendingFocusBorrows.clear()
     if (this.wss) {
       this.wss.close()
       this.wss = null
@@ -403,7 +416,11 @@ export class CdpWsProxy {
       void this.withBorrowedFocus(
         () => this.forwardInsertText(client, clientId, msg.params ?? {}, effectiveSessionId),
         true
-      )
+      ).catch((err: Error) => {
+        // Why: forwardInsertText answers its own failures, so only a refused focus
+        // borrow reaches here — and it must still answer, or the client hangs.
+        this.sendError(clientId, err.message, client)
+      })
       return
     }
     // Why: key events need the same native focus as insertText, and mouse presses
@@ -480,19 +497,21 @@ export class CdpWsProxy {
   // Why: the guest lives inside a renderer <webview>, so only the renderer can move
   // DOM focus onto it — webContents.focus() from main does nothing here. Tell the
   // host renderer to lend focus to the guest for the input, then take it back.
-  private notifyAgentInput(phase: 'begin' | 'end'): void {
+  private notifyAgentInput(phase: 'begin' | 'end', borrowId: number): boolean {
     try {
       const host = (this.webContents as unknown as { hostWebContents?: WebContents })
         .hostWebContents
       if (host && !host.isDestroyed()) {
         // Why: the host renders every open tab's pane, so name the guest. Without it
         // a background tab would grab focus on another tab's agent input.
-        host.send('ui:browserAgentInput', { phase, guestId: this.webContents.id })
+        host.send('ui:browserAgentInput', { phase, guestId: this.webContents.id, borrowId })
+        return true
       }
     } catch {
       // Why: offscreen/headless guests have no host renderer to lend focus. The
       // handoff is a courtesy to the user's window, never a reason to drop input.
     }
+    return false
   }
 
   private async withBorrowedFocus<T>(run: () => Promise<T>, acquire: boolean): Promise<T> {
@@ -502,15 +521,60 @@ export class CdpWsProxy {
     if (!acquire) {
       return await run()
     }
-    this.notifyAgentInput('begin')
-    // Why: the renderer moves focus on its own tick; give it one frame to land before
-    // the event goes out, otherwise the input races ahead of the focus it needs.
-    await new Promise((resolve) => setTimeout(resolve, FOCUS_HANDOFF_FRAME_MS))
+    nextFocusBorrowId += 1
+    const borrowId = nextFocusBorrowId
+    // Why: register before announcing, so a reply that lands on the same tick still
+    // finds its borrow waiting.
+    const granted = this.awaitFocusGrant(borrowId)
+    if (!this.notifyAgentInput('begin', borrowId)) {
+      this.pendingFocusBorrows.get(borrowId)?.(true)
+      return await run()
+    }
     try {
+      // Why: the guest can fail to take focus while staying perfectly alive — a hidden
+      // or detached pane still answers CDP. Forwarding then puts the keystroke in
+      // whatever the user is typing into, which is the leak this whole path exists to
+      // close, so fail the command instead and let the agent see it.
+      if (!(await granted)) {
+        throw new Error('Browser tab could not take keyboard focus for agent input')
+      }
       return await run()
     } finally {
-      this.notifyAgentInput('end')
+      this.notifyAgentInput('end', borrowId)
     }
+  }
+
+  private awaitFocusGrant(borrowId: number): Promise<boolean> {
+    this.ensureFocusReplyListener()
+    return new Promise<boolean>((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | null = null
+      const settle = (focused: boolean): void => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        this.pendingFocusBorrows.delete(borrowId)
+        resolve(focused)
+      }
+      // Why: no pane hosts this guest yet, so nobody will answer. Treat silence as the
+      // pre-handoff behaviour — forward the input — rather than dropping it.
+      timer = setTimeout(() => settle(true), FOCUS_ACK_TIMEOUT_MS)
+      this.pendingFocusBorrows.set(borrowId, settle)
+    })
+  }
+
+  private ensureFocusReplyListener(): void {
+    if (this.focusReplyHandler) {
+      return
+    }
+    this.focusReplyHandler = (...args: unknown[]): void => {
+      const reply = args[1] as { borrowId?: number; focused?: boolean } | undefined
+      if (typeof reply?.borrowId !== 'number') {
+        return
+      }
+      this.pendingFocusBorrows.get(reply.borrowId)?.(reply.focused === true)
+    }
+    ipcMain.on('browser:agentInputFocusReply', this.focusReplyHandler)
   }
 
   // Why: input commands must return focus once the event has landed, so they cannot

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -8,6 +8,9 @@ import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 
 const LIFECYCLE_PRIMING_TIMEOUT_MS = 1_000
+// Why: one animation frame is enough for the renderer to move DOM focus onto the
+// guest; longer stalls every agent keystroke, shorter races the focus handoff.
+const FOCUS_HANDOFF_FRAME_MS = 16
 
 export class CdpWsProxy {
   // Why: holds each session's last DOM.focus params to replay right before the next
@@ -397,8 +400,33 @@ export class CdpWsProxy {
     // every eval steals the user's foreground window while background automation
     // is running.
     if (msg.method === 'Input.insertText' && !this.webContents.isDestroyed()) {
-      this.webContents.focus()
-      void this.forwardInsertText(client, clientId, msg.params ?? {}, effectiveSessionId)
+      void this.withBorrowedFocus(
+        () => this.forwardInsertText(client, clientId, msg.params ?? {}, effectiveSessionId),
+        true
+      )
+      return
+    }
+    // Why: key events need the same native focus as insertText, and mouse presses
+    // take it on their own. Both went out unguarded before, so agent input either
+    // leaked into the user's window or left focus parked on the browser pane.
+    if (msg.method === 'Input.dispatchKeyEvent' && !this.webContents.isDestroyed()) {
+      this.forwardInputCommand(client, clientId, msg.method, msg.params ?? {}, msg.sessionId, true)
+      return
+    }
+    if (msg.method === 'Input.dispatchMouseEvent' && !this.webContents.isDestroyed()) {
+      // Why: presses move focus onto the guest, so they need the borrow/return pair.
+      // Moves and wheels never take focus — borrowing for them would create the very
+      // focus hop this guards against.
+      const mouseEventType = (msg.params as { type?: unknown } | undefined)?.type
+      const takesFocus = mouseEventType === 'mousePressed' || mouseEventType === 'mouseReleased'
+      this.forwardInputCommand(
+        client,
+        clientId,
+        msg.method,
+        msg.params ?? {},
+        msg.sessionId,
+        takesFocus
+      )
       return
     }
     // Why: agent-browser waits for network idle to detect navigation completion.
@@ -440,6 +468,75 @@ export class CdpWsProxy {
 
   private isActiveClient(client: WebSocket): boolean {
     return this.client === client && client.readyState === WebSocket.OPEN
+  }
+
+  // Why: CDP input only reaches an Electron <webview> guest while its host window
+  // holds native keyboard focus. Without it Chromium routes the event to whichever
+  // window actually has focus — the user's — so agent keystrokes land in whatever
+  // they are typing into while the CDP call still reports success. Borrow focus for
+  // the duration of the command and hand it straight back, so background automation
+  // neither loses its input nor parks itself in the user's foreground.
+  // Why: the guest lives inside a renderer <webview>, so only the renderer can move
+  // DOM focus onto it — webContents.focus() from main does nothing here. Tell the
+  // host renderer to lend focus to the guest for the input, then take it back.
+  private notifyAgentInput(phase: 'begin' | 'end'): void {
+    try {
+      const host = (this.webContents as unknown as { hostWebContents?: WebContents })
+        .hostWebContents
+      if (host && !host.isDestroyed()) {
+        // Why: the host renders every open tab's pane, so name the guest. Without it
+        // a background tab would grab focus on another tab's agent input.
+        host.send('ui:browserAgentInput', { phase, guestId: this.webContents.id })
+      }
+    } catch {
+      // Why: offscreen/headless guests have no host renderer to lend focus. The
+      // handoff is a courtesy to the user's window, never a reason to drop input.
+    }
+  }
+
+  private async withBorrowedFocus<T>(run: () => Promise<T>, acquire: boolean): Promise<T> {
+    // Why: events that never touch focus (mouse moves, wheels) must not announce a
+    // borrow — the renderer would have nothing to give back and the pairing would
+    // only add a needless focus hop.
+    if (!acquire) {
+      return await run()
+    }
+    this.notifyAgentInput('begin')
+    // Why: the renderer moves focus on its own tick; give it one frame to land before
+    // the event goes out, otherwise the input races ahead of the focus it needs.
+    await new Promise((resolve) => setTimeout(resolve, FOCUS_HANDOFF_FRAME_MS))
+    try {
+      return await run()
+    } finally {
+      this.notifyAgentInput('end')
+    }
+  }
+
+  // Why: input commands must return focus once the event has landed, so they cannot
+  // reuse forwardCommand's fire-and-forget dispatch.
+  private forwardInputCommand(
+    client: WebSocket,
+    clientId: number,
+    method: string,
+    params: Record<string, unknown>,
+    msgSessionId: string | undefined,
+    acquireFocus: boolean
+  ): void {
+    if (this.webContents.isDestroyed()) {
+      this.sendError(clientId, 'Browser tab is no longer available', client)
+      return
+    }
+    const sessionId = this.resolveDebuggerSessionId(msgSessionId)
+    void this.withBorrowedFocus(
+      () => this.sendDebuggerCommand(method, params, sessionId),
+      acquireFocus
+    )
+      .then((result) => {
+        this.sendResult(clientId, result, client)
+      })
+      .catch((err: Error) => {
+        this.sendError(clientId, err.message, client)
+      })
   }
 
   private sendDebuggerCommand(

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -721,7 +721,18 @@ export class CdpWsProxy {
         return
       }
     }
-    this.forwardCommand(client, clientId, 'Input.insertText', params, effectiveSessionId)
+    // Why: forwardCommand only queues, so the focus borrow would end before Chromium
+    // processed the insert and the text would land in the user's window instead.
+    if (this.webContents.isDestroyed()) {
+      this.sendError(clientId, 'Browser tab is no longer available', client)
+      return
+    }
+    try {
+      const result = await this.sendDebuggerCommand('Input.insertText', params, effectiveSessionId)
+      this.sendResult(clientId, result, client)
+    } catch (err) {
+      this.sendError(clientId, err instanceof Error ? err.message : String(err), client)
+    }
   }
 
   private async handlePrintToPdf(

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -414,11 +414,12 @@ export class CdpWsProxy {
       return
     }
     if (msg.method === 'Input.dispatchMouseEvent' && !this.webContents.isDestroyed()) {
-      // Why: presses move focus onto the guest, so they need the borrow/return pair.
-      // Moves and wheels never take focus — borrowing for them would create the very
-      // focus hop this guards against.
+      // Why: only the press moves focus onto the guest, so only it needs the
+      // borrow/return pair. Releases, moves and wheels never take focus — borrowing
+      // for them would add a frame of latency to every click and, worse, create the
+      // very focus hop this guards against.
       const mouseEventType = (msg.params as { type?: unknown } | undefined)?.type
-      const takesFocus = mouseEventType === 'mousePressed' || mouseEventType === 'mouseReleased'
+      const takesFocus = mouseEventType === 'mousePressed'
       this.forwardInputCommand(
         client,
         clientId,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3206,6 +3206,9 @@ export type PreloadApi = {
     replyTabClose: (reply: { requestId: string; error?: string }) => void
     onNewTerminalTab: (callback: () => void) => () => void
     onFocusBrowserAddressBar: (callback: () => void) => () => void
+    onBrowserAgentInput: (
+      callback: (detail: { phase: 'begin' | 'end'; guestId: number }) => void
+    ) => () => void
     onFindInBrowserPage: (source: BrowserFindSource, callback: () => void) => () => void
     onReloadBrowserPage: (callback: () => void) => () => void
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3207,8 +3207,9 @@ export type PreloadApi = {
     onNewTerminalTab: (callback: () => void) => () => void
     onFocusBrowserAddressBar: (callback: () => void) => () => void
     onBrowserAgentInput: (
-      callback: (detail: { phase: 'begin' | 'end'; guestId: number }) => void
+      callback: (detail: { phase: 'begin' | 'end'; guestId: number; borrowId: number }) => void
     ) => () => void
+    replyBrowserAgentInputFocus: (reply: { borrowId: number; focused: boolean }) => void
     onFindInBrowserPage: (source: BrowserFindSource, callback: () => void) => () => void
     onReloadBrowserPage: (callback: () => void) => () => void
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3667,14 +3667,17 @@ const api = {
       return () => ipcRenderer.removeListener('ui:focusBrowserAddressBar', listener)
     },
     onBrowserAgentInput: (
-      callback: (detail: { phase: 'begin' | 'end'; guestId: number }) => void
+      callback: (detail: { phase: 'begin' | 'end'; guestId: number; borrowId: number }) => void
     ): (() => void) => {
       const listener = (
         _event: Electron.IpcRendererEvent,
-        detail: { phase: 'begin' | 'end'; guestId: number }
+        detail: { phase: 'begin' | 'end'; guestId: number; borrowId: number }
       ): void => callback(detail)
       ipcRenderer.on('ui:browserAgentInput', listener)
       return () => ipcRenderer.removeListener('ui:browserAgentInput', listener)
+    },
+    replyBrowserAgentInputFocus: (reply: { borrowId: number; focused: boolean }): void => {
+      ipcRenderer.send('browser:agentInputFocusReply', reply)
     },
     onFindInBrowserPage: browserFindSubscriptions.subscribe,
     onReloadBrowserPage: (callback: () => void): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3666,6 +3666,16 @@ const api = {
       ipcRenderer.on('ui:focusBrowserAddressBar', listener)
       return () => ipcRenderer.removeListener('ui:focusBrowserAddressBar', listener)
     },
+    onBrowserAgentInput: (
+      callback: (detail: { phase: 'begin' | 'end'; guestId: number }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        detail: { phase: 'begin' | 'end'; guestId: number }
+      ): void => callback(detail)
+      ipcRenderer.on('ui:browserAgentInput', listener)
+      return () => ipcRenderer.removeListener('ui:browserAgentInput', listener)
+    },
     onFindInBrowserPage: browserFindSubscriptions.subscribe,
     onReloadBrowserPage: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -3225,12 +3225,10 @@ function BrowserPagePane({
         // strand focus on the browser pane once the agent is done.
         return active && active !== webviewRef.current ? active : null
       },
-      focusGuest: () => {
-        focusWebviewNow()
-      },
+      focusGuest: () => focusWebviewNow(),
       restore: (owner) => owner?.focus?.()
     })
-    return window.api.ui.onBrowserAgentInput(({ phase, guestId }) => {
+    return window.api.ui.onBrowserAgentInput(({ phase, guestId, borrowId }) => {
       const webview = webviewRef.current
       if (!webview) {
         return
@@ -3246,7 +3244,13 @@ function BrowserPagePane({
       if (ownGuestId !== guestId) {
         return
       }
-      borrow(phase)
+      const focused = borrow(phase)
+      if (phase === 'begin') {
+        // Why: main holds the input until it knows focus landed. A pane that stayed
+        // silent here — hidden, detached, or hosting another guest — leaves main to
+        // time out and forward anyway, which is the pre-handoff behaviour.
+        window.api.ui.replyBrowserAgentInputFocus({ borrowId, focused })
+      }
     })
   }, [focusWebviewNow])
 

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -3210,6 +3210,43 @@ function BrowserPagePane({
       window.removeEventListener(ORCA_BROWSER_FOCUS_REQUEST_EVENT, handleBrowserFocusRequest)
   }, [browserTab.id, focusAddressBarNow, focusWebviewNow, isActive])
 
+  // Why: agent CDP input only reaches the guest while it holds DOM focus, but taking
+  // focus outright hijacks whatever the user is typing into — and skipping it lets the
+  // keystrokes land in their terminal instead. Lend focus for the input, hand it back.
+  // Why: deliberately not gated on isActive — the whole point is that agents drive
+  // background tabs while the user works elsewhere, which is exactly when the
+  // keystrokes used to leak into their terminal.
+  useEffect(() => {
+    let borrowedFrom: HTMLElement | null = null
+    return window.api.ui.onBrowserAgentInput(({ phase, guestId }) => {
+      const webview = webviewRef.current
+      if (!webview) {
+        return
+      }
+      // Why: every pane hears this, so only the one hosting the addressed guest may
+      // act; getWebContentsId() throws until the guest attaches.
+      let ownGuestId: number | null = null
+      try {
+        ownGuestId = webview.getWebContentsId()
+      } catch {
+        return
+      }
+      if (ownGuestId !== guestId) {
+        return
+      }
+      if (phase === 'begin') {
+        const active = document.activeElement as HTMLElement | null
+        // Why: only remember a real prior owner. Recording the guest itself would
+        // strand focus on the browser pane once the agent is done.
+        borrowedFrom = active && active !== webview ? active : null
+        focusWebviewNow()
+        return
+      }
+      borrowedFrom?.focus?.()
+      borrowedFrom = null
+    })
+  }, [focusWebviewNow])
+
   // Cmd/Ctrl+F — find in page (renderer path: focus on browser chrome)
   // Why: unlike bare C/S grab shortcuts, Cmd+F should always open find even from the address bar (matches Chrome/Safari).
   useEffect(() => {

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -141,6 +141,7 @@ import {
 } from './remote-browser-keyboard'
 import {
   consumeBrowserFocusRequest,
+  createAgentInputFocusBorrow,
   ORCA_BROWSER_FOCUS_REQUEST_EVENT,
   type BrowserFocusRequestDetail
 } from './browser-focus'
@@ -3217,7 +3218,18 @@ function BrowserPagePane({
   // background tabs while the user works elsewhere, which is exactly when the
   // keystrokes used to leak into their terminal.
   useEffect(() => {
-    let borrowedFrom: HTMLElement | null = null
+    const borrow = createAgentInputFocusBorrow<HTMLElement>({
+      captureOwner: () => {
+        const active = document.activeElement as HTMLElement | null
+        // Why: only remember a real prior owner. Recording the guest itself would
+        // strand focus on the browser pane once the agent is done.
+        return active && active !== webviewRef.current ? active : null
+      },
+      focusGuest: () => {
+        focusWebviewNow()
+      },
+      restore: (owner) => owner?.focus?.()
+    })
     return window.api.ui.onBrowserAgentInput(({ phase, guestId }) => {
       const webview = webviewRef.current
       if (!webview) {
@@ -3234,16 +3246,7 @@ function BrowserPagePane({
       if (ownGuestId !== guestId) {
         return
       }
-      if (phase === 'begin') {
-        const active = document.activeElement as HTMLElement | null
-        // Why: only remember a real prior owner. Recording the guest itself would
-        // strand focus on the browser pane once the agent is done.
-        borrowedFrom = active && active !== webview ? active : null
-        focusWebviewNow()
-        return
-      }
-      borrowedFrom?.focus?.()
-      borrowedFrom = null
+      borrow(phase)
     })
   }, [focusWebviewNow])
 

--- a/src/renderer/src/components/browser-pane/browser-focus.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-focus.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   consumeBrowserFocusRequest,
+  createAgentInputFocusBorrow,
   ORCA_BROWSER_FOCUS_REQUEST_EVENT,
   queueBrowserFocusRequest,
   requestBrowserFocus
@@ -53,5 +54,70 @@ describe('browser-focus', () => {
     vi.advanceTimersByTime(30_000)
 
     expect(consumeBrowserFocusRequest('page-stale')).toBeNull()
+  })
+})
+
+describe('createAgentInputFocusBorrow', () => {
+  function makeBorrow() {
+    const owner = { id: 'terminal-input' }
+    const calls: string[] = []
+    let captured = 0
+    const borrow = createAgentInputFocusBorrow<typeof owner>({
+      captureOwner: () => {
+        captured += 1
+        // Why: mirrors the pane — once the guest holds focus there is no prior owner
+        // left to capture, so a nested begin would record null.
+        return captured === 1 ? owner : null
+      },
+      focusGuest: () => calls.push('focus-guest'),
+      restore: (o) => calls.push(`restore:${o ? o.id : 'null'}`)
+    })
+    return { borrow, calls }
+  }
+
+  it('returns focus to the original owner for a single borrow', () => {
+    const { borrow, calls } = makeBorrow()
+
+    borrow('begin')
+    borrow('end')
+
+    expect(calls).toEqual(['focus-guest', 'restore:terminal-input'])
+  })
+
+  it('restores the outermost owner when borrows nest', () => {
+    const { borrow, calls } = makeBorrow()
+
+    // A single typed character: keyDown/char/keyUp each announce their own pair.
+    borrow('begin')
+    borrow('begin')
+    borrow('begin')
+    borrow('end')
+    borrow('end')
+    borrow('end')
+
+    expect(calls.filter((c) => c.startsWith('restore'))).toEqual(['restore:terminal-input'])
+  })
+
+  it('does not restore while an inner borrow is still open', () => {
+    const { borrow, calls } = makeBorrow()
+
+    borrow('begin')
+    borrow('begin')
+    borrow('end')
+
+    expect(calls.some((c) => c.startsWith('restore'))).toBe(false)
+  })
+
+  it('ignores an unmatched end so the next borrow still restores', () => {
+    const { borrow, calls } = makeBorrow()
+
+    // A command already in flight when the listener mounted.
+    borrow('end')
+    calls.length = 0
+
+    borrow('begin')
+    borrow('end')
+
+    expect(calls).toEqual(['focus-guest', 'restore:terminal-input'])
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-focus.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-focus.test.ts
@@ -58,7 +58,7 @@ describe('browser-focus', () => {
 })
 
 describe('createAgentInputFocusBorrow', () => {
-  function makeBorrow() {
+  function makeBorrow(focusSucceeds = true) {
     const owner = { id: 'terminal-input' }
     const calls: string[] = []
     let captured = 0
@@ -69,7 +69,10 @@ describe('createAgentInputFocusBorrow', () => {
         // left to capture, so a nested begin would record null.
         return captured === 1 ? owner : null
       },
-      focusGuest: () => calls.push('focus-guest'),
+      focusGuest: () => {
+        calls.push('focus-guest')
+        return focusSucceeds
+      },
       restore: (o) => calls.push(`restore:${o ? o.id : 'null'}`)
     })
     return { borrow, calls }
@@ -119,5 +122,26 @@ describe('createAgentInputFocusBorrow', () => {
     borrow('end')
 
     expect(calls).toEqual(['focus-guest', 'restore:terminal-input'])
+  })
+
+  // Why: main forwards the input only once the pane confirms the guest took focus.
+  it('reports whether the guest actually took focus', () => {
+    expect(makeBorrow(true).borrow('begin')).toBe(true)
+    expect(makeBorrow(false).borrow('begin')).toBe(false)
+  })
+
+  it('still unwinds a borrow whose focus failed', () => {
+    const { borrow, calls } = makeBorrow(false)
+
+    borrow('begin')
+    borrow('end')
+    calls.length = 0
+
+    // Why: a failed begin that skipped the count would strand the depth above zero and
+    // swallow every later restore.
+    borrow('begin')
+    borrow('end')
+
+    expect(calls).toEqual(['focus-guest', 'restore:null'])
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-focus.ts
+++ b/src/renderer/src/components/browser-pane/browser-focus.ts
@@ -86,7 +86,8 @@ export type AgentInputBorrowPhase = 'begin' | 'end'
 export type AgentInputFocusBorrowHandlers<T> = {
   /** The element focus should return to, or null when the guest already owns it. */
   captureOwner: () => T | null
-  focusGuest: () => void
+  /** Whether the guest actually ended up holding focus. */
+  focusGuest: () => boolean
   restore: (owner: T | null) => void
 }
 
@@ -98,10 +99,12 @@ export type AgentInputFocusBorrowHandlers<T> = {
  * owner on every begin would overwrite it with null the second time around (the
  * guest already holds focus by then) and focus would never return to the user.
  * Only the outermost begin captures, and only the outermost end restores.
+ *
+ * Returns whether the guest holds focus, which only a 'begin' can answer for.
  */
 export function createAgentInputFocusBorrow<T>(
   handlers: AgentInputFocusBorrowHandlers<T>
-): (phase: AgentInputBorrowPhase) => void {
+): (phase: AgentInputBorrowPhase) => boolean {
   let owner: T | null = null
   let depth = 0
   return (phase) => {
@@ -109,18 +112,20 @@ export function createAgentInputFocusBorrow<T>(
       if (depth === 0) {
         owner = handlers.captureOwner()
       }
+      // Why: count the borrow even when focus fails, so the matching 'end' still
+      // unwinds it instead of leaving the depth stuck above zero forever.
       depth += 1
-      handlers.focusGuest()
-      return
+      return handlers.focusGuest()
     }
     // Why: an 'end' with no matching 'begin' (a command already in flight when this
     // listener mounted) must not drive the counter negative and swallow the next
     // real restore.
     depth = Math.max(0, depth - 1)
     if (depth > 0) {
-      return
+      return true
     }
     handlers.restore(owner)
     owner = null
+    return true
   }
 }

--- a/src/renderer/src/components/browser-pane/browser-focus.ts
+++ b/src/renderer/src/components/browser-pane/browser-focus.ts
@@ -80,3 +80,47 @@ export function consumeBrowserFocusRequest(pageId: string): BrowserFocusTarget |
   clearExpiredRequestCleanupTimerIfIdle()
   return pending.target
 }
+
+export type AgentInputBorrowPhase = 'begin' | 'end'
+
+export type AgentInputFocusBorrowHandlers<T> = {
+  /** The element focus should return to, or null when the guest already owns it. */
+  captureOwner: () => T | null
+  focusGuest: () => void
+  restore: (owner: T | null) => void
+}
+
+/**
+ * Tracks the nesting of agent input focus borrows.
+ *
+ * Why: one agent action nests borrows — typing a single character sends
+ * keyDown/char/keyUp, and each announces its own begin/end pair. Recording the
+ * owner on every begin would overwrite it with null the second time around (the
+ * guest already holds focus by then) and focus would never return to the user.
+ * Only the outermost begin captures, and only the outermost end restores.
+ */
+export function createAgentInputFocusBorrow<T>(
+  handlers: AgentInputFocusBorrowHandlers<T>
+): (phase: AgentInputBorrowPhase) => void {
+  let owner: T | null = null
+  let depth = 0
+  return (phase) => {
+    if (phase === 'begin') {
+      if (depth === 0) {
+        owner = handlers.captureOwner()
+      }
+      depth += 1
+      handlers.focusGuest()
+      return
+    }
+    // Why: an 'end' with no matching 'begin' (a command already in flight when this
+    // listener mounted) must not drive the counter negative and swallow the next
+    // real restore.
+    depth = Math.max(0, depth - 1)
+    if (depth > 0) {
+      return
+    }
+    handlers.restore(owner)
+    owner = null
+  }
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2723,6 +2723,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     // Why: the web client streams a remote viewport instead of hosting a <webview>,
     // so there is no local guest to lend DOM focus to.
     onBrowserAgentInput: () => noopUnsubscribe,
+    replyBrowserAgentInputFocus: () => {},
     onFindInBrowserPage: () => noopUnsubscribe,
     onReloadBrowserPage: () => noopUnsubscribe,
     onBrowserHistoryNavigate: () => noopUnsubscribe,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2720,6 +2720,9 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     replyTabClose: () => {},
     onNewTerminalTab: () => noopUnsubscribe,
     onFocusBrowserAddressBar: () => noopUnsubscribe,
+    // Why: the web client streams a remote viewport instead of hosting a <webview>,
+    // so there is no local guest to lend DOM focus to.
+    onBrowserAgentInput: () => noopUnsubscribe,
     onFindInBrowserPage: () => noopUnsubscribe,
     onReloadBrowserPage: () => noopUnsubscribe,
     onBrowserHistoryNavigate: () => noopUnsubscribe,


### PR DESCRIPTION
## The problem

While an agent drives the built-in browser, its keystrokes land in whatever the user is typing into.

CDP input only reaches an Electron `<webview>` guest while that guest holds native DOM focus. Without it Chromium routes the event to whichever surface actually has focus — the user's terminal — and the CDP call still resolves `ok`, so the agent never learns its input went somewhere else. It retries, and the user's prompt fills with fragments of the agent's typing.

The same root cause shows up as focus theft: `mousePressed` moves focus onto the guest and nothing gives it back, so the user's cursor silently jumps out of the terminal they were working in.

## Why main can't fix it

`webContents.focus()` is a no-op for a `<webview>` guest — the guest is a DOM element owned by the host renderer, so only the renderer can focus it. Confirmed by measurement: text reached the page only when a human physically clicked into it. `Page.bringToFront`, `tab switch --focus`, and bringing the app to the foreground all failed to make input land.

## The fix

Route the focus handoff through the host renderer.

```
main (cdp-ws-proxy)                renderer (BrowserPane)
──────────────────────────────────────────────────────────
input command detected
  → 'begin' + guestId ───────────→ save document.activeElement
                                    focusWebviewNow()
  ← granted / refused ───────────  did the guest actually take focus?
  forward CDP input ─────────────→ guest holds focus → input lands
  → 'end' ───────────────────────→ restore the saved element
```

Main cannot see whether the guest took focus — only the pane hosting it can — so the pane answers the borrow and main acts on the answer:

- **granted** → forward the input.
- **refused** → fail the command. A guest can refuse focus while staying perfectly alive: a hidden or detached pane still answers CDP, so forwarding would put the keystroke back in whatever the user is typing into. Failing is what lets the agent learn its input did not land, instead of getting the `ok` that hid this bug in the first place.
- **silence** → fail it too. The host renderer accepted the announcement, so no answer means no pane is holding this guest — it is mounting, unmounting, or being swapped out — and none of those can take focus. The wait is bounded at 250 ms, which is slack for a busy renderer rather than an expected pause; a mounted pane answers immediately and never reaches it.

Only a guest with **no host renderer at all** — offscreen, headless — skips the borrow and forwards straight through, exactly as it did before this handoff existed.

Scope is deliberately narrow:

- `Input.insertText` / `Input.dispatchKeyEvent` always borrow — key events reach nothing without focus.
- `Input.dispatchMouseEvent` borrows only for `mousePressed`. Moves, wheels and releases never take focus, so borrowing for them would create the very focus hop this prevents.
- `Runtime.evaluate`, screenshots, and read-only traffic are untouched.

The renderer listener is intentionally **not** gated on the pane being active. Agents drive background tabs while the user works elsewhere — that is exactly when the leak happened. Panes filter by guest `webContents` id so only the addressed one reacts.

Also included: `orca tab create` never sent `activate`, even though `TabCreate` documents *"User-initiated opens focus the tab; agent/automation opens stay background."* Every agent-created tab surfaced the browser pane and took focus. It now mirrors `tab switch` — `--focus` is opt-in.

## How this was verified

Measured per command by focusing a probe input in the page, firing the command, then reading the field back. A command is "leaking" when the field stays empty and the text appears in the user's terminal instead.

| Command | Before | After |
|---|---|---|
| `inserttext` / `type` / `keypress` | leaked into the user's terminal | lands in the page |
| `mouse down` / `up`, `click` | stole focus, never returned | focus returns to the user |
| `tab create` | surfaced the pane, took focus | stays in the background |
| `eval`, `screenshot`, `mouse move` | already fine | unchanged |
| `snapshot`, `set device`, `goto`, `tab switch`, `tab close` | already fine | unchanged |

Every command an agent session had actually issued was measured, not just the suspected ones — the innocent ones were confirmed innocent so the fix could stay minimal.

Reproduced in the failing configuration — browser as a **background** tab while the user typed in a floating terminal — before and after. Focus stayed with the user and the input reached the page.

The refused-focus case is covered by tests rather than by hand: it needs a guest that stays alive while its pane cannot hold focus, which the suites drive directly through the borrow reply.

## No visual change

This changes focus behavior only. No UI is added, removed, or restyled, so there are no screenshots to attach.

## Tests

`cdp-ws-proxy` suites updated and extended: the mock now carries a host renderer that answers borrows the way a mounted pane does, and the input paths assert the borrow is announced (`ui:browserAgentInput` / `begin`) instead of the old native `webContents.focus()`.

`cdp-ws-proxy-focus-borrow.test.ts` covers what main does with each answer — forwards on a grant, fails the command on a refusal (key events and `Input.insertText` both), fails on silence, and skips the ask entirely when the guest has no host renderer. `browser-focus.test.ts` covers the pane side: a failed focus is reported as such, and still unwinds its borrow so later restores are not swallowed.

980 tests pass across `src/main/browser`, `src/renderer/src/components/browser-pane` and `src/cli/browser.test.ts`, on top of the current `main`.

## Code review summary

- **Cross-platform** — No platform branches. `hostWebContents`, `send`, and DOM focus are Electron/DOM APIs available on macOS, Linux, and Windows. Verified on macOS; the logic contains nothing OS-specific.
- **SSH / remote / local** — Remote panes stream a viewport instead of hosting a local `<webview>`, so they never take this path; the web preload API gets a no-op stub for both directions. Offscreen/headless guests have no host renderer, so they skip the borrow entirely rather than waiting on an answer that cannot come.
- **Agents / integrations** — Only the agent-browser CDP path is affected. No agent, git provider, or integration-specific behavior is touched.
- **Performance** — Input now waits for the pane's answer instead of a fixed frame, so the common path got *faster*: the old 16 ms per key event and per mouse press is gone. A guest whose pane never answers pays the 250 ms bound before failing, and one with no host renderer pays nothing. Wait-polling and read-only probes (`Runtime.evaluate`, screenshots, mouse moves) are untouched.
- **UI quality** — No visual change. Focus visibly returns to where the user left it rather than parking on the browser pane.
- **Security** — The IPC carries a phase string, a numeric guest id and a numeric borrow id outbound, and a borrow id plus a boolean inbound. No new privilege, no page content, no user data crosses the boundary.

## Testing notes

- Verified on macOS with a local worktree and the desktop `<webview>` path.
- Remote/SSH and headless paths are covered by construction (stub + skipped borrow) but were not exercised on real remote hosts.
- Rebased onto current `main` (`54a9b58`). `browser-pane/` was refactored substantially in the meantime; there were no textual conflicts and the suites above pass on top of it.

---

X: [@songminsns63384](https://x.com/songminsns63384)

