### PR TITLE
Fix orchestration gate authorization to scope by Run binding

### DIFF
--- a/src/cli/handlers/orchestration-gate-cli.test.ts
+++ b/src/cli/handlers/orchestration-gate-cli.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { callMock, getTerminalHandleMock } = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  getTerminalHandleMock: vi.fn()
+}))
+
+vi.mock('../runtime-client', async () => {
+  // Why: re-export the REAL error classes so format.ts `instanceof` narrowing still matches.
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('../runtime/types.js')
+  class RuntimeClient {
+    readonly isRemote = false
+    call = callMock
+    getCliStatus = vi.fn()
+    openOrca = vi.fn()
+  }
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError,
+    serveOrcaApp: vi.fn(),
+    getDefaultUserDataPath: vi.fn(() => '/tmp/orca-user-data')
+  }
+})
+
+vi.mock('../selectors', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getTerminalHandle: getTerminalHandleMock
+}))
+
+import { main } from '../index'
+import { RuntimeClientError } from '../runtime/types'
+import { okFixture, queueFixtures } from '../test-fixtures'
+
+const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
+const originalPaneKey = process.env.ORCA_PANE_KEY
+
+const restoreEnv = (name: string, value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
+describe('orchestration gate commands carry caller identity', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    callMock.mockReset()
+    getTerminalHandleMock.mockReset()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    delete process.env.ORCA_TERMINAL_HANDLE
+    delete process.env.ORCA_PANE_KEY
+    process.exitCode = 0
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    restoreEnv('ORCA_TERMINAL_HANDLE', originalTerminalHandle)
+    restoreEnv('ORCA_PANE_KEY', originalPaneKey)
+    process.exitCode = 0
+  })
+
+  const paramsFor = (method: string): Record<string, unknown> =>
+    callMock.mock.calls.find((call) => call[0] === method)?.[1] as Record<string, unknown>
+
+  it('sends the bound coordinator handle to gateCreate', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_coord'
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { terminal: { handle: 'term_coord' } }),
+      okFixture('req_gate', { gate: { id: 'gate_1', task_id: 'task_1', status: 'pending' } })
+    )
+
+    await main(
+      ['orchestration', 'gate-create', '--task', 'task_1', '--question', 'ship?', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(process.exitCode).toBe(0)
+    expect(paramsFor('orchestration.gateCreate')).toEqual(
+      expect.objectContaining({ task: 'task_1', question: 'ship?', from: 'term_coord' })
+    )
+  })
+
+  it('remints a stale environment handle before authorizing gateCreate', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale'
+    process.env.ORCA_PANE_KEY = 'tab_coord:leaf_coord'
+    callMock.mockImplementation(async (method: string) => {
+      if (method === 'terminal.show') {
+        throw new RuntimeClientError('terminal_handle_stale', 'stale')
+      }
+      if (method === 'terminal.resolvePane') {
+        return okFixture('req_pane', { terminal: { handle: 'term_live' } })
+      }
+      return okFixture('req_gate', {
+        gate: { id: 'gate_1', task_id: 'task_1', status: 'pending' }
+      })
+    })
+
+    await main(
+      ['orchestration', 'gate-create', '--task', 'task_1', '--question', 'ship?', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(paramsFor('orchestration.gateCreate')).toEqual(
+      expect.objectContaining({ from: 'term_live' })
+    )
+  })
+
+  it('accepts an explicit --from without probing terminal liveness', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_gate', {
+        gate: { id: 'gate_1', task_id: 'task_1', status: 'resolved', resolution: 'go' }
+      })
+    )
+
+    await main(
+      [
+        'orchestration',
+        'gate-resolve',
+        '--id',
+        'gate_1',
+        '--resolution',
+        'go',
+        '--from',
+        'term_explicit',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(process.exitCode).toBe(0)
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(paramsFor('orchestration.gateResolve')).toEqual(
+      expect.objectContaining({ id: 'gate_1', resolution: 'go', from: 'term_explicit' })
+    )
+  })
+
+  it('scopes gate-list to the caller when no Run is named', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_coord'
+    queueFixtures(
+      callMock,
+      okFixture('req_show', { terminal: { handle: 'term_coord' } }),
+      okFixture('req_list', { gates: [], count: 0 })
+    )
+
+    await main(['orchestration', 'gate-list', '--json'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(0)
+    expect(paramsFor('orchestration.gateList')).toEqual(
+      expect.objectContaining({ from: 'term_coord', run: undefined })
+    )
+  })
+
+  it('inspects a named Run without resolving a caller terminal', async () => {
+    // Why: read-only inspection must stay reachable from a pane with no bound Run.
+    getTerminalHandleMock.mockRejectedValue(
+      new RuntimeClientError('no_active_terminal', 'no active terminal')
+    )
+    queueFixtures(
+      callMock,
+      okFixture('req_list', {
+        gates: [{ id: 'gate_1', task_id: 'task_1', question: 'ship?', status: 'pending' }],
+        count: 1
+      })
+    )
+
+    await main(['orchestration', 'gate-list', '--run', 'run_adopted', '--json'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(0)
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+    expect(paramsFor('orchestration.gateList')).toEqual(
+      expect.objectContaining({ run: 'run_adopted', from: undefined })
+    )
+  })
+
+  it('fails an unbound gate-create with an actionable error and no mutation', async () => {
+    getTerminalHandleMock.mockRejectedValue(
+      new RuntimeClientError('no_active_terminal', 'no active terminal')
+    )
+
+    await main(
+      ['orchestration', 'gate-create', '--task', 'task_1', '--question', 'ship?'],
+      '/tmp/repo'
+    )
+
+    expect(process.exitCode).toBe(1)
+    const stderr = errorSpy.mock.calls.map((call) => String(call[0])).join('\n')
+    expect(stderr).toContain('Pass --from <terminal-handle>')
+    expect(callMock).not.toHaveBeenCalledWith('orchestration.gateCreate', expect.anything())
+  })
+})

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -1093,13 +1093,15 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     )
   },
 
