### PR TITLE
fix(sidebar): stabilize cross-host project grouping

### DIFF
--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -592,10 +592,14 @@ export function RuntimeEnvironmentsPane({
       await window.api.runtimeEnvironments.disconnect({ selector: environment.id })
       // Why: disconnect is non-destructive; keep the saved server but show the
       // user that this live client is no longer attached to it.
-      useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
-        status: null,
-        checkedAt: Date.now()
-      })
+      useAppStore.getState().setRuntimeEnvironmentStatus(
+        environment.id,
+        {
+          status: null,
+          checkedAt: Date.now()
+        },
+        { suppressDisconnectToast: true }
+      )
       if (mountedRef.current) {
         setDetailsByEnvironmentId((current) => ({
           ...current,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -765,7 +765,7 @@ describe('buildRows with pinned worktrees', () => {
     )
   })
 
-  it('splits all project setups when one host has duplicate checkouts', () => {
+  it('splits only the surface with duplicate checkouts', () => {
     const localRepoB: Repo = {
       ...repo,
       id: 'repo-local-b',
@@ -822,8 +822,141 @@ describe('buildRows with pinned worktrees', () => {
     expect(headers.map((row) => row.key)).toEqual([
       'project:github:stablyai/orca::setup:repo-1',
       'project:github:stablyai/orca::setup:repo-local-b',
-      'project:github:stablyai/orca::setup:repo-remote'
+      'project:github:stablyai/orca'
     ])
+  })
+
+  it('counts projection twins for one directory as one checkout', () => {
+    const runtimeHostId = 'runtime:m2-air'
+    const runtimeRepo: Repo = {
+      ...remoteRepo,
+      id: 'repo-runtime',
+      path: '/home/alice/orca-runtime',
+      connectionId: undefined,
+      executionHostId: runtimeHostId
+    }
+    const runtimeWorktree: Worktree = {
+      ...remoteWorktree,
+      id: 'wt-runtime',
+      repoId: runtimeRepo.id,
+      path: '/home/alice/orca-runtime-feature'
+    }
+    const runtimeSetup: ProjectHostSetup = {
+      ...projectHostSetups[1]!,
+      id: runtimeRepo.id,
+      repoId: runtimeRepo.id,
+      path: runtimeRepo.path,
+      hostId: runtimeHostId,
+      executionHostId: runtimeHostId
+    }
+    const derivedSetup: ProjectHostSetup = {
+      ...projectHostSetups[1]!,
+      hostId: runtimeHostId,
+      connectionId: 'intel mac',
+      executionHostId: runtimeHostId
+    }
+    const authoritativeSetup: ProjectHostSetup = {
+      ...derivedSetup,
+      id: 'setup-authoritative',
+      path: `${derivedSetup.path}/`,
+      connectionId: null,
+      executionHostId: 'ssh:intel%20mac'
+    }
+    const grouping = {
+      projects: [{ ...project, sourceRepoIds: [remoteRepo.id, runtimeRepo.id] }],
+      projectHostSetups: [runtimeSetup, derivedSetup, authoritativeSetup]
+    }
+
+    expect([
+      getGroupKeyForWorktree(
+        'repo',
+        remoteWorktree,
+        new Map([[remoteRepo.id, remoteRepo]]),
+        null,
+        undefined,
+        undefined,
+        grouping
+      ),
+      getGroupKeyForWorktree(
+        'repo',
+        runtimeWorktree,
+        new Map([[runtimeRepo.id, runtimeRepo]]),
+        null,
+        undefined,
+        undefined,
+        grouping
+      )
+    ]).toEqual(['project:github:stablyai/orca', 'project:github:stablyai/orca'])
+  })
+
+  it('keeps Git hosts grouped when folder setups share the project identity', () => {
+    const windowsHostId = 'runtime:windows-server'
+    const windowsRepo: Repo = {
+      ...repo,
+      id: 'repo-windows',
+      path: 'C:\\Users\\neil\\orca\\orca',
+      executionHostId: windowsHostId
+    }
+    const folderRepoA: Repo = {
+      ...repo,
+      id: 'folder-qa-a',
+      path: '/tmp/pr11751-folder-qa',
+      displayName: 'pr11751-folder-qa',
+      kind: 'folder'
+    }
+    const folderRepoB: Repo = {
+      ...folderRepoA,
+      id: 'folder-qa-b',
+      path: '/tmp/pr11767-runtime-folder',
+      displayName: 'pr11767-runtime-folder'
+    }
+    const setups: ProjectHostSetup[] = [
+      projectHostSetups[0]!,
+      { ...projectHostSetups[0]!, id: 'projection-twin' },
+      projectHostSetups[1]!,
+      {
+        ...projectHostSetups[0]!,
+        id: windowsRepo.id,
+        repoId: windowsRepo.id,
+        path: windowsRepo.path,
+        hostId: windowsHostId,
+        executionHostId: windowsHostId
+      },
+      {
+        ...projectHostSetups[0]!,
+        id: folderRepoA.id,
+        repoId: folderRepoA.id,
+        path: folderRepoA.path,
+        displayName: folderRepoA.displayName,
+        kind: 'folder'
+      },
+      {
+        ...projectHostSetups[0]!,
+        id: folderRepoB.id,
+        repoId: folderRepoB.id,
+        path: folderRepoB.path,
+        displayName: folderRepoB.displayName,
+        kind: 'folder'
+      }
+    ]
+    const repos = [repo, remoteRepo, windowsRepo, folderRepoA, folderRepoB]
+    const grouping = {
+      projects: [{ ...project, sourceRepoIds: repos.map((entry) => entry.id) }],
+      projectHostSetups: setups
+    }
+
+    const groupKeys = repos.map((entry) =>
+      getGroupKeyForWorktree(
+        'repo',
+        { ...worktree, id: `wt-${entry.id}`, repoId: entry.id, path: entry.path },
+        new Map([[entry.id, entry]]),
+        null,
+        undefined,
+        undefined,
+        grouping
+      )
+    )
+    expect(new Set(groupKeys)).toEqual(new Set(['project:github:stablyai/orca']))
   })
 
   it('keeps a provisioned runtime copy under the project header alongside a same-host checkout', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -39,10 +39,14 @@ import {
   LOCAL_EXECUTION_HOST_ID,
   getRepoExecutionHostId,
   getWorktreeExecutionHostId,
+  toSshExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { parseWslUncPath } from '../../../../shared/wsl-paths'
-import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
+import {
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import {
   getCyclicProjectedWorktreeLineageIds,
   getLineageRenderInfo
@@ -177,28 +181,43 @@ type WorktreeGroupEntry = {
 type ProjectGroupingIndex = {
   projectById: Map<string, Project>
   setupByRepoId: Map<string, ProjectHostSetup>
-  projectIdsRequiringSetupGroups: Set<string>
+  surfaceKeysRequiringSetupGroups: Set<string>
 }
 
 const projectGroupingIndexCache = new WeakMap<ProjectGroupingModel, ProjectGroupingIndex | null>()
 
-// Why: `provisioned` setups are ephemeral recipe-created runtime copies that
-// nest under the project header; every other method is a real user checkout. See #5374.
+// Why: provisioned and folder setups are not independent Git checkouts.
 function isDistinctUserCheckout(setup: ProjectHostSetup): boolean {
-  return setup.setupMethod !== 'provisioned'
+  return setup.setupMethod !== 'provisioned' && setup.kind !== 'folder'
 }
 
+// Why: execution target and filesystem namespace independently identify a surface.
 function getProjectSetupSurfaceKey(setup: ProjectHostSetup): string {
+  return `${setup.projectId}::${setup.hostId}::${getExecutionSurface(setup)}::${getPathSurface(setup)}`
+}
+
+function getExecutionSurface(setup: ProjectHostSetup): string {
+  const connectionId = setup.connectionId?.trim()
+  if (connectionId) {
+    return toSshExecutionHostId(connectionId)
+  }
+  return setup.executionHostId?.trim() || setup.hostId
+}
+
+// Why: projection twins differ by row identity, not checkout directory.
+function getCheckoutIdentity(setup: ProjectHostSetup): string {
+  return normalizeRuntimePathForComparison(setup.path.trim()) || setup.repoId || setup.id
+}
+
+function getPathSurface(setup: ProjectHostSetup): string {
   const wslPath = parseWslUncPath(setup.path)
   if (wslPath) {
-    // Why: Windows host and WSL on one machine are separate execution surfaces;
-    // only duplicate checkouts within one surface make project grouping ambiguous.
-    return `${setup.projectId}::${setup.hostId}::wsl:${wslPath.distro.toLowerCase()}`
+    return `wsl:${wslPath.distro.toLowerCase()}`
   }
   if (isWindowsAbsolutePathLike(setup.path)) {
-    return `${setup.projectId}::${setup.hostId}::windows-host`
+    return 'windows-host'
   }
-  return `${setup.projectId}::${setup.hostId}::default`
+  return 'default'
 }
 
 function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupingIndex | null {
@@ -215,9 +234,7 @@ function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupin
     projectGroupingIndexCache.set(model, null)
     return null
   }
-  // Count real user checkouts per host surface (provisioned copies excluded so
-  // they keep nesting); more than one on a surface makes that project ambiguous.
-  const checkoutsByProjectSurface = new Map<string, { projectId: string; count: number }>()
+  const checkoutsByProjectSurface = new Map<string, Set<string>>()
   for (const setup of projectHostSetups) {
     if (!isDistinctUserCheckout(setup)) {
       continue
@@ -225,21 +242,21 @@ function buildProjectGroupingIndex(model?: ProjectGroupingModel): ProjectGroupin
     const key = getProjectSetupSurfaceKey(setup)
     const existing = checkoutsByProjectSurface.get(key)
     if (existing) {
-      existing.count += 1
+      existing.add(getCheckoutIdentity(setup))
     } else {
-      checkoutsByProjectSurface.set(key, { projectId: setup.projectId, count: 1 })
+      checkoutsByProjectSurface.set(key, new Set([getCheckoutIdentity(setup)]))
     }
   }
-  const projectIdsRequiringSetupGroups = new Set<string>()
-  for (const { projectId, count } of checkoutsByProjectSurface.values()) {
-    if (count > 1) {
-      projectIdsRequiringSetupGroups.add(projectId)
+  const surfaceKeysRequiringSetupGroups = new Set<string>()
+  for (const [surfaceKey, checkouts] of checkoutsByProjectSurface) {
+    if (checkouts.size > 1) {
+      surfaceKeysRequiringSetupGroups.add(surfaceKey)
     }
   }
   const index = {
     projectById: new Map(projects.map((project) => [project.id, project])),
     setupByRepoId: new Map(projectHostSetups.map((setup) => [setup.repoId, setup])),
-    projectIdsRequiringSetupGroups
+    surfaceKeysRequiringSetupGroups
   }
   projectGroupingIndexCache.set(model, index)
   return index
@@ -268,11 +285,10 @@ function getProjectGroupingForRepo(
     }
   }
   if (
-    projectIndex?.projectIdsRequiringSetupGroups.has(setup.projectId) &&
+    projectIndex?.surfaceKeysRequiringSetupGroups.has(getProjectSetupSurfaceKey(setup)) &&
     isDistinctUserCheckout(setup)
   ) {
-    // Why: independent user checkouts of one project on the same host surface
-    // can't be safely merged, so each keeps its own sidebar entry. See #5374.
+    // Why: only the ambiguous surface needs checkout-specific headers.
     return {
       key: `project:${project.id}::setup:${repoId}`,
       label: repo?.displayName ?? setup.displayName,

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -254,7 +254,11 @@ export function SshStatusSegment({
     async (environmentId: string): Promise<void> => {
       try {
         await window.api.runtimeEnvironments.disconnect({ selector: environmentId })
-        setRuntimeEnvironmentStatus(environmentId, { status: null, checkedAt: Date.now() })
+        setRuntimeEnvironmentStatus(
+          environmentId,
+          { status: null, checkedAt: Date.now() },
+          { suppressDisconnectToast: true }
+        )
         recordFeatureInteraction('ssh')
       } catch (err) {
         toast.error(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -322,6 +322,11 @@
             "f518e89aa5": "Project already exists in that profile",
             "f03ae7f27b": "Failed to transfer project"
           }
+        },
+        "runtime": {
+          "status": {
+            "runtimeHostDisconnectedDescription": "Workspaces and terminals on this server are unavailable."
+          }
         }
       }
     },

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -256,6 +256,23 @@ describe('runtime-status slice', () => {
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status).toBeNull()
   })
 
+  it('dismisses an outage toast opened while an intentional disconnect was pending', () => {
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 2 })
+
+    store
+      .getState()
+      .setRuntimeEnvironmentStatus(
+        'env-a',
+        { status: null, checkedAt: 3 },
+        { suppressDisconnectToast: true }
+      )
+
+    expect(toast.warning).toHaveBeenCalledTimes(1)
+    expect(toast.dismiss).toHaveBeenCalledWith('runtime-environment-disconnected:env-a')
+  })
+
   it('clears a single environment entry', () => {
     const store = createSliceStore()
     store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -78,6 +78,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.unstubAllGlobals()
 })
 
@@ -207,7 +208,16 @@ describe('runtime-status slice', () => {
     expect(toast.dismiss).toHaveBeenCalledWith('runtime-environment-disconnected:env-a')
   })
 
-  it('retries from the toast and re-surfaces it when the server is still offline', async () => {
+  it('keeps the keyed action toast visible when an offline retry settles', async () => {
+    vi.useFakeTimers()
+    const toastId = 'runtime-environment-disconnected:env-a'
+    const visibleToastIds = new Set<string | number>()
+    vi.mocked(toast.warning).mockImplementation((_title, options) => {
+      if (options?.id !== undefined) {
+        visibleToastIds.add(options.id)
+      }
+      return options?.id ?? ''
+    })
     const getStatus = vi.fn().mockRejectedValue(new Error('closed'))
     stubRuntimeEnvironmentApi({ getStatus })
     const store = createSliceStore()
@@ -215,18 +225,39 @@ describe('runtime-status slice', () => {
     store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
     store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 2 })
     const options = vi.mocked(toast.warning).mock.calls[0]?.[1] as unknown as {
-      action: { onClick: () => void }
+      action: { onClick: (event: { preventDefault: () => void }) => void }
+    }
+    const clickAction = (): { defaultPrevented: boolean } => {
+      const event = {
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true
+        }
+      }
+      options.action.onClick(event)
+      if (!event.defaultPrevented) {
+        setTimeout(() => visibleToastIds.delete(toastId), 200)
+      }
+      return event
     }
 
-    options.action.onClick()
+    const firstClick = clickAction()
+    const secondClick = clickAction()
+    await vi.advanceTimersByTimeAsync(0)
 
-    await vi.waitFor(() => {
-      expect(getStatus).toHaveBeenCalledWith({ selector: 'env-a', timeoutMs: 10_000 })
-      expect(toast.warning).toHaveBeenCalledTimes(2)
-    })
-    expect(vi.mocked(toast.warning).mock.calls[1]?.[1]?.id).toBe(
-      'runtime-environment-disconnected:env-a'
-    )
+    expect(firstClick.defaultPrevented).toBe(true)
+    expect(secondClick.defaultPrevented).toBe(true)
+    expect(getStatus).toHaveBeenCalledWith({ selector: 'env-a', timeoutMs: 10_000 })
+    await vi.advanceTimersByTimeAsync(200)
+    expect(visibleToastIds.has(toastId)).toBe(true)
+    expect(getStatus).toHaveBeenCalledTimes(1)
+    expect(toast.warning).toHaveBeenCalledTimes(3)
+    expect(vi.mocked(toast.warning).mock.calls.map((call) => call[1]?.duration)).toEqual([
+      4_000,
+      Number.POSITIVE_INFINITY,
+      4_000
+    ])
+    expect(vi.mocked(toast.warning).mock.calls.every((call) => call[1]?.id === toastId)).toBe(true)
   })
 
   it('does not report removal or explicit status clearing as a disconnect', () => {

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -240,6 +240,22 @@ describe('runtime-status slice', () => {
     expect(toast.warning).not.toHaveBeenCalled()
   })
 
+  it('does not report an intentional disconnect as an outage', () => {
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+
+    store
+      .getState()
+      .setRuntimeEnvironmentStatus(
+        'env-a',
+        { status: null, checkedAt: 2 },
+        { suppressDisconnectToast: true }
+      )
+
+    expect(toast.warning).not.toHaveBeenCalled()
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status).toBeNull()
+  })
+
   it('clears a single environment entry', () => {
     const store = createSliceStore()
     store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
+import { toast } from 'sonner'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import { createCompatibleRuntimeStatusResponse } from '../../runtime/runtime-compatibility-test-fixture'
 import {
   callRuntimeRpc,
@@ -11,6 +13,10 @@ import {
   type RuntimeStatusSlice,
   getRuntimeEnvironmentConnectionGeneration
 } from './runtime-status'
+
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn(), dismiss: vi.fn() }
+}))
 
 function createSliceStore() {
   return create<RuntimeStatusSlice>()((...a) => ({
@@ -32,6 +38,22 @@ function makeStatus(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
   } as RuntimeStatus
 }
 
+function makeEnvironment(
+  overrides: Partial<PublicKnownRuntimeEnvironment> = {}
+): PublicKnownRuntimeEnvironment {
+  return {
+    id: 'env-a',
+    name: 'Dev Box',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: null,
+    endpoints: [{ id: 'ws-a', kind: 'websocket', label: 'WebSocket', endpoint: 'ws://x' }],
+    preferredEndpointId: 'ws-a',
+    ...overrides
+  }
+}
+
 function stubRuntimeEnvironmentApi({
   getStatus = vi.fn(),
   list = vi.fn()
@@ -49,6 +71,11 @@ function stubRuntimeEnvironmentApi({
   })
   return { getStatus, list }
 }
+
+beforeEach(() => {
+  vi.mocked(toast.warning).mockReset()
+  vi.mocked(toast.dismiss).mockReset()
+})
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -140,6 +167,77 @@ describe('runtime-status slice', () => {
     const map = store.getState().runtimeStatusByEnvironmentId
     expect(map.size).toBe(1)
     expect(map.get('env-a')).toEqual({ status: null, checkedAt: 5, connectionGeneration: 1 })
+  })
+
+  it('does not toast when the first probe finds a saved server offline', () => {
+    const store = createSliceStore()
+    store.setState({ runtimeEnvironments: [makeEnvironment()] })
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 1 })
+
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
+  it('toasts once when a connected server becomes unavailable', () => {
+    const store = createSliceStore()
+    store.setState({ runtimeEnvironments: [makeEnvironment()] })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 2 })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 3 })
+
+    expect(toast.warning).toHaveBeenCalledTimes(1)
+    expect(toast.warning).toHaveBeenCalledWith(
+      'Dev Box disconnected',
+      expect.objectContaining({
+        id: 'runtime-environment-disconnected:env-a',
+        description: 'Workspaces and terminals on this server are unavailable.',
+        action: expect.objectContaining({ label: 'Retry' })
+      })
+    )
+  })
+
+  it('dismisses the disconnect toast when the server recovers', () => {
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 2 })
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 3 })
+
+    expect(toast.dismiss).toHaveBeenCalledWith('runtime-environment-disconnected:env-a')
+  })
+
+  it('retries from the toast and re-surfaces it when the server is still offline', async () => {
+    const getStatus = vi.fn().mockRejectedValue(new Error('closed'))
+    stubRuntimeEnvironmentApi({ getStatus })
+    const store = createSliceStore()
+    store.setState({ runtimeEnvironments: [makeEnvironment()] })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 2 })
+    const options = vi.mocked(toast.warning).mock.calls[0]?.[1] as unknown as {
+      action: { onClick: () => void }
+    }
+
+    options.action.onClick()
+
+    await vi.waitFor(() => {
+      expect(getStatus).toHaveBeenCalledWith({ selector: 'env-a', timeoutMs: 10_000 })
+      expect(toast.warning).toHaveBeenCalledTimes(2)
+    })
+    expect(vi.mocked(toast.warning).mock.calls[1]?.[1]?.id).toBe(
+      'runtime-environment-disconnected:env-a'
+    )
+  })
+
+  it('does not report removal or explicit status clearing as a disconnect', () => {
+    const store = createSliceStore()
+    store.setState({ runtimeEnvironments: [makeEnvironment()] })
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: makeStatus(), checkedAt: 1 })
+
+    store.getState().clearRuntimeEnvironmentStatus('env-a')
+    store.getState().setRuntimeEnvironments([])
+
+    expect(toast.warning).not.toHaveBeenCalled()
   })
 
   it('clears a single environment entry', () => {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -1,4 +1,5 @@
 import type { StateCreator } from 'zustand'
+import { toast } from 'sonner'
 import type { AppState } from '../types'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
@@ -8,6 +9,7 @@ import {
   unwrapRuntimeRpcResult
 } from '@/runtime/runtime-rpc-client'
 import { replaceRuntimeEnvironmentRevisions } from '@/runtime/runtime-environment-revision'
+import { translate } from '@/i18n/i18n'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -57,6 +59,65 @@ export type RuntimeStatusSlice = {
 }
 
 const connectionGenerationByEnvironment = new Map<string, number>()
+const activeRuntimeDisconnectedToasts = new Map<string, symbol>()
+
+function getRuntimeDisconnectedToastId(environmentId: string): string {
+  return `runtime-environment-disconnected:${environmentId}`
+}
+
+function showRuntimeDisconnectedToast(environmentId: string, getState: () => AppState): void {
+  const environment = getState().runtimeEnvironments.find((entry) => entry.id === environmentId)
+  const toastId = getRuntimeDisconnectedToastId(environmentId)
+  const activation = Symbol(toastId)
+  const title = environment?.name
+    ? translate(
+        'auto.components.sidebar.WorktreeCard.runtimeHostDisconnectedNamed',
+        '{{hostName}} disconnected',
+        { hostName: environment.name }
+      )
+    : translate(
+        'auto.components.sidebar.WorktreeCard.runtimeHostDisconnected',
+        'Server disconnected'
+      )
+  activeRuntimeDisconnectedToasts.set(toastId, activation)
+  const clearActiveToast = (): void => {
+    if (activeRuntimeDisconnectedToasts.get(toastId) === activation) {
+      activeRuntimeDisconnectedToasts.delete(toastId)
+    }
+  }
+  toast.warning(title, {
+    id: toastId,
+    description: translate(
+      'auto.store.slices.runtime.status.runtimeHostDisconnectedDescription',
+      'Workspaces and terminals on this server are unavailable.'
+    ),
+    action: {
+      label: translate('browser.loadFailure.retry', 'Retry'),
+      onClick: () => {
+        void getState()
+          .refreshRuntimeEnvironmentStatus(environmentId)
+          .then((reachable) => {
+            const stillSaved = getState().runtimeEnvironments.some(
+              (entry) => entry.id === environmentId
+            )
+            if (!reachable && stillSaved) {
+              showRuntimeDisconnectedToast(environmentId, getState)
+            }
+          })
+      }
+    },
+    onDismiss: clearActiveToast,
+    onAutoClose: clearActiveToast
+  })
+}
+
+function dismissRuntimeDisconnectedToast(environmentId: string): void {
+  const toastId = getRuntimeDisconnectedToastId(environmentId)
+  if (!activeRuntimeDisconnectedToasts.delete(toastId)) {
+    return
+  }
+  toast.dismiss?.(toastId)
+}
 
 export function getRuntimeEnvironmentConnectionGeneration(environmentId: string): number {
   return connectionGenerationByEnvironment.get(environmentId) ?? 0
@@ -158,10 +219,12 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     const retiredEnvironmentIds = [...new Set([...removedIds, ...replacedEnvironmentIds])]
     if (retiredEnvironmentIds.length > 0) {
       get().purgeStaleRuntimeHostState?.(retiredEnvironmentIds)
+      retiredEnvironmentIds.forEach(dismissRuntimeDisconnectedToast)
     }
   },
 
   setRuntimeEnvironmentStatus: (environmentId, status) => {
+    const previous = get().runtimeStatusByEnvironmentId.get(environmentId)
     // Why: a non-null status proves the runtime just answered, so drop any stale
     // "offline" compat failure before this online transition fires the
     // reuse-flagged background refetches — a recovered host must re-probe.
@@ -170,7 +233,6 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     }
     set((s) => {
       const next = new Map(s.runtimeStatusByEnvironmentId)
-      const previous = next.get(environmentId)
       const connectionChanged =
         status.status !== null &&
         (previous?.status == null || previous.status.runtimeId !== status.status.runtimeId)
@@ -185,9 +247,15 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       })
       return { runtimeStatusByEnvironmentId: next }
     })
+    if (previous?.status === null && status.status !== null) {
+      dismissRuntimeDisconnectedToast(environmentId)
+    } else if (previous && previous.status !== null && status.status === null) {
+      showRuntimeDisconnectedToast(environmentId, get)
+    }
   },
 
-  clearRuntimeEnvironmentStatus: (environmentId) =>
+  clearRuntimeEnvironmentStatus: (environmentId) => {
+    dismissRuntimeDisconnectedToast(environmentId)
     set((s) => {
       advanceRuntimeEnvironmentConnectionGeneration(environmentId)
       if (!s.runtimeStatusByEnvironmentId.has(environmentId)) {
@@ -196,11 +264,17 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       const next = new Map(s.runtimeStatusByEnvironmentId)
       next.delete(environmentId)
       return { runtimeStatusByEnvironmentId: next }
-    }),
+    })
+  },
 
-  retainRuntimeEnvironmentStatuses: (environmentIds) =>
+  retainRuntimeEnvironmentStatuses: (environmentIds) => {
+    const keep = new Set(environmentIds)
+    for (const id of get().runtimeStatusByEnvironmentId.keys()) {
+      if (!keep.has(id)) {
+        dismissRuntimeDisconnectedToast(id)
+      }
+    }
     set((s) => {
-      const keep = new Set(environmentIds)
       let changed = false
       const next = new Map(s.runtimeStatusByEnvironmentId)
       for (const id of next.keys()) {
@@ -210,7 +284,8 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         }
       }
       return changed ? { runtimeStatusByEnvironmentId: next } : s
-    }),
+    })
+  },
 
   refreshRuntimeEnvironmentStatus: async (environmentId, timeoutMs = 10_000) => {
     try {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -46,7 +46,11 @@ export type RuntimeStatusSlice = {
    * retires state owned by any environment that just left the saved list. */
   setRuntimeEnvironments: (environments: PublicKnownRuntimeEnvironment[]) => void
   /** Merges one environment's status. Replaces the prior entry for that id. */
-  setRuntimeEnvironmentStatus: (environmentId: string, status: RuntimeEnvironmentStatus) => void
+  setRuntimeEnvironmentStatus: (
+    environmentId: string,
+    status: RuntimeEnvironmentStatus,
+    options?: { suppressDisconnectToast?: boolean }
+  ) => void
   /** Drops a removed environment so stale hosts don't linger in the registry. */
   clearRuntimeEnvironmentStatus: (environmentId: string) => void
   /** Drops every entry whose id is not in the saved-environments set. */
@@ -223,7 +227,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     }
   },
 
-  setRuntimeEnvironmentStatus: (environmentId, status) => {
+  setRuntimeEnvironmentStatus: (environmentId, status, options) => {
     const previous = get().runtimeStatusByEnvironmentId.get(environmentId)
     // Why: a non-null status proves the runtime just answered, so drop any stale
     // "offline" compat failure before this online transition fires the
@@ -249,7 +253,12 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     })
     if (previous?.status === null && status.status !== null) {
       dismissRuntimeDisconnectedToast(environmentId)
-    } else if (previous && previous.status !== null && status.status === null) {
+    } else if (
+      previous &&
+      previous.status !== null &&
+      status.status === null &&
+      !options?.suppressDisconnectToast
+    ) {
       showRuntimeDisconnectedToast(environmentId, get)
     }
   },

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -251,14 +251,11 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       })
       return { runtimeStatusByEnvironmentId: next }
     })
