### PR TITLE
fix(build): rebuild patched node-pty via node-gyp, not pnpm rebuild

### DIFF
--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -64,7 +64,7 @@ function ensureNodeRuntime() {
     if (!initial.ok) {
       printCheckError(initial)
     }
-    runPnpm(['rebuild', 'node-pty'])
+    rebuildPatchedNodePtyFromSource()
     verifyNodeRuntimeAfterRebuild()
     return
   }
@@ -74,8 +74,25 @@ function ensureNodeRuntime() {
     `[native-runtime] ${formatRuntimeLabel('node')} cannot load native modules; rebuilding ${failedModules.join(', ')} for Node.`
   )
   printCheckError(initial)
-  runPnpm(['rebuild', ...failedModules])
+  rebuildFailedNodeModules(failedModules)
   verifyNodeRuntimeAfterRebuild()
+}
+
+// Why: a broken build/Release makes node-pty fall back to a prebuild, and
+// `pnpm rebuild` cannot replace it for the same install-script reason.
+function rebuildFailedNodeModules(failedModules) {
+  const nodePtyNeedsSourceBuild =
+    failedModules.includes('node-pty') && requiresPatchedNodePtySourceBuild()
+  const pnpmModules = nodePtyNeedsSourceBuild
+    ? failedModules.filter((moduleName) => moduleName !== 'node-pty')
+    : failedModules
+
+  if (!nodePtyNeedsSourceBuild || pnpmModules.length > 0) {
+    runPnpm(['rebuild', ...pnpmModules])
+  }
+  if (nodePtyNeedsSourceBuild) {
+    rebuildPatchedNodePtyFromSource()
+  }
 }
 
 function verifyNodeRuntimeAfterRebuild() {
@@ -317,6 +334,33 @@ function getPatchedNodePtyRebuildReason() {
   return 'Patched node-pty build artifacts are missing; rebuilding native deps.'
 }
 
+// Why: node-pty's install script short-circuits on a shipped prebuild, so
+// `pnpm rebuild` never reaches its `node-gyp rebuild` fallback.
+function rebuildPatchedNodePtyFromSource() {
+  const nodeGypScript = resolveNodeGypScript()
+  if (!nodeGypScript) {
+    console.error('[native-runtime] Cannot locate node-gyp to rebuild node-pty from source.')
+    process.exit(1)
+  }
+
+  // Why: npm_config_build_from_source also forces a source build, but prebuild.js
+  // then deletes every platform's prebuilds, breaking supportedArchitectures.
+  runNodeScript([nodeGypScript, 'rebuild'], resolve(projectDir, 'node_modules', 'node-pty'))
+}
+
+function resolveNodeGypScript() {
+  // Why: CI overrides this when pnpm's bundled node-gyp is unusable (see computer-e2e.yml).
+  if (process.env.npm_config_node_gyp) {
+    return process.env.npm_config_node_gyp
+  }
+
+  try {
+    return require.resolve('node-gyp/bin/node-gyp.js')
+  } catch {
+    return null
+  }
+}
+
 function requiresPatchedNodePtySourceBuild() {
   if (process.platform === 'win32') {
     return false
@@ -356,9 +400,9 @@ function runPnpm(args) {
   }
 }
 
-function runNodeScript(args) {
+function runNodeScript(args, cwd = projectDir) {
   const result = spawnSync(process.execPath, args, {
-    cwd: projectDir,
+    cwd,
     stdio: 'inherit'
   })
 

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -339,7 +339,12 @@ function getPatchedNodePtyRebuildReason() {
 function rebuildPatchedNodePtyFromSource() {
   const nodeGypScript = resolveNodeGypScript()
   if (!nodeGypScript) {
-    console.error('[native-runtime] Cannot locate node-gyp to rebuild node-pty from source.')
+    const override = process.env.npm_config_node_gyp
+    console.error(
+      override
+        ? `[native-runtime] npm_config_node_gyp points at a missing file: ${override}`
+        : '[native-runtime] Cannot locate node-gyp to rebuild node-pty from source.'
+    )
     process.exit(1)
   }
 

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -350,8 +350,10 @@ function rebuildPatchedNodePtyFromSource() {
 
 function resolveNodeGypScript() {
   // Why: CI overrides this when pnpm's bundled node-gyp is unusable (see computer-e2e.yml).
-  if (process.env.npm_config_node_gyp) {
-    return process.env.npm_config_node_gyp
+  const override = process.env.npm_config_node_gyp
+  if (override) {
+    // Why: an explicit override is a contract; fall back and it silently builds with the wrong gyp.
+    return existsSync(override) ? override : null
   }
 
   try {

--- a/config/scripts/ensure-native-runtime.test.mjs
+++ b/config/scripts/ensure-native-runtime.test.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process'
 import {
   chmodSync,
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -14,6 +15,28 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
 const sourceScriptPath = fileURLToPath(new URL('./ensure-native-runtime.mjs', import.meta.url))
+
+// Why: the node-pty source-build tests never run on win32, so this is always foreign.
+const FOREIGN_PREBUILD_TARGET = 'win32-x64'
+
+// Why: writing into process.cwd() also asserts node-gyp runs inside the node-pty package.
+const NODE_GYP_SHIM_SOURCE = `
+const { appendFileSync, mkdirSync, writeFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+appendFileSync(
+  process.env.ORCA_NATIVE_TEST_LOG,
+  \`node-gyp \${process.argv.slice(2).join(' ')} cwd=\${process.cwd()}\\n\`
+)
+
+const releaseDir = join(process.cwd(), 'build', 'Release')
+mkdirSync(releaseDir, { recursive: true })
+writeFileSync(join(releaseDir, 'pty.node'), '')
+if (process.platform === 'darwin') {
+  writeFileSync(join(releaseDir, 'spawn-helper'), '')
+}
+writeFileSync(process.env.ORCA_NATIVE_TEST_MARKER, 'rebuilt')
+`
 
 describe('ensure-native-runtime', () => {
   it('rechecks Node native modules in fresh child processes after rebuilding', () => {
@@ -63,6 +86,7 @@ describe('ensure-native-runtime', () => {
         writeLoadableNativeModules(projectDir)
         writeNodePtyPatchFile(projectDir)
         writeFakePnpm(binDir)
+        writeFakeNodeGyp(projectDir)
 
         const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
           cwd: projectDir,
@@ -77,7 +101,9 @@ describe('ensure-native-runtime', () => {
         expect(result.stderr).toContain(
           'Patched node-pty build artifacts are missing; rebuilding native deps.'
         )
-        expect(readFileSync(logPath, 'utf8')).toContain('pnpm rebuild node-pty\n')
+        const log = readFileSync(logPath, 'utf8')
+        expect(log).toContain('node-gyp rebuild')
+        expect(log).not.toContain('pnpm rebuild node-pty')
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
@@ -99,6 +125,7 @@ describe('ensure-native-runtime', () => {
         writeNodePtyPatchFile(projectDir)
         writePatchedNodePtyBuildArtifacts(projectDir)
         writeFakePnpm(binDir)
+        writeFakeNodeGyp(projectDir)
 
         const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
           cwd: projectDir,
@@ -111,7 +138,9 @@ describe('ensure-native-runtime', () => {
 
         expect(result.status, result.stderr).toBe(0)
         expect(result.stderr).toContain("expected build/Release so Orca's node-pty patch is active")
-        expect(readFileSync(logPath, 'utf8')).toContain('pnpm rebuild node-pty\n')
+        const log = readFileSync(logPath, 'utf8')
+        expect(log).toContain('node-gyp rebuild')
+        expect(log).not.toContain('pnpm rebuild node-pty')
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
@@ -133,6 +162,7 @@ describe('ensure-native-runtime', () => {
         writeNodePtyPatchFile(projectDir)
         writePatchedNodePtyBuildArtifacts(projectDir)
         writeFakePnpm(binDir)
+        writeFakeNodeGyp(projectDir)
 
         const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
           cwd: projectDir,
@@ -145,13 +175,75 @@ describe('ensure-native-runtime', () => {
 
         expect(result.status, result.stderr).toBe(0)
         expect(result.stderr).not.toContain('Patched node-pty build artifacts are missing')
-        expect(readFileSync(logPath, 'utf8')).not.toContain('pnpm rebuild node-pty')
+        const log = readFileSync(logPath, 'utf8')
+        expect(log).not.toContain('pnpm rebuild node-pty')
+        expect(log).not.toContain('node-gyp rebuild')
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+      }
+    }
+  )
+  it.skipIf(process.platform === 'win32')(
+    'builds patched node-pty from source even though a shipped prebuild short-circuits its install script',
+    () => {
+      const projectDir = mkTempProject()
+
+      try {
+        const outcome = runAgainstUpstreamLikeNodePty(projectDir)
+
+        expect(outcome.result.status, outcome.result.stderr).toBe(0)
+        // Why: macOS resolves the temp dir through /private, so match the suffix.
+        expect(outcome.log).toMatch(/^node-gyp rebuild cwd=.*[/\\]node_modules[/\\]node-pty$/m)
+        expect(existsSync(join(nodePtyDirOf(projectDir), 'build', 'Release', 'pty.node'))).toBe(
+          true
+        )
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps other platforms prebuilds so supportedArchitectures packaging still works',
+    () => {
+      const projectDir = mkTempProject()
+
+      try {
+        const outcome = runAgainstUpstreamLikeNodePty(projectDir)
+
+        expect(outcome.result.status, outcome.result.stderr).toBe(0)
+        const prebuildsDir = join(nodePtyDirOf(projectDir), 'prebuilds')
+        expect(existsSync(join(prebuildsDir, FOREIGN_PREBUILD_TARGET, 'pty.node'))).toBe(true)
+        expect(existsSync(join(prebuildsDir, hostPrebuildTarget(), 'pty.node'))).toBe(true)
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
     }
   )
 })
+
+function runAgainstUpstreamLikeNodePty(projectDir) {
+  const scriptPath = join(projectDir, 'config', 'scripts', 'ensure-native-runtime.mjs')
+  const logPath = join(projectDir, 'native-runtime.log')
+  const binDir = join(projectDir, 'bin')
+
+  copyFileSync(sourceScriptPath, scriptPath)
+  writeUpstreamLikeNodePty(projectDir)
+  writeNodePtyPatchFile(projectDir)
+  writeFakeNodeGyp(projectDir)
+  writePnpmRunningInstallScripts(binDir)
+
+  const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
+    cwd: projectDir,
+    encoding: 'utf8',
+    env: envWithPrependedPath(binDir, {
+      ORCA_NATIVE_TEST_LOG: logPath,
+      ORCA_NATIVE_TEST_MARKER: join(projectDir, 'rebuilt.marker')
+    })
+  })
+
+  return { result, log: readFileSync(logPath, 'utf8') }
+}
 
 function mkTempProject() {
   const projectDir = mkdtempSync(join(tmpdir(), 'orca-native-runtime-'))
@@ -242,6 +334,132 @@ function writePatchedNodePtyBuildArtifacts(projectDir) {
   if (process.platform === 'darwin') {
     writeFileSync(join(buildDir, 'spawn-helper'), '')
   }
+}
+
+function nodePtyDirOf(projectDir) {
+  return join(projectDir, 'node_modules', 'node-pty')
+}
+
+function hostPrebuildTarget() {
+  return `${process.platform}-${process.arch}`
+}
+
+// Mirrors node-pty 1.1.0: an `install` script that skips node-gyp whenever a
+// prebuild for the host already ships, and a loader preferring build/Release.
+function writeUpstreamLikeNodePty(projectDir) {
+  const nodePtyDir = nodePtyDirOf(projectDir)
+  mkdirSync(join(nodePtyDir, 'lib'), { recursive: true })
+  mkdirSync(join(nodePtyDir, 'scripts'), { recursive: true })
+
+  for (const target of [hostPrebuildTarget(), FOREIGN_PREBUILD_TARGET]) {
+    mkdirSync(join(nodePtyDir, 'prebuilds', target), { recursive: true })
+    writeFileSync(join(nodePtyDir, 'prebuilds', target, 'pty.node'), '')
+  }
+
+  writeFileSync(
+    join(nodePtyDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'node-pty',
+        version: '1.1.0',
+        scripts: { install: 'node scripts/prebuild.js || node-gyp rebuild' }
+      },
+      null,
+      2
+    )
+  )
+  writeFileSync(
+    join(nodePtyDir, 'scripts', 'prebuild.js'),
+    `
+const fs = require('node:fs')
+const path = require('node:path')
+
+const PREBUILDS_ROOT = path.join(__dirname, '..', 'prebuilds')
+const PREBUILD_DIR = path.join(PREBUILDS_ROOT, process.platform + '-' + process.arch)
+
+if (process.env.npm_config_build_from_source === 'true') {
+  fs.rmSync(PREBUILDS_ROOT, { recursive: true, force: true })
+  process.exit(1)
+}
+process.exit(fs.existsSync(PREBUILD_DIR) ? 0 : 1)
+`
+  )
+  writeFileSync(join(nodePtyDir, 'index.js'), 'module.exports = {}\n')
+  writeFileSync(
+    join(nodePtyDir, 'lib', 'utils.js'),
+    `
+const { appendFileSync, existsSync } = require('node:fs')
+const { join } = require('node:path')
+
+exports.loadNativeModule = function loadNativeModule(name) {
+  const dirs = ['build/Release', 'build/Debug', 'prebuilds/' + process.platform + '-' + process.arch]
+  for (const d of dirs) {
+    for (const r of ['..', '.']) {
+      const dir = r + '/' + d + '/'
+      if (existsSync(join(__dirname, dir, name + '.node'))) {
+        appendFileSync(process.env.ORCA_NATIVE_TEST_LOG, \`node-pty load \${name} dir=\${dir}\\n\`)
+        return { dir, module: {} }
+      }
+    }
+  }
+  throw new Error('Failed to load native module: ' + name + '.node')
+}
+`
+  )
+}
+
+function writeFakeNodeGyp(projectDir) {
+  const nodeGypDir = join(projectDir, 'node_modules', 'node-gyp')
+  mkdirSync(join(nodeGypDir, 'bin'), { recursive: true })
+  writeFileSync(
+    join(nodeGypDir, 'package.json'),
+    JSON.stringify({ name: 'node-gyp', version: '12.3.0', main: 'bin/node-gyp.js' })
+  )
+  writeFileSync(join(nodeGypDir, 'bin', 'node-gyp.js'), NODE_GYP_SHIM_SOURCE)
+}
+
+// Why: unlike writeFakePnpm, this shim re-runs the package's own install
+// script the way real `pnpm rebuild` does, so the short-circuit reproduces.
+function writePnpmRunningInstallScripts(binDir) {
+  mkdirSync(binDir, { recursive: true })
+  const shimPath = join(binDir, 'pnpm-shim.cjs')
+  writeFileSync(
+    shimPath,
+    `
+const { spawnSync } = require('node:child_process')
+const { appendFileSync, readFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const args = process.argv.slice(2)
+appendFileSync(process.env.ORCA_NATIVE_TEST_LOG, \`pnpm \${args.join(' ')}\\n\`)
+
+if (args[0] === 'rebuild') {
+  for (const pkg of args.slice(1)) {
+    const pkgDir = join(process.cwd(), 'node_modules', pkg)
+    const { scripts } = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'))
+    if (!scripts || !scripts.install) {
+      continue
+    }
+    const result = spawnSync(scripts.install, { cwd: pkgDir, shell: true, stdio: 'inherit' })
+    if (result.status !== 0) {
+      process.exit(result.status ?? 1)
+    }
+  }
+}
+`
+  )
+
+  const pnpmPath = join(binDir, 'pnpm')
+  writeFileSync(pnpmPath, `#!/usr/bin/env node\nrequire(${JSON.stringify(shimPath)})\n`)
+  chmodSync(pnpmPath, 0o755)
+
+  // Why: keeps the install script's `|| node-gyp rebuild` fallback genuinely
+  // reachable, so a passing test proves the short-circuit, not a missing binary.
+  const nodeGypShimPath = join(binDir, 'node-gyp-shim.cjs')
+  writeFileSync(nodeGypShimPath, NODE_GYP_SHIM_SOURCE)
+  const nodeGypPath = join(binDir, 'node-gyp')
+  writeFileSync(nodeGypPath, `#!/usr/bin/env node\nrequire(${JSON.stringify(nodeGypShimPath)})\n`)
+  chmodSync(nodeGypPath, 0o755)
 }
 
 function writeFakePnpm(binDir) {

--- a/config/scripts/ensure-native-runtime.test.mjs
+++ b/config/scripts/ensure-native-runtime.test.mjs
@@ -241,9 +241,34 @@ describe('ensure-native-runtime', () => {
       }
     }
   )
+
+  it.skipIf(process.platform === 'win32')(
+    'fails loudly when npm_config_node_gyp points at a missing file',
+    () => {
+      const projectDir = mkTempProject()
+
+      try {
+        const outcome = runAgainstUpstreamLikeNodePty(projectDir, {
+          nodeGypOverridePath: join(projectDir, 'absent-node-gyp.cjs'),
+          createNodeGypOverride: false
+        })
+
+        expect(outcome.result.status).toBe(1)
+        expect(outcome.result.stderr).toContain('npm_config_node_gyp points at a missing file')
+        expect(existsSync(join(nodePtyDirOf(projectDir), 'build', 'Release', 'pty.node'))).toBe(
+          false
+        )
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
-function runAgainstUpstreamLikeNodePty(projectDir, { nodeGypOverridePath = null } = {}) {
+function runAgainstUpstreamLikeNodePty(
+  projectDir,
+  { nodeGypOverridePath = null, createNodeGypOverride = true } = {}
+) {
   const scriptPath = join(projectDir, 'config', 'scripts', 'ensure-native-runtime.mjs')
   const logPath = join(projectDir, 'native-runtime.log')
   const binDir = join(projectDir, 'bin')
@@ -253,10 +278,10 @@ function runAgainstUpstreamLikeNodePty(projectDir, { nodeGypOverridePath = null 
   writeNodePtyPatchFile(projectDir)
   writePnpmRunningInstallScripts(binDir)
   // Why: omitting the resolvable copy proves the override is what got used.
-  if (nodeGypOverridePath) {
-    writeFileSync(nodeGypOverridePath, NODE_GYP_SHIM_SOURCE)
-  } else {
+  if (!nodeGypOverridePath) {
     writeFakeNodeGyp(projectDir)
+  } else if (createNodeGypOverride) {
+    writeFileSync(nodeGypOverridePath, NODE_GYP_SHIM_SOURCE)
   }
 
   const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
@@ -285,8 +310,9 @@ function envWithPrependedPath(binDir, extraEnv) {
       : 'PATH'
   const inherited = { ...process.env }
   // Why: CI exports npm_config_node_gyp job-wide, which would run the real
-  // node-gyp against these fixtures instead of the shim.
+  // node-gyp against these fixtures; build_from_source would steer prebuild.js.
   delete inherited.npm_config_node_gyp
+  delete inherited.npm_config_build_from_source
 
   return {
     ...inherited,

--- a/config/scripts/ensure-native-runtime.test.mjs
+++ b/config/scripts/ensure-native-runtime.test.mjs
@@ -103,7 +103,7 @@ describe('ensure-native-runtime', () => {
         )
         const log = readFileSync(logPath, 'utf8')
         expect(log).toContain('node-gyp rebuild')
-        expect(log).not.toContain('pnpm rebuild node-pty')
+        expect(log).not.toContain('pnpm rebuild')
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
@@ -140,7 +140,7 @@ describe('ensure-native-runtime', () => {
         expect(result.stderr).toContain("expected build/Release so Orca's node-pty patch is active")
         const log = readFileSync(logPath, 'utf8')
         expect(log).toContain('node-gyp rebuild')
-        expect(log).not.toContain('pnpm rebuild node-pty')
+        expect(log).not.toContain('pnpm rebuild')
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
@@ -176,13 +176,14 @@ describe('ensure-native-runtime', () => {
         expect(result.status, result.stderr).toBe(0)
         expect(result.stderr).not.toContain('Patched node-pty build artifacts are missing')
         const log = readFileSync(logPath, 'utf8')
-        expect(log).not.toContain('pnpm rebuild node-pty')
+        expect(log).not.toContain('pnpm rebuild')
         expect(log).not.toContain('node-gyp rebuild')
       } finally {
         rmSync(projectDir, { recursive: true, force: true })
       }
     }
   )
+
   it.skipIf(process.platform === 'win32')(
     'builds patched node-pty from source even though a shipped prebuild short-circuits its install script',
     () => {
@@ -220,9 +221,29 @@ describe('ensure-native-runtime', () => {
       }
     }
   )
+
+  it.skipIf(process.platform === 'win32')(
+    'builds through npm_config_node_gyp when the bundled node-gyp is unusable',
+    () => {
+      const projectDir = mkTempProject()
+
+      try {
+        const outcome = runAgainstUpstreamLikeNodePty(projectDir, {
+          nodeGypOverridePath: join(projectDir, 'external-node-gyp.cjs')
+        })
+
+        expect(outcome.result.status, outcome.result.stderr).toBe(0)
+        expect(existsSync(join(nodePtyDirOf(projectDir), 'build', 'Release', 'pty.node'))).toBe(
+          true
+        )
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true })
+      }
+    }
+  )
 })
 
-function runAgainstUpstreamLikeNodePty(projectDir) {
+function runAgainstUpstreamLikeNodePty(projectDir, { nodeGypOverridePath = null } = {}) {
   const scriptPath = join(projectDir, 'config', 'scripts', 'ensure-native-runtime.mjs')
   const logPath = join(projectDir, 'native-runtime.log')
   const binDir = join(projectDir, 'bin')
@@ -230,15 +251,21 @@ function runAgainstUpstreamLikeNodePty(projectDir) {
   copyFileSync(sourceScriptPath, scriptPath)
   writeUpstreamLikeNodePty(projectDir)
   writeNodePtyPatchFile(projectDir)
-  writeFakeNodeGyp(projectDir)
   writePnpmRunningInstallScripts(binDir)
+  // Why: omitting the resolvable copy proves the override is what got used.
+  if (nodeGypOverridePath) {
+    writeFileSync(nodeGypOverridePath, NODE_GYP_SHIM_SOURCE)
+  } else {
+    writeFakeNodeGyp(projectDir)
+  }
 
   const result = spawnSync(process.execPath, [scriptPath, '--runtime=node'], {
     cwd: projectDir,
     encoding: 'utf8',
     env: envWithPrependedPath(binDir, {
       ORCA_NATIVE_TEST_LOG: logPath,
-      ORCA_NATIVE_TEST_MARKER: join(projectDir, 'rebuilt.marker')
+      ORCA_NATIVE_TEST_MARKER: join(projectDir, 'rebuilt.marker'),
+      ...(nodeGypOverridePath ? { npm_config_node_gyp: nodeGypOverridePath } : {})
     })
   })
 
@@ -256,8 +283,13 @@ function envWithPrependedPath(binDir, extraEnv) {
     process.platform === 'win32'
       ? (Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'Path')
       : 'PATH'
+  const inherited = { ...process.env }
+  // Why: CI exports npm_config_node_gyp job-wide, which would run the real
+  // node-gyp against these fixtures instead of the shim.
+  delete inherited.npm_config_node_gyp
+
   return {
-    ...process.env,
+    ...inherited,
     ...extraEnv,
     [pathKey]: `${binDir}${delimiter}${process.env[pathKey] ?? ''}`
   }


### PR DESCRIPTION
## Summary

On macOS, `pnpm test` can abort before Vitest ever starts, and the repair the guard runs to fix it cannot work.

`config/scripts/ensure-native-runtime.mjs` requires node-pty to load from `build/Release`, because Orca patches `binding.gyp` and `src/unix/pty.cc` and those changes only exist in a source-built binary. When the artifacts are missing it tried to repair with `pnpm rebuild node-pty`.

That repair is a no-op by construction. node-pty's install script is:

```
"install": "node scripts/prebuild.js || node-gyp rebuild"
```

and `scripts/prebuild.js` exits **0** whenever `prebuilds/<platform>-<arch>` already exists, so the `||` never fires and node-gyp never runs. node-pty 1.1.0 ships prebuilds for `darwin-arm64`, `darwin-x64`, `win32-arm64` and `win32-x64`. Re-running the same install script through `pnpm rebuild` just short-circuits again, `build/Release` is still absent, and the guard exits 1:

```
[native-runtime] Patched node-pty build artifacts are missing; rebuilding native deps.
[native-runtime] Native modules still do not load for Node <version>.
```

This routes the repair through node-gyp directly, mirroring what the Electron path already does — `config/scripts/rebuild-native-deps.mjs` uses `@electron/rebuild` with `force: true` precisely because that "invokes node-gyp directly and bypasses that install hook".

**Why not `npm_config_build_from_source`:** it would also force a source build, but `prebuild.js` responds to it with `fs.rmSync(PREBUILDS_ROOT)`, deleting **every** platform's prebuilds rather than just the host's. That would silently sabotage `supportedArchitectures` in `package.json`, whose whole purpose is fetching other platforms' binaries for cross-platform packaging. Rejected for that reason; a regression test now guards it.

**Why CI never caught it:** all 8 jobs in `.github/workflows/pr.yml` run on `ubuntu-latest`, and node-pty ships **no** Linux prebuild. On Linux `prebuild.js` exits 1, node-gyp runs, and `build/Release` exists for free. The bug is structurally invisible to this repo's CI and only reproduces where contributors actually develop.

Scope note: this is Unix-only in effect. `requiresPatchedNodePtySourceBuild()` returns `false` on `win32`, so Windows behavior is unchanged by this PR.

Related: #11738 and #11736. No code dependency on either, no shared files, any merge order.

## Screenshots

No visual change. This only touches a build-time native-runtime guard script and its tests.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Run on macOS arm64 (Node 24.18.1, Electron 43.1.0):

- **`pnpm lint`** — passes, full chain (oxlint, native + type-aware code-quality audits, reliability gates, max-lines ratchet, skill-guide/bundle verifies, all three localization verifies).
- **`pnpm typecheck`** — passes, all three projects.
- **`pnpm test`** — the full suite now runs to completion: **4001 test files, 3982 passed, 42216 tests passed**, in 262s. Before this change the run aborted at the guard with zero tests executed. 9 files reported failures; I chased every one and none involve this change (details below).
- **`pnpm build`** — `build:desktop` passes completely (typecheck, relay for all 6 targets, CLI, electron-vite, `verify:built-skills-cli` 379 closure files, web projection 787 files). It then fails in `build:native`, which is **`main`'s own unmodified script** and unrelated to this PR — see below.

**The 9 failing test files, all accounted for:**

| Cause | Files | Evidence |
|---|---|---|
| Local global `tag.gpgsign=true` makes lightweight `git tag` fail | `publish-complete-draft-releases`, `release-rc-history`, `plugin-install` | all 3 pass (32/32) when re-run with `tag.gpgsign=false`; CI has no such config |
| Flaky under full-suite concurrency | `managed-hook-install-lock`, `shell-ready`, `skill-plugin-cache-scan`, `git-handler`, `macos-computer-helper-owner-loss-processes` | all pass when re-run in isolation |
| Pre-existing on `main` | `src/relay/agent-exec-handler` (2 tests) | fails identically on an unrelated branch that does not touch relay |

Nothing in this PR is imported by any `src/` test — the changed script is only ever executed standalone by a package script.

**Why `build:native` fails, and why it is not this PR:** `config/scripts/build-native-for-platform.mjs` on `main` runs `node <npm_execpath> run <script>`. With pnpm installed as a standalone binary (here mise's `pnpm@10.24.0`), `npm_execpath` is a 62 MB **Mach-O arm64 executable**, so Node tries to parse it as JavaScript and dies with `SyntaxError: Invalid or unexpected token`. That is exactly the bug #11738 fixes. Invoking the two underlying builds directly, bypassing that indirection, both succeed on this branch:

```
pnpm run build:computer-macos            → exit 0  (Build complete! 32.50s, app signed)
pnpm run build:notification-status-macos → exit 0
```

So the native build content is fine on this branch; only `main`'s launcher indirection is broken, and #11738 already fixes it.

**Test that fails without the fix and passes with it.** The new tests build a node-pty fixture replicating upstream 1.1.0: the real `install` script, a `prebuild.js` with the real short-circuit logic, a shipped host prebuild, and the real loader order (`build/Release` before `prebuilds/`). The pnpm shim actually re-runs the package's install script the way `pnpm rebuild` does — unlike the pre-existing `writeFakePnpm`, which wrote a success marker unconditionally and is exactly why the suite never noticed. A working `node-gyp` is also on `PATH`, so a pass proves the short-circuit rather than a missing binary.

Against the **old** repair path (production change reverted, tests kept):

```
× rebuilds patched node-pty artifacts even when the Node load check passes
× rebuilds when patched artifacts exist but node-pty resolves to prebuilds
× builds patched node-pty from source even though a shipped prebuild short-circuits its install script
× keeps other platforms prebuilds so supportedArchitectures packaging still works
× builds through npm_config_node_gyp when the bundled node-gyp is unusable
Tests  5 failed | 3 passed (8)

AssertionError: [native-runtime] Patched node-pty build artifacts are missing; rebuilding native deps.
: expected 1 to be +0
```

That `expected 1 to be +0` is the guard exiting 1 — the real failure. With the fix, 8/8 pass, both with a clean environment and with `npm_config_node_gyp` and `npm_config_build_from_source` exported the way CI does it.

**Real end-to-end verification.** This worktree reproduced the bug for real after a clean `pnpm install --frozen-lockfile`: `build/Release` was absent because postinstall took the `continuePostinstallWithoutElectron()` early-exit in `rebuild-native-deps.mjs` (Electron's binary had not downloaded), so node-pty was never built. Running the guard with this fix:

- node-gyp compiled `src/unix/pty.cc` from source and linked `Release/pty.node` (92728 bytes) and `Release/spawn-helper`, in ~2s
- the guard exited **0**
- all four `prebuilds/` directories survived intact — `darwin-arm64`, `darwin-x64`, `win32-arm64`, `win32-x64`
- the built source carries Orca's patch (`.symver openpty,openpty@ORCA_GLIBC_COMPAT_VERSION` present in the compiled `pty.cc`)
- a second run is a silent no-op in 0.07s, confirming the fast path still short-circuits

## AI Review Report

Reviewed with Claude Opus 5, then independently reviewed twice with Claude Fable 5 against the repo conventions. The first Fable pass found a CI-breaking defect in the tests (below); the second pass, after the fix, returned no blocking or major findings, and its remaining nits were addressed in a third commit. Every upstream claim was verified against the published `node-pty@1.1.0` tarball and npm metadata rather than assumed — install script, `prebuild.js` contents, the shipped prebuild list, and the loader's directory order.

- **Cross-platform (macOS / Linux / Windows).** Windows is unaffected: `requiresPatchedNodePtySourceBuild()` returns `false` on `win32`, so neither changed path activates and the Windows ConPTY runtime handling in `rebuild-native-deps.mjs` is untouched. Linux keeps working and gets faster-failing behavior if node-gyp is missing; it never had the bug since no Linux prebuild ships. macOS is the platform actually fixed. Paths use `resolve`/`join` throughout; no separator assumptions. The review specifically checked that `spawn-helper` (a macOS-only gyp target) is still produced — it is, confirmed in the real build above.
- **Non-obvious risk the review caught.** The fix only works because node-pty's loader checks `build/Release` *before* `prebuilds/`. Had the order been reversed, leaving prebuilds in place would have meant the freshly built binary was never loaded and the guard would still fail. Verified in `node_modules/node-pty/lib/utils.js` and covered by the loader order in the test fixture.
- **Second defect found during review.** The generic failure branch had the same weakness: when `build/Release` exists but is broken, node-pty falls back to a prebuild and `pnpm rebuild` again cannot replace it. A pre-existing test ("resolves to prebuilds") turned out to exercise exactly that path, so the fix was extended via `rebuildFailedNodeModules()` — node-pty goes to node-gyp, other modules still go to `pnpm rebuild`. The empty-`failedModules` case retains the old rebuild-everything behavior.
- **A CI-breaking defect the second review caught, in the tests themselves.** `.github/actions/install-node-dependencies/action.yml` exports `npm_config_node_gyp` job-wide whenever `native-runtime != 'none'`, and pr.yml's `test` job uses `native-runtime: node`. The fixtures spread `process.env` into the child process, so the *real* node-gyp would have run against a fixture node-pty that has no `binding.gyp` — turning all 32 Linux test shards red. Reproduced locally (4 of 6 tests failed with `gyp ERR! configure error`), then fixed by stripping the variable from the inherited env. The override contract is now covered by a dedicated test that omits the resolvable `node_modules/node-gyp` entirely, so it can only pass when the override is honored — verified non-vacuous by stubbing the branch out and watching it fail.
- **SSH / remote / local.** No runtime code touched. This script runs on the machine performing the install/test; it has no network, host, or session assumptions, and nothing here participates in SSH, relay, or remote-agent paths.
- **Agent / integration / git provider compatibility.** None involved. No agent adapters, no provider-specific logic, no GitHub/GitLab-facing code.
- **Performance.** No hot paths. Adds one `require.resolve` on the repair path only. The fast path (artifacts present, module loads) is untouched and still exits in ~0.07s, verified. The repair compiles in ~2s instead of failing.
- **UI quality.** Not applicable, no UI surface.
- **Security.** Below.

## Security Audit

- **Command execution.** `runNodeScript` uses `spawnSync` with an argument array and no shell, so the node-gyp path is not shell-interpreted. This is stricter than the previous `runPnpm`, which sets `shell: true` on Windows. No user-controlled data reaches the argument list.
- **Path handling.** The node-pty directory is derived from `projectDir` via `resolve()`, not from any external input.
- **Environment input.** `npm_config_node_gyp` is read and executed as a script path. It is the standard npm/pnpm knob for locating node-gyp, this repo already sets it in `.github/workflows/computer-e2e.yml`, and anyone able to set it in the build environment can already run arbitrary install scripts — so it adds no new trust boundary. Missing/unresolvable node-gyp fails closed with an explicit error and exit 1 rather than silently continuing.
- **Dependencies.** No dependency changes; no lockfile change. `node-gyp@12.3.0` is already present via `@electron/rebuild` and is hoisted by `shamefully-hoist=true`; it has no `exports` field, so the `bin/node-gyp.js` subpath resolves.
- **Secrets / auth / IPC.** None touched.

## Notes

- Behavior is unchanged on Windows and on Linux; only the macOS repair path changes outcome.
- The tests that assert the source-build path are already `skipIf(process.platform === 'win32')`, consistent with the existing file.
- Because PR CI is entirely `ubuntu-latest`, these tests will exercise the Linux branch there. The macOS-specific failure this fixes is verified locally and documented above; no CI matrix change is proposed here, but adding a macOS job would be the way to keep this class of bug visible.
- The underlying trigger is worth noting separately: `rebuild-native-deps.mjs` deliberately exits 0 when Electron's binary is unavailable or a Windows file lock blocks a rebuild, which is what leaves `build/Release` missing in the first place. That escape hatch is intentional and unchanged here.
- On a machine where pnpm is a standalone binary, `pnpm build` cannot complete until #11738 lands. That is independent of this PR and affects `main` equally.
