### PR TITLE
fix(terminal): stop IME newline defer holding Shift+Enter with no composition (#10203)

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -47,6 +47,16 @@ describe('sendTerminalInputAfterComposition', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
+  it('sends on the next macrotask when no composition is pending instead of waiting for the fallback (#10203)', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    // Why: with no pending composition the newline must not be held for the 200ms fallback.
+    vi.advanceTimersByTime(1)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
   it('finishes from the captured xterm transaction when deferral starts after compositionend', () => {
     const el = document.createElement('div')
     const send = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -15,6 +15,14 @@ export function sendTerminalInputAfterComposition(
     return
   }
 
+  // Why: only hold the newline while an IME composition is genuinely pending; otherwise the
+  // 200ms fallback delays every modified-Enter (Shift+Enter newline) on Windows even when no
+  // composition is active, surfacing as a brief input freeze vs non-Enter chords like Alt+J (#10203).
+  if (!hasPendingTerminalImeComposition(terminalElement)) {
+    window.setTimeout(send, 0)
+    return
+  }
+
   const fallbackMs = options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS
   let done = false
 


### PR DESCRIPTION
## Summary

Fixes the "Pi input freezes briefly on Shift+Enter" symptom from #10203 — and more precisely, the freeze anyone sees on Windows when comparing Shift+Enter (freezes ~200ms before the newline lands) vs Alt+J (smooth).

### Root cause

On Windows, Shift+Enter is a *modified-Enter chord*. `keyboard-handlers.ts` routes modified Enter through the IME deferred-newline path:

\`\`\`ts
if ((e.isComposing || hasPendingImeComposition) && (e.key === 'Enter' || imeProcessEnter)) {
  ...
  deferredNewlineSender.defer(e, pane.terminal.element, sendResolvedInput)
  return
}
\`\`\`

`defer()` calls \`sendTerminalInputAfterComposition\`, which **always** armed a 200ms fallback timer and waited for \`compositionend\` / a captured xterm transaction end — even when **no IME composition was actually pending**:

\`\`\`ts
const fallbackTimer = window.setTimeout(finish, fallbackMs)   // 200ms
\`\`\`

When no compositionend arrives (the common case: IME idle, or no IME), the newline is held for the full \`TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200\` — the visible "brief freeze before the newline is accepted."

Alt+J is **not** an Enter chord (\`e.key !== 'Enter'\`), so it never enters this defer and is sent immediately — which is exactly why Alt+J is smooth and Shift+Enter is not.

### Fix

Only hold the newline while a composition is **genuinely pending** (\`hasPendingTerminalImeComposition\`). If nothing is pending, send on the next macrotask (matching the existing no-terminal-element path). Genuine pending compositions still wait for \`compositionend\` / the captured xterm transaction to settle, so IME correctness is preserved.

\`\`\`ts
if (!hasPendingTerminalImeComposition(terminalElement)) {
  window.setTimeout(send, 0)
  return
}
\`\`\`

## Test

New regression case in \`terminal-ime-deferred-newline.test.ts\`: with no pending composition, \`sendTerminalInputAfterComposition\` sends on the next macrotask instead of waiting for the 200ms fallback. This test **fails on main** (\`expected 1, got 0\` after \`advanceTimersByTime(1)\`) and passes with the fix.

All 33 existing \`terminal-ime-deferred-newline\` tests still pass, including the overlapping-transaction and compositionend-flush cases.

## Verification

- \`pnpm typecheck\` — clean.
- \`pnpm exec vitest run terminal-ime-deferred-newline.test.ts\` — 33/33 pass (incl. new regression test, which fails on \`main\`).
- \`pnpm exec oxlint\` + \`pnpm exec oxfmt --check\` on changed files — clean.
- (\`keyboard-handlers-ime.test.tsx\` fails to load on this host due to a pre-existing \`@/lib/...\` alias resolution issue that also fails on \`main\`; unrelated to this change.)

## Cross-platform / compatibility notes

- Windows-only in effect (the defer is gated \`isWindows\` in \`keyboard-handlers.ts\`); macOS/Linux paths untouched.
- Agent-agnostic: applies to any agent whose Shift+Enter enters the defer (Pi, and any other modified-Enter user). This is the likely root cause of the Pi-specific freeze reported in #10203; the "only Pi" framing there is most likely because Pi is where multiline Shift+Enter input is most used.
- No UI/visual change. No perf risk — it removes a 200ms wait, and the pending-composition check is a \`WeakMap\` lookup.
- IME correctness preserved: real pending compositions still defer until \`compositionend\`/transaction end.

## Reviewer checklist

- [x] Cross-platform: Windows fix; macOS/Linux untouched
- [x] SSH/remote/local: input path is renderer-local; unaffected by transport
- [x] Agent/integration: agent-agnostic; no per-agent config changed
- [x] Performance: removes a 200ms hold; check is O(1)
- [x] Security: no new surface

Closes #10203

X handle: @itisvincent