### PR TITLE
test: isolate release and relay fixtures from local git config

### DIFF
--- a/config/scripts/publish-complete-draft-releases.test.mjs
+++ b/config/scripts/publish-complete-draft-releases.test.mjs
@@ -24,6 +24,10 @@ function withGitRepo(run) {
     git(dir, ['init', '--initial-branch=main'])
     git(dir, ['config', 'user.name', 'Test Bot'])
     git(dir, ['config', 'user.email', 'test@example.com'])
+    // Why: a contributor signing commits and tags globally turns these lightweight
+    // fixture tags into annotated ones, which then fail on a missing tag message.
+    git(dir, ['config', 'commit.gpgsign', 'false'])
+    git(dir, ['config', 'tag.gpgsign', 'false'])
     run(dir)
   } finally {
     rmSync(dir, { recursive: true, force: true })

--- a/config/scripts/release-rc-history.test.mjs
+++ b/config/scripts/release-rc-history.test.mjs
@@ -23,6 +23,10 @@ function withGitRepo(run) {
     git(dir, ['init', '--initial-branch=main'])
     git(dir, ['config', 'user.name', 'Test Bot'])
     git(dir, ['config', 'user.email', 'test@example.com'])
+    // Why: a contributor signing commits and tags globally turns these lightweight
+    // fixture tags into annotated ones, which then fail on a missing tag message.
+    git(dir, ['config', 'commit.gpgsign', 'false'])
+    git(dir, ['config', 'tag.gpgsign', 'false'])
     run(dir)
   } finally {
     rmSync(dir, { recursive: true, force: true })

--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -18,6 +18,14 @@ const execFileMock = vi.mocked(execFile)
 
 type AgentExecResult = { exitCode: number | null; timedOut: boolean }
 
+// Why: the guard appends its indexed config after inherited entries, so a
+// developer's own GIT_CONFIG_* shifts the expected count and indices.
+function inheritedEnvWithoutGitConfig(): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_CONFIG_'))
+  )
+}
+
 describe('AgentExecHandler', () => {
   beforeEach(() => {
     spawnMock.mockReset()
@@ -54,7 +62,7 @@ describe('AgentExecHandler', () => {
     expect(spawnMock).toHaveBeenCalledWith('agent', ['--flag', '42'], {
       cwd: '/repo',
       env: expect.objectContaining({
-        ...process.env,
+        ...inheritedEnvWithoutGitConfig(),
         GIT_TERMINAL_PROMPT: '0',
         GCM_INTERACTIVE: 'never'
       }),
@@ -93,7 +101,7 @@ describe('AgentExecHandler', () => {
     expect(spawnMock).toHaveBeenCalledWith('codex', ['exec'], {
       cwd: '/repo',
       env: expect.objectContaining({
-        ...process.env,
+        ...inheritedEnvWithoutGitConfig(),
         CODEX_HOME: '/managed/codex-home',
         PATH: '/managed/bin'
       }),


### PR DESCRIPTION
## Summary

No user-visible change. Three test files failed on a contributor machine because they read the developer's own Git configuration instead of pinning their own, so a clean checkout was red for reasons unrelated to the product.

Two distinct root causes, both in the tests:

1. `config/scripts/release-rc-history.test.mjs` and `config/scripts/publish-complete-draft-releases.test.mjs` build a throwaway repo and tag it with lightweight tags (`git tag v1.4.36-rc.5`). With `tag.gpgsign=true` set globally, Git promotes those to annotated signed tags and aborts with `fatal: no tag message?`; with `commit.gpgsign=true` the fixture commits go through the signing path too. The fix pins `commit.gpgsign=false` and `tag.gpgsign=false` in `withGitRepo()`, so the fixture repo owns its own configuration rather than repeating `-c` on each of the five tag calls.

2. `src/relay/agent-exec-handler.test.ts` spread `...process.env` into the expected spawn environment, which pins whatever `GIT_CONFIG_COUNT` the shell exported. `AgentExecHandler` applies the credential guard through `appendGitConfigEnv`, which appends its two entries *after* the inherited indexed pairs; with `GIT_CONFIG_COUNT=2` inherited, the spawned environment correctly becomes `COUNT=4` with the guard at indices 2 and 3. The assertion expected `COUNT=2`, so it only held when the shell exported nothing.

The fix is on the test side in both cases. For the relay in particular the product is right: appending is what keeps a caller's own indexed Git config intact, and making the test pass by clobbering the parent's entries would be a real regression. The expectation now builds the inherited environment through a local `inheritedEnvWithoutGitConfig()` helper that filters `GIT_CONFIG_*`, and keeps asserting every other inherited variable. The file already saved, set and restored `GIT_CONFIG_*` around the dedicated indexed-config test, so isolating that surface was the established intent.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm test` does not reach vitest in this worktree: the `ensure-native-runtime` preflight fails to rebuild node-pty for Node 24.18.1 and exits before the run. That blocker is pre-existing and unrelated to this change. Vitest was run directly instead, on the affected files and then on the whole suite:

```
node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts \
  config/scripts/release-rc-history.test.mjs \
  config/scripts/publish-complete-draft-releases.test.mjs \
  src/relay/agent-exec-handler.test.ts
```

Both failures were reproduced before the fix and confirmed gone after it:

- Release fixtures, before: 5 failed with `fatal: no tag message?`, using only the machine's existing global config. After: green.
- Relay, before: 2 failed with `GIT_CONFIG_COUNT` expected `2`, received `4`, running under `GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=credential.interactive GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=credential.guiPrompt GIT_CONFIG_VALUE_1=false`. After: green both with those variables set and with them unset, which is the point of the change.

Total after the fix: 23 passed across the three files. The full suite through the same direct vitest invocation ends at 8 failed files, 3983 passed, 10 skipped (42205 tests passed). None of the three files in this PR is among the 8; they are all in the node-pty, daemon, pty, subprocess and runtime area, matching the native build problem described above, and none of them is touched here.

`pnpm build` was not run; the change touches test files only and produces no shipped code.

## AI Review Report

Reviewed for correctness of the diagnosis, over-reach of the assertion change, and cross-platform behavior.

- Checked that the relay change does not weaken the test into vacuity: `expect.objectContaining` still asserts every inherited variable except the `GIT_CONFIG_*` family, and the indexed-config contract itself stays covered by the dedicated test that asserts `GIT_CONFIG_COUNT=3`, the guard at indices 1 and 2, and that a superseded inherited value is dropped.
- Confirmed the product behavior is correct and left untouched: `appendGitConfigEnv` returns early when the inherited protocol is ambiguous, and appends from a validated count otherwise, so caller entries are never overwritten.
- Cross-platform (macOS, Linux, Windows): the fixture change is plain `git config` writes in a temporary repo, with no path, shell or platform assumptions, and both files already used `path.join`-free temp dirs from `mkdtempSync`. The helper filters environment keys by prefix only. The Windows-specific `WSLENV` registration in `gitCredentialPromptGuardEnv` is untouched, and `src/relay/agent-exec-handler-windows.test.ts` still passes. No shortcuts, labels or Electron platform behavior are involved.
- Git binary compatibility: `git config <key> <value>` and `git tag` predate the 2.25 baseline, so no capability probe or fallback is needed.

## Security Audit

Test-only change; no product code, IPC surface, input handling or dependency is modified.

The one security-relevant point is what the relay test asserts. The previous expectation would only have held if `AgentExecHandler` overwrote the parent process's indexed Git config, which would let a guarded spawn silently drop a caller's `http.proxy` or credential settings. Adjusting the test preserves the safer append semantics rather than pressuring the handler toward clobbering. Signing configuration is disabled only inside a `mkdtempSync` fixture repo that is removed in the `finally` block, never in the contributor's global or repository config. No secrets, credentials or network calls are added.

## Notes

- No follow-up work required for this change.
- Unrelated and pre-existing on this machine: `pnpm test` cannot start because the node-pty native rebuild fails for Node 24.18.1, and 8 files stay red under a direct vitest run for what looks like the same native cause. This PR does not claim to address them.
