### PR TITLE
fix(rate-limits): fall back to context_window for Claude usage on Vertex/proxy backends

### DIFF
--- a/src/main/claude/statusline-script.test.ts
+++ b/src/main/claude/statusline-script.test.ts
@@ -17,11 +17,12 @@ afterEach(() => {
 })
 
 describe('getManagedStatusLineScript (posix)', () => {
-  it('guards on rate_limits before sourcing the endpoint or spawning curl', () => {
+  it('guards on rate_limits or context_window before sourcing the endpoint or spawning curl', () => {
     stubPlatform('darwin')
     const script = getManagedStatusLineScript('local')
     expect(script).toBe(getManagedStatusLineScript('posix'))
     const guardIndex = script.indexOf('*\'"rate_limits"\'*')
+    expect(script).toContain('*\'"context_window"\'*')
     const endpointIndex = script.indexOf('ORCA_AGENT_HOOK_ENDPOINT')
     const curlIndex = script.indexOf('curl -sS')
     expect(guardIndex).toBeGreaterThan(-1)
@@ -40,12 +41,12 @@ describe('getManagedStatusLineScript (posix)', () => {
 })
 
 describe('getManagedStatusLineScript (win32 local)', () => {
-  it('guards on rate_limits via findstr before the endpoint call and curl spawn', () => {
+  it('guards on rate_limits or context_window via findstr before the endpoint call and curl spawn', () => {
     stubPlatform('win32')
     const script = getManagedStatusLineScript('local')
     const captureIndex = script.indexOf('more.com')
     // Why: the \"-escaped needle makes findstr match the quoted JSON key, not any path containing rate_limits.
-    const guardIndex = script.indexOf('findstr.exe" /c:\\"rate_limits\\"')
+    const guardIndex = script.indexOf('findstr.exe" /c:\\"rate_limits\\" /c:\\"context_window\\"')
     const endpointIndex = script.indexOf('call "%ORCA_AGENT_HOOK_ENDPOINT%"')
     const curlIndex = script.indexOf('curl.exe')
     expect(captureIndex).toBeGreaterThan(-1)
@@ -345,11 +346,22 @@ describe.skipIf(process.platform === 'win32')('statusline curl throttle (posix b
     expect(readFileSync(stampPathFor(dir, 'legacy-tab-b_1'), 'utf8')).toBe('1')
   })
 
-  it('never touches curl or the stamp for payloads without rate_limits', async () => {
+  it('never touches curl or the stamp for payloads without rate_limits or context_window', async () => {
     const { scriptPath, dir, curlLog, dateLog } = makeHarness()
     await runScript(scriptPath, dir, '{"model":{"id":"claude-fable-5"}}')
     expect(lineCount(curlLog)).toBe(0)
     expect(lineCount(dateLog)).toBe(0)
     expect(() => readFileSync(stampPathFor(dir), 'utf8')).toThrow()
+  })
+
+  it('posts for a context_window-only payload (Vertex AI / internal-proxy backends lack rate_limits)', async () => {
+    const { scriptPath, dir, curlLog, payloadLog } = makeHarness()
+    const payload = JSON.stringify({
+      cost: { total_duration_ms: 1_000 },
+      context_window: { used_percentage: 42 }
+    })
+    await runScript(scriptPath, dir, payload)
+    expect(lineCount(curlLog)).toBe(1)
+    expect(readFileSync(payloadLog, 'utf8')).toBe(payload)
   })
 })

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -41,10 +41,11 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
       `if not defined ORCA_STATUSLINE_ELAPSED goto :${STATUSLINE_PROBE_LABEL}`,
       `if %ORCA_STATUSLINE_ELAPSED% GEQ 0 if %ORCA_STATUSLINE_ELAPSED% LSS ${CLAUDE_STATUSLINE_MIN_POST_INTERVAL_SECONDS} goto :${STATUSLINE_CLEANUP_LABEL}`,
       `:${STATUSLINE_PROBE_LABEL}`,
-      // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response; the
-      // statusline ticks ~3x/sec during streaming, so skip the endpoint call and curl spawn otherwise.
+      // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response;
+      // context_window is reported by every backend (Vertex AI/proxy included), so it also opens the
+      // gate. The statusline ticks ~3x/sec during streaming, so skip the endpoint call and curl spawn otherwise.
       // Why: \" is the MSVC argv escape — findstr sees the quoted JSON key, so a cwd containing rate_limits can't false-match (POSIX guard parity).
-      '"%SystemRoot%\\System32\\findstr.exe" /c:\\"rate_limits\\" "%ORCA_STATUSLINE_PAYLOAD_FILE%" >nul 2>nul',
+      '"%SystemRoot%\\System32\\findstr.exe" /c:\\"rate_limits\\" /c:\\"context_window\\" "%ORCA_STATUSLINE_PAYLOAD_FILE%" >nul 2>nul',
       `if errorlevel 1 goto :${STATUSLINE_CLEANUP_LABEL}`,
       // Why: call the endpoint file to refresh port/token — a PTY that survived an Orca restart carries stale env; falls through to PTY env if missing.
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
@@ -88,9 +89,11 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
     'if [ -z "$payload" ]; then',
     '  exit 0',
     'fi',
-    // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response; skip the post (and its curl spawn) otherwise.
+    // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response;
+    // context_window is reported by every backend (Vertex AI/proxy included), so it also opens the
+    // gate; otherwise skip the post (and its curl spawn).
     'case "$payload" in',
-    '  *\'"rate_limits"\'*) ;;',
+    '  *\'"rate_limits"\'*|*\'"context_window"\'*) ;;',
     '  *) exit 0 ;;',
     'esac',
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',

--- a/src/shared/claude-statusline-rate-limits.test.ts
+++ b/src/shared/claude-statusline-rate-limits.test.ts
@@ -64,12 +64,33 @@ describe('parseClaudeStatusLineBody', () => {
     expect(parsed?.sevenDay).toEqual({ used_percentage: 8, resets_at: undefined })
   })
 
-  it('returns null when rate_limits is absent or empty', () => {
-    expect(
-      parseClaudeStatusLineBody(formBody({ context_window: { used_percentage: 8 } }))
-    ).toBeNull()
+  it('returns null when rate_limits and context_window are both absent or empty', () => {
     expect(parseClaudeStatusLineBody(formBody({ rate_limits: {} }))).toBeNull()
     expect(parseClaudeStatusLineBody(formBody({ rate_limits: null }))).toBeNull()
+    expect(parseClaudeStatusLineBody(formBody({ context_window: {} }))).toBeNull()
+  })
+
+  it('falls back to context_window as the session window when rate_limits is absent', () => {
+    // Why: Vertex AI / internal-proxy deployments never receive rate_limits (Claude.ai-subscription
+    // billing only), but Claude Code still reports local context window usage regardless of backend.
+    const parsed = parseClaudeStatusLineBody(
+      formBody({ context_window: { used_percentage: 8, resets_at: undefined } })
+    )
+    expect(parsed).toEqual({
+      configDir: null,
+      fiveHour: { used_percentage: 8, resets_at: undefined },
+      sevenDay: null
+    })
+  })
+
+  it('prefers rate_limits over context_window when both are present', () => {
+    const parsed = parseClaudeStatusLineBody(
+      formBody({
+        rate_limits: { five_hour: { used_percentage: 23.5 } },
+        context_window: { used_percentage: 91 }
+      })
+    )
+    expect(parsed?.fiveHour).toEqual({ used_percentage: 23.5, resets_at: undefined })
   })
 
   it('rejects malformed bodies without throwing', () => {

--- a/src/shared/claude-statusline-rate-limits.ts
+++ b/src/shared/claude-statusline-rate-limits.ts
@@ -75,11 +75,18 @@ export function parseClaudeStatusLineBody(body: unknown): ClaudeStatusLineRateLi
     return null
   }
   const rateLimits = (payload as { rate_limits?: unknown }).rate_limits
-  if (typeof rateLimits !== 'object' || rateLimits === null) {
-    return null
+  let fiveHour: ClaudeStatusLineWindow | null = null
+  let sevenDay: ClaudeStatusLineWindow | null = null
+  if (typeof rateLimits === 'object' && rateLimits !== null) {
+    fiveHour = parseWindow((rateLimits as { five_hour?: unknown }).five_hour)
+    sevenDay = parseWindow((rateLimits as { seven_day?: unknown }).seven_day)
   }
-  const fiveHour = parseWindow((rateLimits as { five_hour?: unknown }).five_hour)
-  const sevenDay = parseWindow((rateLimits as { seven_day?: unknown }).seven_day)
+  if (!fiveHour && !sevenDay) {
+    // Why: rate_limits is Claude.ai-subscription-billing only — Vertex AI and internal-proxy
+    // deployments never receive it, but Claude Code still reports local context window usage
+    // regardless of backend. Fall back to it so the usage bar stays live instead of going dark.
+    fiveHour = parseWindow((payload as { context_window?: unknown }).context_window)
+  }
   if (!fiveHour && !sevenDay) {
     return null
   }


### PR DESCRIPTION
## Summary
- The managed Claude statusline script only forwarded the per-turn payload to Orca's agent-hook endpoint when it contained a `rate_limits` key, which Anthropic only includes in standard Claude.ai-subscription API responses.
- Deployments routed through Vertex AI or an internal Anthropic-API-compatible proxy never receive `rate_limits`, so the live usage bar silently stopped updating even though the network itself was fine.
- `context_window` is reported by every backend (computed locally from conversation length, not pulled from Claude.ai billing), so use it as a fallback session-usage source — both in the shell script's early-exit guard (POSIX `case`/Windows `findstr`) and in `parseClaudeStatusLineBody` — when `rate_limits` is absent.

## Test plan
- [x] `src/shared/claude-statusline-rate-limits.test.ts` — added coverage for the `context_window` fallback and for `rate_limits` taking priority when both are present
- [x] `src/main/claude/statusline-script.test.ts` — updated the POSIX/Windows guard assertions and added a behavioral test confirming a `context_window`-only payload now reaches curl