### PR TITLE
fix(sidebar): nest compact subagent rows past their parent

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.lineage-indent.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.lineage-indent.test.tsx
@@ -1,0 +1,126 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Why: the compact row's leading column is what actually nests a descendant. The lineage wrapper
+// only indents 17px, so a leaf that renders no chevron gutter spends that indent right back and
+// lands left of its parent's state dot — the tree reads flat. These tests pin the gutter.
+
+let mockAgents: unknown[] = []
+
+function mockAgent(paneKey: string, prompt: string, parentPaneKey?: string): unknown {
+  return {
+    paneKey,
+    tab: { id: paneKey.split(':')[0] },
+    agentType: 'claude',
+    rowSource: undefined,
+    state: 'working',
+    startedAt: 1000,
+    entry: {
+      prompt,
+      state: 'working',
+      stateStartedAt: 1000,
+      stateHistory: [],
+      orchestration: parentPaneKey ? { parentPaneKey } : undefined
+    },
+    lineage: undefined
+  }
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      agentActivityDisplayMode: 'compact',
+      acknowledgedAgentsByPaneKey: {},
+      cacheTimerByKey: {},
+      dropAgentStatus: vi.fn(),
+      dismissRetainedAgent: vi.fn(),
+      agentSendPopoverTargetMode: null,
+      agentStatusByPaneKey: {},
+      agentStatusEpoch: 0,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      runtimePaneTitlesByTabId: {},
+      sendPromptToSidebarAgentTarget: vi.fn(),
+      settings: { promptCacheTimerEnabled: false, promptCacheTtlMs: 60_000 }
+    })
+}))
+
+vi.mock('./useWorktreeAgentRows', () => ({
+  useWorktreeAgentRows: vi.fn(() => mockAgents)
+}))
+
+vi.mock('@/components/dashboard/useNow', () => ({
+  useNow: vi.fn(() => 2000)
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownForPane: () => null,
+  usePromptCacheCountdownStartedAt: () => null
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
+  activateTabAndFocusPane: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+/** Reserved leading spacers — the chevron itself is a button, so this counts leaves only. */
+function countReservedGutters(markup: string): number {
+  return markup.match(/<span class="size-4 shrink-0"/g)?.length ?? 0
+}
+
+describe('compact agent lineage indentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reserves the chevron gutter on a descendant leaf so it nests past its parent', async () => {
+    mockAgents = [
+      mockAgent('tab-parent:1', 'Parent'),
+      mockAgent('tab-child:1', 'Child', 'tab-parent:1')
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).toContain('worktree-agent-lineage-children')
+    expect(markup).toContain('compact-agent-child-disclosure-button')
+    // The parent owns the chevron, so the single spacer is the child's.
+    expect(countReservedGutters(markup)).toBe(1)
+  })
+
+  it('reserves the gutter at every depth so nesting compounds', async () => {
+    mockAgents = [
+      mockAgent('tab-a:1', 'Root'),
+      mockAgent('tab-b:1', 'Middle', 'tab-a:1'),
+      mockAgent('tab-c:1', 'Leaf', 'tab-b:1')
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    // Root and middle both render chevrons; only the depth-2 leaf reserves a spacer.
+    expect(countReservedGutters(markup)).toBe(1)
+    expect(markup.match(/worktree-agent-lineage-children/g)).toHaveLength(2)
+  })
+
+  it('leaves a lone flat root without a reserved gutter', async () => {
+    mockAgents = [mockAgent('tab-solo:1', 'Solo')]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    const markup = renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+
+    expect(markup).not.toContain('worktree-agent-lineage-children')
+    expect(countReservedGutters(markup)).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.lineage-indent.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.lineage-indent.test.tsx
@@ -2,9 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Why: the compact row's leading column is what actually nests a descendant. The lineage wrapper
-// only indents 17px, so a leaf that renders no chevron gutter spends that indent right back and
-// lands left of its parent's state dot — the tree reads flat. These tests pin the gutter.
+// Why: a descendant leaf that skips the chevron gutter lands left of its parent's dot, reading flat.
 
 let mockAgents: unknown[] = []
 

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -333,9 +333,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           onToggleChildAgents={
             hasChildAgents ? () => toggleLineageParent(agent.paneKey) : undefined
           }
-          // Why: the lineage wrapper only indents 17px, so a descendant leaf that skips the 20px
-          // chevron gutter spends the indent right back and lands left of its parent's dot. Always
-          // reserve it below the root so each level nests by a visible step.
+          // Why: a descendant leaf that skips the chevron gutter lands left of its parent's dot.
           reserveDisclosureGutter={hasChildAgents ? false : isRootAgent ? anyRootHasChildren : true}
           isFocusedPane={agent.paneKey === focusedAgentPaneKey}
           cacheTimerActive={cacheTimerActive}

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -230,7 +230,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     e.stopPropagation()
   }, [])
 
-  // Why: root leaf siblings reserve a leading spacer when any root has a chevron, keeping the state-dot column aligned (descendants already indent).
+  // Why: root leaf siblings reserve a leading spacer when any root has a chevron, keeping the state-dot column aligned.
   const anyRootHasChildren = rootAgents.some(
     (agent) => (childrenByParentPaneKey.get(agent.paneKey) ?? []).length > 0
   )
@@ -333,7 +333,10 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           onToggleChildAgents={
             hasChildAgents ? () => toggleLineageParent(agent.paneKey) : undefined
           }
-          reserveDisclosureGutter={isRootAgent && anyRootHasChildren && !hasChildAgents}
+          // Why: the lineage wrapper only indents 17px, so a descendant leaf that skips the 20px
+          // chevron gutter spends the indent right back and lands left of its parent's dot. Always
+          // reserve it below the root so each level nests by a visible step.
+          reserveDisclosureGutter={hasChildAgents ? false : isRootAgent ? anyRootHasChildren : true}
           isFocusedPane={agent.paneKey === focusedAgentPaneKey}
           cacheTimerActive={cacheTimerActive}
         />


### PR DESCRIPTION
## Summary

In the sidebar's compact agent list (the default mode), nested subagent rows rendered **left of** their parent instead of under it, so a lineage tree read as a flat sibling list.

Measured from the row list's left edge:

| | leading column | content starts at |
|---|---|---|
| Parent row | `px-1` 4px + chevron 16px + `gap-1` 4px | **24px** |
| Descendant leaf (before) | wrapper 17px + `px-1` 4px | **21px** |
| Descendant leaf (after) | wrapper 17px + `px-1` 4px + spacer 16px + `gap-1` 4px | **41px** |

`.worktree-agent-lineage-children` (`main.css:1415`) contributes 17px of indent, but a descendant leaf reserved no chevron gutter while its parent reserved 20px — so the leaf spent the whole indent back and landed 3px to the *left* of its parent's state dot.

`reserveDisclosureGutter` was gated on `isRootAgent`, and the comment beside it assumed "descendants already indent". They do indent — just not by enough to cover the gutter they skip. The fix reserves the gutter for descendant leaves too, so each level nests by a visible ~17px step, the same order as the `SIDEBAR_TREE_INDENT` (18px) already used by the folder/repo/worktree tree in this sidebar.

Full (non-compact) mode is deliberately untouched: it compensates separately via `pl-5` on lineage children and is already positively indented, and its connector spans are absolutely positioned against that padding. Leaving it alone keeps the blast radius on the surface that is actually broken.

Not folder-specific — `WorktreeCard.tsx:1067` computes `showInlineAgentList` with no `isFolder` branch and passes only `worktreeId` down, so one rendering path serves folder workspaces and git worktrees alike. Reproduced in both.

## Screenshots

⚠️ No image attached — reported from a user screenshot I cannot re-upload here. The change is purely horizontal offset of nested rows; the exact geometry is tabulated above and pinned by the new tests.

```
BEFORE                              AFTER

v ✳ Monitore toda a importa... 46m  v ✳ Monitore toda a importa... 46m
  · qt-monitor-charlotte      2m        · qt-monitor-charlotte     2m
  · qt-monitor-buffalo        1m        · qt-monitor-buffalo       1m
  · qt-monitor-argentina      1m        · qt-monitor-argentina     1m
  ^                                     ^
  children land LEFT of the             children clear the parent's
  parent's state dot (-3px)             dot by a full step (+17px)
```

## Testing

- [x] `pnpm lint` — exit 0
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm test` — exit 0, 3955 files / 41844 tests passed (9 files / 71 skipped)
- [x] `pnpm build` — exit 0
- [x] Added or updated high-quality tests that would catch regressions

New `WorktreeCardAgents.lineage-indent.test.tsx` — a sibling test file matching the existing `.activation` / `.send-target` / `.expansion-remount` pattern, because the main `WorktreeCardAgents.test.tsx` sits at the 800-line `max-lines` ceiling and per `AGENTS.md` that limit must not be bumped or disabled.

Three cases: descendant leaf reserves the gutter, nesting compounds at depth 2, and a lone flat root reserves nothing (guard against over-reserving). The first two were verified to **fail on `main`** and pass with the fix — checked by stashing the source change and re-running, so they are not vacuous.

## AI Review Report

Reviewed by CodeRabbit and Greptile on this PR, plus my own trace of the render path before writing the fix.

- **Greptile**: confidence 5/5, "safe to merge". Confirmed the change is confined to a single ternary in the compact path, that non-compact mode is explicitly untouched, and that the three tests cover the corrected logic. No files flagged for attention.
- **CodeRabbit**: 1 actionable comment — the rationale comments spanned three lines each, against the repo guideline "Comments must be concise, limited to non-obvious information, and preferably one line". Reduced both to a single line in 18c2e016. Its other pre-merge checks passed except the description template, which this rewrite addresses.
- **Risks I checked myself**: (a) whether the root-alignment rule regressed — `anyRootHasChildren` still gates root leaves only, and the third test pins that a lone flat root reserves nothing; (b) whether full mode would double-compensate if the same change were applied there — it would (`pl-5` + a 20px gutter), which is why it is excluded; (c) whether folder workspaces take a different path — they do not.

**Cross-platform compatibility (macOS / Linux / Windows): explicitly checked.** The diff changes one JSX ternary that decides whether a 16px Tailwind spacer `<span>` renders, plus a new test file. It touches no keyboard shortcuts (no `metaKey`/`ctrlKey`), no shortcut labels, no file paths, no shell invocation, no Git commands, and no Electron platform APIs. Layout is pure CSS and renders identically on all three targets. Nothing here interacts with the SSH or remote-runtime paths either.

## Security Audit

No security surface touched. This is a renderer-only layout change: no input handling, no command execution, no path handling, no auth or secrets, no IPC messages added or changed, and no dependency changes. The rendered spacer is a static `aria-hidden` element with no interpolated content, so it introduces no injection vector. No follow-up needed.

## Notes

- The `AgentStateDot` on these nested rows is 6px in compact mode and subagent rows hide the identity icon, so a running teammate and a parked one are hard to tell apart at a glance. That is a separate legibility issue and is **not** addressed here — it is being tracked for its own PR.
- Full (non-compact) agent rows still nest by only ~9px because of the hand-tuned `pl-5`. Unifying both modes on the gutter mechanism would be cleaner, but it would require re-tuning the `left-[13px]` lineage connector spans in `DashboardAgentRow`, so it is deliberately out of scope.
