### PR TITLE
fix(orchestration): mark fresh workers in environment

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5342,7 +5342,14 @@ describe('OrcaRuntimeService', () => {
       getSettings: () => ({
         ...store.getSettings(),
         terminalWindowsShell: 'cmd.exe',
-        agentCmdOverrides: {}
+        agentCmdOverrides: {},
+        agentDefaultEnv: {
+          codex: {
+            ORCA_ORCH_ROLE: 'coordinator',
+            ORCA_ORCH_DEPTH: '0',
+            EXISTING_AGENT_ENV: 'preserved'
+          }
+        }
       }),
       getRepos: () => [remoteRepo],
       getRepo: (id: string) => (id === TEST_REPO_ID ? remoteRepo : undefined),
@@ -5418,7 +5425,8 @@ describe('OrcaRuntimeService', () => {
           command: "codex '--dangerously-bypass-approvals-and-sandbox' 'hi'",
           env: expect.objectContaining({
             ORCA_ORCH_ROLE: 'worker',
-            ORCA_ORCH_DEPTH: '1'
+            ORCA_ORCH_DEPTH: '1',
+            EXISTING_AGENT_ENV: 'preserved'
           }),
           worktreeId: result.worktree.id
         })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5407,6 +5407,7 @@ describe('OrcaRuntimeService', () => {
         repoSelector: TEST_REPO_ID,
         name: 'agent-feature',
         startupAgent: 'codex',
+        startupAgentEnv: { ORCA_ORCH_ROLE: 'worker', ORCA_ORCH_DEPTH: '1' },
         startupPrompt: 'hi',
         activate: true
       })
@@ -5415,6 +5416,10 @@ describe('OrcaRuntimeService', () => {
         expect.objectContaining({
           cwd: '/remote/agent-feature',
           command: "codex '--dangerously-bypass-approvals-and-sandbox' 'hi'",
+          env: expect.objectContaining({
+            ORCA_ORCH_ROLE: 'worker',
+            ORCA_ORCH_DEPTH: '1'
+          }),
           worktreeId: result.worktree.id
         })
       )

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -20520,6 +20520,7 @@ export class OrcaRuntimeService {
     observeSetupCompletion?: boolean
     createdWithAgent?: TuiAgent
     startupAgent?: TuiAgent
+    startupAgentEnv?: Record<string, string>
     startupPrompt?: string
     pendingFirstAgentMessageRename?: boolean
     automationProvenance?: AutomationWorkspaceProvenance
@@ -20558,7 +20559,14 @@ export class OrcaRuntimeService {
       !args.startup && !agentStartup && args.startupDraft
         ? await this.buildStartupForDraft(repo, args.startupDraft, requestedAgent)
         : null
-    const effectiveStartup = args.startup ?? agentStartup?.startup ?? draftStartup?.startup
+    const resolvedStartup = args.startup ?? agentStartup?.startup ?? draftStartup?.startup
+    const effectiveStartup =
+      resolvedStartup && args.startupAgentEnv
+        ? {
+            ...resolvedStartup,
+            env: { ...resolvedStartup.env, ...args.startupAgentEnv }
+          }
+        : resolvedStartup
     const effectiveStartupFollowup = agentStartup?.followup
     const effectiveCreatedWithAgent = args.startup
       ? args.createdWithAgent

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -2,6 +2,11 @@ import type { TuiAgent } from '../../../../shared/types'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
 
+const ORCHESTRATION_WORKER_ENV = {
+  ORCA_ORCH_ROLE: 'worker',
+  ORCA_ORCH_DEPTH: '1'
+}
+
 export type WorkerEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
   action?: string
@@ -60,6 +65,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
 }): Promise<{ handle: string; warning?: string }> {
   const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
     command: args.agent,
+    env: ORCHESTRATION_WORKER_ENV,
     title: `worker-${args.taskId}`,
     // Why: dispatching a worker is background work; it must not pull the sidebar
     // to the worker's workspace while the user is reading somewhere else.
@@ -135,6 +141,7 @@ export async function createWorkerWorktree(args: {
     observeSetupCompletion: true,
     createdWithAgent: args.agent,
     startupAgent: args.agent,
+    startupAgentEnv: ORCHESTRATION_WORKER_ENV,
     activate: false,
     lineage: {
       parentWorktree: requestedWorktree === 'new-child' ? coordinatorWorktree.id : undefined,

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -132,6 +132,7 @@ describe('orchestration new-worktree workers', () => {
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
       expect.objectContaining({
         startupAgent: 'codex',
+        startupAgentEnv: { ORCA_ORCH_ROLE: 'worker', ORCA_ORCH_DEPTH: '1' },
         awaitTerminalProvisioning: true,
         observeSetupCompletion: true,
         lineage: expect.objectContaining({ noParent: true, parentWorktree: undefined })

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -2180,6 +2180,7 @@ describe('orchestration RPC methods', () => {
       // the tab without scrolling the sidebar to the worker's workspace.
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
         command: 'codex',
+        env: { ORCA_ORCH_ROLE: 'worker', ORCA_ORCH_DEPTH: '1' },
         title: `worker-${task.id}`,
         surfaceOwner: false
       })


### PR DESCRIPTION
## Summary

Fresh workers created by `orchestration.workerStart` now receive `ORCA_ORCH_ROLE=worker` and `ORCA_ORCH_DEPTH=1`.

- Pass the markers to fresh terminals in existing worktrees and folder workspaces.
- Merge the markers into startup-agent environments for new local and SSH worktrees.
- Preserve existing startup environment values while applying the worker markers.

This lets inherited agent hooks distinguish top-level coordinators from dispatched workers without relying on prompt text.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint not run; the pre-commit hook passed oxlint and react-doctor oxlint for all changed files.
- [ ] `pnpm typecheck` — full multi-target typecheck not run; `tsc --noEmit -p config/tsconfig.node.json` passed.
- [ ] `pnpm test` — full suite not run; three focused worker-environment tests passed.
- [ ] `pnpm build` — not run because this is a focused runtime patch before release integration.
- [x] Added or updated high-quality tests that would catch regressions.

Focused tests covered:

- Fresh worker creation in the coordinator current worktree.
- New top-level worktree agent-terminal reuse.
- SSH startup-agent environment propagation, existing environment preservation, and worker-marker precedence.

The updated SSH precedence test passed after review. Formatting checks and `git diff --check` also passed.

## AI Review Report

The coordinator reviewed the complete five-file product diff and traced the environment through existing-worktree `createTerminal`, new-worktree `createManagedWorktree`, folder workspace, local startup, and SSH startup paths. The review checked merge precedence, preservation of existing startup environment entries, and the explicit existing-terminal reuse limitation.

An independent Claude Fable high review was attempted with a five-minute cap. It expanded beyond its assigned five-file scope and did not return a verdict before the cap, so it was stopped and is not represented as a passing review.

Greptile rated the change 4/5 and safe to merge. It flagged two future-contract concerns: env-only startup calls and nested orchestration depth. The current worker path always pairs `startupAgentEnv` with `startupAgent`, whose startup builder returns a valid launch or throws, and the current orchestration contract is intentionally one level. CodeRabbit requested explicit coverage for conflicting worker markers and preservation of unrelated startup environment values; commit `ad4eaf1` added that coverage.

Cross-platform compatibility was reviewed explicitly for macOS, Linux, and Windows. The patch adds no platform-specific shortcuts, labels, paths, shell behavior, or Electron behavior and uses the existing platform-neutral environment maps. The SSH path has focused coverage; Windows was reviewed statically but not exercised live.

## Security Audit

The patch adds two fixed non-secret environment values and does not accept new user input. It changes no command construction, path handling, authentication, IPC authorization, dependency, or secret flow. Worker markers intentionally override conflicting values at the final startup merge so a dispatched fresh worker cannot inherit a coordinator role.

## Notes

A process supplied through `worker-start --terminal` already exists before dispatch, so its parent environment cannot be changed retroactively. This PR covers every fresh worker created by Orca, including current/existing worktrees and new local or SSH worktrees; callers reusing a terminal must launch that terminal with the worker markers already present.

Nested worker dispatch is not supported by this change. `ORCA_ORCH_DEPTH=1` represents the current one-level worker contract; a future nested-orchestration feature would require end-to-end incrementing depth propagation.

Contributor X handle: not provided.
