### PR TITLE
fix(mobile): refresh folder workspaces in Home catalog

### DIFF
--- a/mobile/src/worktree/host-worktree-refresh.test.ts
+++ b/mobile/src/worktree/host-worktree-refresh.test.ts
@@ -101,12 +101,14 @@ describe('startHostWorktreeRefresh', () => {
     expect(fetchRepoMetadata).not.toHaveBeenCalled()
   })
 
-  it('force-refreshes repo metadata on reposChanged', () => {
+  it('refreshes worktrees and repo metadata on reposChanged', () => {
     start()
+    fetchWorktrees.mockClear()
     fetchRepoMetadata.mockClear()
 
     eventListener?.({ type: 'reposChanged' })
 
+    expect(fetchWorktrees).toHaveBeenCalledOnce()
     expect(fetchRepoMetadata).toHaveBeenCalledOnce()
     expect(fetchRepoMetadata).toHaveBeenCalledWith({ force: true, queueIfInFlight: true })
   })

--- a/mobile/src/worktree/host-worktree-refresh.ts
+++ b/mobile/src/worktree/host-worktree-refresh.ts
@@ -69,6 +69,8 @@ export function startHostWorktreeRefresh({
         return
       }
       if (event.type === 'reposChanged') {
+        // Why: folder workspace mutations publish reposChanged, and worktree.ps owns this catalog.
+        void fetchWorktrees()
         void fetchRepoMetadata({ force: true, queueIfInFlight: true })
       } else if (event.type === 'worktreesChanged') {
         void fetchWorktrees()


### PR DESCRIPTION
## Summary

Fix Mobile Home so a runtime-created folder workspace enters the existing workspace catalog when its paired host publishes reposChanged. Search and selection use that same refreshed worktree.ps catalog.

This is a separate catalog invalidation fix from #11751; it does not change native-chat routing or readability.

## Before / after

Before: a folder workspace could exist on the paired host while Mobile Home and search continued showing the stale catalog. The reposChanged handler refreshed only decorative repo metadata.

After: reposChanged also requests the authoritative host-scoped worktree catalog, so folder workspaces and Git worktrees converge through the existing Home refresh path.

## Scope

The effective diff is two files and 5 additions / 1 deletion. It adds one existing read-only catalog refresh call plus its regression assertion.

There are no new timers, polling loops, caches, dependencies, protocol changes, UI changes, lockfile changes, or native changes. SSH and relay hosts keep using the same connection-scoped worktree.ps request on the host that emitted the event.

## Validation

Validated exact head 8112265ef6f2b8f1085eece3fc851ea5f7c52127 atop origin/main 278a4b28c84a4d3550a54b998bf3ff653e571a86:

- Focused regression: 5/5 passed.
- Full Mobile suite: 382 files passed; 2,851 tests passed and 3 skipped.
- Mobile typecheck, oxlint, and format check passed.
- Root typecheck and full lint passed, including 58 reliability gates and the max-lines ratchet.
- All 43 exact-head GitHub checks passed or were intentionally skipped.
- git diff --check passed.

## Native QA

Fresh exact-head native iPad revalidation passed on 8112265ef6f2b8f1085eece3fc851ea5f7c52127. The exact-head Mobile bundle ran on approved iPad C589AF84-2F0C-4978-952B-748933DE6804 at port 3101; the already-running approved iPhone 50FD514C-96F6-446E-AC90-D07A24CAB3A0 remained untouched at port 3100, and no third device or stream was started.

Using an authenticated, isolated direct-LAN Host 9 catalog:

- A folder workspace created after the host mounted appeared immediately from reposChanged, alongside the Git worktree, without relaunch or manual refresh.
- Search for `Exact` isolated only the folder result.
- Folder selection showed the correct folder name and `/tmp/pr11767-exact-head-ipad/folder-catalog` identity; switching to the Git row showed `brennanb2025/mobile-folder-workspace-catalog-refresh`.
- A second reposChanged rename converged to exactly one renamed folder row and one Git row: the old folder label count was 0, so there was no stale or duplicate entry.
- Home-backgrounding, Spotlight foregrounding, and a full runtime stop/restart on the same endpoint remounted the authenticated host. Host 9 retained exactly one folder and one Git row, refreshed its device `lastSeenAt`, and showed no pairing or reachability error.

![Folder workspace appears immediately](https://github.com/user-attachments/assets/d71f749f-427f-4d36-ab0a-dbc8d363ad15)

![Folder workspace search](https://github.com/user-attachments/assets/35f5d3d8-1c4f-4409-b521-eb4ef85537de)

![Folder workspace selected](https://github.com/user-attachments/assets/0f1df718-9f34-494f-a55c-1d2946da6eec)

![Git worktree selected](https://github.com/user-attachments/assets/fb17f54e-1b99-4b62-8f6b-6f562a711e98)

![Authenticated runtime reconnect](https://github.com/user-attachments/assets/c7da7c90-bd23-4631-bd7d-cc41cd2a777b)

SSH/Relay was not exercised: the iPad's previously saved targets were offline or stale, and no already-available SSH or Relay mobile target permitted a safe additional lane. The successful revalidation used the supported headless direct-LAN pairing path and did not automate the desktop Electron UI.

## AI review

A genuinely fresh same-model gpt-5.6-sol xhigh review on exact head 8112265ef6f2b8f1085eece3fc851ea5f7c52127 returned literal CLEAN. The read-only review traced event and catalog authority, host/client scope, folder-workspace and Git-worktree behavior, SSH/relay semantics, reconnect and polling interactions, regression and performance risk, security scope, tests, and this PR body; its 25 focused tests and git diff --check passed.
