### PR TITLE
fix(mobile): lazily retrieve full native chat responses

### DIFF
--- a/mobile/src/session/MobileNativeChatLongText.tsx
+++ b/mobile/src/session/MobileNativeChatLongText.tsx
@@ -5,10 +5,12 @@ import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 
 export function MobileNativeChatLongText({
   content,
-  fontScale
+  fontScale,
+  invert
 }: {
   content: string
   fontScale: number
+  invert?: boolean
 }): React.JSX.Element {
   const chunks = useMemo(() => splitMobileNativeChatLongText(content), [content])
   return (
@@ -16,7 +18,14 @@ export function MobileNativeChatLongText({
       {chunks.map((chunk) => (
         <Text
           key={chunk.start}
-          style={[styles.longTextPlain, { fontSize: TEXT_SIZE * fontScale }]}
+          style={[
+            styles.longTextPlain,
+            invert && styles.userText,
+            {
+              fontSize: TEXT_SIZE * fontScale,
+              lineHeight: (TEXT_SIZE + 6) * fontScale
+            }
+          ]}
           selectable
         >
           {chunk.text}

--- a/mobile/src/session/MobileNativeChatLongText.tsx
+++ b/mobile/src/session/MobileNativeChatLongText.tsx
@@ -13,13 +13,13 @@ export function MobileNativeChatLongText({
   const chunks = useMemo(() => splitMobileNativeChatLongText(content), [content])
   return (
     <View>
-      {chunks.map((chunk, index) => (
+      {chunks.map((chunk) => (
         <Text
-          key={`${index}:${chunk.length}`}
+          key={chunk.start}
           style={[styles.longTextPlain, { fontSize: TEXT_SIZE * fontScale }]}
           selectable
         >
-          {chunk}
+          {chunk.text}
         </Text>
       ))}
     </View>

--- a/mobile/src/session/MobileNativeChatLongText.tsx
+++ b/mobile/src/session/MobileNativeChatLongText.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import { Text, View } from 'react-native'
+import { splitMobileNativeChatLongText } from './mobile-native-chat-long-text'
+import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
+
+export function MobileNativeChatLongText({
+  content,
+  fontScale
+}: {
+  content: string
+  fontScale: number
+}): React.JSX.Element {
+  const chunks = useMemo(() => splitMobileNativeChatLongText(content), [content])
+  return (
+    <View>
+      {chunks.map((chunk, index) => (
+        <Text
+          key={`${index}:${chunk.length}`}
+          style={[styles.longTextPlain, { fontSize: TEXT_SIZE * fontScale }]}
+          selectable
+        >
+          {chunk}
+        </Text>
+      ))}
+    </View>
+  )
+}

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -118,6 +118,40 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     expect(tree.root.findByProps({ accessibilityLabel: 'Show less' })).toBeTruthy()
   })
 
+  it('chunks very long expanded prose into visible native text nodes', () => {
+    const fullText = Array.from(
+      { length: 3000 },
+      (_, index) => `Paragraph ${index}: readable native chat prose.`
+    ).join('\n\n')
+    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: fullText.length }
+    const message: NativeChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: `${fullText.slice(0, 4000)}\n… (truncated)`, retrieval }],
+      timestamp: null,
+      source: 'transcript'
+    }
+    const key = mobileNativeChatTextKey(message.id, retrieval)
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: { key, text: fullText },
+      expandedKey: key,
+      loadingKey: null,
+      errorKey: null,
+      toggle: vi.fn()
+    }
+
+    const tree = render(message, textExpansion)
+    const chunks = tree.root
+      .findAllByType('Text' as never)
+      .filter((node) => node.props.selectable === true)
+      .map((node) => node.children.join(''))
+
+    expect(fullText.length).toBeGreaterThan(100_000)
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.join('')).toBe(fullText)
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(0)
+  })
+
   it('strips the image prompt marker from expanded user text', () => {
     const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
     const message = userMessage([{ type: 'text', text: 'caption preview', retrieval }])

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -258,12 +258,15 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       loadForCopy: vi.fn()
     }
 
-    const actions = render(message, textExpansion).root.findAll(
-      (node) => node.props.accessibilityState?.disabled === true
-    )
+    const tree = render(message, textExpansion)
+    const actions = tree.root.findAll((node) => node.props.accessibilityState?.disabled === true)
 
     expect(actions).toHaveLength(2)
     expect(actions.every((action) => action.props.disabled === true)).toBe(true)
+    expect(
+      tree.root.findByProps({ accessibilityLabel: 'Loading full response…' }).props
+        .accessibilityState
+    ).toMatchObject({ busy: true })
   })
 
   it('recovers every clipped prose block before copying the exact message', async () => {
@@ -305,6 +308,10 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       tree.root.findByProps({ accessibilityLabel: 'Copy message' }).props.onPress()
     )
 
-    expect(tree.root.findByProps({ accessibilityLabel: 'Copy failed. Retry' })).toBeTruthy()
+    expect(tree.root.findByProps({ accessibilityLabel: 'Retry copying message' })).toBeTruthy()
+    expect(tree.root.findByProps({ accessibilityRole: 'alert' })).toBeTruthy()
+    expect(
+      tree.root.findAllByType('Text' as never).map((node) => node.children.join(''))
+    ).toContain('Copy failed')
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -117,4 +117,55 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     expect(tree.root.findByType('MobileMarkdown' as never).props.content).toBe(fullText)
     expect(tree.root.findByProps({ accessibilityLabel: 'Show less' })).toBeTruthy()
   })
+
+  it('strips the image prompt marker from expanded user text', () => {
+    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
+    const message = userMessage([{ type: 'text', text: 'caption preview', retrieval }])
+    const key = mobileNativeChatTextKey(message.id, retrieval)
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: { key, text: '[Image #1] complete caption' },
+      expandedKey: key,
+      loadingKey: null,
+      errorKey: null,
+      toggle: vi.fn()
+    }
+
+    const tree = render(message, textExpansion)
+    const text = tree.root
+      .findAllByType('Text' as never)
+      .map((node) => node.children.join(''))
+      .join(' ')
+
+    expect(text).toContain('complete caption')
+    expect(text).not.toContain('[Image #1]')
+  })
+
+  it('disables all expansion actions while one block is loading', () => {
+    const firstRetrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
+    const secondRetrieval = { recordOffset: 84, blockIndex: 1, originalChars: 8000 }
+    const message: NativeChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'first preview', retrieval: firstRetrieval },
+        { type: 'text', text: 'second preview', retrieval: secondRetrieval }
+      ],
+      timestamp: null,
+      source: 'transcript'
+    }
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: null,
+      expandedKey: null,
+      loadingKey: mobileNativeChatTextKey(message.id, firstRetrieval),
+      errorKey: null,
+      toggle: vi.fn()
+    }
+
+    const actions = render(message, textExpansion).root.findAll(
+      (node) => node.props.accessibilityState?.disabled === true
+    )
+
+    expect(actions).toHaveLength(2)
+    expect(actions.every((action) => action.props.disabled === true)).toBe(true)
+  })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Clipboard from 'expo-clipboard'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 
 vi.mock('react-native', async () => {
@@ -33,11 +34,16 @@ function userMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
   return { id: 'u1', role: 'user', blocks, timestamp: null, source: 'transcript' }
 }
 
+function assistantMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
+  return { id: 'a1', role: 'assistant', blocks, timestamp: null, source: 'transcript' }
+}
+
 describe('MobileNativeChatMessage image-ref rendering', () => {
   let renderer: ReactTestRenderer | null = null
 
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.mocked(Clipboard.setStringAsync).mockReset().mockResolvedValue()
   })
   afterEach(() => {
     act(() => renderer?.unmount())
@@ -46,7 +52,8 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
 
   function render(
     message: NativeChatMessage,
-    textExpansion?: MobileNativeChatTextExpansion
+    textExpansion?: MobileNativeChatTextExpansion,
+    fontScale = 1
   ): ReactTestRenderer {
     const original = console.error
     const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
@@ -57,7 +64,9 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     })
     try {
       act(() => {
-        renderer = create(createElement(MobileNativeChatMessage, { message, textExpansion }))
+        renderer = create(
+          createElement(MobileNativeChatMessage, { message, textExpansion, fontScale })
+        )
       })
     } finally {
       spy.mockRestore()
@@ -95,7 +104,7 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     ['ordinary prose', `Summary\n\n${'Readable paragraph. '.repeat(300)}`],
     ['fenced code', `\`\`\`ts\n${'const answer = 42\n'.repeat(300)}\`\`\``]
   ])('renders complete %s after lazy expansion', (_label, fullText) => {
-    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: fullText.length }
+    const retrieval = { capability: 'capability-expanded', originalChars: fullText.length }
     const message: NativeChatMessage = {
       id: 'assistant-1',
       role: 'assistant',
@@ -109,7 +118,8 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       expandedKey: key,
       loadingKey: null,
       errorKey: null,
-      toggle: vi.fn()
+      toggle: vi.fn(),
+      loadForCopy: vi.fn().mockResolvedValue(fullText)
     }
 
     const tree = render(message, textExpansion)
@@ -123,7 +133,7 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       { length: 3000 },
       (_, index) => `Paragraph ${index}: readable native chat prose.`
     ).join('\n\n')
-    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: fullText.length }
+    const retrieval = { capability: 'capability-long', originalChars: fullText.length }
     const message: NativeChatMessage = {
       id: 'assistant-1',
       role: 'assistant',
@@ -137,7 +147,8 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       expandedKey: key,
       loadingKey: null,
       errorKey: null,
-      toggle: vi.fn()
+      toggle: vi.fn(),
+      loadForCopy: vi.fn().mockResolvedValue(fullText)
     }
 
     const tree = render(message, textExpansion)
@@ -152,8 +163,58 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(0)
   })
 
