### PR TITLE
fix(ssh): align non-interactive exec request timeout with the relay budget

### DIFF
--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -278,13 +278,47 @@ describe('SshGitProvider', () => {
 
     const result = await provider.execNonInteractive('pnpm', ['--version'], '/home/user/repo', 8000)
 
-    expect(mux.request).toHaveBeenCalledWith('agent.execNonInteractive', {
-      binary: 'pnpm',
-      args: ['--version'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 8000
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'agent.execNonInteractive',
+      {
+        binary: 'pnpm',
+        args: ['--version'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 8000
+      },
+      { timeoutMs: 38_000 }
+    )
+    expect(result).toEqual(execResult)
+  })
+
+  it('execNonInteractive forwards a request timeout with margin for the relay exec budget', async () => {
+    const execResult = {
+      stdout: 'host example.com\n',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    }
+    mux.request.mockResolvedValue(execResult)
+
+    const result = await provider.execNonInteractive(
+      'ssh',
+      ['-G', '--', 'example.com'],
+      '/home/user/repo',
+      5_000
+    )
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'agent.execNonInteractive',
+      {
+        binary: 'ssh',
+        args: ['-G', '--', 'example.com'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 5_000
+      },
+      { timeoutMs: 35_000 }
+    )
     expect(result).toEqual(execResult)
   })
 
@@ -309,17 +343,21 @@ describe('SshGitProvider', () => {
       }
     )
 
-    expect(mux.request).toHaveBeenCalledWith('agent.execNonInteractive', {
-      binary: '/bin/bash',
-      args: ['-lc', 'echo "$ORCA_WORKTREE_PATH"'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 120_000,
-      env: {
-        ORCA_ROOT_PATH: '/home/user/repo',
-        ORCA_WORKTREE_PATH: '/home/user/repo-feature'
-      }
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'agent.execNonInteractive',
+      {
+        binary: '/bin/bash',
+        args: ['-lc', 'echo "$ORCA_WORKTREE_PATH"'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 120_000,
+        env: {
+          ORCA_ROOT_PATH: '/home/user/repo',
+          ORCA_WORKTREE_PATH: '/home/user/repo-feature'
+        }
+      },
+      { timeoutMs: 150_000 }
+    )
   })
 
   it('cancelNonInteractiveExec sends best-effort relay cancellation', async () => {
@@ -452,14 +490,18 @@ describe('SshGitProvider', () => {
       60_000
     )
 
-    expect(mux.request).toHaveBeenCalledWith('agent.execNonInteractive', {
-      binary: 'codex',
-      args: ['exec', 'PROMPT'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 60_000,
-      operation: 'commit-message'
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'agent.execNonInteractive',
+      {
+        binary: 'codex',
+        args: ['exec', 'PROMPT'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 60_000,
+        operation: 'commit-message'
+      },
+      { timeoutMs: 90_000 }
+    )
     expect(result).toEqual(execResult)
   })
 
@@ -496,22 +538,32 @@ describe('SshGitProvider', () => {
     )
 
     await waitForRequestCount(mux.request, 2)
-    expect(mux.request).toHaveBeenNthCalledWith(1, 'agent.execNonInteractive', {
-      binary: 'codex',
-      args: ['exec', 'PROMPT'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 60_000,
-      operation: 'commit-message'
-    })
-    expect(mux.request).toHaveBeenNthCalledWith(2, 'agent.execNonInteractive', {
-      binary: 'codex',
-      args: ['exec', 'PROMPT'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 60_000,
-      operation: 'pull-request-fields'
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'agent.execNonInteractive',
+      {
+        binary: 'codex',
+        args: ['exec', 'PROMPT'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 60_000,
+        operation: 'commit-message'
+      },
+      { timeoutMs: 90_000 }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'agent.execNonInteractive',
+      {
+        binary: 'codex',
+        args: ['exec', 'PROMPT'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 60_000,
+        operation: 'pull-request-fields'
+      },
+      { timeoutMs: 90_000 }
+    )
 
     await provider.cancelGenerateCommitMessage('/home/user/repo')
     await provider.cancelGenerateCommitMessage('/home/user/repo', 'pull-request-fields')
@@ -556,13 +608,18 @@ describe('SshGitProvider', () => {
     await first
     await waitForRequestCount(mux.request, 2)
 
-    expect(mux.request).toHaveBeenNthCalledWith(2, 'agent.execNonInteractive', {
-      binary: 'pnpm',
-      args: ['install'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 8000
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'agent.execNonInteractive',
+      {
+        binary: 'pnpm',
+        args: ['install'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 8000
+      },
+      { timeoutMs: 38_000 }
+    )
     completeRequests.shift()?.()
     await second
   })
@@ -637,15 +694,36 @@ describe('SshGitProvider', () => {
     completeRequests.shift()?.()
     await first
     await waitForRequestCount(mux.request, 3)
-    expect(mux.request).toHaveBeenNthCalledWith(3, 'agent.execNonInteractive', {
-      binary: 'pnpm',
-      args: ['install'],
-      cwd: '/home/user/repo',
-      stdin: null,
-      timeoutMs: 8000
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      3,
+      'agent.execNonInteractive',
+      {
+        binary: 'pnpm',
+        args: ['install'],
+        cwd: '/home/user/repo',
+        stdin: null,
+        timeoutMs: 8000
+      },
+      { timeoutMs: 38_000 }
+    )
     completeRequests.shift()?.()
     await second
+  })
+
+  it('releases the lane when a mux request times out so queued work still runs', async () => {
+    const execResult = { stdout: '', stderr: '', exitCode: 0, timedOut: false }
+    mux.request
+      .mockRejectedValueOnce(
+        new Error('Request "agent.execNonInteractive" timed out after 38000ms')
+      )
+      .mockResolvedValue(execResult)
+
+    const first = provider.execNonInteractive('pnpm', ['store', 'prune'], '/home/user/repo', 8000)
+    const second = provider.execNonInteractive('pnpm', ['install'], '/home/user/repo', 8000)
+
+    await expect(first).rejects.toThrow('timed out after 38000ms')
+    await expect(second).resolves.toEqual(execResult)
+    expect(mux.request).toHaveBeenCalledTimes(2)
   })
 
   it('cancelGenerateCommitMessage sends best-effort relay cancellation', async () => {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -40,6 +40,11 @@ type NonInteractiveExecQueueEntry = {
   release: () => void
 }
 
+// Why: the mux default (30s) aborts relay execs before their payload timeout
+// elapses (see #11723). This margin covers relay tree-kill plus SSH RTT so the
+// client never cuts a legitimate execution short.
+const REMOTE_EXEC_REQUEST_TIMEOUT_MARGIN_MS = 30_000
+
 function isJsonRpcMethodNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
     return false
@@ -372,7 +377,10 @@ export class SshGitProvider implements IGitProvider {
       entry.started = true
       return (await this.mux.request(
         'agent.execNonInteractive',
-        payload
+        payload,
+        // Why: #11723 — the 30s mux default aborted legit 31–60s generations;
+        // margin covers relay tree-kill and SSH RTT beyond the exec budget.
+        { timeoutMs: payload.timeoutMs + REMOTE_EXEC_REQUEST_TIMEOUT_MARGIN_MS }
       )) as RemoteCommitMessageExecResult
     } finally {
       signal?.removeEventListener('abort', abortEntry)

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -575,6 +575,17 @@ describe('generateCommitMessageFromContext', () => {
     })
   })
 
+  it('reports client-side mux timeouts during remote model discovery', async () => {
+    const result = await discoverCommitMessageModelsRemote('cursor', '/remote/repo', async () => {
+      throw new Error('Request "agent.execNonInteractive" timed out after 90000ms')
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Cursor model discovery timed out after 60s.'
+    })
+  })
+
   it('uses a prepared remote execution plan instead of running git on the remote side', async () => {
     const result = await generateCommitMessageFromContext(
       {
@@ -1098,6 +1109,34 @@ describe('generateCommitMessageFromContext', () => {
       success: false,
       error:
         'agent could not be reached on the remote PATH. Try again after the SSH connection recovers.'
+    })
+  })
+
+  it('reports client-side mux timeouts as generation timeouts', async () => {
+    const result = await generateCommitMessageFromContext(
+      {
+        branch: 'main',
+        stagedSummary: 'M\tREADME.md',
+        stagedPatch: '+hello'
+      },
+      {
+        agentId: 'custom',
+        model: '',
+        customAgentCommand: 'agent'
+      },
+      {
+        kind: 'remote',
+        cwd: '/repo',
+        missingBinaryLocation: 'remote PATH',
+        execute: async () => {
+          throw new Error('Request "agent.execNonInteractive" timed out after 90000ms')
+        }
+      }
+    )
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Generation timed out after 60s.'
     })
   })
 

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -58,6 +58,12 @@ import { wslAwareSpawn } from '../git/runner'
 const GENERATION_TIMEOUT_MS = 60_000
 const MAX_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024
 
+// Why: #11723 — mux rejects `Request "<method>" timed out after <n>ms` when the
+// client-side budget aborts a relay exec; that is a timeout, not a transport failure.
+function isRemoteRequestTimeoutError(error: unknown): boolean {
+  return error instanceof Error && /timed out after \d+ms/.test(error.message)
+}
+
 export type GenerateCommitMessageParams = ResolvedSourceControlAiGenerationParams
 
 export type GenerateCommitMessageResult =
@@ -455,6 +461,12 @@ export async function discoverCommitMessageModelsRemote(
     result = await execute(planned.plan, cwd, GENERATION_TIMEOUT_MS)
   } catch (error) {
     console.error('[commit-message] Remote model discovery request failed:', error)
+    if (isRemoteRequestTimeoutError(error)) {
+      return {
+        success: false,
+        error: `${spec.label} model discovery timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
+      }
+    }
     return {
       success: false,
       error: `${spec.label} model discovery could not be reached on the remote PATH. Try again after the SSH connection recovers.`
@@ -795,6 +807,12 @@ async function runRemotePlan(
     result = await target.execute(plan, target.cwd, GENERATION_TIMEOUT_MS, operation)
   } catch (error) {
     console.error('[commit-message] Remote generator request failed:', error)
+    if (isRemoteRequestTimeoutError(error)) {
+      return {
+        success: false,
+        error: `Generation timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
+      }
+    }
     return {
       success: false,
       error: `${label} could not be reached on the ${target.missingBinaryLocation}. Try again after the SSH connection recovers.`


### PR DESCRIPTION
## Summary

Fixes #11723

AI commit-message generation over SSH always failed after exactly 30s with the misleading *"could not be reached on the remote PATH"* message. The queued non-interactive exec request inherited the mux default 30s `REQUEST_TIMEOUT_MS`, while the relay-side execution budget is 60s (commit-message) / 120s (worktree-archive hooks) — so any generation taking 31–60s was aborted client-side mid-run, and the catch rewrote every failure into a transport-failure message.

This PR:

- Passes a per-request mux timeout of `payload.timeoutMs + 30s` margin to `agent.execNonInteractive` (`90s` commit-message, `150s` archive hooks, `35s` `ssh -G`), so the client always waits out the relay budget. The 30s default for every other mux caller is untouched.
- Distinguishes mux request timeouts from real transport failures: they now surface the honest `Generation timed out after 60s.` (or `<label> model discovery timed out after 60s.`) instead of "could not be reached on the remote PATH".
- Bonus: the same single call site also fixes the same latent bug for worktree-archive hooks (120s budget, previously aborted at 30s).

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (full)
- [x] `pnpm typecheck` (full, all three tsconfig projects)
- [x] `pnpm test` (targeted: `ssh-git-provider.test.ts` 85/85 — 6 assertions updated to the 3-arg request shape + 2 new cases; `commit-message-text-generation.test.ts` 63/63 — 2 new mux-timeout cases; spawn-failure and transport-failure cases preserved). Full suite not run locally; CI covers it.
- [ ] `pnpm build` (not run; no build-affecting surface)
- [x] Added or updated high-quality tests (TDD: failing-then-passing, oxfmt/oxlint clean)

## AI Review Report

Reviewed by the full 4-lens set (risk, resilience, readability, reliability) against the exact candidate diff:

- **Request-timeout contract**: the override is strictly per-request (`options.timeoutMs` on the single `agent.execNonInteractive` call); the mux default stays 30s for the other ~105 callers. All budgets are main-process constants (60s/120s/8s/5s) — nothing renderer- or attacker-controlled reaches `payload.timeoutMs`.
- **Resource safety**: relay-side exec stays bounded by `payload.timeoutMs` + 30s margin; a dead link is still torn down by the connection health timer (~20s), which rejects all pending requests; the queued-lane `finally` release is pinned by a regression test.
- **Honest failure paths**: relay-side timeouts already returned a clean `timedOut: true` result (handled before); only client-side mux timeouts reach the new message. The raw error is still logged via `console.error`; user-facing strings carry no internals.
- **Cross-platform**: no platform-specific code touched; the change is transport-agnostic (SSH mux) and behaves identically on macOS, Linux, and Windows.
- Info-level findings only (no blockers): the `/timed out after \d+ms/` predicate could misclassify a hypothetical relay JSON-RPC error containing that text (accepted: relay timeouts never throw, they resolve); the honest message hardcodes 60s while the client waits 90s (deliberate consistency with the existing `result.timedOut` wording).

## Security Audit

- No new input handling, no auth changes, no secrets, no new dependencies, no IPC surface change.
- The timeout extension cannot be used to hold relay resources beyond the fixed per-operation budgets + 30s margin (main-process constants only).
- User-facing messages contain no internal details, paths, or secrets; full errors remain console-only.

## Notes

- Verified through the existing mock-mux and mocked-`execute` unit harnesses; no live SSH relay host was available to reproduce the 31–60s window end-to-end.
- The `ssh -G` probe (5s budget) now carries a 35s request timeout — harmless margin on an already-fast call, keeps the single call site uniform.

- X: @umillann