-  'orchestration gate-create': async ({ flags, client, json }) => {
+  'orchestration gate-create': async ({ flags, client, cwd, json }) => {
     const result = await callMutation<{
       gate: { id: string; task_id: string; status: string }
     }>(client, flags, 'orchestration.gateCreate', {
       task: getRequiredStringFlag(flags, 'task'),
       question: getRequiredStringFlag(flags, 'question'),
-      options: getOptionalStringFlag(flags, 'options')
+      options: getOptionalStringFlag(flags, 'options'),
+      // Why: gates are Run-scoped, so the coordinator handle is the caller identity the runtime authorizes against.
+      from: await resolveCoordinatorTerminalHandle(flags, cwd, client)
     })
     printResult(
       result,
@@ -1108,23 +1110,30 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     )
   },
 
-  'orchestration gate-resolve': async ({ flags, client, json }) => {
+  'orchestration gate-resolve': async ({ flags, client, cwd, json }) => {
     const result = await callMutation<{
       gate: { id: string; task_id: string; status: string; resolution: string }
     }>(client, flags, 'orchestration.gateResolve', {
       id: getRequiredStringFlag(flags, 'id'),
-      resolution: getRequiredStringFlag(flags, 'resolution')
+      resolution: getRequiredStringFlag(flags, 'resolution'),
+      from: await resolveCoordinatorTerminalHandle(flags, cwd, client)
     })
     printResult(result, json, (r) => `Gate ${r.gate.id} resolved: ${r.gate.resolution}`)
   },
 
-  'orchestration gate-list': async ({ flags, client, json }) => {
+  'orchestration gate-list': async ({ flags, client, cwd, json }) => {
+    const run = getOptionalStringFlag(flags, 'run')
+    // Why: same read posture as task-list — an explicitly named Run stays inspectable without a bound pane, so identity is only resolved for the implicit "my own Run" case.
+    const from = run ? undefined : await resolveCoordinatorTerminalHandle(flags, cwd, client)
     const result = await client.call<{
       gates: { id: string; task_id: string; question: string; status: string }[]
       count: number
+      runId?: string
     }>('orchestration.gateList', {
       task: getOptionalStringFlag(flags, 'task'),
-      status: getOptionalStringFlag(flags, 'status')
+      status: getOptionalStringFlag(flags, 'status'),
+      run,
+      from
     })
     printResult(result, json, (r) => {
       if (r.gates.length === 0) {

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -236,20 +236,23 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     path: ['orchestration', 'gate-create'],
     summary: 'Create a decision gate blocking a task',
     usage:
-      'orca orchestration gate-create --task <task_id> --question <text> [--options <json_array>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'task', 'question', 'options', 'retry-request']
+      'orca orchestration gate-create --task <task_id> --question <text> [--options <json_array>] [--from <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'task', 'question', 'options', 'from', 'retry-request']
   },
   {
     path: ['orchestration', 'gate-resolve'],
     summary: 'Resolve a pending decision gate',
-    usage: 'orca orchestration gate-resolve --id <gate_id> --resolution <text> [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'id', 'resolution', 'retry-request']
+    usage:
+      'orca orchestration gate-resolve --id <gate_id> --resolution <text> [--from <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'id', 'resolution', 'from', 'retry-request']
   },
   {
     path: ['orchestration', 'gate-list'],
     summary: 'List decision gates',
-    usage: 'orca orchestration gate-list [--task <task_id>] [--status <status>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'task', 'status']
+    usage:
+      'orca orchestration gate-list [--task <task_id>] [--status <status>] [--run <run_id>] [--from <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'task', 'status', 'run', 'from'],
+    notes: ['--run inspects a named Run without binding; otherwise gates are scoped to the caller.']
   },
   {
     path: ['orchestration', 'reset'],

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -55,6 +55,16 @@ function isEquivalentPaneKey(a: string, b: string): boolean {
   return Boolean(aLeaf && bLeaf && aLeaf === bLeaf)
 }
 
+// Why: indexable pre-filter for isEquivalentPaneKey — equal strings and equal leaves both share the
+// text after the first ':', so this narrows candidates without deciding equivalence itself.
+const PANE_KEY_MATCH_SUFFIX_SQL =
+  "substr(coordinator_pane_key, instr(coordinator_pane_key, ':') + 1)"
+
+function paneKeyMatchSuffix(paneKey: string): string {
+  const colon = paneKey.indexOf(':')
+  return colon < 0 ? paneKey : paneKey.slice(colon + 1)
+}
+
 export type {
   MessageType,
   MessagePriority,
@@ -510,6 +520,10 @@ export class OrchestrationDb {
 
       CREATE INDEX IF NOT EXISTS idx_gates_task ON decision_gates(task_id);
       CREATE INDEX IF NOT EXISTS idx_gates_status ON decision_gates(status);
+
+      CREATE INDEX IF NOT EXISTS idx_runs_coordinator_pane_leaf
+        ON runs(${PANE_KEY_MATCH_SUFFIX_SQL})
+        WHERE coordinator_pane_key IS NOT NULL;
 
       CREATE TABLE IF NOT EXISTS coordinator_runs (
         id                  TEXT PRIMARY KEY,
@@ -2245,6 +2259,8 @@ export class OrchestrationDb {
           'Legacy takeover is only available for the automatically adopted Run.'
         )
       }
+      // Why: only LIVE legacy work needs the flag — settled work has no competing authority left, and
+      // fencing it would strand the recovered graph behind an attestation the caller may not have.
       if (
         activeLegacyAssignment &&
         !sameBinding &&
@@ -2338,15 +2354,26 @@ export class OrchestrationDb {
   }
 
   getCurrentRunForPane(paneKey: string): RunRow | undefined {
-    const runs = this.db
-      .prepare('SELECT * FROM runs WHERE coordinator_pane_key IS NOT NULL AND legacy = 0')
-      .all() as RunRow[]
-    const run = runs.find(
-      (candidate) =>
-        candidate.coordinator_pane_key !== null &&
-        isEquivalentPaneKey(candidate.coordinator_pane_key, paneKey)
-    )
+    const run = this.runsBoundToPane(paneKey)[0]
     return run ? exposeRunTimestamps(run) : undefined
+  }
+
+  // Why: the indexed suffix only narrows candidates; isEquivalentPaneKey still decides, so
+  // reminted tab halves keep matching and unparseable keys keep requiring an exact match.
+  private runsBoundToPane(paneKey: string): RunRow[] {
+    return (
+      this.db
+        .prepare(
+          `SELECT * FROM runs
+           WHERE coordinator_pane_key IS NOT NULL AND legacy = 0
+             AND ${PANE_KEY_MATCH_SUFFIX_SQL} = ?
+           ORDER BY rowid`
+        )
+        .all(paneKeyMatchSuffix(paneKey)) as RunRow[]
+    ).filter(
+      (run) =>
+        run.coordinator_pane_key !== null && isEquivalentPaneKey(run.coordinator_pane_key, paneKey)
+    )
   }
 
   private getRunRaw(id: string): RunRow | undefined {
@@ -2354,15 +2381,8 @@ export class OrchestrationDb {
   }
 
   private unbindOtherRunsForPane(paneKey: string, exceptRunId?: string): void {
-    const bound = this.db
-      .prepare('SELECT * FROM runs WHERE coordinator_pane_key IS NOT NULL AND legacy = 0')
-      .all() as RunRow[]
-    for (const run of bound) {
-      if (
-        run.id !== exceptRunId &&
-        run.coordinator_pane_key &&
-        isEquivalentPaneKey(run.coordinator_pane_key, paneKey)
-      ) {
+    for (const run of this.runsBoundToPane(paneKey)) {
+      if (run.id !== exceptRunId) {
         this.db
           .prepare(
             `UPDATE runs

--- a/src/main/runtime/orchestration/orchestration-adopted-run-binding.test.ts
+++ b/src/main/runtime/orchestration/orchestration-adopted-run-binding.test.ts
@@ -339,10 +339,6 @@ describe('pane-bound Run lookup', () => {
     bind(61, 2001)
     const large = measure()
 
-    // eslint-disable-next-line no-console
-    console.log(
-      `[bench] getCurrentRunForPane 61 runs=${small.toFixed(4)}ms 2001 runs=${large.toFixed(4)}ms`
-    )
     // The pre-index scan grew ~28x across this range; the index keeps it flat.
     expect(large).toBeLessThan(small * 6)
     expect(explain(db, 'x')).toContain('USING INDEX idx_runs_coordinator_pane_leaf')

--- a/src/main/runtime/orchestration/orchestration-adopted-run-binding.test.ts
+++ b/src/main/runtime/orchestration/orchestration-adopted-run-binding.test.ts
@@ -1,0 +1,379 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type Database from '../../sqlite/sync-database'
+import SyncDatabase from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+
+const LEGACY_COORDINATOR_HANDLE = 'term_legacy_coord'
+const LEGACY_COORDINATOR_PANE = 'tab_coord:44444444-4444-4444-8444-444444444444'
+const LEGACY_WORKER_HANDLE = 'term_legacy_worker'
+const LEGACY_WORKER_PANE = 'tab_worker:33333333-3333-4333-8333-333333333333'
+const CURRENT_COORDINATOR_HANDLE = 'term_current_coord'
+const CURRENT_COORDINATOR_PANE = 'tab_current:11111111-1111-4111-8111-111111111111'
+
+const tempDirs: string[] = []
+const databases: OrchestrationDb[] = []
+
+afterEach(() => {
+  for (const database of databases.splice(0)) {
+    database.close()
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function track(db: OrchestrationDb): OrchestrationDb {
+  databases.push(db)
+  return db
+}
+
+type AdoptedFixture = {
+  db: OrchestrationDb
+  adoptedRunId: string
+  taskId: string
+  dispatchId: string
+  recoveryMessageId: string
+}
+
+/** Builds a pre-cutover graph at schema 18 and reopens it so adoption runs. */
+function createAdoptedFixture(options: { settleWork: boolean }): AdoptedFixture {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-adopted-bind-'))
+  tempDirs.push(dir)
+  const dbPath = join(dir, 'orchestration.db')
+
+  const before = new OrchestrationDb(dbPath)
+  const task = before.createTask({
+    spec: 'legacy assignment',
+    createdByTerminalHandle: LEGACY_COORDINATOR_HANDLE
+  })
+  const dispatch = before.createDispatchContext(task.id, LEGACY_WORKER_HANDLE, LEGACY_WORKER_PANE)
+  const recovery = before.insertMessage({
+    from: LEGACY_WORKER_HANDLE,
+    to: LEGACY_COORDINATOR_HANDLE,
+    subject: 'recovered worker outcome',
+    type: 'worker_done'
+  })
+  before.close()
+
+  const raw = new SyncDatabase(dbPath)
+  if (options.settleWork) {
+    raw.exec("UPDATE dispatch_contexts SET status = 'completed'")
+  }
+  raw.exec(`
+    DROP INDEX IF EXISTS idx_messages_delivery_contract;
+    DROP TABLE legacy_mail_receipts;
+    DROP TABLE legacy_operation_receipts;
+    DROP TABLE legacy_compatibility_principals;
+    DROP TABLE legacy_adoptions;
+  `)
+  raw.pragma('user_version = 18')
+  raw.close()
+
+  const db = track(new OrchestrationDb(dbPath))
+  return {
+    db,
+    adoptedRunId: db.getLegacyAdoption()?.adopted_run_id as string,
+    taskId: task.id,
+    dispatchId: dispatch.id,
+    recoveryMessageId: recovery.id
+  }
+}
+
+function commitLegacyCoordinator(db: OrchestrationDb, runId: string): string {
+  return db.commitLegacyCompatibilityPrincipal({
+    runId,
+    role: 'coordinator',
+    hostScope: 'local:runtime_1',
+    terminalHandle: LEGACY_COORDINATOR_HANDLE,
+    paneKey: LEGACY_COORDINATOR_PANE,
+    launchTokenHash: 'coord_launch_hash',
+    processIncarnation: 'process_coord'
+  }).principal.id
+}
+
+// Why: --takeover-legacy guards LIVE legacy work only. Settled work has no competing authority to
+// seize, and requiring the flag there would strand the recovered graph behind an attestation the
+// caller may not hold (runUse rejects the flag unless caller authority matches the binding pane).
+describe('adopted Run binding without --takeover-legacy', () => {
+  it('fences a bind while legacy work is still live, and names the recovery command', () => {
+    const { db, adoptedRunId } = createAdoptedFixture({ settleWork: false })
+
+    expect(() =>
+      db.bindRun({
+        runId: adoptedRunId,
+        coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+        coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'consumer_fenced',
+        data: {
+          effectsApplied: false,
+          recoveryCommand: `orca orchestration run-use --id ${adoptedRunId} --takeover-legacy`
+        }
+      })
+    )
+    expect(db.getRun(adoptedRunId)).toMatchObject({
+      coordinator_handle: null,
+      coordinator_pane_key: null,
+      consumer_generation: 0
+    })
+  })
+
+  it('claims the settled adopted Run and inherits its recovered task graph', () => {
+    const { db, adoptedRunId } = createAdoptedFixture({ settleWork: true })
+
+    const run = db.bindRun({
+      runId: adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+
+    expect(run).toMatchObject({
+      coordinator_handle: CURRENT_COORDINATOR_HANDLE,
+      coordinator_pane_key: CURRENT_COORDINATOR_PANE,
+      consumer_generation: 1
+    })
+    expect(db.listTasks({ runId: adoptedRunId })).toHaveLength(1)
+    expect(db.getCurrentRunForPane(CURRENT_COORDINATOR_PANE)?.id).toBe(adoptedRunId)
+  })
+
+  // Why: this is what makes the unflagged claim safe — the recovered coordinator's mail is not orphaned.
+  it('promotes the retained coordinator mail onto the claiming Run', () => {
+    const { db, adoptedRunId, recoveryMessageId } = createAdoptedFixture({ settleWork: true })
+    expect(db.getMessageById(recoveryMessageId)).toMatchObject({
+      to_handle: LEGACY_COORDINATOR_HANDLE,
+      delivery_contract: 'legacy_direct'
+    })
+
+    const run = db.bindRun({
+      runId: adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })!
+
+    expect(db.getMessageById(recoveryMessageId)).toMatchObject({
+      to_handle: `run:${adoptedRunId}`,
+      delivery_contract: 'current_delivery',
+      read: 0
+    })
+    expect(
+      db
+        .getOrCreateRunDelivery({
+          runId: adoptedRunId,
+          consumerGeneration: run.consumer_generation
+        })
+        ?.messages.map((message) => message.id)
+    ).toContain(recoveryMessageId)
+  })
+
+  it('revokes an attested legacy coordinator when it claims the settled Run', () => {
+    const { db, adoptedRunId } = createAdoptedFixture({ settleWork: true })
+    const principalId = commitLegacyCoordinator(db, adoptedRunId)
+
+    db.bindRun({
+      runId: adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+
+    expect(db.getLegacyCompatibilityPrincipal(principalId)?.status).toBe('revoked')
+  })
+
+  // Why: the acknowledgement is per claimant, not one-shot — a prior takeover does not license the next.
+  it('keeps fencing new claimants while legacy work stays live', () => {
+    const { db, adoptedRunId } = createAdoptedFixture({ settleWork: false })
+    db.bindRun({
+      runId: adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE,
+      takeoverLegacy: true
+    })
+
+    expect(() =>
+      db.bindRun({
+        runId: adoptedRunId,
+        coordinatorHandle: 'term_second_coord',
+        coordinatorPaneKey: 'tab_second:22222222-2222-4222-8222-222222222222'
+      })
+    ).toThrowError(expect.objectContaining({ code: 'consumer_fenced' }))
+  })
+
+  it('lets a later coordinator claim the settled Run once the first one has', () => {
+    const { db, adoptedRunId } = createAdoptedFixture({ settleWork: true })
+    db.bindRun({
+      runId: adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+
+    expect(
+      db.bindRun({
+        runId: adoptedRunId,
+        coordinatorHandle: 'term_second_coord',
+        coordinatorPaneKey: 'tab_second:22222222-2222-4222-8222-222222222222'
+      })
+    ).toMatchObject({ coordinator_handle: 'term_second_coord', consumer_generation: 2 })
+  })
+})
+
+// Why: the SQL narrows on the text after the first ':' — a superset of leaf-equivalence — so the
+// JS isEquivalentPaneKey filter stays authoritative. These pin both halves of that contract.
+describe('pane-bound Run lookup', () => {
+  function explain(db: OrchestrationDb, paneKey: string): string {
+    const sqlite = (db as unknown as { db: Database.Database }).db
+    return (
+      sqlite
+        .prepare(
+          `EXPLAIN QUERY PLAN
+           SELECT * FROM runs
+           WHERE coordinator_pane_key IS NOT NULL AND legacy = 0
+             AND substr(coordinator_pane_key, instr(coordinator_pane_key, ':') + 1) = ?
+           ORDER BY rowid`
+        )
+        .all(paneKey) as { detail: string }[]
+    )
+      .map((row) => row.detail)
+      .join(' | ')
+  }
+
+  it('matches a reminted tab half by leaf UUID', () => {
+    const db = track(new OrchestrationDb(':memory:'))
+    const run = db.createRun({
+      objective: 'work',
+      coordinatorHandle: 'term_a',
+      coordinatorPaneKey: 'tab_original:77777777-7777-4777-8777-777777777777'
+    })
+
+    expect(db.getCurrentRunForPane('tab_broken_out:77777777-7777-4777-8777-777777777777')?.id).toBe(
+      run.id
+    )
+  })
+
+  it('requires an exact match for keys that do not parse', () => {
+    const db = track(new OrchestrationDb(':memory:'))
+    // Extra ':' makes parsePaneKey return null even though the leaf-looking suffix matches.
+    const unparseable = 'tab:extra:88888888-8888-4888-8888-888888888888'
+    db.createRun({
+      objective: 'unparseable',
+      coordinatorHandle: 'term_b',
+      coordinatorPaneKey: unparseable
+    })
+
+    expect(db.getCurrentRunForPane(unparseable)?.coordinator_pane_key).toBe(unparseable)
+    expect(
+      db.getCurrentRunForPane('tab_other:88888888-8888-4888-8888-888888888888')
+    ).toBeUndefined()
+  })
+
+  it('matches colon-free keys only on exact equality', () => {
+    const db = track(new OrchestrationDb(':memory:'))
+    db.createRun({ objective: 'flat', coordinatorHandle: 'term_c', coordinatorPaneKey: 'flatkey' })
+
+    expect(db.getCurrentRunForPane('flatkey')?.objective).toBe('flat')
+    expect(db.getCurrentRunForPane('tab:flatkey')).toBeUndefined()
+  })
+
+  it('unbinds only the leaf-equivalent Run when a pane rebinds', () => {
+    const db = track(new OrchestrationDb(':memory:'))
+    const shared = db.createRun({
+      objective: 'first',
+      coordinatorHandle: 'term_d',
+      coordinatorPaneKey: 'tab_one:99999999-9999-4999-8999-999999999999'
+    })
+    const untouched = db.createRun({
+      objective: 'other pane',
+      coordinatorHandle: 'term_e',
+      coordinatorPaneKey: 'tab_two:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+
+    const rebound = db.createRun({
+      objective: 'second',
+      coordinatorHandle: 'term_d',
+      coordinatorPaneKey: 'tab_reminted:99999999-9999-4999-8999-999999999999'
+    })
+
+    // createRun binds at generation 1; the unbind fences it to 2.
+    expect(db.getRun(shared.id)).toMatchObject({
+      coordinator_pane_key: null,
+      consumer_generation: 2
+    })
+    expect(db.getRun(untouched.id)).toMatchObject({
+      coordinator_pane_key: 'tab_two:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    expect(db.getCurrentRunForPane('tab_one:99999999-9999-4999-8999-999999999999')?.id).toBe(
+      rebound.id
+    )
+  })
+
+  it('stays flat as the bound-Run set grows', () => {
+    const db = track(new OrchestrationDb(':memory:'))
+    const leafOf = (i: number) => `${i.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+    const bind = (from: number, to: number): void => {
+      for (let i = from; i < to; i++) {
+        db.createRun({
+          objective: `run ${i}`,
+          coordinatorHandle: `term_${i}`,
+          coordinatorPaneKey: `tab_${i}:${leafOf(i)}`
+        })
+      }
+    }
+    const probe = `tab_reminted:${leafOf(0)}`
+    const measure = (): number => {
+      for (let i = 0; i < 200; i++) {
+        db.getCurrentRunForPane(probe)
+      }
+      const start = performance.now()
+      for (let i = 0; i < 2000; i++) {
+        db.getCurrentRunForPane(probe)
+      }
+      return (performance.now() - start) / 2000
+    }
+
+    bind(0, 61)
+    expect(db.getCurrentRunForPane(probe)).toBeDefined()
+    const small = measure()
+    bind(61, 2001)
+    const large = measure()
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[bench] getCurrentRunForPane 61 runs=${small.toFixed(4)}ms 2001 runs=${large.toFixed(4)}ms`
+    )
+    // The pre-index scan grew ~28x across this range; the index keeps it flat.
+    expect(large).toBeLessThan(small * 6)
+    expect(explain(db, 'x')).toContain('USING INDEX idx_runs_coordinator_pane_leaf')
+  })
+
+  it('hands the JS filter an O(1) candidate set regardless of bound-Run count', () => {
+    const db = track(new OrchestrationDb(':memory:'))
+    const sqlite = (db as unknown as { db: Database.Database }).db
+    const leaf = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    for (let i = 0; i < 500; i++) {
+      db.createRun({
+        objective: `run ${i}`,
+        coordinatorHandle: `term_${i}`,
+        coordinatorPaneKey: `tab_${i}:${i.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`
+      })
+    }
+    db.createRun({
+      objective: 'target',
+      coordinatorHandle: 'term_target',
+      coordinatorPaneKey: `tab_target:${leaf}`
+    })
+
+    const candidates = sqlite
+      .prepare(
+        `SELECT id FROM runs
+         WHERE coordinator_pane_key IS NOT NULL AND legacy = 0
+           AND substr(coordinator_pane_key, instr(coordinator_pane_key, ':') + 1) = ?`
+      )
+      .all(leaf) as { id: string }[]
+
+    expect(candidates).toHaveLength(1)
+    expect(db.getCurrentRunForPane(`tab_reminted:${leaf}`)?.objective).toBe('target')
+  })
+})

--- a/src/main/runtime/rpc/core.ts
+++ b/src/main/runtime/rpc/core.ts
@@ -88,6 +88,8 @@ export type RpcContext = {
     method: string
     payloadHash: string
   }
+  // Why: Run-scoped handlers must compare declared handles with request attestation.
+  orchestrationCompatibilityEvidence?: OrchestrationCompatibilityEvidence
   // Why: only the compatibility authority router can set this trusted scope; user params cannot bypass Run consumer binding.
   legacyCoordinatorRunId?: string
   legacyCoordinatorAuthority?: LegacyCoordinatorAuthorityProof

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -104,7 +104,8 @@ export class RpcDispatcher {
           legacyCoordinatorAuthority: legacyCoordinator?.authority,
           revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
           orchestrationCompatibilityCallerAuthority:
-            compatibility.orchestrationCompatibilityCallerAuthority
+            compatibility.orchestrationCompatibilityCallerAuthority,
+          orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
         })
       }
       const result = await this.orchestrationMutations.run(
@@ -199,7 +200,8 @@ export class RpcDispatcher {
             legacyCoordinatorAuthority: legacyCoordinator?.authority,
             revalidateLegacyCoordinator: legacyCoordinator?.revalidate,
             orchestrationCompatibilityCallerAuthority:
-              compatibility.orchestrationCompatibilityCallerAuthority
+              compatibility.orchestrationCompatibilityCallerAuthority,
+            orchestrationCompatibilityEvidence: request.orchestrationCompatibilityEvidence
           })
         }
         const result = await this.orchestrationMutations.run(

--- a/src/main/runtime/rpc/methods/orchestration-gate-run-authorization.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gate-run-authorization.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  cleanupLegacyCompatibilityDispatcherHarnesses,
+  COORDINATOR_HANDLE,
+  createHarness,
+  currentEvidence,
+  CURRENT_COORDINATOR_HANDLE,
+  CURRENT_COORDINATOR_PANE,
+  evidence,
+  invoke,
+  request,
+  type LegacyCompatibilityDispatcherHarness
+} from '../orchestration-legacy-compatibility-dispatcher-test-fixture'
+
+const STRANGER_HANDLE = 'term_stranger_coord'
+const STRANGER_PANE = 'tab_stranger:77777777-7777-4777-8777-777777777777'
+
+afterEach(() => {
+  cleanupLegacyCompatibilityDispatcherHarnesses()
+})
+
+function bindCurrentCoordinatorRun(harness: LegacyCompatibilityDispatcherHarness): string {
+  return harness.db.createRun({
+    objective: 'current work',
+    coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+    coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+  }).id
+}
+
+// Why: the adopted Run's recovered task is the cross-Run target; its dispatch must stay live when a gate is refused.
+function adoptedTaskState(harness: LegacyCompatibilityDispatcherHarness) {
+  return {
+    task: harness.db.getTask(harness.taskId)?.status,
+    dispatch: harness.db.getDispatchContextById(harness.dispatchId)?.status,
+    gates: harness.db.listGates({ taskId: harness.taskId }).length
+  }
+}
+
+const UNATTESTED_CURRENT_COORDINATOR = { ...currentEvidence('coordinator'), launchToken: '' }
+
+describe('orchestration gate Run authorization', () => {
+  it.each(['dispatch', 'websocket'] as const)(
+    'G1 %s refuses an unbound attested caller creating a gate on the adopted Run',
+    async (transport) => {
+      const harness = createHarness()
+      const before = adoptedTaskState(harness)
+
+      const response = await invoke(
+        harness.dispatcher,
+        request(
+          'orchestration.gateCreate',
+          { task: harness.taskId, question: 'Proceed?' },
+          currentEvidence('coordinator'),
+          `g1-unbound-gate-create-${transport}`
+        ),
+        transport
+      )
+
+      expect(response).toMatchObject({ ok: false, error: { code: 'run_required' } })
+      expect(adoptedTaskState(harness)).toEqual(before)
+    }
+  )
+
+  it('G2 refuses an unattested caller creating a gate on another Run task', async () => {
+    const harness = createHarness()
+    const runA = bindCurrentCoordinatorRun(harness)
+    const before = adoptedTaskState(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: CURRENT_COORDINATOR_HANDLE },
+        UNATTESTED_CURRENT_COORDINATOR,
+        'g2-cross-run-gate-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'task_not_found',
+        message: `Task ${harness.taskId} was not found in Run ${runA}.`
+      }
+    })
+    expect(adoptedTaskState(harness)).toEqual(before)
+  })
+
+  it('G2 refuses the same caller when it names no sender terminal at all', async () => {
+    const harness = createHarness()
+    bindCurrentCoordinatorRun(harness)
+    const before = adoptedTaskState(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?' },
+        UNATTESTED_CURRENT_COORDINATOR,
+        'g2-anonymous-gate-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'run_required' } })
+    expect(adoptedTaskState(harness)).toEqual(before)
+  })
+
+  it('G3 refuses an unattested caller once the adopted Run is claimed', async () => {
+    const harness = createHarness()
+    const claim = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        { id: harness.adoptedRunId, from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'g3-legacy-claim'
+      )
+    )
+    expect(claim).toMatchObject({ ok: true })
+    bindCurrentCoordinatorRun(harness)
+    const before = adoptedTaskState(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: CURRENT_COORDINATOR_HANDLE },
+        UNATTESTED_CURRENT_COORDINATOR,
+        'g3-claimed-gate-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(adoptedTaskState(harness)).toEqual(before)
+  })
+
+  it('G4 refuses an attested bound caller creating a gate in a stranger Run', async () => {
+    const harness = createHarness()
+    const runA = bindCurrentCoordinatorRun(harness)
+    const strangerRun = harness.db.createRun({
+      objective: 'stranger work',
+      coordinatorHandle: STRANGER_HANDLE,
+      coordinatorPaneKey: STRANGER_PANE
+    })
+    const strangerTask = harness.db.createTask({
+      spec: 'stranger assignment',
+      runId: strangerRun.id
+    })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: strangerTask.id, question: 'Proceed?', from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('coordinator'),
+        'g4-stranger-gate-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'task_not_found',
+        message: `Task ${strangerTask.id} was not found in Run ${runA}.`
+      }
+    })
+    expect(harness.db.getTask(strangerTask.id)?.status).toBe('ready')
+    expect(harness.db.listGates({ taskId: strangerTask.id })).toHaveLength(0)
+  })
+
+  it('G4 refuses the stranger Run even when it is named explicitly', async () => {
+    const harness = createHarness()
+    const runA = bindCurrentCoordinatorRun(harness)
+    const strangerRun = harness.db.createRun({
+      objective: 'stranger work',
+      coordinatorHandle: STRANGER_HANDLE,
+      coordinatorPaneKey: STRANGER_PANE
+    })
+    const strangerTask = harness.db.createTask({
+      spec: 'stranger assignment',
+      runId: strangerRun.id
+    })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        {
+          task: strangerTask.id,
+          question: 'Proceed?',
+          from: CURRENT_COORDINATOR_HANDLE,
+          run: strangerRun.id
+        },
+        currentEvidence('coordinator'),
+        'g4-explicit-stranger-gate-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: {
+        code: 'consumer_fenced',
+        message: `This coordinator terminal is bound to ${runA}, not ${strangerRun.id}.`
+      }
+    })
+    expect(harness.db.getTask(strangerTask.id)?.status).toBe('ready')
+  })
+
+  it('G5 refuses an unattested caller resolving another Run gate', async () => {
+    const harness = createHarness()
+    bindCurrentCoordinatorRun(harness)
+    const gate = harness.db.createGate({ taskId: harness.taskId, question: 'Proceed?' })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateResolve',
+        { id: gate.id, resolution: 'yes', from: CURRENT_COORDINATOR_HANDLE },
+        UNATTESTED_CURRENT_COORDINATOR,
+        'g5-cross-run-gate-resolve'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { message: `Gate not found: ${gate.id}` } })
+    expect(harness.db.getGate(gate.id)?.status).toBe('pending')
+    expect(harness.db.getTask(harness.taskId)?.status).toBe('blocked')
+  })
+
+  it('keeps gate-list from leaking gates outside the caller Run', async () => {
+    const harness = createHarness()
+    const runA = bindCurrentCoordinatorRun(harness)
+    const ownTask = harness.db.createTask({ spec: 'own assignment', runId: runA })
+    const ownGate = harness.db.createGate({ taskId: ownTask.id, question: 'Own?' })
+    harness.db.createGate({ taskId: harness.taskId, question: 'Adopted?' })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateList',
+        { from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('coordinator'),
+        'gate-list-scope'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { runId: runA, count: 1, gates: [{ id: ownGate.id }] }
+    })
+  })
+
+  it('lets the bound coordinator create, list, and resolve its own Run gates', async () => {
+    const harness = createHarness()
+    const runA = bindCurrentCoordinatorRun(harness)
+    const ownTask = harness.db.createTask({ spec: 'own assignment', runId: runA })
+
+    const created = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        {
+          task: ownTask.id,
+          question: 'Ship it?',
+          options: JSON.stringify(['yes', 'no']),
+          from: CURRENT_COORDINATOR_HANDLE
+        },
+        currentEvidence('coordinator'),
+        'own-gate-create'
+      )
+    )) as { ok: true; result: { gate: { id: string } } }
+
+    expect(created).toMatchObject({ ok: true, result: { gate: { task_id: ownTask.id } } })
+    expect(harness.db.getTask(ownTask.id)?.status).toBe('blocked')
+
+    const resolved = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateResolve',
+        {
+          id: created.result.gate.id,
+          resolution: 'yes',
+          from: CURRENT_COORDINATOR_HANDLE
+        },
+        currentEvidence('coordinator'),
+        'own-gate-resolve'
+      )
+    )
+
+    expect(resolved).toMatchObject({
+      ok: true,
+      result: { gate: { status: 'resolved', resolution: 'yes' } }
+    })
+    expect(harness.db.getTask(ownTask.id)?.status).toBe('ready')
+  })
+
+  it('keeps the retained legacy coordinator operating on the adopted Run', async () => {
+    const harness = createHarness()
+
+    const created = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'legacy-gate-create'
+      )
+    )) as { ok: true; result: { gate: { id: string; run_id: string } } }
+
+    expect(created).toMatchObject({
+      ok: true,
+      result: { gate: { task_id: harness.taskId, run_id: harness.adoptedRunId } }
+    })
+
+    const resolved = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateResolve',
+        { id: created.result.gate.id, resolution: 'go', from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'legacy-gate-resolve'
+      )
+    )
+
+    expect(resolved).toMatchObject({ ok: true, result: { gate: { status: 'resolved' } } })
+    expect(harness.db.getTask(harness.taskId)?.status).toBe('ready')
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-gates.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gates.ts
@@ -3,6 +3,10 @@ import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
 import type { GateStatus } from '../../orchestration/db'
 import { Coordinator } from '../../orchestration/coordinator'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+import { orchestrationSkillRecoveryData } from '../../../../shared/orchestration-rpc-contract'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RunRow } from '../../orchestration/types'
 
 // Why: the coordinator instance is stored at module scope so orchestration.runStop
 // can signal it to halt. Only one coordinator can run at a time (enforced by
@@ -22,18 +26,85 @@ const RunStopParams = z.object({})
 const GateCreateParams = z.object({
   task: requiredString('Missing --task'),
   question: requiredString('Missing --question'),
-  options: OptionalString
+  options: OptionalString,
+  from: OptionalString,
+  run: OptionalString
 })
 
 const GateResolveParams = z.object({
   id: requiredString('Missing --id'),
-  resolution: requiredString('Missing --resolution')
+  resolution: requiredString('Missing --resolution'),
+  from: OptionalString,
+  run: OptionalString
 })
 
 const GateListParams = z.object({
   task: OptionalString,
-  status: z.enum(['pending', 'resolved', 'timeout']).optional()
+  status: z.enum(['pending', 'resolved', 'timeout']).optional(),
+  from: OptionalString,
+  run: OptionalString
 })
+
+// Why: gates are Run-scoped state, so every gate method resolves the caller's Run the same way
+// resolveRunScope does for taskCreate/taskUpdate/dispatch (orchestration.ts). Duplicated rather than
+// imported because orchestration.ts already imports this module.
+function resolveGateRunScope(
+  runtime: OrcaRuntimeService,
+  params: {
+    runId?: string
+    callerTerminalHandle?: string
+    requireCurrentConsumer: boolean
+    legacyCoordinatorRunId?: string
+  }
+): RunRow {
+  const db = runtime.getOrchestrationDb()
+  const explicit = params.runId ? db.getRun(params.runId) : undefined
+  if (params.runId && (!explicit || explicit.legacy === 1)) {
+    throw new OrchestrationError('run_not_found', `Run ${params.runId} was not found.`)
+  }
+
+  if (!params.requireCurrentConsumer && explicit) {
+    return explicit
+  }
+  if (explicit && params.legacyCoordinatorRunId === explicit.id) {
+    return explicit
+  }
+  if (!params.callerTerminalHandle) {
+    throw new OrchestrationError(
+      'run_required',
+      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
+      orchestrationSkillRecoveryData()
+    )
+  }
+  const paneKey = runtime.getTerminalPaneKey(params.callerTerminalHandle)
+  if (!paneKey) {
+    throw new OrchestrationError(
+      'stable_pane_required',
+      'The coordinator terminal has no stable pane identity.'
+    )
+  }
+  const current = db.getCurrentRunForPane(paneKey)
+  if (!current) {
+    if (explicit) {
+      throw new OrchestrationError(
+        'consumer_fenced',
+        `This coordinator terminal is no longer bound to Run ${explicit.id}.`
+      )
+    }
+    throw new OrchestrationError(
+      'run_required',
+      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
+      orchestrationSkillRecoveryData()
+    )
+  }
+  if (explicit && current.id !== explicit.id) {
+    throw new OrchestrationError(
+      'consumer_fenced',
+      `This coordinator terminal is bound to ${current.id}, not ${explicit.id}.`
+    )
+  }
+  return current
+}
 
 export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
   // Why: Section 4.12 — orchestration.run returns immediately with a run ID.
@@ -105,10 +176,6 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
     params: GateCreateParams,
     handler: (params, { runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
-      const task = db.getTask(params.task)
-      if (legacyCoordinatorRunId && task?.run_id !== legacyCoordinatorRunId) {
-        throw new Error(`Task not found: ${params.task}`)
-      }
       let options: string[] | undefined
       if (params.options) {
         try {
@@ -120,6 +187,22 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
         } catch {
           throw new Error('Invalid --options: must be a JSON array of strings')
         }
+      }
+      const task = db.getTask(params.task)
+      if (!task) {
+        throw new Error(`Task not found: ${params.task}`)
+      }
+      const run = resolveGateRunScope(runtime, {
+        runId: params.run,
+        callerTerminalHandle: params.from,
+        requireCurrentConsumer: true,
+        legacyCoordinatorRunId
+      })
+      if (task.run_id !== run.id) {
+        throw new OrchestrationError(
+          'task_not_found',
+          `Task ${params.task} was not found in Run ${run.id}.`
+        )
       }
       const gate = db.createGate({
         taskId: params.task,
@@ -136,7 +219,17 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
     handler: (params, { runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       const existing = db.getGate(params.id)
-      if (legacyCoordinatorRunId && existing?.run_id !== legacyCoordinatorRunId) {
+      if (!existing) {
+        throw new Error(`Gate not found: ${params.id}`)
+      }
+      const run = resolveGateRunScope(runtime, {
+        runId: params.run,
+        callerTerminalHandle: params.from,
+        requireCurrentConsumer: true,
+        legacyCoordinatorRunId
+      })
+      // Why: a gate outside the caller's Run is indistinguishable from a missing one, so probing cannot map foreign Runs.
+      if (existing.run_id !== run.id) {
         throw new Error(`Gate not found: ${params.id}`)
       }
       const gate = db.resolveGate(params.id, params.resolution)
@@ -150,13 +243,26 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.gateList',
     params: GateListParams,
-    handler: (params, { runtime }) => {
+    handler: (params, { runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
-      const gates = db.listGates({
-        taskId: params.task,
-        status: params.status as GateStatus
-      })
-      return { gates, count: gates.length }
+      const explicitRun = params.run ? db.getRun(params.run) : undefined
+      // Why: same read posture as taskList — an explicitly named Run is inspectable, an unnamed one means the caller's own.
+      const run =
+        explicitRun?.legacy === 1
+          ? explicitRun
+          : resolveGateRunScope(runtime, {
+              runId: params.run,
+              callerTerminalHandle: params.from,
+              requireCurrentConsumer: params.run === undefined,
+              legacyCoordinatorRunId
+            })
+      const gates = db
+        .listGates({
+          taskId: params.task,
+          status: params.status as GateStatus
+        })
+        .filter((gate) => gate.run_id === run.id)
+      return { runId: run.id, gates, count: gates.length }
     }
   })
 ]

--- a/src/main/runtime/rpc/methods/orchestration-gates.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gates.ts
@@ -3,10 +3,8 @@ import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
 import type { GateStatus } from '../../orchestration/db'
 import { Coordinator } from '../../orchestration/coordinator'
+import { resolveRunScope } from './orchestration-run-scope'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
-import { orchestrationSkillRecoveryData } from '../../../../shared/orchestration-rpc-contract'
-import type { OrcaRuntimeService } from '../../orca-runtime'
-import type { RunRow } from '../../orchestration/types'
 
 // Why: the coordinator instance is stored at module scope so orchestration.runStop
 // can signal it to halt. Only one coordinator can run at a time (enforced by
@@ -44,67 +42,6 @@ const GateListParams = z.object({
   from: OptionalString,
   run: OptionalString
 })
-
-// Why: gates are Run-scoped state, so every gate method resolves the caller's Run the same way
-// resolveRunScope does for taskCreate/taskUpdate/dispatch (orchestration.ts). Duplicated rather than
-// imported because orchestration.ts already imports this module.
-function resolveGateRunScope(
-  runtime: OrcaRuntimeService,
-  params: {
-    runId?: string
-    callerTerminalHandle?: string
-    requireCurrentConsumer: boolean
-    legacyCoordinatorRunId?: string
-  }
-): RunRow {
-  const db = runtime.getOrchestrationDb()
-  const explicit = params.runId ? db.getRun(params.runId) : undefined
-  if (params.runId && (!explicit || explicit.legacy === 1)) {
-    throw new OrchestrationError('run_not_found', `Run ${params.runId} was not found.`)
-  }
-
-  if (!params.requireCurrentConsumer && explicit) {
-    return explicit
-  }
-  if (explicit && params.legacyCoordinatorRunId === explicit.id) {
-    return explicit
-  }
-  if (!params.callerTerminalHandle) {
-    throw new OrchestrationError(
-      'run_required',
-      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
-      orchestrationSkillRecoveryData()
-    )
-  }
-  const paneKey = runtime.getTerminalPaneKey(params.callerTerminalHandle)
-  if (!paneKey) {
-    throw new OrchestrationError(
-      'stable_pane_required',
-      'The coordinator terminal has no stable pane identity.'
-    )
-  }
-  const current = db.getCurrentRunForPane(paneKey)
-  if (!current) {
-    if (explicit) {
-      throw new OrchestrationError(
-        'consumer_fenced',
-        `This coordinator terminal is no longer bound to Run ${explicit.id}.`
-      )
-    }
-    throw new OrchestrationError(
-      'run_required',
-      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
-      orchestrationSkillRecoveryData()
-    )
-  }
-  if (explicit && current.id !== explicit.id) {
-    throw new OrchestrationError(
-      'consumer_fenced',
-      `This coordinator terminal is bound to ${current.id}, not ${explicit.id}.`
-    )
-  }
-  return current
-}
 
 export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
   // Why: Section 4.12 — orchestration.run returns immediately with a run ID.
@@ -174,7 +111,7 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.gateCreate',
     params: GateCreateParams,
-    handler: (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       let options: string[] | undefined
       if (params.options) {
@@ -192,11 +129,12 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
       if (!task) {
         throw new Error(`Task not found: ${params.task}`)
       }
-      const run = resolveGateRunScope(runtime, {
+      const run = resolveRunScope(runtime, {
         runId: params.run,
         callerTerminalHandle: params.from,
         requireCurrentConsumer: true,
-        legacyCoordinatorRunId
+        legacyCoordinatorRunId,
+        callerEvidence: orchestrationCompatibilityEvidence
       })
       if (task.run_id !== run.id) {
         throw new OrchestrationError(
@@ -216,17 +154,18 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.gateResolve',
     params: GateResolveParams,
-    handler: (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       const existing = db.getGate(params.id)
       if (!existing) {
         throw new Error(`Gate not found: ${params.id}`)
       }
-      const run = resolveGateRunScope(runtime, {
+      const run = resolveRunScope(runtime, {
         runId: params.run,
         callerTerminalHandle: params.from,
         requireCurrentConsumer: true,
-        legacyCoordinatorRunId
+        legacyCoordinatorRunId,
+        callerEvidence: orchestrationCompatibilityEvidence
       })
       // Why: a gate outside the caller's Run is indistinguishable from a missing one, so probing cannot map foreign Runs.
       if (existing.run_id !== run.id) {
@@ -243,18 +182,19 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.gateList',
     params: GateListParams,
-    handler: (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       const explicitRun = params.run ? db.getRun(params.run) : undefined
       // Why: same read posture as taskList — an explicitly named Run is inspectable, an unnamed one means the caller's own.
       const run =
         explicitRun?.legacy === 1
           ? explicitRun
-          : resolveGateRunScope(runtime, {
+          : resolveRunScope(runtime, {
               runId: params.run,
               callerTerminalHandle: params.from,
               requireCurrentConsumer: params.run === undefined,
-              legacyCoordinatorRunId
+              legacyCoordinatorRunId,
+              callerEvidence: orchestrationCompatibilityEvidence
             })
       const gates = db
         .listGates({

--- a/src/main/runtime/rpc/methods/orchestration-run-scope.ts
+++ b/src/main/runtime/rpc/methods/orchestration-run-scope.ts
@@ -1,0 +1,86 @@
+import type { OrchestrationCompatibilityEvidence } from '../../../../shared/orchestration-compatibility-evidence'
+import { orchestrationSkillRecoveryData } from '../../../../shared/orchestration-rpc-contract'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+import type { RunRow } from '../../orchestration/types'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+
+export type RunScopeParams = {
+  runId?: string
+  callerTerminalHandle?: string
+  callerPaneKey?: string
+  requireCurrentConsumer: boolean
+  legacyCoordinatorRunId?: string
+  // Why: the caller's declared handle is a user param; this is the attested one to check it against.
+  callerEvidence?: OrchestrationCompatibilityEvidence
+}
+
+// Why: declared handles select mutable Run bindings, so attested callers may only name themselves.
+export function assertCallerHandleMatchesEvidence(
+  runtime: OrcaRuntimeService,
+  callerTerminalHandle: string,
+  callerEvidence?: OrchestrationCompatibilityEvidence
+): void {
+  if (!callerEvidence) {
+    return
+  }
+  const attested = runtime.verifyOrchestrationCompatibilityCaller(callerEvidence)
+  if (attested && attested.terminalHandle !== callerTerminalHandle) {
+    throw new OrchestrationError(
+      'consumer_fenced',
+      `This terminal is attested as ${attested.terminalHandle} and cannot act as ${callerTerminalHandle}.`,
+      { effectsApplied: false }
+    )
+  }
+}
+
+// Why: task and gate mutations must share one Run-binding rule.
+export function resolveRunScope(runtime: OrcaRuntimeService, params: RunScopeParams): RunRow {
+  const db = runtime.getOrchestrationDb()
+  const explicit = params.runId ? db.getRun(params.runId) : undefined
+  if (params.runId && (!explicit || explicit.legacy === 1)) {
+    throw new OrchestrationError('run_not_found', `Run ${params.runId} was not found.`)
+  }
+
+  if (!params.requireCurrentConsumer && explicit) {
+    return explicit
+  }
+  if (!params.callerTerminalHandle) {
+    throw new OrchestrationError(
+      'run_required',
+      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
+      orchestrationSkillRecoveryData()
+    )
+  }
+  assertCallerHandleMatchesEvidence(runtime, params.callerTerminalHandle, params.callerEvidence)
+  if (explicit && params.legacyCoordinatorRunId === explicit.id) {
+    return explicit
+  }
+  const paneKey = params.callerPaneKey ?? runtime.getTerminalPaneKey(params.callerTerminalHandle)
+  if (!paneKey) {
+    throw new OrchestrationError(
+      'stable_pane_required',
+      'The coordinator terminal has no stable pane identity.'
+    )
+  }
+  const current = db.getCurrentRunForPane(paneKey)
+  if (!current) {
+    if (explicit) {
+      throw new OrchestrationError(
+        'consumer_fenced',
+        `This coordinator terminal is no longer bound to Run ${explicit.id}.`
+      )
+    }
+    throw new OrchestrationError(
+      'run_required',
+      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
+      orchestrationSkillRecoveryData()
+    )
+  }
+  if (explicit && current.id !== explicit.id) {
+    throw new OrchestrationError(
+      'consumer_fenced',
+      `This coordinator terminal is bound to ${current.id}, not ${explicit.id}.`
+    )
+  }
+  return current
+}

--- a/src/main/runtime/rpc/methods/orchestration-runs.ts
+++ b/src/main/runtime/rpc/methods/orchestration-runs.ts
@@ -4,6 +4,7 @@ import { OptionalBoolean, OptionalString, requiredString } from '../schemas'
 import { ORCHESTRATION_RUN_PAGE_LIMIT } from '../../../../shared/orchestration-run-pagination'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
+import { assertCallerHandleMatchesEvidence } from './orchestration-run-scope'
 
 const RunCreateParams = z.object({
   objective: requiredString('Missing --objective'),
@@ -38,7 +39,8 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.runCreate',
     params: RunCreateParams,
-    handler: (params, { runtime }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime }) => {
+      assertCallerHandleMatchesEvidence(runtime, params.from, orchestrationCompatibilityEvidence)
       const paneKey = requireCallerPane(runtime, params.from)
       const db = runtime.getOrchestrationDb()
       const priorRun = db.getCurrentRunForPane(paneKey)
@@ -61,6 +63,7 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
       {
         runtime,
         legacyCoordinatorAuthority,
+        orchestrationCompatibilityEvidence,
         orchestrationCompatibilityCallerAuthority: callerAuthority
       }
     ) => {
@@ -75,6 +78,7 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
           { effectsApplied: false }
         )
       }
+      assertCallerHandleMatchesEvidence(runtime, params.from, orchestrationCompatibilityEvidence)
       const db = runtime.getOrchestrationDb()
       const priorRun = db.getCurrentRunForPane(paneKey)
       const run = db.bindRun({
@@ -100,7 +104,8 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.runCurrent',
     params: RunCurrentParams,
-    handler: (params, { runtime }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime }) => {
+      assertCallerHandleMatchesEvidence(runtime, params.from, orchestrationCompatibilityEvidence)
       const paneKey = requireCallerPane(runtime, params.from)
       return { run: runtime.getOrchestrationDb().getCurrentRunForPane(paneKey) ?? null }
     }

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -83,6 +83,13 @@ describe('orchestration RPC methods', () => {
       } else if (name === 'orchestration.dispatch') {
         scopedParams.run ??= activeRunId
         scopedParams.from ??= 'term_coord'
+      } else if (
+        name === 'orchestration.gateCreate' ||
+        name === 'orchestration.gateResolve' ||
+        name === 'orchestration.gateList'
+      ) {
+        // Why: gates resolve their Run from the sender's pane binding, so naming the run would skip that check.
+        scopedParams.from ??= 'term_coord'
       }
     }
     const parsed = method.params ? method.params.parse(scopedParams) : undefined

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../shared/orchestration-rpc-contract'
 import { clampOrchestrationAskTimeoutMs } from '../../../../shared/orchestration-ask-timeout'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
+import { resolveRunScope } from './orchestration-run-scope'
 import { ORCHESTRATION_RUN_METHODS } from './orchestration-runs'
 import { ORCHESTRATION_WORKER_METHODS } from './orchestration-worker-methods'
 import { ORCHESTRATION_FEDERATION_METHODS } from './orchestration-federation-methods'
@@ -247,65 +248,6 @@ const ResetParams = z
       })
     }
   })
-
-function resolveRunScope(
-  runtime: OrcaRuntimeService,
-  params: {
-    runId?: string
-    callerTerminalHandle?: string
-    callerPaneKey?: string
-    requireCurrentConsumer: boolean
-    legacyCoordinatorRunId?: string
-  }
-): RunRow {
-  const db = runtime.getOrchestrationDb()
-  const explicit = params.runId ? db.getRun(params.runId) : undefined
-  if (params.runId && (!explicit || explicit.legacy === 1)) {
-    throw new OrchestrationError('run_not_found', `Run ${params.runId} was not found.`)
-  }
-
-  if (!params.requireCurrentConsumer && explicit) {
-    return explicit
-  }
-  if (explicit && params.legacyCoordinatorRunId === explicit.id) {
-    return explicit
-  }
-  if (!params.callerTerminalHandle) {
-    throw new OrchestrationError(
-      'run_required',
-      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
-      orchestrationSkillRecoveryData()
-    )
-  }
-  const paneKey = params.callerPaneKey ?? runtime.getTerminalPaneKey(params.callerTerminalHandle)
-  if (!paneKey) {
-    throw new OrchestrationError(
-      'stable_pane_required',
-      'The coordinator terminal has no stable pane identity.'
-    )
-  }
-  const current = db.getCurrentRunForPane(paneKey)
-  if (!current) {
-    if (explicit) {
-      throw new OrchestrationError(
-        'consumer_fenced',
-        `This coordinator terminal is no longer bound to Run ${explicit.id}.`
-      )
-    }
-    throw new OrchestrationError(
-      'run_required',
-      'No Run is bound. Use orchestration run-create or run-use first. No effects were applied.',
-      orchestrationSkillRecoveryData()
-    )
-  }
-  if (explicit && current.id !== explicit.id) {
-    throw new OrchestrationError(
-      'consumer_fenced',
-      `This coordinator terminal is bound to ${current.id}, not ${explicit.id}.`
-    )
-  }
-  return current
-}
 
 function parseMessageTypes(rawTypes: string | undefined): MessageType[] | undefined {
   const types = rawTypes
@@ -722,6 +664,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     handler: async (
       params,
       {
+        orchestrationCompatibilityEvidence,
         runtime,
         signal,
         legacyCoordinatorRunId,
@@ -742,7 +685,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           callerTerminalHandle: handle,
           callerPaneKey: paneKey ?? undefined,
           requireCurrentConsumer: true,
-          legacyCoordinatorRunId
+          legacyCoordinatorRunId,
+          callerEvidence: orchestrationCompatibilityEvidence
         })
         const generation = run.consumer_generation
         const address = `run:${run.id}`
@@ -1026,7 +970,10 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.reply',
     params: ReplyParams,
-    handler: async (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: async (
+      params,
+      { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }
+    ) => {
       const db = runtime.getOrchestrationDb()
       const original = db.getMessageById(params.id)
       if (!original) {
@@ -1061,7 +1008,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           runId: params.run ?? question.run_id,
           callerTerminalHandle: params.from,
           requireCurrentConsumer: true,
-          legacyCoordinatorRunId
+          legacyCoordinatorRunId,
+          callerEvidence: orchestrationCompatibilityEvidence
         })
         const answered = db.answerQuestion({
           messageId: question.message_id,
@@ -1124,7 +1072,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.taskCreate',
     params: TaskCreateParams,
-    handler: (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       let deps: string[] | undefined
       if (params.deps) {
@@ -1149,7 +1097,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           runId: params.run,
           callerTerminalHandle: params.callerTerminalHandle,
           requireCurrentConsumer: true,
-          legacyCoordinatorRunId
+          legacyCoordinatorRunId,
+          callerEvidence: orchestrationCompatibilityEvidence
         }).id
       })
       return { task }
@@ -1159,7 +1108,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.taskList',
     params: TaskListParams,
-    handler: (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       const explicitRun = params.run ? db.getRun(params.run) : undefined
       const run =
@@ -1169,7 +1118,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
               runId: params.run,
               callerTerminalHandle: params.callerTerminalHandle,
               requireCurrentConsumer: params.run === undefined,
-              legacyCoordinatorRunId
+              legacyCoordinatorRunId,
+              callerEvidence: orchestrationCompatibilityEvidence
             })
       // Why: listTasksWithDispatch adds assignee_handle + dispatch_id (NULL for non-dispatched), so legacy-shape consumers are unaffected.
       const joined = db.listTasksWithDispatch({
@@ -1196,13 +1146,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.taskUpdate',
     params: TaskUpdateParams,
-    handler: (params, { runtime, legacyCoordinatorRunId }) => {
+    handler: (params, { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }) => {
       const db = runtime.getOrchestrationDb()
       const run = resolveRunScope(runtime, {
         runId: params.run,
         callerTerminalHandle: params.callerTerminalHandle,
         requireCurrentConsumer: true,
-        legacyCoordinatorRunId
+        legacyCoordinatorRunId,
+        callerEvidence: orchestrationCompatibilityEvidence
       })
       const existing = db.getTask(params.id)
       if (!existing || existing.run_id !== run.id) {
@@ -1222,7 +1173,15 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.dispatch',
     params: DispatchParams,
-    handler: async (params, { runtime, legacyCoordinatorRunId, revalidateLegacyCoordinator }) => {
+    handler: async (
+      params,
+      {
+        orchestrationCompatibilityEvidence,
+        runtime,
+        legacyCoordinatorRunId,
+        revalidateLegacyCoordinator
+      }
+    ) => {
       const db = runtime.getOrchestrationDb()
       const task = db.getTask(params.task)
       if (!task) {
@@ -1232,7 +1191,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         runId: params.run,
         callerTerminalHandle: params.from,
         requireCurrentConsumer: true,
-        legacyCoordinatorRunId
+        legacyCoordinatorRunId,
+        callerEvidence: orchestrationCompatibilityEvidence
       })
       if (task.run_id !== run.id) {
         throw new OrchestrationError(

--- a/src/main/runtime/rpc/orchestration-11745-regression-verification.test.ts
+++ b/src/main/runtime/rpc/orchestration-11745-regression-verification.test.ts
@@ -1,0 +1,820 @@
+// Why: independent adversarial verification of every #11745 fix. Each case reproduces the ORIGINAL
+// defect and asserts it is closed by observing state, not just the response envelope — a refusal
+// that still mutated the graph is a failure, and so is a fix that fences a legitimate coordinator.
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { OrchestrationCompatibilityEvidence } from '../../../shared/orchestration-compatibility-evidence'
+import SyncDatabase from '../../sqlite/sync-database'
+import { OrchestrationDb } from '../orchestration/db'
+import {
+  cleanupLegacyCompatibilityDispatcherHarnesses,
+  COORDINATOR_HANDLE,
+  counts,
+  createHarness,
+  currentEvidence,
+  CURRENT_COORDINATOR_HANDLE,
+  CURRENT_COORDINATOR_PANE,
+  CURRENT_WORKER_HANDLE,
+  CURRENT_WORKER_PANE,
+  evidence,
+  invoke,
+  request,
+  type LegacyCompatibilityDispatcherHarness
+} from './orchestration-legacy-compatibility-dispatcher-test-fixture'
+
+// Why: an unrelated caller the runtime CAN resolve to a pane — otherwise the refusal would be
+// stable_pane_required and would prove nothing about Run authorization.
+const OUTSIDER_HANDLE = CURRENT_WORKER_HANDLE
+const OUTSIDER_PANE = CURRENT_WORKER_PANE
+
+const tempDirs: string[] = []
+const databases: OrchestrationDb[] = []
+
+afterEach(() => {
+  cleanupLegacyCompatibilityDispatcherHarnesses()
+  for (const database of databases.splice(0)) {
+    database.close()
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function unattested(proof: OrchestrationCompatibilityEvidence): OrchestrationCompatibilityEvidence {
+  return { ...proof, launchToken: '' }
+}
+
+/** Every observable the adopted Run's recovered graph exposes; a refusal must leave all of it equal. */
+function adoptedGraph(harness: LegacyCompatibilityDispatcherHarness) {
+  return {
+    task: harness.db.getTask(harness.taskId)?.status,
+    dispatch: harness.db.getDispatchContextById(harness.dispatchId)?.status,
+    gates: harness.db.listGates({ taskId: harness.taskId }).length,
+    tasksInRun: harness.db.listTasks({ runId: harness.adoptedRunId }).length,
+    run: harness.db.getRun(harness.adoptedRunId)?.coordinator_handle ?? null,
+    tables: counts(harness.db)
+  }
+}
+
+function bindRunA(harness: LegacyCompatibilityDispatcherHarness): string {
+  return harness.db.createRun({
+    objective: 'run A work',
+    coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+    coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+  }).id
+}
+
+async function legacyClaimsAdoptedRun(
+  harness: LegacyCompatibilityDispatcherHarness,
+  id: string
+): Promise<void> {
+  const response = await harness.dispatcher.dispatch(
+    request(
+      'orchestration.runUse',
+      { id: harness.adoptedRunId, from: COORDINATOR_HANDLE },
+      evidence('coordinator'),
+      `${id}-legacy-claim`
+    )
+  )
+  expect(response).toMatchObject({ ok: true })
+}
+
+async function currentCoordinatorTakesOver(
+  harness: LegacyCompatibilityDispatcherHarness,
+  id: string
+): Promise<void> {
+  const response = await harness.dispatcher.dispatch(
+    request(
+      'orchestration.runUse',
+      { id: harness.adoptedRunId, from: CURRENT_COORDINATOR_HANDLE, takeoverLegacy: true },
+      currentEvidence('coordinator'),
+      `${id}-takeover`
+    )
+  )
+  expect(response).toMatchObject({ ok: true })
+}
+
+describe('#11745 H1 — gate methods authorize the caller Run', () => {
+  it.each(['dispatch', 'websocket'] as const)(
+    'G1 %s leaves the recovered task and its dispatch untouched for an unbound attested caller',
+    async (transport) => {
+      const harness = createHarness()
+      const before = adoptedGraph(harness)
+
+      const response = await invoke(
+        harness.dispatcher,
+        request(
+          'orchestration.gateCreate',
+          { task: harness.taskId, question: 'Proceed?' },
+          currentEvidence('coordinator'),
+          `v-g1-${transport}`
+        ),
+        transport
+      )
+
+      expect(response).toMatchObject({ ok: false, error: { code: 'run_required' } })
+      expect(adoptedGraph(harness)).toEqual(before)
+      // The recovered graph really is live work, so "unchanged" is a meaningful assertion.
+      expect(before.task).toBe('dispatched')
+      expect(before.gates).toBe(0)
+    }
+  )
+
+  it('G2 leaves the adopted Run untouched for an unattested caller bound to Run A', async () => {
+    const harness = createHarness()
+    bindRunA(harness)
+    const before = adoptedGraph(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: CURRENT_COORDINATOR_HANDLE },
+        unattested(currentEvidence('coordinator')),
+        'v-g2'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'task_not_found' } })
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+
+  it('G3 leaves the adopted Run untouched once the legacy coordinator has claimed it', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-g3')
+    bindRunA(harness)
+    const before = adoptedGraph(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: CURRENT_COORDINATOR_HANDLE },
+        unattested(currentEvidence('coordinator')),
+        'v-g3-gate'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+
+  it('G5 leaves a foreign gate pending and its task blocked', async () => {
+    const harness = createHarness()
+    bindRunA(harness)
+    const gate = harness.db.createGate({ taskId: harness.taskId, question: 'Proceed?' })
+    const before = adoptedGraph(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateResolve',
+        { id: gate.id, resolution: 'yes', from: CURRENT_COORDINATOR_HANDLE },
+        unattested(currentEvidence('coordinator')),
+        'v-g5'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { message: `Gate not found: ${gate.id}` } })
+    expect(harness.db.getGate(gate.id)).toMatchObject({ status: 'pending', resolution: null })
+    expect(adoptedGraph(harness)).toEqual(before)
+    expect(before.task).toBe('blocked')
+  })
+
+  it('G4 refuses a stranger Run with NO legacy adoption in play', () => {
+    // Why: G4 must hold on a plain runtime, so the fix cannot be an artifact of adoption state.
+    const dir = mkdtempSync(join(tmpdir(), 'orca-11745-g4-'))
+    tempDirs.push(dir)
+    const db = new OrchestrationDb(join(dir, 'orchestration.db'))
+    databases.push(db)
+    expect(db.getLegacyAdoption()).toBeUndefined()
+
+    const runA = db.createRun({
+      objective: 'run A',
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+    const runC = db.createRun({
+      objective: 'run C',
+      coordinatorHandle: OUTSIDER_HANDLE,
+      coordinatorPaneKey: OUTSIDER_PANE
+    })
+    const strangerTask = db.createTask({ spec: 'stranger work', runId: runC.id })
+
+    // The Run-scope decision the gate handler makes: A's pane resolves to A, never to C.
+    expect(db.getCurrentRunForPane(CURRENT_COORDINATOR_PANE)?.id).toBe(runA.id)
+    expect(strangerTask.run_id).toBe(runC.id)
+    expect(db.listGates({ taskId: strangerTask.id })).toHaveLength(0)
+    expect(db.getTask(strangerTask.id)?.status).toBe('ready')
+  })
+
+  it('POSITIVE: a legitimately bound coordinator still gates its own Run end to end', async () => {
+    const harness = createHarness()
+    const runA = bindRunA(harness)
+    const ownTask = harness.db.createTask({ spec: 'own work', runId: runA })
+
+    const created = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        {
+          task: ownTask.id,
+          question: 'Ship?',
+          options: JSON.stringify(['yes', 'no']),
+          from: CURRENT_COORDINATOR_HANDLE
+        },
+        currentEvidence('coordinator'),
+        'v-positive-create'
+      )
+    )) as { ok: true; result: { gate: { id: string; run_id: string } } }
+
+    expect(created).toMatchObject({ ok: true, result: { gate: { run_id: runA } } })
+    expect(harness.db.getTask(ownTask.id)?.status).toBe('blocked')
+
+    const listed = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateList',
+        { from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('coordinator'),
+        'v-positive-list'
+      )
+    )
+    expect(listed).toMatchObject({ ok: true, result: { runId: runA, count: 1 } })
+
+    const resolved = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateResolve',
+        { id: created.result.gate.id, resolution: 'yes', from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('coordinator'),
+        'v-positive-resolve'
+      )
+    )
+    expect(resolved).toMatchObject({ ok: true, result: { gate: { status: 'resolved' } } })
+    expect(harness.db.getTask(ownTask.id)?.status).toBe('ready')
+  })
+
+  it('POSITIVE: the proven legacy coordinator still gates the adopted Run task', async () => {
+    const harness = createHarness()
+
+    const created = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'v-legacy-create'
+      )
+    )) as { ok: true; result: { gate: { id: string; run_id: string } } }
+
+    expect(created).toMatchObject({
+      ok: true,
+      result: { gate: { run_id: harness.adoptedRunId, task_id: harness.taskId } }
+    })
+    expect(harness.db.getTask(harness.taskId)?.status).toBe('blocked')
+
+    const resolved = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateResolve',
+        { id: created.result.gate.id, resolution: 'go', from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'v-legacy-resolve'
+      )
+    )
+    expect(resolved).toMatchObject({ ok: true, result: { gate: { status: 'resolved' } } })
+    expect(harness.db.getTask(harness.taskId)?.status).toBe('ready')
+  })
+})
+
+describe('#11745 H1 — is --from an authenticated identity?', () => {
+  // Why: Run scoping authorizes on a declared handle, so an attested caller naming someone else's
+  // handle must be refused. Both cases run through the shared resolveRunScope, so they also pin
+  // that the gate path and the older task path cannot diverge again.
+  it('refuses an attested caller naming ANOTHER coordinator handle in --from', async () => {
+    const harness = createHarness()
+    const runA = bindRunA(harness)
+    const victimTask = harness.db.createTask({ spec: 'victim work', runId: runA })
+
+    // Caller is the current WORKER — attested as itself, bound to no Run — but names the
+    // coordinator's handle. Nothing on this request proves it may speak for that handle.
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: victimTask.id, question: 'spoofed?', from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('worker'),
+        'v-spoof-gate-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(harness.db.getTask(victimTask.id)?.status).not.toBe('blocked')
+    expect(harness.db.listGates({ taskId: victimTask.id })).toHaveLength(0)
+  })
+
+  it('refuses the same spoof against taskCreate, which predates this change', async () => {
+    const harness = createHarness()
+    const runA = bindRunA(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        { spec: 'spoofed assignment', callerTerminalHandle: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('worker'),
+        'v-spoof-task-create'
+      )
+    )
+
+    // Why: the weakness was inherited from this older path, so the fix has to cover it too.
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(harness.db.listTasks({ runId: runA })).toHaveLength(0)
+  })
+
+  it('refuses an attested caller creating a Run for another terminal', async () => {
+    const harness = createHarness()
+    const runA = bindRunA(harness)
+    const before = harness.db.listRuns().runs
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runCreate',
+        { objective: 'spoofed Run', from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('worker'),
+        'v-spoof-run-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(harness.db.listRuns().runs).toEqual(before)
+    expect(harness.db.getCurrentRunForPane(CURRENT_COORDINATOR_PANE)?.id).toBe(runA)
+  })
+
+  it('refuses an attested caller rebinding another terminal with runUse', async () => {
+    const harness = createHarness()
+    const runA = bindRunA(harness)
+    const workerRun = harness.db.createRun({
+      objective: 'worker Run',
+      coordinatorHandle: CURRENT_WORKER_HANDLE,
+      coordinatorPaneKey: CURRENT_WORKER_PANE
+    })
+    const beforeA = harness.db.getRun(runA)
+    const beforeWorker = harness.db.getRun(workerRun.id)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        { id: workerRun.id, from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('worker'),
+        'v-spoof-run-use'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(harness.db.getRun(runA)).toEqual(beforeA)
+    expect(harness.db.getRun(workerRun.id)).toEqual(beforeWorker)
+  })
+
+  it('refuses an attested caller querying another terminal with runCurrent', async () => {
+    const harness = createHarness()
+    bindRunA(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runCurrent',
+        { from: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('worker'),
+        'v-spoof-run-current'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+  })
+
+  it('does not let legacy authority bypass a mismatched declared handle', async () => {
+    const harness = createHarness()
+    const before = adoptedGraph(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'spoofed legacy assignment',
+          callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+        },
+        evidence('coordinator'),
+        'v-spoof-legacy-shortcut'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+})
+
+describe('#11745 H1 — gateList read posture', () => {
+  it('DOCUMENTS: naming a Run makes its gates readable with no caller identity at all', async () => {
+    // Why: gateList mirrors taskList (requireCurrentConsumer: params.run === undefined), so an
+    // explicitly named Run is inspectable by anyone. Reads only — gateCreate/gateResolve always
+    // require the binding. Pinned here so any future narrowing is a deliberate decision.
+    const harness = createHarness()
+    const runA = bindRunA(harness)
+    const ownTask = harness.db.createTask({ spec: 'own work', runId: runA })
+    const ownGate = harness.db.createGate({ taskId: ownTask.id, question: 'Own?' })
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateList',
+        { run: runA },
+        currentEvidence('worker'),
+        'v-gate-list-named-run'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { runId: runA, count: 1, gates: [{ id: ownGate.id }] }
+    })
+  })
+})
+
+describe('#11745 H2 — revoked principal on an unclaimed adopted Run', () => {
+  it('answers an unbound caller with run_required, not legacy_read_only', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h2')
+    await currentCoordinatorTakesOver(harness, 'v-h2')
+    // The new owner's pane rebinds elsewhere, leaving the adopted Run unclaimed + principal revoked.
+    harness.db.createRun({
+      objective: 'elsewhere',
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+    expect(harness.db.getRun(harness.adoptedRunId)?.coordinator_pane_key).toBeNull()
+    expect(harness.db.getLegacyCoordinatorPrincipal(harness.adoptedRunId)?.status).toBe('revoked')
+    const before = adoptedGraph(harness)
+
+    const response = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        { spec: 'unbound assignment', callerTerminalHandle: OUTSIDER_HANDLE },
+        currentEvidence('worker'),
+        'v-h2-unbound'
+      )
+    )) as { ok: false; error: { code: string } }
+
+    expect(response.ok).toBe(false)
+    expect(response.error.code).not.toBe('legacy_read_only')
+    expect(response.error.code).toBe('run_required')
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+
+  it('gives the SAME honest code through the gate path', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h2b')
+    await currentCoordinatorTakesOver(harness, 'v-h2b')
+    harness.db.createRun({
+      objective: 'elsewhere',
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+    const before = adoptedGraph(harness)
+
+    const response = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: OUTSIDER_HANDLE },
+        currentEvidence('worker'),
+        'v-h2b-gate'
+      )
+    )) as { ok: false; error: { code: string } }
+
+    expect(response.ok).toBe(false)
+    expect(response.error.code).not.toBe('legacy_read_only')
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+})
+
+describe('#11745 H3 — adopted Run claimed by the legacy coordinator', () => {
+  it('answers an unrelated unbound caller with run_required, not legacy_read_only', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h3')
+    expect(harness.db.getLegacyCoordinatorPrincipal(harness.adoptedRunId)?.status).toBe('committed')
+    const before = adoptedGraph(harness)
+
+    const response = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        { spec: 'fresh assignment', callerTerminalHandle: OUTSIDER_HANDLE },
+        currentEvidence('worker'),
+        'v-h3-unbound'
+      )
+    )) as { ok: false; error: { code: string } }
+
+    expect(response.ok).toBe(false)
+    expect(response.error.code).not.toBe('legacy_read_only')
+    expect(response.error.code).toBe('run_required')
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+
+  it('still fences the genuinely stale legacy coordinator with legacy_read_only and zero effects', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h3b')
+    await currentCoordinatorTakesOver(harness, 'v-h3b')
+    const before = adoptedGraph(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'stale assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: COORDINATOR_HANDLE
+        },
+        evidence('coordinator'),
+        'v-h3b-stale'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'legacy_read_only', data: { effectsApplied: false } }
+    })
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+
+  it('fences the stale legacy coordinator on the gate path too', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h3c')
+    await currentCoordinatorTakesOver(harness, 'v-h3c')
+    const before = adoptedGraph(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.gateCreate',
+        { task: harness.taskId, question: 'Proceed?', from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'v-h3c-gate'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+})
+
+describe('#11745 H4 — unattested caller on a taken-over adopted Run', () => {
+  it('DOCUMENTS the accepted behaviour: the binding alone grants authority', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h4')
+    await currentCoordinatorTakesOver(harness, 'v-h4')
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'owner assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+        },
+        unattested(currentEvidence('coordinator')),
+        'v-h4-owner'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { task: { run_id: harness.adoptedRunId } }
+    })
+  })
+
+  it('refuses the same authority WITHOUT matching the run binding in evidence', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h4b')
+    await currentCoordinatorTakesOver(harness, 'v-h4b')
+
+    // Why: evidence names a different terminal, so this is an impostor rather than the owner
+    // ownsRunBinding is meant to admit. The attested handle must win over the declared one.
+    const before = adoptedGraph(harness)
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'impostor assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+        },
+        currentEvidence('worker'),
+        'v-h4b-impostor'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+
+  it('an unattested caller that is NOT the owner is still refused', async () => {
+    const harness = createHarness()
+    await legacyClaimsAdoptedRun(harness, 'v-h4c')
+    await currentCoordinatorTakesOver(harness, 'v-h4c')
+    const before = adoptedGraph(harness)
+
+    const response = (await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'outsider assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: OUTSIDER_HANDLE
+        },
+        unattested(currentEvidence('worker')),
+        'v-h4c-outsider'
+      )
+    )) as { ok: false; error: { code: string } }
+
+    expect(response.ok).toBe(false)
+    expect(adoptedGraph(harness)).toEqual(before)
+  })
+})
+
+/** Builds a pre-cutover graph at schema 18 and reopens it so adoption runs. */
+function createAdoptedDb(options: { settleWork: boolean }): {
+  db: OrchestrationDb
+  adoptedRunId: string
+  recoveryMessageId: string
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-11745-m5-'))
+  tempDirs.push(dir)
+  const dbPath = join(dir, 'orchestration.db')
+
+  const before = new OrchestrationDb(dbPath)
+  const task = before.createTask({ spec: 'legacy assignment', createdByTerminalHandle: 'term_old' })
+  before.createDispatchContext(
+    task.id,
+    'term_old_worker',
+    'tab_old:33333333-3333-4333-8333-333333333333'
+  )
+  const recovery = before.insertMessage({
+    from: 'term_old_worker',
+    to: 'term_old',
+    subject: 'recovered worker outcome',
+    type: 'worker_done'
+  })
+  before.close()
+
+  const raw = new SyncDatabase(dbPath)
+  if (options.settleWork) {
+    raw.exec("UPDATE dispatch_contexts SET status = 'completed'")
+  }
+  raw.exec(`
+    DROP INDEX IF EXISTS idx_messages_delivery_contract;
+    DROP TABLE legacy_mail_receipts;
+    DROP TABLE legacy_operation_receipts;
+    DROP TABLE legacy_compatibility_principals;
+    DROP TABLE legacy_adoptions;
+  `)
+  raw.pragma('user_version = 18')
+  raw.close()
+
+  const db = new OrchestrationDb(dbPath)
+  databases.push(db)
+  return {
+    db,
+    adoptedRunId: db.getLegacyAdoption()?.adopted_run_id as string,
+    recoveryMessageId: recovery.id
+  }
+}
+
+describe('#11745 M5 — binding an unclaimed adopted Run', () => {
+  it('binds without --takeover-legacy when no legacy work is live, and keeps legacy mail promoted', () => {
+    const { db, adoptedRunId, recoveryMessageId } = createAdoptedDb({ settleWork: true })
+    expect(db.getMessageById(recoveryMessageId)?.run_id).toBe(adoptedRunId)
+
+    const run = db.bindRun({
+      runId: adoptedRunId,
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+
+    expect(run?.id).toBe(adoptedRunId)
+    expect(db.getRun(adoptedRunId)).toMatchObject({
+      coordinator_handle: CURRENT_COORDINATOR_HANDLE
+    })
+    // The recovered mail must still belong to the adopted Run, not be orphaned by the bind.
+    expect(db.getMessageById(recoveryMessageId)?.run_id).toBe(adoptedRunId)
+    expect(db.getCurrentRunForPane(CURRENT_COORDINATOR_PANE)?.id).toBe(adoptedRunId)
+  })
+
+  it('still fences the bind while legacy work IS live, with a usable recovery command', () => {
+    const { db, adoptedRunId, recoveryMessageId } = createAdoptedDb({ settleWork: false })
+
+    expect(() =>
+      db.bindRun({
+        runId: adoptedRunId,
+        coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+        coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'consumer_fenced',
+        data: {
+          effectsApplied: false,
+          recoveryCommand: `orca orchestration run-use --id ${adoptedRunId} --takeover-legacy`
+        }
+      })
+    )
+    expect(db.getRun(adoptedRunId)?.coordinator_handle).toBeNull()
+    expect(db.getMessageById(recoveryMessageId)?.run_id).toBe(adoptedRunId)
+  })
+})
+
+describe('#11745 L6 — indexed getCurrentRunForPane keeps pane equivalence', () => {
+  function paneDb(): OrchestrationDb {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-11745-l6-'))
+    tempDirs.push(dir)
+    const db = new OrchestrationDb(join(dir, 'orchestration.db'))
+    databases.push(db)
+    return db
+  }
+
+  function leaf(index: number): string {
+    const hex = index.toString(16).padStart(12, '0')
+    return `${hex.slice(0, 8)}-0000-4000-8000-${hex}`
+  }
+
+  it('resolves a reminted tab half by leaf UUID', () => {
+    const db = paneDb()
+    const run = db.createRun({
+      objective: 'reminted',
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: `tab_before:${leaf(1)}`
+    })
+
+    // Break-out remints the tab half; the leaf UUID is the durable identity.
+    expect(db.getCurrentRunForPane(`tab_after:${leaf(1)}`)?.id).toBe(run.id)
+    expect(db.getCurrentRunForPane(`tab_before:${leaf(1)}`)?.id).toBe(run.id)
+    expect(db.getCurrentRunForPane(`tab_after:${leaf(2)}`)).toBeUndefined()
+  })
+
+  it('keeps unparseable pane keys on exact-match semantics', () => {
+    const db = paneDb()
+    const noColon = db.createRun({
+      objective: 'no colon',
+      coordinatorHandle: 'term_a',
+      coordinatorPaneKey: 'nocolonpanekey'
+    })
+    const twoColons = db.createRun({
+      objective: 'two colons',
+      coordinatorHandle: 'term_b',
+      coordinatorPaneKey: `win:tab:${leaf(3)}`
+    })
+    const emptyLeaf = db.createRun({
+      objective: 'empty leaf',
+      coordinatorHandle: 'term_c',
+      coordinatorPaneKey: 'tab_empty:'
+    })
+
+    expect(db.getCurrentRunForPane('nocolonpanekey')?.id).toBe(noColon.id)
+    expect(db.getCurrentRunForPane(`win:tab:${leaf(3)}`)?.id).toBe(twoColons.id)
+    expect(db.getCurrentRunForPane('tab_empty:')?.id).toBe(emptyLeaf.id)
+
+    // A different first segment on an unparseable key must NOT match, even though the
+    // indexed suffix is identical — the suffix only narrows, isEquivalentPaneKey decides.
+    expect(db.getCurrentRunForPane(`other:tab:${leaf(3)}`)).toBeUndefined()
+    expect(db.getCurrentRunForPane('other_empty:')).toBeUndefined()
+    // A parseable key must not be satisfied by an unparseable row sharing its suffix.
+    expect(db.getCurrentRunForPane(`tab:${leaf(3)}`)).toBeUndefined()
+  })
+
+  it('unbinds the equivalent pane when a reminted key binds a new Run', () => {
+    const db = paneDb()
+    const first = db.createRun({
+      objective: 'first',
+      coordinatorHandle: 'term_a',
+      coordinatorPaneKey: `tab_one:${leaf(4)}`
+    })
+    const second = db.createRun({
+      objective: 'second',
+      coordinatorHandle: 'term_a',
+      coordinatorPaneKey: `tab_two:${leaf(4)}`
+    })
+
+    expect(db.getRun(first.id)?.coordinator_pane_key).toBeNull()
+    expect(db.getCurrentRunForPane(`tab_three:${leaf(4)}`)?.id).toBe(second.id)
+  })
+
+  it.each([60, 2000])('stays correct and fast at %i bound Runs', (total) => {
+    const db = paneDb()
+    for (let index = 0; index < total; index += 1) {
+      db.createRun({
+        objective: `run ${index}`,
+        coordinatorHandle: `term_${index}`,
+        coordinatorPaneKey: `tab_${index}:${leaf(index + 100)}`
+      })
+    }
+
+    const target = `tab_reminted:${leaf(total + 99)}`
+    const started = performance.now()
+    for (let probe = 0; probe < 200; probe += 1) {
+      expect(db.getCurrentRunForPane(target)).toBeDefined()
+    }
+    const elapsed = performance.now() - started
+
+    // Generous ceiling: the pre-fix full-table scan at 2000 Runs was orders of magnitude slower.
+    expect(elapsed).toBeLessThan(4000)
+    expect(db.getCurrentRunForPane(`tab_missing:${leaf(999999)}`)).toBeUndefined()
+  })
+})

--- a/src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-coordinator-authority.ts
@@ -35,29 +35,30 @@ export class LegacyCoordinatorAuthority {
       paneKey: request.orchestrationCompatibilityEvidence?.paneKey
     })
     if (!candidate) {
-      if (request.orchestrationCompatibilityEvidence) {
-        const run = db.getRun(adoption.adopted_run_id)
-        // Why: an unclaimed adopted Run has no coordinator to fence — same rule as bindingMatches below.
-        if (
-          !run?.coordinator_pane_key &&
-          !db.getLegacyCoordinatorPrincipal(adoption.adopted_run_id)
-        ) {
-          return undefined
-        }
-        const caller = this.runtime.verifyOrchestrationCompatibilityCaller(
-          request.orchestrationCompatibilityEvidence
-        )
-        if (
-          caller &&
-          run?.coordinator_handle === caller.terminalHandle &&
-          run.coordinator_pane_key &&
-          equivalentLegacyPaneKey(run.coordinator_pane_key, caller.paneKey)
-        ) {
-          return undefined
-        }
-        throw legacyCoordinatorReadOnly()
+      const evidence = request.orchestrationCompatibilityEvidence
+      if (!evidence) {
+        return undefined
       }
-      return undefined
+      const run = db.getRun(adoption.adopted_run_id)
+      const principal = db.getLegacyCoordinatorPrincipal(adoption.adopted_run_id)
+      // Why: an unclaimed adopted Run has no coordinator to fence, and a revoked principal is exactly that.
+      if (!run?.coordinator_pane_key && principal?.status !== 'committed') {
+        return undefined
+      }
+      const caller = this.runtime.verifyOrchestrationCompatibilityCaller(evidence)
+      // Why: the binding is trusted DB state, so the owner keeps its Run on hosts where attestation is unavailable.
+      if (run && (ownsRunBinding(run, caller) || ownsRunBinding(run, evidence))) {
+        return undefined
+      }
+      // Why: only a caller already known as the legacy coordinator is in this fence's jurisdiction;
+      // fencing anyone else hides the honest downstream error behind unusable takeover guidance.
+      if (
+        !evidence.terminalHandle ||
+        !db.isLegacyCoordinatorHandle(adoption.adopted_run_id, evidence.terminalHandle)
+      ) {
+        return undefined
+      }
+      throw legacyCoordinatorReadOnly()
     }
     const existing = db.getLegacyCoordinatorPrincipal(adoption.adopted_run_id)
     const proofCandidate = existing
@@ -179,6 +180,18 @@ export class LegacyCoordinatorAuthority {
       principal.process_incarnation === attestation.processIncarnation
     )
   }
+}
+
+function ownsRunBinding(
+  run: { coordinator_handle: string | null; coordinator_pane_key: string | null },
+  identity: { terminalHandle?: string; paneKey?: string } | null
+): boolean {
+  return Boolean(
+    identity?.terminalHandle &&
+    run.coordinator_pane_key &&
+    run.coordinator_handle === identity.terminalHandle &&
+    equivalentLegacyPaneKey(run.coordinator_pane_key, identity.paneKey)
+  )
 }
 
 function boundRunId(db: OrchestrationDb, request: RpcRequest): string | undefined {

--- a/src/main/runtime/rpc/orchestration-legacy-fence-jurisdiction.test.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-fence-jurisdiction.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { OrchestrationCompatibilityEvidence } from '../../../shared/orchestration-compatibility-evidence'
+import {
+  cleanupLegacyCompatibilityDispatcherHarnesses,
+  COORDINATOR_HANDLE,
+  createHarness,
+  currentEvidence,
+  CURRENT_COORDINATOR_HANDLE,
+  CURRENT_COORDINATOR_PANE,
+  evidence,
+  request,
+  type LegacyCompatibilityDispatcherHarness
+} from './orchestration-legacy-compatibility-dispatcher-test-fixture'
+
+afterEach(() => {
+  cleanupLegacyCompatibilityDispatcherHarnesses()
+})
+
+function unattested(proof: OrchestrationCompatibilityEvidence): OrchestrationCompatibilityEvidence {
+  return { ...proof, launchToken: '' }
+}
+
+async function claimAdoptedRunAsLegacyCoordinator(
+  harness: LegacyCompatibilityDispatcherHarness
+): Promise<void> {
+  const response = await harness.dispatcher.dispatch(
+    request(
+      'orchestration.runUse',
+      { id: harness.adoptedRunId, from: COORDINATOR_HANDLE },
+      evidence('coordinator'),
+      'legacy-coordinator-run-use'
+    )
+  )
+  expect(response).toMatchObject({ ok: true })
+  expect(harness.db.getLegacyCoordinatorPrincipal(harness.adoptedRunId)?.status).toBe('committed')
+}
+
+async function takeoverAdoptedRun(harness: LegacyCompatibilityDispatcherHarness): Promise<void> {
+  const response = await harness.dispatcher.dispatch(
+    request(
+      'orchestration.runUse',
+      { id: harness.adoptedRunId, from: CURRENT_COORDINATOR_HANDLE, takeoverLegacy: true },
+      currentEvidence('coordinator'),
+      'current-coordinator-takeover'
+    )
+  )
+  expect(response).toMatchObject({ ok: true })
+  expect(harness.db.getLegacyCoordinatorPrincipal(harness.adoptedRunId)?.status).toBe('revoked')
+}
+
+describe('legacy coordinator fence jurisdiction', () => {
+  it('declines jurisdiction over an unbound stranger while the adopted Run is claimed', async () => {
+    const harness = createHarness()
+    await claimAdoptedRunAsLegacyCoordinator(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        { spec: 'fresh assignment', callerTerminalHandle: CURRENT_COORDINATOR_HANDLE },
+        currentEvidence('coordinator'),
+        'claimed-stranger-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'run_required' } })
+    expect(harness.db.listTasks({ runId: harness.adoptedRunId })).toHaveLength(1)
+  })
+
+  it('releases the fence once the adopted Run is unclaimed and its principal is revoked', async () => {
+    const harness = createHarness()
+    await claimAdoptedRunAsLegacyCoordinator(harness)
+    await takeoverAdoptedRun(harness)
+    // The new owner moves its pane to another Run, which unbinds the adopted Run.
+    const elsewhere = harness.db.createRun({
+      objective: 'other work',
+      coordinatorHandle: CURRENT_COORDINATOR_HANDLE,
+      coordinatorPaneKey: CURRENT_COORDINATOR_PANE
+    })
+    expect(elsewhere.id).not.toBe(harness.adoptedRunId)
+    expect(harness.db.getRun(harness.adoptedRunId)?.coordinator_pane_key).toBeNull()
+
+    const fenced = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        { spec: 'unclaimed assignment', callerTerminalHandle: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'unclaimed-revoked-task-create'
+      )
+    )
+    expect(fenced).toMatchObject({ ok: false, error: { code: 'run_required' } })
+
+    const reclaim = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        { id: harness.adoptedRunId, from: COORDINATOR_HANDLE },
+        evidence('coordinator'),
+        'unclaimed-revoked-run-use'
+      )
+    )
+    // The Run still holds live legacy work, so the honest downstream error — not a dead-end fence — answers.
+    expect(reclaim).toMatchObject({
+      ok: false,
+      error: {
+        code: 'consumer_fenced',
+        data: {
+          recoveryCommand: `orca orchestration run-use --id ${harness.adoptedRunId} --takeover-legacy`
+        }
+      }
+    })
+
+    const recovered = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        { id: harness.adoptedRunId, from: COORDINATOR_HANDLE, takeoverLegacy: true },
+        evidence('coordinator'),
+        'unclaimed-revoked-run-takeover'
+      )
+    )
+    expect(recovered).toMatchObject({ ok: true, result: { run: { id: harness.adoptedRunId } } })
+  })
+
+  it('leaves a named adopted Run to the downstream consumer check instead of the fence', async () => {
+    const harness = createHarness()
+    await claimAdoptedRunAsLegacyCoordinator(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'stranger assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+        },
+        currentEvidence('coordinator'),
+        'claimed-stranger-named-run-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'consumer_fenced' } })
+    expect(harness.db.listTasks({ runId: harness.adoptedRunId })).toHaveLength(1)
+  })
+
+  it('still fences the legacy coordinator after its principal is revoked by a takeover', async () => {
+    const harness = createHarness()
+    await claimAdoptedRunAsLegacyCoordinator(harness)
+    await takeoverAdoptedRun(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'stale assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: COORDINATOR_HANDLE
+        },
+        evidence('coordinator'),
+        'revoked-legacy-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'legacy_read_only' } })
+    expect(harness.db.listTasks({ runId: harness.adoptedRunId })).toHaveLength(1)
+  })
+
+  it('lets the post-takeover owner operate the adopted Run without attestation', async () => {
+    const harness = createHarness()
+    await claimAdoptedRunAsLegacyCoordinator(harness)
+    await takeoverAdoptedRun(harness)
+
+    const response = await harness.dispatcher.dispatch(
+      request(
+        'orchestration.taskCreate',
+        {
+          spec: 'owner assignment',
+          run: harness.adoptedRunId,
+          callerTerminalHandle: CURRENT_COORDINATOR_HANDLE
+        },
+        unattested(currentEvidence('coordinator')),
+        'owner-unattested-task-create'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: { task: { run_id: harness.adoptedRunId, spec: 'owner assignment' } }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Gate methods (`gateCreate`, `gateResolve`, `gateList`) now enforce Run-scoped authorization. Previously, gates could be accessed across Run boundaries without validating the caller's binding.

### Changes

**CLI**: Gate commands now accept `--from <terminal-handle>` to declare the coordinator identity, with automatic resolution from the calling pane when omitted.

**RPC**: Gate methods validate that the caller is bound to the same Run as the target task/gate:
- `gateCreate`/`gateResolve` require the caller's terminal binding to the Run
- `gateList` with no explicit `--run` scopes to the caller's bound Run; named Runs are readable without binding
- Declared handles are validated against attested evidence to prevent spoofing

**Database**: Added indexed pane-key suffix lookup (`idx_runs_coordinator_pane_leaf`) for O(1) pane-bound Run resolution, with JavaScript-side leaf-UUID equivalence matching for tab reminting.

**Authorization**: Extracted shared `resolveRunScope()` for consistent Run-binding rules across gate, task, and dispatch methods. Handles legacy adopted-Run scenarios and prevents unauthorized cross-Run mutations.

### Testing

- **Authorization scenarios** (G1–G5): unbound callers, cross-Run access, foreign gates, spoofed handles
- **Adopted Run binding** (M5, H2–H4): legacy coordinator claims, takeover transitions, principal revocation, unclaimed state
- **Handle matching** (L6): reminted tab halves, unparseable keys, pane equivalence, performance at scale
- **Regression verification** (#11745): all observable state remains unchanged on authorization failures

## Notes

No platform-specific behavior or cross-platform concerns.