### PR TITLE
[codex] Add OpenInterpreter agent preset

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -570,7 +570,8 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "openinterpreter": "OpenInterpreter"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -306,6 +306,15 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     cmd: 'openclaw',
     faviconDomain: 'openclaw.ai',
     homepageUrl: 'https://github.com/openclaw/openclaw'
+  },
+  {
+    id: 'openinterpreter',
+    label: translate('auto.lib.agent.catalog.openinterpreter', 'OpenInterpreter'),
+    cmd: 'interpreter',
+    faviconDomain: 'openinterpreter.com',
+    // Why: the undetected-agent Settings row uses this URL as its Install
+    // action; link to the cross-platform quickstart instead of a source repo.
+    homepageUrl: 'https://www.openinterpreter.com/docs/terminal/quickstart'
   }
 ])
 

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -133,7 +133,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   grok: true,
   devin: true,
   ante: true,
-  trae: true
+  trae: true,
+  openinterpreter: true
 }
 
 // Why: return null (not a 'claude' fallback) for unknown so Codex panes don't flash the Claude icon before the hook fires.

--- a/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
+++ b/src/renderer/src/lib/quick-workspace-agent-selection.test.ts
@@ -12,6 +12,12 @@ describe('pickQuickWorkspaceAgent', () => {
     expect(new Set(TUI_AGENT_AUTO_PICK_ORDER).size).toBe(TUI_AGENT_AUTO_PICK_ORDER.length)
   })
 
+  it('uses the cross-platform OpenInterpreter quickstart for the install action', () => {
+    expect(AGENT_CATALOG.find((agent) => agent.id === 'openinterpreter')?.homepageUrl).toBe(
+      'https://www.openinterpreter.com/docs/terminal/quickstart'
+    )
+  })
+
   it('uses the first enabled catalog agent while detection is pending', () => {
     expect(pickQuickWorkspaceAgent(null, null, [])).toBe('claude')
     expect(pickQuickWorkspaceAgent(null, null, ['claude'])).toBe('claude-agent-teams')

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -49,7 +49,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   grok: 'grok',
   devin: 'devin',
   ante: 'ante',
-  trae: 'trae'
+  trae: 'trae',
+  openinterpreter: 'openinterpreter'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -47,6 +47,7 @@ export type WellKnownAgentType =
   | 'devin'
   | 'ante'
   | 'trae'
+  | 'openinterpreter'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -49,7 +49,9 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   devin: 'devin',
   ante: null,
   // Why: Orca detects trae by `traecli`, an alias only TRAE CN ships.
-  trae: 'trae-cn'
+  trae: 'trae-cn',
+  // Why: OpenInterpreter does not have a documented skills CLI namespace yet.
+  openinterpreter: null
 } satisfies Record<TuiAgent, string | null>
 
 /**

--- a/src/shared/telemetry-property-schemas.ts
+++ b/src/shared/telemetry-property-schemas.ts
@@ -44,6 +44,7 @@ export const AGENT_KIND_VALUES = [
   'devin',
   'ante',
   'trae',
+  'openinterpreter',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -26,8 +26,6 @@ export type TuiAgentConfig = {
   /** Detection runtimes where this launch mode is not available as a detected agent. */
   detectUnsupportedRuntimes?: readonly TuiAgentDetectionRuntime[]
   launchCmd: string
-  /** Optional Agent Client Protocol entry point for agents that expose one. */
-  acpLaunchCmd?: string
   /** Platform-specific launch command when the public binary name differs. */
   launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
   expectedProcess: string
@@ -294,7 +292,6 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     // an unrelated executable with the same name.
     detectCmd: 'interpreter',
     launchCmd: 'interpreter',
-    acpLaunchCmd: 'interpreter acp',
     expectedProcess: 'interpreter',
     promptInjectionMode: 'stdin-after-start'
   }

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -26,6 +26,8 @@ export type TuiAgentConfig = {
   /** Detection runtimes where this launch mode is not available as a detected agent. */
   detectUnsupportedRuntimes?: readonly TuiAgentDetectionRuntime[]
   launchCmd: string
+  /** Optional Agent Client Protocol entry point for agents that expose one. */
+  acpLaunchCmd?: string
   /** Platform-specific launch command when the public binary name differs. */
   launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
   expectedProcess: string
@@ -284,6 +286,16 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
   devin: {
     detectCmd: 'devin',
     // Why: `devin -- <prompt>` auto-submits immediately (docs.devin.ai/cli), so start the REPL with no argv prompt.
+    promptInjectionMode: 'stdin-after-start'
+  },
+  openinterpreter: {
+    // Why: OpenInterpreter's documented terminal entry point is the generic
+    // `interpreter` binary. Keep it last in auto-pick order to avoid claiming
+    // an unrelated executable with the same name.
+    detectCmd: 'interpreter',
+    launchCmd: 'interpreter',
+    acpLaunchCmd: 'interpreter acp',
+    expectedProcess: 'interpreter',
     promptInjectionMode: 'stdin-after-start'
   }
 }

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -41,7 +41,8 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   hermes: 'Hermes',
   openclaw: 'OpenClaw',
   copilot: 'GitHub Copilot',
