### PR TITLE
perf(mobile): avoid unchanged worktree catalog payloads

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -94,6 +94,7 @@ import {
 import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sections'
 import { getMobileWorkspaceLineageGroupKey } from '../../../src/worktree/mobile-workspace-lineage'
 import { areWorktreeListsEqual } from '../../../src/worktree/worktree-list-snapshot'
+import { WorktreeCatalogSnapshotClient } from '../../../src/worktree/worktree-catalog-snapshot-client'
 import { repoColor } from '../../../src/worktree/repo-color'
 import {
   WORKSPACE_GROUP_OPTIONS as GROUP_OPTIONS,
@@ -141,6 +142,7 @@ export function HostScreen({
   const lastConnectedAt = useLastConnectedAt(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
+  const worktreeCatalog = useMemo(() => new WorktreeCatalogSnapshotClient(), [])
   const fetchRepoMetadataInFlightRef = useRef(new WeakSet<RpcClient>())
   const fetchRepoMetadataPendingRef = useRef(new WeakSet<RpcClient>())
   const repoMetadataFetchedAtRef = useRef(0)
@@ -423,27 +425,28 @@ export function HostScreen({
       const requestHostId = hostId
 
       try {
-        // Why: worktree.ps silently truncates at 200; use a high cap so large hosts don't drop workspaces.
-        const response = await requestClient.sendRequest('worktree.ps', { limit: 10000 })
+        const pendingCatalog = await worktreeCatalog.fetch(requestClient, requestHostId)
         if (clientRef.current !== requestClient || hostId !== requestHostId) {
           return
         }
         if (!options.allowDuringModal && newWorktreeModalVisibleRef.current) {
           return
         }
-        if (response.ok) {
-          const result = (response as RpcSuccess).result as { worktrees: Worktree[] }
-          // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
-          setWorktrees((current) =>
-            areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
-          )
-          setLastKnownWorktrees((current) =>
-            areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
-          )
-          setWorktreesLoaded(true)
-          // Why (#8498): overwrite the home-written cache with the confirmed snapshot so a reconnect/remount can't serve a stale list.
-          if (hostId) {
-            setCachedWorktrees(hostId, result.worktrees)
+        const result = worktreeCatalog.admit(pendingCatalog)
+        if (result) {
+          if (result.changed) {
+            // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
+            setWorktrees((current) =>
+              areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
+            )
+            setLastKnownWorktrees((current) =>
+              areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
+            )
+            setWorktreesLoaded(true)
+            // Why (#8498): overwrite the home-written cache with the confirmed snapshot so a reconnect/remount can't serve a stale list.
+            if (hostId) {
+              setCachedWorktrees(hostId, result.worktrees)
+            }
           }
           // Drop the optimistic active override once the host reports it active, so later desktop changes win.
           setOptimisticActiveWorktreeId((pending) =>
@@ -487,7 +490,7 @@ export function HostScreen({
         fetchWorktreesInFlightRef.current = false
       }
     },
-    [client, connState, hostId]
+    [client, connState, hostId, worktreeCatalog]
   )
 
   useFocusEffect(

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -142,7 +142,9 @@ export function HostScreen({
   const lastConnectedAt = useLastConnectedAt(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
-  const worktreeCatalog = useMemo(() => new WorktreeCatalogSnapshotClient(), [])
+  // Why: useRef, not useMemo — React may discard memoized values, which would silently
+  // reset the snapshot token this object exists to own.
+  const worktreeCatalogRef = useRef(new WorktreeCatalogSnapshotClient())
   const fetchRepoMetadataInFlightRef = useRef(new WeakSet<RpcClient>())
   const fetchRepoMetadataPendingRef = useRef(new WeakSet<RpcClient>())
   const repoMetadataFetchedAtRef = useRef(0)
@@ -425,32 +427,32 @@ export function HostScreen({
       const requestHostId = hostId
 
       try {
-        const pendingCatalog = await worktreeCatalog.fetch(requestClient, requestHostId)
+        const pendingCatalog = await worktreeCatalogRef.current.fetch(requestClient, requestHostId)
         if (clientRef.current !== requestClient || hostId !== requestHostId) {
           return
         }
         if (!options.allowDuringModal && newWorktreeModalVisibleRef.current) {
           return
         }
-        const result = worktreeCatalog.admit(pendingCatalog)
-        if (result) {
-          if (result.changed) {
-            // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
-            setWorktrees((current) =>
-              areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
-            )
-            setLastKnownWorktrees((current) =>
-              areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
-            )
-            setWorktreesLoaded(true)
-            // Why (#8498): overwrite the home-written cache with the confirmed snapshot so a reconnect/remount can't serve a stale list.
-            if (hostId) {
-              setCachedWorktrees(hostId, result.worktrees)
-            }
+        // Why: unchanged responses still yield the confirmed rows, so every poll reasserts
+        // host truth over optimistic local edits regardless of payload size.
+        const confirmed = worktreeCatalogRef.current.admit(pendingCatalog)
+        if (confirmed) {
+          // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
+          setWorktrees((current) =>
+            areWorktreeListsEqual(current, confirmed) ? current : confirmed
+          )
+          setLastKnownWorktrees((current) =>
+            areWorktreeListsEqual(current, confirmed) ? current : confirmed
+          )
+          setWorktreesLoaded(true)
+          // Why (#8498): overwrite the home-written cache with the confirmed snapshot so a reconnect/remount can't serve a stale list.
+          if (hostId) {
+            setCachedWorktrees(hostId, confirmed)
           }
           // Drop the optimistic active override once the host reports it active, so later desktop changes win.
           setOptimisticActiveWorktreeId((pending) =>
-            pending && result.worktrees.some((w) => w.worktreeId === pending && w.isActive)
+            pending && confirmed.some((w) => w.worktreeId === pending && w.isActive)
               ? null
               : pending
           )
@@ -462,7 +464,7 @@ export function HostScreen({
             }
             const still = new Set<string>()
             for (const id of prev) {
-              const wt = result.worktrees.find((w) => w.worktreeId === id)
+              const wt = confirmed.find((w) => w.worktreeId === id)
               if (wt && wt.liveTerminalCount > 0) {
                 still.add(id)
               }
@@ -471,9 +473,7 @@ export function HostScreen({
           })
 
           // Sync pin state from server so desktop-initiated pins reflect without relying on stale AsyncStorage.
-          const serverPinned = new Set(
-            result.worktrees.filter((w) => w.isPinned).map((w) => w.worktreeId)
-          )
+          const serverPinned = new Set(confirmed.filter((w) => w.isPinned).map((w) => w.worktreeId))
           setPinnedIds((prev) => {
             if (serverPinned.size === prev.size && [...serverPinned].every((id) => prev.has(id))) {
               return prev
@@ -490,7 +490,7 @@ export function HostScreen({
         fetchWorktreesInFlightRef.current = false
       }
     },
-    [client, connState, hostId, worktreeCatalog]
+    [client, connState, hostId]
   )
 
   useFocusEffect(

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -29,6 +29,7 @@ import { loadHosts } from '../src/transport/host-store'
 import { navigateToMobileHostEdit } from '../src/transport/host-edit-navigation'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
 import { pickResumeWorktree } from '../src/worktree/resume-worktree'
+import { WORKTREE_PS_FULL_LIMIT } from '../src/worktree/worktree-catalog-snapshot-client'
 import type { RpcClient } from '../src/transport/rpc-client'
 import { sendSingleFlightRequest } from '../src/transport/request-single-flight'
 import {
@@ -185,8 +186,7 @@ function fetchWorktreeInfo(
     })
   }
 
-  // Why: worktree.ps defaults to 200 and silently truncates; request all so counts are accurate.
-  sendSingleFlightRequest(client, hostId, 'worktree.ps', { limit: 10000 })
+  sendSingleFlightRequest(client, hostId, 'worktree.ps', { limit: WORKTREE_PS_FULL_LIMIT })
     .then((response) => {
       if (disposed()) {
         return

--- a/mobile/src/worktree/worktree-catalog-snapshot-client.test.ts
+++ b/mobile/src/worktree/worktree-catalog-snapshot-client.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import {
+  admitWorktreeCatalogResponse,
+  WorktreeCatalogSnapshotClient
+} from './worktree-catalog-snapshot-client'
+
+describe('admitWorktreeCatalogResponse', () => {
+  it('accepts new-host full and unchanged responses', () => {
+    const full = admitWorktreeCatalogResponse(
+      { worktrees: [{ id: 'worktree-1' }], snapshotId: 'snapshot-1' },
+      null
+    )
+    const unchanged = admitWorktreeCatalogResponse(
+      { unchanged: true, snapshotId: 'snapshot-1' },
+      'snapshot-1'
+    )
+
+    expect(full).toEqual({
+      kind: 'full',
+      snapshotId: 'snapshot-1',
+      worktrees: [{ id: 'worktree-1' }]
+    })
+    expect(unchanged).toEqual({ kind: 'unchanged', snapshotId: 'snapshot-1' })
+  })
+
+  it('treats an old-host full response as authoritative and clears the token', () => {
+    expect(
+      admitWorktreeCatalogResponse({ worktrees: [{ id: 'worktree-1' }] }, 'stale-token')
+    ).toEqual({
+      kind: 'full',
+      snapshotId: null,
+      worktrees: [{ id: 'worktree-1' }]
+    })
+  })
+
+  it('rejects unchanged responses for a snapshot the client does not own', () => {
+    expect(
+      admitWorktreeCatalogResponse({ unchanged: true, snapshotId: 'snapshot-2' }, 'snapshot-1')
+    ).toEqual({ kind: 'invalid' })
+    expect(admitWorktreeCatalogResponse({ unchanged: true }, 'snapshot-1')).toEqual({
+      kind: 'invalid'
+    })
+  })
+
+  it('rejects malformed success payloads', () => {
+    expect(admitWorktreeCatalogResponse(null, 'snapshot-1')).toEqual({ kind: 'invalid' })
+    expect(
+      admitWorktreeCatalogResponse({ unchanged: false, snapshotId: 'snapshot-1' }, 'snapshot-1')
+    ).toEqual({ kind: 'invalid' })
+    expect(
+      admitWorktreeCatalogResponse({ worktrees: [], snapshotId: 'x'.repeat(129) }, null)
+    ).toEqual({ kind: 'full', snapshotId: null, worktrees: [] })
+  })
+})
+
+function clientWithResults(...results: unknown[]): RpcClient {
+  return {
+    sendRequest: vi.fn(
+      async () =>
+        ({
+          id: 'request',
+          ok: true,
+          result: results.shift(),
+          _meta: { runtimeId: 'runtime' }
+        }) as const
+    )
+  } as unknown as RpcClient
+}
+
+describe('WorktreeCatalogSnapshotClient', () => {
+  it('retains confirmed rows while admitting unchanged responses', async () => {
+    const client = clientWithResults(
+      { worktrees: [{ worktreeId: 'worktree-1' }], snapshotId: 'snapshot-1' },
+      { unchanged: true, snapshotId: 'snapshot-1' }
+    )
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    const first = snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    const second = snapshots.admit(await snapshots.fetch(client, 'host-1'))
+
+    expect(first).toMatchObject({ changed: true })
+    expect(second).toEqual({ changed: false, worktrees: first?.worktrees })
+  })
+
+  it('does not advance the token until the caller admits a response', async () => {
+    const client = clientWithResults(
+      { worktrees: [], snapshotId: 'snapshot-1' },
+      { worktrees: [], snapshotId: 'snapshot-1' }
+    )
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    await snapshots.fetch(client, 'host-1')
+    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+
+    expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
+      limit: 10_000,
+      afterSnapshotId: null
+    })
+  })
+
+  it('preserves the last admitted token across transport failures', async () => {
+    const client = clientWithResults({ worktrees: [], snapshotId: 'snapshot-1' })
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    snapshots.admit(null)
+    await snapshots.fetch(client, 'host-1')
+
+    expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
+      limit: 10_000,
+      afterSnapshotId: 'snapshot-1'
+    })
+  })
+
+  it('clears snapshot ownership after a mismatched unchanged response', async () => {
+    const client = clientWithResults(
+      { worktrees: [], snapshotId: 'snapshot-1' },
+      { unchanged: true, snapshotId: 'snapshot-2' },
+      { worktrees: [], snapshotId: 'snapshot-3' }
+    )
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    await snapshots.fetch(client, 'host-1')
+
+    expect(client.sendRequest).toHaveBeenNthCalledWith(3, 'worktree.ps', {
+      limit: 10_000,
+      afterSnapshotId: null
+    })
+  })
+
+  it('resets snapshot ownership when the client or host changes', async () => {
+    const firstClient = clientWithResults({ worktrees: [], snapshotId: 'snapshot-1' })
+    const secondClient = clientWithResults({ worktrees: [], snapshotId: 'snapshot-2' })
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    snapshots.admit(await snapshots.fetch(firstClient, 'host-1'))
+    await snapshots.fetch(secondClient, 'host-2')
+
+    expect(secondClient.sendRequest).toHaveBeenCalledWith('worktree.ps', {
+      limit: 10_000,
+      afterSnapshotId: null
+    })
+  })
+})

--- a/mobile/src/worktree/worktree-catalog-snapshot-client.test.ts
+++ b/mobile/src/worktree/worktree-catalog-snapshot-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import {
   admitWorktreeCatalogResponse,
+  WORKTREE_PS_FULL_LIMIT,
   WorktreeCatalogSnapshotClient
 } from './worktree-catalog-snapshot-client'
 
@@ -34,6 +35,19 @@ describe('admitWorktreeCatalogResponse', () => {
     })
   })
 
+  it('classifies by rows, so a future `unchanged` catalog field cannot hide a full response', () => {
+    expect(
+      admitWorktreeCatalogResponse(
+        { worktrees: [{ id: 'worktree-1' }], unchanged: false, snapshotId: 'snapshot-1' },
+        'snapshot-1'
+      )
+    ).toEqual({
+      kind: 'full',
+      snapshotId: 'snapshot-1',
+      worktrees: [{ id: 'worktree-1' }]
+    })
+  })
+
   it('rejects unchanged responses for a snapshot the client does not own', () => {
     expect(
       admitWorktreeCatalogResponse({ unchanged: true, snapshotId: 'snapshot-2' }, 'snapshot-1')
@@ -45,9 +59,12 @@ describe('admitWorktreeCatalogResponse', () => {
 
   it('rejects malformed success payloads', () => {
     expect(admitWorktreeCatalogResponse(null, 'snapshot-1')).toEqual({ kind: 'invalid' })
-    expect(
-      admitWorktreeCatalogResponse({ unchanged: false, snapshotId: 'snapshot-1' }, 'snapshot-1')
-    ).toEqual({ kind: 'invalid' })
+    expect(admitWorktreeCatalogResponse({ unchanged: false }, 'snapshot-1')).toEqual({
+      kind: 'invalid'
+    })
+  })
+
+  it('accepts a full response but ignores an out-of-bounds snapshot id', () => {
     expect(
       admitWorktreeCatalogResponse({ worktrees: [], snapshotId: 'x'.repeat(129) }, null)
     ).toEqual({ kind: 'full', snapshotId: null, worktrees: [] })
@@ -69,9 +86,10 @@ function clientWithResults(...results: unknown[]): RpcClient {
 }
 
 describe('WorktreeCatalogSnapshotClient', () => {
-  it('retains confirmed rows while admitting unchanged responses', async () => {
+  it('returns the confirmed rows on unchanged responses so callers can reassert them', async () => {
+    const rows = [{ worktreeId: 'worktree-1' }]
     const client = clientWithResults(
-      { worktrees: [{ worktreeId: 'worktree-1' }], snapshotId: 'snapshot-1' },
+      { worktrees: rows, snapshotId: 'snapshot-1' },
       { unchanged: true, snapshotId: 'snapshot-1' }
     )
     const snapshots = new WorktreeCatalogSnapshotClient()
@@ -79,8 +97,8 @@ describe('WorktreeCatalogSnapshotClient', () => {
     const first = snapshots.admit(await snapshots.fetch(client, 'host-1'))
     const second = snapshots.admit(await snapshots.fetch(client, 'host-1'))
 
-    expect(first).toMatchObject({ changed: true })
-    expect(second).toEqual({ changed: false, worktrees: first?.worktrees })
+    expect(first).toEqual(rows)
+    expect(second).toEqual(rows)
   })
 
   it('does not advance the token until the caller admits a response', async () => {
@@ -94,7 +112,7 @@ describe('WorktreeCatalogSnapshotClient', () => {
     snapshots.admit(await snapshots.fetch(client, 'host-1'))
 
     expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
-      limit: 10_000,
+      limit: WORKTREE_PS_FULL_LIMIT,
       afterSnapshotId: null
     })
   })
@@ -108,7 +126,7 @@ describe('WorktreeCatalogSnapshotClient', () => {
     await snapshots.fetch(client, 'host-1')
 
     expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
-      limit: 10_000,
+      limit: WORKTREE_PS_FULL_LIMIT,
       afterSnapshotId: 'snapshot-1'
     })
   })
@@ -126,7 +144,7 @@ describe('WorktreeCatalogSnapshotClient', () => {
     await snapshots.fetch(client, 'host-1')
 
     expect(client.sendRequest).toHaveBeenNthCalledWith(3, 'worktree.ps', {
-      limit: 10_000,
+      limit: WORKTREE_PS_FULL_LIMIT,
       afterSnapshotId: null
     })
   })
@@ -140,8 +158,25 @@ describe('WorktreeCatalogSnapshotClient', () => {
     await snapshots.fetch(secondClient, 'host-2')
 
     expect(secondClient.sendRequest).toHaveBeenCalledWith('worktree.ps', {
-      limit: 10_000,
+      limit: WORKTREE_PS_FULL_LIMIT,
       afterSnapshotId: null
+    })
+  })
+
+  it('drops a superseded host response without invalidating the current token', async () => {
+    const firstClient = clientWithResults({ worktrees: [], snapshotId: 'snapshot-1' })
+    const secondClient = clientWithResults({ worktrees: [], snapshotId: 'snapshot-2' })
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    // Host A's response is still in flight when the screen switches to host B.
+    const stale = await snapshots.fetch(firstClient, 'host-1')
+    snapshots.admit(await snapshots.fetch(secondClient, 'host-2'))
+    expect(snapshots.admit(stale)).toBeNull()
+
+    await snapshots.fetch(secondClient, 'host-2')
+    expect(secondClient.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
+      limit: WORKTREE_PS_FULL_LIMIT,
+      afterSnapshotId: 'snapshot-2'
     })
   })
 })

--- a/mobile/src/worktree/worktree-catalog-snapshot-client.ts
+++ b/mobile/src/worktree/worktree-catalog-snapshot-client.ts
@@ -1,0 +1,108 @@
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcSuccess } from '../transport/types'
+import type { Worktree } from './workspace-list-sections'
+
+export type WorktreeCatalogAdmission<T> =
+  | { kind: 'full'; snapshotId: string | null; worktrees: T[] }
+  | { kind: 'unchanged'; snapshotId: string }
+  | { kind: 'invalid' }
+
+type PendingWorktreeCatalog = {
+  admission: WorktreeCatalogAdmission<Worktree>
+  client: RpcClient
+  hostId: string
+}
+
+export type AdmittedWorktreeCatalog = {
+  changed: boolean
+  worktrees: Worktree[]
+}
+
+function validSnapshotId(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 && value.length <= 128 ? value : null
+}
+
+export function admitWorktreeCatalogResponse<T>(
+  result: unknown,
+  requestedSnapshotId: string | null
+): WorktreeCatalogAdmission<T> {
+  if (!result || typeof result !== 'object') {
+    return { kind: 'invalid' }
+  }
+  const response = result as {
+    snapshotId?: unknown
+    unchanged?: unknown
+    worktrees?: unknown
+  }
+  if ('unchanged' in response) {
+    const snapshotId = validSnapshotId(response.snapshotId)
+    if (response.unchanged === true && snapshotId && snapshotId === requestedSnapshotId) {
+      return { kind: 'unchanged', snapshotId }
+    }
+    return { kind: 'invalid' }
+  }
+
+  if (!Array.isArray(response.worktrees)) {
+    return { kind: 'invalid' }
+  }
+  return {
+    kind: 'full',
+    snapshotId: validSnapshotId(response.snapshotId),
+    worktrees: response.worktrees as T[]
+  }
+}
+
+export class WorktreeCatalogSnapshotClient {
+  private client: RpcClient | null = null
+  private hostId: string | null = null
+  private snapshotId: string | null = null
+  private confirmedWorktrees: Worktree[] | null = null
+
+  async fetch(client: RpcClient, hostId: string): Promise<PendingWorktreeCatalog | null> {
+    if (this.client !== client || this.hostId !== hostId) {
+      this.client = client
+      this.hostId = hostId
+      this.snapshotId = null
+      this.confirmedWorktrees = null
+    }
+    const requestedSnapshotId = this.snapshotId
+    const response = await client.sendRequest('worktree.ps', {
+      limit: 10_000,
+      afterSnapshotId: requestedSnapshotId
+    })
+    if (!response.ok) {
+      return null
+    }
+    return {
+      admission: admitWorktreeCatalogResponse<Worktree>(
+        (response as RpcSuccess).result,
+        requestedSnapshotId
+      ),
+      client,
+      hostId
+    }
+  }
+
+  admit(pending: PendingWorktreeCatalog | null): AdmittedWorktreeCatalog | null {
+    if (!pending) {
+      return null
+    }
+    if (
+      pending.client !== this.client ||
+      pending.hostId !== this.hostId ||
+      pending.admission.kind === 'invalid'
+    ) {
+      this.snapshotId = null
+      return null
+    }
+
+    const admission = pending.admission
+    this.snapshotId = admission.snapshotId
+    if (admission.kind === 'full') {
+      this.confirmedWorktrees = admission.worktrees
+    }
+    return this.confirmedWorktrees
+      ? { changed: admission.kind === 'full', worktrees: this.confirmedWorktrees }
+      : null
+  }
+}

--- a/mobile/src/worktree/worktree-catalog-snapshot-client.ts
+++ b/mobile/src/worktree/worktree-catalog-snapshot-client.ts
@@ -2,6 +2,9 @@ import type { RpcClient } from '../transport/rpc-client'
 import type { RpcSuccess } from '../transport/types'
 import type { Worktree } from './workspace-list-sections'
 
+// Why: worktree.ps silently truncates at 200; use a high cap so large hosts don't drop workspaces.
+export const WORKTREE_PS_FULL_LIMIT = 10_000
+
 export type WorktreeCatalogAdmission<T> =
   | { kind: 'full'; snapshotId: string | null; worktrees: T[] }
   | { kind: 'unchanged'; snapshotId: string }
@@ -11,11 +14,6 @@ type PendingWorktreeCatalog = {
   admission: WorktreeCatalogAdmission<Worktree>
   client: RpcClient
   hostId: string
-}
-
-export type AdmittedWorktreeCatalog = {
-  changed: boolean
-  worktrees: Worktree[]
 }
 
 function validSnapshotId(value: unknown): string | null {
@@ -34,22 +32,22 @@ export function admitWorktreeCatalogResponse<T>(
     unchanged?: unknown
     worktrees?: unknown
   }
-  if ('unchanged' in response) {
-    const snapshotId = validSnapshotId(response.snapshotId)
-    if (response.unchanged === true && snapshotId && snapshotId === requestedSnapshotId) {
-      return { kind: 'unchanged', snapshotId }
+  // Why: a full response is defined by carrying rows, so discriminate on that rather
+  // than on the presence of `unchanged` — the latter could collide with a future
+  // catalog field and silently reclassify a full response.
+  if (Array.isArray(response.worktrees)) {
+    return {
+      kind: 'full',
+      snapshotId: validSnapshotId(response.snapshotId),
+      worktrees: response.worktrees as T[]
     }
-    return { kind: 'invalid' }
   }
 
-  if (!Array.isArray(response.worktrees)) {
-    return { kind: 'invalid' }
+  const snapshotId = validSnapshotId(response.snapshotId)
+  if (response.unchanged === true && snapshotId && snapshotId === requestedSnapshotId) {
+    return { kind: 'unchanged', snapshotId }
   }
-  return {
-    kind: 'full',
-    snapshotId: validSnapshotId(response.snapshotId),
-    worktrees: response.worktrees as T[]
-  }
+  return { kind: 'invalid' }
 }
 
 export class WorktreeCatalogSnapshotClient {
@@ -67,7 +65,7 @@ export class WorktreeCatalogSnapshotClient {
     }
     const requestedSnapshotId = this.snapshotId
     const response = await client.sendRequest('worktree.ps', {
-      limit: 10_000,
+      limit: WORKTREE_PS_FULL_LIMIT,
       afterSnapshotId: requestedSnapshotId
     })
     if (!response.ok) {
@@ -83,26 +81,27 @@ export class WorktreeCatalogSnapshotClient {
     }
   }
 
-  admit(pending: PendingWorktreeCatalog | null): AdmittedWorktreeCatalog | null {
+  /** The confirmed host catalog to apply, or null when there is nothing to apply. */
+  admit(pending: PendingWorktreeCatalog | null): Worktree[] | null {
     if (!pending) {
       return null
     }
-    if (
-      pending.client !== this.client ||
-      pending.hostId !== this.hostId ||
-      pending.admission.kind === 'invalid'
-    ) {
+    // Why: a response from a superseded client/host is stale, not wrong — dropping it
+    // must not invalidate the token the current client/host just established.
+    if (pending.client !== this.client || pending.hostId !== this.hostId) {
+      return null
+    }
+    if (pending.admission.kind === 'invalid') {
       this.snapshotId = null
       return null
     }
 
-    const admission = pending.admission
-    this.snapshotId = admission.snapshotId
-    if (admission.kind === 'full') {
-      this.confirmedWorktrees = admission.worktrees
+    this.snapshotId = pending.admission.snapshotId
+    if (pending.admission.kind === 'full') {
+      this.confirmedWorktrees = pending.admission.worktrees
     }
+    // Why: unchanged responses still return the confirmed rows so every poll reasserts
+    // host truth over optimistic local edits, exactly as the full-payload path did.
     return this.confirmedWorktrees
-      ? { changed: admission.kind === 'full', worktrees: this.confirmedWorktrees }
-      : null
   }
 }

--- a/src/main/runtime/rpc/methods/worktree-catalog-snapshot-method.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-catalog-snapshot-method.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { RpcDispatcher } from '../dispatcher'
+import { WORKTREE_METHODS } from './worktree'
+
+function makeRuntime() {
+  return {
+    getRuntimeId: () => 'test-runtime',
+    getWorktreePs: vi.fn().mockResolvedValue({
+      worktrees: [],
+      totalCount: 0,
+      truncated: false
+    })
+  } as unknown as OrcaRuntimeService
+}
+
+describe('worktree.ps catalog snapshots', () => {
+  it('preserves the exact legacy response when no snapshot field is sent', async () => {
+    const runtime = makeRuntime()
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+    const response = await dispatcher.dispatch({
+      id: 'legacy',
+      authToken: 'token',
+      method: 'worktree.ps',
+      params: { limit: 10_000 }
+    })
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { worktrees: [], totalCount: 0, truncated: false }
+    })
+    expect((response as { result: unknown }).result).not.toHaveProperty('snapshotId')
+  })
+
+  it('returns a full snapshot followed by a tiny unchanged response', async () => {
+    const runtime = makeRuntime()
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+    const first = await dispatcher.dispatch({
+      id: 'first',
+      authToken: 'token',
+      method: 'worktree.ps',
+      params: { limit: 10_000, afterSnapshotId: null }
+    })
+    const snapshotId = (first as { result: { snapshotId: string } }).result.snapshotId
+
+    const second = await dispatcher.dispatch({
+      id: 'second',
+      authToken: 'token',
+      method: 'worktree.ps',
+      params: { limit: 10_000, afterSnapshotId: snapshotId }
+    })
+
+    expect(snapshotId).toEqual(expect.any(String))
+    expect(second).toMatchObject({
+      ok: true,
+      result: { unchanged: true, snapshotId }
+    })
+    expect(runtime.getWorktreePs).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -57,7 +57,8 @@ export const WorktreeTeardownMissingTerminalsParams = WorktreeDetectedListParams
 })
 
 export const WorktreePsParams = z.object({
-  limit: OptionalFiniteNumber
+  limit: OptionalFiniteNumber,
+  afterSnapshotId: z.string().min(1).max(128).nullable().optional()
 })
 
 export const WorktreeSortOrder = z.object({

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../automations/workspace-provenance'
 import { buildCliWorkspaceProvenance } from '../../../../shared/cli-workspace-provenance'
 import { defineMethod, type RpcMethod } from '../core'
+import { resolveWorktreeCatalogSnapshot } from '../worktree-catalog-snapshot'
 import { resolveRuntimeNavigationTarget } from '../../../../shared/runtime-navigation'
 import {
   WorktreeCreate,
@@ -27,7 +28,13 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.ps',
     params: WorktreePsParams,
-    handler: async (params, { runtime }) => runtime.getWorktreePs(params.limit)
+    handler: async (params, { runtime }) => {
+      const result = await runtime.getWorktreePs(params.limit)
+      if (params.afterSnapshotId === undefined) {
+        return result
+      }
+      return resolveWorktreeCatalogSnapshot(runtime, params.limit, result, params.afterSnapshotId)
+    }
   }),
   defineMethod({
     name: 'worktree.list',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -30,10 +30,11 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     params: WorktreePsParams,
     handler: async (params, { runtime }) => {
       const result = await runtime.getWorktreePs(params.limit)
+      // Why: callers that never send the field get the byte-exact legacy response.
       if (params.afterSnapshotId === undefined) {
         return result
       }
-      return resolveWorktreeCatalogSnapshot(runtime, params.limit, result, params.afterSnapshotId)
+      return resolveWorktreeCatalogSnapshot(result, params.afterSnapshotId)
     }
   }),
   defineMethod({

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
@@ -34,6 +34,47 @@ describe('WorktreeCatalogSnapshotCache', () => {
     expect(differentLimit.snapshotId).not.toBe(changed.snapshotId)
   })
 
+  it('keeps alternating conditional limits independent', () => {
+    const snapshots = new WorktreeCatalogSnapshotCache()
+    const wide = snapshots.resolve(10_000, result(2), null)
+    const narrow = snapshots.resolve(200, result(1), null)
+
+    expect(snapshots.resolve(10_000, result(2), wide.snapshotId)).toEqual({
+      unchanged: true,
+      snapshotId: wide.snapshotId
+    })
+    expect(snapshots.resolve(200, result(1), narrow.snapshotId)).toEqual({
+      unchanged: true,
+      snapshotId: narrow.snapshotId
+    })
+  })
+
+  it('bounds snapshots retained for distinct limits', () => {
+    const snapshots = new WorktreeCatalogSnapshotCache()
+    const first = snapshots.resolve(1, result(1), null)
+    for (let limit = 2; limit <= 9; limit += 1) {
+      snapshots.resolve(limit, result(limit), null)
+    }
+
+    const replaced = snapshots.resolve(1, result(1), first.snapshotId)
+    expect(replaced).not.toHaveProperty('unchanged')
+    expect(replaced.snapshotId).not.toBe(first.snapshotId)
+  })
+
+  it('retains recently used limits when the cache is full', () => {
+    const snapshots = new WorktreeCatalogSnapshotCache()
+    const ids = Array.from({ length: 8 }, (_, index) => {
+      const limit = index + 1
+      return snapshots.resolve(limit, result(limit), null).snapshotId
+    })
+
+    snapshots.resolve(1, result(1), ids[0])
+    snapshots.resolve(9, result(9), null)
+
+    expect(snapshots.resolve(1, result(1), ids[0])).toHaveProperty('unchanged', true)
+    expect(snapshots.resolve(2, result(2), ids[1])).not.toHaveProperty('unchanged')
+  })
+
   it('repairs completion-order cache replacement with a full response', () => {
     const snapshots = new WorktreeCatalogSnapshotCache()
     const older = snapshots.resolve(10_000, result(1), null)

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
@@ -1,95 +1,71 @@
 import { describe, expect, it } from 'vitest'
 import type { RuntimeWorktreePsResult } from '../../../shared/runtime-types'
-import { WorktreeCatalogSnapshotCache } from './worktree-catalog-snapshot'
+import { resolveWorktreeCatalogSnapshot } from './worktree-catalog-snapshot'
 
 function result(totalCount: number): RuntimeWorktreePsResult {
   return { worktrees: [], totalCount, truncated: false }
 }
 
-describe('WorktreeCatalogSnapshotCache', () => {
-  it('returns unchanged only when the caller owns the exact completed snapshot', () => {
-    const snapshots = new WorktreeCatalogSnapshotCache()
-    const first = snapshots.resolve(10_000, result(1), null)
+describe('resolveWorktreeCatalogSnapshot', () => {
+  it('returns unchanged only when the caller owns the exact current snapshot', () => {
+    const first = resolveWorktreeCatalogSnapshot(result(1), null)
     expect(first).toMatchObject({ totalCount: 1 })
-    expect('snapshotId' in first).toBe(true)
 
     const snapshotId = first.snapshotId
-    expect(snapshots.resolve(10_000, result(1), snapshotId)).toEqual({
+    expect(resolveWorktreeCatalogSnapshot(result(1), snapshotId)).toEqual({
       unchanged: true,
       snapshotId
     })
-    expect(snapshots.resolve(10_000, result(1), 'unknown')).toEqual({
+    expect(resolveWorktreeCatalogSnapshot(result(1), 'unknown')).toEqual({
       ...result(1),
       snapshotId
     })
   })
 
-  it('issues a new snapshot for changed content or a different limit', () => {
-    const snapshots = new WorktreeCatalogSnapshotCache()
-    const first = snapshots.resolve(10_000, result(1), null)
-    const changed = snapshots.resolve(10_000, result(2), first.snapshotId)
-    const differentLimit = snapshots.resolve(200, result(2), changed.snapshotId)
+  it('issues a new snapshot id for changed content', () => {
+    const first = resolveWorktreeCatalogSnapshot(result(1), null)
+    const changed = resolveWorktreeCatalogSnapshot(result(2), first.snapshotId)
 
     expect(changed.snapshotId).not.toBe(first.snapshotId)
-    expect(differentLimit.snapshotId).not.toBe(changed.snapshotId)
+    expect(changed).not.toHaveProperty('unchanged')
   })
 
-  it('keeps alternating conditional limits independent', () => {
-    const snapshots = new WorktreeCatalogSnapshotCache()
-    const wide = snapshots.resolve(10_000, result(2), null)
-    const narrow = snapshots.resolve(200, result(1), null)
+  it('keeps concurrent callers independent without server-held state', () => {
+    // Two clients on different catalogs interleave; neither can displace the other.
+    const wide = resolveWorktreeCatalogSnapshot(result(2), null)
+    const narrow = resolveWorktreeCatalogSnapshot(result(1), null)
 
-    expect(snapshots.resolve(10_000, result(2), wide.snapshotId)).toEqual({
+    expect(resolveWorktreeCatalogSnapshot(result(2), wide.snapshotId)).toEqual({
       unchanged: true,
       snapshotId: wide.snapshotId
     })
-    expect(snapshots.resolve(200, result(1), narrow.snapshotId)).toEqual({
+    expect(resolveWorktreeCatalogSnapshot(result(1), narrow.snapshotId)).toEqual({
       unchanged: true,
       snapshotId: narrow.snapshotId
     })
   })
 
-  it('bounds snapshots retained for distinct limits', () => {
-    const snapshots = new WorktreeCatalogSnapshotCache()
-    const first = snapshots.resolve(1, result(1), null)
-    for (let limit = 2; limit <= 9; limit += 1) {
-      snapshots.resolve(limit, result(limit), null)
-    }
+  it('repairs a caller holding a superseded snapshot with a full response', () => {
+    const older = resolveWorktreeCatalogSnapshot(result(1), null)
 
-    const replaced = snapshots.resolve(1, result(1), first.snapshotId)
-    expect(replaced).not.toHaveProperty('unchanged')
-    expect(replaced.snapshotId).not.toBe(first.snapshotId)
-  })
-
-  it('retains recently used limits when the cache is full', () => {
-    const snapshots = new WorktreeCatalogSnapshotCache()
-    const ids = Array.from({ length: 8 }, (_, index) => {
-      const limit = index + 1
-      return snapshots.resolve(limit, result(limit), null).snapshotId
-    })
-
-    snapshots.resolve(1, result(1), ids[0])
-    snapshots.resolve(9, result(9), null)
-
-    expect(snapshots.resolve(1, result(1), ids[0])).toHaveProperty('unchanged', true)
-    expect(snapshots.resolve(2, result(2), ids[1])).not.toHaveProperty('unchanged')
-  })
-
-  it('repairs completion-order cache replacement with a full response', () => {
-    const snapshots = new WorktreeCatalogSnapshotCache()
-    const older = snapshots.resolve(10_000, result(1), null)
-    const newer = snapshots.resolve(10_000, result(2), older.snapshotId)
-    snapshots.resolve(10_000, result(1), older.snapshotId)
-
-    const repaired = snapshots.resolve(10_000, result(2), newer.snapshotId)
+    const repaired = resolveWorktreeCatalogSnapshot(result(2), older.snapshotId)
     expect(repaired).toMatchObject({ totalCount: 2 })
     expect(repaired).not.toHaveProperty('unchanged')
+    expect(repaired.snapshotId).not.toBe(older.snapshotId)
   })
 
-  it('scopes snapshot ids to one runtime cache', () => {
-    const left = new WorktreeCatalogSnapshotCache().resolve(10_000, result(1), null)
-    const right = new WorktreeCatalogSnapshotCache().resolve(10_000, result(1), null)
+  it('derives ids from content alone, so memo state cannot change the answer', () => {
+    // Identical catalogs must yield identical ids whether the memo is warm or was just
+    // displaced — that is what makes the memo droppable and restarts safe.
+    const warm = resolveWorktreeCatalogSnapshot(result(1), null).snapshotId
+    resolveWorktreeCatalogSnapshot(result(99), null)
 
-    expect(left.snapshotId).not.toBe(right.snapshotId)
+    expect(resolveWorktreeCatalogSnapshot(result(1), null).snapshotId).toBe(warm)
+  })
+
+  it('produces ids within the request schema bound', () => {
+    const { snapshotId } = resolveWorktreeCatalogSnapshot(result(1), null)
+    expect(snapshotId.length).toBeGreaterThan(0)
+    expect(snapshotId.length).toBeLessThanOrEqual(128)
   })
 })

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
@@ -63,6 +63,18 @@ describe('resolveWorktreeCatalogSnapshot', () => {
     expect(resolveWorktreeCatalogSnapshot(result(1), null).snapshotId).toBe(warm)
   })
 
+  it('isolates the memo from mutation of a previously resolved catalog', () => {
+    const mutable = result(1)
+    const first = resolveWorktreeCatalogSnapshot(mutable, null)
+
+    mutable.totalCount = 2
+    const changed = resolveWorktreeCatalogSnapshot(mutable, first.snapshotId)
+
+    expect(changed).toMatchObject({ totalCount: 2 })
+    expect(changed).not.toHaveProperty('unchanged')
+    expect(changed.snapshotId).not.toBe(first.snapshotId)
+  })
+
   it('produces ids within the request schema bound', () => {
     const { snapshotId } = resolveWorktreeCatalogSnapshot(result(1), null)
     expect(snapshotId.length).toBeGreaterThan(0)

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeWorktreePsResult } from '../../../shared/runtime-types'
+import { WorktreeCatalogSnapshotCache } from './worktree-catalog-snapshot'
+
+function result(totalCount: number): RuntimeWorktreePsResult {
+  return { worktrees: [], totalCount, truncated: false }
+}
+
+describe('WorktreeCatalogSnapshotCache', () => {
+  it('returns unchanged only when the caller owns the exact completed snapshot', () => {
+    const snapshots = new WorktreeCatalogSnapshotCache()
+    const first = snapshots.resolve(10_000, result(1), null)
+    expect(first).toMatchObject({ totalCount: 1 })
+    expect('snapshotId' in first).toBe(true)
+
+    const snapshotId = first.snapshotId
+    expect(snapshots.resolve(10_000, result(1), snapshotId)).toEqual({
+      unchanged: true,
+      snapshotId
+    })
+    expect(snapshots.resolve(10_000, result(1), 'unknown')).toEqual({
+      ...result(1),
+      snapshotId
+    })
+  })
+
+  it('issues a new snapshot for changed content or a different limit', () => {
+    const snapshots = new WorktreeCatalogSnapshotCache()
+    const first = snapshots.resolve(10_000, result(1), null)
+    const changed = snapshots.resolve(10_000, result(2), first.snapshotId)
+    const differentLimit = snapshots.resolve(200, result(2), changed.snapshotId)
+
+    expect(changed.snapshotId).not.toBe(first.snapshotId)
+    expect(differentLimit.snapshotId).not.toBe(changed.snapshotId)
+  })
+
+  it('repairs completion-order cache replacement with a full response', () => {
+    const snapshots = new WorktreeCatalogSnapshotCache()
+    const older = snapshots.resolve(10_000, result(1), null)
+    const newer = snapshots.resolve(10_000, result(2), older.snapshotId)
+    snapshots.resolve(10_000, result(1), older.snapshotId)
+
+    const repaired = snapshots.resolve(10_000, result(2), newer.snapshotId)
+    expect(repaired).toMatchObject({ totalCount: 2 })
+    expect(repaired).not.toHaveProperty('unchanged')
+  })
+
+  it('scopes snapshot ids to one runtime cache', () => {
+    const left = new WorktreeCatalogSnapshotCache().resolve(10_000, result(1), null)
+    const right = new WorktreeCatalogSnapshotCache().resolve(10_000, result(1), null)
+
+    expect(left.snapshotId).not.toBe(right.snapshotId)
+  })
+})

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.ts
@@ -24,11 +24,13 @@ function worktreeCatalogSnapshotId(result: RuntimeWorktreePsResult): string {
   if (memoizedId && isDeepStrictEqual(memoizedId.result, result)) {
     return memoizedId.snapshotId
   }
+  const serialized = JSON.stringify(result)
   const snapshotId = createHash('sha256')
-    .update(JSON.stringify(result))
+    .update(serialized)
     .digest('base64url')
     .slice(0, SNAPSHOT_ID_LENGTH)
-  memoizedId = { result, snapshotId }
+  // Why: caller-owned mutation must not let an old id label new catalog content.
+  memoizedId = { result: JSON.parse(serialized) as RuntimeWorktreePsResult, snapshotId }
   return snapshotId
 }
 

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.ts
@@ -1,59 +1,48 @@
-import { randomUUID } from 'node:crypto'
+import { createHash } from 'node:crypto'
 import { isDeepStrictEqual } from 'node:util'
 import type {
   RuntimeWorktreePsConditionalResult,
   RuntimeWorktreePsResult
 } from '../../../shared/runtime-types'
 
-type CachedWorktreeCatalog = {
+// Why: 192 bits of a sha256 over the serialized catalog. Accidental collision is
+// impossible at any realistic poll rate, and this is not an auth boundary.
+const SNAPSHOT_ID_LENGTH = 32
+
+type MemoizedCatalogId = {
   result: RuntimeWorktreePsResult
   snapshotId: string
 }
 
-const MAX_CACHED_LIMITS = 8
+// Why: a pure memo over the most recent catalog. Because ids are derived from content
+// rather than from cache state, dropping or thrashing this slot costs CPU and nothing
+// else — it can never produce a wrong answer, so it needs no scoping, eviction policy,
+// or per-caller isolation. Serializing every poll instead would cost ~3x the compare.
+let memoizedId: MemoizedCatalogId | null = null
 
-export class WorktreeCatalogSnapshotCache {
-  private readonly runtimeScope = randomUUID()
-  private sequence = 0
-  private readonly cachedByLimit = new Map<number | undefined, CachedWorktreeCatalog>()
-
-  resolve(
-    limit: number | undefined,
-    result: RuntimeWorktreePsResult,
-    afterSnapshotId: string | null
-  ): RuntimeWorktreePsConditionalResult {
-    const cached = this.cachedByLimit.get(limit)
-    if (cached && isDeepStrictEqual(cached.result, result)) {
-      this.cachedByLimit.delete(limit)
-      this.cachedByLimit.set(limit, cached)
-      if (afterSnapshotId === cached.snapshotId) {
-        return { unchanged: true, snapshotId: cached.snapshotId }
-      }
-      return { ...result, snapshotId: cached.snapshotId }
-    }
-
-    const snapshotId = `${this.runtimeScope}:${++this.sequence}`
-    this.cachedByLimit.delete(limit)
-    this.cachedByLimit.set(limit, { result, snapshotId })
-    if (this.cachedByLimit.size > MAX_CACHED_LIMITS) {
-      this.cachedByLimit.delete(this.cachedByLimit.keys().next().value)
-    }
-    return { ...result, snapshotId }
+function worktreeCatalogSnapshotId(result: RuntimeWorktreePsResult): string {
+  if (memoizedId && isDeepStrictEqual(memoizedId.result, result)) {
+    return memoizedId.snapshotId
   }
+  const snapshotId = createHash('sha256')
+    .update(JSON.stringify(result))
+    .digest('base64url')
+    .slice(0, SNAPSHOT_ID_LENGTH)
+  memoizedId = { result, snapshotId }
+  return snapshotId
 }
 
-const snapshotsByRuntime = new WeakMap<object, WorktreeCatalogSnapshotCache>()
-
+// Why: content-addressed like an HTTP ETag, so snapshot ownership lives entirely in the
+// id. Any number of concurrent clients, any `limit`, and any runtime restart stay correct
+// by construction: ids match only when the catalogs are byte-identical, which is exactly
+// when `unchanged` is the right answer.
 export function resolveWorktreeCatalogSnapshot(
-  runtime: object,
-  limit: number | undefined,
   result: RuntimeWorktreePsResult,
   afterSnapshotId: string | null
 ): RuntimeWorktreePsConditionalResult {
-  let snapshots = snapshotsByRuntime.get(runtime)
-  if (!snapshots) {
-    snapshots = new WorktreeCatalogSnapshotCache()
-    snapshotsByRuntime.set(runtime, snapshots)
+  const snapshotId = worktreeCatalogSnapshotId(result)
+  if (afterSnapshotId === snapshotId) {
+    return { unchanged: true, snapshotId }
   }
-  return snapshots.resolve(limit, result, afterSnapshotId)
+  return { ...result, snapshotId }
 }

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.ts
@@ -6,23 +6,26 @@ import type {
 } from '../../../shared/runtime-types'
 
 type CachedWorktreeCatalog = {
-  limit: number | undefined
   result: RuntimeWorktreePsResult
   snapshotId: string
 }
 
+const MAX_CACHED_LIMITS = 8
+
 export class WorktreeCatalogSnapshotCache {
   private readonly runtimeScope = randomUUID()
   private sequence = 0
-  private cached: CachedWorktreeCatalog | null = null
+  private readonly cachedByLimit = new Map<number | undefined, CachedWorktreeCatalog>()
 
   resolve(
     limit: number | undefined,
     result: RuntimeWorktreePsResult,
     afterSnapshotId: string | null
   ): RuntimeWorktreePsConditionalResult {
-    const cached = this.cached
-    if (cached !== null && cached.limit === limit && isDeepStrictEqual(cached.result, result)) {
+    const cached = this.cachedByLimit.get(limit)
+    if (cached && isDeepStrictEqual(cached.result, result)) {
+      this.cachedByLimit.delete(limit)
+      this.cachedByLimit.set(limit, cached)
       if (afterSnapshotId === cached.snapshotId) {
         return { unchanged: true, snapshotId: cached.snapshotId }
       }
@@ -30,7 +33,11 @@ export class WorktreeCatalogSnapshotCache {
     }
 
     const snapshotId = `${this.runtimeScope}:${++this.sequence}`
-    this.cached = { limit, result, snapshotId }
+    this.cachedByLimit.delete(limit)
+    this.cachedByLimit.set(limit, { result, snapshotId })
+    if (this.cachedByLimit.size > MAX_CACHED_LIMITS) {
+      this.cachedByLimit.delete(this.cachedByLimit.keys().next().value)
+    }
     return { ...result, snapshotId }
   }
 }

--- a/src/main/runtime/rpc/worktree-catalog-snapshot.ts
+++ b/src/main/runtime/rpc/worktree-catalog-snapshot.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
+import type {
+  RuntimeWorktreePsConditionalResult,
+  RuntimeWorktreePsResult
+} from '../../../shared/runtime-types'
+
+type CachedWorktreeCatalog = {
+  limit: number | undefined
+  result: RuntimeWorktreePsResult
+  snapshotId: string
+}
+
+export class WorktreeCatalogSnapshotCache {
+  private readonly runtimeScope = randomUUID()
+  private sequence = 0
+  private cached: CachedWorktreeCatalog | null = null
+
+  resolve(
+    limit: number | undefined,
+    result: RuntimeWorktreePsResult,
+    afterSnapshotId: string | null
+  ): RuntimeWorktreePsConditionalResult {
+    const cached = this.cached
+    if (cached !== null && cached.limit === limit && isDeepStrictEqual(cached.result, result)) {
+      if (afterSnapshotId === cached.snapshotId) {
+        return { unchanged: true, snapshotId: cached.snapshotId }
+      }
+      return { ...result, snapshotId: cached.snapshotId }
+    }
+
+    const snapshotId = `${this.runtimeScope}:${++this.sequence}`
+    this.cached = { limit, result, snapshotId }
+    return { ...result, snapshotId }
+  }
+}
+
+const snapshotsByRuntime = new WeakMap<object, WorktreeCatalogSnapshotCache>()
+
+export function resolveWorktreeCatalogSnapshot(
+  runtime: object,
+  limit: number | undefined,
+  result: RuntimeWorktreePsResult,
+  afterSnapshotId: string | null
+): RuntimeWorktreePsConditionalResult {
+  let snapshots = snapshotsByRuntime.get(runtime)
+  if (!snapshots) {
+    snapshots = new WorktreeCatalogSnapshotCache()
+    snapshotsByRuntime.set(runtime, snapshots)
+  }
+  return snapshots.resolve(limit, result, afterSnapshotId)
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -843,6 +843,19 @@ export type RuntimeWorktreePsResult = {
   truncated: boolean
 }
 
+export type RuntimeWorktreePsSnapshotResult = RuntimeWorktreePsResult & {
+  snapshotId: string
+}
+
+export type RuntimeWorktreePsUnchangedResult = {
+  unchanged: true
+  snapshotId: string
+}
+
+export type RuntimeWorktreePsConditionalResult =
+  | RuntimeWorktreePsSnapshotResult
+  | RuntimeWorktreePsUnchangedResult
+
 export type RuntimeRepoList = {
   repos: Repo[]
 }


### PR DESCRIPTION
## ELI5

Every three seconds, the mobile app asks the host, “What worktrees do you have right now?” Previously, the host mailed back the entire catalog even when nothing changed—477 KB on the measured host.

With this change, the host still rebuilds and checks the complete catalog for safety. It labels that catalog with a fingerprint of its contents. If the phone already holds that exact fingerprint, the host replies with a ~192-byte “same as X” receipt and the phone reuses the catalog it already confirmed. If the fingerprint is unknown, either side is old, or anything changed, the host sends the complete catalog again.

Because the label is derived from the contents rather than from bookkeeping, any number of phones, any request size, and any host restart all line up automatically—the labels can only match when the catalogs are identical.

## Summary

- add opt-in, content-addressed snapshot IDs to `worktree.ps`
- let the mobile host screen request a tiny unchanged response while retaining the confirmed rows it reapplies on every poll
- preserve exact legacy responses for old callers and automatically fall back to full responses with old hosts

## Measured impact

Measured against a live 288-worktree host:

| Response | Compact RPC bytes |
| --- | ---: |
| Full snapshot | 477,423 |
| Unchanged snapshot | ~192 |

That avoids roughly 477,231 bytes per unchanged poll (99.96%). At the existing three-second cadence, this is about 9.11 MiB/minute or 546 MiB/hour per active client before transport overhead.

The savings are redundant serialization/transfer, relay encryption/decryption work, mobile JSON parsing/allocation, cache writes, and downstream list work. This deliberately still builds the complete host catalog and preserves the safety poll—catalog construction is unchanged.

**Host CPU.** The steady-state path is an exact deep comparison against the last catalog, measured at about 0.418 ms/poll on this catalog versus about 0.581 ms/poll for JSON serialization alone. Hashing is reached only when that comparison fails, i.e. only on polls that were going to send a full payload anyway. Hashing unconditionally instead was measured at roughly 3x the compare on a synthetic catalog of similar size, which is why the memo in front of it stays.

## Design

`snapshotId` is a truncated sha256 over the serialized catalog—HTTP `ETag` semantics. Snapshot ownership therefore lives entirely in the ID rather than in server-side bookkeeping:

- **Concurrent clients** converge with no coordination. A client presenting an unknown ID gets the current full catalog carrying the current ID.
- **Differing `limit` values** need no isolation, because a limit that changes the response also changes its fingerprint, and one that does not is genuinely the same catalog.
- **Restarts** are safe without scoping. IDs match only when catalogs are byte-identical, which is exactly when the client's retained rows are already correct.

A single-slot memo sits in front of the hash so the common case stays a deep compare. The memo is a pure CPU optimization and is deliberately outside the correctness argument: because IDs derive from content, dropping or thrashing that slot can change performance and nothing else.

On the client, an unchanged response still yields the confirmed rows, and `HostScreen` reapplies them exactly as it does for a full response. Every poll therefore continues to reassert host truth over optimistic local edits (pin toggles, delete rollbacks) and continues to overwrite the home-written worktree cache (#8498). This costs nothing in the steady state: the cache write is an in-memory `Map.set`, and `areWorktreeListsEqual` already ran on every poll and still short-circuits to the existing array on an identical catalog, keeping SectionList/sort rebuilds off the tap path.

## Proof of no regression

| Invariant | Evidence |
| --- | --- |
| The three-second safety poll still executes the full host catalog build | Method test makes two conditional polls and asserts `getWorktreePs` ran twice. No code inside `getWorktreePs` changed. |
| Any catalog change produces a full response with a new ID | `issues a new snapshot id for changed content`; `repairs a caller holding a superseded snapshot with a full response`. |
| Concurrent callers cannot displace each other | `keeps concurrent callers independent without server-held state` interleaves two catalogs and asserts both callers still get `unchanged`. |
| Server-side memo state cannot affect the answer | `derives ids from content alone, so memo state cannot change the answer` displaces the memo and asserts the ID is unchanged. |
| A client presenting an unknown ID is repaired | `returns unchanged only when the caller owns the exact current snapshot` asserts the full current result carrying the current ID. |
| Generated IDs satisfy the request schema | `produces ids within the request schema bound`. |
| Old clients receive the exact legacy shape | Method test omits `afterSnapshotId` and asserts no `snapshotId` is added. |
| New mobile remains compatible with old hosts | Old schemas strip the unknown optional request field; `treats an old-host full response as authoritative and clears the token`. |
| Unchanged polls still reassert host truth over optimistic edits | `returns the confirmed rows on unchanged responses so callers can reassert them`; `HostScreen` applies them through the same path as a full response. |
| Dropped/modal-blocked responses cannot advance the token | Token advances only in `admit`, after the existing current-client/current-host/modal guards; `does not advance the token until the caller admits a response`. |
| Superseded responses cannot corrupt current ownership | `drops a superseded host response without invalidating the current token`; `resets snapshot ownership when the client or host changes`. |
| Transport failures and malformed responses recover safely | `preserves the last admitted token across transport failures`; `clears snapshot ownership after a mismatched unchanged response`; malformed-payload cases force a full repair. |
| A future `unchanged` catalog field cannot reclassify a full response | Responses are discriminated on the presence of rows: `classifies by rows, so a future 'unchanged' catalog field cannot hide a full response`. |
| SSH, relay, Git providers, and folder workspaces retain their behavior | Snapshotting treats the completed `worktree.ps` result as opaque data and does not alter catalog construction, provider access, paths, Git commands, or polling. |

Validation performed locally:

- 2,784 mobile tests passed (3 skipped)
- 1,064 `src/main/runtime/rpc` tests passed (1 skipped)
- node and mobile typechecks passed
- oxlint and oxfmt passed
- max-lines ratchet passed with no new bypasses

## Safety and compatibility

- snapshot IDs are derived from the complete post-build result; any difference yields a full response under a new ID
- unknown or superseded IDs receive a repairing full response
- only advance the mobile token after the current-client/current-host/modal admission guards
- retain the token across transport failures and superseded responses, but clear it for malformed or mismatched unchanged responses
- old client → new host: exact legacy response, without `snapshotId`
- new client → old host: unknown request field is stripped and the full legacy response remains authoritative
- folder workspaces, SSH/relay hosts, and the existing three-second refresh path are unchanged

## Follow-ups (deliberately not in this PR)

- **Capability-gated opt-in.** `afterSnapshotId` currently carries three states (`undefined` = legacy caller, `null` = opted in holding nothing, string = holding an ID). The repo already has the idiomatic mechanism for this—`status.get` capabilities read via `startRuntimeCapabilityProbe`—and `TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY` exists for the identical hazard of an old host silently stripping an unknown field. Advertising `worktree.catalog-snapshot.v1` would reduce the field to `string | undefined`.
- **Generalize to the RPC envelope.** Conditional responses are an envelope concern, not a `worktree.ps` concern. Moving `afterSnapshotId` onto `RpcRequest` and `snapshotId`/`notModified` onto `_meta`, gated by a flag on `defineMethod`, would let other polled methods (`ui.get`, repo metadata, terminal lists) opt in without their own result unions or client wrappers.

## Review loops

- [Loop #1 — CHANGES REQUESTED → FIXED](https://github.com/stablyai/orca/pull/11735#issuecomment-5140992779): fixed cross-limit cache thrashing with a bounded per-limit LRU and three regression cases.
- [Loop #2 — CLEAN](https://github.com/stablyai/orca/pull/11735#issuecomment-5141010949): two independent Sol reviewers found no actionable issues on the updated head.
- Loop #3 — CHANGES REQUESTED → FIXED (`3e6a62d`): restored unconditional reassertion of the confirmed catalog on the client, stopped superseded responses from clearing the current token, and replaced the per-limit LRU from Loop #1 with content-addressed IDs—which removes the cross-limit thrashing class outright rather than bounding it.
