### PR TITLE
fix(sidebar): show completion timer

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -30,6 +30,7 @@ import {
   type TerminalTitleTracker
 } from '../../shared/terminal-output-side-effects'
 import { createCommandCodeOutputStatusDetector } from '../../shared/command-code-output-status'
+import { createKiroOutputStatusDetector } from '../../shared/kiro-output-status'
 import type {
   TerminalSideEffectBatch,
   TerminalSideEffectFact
@@ -1484,6 +1485,8 @@ type RuntimePtyTitleTrackerEntry = {
   // TUI output. Null when no side-effect consumer exists (headless serve) —
   // the scrape produces facts only.
   commandCodeDetector: { observe: (data: string) => boolean } | null
+  // Kiro also lacks hooks/status titles; its detector follows the same fact-only lifetime.
+  kiroDetector: { observe: (data: string) => boolean } | null
 }
 
 // Why: the full OSC 9999 payload flows through emitTerminalAgentStatusEvents and
@@ -9730,6 +9733,7 @@ export class OrcaRuntimeService {
       // detector's bounded recent-text window; the detector strips remaining
       // control sequences itself, exactly like the renderer byte path.
       titleTrackerEntry.commandCodeDetector?.observe(agentStatusChunk.cleanData)
+      titleTrackerEntry.kiroDetector?.observe(agentStatusChunk.cleanData)
     } finally {
       titleTrackerEntry.applyingChunk = false
       try {
@@ -10230,6 +10234,9 @@ export class OrcaRuntimeService {
       // saw one) mirrors the renderer detector's startupCommand fast-arm.
       commandCodeDetector: this.terminalSideEffectConsumerAvailable
         ? this.createTerminalSideEffectCommandCodeDetector(ptyId)
+        : null,
+      kiroDetector: this.terminalSideEffectConsumerAvailable
+        ? this.createTerminalSideEffectKiroDetector(ptyId)
         : null
     }
     this.ptyTitleTrackersByPtyId.set(ptyId, entry)
@@ -10380,6 +10387,7 @@ export class OrcaRuntimeService {
       entry.commandCodeDetector = nextAvailable
         ? this.createTerminalSideEffectCommandCodeDetector(ptyId)
         : null
+      entry.kiroDetector = nextAvailable ? this.createTerminalSideEffectKiroDetector(ptyId) : null
     }
   }
 
@@ -10393,6 +10401,27 @@ export class OrcaRuntimeService {
       },
       onDone: (prompt) => {
         this.recordTerminalSideEffectFact(ptyId, { kind: 'command-code-done', prompt })
+      }
+    })
+  }
+
+  private createTerminalSideEffectKiroDetector(
+    ptyId: string
+  ): NonNullable<RuntimePtyTitleTrackerEntry['kiroDetector']> {
+    const pty = this.ptysById.get(ptyId)
+    const knownKiroSession = [
+      pty?.lastOscTitle,
+      pty?.managementTitle,
+      ...this.getLeavesForPty(ptyId).map((leaf) => leaf.paneTitle)
+    ].some((title) => recognizeAgentProcess(title)?.agent === 'kiro')
+    return createKiroOutputStatusDetector({
+      startupCommand: this.terminalSpawnCommandsByPtyId.get(ptyId) ?? null,
+      knownKiroSession,
+      onWorking: () => {
+        this.recordTerminalSideEffectFact(ptyId, { kind: 'kiro-working' })
+      },
+      onDone: () => {
+        this.recordTerminalSideEffectFact(ptyId, { kind: 'kiro-done' })
       }
     })
   }

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -44,6 +44,16 @@ function formatTimeAgo(ts: number, now: number): string {
   return `${days}d ago`
 }
 
