### PR TITLE
Prevent Agent sleep while orchestration dispatch is active

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36036,6 +36036,7 @@ describe('OrcaRuntimeService', () => {
     expect(result.agentOrchestrationByPaneKey?.[workerPaneKey]).toMatchObject({
       taskId: 'task-1',
       dispatchId: 'ctx-1',
+      dispatchStatus: 'dispatched',
       taskTitle: 'Dispatch prompt work',
       displayName: 'Review dispatch prompts and make worker labels distinct',
       parentPaneKey: coordinatorPaneKey,
@@ -36113,6 +36114,7 @@ describe('OrcaRuntimeService', () => {
     expect(result.agentOrchestrationByPaneKey?.[workerPaneKey]).toMatchObject({
       taskId: 'task-done',
       dispatchId: 'ctx-done',
+      dispatchStatus: 'completed',
       parentPaneKey: coordinatorPaneKey,
       parentTerminalHandle: coordinatorHandle
     })
@@ -36170,7 +36172,8 @@ describe('OrcaRuntimeService', () => {
 
     expect(result.agentOrchestrationByPaneKey?.[workerPaneKey]).toEqual({
       taskId: 'task-done',
-      dispatchId: 'ctx-done'
+      dispatchId: 'ctx-done',
+      dispatchStatus: 'completed'
     })
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36177,6 +36177,61 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it.each(['failed', 'circuit_broken'] as const)(
+    'returns recent %s orchestration context without an active coordinator',
+    (dispatchStatus) => {
+      const runtime = new OrcaRuntimeService(store)
+      const workerLeafId = '66666666-6666-4666-8666-666666666666'
+      const workerPaneKey = makePaneKey('tab-worker', workerLeafId)
+      const workerHandle = runtime.preAllocateHandleForPty('pty-worker')
+      const getActiveCoordinatorRun = vi.fn(() => ({
+        id: 'run-unrelated',
+        coordinator_handle: 'term_unrelated'
+      }))
+      runtime.setOrchestrationDb({
+        getActiveDispatchForTerminal: vi.fn(() => undefined),
+        getLatestDispatchForTerminal: vi.fn(() => ({
+          id: 'ctx-settled',
+          task_id: 'task-settled',
+          assignee_handle: workerHandle,
+          status: dispatchStatus,
+          completed_at: new Date(Date.now()).toISOString()
+        })),
+        getActiveCoordinatorRun
+      } as never)
+      runtime.attachWindow(1)
+
+      const result = runtime.syncWindowGraph(1, {
+        tabs: [
+          {
+            tabId: 'tab-worker',
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Claude Code',
+            activeLeafId: workerLeafId,
+            layout: null
+          }
+        ],
+        leaves: [
+          {
+            tabId: 'tab-worker',
+            worktreeId: TEST_WORKTREE_ID,
+            leafId: workerLeafId,
+            paneRuntimeId: 1,
+            ptyId: 'pty-worker',
+            paneTitle: null
+          }
+        ]
+      })
+
+      expect(result.agentOrchestrationByPaneKey?.[workerPaneKey]).toEqual({
+        taskId: 'task-settled',
+        dispatchId: 'ctx-settled',
+        dispatchStatus
+      })
+      expect(getActiveCoordinatorRun).not.toHaveBeenCalled()
+    }
+  )
+
   it('does not return stale completed orchestration context for renderer-synced terminal leaves', () => {
     const runtime = new OrcaRuntimeService(store)
     const workerLeafId = '77777777-7777-4777-8777-777777777777'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29169,10 +29169,10 @@ export class OrcaRuntimeService {
     handle: string,
     db = this.getOrchestrationDbIfAvailable()
   ): AgentStatusOrchestrationContext | undefined {
-    // Why: active dispatch is authoritative for reused terminals; completed context stale-groups future work once its done row is gone.
+    // Why: active dispatch is authoritative for reused terminals; settled context stale-groups later work once its row is gone.
     const dispatch =
       db?.getActiveDispatchForTerminal?.(handle) ??
-      this.getRecentCompletedDispatchForTerminal(handle, db)
+      this.getRecentSettledDispatchForTerminal(handle, db)
     if (!dispatch) {
       return undefined
     }
@@ -29185,7 +29185,10 @@ export class OrcaRuntimeService {
             displayName: task.display_name
           })
         : { taskTitle: '', displayName: '' }
-    const activeRun = dispatch.status === 'completed' ? undefined : db?.getActiveCoordinatorRun?.()
+    const activeRun =
+      dispatch.status === 'pending' || dispatch.status === 'dispatched'
+        ? db?.getActiveCoordinatorRun?.()
+        : undefined
     const parentTerminalHandle =
       task?.created_by_terminal_handle ??
       (activeRun?.coordinator_handle && activeRun.coordinator_handle !== handle
@@ -29208,12 +29211,16 @@ export class OrcaRuntimeService {
     }
   }
 
-  private getRecentCompletedDispatchForTerminal(
+  private getRecentSettledDispatchForTerminal(
     handle: string,
     db = this.getOrchestrationDbIfAvailable()
   ): ReturnType<OrchestrationDb['getLatestDispatchForTerminal']> {
     const dispatch = db?.getLatestDispatchForTerminal?.(handle)
-    if (dispatch?.status !== 'completed' || !dispatch.completed_at) {
+    if (
+      !dispatch?.completed_at ||
+      dispatch.status === 'pending' ||
+      dispatch.status === 'dispatched'
+    ) {
       return undefined
     }
     const completedAtMs = Date.parse(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29198,6 +29198,7 @@ export class OrcaRuntimeService {
     return {
       taskId: dispatch.task_id,
       dispatchId: dispatch.id,
+      dispatchStatus: dispatch.status,
       ...(display.taskTitle ? { taskTitle: display.taskTitle } : {}),
       ...(display.displayName ? { displayName: display.displayName } : {}),
       ...(parentTerminalHandle ? { parentTerminalHandle } : {}),

--- a/src/main/runtime/orchestration/db.test.ts
+++ b/src/main/runtime/orchestration/db.test.ts
@@ -473,6 +473,7 @@ describe('OrchestrationDb', () => {
       const after3 = d.failDispatch(ctx3.id, 'timeout')
       expect(after3?.failure_count).toBe(3)
       expect(after3?.status).toBe('circuit_broken')
+      expect([after1, after2, after3].every((dispatch) => dispatch?.completed_at)).toBe(true)
       expect(d.getTask(task.id)?.status).toBe('failed')
     })
 

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -5826,6 +5826,7 @@ export class OrchestrationDb {
       .prepare(
         `UPDATE dispatch_contexts
          SET status = ?, failure_count = ?, last_failure = ?,
+             completed_at = COALESCE(completed_at, datetime('now')),
              capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
          WHERE id = ?`
       )

--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -356,6 +356,35 @@ describe('agent sleep coordinator', () => {
     expect(shutdown).not.toHaveBeenCalled()
   })
 
+  it('rechecks dispatch settlement before shutdown', async () => {
+    vi.useFakeTimers()
+    const completed = {
+      ...entry(),
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        dispatchStatus: 'completed' as const
+      }
+    }
+    const shutdown = installEligibleState(vi.fn().mockResolvedValue(undefined), {
+      agentStatusByPaneKey: { [completed.paneKey]: completed }
+    })
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    useAppStore.setState({
+      agentStatusByPaneKey: {
+        [completed.paneKey]: {
+          ...completed,
+          orchestration: { ...completed.orchestration, dispatchStatus: 'dispatched' }
+        }
+      }
+    })
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
   it('restarts confirmation when a foreground terminal visit refreshes idle state', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -134,6 +134,39 @@ describe('agent sleep planner', () => {
     ).toEqual([])
   })
 
+  it.each([undefined, 'pending', 'dispatched'] as const)(
+    'blocks orchestration panes while dispatch status is %s',
+    (dispatchStatus) => {
+      const orchestrated = entry({
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          ...(dispatchStatus ? { dispatchStatus } : {})
+        }
+      })
+
+      expect(
+        plannedPaneKeys(
+          snapshot({ agentStatusByPaneKey: { [orchestrated.paneKey]: orchestrated } })
+        )
+      ).toEqual([])
+    }
+  )
+
+  it('allows orchestration panes after authoritative dispatch settlement', () => {
+    const orchestrated = entry({
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        dispatchStatus: 'completed'
+      }
+    })
+
+    expect(
+      plannedPaneKeys(snapshot({ agentStatusByPaneKey: { [orchestrated.paneKey]: orchestrated } }))
+    ).toEqual([orchestrated.paneKey])
+  })
+
   it('requires the idle threshold and blocks input after done', () => {
     const fresh = entry({ updatedAt: NOW - 1_000 })
     expect(

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -134,6 +134,29 @@ describe('agent sleep planner', () => {
     ).toEqual([])
   })
 
+  it('blocks done panes until their live subagent roster clears', () => {
+    const withIdleTeammate = entry({
+      subagents: [
+        {
+          id: 'reviewer-1',
+          agentType: 'reviewer',
+          state: 'idle',
+          startedAt: OLD
+        }
+      ]
+    })
+    expect(
+      plannedPaneKeys(
+        snapshot({ agentStatusByPaneKey: { [withIdleTeammate.paneKey]: withIdleTeammate } })
+      )
+    ).toEqual([])
+
+    const cleared = { ...withIdleTeammate, subagents: undefined }
+    expect(
+      plannedPaneKeys(snapshot({ agentStatusByPaneKey: { [cleared.paneKey]: cleared } }))
+    ).toEqual([cleared.paneKey])
+  })
+
   it.each([undefined, 'pending', 'dispatched'] as const)(
     'blocks orchestration panes while dispatch status is %s',
     (dispatchStatus) => {
@@ -153,19 +176,24 @@ describe('agent sleep planner', () => {
     }
   )
 
-  it('allows orchestration panes after authoritative dispatch settlement', () => {
-    const orchestrated = entry({
-      orchestration: {
-        taskId: 'task-1',
-        dispatchId: 'ctx-1',
-        dispatchStatus: 'completed'
-      }
-    })
+  it.each(['completed', 'failed', 'circuit_broken'] as const)(
+    'allows orchestration panes after authoritative %s settlement',
+    (dispatchStatus) => {
+      const orchestrated = entry({
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          dispatchStatus
+        }
+      })
 
-    expect(
-      plannedPaneKeys(snapshot({ agentStatusByPaneKey: { [orchestrated.paneKey]: orchestrated } }))
-    ).toEqual([orchestrated.paneKey])
-  })
+      expect(
+        plannedPaneKeys(
+          snapshot({ agentStatusByPaneKey: { [orchestrated.paneKey]: orchestrated } })
+        )
+      ).toEqual([orchestrated.paneKey])
+    }
+  )
 
   it('requires the idle threshold and blocks input after done', () => {
     const fresh = entry({ updatedAt: NOW - 1_000 })

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -110,12 +110,11 @@ function getEntryTabId(entry: AgentStatusEntry): string | null {
   return parsePaneKey(entry.paneKey)?.tabId ?? null
 }
 
-function hasUnsettledOrUnknownDispatch({ orchestration }: AgentStatusEntry): boolean {
-  // Why: provider done hooks can fire mid-Dispatch; only runtime-confirmed settlement makes sleep safe.
-  return orchestration
+// Why: provider done hooks can fire mid-Dispatch; only runtime-confirmed settlement makes sleep safe.
+const hasUnsettledOrUnknownDispatch = ({ orchestration }: AgentStatusEntry): boolean =>
+  orchestration
     ? !['completed', 'failed', 'circuit_broken'].includes(orchestration.dispatchStatus ?? '')
     : false
-}
 
 function getEligiblePane(args: {
   entry: AgentStatusEntry
@@ -147,6 +146,7 @@ function getEligiblePane(args: {
   if (
     entry.state !== 'done' ||
     entry.interrupted === true ||
+    Boolean(entry.subagents?.length) ||
     hasUnsettledOrUnknownDispatch(entry) ||
     (sleepingRecord && !hasOnlyLivePiCompatibleRecoveryIdentity)
   ) {

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -110,6 +110,13 @@ function getEntryTabId(entry: AgentStatusEntry): string | null {
   return parsePaneKey(entry.paneKey)?.tabId ?? null
 }
 
+function hasUnsettledOrUnknownDispatch({ orchestration }: AgentStatusEntry): boolean {
+  // Why: provider done hooks can fire mid-Dispatch; only runtime-confirmed settlement makes sleep safe.
+  return orchestration
+    ? !['completed', 'failed', 'circuit_broken'].includes(orchestration.dispatchStatus ?? '')
+    : false
+}
+
 function getEligiblePane(args: {
   entry: AgentStatusEntry
   tab: TerminalTab
@@ -140,6 +147,7 @@ function getEligiblePane(args: {
   if (
     entry.state !== 'done' ||
     entry.interrupted === true ||
+    hasUnsettledOrUnknownDispatch(entry) ||
     (sleepingRecord && !hasOnlyLivePiCompatibleRecoveryIdentity)
   ) {
     return null

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -295,6 +295,33 @@ describe('agent status runtime orchestration metadata', () => {
     })
   })
 
+  it.each(['failed', 'circuit_broken'] as const)(
+    'updates runtime status to %s for the same dispatch',
+    (dispatchStatus) => {
+      vi.useFakeTimers()
+      const store = createTestStore()
+      const childPaneKey = 'tab-child:11111111-1111-4111-8111-111111111111'
+
+      store.getState().setAgentStatus(childPaneKey, {
+        state: 'done',
+        prompt: 'child agent',
+        agentType: 'claude',
+        orchestration: {
+          taskId: 'task-1',
+          dispatchId: 'ctx-1',
+          dispatchStatus: 'dispatched'
+        }
+      })
+      store.getState().setRuntimeAgentOrchestrationByPaneKey({
+        [childPaneKey]: { taskId: 'task-1', dispatchId: 'ctx-1', dispatchStatus }
+      })
+
+      expect(
+        store.getState().agentStatusByPaneKey[childPaneKey].orchestration?.dispatchStatus
+      ).toBe(dispatchStatus)
+    }
+  )
+
   it('keeps current payload orchestration ahead of a stale runtime map entry', () => {
     vi.useFakeTimers()
     const store = createTestStore()

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -265,6 +265,36 @@ describe('agent status runtime orchestration metadata', () => {
     })
   })
 
+  it('updates runtime status for the same dispatch', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const childPaneKey = 'tab-child:11111111-1111-4111-8111-111111111111'
+
+    store.getState().setAgentStatus(childPaneKey, {
+      state: 'done',
+      prompt: 'child agent',
+      agentType: 'claude',
+      orchestration: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        dispatchStatus: 'dispatched'
+      }
+    })
+    store.getState().setRuntimeAgentOrchestrationByPaneKey({
+      [childPaneKey]: {
+        taskId: 'task-1',
+        dispatchId: 'ctx-1',
+        dispatchStatus: 'completed'
+      }
+    })
+
+    expect(store.getState().agentStatusByPaneKey[childPaneKey].orchestration).toMatchObject({
+      taskId: 'task-1',
+      dispatchId: 'ctx-1',
+      dispatchStatus: 'completed'
+    })
+  })
+
   it('keeps current payload orchestration ahead of a stale runtime map entry', () => {
     vi.useFakeTimers()
     const store = createTestStore()

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1090,6 +1090,7 @@ function orchestrationContextsEqual(
   return (
     a.taskId === b.taskId &&
     a.dispatchId === b.dispatchId &&
+    a.dispatchStatus === b.dispatchStatus &&
     a.taskTitle === b.taskTitle &&
     a.displayName === b.displayName &&
     a.parentTerminalHandle === b.parentTerminalHandle &&

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3008,6 +3008,27 @@ describe('shared agent-hook-listener', () => {
       expect(stop?.payload.subagents).toBeUndefined()
     })
 
+    it.each([
+      {
+        label: 'a running shell task',
+        eventName: 'Stop',
+        payload: { background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }] }
+      },
+      {
+        label: 'a pending session cron',
+        eventName: 'StopFailure',
+        payload: { session_crons: [{ id: 'cron-1' }] }
+      }
+    ])(
+      'reports Stop as working for $label without adding a subagent row',
+      ({ eventName, payload }) => {
+        claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'run in background' })
+        const stop = claudeEvent({ hook_event_name: eventName, ...payload })
+        expect(stop?.payload.state).toBe('working')
+        expect(stop?.payload.subagents).toBeUndefined()
+      }
+    )
+
     it('reports Stop as working while a background subagent is still running', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'review the PR' })
       claudeEvent({

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -31,6 +31,7 @@ import {
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
+  hasActiveClaudeNonAgentBackgroundWork,
   idleClaudeTeammateByName,
   readClaudeBackgroundAgentTasks,
   reapRestoredClaudeSubagentsWithoutLiveAgent,
@@ -2600,6 +2601,9 @@ function normalizeClaudeEvent(
   if (!stateName) {
     return null
   }
+  const hasActiveNonAgentBackgroundWork =
+    (eventName === 'Stop' || eventName === 'StopFailure') &&
+    hasActiveClaudeNonAgentBackgroundWork(hookPayload)
 
   const eventAgentId = readString(hookPayload, 'agent_id')
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
@@ -2682,10 +2686,13 @@ function normalizeClaudeEvent(
     ...(stateBeforeWait ? { stateBeforeWait } : {})
   })
 
-  // Why: a lead Stop isn't "done" while subagents/teammates run (would show a finished row mid-flight); Claude re-wakes the lead, so a later empty-roster Stop resolves to done.
+  // Why: a lead Stop isn't done while children, shells, or crons remain live; a later drained Stop resolves it.
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   const effectiveState =
-    stateName === 'done' && claudeRosterHasWorkingSubagent(roster) ? 'working' : stateName
+    stateName === 'done' &&
+    (hasActiveNonAgentBackgroundWork || claudeRosterHasWorkingSubagent(roster))
+      ? 'working'
+      : stateName
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -60,6 +60,8 @@ export const AGENT_STATE_HISTORY_MAX = 20
 export type AgentStatusOrchestrationContext = {
   taskId: string
   dispatchId: string
+  /** Runtime-authoritative lifecycle state. Hook-only contexts may omit it. */
+  dispatchStatus?: 'pending' | 'dispatched' | 'completed' | 'failed' | 'circuit_broken'
   taskTitle?: string
   displayName?: string
   parentTerminalHandle?: string

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -5,6 +5,7 @@ import {
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
+  hasActiveClaudeNonAgentBackgroundWork,
   idleClaudeTeammateByName,
   readClaudeBackgroundAgentTasks,
   reapRestoredClaudeSubagentsWithoutLiveAgent,
@@ -200,6 +201,27 @@ describe('claude-subagent-roster', () => {
         teammate: true
       }
     ])
+  })
+
+  it('detects live non-agent background work without treating agent tasks as shell work', () => {
+    expect(
+      hasActiveClaudeNonAgentBackgroundWork({
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+      })
+    ).toBe(true)
+    expect(hasActiveClaudeNonAgentBackgroundWork({ session_crons: [{ id: 'cron-1' }] })).toBe(true)
+    expect(
+      hasActiveClaudeNonAgentBackgroundWork({
+        background_tasks: [
+          { id: 'agent-1', type: 'subagent', status: 'running' },
+          { id: 'team-1', type: 'teammate', status: 'running' }
+        ]
+      })
+    ).toBe(false)
+    expect(hasActiveClaudeNonAgentBackgroundWork({ background_tasks: [], session_crons: [] })).toBe(
+      false
+    )
+    expect(hasActiveClaudeNonAgentBackgroundWork({})).toBe(false)
   })
 
   it('reports background_tasks as absent when missing or malformed', () => {

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -142,6 +142,27 @@ export function stopClaudeSubagent(roster: ClaudeSubagentRoster, id: string): vo
   tracked.state = 'idle'
 }
 
+/** Shell tasks and session crons outlive a lead Stop but do not belong in the agent roster. */
+export function hasActiveClaudeNonAgentBackgroundWork(
+  hookPayload: Record<string, unknown>
+): boolean {
+  const sessionCrons = hookPayload['session_crons']
+  if (Array.isArray(sessionCrons) && sessionCrons.length > 0) {
+    return true
+  }
+  const backgroundTasks = hookPayload['background_tasks']
+  return (
+    Array.isArray(backgroundTasks) &&
+    backgroundTasks.some((item) => {
+      if (typeof item !== 'object' || item === null) {
+        return false
+      }
+      const task = item as Record<string, unknown>
+      return task.status === 'running' && task.type !== 'subagent' && task.type !== 'teammate'
+    })
+  )
+}
+
 /** Read the agent-typed entries of a hook payload's `background_tasks` field.
  *  `present: false` means the field was absent/malformed (older Claude builds),
  *  so callers must keep their tracked roster instead of clearing it. */


### PR DESCRIPTION
## Summary

- preserve runtime-authoritative Dispatch state in renderer Agent status
- block Agent sleep while an orchestration Dispatch is pending, dispatched, or has unknown settlement
- publish recent completed, failed, and circuit-broken settlement so stale active state cannot block sleep forever
- keep Claude awake while shell background tasks, session crons, or a live subagent/teammate roster remain
- re-evaluate sleep eligibility during the hibernation confirmation window

## Reproduction

The reported incident involved an orchestrated child Claude worker that never completed; reopening its worktree showed `--- session restored ---`, indicating that its original PTY had been interrupted.

A controlled Electron A/B reproduced the underlying race with a real Claude session:

1. Keep its orchestration Dispatch at `dispatched`.
2. Ask Claude to run `sleep 300` in the background. The visible TUI reports `1 shell still running`.
3. Claude naturally reports Agent `state: done` while the `sleep 300` child process is still live.
4. With the sleep veto temporarily removed, two hibernation confirmation passes remove the PTY and kill Claude; `sleep 300` survives orphaned under PID 1.
5. With this PR loaded, the same passes keep the Claude PTY and child process alive.

Output activity only changes the confirmation signature. Once output is quiet across two passes, it cannot distinguish a truly idle session from background work after the provider has reported `done`. This PR uses the structured Claude background-work payload, live roster, and runtime Dispatch state as conservative sleepability signals.

## Reliability contract

- **Invariant:** a pane is not sleepable while Claude reports non-agent background work, its live roster is nonempty, or its orchestration Dispatch is pending, dispatched, or lacks authoritative settlement.
- **Failure sources covered:** lead `Stop` while shell/cron work remains; idle teammates that remain alive for mail; stale `dispatched` renderer state after failed or circuit-broken settlement.
- **Oracle:** provider hook payload + tracked roster + orchestration DB/runtime graph. The planner re-reads these signals during its existing confirmation pass before teardown.
- **Provider/platform coverage:** Claude background-task detection is provider-specific; Dispatch and roster vetoes use existing runtime data. There is no local process-tree assumption, so native, Windows, WSL, SSH, git-worktree, and folder-workspace paths retain the same behavior.
- **Performance budget:** event-driven only; one scan of the hook payload's existing background-task array and O(1) planner checks. No polling, process scan, provider fanout, or new IPC round trip.
- **Diagnostics:** existing Agent status and Dispatch context remain the inspectable source of truth; no new log or telemetry surface is introduced.
- **Accepted gap:** no dedicated Agent-hibernation reliability manifest exists today. The relevant regression and resume tests are run directly rather than expanding this PR into reliability-gate infrastructure. Providers without a structured background-work signal retain their existing behavior; unknown orchestration settlement fails closed.

## cmux reference

Compared against `manaflow-ai/cmux` at [`184bd48`](https://github.com/manaflow-ai/cmux/commit/184bd483658b3fa5aab3384243efca8bd11f4fbe). The shared design is conservative aggregation: explicit idle is required, background work vetoes sleep, and teardown eligibility is revalidated. In particular, cmux has a regression test for a background shell `sleep` process.

cmux's macOS process-generation, TTY, and process-group validation was not copied because Orca must support native Windows, WSL, SSH, and remote providers. The event-driven signals above provide the portable boundary without new polling or process inspection.

## Test plan

- existing Electron A/B above with visible Claude TUI plus runtime/store/process inspection
- focused Vitest suite across runtime, orchestration DB, planner/coordinator, renderer store, Claude listener/roster, and resume reliability: 1,297 passed, 1 skipped
- `pnpm run typecheck`
- targeted oxfmt, default oxlint, native-plugin lint, and type-aware lint checks
- `git diff --check`
- same-model senior review loop: final pass `CLEAN`
- PR checks: 41 passed, e2e intentionally skipped; one unrelated Node 26 activity-portal timing failure passed locally and on CI rerun

## Screenshots

No visual change. The existing Electron A/B was retained and was not rerun after review because the follow-up changes are state plumbing and regression tests; no new screenshots were produced.

## Security

No new command execution, process inspection, network access, permissions, or persisted user data. The change only consumes existing provider/runtime state to make teardown more conservative.