+  it('uses the same chunked renderer before and after a very long Markdown expansion', () => {
+    const fullText = `# Result\n\n\`\`\`ts\n${'const value = 42\n'.repeat(7000)}\`\`\``
+    const preview = `${fullText.slice(0, 4000)}\n… (truncated)`
+    const retrieval = { capability: 'capability-markdown', originalChars: fullText.length }
+    const message = assistantMessage([{ type: 'text', text: preview, retrieval }])
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: null,
+      expandedKey: null,
+      loadingKey: null,
+      errorKey: null,
+      toggle: vi.fn(),
+      loadForCopy: vi.fn().mockResolvedValue(fullText)
+    }
+
+    const tree = render(message, textExpansion)
+    const previewChunks = tree.root
+      .findAllByType('Text' as never)
+      .filter((node) => node.props.selectable === true)
+      .map((node) => node.children.join(''))
+
+    expect(fullText.length).toBeGreaterThan(100_000)
+    expect(previewChunks.join('')).toBe(preview)
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(0)
+  })
+
+  it('chunks very long user text and scales its line height with pinch zoom', () => {
+    const fullText = 'User prose. '.repeat(10_000)
+    const retrieval = { capability: 'capability-user-long', originalChars: fullText.length }
+    const message = userMessage([{ type: 'text', text: 'User prose preview', retrieval }])
+    const key = mobileNativeChatTextKey(message.id, retrieval)
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: { key, text: fullText },
+      expandedKey: key,
+      loadingKey: null,
+      errorKey: null,
+      toggle: vi.fn(),
+      loadForCopy: vi.fn().mockResolvedValue(fullText)
+    }
+
+    const chunks = render(message, textExpansion, 1.8)
+      .root.findAllByType('Text' as never)
+      .filter((node) => node.props.selectable === true)
+
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.map((node) => node.children.join('')).join('')).toBe(fullText)
+    expect(chunks[0].props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontSize: 30.6, lineHeight: 41.4 })])
+    )
+  })
+
   it('strips the image prompt marker from expanded user text', () => {
-    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
+    const retrieval = { capability: 'capability-caption', originalChars: 9000 }
     const message = userMessage([{ type: 'text', text: 'caption preview', retrieval }])
     const key = mobileNativeChatTextKey(message.id, retrieval)
     const textExpansion: MobileNativeChatTextExpansion = {
@@ -161,7 +222,8 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       expandedKey: key,
       loadingKey: null,
       errorKey: null,
-      toggle: vi.fn()
+      toggle: vi.fn(),
+      loadForCopy: vi.fn().mockResolvedValue('[Image #1] complete caption')
     }
 
     const tree = render(message, textExpansion)
@@ -175,8 +237,8 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
   })
 
   it('disables all expansion actions while one block is loading', () => {
-    const firstRetrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
-    const secondRetrieval = { recordOffset: 84, blockIndex: 1, originalChars: 8000 }
+    const firstRetrieval = { capability: 'capability-first', originalChars: 9000 }
+    const secondRetrieval = { capability: 'capability-second', originalChars: 8000 }
     const message: NativeChatMessage = {
       id: 'assistant-1',
       role: 'assistant',
@@ -192,7 +254,8 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       expandedKey: null,
       loadingKey: mobileNativeChatTextKey(message.id, firstRetrieval),
       errorKey: null,
-      toggle: vi.fn()
+      toggle: vi.fn(),
+      loadForCopy: vi.fn()
     }
 
     const actions = render(message, textExpansion).root.findAll(
@@ -201,5 +264,47 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
 
     expect(actions).toHaveLength(2)
     expect(actions.every((action) => action.props.disabled === true)).toBe(true)
+  })
+
+  it('recovers every clipped prose block before copying the exact message', async () => {
+    const first = { capability: 'capability-copy-first', originalChars: 5000 }
+    const second = { capability: 'capability-copy-second', originalChars: 6000 }
+    const loadForCopy = vi
+      .fn()
+      .mockResolvedValueOnce('complete first')
+      .mockResolvedValueOnce('complete second')
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: null,
+      expandedKey: null,
+      loadingKey: null,
+      errorKey: null,
+      toggle: vi.fn(),
+      loadForCopy
+    }
+    const tree = render(
+      assistantMessage([
+        { type: 'text', text: 'first preview', retrieval: first },
+        { type: 'text', text: 'second preview', retrieval: second }
+      ]),
+      textExpansion
+    )
+
+    await act(async () =>
+      tree.root.findByProps({ accessibilityLabel: 'Copy message' }).props.onPress()
+    )
+
+    expect(loadForCopy.mock.calls.map((call) => call[1])).toEqual([first, second])
+    expect(Clipboard.setStringAsync).toHaveBeenCalledWith('complete first\n\ncomplete second')
+  })
+
+  it('reports clipboard rejection without showing copied success', async () => {
+    vi.mocked(Clipboard.setStringAsync).mockRejectedValueOnce(new Error('clipboard full'))
+    const tree = render(assistantMessage([{ type: 'text', text: 'complete' }]))
+
+    await act(async () =>
+      tree.root.findByProps({ accessibilityLabel: 'Copy message' }).props.onPress()
+    )
+
+    expect(tree.root.findByProps({ accessibilityLabel: 'Copy failed. Retry' })).toBeTruthy()
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -7,6 +7,7 @@ vi.mock('react-native', async () => {
   const React = await import('react')
   return {
     Image: 'Image',
+    ActivityIndicator: 'ActivityIndicator',
     Pressable: 'Pressable',
     Text: ({ children, ...props }: { children?: unknown }) =>
       React.createElement('Text', props, children),
@@ -25,6 +26,8 @@ vi.mock('lucide-react-native', () => ({
 vi.mock('../components/MobileMarkdown', () => ({ MobileMarkdown: 'MobileMarkdown' }))
 
 import { MobileNativeChatMessage } from './MobileNativeChatMessage'
+import { mobileNativeChatTextKey } from './use-mobile-native-chat-text-expansion'
+import type { MobileNativeChatTextExpansion } from './use-mobile-native-chat-text-expansion'
 
 function userMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
   return { id: 'u1', role: 'user', blocks, timestamp: null, source: 'transcript' }
@@ -41,7 +44,10 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     renderer = null
   })
 
-  function render(message: NativeChatMessage): ReactTestRenderer {
+  function render(
+    message: NativeChatMessage,
+    textExpansion?: MobileNativeChatTextExpansion
+  ): ReactTestRenderer {
     const original = console.error
     const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
       if (typeof a[0] === 'string' && a[0].includes('react-test-renderer is deprecated')) {
@@ -51,7 +57,7 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     })
     try {
       act(() => {
-        renderer = create(createElement(MobileNativeChatMessage, { message }))
+        renderer = create(createElement(MobileNativeChatMessage, { message, textExpansion }))
       })
     } finally {
       spy.mockRestore()
@@ -83,5 +89,32 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       .findAllByType('Text' as never)
       .map((node) => String(node.children.join('')))
     expect(texts.some((text) => text.includes('/tmp/host.png'))).toBe(true)
+  })
+
+  it.each([
+    ['ordinary prose', `Summary\n\n${'Readable paragraph. '.repeat(300)}`],
+    ['fenced code', `\`\`\`ts\n${'const answer = 42\n'.repeat(300)}\`\`\``]
+  ])('renders complete %s after lazy expansion', (_label, fullText) => {
+    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: fullText.length }
+    const message: NativeChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: `${fullText.slice(0, 4000)}\n… (truncated)`, retrieval }],
+      timestamp: null,
+      source: 'transcript'
+    }
+    const key = mobileNativeChatTextKey(message.id, retrieval)
+    const textExpansion: MobileNativeChatTextExpansion = {
+      cached: { key, text: fullText },
+      expandedKey: key,
+      loadingKey: null,
+      errorKey: null,
+      toggle: vi.fn()
+    }
+
+    const tree = render(message, textExpansion)
+
+    expect(tree.root.findByType('MobileMarkdown' as never).props.content).toBe(fullText)
+    expect(tree.root.findByProps({ accessibilityLabel: 'Show less' })).toBeTruthy()
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -19,10 +19,7 @@ import {
   summarizeToolRun,
   toolFilePath
 } from './mobile-native-chat-tool-summary'
-import {
-  mobileNativeChatTextKey,
-  type MobileNativeChatTextExpansion
-} from './use-mobile-native-chat-text-expansion'
+import type { MobileNativeChatTextExpansion } from './use-mobile-native-chat-text-expansion'
 
 const MAX_VISIBLE_TOOL_PAIRS = 6
 const MAX_TOOL_RUN_DIFF_ROWS = 240
@@ -204,18 +201,30 @@ function ToolRun({
  *  this message's top aligns to the top of the viewport. */
 function AgentControls({
   onCopy,
+  copyState,
   onScrollToTop
 }: {
-  onCopy: () => void
+  onCopy: () => Promise<void>
+  copyState: 'idle' | 'copying' | 'failed'
   onScrollToTop?: () => void
 }): React.JSX.Element {
+  const copying = copyState === 'copying'
   return (
     <View style={styles.controls}>
       <Pressable
         style={({ pressed }) => [styles.controlButton, pressed && styles.controlPressed]}
-        onPress={onCopy}
+        onPress={() => void onCopy()}
+        disabled={copying}
         hitSlop={8}
-        accessibilityLabel="Copy message"
+        accessibilityLabel={
+          copying
+            ? 'Copying message'
+            : copyState === 'failed'
+              ? 'Copy failed. Retry'
+              : 'Copy message'
+        }
+        accessibilityLiveRegion="polite"
+        accessibilityState={{ busy: copying, disabled: copying }}
       >
         <Copy size={14} color={colors.textMuted} strokeWidth={2} />
       </Pressable>
@@ -260,6 +269,7 @@ function MobileNativeChatMessageImpl({
   const isAgent = !isUser
   // Briefly tint the bubble to confirm a copy landed.
   const [copied, setCopied] = useState(false)
+  const [copyState, setCopyState] = useState<'idle' | 'copying' | 'failed'>('idle')
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(
     () => () => {
@@ -275,23 +285,35 @@ function MobileNativeChatMessageImpl({
   const { prose, tools } = splitNativeChatBlocks(message.blocks)
   const firstUserTextIndex = isUser ? prose.findIndex(isTextBlock) : -1
 
-  const handleCopy = (): void => {
-    const text = nativeChatMessageText(message.blocks, (block) => {
-      if (!block.retrieval || !textExpansion?.cached) {
-        return undefined
+  const handleCopy = async (): Promise<void> => {
+    setCopyState('copying')
+    const recovered = new Map<Extract<NativeChatBlock, { type: 'text' }>, string>()
+    try {
+      for (const block of message.blocks) {
+        if (!isTextBlock(block) || !block.retrieval) {
+          continue
+        }
+        if (!textExpansion) {
+          throw new Error('Full message unavailable')
+        }
+        recovered.set(block, await textExpansion.loadForCopy(message.id, block.retrieval))
       }
-      const key = mobileNativeChatTextKey(message.id, block.retrieval)
-      return textExpansion.cached.key === key ? textExpansion.cached.text : undefined
-    })
-    if (!text) {
-      return
+      const text = nativeChatMessageText(message.blocks, (block) => recovered.get(block))
+      if (!text) {
+        setCopyState('idle')
+        return
+      }
+      await Clipboard.setStringAsync(text)
+      setCopyState('idle')
+      setCopied(true)
+      if (copyTimer.current) {
+        clearTimeout(copyTimer.current)
+      }
+      copyTimer.current = setTimeout(() => setCopied(false), 700)
+    } catch {
+      setCopied(false)
+      setCopyState('failed')
     }
-    void Clipboard.setStringAsync(text)
-    setCopied(true)
-    if (copyTimer.current) {
-      clearTimeout(copyTimer.current)
-    }
-    copyTimer.current = setTimeout(() => setCopied(false), 700)
   }
 
   // Copy + scroll-to-top, shown inline with the first tool call (or after the
@@ -300,6 +322,7 @@ function MobileNativeChatMessageImpl({
     isAgent && !queued ? (
       <AgentControls
         onCopy={handleCopy}
+        copyState={copyState}
         onScrollToTop={
           onScrollToMessage && messageIndex !== undefined
             ? () => onScrollToMessage(messageIndex)

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -211,6 +211,11 @@ function AgentControls({
   const copying = copyState === 'copying'
   return (
     <View style={styles.controls}>
+      {copyState === 'failed' ? (
+        <Text style={styles.copyError} accessibilityRole="alert">
+          Copy failed
+        </Text>
+      ) : null}
       <Pressable
         style={({ pressed }) => [styles.controlButton, pressed && styles.controlPressed]}
         onPress={() => void onCopy()}
@@ -220,9 +225,10 @@ function AgentControls({
           copying
             ? 'Copying message'
             : copyState === 'failed'
-              ? 'Copy failed. Retry'
+              ? 'Retry copying message'
               : 'Copy message'
         }
+        accessibilityRole="button"
         accessibilityLiveRegion="polite"
         accessibilityState={{ busy: copying, disabled: copying }}
       >

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -4,7 +4,12 @@ import * as Clipboard from 'expo-clipboard'
 import { ArrowUp, ChevronDown, Copy, SquareChevronRight } from 'lucide-react-native'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { colors } from '../theme/mobile-theme'
-import { pairToolBlocks, splitNativeChatBlocks, type ToolPair } from './mobile-native-chat-blocks'
+import {
+  isTextBlock,
+  pairToolBlocks,
+  splitNativeChatBlocks,
+  type ToolPair
+} from './mobile-native-chat-blocks'
 import { diffFromText, diffFromToolCall, type DiffLine } from './mobile-native-chat-diff'
 import { MAX_TOOL_RESULT_CHARS, styles } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
@@ -268,6 +273,7 @@ function MobileNativeChatMessageImpl({
   // tool calls fold into a collapsible run beneath. The user's own messages get
   // an inverted (filled accent) bubble so they stand apart from agent prose.
   const { prose, tools } = splitNativeChatBlocks(message.blocks)
+  const firstUserTextIndex = isUser ? prose.findIndex(isTextBlock) : -1
 
   const handleCopy = (): void => {
     const text = nativeChatMessageText(message.blocks, (block) => {
@@ -322,6 +328,7 @@ function MobileNativeChatMessageImpl({
             invert={isUser}
             fontScale={fontScale}
             textExpansion={textExpansion}
+            normalizeImagePromptMarker={index === firstUserTextIndex}
             onOpenFile={onOpenFile}
           />
         ))}

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -1,26 +1,23 @@
 import { memo, useEffect, useRef, useState } from 'react'
-import { Image, Pressable, Text, View } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import { ArrowUp, ChevronDown, Copy, SquareChevronRight } from 'lucide-react-native'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
-import { MobileMarkdown } from '../components/MobileMarkdown'
 import { colors } from '../theme/mobile-theme'
-import {
-  isImageRefBlock,
-  isTextBlock,
-  pairToolBlocks,
-  splitNativeChatBlocks,
-  type ToolPair
-} from './mobile-native-chat-blocks'
+import { pairToolBlocks, splitNativeChatBlocks, type ToolPair } from './mobile-native-chat-blocks'
 import { diffFromText, diffFromToolCall, type DiffLine } from './mobile-native-chat-diff'
-import { isRenderableImageUri } from './mobile-native-chat-image-preview'
-import { MAX_TOOL_RESULT_CHARS, styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
+import { MAX_TOOL_RESULT_CHARS, styles } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
+import { MobileNativeChatProseBlock } from './MobileNativeChatProseBlock'
 import {
   summarizeToolInput,
   summarizeToolRun,
   toolFilePath
 } from './mobile-native-chat-tool-summary'
+import {
+  mobileNativeChatTextKey,
+  type MobileNativeChatTextExpansion
+} from './use-mobile-native-chat-text-expansion'
 
 const MAX_VISIBLE_TOOL_PAIRS = 6
 const MAX_TOOL_RUN_DIFF_ROWS = 240
@@ -137,52 +134,6 @@ function ToolLine({
   )
 }
 
-function Prose({
-  block,
-  invert,
-  fontScale,
-  onOpenFile
-}: {
-  block: NativeChatBlock
-  invert?: boolean
-  fontScale: number
-  onOpenFile?: (relativePath: string) => void
-}): React.JSX.Element | null {
-  if (isTextBlock(block)) {
-    // Inverted (user) bubbles use a fixed dark-on-light text rather than the
-    // markdown renderer's light-on-dark palette.
-    if (invert) {
-      return (
-        <Text style={[styles.userText, { fontSize: TEXT_SIZE * fontScale }]}>{block.text}</Text>
-      )
-    }
-    return (
-      <MobileMarkdown content={block.text} textScale={1.25 * fontScale} onOpenFile={onOpenFile} />
-    )
-  }
-  if (isImageRefBlock(block)) {
-    // A local preview (composer echo) or real URL renders as a thumbnail; a bare
-    // host path (not loadable on the device) falls back to a text placeholder.
-    const uri = block.url ?? block.path
-    if (isRenderableImageUri(uri)) {
-      return (
-        <Image
-          source={{ uri }}
-          style={styles.imageThumb}
-          resizeMode="contain"
-          accessibilityLabel={block.alt ?? 'Attached image'}
-        />
-      )
-    }
-    return (
-      <Text style={[styles.imageRef, { fontSize: TEXT_SIZE * fontScale }]}>
-        🖼 {block.alt ?? block.path ?? block.url ?? 'image'}
-      </Text>
-    )
-  }
-  return null
-}
-
 /** A run of a message's tool calls/results, collapsed to a one-line summary that
  *  expands to the individual inline tool lines. `defaultExpanded` lets the global
  *  toolbar toggle drive every run at once while still allowing per-run override. */
@@ -284,7 +235,8 @@ function MobileNativeChatMessageImpl({
   fontScale = 1,
   messageIndex,
   onScrollToMessage,
-  onOpenFile
+  onOpenFile,
+  textExpansion
 }: {
   message: NativeChatMessage
   queued?: boolean
@@ -296,6 +248,7 @@ function MobileNativeChatMessageImpl({
   /** Ask the list to align this message's top to the top of the viewport. */
   onScrollToMessage?: (index: number) => void
   onOpenFile?: (relativePath: string) => void
+  textExpansion?: MobileNativeChatTextExpansion
 }): React.JSX.Element {
   const isUser = message.role === 'user'
   const isReasoning = message.role === 'reasoning'
@@ -317,7 +270,13 @@ function MobileNativeChatMessageImpl({
   const { prose, tools } = splitNativeChatBlocks(message.blocks)
 
   const handleCopy = (): void => {
-    const text = nativeChatMessageText(message.blocks)
+    const text = nativeChatMessageText(message.blocks, (block) => {
+      if (!block.retrieval || !textExpansion?.cached) {
+        return undefined
+      }
+      const key = mobileNativeChatTextKey(message.id, block.retrieval)
+      return textExpansion.cached.key === key ? textExpansion.cached.text : undefined
+    })
     if (!text) {
       return
     }
@@ -356,11 +315,13 @@ function MobileNativeChatMessageImpl({
         ]}
       >
         {prose.map((block, index) => (
-          <Prose
+          <MobileNativeChatProseBlock
             key={index}
             block={block}
+            messageId={message.id}
             invert={isUser}
             fontScale={fontScale}
+            textExpansion={textExpansion}
             onOpenFile={onOpenFile}
           />
         ))}

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -61,6 +61,7 @@ export function MobileNativeChatOverlay({
         hasMore={session.hasMore}
         loadingEarlier={session.loadingEarlier}
         onLoadEarlier={session.loadEarlier}
+        loadFullText={session.loadFullText}
         onSend={images.sendNativeChat}
         pending={controller.chatPending}
         composerText={controller.chatComposerText}

--- a/mobile/src/session/MobileNativeChatProseBlock.tsx
+++ b/mobile/src/session/MobileNativeChatProseBlock.tsx
@@ -90,6 +90,8 @@ function TextBlock({
     key !== null && textExpansion?.cached?.key === key ? textExpansion.cached.text : null
   const rawContent = expanded && cached !== null ? cached : block.text
   const content = normalizeImagePromptMarker ? stripImagePromptMarker(rawContent) : rawContent
+  const useLongText =
+    (block.retrieval?.originalChars ?? content.length) > MAX_EXPANDED_MARKDOWN_CHARS
   const loading = key !== null && textExpansion?.loadingKey === key
   const expansionBusy = textExpansion?.loadingKey != null
   const failed = key !== null && textExpansion?.errorKey === key
@@ -105,10 +107,17 @@ function TextBlock({
 
   return (
     <View>
-      {invert ? (
-        <Text style={[styles.userText, { fontSize: TEXT_SIZE * fontScale }]}>{content}</Text>
-      ) : content.length > MAX_EXPANDED_MARKDOWN_CHARS ? (
-        <MobileNativeChatLongText content={content} fontScale={fontScale} />
+      {useLongText ? (
+        <MobileNativeChatLongText content={content} fontScale={fontScale} invert={invert} />
+      ) : invert ? (
+        <Text
+          style={[
+            styles.userText,
+            { fontSize: TEXT_SIZE * fontScale, lineHeight: (TEXT_SIZE + 6) * fontScale }
+          ]}
+        >
+          {content}
+        </Text>
       ) : (
         <MobileMarkdown content={content} textScale={1.25 * fontScale} onOpenFile={onOpenFile} />
       )}

--- a/mobile/src/session/MobileNativeChatProseBlock.tsx
+++ b/mobile/src/session/MobileNativeChatProseBlock.tsx
@@ -97,8 +97,9 @@ function TextBlock({
   const failed = key !== null && textExpansion?.errorKey === key
   const showLoading = useDelayedLoading(loading)
   const contentNoun = invert ? 'message' : 'response'
+  const loadingLabel = `Loading full ${contentNoun}…`
   const actionLabel = showLoading
-    ? `Loading full ${contentNoun}…`
+    ? loadingLabel
     : failed
       ? `Retry full ${contentNoun}`
       : expanded
@@ -127,8 +128,8 @@ function TextBlock({
           disabled={expansionBusy}
           onPress={() => textExpansion.toggle(messageId, block.retrieval!)}
           accessibilityRole="button"
-          accessibilityLabel={actionLabel}
-          accessibilityState={{ disabled: expansionBusy, expanded }}
+          accessibilityLabel={loading ? loadingLabel : actionLabel}
+          accessibilityState={{ busy: loading, disabled: expansionBusy, expanded }}
         >
           {showLoading ? (
             <ActivityIndicator size="small" color={invert ? colors.bgBase : colors.textSecondary} />

--- a/mobile/src/session/MobileNativeChatProseBlock.tsx
+++ b/mobile/src/session/MobileNativeChatProseBlock.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Image, Pressable, Text, View } from 'react-native'
+import type { NativeChatBlock } from '../../../src/shared/native-chat-types'
+import { MobileMarkdown } from '../components/MobileMarkdown'
+import { colors } from '../theme/mobile-theme'
+import { isImageRefBlock, isTextBlock } from './mobile-native-chat-blocks'
+import { isRenderableImageUri } from './mobile-native-chat-image-preview'
+import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
+import {
+  mobileNativeChatTextKey,
+  type MobileNativeChatTextExpansion
+} from './use-mobile-native-chat-text-expansion'
+
+const MAX_EXPANDED_MARKDOWN_CHARS = 100_000
+const LOADING_FEEDBACK_DELAY_MS = 200
+
+export function MobileNativeChatProseBlock({
+  block,
+  messageId,
+  invert,
+  fontScale,
+  textExpansion,
+  onOpenFile
+}: {
+  block: NativeChatBlock
+  messageId: string
+  invert?: boolean
+  fontScale: number
+  textExpansion?: MobileNativeChatTextExpansion
+  onOpenFile?: (relativePath: string) => void
+}): React.JSX.Element | null {
+  if (isTextBlock(block)) {
+    return (
+      <TextBlock
+        block={block}
+        messageId={messageId}
+        invert={invert}
+        fontScale={fontScale}
+        textExpansion={textExpansion}
+        onOpenFile={onOpenFile}
+      />
+    )
+  }
+  if (!isImageRefBlock(block)) {
+    return null
+  }
+  const uri = block.url ?? block.path
+  if (isRenderableImageUri(uri)) {
+    return (
+      <Image
+        source={{ uri }}
+        style={styles.imageThumb}
+        resizeMode="contain"
+        accessibilityLabel={block.alt ?? 'Attached image'}
+      />
+    )
+  }
+  return (
+    <Text style={[styles.imageRef, { fontSize: TEXT_SIZE * fontScale }]}>
+      🖼 {block.alt ?? block.path ?? block.url ?? 'image'}
+    </Text>
+  )
+}
+
+function TextBlock({
+  block,
+  messageId,
+  invert,
+  fontScale,
+  textExpansion,
+  onOpenFile
+}: {
+  block: Extract<NativeChatBlock, { type: 'text' }>
+  messageId: string
+  invert?: boolean
+  fontScale: number
+  textExpansion?: MobileNativeChatTextExpansion
+  onOpenFile?: (relativePath: string) => void
+}): React.JSX.Element {
+  const key = block.retrieval ? mobileNativeChatTextKey(messageId, block.retrieval) : null
+  const expanded = key !== null && textExpansion?.expandedKey === key
+  const cached =
+    key !== null && textExpansion?.cached?.key === key ? textExpansion.cached.text : null
+  const content = expanded && cached !== null ? cached : block.text
+  const loading = key !== null && textExpansion?.loadingKey === key
+  const failed = key !== null && textExpansion?.errorKey === key
+  const showLoading = useDelayedLoading(loading)
+  const contentNoun = invert ? 'message' : 'response'
+  const actionLabel = showLoading
+    ? `Loading full ${contentNoun}…`
+    : failed
+      ? `Retry full ${contentNoun}`
+      : expanded
+        ? 'Show less'
+        : `Show full ${contentNoun}`
+
+  return (
+    <View>
+      {invert ? (
+        <Text style={[styles.userText, { fontSize: TEXT_SIZE * fontScale }]}>{content}</Text>
+      ) : content.length > MAX_EXPANDED_MARKDOWN_CHARS ? (
+        <Text style={[styles.longTextPlain, { fontSize: TEXT_SIZE * fontScale }]} selectable>
+          {content}
+        </Text>
+      ) : (
+        <MobileMarkdown content={content} textScale={1.25 * fontScale} onOpenFile={onOpenFile} />
+      )}
+      {block.retrieval && textExpansion ? (
+        <Pressable
+          style={styles.longTextAction}
+          disabled={loading}
+          onPress={() => textExpansion.toggle(messageId, block.retrieval!)}
+          accessibilityRole="button"
+          accessibilityLabel={actionLabel}
+          accessibilityState={{ disabled: loading, expanded }}
+        >
+          {showLoading ? (
+            <ActivityIndicator size="small" color={invert ? colors.bgBase : colors.textSecondary} />
+          ) : null}
+          <Text
+            style={[
+              styles.longTextActionText,
+              invert && styles.longTextActionTextInverted,
+              failed && styles.longTextActionError
+            ]}
+          >
+            {actionLabel}
+          </Text>
+        </Pressable>
+      ) : null}
+    </View>
+  )
+}
+
+function useDelayedLoading(loading: boolean): boolean {
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    if (!loading) {
+      setVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setVisible(true), LOADING_FEEDBACK_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [loading])
+  return visible
+}

--- a/mobile/src/session/MobileNativeChatProseBlock.tsx
+++ b/mobile/src/session/MobileNativeChatProseBlock.tsx
@@ -7,6 +7,7 @@ import { isImageRefBlock, isTextBlock } from './mobile-native-chat-blocks'
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
 import { stripImagePromptMarker } from './mobile-native-chat-image-transcript-markers'
 import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
+import { MobileNativeChatLongText } from './MobileNativeChatLongText'
 import {
   mobileNativeChatTextKey,
   type MobileNativeChatTextExpansion
@@ -107,9 +108,7 @@ function TextBlock({
       {invert ? (
         <Text style={[styles.userText, { fontSize: TEXT_SIZE * fontScale }]}>{content}</Text>
       ) : content.length > MAX_EXPANDED_MARKDOWN_CHARS ? (
-        <Text style={[styles.longTextPlain, { fontSize: TEXT_SIZE * fontScale }]} selectable>
-          {content}
-        </Text>
+        <MobileNativeChatLongText content={content} fontScale={fontScale} />
       ) : (
         <MobileMarkdown content={content} textScale={1.25 * fontScale} onOpenFile={onOpenFile} />
       )}

--- a/mobile/src/session/MobileNativeChatProseBlock.tsx
+++ b/mobile/src/session/MobileNativeChatProseBlock.tsx
@@ -5,6 +5,7 @@ import { MobileMarkdown } from '../components/MobileMarkdown'
 import { colors } from '../theme/mobile-theme'
 import { isImageRefBlock, isTextBlock } from './mobile-native-chat-blocks'
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
+import { stripImagePromptMarker } from './mobile-native-chat-image-transcript-markers'
 import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 import {
   mobileNativeChatTextKey,
@@ -20,6 +21,7 @@ export function MobileNativeChatProseBlock({
   invert,
   fontScale,
   textExpansion,
+  normalizeImagePromptMarker,
   onOpenFile
 }: {
   block: NativeChatBlock
@@ -27,6 +29,7 @@ export function MobileNativeChatProseBlock({
   invert?: boolean
   fontScale: number
   textExpansion?: MobileNativeChatTextExpansion
+  normalizeImagePromptMarker?: boolean
   onOpenFile?: (relativePath: string) => void
 }): React.JSX.Element | null {
   if (isTextBlock(block)) {
@@ -37,6 +40,7 @@ export function MobileNativeChatProseBlock({
         invert={invert}
         fontScale={fontScale}
         textExpansion={textExpansion}
+        normalizeImagePromptMarker={normalizeImagePromptMarker}
         onOpenFile={onOpenFile}
       />
     )
@@ -68,6 +72,7 @@ function TextBlock({
   invert,
   fontScale,
   textExpansion,
+  normalizeImagePromptMarker,
   onOpenFile
 }: {
   block: Extract<NativeChatBlock, { type: 'text' }>
@@ -75,14 +80,17 @@ function TextBlock({
   invert?: boolean
   fontScale: number
   textExpansion?: MobileNativeChatTextExpansion
+  normalizeImagePromptMarker?: boolean
   onOpenFile?: (relativePath: string) => void
 }): React.JSX.Element {
   const key = block.retrieval ? mobileNativeChatTextKey(messageId, block.retrieval) : null
   const expanded = key !== null && textExpansion?.expandedKey === key
   const cached =
     key !== null && textExpansion?.cached?.key === key ? textExpansion.cached.text : null
-  const content = expanded && cached !== null ? cached : block.text
+  const rawContent = expanded && cached !== null ? cached : block.text
+  const content = normalizeImagePromptMarker ? stripImagePromptMarker(rawContent) : rawContent
   const loading = key !== null && textExpansion?.loadingKey === key
+  const expansionBusy = textExpansion?.loadingKey != null
   const failed = key !== null && textExpansion?.errorKey === key
   const showLoading = useDelayedLoading(loading)
   const contentNoun = invert ? 'message' : 'response'
@@ -108,11 +116,11 @@ function TextBlock({
       {block.retrieval && textExpansion ? (
         <Pressable
           style={styles.longTextAction}
-          disabled={loading}
+          disabled={expansionBusy}
           onPress={() => textExpansion.toggle(messageId, block.retrieval!)}
           accessibilityRole="button"
           accessibilityLabel={actionLabel}
-          accessibilityState={{ disabled: loading, expanded }}
+          accessibilityState={{ disabled: expansionBusy, expanded }}
         >
           {showLoading ? (
             <ActivityIndicator size="small" color={invert ? colors.bgBase : colors.textSecondary} />

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -1,7 +1,9 @@
-import { createElement } from 'react'
+import { createElement, type ReactElement } from 'react'
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MobileNativeChatView } from './MobileNativeChatView'
+import type { MobileNativeChatTextExpansion } from './use-mobile-native-chat-text-expansion'
 
 vi.mock('react-native', () => ({
   ActivityIndicator: 'ActivityIndicator',
@@ -58,10 +60,12 @@ vi.mock('./MobileNativeChatComposer', async () => {
 })
 
 type Overrides = {
+  messages?: NativeChatMessage[]
   sendErrorMessage?: string | null
   onClearSendError?: () => void
   inputLockReason?: 'disconnected' | 'waiting' | null
   onSend?: (text: string) => Promise<boolean>
+  loadFullText?: () => Promise<string>
 }
 
 function suppressRendererWarning(): () => void {
@@ -160,5 +164,29 @@ describe('MobileNativeChatView send-error banner', () => {
     await pressSend()
 
     expect(onClearSendError).toHaveBeenCalledOnce()
+  })
+
+  it('pauses tail-follow before expanding a clipped response', async () => {
+    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
+    const message: NativeChatMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'preview', retrieval }],
+      timestamp: 1,
+      source: 'transcript'
+    }
+    await render({
+      messages: [message],
+      loadFullText: () => new Promise<string>(() => {})
+    })
+    const list = renderer!.root.findByType('FlatList' as never)
+    const item = list.props.data[0] as NativeChatMessage
+    const row = list.props.renderItem({ item, index: 0 }) as ReactElement<{
+      textExpansion: MobileNativeChatTextExpansion
+    }>
+
+    act(() => row.props.textExpansion.toggle(message.id, retrieval))
+
+    expect(renderer!.root.findByProps({ accessibilityLabel: 'Scroll to latest' })).toBeTruthy()
   })
 })

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -167,7 +167,7 @@ describe('MobileNativeChatView send-error banner', () => {
   })
 
   it('pauses tail-follow before expanding a clipped response', async () => {
-    const retrieval = { recordOffset: 42, blockIndex: 0, originalChars: 9000 }
+    const retrieval = { capability: 'capability-preview', originalChars: 9000 }
     const message: NativeChatMessage = {
       id: 'assistant-1',
       role: 'assistant',

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -11,7 +11,10 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
 import { ArrowDown, ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
-import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import type {
+  NativeChatMessage,
+  NativeChatTextRetrieval
+} from '../../../src/shared/native-chat-types'
 import { colors } from '../theme/mobile-theme'
 import { styles } from './mobile-native-chat-view-styles'
 import {
@@ -33,6 +36,11 @@ import type { MobileChatPermission } from './mobile-native-chat-permission'
 import { MobileNativeChatQuestion } from './MobileNativeChatQuestion'
 import { mobileChatQuestionKey, type MobileChatQuestion } from './mobile-native-chat-question'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
+import { useMobileNativeChatTextExpansion } from './use-mobile-native-chat-text-expansion'
+
+const unavailableFullText = async (): Promise<string> => {
+  throw new Error('Full message unavailable')
+}
 
 /** Why the composer input is locked: the transport is disconnected, or the
  *  terminal subscription has not acknowledged its input lease yet. */
@@ -53,6 +61,7 @@ type Props = {
   hasMore?: boolean
   loadingEarlier?: boolean
   onLoadEarlier?: () => void
+  loadFullText?: (messageId: string, retrieval: NativeChatTextRetrieval) => Promise<string>
   onSend: (text: string) => Promise<boolean>
   /** Optimistic queued sends (owned by the route so they survive view switches). */
   /** Optimistic user echoes, including any ridden-along image preview URIs. */
@@ -111,6 +120,7 @@ export function MobileNativeChatView({
   hasMore,
   loadingEarlier,
   onLoadEarlier,
+  loadFullText,
   onSend,
   pending,
   composerText,
@@ -152,6 +162,7 @@ export function MobileNativeChatView({
   const [atBottom, setAtBottom] = useState(true)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
+  const textExpansion = useMobileNativeChatTextExpansion(loadFullText ?? unavailableFullText)
   useEffect(
     () => () => {
       if (sendScrollTimerRef.current) {
@@ -234,9 +245,10 @@ export function MobileNativeChatView({
         messageIndex={index}
         onScrollToMessage={onScrollToMessage}
         onOpenFile={onOpenFile}
+        textExpansion={textExpansion}
       />
     ),
-    [pendingIds, toolsExpanded, fontScale, onScrollToMessage, onOpenFile]
+    [pendingIds, toolsExpanded, fontScale, onScrollToMessage, onOpenFile, textExpansion]
   )
 
   const emptyState = mobileNativeChatEmptyState(status, agent ?? null, error)

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -162,7 +162,11 @@ export function MobileNativeChatView({
   const [atBottom, setAtBottom] = useState(true)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
-  const textExpansion = useMobileNativeChatTextExpansion(loadFullText ?? unavailableFullText)
+  const pauseTailFollow = useCallback(() => setAtBottom(false), [])
+  const textExpansion = useMobileNativeChatTextExpansion(
+    loadFullText ?? unavailableFullText,
+    pauseTailFollow
+  )
   useEffect(
     () => () => {
       if (sendScrollTimerRef.current) {

--- a/mobile/src/session/mobile-native-chat-long-text.test.ts
+++ b/mobile/src/session/mobile-native-chat-long-text.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS,
+  splitMobileNativeChatLongText
+} from './mobile-native-chat-long-text'
+
+describe('splitMobileNativeChatLongText', () => {
+  it('bounds render nodes while preserving the exact full text', () => {
+    const text = Array.from(
+      { length: 1800 },
+      (_, index) => `Paragraph ${index}: readable prose.`
+    ).join('\n\n')
+    const chunks = splitMobileNativeChatLongText(text)
+
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.every((chunk) => chunk.length <= MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS)).toBe(true)
+    expect(chunks.join('')).toBe(text)
+  })
+
+  it('does not split surrogate pairs at a hard boundary', () => {
+    const text = `${'a'.repeat(MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS - 1)}😀tail`
+    const chunks = splitMobileNativeChatLongText(text)
+
+    expect(chunks.join('')).toBe(text)
+    expect(chunks[0]?.endsWith('\ud83d')).toBe(false)
+    expect(chunks[1]?.startsWith('\ude00')).toBe(false)
+  })
+})

--- a/mobile/src/session/mobile-native-chat-long-text.test.ts
+++ b/mobile/src/session/mobile-native-chat-long-text.test.ts
@@ -13,16 +13,22 @@ describe('splitMobileNativeChatLongText', () => {
     const chunks = splitMobileNativeChatLongText(text)
 
     expect(chunks.length).toBeGreaterThan(1)
-    expect(chunks.every((chunk) => chunk.length <= MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS)).toBe(true)
-    expect(chunks.join('')).toBe(text)
+    expect(chunks.every((chunk) => chunk.text.length <= MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS)).toBe(
+      true
+    )
+    expect(chunks.map((chunk) => chunk.text).join('')).toBe(text)
+    expect(new Set(chunks.map((chunk) => chunk.start)).size).toBe(chunks.length)
+    expect(splitMobileNativeChatLongText(text).map((chunk) => chunk.start)).toEqual(
+      chunks.map((chunk) => chunk.start)
+    )
   })
 
   it('does not split surrogate pairs at a hard boundary', () => {
     const text = `${'a'.repeat(MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS - 1)}😀tail`
     const chunks = splitMobileNativeChatLongText(text)
 
-    expect(chunks.join('')).toBe(text)
-    expect(chunks[0]?.endsWith('\ud83d')).toBe(false)
-    expect(chunks[1]?.startsWith('\ude00')).toBe(false)
+    expect(chunks.map((chunk) => chunk.text).join('')).toBe(text)
+    expect(chunks[0]?.text.endsWith('\ud83d')).toBe(false)
+    expect(chunks[1]?.text.startsWith('\ude00')).toBe(false)
   })
 })

--- a/mobile/src/session/mobile-native-chat-long-text.ts
+++ b/mobile/src/session/mobile-native-chat-long-text.ts
@@ -1,7 +1,9 @@
 export const MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS = 4000
 
-export function splitMobileNativeChatLongText(text: string): string[] {
-  const chunks: string[] = []
+export type MobileNativeChatTextChunk = { start: number; text: string }
+
+export function splitMobileNativeChatLongText(text: string): MobileNativeChatTextChunk[] {
+  const chunks: MobileNativeChatTextChunk[] = []
   let start = 0
   while (start < text.length) {
     const hardEnd = Math.min(start + MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS, text.length)
@@ -9,7 +11,7 @@ export function splitMobileNativeChatLongText(text: string): string[] {
     if (hardEnd < text.length) {
       end = preferredTextBoundary(text, start, end)
     }
-    chunks.push(text.slice(start, end))
+    chunks.push({ start, text: text.slice(start, end) })
     start = end
   }
   return chunks

--- a/mobile/src/session/mobile-native-chat-long-text.ts
+++ b/mobile/src/session/mobile-native-chat-long-text.ts
@@ -1,0 +1,39 @@
+export const MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS = 4000
+
+export function splitMobileNativeChatLongText(text: string): string[] {
+  const chunks: string[] = []
+  let start = 0
+  while (start < text.length) {
+    const hardEnd = Math.min(start + MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS, text.length)
+    let end = safeCodePointBoundary(text, hardEnd)
+    if (hardEnd < text.length) {
+      end = preferredTextBoundary(text, start, end)
+    }
+    chunks.push(text.slice(start, end))
+    start = end
+  }
+  return chunks
+}
+
+function safeCodePointBoundary(text: string, end: number): number {
+  const previous = text.charCodeAt(end - 1)
+  const next = text.charCodeAt(end)
+  return previous >= 0xd800 && previous <= 0xdbff && next >= 0xdc00 && next <= 0xdfff
+    ? end - 1
+    : end
+}
+
+function preferredTextBoundary(text: string, start: number, hardEnd: number): number {
+  const minimum = start + Math.floor(MOBILE_NATIVE_CHAT_TEXT_CHUNK_CHARS * 0.75)
+  for (let index = hardEnd - 1; index >= minimum; index--) {
+    if (text.charCodeAt(index) === 10) {
+      return index + 1
+    }
+  }
+  for (let index = hardEnd - 1; index >= minimum; index--) {
+    if (text.charCodeAt(index) === 32) {
+      return index + 1
+    }
+  }
+  return hardEnd
+}

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -78,6 +78,29 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-end'
   },
+  longTextAction: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.xs
+  },
+  longTextActionText: {
+    color: colors.accentBlue,
+    fontSize: typography.metaSize,
+    fontWeight: '600'
+  },
+  longTextActionTextInverted: {
+    color: colors.bgBase
+  },
+  longTextActionError: {
+    color: colors.statusRed
+  },
+  longTextPlain: {
+    color: colors.textPrimary,
+    fontSize: TEXT_SIZE,
+    lineHeight: TEXT_SIZE + 6
+  },
   toolRunCount: {
     color: colors.statusGreen,
     fontFamily: typography.monoFamily,

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -43,6 +43,12 @@ export const styles = StyleSheet.create({
   controlPressed: {
     opacity: 0.5
   },
+  copyError: {
+    alignSelf: 'center',
+    color: colors.statusRed,
+    fontSize: typography.metaSize,
+    fontWeight: '600'
+  },
   copied: {
     backgroundColor: colors.diffAddedBg,
     borderRadius: radii.card

--- a/mobile/src/session/mobile-native-chat-message-text.ts
+++ b/mobile/src/session/mobile-native-chat-message-text.ts
@@ -3,10 +3,13 @@ import { isTextBlock } from './mobile-native-chat-blocks'
 
 /** Concatenate a message's text blocks into a single copyable string. Tool
  *  calls/results and image refs are skipped — Copy is for the agent's prose. */
-export function nativeChatMessageText(blocks: readonly NativeChatBlock[]): string {
+export function nativeChatMessageText(
+  blocks: readonly NativeChatBlock[],
+  textOverride?: (block: Extract<NativeChatBlock, { type: 'text' }>) => string | undefined
+): string {
   return blocks
     .filter(isTextBlock)
-    .map((b) => b.text)
+    .map((block) => textOverride?.(block) ?? block.text)
     .join('\n\n')
     .trim()
 }

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -18,6 +18,15 @@ function message(id: string): NativeChatMessage {
   }
 }
 
+const currentRetrieval = { capability: 'capability-current', originalChars: 9000 }
+
+function messageWithRetrieval(id: string): NativeChatMessage {
+  return {
+    ...message(id),
+    blocks: [{ type: 'text', text: `${id} preview`, retrieval: currentRetrieval }]
+  }
+}
+
 describe('useMobileNativeChatSession', () => {
   let renderer: ReactTestRenderer | null = null
   let state: MobileNativeChatSession | null = null
@@ -227,17 +236,14 @@ describe('useMobileNativeChatSession', () => {
   it('retrieves a full text block through the active session identity', async () => {
     const sendRequest = vi.fn().mockResolvedValue({ ok: true, result: { text: 'complete text' } })
     const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
-      onData({ type: 'snapshot', messages: [message('current')], hasMore: false })
+      onData({ type: 'snapshot', messages: [messageWithRetrieval('current')], hasMore: false })
       return () => {}
     })
     await mount({ sendRequest, subscribe } as unknown as RpcClient, '/remote/chat.jsonl')
 
     let text = ''
     await act(async () => {
-      text = await state!.loadFullText('current', {
-        capability: 'capability-current',
-        originalChars: 9000
-      })
+      text = await state!.loadFullText('current', currentRetrieval)
     })
 
     expect(text).toBe('complete text')
@@ -250,13 +256,13 @@ describe('useMobileNativeChatSession', () => {
     let resolveRead: (response: unknown) => void = () => {}
     const sendRequest = vi.fn(() => new Promise((resolve) => (resolveRead = resolve)))
     const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
-      onData({ type: 'snapshot', messages: [message('current')], hasMore: false })
+      onData({ type: 'snapshot', messages: [messageWithRetrieval('current')], hasMore: false })
       return () => {}
     })
     await mount({ sendRequest, subscribe } as unknown as RpcClient)
 
     const outcome = state!
-      .loadFullText('current', { capability: 'capability-current', originalChars: 9000 })
+      .loadFullText('current', currentRetrieval)
       .catch((error: unknown) => error)
     await act(async () => renderer?.update(createElement(Harness, { client: null })))
     await act(async () => {
@@ -274,15 +280,18 @@ describe('useMobileNativeChatSession', () => {
       const sendRequest = vi.fn(() => new Promise((resolve) => (resolveRead = resolve)))
       const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
         emit = onData
-        onData({ type: 'snapshot', messages: [message('current')], hasMore: false })
+        onData({
+          type: 'snapshot',
+          messages: [messageWithRetrieval('current')],
+          hasMore: false
+        })
         return () => {}
       })
       await mount({ sendRequest, subscribe } as unknown as RpcClient)
       const loaderBeforeReplacement = state!.loadFullText
-      const outcome = loaderBeforeReplacement('current', {
-        capability: 'capability-current',
-        originalChars: 9000
-      }).catch((error: unknown) => error)
+      const outcome = loaderBeforeReplacement('current', currentRetrieval).catch(
+        (error: unknown) => error
+      )
 
       await act(async () => {
         emit({ type: frameType, messages: [message('current')], hasMore: false })
@@ -296,6 +305,40 @@ describe('useMobileNativeChatSession', () => {
       await expect(outcome).resolves.toMatchObject({ message: 'Chat transcript changed' })
     }
   )
+
+  it('rejects a full-text response after a same-id live append replaces its preview', async () => {
+    let resolveRead: (response: unknown) => void = () => {}
+    const oldRetrieval = { capability: 'capability-old', originalChars: 9000 }
+    const newRetrieval = { capability: 'capability-new', originalChars: 10_000 }
+    const current = {
+      ...message('current'),
+      blocks: [{ type: 'text' as const, text: 'old preview', retrieval: oldRetrieval }]
+    }
+    const sendRequest = vi.fn(() => new Promise((resolve) => (resolveRead = resolve)))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: [current], hasMore: false })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    const outcome = state!.loadFullText('current', oldRetrieval).catch((error: unknown) => error)
+
+    await act(async () => {
+      emit({
+        type: 'appended',
+        messages: [
+          {
+            ...current,
+            blocks: [{ type: 'text', text: 'new preview', retrieval: newRetrieval }]
+          }
+        ]
+      })
+      resolveRead({ ok: true, result: { text: 'stale full text' } })
+      await Promise.resolve()
+    })
+
+    await expect(outcome).resolves.toMatchObject({ message: 'Chat transcript changed' })
+  })
 })
 
 describe('useMobileNativeChatSession transcriptLoading', () => {

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -33,17 +33,23 @@ describe('useMobileNativeChatSession', () => {
     renderer = null
   })
 
-  function Harness({ client }: { client: RpcClient | null }): null {
+  function Harness({
+    client,
+    transcriptPath = null
+  }: {
+    client: RpcClient | null
+    transcriptPath?: string | null
+  }): null {
     state = useMobileNativeChatSession({
       client,
       agent: 'claude',
       sessionId: 'session',
-      transcriptPath: null
+      transcriptPath
     })
     return null
   }
 
-  async function mount(client: RpcClient): Promise<void> {
+  async function mount(client: RpcClient, transcriptPath?: string): Promise<void> {
     const original = console.error
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
       if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
@@ -53,7 +59,7 @@ describe('useMobileNativeChatSession', () => {
     })
     try {
       await act(async () => {
-        renderer = create(createElement(Harness, { client }))
+        renderer = create(createElement(Harness, { client, transcriptPath }))
       })
     } finally {
       consoleSpy.mockRestore()
@@ -216,6 +222,55 @@ describe('useMobileNativeChatSession', () => {
       limit: 100
     })
     expect(state?.messages.map((entry) => entry.id)).toEqual(['fresh-growing-tail'])
+  })
+
+  it('retrieves a full text block through the active session identity', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({ ok: true, result: { text: 'complete text' } })
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      onData({ type: 'snapshot', messages: [message('current')], hasMore: false })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient, '/remote/chat.jsonl')
+
+    let text = ''
+    await act(async () => {
+      text = await state!.loadFullText('current', {
+        recordOffset: 81,
+        blockIndex: 2,
+        originalChars: 9000
+      })
+    })
+
+    expect(text).toBe('complete text')
+    expect(sendRequest).toHaveBeenCalledWith('nativeChat.readTextBlock', {
+      agent: 'claude',
+      sessionId: 'session',
+      messageId: 'current',
+      recordOffset: 81,
+      blockIndex: 2,
+      transcriptPath: '/remote/chat.jsonl'
+    })
+  })
+
+  it('rejects a full-text response after the client source changes', async () => {
+    let resolveRead: (response: unknown) => void = () => {}
+    const sendRequest = vi.fn(() => new Promise((resolve) => (resolveRead = resolve)))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      onData({ type: 'snapshot', messages: [message('current')], hasMore: false })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    const outcome = state!
+      .loadFullText('current', { recordOffset: 81, blockIndex: 0, originalChars: 9000 })
+      .catch((error: unknown) => error)
+    await act(async () => renderer?.update(createElement(Harness, { client: null })))
+    await act(async () => {
+      resolveRead({ ok: true, result: { text: 'stale text' } })
+      await Promise.resolve()
+    })
+
+    await expect(outcome).resolves.toMatchObject({ message: 'Chat session changed' })
   })
 })
 

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -272,6 +272,37 @@ describe('useMobileNativeChatSession', () => {
 
     await expect(outcome).resolves.toMatchObject({ message: 'Chat session changed' })
   })
+
+  it.each(['replacement', 'snapshot'] as const)(
+    'invalidates pending and cached full text after an authoritative %s',
+    async (frameType) => {
+      let resolveRead: (response: unknown) => void = () => {}
+      const sendRequest = vi.fn(() => new Promise((resolve) => (resolveRead = resolve)))
+      const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+        emit = onData
+        onData({ type: 'snapshot', messages: [message('current')], hasMore: false })
+        return () => {}
+      })
+      await mount({ sendRequest, subscribe } as unknown as RpcClient)
+      const loaderBeforeReplacement = state!.loadFullText
+      const outcome = loaderBeforeReplacement('current', {
+        recordOffset: 81,
+        blockIndex: 0,
+        originalChars: 9000
+      }).catch((error: unknown) => error)
+
+      await act(async () => {
+        emit({ type: frameType, messages: [message('current')], hasMore: false })
+      })
+      expect(state!.loadFullText).not.toBe(loaderBeforeReplacement)
+      await act(async () => {
+        resolveRead({ ok: true, result: { text: 'stale text' } })
+        await Promise.resolve()
+      })
+
+      await expect(outcome).resolves.toMatchObject({ message: 'Chat transcript changed' })
+    }
+  )
 })
 
 describe('useMobileNativeChatSession transcriptLoading', () => {

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -235,20 +235,14 @@ describe('useMobileNativeChatSession', () => {
     let text = ''
     await act(async () => {
       text = await state!.loadFullText('current', {
-        recordOffset: 81,
-        blockIndex: 2,
+        capability: 'capability-current',
         originalChars: 9000
       })
     })
 
     expect(text).toBe('complete text')
     expect(sendRequest).toHaveBeenCalledWith('nativeChat.readTextBlock', {
-      agent: 'claude',
-      sessionId: 'session',
-      messageId: 'current',
-      recordOffset: 81,
-      blockIndex: 2,
-      transcriptPath: '/remote/chat.jsonl'
+      capability: 'capability-current'
     })
   })
 
@@ -262,7 +256,7 @@ describe('useMobileNativeChatSession', () => {
     await mount({ sendRequest, subscribe } as unknown as RpcClient)
 
     const outcome = state!
-      .loadFullText('current', { recordOffset: 81, blockIndex: 0, originalChars: 9000 })
+      .loadFullText('current', { capability: 'capability-current', originalChars: 9000 })
       .catch((error: unknown) => error)
     await act(async () => renderer?.update(createElement(Harness, { client: null })))
     await act(async () => {
@@ -286,8 +280,7 @@ describe('useMobileNativeChatSession', () => {
       await mount({ sendRequest, subscribe } as unknown as RpcClient)
       const loaderBeforeReplacement = state!.loadFullText
       const outcome = loaderBeforeReplacement('current', {
-        recordOffset: 81,
-        blockIndex: 0,
+        capability: 'capability-current',
         originalChars: 9000
       }).catch((error: unknown) => error)
 

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type {
   NativeChatMessage,
   NativeChatTextRetrieval
@@ -96,12 +96,16 @@ export function useMobileNativeChatSession(args: {
   const limitRef = useRef(INITIAL_LIMIT)
   // Tracks the live session so a late loadEarlier resolve can detect a swap.
   const sessionIdRef = useRef<string | null>(sessionId)
-  sessionIdRef.current = sessionId
   const identityRef = useRef(identity)
-  identityRef.current = identity
   const clientRef = useRef(client)
-  clientRef.current = client
   const streamGenerationRef = useRef(0)
+
+  useLayoutEffect(() => {
+    // Async completions must only observe inputs from a committed render.
+    sessionIdRef.current = sessionId
+    identityRef.current = identity
+    clientRef.current = client
+  }, [client, identity, sessionId])
 
   // Replace the base list (read results are an ordered tail). Resets the merger
   // cache so the index is rebuilt once over the new base.

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -273,12 +273,7 @@ export function useMobileNativeChatSession(args: {
       const requestGeneration = streamGenerationRef.current
       const requestTextSourceRevision = textSourceRevision
       const response = await client.sendRequest('nativeChat.readTextBlock', {
-        agent,
-        sessionId,
-        messageId,
-        recordOffset: retrieval.recordOffset,
-        blockIndex: retrieval.blockIndex,
-        ...(transcriptPath ? { transcriptPath } : {})
+        capability: retrieval.capability
       })
       if (identityRef.current !== requestIdentity || clientRef.current !== client) {
         throw new Error('Chat session changed')
@@ -298,7 +293,7 @@ export function useMobileNativeChatSession(args: {
       }
       return result.text
     },
-    [client, agent, sessionId, transcriptPath, identity, textSourceRevision]
+    [client, agent, sessionId, identity, textSourceRevision]
   )
 
   return {

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -45,6 +45,35 @@ type ReadSessionResult =
   | { messages: NativeChatMessage[]; hasMore?: boolean; beforeOffset?: number }
   | { error: string }
 type ReadTextBlockResult = { text: string } | { error: string }
+
+function textRetrievalKey(messageId: string, retrieval: NativeChatTextRetrieval): string {
+  return `${messageId}\0${retrieval.capability}\0${retrieval.originalChars}`
+}
+
+type TextRetrievalIndex = Map<string, Set<string>>
+
+function indexTextRetrievals(messages: readonly NativeChatMessage[]): TextRetrievalIndex {
+  const index: TextRetrievalIndex = new Map()
+  for (const message of messages) {
+    updateTextRetrievalIndex(index, message)
+  }
+  return index
+}
+
+function updateTextRetrievalIndex(index: TextRetrievalIndex, message: NativeChatMessage): void {
+  const keys = new Set<string>()
+  for (const block of message.blocks) {
+    if (block.type === 'text' && block.retrieval) {
+      keys.add(textRetrievalKey(message.id, block.retrieval))
+    }
+  }
+  if (keys.size > 0) {
+    index.set(message.id, keys)
+  } else {
+    index.delete(message.id)
+  }
+}
+
 /** Subscribe to an agent's native-chat transcript over the paired connection.
  *  Reads a small recent window for a fast first paint, tails it for live turns,
  *  and pages in older history on demand. Read results replace the list (they are
@@ -101,6 +130,7 @@ export function useMobileNativeChatSession(args: {
   const streamGenerationRef = useRef(0)
   const textSourceRevisionRef = useRef(0)
   const [textSourceRevision, setTextSourceRevision] = useState(0)
+  const textRetrievalIndexRef = useRef<TextRetrievalIndex>(new Map())
 
   useLayoutEffect(() => {
     // Async completions must only observe inputs from a committed render.
@@ -113,6 +143,7 @@ export function useMobileNativeChatSession(args: {
   // cache so the index is rebuilt once over the new base.
   const setList = useCallback((next: readonly NativeChatMessage[]) => {
     replaceList(mergerRef.current, next)
+    textRetrievalIndexRef.current = indexTextRetrievals(mergerRef.current.list)
     setMessages(mergerRef.current.list)
   }, [])
 
@@ -173,6 +204,21 @@ export function useMobileNativeChatSession(args: {
           setRead({ client, identity, status: 'error' })
           setError(applied.error)
           return
+        }
+        if (
+          frame.type !== 'appended' ||
+          applied.cursorInvalidated ||
+          !Array.isArray(frame.messages)
+        ) {
+          textRetrievalIndexRef.current = indexTextRetrievals(applied.messages)
+        } else {
+          for (const incoming of frame.messages) {
+            const index = mergerRef.current.indexById.get(incoming.id)
+            const currentMessage = index === undefined ? undefined : applied.messages[index]
+            if (currentMessage) {
+              updateTextRetrievalIndex(textRetrievalIndexRef.current, currentMessage)
+            }
+          }
         }
         setMessages(applied.messages)
         if (applied.hasMore != null) {
@@ -272,6 +318,10 @@ export function useMobileNativeChatSession(args: {
       const requestIdentity = identity
       const requestGeneration = streamGenerationRef.current
       const requestTextSourceRevision = textSourceRevision
+      const requestRetrievalKey = textRetrievalKey(messageId, retrieval)
+      if (!textRetrievalIndexRef.current.get(messageId)?.has(requestRetrievalKey)) {
+        throw new Error('Chat transcript changed')
+      }
       const response = await client.sendRequest('nativeChat.readTextBlock', {
         capability: retrieval.capability
       })
@@ -280,7 +330,8 @@ export function useMobileNativeChatSession(args: {
       }
       if (
         streamGenerationRef.current !== requestGeneration ||
-        textSourceRevisionRef.current !== requestTextSourceRevision
+        textSourceRevisionRef.current !== requestTextSourceRevision ||
+        !textRetrievalIndexRef.current.get(messageId)?.has(requestRetrievalKey)
       ) {
         throw new Error('Chat transcript changed')
       }

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -99,6 +99,8 @@ export function useMobileNativeChatSession(args: {
   const identityRef = useRef(identity)
   const clientRef = useRef(client)
   const streamGenerationRef = useRef(0)
+  const textSourceRevisionRef = useRef(0)
+  const [textSourceRevision, setTextSourceRevision] = useState(0)
 
   useLayoutEffect(() => {
     // Async completions must only observe inputs from a committed render.
@@ -151,6 +153,8 @@ export function useMobileNativeChatSession(args: {
           // Why: replacement and reconnect snapshots are authoritative windows;
           // stale page limits/results must not constrain the fresh generation.
           streamGenerationRef.current += 1
+          textSourceRevisionRef.current += 1
+          setTextSourceRevision(textSourceRevisionRef.current)
           limitRef.current = INITIAL_LIMIT
           loadingEarlierRef.current = false
           setLoadingEarlier(false)
@@ -266,6 +270,8 @@ export function useMobileNativeChatSession(args: {
         throw new Error('Full message unavailable')
       }
       const requestIdentity = identity
+      const requestGeneration = streamGenerationRef.current
+      const requestTextSourceRevision = textSourceRevision
       const response = await client.sendRequest('nativeChat.readTextBlock', {
         agent,
         sessionId,
@@ -277,6 +283,12 @@ export function useMobileNativeChatSession(args: {
       if (identityRef.current !== requestIdentity || clientRef.current !== client) {
         throw new Error('Chat session changed')
       }
+      if (
+        streamGenerationRef.current !== requestGeneration ||
+        textSourceRevisionRef.current !== requestTextSourceRevision
+      ) {
+        throw new Error('Chat transcript changed')
+      }
       if (!response.ok) {
         throw new Error('Full message unavailable')
       }
@@ -286,7 +298,7 @@ export function useMobileNativeChatSession(args: {
       }
       return result.text
     },
-    [client, agent, sessionId, transcriptPath, identity]
+    [client, agent, sessionId, transcriptPath, identity, textSourceRevision]
   )
 
   return {

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import type {
+  NativeChatMessage,
+  NativeChatTextRetrieval
+} from '../../../src/shared/native-chat-types'
 import { buildNativeChatSubscriptionId } from '../../../src/shared/native-chat-stream-unsubscribe'
 import type { RpcClient } from '../transport/rpc-client'
 import { createNativeChatMerger, replaceList } from './mobile-native-chat-merge'
@@ -26,6 +29,8 @@ export type MobileNativeChatSession = {
   loadingEarlier: boolean
   /** Grow the window to page in older history. */
   loadEarlier: () => void
+  /** Fetch one full text block represented by a bounded mobile preview. */
+  loadFullText: (messageId: string, retrieval: NativeChatTextRetrieval) => Promise<string>
 }
 
 // Stable empty reference so a not-yet-current read doesn't churn consumers.
@@ -39,6 +44,7 @@ const MAX_MESSAGES = 2000
 type ReadSessionResult =
   | { messages: NativeChatMessage[]; hasMore?: boolean; beforeOffset?: number }
   | { error: string }
+type ReadTextBlockResult = { text: string } | { error: string }
 /** Subscribe to an agent's native-chat transcript over the paired connection.
  *  Reads a small recent window for a fast first paint, tails it for live turns,
  *  and pages in older history on demand. Read results replace the list (they are
@@ -91,6 +97,10 @@ export function useMobileNativeChatSession(args: {
   // Tracks the live session so a late loadEarlier resolve can detect a swap.
   const sessionIdRef = useRef<string | null>(sessionId)
   sessionIdRef.current = sessionId
+  const identityRef = useRef(identity)
+  identityRef.current = identity
+  const clientRef = useRef(client)
+  clientRef.current = client
   const streamGenerationRef = useRef(0)
 
   // Replace the base list (read results are an ordered tail). Resets the merger
@@ -246,6 +256,35 @@ export function useMobileNativeChatSession(args: {
     })()
   }, [client, agent, sessionId, transcriptPath, hasMore, setList])
 
+  const loadFullText = useCallback(
+    async (messageId: string, retrieval: NativeChatTextRetrieval): Promise<string> => {
+      if (!client || !agent || !sessionId) {
+        throw new Error('Full message unavailable')
+      }
+      const requestIdentity = identity
+      const response = await client.sendRequest('nativeChat.readTextBlock', {
+        agent,
+        sessionId,
+        messageId,
+        recordOffset: retrieval.recordOffset,
+        blockIndex: retrieval.blockIndex,
+        ...(transcriptPath ? { transcriptPath } : {})
+      })
+      if (identityRef.current !== requestIdentity || clientRef.current !== client) {
+        throw new Error('Chat session changed')
+      }
+      if (!response.ok) {
+        throw new Error('Full message unavailable')
+      }
+      const result = response.result as ReadTextBlockResult
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      return result.text
+    },
+    [client, agent, sessionId, transcriptPath, identity]
+  )
+
   return {
     // Withheld until the settled read belongs to this identity: the effect that
     // clears the previous tab's list is passive, so `messages` lags a commit.
@@ -255,6 +294,7 @@ export function useMobileNativeChatSession(args: {
     error,
     hasMore,
     loadingEarlier,
-    loadEarlier
+    loadEarlier,
+    loadFullText
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
@@ -1,0 +1,99 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useMobileNativeChatTextExpansion,
+  type MobileNativeChatTextExpansion
+} from './use-mobile-native-chat-text-expansion'
+
+const first = { recordOffset: 10, blockIndex: 0, originalChars: 5000 }
+const second = { recordOffset: 20, blockIndex: 1, originalChars: 6000 }
+
+describe('useMobileNativeChatTextExpansion', () => {
+  let renderer: ReactTestRenderer | null = null
+  let expansion: MobileNativeChatTextExpansion | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    expansion = null
+  })
+
+  function Harness({ load }: { load: () => Promise<string> }): null {
+    expansion = useMobileNativeChatTextExpansion(load)
+    return null
+  }
+
+  async function mount(load: () => Promise<string>): Promise<void> {
+    const original = console.error
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      original(...args)
+    })
+    try {
+      await act(async () => {
+        renderer = create(createElement(Harness, { load }))
+      })
+    } finally {
+      spy.mockRestore()
+    }
+  }
+
+  it('caches one full block and re-expands it without another read', async () => {
+    const load = vi.fn().mockResolvedValue('full first')
+    await mount(load)
+
+    await act(async () => {
+      expansion?.toggle('message', first)
+      await Promise.resolve()
+    })
+    expect(expansion?.cached?.text).toBe('full first')
+    expect(expansion?.expandedKey).toBe(expansion?.cached?.key)
+
+    act(() => expansion?.toggle('message', first))
+    expect(expansion?.expandedKey).toBeNull()
+    act(() => expansion?.toggle('message', first))
+
+    expect(expansion?.expandedKey).toBe(expansion?.cached?.key)
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces the cache instead of retaining every expanded message', async () => {
+    const load = vi.fn().mockResolvedValueOnce('full first').mockResolvedValueOnce('full second')
+    await mount(load)
+    await act(async () => {
+      expansion?.toggle('message-1', first)
+      await Promise.resolve()
+    })
+    await act(async () => {
+      expansion?.toggle('message-2', second)
+      await Promise.resolve()
+    })
+
+    expect(expansion?.cached).toMatchObject({ text: 'full second' })
+    expect(JSON.stringify(expansion)).not.toContain('full first')
+  })
+
+  it('clears retained text and ignores an old read when the session loader changes', async () => {
+    let resolveFirst: (text: string) => void = () => {}
+    const loadFirst = vi.fn(() => new Promise<string>((resolve) => (resolveFirst = resolve)))
+    const loadSecond = vi.fn().mockResolvedValue('new session')
+    await mount(loadFirst)
+    act(() => expansion?.toggle('message-1', first))
+
+    await act(async () => renderer?.update(createElement(Harness, { load: loadSecond })))
+    await act(async () => {
+      resolveFirst('stale session')
+      await Promise.resolve()
+    })
+
+    expect(expansion?.cached).toBeNull()
+    expect(expansion?.expandedKey).toBeNull()
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
@@ -119,6 +119,28 @@ describe('useMobileNativeChatTextExpansion', () => {
     expect(load).toHaveBeenCalledTimes(2)
   })
 
+  it('rejects copy retrieval while another full block is loading', async () => {
+    let resolveFirst: (text: string) => void = () => {}
+    const load = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<string>((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValueOnce('full second')
+    await mount(load)
+
+    act(() => expansion?.toggle('message-1', first))
+    await expect(expansion!.loadForCopy('message-2', second)).rejects.toThrow(
+      'Another full message is loading'
+    )
+    expect(load).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      resolveFirst('full first')
+      await Promise.resolve()
+    })
+    await expect(expansion!.loadForCopy('message-2', second)).resolves.toBe('full second')
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
   it('clears retained text and ignores an old read when the session loader changes', async () => {
     let resolveFirst: (text: string) => void = () => {}
     const loadFirst = vi.fn(() => new Promise<string>((resolve) => (resolveFirst = resolve)))
@@ -127,6 +149,9 @@ describe('useMobileNativeChatTextExpansion', () => {
     act(() => expansion?.toggle('message-1', first))
 
     await act(async () => renderer?.update(createElement(Harness, { load: loadSecond })))
+    await expect(expansion!.loadForCopy('message-2', second)).rejects.toThrow(
+      'Another full message is loading'
+    )
     await act(async () => {
       resolveFirst('stale session')
       await Promise.resolve()
@@ -134,6 +159,7 @@ describe('useMobileNativeChatTextExpansion', () => {
 
     expect(expansion?.cached).toBeNull()
     expect(expansion?.expandedKey).toBeNull()
+    await expect(expansion!.loadForCopy('message-2', second)).resolves.toBe('new session')
   })
 })
 

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
@@ -6,8 +6,8 @@ import {
   type MobileNativeChatTextExpansion
 } from './use-mobile-native-chat-text-expansion'
 
-const first = { recordOffset: 10, blockIndex: 0, originalChars: 5000 }
-const second = { recordOffset: 20, blockIndex: 1, originalChars: 6000 }
+const first = { capability: 'capability-first', originalChars: 5000 }
+const second = { capability: 'capability-second', originalChars: 6000 }
 
 describe('useMobileNativeChatTextExpansion', () => {
   let renderer: ReactTestRenderer | null = null
@@ -81,6 +81,22 @@ describe('useMobileNativeChatTextExpansion', () => {
 
     expect(expansion?.cached).toMatchObject({ text: 'full second' })
     expect(JSON.stringify(expansion)).not.toContain('full first')
+  })
+
+  it('reuses the singleton display cache for copy without retaining other copied blocks', async () => {
+    const load = vi.fn().mockResolvedValueOnce('full first').mockResolvedValueOnce('full second')
+    await mount(load)
+    await act(async () => {
+      expansion?.toggle('message-1', first)
+      await Promise.resolve()
+    })
+
+    await expect(expansion!.loadForCopy('message-1', first)).resolves.toBe('full first')
+    await expect(expansion!.loadForCopy('message-1', second)).resolves.toBe('full second')
+
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(expansion?.cached).toMatchObject({ text: 'full first' })
+    expect(JSON.stringify(expansion)).not.toContain('full second')
   })
 
   it('serializes reads across distinct blocks', async () => {

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
@@ -23,36 +23,38 @@ describe('useMobileNativeChatTextExpansion', () => {
     expansion = null
   })
 
-  function Harness({ load }: { load: () => Promise<string> }): null {
-    expansion = useMobileNativeChatTextExpansion(load)
+  function Harness({
+    load,
+    onExpand
+  }: {
+    load: () => Promise<string>
+    onExpand?: () => void
+  }): null {
+    expansion = useMobileNativeChatTextExpansion(load, onExpand)
     return null
   }
 
-  async function mount(load: () => Promise<string>): Promise<void> {
-    const original = console.error
-    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
-      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
-        return
-      }
-      original(...args)
-    })
+  async function mount(load: () => Promise<string>, onExpand?: () => void): Promise<void> {
+    const restore = suppressRendererWarning()
     try {
       await act(async () => {
-        renderer = create(createElement(Harness, { load }))
+        renderer = create(createElement(Harness, { load, onExpand }))
       })
     } finally {
-      spy.mockRestore()
+      restore()
     }
   }
 
   it('caches one full block and re-expands it without another read', async () => {
     const load = vi.fn().mockResolvedValue('full first')
-    await mount(load)
+    const onExpand = vi.fn()
+    await mount(load, onExpand)
 
     await act(async () => {
       expansion?.toggle('message', first)
       await Promise.resolve()
     })
+    expect(onExpand).toHaveBeenCalledOnce()
     expect(expansion?.cached?.text).toBe('full first')
     expect(expansion?.expandedKey).toBe(expansion?.cached?.key)
 
@@ -60,6 +62,7 @@ describe('useMobileNativeChatTextExpansion', () => {
     expect(expansion?.expandedKey).toBeNull()
     act(() => expansion?.toggle('message', first))
 
+    expect(onExpand).toHaveBeenCalledTimes(2)
     expect(expansion?.expandedKey).toBe(expansion?.cached?.key)
     expect(load).toHaveBeenCalledTimes(1)
   })
@@ -97,3 +100,14 @@ describe('useMobileNativeChatTextExpansion', () => {
     expect(expansion?.expandedKey).toBeNull()
   })
 })
+
+function suppressRendererWarning(): () => void {
+  const original = console.error
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+      return
+    }
+    original(...args)
+  })
+  return () => spy.mockRestore()
+}

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.test.ts
@@ -83,6 +83,26 @@ describe('useMobileNativeChatTextExpansion', () => {
     expect(JSON.stringify(expansion)).not.toContain('full first')
   })
 
+  it('serializes reads across distinct blocks', async () => {
+    let resolveFirst: (text: string) => void = () => {}
+    const load = vi.fn(() => new Promise<string>((resolve) => (resolveFirst = resolve)))
+    await mount(load)
+
+    act(() => {
+      expansion?.toggle('message-1', first)
+      expansion?.toggle('message-2', second)
+    })
+
+    expect(load).toHaveBeenCalledOnce()
+    expect(expansion?.loadingKey).toBeTruthy()
+    await act(async () => {
+      resolveFirst('full first')
+      await Promise.resolve()
+    })
+    act(() => expansion?.toggle('message-2', second))
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
   it('clears retained text and ignores an old read when the session loader changes', async () => {
     let resolveFirst: (text: string) => void = () => {}
     const loadFirst = vi.fn(() => new Promise<string>((resolve) => (resolveFirst = resolve)))

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.ts
@@ -30,7 +30,8 @@ export function mobileNativeChatTextKey(
 
 /** Retains at most one full block and reuses it across collapse/re-expand. */
 export function useMobileNativeChatTextExpansion(
-  loadFullText: FullTextLoader
+  loadFullText: FullTextLoader,
+  onExpand?: () => void
 ): MobileNativeChatTextExpansion {
   const [state, setState] = useState<ExpansionState>(() => emptyState(loadFullText))
   let current = state
@@ -50,9 +51,11 @@ export function useMobileNativeChatTextExpansion(
         return
       }
       if (current.cached?.key === key) {
+        onExpand?.()
         setState({ ...current, expandedKey: key, errorKey: null })
         return
       }
+      onExpand?.()
       const request = { key }
       setState({
         source: loadFullText,
@@ -83,7 +86,7 @@ export function useMobileNativeChatTextExpansion(
           )
         })
     },
-    [current, loadFullText]
+    [current, loadFullText, onExpand]
   )
 
   return useMemo(

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.ts
@@ -19,13 +19,14 @@ export type MobileNativeChatTextExpansion = {
   loadingKey: string | null
   errorKey: string | null
   toggle: (messageId: string, retrieval: NativeChatTextRetrieval) => void
+  loadForCopy: (messageId: string, retrieval: NativeChatTextRetrieval) => Promise<string>
 }
 
 export function mobileNativeChatTextKey(
   messageId: string,
   retrieval: NativeChatTextRetrieval
 ): string {
-  return `${messageId}\0${retrieval.recordOffset}\0${retrieval.blockIndex}\0${retrieval.originalChars}`
+  return `${messageId}\0${retrieval.capability}\0${retrieval.originalChars}`
 }
 
 /** Retains at most one full block and reuses it across collapse/re-expand. */
@@ -99,15 +100,26 @@ export function useMobileNativeChatTextExpansion(
     [current, loadFullText, onExpand]
   )
 
+  const loadForCopy = useCallback(
+    (messageId: string, retrieval: NativeChatTextRetrieval): Promise<string> => {
+      const key = mobileNativeChatTextKey(messageId, retrieval)
+      return current.cached?.key === key
+        ? Promise.resolve(current.cached.text)
+        : loadFullText(messageId, retrieval)
+    },
+    [current.cached, loadFullText]
+  )
+
   return useMemo(
     () => ({
       cached: current.cached,
       expandedKey: current.expandedKey,
       loadingKey: current.request?.key ?? null,
       errorKey: current.errorKey,
-      toggle
+      toggle,
+      loadForCopy
     }),
-    [current, toggle]
+    [current, loadForCopy, toggle]
   )
 }
 

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { NativeChatTextRetrieval } from '../../../src/shared/native-chat-types'
 
 type FullTextLoader = (messageId: string, retrieval: NativeChatTextRetrieval) => Promise<string>
@@ -34,16 +34,20 @@ export function useMobileNativeChatTextExpansion(
   onExpand?: () => void
 ): MobileNativeChatTextExpansion {
   const [state, setState] = useState<ExpansionState>(() => emptyState(loadFullText))
+  const requestRef = useRef<ExpansionRequest | null>(null)
   let current = state
   if (current.source !== loadFullText) {
     current = emptyState(loadFullText)
     setState(current)
   }
+  useLayoutEffect(() => {
+    requestRef.current = null
+  }, [loadFullText])
 
   const toggle = useCallback(
     (messageId: string, retrieval: NativeChatTextRetrieval): void => {
       const key = mobileNativeChatTextKey(messageId, retrieval)
-      if (current.request?.key === key) {
+      if (requestRef.current !== null) {
         return
       }
       if (current.expandedKey === key) {
@@ -57,6 +61,7 @@ export function useMobileNativeChatTextExpansion(
       }
       onExpand?.()
       const request = { key }
+      requestRef.current = request
       setState({
         source: loadFullText,
         cached: null,
@@ -84,6 +89,11 @@ export function useMobileNativeChatTextExpansion(
               ? { ...latest, request: null, errorKey: key }
               : latest
           )
+        })
+        .finally(() => {
+          if (requestRef.current === request) {
+            requestRef.current = null
+          }
         })
     },
     [current, loadFullText, onExpand]

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.ts
@@ -1,0 +1,103 @@
+import { useCallback, useMemo, useState } from 'react'
+import type { NativeChatTextRetrieval } from '../../../src/shared/native-chat-types'
+
+type FullTextLoader = (messageId: string, retrieval: NativeChatTextRetrieval) => Promise<string>
+
+type CachedText = { key: string; text: string }
+type ExpansionRequest = { key: string }
+type ExpansionState = {
+  source: FullTextLoader
+  cached: CachedText | null
+  expandedKey: string | null
+  request: ExpansionRequest | null
+  errorKey: string | null
+}
+
+export type MobileNativeChatTextExpansion = {
+  cached: CachedText | null
+  expandedKey: string | null
+  loadingKey: string | null
+  errorKey: string | null
+  toggle: (messageId: string, retrieval: NativeChatTextRetrieval) => void
+}
+
+export function mobileNativeChatTextKey(
+  messageId: string,
+  retrieval: NativeChatTextRetrieval
+): string {
+  return `${messageId}\0${retrieval.recordOffset}\0${retrieval.blockIndex}\0${retrieval.originalChars}`
+}
+
+/** Retains at most one full block and reuses it across collapse/re-expand. */
+export function useMobileNativeChatTextExpansion(
+  loadFullText: FullTextLoader
+): MobileNativeChatTextExpansion {
+  const [state, setState] = useState<ExpansionState>(() => emptyState(loadFullText))
+  let current = state
+  if (current.source !== loadFullText) {
+    current = emptyState(loadFullText)
+    setState(current)
+  }
+
+  const toggle = useCallback(
+    (messageId: string, retrieval: NativeChatTextRetrieval): void => {
+      const key = mobileNativeChatTextKey(messageId, retrieval)
+      if (current.request?.key === key) {
+        return
+      }
+      if (current.expandedKey === key) {
+        setState({ ...current, expandedKey: null })
+        return
+      }
+      if (current.cached?.key === key) {
+        setState({ ...current, expandedKey: key, errorKey: null })
+        return
+      }
+      const request = { key }
+      setState({
+        source: loadFullText,
+        cached: null,
+        expandedKey: null,
+        request,
+        errorKey: null
+      })
+      void loadFullText(messageId, retrieval)
+        .then((text) => {
+          setState((latest) =>
+            latest.source === loadFullText && latest.request === request
+              ? {
+                  source: loadFullText,
+                  cached: { key, text },
+                  expandedKey: key,
+                  request: null,
+                  errorKey: null
+                }
+              : latest
+          )
+        })
+        .catch(() => {
+          setState((latest) =>
+            latest.source === loadFullText && latest.request === request
+              ? { ...latest, request: null, errorKey: key }
+              : latest
+          )
+        })
+    },
+    [current, loadFullText]
+  )
+
+  return useMemo(
+    () => ({
+      cached: current.cached,
+      expandedKey: current.expandedKey,
+      loadingKey: current.request?.key ?? null,
+      errorKey: current.errorKey,
+      toggle
+    }),
+    [current, toggle]
+  )
+}
+
+function emptyState(source: FullTextLoader): ExpansionState {
+  return { source, cached: null, expandedKey: null, request: null, errorKey: null }
+}

--- a/mobile/src/session/use-mobile-native-chat-text-expansion.ts
+++ b/mobile/src/session/use-mobile-native-chat-text-expansion.ts
@@ -5,6 +5,7 @@ type FullTextLoader = (messageId: string, retrieval: NativeChatTextRetrieval) =>
 
 type CachedText = { key: string; text: string }
 type ExpansionRequest = { key: string }
+type RetrievalGate = { source: FullTextLoader; active: boolean }
 type ExpansionState = {
   source: FullTextLoader
   cached: CachedText | null
@@ -36,14 +37,34 @@ export function useMobileNativeChatTextExpansion(
 ): MobileNativeChatTextExpansion {
   const [state, setState] = useState<ExpansionState>(() => emptyState(loadFullText))
   const requestRef = useRef<ExpansionRequest | null>(null)
+  const retrievalGateRef = useRef<RetrievalGate>({ source: loadFullText, active: false })
   let current = state
   if (current.source !== loadFullText) {
     current = emptyState(loadFullText)
     setState(current)
   }
+  if (retrievalGateRef.current.source !== loadFullText) {
+    retrievalGateRef.current.source = loadFullText
+  }
   useLayoutEffect(() => {
     requestRef.current = null
   }, [loadFullText])
+
+  const readFullText = useCallback(
+    async (messageId: string, retrieval: NativeChatTextRetrieval): Promise<string> => {
+      const gate = retrievalGateRef.current
+      if (gate.source !== loadFullText || gate.active) {
+        throw new Error('Another full message is loading')
+      }
+      gate.active = true
+      try {
+        return await loadFullText(messageId, retrieval)
+      } finally {
+        gate.active = false
+      }
+    },
+    [loadFullText]
+  )
 
   const toggle = useCallback(
     (messageId: string, retrieval: NativeChatTextRetrieval): void => {
@@ -70,7 +91,7 @@ export function useMobileNativeChatTextExpansion(
         request,
         errorKey: null
       })
-      void loadFullText(messageId, retrieval)
+      void readFullText(messageId, retrieval)
         .then((text) => {
           setState((latest) =>
             latest.source === loadFullText && latest.request === request
@@ -97,7 +118,7 @@ export function useMobileNativeChatTextExpansion(
           }
         })
     },
-    [current, loadFullText, onExpand]
+    [current, loadFullText, onExpand, readFullText]
   )
 
   const loadForCopy = useCallback(
@@ -105,9 +126,9 @@ export function useMobileNativeChatTextExpansion(
       const key = mobileNativeChatTextKey(messageId, retrieval)
       return current.cached?.key === key
         ? Promise.resolve(current.cached.text)
-        : loadFullText(messageId, retrieval)
+        : readFullText(messageId, retrieval)
     },
-    [current.cached, loadFullText]
+    [current.cached, readFullText]
   )
 
   return useMemo(

--- a/src/main/native-chat/mobile-payload-bounds.ts
+++ b/src/main/native-chat/mobile-payload-bounds.ts
@@ -1,0 +1,155 @@
+import type { AgentType, NativeChatBlock, NativeChatMessage } from '../../shared/native-chat-types'
+import { nativeChatTextRetrievalCapabilities } from './text-retrieval-capabilities'
+import { transcriptRecordOffset } from './transcript-record-position'
+
+export const MOBILE_NATIVE_CHAT_DEFAULT_WINDOW = 40
+export const MOBILE_NATIVE_CHAT_MAX_WINDOW = 2000
+
+const MOBILE_BLOCK_CHAR_CAP = 4000
+const MOBILE_TOOL_INPUT_ITEMS_CAP = 20
+const MOBILE_TOOL_INPUT_NODE_CAP = 100
+const TRUNCATION_MARKER = '\n… (truncated)'
+
+export type AuthorizedNativeChatPayloadSession = {
+  owner: string
+  agent: AgentType
+  sessionId: string
+  transcriptPath?: string
+}
+
+function clip(text: string): string {
+  return text.length > MOBILE_BLOCK_CHAR_CAP
+    ? text.slice(0, MOBILE_BLOCK_CHAR_CAP) + TRUNCATION_MARKER
+    : text
+}
+
+function clipBlock(
+  block: NativeChatBlock,
+  blockIndex: number,
+  recordOffset: number | undefined,
+  messageId: string,
+  session: AuthorizedNativeChatPayloadSession
+): NativeChatBlock {
+  if (block.type === 'text') {
+    if (block.text.length <= MOBILE_BLOCK_CHAR_CAP) {
+      return block
+    }
+    return {
+      ...block,
+      text: clip(block.text),
+      ...(recordOffset === undefined
+        ? {}
+        : {
+            retrieval: {
+              capability: nativeChatTextRetrievalCapabilities.issue({
+                ...session,
+                messageId,
+                recordOffset,
+                blockIndex,
+                originalChars: block.text.length,
+                text: block.text
+              }),
+              originalChars: block.text.length
+            }
+          })
+    }
+  }
+  if (block.type === 'tool-result') {
+    return block.output.length > MOBILE_BLOCK_CHAR_CAP
+      ? { ...block, output: clip(block.output) }
+      : block
+  }
+  if (block.type === 'tool-call') {
+    const budget = { remaining: MOBILE_BLOCK_CHAR_CAP, nodes: MOBILE_TOOL_INPUT_NODE_CAP }
+    return { ...block, input: sanitizeToolInput(block.input, budget, 0) }
+  }
+  return block
+}
+
+function sanitizeToolInput(
+  value: unknown,
+  budget: { remaining: number; nodes: number },
+  depth: number
+): unknown {
+  budget.nodes--
+  if (budget.nodes < 0 || budget.remaining <= 0) {
+    return '… (truncated)'
+  }
+  if (typeof value === 'string') {
+    const length = Math.min(value.length, budget.remaining)
+    budget.remaining -= length
+    return length < value.length ? `${value.slice(0, length)}… (truncated)` : value
+  }
+  if (!value || typeof value !== 'object' || depth >= 5) {
+    return value && typeof value === 'object' ? '… (truncated)' : value
+  }
+  if (Array.isArray(value)) {
+    const result = value
+      .slice(0, MOBILE_TOOL_INPUT_ITEMS_CAP)
+      .map((item) => sanitizeToolInput(item, budget, depth + 1))
+    if (value.length > MOBILE_TOOL_INPUT_ITEMS_CAP) {
+      result.push('… (truncated)')
+    }
+    return result
+  }
+  const result: Record<string, unknown> = {}
+  let count = 0
+  for (const key in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      continue
+    }
+    if (count >= MOBILE_TOOL_INPUT_ITEMS_CAP || budget.remaining <= 0) {
+      result['…'] = 'truncated'
+      break
+    }
+    let boundedKey = key.slice(0, Math.min(key.length, budget.remaining, 128))
+    // Why: sibling keys sharing a bounded prefix must not silently replace one another.
+    if (Object.prototype.hasOwnProperty.call(result, boundedKey)) {
+      boundedKey = `${boundedKey}~${count}`
+    }
+    budget.remaining -= boundedKey.length
+    result[boundedKey] = sanitizeToolInput(
+      (value as Record<string, unknown>)[key],
+      budget,
+      depth + 1
+    )
+    count++
+  }
+  return result
+}
+
+function sanitizeMessage(
+  message: NativeChatMessage,
+  session: AuthorizedNativeChatPayloadSession
+): NativeChatMessage {
+  const recordOffset = transcriptRecordOffset(message)
+  return {
+    ...message,
+    blocks: message.blocks.map((block, blockIndex) =>
+      clipBlock(block, blockIndex, recordOffset, message.id, session)
+    )
+  }
+}
+
+export function sanitizeAppendForClient(
+  messages: readonly NativeChatMessage[],
+  clientKind: 'mobile' | 'runtime' | undefined,
+  session: AuthorizedNativeChatPayloadSession
+): NativeChatMessage[] {
+  return clientKind === 'mobile'
+    ? messages.map((message) => sanitizeMessage(message, session))
+    : messages.slice()
+}
+
+export function windowForClient(
+  messages: readonly NativeChatMessage[],
+  clientKind: 'mobile' | 'runtime' | undefined,
+  session: AuthorizedNativeChatPayloadSession,
+  limit = MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
+): NativeChatMessage[] {
+  const window = Math.min(Math.max(limit, 1), MOBILE_NATIVE_CHAT_MAX_WINDOW)
+  const windowed = messages.length > window ? messages.slice(-window) : messages.slice()
+  return clientKind === 'mobile'
+    ? windowed.map((message) => sanitizeMessage(message, session))
+    : windowed
+}

--- a/src/main/native-chat/mobile-payload-bounds.ts
+++ b/src/main/native-chat/mobile-payload-bounds.ts
@@ -18,9 +18,16 @@ export type AuthorizedNativeChatPayloadSession = {
 }
 
 function clip(text: string): string {
-  return text.length > MOBILE_BLOCK_CHAR_CAP
-    ? text.slice(0, MOBILE_BLOCK_CHAR_CAP) + TRUNCATION_MARKER
-    : text
+  if (text.length <= MOBILE_BLOCK_CHAR_CAP) {
+    return text
+  }
+  let end = MOBILE_BLOCK_CHAR_CAP
+  const previous = text.charCodeAt(end - 1)
+  const next = text.charCodeAt(end)
+  if (previous >= 0xd800 && previous <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+    end--
+  }
+  return text.slice(0, end) + TRUNCATION_MARKER
 }
 
 function clipBlock(

--- a/src/main/native-chat/session-authorization.test.ts
+++ b/src/main/native-chat/session-authorization.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import { authorizeNativeChatSession } from './session-authorization'
+
+const providerSession = {
+  key: 'session_id' as const,
+  id: 'session-1',
+  transcriptPath: '/trusted/session-1.jsonl'
+}
+
+function status(agentType = 'claude'): AgentStatusIpcPayload {
+  return {
+    paneKey: 'tab:leaf',
+    state: 'done',
+    prompt: '',
+    agentType,
+    connectionId: null,
+    receivedAt: 20,
+    stateStartedAt: 10,
+    providerSession
+  }
+}
+
+function snapshot(): RuntimeMobileSessionTabsSnapshot {
+  return {
+    worktree: 'folder:/workspace',
+    publicationEpoch: 'epoch',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: 'tab',
+    activeTabType: 'terminal',
+    tabs: [
+      {
+        type: 'terminal',
+        id: 'tab:leaf',
+        title: 'Claude',
+        parentTabId: 'tab',
+        leafId: 'leaf',
+        isActive: true,
+        agentStatus: {
+          state: 'done',
+          prompt: '',
+          updatedAt: 30,
+          stateStartedAt: 10,
+          paneKey: 'tab:leaf',
+          stateHistory: [],
+          agentType: 'openclaude',
+          providerSession
+        }
+      }
+    ]
+  }
+}
+
+describe('authorizeNativeChatSession', () => {
+  it.each(['claude', 'codex', 'grok'])(
+    'returns only the server-owned provider path for a matching %s session',
+    (agent) => {
+      expect(
+        authorizeNativeChatSession({
+          agent,
+          sessionId: 'session-1',
+          transcriptPath: '/trusted/session-1.jsonl',
+          statuses: [status(agent)],
+          snapshots: []
+        })
+      ).toEqual({ transcriptPath: '/trusted/session-1.jsonl' })
+    }
+  )
+
+  it('rejects a caller path or session absent from server-owned state', () => {
+    const base = { agent: 'claude', statuses: [status()], snapshots: [] }
+    expect(
+      authorizeNativeChatSession({
+        ...base,
+        sessionId: 'session-1',
+        transcriptPath: '/private/other.jsonl'
+      })
+    ).toBeNull()
+    expect(authorizeNativeChatSession({ ...base, sessionId: 'session-2' })).toBeNull()
+  })
+
+  it('authorizes compatible provider identity retained by a folder-workspace snapshot', () => {
+    expect(
+      authorizeNativeChatSession({
+        agent: 'claude',
+        sessionId: 'session-1',
+        statuses: [],
+        snapshots: [snapshot()]
+      })
+    ).toEqual({ transcriptPath: '/trusted/session-1.jsonl' })
+  })
+
+  it('does not let another provider claim the same session id', () => {
+    expect(
+      authorizeNativeChatSession({
+        agent: 'codex',
+        sessionId: 'session-1',
+        statuses: [status()],
+        snapshots: [snapshot()]
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/native-chat/session-authorization.ts
+++ b/src/main/native-chat/session-authorization.ts
@@ -1,0 +1,83 @@
+import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+
+export type AuthorizedNativeChatSession = { transcriptPath?: string }
+
+type Candidate = {
+  agent: string | undefined
+  sessionId: string
+  transcriptPath?: string
+  updatedAt: number
+}
+
+export function authorizeNativeChatSession(args: {
+  agent: string
+  sessionId: string
+  transcriptPath?: string
+  statuses: readonly AgentStatusIpcPayload[]
+  snapshots: Iterable<RuntimeMobileSessionTabsSnapshot>
+}): AuthorizedNativeChatSession | null {
+  const requestedAgent = resolveNativeChatTranscriptAgent(args.agent)
+  if (!requestedAgent) {
+    return null
+  }
+  const requestedPath = args.transcriptPath?.trim()
+  let match: Candidate | null = null
+  for (const status of args.statuses) {
+    if (status.providerSession) {
+      match = selectCandidate(
+        match,
+        {
+          agent: status.agentType,
+          sessionId: status.providerSession.id,
+          ...(status.providerSession.transcriptPath
+            ? { transcriptPath: status.providerSession.transcriptPath.trim() }
+            : {}),
+          updatedAt: status.receivedAt
+        },
+        requestedAgent,
+        args.sessionId,
+        requestedPath
+      )
+    }
+  }
+  for (const snapshot of args.snapshots) {
+    for (const tab of snapshot.tabs) {
+      if (tab.type !== 'terminal') {
+        continue
+      }
+      const session = tab.agentStatus?.providerSession
+      if (session) {
+        match = selectCandidate(
+          match,
+          {
+            agent: tab.agentStatus?.agentType ?? tab.launchAgent,
+            sessionId: session.id,
+            ...(session.transcriptPath ? { transcriptPath: session.transcriptPath.trim() } : {}),
+            updatedAt: tab.agentStatus?.updatedAt ?? 0
+          },
+          requestedAgent,
+          args.sessionId,
+          requestedPath
+        )
+      }
+    }
+  }
+  return match ? (match.transcriptPath ? { transcriptPath: match.transcriptPath } : {}) : null
+}
+
+function selectCandidate(
+  current: Candidate | null,
+  candidate: Candidate,
+  agent: string,
+  sessionId: string,
+  transcriptPath: string | undefined
+): Candidate | null {
+  return resolveNativeChatTranscriptAgent(candidate.agent) === agent &&
+    candidate.sessionId === sessionId &&
+    (transcriptPath === undefined || candidate.transcriptPath === transcriptPath) &&
+    (!current || candidate.updatedAt > current.updatedAt)
+    ? candidate
+    : current
+}

--- a/src/main/native-chat/text-retrieval-capabilities.test.ts
+++ b/src/main/native-chat/text-retrieval-capabilities.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  nativeChatTextDigest,
+  NativeChatTextRetrievalCapabilities
+} from './text-retrieval-capabilities'
+
+describe('NativeChatTextRetrievalCapabilities', () => {
+  it('issues opaque grants scoped to one owner and exact block digest', () => {
+    const capabilities = new NativeChatTextRetrievalCapabilities()
+    const text = 'complete response'
+    const capability = capabilities.issue(
+      {
+        owner: 'paired:device-1',
+        agent: 'claude',
+        sessionId: 'session-1',
+        transcriptPath: '/trusted/session.jsonl',
+        messageId: 'message-1',
+        recordOffset: 42,
+        blockIndex: 1,
+        originalChars: text.length,
+        text
+      },
+      100
+    )
+
+    expect(capability).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(capabilities.redeem(capability, 'paired:device-2', 101)).toBeNull()
+    expect(capabilities.redeem(capability, 'paired:device-1', 101)).toMatchObject({
+      transcriptPath: '/trusted/session.jsonl',
+      messageId: 'message-1',
+      recordOffset: 42,
+      blockIndex: 1,
+      digest: nativeChatTextDigest(text)
+    })
+  })
+
+  it('expires grants without retaining redeemable authority', () => {
+    const capabilities = new NativeChatTextRetrievalCapabilities()
+    const capability = capabilities.issue(
+      {
+        owner: 'local',
+        agent: 'codex',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        recordOffset: 0,
+        blockIndex: 0,
+        originalChars: 4,
+        text: 'text'
+      },
+      0
+    )
+
+    expect(capabilities.redeem(capability, 'local', 2 * 60 * 60 * 1000)).toBeNull()
+  })
+})

--- a/src/main/native-chat/text-retrieval-capabilities.ts
+++ b/src/main/native-chat/text-retrieval-capabilities.ts
@@ -1,0 +1,79 @@
+import { createHash, randomBytes } from 'node:crypto'
+import type { AgentType } from '../../shared/native-chat-types'
+
+const MAX_GRANTS = 16_384
+const GRANT_TTL_MS = 2 * 60 * 60 * 1000
+
+export type NativeChatTextRetrievalGrant = {
+  owner: string
+  agent: AgentType
+  sessionId: string
+  transcriptPath?: string
+  messageId: string
+  recordOffset: number
+  blockIndex: number
+  originalChars: number
+  digest: string
+  expiresAt: number
+}
+
+type IssueGrantArgs = Omit<NativeChatTextRetrievalGrant, 'digest' | 'expiresAt'> & {
+  text: string
+}
+
+export class NativeChatTextRetrievalCapabilities {
+  private readonly grants = new Map<string, NativeChatTextRetrievalGrant>()
+
+  issue(args: IssueGrantArgs, now = Date.now()): string {
+    this.ensureCapacity(now)
+    const capability = randomBytes(32).toString('base64url')
+    this.grants.set(capability, {
+      owner: args.owner,
+      agent: args.agent,
+      sessionId: args.sessionId,
+      ...(args.transcriptPath ? { transcriptPath: args.transcriptPath } : {}),
+      messageId: args.messageId,
+      recordOffset: args.recordOffset,
+      blockIndex: args.blockIndex,
+      originalChars: args.originalChars,
+      digest: nativeChatTextDigest(args.text),
+      expiresAt: now + GRANT_TTL_MS
+    })
+    return capability
+  }
+
+  redeem(capability: string, owner: string, now = Date.now()): NativeChatTextRetrievalGrant | null {
+    const grant = this.grants.get(capability)
+    if (!grant || grant.owner !== owner || grant.expiresAt <= now) {
+      if (grant?.expiresAt && grant.expiresAt <= now) {
+        this.grants.delete(capability)
+      }
+      return null
+    }
+    return grant
+  }
+
+  private ensureCapacity(now: number): void {
+    if (this.grants.size < MAX_GRANTS) {
+      return
+    }
+    for (const [capability, grant] of this.grants) {
+      if (grant.expiresAt <= now) {
+        this.grants.delete(capability)
+      }
+    }
+    while (this.grants.size >= MAX_GRANTS) {
+      const oldest = this.grants.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.grants.delete(oldest)
+    }
+  }
+}
+
+export const nativeChatTextRetrievalCapabilities = new NativeChatTextRetrievalCapabilities()
+
+export function nativeChatTextDigest(text: string): string {
+  return createHash('sha256').update(text).digest('base64url')
+}

--- a/src/main/native-chat/transcript-incremental-reader.ts
+++ b/src/main/native-chat/transcript-incremental-reader.ts
@@ -1,6 +1,7 @@
 import { open, stat } from 'node:fs/promises'
 import type { NativeChatMessage, NativeChatTurnLifecycle } from '../../shared/native-chat-types'
 import { transcriptFallbackId } from './transcript-fallback-id'
+import { markTranscriptRecordOffset } from './transcript-record-position'
 import {
   MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES,
   type NativeChatLineDecoder
@@ -102,6 +103,7 @@ export async function readIncrementalTranscriptMessages(
     if (!message) {
       return
     }
+    markTranscriptRecordOffset(message, state.pendingStart)
     messages.push(message)
     if (onBatch && messages.length >= APPEND_BATCH_MESSAGE_LIMIT) {
       onBatch(messages.splice(0))

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { readNativeChatTranscript } from './transcript-reader'
+import { transcriptRecordOffset } from './transcript-record-position'
 import {
   nativeChatLineDecoderForAgent,
   readNativeChatTranscriptTail,
@@ -301,6 +302,31 @@ describe('readNativeChatTranscript (errors)', () => {
 })
 
 describe('readNativeChatTranscriptTailFile', () => {
+  it('retains each decoded record position outside the serialized message', async () => {
+    const decode = nativeChatLineDecoderForAgent('claude')!
+    const records = [
+      {
+        type: 'assistant',
+        uuid: 'a-1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'one' }] }
+      },
+      {
+        type: 'assistant',
+        uuid: 'a-2',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'two' }] }
+      }
+    ]
+    const filePath = await writeFixture('orca-native-chat-tail-position-', records)
+
+    const result = await readNativeChatTranscriptTailFile(filePath, 2, decode, true)
+
+    expect(transcriptRecordOffset(result.messages[0]!)).toBe(0)
+    expect(transcriptRecordOffset(result.messages[1]!)).toBe(
+      Buffer.byteLength(JSON.stringify(records[0]), 'utf8') + 1
+    )
+    expect(JSON.stringify(result.messages)).not.toContain('recordOffset')
+  })
+
   it('keeps a missing tail retry-worthy for the live-session seed', async () => {
     const result = await readNativeChatTranscriptTail({
       agent: 'claude',

--- a/src/main/native-chat/transcript-record-position.ts
+++ b/src/main/native-chat/transcript-record-position.ts
@@ -1,0 +1,11 @@
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+
+const recordOffsets = new WeakMap<NativeChatMessage, number>()
+
+export function markTranscriptRecordOffset(message: NativeChatMessage, offset: number): void {
+  recordOffsets.set(message, offset)
+}
+
+export function transcriptRecordOffset(message: NativeChatMessage): number | undefined {
+  return recordOffsets.get(message)
+}

--- a/src/main/native-chat/transcript-record-reader.test.ts
+++ b/src/main/native-chat/transcript-record-reader.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { readNativeChatTextBlock } from './transcript-record-reader'
+import { transcriptFallbackId } from './transcript-fallback-id'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function writeClaudeRecords(
+  records: unknown[]
+): Promise<{ filePath: string; offsets: number[] }> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-record-'))
+  roots.push(root)
+  const lines = records.map((record) => JSON.stringify(record))
+  const offsets: number[] = []
+  let offset = 0
+  for (const line of lines) {
+    offsets.push(offset)
+    offset += Buffer.byteLength(line, 'utf8') + 1
+  }
+  const filePath = join(root, 'transcript.jsonl')
+  await writeFile(filePath, lines.join('\n'))
+  return { filePath, offsets }
+}
+
+function assistantRecord(id: string, text: string): unknown {
+  return {
+    type: 'assistant',
+    uuid: id,
+    message: { role: 'assistant', content: [{ type: 'text', text }] }
+  }
+}
+
+describe('readNativeChatTextBlock', () => {
+  it.each([
+    ['ordinary prose', `Summary\n\n${'Readable paragraph. '.repeat(300).trimEnd()}`],
+    ['fenced code', `\`\`\`ts\n${'const answer = 42\n'.repeat(300)}\`\`\``]
+  ])('seeks directly to and returns complete %s', async (_label, fullText) => {
+    const { filePath, offsets } = await writeClaudeRecords([
+      assistantRecord('skip', 'small'),
+      assistantRecord('target', fullText)
+    ])
+
+    await expect(
+      readNativeChatTextBlock({
+        agent: 'claude',
+        sessionId: 'session',
+        messageId: 'target',
+        recordOffset: offsets[1]!,
+        blockIndex: 0,
+        filePath
+      })
+    ).resolves.toEqual({ text: fullText })
+  })
+
+  it('seeks past unrelated transcript history without decoding it', async () => {
+    const fullText = 'target text '.repeat(500).trimEnd()
+    const { filePath, offsets } = await writeClaudeRecords([
+      assistantRecord('large-prefix', 'x'.repeat(4 * 1024 * 1024)),
+      assistantRecord('target', fullText)
+    ])
+
+    await expect(
+      readNativeChatTextBlock({
+        agent: 'claude',
+        sessionId: 'session',
+        messageId: 'target',
+        recordOffset: offsets[1]!,
+        blockIndex: 0,
+        filePath
+      })
+    ).resolves.toEqual({ text: fullText })
+  })
+
+  it('rejects a locator that does not match a record boundary or message id', async () => {
+    const { filePath, offsets } = await writeClaudeRecords([assistantRecord('target', 'full')])
+    const base = {
+      agent: 'claude' as const,
+      sessionId: 'session',
+      messageId: 'target',
+      blockIndex: 0,
+      filePath
+    }
+
+    await expect(
+      readNativeChatTextBlock({ ...base, recordOffset: offsets[0]! + 1 })
+    ).resolves.toEqual({ error: 'Full message unavailable' })
+    await expect(
+      readNativeChatTextBlock({ ...base, messageId: 'other', recordOffset: offsets[0]! })
+    ).resolves.toEqual({ error: 'Full message unavailable' })
+  })
+
+  it.each([
+    {
+      agent: 'codex' as const,
+      record: (text: string) => ({
+        type: 'event_msg',
+        payload: { type: 'agent_message', id: 'codex-message', message: text }
+      }),
+      messageId: (_filePath: string) => 'codex-message'
+    },
+    {
+      agent: 'grok' as const,
+      record: (text: string) => ({
+        type: 'assistant',
+        id: 'grok-message',
+        content: [{ type: 'text', text }]
+      }),
+      messageId: (filePath: string) => `${transcriptFallbackId(filePath, 0)}:grok-message`
+    }
+  ])('uses the $agent decoder without provider-specific retrieval behavior', async (fixture) => {
+    const fullText = 'provider-neutral '.repeat(400).trimEnd()
+    const { filePath } = await writeClaudeRecords([fixture.record(fullText)])
+
+    await expect(
+      readNativeChatTextBlock({
+        agent: fixture.agent,
+        sessionId: 'session',
+        messageId: fixture.messageId(filePath),
+        recordOffset: 0,
+        blockIndex: 0,
+        filePath
+      })
+    ).resolves.toEqual({ text: fullText })
+  })
+})

--- a/src/main/native-chat/transcript-record-reader.ts
+++ b/src/main/native-chat/transcript-record-reader.ts
@@ -1,0 +1,99 @@
+import { open } from 'node:fs/promises'
+import type { AgentType } from '../../shared/native-chat-types'
+import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
+import { transcriptFallbackId } from './transcript-fallback-id'
+import {
+  MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES,
+  nativeChatLineDecoderForAgent
+} from './transcript-tail-reader'
+
+const RECORD_READ_CHUNK_BYTES = 64 * 1024
+const UNAVAILABLE = 'Full message unavailable'
+
+export type ReadNativeChatTextBlockArgs = ResolveSessionFileOptions & {
+  agent: AgentType
+  sessionId: string
+  messageId: string
+  recordOffset: number
+  blockIndex: number
+  /** Direct path for isolated tests. */
+  filePath?: string
+}
+
+export async function readNativeChatTextBlock(
+  args: ReadNativeChatTextBlockArgs
+): Promise<{ text: string } | { error: string }> {
+  const decode = nativeChatLineDecoderForAgent(args.agent)
+  if (!decode) {
+    return { error: UNAVAILABLE }
+  }
+  const filePath = args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args))
+  if (!filePath) {
+    return { error: UNAVAILABLE }
+  }
+  try {
+    const line = await readRecordAt(filePath, args.recordOffset)
+    if (line === null) {
+      return { error: UNAVAILABLE }
+    }
+    const message = decode(line, transcriptFallbackId(filePath, args.recordOffset))
+    if (!message || message.id !== args.messageId) {
+      return { error: UNAVAILABLE }
+    }
+    const block = message.blocks[args.blockIndex]
+    return block?.type === 'text' ? { text: block.text } : { error: UNAVAILABLE }
+  } catch {
+    return { error: UNAVAILABLE }
+  }
+}
+
+async function readRecordAt(filePath: string, offset: number): Promise<string | null> {
+  const handle = await open(filePath, 'r')
+  try {
+    const { size } = await handle.stat()
+    if (offset < 0 || offset >= size || !(await isRecordBoundary(handle, offset))) {
+      return null
+    }
+    const chunks: Buffer[] = []
+    let retainedBytes = 0
+    let cursor = offset
+    while (cursor < size) {
+      const buffer = Buffer.allocUnsafe(Math.min(RECORD_READ_CHUNK_BYTES, size - cursor))
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, cursor)
+      if (bytesRead === 0) {
+        break
+      }
+      const content = buffer.subarray(0, bytesRead)
+      const newline = content.indexOf(0x0a)
+      const part = newline >= 0 ? content.subarray(0, newline) : content
+      retainedBytes += part.length
+      if (retainedBytes > MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES) {
+        return null
+      }
+      chunks.push(part)
+      if (newline >= 0) {
+        break
+      }
+      cursor += bytesRead
+    }
+    let line = Buffer.concat(chunks, retainedBytes).toString('utf8')
+    if (line.endsWith('\r')) {
+      line = line.slice(0, -1)
+    }
+    return line || null
+  } finally {
+    await handle.close()
+  }
+}
+
+async function isRecordBoundary(
+  handle: Awaited<ReturnType<typeof open>>,
+  offset: number
+): Promise<boolean> {
+  if (offset === 0) {
+    return true
+  }
+  const previous = Buffer.allocUnsafe(1)
+  const { bytesRead } = await handle.read(previous, 0, 1, offset - 1)
+  return bytesRead === 1 && previous[0] === 0x0a
+}

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -12,6 +12,7 @@ import {
   decodeGrokTranscriptLine
 } from './transcript-line-decoders'
 import { transcriptFallbackId } from './transcript-fallback-id'
+import { markTranscriptRecordOffset } from './transcript-record-position'
 import {
   nativeChatTurnLifecycleDecoderForAgent,
   type NativeChatTurnLifecycleDecoder
@@ -164,6 +165,7 @@ export async function readNativeChatTranscriptTailFile(
     lifecycle ??= decodeLifecycle?.(line, fallbackId) ?? undefined
     const message = decode(line, fallbackId)
     if (message) {
+      markTranscriptRecordOffset(message, lineOffset)
       messages.push({ message, offset: lineOffset })
     }
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -44,6 +44,10 @@ import {
   type AgentStatusEntry
 } from '../../shared/agent-status-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
+import {
+  authorizeNativeChatSession as authorizeNativeChatSessionFromState,
+  type AuthorizedNativeChatSession
+} from '../native-chat/session-authorization'
 import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
 import type {
   AgentSessionClaimedSpawnResult,
@@ -5460,6 +5464,20 @@ export class OrcaRuntimeService {
         clientNavigationId
       )
     )
+  }
+
+  authorizeNativeChatSession(
+    agent: string,
+    sessionId: string,
+    transcriptPath?: string
+  ): AuthorizedNativeChatSession | null {
+    return authorizeNativeChatSessionFromState({
+      agent,
+      sessionId,
+      ...(transcriptPath ? { transcriptPath } : {}),
+      statuses: this.getAgentProviderSessionSnapshotFn?.() ?? [],
+      snapshots: this.mobileSessionTabsByWorktree.values()
+    })
   }
 
   private hydrateHeadlessMobileSessionTabsFromWorkspaceSession(

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -56,7 +56,8 @@ const watcher = vi.hoisted(() => ({
   watching: true
 }))
 const textBlockRead = vi.hoisted(() => ({
-  value: { text: '' } as { text: string } | { error: string }
+  value: { text: '' } as { text: string } | { error: string },
+  args: null as null | Record<string, unknown>
 }))
 vi.mock('../../../native-chat/transcript-watch', () => ({
   readNativeChatTranscriptTail: ({ limit }: { limit: number }) => {
@@ -74,7 +75,10 @@ vi.mock('../../../native-chat/transcript-watch', () => ({
   }
 }))
 vi.mock('../../../native-chat/transcript-record-reader', () => ({
-  readNativeChatTextBlock: () => Promise.resolve(textBlockRead.value)
+  readNativeChatTextBlock: (args: Record<string, unknown>) => {
+    textBlockRead.args = args
+    return Promise.resolve(textBlockRead.value)
+  }
 }))
 
 import { NATIVE_CHAT_METHODS } from './native-chat'
@@ -136,15 +140,31 @@ function streamingContext(clientKind: RpcContext['clientKind']): RpcContext {
     runtime: {
       registerSubscriptionCleanup: vi.fn(),
       cleanupSubscription: vi.fn(),
-      cleanupSubscriptionsByPrefix: vi.fn()
+      cleanupSubscriptionsByPrefix: vi.fn(),
+      authorizeNativeChatSession: vi.fn(() => ({ transcriptPath: '/trusted/session.jsonl' }))
     } as unknown as RpcContext['runtime'],
     connectionId: 'connection-1',
+    pairedDeviceId: 'device-1',
     clientKind
   }
 }
 
-function ctxWith(clientKind: RpcContext['clientKind']): RpcContext {
-  return { runtime: {} as RpcContext['runtime'], clientKind }
+function ctxWith(
+  clientKind: RpcContext['clientKind'],
+  options: {
+    pairedDeviceId?: string
+    authorize?: (agent: string, sessionId: string, transcriptPath?: string) => unknown
+  } = {}
+): RpcContext {
+  return {
+    runtime: {
+      authorizeNativeChatSession: vi.fn(
+        options.authorize ?? (() => ({ transcriptPath: '/trusted/session.jsonl' }))
+      )
+    } as unknown as RpcContext['runtime'],
+    pairedDeviceId: options.pairedDeviceId ?? 'device-1',
+    clientKind
+  }
 }
 
 function firstOutput(result: unknown): string {
@@ -179,21 +199,21 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     expect(block).toMatchObject({ type: 'text' })
     expect((block as { text: string }).text.length).toBeLessThan(fullText.length)
     expect(block).toMatchObject({
-      retrieval: { recordOffset: 73, blockIndex: 0, originalChars: fullText.length }
+      retrieval: { capability: expect.any(String), originalChars: fullText.length }
     })
+    const capability = (block as { retrieval: { capability: string } }).retrieval.capability
 
-    await expect(
-      readTextBlockHandler()(
-        {
-          agent: 'claude',
-          sessionId: 's',
-          messageId: message.id,
-          recordOffset: 73,
-          blockIndex: 0
-        },
-        ctxWith('mobile')
-      )
-    ).resolves.toEqual({ text: fullText })
+    await expect(readTextBlockHandler()({ capability }, ctxWith('mobile'))).resolves.toEqual({
+      text: fullText
+    })
+    expect(textBlockRead.args).toMatchObject({
+      agent: 'claude',
+      sessionId: 's',
+      transcriptPath: '/trusted/session.jsonl',
+      messageId: message.id,
+      recordOffset: 73,
+      blockIndex: 0
+    })
   })
 
   it('does not offer irreversible text retrieval when no record position exists', async () => {
@@ -207,6 +227,58 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
 
     expect(block).toMatchObject({ type: 'text' })
     expect(block).not.toHaveProperty('retrieval')
+  })
+
+  it('rejects a transcript session absent from server-owned state', async () => {
+    cachedResult.value = { messages: [makeTextMessage(OVERSIZED)] }
+
+    await expect(
+      readSessionHandler()(
+        { agent: 'claude', sessionId: 'unrelated', transcriptPath: '/private/other.jsonl' },
+        ctxWith('mobile', { authorize: () => null })
+      )
+    ).resolves.toEqual({ error: 'Transcript unavailable' })
+  })
+
+  it('binds opaque retrieval capabilities to the paired device and exact text', async () => {
+    const fullText = `prefix-${'x'.repeat(5000)}`
+    const message = makeTextMessage(fullText)
+    markTranscriptRecordOffset(message, 73)
+    cachedResult.value = { messages: [message] }
+    textBlockRead.value = { text: fullText }
+    const result = await readSessionHandler()(
+      { agent: 'claude', sessionId: 's' },
+      ctxWith('mobile')
+    )
+    const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0] as {
+      retrieval: { capability: string }
+    }
+
+    await expect(
+      readTextBlockHandler()(
+        { capability: block.retrieval.capability },
+        ctxWith('mobile', { pairedDeviceId: 'device-2' })
+      )
+    ).resolves.toEqual({ error: 'Full message unavailable' })
+
+    textBlockRead.value = { text: `tamper-${'y'.repeat(fullText.length - 7)}` }
+    await expect(
+      readTextBlockHandler()({ capability: block.retrieval.capability }, ctxWith('mobile'))
+    ).resolves.toEqual({ error: 'Full message unavailable' })
+  })
+
+  it('does not accept caller-controlled transcript coordinates for full-text reads', () => {
+    const method = NATIVE_CHAT_METHODS.find((m) => m.name === 'nativeChat.readTextBlock')
+    expect(() =>
+      method?.params?.parse({
+        agent: 'claude',
+        sessionId: 's',
+        transcriptPath: '/private/other.jsonl',
+        messageId: 'message',
+        recordOffset: 0,
+        blockIndex: 0
+      })
+    ).toThrow()
   })
 
   it('clips oversized tool output for mobile clients', async () => {
@@ -396,6 +468,26 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
 })
 
 describe('nativeChat.subscribe initial snapshot', () => {
+  it('stops emitting text grants after server-owned session authority changes', async () => {
+    watcher.watching = true
+    watcher.args = null
+    const emitted: unknown[] = []
+    const context = streamingContext('mobile')
+    const authorize = vi.mocked(context.runtime.authorizeNativeChatSession)
+    authorize
+      .mockReturnValueOnce({ transcriptPath: '/trusted/session.jsonl' })
+      .mockReturnValue(null)
+    await subscribeHandler()({ agent: 'claude', sessionId: 's' }, context, (value) =>
+      emitted.push(value)
+    )
+    const appended = makeTextMessage(OVERSIZED)
+    markTranscriptRecordOffset(appended, 101)
+
+    activeWatcherArgs().onAppend([appended])
+
+    expect(emitted).toEqual([])
+  })
+
   it('attaches fresh retrieval locators to mobile appends and replacements', async () => {
     watcher.watching = true
     watcher.args = null
@@ -417,11 +509,11 @@ describe('nativeChat.subscribe initial snapshot', () => {
     expect(emitted).toMatchObject([
       {
         type: 'appended',
-        messages: [{ blocks: [{ retrieval: { recordOffset: 101, blockIndex: 0 } }] }]
+        messages: [{ blocks: [{ retrieval: { capability: expect.any(String) } }] }]
       },
       {
         type: 'replacement',
-        messages: [{ blocks: [{ retrieval: { recordOffset: 202, blockIndex: 0 } }] }]
+        messages: [{ blocks: [{ retrieval: { capability: expect.any(String) } }] }]
       }
     ])
   })

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -229,6 +229,25 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     expect(block).not.toHaveProperty('retrieval')
   })
 
+  it('does not split a Unicode surrogate pair at the mobile preview boundary', async () => {
+    const fullText = `${'a'.repeat(3999)}😀tail`
+    const message = makeTextMessage(fullText)
+    markTranscriptRecordOffset(message, 73)
+    cachedResult.value = { messages: [message] }
+
+    const result = await readSessionHandler()(
+      { agent: 'claude', sessionId: 's' },
+      ctxWith('mobile')
+    )
+    const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0] as {
+      text: string
+    }
+    const preview = block.text.slice(0, block.text.indexOf('\n… (truncated)'))
+
+    expect(preview).toBe('a'.repeat(3999))
+    expect(preview.endsWith('\ud83d')).toBe(false)
+  })
+
   it('rejects a transcript session absent from server-owned state', async () => {
     cachedResult.value = { messages: [makeTextMessage(OVERSIZED)] }
 

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -55,6 +55,9 @@ const watcher = vi.hoisted(() => ({
   },
   watching: true
 }))
+const textBlockRead = vi.hoisted(() => ({
+  value: { text: '' } as { text: string } | { error: string }
+}))
 vi.mock('../../../native-chat/transcript-watch', () => ({
   readNativeChatTranscriptTail: ({ limit }: { limit: number }) => {
     const messages = cachedResult.value.messages
@@ -70,8 +73,12 @@ vi.mock('../../../native-chat/transcript-watch', () => ({
     return Promise.resolve({ unsubscribe: vi.fn(), watching: watcher.watching })
   }
 }))
+vi.mock('../../../native-chat/transcript-record-reader', () => ({
+  readNativeChatTextBlock: () => Promise.resolve(textBlockRead.value)
+}))
 
 import { NATIVE_CHAT_METHODS } from './native-chat'
+import { markTranscriptRecordOffset } from '../../../native-chat/transcript-record-position'
 
 function makeMessage(text: string): NativeChatMessage {
   return {
@@ -80,6 +87,13 @@ function makeMessage(text: string): NativeChatMessage {
     timestamp: 1_717_236_000_000,
     source: 'transcript',
     blocks: [{ type: 'tool-result', output: text, isError: false }]
+  }
+}
+
+function makeTextMessage(text: string): NativeChatMessage {
+  return {
+    ...makeMessage('ignored'),
+    blocks: [{ type: 'text', text }]
   }
 }
 
@@ -105,6 +119,16 @@ function subscribeHandler(): (
     ctx: RpcContext,
     emit: (value: unknown) => void
   ) => Promise<void>
+}
+
+function readTextBlockHandler(): (params: unknown, ctx: RpcContext) => Promise<unknown> {
+  const method = NATIVE_CHAT_METHODS.find(
+    (candidate) => candidate.name === 'nativeChat.readTextBlock'
+  )
+  if (!method) {
+    throw new Error('readTextBlock method not registered')
+  }
+  return method.handler as (params: unknown, ctx: RpcContext) => Promise<unknown>
 }
 
 function streamingContext(clientKind: RpcContext['clientKind']): RpcContext {
@@ -137,6 +161,54 @@ function activeWatcherArgs(): NonNullable<typeof watcher.args> {
 }
 
 describe('nativeChat.readSession clientKind truncation gating', () => {
+  it.each([
+    ['ordinary assistant prose', `Summary\n\n${'Readable paragraph. '.repeat(300)}`],
+    ['fenced assistant code', `\`\`\`ts\n${'const answer = 42\n'.repeat(300)}\`\`\``]
+  ])('lazily retrieves complete %s from a bounded mobile preview', async (_label, fullText) => {
+    const message = makeTextMessage(fullText)
+    markTranscriptRecordOffset(message, 73)
+    cachedResult.value = { messages: [message] }
+    textBlockRead.value = { text: fullText }
+
+    const result = await readSessionHandler()(
+      { agent: 'claude', sessionId: 's' },
+      ctxWith('mobile')
+    )
+    const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0]
+
+    expect(block).toMatchObject({ type: 'text' })
+    expect((block as { text: string }).text.length).toBeLessThan(fullText.length)
+    expect(block).toMatchObject({
+      retrieval: { recordOffset: 73, blockIndex: 0, originalChars: fullText.length }
+    })
+
+    await expect(
+      readTextBlockHandler()(
+        {
+          agent: 'claude',
+          sessionId: 's',
+          messageId: message.id,
+          recordOffset: 73,
+          blockIndex: 0
+        },
+        ctxWith('mobile')
+      )
+    ).resolves.toEqual({ text: fullText })
+  })
+
+  it('does not offer irreversible text retrieval when no record position exists', async () => {
+    cachedResult.value = { messages: [makeTextMessage(OVERSIZED)] }
+
+    const result = await readSessionHandler()(
+      { agent: 'claude', sessionId: 's' },
+      ctxWith('mobile')
+    )
+    const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0]
+
+    expect(block).toMatchObject({ type: 'text' })
+    expect(block).not.toHaveProperty('retrieval')
+  })
+
   it('clips oversized tool output for mobile clients', async () => {
     cachedResult.value = { messages: [makeMessage(OVERSIZED)] }
     const result = await readSessionHandler()(
@@ -324,6 +396,36 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
 })
 
 describe('nativeChat.subscribe initial snapshot', () => {
+  it('attaches fresh retrieval locators to mobile appends and replacements', async () => {
+    watcher.watching = true
+    watcher.args = null
+    const emitted: unknown[] = []
+    await subscribeHandler()(
+      { agent: 'claude', sessionId: 's' },
+      streamingContext('mobile'),
+      (value) => emitted.push(value)
+    )
+    const appended = makeTextMessage(OVERSIZED)
+    const replacement = { ...makeTextMessage(OVERSIZED), id: 'replacement' }
+    markTranscriptRecordOffset(appended, 101)
+    markTranscriptRecordOffset(replacement, 202)
+
+    const callbacks = activeWatcherArgs()
+    callbacks.onAppend([appended])
+    callbacks.onReplace?.([replacement], false, 202)
+
+    expect(emitted).toMatchObject([
+      {
+        type: 'appended',
+        messages: [{ blocks: [{ retrieval: { recordOffset: 101, blockIndex: 0 } }] }]
+      },
+      {
+        type: 'replacement',
+        messages: [{ blocks: [{ retrieval: { recordOffset: 202, blockIndex: 0 } }] }]
+      }
+    ])
+  })
+
   it('emits one windowed snapshot with pagination state before live appends', async () => {
     watcher.watching = true
     watcher.args = null

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -1,14 +1,17 @@
 import { z } from 'zod'
-import type {
-  NativeChatBlock,
-  NativeChatMessage,
-  AgentType
-} from '../../../../shared/native-chat-types'
+import type { AgentType } from '../../../../shared/native-chat-types'
 import {
-  readNativeChatTextBlock,
-  type ReadNativeChatTextBlockArgs
-} from '../../../native-chat/transcript-record-reader'
-import { transcriptRecordOffset } from '../../../native-chat/transcript-record-position'
+  MOBILE_NATIVE_CHAT_DEFAULT_WINDOW,
+  MOBILE_NATIVE_CHAT_MAX_WINDOW,
+  sanitizeAppendForClient,
+  windowForClient,
+  type AuthorizedNativeChatPayloadSession
+} from '../../../native-chat/mobile-payload-bounds'
+import { readNativeChatTextBlock } from '../../../native-chat/transcript-record-reader'
+import {
+  nativeChatTextDigest,
+  nativeChatTextRetrievalCapabilities
+} from '../../../native-chat/text-retrieval-capabilities'
 import {
   readNativeChatTranscriptTail,
   subscribeNativeChatTranscript
@@ -58,181 +61,72 @@ const NativeChatUnsubscribe = z.object({
 })
 
 const NativeChatTextBlockRequest = z.object({
-  agent: NativeChatSession.shape.agent,
-  sessionId: NativeChatSession.shape.sessionId,
-  transcriptPath: NativeChatSession.shape.transcriptPath,
-  messageId: z.string().min(1).max(4096),
-  recordOffset: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
-  blockIndex: z.number().int().nonnegative().max(10_000)
+  capability: z.string().min(32).max(128)
 })
 
-// Why: a long agent session can hold thousands of turns (with full tool I/O).
-// Shipping all of them over the paired connection and rendering them at once
-// freezes the mobile app, so the runtime RPC windows to the most recent slice —
-// the conversation tail is what the chat view shows first. The desktop IPC path
-// is unaffected (it reads locally with a virtualized list).
-// Small first page for a fast initial paint; the client raises `limit` to load
-// older history as the user scrolls back.
-const MOBILE_NATIVE_CHAT_DEFAULT_WINDOW = 40
-const MOBILE_NATIVE_CHAT_MAX_WINDOW = 2000
-// Why: a single tool result (a big file read, a long diff) can be hundreds of KB.
-// The mobile view only previews block bodies, so truncate them on the wire to
-// keep the payload small; the marker tells the user content was clipped.
-const MOBILE_BLOCK_CHAR_CAP = 4000
-const MOBILE_TOOL_INPUT_ITEMS_CAP = 20
-const MOBILE_TOOL_INPUT_NODE_CAP = 100
-const TRUNCATION_MARKER = '\n… (truncated)'
+const FULL_TEXT_UNAVAILABLE = 'Full message unavailable'
 
-function clip(text: string): string {
-  return text.length > MOBILE_BLOCK_CHAR_CAP
-    ? text.slice(0, MOBILE_BLOCK_CHAR_CAP) + TRUNCATION_MARKER
-    : text
+function capabilityOwner(context: RpcContext): string {
+  if (context.pairedDeviceId) {
+    return `paired:${context.pairedDeviceId}`
+  }
+  if (context.clientId) {
+    return `client:${context.clientId}`
+  }
+  if (context.connectionId) {
+    return `connection:${context.connectionId}`
+  }
+  return 'local'
 }
 
-function clipBlock(
-  block: NativeChatBlock,
-  blockIndex: number,
-  recordOffset: number | undefined
-): NativeChatBlock {
-  if (block.type === 'text') {
-    if (block.text.length <= MOBILE_BLOCK_CHAR_CAP) {
-      return block
-    }
-    return {
-      ...block,
-      text: clip(block.text),
-      ...(recordOffset === undefined
-        ? {}
-        : {
-            retrieval: {
-              recordOffset,
-              blockIndex,
-              originalChars: block.text.length
-            }
-          })
-    }
-  }
-  if (block.type === 'tool-result') {
-    return block.output.length > MOBILE_BLOCK_CHAR_CAP
-      ? { ...block, output: clip(block.output) }
-      : block
-  }
-  if (block.type === 'tool-call') {
-    const budget = { remaining: MOBILE_BLOCK_CHAR_CAP, nodes: MOBILE_TOOL_INPUT_NODE_CAP }
-    return { ...block, input: sanitizeToolInput(block.input, budget, 0) }
-  }
-  return block
-}
-
-function sanitizeToolInput(
-  value: unknown,
-  budget: { remaining: number; nodes: number },
-  depth: number
-): unknown {
-  budget.nodes--
-  if (budget.nodes < 0 || budget.remaining <= 0) {
-    return '… (truncated)'
-  }
-  if (typeof value === 'string') {
-    const length = Math.min(value.length, budget.remaining)
-    budget.remaining -= length
-    return length < value.length ? `${value.slice(0, length)}… (truncated)` : value
-  }
-  if (!value || typeof value !== 'object' || depth >= 5) {
-    return value && typeof value === 'object' ? '… (truncated)' : value
-  }
-  if (Array.isArray(value)) {
-    const result = value
-      .slice(0, MOBILE_TOOL_INPUT_ITEMS_CAP)
-      .map((item) => sanitizeToolInput(item, budget, depth + 1))
-    if (value.length > MOBILE_TOOL_INPUT_ITEMS_CAP) {
-      result.push('… (truncated)')
-    }
-    return result
-  }
-  const result: Record<string, unknown> = {}
-  let count = 0
-  for (const key in value) {
-    if (!Object.prototype.hasOwnProperty.call(value, key)) {
-      continue
-    }
-    if (count >= MOBILE_TOOL_INPUT_ITEMS_CAP || budget.remaining <= 0) {
-      result['…'] = 'truncated'
-      break
-    }
-    let boundedKey = key.slice(0, Math.min(key.length, budget.remaining, 128))
-    // Why: sibling keys sharing a >=128-char (or budget-truncated) prefix collapse
-    // to the same bounded key; suffix collisions so neither field is silently lost.
-    if (Object.prototype.hasOwnProperty.call(result, boundedKey)) {
-      boundedKey = `${boundedKey}~${count}`
-    }
-    budget.remaining -= boundedKey.length
-    result[boundedKey] = sanitizeToolInput(
-      (value as Record<string, unknown>)[key],
-      budget,
-      depth + 1
-    )
-    count++
-  }
-  return result
-}
-
-function sanitizeMessage(message: NativeChatMessage): NativeChatMessage {
-  const recordOffset = transcriptRecordOffset(message)
-  return {
-    ...message,
-    blocks: message.blocks.map((block, blockIndex) => clipBlock(block, blockIndex, recordOffset))
-  }
-}
-
-function sanitizeAppendForClient(
-  messages: readonly NativeChatMessage[],
-  clientKind: RpcContext['clientKind']
-): NativeChatMessage[] {
-  return clientKind === 'mobile' ? messages.map(sanitizeMessage) : messages.slice()
-}
-
-/** Window a transcript to its most recent `limit` messages so a long session
- *  can't freeze the client. Windowing by count applies to ALL RPC clients —
- *  shipping thousands of turns over the paired link is bad for web and mobile
- *  alike. Char-clipping (the mobile-only payload diet) is applied separately. */
-function windowTranscript(
-  messages: readonly NativeChatMessage[],
-  limit = MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
-): NativeChatMessage[] {
-  const window = Math.min(Math.max(limit, 1), MOBILE_NATIVE_CHAT_MAX_WINDOW)
-  return messages.length > window ? messages.slice(-window) : messages.slice()
-}
-
-/** Apply the windowed slice plus, for `mobile` clients only, oversized-block
- *  char truncation. Web/desktop (`runtime`, or undefined for in-process callers)
- *  are full-class surfaces and pass block bodies through untruncated — matching
- *  the desktop IPC path, which never clips. */
-function windowForClient(
-  messages: readonly NativeChatMessage[],
-  clientKind: RpcContext['clientKind'],
-  limit = MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
-): NativeChatMessage[] {
-  const windowed = windowTranscript(messages, limit)
-  return clientKind === 'mobile' ? windowed.map(sanitizeMessage) : windowed
+function authorizeSession(
+  params: Pick<z.infer<typeof NativeChatSession>, 'agent' | 'sessionId' | 'transcriptPath'>,
+  context: RpcContext
+): AuthorizedNativeChatPayloadSession | null {
+  const remote =
+    context.clientKind !== undefined ||
+    context.pairedDeviceId !== undefined ||
+    context.clientId !== undefined ||
+    context.connectionId !== undefined
+  const authorization = remote
+    ? context.runtime.authorizeNativeChatSession(
+        params.agent,
+        params.sessionId,
+        params.transcriptPath
+      )
+    : params.transcriptPath
+      ? { transcriptPath: params.transcriptPath }
+      : {}
+  return authorization
+    ? {
+        owner: capabilityOwner(context),
+        agent: params.agent,
+        sessionId: params.sessionId,
+        ...(authorization.transcriptPath ? { transcriptPath: authorization.transcriptPath } : {})
+      }
+    : null
 }
 
 export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
   defineMethod({
     name: 'nativeChat.readSession',
     params: NativeChatSession,
-    handler: async (params, { clientKind }) => {
+    handler: async (params, context) => {
+      const session = authorizeSession(params, context)
+      if (!session) {
+        return { error: 'Transcript unavailable' }
+      }
       const limit = params.limit ?? MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
       const result = await readNativeChatTranscriptTail({
         agent: params.agent,
         sessionId: params.sessionId,
-        transcriptPath: params.transcriptPath,
+        transcriptPath: session.transcriptPath,
         limit,
         beforeOffset: params.beforeOffset
       })
       return 'messages' in result
         ? {
-            messages: windowForClient(result.messages, clientKind, limit),
+            messages: windowForClient(result.messages, context.clientKind, session, limit),
             hasMore: result.hasMore,
             beforeOffset: result.beforeOffset,
             ...(result.lifecycle ? { lifecycle: result.lifecycle } : {})
@@ -243,12 +137,47 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
   defineMethod({
     name: 'nativeChat.readTextBlock',
     params: NativeChatTextBlockRequest,
-    handler: async (params) => readNativeChatTextBlock(params as ReadNativeChatTextBlockArgs)
+    handler: async (params, context) => {
+      const grant = nativeChatTextRetrievalCapabilities.redeem(
+        params.capability,
+        capabilityOwner(context)
+      )
+      if (!grant) {
+        return { error: FULL_TEXT_UNAVAILABLE }
+      }
+      const authorization = context.runtime.authorizeNativeChatSession(
+        grant.agent,
+        grant.sessionId,
+        grant.transcriptPath
+      )
+      if (!authorization) {
+        return { error: FULL_TEXT_UNAVAILABLE }
+      }
+      const result = await readNativeChatTextBlock({
+        agent: grant.agent,
+        sessionId: grant.sessionId,
+        transcriptPath: authorization.transcriptPath,
+        messageId: grant.messageId,
+        recordOffset: grant.recordOffset,
+        blockIndex: grant.blockIndex
+      })
+      return 'text' in result &&
+        result.text.length === grant.originalChars &&
+        nativeChatTextDigest(result.text) === grant.digest
+        ? result
+        : { error: FULL_TEXT_UNAVAILABLE }
+    }
   }),
   defineStreamingMethod({
     name: 'nativeChat.subscribe',
     params: NativeChatSession,
-    handler: async (params, { runtime, connectionId, clientKind }, emit) => {
+    handler: async (params, context, emit) => {
+      const { runtime, connectionId, clientKind } = context
+      const session = authorizeSession(params, context)
+      if (!session) {
+        emit({ type: 'snapshot', messages: [], hasMore: false, error: 'Transcript unavailable' })
+        return
+      }
       let closed = false
       let unsubscribe = (): void => {}
       // Why: the first drain is a bounded tail snapshot; later drains emit only
@@ -276,17 +205,18 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
       const subscription = await subscribeNativeChatTranscript({
         agent: params.agent,
         sessionId: params.sessionId,
-        transcriptPath: params.transcriptPath,
+        transcriptPath: session.transcriptPath,
         initialLimit: limit,
         onInitialSnapshot: (messages, hasMore, beforeOffset, error, lifecycle) => {
-          if (closed) {
+          const currentSession = authorizeSession(params, context)
+          if (closed || !currentSession) {
             return
           }
           // Forward an initial-drain error so a watching client's first frame carries it
           // instead of stranding the view at 'loading' when the read keeps throwing.
           emit({
             type: 'snapshot',
-            messages: windowForClient(messages, clientKind, limit),
+            messages: windowForClient(messages, clientKind, currentSession, limit),
             hasMore,
             beforeOffset,
             ...(error ? { error } : {}),
@@ -294,24 +224,26 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
           })
         },
         onReplace: (messages, hasMore, beforeOffset, lifecycle) => {
-          if (closed) {
+          const currentSession = authorizeSession(params, context)
+          if (closed || !currentSession) {
             return
           }
           emit({
             type: 'replacement',
-            messages: windowForClient(messages, clientKind, limit),
+            messages: windowForClient(messages, clientKind, currentSession, limit),
             hasMore,
             beforeOffset,
             ...(lifecycle ? { lifecycle } : {})
           })
         },
         onAppend: (messages, lifecycle) => {
-          if (closed) {
+          const currentSession = authorizeSession(params, context)
+          if (closed || !currentSession) {
             return
           }
           emit({
             type: 'appended',
-            messages: sanitizeAppendForClient(messages, clientKind),
+            messages: sanitizeAppendForClient(messages, clientKind, currentSession),
             ...(lifecycle ? { lifecycle } : {})
           })
         }

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -5,6 +5,11 @@ import type {
   AgentType
 } from '../../../../shared/native-chat-types'
 import {
+  readNativeChatTextBlock,
+  type ReadNativeChatTextBlockArgs
+} from '../../../native-chat/transcript-record-reader'
+import { transcriptRecordOffset } from '../../../native-chat/transcript-record-position'
+import {
   readNativeChatTranscriptTail,
   subscribeNativeChatTranscript
 } from '../../../native-chat/transcript-watch'
@@ -52,6 +57,15 @@ const NativeChatUnsubscribe = z.object({
   subscriptionId: z.string().min(1).optional()
 })
 
+const NativeChatTextBlockRequest = z.object({
+  agent: NativeChatSession.shape.agent,
+  sessionId: NativeChatSession.shape.sessionId,
+  transcriptPath: NativeChatSession.shape.transcriptPath,
+  messageId: z.string().min(1).max(4096),
+  recordOffset: z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+  blockIndex: z.number().int().nonnegative().max(10_000)
+})
+
 // Why: a long agent session can hold thousands of turns (with full tool I/O).
 // Shipping all of them over the paired connection and rendering them at once
 // freezes the mobile app, so the runtime RPC windows to the most recent slice —
@@ -75,9 +89,28 @@ function clip(text: string): string {
     : text
 }
 
-function clipBlock(block: NativeChatBlock): NativeChatBlock {
+function clipBlock(
+  block: NativeChatBlock,
+  blockIndex: number,
+  recordOffset: number | undefined
+): NativeChatBlock {
   if (block.type === 'text') {
-    return block.text.length > MOBILE_BLOCK_CHAR_CAP ? { ...block, text: clip(block.text) } : block
+    if (block.text.length <= MOBILE_BLOCK_CHAR_CAP) {
+      return block
+    }
+    return {
+      ...block,
+      text: clip(block.text),
+      ...(recordOffset === undefined
+        ? {}
+        : {
+            retrieval: {
+              recordOffset,
+              blockIndex,
+              originalChars: block.text.length
+            }
+          })
+    }
   }
   if (block.type === 'tool-result') {
     return block.output.length > MOBILE_BLOCK_CHAR_CAP
@@ -145,7 +178,11 @@ function sanitizeToolInput(
 }
 
 function sanitizeMessage(message: NativeChatMessage): NativeChatMessage {
-  return { ...message, blocks: message.blocks.map(clipBlock) }
+  const recordOffset = transcriptRecordOffset(message)
+  return {
+    ...message,
+    blocks: message.blocks.map((block, blockIndex) => clipBlock(block, blockIndex, recordOffset))
+  }
 }
 
 function sanitizeAppendForClient(
@@ -202,6 +239,11 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
           }
         : result
     }
+  }),
+  defineMethod({
+    name: 'nativeChat.readTextBlock',
+    params: NativeChatTextBlockRequest,
+    handler: async (params) => readNativeChatTextBlock(params as ReadNativeChatTextBlockArgs)
   }),
   defineStreamingMethod({
     name: 'nativeChat.subscribe',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -365,6 +365,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'session.tabs.unsubscribe',
   'session.tabs.unsubscribeAll',
   'nativeChat.readSession',
+  'nativeChat.readTextBlock',
   'nativeChat.subscribe',
   'nativeChat.unsubscribe',
   'settings.get',

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -28,9 +28,18 @@ export const NATIVE_CHAT_ROLES = ['user', 'assistant', 'tool', 'reasoning', 'sys
 export type NativeChatRole = (typeof NATIVE_CHAT_ROLES)[number]
 
 /** Plain prose / markdown. The assistant body, a user prompt, reasoning text. */
+export type NativeChatTextRetrieval = {
+  /** JSONL byte offset used for a bounded, direct record read. */
+  recordOffset: number
+  blockIndex: number
+  originalChars: number
+}
+
 export type NativeChatTextBlock = {
   type: 'text'
   text: string
+  /** Present when `text` is a bounded mobile preview. */
+  retrieval?: NativeChatTextRetrieval
 }
 
 /** A tool invocation by the agent. `input` is the (already-serialized) tool

--- a/src/shared/native-chat-types.ts
+++ b/src/shared/native-chat-types.ts
@@ -29,9 +29,8 @@ export type NativeChatRole = (typeof NATIVE_CHAT_ROLES)[number]
 
 /** Plain prose / markdown. The assistant body, a user prompt, reasoning text. */
 export type NativeChatTextRetrieval = {
-  /** JSONL byte offset used for a bounded, direct record read. */
-  recordOffset: number
-  blockIndex: number
+  /** Opaque, server-issued authority for one exact transcript text block. */
+  capability: string
   originalChars: number
 }
 


### PR DESCRIPTION
## Complaint

Long native-chat messages were clipped to 4,000 characters before reaching the mobile renderer. Because the clipped payload replaced the original prose, ordinary long assistant answers and fenced code could appear blank or unreadable and the omitted text could not be recovered for expand, copy, reconnect, pagination, or route changes.

## Before / after

Before: history and live updates retained only the clipped prose block. Mobile had no authorized way to recover the omitted text.

After: snapshots and live appends still carry a bounded readable preview. Oversized user, assistant, system, and reasoning prose expose an accessible **Show full message/response** action. Expansion retrieves the exact source lazily, collapse and re-expand reuse a single-entry cache, expanding another block releases the prior full block, and copy retrieves the intended full message without retaining another copy. Loading, retry, and copy-failure states are visible and accessible.

Tool-input/tool-result truncation and message-count pagination are intentionally unchanged. Recovering tool payloads is a separate enhancement, not part of this fix.

## Root cause and implementation

- Keep prose in normal native-chat snapshots/live frames bounded to a 4,000-character preview.
- Attach an opaque server-issued capability only when the full prose can be recovered safely.
- Add `nativeChat.readTextBlock`, which accepts only that capability and performs an authorized direct record read on the host.
- Bind expansion state to message ID, capability, and original length so same-ID transcript replacements invalidate stale results.
- Serialize expand/copy retrievals, retain at most one expanded full block, and reset it across client/session/route changes.
- Preserve streaming replacement/append behavior and avoid routing full payloads through ordinary session snapshots.

## Screenshots

No screenshots are attached. The supported `orca emulator` surface for the assigned iPhone exposes interaction and accessibility output but no compliant screenshot command. Raw `simctl`, raw `serve-sim`, Simulator Computer Use, and substitute capture paths were prohibited, so the PR intentionally contains no screenshot evidence.

## Fresh AI review

Two genuinely fresh `gpt-5.6-sol` / `xhigh` reviews covered the complete diff, current-main integration, authorization, retention, concurrency, streaming/replacement behavior, accessibility, Unicode boundaries, and hot paths.

The first review found and fixed only material in-scope issues:

- serialized expansion and copy retrievals, including route/session changes;
- rejected stale full-text responses after same-ID live replacement;
- added truthful visible/accessibility copy failure and loading feedback;
- prevented preview truncation from splitting Unicode surrogate pairs; and
- preserved O(incoming) live-append bookkeeping.

The fixes were committed and pushed as exact head `de2f1963fb2f870ba2858f008c9c094fb33d9629`. A second independent same-model/xhigh review made no edits and returned explicit **CLEAN** with no unresolved correctness, security, retention, concurrency, performance, UX, Unicode, authorization, streaming, replacement, reconnect, or copy findings.

## Security audit

Mobile can submit only a 32–128 character opaque capability to `nativeChat.readTextBlock`; it cannot select a transcript path, agent session, record offset, block index, or unrelated transcript.

- The host issues 256-bit random capabilities only while producing an already-authorized native-chat session payload.
- Each server-side grant is bound to the paired device/connection owner, provider, authorized session, message, block, exact character count, and SHA-256 digest of the exact text.
- Redemption re-authorizes the native-chat session, direct-reads the recorded JSONL entry under the existing record-size ceiling, and returns text only when length and digest still match.
- Grants expire after two hours. The in-memory table is capped at 16,384 entries, removes expired grants, and evicts oldest grants at capacity, preventing unbounded retention.
- Failures are generic and do not disclose transcript layout or authorization details.
- SSH/relay requests execute against the authoritative host runtime; folder workspaces do not assume a Git worktree.

No command execution, Git behavior, dependency, authentication, secret storage, or persistent capability store was added.

## Performance

- Initial/history/live payloads remain bounded; full text crosses the connection only after an explicit expand or copy.
- Reads seek directly to one transcript record instead of decoding the prefix. A focused case retrieved a target after 4 MiB of unrelated history in 17 ms locally.
- Mobile serializes bounded retrievals and holds at most one full block. Same-block collapse/re-expand reuses that one entry; another expansion replaces it.
- Append/replacement indexing stays proportional to incoming changes, and route/client changes reject late work.
- Rapid native scrolling, long Markdown/code, replacement, append, and route cycles stayed responsive.
- Exact-head fixture memory after the full QA cycle changed by +6.83 MiB RSS, +1.43 MiB JS heap, and +1.22 MiB external memory; there was no per-expansion accumulation signal.

## Validation

Automated validation:

- Full mobile suite: 376 files passed; 2,784 tests passed and 3 skipped.
- Native-chat/runtime suite: 16 files passed; 145 tests passed.
- Fresh-review host/runtime: 50 tests passed; mobile: 38 tests passed; post-fix focused rerun: 57 tests passed.
- Independent clean review rerun: 39 runtime/native-chat tests and 38 mobile tests passed.
- Node and mobile typechecks passed.
- Lint, formatting, changed-code quality, max-lines ratchet, reliability gates, localization checks, `git diff --check`, and broad mobile validation passed.
- Exact-head GitHub CI is green across Mobile Checks, static analysis, typecheck, Git compatibility, shell contracts, Node 24/26 shards, packaging, verification, and external review.

Exact-head Release/native validation:

- Repository and `mobile/pnpm-lock.yaml` were clean before build at `de2f1963fb2f870ba2858f008c9c094fb33d9629`; lockfile SHA-256 is `c27ea16a5b176291cb14227fc44970f47b9e3d7e61c8cf8e6433109db3967487`.
- The supported Expo iOS Release build/install path succeeded for the assigned iPhone only.
- The resulting `com.stably.orca.mobile` artifact has a valid sealed ad-hoc simulator signature, CDHash `d0ed0f0e6f45ca9d112be31cb4cba11ed8c4bd31`, executable SHA-256 `389e0d8da14e97f32a87907fb2ace19523dbca3ae126f36612cfe39cef3b121b`, and Hermes SHA-256 `a3870011c532b202932a5da10419c35a953efe641f2949756b0ccd24a744de03`.
- Native QA used only supported Orca emulator interaction/AX controls on assigned iPhone `50FD514C-96F6-446E-AC90-D07A24CAB3A0` at port 3101.

Native behavior verified:

- user preview bounded at 4,014 AX characters; exact 7,303-character expand, collapse, and re-expand;
- assistant exact 7,322-character expansion; copy pasted back byte-for-byte, including all 379 emoji, without sending;
- reasoning exact 7,307-character expansion;
- system expansion and replacement expansion exposed complete rendered content; AX omitted only one trailing U+0020 immediately before `\n`, exactly matching Markdown/AX trailing-space normalization rather than a source-text change;
- fenced-code body exact at 7,647 characters within a 7,732-character Markdown source, with responsive horizontal and vertical gestures;
- one-expanded-block invariant, accessible expanded state, Show less/retry/copy labels, and no stale expansion after route/session changes;
- same-ID live replacement removed the old assistant immediately and expanded the new source; live append produced a bounded preview and exact 7,238-character expansion;
- second session and Long Chat B switching cleared stale expansion; Long Chat B expanded exactly to 7,236 characters;
- tool UI retained its existing bounded input/result truncation;
- rapid scrolling, background/foreground recovery, copy success, and repeated route cycles remained responsive.

## Remaining bounded gaps

- The allowed Orca surface cannot hash or inspect the installed Simulator container/binary. Artifact identity is proven, and the supported Expo install plus assigned-iPhone runtime QA succeeded, but installed-binary hash equality cannot be proven without violating the simulator-control boundary.
- The `/tmp` fixture uses the exact runtime/native-chat authorization and transcript code but deliberately rejects PTY writes. Composer sending to a real terminal is therefore not claimed.
- Background/foreground connection recovery passed. A forced network disconnect/reconnect was not manufactured because no allowed Orca emulator control provides that operation without stopping/replacing the shared stream.
- Native assistant copy success was verified byte-for-byte. Clipboard-denial failure could not be reproduced safely; truthful failure/retry behavior remains covered by focused tests.
- No compliant screenshot command is available, so no screenshot was uploaded.

## Current-main audit

- Exact pushed PR head: `de2f1963fb2f870ba2858f008c9c094fb33d9629`.
- Freshly fetched `origin/main`: `79251d7a9861568dc261faabfa16df5347d1d008`.
- Conflict-free merge tree: `cb7bdc6861405dd0825d349296a1bbc8d79b75c6`.
- Worktree and child mobile lockfile are clean.
- The PR remains open and unmerged.
