### PR TITLE
fix(orchestration): route the legacy coordinator gate at the caller's own Run

### DIFF
--- a/src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts
@@ -1,4 +1,5 @@
 import type { OrcaRuntimeService, OrchestrationCompatibilityCallerAuthority } from '../orca-runtime'
+import type { OrchestrationDb } from '../orchestration/db'
 import type { LegacyCompatibilityPrincipalRow } from '../orchestration/types'
 import type { LegacyCoordinatorAuthorityProof, RpcRequest } from './core'
 import {
@@ -24,7 +25,7 @@ export class LegacyCoordinatorAuthority {
       return undefined
     }
     // Why: an unnamed Run means the caller's own binding; only an unbound caller can still mean the adopted Run.
-    const requestedRun = requestedRunId ?? this.boundRunId(request) ?? adoption.adopted_run_id
+    const requestedRun = requestedRunId ?? boundRunId(db, request) ?? adoption.adopted_run_id
     if (requestedRun !== adoption.adopted_run_id) {
       return undefined
     }
@@ -137,14 +138,6 @@ export class LegacyCoordinatorAuthority {
     return run.id
   }
 
-  private boundRunId(request: RpcRequest): string | undefined {
-    const paneKey = request.orchestrationCompatibilityEvidence?.paneKey
-    if (!paneKey) {
-      return undefined
-    }
-    return this.runtime.getOrchestrationDb().getCurrentRunForPane(paneKey)?.id
-  }
-
   private candidate(
     runId: string,
     identity: {
@@ -186,4 +179,9 @@ export class LegacyCoordinatorAuthority {
       principal.process_incarnation === attestation.processIncarnation
     )
   }
+}
+
+function boundRunId(db: OrchestrationDb, request: RpcRequest): string | undefined {
+  const paneKey = request.orchestrationCompatibilityEvidence?.paneKey
+  return paneKey ? db.getCurrentRunForPane(paneKey)?.id : undefined
 }

--- a/src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts
@@ -20,8 +20,12 @@ export class LegacyCoordinatorAuthority {
   ): LegacyCoordinatorAuthorityProof | undefined {
     const db = this.runtime.getOrchestrationDb()
     const adoption = db.getLegacyAdoption()
-    const requestedRun = requestedRunId ?? adoption?.adopted_run_id
-    if (!adoption || requestedRun !== adoption.adopted_run_id) {
+    if (!adoption) {
+      return undefined
+    }
+    // Why: an unnamed Run means the caller's own binding; only an unbound caller can still mean the adopted Run.
+    const requestedRun = requestedRunId ?? this.boundRunId(request) ?? adoption.adopted_run_id
+    if (requestedRun !== adoption.adopted_run_id) {
       return undefined
     }
     const candidate = db.resolveLegacyCoordinatorCandidate({
@@ -31,10 +35,17 @@ export class LegacyCoordinatorAuthority {
     })
     if (!candidate) {
       if (request.orchestrationCompatibilityEvidence) {
+        const run = db.getRun(adoption.adopted_run_id)
+        // Why: an unclaimed adopted Run has no coordinator to fence — same rule as bindingMatches below.
+        if (
+          !run?.coordinator_pane_key &&
+          !db.getLegacyCoordinatorPrincipal(adoption.adopted_run_id)
+        ) {
+          return undefined
+        }
         const caller = this.runtime.verifyOrchestrationCompatibilityCaller(
           request.orchestrationCompatibilityEvidence
         )
-        const run = db.getRun(adoption.adopted_run_id)
         if (
           caller &&
           run?.coordinator_handle === caller.terminalHandle &&
@@ -124,6 +135,14 @@ export class LegacyCoordinatorAuthority {
       throw legacyCoordinatorReadOnly()
     }
     return run.id
+  }
+
+  private boundRunId(request: RpcRequest): string | undefined {
+    const paneKey = request.orchestrationCompatibilityEvidence?.paneKey
+    if (!paneKey) {
+      return undefined
+    }
+    return this.runtime.getOrchestrationDb().getCurrentRunForPane(paneKey)?.id
   }
 
   private candidate(

--- a/src/main/runtime/rpc/orchestration-legacy-run-routing.test.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-run-routing.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  cleanupLegacyCompatibilityDispatcherHarnesses,
+  COORDINATOR_HANDLE,
+  createHarness,
+  currentEvidence,
+  CURRENT_COORDINATOR_HANDLE,
+  CURRENT_COORDINATOR_PANE,
+  evidence,
+  invoke,
+  request
+} from './orchestration-legacy-compatibility-dispatcher-test-fixture'
+
+afterEach(() => {
+  cleanupLegacyCompatibilityDispatcherHarnesses()
+})
+
+describe('legacy coordinator gate run routing', () => {
+  it.each(['dispatch', 'websocket'] as const)(
+    '%s asks an unbound caller to bind a Run instead of fencing it as a legacy coordinator',
+    async (transport) => {
+      const harness = createHarness()
+
+      const response = await invoke(
+        harness.dispatcher,
+        request(
+          'orchestration.taskCreate',
+          {
+            spec: 'fresh assignment',
+            callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+          },
+          currentEvidence('coordinator'),
+          `unbound-task-create-${transport}`
+        ),
+        transport
+      )
+
+      expect(response).toMatchObject({
+        ok: false,
+        error: { code: 'run_required' }
+      })
+      expect(harness.db.listTasks({ runId: harness.adoptedRunId })).toHaveLength(1)
+    }
+  )
+
+  it('routes an unnamed Run to the caller binding even when attestation fails', async () => {
+    const harness = createHarness()
+    const run = harness.db.createRun({
+      objective: 'current work',
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'fresh assignment',
+          callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+        },
+        { ...currentEvidence('coordinator'), launchToken: '' },
+        'unattested-bound-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { task: { run_id: run.id, spec: 'fresh assignment' } }
+    })
+  })
+
+  it('lets a current coordinator rebind the unclaimed adopted Run with actionable guidance', async () => {
+    const harness = createHarness()
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        { id: harness.adoptedRunId, from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('coordinator'),
+        'unclaimed-adopted-run-use'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'consumer_fenced',
+        data: {
+          recoveryCommand: `orca orchestration run-use --id ${harness.adoptedRunId} --takeover-legacy`
+        }
+      }
+    })
+  })
+
+  it('still routes the retained legacy coordinator to the adopted Run without --run', async () => {
+    const harness = createHarness()
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'retained assignment',
+          callerTerminalHandle: COORDINATOR_HANDLE
+        },
+        evidence('coordinator'),
+        'retained-adopted-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: {
+        task: { run_id: harness.adoptedRunId, spec: 'retained assignment' }
+      }
+    })
+  })
+
+  it('still fences a stale legacy coordinator once the adopted Run is claimed', async () => {
+    const harness = createHarness()
+    harness.db.bindRun({
+      runId: harness.adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE,
+      takeoverLegacy: true
+    })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'stale assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: COORDINATOR_HANDLE
+        },
+        evidence('coordinator'),
+        'claimed-adopted-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'legacy_read_only' }
+    })
+    expect(harness.db.listTasks({ runId: harness.adoptedRunId })).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## ELI5

