### PR TITLE
fix(terminal): stop dropping agent completions at the side-effect cap

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -892,7 +892,7 @@ describe('createIpcPtyTransport', () => {
     }
   })
 
-  it('bounds the deferred side-effect queue under a stalled drain, keeping the newest title and a pending bell', async () => {
+  it('bounds the deferred queue under a stalled drain without dropping facts', async () => {
     vi.useFakeTimers()
     try {
       const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
@@ -903,22 +903,21 @@ describe('createIpcPtyTransport', () => {
       const callbacks = { onData: vi.fn() }
       const total = MAX_PENDING_PTY_SIDE_EFFECTS * 4
 
-      // Why: the bell is queued first so the cap must evict it — the latch has to survive onto a newer entry.
       processor.processData('\x07', callbacks)
-      for (let i = 0; i < total / 2; i++) {
-        processor.processData(`\x1b]0;cap-title-${i}\x07`, callbacks)
-      }
-      // Why: a paused drain (background shutdown window) must not disable the bound either.
-      processor.pausePendingSideEffects()
-      for (let i = total / 2; i < total; i++) {
+      for (let i = 0; i < total; i++) {
         processor.processData(`\x1b]0;cap-title-${i}\x07`, callbacks)
       }
 
-      expect(onTitleChange).not.toHaveBeenCalled()
+      // The bound holds by applying the excess inline, so the backlog is capped
+      // before any timer runs...
+      expect(onTitleChange.mock.calls.length).toBeGreaterThanOrEqual(
+        total - MAX_PENDING_PTY_SIDE_EFFECTS
+      )
       processor.flushPendingSideEffects()
 
-      // Why: exactly the cap survives — every older title was evicted, never applied.
-      expect(onTitleChange).toHaveBeenCalledTimes(MAX_PENDING_PTY_SIDE_EFFECTS)
+      // ...and every title still arrives, in order, rather than being evicted.
+      expect(onTitleChange).toHaveBeenCalledTimes(total)
+      expect(onTitleChange).toHaveBeenNthCalledWith(1, 'cap-title-0', 'cap-title-0')
       expect(onTitleChange).toHaveBeenLastCalledWith(
         `cap-title-${total - 1}`,
         `cap-title-${total - 1}`
@@ -929,14 +928,36 @@ describe('createIpcPtyTransport', () => {
     }
   })
 
-  it('collapses evicted agent-status payloads onto the survivor, keeping the newest', async () => {
+  it('never drops an agent working->idle completion under overflow', async () => {
     vi.useFakeTimers()
     try {
-      const {
-        createPtyOutputProcessor,
-        MAX_PENDING_PTY_SIDE_EFFECTS,
-        MAX_EVICTED_AGENT_STATUS_PAYLOAD_CARRY
-      } = await import('./pty-transport')
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const onAgentBecameIdle = vi.fn()
+      const processor = createPtyOutputProcessor({ onTitleChange, onAgentBecameIdle })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;\u280b Claude working\x07', callbacks)
+      // The completion edge — this is what mints the unread notification.
+      processor.processData('\x1b]0;\u2733 Claude done\x07', callbacks)
+      for (let i = 0; i < MAX_PENDING_PTY_SIDE_EFFECTS + 50; i++) {
+        processor.processData(`\x1b]0;\u280b Claude working ${i}\x07`, callbacks)
+      }
+      processor.flushPendingSideEffects()
+
+      expect(onAgentBecameIdle).toHaveBeenCalledTimes(1)
+      expect(onAgentBecameIdle).toHaveBeenCalledWith('\u2733 Claude done')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps every agent status payload through overflow, in order', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
       const onAgentStatus = vi.fn()
       const processor = createPtyOutputProcessor({ onAgentStatus })
       const callbacks = { onData: vi.fn() }
@@ -951,14 +972,74 @@ describe('createIpcPtyTransport', () => {
       processor.flushPendingSideEffects()
 
       const delivered = onAgentStatus.mock.calls.map(([payload]) => payload.prompt)
-      expect(delivered.length).toBeLessThanOrEqual(
-        MAX_PENDING_PTY_SIDE_EFFECTS + MAX_EVICTED_AGENT_STATUS_PAYLOAD_CARRY
+      expect(delivered).toEqual(Array.from({ length: total }, (_, i) => `cap-status-${i}`))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still bounds the queue by eviction while the drain is paused for shutdown', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
+      const onTitleChange = vi.fn()
+      const onBell = vi.fn()
+      const processor = createPtyOutputProcessor({ onTitleChange, onBell })
+      const callbacks = { onData: vi.fn() }
+      const total = MAX_PENDING_PTY_SIDE_EFFECTS * 4
+
+      // Why: pending facts are provisional in the shutdown window (commit drops
+      // them wholesale), so the bound is held by eviction there rather than by
+      // firing side effects the pause exists to withhold.
+      processor.processData('\x07', callbacks)
+      processor.pausePendingSideEffects()
+      for (let i = 0; i < total; i++) {
+        processor.processData(`\x1b]0;paused-title-${i}\x07`, callbacks)
+      }
+
+      expect(onTitleChange).not.toHaveBeenCalled()
+      processor.flushPendingSideEffects()
+
+      expect(onTitleChange).toHaveBeenCalledTimes(MAX_PENDING_PTY_SIDE_EFFECTS)
+      expect(onTitleChange).toHaveBeenLastCalledWith(
+        `paused-title-${total - 1}`,
+        `paused-title-${total - 1}`
       )
-      expect(delivered.at(-1)).toBe(`cap-status-${total - 1}`)
-      // Why: eviction collapse must preserve chronological delivery order.
-      expect(delivered).toEqual(
-        [...delivered].sort((a, b) => Number(a.slice(11)) - Number(b.slice(11)))
-      )
+      expect(onBell).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('survives a title consumer that feeds output back during inline overflow', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
+      const callbacks = { onData: vi.fn() }
+      // Why: real consumers write back into the terminal (echo, resize probes).
+      // Sustained feedback recurses into the inline valve; without the reentrancy
+      // guard this overflows the stack rather than queueing.
+      const feedbackWrites = 5_000
+      let reentered = 0
+      const onTitleChange = vi.fn((_title: string, _rawTitle: string) => {
+        if (reentered < feedbackWrites) {
+          reentered += 1
+          processor.processData(`\x1b]0;reentrant-${reentered}\x07`, callbacks)
+        }
+      })
+      const processor = createPtyOutputProcessor({ onTitleChange })
+
+      for (let i = 0; i < MAX_PENDING_PTY_SIDE_EFFECTS * 2; i++) {
+        processor.processData(`\x1b]0;overflow-title-${i}\x07`, callbacks)
+      }
+      processor.flushPendingSideEffects()
+
+      expect(reentered).toBe(feedbackWrites)
+      const delivered = onTitleChange.mock.calls.map(([title]) => title)
+      expect(delivered).toHaveLength(MAX_PENDING_PTY_SIDE_EFFECTS * 2 + feedbackWrites)
+      expect(delivered).toContain(`reentrant-${feedbackWrites}`)
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -71,10 +71,10 @@ const STALE_TITLE_TIMEOUT = 3000 // ms before stale working title is cleared
 const MAX_PTY_SIDE_EFFECTS_PER_DRAIN = 64
 // Why: background timer throttling clamps the drain to ~64 effects/s while an agent CLI can queue
 // hundreds/s, so an overnight minimized window otherwise grows this queue without bound (C1/H2).
-// 512 ≈ 8 drain ticks of catch-up latency once visible; entries are compact facts (≤1 title/payload).
+// Past this depth the deferral is applied inline rather than queued further.
 export const MAX_PENDING_PTY_SIDE_EFFECTS = 512
-// Why: agent status is last-wins store state, but payloads can carry KB-scale prompt/tool strings;
-// carry only the newest few through eviction so a status flood cannot re-grow what it evicted.
+// Why: only the paused-shutdown fallback evicts; carry the newest few statuses
+// so a flood in that window cannot re-grow what it evicted.
 export const MAX_EVICTED_AGENT_STATUS_PAYLOAD_CARRY = 16
 
 type PtyOutputCallbacks = Parameters<PtyTransport['connect']>[0]['callbacks']
@@ -165,6 +165,10 @@ export function createPtyOutputProcessor({
   let pendingSideEffects: PendingPtySideEffect[] = []
   let pendingSideEffectIndex = 0
   let pendingWorkingTitleSideEffects = 0
+  // Why: shutdown pauses the drain deliberately; the overflow valve must not
+  // resurrect side effects during that window.
+  let sideEffectsPaused = false
+  let applyingOverflowingSideEffects = false
   const agentTracker =
     onAgentBecameIdle || onAgentBecameWorking || onAgentExited
       ? createAgentStatusTracker(
@@ -214,9 +218,44 @@ export function createPtyOutputProcessor({
     sideEffectDrainTimer = setTimeout(drainPtySideEffects, 0)
   }
 
-  // Why: oldest-first eviction at the cap. Evicted titles are safe to drop (titles are last-wins);
-  // bells and agent-status payloads collapse onto the next-oldest survivor so a pending bell latch
-  // and the newest statuses still apply on drain instead of vanishing.
+  // Why not evict at the cap: titles are not last-wins facts. A working→idle
+  // transition is what mints the agent-completion notification, and evicted
+  // entries are older than what survives, so dropping them silently loses the
+  // completion. The deferral only exists to yield to xterm's parse timer and
+  // paint; at this depth the drain is starved (throttled background timers), so
+  // yielding buys nothing. Apply the excess inline instead — the queue stays
+  // bounded and every title, status and bell still fires, in order.
+  function boundPendingSideEffects(): void {
+    // Why: title/bell consumers can write back into the terminal; without this
+    // an overflowing enqueue would recurse through its own callbacks.
+    if (applyingOverflowingSideEffects) {
+      return
+    }
+    if (sideEffectsPaused) {
+      evictOldestPendingSideEffectsIfFull()
+      return
+    }
+    applyingOverflowingSideEffects = true
+    try {
+      while (pendingSideEffects.length - pendingSideEffectIndex >= MAX_PENDING_PTY_SIDE_EFFECTS) {
+        const next = pendingSideEffects[pendingSideEffectIndex]
+        if (!next) {
+          return
+        }
+        pendingSideEffectIndex += 1
+        applyPtySideEffect(next)
+        compactPendingSideEffectsIfNeeded()
+      }
+    } finally {
+      applyingOverflowingSideEffects = false
+    }
+  }
+
+  // Why eviction is still correct here and nowhere else: a paused drain is the
+  // shutdown handshake, where every pending fact is provisional — commit drops
+  // the whole queue anyway. Applying inline would fire side effects the pause
+  // exists to withhold, so hold the memory bound by dropping instead, exactly
+  // as before. Bells and statuses still collapse onto the next-oldest survivor.
   function evictOldestPendingSideEffectsIfFull(): void {
     while (pendingSideEffects.length - pendingSideEffectIndex >= MAX_PENDING_PTY_SIDE_EFFECTS) {
       const evicted = pendingSideEffects[pendingSideEffectIndex]
@@ -264,7 +303,7 @@ export function createPtyOutputProcessor({
       pendingWorkingTitleSideEffects += workingTitleCount
       return
     }
-    evictOldestPendingSideEffectsIfFull()
+    boundPendingSideEffects()
     pendingSideEffects.push(next)
     pendingWorkingTitleSideEffects += workingTitleCount
   }
@@ -409,6 +448,9 @@ export function createPtyOutputProcessor({
   }
 
   function flushPendingSideEffects(): void {
+    // Why: rollback partner of pausePendingSideEffects — the session keeps
+    // running, so lift the pause or the overflow valve stays disarmed.
+    sideEffectsPaused = false
     clearSideEffectDrainTimer()
     drainPtySideEffects({ flushAll: true })
   }
@@ -488,12 +530,14 @@ export function createPtyOutputProcessor({
     pendingSideEffects.length = 0
     pendingSideEffectIndex = 0
     pendingWorkingTitleSideEffects = 0
+    sideEffectsPaused = false
     clearStaleTitleTimer()
     agentTracker?.reset()
     bellDetector.reset()
   }
 
   function pausePendingSideEffects(): void {
+    sideEffectsPaused = true
     clearSideEffectDrainTimer()
     clearStaleTitleTimer()
   }


### PR DESCRIPTION
## Summary

The deferred side-effect cap added in #10625 drops agent-completion notifications. `evictOldestPendingSideEffectsIfFull` discards evicted titles on the premise that titles are last-wins:

```js
// Why: oldest-first eviction at the cap. Evicted titles are safe to drop (titles are last-wins);
```

They are not. A working→idle **transition** is what mints the completion notification (`agentTracker.handleTitle` → `onAgentBecameIdle`, and `agentCompletionCoordinator.observeTitle`). Eviction runs oldest-first, so the entries it drops are exactly the ones carrying edges the survivors no longer imply.

## Reproduction

```
working title → completion (idle) → 512+ working titles flood in

onAgentBecameIdle calls: 0        (expected 1)
```

A minimized window with a busy agent is enough: the drain is clamped to ~64 effects/s by background timer throttling while the agent queues hundreds/s, the cap engages, and the "agent done" notification the user is waiting on is silently discarded. This is live on `main`.

## Fix

Hold the same bound by **applying the excess inline instead of discarding it**.

The deferral exists only to yield to xterm's parse timer and paint. At a 512-deep backlog the drain is already starved — that is the precondition for hitting the cap at all — so yielding buys nothing. Applying inline keeps the queue just as bounded while every title, status and bell still fires, in order.

`MAX_PENDING_PTY_SIDE_EFFECTS` is unchanged at 512, so the memory guarantee is identical.

## Two edges worth reviewing

**Re-entrancy.** Applying inline means title/bell consumers that write back into the terminal (echo, resize probes) can recurse into the valve. Unguarded, sustained feedback **overflows the stack** — I confirmed by removing the guard. Guarded, with a 5,000-write regression test that fails without it.

**A paused drain still evicts.** `pausePendingSideEffects` is the shutdown handshake, where pending facts are provisional: `commit` drops the whole queue wholesale, and only `rollback` applies it. Firing side effects inline there would fire exactly what the pause exists to withhold, so that window keeps the existing eviction behavior — including #10625's requirement that the bound hold while paused, which has its own test.

## Testing

- **5,024 tests pass** across `terminal-pane` and `store`
- Four new tests, all of which **fail against `main`'s eviction** and pass with the valve:
  - completion edge survives overflow
  - all titles delivered, in order, under a stalled drain
  - all agent-status payloads delivered, in order
  - deep re-entrancy does not overflow the stack
- The pre-existing paused-drain bound test is kept and still passes
- `typecheck:web`; oxlint; oxfmt

## Context

Split out of #11038, which fixes the actual renderer OOM (a V8 sliced-string leak where a short OSC title pins its whole multi-megabyte PTY frame — 32 titles retained 256 MiB). The two are independent: that PR touches only `src/shared`, this one only `pty-transport.ts`.

Worth noting for reviewers of this cap: once titles are detached by #11038, this queue costs **~0.35 MiB at 2,048 entries** against a 3,586 MiB heap limit. The 16 GiB figure that motivated the bound came from each queued entry pinning its source chunk — i.e. from the leak, not from queue depth. The bound is still worth keeping as a backstop, but it does not need to be lossy to do its job.

Made with [Orca](https://github.com/stablyai/orca) 🐋
