### PR TITLE
fix(mobile): keep pairing Save hit target aligned above keyboard

### DIFF
--- a/mobile/src/components/TextInputModal.test.ts
+++ b/mobile/src/components/TextInputModal.test.ts
@@ -1,0 +1,80 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TextInputModal } from './TextInputModal'
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  Pressable: 'Pressable',
+  StyleSheet: { create: (styles: unknown) => styles },
+  Text: 'Text',
+  TextInput: 'TextInput',
+  View: 'View'
+}))
+
+vi.mock('./BottomDrawer', () => ({
+  BottomDrawer: ({ children }: { children: unknown }) => children
+}))
+
+function renderModal(defaultValue: string, onSubmit = vi.fn()): ReactTestRenderer {
+  let renderer: ReactTestRenderer | null = null
+  act(() => {
+    renderer = create(
+      createElement(TextInputModal, {
+        defaultValue,
+        onCancel: vi.fn(),
+        onSubmit,
+        title: 'Paste pairing code',
+        visible: true
+      })
+    )
+  })
+  if (!renderer) {
+    throw new Error('Text input modal did not render')
+  }
+  return renderer
+}
+
+describe('TextInputModal actions', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exposes an enabled 44pt Save action and submits its trimmed value', () => {
+    const onSubmit = vi.fn()
+    const renderer = renderModal('  orca://pair?code=abc  ', onSubmit)
+    const save = renderer.root
+      .findAllByType('Pressable')
+      .find((node) => node.props.accessibilityLabel === 'Save')
+
+    expect(save?.props.accessibilityRole).toBe('button')
+    expect(save?.props.accessibilityState).toEqual({ disabled: false })
+    expect(save?.props.style({ pressed: false })[0]).toMatchObject({ minHeight: 44 })
+
+    act(() => save?.props.onPress())
+    expect(onSubmit).toHaveBeenCalledWith('orca://pair?code=abc')
+    act(() => renderer.unmount())
+  })
+
+  it('reports the Save action as disabled when validation blocks submission', () => {
+    const renderer = renderModal('   ')
+    const save = renderer.root
+      .findAllByType('Pressable')
+      .find((node) => node.props.accessibilityLabel === 'Save')
+
+    expect(save?.props.disabled).toBe(true)
+    expect(save?.props.accessibilityState).toEqual({ disabled: true })
+    act(() => renderer.unmount())
+  })
+})

--- a/mobile/src/components/TextInputModal.test.ts
+++ b/mobile/src/components/TextInputModal.test.ts
@@ -65,12 +65,17 @@ describe('TextInputModal actions', () => {
     vi.restoreAllMocks()
   })
 