A security guard checks your badge against the wrong door — and that door has no owner on file, so nobody's badge can ever match.

1. Run an orchestration command **without naming a Run**, and the gate assumed you meant the sealed-off Run left over from the update migration — never the Run you were actually bound to.
2. That leftover Run's owner field is **always `NULL`** (the SQL that creates it never sets it). The owner check is a plain `===`, so `null === "term_…"` is false for every caller that will ever exist.

Alone, each is harmless. Together: everyone gets stopped at a door they never asked for, then fails a test nobody can pass.

This PR fixes both halves. The gate now asks *"which Run is this caller actually on?"*, and an adopted Run nobody has claimed is treated as free rather than locked.

## Root cause

Both in `src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts`, introduced by #11271.

**A — the caller's Run defaulted to the adopted Run** (`:23`)

```js
const requestedRun = requestedRunId ?? adoption?.adopted_run_id
```

`requestedRunId` is just the `--run` argument (`orchestration-legacy-compatibility.ts:90-91`). Omit `--run` and it is `undefined`, so `??` substituted the adopted Run. The caller's own binding was never consulted, so every gated call became — in the gate's view — a call about the adopted Run.

**B — the adopted Run has no coordinator, and `NULL` failed the check** (`:38-46`)

`adoptLegacyRunIfNeeded` (`db.ts:1150`) inserts the adopted Run with only `(id, objective, home_database, consumer_generation, legacy)`, leaving `coordinator_handle` / `coordinator_pane_key` `NULL`. The escape hatch requires `run.coordinator_handle === caller.terminalHandle`, so it was unreachable by construction.

The file already contradicted itself: `bindingMatches()` at `:146-155` treats a null coordinator as *unclaimed and fine*, while the check above treated it as *locked and refuse*.

