### PR TITLE
fix(fonts): prefer pwsh and log failures in Windows font enumeration

### DIFF
--- a/src/main/system-fonts.test.ts
+++ b/src/main/system-fonts.test.ts
@@ -9,6 +9,14 @@ vi.mock('child_process', () => ({
   execFile: execFileMock
 }))
 
+const WIN32_FALLBACK_FONTS = [
+  'Cascadia Mono',
+  'Consolas',
+  'Lucida Console',
+  'JetBrains Mono',
+  'Fira Code'
+]
+
 function expectedFallbackFont(platform = process.platform): string {
   if (platform === 'darwin') {
     return 'SF Mono'
@@ -32,9 +40,26 @@ async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>):
   }
 }
 
+function mockSpawnSuccess(...lines: string[]): void {
+  execFileMock.mockImplementation(
+    (_command, _args, _options, callback: (error: Error | null, stdout: string) => void) => {
+      callback(null, `${lines.join('\n')}\n`)
+    }
+  )
+}
+
+function mockSpawnError(error: Error): void {
+  execFileMock.mockImplementation(
+    (_command, _args, _options, callback: (error: Error | null, stdout?: string) => void) => {
+      callback(error)
+    }
+  )
+}
+
 async function expectFontCommandTimeout(
   platform: NodeJS.Platform,
-  timeoutMs: number
+  timeoutMs: number,
+  expectedKills: number
 ): Promise<void> {
   await withPlatform(platform, async () => {
     vi.useFakeTimers()
@@ -50,12 +75,12 @@ async function expectFontCommandTimeout(
     await vi.advanceTimersByTimeAsync(timeoutMs - 1)
 
     expect(resolvedFonts).toBeNull()
-    expect(killMock).not.toHaveBeenCalled()
+    expect(killMock).toHaveBeenCalledTimes(expectedKills - 1)
 
     await vi.advanceTimersByTimeAsync(1)
 
     await expect(fontsPromise).resolves.toContain(expectedFallbackFont(platform))
-    expect(killMock).toHaveBeenCalledOnce()
+    expect(killMock).toHaveBeenCalledTimes(expectedKills)
   })
 }
 
@@ -78,21 +103,104 @@ describe('listSystemFontFamilies', () => {
       resolvedFonts = fonts
     })
 
-    await vi.advanceTimersByTimeAsync(60_000)
+    // Windows retries a second PowerShell candidate, so its chain needs 30s;
+    // 60s covers every host platform.
+    const totalTimeout = process.platform === 'win32' ? 30_000 : 60_000
+    await vi.advanceTimersByTimeAsync(totalTimeout)
 
     expect(resolvedFonts).not.toBeNull()
     expect(resolvedFonts).toContain(expectedFallbackFont())
-    expect(killMock).toHaveBeenCalledOnce()
+    expect(killMock).toHaveBeenCalledTimes(process.platform === 'win32' ? 2 : 1)
   })
 
   it('uses the longer timeout for macOS profiler scans', async () => {
-    await expectFontCommandTimeout('darwin', 45_000)
+    await expectFontCommandTimeout('darwin', 45_000, 1)
   })
 
   it.each([
-    ['linux' as NodeJS.Platform, 15_000],
-    ['win32' as NodeJS.Platform, 15_000]
-  ])('keeps the %s font command timeout short', async (platform, timeoutMs) => {
-    await expectFontCommandTimeout(platform, timeoutMs)
+    ['linux' as NodeJS.Platform, 15_000, 1],
+    ['win32' as NodeJS.Platform, 30_000, 2]
+  ])(
+    'falls back when the %s font command times out',
+    async (platform, timeoutMs, expectedKills) => {
+      await expectFontCommandTimeout(platform, timeoutMs, expectedKills)
+    }
+  )
+
+  describe('on Windows', () => {
+    it('tries pwsh.exe first and stops once it succeeds', async () => {
+      await withPlatform('win32', async () => {
+        mockSpawnSuccess('Cascadia Mono', 'Consolas')
+
+        const { listSystemFontFamilies } = await import('./system-fonts')
+        const fonts = await listSystemFontFamilies()
+
+        expect(execFileMock).toHaveBeenCalledTimes(1)
+        expect(execFileMock.mock.calls[0][0]).toBe('pwsh.exe')
+        expect(fonts).toEqual(['Cascadia Mono', 'Consolas'])
+      })
+    })
+
+    it('falls back to the absolute Windows PowerShell path when pwsh is unavailable', async () => {
+      await withPlatform('win32', async () => {
+        const originalWindir = process.env.WINDIR
+        process.env.WINDIR = 'C:\\Windows'
+        try {
+          execFileMock.mockImplementation(
+            (
+              command,
+              _args,
+              _options,
+              callback: (error: Error | null, stdout?: string) => void
+            ) => {
+              if (command === 'pwsh.exe') {
+                callback(new Error('spawn pwsh.exe ENOENT'))
+                return
+              }
+              callback(null, 'Cascadia Mono\nConsolas\n')
+            }
+          )
+
+          const { listSystemFontFamilies } = await import('./system-fonts')
+          const fonts = await listSystemFontFamilies()
+
+          expect(execFileMock).toHaveBeenCalledTimes(2)
+          expect(execFileMock.mock.calls[0][0]).toBe('pwsh.exe')
+          expect(execFileMock.mock.calls[1][0]).toBe(
+            'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+          )
+          expect(fonts).toEqual(['Cascadia Mono', 'Consolas'])
+        } finally {
+          if (originalWindir === undefined) {
+            delete process.env.WINDIR
+          } else {
+            process.env.WINDIR = originalWindir
+          }
+        }
+      })
+    })
+
+    it('falls back to hardcoded fonts and logs the real error when every candidate fails', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        await withPlatform('win32', async () => {
+          const spawnError = new Error('spawn UNKNOWN (errno -4094)')
+          mockSpawnError(spawnError)
+
+          const { listSystemFontFamilies } = await import('./system-fonts')
+          const fonts = await listSystemFontFamilies()
+
+          expect(execFileMock).toHaveBeenCalledTimes(2)
+          expect(fonts).toEqual(WIN32_FALLBACK_FONTS)
+          expect(warnSpy).toHaveBeenCalledTimes(1)
+          expect(warnSpy).toHaveBeenCalledWith(
+            '[system-fonts] failed to enumerate Windows fonts, using fallback:',
+            spawnError
+          )
+        })
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
   })
 })