-    if (previous?.status === null && status.status !== null) {
+    if (options?.suppressDisconnectToast) {
       dismissRuntimeDisconnectedToast(environmentId)
-    } else if (
-      previous &&
-      previous.status !== null &&
-      status.status === null &&
-      !options?.suppressDisconnectToast
-    ) {
+    } else if (previous?.status === null && status.status !== null) {
+      dismissRuntimeDisconnectedToast(environmentId)
+    } else if (previous && previous.status !== null && status.status === null) {
       showRuntimeDisconnectedToast(environmentId, get)
     }
   },

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -64,6 +64,7 @@ export type RuntimeStatusSlice = {
 
 const connectionGenerationByEnvironment = new Map<string, number>()
 const activeRuntimeDisconnectedToasts = new Map<string, symbol>()
+const RUNTIME_DISCONNECTED_TOAST_DURATION_MS = 4_000
 
 function getRuntimeDisconnectedToastId(environmentId: string): string {
   return `runtime-environment-disconnected:${environmentId}`
@@ -89,30 +90,49 @@ function showRuntimeDisconnectedToast(environmentId: string, getState: () => App
       activeRuntimeDisconnectedToasts.delete(toastId)
     }
   }
-  toast.warning(title, {
-    id: toastId,
-    description: translate(
-      'auto.store.slices.runtime.status.runtimeHostDisconnectedDescription',
-      'Workspaces and terminals on this server are unavailable.'
-    ),
-    action: {
-      label: translate('browser.loadFailure.retry', 'Retry'),
-      onClick: () => {
-        void getState()
-          .refreshRuntimeEnvironmentStatus(environmentId)
-          .then((reachable) => {
-            const stillSaved = getState().runtimeEnvironments.some(
-              (entry) => entry.id === environmentId
-            )
-            if (!reachable && stillSaved) {
-              showRuntimeDisconnectedToast(environmentId, getState)
-            }
-          })
-      }
-    },
-    onDismiss: clearActiveToast,
-    onAutoClose: clearActiveToast
-  })
+  let retrying = false
+  const showToast = (duration = RUNTIME_DISCONNECTED_TOAST_DURATION_MS): void => {
+    toast.warning(title, {
+      id: toastId,
+      description: translate(
+        'auto.store.slices.runtime.status.runtimeHostDisconnectedDescription',
+        'Workspaces and terminals on this server are unavailable.'
+      ),
+      duration,
+      action: {
+        label: translate('browser.loadFailure.retry', 'Retry'),
+        onClick: (event) => {
+          // Why: Sonner otherwise deletes the keyed toast after the action callback.
+          event.preventDefault()
+          if (retrying) {
+            return
+          }
+          retrying = true
+          showToast(Number.POSITIVE_INFINITY)
+          void getState()
+            .refreshRuntimeEnvironmentStatus(environmentId)
+            .then((reachable) => {
+              const stillSaved = getState().runtimeEnvironments.some(
+                (entry) => entry.id === environmentId
+              )
+              if (
+                !reachable &&
+                stillSaved &&
+                activeRuntimeDisconnectedToasts.get(toastId) === activation
+              ) {
+                showToast()
+              }
+            })
+            .finally(() => {
+              retrying = false
+            })
+        }
+      },
+      onDismiss: clearActiveToast,
+      onAutoClose: clearActiveToast
+    })
+  }
+  showToast()
 }
 
 function dismissRuntimeDisconnectedToast(environmentId: string): void {


### PR DESCRIPTION
## Summary

Keep one logical project grouped under one sidebar identity across local, SSH, and Orca-server checkouts, even when a remote server goes offline or the setup catalog contains duplicate/folder projection rows.

Also show a retryable warning toast when a previously connected Orca server becomes unavailable.

### Before

One execution surface with multiple setup rows marked the entire project as ambiguous. This included:

- derived and authoritative catalog rows describing the same checkout directory
- non-Git folder workspaces associated with the project
- genuinely separate Git checkouts on only one host

Once marked ambiguous, every checkout on every host switched to a setup-specific group key. The label collision fallback then exposed path tails, so one `stablyai/orca` project could suddenly look like three unrelated sidebar projects after a catalog refresh:

```text
brennanbenson/orca/orca
home/brennan/orca
neil/orca/orca
```

A server outage could trigger the refresh that exposed the split, even though connection status was not itself part of the grouping key. Users retained the persistent red disconnected indicator but received no transient explanation.

### After

Conceptually, the same checkouts remain presented as:

```text
Orca
  local workspaces
  SSH workspaces
  Orca-server workspaces (disconnected when unavailable)
```

- Ambiguity is scoped to the exact project, owning host, execution target, and Windows/WSL path surface.
- Setup rows count distinct normalized checkout directories, so projection twins count once.
- Folder workspaces and provisioned copies do not count as independent Git checkouts.
- If one surface genuinely has two Git checkouts, only those checkouts receive setup-specific headers; other hosts remain under `Orca`.
- Online/offline changes do not alter project keys, labels, ordering, or collapsed state.
- A connected-to-offline transition shows one deduplicated warning toast with the server name and a **Retry** action.
- Cold-start offline detection and repeated failed probes do not spam toasts; recovery or server removal dismisses any active notification.

## Screenshots

Not included: the regression requires a multi-host catalog with duplicate projections plus a live server transition. The before/after presentation is documented above and covered by grouping and runtime-status regression tests.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts src/renderer/src/store/slices/runtime-status.test.ts src/renderer/src/components/right-sidebar/file-explorer-operation-generation.test.ts src/renderer/src/store/slices/runtime-environment-ssh.test.ts` — 154 tests passed
- `pnpm run typecheck:web`
- focused `oxlint` on the four changed TypeScript files
- `pnpm run verify:localization-catalog`
- `pnpm run verify:localization-extraction`
- `pnpm run verify:localization-coverage`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

## AI Review Report

Reviewed the grouping boundary, checkout identity, disconnect transition lifecycle, retry behavior, and cleanup paths.

The review explicitly checked macOS, Linux, Windows drive paths, WSL UNC aliases, local/SSH/runtime execution hosts, nested SSH identity spelling, and folder-workspace behavior. It also confirmed that this PR does not change shortcuts, shell commands, terminal launching, or other Electron platform behavior.

The review flagged that cleanup initially called Sonner's dismiss path even when no toast had been shown. That was tightened to track active toast generations only, preventing unnecessary renderer work and stale callback races; headless consumer tests were added to the validation set.

## Security Audit

- No new dependencies, auth flows, command execution, shell input, or filesystem mutations.
- Runtime paths are used only through the existing comparison normalizer; normalized values are never used as real filesystem paths.
- The Retry action calls the existing saved-environment status IPC with an internal environment id; no user-controlled text is interpolated into commands or IPC methods.
- Server names are rendered through React/Sonner and the existing localization layer.
- No secrets or endpoint credentials are logged or added to state.

No security follow-up is required.

## Notes

- This changes projection/grouping behavior only; it does not delete or migrate existing checkout or folder records.
- The persistent sidebar disconnected state remains the durable indicator. The toast is intentionally transient and transition-based.