## Fix

```diff
-const requestedRun = requestedRunId ?? adoption?.adopted_run_id
+// Why: an unnamed Run means the caller's own binding; only an unbound caller can still mean the adopted Run.
+const requestedRun = requestedRunId ?? this.boundRunId(request) ?? adoption.adopted_run_id
```

`boundRunId` resolves `db.getCurrentRunForPane(evidence.paneKey)` — the same question `resolveRunScope` (`methods/orchestration.ts:287`) already asks downstream, so the gate and the handler now agree on which Run a call is about. Keeping the adopted Run as the **last-resort fallback** (rather than replacing the default outright) is what preserves #11271's actual feature: a retained legacy coordinator has no pane binding, so it still routes to the adopted Run without `--run`.

For B, an adopted Run with no `coordinator_pane_key` **and** no legacy coordinator principal is unclaimed, so there is no coordinator to fence and the gate steps aside. If either exists, the fence behaves exactly as before.

Callers are no longer told "this retained legacy coordinator could not prove its original process identity" about a Run they never mentioned. They get the honest, actionable error instead — `run_required` ("Use orchestration run-create or run-use first") or `consumer_fenced` with its `--takeover-legacy` recovery command.

## Proof of fix

New suite `orchestration-legacy-run-routing.test.ts`, run against this branch with the fix reverted:

```
× dispatch asks an unbound caller to bind a Run instead of fencing it as a legacy coordinator
× websocket asks an unbound caller to bind a Run instead of fencing it as a legacy coordinator
-  "code": "run_required"
+  "code": "legacy_read_only"

× routes an unnamed Run to the caller binding even when attestation fails
-  "ok": true, "result": { "task": { "run_id": "run_6a09fafe1e9b" } }
+  "ok": false

× lets a current coordinator rebind the unclaimed adopted Run with actionable guidance
-  "code": "consumer_fenced", "data": { "recoveryCommand": "…--takeover-legacy" }
+  "code": "legacy_read_only", "data": { "effectsApplied": false }

Tests  4 failed | 2 passed (6)
```

With the fix: `Tests 6 passed (6)`.

The two that passed both ways are the no-regression cases, deliberately written to pass before and after:

- **retained legacy coordinator still routes to the adopted Run without `--run`** — the #11271 behaviour this fix must not break.
- **a stale legacy coordinator is still fenced once the adopted Run is claimed** — `legacy_read_only`, zero effects.

## Proof of no regression

| Scope | Result |
|---|---|
| All `src/main/runtime` orchestration suites (46 files) | **569 passed** |
| All `src/cli` orchestration suites (10 files) | **126 passed** |
| Legacy-compat suites specifically (dispatcher, current-authority precedence, coordinator race, takeover, question takeover, compatibility authority) | **72 passed** |
| `pnpm typecheck` (node + cli + web) | clean |
| `oxlint` | clean |

## Release context

Verified with `git merge-base --is-ancestor`: #11271 landed in **v1.4.163-rc.0 / rc.1 only**. v1.4.161, v1.4.162 and v1.4.162-rc.1 are all clean — **no stable release is affected**. Neither rc contains the #11737 mitigation.

## Notes

- **#11737 narrowed this, it did not fix it.** Its `usesCurrentAuthority()` preflight added a bypass for attested callers with a current binding, which covers the reporter's literal repro. The gate itself was still misrouted, so it kept firing for: callers with no bound Run, callers whose attestation fails (relay/SSH dropping `ORCA_AGENT_LAUNCH_TOKEN`), callers passing `--from`/`--terminal` for another handle, legacy workers on `taskCreate`/`dispatch`/`gateCreate`, and every `run-use` on the adopted Run without `--takeover-legacy` (`runUse` always skips the preflight). This PR fixes the routing rather than adding a third special case.
- **Overlaps open PR #11582** (@leofmarciano), which fences only callers already known as the legacy coordinator. That addresses a slice of defect B and none of defect A. Whichever lands first, the other should rebase — happy to fold their `isKnownLegacyCoordinatorIdentity` in if preferred.
- **Not addressed here:** the `worker-start --on <env>` → `runtime_unavailable` observation in the appendix of the report (CLI gives up on a long federated call whose effects did land). Unrelated transport-layer issue, undiagnosed, worth its own issue.
- **No revert.** #11271 is 152 files / +22,217 / −3,144, bundles unrelated Windows updater fixes, has 136 commits on top of it, and fixes something real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
