### PR TITLE
chore(pnpm): move pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,39 +260,6 @@
     "node": "24"
   },
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
-  "pnpm": {
-    "overrides": {
-      "@modelcontextprotocol/sdk>@hono/node-server": "2.0.10",
-      "monaco-editor>dompurify": "3.4.12"
-    },
-    "supportedArchitectures": {
-      "os": [
-        "current",
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "cpu": [
-        "current",
-        "x64",
-        "arm64"
-      ]
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "cpu-features",
-      "esbuild",
-      "node-pty",
-      "sherpa-onnx"
-    ],
-    "patchedDependencies": {
-      "node-pty@1.1.0": "config/patches/node-pty@1.1.0.patch",
-      "@xterm/addon-ligatures@0.11.0-beta.287": "config/patches/@xterm__addon-ligatures@0.11.0-beta.287.patch",
-      "@xterm/addon-webgl@0.20.0-beta.286": "config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch",
-      "@xterm/addon-serialize@0.15.0-beta.287": "config/patches/@xterm__addon-serialize@0.15.0-beta.287.patch",
-      "@xterm/xterm@6.1.0-beta.287": "config/patches/@xterm__xterm@6.1.0-beta.287.patch"
-    }
-  },
   "reactDoctor": {
     "rules": {
       "react-doctor/js-combine-iterations": "off"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,34 @@
 # package graph. Without this file `pnpm -r` auto-discovers mobile/ and its
 # nested package, and the root's patchedDependencies fail as ERR_PNPM_UNUSED_PATCH.
 packages: []
+
+overrides:
+  '@modelcontextprotocol/sdk>@hono/node-server': '2.0.10'
+  'monaco-editor>dompurify': '3.4.12'
+
+# Fetch optional binaries for every OS/CPU we package for, not just the host's,
+# so any build machine still resolves the other platforms' artifacts.
+supportedArchitectures:
+  os:
+    - current
+    - darwin
+    - linux
+    - win32
+  cpu:
+    - current
+    - x64
+    - arm64
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - cpu-features
+  - esbuild
+  - node-pty
+  - sherpa-onnx
+
+patchedDependencies:
+  node-pty@1.1.0: config/patches/node-pty@1.1.0.patch
+  '@xterm/addon-ligatures@0.11.0-beta.287': config/patches/@xterm__addon-ligatures@0.11.0-beta.287.patch
+  '@xterm/addon-webgl@0.20.0-beta.286': config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch
+  '@xterm/addon-serialize@0.15.0-beta.287': config/patches/@xterm__addon-serialize@0.15.0-beta.287.patch
+  '@xterm/xterm@6.1.0-beta.287': config/patches/@xterm__xterm@6.1.0-beta.287.patch


### PR DESCRIPTION
## Summary

`package.json` still carries a `pnpm` field, but the version this repo pins — `"packageManager": "pnpm@10.24.0"` — no longer reads it. pnpm says so on every command:

```
The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored:
"pnpm.overrides", "pnpm.supportedArchitectures", "pnpm.onlyBuiltDependencies", "pnpm.patchedDependencies".
```

All four settings are ignored at their source. What is left is a lockfile that happens to remember two of them:

| Setting | Recorded in `pnpm-lock.yaml`? | Exposure |
| --- | --- | --- |
| `overrides` | yes | survives only while installs stay `--frozen-lockfile` |
| `patchedDependencies` | yes | same |
| `onlyBuiltDependencies` | **no** | no safety net at all |
| `supportedArchitectures` | **no** | no safety net at all |

So the repo is one lockfile regeneration away from silently dropping all five patches in `config/patches/` — including the `node-pty` patch whose `.symver` pins exist to hold the Ubuntu 20.04 / glibc 2.31 floor documented in `AGENTS.md`. `supportedArchitectures` is already unprotected today, and it is what makes a build machine fetch the other platforms' optional binaries rather than only the host's.

This PR moves all four keys into `pnpm-workspace.yaml`, where pnpm 10 reads them, and deletes the dead `package.json` field. `packages: []` and its explanatory comment are preserved verbatim — that entry exists to stop `pnpm -r` crawling `mobile/` and breaking patches with `ERR_PNPM_UNUSED_PATCH`.

No dependency specifier changes. `pnpm-lock.yaml` is untouched.

## Screenshots

`No visual change` — build and dependency configuration only.

## Testing

- [x] `pnpm install` — full install run and verified, see below
- [ ] `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` — not meaningful signals for this change; it modifies no source. The evidence that matters is the install itself.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed — no test is added: this is configuration relocation, and its correctness is proven by install behavior, not by unit tests

**The headline evidence: the lockfile did not move.** The verification install deliberately did **not** use `--frozen-lockfile`, so pnpm was free to rewrite `pnpm-lock.yaml`, and it chose not to. The file is byte-identical to its pre-change state (blob `491c536773bea156b9c5a5ccfcd20f86f875cdfd`, empty `git diff`). Relocating the settings changed resolution in no way.

Behaviorally confirmed after the install:

- **`patchedDependencies`** — all 5 patches applied, `patch_hash` directories matching the lockfile hashes exactly, and the Orca `.symver` marker present in `node_modules/node-pty/binding.gyp`.
- **`overrides`** — both pins resolved (`@hono/node-server` 2.0.10, `dompurify` 3.4.12), single copy each.
- **`supportedArchitectures`** — full cross-platform matrix materialized: esbuild 6/6, `@parcel/watcher` 8/8 including Linux glibc and musl, sherpa-onnx 5/5.

**One honest non-pass. `onlyBuiltDependencies` is NOT behaviorally proven.** `.modules.yaml` shows `ignoredBuilds: []`, which is a good sign that nothing was blocked, but `pendingBuilds` is non-empty and `cpu-features` produced no `.node`. The reason is worth stating because it changes which CI check matters: **node-pty ships prebuilds for darwin-arm64, darwin-x64, win32-arm64 and win32-x64, and none for Linux.** Linux is therefore the only OS that compiles it from source, and the only place the build allowlist and the `.symver` pins are ever exercised. A green macOS or Windows run proves nothing about the one path that matters here.

Key names and value shapes were checked against the pnpm v10 documentation (`settings.md`, `cli/patch.md`) and the machine-readable SchemaStore *pnpm Workspace Specification*. This mattered more than it sounds: pnpm's config surface is a passthrough store that echoes back deliberately misspelled keys unchanged and performs no shape validation, so a typo would reproduce the original bug with no warning at all. `patchedDependencies` is the one key whose recognition could be proven behaviorally rather than by documentation — pnpm resolves its values to absolute paths, while a deliberately misspelled `patchDependencies` keeps its raw relative string.

## AI Review Report

The main risk reviewed was the silently-wrong key name: a misspelling relocates the settings into a file pnpm reads but under names it ignores, reproducing the exact bug this PR fixes while looking correct and emitting no warning. That drove the negative-control test above and the decision to verify against both the official docs and the published JSON schema rather than trusting that the settings appeared to load.

Second risk reviewed: unintended dependency movement hiding inside a settings relocation. Addressed by running a non-frozen install and showing the lockfile is byte-identical, which is stronger evidence than a frozen install could produce.

Third: losing `packages: []`. Confirmed preserved with its comment; the `pnpm-workspace.yaml` diff is purely additive.

**Cross-platform (macOS, Linux, Windows):** central to this change. `supportedArchitectures` is what makes any build host fetch all three platforms' optional binaries, and it is currently ignored. The full matrix was verified to materialize after the change. Per the note above, Linux is the highest-value runner here because it is the only OS where node-pty compiles from source.

**SSH / remote / local:** no runtime code touched; this affects install-time dependency resolution only.

**Agent / integration / git-provider compatibility:** not touched.

**Performance:** no runtime impact.

**UI quality:** not applicable.

## Security Audit

Low risk, and mildly risk-reducing. No dependency specifier, version or source changes: both `overrides` pins are preserved exactly, which matters because `monaco-editor>dompurify` and `@modelcontextprotocol/sdk>@hono/node-server` are pinned overrides of transitive dependencies. The security-relevant improvement is that `patchedDependencies` and `onlyBuiltDependencies` now come from a file pnpm actually reads, rather than depending on the lockfile happening to remember them — a lockfile regeneration currently drops the patches silently.

`onlyBuiltDependencies` is an allowlist of packages permitted to run install scripts. It being ignored is a live weakness, and it is the one item this PR cannot yet prove is fixed (see Testing). No secrets, auth, IPC or input handling involved.

## Notes

This is a CI-validated change: the local install proves it on macOS only, and the finding above means **the Linux runner is the check that matters**, not one of three.

Follow-up, out of scope here: **pnpm v11 removes `onlyBuiltDependencies` in favour of `allowBuilds`.** The next pnpm major will need that rename, or native build scripts will stop running with no warning — the same silent-failure shape this PR is fixing.

The pnpm warning quoted in Summary is field-dependent and observed to disappear in this repo's worktrees once the field is removed. The emitting layer could not be isolated locally, because this machine's pnpm launcher is itself broken — which is the subject of the related PR below.

## Related

Independent of, and mergeable in any order with, the `build:native` fix in the linked PR below. Same theme — this repo's pnpm integration drifting from the behavior of the pinned `pnpm@10.24.0` — but no dependency between them, and no shared files.

See #11738.
