### PR TITLE
[P2] fix(updater): route hourly release-notes links to the hourly repo and let the disabled channel tooltip open

### DIFF
--- a/src/renderer/src/components/UpdateCard.error-card.test.tsx
+++ b/src/renderer/src/components/UpdateCard.error-card.test.tsx
@@ -98,6 +98,29 @@ describe('UpdateCard Windows signature failures', () => {
   })
 })
 
+describe('UpdateCard hourly builds', () => {
+  it('links a pinned hourly build to its own repo instead of a 404 main-repo tag', () => {
+    useAppStore.setState({
+      updateStatus: {
+        state: 'available',
+        version: '1.4.160-hourly.202607281400',
+        changelog: null,
+        source: 'hourly'
+      },
+      updateChangelog: null,
+      dismissedUpdateVersion: null,
+      updateCardCollapsed: false,
+      updateReassuranceSeen: true
+    })
+    render(<UpdateCard />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Release notes' }))
+    expect(openUrl).toHaveBeenCalledWith(
+      'https://github.com/stablyai/orca-hourly/releases/tag/v1.4.160-hourly.202607281400'
+    )
+  })
+})
+
 describe('UpdateCard local builds', () => {
   it('does not link local versions to GitHub release downloads', () => {
     useAppStore.setState({

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -21,16 +21,10 @@ import {
   isWindowsSignatureCheckUnavailableFailure,
   isWindowsSignatureMismatchFailure
 } from '../../../shared/updater-windows-signature-check'
+import { getReleaseNotesUrlForVersion } from '../../../shared/release-channel'
 import { translate } from '@/i18n/i18n'
 
 // ── Helpers ──────────────────────────────────────────────────────────
-
-function releaseUrlForVersion(version: string | null): string {
-  // Why: fall back to the plain releases listing (not /releases/latest) — /latest also breaks when GitHub's API is degraded.
-  return version
-    ? `https://github.com/stablyai/orca/releases/tag/v${version}`
-    : 'https://github.com/stablyai/orca/releases'
-}
 
 function isAnimatedGif(url: string | undefined): boolean {
   return typeof url === 'string' && url.toLowerCase().endsWith('.gif')
@@ -357,7 +351,7 @@ export function UpdateCard() {
                 'This turns on a process-wide Electron networking switch after restart. Use it for corporate VPNs or proxies that reject HTTP/2 update downloads.'
               ),
               detail: compatibilitySetupError ?? status.message,
-              releaseUrl: releaseUrlForVersion(cachedVersion),
+              releaseUrl: getReleaseNotesUrlForVersion(cachedVersion),
               primaryAction: {
                 label: translate('auto.components.UpdateCard.933c6fdf5b', 'Enable & Restart'),
                 pendingLabel: 'Restarting...',
@@ -379,7 +373,7 @@ export function UpdateCard() {
                 ),
                 detail: status.message,
                 // Why: linking the rejected version would let users bypass the publisher check by re-running it.
-                releaseUrl: releaseUrlForVersion(null),
+                releaseUrl: getReleaseNotesUrlForVersion(null),
                 manualLabel: translate(
                   'auto.components.UpdateCard.c9ff9b9ec2',
                   'Check official releases'
@@ -396,7 +390,7 @@ export function UpdateCard() {
                     "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases."
                   ),
                   detail: status.message,
-                  releaseUrl: releaseUrlForVersion(cachedVersion),
+                  releaseUrl: getReleaseNotesUrlForVersion(cachedVersion),
                   primaryAction: {
                     label: translate('auto.components.UpdateCard.48565a32bc', 'Retry Download'),
                     onClick: handleUpdate
@@ -409,7 +403,7 @@ export function UpdateCard() {
                     ? 'Could not complete the update.'
                     : 'Could not check for updates.',
                   detail: status.message,
-                  releaseUrl: releaseUrlForVersion(cachedVersion),
+                  releaseUrl: getReleaseNotesUrlForVersion(cachedVersion),
                   // Why: check-time failures are often transient, so offer a Re-check instead of forcing manual download.
                   primaryAction: cachedVersion
                     ? {
@@ -428,7 +422,7 @@ export function UpdateCard() {
             title: translate('auto.components.UpdateCard.4cf109845a', 'Update Error'),
             summary: 'Could not restart to install the update.',
             detail: installError,
-            releaseUrl: releaseUrlForVersion(cachedVersion),
+            releaseUrl: getReleaseNotesUrlForVersion(cachedVersion),
             primaryAction: {
               label: translate('auto.components.UpdateCard.2c2d3e03ca', 'Try Again'),
               onClick: handleInstallRetry
@@ -598,7 +592,7 @@ export function UpdateCard() {
     const releaseUrl = isLocalBuild
       ? undefined
       : (('releaseUrl' in status ? status.releaseUrl : undefined) ??
-        releaseUrlForVersion(status.version))
+        getReleaseNotesUrlForVersion(status.version))
 
     if (isRichMode && changelog) {
       return (
@@ -914,7 +908,7 @@ function DownloadingContent({
           className="text-xs text-muted-foreground underline hover:text-foreground self-start"
           onClick={() =>
             void window.api.shell.openUrl(
-              release ? release.releaseNotesUrl : releaseUrlForVersion(version)
+              release ? release.releaseNotesUrl : getReleaseNotesUrlForVersion(version)
             )
           }
         >

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -48,7 +48,7 @@ describe('AccountsPane', () => {
 
     expect(markup).toContain('Account location')
     expect(markup).toContain('aria-label="Account location"')
-    expect(markup).toContain('role="radio" aria-checked="true" disabled=""')
+    expect(markup).toContain('role="radio" aria-checked="true" aria-disabled="true"')
   })
 
   it('selects the WSL account location under auto when the global project runtime is WSL', () => {
@@ -70,8 +70,8 @@ describe('AccountsPane', () => {
       )
 
       expect(markup).toContain('aria-label="Account location"')
-      // The resolved WSL radio is the checked option (disabled while capabilities load).
-      expect(markup).toContain('role="radio" aria-checked="true" disabled=""')
+      // The resolved WSL radio is the checked option (unavailable while capabilities load).
+      expect(markup).toContain('role="radio" aria-checked="true" aria-disabled="true"')
     } finally {
       if (originalOwnUserAgent) {
         Object.defineProperty(globalThis.navigator, 'userAgent', originalOwnUserAgent)

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -10,6 +10,7 @@ import { translate } from '@/i18n/i18n'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from '@/lib/update-check-click-options'
 import { GeneralRemoteServerUpdates } from './GeneralRemoteServerUpdates'
 import { ReleaseChannelSection } from './ReleaseChannelSection'
+import { getReleaseNotesUrlForVersion } from '../../../../shared/release-channel'
 
 export function GeneralUpdateSettingsSection(): React.JSX.Element {
   const updateStatus = useAppStore((s) => s.updateStatus)
@@ -184,8 +185,7 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
               {updateStatus.source !== 'local' && (
                 <a
                   href={
-                    updateStatus.releaseUrl ??
-                    `https://github.com/stablyai/orca/releases/tag/v${updateStatus.version}`
+                    updateStatus.releaseUrl ?? getReleaseNotesUrlForVersion(updateStatus.version)
                   }
                   target="_blank"
                   rel="noopener noreferrer"
@@ -224,8 +224,7 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
               {updateStatus.source !== 'local' && (
                 <a
                   href={
-                    updateStatus.releaseUrl ??
-                    `https://github.com/stablyai/orca/releases/tag/v${updateStatus.version}`
+                    updateStatus.releaseUrl ?? getReleaseNotesUrlForVersion(updateStatus.version)
                   }
                   target="_blank"
                   rel="noopener noreferrer"

--- a/src/renderer/src/components/settings/SettingsFormControls.segmented-control.test.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.segmented-control.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '../ui/tooltip'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+
+afterEach(cleanup)
+
+function renderControl(onChange = vi.fn()): { onChange: ReturnType<typeof vi.fn> } {
+  render(
+    <TooltipProvider>
+      <SettingsSegmentedControl<string>
+        value="stable"
+        onChange={onChange}
+        options={[
+          { value: 'stable', label: 'Stable' },
+          {
+            value: 'hourly',
+            label: 'Hourly',
+            disabled: true,
+            ariaLabel: 'Hourly (macOS only)',
+            tooltip: 'Hourly builds are produced only for macOS.'
+          }
+        ]}
+      />
+    </TooltipProvider>
+  )
+  return { onChange }
+}
+
+describe('SettingsSegmentedControl unavailable options', () => {
+  // Why: a native disabled button leaves the tab order, so keyboard users can never
+  // focus it to open the tooltip explaining why the option is unavailable.
+  it('marks unavailable options aria-disabled so their tooltip stays reachable', async () => {
+    renderControl()
+
+    const hourly = screen.getByRole('radio', { name: 'Hourly (macOS only)' })
+    expect(hourly.hasAttribute('disabled')).toBe(false)
+    expect(hourly.getAttribute('aria-disabled')).toBe('true')
+
+    fireEvent.focus(hourly)
+    expect(
+      await screen.findAllByText('Hourly builds are produced only for macOS.')
+    ).not.toHaveLength(0)
+  })
+
+  it('ignores clicks on unavailable options', () => {
+    const { onChange } = renderControl()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Hourly (macOS only)' }))
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Stable' }))
+    expect(onChange).toHaveBeenCalledWith('stable')
+  })
+})

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -179,7 +179,10 @@ export function SettingsSegmentedControl<T extends string | number>({
             role="radio"
             aria-checked={active}
             aria-label={opt.ariaLabel}
-            disabled={opt.disabled}
+            // Why aria-disabled, not disabled: a native disabled button leaves the tab
+            // order, so keyboard users can never focus it to open the tooltip explaining
+            // why the option is unavailable. The click guard below keeps it inert.
+            aria-disabled={opt.disabled}
             onClick={() => {
               if (!opt.disabled) {
                 onChange(opt.value)

--- a/src/shared/release-channel.test.ts
+++ b/src/shared/release-channel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatHourlyVersion,
+  getReleaseNotesUrlForVersion,
   getReleaseRepoForChannel,
   getVersionChannel,
   isChannelSupportedOnPlatform,
@@ -28,6 +29,21 @@ describe('release channel', () => {
     expect(getReleaseRepoForChannel('hourly')).toBe('stablyai/orca-hourly')
     expect(getReleaseRepoForChannel('stable')).toBe('stablyai/orca')
     expect(getReleaseRepoForChannel('rc')).toBe('stablyai/orca')
+  })
+
+  // Why: an hourly tag linked against the main repo 404s — the tag only exists
+  // in the hourly repo.
+  it('builds release-notes links against the repo that published the version', () => {
+    expect(getReleaseNotesUrlForVersion('1.4.160-hourly.202607281400')).toBe(
+      'https://github.com/stablyai/orca-hourly/releases/tag/v1.4.160-hourly.202607281400'
+    )
+    expect(getReleaseNotesUrlForVersion('1.4.160')).toBe(
+      'https://github.com/stablyai/orca/releases/tag/v1.4.160'
+    )
+    expect(getReleaseNotesUrlForVersion('v1.4.160-rc.3')).toBe(
+      'https://github.com/stablyai/orca/releases/tag/v1.4.160-rc.3'
+    )
+    expect(getReleaseNotesUrlForVersion(null)).toBe('https://github.com/stablyai/orca/releases')
   })
 
   it('round-trips an hourly version stamp as UTC', () => {

--- a/src/shared/release-channel.ts
+++ b/src/shared/release-channel.ts
@@ -82,6 +82,20 @@ export function getVersionChannel(version: string): ReleaseChannel | null {
   return normalized.includes('-') ? 'rc' : 'stable'
 }
 
+/**
+ * Release-notes page for a version, in whichever repo published it. Hourly tags
+ * exist only in the hourly repo, so a main-repo tag URL for one 404s.
+ * A null version falls back to the plain releases listing (not /releases/latest
+ * — /latest also breaks when GitHub's API is degraded).
+ */
+export function getReleaseNotesUrlForVersion(version: string | null): string {
+  const repo =
+    version && getVersionChannel(version) === 'hourly' ? HOURLY_RELEASE_REPO : MAIN_RELEASE_REPO
+  return version
+    ? `https://github.com/${repo}/releases/tag/v${normalizeTagToVersion(version)}`
+    : `https://github.com/${repo}/releases`
+}
+
 export type ReleaseBuild = {
   tag: string
   version: string


### PR DESCRIPTION
## Summary

Two independent P2s found by the `v1.4.163-rc.1..v1.4.163-rc.3` production release scan, both on the update / release-channel surface.

### Bug A — a pinned hourly build links "Release notes" to a tag that does not exist (404)

`UpdateCard.tsx` kept a private `releaseUrlForVersion()` that hardcoded the main repo:

```ts
return version
  ? `https://github.com/stablyai/orca/releases/tag/v${version}`
  : 'https://github.com/stablyai/orca/releases'
```

Hourly builds are not published there. `src/shared/release-channel.ts` already knows this — hourly artifacts go to `stablyai/orca-hourly` (`HOURLY_RELEASE_REPO`), stable and RC to `stablyai/orca` (`MAIN_RELEASE_REPO`). An hourly tag has no counterpart in the main repo, so every "Release notes" / "Check official releases" link rendered on an updater error card while running a pinned hourly build resolved to a GitHub 404.

`GeneralUpdateSettingsSection.tsx` had the same hardcoded main-repo URL in two more places.

**Fix:** one shared `getReleaseNotesUrlForVersion(version)` in `src/shared/release-channel.ts:85`, deriving the repo from the existing `getVersionChannel(version)`. Seven call sites in `UpdateCard.tsx` and two in `GeneralUpdateSettingsSection.tsx` now route through it. It also runs the version through `normalizeTagToVersion`, so an already-`v`-prefixed version no longer yields `.../releases/tag/vv1.4.163`.

**Deliberately preserved:** the Windows signature-mismatch card passes `null`, and `null` still resolves to the *main* repo's plain releases listing. That is intentional and the existing comment says why — linking the rejected version would let a user bypass the publisher check by re-running it. `null` also does not use `/releases/latest`, because `/latest` breaks when GitHub's API is degraded. Both behaviors are unchanged and are pinned by new tests.

### Bug B — the "macOS only" tooltip on the disabled Hourly segment is unreachable by keyboard

`ReleaseChannelSection.tsx:184-209` disables the Hourly segment on Linux and Windows and attaches a tooltip explaining why. The code says exactly what it is for:

```ts
// Why disabled rather than hidden: a Linux/Windows dev who has heard
// about the hourly channel should see that it exists and why it is
// unavailable, instead of silently not finding it.
```

`SettingsSegmentedControl` rendered that option with the **native `disabled` attribute**, and `TooltipTrigger` uses `asChild`, so the Radix trigger *is* the disabled button rather than a wrapper around it. A natively disabled button is removed from the tab order, so it can never receive focus — and the focus-driven half of the tooltip never fires. A keyboard or screen-reader user on Linux/Windows tabs straight past a greyed-out segment with an Apple glyph and no way to find out why it is greyed out.

**Fix:** `aria-disabled={opt.disabled}` instead of `disabled={opt.disabled}`. `aria-disabled` conveys the same state to assistive technology while leaving the button focusable. The component already had an `if (!opt.disabled) { onChange(...) }` click guard, so the option stays inert.

> **Scope correction vs. the release-scan finding.** The scan reported this as "disabled buttons emit no pointer or focus events … the rationale isn't delivered for mouse users." The pointer half of that is **wrong**, and it was caught by capturing the screenshots below rather than reasoning about it. Chromium *does* dispatch pointer events to disabled buttons, so hover already worked on `origin/main`. The before/after hover screenshots came out **byte-identical (matching SHA-256)**, which is the proof. Only the keyboard path was broken. The fix is unchanged — but it is an accessibility fix, not a mouse-affordance fix, and the code comment was reworded to stop asserting the false claim.

## ELI5

**A.** Orca can install builds from two different shelves: the normal shelf and an extra "hourly" shelf that only exists for macOS. If you were running something off the hourly shelf and the updater showed you an error, the "Release notes" link always pointed at the *normal* shelf — where your build was never stored. So you clicked it and got GitHub's "this page does not exist". Now the link looks up which shelf your build actually came from.

**B.** In Settings there is a row of buttons for picking your update channel: Stable / RC / Hourly. On Windows and Linux the Hourly button is greyed out, and it has a little popup that says "hourly builds are macOS-only".

If you use a mouse, you could hover it and read that popup — fine. But if you navigate with the keyboard, you couldn't: a greyed-out button is skipped entirely when you press Tab, so you can never land on it, so the popup explaining *why* it's greyed out can never appear. Keyboard and screen-reader users got a dead button and no explanation at all.

The fix marks the button as unavailable in a way that still lets you Tab to it and read the explanation, while pressing it still does nothing.

## Screenshots

Captured from the Electron dev build over CDP, Settings → Updates → Release channel. Hourly is *enabled* on macOS (it is the only platform it ships for), so the disabled state cannot render on this host — `navigator.userAgent` was spoofed to Windows over CDP, since `getShortcutPlatform()` is what `ReleaseChannelSection` reads. Disclosing that rather than implying a real Windows box.

**Keyboard — this is the bug.** Tab to the Hourly segment:

| Before (`disabled`) | After (`aria-disabled`) |
|---|---|
| ![before](https://github.com/user-attachments/assets/6e38527f-aabf-458a-a27d-360ec734b13c) | ![after](https://github.com/user-attachments/assets/39f08c54-e1ac-40b0-a6c1-1ca0153fe554) |
| Focus skips straight past the greyed-out segment. No focus ring, no tooltip, no explanation. | The segment takes focus (visible ring) and the tooltip opens: *"Hourly builds are produced only for macOS. Linux and Windows stay on Stable or RC."* |

**Hover — unchanged, and that is the point.** Hovering the disabled segment before and after:

![hover](https://github.com/user-attachments/assets/7a232a5c-d5e9-448e-8cac-3759b608190a)

The before and after hover captures came out **byte-identical** (SHA-256 `f498c53b2a562dad746251b93509983891bde228069cee92f83ca4331dadc2cd` for both), so only one is shown. Chromium dispatches pointer events to natively disabled buttons, so mouse hover already worked on `origin/main`. See the scope correction above — this is a keyboard/AT fix only.

## Proof of fix

Run against this branch with **only the production files reverted to `origin/main`** (tests kept), `npx vitest run --config config/vitest.config.ts` over the four touched test files:

```
 × builds release-notes links against the repo that published the version
 × links a pinned hourly build to its own repo instead of a 404 main-repo tag
 × marks unavailable options aria-disabled so their tooltip stays reachable
 × keeps the WSL account location controls on Windows-class hosts
 × selects the WSL account location under auto when the global project runtime is WSL

TypeError: getReleaseNotesUrlForVersion is not a function
AssertionError: expected "vi.fn()" to be called with arguments: [ Array(1) ]
AssertionError: expected '<link rel="preload" as="image" href="…' to contain 'role="radio" aria-checked="true" aria…'
AssertionError: expected true to be false // Object.is equality

 Test Files  4 failed (4)
      Tests  5 failed | 20 passed (25)
```

The last two `AccountsPane` failures are the same defect showing up on a second consumer: those assertions look for `aria-disabled="true"` on the WSL account-location segments and find the native `disabled` attribute instead.

With the fix restored, the same command is **4 files / 25 tests passed**.

New coverage added:
- `src/shared/release-channel.test.ts` — hourly / stable / RC / `null` cases for `getReleaseNotesUrlForVersion`, including the `null` → main-repo-listing behavior the Windows signature-mismatch card depends on.
- `src/renderer/src/components/UpdateCard.error-card.test.tsx` — a new "UpdateCard hourly builds" block asserting the rendered error-card link points at `stablyai/orca-hourly`.
- `src/renderer/src/components/settings/SettingsFormControls.segmented-control.test.tsx` (new file) — asserts an unavailable option renders `aria-disabled="true"` with no native `disabled` attribute, and that clicking it does not call `onChange`.

## Proof of no regression

- Targeted suite at branch tip: **4 files / 25 tests passed**.
- Full desktop suite was run on the merged tree containing all eight scan fixes: **359 files / 3830 tests passed**.
- `npx oxfmt --check` and `npx oxlint` clean on all changed files (enforced by lint-staged on commit).
- `AccountsPane.test.tsx` is updated, not deleted: the two assertions moved from `disabled=""` to `aria-disabled="true"`. That is the *only* behavioral assertion change in this PR, and it is asserting the fix.

### Blast radius: `SettingsSegmentedControl` is shared

Bug B's fix touches a primitive with seven other consumers (WSL runtime pickers in `AccountsPane`, `AgentRuntimeSetting`, `DefaultWindowsProjectRuntimeSetting`, `ProjectWindowsRuntimeSetting`; the fork-sync segments in `RepositoryForkSyncSection`; `TerminalAdvancedSection`; `TerminalWindowsShellSection`). Verified safe for all of them:

- **Still inert.** The `onClick` guard is unchanged and catches both mouse clicks and keyboard `Enter`/`Space` activation, since both dispatch a `click` event on a `<button>`.
- **Still looks disabled.** The styling at `SettingsFormControls.tsx:197` is an explicit `opt.disabled ? … : …` conditional, not a Tailwind `disabled:` variant, so it does not depend on the native attribute.
- **No form submission risk.** The element is `type="button"`.
- **Accessibility is improved, not degraded.** `aria-disabled` is the ARIA-recommended pattern for a disabled control that must remain discoverable, and it keeps the `role="radio"` semantics intact.

## Testing

- [x] `pnpm lint` — clean (oxlint, type-aware audit, reliability gates, max-lines ratchet, localization catalog/extraction/coverage); `oxfmt --check` clean via lint-staged
- [x] `pnpm typecheck` — clean (tsc: node + cli + web)
- [x] `pnpm test` (targeted files at tip + full desktop suite on the combined tree)
- [ ] `pnpm build` — not run; no build-graph, packaging, or dependency change in this PR
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed by Claude Opus 5 as part of a 45-agent release scan with adversarial refutation (21 candidates raised, 6 confirmed, 13 refuted). Risks checked for this change:

- **Cross-platform:** this PR is *about* platform difference. Bug B only manifests on Linux/Windows (Hourly is enabled on macOS, so the disabled state never renders there) — which is why it survived local testing. Bug A only manifests on macOS, since hourly builds are macOS-only. No hardcoded `metaKey`, no path assumptions, no shell invocation. `getReleaseNotesUrlForVersion` builds a URL string only.
- **Updater safety:** confirmed the `null` → main-repo-listing path is untouched, so the Windows signature-mismatch card still refuses to link the rejected artifact. `verifyUpdateCodeSignature` is not referenced or reassigned anywhere in this diff.
- **Shared-primitive blast radius:** all seven other `SettingsSegmentedControl` consumers audited (see above).
- **Provider neutrality / SSH / folder workspaces:** not applicable — no git, provider, or execution-host code paths touched.

## Security Audit

- No new dependencies, no lockfile change, no install hooks.
- No shell execution, no `eval`, no dynamic `import()`.
- Input handling: `getReleaseNotesUrlForVersion` interpolates a version string into a `https://github.com/…` URL. The repo half is chosen from a closed set of two module-level constants — it is never caller-controlled. The version half comes from the updater's own release feed, not user input, and is passed through `normalizeTagToVersion`. The result is only ever handed to Orca's existing external-link opener, which is unchanged.
- The `disabled` → `aria-disabled` swap widens which events the element emits, so it was checked for a click-through hole. The pre-existing `if (!opt.disabled)` guard closes it, and a new test pins that.
- No auth, secrets, IPC, or path handling touched.

## Notes

- Bug B is **not observable on macOS**, because Hourly is supported there and the segment is never disabled. The disabled state is reached via `getShortcutPlatform()` in `src/renderer/src/lib/shortcut-platform.ts`, which reads `navigator.userAgent`.
- Bug A's fix now covers `GeneralUpdateSettingsSection.tsx` too, which was beyond the original finding — the scan flagged `UpdateCard.tsx` only, but the same hardcoded URL was present there and would 404 identically.

Made with [Orca](https://github.com/stablyai/orca) 🐋