+// Why: a fresh completion reads in seconds so a just-finished agent is visibly distinct from a minute-old one.
+function formatDoneTimeAgo(ts: number, now: number): string {
+  const delta = now - ts
+  if (delta < 60_000) {
+    const seconds = Math.max(0, Math.floor(delta / 1_000))
+    return `${seconds}s ago`
+  }
+  return formatTimeAgo(ts, now)
+}
+
 function stateDotTooltipLabel(agent: DashboardAgentRowData, dotState: AgentDotState): string {
   if (agent.entry.interrupted === true) {
     return 'Interrupted by user'
@@ -166,8 +176,14 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
 
   // Why: always show the chevron so the row's right edge doesn't flicker as content grows/shrinks.
 
-  const startedTimeAgo = startedAt !== null ? formatTimeAgo(startedAt, now) : null
-  const doneTimeAgo = doneAt !== null ? formatTimeAgo(doneAt, now) : null
+  const showCompletionTime = doneAt !== null && isUnvisited
+  const startedTimeAgo =
+    doneAt !== null && !showCompletionTime
+      ? null
+      : startedAt !== null
+        ? formatTimeAgo(startedAt, now)
+        : null
+  const doneTimeAgo = showCompletionTime ? formatDoneTimeAgo(doneAt, now) : null
   const relativeTimestamp = doneTimeAgo ?? startedTimeAgo
   const tsParts: string[] = []
   if (startedTimeAgo !== null) {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import DashboardAgentRow from '@/components/dashboard/DashboardAgentRow'
 import { useNow } from '@/components/dashboard/useNow'
+import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
 import {
   selectSendTargetControlInputs,
@@ -13,8 +12,6 @@ import {
 import { useWorktreeAgentRows } from './useWorktreeAgentRows'
 import { cn } from '@/lib/utils'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
-import { parsePaneKey } from '../../../../shared/stable-pane-id'
-import { dismissStaleAgentRowByKey } from '../terminal-pane/stale-agent-row'
 import { useFocusedAgentPaneKey } from './focused-agent-row-highlight'
 import {
   CompactAgentExpansion,
@@ -26,6 +23,7 @@ import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constant
 import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
 import { useWorktreeAgentExpansionState } from './worktree-card-agents-expansion-state'
 import { translate } from '@/i18n/i18n'
+import { useWorktreeCardAgentActivation } from './use-worktree-card-agent-activation'
 
 export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
   'orca-suppress-worktree-list-scroll-adjustment'
@@ -147,49 +145,19 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     [sendPromptToSidebarAgentTarget]
   )
 
-  const handleActivateAgentTab = useCallback(
-    (tabId: string, paneKey: string) => {
-      const parsed = parsePaneKey(paneKey)
-      if (!parsed) {
-        // Why: malformed/legacy numeric keys can't be resolved after pane replay/remount, so drop the stale row instead of guessing.
-        console.warn('[WorktreeCardAgents] malformed paneKey, skipping pane focus', paneKey)
-        dismissStaleAgentRowByKey(paneKey)
-        return
-      }
-      if (parsed.tabId !== tabId) {
-        console.warn('[WorktreeCardAgents] paneKey tabId mismatch, dismissing row', {
-          tabId,
-          paneKey
-        })
-        dismissStaleAgentRowByKey(paneKey)
-        return
-      }
-      // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
-      activateAndRevealWorktree(worktreeId)
-      const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
-      if (tabs.some((t) => t.id === tabId)) {
-        activateTabAndFocusPane(tabId, parsed.leafId, {
-          ackPaneKeyOnSuccess: paneKey,
-          flashFocusedPane: true,
-          scrollToBottomIfOutputSinceLastView: true
-        })
-      } else {
-        const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
-        if (liveEntry?.worktreeId === worktreeId) {
-          // Why: orchestration worker status can be worktree-attributed before the renderer knows its tab; keep the live row instead of dismissing as stale.
-          return
-        }
-        dismissStaleAgentRowByKey(paneKey)
-      }
-    },
-    [worktreeId]
-  )
-  const handleActivateRetainedAgent = useCallback(() => {
-    // Why: hibernation-retained rows are passive completion evidence; activating would resume sleeping sessions, so the row is inert.
-  }, [])
+  const { handleActivateAgentTab, handleActivateRetainedAgent } = useWorktreeCardAgentActivation({
+    worktreeId
+  })
 
-  // Why: one 30s tick per non-empty inline list; zero-agent cards never mount this (see WorktreeCardAgents), so idle worktrees pay no timer cost.
-  const now = useNow(30_000)
+  // Why: tick every second only while a completion label uses seconds; all cards share that visibility-gated clock.
+  const hasRecentDoneAgent = agents.some((a) => {
+    if (!(unvisitedByPaneKey[a.paneKey] ?? false)) {
+      return false
+    }
+    const doneAt = lastEnteredDoneAt(a)
+    return doneAt !== null && Date.now() - doneAt < 60_000
+  })
+  const now = useNow(hasRecentDoneAgent ? 1_000 : 30_000)
   const { rootRows: rootAgents, childrenByParentPaneKey } = useMemo(
     () => buildAgentRowLineageTree(agents),
     [agents]
@@ -335,6 +303,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           }
           reserveDisclosureGutter={isRootAgent && anyRootHasChildren && !hasChildAgents}
           isFocusedPane={agent.paneKey === focusedAgentPaneKey}
+          isUnvisited={unvisitedByPaneKey[agent.paneKey] ?? false}
           cacheTimerActive={cacheTimerActive}
         />
         {hasChildAgents ? (

--- a/src/renderer/src/components/sidebar/use-worktree-card-agent-activation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-agent-activation.ts
@@ -1,0 +1,59 @@
+import { useCallback } from 'react'
+import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { useAppStore } from '@/store'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { dismissStaleAgentRowByKey } from '../terminal-pane/stale-agent-row'
+
+type WorktreeCardAgentActivationArgs = {
+  worktreeId: string
+}
+
+export function useWorktreeCardAgentActivation({ worktreeId }: WorktreeCardAgentActivationArgs): {
+  handleActivateAgentTab: (tabId: string, paneKey: string) => void
+  handleActivateRetainedAgent: (tabId: string, paneKey: string) => void
+} {
+  const handleActivateAgentTab = useCallback(
+    (tabId: string, paneKey: string) => {
+      const parsed = parsePaneKey(paneKey)
+      if (!parsed) {
+        console.warn('[WorktreeCardAgents] malformed paneKey, skipping pane focus', paneKey)
+        dismissStaleAgentRowByKey(paneKey)
+        return
+      }
+      if (parsed.tabId !== tabId) {
+        console.warn('[WorktreeCardAgents] paneKey tabId mismatch, dismissing row', {
+          tabId,
+          paneKey
+        })
+        dismissStaleAgentRowByKey(paneKey)
+        return
+      }
+      // Why: all user-initiated worktree switches must preserve cross-repo activation and nav history.
+      activateAndRevealWorktree(worktreeId)
+      const state = useAppStore.getState()
+      const tabs = state.tabsByWorktree[worktreeId] ?? []
+      if (tabs.some((tab) => tab.id === tabId)) {
+        activateTabAndFocusPane(tabId, parsed.leafId, {
+          ackPaneKeyOnSuccess: paneKey,
+          flashFocusedPane: true,
+          scrollToBottomIfOutputSinceLastView: true
+        })
+        return
+      }
+      const liveEntry = state.agentStatusByPaneKey[paneKey]
+      if (liveEntry?.worktreeId === worktreeId) {
+        // Why: orchestration status can be worktree-attributed before its tab reaches this renderer.
+        return
+      }
+      dismissStaleAgentRowByKey(paneKey)
+    },
+    [worktreeId]
+  )
+
+  const handleActivateRetainedAgent = useCallback(() => {
+    // Why: retained rows must stay inert so a sleeping session is never resumed.
+  }, [])
+
+  return { handleActivateAgentTab, handleActivateRetainedAgent }
+}

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -28,6 +28,15 @@ function formatShortTimeAgo(ts: number, now: number): string {
   return `${Math.floor(hours / 24)}d`
 }
 
+function formatShortDoneTimeAgo(ts: number, now: number): string {
+  const delta = now - ts
+  if (delta < 60_000) {
+    const seconds = Math.max(0, Math.floor(delta / 1_000))
+    return `${seconds}s`
+  }
+  return formatShortTimeAgo(ts, now)
+}
+
 function getCompactAgentPrimary(
   agent: DashboardAgentRowData,
   conversationName: string | null
@@ -61,10 +70,14 @@ function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
   return formatAgentTypeLabel(agent.agentType)
 }
 
-function getCompactAgentTime(agent: DashboardAgentRowData, now: number): string | null {
+function getCompactAgentTime(
+  agent: DashboardAgentRowData,
+  now: number,
+  isUnvisited: boolean
+): string | null {
   const doneAt = lastEnteredDoneAt(agent)
   if (doneAt !== null) {
-    return formatShortTimeAgo(doneAt, now)
+    return isUnvisited ? formatShortDoneTimeAgo(doneAt, now) : null
   }
   const startedAt = agent.startedAt > 0 ? agent.startedAt : agent.entry.stateStartedAt
   return startedAt > 0 ? formatShortTimeAgo(startedAt, now) : null
@@ -92,6 +105,7 @@ type CompactAgentRowProps = {
   onToggleChildAgents?: () => void
   reserveDisclosureGutter?: boolean
   isFocusedPane?: boolean
+  isUnvisited?: boolean
   hideIdentityIcon?: boolean
   cacheTimerActive?: boolean
 }
@@ -108,6 +122,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   onToggleChildAgents,
   reserveDisclosureGutter = false,
   isFocusedPane = false,
+  isUnvisited = false,
   hideIdentityIcon = false,
   cacheTimerActive = true
 }: CompactAgentRowProps) {
@@ -125,7 +140,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   const isLineageChild = agent.lineage?.depth === 1
   const secondary = getCompactAgentSecondary(agent)
   const model = agent.entry.model?.trim() ?? ''
-  const shortTime = getCompactAgentTime(agent, now)
+  const shortTime = getCompactAgentTime(agent, now, isUnvisited)
   const cacheTimer = usePromptCacheCountdownForPane(agent.paneKey, cacheTimerActive)
 
   const handleActivate = useCallback(

--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
@@ -17,6 +17,7 @@ import {
   isAgentTaskCompleteTrackingEnabledFromState
 } from './agent-task-complete-policy'
 import { createCommandCodeOutputStatusDetector } from '../../../../shared/command-code-output-status'
+import { createKiroOutputStatusDetector } from '../../../../shared/kiro-output-status'
 import { createOsc133CommandFinishedScanner } from '../../../../shared/terminal-osc133-command-finished'
 import {
   createParkedTerminalCommandStatusPolicy,
@@ -204,6 +205,16 @@ export function startParkedTerminalByteWatcher(
     paneId,
     paneKey
   })
+  const onKiroWorking = (): void => {
+    if (commandStatusPolicy.onKiroWorking()) {
+      sideEffectCallbacks.onAgentBecameWorking()
+    }
+  }
+  const onKiroDone = (): void => {
+    if (commandStatusPolicy.onKiroDone()) {
+      sideEffectCallbacks.onAgentBecameIdle('Kiro')
+    }
+  }
 
   // Why: with the authority switch on, the fact consumer is the single policy consumer — registering byte parsers too would double-fire bells.
   const mainSideEffectAuthority =
@@ -251,6 +262,17 @@ export function startParkedTerminalByteWatcher(
         onWorking: commandStatusPolicy.onCommandCodeWorking,
         onDone: commandStatusPolicy.onCommandCodeDone
       })
+  const kiroOutputStatusDetector = factSideEffectAuthority
+    ? null
+    : createKiroOutputStatusDetector({
+        knownKiroSession:
+          useAppStore.getState().paneForegroundAgentByPaneKey?.[paneKey]?.agent === 'kiro',
+        inFlightTurn:
+          useAppStore.getState().agentStatusByPaneKey?.[paneKey]?.agentType === 'kiro' &&
+          useAppStore.getState().agentStatusByPaneKey?.[paneKey]?.state === 'working',
+        onWorking: onKiroWorking,
+        onDone: onKiroDone
+      })
   const unregisterFactConsumer = factSideEffectAuthority
     ? registerTerminalSideEffectFactConsumer({
         ptyId,
@@ -260,6 +282,8 @@ export function startParkedTerminalByteWatcher(
           onCommandFinished: commandStatusPolicy.onCommandFinished,
           onCommandCodeWorking: commandStatusPolicy.onCommandCodeWorking,
           onCommandCodeDone: commandStatusPolicy.onCommandCodeDone,
+          onKiroWorking,
+          onKiroDone,
           onPrLink: (link) =>
             useAppStore.getState().observeTerminalGitHubPullRequestLink(worktreeId, link),
           // Why (gate mode only): the 2031 subscribe arrives as a fact, but the reply stays here — query authority stays with the view/watcher (invariant 6).
@@ -287,6 +311,7 @@ export function startParkedTerminalByteWatcher(
     processor.processData(data, {})
     commandFinishedScanner?.scan(data)
     commandCodeOutputStatusDetector?.observe(data)
+    kiroOutputStatusDetector?.observe(data)
     if (observeTerminalGitHubPRLink) {
       for (const link of observeTerminalGitHubPRLink(data)) {
         useAppStore.getState().observeTerminalGitHubPullRequestLink(worktreeId, link)

--- a/src/renderer/src/components/terminal-pane/parked-terminal-command-status.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-command-status.ts
@@ -22,6 +22,8 @@ export type ParkedTerminalCommandStatusPolicy = {
   onCommandFinished: (bestEffortExitCode: number | null) => void
   onCommandCodeWorking: (prompt: string) => void
   onCommandCodeDone: (prompt: string) => void
+  onKiroWorking: () => boolean
+  onKiroDone: () => boolean
   dispose: () => void
 }
 
@@ -144,6 +146,37 @@ export function createParkedTerminalCommandStatusPolicy(options: {
     settleCommandCodeDone
   )
 
+  const setKiroStatus = (status: 'working' | 'done'): boolean => {
+    const routing = resolveRouting()
+    if (!routing) {
+      return false
+    }
+    const currentState = useAppStore.getState()
+    const currentEntry = currentState.agentStatusByPaneKey[paneKey]
+    if (
+      status === 'done' &&
+      (currentEntry?.agentType !== 'kiro' || currentEntry.state !== 'working')
+    ) {
+      return false
+    }
+    const currentTitle = currentState.runtimePaneTitlesByTabId?.[tabId]?.[paneId]
+    currentState.setAgentStatus(
+      paneKey,
+      {
+        state: status,
+        prompt:
+          currentEntry?.agentType === 'kiro' && currentEntry.prompt.trim()
+            ? currentEntry.prompt
+            : 'Kiro',
+        agentType: 'kiro'
+      },
+      currentTitle,
+      undefined,
+      routing
+    )
+    return true
+  }
+
   return {
     onCommandFinished: (bestEffortExitCode: number | null): void => {
       if (disposed) {
@@ -210,6 +243,9 @@ export function createParkedTerminalCommandStatusPolicy(options: {
       }
       openCommandCodeDoneSettle(paneKey, normalizedPrompt)
     },
+
+    onKiroWorking: (): boolean => setKiroStatus('working'),
+    onKiroDone: (): boolean => setKiroStatus('done'),
 
     dispose: (): void => {
       // Why release, not flush: the settle window belongs to the turn and outlives this

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -235,6 +235,7 @@ import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform
 import { resolveTerminalPasteRuntime } from './terminal-paste-runtime'
 import { isKnownTuiAgentTerminalStartupCommand } from './terminal-startup-command-classifier'
 import { createCommandCodeOutputStatusDetector } from '../../../../shared/command-code-output-status'
+import { createKiroOutputStatusDetector } from '../../../../shared/kiro-output-status'
 import type { PtyDataMeta } from './pty-dispatcher'
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
 import { createTerminalGitHubPRLinkDetector } from '../../../../shared/terminal-github-pr-link-detector'
@@ -2344,6 +2345,8 @@ export function connectPanePty(
         // renderer seeds also write), so main only emits scrape facts.
         onCommandCodeWorking: seedCommandCodeOutputWorkingStatus,
         onCommandCodeDone: scheduleCommandCodeOutputDoneStatus,
+        onKiroWorking: onKiroOutputWorking,
+        onKiroDone: onKiroOutputDone,
         ...(shouldOwnAgentStatusInRenderer
           ? { onAgentStatus: (payload) => handleRendererOwnedAgentStatus(payload) }
           : {}),
@@ -2932,6 +2935,26 @@ export function connectPanePty(
     // complete the row if no active status repaint arrives during this window.
     openCommandCodeDoneSettle(cacheKey, normalizedPrompt)
   }
+
+  const setKiroOutputStatus = (status: 'working' | 'done'): void => {
+    const currentEntry = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+    if (
+      status === 'done' &&
+      (currentEntry?.agentType !== 'kiro' || currentEntry.state !== 'working')
+    ) {
+      return
+    }
+    handleRendererOwnedAgentStatus({
+      state: status,
+      prompt:
+        currentEntry?.agentType === 'kiro' && currentEntry.prompt.trim()
+          ? currentEntry.prompt
+          : 'Kiro',
+      agentType: 'kiro'
+    })
+  }
+  const onKiroOutputWorking = (): void => setKiroOutputStatus('working')
+  const onKiroOutputDone = (): void => setKiroOutputStatus('done')
 
   const observeTerminalGitHubPRLink = createTerminalGitHubPRLinkDetector()
   const reportPanePtyVisibility = (ptyId: string | null | undefined, visible: boolean): void => {
@@ -3704,6 +3727,19 @@ export function connectPanePty(
         inFlightTurn: readInFlightCommandCodeTurn(cacheKey),
         onWorking: seedCommandCodeOutputWorkingStatus,
         onDone: scheduleCommandCodeOutputDoneStatus
+      })
+  const kiroOutputStatusDetector = mainSideEffectAuthority
+    ? null
+    : createKiroOutputStatusDetector({
+        startupCommand: paneStartup?.command,
+        knownKiroSession:
+          paneStartup?.launchAgent === 'kiro' ||
+          useAppStore.getState().paneForegroundAgentByPaneKey?.[cacheKey]?.agent === 'kiro',
+        inFlightTurn:
+          useAppStore.getState().agentStatusByPaneKey?.[cacheKey]?.agentType === 'kiro' &&
+          useAppStore.getState().agentStatusByPaneKey?.[cacheKey]?.state === 'working',
+        onWorking: onKiroOutputWorking,
+        onDone: onKiroOutputDone
       })
   const shouldDeliverStartupViaTerminalPaste = paneStartup?.delivery === 'terminal-paste'
   const hadExistingPaneTransportAtConnect = deps.paneTransportsRef.current.size > 0
@@ -7747,6 +7783,7 @@ export function connectPanePty(
         commandLifecycle.handlePtyData(data)
       }
       commandCodeOutputStatusDetector?.observe(data)
+      kiroOutputStatusDetector?.observe(data)
       // Why: split panes have visible-but-inactive panes the user watches; throttle only when the pane or whole document is hidden.
       const foreground =
         shouldWritePtyOutputForeground(deps.isVisibleRef.current) && meta?.background !== true

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
@@ -85,6 +85,8 @@ export type TerminalSideEffectFactConsumerCallbacks = {
    *  done is settle-checked by the pane policy before completing the turn. */
   onCommandCodeWorking?: (prompt: string) => void
   onCommandCodeDone?: (prompt: string) => void
+  onKiroWorking?: () => void
+  onKiroDone?: () => void
   /** DECSET 2031 subscribe observed by main's tracker. Registered only by
    *  hidden-delivery-gated consumers (their bytes never arrive); the theme
    *  reply is sent renderer-side — query authority stays with the view. */
@@ -143,6 +145,12 @@ function applyLiveFact(entry: ConsumerEntry, fact: TerminalSideEffectFact, seq: 
       return
     case 'command-code-done':
       entry.callbacks.onCommandCodeDone?.(fact.prompt)
+      return
+    case 'kiro-working':
+      entry.callbacks.onKiroWorking?.()
+      return
+    case 'kiro-done':
+      entry.callbacks.onKiroDone?.()
       return
     case '2031-subscribe':
       entry.callbacks.onMode2031Subscribe?.()

--- a/src/shared/kiro-output-status.test.ts
+++ b/src/shared/kiro-output-status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { createKiroOutputStatusDetector } from './kiro-output-status'
+
+const ESC = String.fromCharCode(0x1b)
+const KIRO_UI = 'ask a question or describe a task ↵'
+const WORKING = 'Thinking... (esc to cancel)'
+const DONE = 'Credits: 0.42 • Time: 12.3 s'
+
+function trackDetector(args?: { startupCommand?: string; knownKiroSession?: boolean }) {
+  const calls: string[] = []
+  const detector = createKiroOutputStatusDetector({
+    ...args,
+    onWorking: () => calls.push('working'),
+    onDone: () => calls.push('done')
+  })
+  return { calls, observe: detector.observe }
+}
+
+describe('kiro output status detector', () => {
+  it('ignores status-shaped output until the Kiro UI is seen', () => {
+    const { calls, observe } = trackDetector()
+    expect(observe(`${WORKING}\n${DONE}\n`)).toBe(false)
+    expect(calls).toEqual([])
+  })
+
+  it('reports working then done once the Kiro UI is seen', () => {
+    const { calls, observe } = trackDetector()
+    observe(`${KIRO_UI}\n`)
+    observe(`${WORKING}\n`)
+    observe(`${DONE}\n`)
+    expect(calls).toEqual(['working', 'done'])
+  })
+
+  it('ignores a done line with no in-flight turn', () => {
+    const { calls, observe } = trackDetector()
+    observe(`${KIRO_UI}\n`)
+    expect(observe(`${DONE}\n`)).toBe(false)
+    expect(calls).toEqual([])
+  })
+
+  // Why: the PTY splits at arbitrary byte offsets, so a status line routinely straddles two chunks.
+  it('detects a status line split across chunks', () => {
+    const { calls, observe } = trackDetector()
+    observe(`${KIRO_UI}\n`)
+    observe('Thinki')
+    observe('ng... (esc to cancel)\n')
+    observe('Credits: 0.42 • Ti')
+    observe('me: 12.3 s\n')
+    expect(calls).toEqual(['working', 'done'])
+  })
+
+  // Why: the carry window re-scans prior text, so a settled match must not fire again.
+  it('fires once per turn across consecutive turns', () => {
+    const { calls, observe } = trackDetector()
+    observe(`${KIRO_UI}\n`)
+    observe(`${WORKING}\n`)
+    observe('tool output\n')
+    observe(`${DONE}\n`)
+    observe('more output\n')
+    observe(`${WORKING}\n`)
+    observe(`${DONE}\n`)
+    expect(calls).toEqual(['working', 'done', 'working', 'done'])
+  })
+
+  it('trusts a known Kiro startup command without waiting for the UI', () => {
+    const { calls, observe } = trackDetector({ startupCommand: 'kiro-cli chat --tui' })
+    observe(`${WORKING}\n`)
+    observe(`${DONE}\n`)
+    expect(calls).toEqual(['working', 'done'])
+  })
+
+  it('detects status lines wrapped in ANSI control sequences', () => {
+    const { calls, observe } = trackDetector({ knownKiroSession: true })
+    observe(`${ESC}[1mThinking...${ESC}[0m (esc to cancel)\r\n`)
+    observe(`${ESC}[2K${ESC}[32mCredits: 0.42 • Time: 12.3 s${ESC}[0m\r\n`)
+    expect(calls).toEqual(['working', 'done'])
+  })
+})

--- a/src/shared/kiro-output-status.ts
+++ b/src/shared/kiro-output-status.ts
@@ -1,0 +1,102 @@
+import { recognizeAgentProcessFromCommandLine } from './agent-process-recognition'
+import { stripTerminalControl } from './terminal-control-stripping'
+
+type KiroOutputStatusDetector = {
+  observe: (data: string) => boolean
+}
+
+const RECENT_RAW_TEXT_LIMIT = 320
+const STATUS_SCAN_TEXT_LIMIT = 4096
+const KIRO_UI_RE = /(?:ask a question or describe a task\s*↵|\bkiro_[\w-]+\s*·\s*auto\b)/i
+const KIRO_WORKING_RE = /\bThinking(?:\.{3}|…)[ \t]*\(esc to cancel\)/i
+const KIRO_DONE_RE = /\bCredits:\s*\d+(?:\.\d+)?\s*[•·]\s*Time:\s*\d+(?:\.\d+)?\s*[a-z]+\b/i
+
+function appendRecentRawText(previous: string, data: string): string {
+  if (data.length >= RECENT_RAW_TEXT_LIMIT) {
+    return data.slice(-RECENT_RAW_TEXT_LIMIT)
+  }
+  return (previous + data).slice(-RECENT_RAW_TEXT_LIMIT)
+}
+
+function buildScanRawText(previous: string, data: string): string {
+  const prefix = previous.slice(-RECENT_RAW_TEXT_LIMIT)
+  const budget = STATUS_SCAN_TEXT_LIMIT - prefix.length
+  if (data.length <= budget) {
+    return prefix + data
+  }
+  const headLength = Math.max(0, Math.floor((budget - 1) / 2))
+  const tailLength = Math.max(0, budget - headLength - 1)
+  return `${prefix}${data.slice(0, headLength)}\n${data.slice(-tailLength)}`
+}
+
+function newMatchIndex(
+  pattern: RegExp,
+  previousTextLength: number,
+  combinedText: string
+): number | null {
+  const globalPattern = new RegExp(
+    pattern.source,
+    pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`
+  )
+  for (const match of combinedText.matchAll(globalPattern)) {
+    const index = match.index ?? 0
+    if (index + match[0].length > previousTextLength) {
+      return index
+    }
+  }
+  return null
+}
+
+export function createKiroOutputStatusDetector(args: {
+  startupCommand?: string | null
+  knownKiroSession?: boolean
+  inFlightTurn?: boolean
+  onWorking: () => void
+  onDone: () => void
+}): KiroOutputStatusDetector {
+  let hasSeenKiroUi =
+    args.knownKiroSession === true ||
+    recognizeAgentProcessFromCommandLine(args.startupCommand)?.agent === 'kiro'
+  let turnInFlight = args.inFlightTurn === true
+  let recentRawText = ''
+
+  return {
+    observe(data: string): boolean {
+      const previousRawText = recentRawText
+      recentRawText = appendRecentRawText(previousRawText, data)
+      const combinedText = stripTerminalControl(buildScanRawText(previousRawText, data))
+      const previousTextLength = stripTerminalControl(previousRawText).length
+
+      if (!hasSeenKiroUi) {
+        const uiIndex = newMatchIndex(KIRO_UI_RE, previousTextLength, combinedText)
+        if (uiIndex === null) {
+          return false
+        }
+        hasSeenKiroUi = true
+      }
+
+      const workingIndex = newMatchIndex(KIRO_WORKING_RE, previousTextLength, combinedText)
+      const doneIndex = newMatchIndex(KIRO_DONE_RE, previousTextLength, combinedText)
+      let matched = false
+
+      if (
+        workingIndex !== null &&
+        (!turnInFlight || (doneIndex !== null && workingIndex > doneIndex))
+      ) {
+        turnInFlight = true
+        args.onWorking()
+        matched = true
+      }
+      if (
+        doneIndex !== null &&
+        turnInFlight &&
+        (workingIndex === null || doneIndex > workingIndex)
+      ) {
+        turnInFlight = false
+        args.onDone()
+        matched = true
+      }
+      return matched
+    }
+  }
+}

--- a/src/shared/terminal-side-effect-facts.ts
+++ b/src/shared/terminal-side-effect-facts.ts
@@ -29,6 +29,10 @@ export type TerminalSideEffectFact =
    *  against its live status row before completing the turn. */
   | { kind: 'command-code-working'; prompt: string }
   | { kind: 'command-code-done'; prompt: string }
+  /** Kiro CLI emits neither hooks nor status titles; these are derived from its
+   *  in-flight spinner and per-turn Credits/Time footer. */
+  | { kind: 'kiro-working' }
+  | { kind: 'kiro-done' }
   /** DECSET 2031 color-scheme subscribe observed in the byte stream. Emitted
    *  so hidden-delivery-gated views (whose bytes never arrive) can still send
    *  the theme reply — the reply stays renderer-side because query authority


### PR DESCRIPTION
## Summary

- Detect Kiro working and done transitions from bounded terminal output so completion timing has a reliable status source.
- Show completion age in Worktree agent rows, updating in seconds for the first minute and using the existing minute-based format afterward.
- Hide the completion age after the exact terminal pane has been viewed.

## Screenshots
<img width="313" height="205" alt="timerCount" src="https://github.com/user-attachments/assets/cfde3983-5da1-4500-b452-b5e05e8f66ed" />
<img width="169" height="101" alt="timerCount2" src="https://github.com/user-attachments/assets/11411852-5d8c-4047-9884-fef894d9bbc1" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Sidebar, dashboard, terminal-pane, and shared suites: 6,356 passed. The only failure, `src/shared/posix-command-path-lookup.test.ts`, reproduces on unmodified `main` and is unrelated to this change.
- [x] `pnpm build`
- [x] `pnpm test`
- [x] Added `src/shared/kiro-output-status.test.ts` (7 cases): chunk-split status lines, Kiro-UI gating, in-flight turn gating, repeat-turn deduplication, startup-command trust, and ANSI-wrapped output

The tested suites included the dashboard row, Worktree card, parked terminal policy, terminal side-effect facts, PTY connection, and main runtime. Commit hooks also passed Oxlint, React Doctor, and Oxfmt.

## AI Review Report

An independent read-only review found no blocking findings. It checked bounded scanning, Kiro done gating, main/renderer side-effect ownership, visible and parked terminal paths, SSH/remote behavior, timer refresh cost, exact-pane acknowledgement, and accidental scope.

## Security Audit

- Terminal output is treated as untrusted text and scanned with fixed regular expressions over bounded buffers (320-byte carry and 4 KiB scan budget).
- No shell execution, dynamic evaluation, user-controlled path construction, credential handling, network request, telemetry, dependency, schema migration, or new IPC channel was added.
- Kiro done is accepted only after a matching in-flight Kiro turn, reducing stale-output effects.

## Notes

- Rebased onto current `main` (7e60b338e), resolving the earlier conflict in `DashboardAgentRow.tsx`.
- Dropped this PR's local `lastEnteredDoneAt` copy in favor of the shared `@/components/dashboard/agent-finished-timestamp` helper, addressing the duplicate-implementation review comment.

- Main-runtime fact ownership and renderer byte scanning are mutually exclusive to avoid duplicate transitions.
- The activation logic extraction preserves existing behavior and keeps the Worktree card within file-size gates.
- This PR is complementary to #11683 but is based directly on `main` and contains no foreground-session fallback code from that PR.
- Local validation used Node 25.9.0 while the project declares Node 24; all commands passed with the engine warning.
- X (Twitter) handle: @bamtori_kr