### PR TITLE
[P2] fix(checks): give the PR page and work-item dialog the shared check-count labels

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -234,6 +234,7 @@ import {
 import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
 import {
   getCheckConclusion,
+  getCheckCountChips,
   getCheckCounts,
   getChecksSummaryLabel
 } from '@/components/pr-check-counts'
@@ -5123,51 +5124,7 @@ function ChecksTab({
     )
   }
   if (variant === 'page') {
-    const countChips: { label: string; className: string }[] = []
-    if (counts.passing > 0) {
-      countChips.push({
-        label: translate('auto.components.GitHubItemDialog.311d0cee55', '{{value0}} passing', {
-          value0: counts.passing
-        }),
-        className: CHECK_COLOR.success
-      })
-    }
-    if (counts.failing > 0) {
-      countChips.push({
-        label: translate('auto.components.GitHubItemDialog.b1ac991806', '{{value0}} failing', {
-          value0: counts.failing
-        }),
-        className: CHECK_COLOR.failure
-      })
-    }
-    if (counts.needsAction > 0) {
-      countChips.push({
-        label: translate(
-          'auto.components.GitHubItemDialog.checksNeedActionChip',
-          '{{value0}} action required',
-          {
-            value0: counts.needsAction
-          }
-        ),
-        className: CHECK_COLOR.action_required
-      })
-    }
-    if (counts.pending > 0) {
-      countChips.push({
-        label: translate('auto.components.GitHubItemDialog.18f80e1329', '{{value0}} pending', {
-          value0: counts.pending
-        }),
-        className: CHECK_COLOR.pending
-      })
-    }
-    if (counts.neutral > 0) {
-      countChips.push({
-        label: translate('auto.components.GitHubItemDialog.d23bbb6416', '{{value0}} skipped', {
-          value0: counts.neutral
-        }),
-        className: 'text-muted-foreground'
-      })
-    }
+    const countChips = getCheckCountChips(counts)
     return (
       <div className="flex flex-col gap-3 px-4 py-3">
         <div className="flex min-w-0 items-center gap-3">
@@ -5183,9 +5140,9 @@ function ChecksTab({
             {countChips.length > 1 && (
               <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                 {countChips.map((chip, i) => (
-                  <React.Fragment key={chip.label}>
+                  <React.Fragment key={chip.tone}>
                     {i > 0 && <span className="opacity-40">·</span>}
-                    <span className={chip.className}>{chip.label}</span>
+                    <span className={CHECK_COLOR[chip.tone]}>{chip.label}</span>
                   </React.Fragment>
                 ))}
               </span>

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -230,6 +230,7 @@ import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
 import {
   getCheckConclusion,
+  getCheckCountChips,
   getCheckCounts,
   getChecksSummaryLabel
 } from '@/components/pr-check-counts'
@@ -5257,51 +5258,7 @@ function ChecksTab({
     )
   }
   if (variant === 'page') {
-    const countChips: { label: string; className: string }[] = []
-    if (counts.passing > 0) {
-      countChips.push({
-        label: translate('auto.components.PullRequestPage.7c5035931a', '{{value0}} passing', {
-          value0: counts.passing
-        }),
-        className: CHECK_COLOR.success
-      })
-    }
-    if (counts.failing > 0) {
-      countChips.push({
-        label: translate('auto.components.PullRequestPage.ae2a34c7b8', '{{value0}} failing', {
-          value0: counts.failing
-        }),
-        className: CHECK_COLOR.failure
-      })
-    }
-    if (counts.needsAction > 0) {
-      countChips.push({
-        label: translate(
-          'auto.components.PullRequestPage.checksNeedActionChip',
-          '{{value0}} action required',
-          {
-            value0: counts.needsAction
-          }
-        ),
-        className: CHECK_COLOR.action_required
-      })
-    }
-    if (counts.pending > 0) {
-      countChips.push({
-        label: translate('auto.components.PullRequestPage.88267924d5', '{{value0}} pending', {
-          value0: counts.pending
-        }),
-        className: CHECK_COLOR.pending
-      })
-    }
-    if (counts.neutral > 0) {
-      countChips.push({
-        label: translate('auto.components.PullRequestPage.e6ad0a8d06', '{{value0}} skipped', {
-          value0: counts.neutral
-        }),
-        className: 'text-muted-foreground'
-      })
-    }
+    const countChips = getCheckCountChips(counts)
     return (
       <>
         <div className="flex flex-col gap-3 px-4 py-3">
@@ -5320,9 +5277,9 @@ function ChecksTab({
               {countChips.length > 1 && (
                 <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                   {countChips.map((chip, i) => (
-                    <React.Fragment key={chip.label}>
+                    <React.Fragment key={chip.tone}>
                       {i > 0 && <span className="opacity-40">·</span>}
-                      <span className={chip.className}>{chip.label}</span>
+                      <span className={CHECK_COLOR[chip.tone]}>{chip.label}</span>
                     </React.Fragment>
                   ))}
                 </span>

--- a/src/renderer/src/components/pr-check-counts.ts
+++ b/src/renderer/src/components/pr-check-counts.ts
@@ -1,4 +1,5 @@
-import { classifyCheckOutcome } from '../../../shared/provider-check-summary'
+import { translate } from '../i18n/i18n'
+import { summarizeProviderChecks } from '../../../shared/provider-check-summary'
 import type { PRCheckDetail } from '../../../shared/types'
 
 export type PRCheckCounts = {
@@ -21,27 +22,78 @@ export function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDet
  * private copies, which is how one drifted from the Checks panel's own header.
  */
 export function getCheckCounts(checks: readonly PRCheckDetail[]): PRCheckCounts {
-  return checks.reduce<PRCheckCounts>(
-    (counts, check) => {
-      const conclusion = getCheckConclusion(check)
-      // Why: the shared classifier counts a skipped check as passing, so bucketing it separately
-      // made this pane say "2 passing" for the same list the Checks panel called "5 passing".
-      // action_required stays its own bucket: it blocks merge but is not a red failure.
-      if (classifyCheckOutcome(check) === 'passed') {
-        counts.passing += 1
-      } else if (conclusion === 'action_required') {
-        counts.needsAction += 1
-      } else if (['failure', 'cancelled', 'timed_out'].includes(conclusion)) {
-        counts.failing += 1
-      } else if (conclusion === 'neutral') {
-        counts.neutral += 1
-      } else {
-        counts.pending += 1
-      }
-      return counts
-    },
-    { passing: 0, failing: 0, needsAction: 0, pending: 0, neutral: 0 }
-  )
+  // Why: every bucket is read off the shared rollup rather than re-derived, so these panes cannot
+  // disagree with the checks pill. action_required is the one split back out: it blocks merge like
+  // a failure but reads amber, not red.
+  const summary = summarizeProviderChecks(checks)
+  const needsAction = checks.filter(
+    (check) => getCheckConclusion(check) === 'action_required'
+  ).length
+  return {
+    passing: summary.passed,
+    failing: summary.failed - needsAction,
+    needsAction,
+    pending: summary.pending,
+    neutral: summary.neutral
+  }
+}
+
+/** `tone` keys the caller's `CHECK_COLOR`/`CHECK_ICON` maps so styling stays with the surface. */
+export type PRCheckCountChip = {
+  tone: 'success' | 'failure' | 'action_required' | 'pending' | 'neutral'
+  label: string
+}
+
+/**
+ * The count chips above the check list on the PR page and the work-item dialog. One builder so the
+ * two panes cannot word the same bucket differently — the neutral bucket read "skipped" here while
+ * the sidebar Checks panel called the identical checks "unresolved".
+ */
+export function getCheckCountChips(counts: PRCheckCounts): PRCheckCountChip[] {
+  const chips: PRCheckCountChip[] = []
+  if (counts.passing > 0) {
+    chips.push({
+      tone: 'success',
+      label: translate('auto.components.pr-check-counts.passingChip', '{{value0}} passing', {
+        value0: counts.passing
+      })
+    })
+  }
+  if (counts.failing > 0) {
+    chips.push({
+      tone: 'failure',
+      label: translate('auto.components.pr-check-counts.failingChip', '{{value0}} failing', {
+        value0: counts.failing
+      })
+    })
+  }
+  if (counts.needsAction > 0) {
+    chips.push({
+      tone: 'action_required',
+      label: translate(
+        'auto.components.pr-check-counts.needsActionChip',
+        '{{value0}} action required',
+        { value0: counts.needsAction }
+      )
+    })
+  }
+  if (counts.pending > 0) {
+    chips.push({
+      tone: 'pending',
+      label: translate('auto.components.pr-check-counts.pendingChip', '{{value0}} pending', {
+        value0: counts.pending
+      })
+    })
+  }
+  if (counts.neutral > 0) {
+    chips.push({
+      tone: 'neutral',
+      label: translate('auto.components.pr-check-counts.unresolvedChip', '{{value0}} unresolved', {
+        value0: counts.neutral
+      })
+    })
+  }
+  return chips
 }
 
 export function getChecksSummaryLabel(checks: readonly PRCheckDetail[]): string {

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { deriveTaskPagePRCheckSummary } from './task-page-pr-check-summary'
+import { getCheckCountChips, getCheckCounts } from './pr-check-counts'
 import { derivePipelineStatus } from '../../../main/gitlab/mappers'
 import { gitLabPipelineJobsToPRChecks } from '../../../shared/gitlab-pipeline-checks'
 import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from '../../../shared/pr-check-status'
@@ -171,6 +172,24 @@ describe('provider check classification parity', () => {
       const summary = { ...expected, total: checks.length }
       expect(summarizeProviderChecks(checks)).toEqual(summary)
       expect(deriveTaskPagePRCheckSummary(checks)).toEqual(summary)
+      // Why: the PR page and the work-item dialog share these counts; their absence here is how
+      // their neutral chip kept saying "skipped" for what the sidebar calls "unresolved".
+      const paneCounts = getCheckCounts(checks)
+      expect({
+        passed: paneCounts.passing,
+        // Both panes split action_required into its own amber chip; it is still the failed bucket.
+        failed: paneCounts.failing + paneCounts.needsAction,
+        pending: paneCounts.pending,
+        neutral: paneCounts.neutral
+      }).toEqual({
+        passed: expected.passed,
+        failed: expected.failed,
+        pending: expected.pending,
+        neutral: expected.neutral
+      })
+      expect(getCheckCountChips(paneCounts).find((chip) => chip.tone === 'neutral')?.label).toBe(
+        expected.neutral > 0 ? `${expected.neutral} unresolved` : undefined
+      )
       expect(derivePRCheckStatus(checks)).toBe(expected.state)
       expect(derivePRCheckStatusFromRollup(checks.map(toGraphQLRollup))).toBe(expected.state)
       if (gitLabJobStatuses) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -893,11 +893,6 @@
         "83ac703dda": "Assignees",
         "00ccdf9b5a": "Status",
         "2aa9acdf34": "Edit labels on GitHub",
-        "d23bbb6416": "{{value0}} skipped",
-        "18f80e1329": "{{value0}} pending",
-        "b1ac991806": "{{value0}} failing",
-        "checksNeedActionChip": "{{value0}} action required",
-        "311d0cee55": "{{value0}} passing",
         "e52bed9264": "No checks reported yet",
         "90020cc1f3": "This pull request has no reported checks yet.",
         "ecffebc251": "No checks found",
@@ -1391,11 +1386,6 @@
         "bc215fea4d": "+ Label",
         "b936cc51a4": "Closed",
         "7b8f6bf6d8": "Open",
-        "e6ad0a8d06": "{{value0}} skipped",
-        "88267924d5": "{{value0}} pending",
-        "ae2a34c7b8": "{{value0}} failing",
-        "checksNeedActionChip": "{{value0}} action required",
-        "7c5035931a": "{{value0}} passing",
         "a18d01cda3": "No checks reported yet",
         "3912daf310": "This pull request has no reported checks yet.",
         "45877f5089": "No checks found",
@@ -14380,6 +14370,13 @@
         "title": "Workspace created from a local base",
         "description": "The remote-tracking ref \"{{value0}}\" was unavailable, so Orca used local \"{{value1}}\" instead. This workspace may not include the latest remote changes.",
         "dismiss": "Got it"
+      },
+      "pr-check-counts": {
+        "passingChip": "{{value0}} passing",
+        "failingChip": "{{value0}} failing",
+        "pendingChip": "{{value0}} pending",
+        "needsActionChip": "{{value0}} action required",
+        "unresolvedChip": "{{value0}} unresolved"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -869,11 +869,6 @@
         "83ac703dda": "Asignados",
         "00ccdf9b5a": "Estado",
         "2aa9acdf34": "Editar etiquetas en GitHub",
-        "d23bbb6416": "{{value0}} omitido",
-        "18f80e1329": "{{value0}} pendiente",
-        "b1ac991806": "{{value0}} fallando",
-        "checksNeedActionChip": "{{value0}} requiere acción",
-        "311d0cee55": "{{value0}} pasando",
         "e52bed9264": "Aún no se reportaron checks",
         "90020cc1f3": "Este pull request aún no tiene checks reportados.",
         "ecffebc251": "No se encontraron checks",
@@ -1363,11 +1358,6 @@
         "bc215fea4d": "+ Etiqueta",
         "b936cc51a4": "Cerrado",
         "7b8f6bf6d8": "Abierto",
-        "e6ad0a8d06": "{{value0}} omitido",
-        "88267924d5": "{{value0}} pendiente",
-        "ae2a34c7b8": "{{value0}} fallando",
-        "checksNeedActionChip": "{{value0}} requiere acción",
-        "7c5035931a": "{{value0}} pasando",
         "a18d01cda3": "Aún no se reportaron checks",
         "3912daf310": "Este pull request aún no tiene checks reportados.",
         "45877f5089": "No se encontraron checks",
@@ -14289,6 +14279,13 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "pr-check-counts": {
+        "passingChip": "{{value0}} pasando",
+        "failingChip": "{{value0}} fallando",
+        "pendingChip": "{{value0}} pendiente",
+        "needsActionChip": "{{value0}} requiere acción",
+        "unresolvedChip": "{{value0}} sin resolver"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -869,11 +869,6 @@
         "83ac703dda": "担当者",
         "00ccdf9b5a": "状態",
         "2aa9acdf34": "GitHub でラベルを編集する",
-        "d23bbb6416": "{{value0}} はスキップされました",
-        "18f80e1329": "{{value0}} 保留中",
-        "b1ac991806": "{{value0}} は失敗しました",
-        "checksNeedActionChip": "{{value0}} 件の対応が必要",
-        "311d0cee55": "{{value0}} 通過",
         "e52bed9264": "まだチェックは報告されていません",
         "90020cc1f3": "この PR にはまだチェックが報告されていません。",
         "ecffebc251": "チェックが見つかりませんでした",
@@ -1363,11 +1358,6 @@
         "bc215fea4d": "+ ラベル",
         "b936cc51a4": "クローズ",
         "7b8f6bf6d8": "オープン",
-        "e6ad0a8d06": "{{value0}} はスキップされました",
-        "88267924d5": "{{value0}} 保留中",
-        "ae2a34c7b8": "{{value0}} は失敗しました",
-        "checksNeedActionChip": "{{value0}} 件の対応が必要",
-        "7c5035931a": "{{value0}} 通過",
         "a18d01cda3": "まだチェックは報告されていません",
         "3912daf310": "この PR にはまだチェックが報告されていません。",
         "45877f5089": "チェックが見つかりませんでした",
@@ -14289,6 +14279,13 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "pr-check-counts": {
+        "passingChip": "{{value0}} 通過",
+        "failingChip": "{{value0}} は失敗しました",
+        "pendingChip": "{{value0}} 保留中",
+        "needsActionChip": "{{value0}} 件の対応が必要",
+        "unresolvedChip": "{{value0}} 件未解決"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -869,11 +869,6 @@
         "83ac703dda": "담당자",
         "00ccdf9b5a": "상태",
         "2aa9acdf34": "GitHub에서 라벨 편집",
-        "d23bbb6416": "{{value0}} 건너뜀",
-        "18f80e1329": "{{value0}} 보류 중",
-        "b1ac991806": "{{value0}} 실패",
-        "checksNeedActionChip": "{{value0}}개 조치 필요",
-        "311d0cee55": "{{value0}} 통과",
         "e52bed9264": "아직 보고된 체크가 없습니다.",
         "90020cc1f3": "이 PR에는 아직 보고된 체크가 없습니다.",
         "ecffebc251": "체크를 찾을 수 없습니다.",
@@ -1363,11 +1358,6 @@
         "bc215fea4d": "+ 라벨",
         "b936cc51a4": "닫힘",
         "7b8f6bf6d8": "열림",
-        "e6ad0a8d06": "{{value0}} 건너뛰었습니다",
-        "88267924d5": "{{value0}} 보류 중",
-        "ae2a34c7b8": "{{value0}} 실패",
-        "checksNeedActionChip": "{{value0}}개 조치 필요",
-        "7c5035931a": "{{value0}} 통과",
         "a18d01cda3": "아직 보고된 체크가 없습니다.",
         "3912daf310": "이 PR에는 아직 보고된 체크가 없습니다.",
         "45877f5089": "체크를 찾을 수 없습니다.",
@@ -14289,6 +14279,13 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "pr-check-counts": {
+        "passingChip": "{{value0}} 통과",
+        "failingChip": "{{value0}} 실패",
+        "pendingChip": "{{value0}} 보류 중",
+        "needsActionChip": "{{value0}}개 조치 필요",
+        "unresolvedChip": "{{value0}}개 미해결"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -869,11 +869,6 @@
         "83ac703dda": "负责人",
         "00ccdf9b5a": "状态",
         "2aa9acdf34": "在 GitHub 上编辑标签",
-        "d23bbb6416": "{{value0}} 已跳过",
-        "18f80e1329": "{{value0}} 待处理",
-        "b1ac991806": "{{value0}} 失败",
-        "checksNeedActionChip": "{{value0}} 个需要操作",
-        "311d0cee55": "{{value0}} 通过",
         "e52bed9264": "尚未报告任何 CI 检查",
         "90020cc1f3": "此PR尚未报告检查。",
         "ecffebc251": "未找到检查",
@@ -1363,11 +1358,6 @@
         "bc215fea4d": "+ 标签",
         "b936cc51a4": "已关闭",
         "7b8f6bf6d8": "进行中",
-        "e6ad0a8d06": "{{value0}} 已跳过",
-        "88267924d5": "{{value0}} 待处理",
-        "ae2a34c7b8": "{{value0}} 失败",
-        "checksNeedActionChip": "{{value0}} 个需要操作",
-        "7c5035931a": "{{value0}} 通过",
         "a18d01cda3": "尚未报告任何 CI 检查",
         "3912daf310": "此PR尚未报告检查。",
         "45877f5089": "未找到检查",
@@ -14289,6 +14279,13 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "pr-check-counts": {
+        "passingChip": "{{value0}} 通过",
+        "failingChip": "{{value0}} 失败",
+        "pendingChip": "{{value0}} 待处理",
+        "needsActionChip": "{{value0}} 个需要操作",
+        "unresolvedChip": "{{value0}} 个未解决"
       }
     },
     "i18n": {


### PR DESCRIPTION
## Summary

Follow-on to #11700, found by the `v1.4.163-rc.1..v1.4.163-rc.3` production release scan. #11700 gave every check surface one shared classifier for the *passed* bucket, but the PR page and the work-item dialog kept re-deriving the other four buckets locally, and then labelled one of them with a word that is now provably wrong.

### The mislabel

On `origin/main`, `PullRequestPage.tsx:5299` and `GitHubItemDialog.tsx` render the neutral bucket as:

```ts
label: translate('auto.components.PullRequestPage.e6ad0a8d06', '{{value0}} skipped', {
  value0: counts.neutral
})
```

But `getCheckCounts` already routes `skipped` into `passing`, because the shared classifier buckets it there:

```ts
// src/shared/provider-check-summary.ts
// Why: a skipped job is a deliberate "not applicable", not an unresolved signal — every surface
const PASSED_CONCLUSIONS = new Set(['success', 'skipped'])
```

So **no skipped check is ever in the bucket labelled "skipped"**. What is actually in it is `neutral` conclusions and GitLab `manual` gates. Meanwhile the checks pill on the sidebar, via the shared `getProviderChecksLabel`, calls that same set **"Unresolved checks"**. Same PR, same data, two panes, two different words — one of which is factually incorrect.

This is exactly the drift class #11700 set out to remove.

### The second classifier

Beyond the label, `getCheckCounts` still hand-rolled the failing / pending / neutral split:

```ts
} else if (['failure', 'cancelled', 'timed_out'].includes(conclusion)) {
  counts.failing += 1
} else if (conclusion === 'neutral') {
  counts.neutral += 1
} else {
  counts.pending += 1
}
```

That is a third rulebook living next to the shared one, and it is what let the label drift in the first place. It also disagrees with the shared summarizer on inputs the shared one has explicit handling for — an unrecognized conclusion falls into `pending` here but is classified deliberately there.

### Fix

- `pr-check-counts.ts:24` — `getCheckCounts` now reads every bucket off `summarizeProviderChecks`. Only `action_required` is split back out of `failed`, because it blocks merge like a failure but is rendered amber rather than red.
- `pr-check-counts.ts:41` — new `getCheckCountChips(counts)` returning `{ tone, label }[]`. Both panes had a ~45-line copy of the identical chip-building block; both now call this. `tone` keys the caller's own `CHECK_COLOR` / `CHECK_ICON` maps, so styling stays with each surface.
- The neutral chip now reads **`{n} unresolved`**, matching `getProviderChecksLabel`.
- `provider-check-classification-parity.test.ts` — both surfaces added to the existing parity assertion list, so a future divergence fails the build.
- i18n: five new `auto.components.pr-check-counts.*` keys across `en/es/ja/ko/zh`; the ten now-orphaned per-surface keys deleted.

## ELI5

A pull request has a list of automated checks. Some pass, some fail, some are still running, some are "skipped — not needed for this change", and a few end in a state that is neither pass nor fail.

Orca counts "skipped" as **passed**, on purpose: skipping a check is a deliberate "not applicable", not a problem. That decision was made once and put in a shared rulebook.

But the PR page had a leftover summary line that said *"3 skipped"* — pointing at a group that, because of that very rule, can never contain a skipped check. It was really showing the leftover checks that ended in nothing conclusive. And the sidebar, three inches away, called the exact same group *"Unresolved checks"*.

So: one PR, two panes, two different words, and the more prominent one was describing something that wasn't there. This PR makes both panes say "unresolved", and makes them get their numbers from the same rulebook as everything else instead of a private copy.

## Screenshots

The only rendered difference on the PR page and the work-item dialog is the chip's **wording**: `3 skipped` → `3 unresolved`.

The colour is unchanged and this is verifiable from the diff rather than by eye: the old code hardcoded `className: 'text-muted-foreground'` for that chip, and the new code resolves `CHECK_COLOR[chip.tone]` where `CHECK_COLOR.neutral === 'text-muted-foreground'` (`right-sidebar/checks-panel-content.tsx:132`). Identical string. The other four chips already used `CHECK_COLOR.*` and pass through unchanged.

Here is the surface, rendered from this branch against a real PR (#11809) in the Electron dev build:

![PR checks tab](https://github.com/user-attachments/assets/ae46dc14-f283-4316-8458-b2bb36549521)

**Read this shot honestly:** it shows the chip row now produced by the shared `getCheckCountChips` — `1 passing · 4 action required` — and confirms the other four chips render unchanged. It does **not** show the fix, because this PR has no neutral checks, so the renamed bucket is absent and the before/after would be identical. Reproducing the renamed chip needs a PR with a `neutral` conclusion or a blocked GitLab `manual` gate, which is not something I can conjure on demand against a live repo. Rather than mock one up and present it as a real capture, the wording change is pinned by the 14-row parity table below, which asserts the literal strings both panes emit.

## Proof of fix

**1. The mislabel, straight from `origin/main`:**

```
$ git show origin/main:src/renderer/src/components/PullRequestPage.tsx | grep -n 'skipped'
5299:  label: translate('auto.components.PullRequestPage.e6ad0a8d06', '{{value0}} skipped', {

$ git show origin/main:src/shared/provider-check-summary.ts | grep -n 'PASSED_CONCLUSIONS'
9:const PASSED_CONCLUSIONS = new Set(['success', 'skipped'])
```

`skipped` is in the passed set, so the chip labelled "skipped" cannot contain one. And the shared label function for the same bucket:

```ts
return summary.state === 'neutral' ? 'Unresolved checks' : `${summary.passed}/${summary.total} passed`
```

**2. The parity test fails without the fix.** With `pr-check-counts.ts` reverted to `origin/main` and the tests kept:

```
 × 'all success' resolves identically on every desktop surface
 × 'success plus skipped' resolves identically on every desktop surface
 × 'all skipped' resolves identically on every desktop surface
 × 'success plus neutral' resolves identically on every desktop surface
 × 'all neutral' resolves identically on every desktop surface
 × 'success plus failure' resolves identically on every desktop surface
 × 'success plus running' resolves identically on every desktop surface
 × 'GitLab manual gate only' resolves identically on every desktop surface
 × 'GitLab manual gate alongside a green pipeline' resolves identically on every desktop surface
 × 'GitLab skipped-only pipeline' resolves identically on every desktop surface
 × 'GitLab success alongside an unrecognised conclusion' resolves identically on every desktop surface
 × 'GitLab canceled job' resolves identically on every desktop surface
 × 'GitLab manual gate alongside a running job' resolves identically on every desktop surface
 × 'genuine action_required' resolves identically on every desktop surface

 Test Files  1 failed | 1 passed (2)
      Tests  14 failed | 6 passed (20)
```

All 14 parity rows now cover these two panes; previously none did. The failure is `getCheckCountChips is not a function`, i.e. the surfaces were literally not in the parity net before.

With the fix restored: **2 files / 20 tests passed**.

## Proof of no regression

- `src/renderer/src/components/pr-check-counts.test.ts` is the pre-existing suite for `getCheckCounts` and is **unmodified** by this PR. It still passes against the rewritten implementation — the bucket *numbers* are unchanged for every case it covers; only the source of truth and the neutral chip's wording changed.
- Targeted suite at branch tip: **2 files / 20 tests passed**.
- Full desktop suite on the merged tree containing all eight scan fixes: **359 files / 3830 tests passed**.
- `npx oxfmt --check` and `npx oxlint` clean.
- All five locale files re-validated as parseable JSON after the edit.
- Net **−34 lines** across the two panes: two ~45-line duplicated chip blocks collapse into one builder.

### Behaviour change disclosed

`getCheckCounts` now derives `failing` and `pending` from `summarizeProviderChecks` rather than its own `['failure','cancelled','timed_out']` list. For every conclusion the old list named, the result is identical. For conclusions it did **not** name — unrecognized/unknown values, which the old code silently swept into `pending` — the shared classifier's deliberate handling now applies instead. That is the intended consequence of removing the third rulebook, and the parity table pins it (`'GitLab success alongside an unrecognised conclusion'`, `'GitLab canceled job'`).

## Testing

- [x] `pnpm lint` — clean (oxlint, type-aware audit, reliability gates, max-lines ratchet, localization catalog/extraction/coverage); `oxfmt --check` clean via lint-staged
- [x] `pnpm typecheck` — clean (tsc: node + cli + web)
- [x] `pnpm test` (targeted at tip + full desktop suite on the combined tree)
- [ ] `pnpm build` — not run; no build-graph, packaging, or dependency change
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed by Claude Opus 5 as part of a 45-agent release scan with adversarial refutation. Risks checked:

- **Provider neutrality:** this is a GitHub *and* GitLab surface. Six of the fourteen parity rows are GitLab cases (manual gate alone, manual gate + green pipeline, manual gate + running job, skipped-only pipeline, canceled job, unrecognized conclusion). GitLab `manual` maps to `neutral` and therefore lands in the newly-renamed chip — the wording fix matters more for GitLab than GitHub, since a blocked GitLab pipeline is the most common way to populate that bucket.
- **Cross-platform:** no platform-dependent code. Pure classification and label logic, no paths, shells, or shortcuts.
- **i18n:** confirmed the five new keys exist in all five locale files and that the ten deleted keys have no remaining referents (`grep` for each hash across `src/`). Non-English locales carry the new keys with translated wording, not English fallbacks.
- **Rendering:** the `React.Fragment key` changed from `chip.label` to `chip.tone`. `tone` is unique per chip by construction (each bucket pushes at most one chip), and it is more stable than the label, which changes with locale and count.
- **SSH / folder workspaces:** not applicable; no execution-host or git code touched.

## Security Audit

- No new dependencies, no lockfile change, no install hooks.
- No shell execution, no `eval`, no path handling, no IPC, no auth, no secrets.
- Untrusted input: check conclusions arrive from the GitHub/GitLab API. They are only ever compared against closed sets and used to select a translation key — never interpolated into a command, path, or URL. Counts are integers derived from `Array.length` / `filter`, and reach the DOM as React text children, so there is no injection surface.
- The i18n deletions were checked for dangling references before removal.

## Notes

- This PR fixes the wording and the classifier source for the two panes. It intentionally does **not** touch `src/shared/pr-check-severity-order.ts`; ordering is a separate concern from classification, and #11700 already settled it.
- Scope grew slightly beyond the original finding: the scan flagged the label divergence, but fixing it properly meant removing the local classifier that caused it, which also brought `GitHubItemDialog.tsx` (same duplicated block) into the change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