-  grok: 'Grok'
+  grok: 'Grok',
+  openinterpreter: 'OpenInterpreter'
 }
 
 /** Canonical agent id list derived from the exhaustive display-name record,

--- a/src/shared/tui-agent-selection.test.ts
+++ b/src/shared/tui-agent-selection.test.ts
@@ -16,6 +16,10 @@ describe('pickTuiAgent', () => {
     expect(pickTuiAgent(null, ['continue', 'command-code'])).toBe('command-code')
   })
 
+  it('keeps the generic OpenInterpreter binary last in auto-pick order', () => {
+    expect(pickTuiAgent(null, ['openinterpreter', 'cursor'])).toBe('cursor')
+  })
+
   it('respects the explicit blank terminal preference', () => {
     expect(pickTuiAgent('blank', ['cursor', 'claude'])).toBeNull()
   })

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -39,7 +39,8 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
-  'openclaw'
+  'openclaw',
+  'openinterpreter'
 ] as const satisfies readonly TuiAgent[]
 
 // Why: fresh installs should expose Claude Agent Teams in agent pickers; the

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -717,8 +717,7 @@ describe('tui agent startup plans', () => {
     expect(resolveTuiAgentLaunchArgs('devin', null)).toBe('--permission-mode bypass')
   })
 
-  it('exposes OpenInterpreter terminal and ACP launch points', () => {
+  it('exposes the OpenInterpreter terminal launch point', () => {
     expect(TUI_AGENT_CONFIG.openinterpreter.launchCmd).toBe('interpreter')
-    expect(TUI_AGENT_CONFIG.openinterpreter.acpLaunchCmd).toBe('interpreter acp')
   })
 })

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -716,4 +716,9 @@ describe('tui agent startup plans', () => {
   it('appends Devin default permission-mode bypass before stdin prompt delivery', () => {
     expect(resolveTuiAgentLaunchArgs('devin', null)).toBe('--permission-mode bypass')
   })
+
+  it('exposes OpenInterpreter terminal and ACP launch points', () => {
+    expect(TUI_AGENT_CONFIG.openinterpreter.launchCmd).toBe('interpreter')
+    expect(TUI_AGENT_CONFIG.openinterpreter.acpLaunchCmd).toBe('interpreter acp')
+  })
 })

--- a/src/shared/tui-agent.ts
+++ b/src/shared/tui-agent.ts
@@ -37,3 +37,4 @@ export type TuiAgent =
   | 'ante' // Ante (Antigma Labs)
   | 'trae' // Trae CLI
   | 'prime-agent' // Prime Agent (Prime Intellect)
+  | 'openinterpreter' // OpenInterpreter


### PR DESCRIPTION
## Summary

- Add OpenInterpreter as a first-class Orca TUI agent preset.
- Detect and launch the documented `interpreter` terminal command using the existing interactive stdin prompt flow.
- Register the agent across selection, status, catalog, localization, telemetry, and skills metadata.
- Link the undetected-agent install action to the official OpenInterpreter quickstart.

Related to #9125

## Implementation

The preset uses `interpreter` for detection, launch, and process matching, and is placed last in automatic selection because the executable name is generic. The catalog exposes the official quickstart URL for installation.

## ACP scope

OpenInterpreter documents `interpreter acp` as an Agent Client Protocol server over stdio. Orca's current TUI preset path is PTY/stdin-based and does not contain an ACP client or runtime adapter, so this PR records no ACP runtime behavior and does not launch `interpreter acp`. A complete ACP integration should be a separate provider/client change.

## Validation

- The branch is based on the current `stablyai/main` at `fbe94ceff686e01d40a55570eb12321c61e9f970`.
- The PR contains two commits and 14 changed files (`+48/-6`); no unrelated synchronization files remain in the final tree.
- Local test execution on the current head remains pending because a complete checkout could not be prepared in the Windows environment.
- GitHub reports successful Greptile review and community-PR tracking for the current head. The repository's `PR Checks` and `PR test LoC` workflows are `action_required` with no jobs, so those project checks have not executed.

## Compatibility

This adds a new optional preset and preserves existing agent defaults and launch behavior. No new process execution path is introduced.
