### PR TITLE
fix(terminal): prune stale remote tab ghosts

### DIFF
--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -492,6 +492,44 @@ describe('closeTerminalTab', () => {
     })
   })
 
+  it('routes a remote PTY close by terminal evidence while the worktree catalog is absent', () => {
+    const closeTab = vi.fn()
+    isWebRuntimeSessionActiveMock.mockImplementation(
+      (environmentId: string) => environmentId === 'owner-runtime'
+    )
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'host-tab-1',
+            ptyId: 'remote:owner-runtime@@terminal-1',
+            worktreeId: 'wt-1'
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'host-tab-1',
+      openFiles: [],
+      closeTab,
+      setActiveTab: vi.fn()
+    })
+
+    closeTerminalTab('host-tab-1')
+
+    expect(closeTab).toHaveBeenCalledWith('host-tab-1', {
+      reason: undefined,
+      remoteCloseOwnedByHost: true
+    })
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'host-tab-1',
+      environmentId: 'owner-runtime',
+      reason: 'user'
+    })
+  })
+
   function makePinnedTabState(
     overrides: { confirmClosePinnedTab: boolean } & Record<string, unknown>
   ): Record<string, unknown> {

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -17,6 +17,8 @@ import type {
   TerminalTabRetirementPlan
 } from '@/store/slices/terminal-tab-retirement'
 import { closeLocalTerminalTabState } from './close-local-terminal-tab-state'
+import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
+
 import { getTerminalIncarnationHandle } from './terminal-close-incarnation'
 import {
   getWorktreeTerminalTabIds,
@@ -39,6 +41,30 @@ function isPinnedVisibleTab(
       (tab) => (tab.id === visibleId || tab.entityId === visibleId) && tab.isPinned
     ) ?? false
   )
+}
+function resolveTerminalRuntimeEnvironmentId(
+  state: TerminalTabActionState,
+  worktreeId: string,
+  terminalTabId: string
+): string | null {
+  const tab = state.tabsByWorktree[worktreeId]?.find((entry) => entry.id === terminalTabId)
+  const ptyIds = [
+    tab?.ptyId,
+    ...(state.ptyIdsByTabId?.[terminalTabId] ?? []),
+    ...Object.values(state.terminalLayoutsByTabId?.[terminalTabId]?.ptyIdsByLeafId ?? {})
+  ]
+  let ownerEnvironmentId: string | null = null
+  for (const ptyId of ptyIds) {
+    const environmentId = ptyId ? getRemoteRuntimePtyEnvironmentId(ptyId) : null
+    if (!environmentId) {
+      continue
+    }
+    if (ownerEnvironmentId && ownerEnvironmentId !== environmentId) {
+      return null
+    }
+    ownerEnvironmentId = environmentId
+  }
+  return ownerEnvironmentId
 }
 
 export function closeTerminalTab(
@@ -73,8 +99,13 @@ export function closeTerminalTab(
     return
   }
   const { worktreeId: owningWorktreeId, terminalTabId } = target
+  const terminalRuntimeEnvironmentId = resolveTerminalRuntimeEnvironmentId(
+    state,
+    owningWorktreeId,
+    terminalTabId
+  )
   const worktreeRoute = resolveTerminalWorktreeRoute(state, owningWorktreeId)
-  if (!worktreeRoute) {
+  if (!worktreeRoute && !terminalRuntimeEnvironmentId) {
     options?.onCancel?.()
     return
   }
@@ -101,7 +132,8 @@ export function closeTerminalTab(
     return
   }
 
-  const runtimeEnvironmentId = worktreeRoute.runtimeEnvironmentId
+  const runtimeEnvironmentId =
+    terminalRuntimeEnvironmentId ?? worktreeRoute?.runtimeEnvironmentId ?? null
   if (runtimeEnvironmentId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
     if (options?.reason === 'pty-exit') {
       // Why: stream exit is not host-tab closure; the HUB snapshot decides whether reconnect restores or removes this tab.

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -797,6 +797,67 @@ describe('applyWebSessionTabsSnapshot', () => {
     )
   })
 
+  it('prunes an aged null-PTY tab after an authoritative host snapshot omits it', () => {
+    const staleTab: TerminalTab = {
+      id: 'stale-local-tab',
+      ptyId: null,
+      worktreeId: WT,
+      title: 'Claude',
+      defaultTitle: 'Claude',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW - 31_000,
+      launchAgent: 'claude'
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: { [WT]: [staleTab] },
+        unifiedTabsByWorktree: {
+          [WT]: [
+            {
+              id: staleTab.id,
+              entityId: staleTab.id,
+              groupId: 'group-1',
+              worktreeId: WT,
+              contentType: 'terminal',
+              label: staleTab.title,
+              customLabel: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: staleTab.createdAt,
+              isPreview: false,
+              isPinned: false
+            }
+          ]
+        }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Codex',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          launchAgent: 'codex',
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.tabsByWorktree?.[WT]?.map((tab) => tab.id)).toEqual([
+      toWebTerminalSurfaceTabId('host-tab-1')
+    ])
+    expect(patch.unifiedTabsByWorktree?.[WT]?.map((tab) => tab.entityId)).toEqual([
+      toWebTerminalSurfaceTabId('host-tab-1')
+    ])
+  })
+
   it('replaces only the provisional tab with an exact structured-create handoff', () => {
     const provisional = (id: string): TerminalTab => ({
       id,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -542,8 +542,8 @@ function shouldReplaceTerminalTab(
     if (tab.pendingActivationSpawn && nextRemotePtyIds.size > 0) {
       return true
     }
-    // Why: restored placeholders need a bounded create window, but once it expires an
-    // authoritative host omission proves that retaining the handle-less tab creates a ghost.
+    // Why: a worktree has one execution host, so null-PTY placeholders inherit this
+    // snapshot's owner; after the bounded create window, omission proves they are ghosts.
     if (now - tab.createdAt >= REMOTE_NULL_PTY_TAB_GRACE_MS) {
       return true
     }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -86,6 +86,7 @@ import {
 import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
+const REMOTE_NULL_PTY_TAB_GRACE_MS = 30_000
 
 type SessionTabsStreamEvent =
   | (RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' })
@@ -525,7 +526,8 @@ function shouldReplaceTerminalTab(
   environmentId: string,
   nextRemotePtyIds: ReadonlySet<string>,
   nextMirroredTerminalIds: ReadonlySet<string>,
-  exactProvisionalHandoffs: ReadonlySet<string>
+  exactProvisionalHandoffs: ReadonlySet<string>,
+  now: number
 ): boolean {
   if (exactProvisionalHandoffs.has(tab.id)) {
     // Why: agent kind is not session identity; retire only the provisional tab
@@ -536,8 +538,15 @@ function shouldReplaceTerminalTab(
     // Why: host snapshots are authoritative for mirrored tabs; replace old mirrors even when the next surface still awaits a stream handle, else parity drifts.
     return true
   }
-  if (tab.pendingActivationSpawn && tab.ptyId === null && nextRemotePtyIds.size > 0) {
-    return true
+  if (tab.ptyId === null) {
+    if (tab.pendingActivationSpawn && nextRemotePtyIds.size > 0) {
+      return true
+    }
+    // Why: restored placeholders need a bounded create window, but once it expires an
+    // authoritative host omission proves that retaining the handle-less tab creates a ghost.
+    if (now - tab.createdAt >= REMOTE_NULL_PTY_TAB_GRACE_MS) {
+      return true
+    }
   }
   if (!isRuntimeTerminalTabForEnvironment(tab, environmentId)) {
     return false
@@ -1818,7 +1827,8 @@ export function applyWebSessionTabsSnapshot(
         environmentId,
         nextRemotePtyIds,
         nextMirroredTerminalIds,
-        exactProvisionalHandoffs
+        exactProvisionalHandoffs,
+        now
       )
   )
   const mirroredTerminalTabs = buildMirroredTerminalTabs(


### PR DESCRIPTION
## Summary

- retire restored null-PTY terminal placeholders after a 30-second create grace period when an authoritative host snapshot still omits them
- preserve fresh in-flight creates and the existing exact structured-handoff behavior
- route terminal closes from unambiguous environment-scoped PTY evidence before falling back to the worktree catalog
- cover both mirrored/unified ghost cleanup and catalog-hydration close routing with renderer regressions

Fixes #11800.

Related: #9585, #11495.

## Verification

- `pnpm typecheck:web`
- `pnpm exec oxlint src/renderer/src/runtime/web-session-tabs-sync.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/components/terminal/terminal-tab-actions.ts src/renderer/src/components/terminal/terminal-tab-actions.test.ts --deny-warnings`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/components/terminal/terminal-tab-actions.test.ts` — 90 tests passed
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:code-quality:changed` (Node 24)