-  it('exposes an enabled 44pt Save action and submits its trimmed value', () => {
+  it('enables a 44pt Save action after paste and submits its trimmed value', () => {
     const onSubmit = vi.fn()
-    const renderer = renderModal('  orca://pair?code=abc  ', onSubmit)
+    const renderer = renderModal('', onSubmit)
+    const input = renderer.root.findByType('TextInput')
+
+    expect(findAction(renderer, 'Save').props.disabled).toBe(true)
+    act(() => input.props.onChangeText('  orca://pair?code=abc  '))
     const save = findAction(renderer, 'Save')
 
     expect(save.props.accessibilityRole).toBe('button')
+    expect(save.props.disabled).toBe(false)
     expect(save.props.accessibilityState).toEqual({ disabled: false })
     expect(save.props.style({ pressed: false })[0]).toMatchObject({ minHeight: 44 })
 
@@ -102,11 +107,14 @@ describe('TextInputModal actions', () => {
   })
 
   it('reports the Save action as disabled when validation blocks submission', () => {
-    const renderer = renderModal('   ')
+    const onSubmit = vi.fn()
+    const renderer = renderModal('   ', onSubmit)
     const save = findAction(renderer, 'Save')
 
     expect(save.props.disabled).toBe(true)
     expect(save.props.accessibilityState).toEqual({ disabled: true })
+    act(() => renderer.root.findByType('TextInput').props.onSubmitEditing())
+    expect(onSubmit).not.toHaveBeenCalled()
     act(() => renderer.unmount())
   })
 })

--- a/mobile/src/components/TextInputModal.test.ts
+++ b/mobile/src/components/TextInputModal.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TextInputModal } from './TextInputModal'
 
@@ -16,13 +16,17 @@ vi.mock('./BottomDrawer', () => ({
   BottomDrawer: ({ children }: { children: unknown }) => children
 }))
 
-function renderModal(defaultValue: string, onSubmit = vi.fn()): ReactTestRenderer {
+function renderModal(
+  defaultValue: string,
+  onSubmit = vi.fn(),
+  onCancel = vi.fn()
+): ReactTestRenderer {
   let renderer: ReactTestRenderer | null = null
   act(() => {
     renderer = create(
       createElement(TextInputModal, {
         defaultValue,
-        onCancel: vi.fn(),
+        onCancel,
         onSubmit,
         title: 'Paste pairing code',
         visible: true
@@ -33,6 +37,16 @@ function renderModal(defaultValue: string, onSubmit = vi.fn()): ReactTestRendere
     throw new Error('Text input modal did not render')
   }
   return renderer
+}
+
+function findAction(renderer: ReactTestRenderer, label: string): ReactTestInstance {
+  const action = renderer.root
+    .findAllByType('Pressable')
+    .find((node) => node.props.accessibilityLabel === label)
+  if (!action) {
+    throw new Error(`${label} action did not render`)
+  }
+  return action
 }
 
 describe('TextInputModal actions', () => {
@@ -54,27 +68,45 @@ describe('TextInputModal actions', () => {
   it('exposes an enabled 44pt Save action and submits its trimmed value', () => {
     const onSubmit = vi.fn()
     const renderer = renderModal('  orca://pair?code=abc  ', onSubmit)
-    const save = renderer.root
-      .findAllByType('Pressable')
-      .find((node) => node.props.accessibilityLabel === 'Save')
+    const save = findAction(renderer, 'Save')
 
-    expect(save?.props.accessibilityRole).toBe('button')
-    expect(save?.props.accessibilityState).toEqual({ disabled: false })
-    expect(save?.props.style({ pressed: false })[0]).toMatchObject({ minHeight: 44 })
+    expect(save.props.accessibilityRole).toBe('button')
+    expect(save.props.accessibilityState).toEqual({ disabled: false })
+    expect(save.props.style({ pressed: false })[0]).toMatchObject({ minHeight: 44 })
 
-    act(() => save?.props.onPress())
+    act(() => save.props.onPress())
     expect(onSubmit).toHaveBeenCalledWith('orca://pair?code=abc')
+    act(() => renderer.unmount())
+  })
+
+  it('submits the trimmed value from the keyboard Return action', () => {
+    const onSubmit = vi.fn()
+    const renderer = renderModal('  bare-pairing-code  ', onSubmit)
+
+    act(() => renderer.root.findByType('TextInput').props.onSubmitEditing())
+
+    expect(onSubmit).toHaveBeenCalledWith('bare-pairing-code')
+    act(() => renderer.unmount())
+  })
+
+  it('exposes a 44pt Cancel button and invokes cancellation', () => {
+    const onCancel = vi.fn()
+    const renderer = renderModal('pairing-code', vi.fn(), onCancel)
+    const cancel = findAction(renderer, 'Cancel')
+
+    expect(cancel.props.accessibilityRole).toBe('button')
+    expect(cancel.props.style({ pressed: false })[0]).toMatchObject({ minHeight: 44 })
+    act(() => cancel.props.onPress())
+    expect(onCancel).toHaveBeenCalledOnce()
     act(() => renderer.unmount())
   })
 
   it('reports the Save action as disabled when validation blocks submission', () => {
     const renderer = renderModal('   ')
-    const save = renderer.root
-      .findAllByType('Pressable')
-      .find((node) => node.props.accessibilityLabel === 'Save')
+    const save = findAction(renderer, 'Save')
 
-    expect(save?.props.disabled).toBe(true)
-    expect(save?.props.accessibilityState).toEqual({ disabled: true })
+    expect(save.props.disabled).toBe(true)
+    expect(save.props.accessibilityState).toEqual({ disabled: true })
     act(() => renderer.unmount())
   })
 })

--- a/mobile/src/components/TextInputModal.tsx
+++ b/mobile/src/components/TextInputModal.tsx
@@ -87,19 +87,29 @@ export function TextInputModal({
 
       <View style={styles.actions}>
         <Pressable
-          style={({ pressed }) => [styles.cancelButton, pressed && styles.buttonPressed]}
+          style={({ pressed }) => [
+            styles.actionButton,
+            styles.cancelButton,
+            pressed && styles.buttonPressed
+          ]}
           onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel"
         >
           <Text style={styles.cancelText}>Cancel</Text>
         </Pressable>
         <Pressable
           style={({ pressed }) => [
+            styles.actionButton,
             styles.submitButton,
             pressed && styles.buttonPressed,
             !canSubmit && styles.submitButtonDisabled
           ]}
           disabled={!canSubmit}
           onPress={handleSubmit}
+          accessibilityRole="button"
+          accessibilityLabel={submitLabel}
+          accessibilityState={{ disabled: !canSubmit }}
         >
           <Text style={styles.submitText}>{submitLabel}</Text>
         </Pressable>
@@ -142,6 +152,11 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     gap: spacing.sm,
     marginTop: spacing.md
+  },
+  actionButton: {
+    minHeight: 44,
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   cancelButton: {
     paddingHorizontal: spacing.lg,

--- a/mobile/src/components/bottom-drawer-keyboard-inset.ts
+++ b/mobile/src/components/bottom-drawer-keyboard-inset.ts
@@ -5,9 +5,9 @@
 //
 // Fill sheets dock chrome to the *true keyboard top* via marginBottom + height
 // shrink. They always use the raw frame height (subtracting safe-bottom on iOS
-// parks the TextInput under the keys). Content-sized sheets keep the legacy
-// translate path: iOS subtracts safe-bottom (padding already covers it),
-// Android uses the full IME height.
+// parks the TextInput under the keys). Content-sized sheets lift in layout:
+// iOS subtracts safe-bottom (padding already covers it), while Android uses the
+// full IME height.
 
 export function resolveBottomDrawerKeyboardInset(input: {
   keyboardHeight: number

--- a/mobile/src/components/mounted-bottom-drawer-keyboard-layout.test.ts
+++ b/mobile/src/components/mounted-bottom-drawer-keyboard-layout.test.ts
@@ -1,0 +1,177 @@
+import { createElement, useRef } from 'react'
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MountedBottomDrawer } from './mounted-bottom-drawer'
+
+type KeyboardEvent = {
+  duration: number
+  endCoordinates: { height: number }
+}
+
+const keyboardListeners = vi.hoisted(() => new Map<string, (event: KeyboardEvent) => void>())
+
+vi.mock('react-native', () => ({
+  BackHandler: { addEventListener: () => ({ remove: vi.fn() }) },
+  Keyboard: {
+    addListener: (event: string, listener: (event: KeyboardEvent) => void) => {
+      keyboardListeners.set(event, listener)
+      return { remove: () => keyboardListeners.delete(event) }
+    },
+    dismiss: vi.fn(),
+    metrics: () => undefined
+  },
+  Modal: 'Modal',
+  Platform: { OS: 'ios', select: (styles: { ios?: unknown }) => styles.ios },
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  StyleSheet: {
+    absoluteFillObject: { bottom: 0, left: 0, position: 'absolute', right: 0, top: 0 },
+    create: (styles: unknown) => styles
+  },
+  View: 'View',
+  useWindowDimensions: () => ({ height: 844, width: 390 })
+}))
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 34, left: 0, right: 0, top: 54 })
+}))
+
+vi.mock('react-native-gesture-handler', () => {
+  function gesture() {
+    const chain = {
+      activeOffsetY: () => chain,
+      onBegin: () => chain,
+      onEnd: () => chain,
+      onUpdate: () => chain,
+      simultaneousWithExternalGesture: () => chain
+    }
+    return chain
+  }
+  return {
+    Gesture: { Native: gesture, Pan: gesture },
+    GestureDetector: 'GestureDetector',
+    GestureHandlerRootView: 'GestureHandlerRootView'
+  }
+})
+
+vi.mock('react-native-reanimated', () => ({
+  default: { ScrollView: 'AnimatedScrollView', View: 'AnimatedView' },
+  Extrapolation: { CLAMP: 'clamp' },
+  interpolate: (value: number, input: number[], output: number[]) =>
+    output[0]! + ((value - input[0]!) / (input[1]! - input[0]!)) * (output[1]! - output[0]!),
+  runOnJS: (callback: (...args: unknown[]) => unknown) => callback,
+  useAnimatedScrollHandler: () => vi.fn(),
+  useAnimatedStyle: (factory: () => unknown) => factory(),
+  useSharedValue: (initial: number) => useRef({ value: initial }).current,
+  withSpring: (value: number) => value,
+  withTiming: (value: number, _config: unknown, completion?: (finished: boolean) => void) => {
+    completion?.(true)
+    return value
+  }
+}))
+
+vi.mock('./bottom-drawer-modal-host', () => ({
+  useInsideBottomDrawerModalHost: () => false
+}))
+
+vi.mock('../layout/responsive-layout', () => ({
+  useResponsiveLayout: () => ({ isWideLayout: false, modalMaxWidth: 640 })
+}))
+
+function findDrawer(renderer: ReactTestRenderer): ReactTestInstance {
+  const drawer = renderer.root.findAllByType('AnimatedView').find((node) => {
+    const style = node.props.style
+    return Array.isArray(style) && style.some((entry) => entry?.width === '100%')
+  })
+  if (!drawer) {
+    throw new Error('Mounted drawer not found')
+  }
+  return drawer
+}
+
+describe('MountedBottomDrawer keyboard layout', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    keyboardListeners.clear()
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('moves a content-sized drawer in layout so visual and native hit frames stay aligned', () => {
+    let renderer: ReactTestRenderer | null = null
+    act(() => {
+      renderer = create(
+        createElement(
+          MountedBottomDrawer,
+          { visible: true, onClose: vi.fn(), onHidden: vi.fn() },
+          createElement('DrawerContent')
+        )
+      )
+    })
+    if (!renderer) {
+      throw new Error('Mounted drawer did not render')
+    }
+
+    act(() => {
+      keyboardListeners.get('keyboardWillShow')?.({
+        duration: 250,
+        endCoordinates: { height: 336 }
+      })
+    })
+
+    const shownStyle = findDrawer(renderer).props.style.at(-1)
+    expect(shownStyle.marginBottom).toBe(302)
+    expect(shownStyle.transform).toEqual([{ translateY: 0 }])
+
+    act(() => {
+      keyboardListeners.get('keyboardWillHide')?.({
+        duration: 250,
+        endCoordinates: { height: 0 }
+      })
+    })
+    expect(findDrawer(renderer).props.style.at(-1).marginBottom).toBe(0)
+    act(() => renderer.unmount())
+  })
+
+  it('preserves fill drawer height shrink and keyboard docking', () => {
+    let renderer: ReactTestRenderer | null = null
+    act(() => {
+      renderer = create(
+        createElement(
+          MountedBottomDrawer,
+          {
+            fillAvailable: true,
+            visible: true,
+            onClose: vi.fn(),
+            onHidden: vi.fn()
+          },
+          createElement('DrawerContent')
+        )
+      )
+    })
+    if (!renderer) {
+      throw new Error('Fill drawer did not render')
+    }
+
+    act(() => {
+      keyboardListeners.get('keyboardWillShow')?.({
+        duration: 250,
+        endCoordinates: { height: 336 }
+      })
+    })
+
+    const style = findDrawer(renderer).props.style
+    expect(style[2]).toMatchObject({ height: 438, paddingBottom: 8 })
+    expect(style.at(-1)).toMatchObject({ marginBottom: 336, transform: [{ translateY: 0 }] })
+    act(() => renderer.unmount())
+  })
+})

--- a/mobile/src/components/mounted-bottom-drawer-keyboard-layout.test.ts
+++ b/mobile/src/components/mounted-bottom-drawer-keyboard-layout.test.ts
@@ -89,6 +89,19 @@ function findDrawer(renderer: ReactTestRenderer): ReactTestInstance {
   return drawer
 }
 
+function findStyleWith(
+  drawer: ReactTestInstance,
+  property: 'marginBottom' | 'transform'
+): Record<string, unknown> {
+  const style = drawer.props.style.findLast(
+    (entry: Record<string, unknown> | null) => entry !== null && property in entry
+  )
+  if (!style) {
+    throw new Error(`Drawer style missing ${property}`)
+  }
+  return style
+}
+
 describe('MountedBottomDrawer keyboard layout', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -128,9 +141,9 @@ describe('MountedBottomDrawer keyboard layout', () => {
       })
     })
 
-    const shownStyle = findDrawer(renderer).props.style.at(-1)
-    expect(shownStyle.marginBottom).toBe(302)
-    expect(shownStyle.transform).toEqual([{ translateY: 0 }])
+    const shownDrawer = findDrawer(renderer)
+    expect(findStyleWith(shownDrawer, 'marginBottom').marginBottom).toBe(302)
+    expect(findStyleWith(shownDrawer, 'transform').transform).toEqual([{ translateY: 0 }])
 
     act(() => {
       keyboardListeners.get('keyboardWillHide')?.({
@@ -138,7 +151,7 @@ describe('MountedBottomDrawer keyboard layout', () => {
         endCoordinates: { height: 0 }
       })
     })
-    expect(findDrawer(renderer).props.style.at(-1).marginBottom).toBe(0)
+    expect(findStyleWith(findDrawer(renderer), 'marginBottom').marginBottom).toBe(0)
     act(() => renderer.unmount())
   })
 
@@ -170,8 +183,18 @@ describe('MountedBottomDrawer keyboard layout', () => {
     })
 
     const style = findDrawer(renderer).props.style
-    expect(style[2]).toMatchObject({ height: 438, paddingBottom: 8 })
-    expect(style.at(-1)).toMatchObject({ marginBottom: 336, transform: [{ translateY: 0 }] })
+    expect(style[2]).toMatchObject({ height: 438, marginBottom: 336, paddingBottom: 8 })
+    expect(findStyleWith(findDrawer(renderer), 'transform').transform).toEqual([{ translateY: 0 }])
+
+    act(() => {
+      keyboardListeners.get('keyboardWillHide')?.({
+        duration: 250,
+        endCoordinates: { height: 0 }
+      })
+    })
+
+    const hiddenStyle = findDrawer(renderer).props.style
+    expect(hiddenStyle[2]).toMatchObject({ height: 774, marginBottom: 0, paddingBottom: 50 })
     act(() => renderer.unmount())
   })
 })

--- a/mobile/src/components/mounted-bottom-drawer-keyboard-layout.test.ts
+++ b/mobile/src/components/mounted-bottom-drawer-keyboard-layout.test.ts
@@ -184,6 +184,9 @@ describe('MountedBottomDrawer keyboard layout', () => {
 
     const style = findDrawer(renderer).props.style
     expect(style[2]).toMatchObject({ height: 438, marginBottom: 336, paddingBottom: 8 })
+    expect(
+      style.filter((entry: Record<string, unknown> | null) => entry?.marginBottom != null)
+    ).toHaveLength(1)
     expect(findStyleWith(findDrawer(renderer), 'transform').transform).toEqual([{ translateY: 0 }])
 
     act(() => {

--- a/mobile/src/components/mounted-bottom-drawer.tsx
+++ b/mobile/src/components/mounted-bottom-drawer.tsx
@@ -261,22 +261,17 @@ export function MountedBottomDrawer({
       }
     })
 
-  const drawerStyle = useAnimatedStyle(() => {
-    // Why: fill mode already shrinks height by the keyboard inset and lifts via
-    // marginBottom (layout). Also subtracting keyboardOffset here would double-
-    // count and park the dock under the keys (input hidden).
-    const keyboardShift = fillAvailable ? 0 : keyboardOffset.value
-    return {
-      transform: [
-        {
-          translateY:
-            interpolate(progress.value, [0, 1], [screenHeight, 0], Extrapolation.CLAMP) +
-            translateY.value -
-            keyboardShift
-        }
-      ]
-    }
-  })
+  const drawerStyle = useAnimatedStyle(() => ({
+    // Why: layout lift keeps native hit/accessibility frames aligned with the rendered drawer.
+    marginBottom: fillAvailable ? keyboardInset : keyboardOffset.value,
+    transform: [
+      {
+        translateY:
+          interpolate(progress.value, [0, 1], [screenHeight, 0], Extrapolation.CLAMP) +
+          translateY.value
+      }
+    ]
+  }))
 
   const backdropStyle = useAnimatedStyle(() => {
     const dragFade = interpolate(translateY.value, [0, 300], [1, 0], Extrapolation.CLAMP)
@@ -365,12 +360,7 @@ export function MountedBottomDrawer({
                 width: '100%',
                 maxWidth: isWideLayout ? modalMaxWidth : undefined,
                 maxHeight: screenHeight - insets.top - spacing.lg,
-                // Why: fill sheets shrink height AND lift with marginBottom so the
-                // bottom edge sits on the keyboard top (height alone still leaves
-                // the dock in the keyboard’s footprint). Non-fill sheets keep
-                // the legacy translateY keyboard shift instead.
                 height: fillHeight,
-                marginBottom: fillAvailable ? keyboardInset : 0,
                 paddingBottom:
                   fillAvailable && keyboardInset > 0 ? spacing.sm : insets.bottom + spacing.lg
               },

--- a/mobile/src/components/mounted-bottom-drawer.tsx
+++ b/mobile/src/components/mounted-bottom-drawer.tsx
@@ -261,9 +261,12 @@ export function MountedBottomDrawer({
       }
     })
 
-  const drawerStyle = useAnimatedStyle(() => ({
+  const keyboardLayoutStyle = useAnimatedStyle(() => ({
     // Why: layout lift keeps native hit/accessibility frames aligned with the rendered drawer.
-    marginBottom: fillAvailable ? keyboardInset : keyboardOffset.value,
+    marginBottom: keyboardOffset.value
+  }))
+
+  const drawerStyle = useAnimatedStyle(() => ({
     transform: [
       {
         translateY:
@@ -361,9 +364,11 @@ export function MountedBottomDrawer({
                 maxWidth: isWideLayout ? modalMaxWidth : undefined,
                 maxHeight: screenHeight - insets.top - spacing.lg,
                 height: fillHeight,
+                marginBottom: fillAvailable ? keyboardInset : 0,
                 paddingBottom:
                   fillAvailable && keyboardInset > 0 ? spacing.sm : insets.bottom + spacing.lg
               },
+              fillAvailable ? null : keyboardLayoutStyle,
               drawerStyle
             ]}
           >


### PR DESCRIPTION
## Complaint

Current-head QA on both iPhone and iPad showed an enabled Save action in the pairing-code TextInputModal, but its native accessibility/touch frame stayed displaced from the rendered button. Tapping could dismiss or reset the drawer instead of submitting, blocking pairing and downstream mobile QA.

## Before / After

Before: content-sized BottomDrawer instances visually lifted above the keyboard with a Reanimated transform. The button moved on screen while its native layout-backed hit and accessibility coordinates remained bottom-anchored.

After: keyboard lift is applied through animated layout margin, so rendered, touch, and accessibility frames move together. TextInputModal actions are explicit accessibility buttons with a 44pt minimum target, and Save reports its validation-disabled state.

## Cause

The non-fill drawer keyboard offset was subtracted from translateY. That presentation-only movement could diverge from the native layout used for accessibility and hit testing by exactly the keyboard inset. Fill drawers already docked through layout and did not have that coordinate split.

## Scope

- Move content-sized drawer keyboard lift from transform to marginBottom while retaining the existing presentation/dismiss/drag transform.
- Preserve fill drawer height shrink and keyboard docking in their original atomic React layout batch, along with safe-area padding, backdrop dismissal, scrolling, and keyboard event contracts.
- Give Cancel and Save explicit button semantics; give both a 44pt minimum target and expose Save disabled state.
- Keep pairing parsing, trimming, validation, submission, transport, SSH behavior, and folder/worktree behavior unchanged.
- No dependency or lockfile changes.

## Native evidence

Exact-head native iPad QA passed on assigned iPad `C589AF84-2F0C-4978-952B-748933DE6804`. The exact Release artifact was installed, relaunched without Metro, and exercised through Save and Return pairing, keyboard-visible geometry, disabled input, rotation, accessibility, dismissal, and content/fill drawer flows.

See the [detailed native QA report](https://github.com/stablyai/orca/pull/11781#issuecomment-5146774693) for exact frames, artifact hashes, pairing proof, and route diagnostics.

Screenshots were not captured because the authorized Orca iOS emulator surface exposes no compliant screenshot command. Raw Simulator and `simctl` capture were intentionally not used; the report records native touch and accessibility evidence instead.

## Testing

- [x] Focused drawer and TextInputModal regressions: 2 files, 6 tests passed
- [x] Full mobile suite: 378 files passed; 2,800 tests passed; 3 skipped
- [x] Mobile typecheck: `tsc --noEmit`
- [x] Full mobile lint: `oxlint`
- [x] Full mobile format check: `oxfmt --check .`
- [x] Repository max-lines ratchet
- [x] `git diff --check`
- [x] Added focused coverage for content-sized and fill keyboard show/hide, atomic fill height/docking restoration, 44pt Save/Cancel semantics, trimming, button/Return submission, and validation state
- [x] Exact-head Release iOS Simulator build succeeded
- [x] Exact-build native iPad Save, Return, keyboard, rotation, accessibility, and pairing validation passed

## Exact Release build and native QA

The exact-head Release iOS Simulator build from `f2e1fb9d6814c48c588d80d6753f901267b2e2ef` is a universal x86_64/arm64 simulator binary with bundle ID `com.stably.orca.mobile`, version `0.0.36`, and build `1`.

The existing artifact was installed directly on the assigned iPad using Expo's verified `--binary`, `--device`, and `--no-bundler` path. Expo reported installing that exact app path on `iPad Pro 13-inch (M5)` and opening `com.stably.orca.mobile`. Relaunch through iPad Home/Spotlight confirmed the embedded Release app rather than Metro. No other device was targeted.

Artifact fingerprints:

- Ad-hoc signature CDHash: `32c171a9a8a548e4b3236d007ccfc8b7fdc5e1fd`
- Executable SHA-256: `c4b934a5687e56a5a8c545377db4dd315c6f1d938fc9ed5e94d479872af72ba2`
- `Info.plist` SHA-256: `70eab6bc600ddebab44aef56605170f9b4bf5ca4486414cef0d46ff244129e93`
- `CodeResources` SHA-256: `5fc75e6da286570d7a162de9234b53faf9df680781aa08275e38938c6b7ece21`
- Release `main.jsbundle` SHA-256: `f4aa543ee68186111789f7e6403297db44af1ca5f7f6ab5542b1bc875e6a5ebe`
- Sorted app-tree fingerprint: `e0f3d8ad74ef3b60c6028b62d4ca36c4fb8f315d3c82f0c7c503b9a0917b04da`

Native results:

- **Keyboard lift and geometry:** with the software keyboard visible, the pairing field and Save accessibility frame lifted together. Save returned to the bottom-docked position after keyboard dismissal and measured exactly 44pt high.
- **Disabled input:** blank and whitespace-only values exposed Save as a disabled button; touching its accessibility center neither submitted nor dismissed.
- **Paste and trimming:** intended-host codes with leading and trailing spaces pasted byte-for-byte, became enabled, and were trimmed correctly without exposing pairing codes in the report.
- **Save and Return:** both native Save touch and Return-key submission paired successfully with the intended desktop over its reachable LAN endpoint.
- **Dismissal:** Cancel and backdrop touches dismissed correctly; disabled Save did not.
- **Rotation and accessibility:** the open drawer survived portrait-to-landscape reflow. Save and Cancel retained button roles, accurate enabled state, and 44pt native accessibility height in both orientations.
- **Content and fill drawers:** the content-sized Create Workspace drawer stayed bottom-docked, while its nested fill-available drawer continued to fill the viewport with its dock and input visible and usable.
- **Data preservation:** existing Hosts 1–5 remained present. Only the two explicit intended-host credentials created by Save and Return QA were added; no simulator data was cleared.
- **Repository integrity:** the worktree and index remained clean after QA, and `mobile/pnpm-lock.yaml` remained byte-identical to HEAD.

The intended desktop's initially advertised Tailscale endpoint timed out, while the same desktop's visible LAN endpoint paired successfully for both Save and Return. This is a separate route-reachability finding, not a failure of the hit-target fix.

## AI Review Report

Reviewed the final five-file diff for responder ordering, accessibility activation, validation, keyboard show/hide, safe-area math, fill versus non-fill behavior, rotation-dependent dimensions, and drawer dismissal. The fill regression keeps the existing 844 - 54 - 16 - 336 = 438pt height and 336pt docking inset; the non-fill regression keeps the iOS home-indicator subtraction (336 - 34 = 302pt) while removing that offset from transform.

Cross-platform review confirmed that the existing platform contract remains intact: iOS content drawers subtract the safe-bottom inset, Android uses the full IME height, fill drawers use the full frame on both, and no desktop shortcuts, labels, paths, shell behavior, Electron behavior, SSH routing, or git/folder-workspace behavior changed.

## Performance

No new listeners, state, polling, network work, or steady-state rendering was added. For content-sized drawers, the existing keyboard shared value now animates one layout property during keyboard show/hide instead of a transform; layout work is bounded to that transition and is required to keep native hit geometry synchronized. Fill drawers retain their prior atomic React height/margin commit. Normal drawer rendering and drag/presentation animation paths are unchanged.

## Security Audit

No command execution, filesystem/path handling, auth, secrets, dependency, IPC, transport, or persistence behavior changed. Pairing input still follows the existing trim, validation, and parsing path, and the restored lockfile is absent from the diff.

## Remaining gaps

- The authorized Orca emulator surface has no compliant screenshot command, so evidence is native interaction and accessibility output rather than image attachments.
- After the helper restarted, the simulator remained in hardware-keyboard mode and exposed no supported keyboard toggle. Software-keyboard lift evidence was captured before that mode change; enabled Save touch and both end-to-end submissions were verified afterward.
- The separately observed Tailscale route timeout may merit follow-up, but the same intended desktop paired over LAN and no PR-introduced product failure remains.

**Readiness: ready.** Exact-head native installation, touch geometry, accessibility semantics, trimming, Save pairing, Return pairing, rotation, and content/fill drawer regressions all passed, and CI is green.
