### PR TITLE
fix(rate-limits): fall back to the local session log for Codex usage

### DIFF
--- a/src/main/rate-limits/codex-fetcher-session-log-abort.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-log-abort.test.ts
@@ -1,0 +1,71 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, readFileMock, readLatestCodexSessionUsedPercentMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  readFileMock: vi.fn(),
+  readLatestCodexSessionUsedPercentMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
+vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+vi.mock('./codex-auth-presence', () => ({
+  probeCodexAuthPresence: vi.fn(async () => 'present')
+}))
+vi.mock('./codex-session-log-usage', () => ({
+  readLatestCodexSessionUsedPercent: readLatestCodexSessionUsedPercentMock
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
+describe('Codex session-log fallback abort handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ tokens: { access_token: 'access-token', account_id: 'account-id' } })
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('discards a session-log result if the fetch aborts while it was being read', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    const controller = new AbortController()
+    readLatestCodexSessionUsedPercentMock.mockImplementationOnce(async () => {
+      controller.abort()
+      return 17
+    })
+
+    const resultPromise = fetchCodexRateLimits({
+      signal: controller.signal,
+      allowPtyFallback: false
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    rpcChild.emit('close')
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      status: 'error',
+      error: 'Rate-limit fetch aborted'
+    })
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -2,11 +2,20 @@ import { EventEmitter } from 'node:events'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+const {
+  childSpawnMock,
+  readFileMock,
+  resolveCodexCommandMock,
+  ptySpawnMock,
+  readLatestCodexSessionUsedPercentMock
+} = vi.hoisted(() => ({
   childSpawnMock: vi.fn(),
   readFileMock: vi.fn(),
   resolveCodexCommandMock: vi.fn(),
-  ptySpawnMock: vi.fn()
+  ptySpawnMock: vi.fn(),
+  // Why: default to "no local fallback available" so the 21 existing status-'error'
+  // assertions below stay accurate; only the dedicated fallback test overrides this.
+  readLatestCodexSessionUsedPercentMock: vi.fn().mockResolvedValue(null)
 }))
 
 vi.mock('node:child_process', () => ({
@@ -29,6 +38,10 @@ vi.mock('node-pty', () => ({
 // itself is covered by codex-auth-presence.test.ts and the no-auth case below.
 vi.mock('./codex-auth-presence', () => ({
   probeCodexAuthPresence: vi.fn(() => 'present')
+}))
+
+vi.mock('./codex-session-log-usage', () => ({
+  readLatestCodexSessionUsedPercent: readLatestCodexSessionUsedPercentMock
 }))
 
 import { fetchCodexRateLimits } from './codex-fetcher'
@@ -326,6 +339,42 @@ describe('fetchCodexRateLimits', () => {
       status: 'error'
     })
     expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the local session log when every network path fails', async () => {
+    readLatestCodexSessionUsedPercentMock.mockResolvedValueOnce(17)
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(0)
+    rpcChild.emit('close')
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      session: { usedPercent: 17 },
+      status: 'ok',
+      error: null,
+      usageMetadata: { source: 'session-log' }
+    })
+  })
+
+  it('does not consult the local session log when the fetch was aborted', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    const controller = new AbortController()
+
+    const resultPromise = fetchCodexRateLimits({ signal: controller.signal })
+    await vi.advanceTimersByTimeAsync(0)
+    controller.abort()
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      status: 'error',
+      error: 'Rate-limit fetch aborted'
+    })
+    expect(readLatestCodexSessionUsedPercentMock).not.toHaveBeenCalled()
   })
 
   it('removes RPC listeners when the app-server timeout settles', async () => {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -1254,6 +1254,9 @@ export async function fetchCodexRateLimits(
   // token_count event is the only usage signal left, so usage doesn't go completely
   // dark on an internal network.
   const usedPercent = await readLatestCodexSessionUsedPercent().catch(() => null)
+  if (options?.signal?.aborted) {
+    return abortedCodexRateLimitResult()
+  }
   if (usedPercent === null) {
     return result
   }

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -11,6 +11,7 @@ import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 import { join } from 'node:path'
 import { probeCodexAuthPresence } from './codex-auth-presence'
 import { extractClaudePtyResetMetadata } from './claude-pty-reset-parser'
+import { readLatestCodexSessionUsedPercent } from './codex-session-log-usage'
 import {
   classifyCodexRateLimitWindows,
   CODEX_SESSION_WINDOW_MINUTES,
@@ -1119,7 +1120,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
 // Public API
 // ---------------------------------------------------------------------------
 
-export async function fetchCodexRateLimits(
+async function fetchCodexRateLimitsViaNetwork(
   options?: FetchCodexRateLimitsOptions
 ): Promise<ProviderRateLimits> {
   if (options?.signal?.aborted) {
@@ -1236,5 +1237,36 @@ export async function fetchCodexRateLimits(
       error: isNotInstalled ? 'Codex CLI not found' : withMacTailscaleDnsHint(message),
       status: isNotInstalled ? 'unavailable' : 'error'
     }
+  }
+}
+
+export async function fetchCodexRateLimits(
+  options?: FetchCodexRateLimitsOptions
+): Promise<ProviderRateLimits> {
+  const result = await fetchCodexRateLimitsViaNetwork(options)
+  // Why: an auth error means the user needs to re-authenticate — masking it with a
+  // locally-derived 'ok' would hide the one thing they actually need to act on.
+  if (result.status !== 'error' || options?.signal?.aborted || isCodexAuthError(result.error)) {
+    return result
+  }
+  // Why: Codex has no live per-turn push like Claude's statusline — when every network
+  // path (backend/RPC/PTY) fails for a non-auth reason, the local session log's last
+  // token_count event is the only usage signal left, so usage doesn't go completely
+  // dark on an internal network.
+  const usedPercent = await readLatestCodexSessionUsedPercent().catch(() => null)
+  if (usedPercent === null) {
+    return result
+  }
+  return {
+    ...result,
+    session: {
+      usedPercent,
+      windowMinutes: CODEX_SESSION_WINDOW_MINUTES,
+      resetsAt: null,
+      resetDescription: null
+    },
+    status: 'ok',
+    error: null,
+    usageMetadata: { ...result.usageMetadata, source: 'session-log' }
   }
 }

--- a/src/main/rate-limits/codex-session-log-usage.test.ts
+++ b/src/main/rate-limits/codex-session-log-usage.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  extractCodexSessionUsedPercentFromLog,
+  readLatestCodexSessionUsedPercent
+} from './codex-session-log-usage'
+
+function tokenCountLine(info: Record<string, unknown>): string {
+  return JSON.stringify({
+    timestamp: '2026-07-31T00:00:00.000Z',
+    type: 'event_msg',
+    payload: { type: 'token_count', info }
+  })
+}
+
+describe('extractCodexSessionUsedPercentFromLog', () => {
+  it('computes used percent from the last token_count event', () => {
+    const content = [
+      tokenCountLine({
+        total_token_usage: { total_tokens: 1000 },
+        model_context_window: 10_000
+      }),
+      tokenCountLine({
+        total_token_usage: { total_tokens: 4000 },
+        model_context_window: 10_000
+      })
+    ].join('\n')
+    expect(extractCodexSessionUsedPercentFromLog(content)).toBe(40)
+  })
+
+  it('falls back to last_token_usage when total_token_usage is absent', () => {
+    const content = tokenCountLine({
+      last_token_usage: { total_tokens: 2_584 },
+      model_context_window: 258_400
+    })
+    expect(extractCodexSessionUsedPercentFromLog(content)).toBe(1)
+  })
+
+  it('ignores non-token_count lines and malformed JSON', () => {
+    const content = [
+      'not json',
+      JSON.stringify({ type: 'session_meta', payload: { id: 'abc' } }),
+      JSON.stringify({
+        type: 'event_msg',
+        payload: { type: 'agent_message', message: 'hi' }
+      }),
+      tokenCountLine({ total_token_usage: { total_tokens: 50 }, model_context_window: 100 })
+    ].join('\n')
+    expect(extractCodexSessionUsedPercentFromLog(content)).toBe(50)
+  })
+
+  it('returns null when no token_count event is present', () => {
+    const content = JSON.stringify({
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'hi' }
+    })
+    expect(extractCodexSessionUsedPercentFromLog(content)).toBeNull()
+  })
+
+  it('skips a token_count event missing a valid model_context_window', () => {
+    const content = [
+      tokenCountLine({ total_token_usage: { total_tokens: 10 }, model_context_window: 0 }),
+      tokenCountLine({ total_token_usage: { total_tokens: 30 }, model_context_window: 100 })
+    ].join('\n')
+    expect(extractCodexSessionUsedPercentFromLog(content)).toBe(30)
+  })
+
+  it('clamps used percent to [0, 100]', () => {
+    const content = tokenCountLine({
+      total_token_usage: { total_tokens: 999_999 },
+      model_context_window: 100
+    })
+    expect(extractCodexSessionUsedPercentFromLog(content)).toBe(100)
+  })
+
+  it('returns null for empty content', () => {
+    expect(extractCodexSessionUsedPercentFromLog('')).toBeNull()
+  })
+})
+
+describe('readLatestCodexSessionUsedPercent', () => {
+  it('reads the most recently modified session file', async () => {
+    const listFiles = vi.fn().mockResolvedValue(['/sessions/old.jsonl', '/sessions/new.jsonl'])
+    const statFile = vi.fn(async (filePath: string) => ({
+      mtimeMs: filePath.includes('new') ? 2_000 : 1_000
+    }))
+    const readFileFn = vi.fn(async (filePath: string) =>
+      filePath.includes('new')
+        ? tokenCountLine({ total_token_usage: { total_tokens: 25 }, model_context_window: 100 })
+        : tokenCountLine({ total_token_usage: { total_tokens: 99 }, model_context_window: 100 })
+    )
+    const result = await readLatestCodexSessionUsedPercent(listFiles, statFile, readFileFn)
+    expect(result).toBe(25)
+    expect(readFileFn).toHaveBeenCalledWith('/sessions/new.jsonl')
+  })
+
+  it('returns null when there are no session files', async () => {
+    const result = await readLatestCodexSessionUsedPercent(
+      vi.fn().mockResolvedValue([]),
+      vi.fn(),
+      vi.fn()
+    )
+    expect(result).toBeNull()
+  })
+
+  it('skips files whose stat call fails and still uses a readable one', async () => {
+    const listFiles = vi.fn().mockResolvedValue(['/sessions/broken.jsonl', '/sessions/ok.jsonl'])
+    const statFile = vi.fn(async (filePath: string) => {
+      if (filePath.includes('broken')) {
+        throw new Error('permission denied')
+      }
+      return { mtimeMs: 1_000 }
+    })
+    const readFileFn = vi.fn(async () =>
+      tokenCountLine({ total_token_usage: { total_tokens: 10 }, model_context_window: 100 })
+    )
+    const result = await readLatestCodexSessionUsedPercent(listFiles, statFile, readFileFn)
+    expect(result).toBe(10)
+  })
+
+  it('returns null when listing session files throws', async () => {
+    const result = await readLatestCodexSessionUsedPercent(
+      vi.fn().mockRejectedValue(new Error('fs unavailable')),
+      vi.fn(),
+      vi.fn()
+    )
+    expect(result).toBeNull()
+  })
+
+  it('returns null when reading the latest file throws', async () => {
+    const result = await readLatestCodexSessionUsedPercent(
+      vi.fn().mockResolvedValue(['/sessions/a.jsonl']),
+      vi.fn().mockResolvedValue({ mtimeMs: 1_000 }),
+      vi.fn().mockRejectedValue(new Error('read failed'))
+    )
+    expect(result).toBeNull()
+  })
+})

--- a/src/main/rate-limits/codex-session-log-usage.test.ts
+++ b/src/main/rate-limits/codex-session-log-usage.test.ts
@@ -134,4 +134,39 @@ describe('readLatestCodexSessionUsedPercent', () => {
     )
     expect(result).toBeNull()
   })
+
+  it('falls back to an older session file when the newest has no usable token_count event', async () => {
+    const listFiles = vi
+      .fn()
+      .mockResolvedValue(['/sessions/older.jsonl', '/sessions/newest.jsonl'])
+    const statFile = vi.fn(async (filePath: string) => ({
+      mtimeMs: filePath.includes('newest') ? 2_000 : 1_000
+    }))
+    const readFileFn = vi.fn(async (filePath: string) =>
+      filePath.includes('newest')
+        ? JSON.stringify({ type: 'session_meta', payload: { id: 'abc' } })
+        : tokenCountLine({ total_token_usage: { total_tokens: 40 }, model_context_window: 100 })
+    )
+    const result = await readLatestCodexSessionUsedPercent(listFiles, statFile, readFileFn)
+    expect(result).toBe(40)
+    expect(readFileFn).toHaveBeenCalledWith('/sessions/newest.jsonl')
+    expect(readFileFn).toHaveBeenCalledWith('/sessions/older.jsonl')
+  })
+
+  it('falls back to an older session file when reading the newest throws', async () => {
+    const listFiles = vi
+      .fn()
+      .mockResolvedValue(['/sessions/older.jsonl', '/sessions/newest.jsonl'])
+    const statFile = vi.fn(async (filePath: string) => ({
+      mtimeMs: filePath.includes('newest') ? 2_000 : 1_000
+    }))
+    const readFileFn = vi.fn(async (filePath: string) => {
+      if (filePath.includes('newest')) {
+        throw new Error('permission denied')
+      }
+      return tokenCountLine({ total_token_usage: { total_tokens: 5 }, model_context_window: 100 })
+    })
+    const result = await readLatestCodexSessionUsedPercent(listFiles, statFile, readFileFn)
+    expect(result).toBe(5)
+  })
 })

--- a/src/main/rate-limits/codex-session-log-usage.ts
+++ b/src/main/rate-limits/codex-session-log-usage.ts
@@ -70,24 +70,30 @@ export async function readLatestCodexSessionUsedPercent(
 ): Promise<number | null> {
   try {
     const files = await listFiles()
-    let latestPath: string | null = null
-    let latestMtimeMs = -Infinity
+    const candidates: { path: string; mtimeMs: number }[] = []
     for (const filePath of files) {
       try {
         const info = await statFile(filePath)
-        if (info.mtimeMs > latestMtimeMs) {
-          latestMtimeMs = info.mtimeMs
-          latestPath = filePath
-        }
+        candidates.push({ path: filePath, mtimeMs: info.mtimeMs })
       } catch {
         // Missing/unreadable file — another session log may still qualify.
       }
     }
-    if (!latestPath) {
-      return null
+    // Why: the newest session log may not have a token_count event yet (e.g. just
+    // created, no turns sent) — fall through to older logs rather than going dark.
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs)
+    for (const { path } of candidates) {
+      try {
+        const content = await readFileFn(path)
+        const usedPercent = extractCodexSessionUsedPercentFromLog(content)
+        if (usedPercent !== null) {
+          return usedPercent
+        }
+      } catch {
+        // Unreadable file — try the next-newest candidate.
+      }
     }
-    const content = await readFileFn(latestPath)
-    return extractCodexSessionUsedPercentFromLog(content)
+    return null
   } catch {
     return null
   }

--- a/src/main/rate-limits/codex-session-log-usage.ts
+++ b/src/main/rate-limits/codex-session-log-usage.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises'
+import { getProcessedFileInfo, listCodexSessionFiles } from '../codex-usage/scanner'
+
+type CodexTokenCountInfo = {
+  total_token_usage?: { total_tokens?: number }
+  last_token_usage?: { total_tokens?: number }
+  model_context_window?: number
+}
+
+function ensurePositiveNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : null
+}
+
+/**
+ * Extracts the used-percentage from the last `token_count` event in a Codex session log
+ * (a rollout .jsonl file). Exported standalone so it can be unit tested with fixture
+ * strings instead of real session files.
+ */
+export function extractCodexSessionUsedPercentFromLog(content: string): number | null {
+  const lines = content.split('\n')
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index].trim()
+    if (!line) {
+      continue
+    }
+    let record: unknown
+    try {
+      record = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (typeof record !== 'object' || record === null) {
+      continue
+    }
+    const { type, payload } = record as { type?: unknown; payload?: unknown }
+    if (type !== 'event_msg' || typeof payload !== 'object' || payload === null) {
+      continue
+    }
+    const { type: payloadType, info } = payload as { type?: unknown; info?: unknown }
+    if (payloadType !== 'token_count' || typeof info !== 'object' || info === null) {
+      continue
+    }
+    const typedInfo = info as CodexTokenCountInfo
+    const contextWindow = ensurePositiveNumber(typedInfo.model_context_window)
+    if (!contextWindow) {
+      continue
+    }
+    const totalTokens =
+      ensurePositiveNumber(typedInfo.total_token_usage?.total_tokens) ??
+      ensurePositiveNumber(typedInfo.last_token_usage?.total_tokens)
+    if (totalTokens === null) {
+      continue
+    }
+    return Math.min(100, Math.max(0, (totalTokens / contextWindow) * 100))
+  }
+  return null
+}
+
+/**
+ * Local, network-free fallback for Codex session usage: reads the most recently modified
+ * session log and returns the used-percentage from its last token_count event. Unlike
+ * Claude, Codex has no live per-turn push into Orca, so every usage refresh normally
+ * depends on reaching chatgpt.com — this is the only signal left when that's unreachable
+ * (e.g. on an internal network). Dependency-injected for testing without touching real fs.
+ */
+export async function readLatestCodexSessionUsedPercent(
+  listFiles: () => Promise<string[]> = listCodexSessionFiles,
+  statFile: (filePath: string) => Promise<{ mtimeMs: number }> = getProcessedFileInfo,
+  readFileFn: (filePath: string) => Promise<string> = (filePath) => readFile(filePath, 'utf8')
+): Promise<number | null> {
+  try {
+    const files = await listFiles()
+    let latestPath: string | null = null
+    let latestMtimeMs = -Infinity
+    for (const filePath of files) {
+      try {
+        const info = await statFile(filePath)
+        if (info.mtimeMs > latestMtimeMs) {
+          latestMtimeMs = info.mtimeMs
+          latestPath = filePath
+        }
+      } catch {
+        // Missing/unreadable file — another session log may still qualify.
+      }
+    }
+    if (!latestPath) {
+      return null
+    }
+    const content = await readFileFn(latestPath)
+    return extractCodexSessionUsedPercentFromLog(content)
+  } catch {
+    return null
+  }
+}

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -15,7 +15,7 @@ export type RateLimitBucket = RateLimitWindow & {
   name: string
 }
 
-export type UsageRateLimitSource = 'oauth' | 'cli' | 'web' | 'live-session'
+export type UsageRateLimitSource = 'oauth' | 'cli' | 'web' | 'live-session' | 'session-log'
 
 export type UsageRateLimitFailureKind =
   | 'missing-credentials'


### PR DESCRIPTION
## Summary
- Unlike Claude, Codex has no live per-turn push into Orca — every usage refresh goes through chatgpt.com (backend fetch, RPC app-server, or a PTY `/status` probe), all of which require reaching OpenAI's network. When all three fail, the usage bar went completely dark with no local fallback (see the related Claude fix in #11760 for the internal-network usage investigation this follows up on).
- Codex's own session log already records a `token_count` event with `total_token_usage` and `model_context_window` on every turn. `fetchCodexRateLimits` now reads the most recently modified session log's last `token_count` event as a last-resort, network-free usage signal when every network path returns a genuine error.
- Auth errors are explicitly excluded from the fallback — masking "you need to re-sign in" with a locally-derived `ok` would hide the one thing the user actually needs to act on.

## Testing
- [x] `pnpm typecheck` (targeted: `tsc --noEmit -p config/tsconfig.node.json`)
- [x] `pnpm lint` (targeted oxlint + type-aware + native-plugins + max-lines-ratchet + reliability-gates on changed files)
- [x] `pnpm test` (targeted: all `src/main/rate-limits/codex-*.test.ts` — 89 tests passing, including 21 pre-existing codex-fetcher tests unchanged and 2 new integration tests for the fallback)
- [x] `pnpm build` — not run; native module rebuild requires Visual Studio Build Tools not available in this environment (unrelated to this change, which is TS-only)

New coverage:
- `codex-session-log-usage.test.ts` — pure `token_count` parsing (last-event priority, `last_token_usage` fallback, malformed lines, missing `model_context_window`, clamping) and the file-selection wrapper via dependency injection
- `codex-fetcher.test.ts` — the fallback engaging when every network path exhausts to `status: 'error'`, and *not* engaging when the fetch was aborted

## AI Review Report
Reviewed with Claude Code. Checked: cross-platform (pure JSON/string parsing, no OS-specific paths — reuses the existing `codex-usage/scanner.ts` directory discovery which already handles Windows/WSL/macOS/Linux session locations), SSH/remote compatibility (session log discovery is unchanged, local-only by design since this is a local fallback), auth-error handling (verified via test that auth errors are never masked by the fallback — this was caught as a real bug during review: an early version applied the fallback to auth-error results too, which surfaced during testing as a live session on the dev machine getting silently marked "ok"), and regression safety (all pre-existing codex-fetcher and codex-fetcher-auth-errors tests pass unchanged).

## Security Audit
- Reads only local files already covered by the existing Codex session-log scanner's directory allowlist; no new file paths or write operations introduced.
- No new network calls, credentials, or IPC surface — purely a local-file read gated behind the same auth-presence check the rest of `fetchCodexRateLimits` already uses.
- JSON parsing is wrapped in try/catch per line; malformed session logs degrade to `null` rather than throwing.

## Notes
- `weekly` stays `null` in the fallback result since the local session log has no 7-day window data — only the 5-hour `session` window is populated.
- Twitter/X handle: not provided.