### PR TITLE
fix(terminal): make remote stop retirement durable

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25781,6 +25781,7 @@ describe('OrcaRuntimeService', () => {
       leafId: HEADLESS_LEAF_ID
     })
     const [terminal] = (await runtime.listTerminals()).terminals
+    getWorkspaceSession.mockClear()
 
     await expect(runtime.closeTerminalTab(terminal.handle)).resolves.toMatchObject({
       tabId: 'host-tab',
@@ -25789,6 +25790,8 @@ describe('OrcaRuntimeService', () => {
 
     expect(localSession.tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
     expect(staleHostSession.tabsByWorktree[TEST_WORKTREE_ID]).toBeUndefined()
+    expect(getWorkspaceSession).toHaveBeenNthCalledWith(1, staleHostId)
+    expect(getWorkspaceSession).toHaveBeenNthCalledWith(2, 'local')
     expect(setWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), 'local')
   })
 
@@ -32673,7 +32676,7 @@ describe('OrcaRuntimeService', () => {
       getForegroundProcess: async () => null
     })
     syncSinglePty(runtime)
-    const stopPty = vi.fn(async (_ptyId: string, stop: () => boolean | Promise<boolean>) => ({
+    const stopPty = vi.fn(async (_ptyId: string, stop: () => Promise<boolean>) => ({
       stopped: await stop(),
       owner: true
     }))
@@ -32703,8 +32706,10 @@ describe('OrcaRuntimeService', () => {
     )
     const flushOrThrow = vi.fn()
     const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow } as never)
+    const physicalStop = makeDeferred()
     const kill = vi.fn(() => true)
     const stopAndWait = vi.fn(async (ptyId: string) => {
+      await physicalStop.promise
       runtime.onPtyExit(ptyId, 0, incarnationId)
       return true
     })
@@ -32721,15 +32726,48 @@ describe('OrcaRuntimeService', () => {
       incarnationId
     })
 
-    await expect(runtime.stopTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`)).resolves.toEqual({
-      stopped: 1
+    const stopping = runtime.stopTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`)
+    await vi.waitFor(() => expect(stopAndWait).toHaveBeenCalledWith('persisted-pty'))
+    let settled = false
+    void stopping.then(() => {
+      settled = true
     })
+    await Promise.resolve()
+    expect(settled).toBe(false)
 
-    expect(stopAndWait).toHaveBeenCalledWith('persisted-pty')
+    physicalStop.resolve()
+    await expect(stopping).resolves.toEqual({ stopped: 1 })
     expect(kill).not.toHaveBeenCalled()
     expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
     expect(flushOrThrow).toHaveBeenCalledOnce()
+  })
+
+  it('continues a worktree terminal sweep after one provider stop rejects', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const stopAndWait = vi.fn(async (ptyId: string) => {
+      if (ptyId === 'pty-1') {
+        throw new Error('relay_unavailable')
+      }
+      return true
+    })
+    runtime.setPtyController({
+      write: () => true,
+      kill: vi.fn(() => true),
+      stopAndWait,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+    runtime.registerPty('pty-2', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-2',
+      leafId: 'pane:2'
+    })
+
+    await expect(runtime.stopTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`)).resolves.toEqual({
+      stopped: 1
+    })
+    expect(stopAndWait).toHaveBeenNthCalledWith(1, 'pty-1')
+    expect(stopAndWait).toHaveBeenNthCalledWith(2, 'pty-2')
   })
 
   it('passes a margin-adjusted RPC deadline into stopAndWait for destructive teardown', async () => {
@@ -32742,7 +32780,7 @@ describe('OrcaRuntimeService', () => {
       getForegroundProcess: async () => null
     })
     syncSinglePty(runtime)
-    const stopPty = vi.fn(async (_ptyId: string, stop: () => boolean | Promise<boolean>) => ({
+    const stopPty = vi.fn(async (_ptyId: string, stop: () => Promise<boolean>) => ({
       stopped: await stop(),
       owner: true
     }))

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25737,6 +25737,61 @@ describe('OrcaRuntimeService', () => {
     expect(closeTerminal).toHaveBeenCalledWith('laptop-tab')
   })
 
+  it('closes a restored tab from its persisted partition when the repo host is stale', async () => {
+    const staleHostId = 'runtime:stale-host'
+    let localSession = makeWorkspaceSessionWithHeadlessTerminal()
+    let staleHostSession = getDefaultWorkspaceSession()
+    const getWorkspaceSession = vi.fn((hostId?: string | null) =>
+      hostId === staleHostId ? staleHostSession : localSession
+    )
+    const setWorkspaceSession = vi.fn((next: WorkspaceSessionState, hostId?: string | null) => {
+      if (hostId === staleHostId) {
+        staleHostSession = next
+      } else {
+        localSession = next
+      }
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => [
+        {
+          ...store.getRepos()[0]!,
+          executionHostId: staleHostId
+        }
+      ],
+      getRepo: () => ({
+        ...store.getRepos()[0]!,
+        executionHostId: staleHostId
+      }),
+      getWorkspaceSession,
+      getWorkspaceSessionHostIds: () => ['local', staleHostId],
+      setWorkspaceSession,
+      flushOrThrow: vi.fn()
+    } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        { id: 'persisted-pty', cwd: TEST_WORKTREE_PATH, title: 'Persisted Terminal' }
+      ]
+    })
+    runtime.registerPty('persisted-pty', TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.closeTerminalTab(terminal.handle)).resolves.toMatchObject({
+      tabId: 'host-tab',
+      closeMode: 'tab'
+    })
+
+    expect(localSession.tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
+    expect(staleHostSession.tabsByWorktree[TEST_WORKTREE_ID]).toBeUndefined()
+    expect(setWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), 'local')
+  })
+
   it('waits for renderer acknowledgement before returning a whole-tab close receipt', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal()
@@ -32635,6 +32690,46 @@ describe('OrcaRuntimeService', () => {
 
     physicalStop.resolve()
     await expect(stopping).resolves.toEqual({ stopped: 1 })
+  })
+
+  it('waits for durable PTY retirement before terminal stop returns', async () => {
+    const incarnationId = '44444444-4444-4444-8444-444444444444'
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        terminalPtyIncarnationsByPaneKey: {
+          [`host-tab:${HEADLESS_LEAF_ID}`]: incarnationId
+        }
+      })
+    )
+    const flushOrThrow = vi.fn()
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow } as never)
+    const kill = vi.fn(() => true)
+    const stopAndWait = vi.fn(async (ptyId: string) => {
+      runtime.onPtyExit(ptyId, 0, incarnationId)
+      return true
+    })
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      stopAndWait,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    runtime.registerPty('persisted-pty', TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID,
+      incarnationId
+    })
+
+    await expect(runtime.stopTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`)).resolves.toEqual({
+      stopped: 1
+    })
+
+    expect(stopAndWait).toHaveBeenCalledWith('persisted-pty')
+    expect(kill).not.toHaveBeenCalled()
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
+    expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
+    expect(flushOrThrow).toHaveBeenCalledOnce()
   })
 
   it('passes a margin-adjusted RPC deadline into stopAndWait for destructive teardown', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -25755,7 +25755,7 @@ export class OrcaRuntimeService {
       deadline?: number
       stopPty?: (
         ptyId: string,
-        stop: () => boolean | Promise<boolean>
+        stop: () => Promise<boolean>
       ) => Promise<{ stopped: boolean; owner: boolean }>
     } = {}
   ): Promise<{ stopped: number }> {
@@ -25787,16 +25787,21 @@ export class OrcaRuntimeService {
         if (options.deadline !== undefined && Date.now() >= options.deadline) {
           return false
         }
-        // Why: terminal.stop is a durable lifecycle receipt; wait for provider exit so onPtyExit de-persists the tab before returning.
-        if (this.ptyController?.stopAndWait) {
-          if (options.deadline !== undefined) {
-            return await this.ptyController.stopAndWait(ptyId, {
-              deadlineMs: teardownRpcDeadline(options.deadline)
-            })
+        try {
+          // Why: terminal.stop is a durable lifecycle receipt; wait for provider exit so onPtyExit de-persists the tab before returning.
+          if (this.ptyController?.stopAndWait) {
+            if (options.deadline !== undefined) {
+              return await this.ptyController.stopAndWait(ptyId, {
+                deadlineMs: teardownRpcDeadline(options.deadline)
+              })
+            }
+            return await this.ptyController.stopAndWait(ptyId)
           }
-          return await this.ptyController.stopAndWait(ptyId)
+          return Boolean(this.ptyController?.kill(ptyId))
+        } catch {
+          // Why: a worktree sweep is best-effort per PTY; one unavailable provider must not leave later terminals running.
+          return false
         }
-        return Boolean(this.ptyController?.kill(ptyId))
       }
       const stopResult = options.stopPty
         ? await options.stopPty(ptyId, stop)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4558,6 +4558,7 @@ export class OrcaRuntimeService {
 
   private getWorkspaceSessionHostIdForWorktree(worktreeId: string): ExecutionHostId {
     const scope = parseWorkspaceKey(worktreeId)
+    let preferredHostId: ExecutionHostId
     if (scope?.type === 'folder') {
       const workspace = this.store
         ?.getFolderWorkspaces?.()
@@ -4566,11 +4567,28 @@ export class OrcaRuntimeService {
         throw new Error('folder_workspace_not_found')
       }
       const connectionId = this.resolveFolderWorkspaceConnectionId(workspace)
-      return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
+      preferredHostId = connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
+    } else {
+      const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+      const repo = this.store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
+      preferredHostId = repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
     }
-    const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
-    const repo = this.store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
-    return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
+    const getWorkspaceSession = this.store?.getWorkspaceSession
+    const persistedHostIds = this.store?.getWorkspaceSessionHostIds?.()
+    if (
+      !getWorkspaceSession ||
+      !persistedHostIds ||
+      Object.hasOwn(getWorkspaceSession(preferredHostId).tabsByWorktree, worktreeId)
+    ) {
+      return preferredHostId
+    }
+    const persistedOwners = persistedHostIds.filter(
+      (hostId) =>
+        hostId !== preferredHostId &&
+        Object.hasOwn(getWorkspaceSession(hostId).tabsByWorktree, worktreeId)
+    )
+    // Why: relay restarts can leave the catalog pointing at an obsolete runtime partition while the durable tab owner remains unique.
+    return persistedOwners.length === 1 ? persistedOwners[0]! : preferredHostId
   }
 
   private getWorkspaceSessionForWorktree(worktreeId: string): WorkspaceSessionState | null {
@@ -25765,30 +25783,24 @@ export class OrcaRuntimeService {
       if (options.deadline !== undefined && Date.now() >= options.deadline) {
         break
       }
-      const stop = (): boolean | Promise<boolean> => {
+      const stop = async (): Promise<boolean> => {
         if (options.deadline !== undefined && Date.now() >= options.deadline) {
           return false
         }
-        if (options.stopPty) {
-          // Why: destructive worktree cleanup must not let its cross-surface
-          // dedupe treat fire-and-forget controller.kill as physical exit.
-          // Why: the RPC deadline makes shutdown/list RPCs settle before the sweep
-          // deadline so a wedged daemon yields the accurate stop failure; no deadline
-          // (non-destructive) keeps the provider default RPC timeout.
+        // Why: terminal.stop is a durable lifecycle receipt; wait for provider exit so onPtyExit de-persists the tab before returning.
+        if (this.ptyController?.stopAndWait) {
           if (options.deadline !== undefined) {
-            return (
-              this.ptyController?.stopAndWait?.(ptyId, {
-                deadlineMs: teardownRpcDeadline(options.deadline)
-              }) ?? false
-            )
+            return await this.ptyController.stopAndWait(ptyId, {
+              deadlineMs: teardownRpcDeadline(options.deadline)
+            })
           }
-          return this.ptyController?.stopAndWait?.(ptyId) ?? false
+          return await this.ptyController.stopAndWait(ptyId)
         }
         return Boolean(this.ptyController?.kill(ptyId))
       }
       const stopResult = options.stopPty
         ? await options.stopPty(ptyId, stop)
-        : { stopped: stop(), owner: true }
+        : { stopped: await stop(), owner: true }
       if (stopResult.owner && stopResult.stopped) {
         stopped += 1
       }


### PR DESCRIPTION
## Summary

- resolve terminal lifecycle mutations through the unique persisted workspace-session owner when repo metadata points at a stale runtime partition
- make direct `terminal.stop` await provider exit so host-side tab retirement and forced persistence finish before the RPC returns
- cover restored whole-tab close and stop-before-restart durability with runtime regressions

Closes #11803.

This stays separate from #11801: that PR repairs paired-viewer null-PTY reconciliation, while this change owns host runtime session routing and durable PTY stop receipts.

## Root cause

A restarted remote runtime could retain repo metadata whose `executionHostId` named an obsolete runtime partition, while the worktree's tabs remained uniquely owned by the local workspace session. Whole-tab close followed the stale catalog owner and returned `tab_not_found`.

Bulk stop had a second gap: its direct path called fire-and-forget `kill`, so the RPC could acknowledge before `onPtyExit` removed and flushed the persisted terminal surface. Restarting the relay during that gap restored the tabs and respawned PTYs.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` — 955 passed, 1 skipped
- `pnpm typecheck`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
