### PR TITLE
fix(mobile): enable Grok native chat in folder workspaces

### DIFF
--- a/mobile/src/session/use-mobile-native-chat-readability.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-readability.test.ts
@@ -21,12 +21,20 @@ describe('useMobileNativeChatReadability', () => {
 
   async function mount(
     connectionId: string | null,
-    worktreeId = 'repo::/worktree'
+    worktreeId = 'repo::/worktree',
+    rejectRequest = false
   ): Promise<ReturnType<typeof vi.fn>> {
-    const sendRequest = vi.fn().mockResolvedValue({
-      ok: true,
-      result: { repos: [{ id: 'repo', connectionId }] }
-    })
+    const sendRequest = rejectRequest
+      ? vi.fn().mockRejectedValue(new Error('method unavailable'))
+      : vi.fn().mockImplementation((method: string) =>
+          Promise.resolve({
+            ok: true,
+            result:
+              method === 'folderWorkspace.list'
+                ? { folderWorkspaces: [{ id: 'folder-1', connectionId }] }
+                : { repos: [{ id: 'repo', connectionId }] }
+          })
+        )
     const client = {
       sendRequest
     } as unknown as RpcClient
@@ -65,6 +73,33 @@ describe('useMobileNativeChatReadability', () => {
   it('fails closed for Model-A SSH transcript hosts', async () => {
     await mount('model-a-ssh')
     expect(readable).toBe(false)
+  })
+
+  it('resolves folder-workspace transcript readability from the folder catalog', async () => {
+    const localRequest = await mount(null, 'folder:folder-1')
+    expect(readable).toBe(true)
+    expect(localRequest).toHaveBeenCalledWith('folderWorkspace.list')
+    act(() => renderer?.unmount())
+    renderer = null
+
+    await mount('runtime-ssh-environment', 'folder:folder-1')
+    expect(readable).toBe(true)
+    act(() => renderer?.unmount())
+    renderer = null
+
+    await mount('model-a-ssh', 'folder:folder-1')
+    expect(readable).toBe(false)
+  })
+
+  it('fails closed when the folder catalog cannot resolve the route', async () => {
+    await mount(null, 'folder:missing')
+    expect(readable).toBe(false)
+    act(() => renderer?.unmount())
+    renderer = null
+
+    const unavailableRequest = await mount(null, 'folder:folder-1', true)
+    expect(readable).toBe(false)
+    expect(unavailableRequest).toHaveBeenCalledWith('folderWorkspace.list')
   })
 
   it('treats the host-local floating workspace as readable without listing repos', async () => {

--- a/mobile/src/session/use-mobile-native-chat-readability.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-readability.test.ts
@@ -22,16 +22,21 @@ describe('useMobileNativeChatReadability', () => {
   async function mount(
     connectionId: string | null,
     worktreeId = 'repo::/worktree',
-    rejectRequest = false
+    options: { rejectRequest?: boolean; folderWorkspaces?: unknown } = {}
   ): Promise<ReturnType<typeof vi.fn>> {
-    const sendRequest = rejectRequest
+    const sendRequest = options.rejectRequest
       ? vi.fn().mockRejectedValue(new Error('method unavailable'))
       : vi.fn().mockImplementation((method: string) =>
           Promise.resolve({
             ok: true,
             result:
               method === 'folderWorkspace.list'
-                ? { folderWorkspaces: [{ id: 'folder-1', connectionId }] }
+                ? {
+                    folderWorkspaces:
+                      'folderWorkspaces' in options
+                        ? options.folderWorkspaces
+                        : [{ id: 'folder-1', connectionId }]
+                  }
                 : { repos: [{ id: 'repo', connectionId }] }
           })
         )
@@ -97,9 +102,45 @@ describe('useMobileNativeChatReadability', () => {
     act(() => renderer?.unmount())
     renderer = null
 
-    const unavailableRequest = await mount(null, 'folder:folder-1', true)
+    const unavailableRequest = await mount(null, 'folder:folder-1', { rejectRequest: true })
     expect(readable).toBe(false)
     expect(unavailableRequest).toHaveBeenCalledWith('folderWorkspace.list')
+  })
+
+  it('fails closed for malformed folder routes without requesting the catalog', async () => {
+    const sendRequest = await mount(null, 'folder:', {
+      folderWorkspaces: [{ id: '', connectionId: null }]
+    })
+
+    expect(readable).toBe(false)
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('rejects duplicate folder catalog IDs regardless of order', async () => {
+    await mount(null, 'folder:folder-1', {
+      folderWorkspaces: [
+        { id: 'folder-1', connectionId: null },
+        { id: 'folder-1', connectionId: 'model-a-ssh' }
+      ]
+    })
+    expect(readable).toBe(false)
+    act(() => renderer?.unmount())
+    renderer = null
+
+    await mount(null, 'folder:folder-1', {
+      folderWorkspaces: [
+        { id: 'folder-1', connectionId: 'model-a-ssh' },
+        { id: 'folder-1', connectionId: null }
+      ]
+    })
+    expect(readable).toBe(false)
+  })
+
+  it('rejects folder catalog matches without explicit authority', async () => {
+    await mount(null, 'folder:folder-1', {
+      folderWorkspaces: [{ id: 'folder-1' }]
+    })
+    expect(readable).toBe(false)
   })
 
   it('treats the host-local floating workspace as readable without listing repos', async () => {

--- a/mobile/src/session/use-mobile-native-chat-readability.ts
+++ b/mobile/src/session/use-mobile-native-chat-readability.ts
@@ -4,7 +4,7 @@ import { isFloatingWorkspaceWorktreeId } from './floating-workspace'
 import { isMobileNativeChatTranscriptReadable } from './mobile-native-chat-eligibility'
 import { getRepoIdFromMobileWorktreeId } from './mobile-session-route-helpers'
 
-type RepoSummary = { id: string; connectionId?: string | null }
+type WorkspaceSummary = { id: string; connectionId?: string | null }
 type ReadabilityState = { client: RpcClient | null; worktreeId: string; readable: boolean }
 
 export function useMobileNativeChatReadability(
@@ -12,6 +12,7 @@ export function useMobileNativeChatReadability(
   worktreeId: string
 ): boolean {
   const isFloatingWorkspace = isFloatingWorkspaceWorktreeId(worktreeId)
+  const isFolderWorkspace = worktreeId.startsWith('folder:')
   const [state, setState] = useState<ReadabilityState>({
     client: null,
     worktreeId: '',
@@ -28,20 +29,27 @@ export function useMobileNativeChatReadability(
       return
     }
     void client
-      .sendRequest('repo.list')
+      .sendRequest(isFolderWorkspace ? 'folderWorkspace.list' : 'repo.list')
       .then((response) => {
         if (!active) {
           return
         }
-        const repos = response.ok
-          ? ((response.result as { repos?: RepoSummary[] }).repos ?? [])
+        const workspaces = response.ok
+          ? isFolderWorkspace
+            ? ((response.result as { folderWorkspaces?: WorkspaceSummary[] }).folderWorkspaces ??
+              [])
+            : ((response.result as { repos?: WorkspaceSummary[] }).repos ?? [])
           : []
-        const repoId = getRepoIdFromMobileWorktreeId(worktreeId)
-        const repo = repos.find((candidate) => candidate.id === repoId)
+        const workspaceId = isFolderWorkspace
+          ? worktreeId.slice('folder:'.length)
+          : getRepoIdFromMobileWorktreeId(worktreeId)
+        const workspace = workspaces.find((candidate) => candidate.id === workspaceId)
         setState({
           client,
           worktreeId,
-          readable: repo ? isMobileNativeChatTranscriptReadable(repo.connectionId ?? null) : false
+          readable: workspace
+            ? isMobileNativeChatTranscriptReadable(workspace.connectionId ?? null)
+            : false
         })
       })
       .catch(() => {
@@ -52,7 +60,7 @@ export function useMobileNativeChatReadability(
     return () => {
       active = false
     }
-  }, [client, isFloatingWorkspace, worktreeId])
+  }, [client, isFloatingWorkspace, isFolderWorkspace, worktreeId])
   if (isFloatingWorkspace) {
     return true
   }

--- a/mobile/src/session/use-mobile-native-chat-readability.ts
+++ b/mobile/src/session/use-mobile-native-chat-readability.ts
@@ -4,8 +4,31 @@ import { isFloatingWorkspaceWorktreeId } from './floating-workspace'
 import { isMobileNativeChatTranscriptReadable } from './mobile-native-chat-eligibility'
 import { getRepoIdFromMobileWorktreeId } from './mobile-session-route-helpers'
 
-type WorkspaceSummary = { id: string; connectionId?: string | null }
+type RepoSummary = { id: string; connectionId?: string | null }
+type FolderWorkspaceSummary = { id: string; connectionId: string | null }
 type ReadabilityState = { client: RpcClient | null; worktreeId: string; readable: boolean }
+
+function resolveFolderWorkspaceSummary(
+  catalog: unknown,
+  workspaceId: string
+): FolderWorkspaceSummary | null {
+  if (!Array.isArray(catalog)) {
+    return null
+  }
+  const matches = catalog.filter(
+    (candidate) =>
+      typeof candidate === 'object' &&
+      candidate !== null &&
+      (candidate as { id?: unknown }).id === workspaceId
+  )
+  if (matches.length !== 1) {
+    return null
+  }
+  const connectionId = (matches[0] as { connectionId?: unknown }).connectionId
+  return connectionId === null || typeof connectionId === 'string'
+    ? { id: workspaceId, connectionId }
+    : null
+}
 
 export function useMobileNativeChatReadability(
   client: RpcClient | null,
@@ -13,6 +36,7 @@ export function useMobileNativeChatReadability(
 ): boolean {
   const isFloatingWorkspace = isFloatingWorkspaceWorktreeId(worktreeId)
   const isFolderWorkspace = worktreeId.startsWith('folder:')
+  const folderWorkspaceId = isFolderWorkspace ? worktreeId.slice('folder:'.length) : null
   const [state, setState] = useState<ReadabilityState>({
     client: null,
     worktreeId: '',
@@ -24,7 +48,7 @@ export function useMobileNativeChatReadability(
       return
     }
     let active = true
-    if (!client) {
+    if (!client || (folderWorkspaceId !== null && folderWorkspaceId.trim().length === 0)) {
       setState({ client, worktreeId, readable: false })
       return
     }
@@ -34,16 +58,18 @@ export function useMobileNativeChatReadability(
         if (!active) {
           return
         }
-        const workspaces = response.ok
-          ? isFolderWorkspace
-            ? ((response.result as { folderWorkspaces?: WorkspaceSummary[] }).folderWorkspaces ??
-              [])
-            : ((response.result as { repos?: WorkspaceSummary[] }).repos ?? [])
-          : []
-        const workspaceId = isFolderWorkspace
-          ? worktreeId.slice('folder:'.length)
-          : getRepoIdFromMobileWorktreeId(worktreeId)
-        const workspace = workspaces.find((candidate) => candidate.id === workspaceId)
+        const workspaceId =
+          folderWorkspaceId !== null ? folderWorkspaceId : getRepoIdFromMobileWorktreeId(worktreeId)
+        const workspace = response.ok
+          ? folderWorkspaceId !== null
+            ? resolveFolderWorkspaceSummary(
+                (response.result as { folderWorkspaces?: unknown }).folderWorkspaces,
+                workspaceId
+              )
+            : ((response.result as { repos?: RepoSummary[] }).repos ?? []).find(
+                (candidate) => candidate.id === workspaceId
+              )
+          : null
         setState({
           client,
           worktreeId,
@@ -60,7 +86,7 @@ export function useMobileNativeChatReadability(
     return () => {
       active = false
     }
-  }, [client, isFloatingWorkspace, isFolderWorkspace, worktreeId])
+  }, [client, folderWorkspaceId, isFloatingWorkspace, isFolderWorkspace, worktreeId])
   if (isFloatingWorkspace) {
     return true
   }


### PR DESCRIPTION
## Summary

Mobile now resolves `folder:<id>` native-chat readability through the existing read-only folder-workspace catalog. This lets a supported Grok session in a local or runtime-owned folder become readable once mobile has a valid session entry carrying both the folder route and real provider session ID.

The change is deliberately narrow: it does not create or refresh mobile `session.tabs` snapshots, change session identity, add providers, alter transcript parsing/rendering/sending, or broaden SSH eligibility. Malformed, ambiguous, unavailable, and unsupported cases remain fail-closed.

## Before / after

**Before:** Mobile treated the synthetic `folder:<id>` route as a repository ID and searched `repo.list`. Folder workspaces are not repositories, so their connection authority could not resolve and native-chat readability stayed false.

**After:** Folder routes request `folderWorkspace.list`, match the underlying folder ID exactly once, and use that record's explicit `connectionId`. Local (`null`) and runtime-owned (`runtime-ssh-*`) authorities satisfy the existing readability rule. Direct Model-A SSH folders, blank or unknown routes, duplicate IDs, missing or malformed authority metadata, rejected requests, and unsuccessful responses remain unavailable. Repository workspaces continue to use `repo.list` unchanged.

## Screenshots

No valid native-chat acceptance screenshot was captured or published. `/tmp/pr11751-folder-session-loading.png` is explicitly excluded: it showed the Terminal route stuck on `Loading tabs`, and its deep link incorrectly placed a `folder:<id>` value in the session-ID segment. It is not evidence for this PR.

There is no visual-design change in the diff.

## Native QA gap

Exact-head setup was proven on iPad simulator `C589AF84-2F0C-4978-952B-748933DE6804`: the installed Release app contains an embedded JavaScript bundle built from `a89846e9e26d29a7423e8c93998d24d9b2f021cb` (SHA-256 `6e9b6f16b30c076b828a1a1c134d385a28f28491a424a89c3cecf4e4cb554af3`). The isolated helper remains on port 3100.

Backend/runtime fixture proof also succeeded. A read-only runtime catalog query returned the live Grok terminal for folder route `folder:2573f8cc-8e3a-4e16-bf2b-95f8bae2eb1d`, real provider session ID `019fb802-68c6-7400-a38e-6afcc8d2690e`, and a transcript containing `FOLDER-GROK-READY`.

Native acceptance is blocked upstream of this PR's readability hook: after bounded foreground, reconnect, relaunch, and catalog-refresh attempts, the paired mobile host never surfaced the folder or a corresponding folder `session.tabs` snapshot. Therefore no supported agent-history/resume entry could supply both `worktreeId=folder:2573f8cc-8e3a-4e16-bf2b-95f8bae2eb1d` and the real provider session ID. Native chat never rendered.

Accordingly, this QA does **not** claim transcript rendering/readability, keyboard or dictation, composer/send, unsent-draft retention, scrolling, drawer/navigation, switching away/back, reconnect, or foreground recovery. Those remain pending behind the separate folder catalog/session-entry rough edge. Runtime-owned relay/direct-host behavior, direct-SSH exclusion, physical iOS devices, and Android also remain unverified natively.

## Testing

- Baseline proof at `f936e7fc9c7defebc40398a1ddf2ce50e93c7dfc`: the folder-workspace regression test failed with `expected false to be true` because the hook requested `repo.list`.
- Fail-closed mutation proof: temporarily restoring first-match catalog selection, blank-route requests, and omitted-authority-to-local fallback made the malformed-route and duplicate-ID tests fail with `expected true to be false`; the hardened implementation was restored before commit.
- `cd mobile && node_modules/.bin/vitest run src/session/use-mobile-native-chat-readability.test.ts src/session/mobile-native-chat-eligibility.test.ts` — 2 files, 19 tests passed.
- `cd mobile && node_modules/.bin/vitest run` — 375 files passed; 2,782 tests passed and 3 skipped.
- `cd mobile && node_modules/.bin/tsc --noEmit` — passed.
- `cd mobile && node_modules/.bin/oxlint` — passed.
- `cd mobile && node_modules/.bin/oxfmt --check .` — passed.
- `git diff --check` — passed.
- Fresh merge-tree at exact head `a89846e9e26d29a7423e8c93998d24d9b2f021cb` against fetched `origin/main` `fdb58695e9d08738c1cc16fd1c0b1f0e7937ca18` — clean.
- GitHub CI at the exact head — 42 successful checks, including Mobile verify, static analysis, typecheck, Git compatibility, shell contracts, all Node 24/26 shards, Linux/Windows packaging, PR verify, and Greptile; path-filtered E2E was skipped. One unrelated activity-portal timing test failed in Node 26 shard 15/16 on its first attempt and passed unchanged on rerun.

## AI Review Report

The requested direct recovery loop used fresh `gpt-5.6-sol` reviewers with xhigh reasoning. This was not a formal Orca orchestration dispatch, and no formal dispatch provenance is claimed.

The first reviewer found one fail-open boundary defect: duplicate folder IDs were order-dependent, and an omitted `connectionId` was treated as local. The follow-up commit requires one exact match and explicit `null` or string authority, adds blank-route and malformed-catalog coverage, and leaves legacy repository compatibility unchanged. A fresh same-model/xhigh reviewer then returned CLEAN at `a89846e9e26d29a7423e8c93998d24d9b2f021cb`.

The final static review covered stale async responses, duplicate IDs in both orders, local/runtime/direct-SSH authority, direct and relay transport, folder workspaces versus git worktrees, unsupported agents, request volume, payload exposure, and adjacent native-chat eligibility/readability. Effect cleanup and keyed state prevent a previous route result from leaking after tab, workspace, client, or host changes. Folder resolution remains one read-only catalog request per route resolution.

## Security Audit

This uses an already registered, authenticated, end-to-end-encrypted, read-only RPC method. The existing response contains the folder catalog, but this hook reads only `id` and `connectionId`; it does not log or persist catalog paths, credentials, linked items, or other metadata.

Blank routes, unknown IDs, duplicate matches, omitted or non-string authority, rejected requests, and unsuccessful responses fail closed. Local `null` and runtime-owned `runtime-ssh-*` values remain readable; direct SSH values remain blocked. No command execution, filesystem access, auth change, secret handling, dependency, persistence, or new IPC/RPC surface was added.

## Notes

The missing mobile folder `session.tabs` snapshot is preserved as a separate confirmed folder catalog/session-entry rough edge; it is not expanded into PR #11751. Irreversible long-response clipping is also a separate finding and remains out of scope.

No simulator helper was stopped. Native QA remains pending, and the iPad lane is ready for coordinator release after the other lane finishes. This PR must not be merged as part of this review.