--- a/src/main/system-fonts.ts
+++ b/src/main/system-fonts.ts
@@ -80,6 +80,33 @@ function listLinuxFonts(): Promise<string[]> {
   )
 }
 
+// Why: the machine PATH resolves powershell.exe to the 5.1 launcher that Group
+// Policy can block. Prefer pwsh (PowerShell 7), then the absolute 5.1 path so
+// PATH resolution never decides the outcome (GH-11771).
+function windowsPowerShellCandidates(): string[] {
+  const windir = process.env.WINDIR ?? 'C:\\Windows'
+  return ['pwsh.exe', `${windir}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`]
+}
+
+// Why: a blocked or missing first candidate must not fail the whole lookup;
+// try each command in order and surface only the last error once all failed.
+async function execFileTextFirst(
+  commands: string[],
+  args: string[],
+  maxBuffer: number,
+  timeoutMs = SYSTEM_FONT_LIST_TIMEOUT_MS
+): Promise<string> {
+  let lastError: unknown
+  for (const command of commands) {
+    try {
+      return await execFileText(command, args, maxBuffer, timeoutMs)
+    } catch (error) {
+      lastError = error
+    }
+  }
+  throw lastError
+}
+
 function listWindowsFonts(): Promise<string[]> {
   const script = `
 Add-Type -AssemblyName System.Drawing
@@ -87,18 +114,25 @@ $fonts = New-Object System.Drawing.Text.InstalledFontCollection
 $fonts.Families | ForEach-Object { $_.Name }
 `
 
-  return execFileText(
-    'powershell.exe',
+  return execFileTextFirst(
+    windowsPowerShellCandidates(),
     ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
     8 * 1024 * 1024
-  ).then((output) =>
-    uniqueSorted(
-      output
-        .split('\n')
-        .map((name) => name.trim())
-        .filter(Boolean)
-    )
   )
+    .then((output) =>
+      uniqueSorted(
+        output
+          .split('\n')
+          .map((name) => name.trim())
+          .filter(Boolean)
+      )
+    )
+    .catch((error: unknown) => {
+      // Why: a GP-blocked PowerShell used to degrade to 5 hardcoded fonts with
+      // no trace; surface the real spawn error so managed hosts are diagnosable.
+      console.warn('[system-fonts] failed to enumerate Windows fonts, using fallback:', error)
+      throw error
+    })
 }
 
 function execFileText(


### PR DESCRIPTION
## Summary

Fixes #11771

When Group Policy blocks Windows PowerShell 5.1, the font picker silently degraded to the 5 hardcoded fallback fonts. `listWindowsFonts()` spawned `powershell.exe` by bare name, which fails with `spawn UNKNOWN (errno -4094)` on a GP-blocked host — and the error was swallowed by the fallback path with no log.

This PR:

- Tries `pwsh.exe` first, then the absolute Windows PowerShell 5.1 path (resolved from `%WINDIR%`, defaulting to `C:\Windows`) — so the enumeration survives GP policy and also works on PowerShell 7-only installs.
- Logs the real spawn error with `console.warn` before falling back, so silent degradation is now visible in the main-process log.
- Keeps the existing memoization and the fallback behavior for genuinely unreachable hosts.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (full, incl. localization coverage audit)
- [x] `pnpm typecheck` (full, all three tsconfig projects)
- [x] `pnpm test` (targeted: `src/main/system-fonts.test.ts` 7/7 — 3 new Windows cases + updated win32 timeout case; `src/main/ipc/settings.test.ts` 28/28). Full suite not run locally; CI covers it.
- [ ] `pnpm build` (not run; no build-affecting surface)
- [x] Added or updated high-quality tests (TDD: failing-then-passing, oxfmt/oxlint clean)

## AI Review Report

Reviewed by a reliability lens against the exact candidate diff (tests + implementation):

- **Spawn-order contract**: `pwsh.exe` is always tried first and the chain stops on first success; the absolute 5.1 path is a fallback, so PowerShell 7-first hosts keep the faster path.
- **Failure path**: when every candidate fails, the last error is rethrown after logging — the outer fallback still returns the 5-font list, preserving prior behavior while making the cause observable.
- **Timeout semantics**: each candidate gets the full 15s budget; worst case before fallback is ~30s only when both shells hang (was 15s). Intentionally bounded, no shared-budget coupling.
- **Regressions**: memoization untouched; `execFileText` signature unchanged; `settings` IPC consumers of `listSystemFontFamilies` unaffected.
- **Cross-platform**: change is runtime-guarded for win32 only — the darwin (`system_profiler`) and linux (`fc-list`) paths are untouched; on non-Windows hosts behavior is byte-identical.

## Security Audit

- No new input handling, no auth/secrets, no new dependencies, no IPC surface change.
- Commands are constructed statically and executed via `execFile` (no shell interpolation).
- `%WINDIR%` resolution is environment-driven with a fixed safe default (`C:\Windows`); the candidate list contains only the two well-known Windows shells.

## Notes

- Windows-only fix, verified through mocked `execFile` in unit tests — no Windows host connected to validate against a real GP-blocked machine.
- Root cause of the silent degradation: the previous `catch` substituted the fallback list without logging, so the failure was invisible to users and maintainers alike.

- X: @umillann
