### PR TITLE
fix: preserve worker stop after terminal exit race

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25737,6 +25737,34 @@ describe('OrcaRuntimeService', () => {
     expect(closeTerminal).toHaveBeenCalledWith('laptop-tab')
   })
 
+  it('keeps a successful close receipt when PTY exit retires the tab first', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'laptop-created-pty' })
+    let runtime!: OrcaRuntimeService
+    const kill = vi.fn(() => {
+      runtime.onPtyExit('laptop-created-pty', 0)
+      return true
+    })
+    runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null
+    })
+
+    const terminal = await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, {
+      tabId: 'laptop-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+
+    await expect(runtime.closeTerminal(terminal.handle)).resolves.toEqual({
+      handle: terminal.handle,
+      tabId: 'laptop-tab',
+      ptyKilled: true
+    })
+    expect(kill).toHaveBeenCalledWith('laptop-created-pty')
+  })
+
   it('waits for renderer acknowledgement before returning a whole-tab close receipt', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -25462,10 +25462,13 @@ export class OrcaRuntimeService {
           try {
             await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId)
           } catch (error) {
-            if (!(error instanceof Error) || error.message !== 'workspace_session_unavailable') {
+            const reason = error instanceof Error ? error.message : null
+            // Why: a successful kill can synchronously retire its tab, so its follow-up tab_not_found is idempotent success.
+            if (reason === 'workspace_session_unavailable') {
+              this.notifier?.closeTerminal(tabId)
+            } else if (!ptyKilled || reason !== 'tab_not_found') {
               throw error
             }
-            this.notifier?.closeTerminal(tabId)
           }
         } else {
           this.notifier?.closeTerminal(tabId)


### PR DESCRIPTION
## Summary

- Treat tab_not_found after a confirmed PTY kill as an idempotent terminal close.
- Prevent orchestration worker-stop from reporting stop_unknown after its exact process already exited.
- Add a regression test for synchronous PTY exit retiring the tab before follow-up session cleanup.

## Screenshots

No visual change.

## Testing

- [ ] pnpm lint — full repository lint not run; changed-file formatting passed.
- [ ] pnpm typecheck — full multi-target typecheck not run; the Node TypeScript check passed.
- [ ] pnpm test — full suite not run; the focused race and orchestration stop tests passed, and all 7 worker recovery tests passed.
- [ ] pnpm build — release build not run; an isolated Electron development build was used for the live canary.
- [x] Added a focused regression test that fails with tab_not_found before the fix.

An integrated live canary on origin/main plus PRs #11773 and #11774 observed:

- Fresh Claude worker output: ROLE=worker DEPTH=1.
- worker-stop result: state=stopped, processAction=closed_agent_terminal, ptyKilled=true.
- worker-show result: state=stopped, stage=process_stopped, exact process status=exited.
- The worker terminal was absent from the live terminal list, all canary terminals were closed, and production Orca 1.4.162 remained ready.

## AI Review Report

The coordinator reproduced the exact tab_not_found race, reviewed the two-file diff, and verified the live worker lifecycle with both related PRs applied. Greptile rated the change 5/5 and safe to merge. CodeRabbit produced no actionable code comments; its description-template warning is addressed by this update.

## Security Audit

The exception is limited to tab_not_found after the PTY controller confirms a successful kill. A failed kill, pin rejection, timeout, workspace error, non-Error exception, and every unrelated failure retain their prior behavior. The patch changes no authentication, authorization, command construction, user input, dependency, or secret flow.

## Notes

The runtime logic is platform-neutral and adds no filesystem or shell assumptions. The live canary ran on macOS; Linux and Windows were reviewed statically but not exercised live. Full repository regression and release builds remain release-boundary CI work.

Contributor X handle: not provided.
