### PR TITLE
Add recursive sleep actions for workspace descendants

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceSleepMenuItems.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceSleepMenuItems.tsx
@@ -1,0 +1,69 @@
+import type { JSX } from 'react'
+import { Moon } from 'lucide-react'
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+type WorkspaceSleepMenuItemsProps = {
+  isMultiContext: boolean
+  sleepLabel: string
+  sleepDisabled: boolean
+  descendantCount: number
+  subtreeSleepDisabled: boolean
+  onSleep: () => void
+  onSleepSubtree: () => void
+}
+
+export function WorkspaceSleepMenuItems({
+  isMultiContext,
+  sleepLabel,
+  sleepDisabled,
+  descendantCount,
+  subtreeSleepDisabled,
+  onSleep,
+  onSleepSubtree
+}: WorkspaceSleepMenuItemsProps): JSX.Element {
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuItem onSelect={onSleep} disabled={sleepDisabled}>
+            <Moon className="size-3.5" />
+            {sleepLabel}
+          </DropdownMenuItem>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={8} className="max-w-[200px] text-pretty">
+          {isMultiContext
+            ? translate(
+                'auto.components.sidebar.WorktreeContextMenu.7d190f7d2b',
+                'Close all active panels in the selected workspaces to free up memory and CPU.'
+              )
+            : translate(
+                'auto.components.sidebar.WorktreeContextMenu.0918b35e4f',
+                'Close all active panels in this workspace to free up memory and CPU.'
+              )}
+        </TooltipContent>
+      </Tooltip>
+      {!isMultiContext && descendantCount > 0 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuItem onSelect={onSleepSubtree} disabled={subtreeSleepDisabled}>
+              <Moon className="size-3.5" />
+              {translate(
+                'auto.components.sidebar.WorktreeContextMenu.sleepWithDescendants',
+                'Sleep with Descendants ({{value0}})',
+                { value0: descendantCount }
+              )}
+            </DropdownMenuItem>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8} className="max-w-[220px] text-pretty">
+            {translate(
+              'auto.components.sidebar.WorktreeContextMenu.sleepWithDescendantsDescription',
+              'Close active panels in this workspace and every nested descendant to free up memory and CPU.'
+            )}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+    </>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldUseNativeContextMenu,
   shouldIgnoreNestedWorktreeContextMenuScope,
@@ -214,28 +213,6 @@ describe('parent picker context menu affordance', () => {
     } as HTMLElement
 
     expect(getWorktreeParentPickerAnchor(scope, 'child')).toBe(scope)
-  })
-})
-
-describe('hasSleepableWorkspaceActivity', () => {
-  it('treats preserved empty PTY arrays as slept, not live', () => {
-    expect(
-      hasSleepableWorkspaceActivity('wt-1', { 'wt-1': [{ id: 'tab-1' }] }, { 'tab-1': [] }, {})
-    ).toBe(false)
-  })
-
-  it('detects live terminal and browser activity', () => {
-    expect(
-      hasSleepableWorkspaceActivity(
-        'wt-1',
-        { 'wt-1': [{ id: 'tab-1' }] },
-        { 'tab-1': ['pty-1'] },
-        {}
-      )
-    ).toBe(true)
-    expect(hasSleepableWorkspaceActivity('wt-1', {}, {}, { 'wt-1': [{ id: 'browser-1' }] })).toBe(
-      true
-    )
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -19,7 +19,6 @@ import {
   Bell,
   BellOff,
   CircleX,
-  Moon,
   Pencil,
   Pin,
   PinOff,
@@ -44,7 +43,6 @@ import type {
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
-import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import {
   getCyclicProjectedWorktreeLineageIds,
@@ -57,6 +55,11 @@ import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
 import { WorktreeParentPickerPopover } from './WorktreeParentPickerPopover'
 import { WorktreeDeveloperMenu } from './WorktreeDeveloperMenu'
 import { getEligibleWorktreeParents } from './worktree-parent-candidates'
+import {
+  hasSleepableWorkspaceActivity,
+  useWorkspaceLineageMenuActions
+} from './workspace-lineage-menu-actions'
+import { WorkspaceSleepMenuItems } from './WorkspaceSleepMenuItems'
 import { isEventTargetInsideCurrentTarget } from './worktree-card-dom-events'
 import { translate } from '@/i18n/i18n'
 import {
@@ -188,18 +191,6 @@ function getWorktreeParentPickerAnchor(
     return dragRow
   }
   return scope
-}
-
-function hasSleepableWorkspaceActivity(
-  worktreeId: string,
-  tabsByWorktree: Record<string, { id: string }[]>,
-  ptyIdsByTabId: Record<string, string[]>,
-  browserTabsByWorktree: Record<string, { id: string }[]>
-): boolean {
-  const tabs = tabsByWorktree[worktreeId] ?? []
-  const hasLiveTerminal = tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
-  const hasBrowser = (browserTabsByWorktree[worktreeId] ?? []).length > 0
-  return hasLiveTerminal || hasBrowser
 }
 
 function shouldRemoveProjectFromContextMenu(
@@ -403,14 +394,31 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const sleepableWorktrees = useMemo(
     () =>
       activeContextWorktrees.filter((item) =>
-        hasSleepableWorkspaceActivity(item.id, tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree)
+        hasSleepableWorkspaceActivity(item.id, {
+          tabsByWorktree,
+          ptyIdsByTabId,
+          browserTabsByWorktree
+        })
       ),
     [activeContextWorktrees, browserTabsByWorktree, ptyIdsByTabId, tabsByWorktree]
   )
+  const lineageMenuActions = useWorkspaceLineageMenuActions({
+    enabled: !isMultiContext,
+    parent: worktree,
+    worktrees: allWorktrees,
+    lineageById: worktreeLineageById,
+    activity: { tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree }
+  })
+  const lineageDescendantCount = lineageMenuActions.descendants.length
+  const subtreeSleepableWorktrees = lineageMenuActions.sleepableTargets
   const deletingContext = useMemo(
     () => activeContextWorktrees.some((item) => deleteStateByWorktreeId[item.id]?.isDeleting),
     [activeContextWorktrees, deleteStateByWorktreeId]
   )
+  const deletingSubtree = lineageMenuActions.targets.some(
+    (item) => deleteStateByWorktreeId[item.id]?.isDeleting
+  )
+  const contextDeletePending = isMultiContext ? deletingContext : deletingSubtree
   const contextWorkspaceStatus = useMemo(() => {
     const [first, ...rest] = activeContextWorktrees
     if (!first) {
@@ -608,6 +616,14 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     }, 50)
   }, [setMenuOpenState, sleepableWorktrees])
 
+  const handleSleepSubtree = useCallback(() => {
+    const worktreeIds = subtreeSleepableWorktrees.map((item) => item.id)
+    setMenuOpenState(false)
+    window.setTimeout(() => {
+      void runSleepWorktrees(worktreeIds)
+    }, 50)
+  }, [setMenuOpenState, subtreeSleepableWorktrees])
+
   const handleDelete = useCallback(() => {
     // Folder mode handled inline because it routes to a different modal;
     // standard delete delegates to the shared runWorktreeDelete helper.
@@ -771,7 +787,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          className={cn('w-52', contentClassName)}
+          className={cn(lineageDescendantCount > 0 ? 'w-60' : 'w-52', contentClassName)}
           sideOffset={0}
           align="start"
           onPointerUpCapture={suppressOpeningPointerEvent}
@@ -951,28 +967,15 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               <DropdownMenuSeparator />
             </>
           ) : null}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuItem
-                onSelect={handleCloseTerminals}
-                disabled={deletingContext || sleepableWorktrees.length === 0}
-              >
-                <Moon className="size-3.5" />
-                {sleepLabel}
-              </DropdownMenuItem>
-            </TooltipTrigger>
-            <TooltipContent side="right" sideOffset={8} className="max-w-[200px] text-pretty">
-              {isMultiContext
-                ? translate(
-                    'auto.components.sidebar.WorktreeContextMenu.7d190f7d2b',
-                    'Close all active panels in the selected workspaces to free up memory and CPU.'
-                  )
-                : translate(
-                    'auto.components.sidebar.WorktreeContextMenu.0918b35e4f',
-                    'Close all active panels in this workspace to free up memory and CPU.'
-                  )}
-            </TooltipContent>
-          </Tooltip>
+          <WorkspaceSleepMenuItems
+            isMultiContext={isMultiContext}
+            sleepLabel={sleepLabel}
+            sleepDisabled={deletingContext || sleepableWorktrees.length === 0}
+            descendantCount={lineageDescendantCount}
+            subtreeSleepDisabled={deletingSubtree || subtreeSleepableWorktrees.length === 0}
+            onSleep={handleCloseTerminals}
+            onSleepSubtree={handleSleepSubtree}
+          />
           {/* Why: primary checkout rows can't be git-worktree-removed, so keep a
              disabled Delete Worktree for parity with non-primary cards and pair
              it with the enabled Remove Project action below. */}
@@ -1005,7 +1008,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             variant="destructive"
             onSelect={handleDelete}
             disabled={
-              deletingContext ||
+              contextDeletePending ||
               (!isMultiContext && worktree.isMainWorktree && !removesProject) ||
               (isMultiContext && batchDeleteWorktrees.length === 0)
             }
@@ -1019,7 +1022,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             }
           >
             <Trash2 className="size-3.5" />
-            {deletingContext
+            {contextDeletePending
               ? translate('auto.components.sidebar.WorktreeContextMenu.b42391d8bf', 'Deleting…')
               : isMultiContext
                 ? deleteLabel
@@ -1033,7 +1036,15 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                         'auto.components.sidebar.WorktreeContextMenu.f5ac91531d',
                         'Remove Project from Orca'
                       )
-                    : translate('auto.components.sidebar.WorktreeContextMenu.f4475537d8', 'Delete')}
+                    : lineageDescendantCount > 0
+                      ? translate(
+                          'auto.components.sidebar.WorktreeContextMenu.deleteWithDescendants',
+                          'Delete with Descendants…'
+                        )
+                      : translate(
+                          'auto.components.sidebar.WorktreeContextMenu.f4475537d8',
+                          'Delete'
+                        )}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -1071,7 +1082,6 @@ export {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
   WORKTREE_NATIVE_CONTEXT_MENU_ATTR,
-  hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   getWorktreeParentPickerAnchor,
   getWorktreeParentPickerLabel,

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -605,24 +605,24 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     openModal
   ])
 
+  const sleepWorktreesAfterMenuClose = useCallback(
+    (worktreeIds: string[]) => {
+      setMenuOpenState(false)
+      // Let Radix tear down before sleeping can remount the virtualized sidebar.
+      window.setTimeout(() => {
+        void runSleepWorktrees(worktreeIds)
+      }, 50)
+    },
+    [setMenuOpenState]
+  )
+
   const handleCloseTerminals = useCallback(() => {
-    const worktreeIds = sleepableWorktrees.map((item) => item.id)
-    setMenuOpenState(false)
-    // Why: Sleep can remount the sidebar when it clears the active workspace.
-    // Let Radix finish closing the menu first so its focus/portal teardown
-    // cannot scroll the virtualized list during that remount.
-    window.setTimeout(() => {
-      void runSleepWorktrees(worktreeIds)
-    }, 50)
-  }, [setMenuOpenState, sleepableWorktrees])
+    sleepWorktreesAfterMenuClose(sleepableWorktrees.map((item) => item.id))
+  }, [sleepWorktreesAfterMenuClose, sleepableWorktrees])
 
   const handleSleepSubtree = useCallback(() => {
-    const worktreeIds = subtreeSleepableWorktrees.map((item) => item.id)
-    setMenuOpenState(false)
-    window.setTimeout(() => {
-      void runSleepWorktrees(worktreeIds)
-    }, 50)
-  }, [setMenuOpenState, subtreeSleepableWorktrees])
+    sleepWorktreesAfterMenuClose(subtreeSleepableWorktrees.map((item) => item.id))
+  }, [sleepWorktreesAfterMenuClose, subtreeSleepableWorktrees])
 
   const handleDelete = useCallback(() => {
     // Folder mode handled inline because it routes to a different modal;

--- a/src/renderer/src/components/sidebar/workspace-lineage-menu-actions.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-lineage-menu-actions.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree, WorktreeLineage } from '../../../../shared/types'
+import {
+  getWorkspaceLineageMenuActions,
+  hasSleepableWorkspaceActivity
+} from './workspace-lineage-menu-actions'
+
+function makeWorktree(id: string): Worktree {
+  return {
+    id,
+    instanceId: `${id}-instance`,
+    repoId: 'repo-1',
+    path: `/workspaces/${id}`,
+    head: 'abc123',
+    branch: id,
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1
+  }
+}
+
+function makeLineage(child: Worktree, parent: Worktree): WorktreeLineage {
+  return {
+    worktreeId: child.id,
+    worktreeInstanceId: child.instanceId ?? '',
+    parentWorktreeId: parent.id,
+    parentWorktreeInstanceId: parent.instanceId ?? '',
+    origin: 'manual',
+    capture: { source: 'manual-action', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+describe('workspace lineage menu actions', () => {
+  it('collects recursive descendants and only targets workspaces with active panels for sleep', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+    const grandchild = makeWorktree('grandchild')
+    const actions = getWorkspaceLineageMenuActions({
+      parent,
+      worktrees: [parent, child, grandchild],
+      lineageById: {
+        [child.id]: makeLineage(child, parent),
+        [grandchild.id]: makeLineage(grandchild, child)
+      },
+      activity: {
+        tabsByWorktree: {
+          [parent.id]: [{ id: 'parent-tab' }],
+          [child.id]: [{ id: 'child-tab' }],
+          [grandchild.id]: [{ id: 'grandchild-tab' }]
+        },
+        ptyIdsByTabId: {
+          'parent-tab': [],
+          'child-tab': ['child-pty'],
+          'grandchild-tab': []
+        },
+        browserTabsByWorktree: {
+          [grandchild.id]: [{ id: 'grandchild-browser' }]
+        }
+      }
+    })
+
+    expect(actions.descendants.map((target) => target.id)).toEqual(['child', 'grandchild'])
+    expect(actions.targets.map((target) => target.id)).toEqual(['parent', 'child', 'grandchild'])
+    expect(actions.sleepableTargets.map((target) => target.id)).toEqual(['child', 'grandchild'])
+  })
+
+  it('does not expose stale descendants through the recursive action scope', () => {
+    const parent = makeWorktree('parent')
+    const child = makeWorktree('child')
+
+    const actions = getWorkspaceLineageMenuActions({
+      parent,
+      worktrees: [parent, child],
+      lineageById: {
+        [child.id]: {
+          ...makeLineage(child, parent),
+          parentWorktreeInstanceId: 'stale-parent-instance'
+        }
+      },
+      activity: {
+        tabsByWorktree: { [child.id]: [{ id: 'child-tab' }] },
+        ptyIdsByTabId: { 'child-tab': ['child-pty'] },
+        browserTabsByWorktree: {}
+      }
+    })
+
+    expect(actions.descendants).toEqual([])
+    expect(actions.sleepableTargets).toEqual([])
+  })
+})
+
+describe('hasSleepableWorkspaceActivity', () => {
+  it('treats preserved empty PTY arrays as slept, not live', () => {
+    expect(
+      hasSleepableWorkspaceActivity('wt-1', {
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+        ptyIdsByTabId: { 'tab-1': [] },
+        browserTabsByWorktree: {}
+      })
+    ).toBe(false)
+  })
+
+  it('detects live terminal and browser activity', () => {
+    expect(
+      hasSleepableWorkspaceActivity('wt-1', {
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        browserTabsByWorktree: {}
+      })
+    ).toBe(true)
+    expect(
+      hasSleepableWorkspaceActivity('wt-1', {
+        tabsByWorktree: {},
+        ptyIdsByTabId: {},
+        browserTabsByWorktree: { 'wt-1': [{ id: 'browser-1' }] }
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/workspace-lineage-menu-actions.ts
+++ b/src/renderer/src/components/sidebar/workspace-lineage-menu-actions.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react'
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import type { Worktree, WorktreeLineage } from '../../../../shared/types'
+import { getWorkspaceDeleteLineage } from './workspace-delete-lineage'
+
+type WorkspaceActivityMaps = {
+  tabsByWorktree: Record<string, { id: string }[]>
+  ptyIdsByTabId: Record<string, string[]>
+  browserTabsByWorktree: Record<string, { id: string }[]>
+}
+
+export type WorkspaceLineageMenuActions = {
+  descendants: Worktree[]
+  targets: Worktree[]
+  sleepableTargets: Worktree[]
+}
+
+export function hasSleepableWorkspaceActivity(
+  worktreeId: string,
+  { tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree }: WorkspaceActivityMaps
+): boolean {
+  const tabs = tabsByWorktree[worktreeId] ?? []
+  return (
+    tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id)) ||
+    (browserTabsByWorktree[worktreeId] ?? []).length > 0
+  )
+}
+
+export function getWorkspaceLineageMenuActions(args: {
+  parent: Worktree
+  worktrees: readonly Worktree[]
+  lineageById: Record<string, WorktreeLineage>
+  activity: WorkspaceActivityMaps
+}): WorkspaceLineageMenuActions {
+  const { descendants } = getWorkspaceDeleteLineage(args.parent, args.worktrees, args.lineageById)
+  const targets = [args.parent, ...descendants]
+  return {
+    descendants,
+    targets,
+    sleepableTargets: targets.filter((target) =>
+      hasSleepableWorkspaceActivity(target.id, args.activity)
+    )
+  }
+}
+
+const EMPTY_LINEAGE_MENU_ACTIONS: WorkspaceLineageMenuActions = {
+  descendants: [],
+  targets: [],
+  sleepableTargets: []
+}
+
+export function useWorkspaceLineageMenuActions(
+  args: Parameters<typeof getWorkspaceLineageMenuActions>[0] & { enabled: boolean }
+): WorkspaceLineageMenuActions {
+  const { enabled, parent, worktrees, lineageById, activity } = args
+  const { tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree } = activity
+  return useMemo(
+    () =>
+      enabled
+        ? getWorkspaceLineageMenuActions({
+            parent,
+            worktrees,
+            lineageById,
+            activity: { tabsByWorktree, ptyIdsByTabId, browserTabsByWorktree }
+          })
+        : EMPTY_LINEAGE_MENU_ACTIONS,
+    [browserTabsByWorktree, enabled, lineageById, parent, ptyIdsByTabId, tabsByWorktree, worktrees]
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4590,7 +4590,10 @@
           "setParentWorkspace": "Set Parent Worktree...",
           "workspaceSection": "Workspace",
           "primaryDeleteDisabled": "Primary worktree — can't be deleted. Remove the project instead.",
-          "deleteWorktree": "Delete Worktree"
+          "deleteWorktree": "Delete Worktree",
+          "sleepWithDescendants": "Sleep with Descendants ({{value0}})",
+          "sleepWithDescendantsDescription": "Close active panels in this workspace and every nested descendant to free up memory and CPU.",
+          "deleteWithDescendants": "Delete with Descendants…"
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -373,7 +373,12 @@ test.describe('Workspace board lane virtualization', () => {
 
     await orcaPage.mouse.move(box.x + 2, box.y + 12)
     await orcaPage.mouse.down()
-    await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80)
+    await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80, { steps: 4 })
+    await expect
+      .poll(() => lane.locator('[data-workspace-board-card-area-selected="true"]').count(), {
+        timeout: 15_000
+      })
+      .toBeGreaterThan(0)
     await laneScroll.evaluate(async (element) => {
       for (let pass = 0; pass < 4; pass++) {
         element.scrollTop = element.scrollHeight

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -366,12 +366,14 @@ test.describe('Workspace board lane virtualization', () => {
     const laneCards = lane.locator('[data-workspace-board-card-id]')
     await expect.poll(() => laneCards.count(), { timeout: 15_000 }).toBeGreaterThan(3)
     const laneScroll = lane.locator('[data-workspace-board-lane-scroll]')
+    const selectionSurface = orcaPage.locator('[data-workspace-board-selection-surface]')
     const box = await laneScroll.boundingBox()
-    if (!box) {
-      throw new Error('Expected the marquee lane to have a bounding box')
+    const selectionBox = await selectionSurface.boundingBox()
+    if (!box || !selectionBox) {
+      throw new Error('Expected the marquee lane and selection surface to have bounding boxes')
     }
 
-    await orcaPage.mouse.move(box.x + 2, box.y + 12)
+    await orcaPage.mouse.move(selectionBox.x + 4, box.y + 12)
     await orcaPage.mouse.down()
     await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80, { steps: 4 })
     await expect

--- a/tests/e2e/worktree-lineage.spec.ts
+++ b/tests/e2e/worktree-lineage.spec.ts
@@ -29,6 +29,15 @@ async function captureSidebarEvidence(page: Page, name: string): Promise<void> {
     })
 }
 
+async function captureLineageMenuEvidence(page: Page, name: string): Promise<void> {
+  if (process.env.ORCA_CAPTURE_EVIDENCE !== '1') {
+    return
+  }
+  const outputDir = resolve(process.cwd(), 'pr-evidence')
+  mkdirSync(outputDir, { recursive: true })
+  await page.screenshot({ path: resolve(outputDir, name) })
+}
+
 test.describe('Worktree Lineage', () => {
   test.describe.configure({ mode: 'serial' })
 
@@ -203,6 +212,79 @@ test.describe('Worktree Lineage', () => {
 
     await markWorkspaceTerminalSlept(orcaPage, { worktreeId: childId, tabId: childTabId })
     await expect(childRow).toContainText('Inactive')
+  })
+
+  test('sleeps a workspace and every descendant from the parent context menu', async ({
+    orcaPage
+  }) => {
+    const { parentId, childId } = await seedLineageScenario(orcaPage)
+    await orcaPage.evaluate((parentId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      store.setState((current) => ({
+        worktreesByRepo: Object.fromEntries(
+          Object.entries(current.worktreesByRepo).map(([repoId, worktrees]) => [
+            repoId,
+            worktrees.map((worktree) =>
+              worktree.id === parentId ? { ...worktree, isMainWorktree: false } : worktree
+            )
+          ])
+        )
+      }))
+    }, parentId)
+    const parentTabId = await seedWorkspaceLiveTerminal(orcaPage, parentId)
+    const childTabId = await seedWorkspaceLiveTerminal(orcaPage, childId)
+
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      store.setState({
+        shutdownWorktreeBrowsers: async (worktreeId: string) => {
+          store.setState((current) => ({
+            browserTabsByWorktree: { ...current.browserTabsByWorktree, [worktreeId]: [] }
+          }))
+        },
+        shutdownWorktreeTerminals: async (worktreeId: string) => {
+          const tabIds = (store.getState().tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id)
+          store.setState((current) => ({
+            ptyIdsByTabId: {
+              ...current.ptyIdsByTabId,
+              ...Object.fromEntries(tabIds.map((tabId) => [tabId, []]))
+            }
+          }))
+        }
+      })
+      window.api.ephemeralVm.suspendWorkspace = async () => null
+    })
+
+    await worktreeOption(orcaPage, parentId).click({ button: 'right' })
+    const sleepSubtree = orcaPage.getByRole('menuitem', {
+      name: 'Sleep with Descendants (1)'
+    })
+    await expect(sleepSubtree).toBeVisible()
+    await expect(sleepSubtree).toBeEnabled()
+    await expect(orcaPage.getByRole('menuitem', { name: 'Delete with Descendants…' })).toBeVisible()
+    await captureLineageMenuEvidence(orcaPage, 'workspace-descendant-actions.png')
+    await sleepSubtree.click()
+
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          ({ parentTabId, childTabId }) => {
+            const state = window.__store?.getState()
+            return {
+              parentPtys: state?.ptyIdsByTabId[parentTabId],
+              childPtys: state?.ptyIdsByTabId[childTabId]
+            }
+          },
+          { parentTabId, childTabId }
+        )
+      )
+      .toEqual({ parentPtys: [], childPtys: [] })
   })
 
   test('shows parent and child agent rows while the parent workspace is active', async ({

--- a/tests/e2e/worktree-lineage.spec.ts
+++ b/tests/e2e/worktree-lineage.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@stablyai/playwright-test'
+import type { Locator, Page } from '@stablyai/playwright-test'
 import { mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { test, expect } from './helpers/orca-app'
@@ -15,27 +15,22 @@ function worktreeOption(page: Page, worktreeId: string) {
   return worktreeRow(page, worktreeId)
 }
 
-async function captureSidebarEvidence(page: Page, name: string): Promise<void> {
+async function captureEvidence(page: Page, name: string, locator?: Locator): Promise<void> {
   if (process.env.ORCA_CAPTURE_EVIDENCE !== '1') {
     return
   }
   const outputDir = resolve(process.cwd(), 'pr-evidence')
   mkdirSync(outputDir, { recursive: true })
-  await page
-    .locator('[data-worktree-sidebar]')
-    .first()
-    .screenshot({
-      path: resolve(outputDir, name)
-    })
+  const path = resolve(outputDir, name)
+  if (locator) {
+    await locator.screenshot({ path })
+    return
+  }
+  await page.screenshot({ path })
 }
 
-async function captureLineageMenuEvidence(page: Page, name: string): Promise<void> {
-  if (process.env.ORCA_CAPTURE_EVIDENCE !== '1') {
-    return
-  }
-  const outputDir = resolve(process.cwd(), 'pr-evidence')
-  mkdirSync(outputDir, { recursive: true })
-  await page.screenshot({ path: resolve(outputDir, name) })
+async function captureSidebarEvidence(page: Page, name: string): Promise<void> {
+  await captureEvidence(page, name, page.locator('[data-worktree-sidebar]').first())
 }
 
 test.describe('Worktree Lineage', () => {
@@ -268,7 +263,7 @@ test.describe('Worktree Lineage', () => {
     await expect(sleepSubtree).toBeVisible()
     await expect(sleepSubtree).toBeEnabled()
     await expect(orcaPage.getByRole('menuitem', { name: 'Delete with Descendants…' })).toBeVisible()
-    await captureLineageMenuEvidence(orcaPage, 'workspace-descendant-actions.png')
+    await captureEvidence(orcaPage, 'workspace-descendant-actions.png')
     await sleepSubtree.click()
 
     await expect


### PR DESCRIPTION
## Summary

- Add a conditional **Sleep with Descendants (N)** context-menu action that sleeps the selected workspace and every validated descendant recursively.
- Make the existing cascading delete behavior explicit with **Delete with Descendants…**.
- Reuse the existing lineage projection so stale links, cycles, host boundaries, repository boundaries, and project boundaries are excluded.

## Screenshots

![Workspace descendant actions](https://github.com/user-attachments/assets/60fd71aa-ac26-480f-b813-d7fe9ee07fb9)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused Vitest coverage passed; the full matrix runs in CI.
- [ ] `pnpm build` — the Electron E2E build passed; packaging runs in CI.
- [x] Added or updated high-quality tests that would catch regressions.

Additional validation:

- 30 focused sidebar sleep/delete unit tests passed after the review fixes; 65 focused tests passed for the original implementation.
- All 6 `worktree-lineage.spec.ts` Electron tests passed, including recursive parent/child PTY cleanup.
- The CI-sensitive virtualized marquee case passed 10/10 locally after adding a preview-selection readiness check.
- `pnpm run check:code-quality:changed` and `pnpm run check:react-doctor:changed` passed with zero findings.

## AI Review Report

Reviewed recursive traversal boundaries, stale/cyclic lineage handling, sleepability filtering, multi-selection behavior, delete pending state, React hook dependencies, and Radix menu teardown ordering. Bot review found duplicated delayed-sleep and screenshot-evidence helpers; both were consolidated and revalidated. CI trace review also found an existing virtualized-marquee test starting on a card under slow-runner layout; the test now starts from guaranteed empty board padding and waits for observable preview state before forcing its large scroll jump.

Cross-platform review covered macOS, Linux, and Windows. This change adds no shortcuts, platform labels, filesystem paths, shell commands, or platform-specific APIs. It uses the existing Electron renderer sleep flow and validated host-aware lineage projection, preserving SSH and folder-workspace behavior.

## Security Audit

No new dependency, authentication, secret, command-execution, filesystem-path, or IPC surface is introduced. Workspace IDs come from existing application state; recursive targets are restricted through the existing validated lineage projection before invoking the established sleep flow. No follow-up security work is required.

## Notes

- Screenshot evidence is attached through GitHub user attachments and is not committed to the repository.
- An unrelated tab-menu timing failure passed on failed-job rerun; no product code was changed for it.
