### PR TITLE
[P2] fix(skills): keep the npx preflight in the forced-PowerShell setup terminal on Windows

### DIFF
--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -3,7 +3,10 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { OnboardingInlineCommandTerminal } from '@/components/onboarding/OnboardingInlineCommandTerminal'
-import { buildSkillCommandForRuntime } from '@/components/settings/CliSkillRuntimeSetup'
+import {
+  buildSkillCommandForRuntime,
+  buildSkillSetupTerminalCommand
+} from '@/components/settings/CliSkillRuntimeSetup'
 import { ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import { translate } from '@/i18n/i18n'
@@ -17,6 +20,11 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
   const skillCommand = buildSkillCommandForRuntime(
     ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
     activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime
+  )
+  // The copied string stays as built; only what we execute is adapted.
+  const setupTerminalCommand = buildSkillSetupTerminalCommand(
+    skillCommand,
+    activeSkillRuntime.terminalShellOverride
   )
 
   const handleCopySkillCommand = async (): Promise<void> => {
@@ -70,7 +78,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
         </Tooltip>
       </div>
       <OnboardingInlineCommandTerminal
-        command={skillCommand}
+        command={setupTerminalCommand}
         title={translate(
           'auto.components.feature.tips.CliSkillSetupTerminal.84e9576dac',
           'Skill setup'

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.freshness.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalOrchestrationDialog.freshness.test.tsx
@@ -37,6 +37,7 @@ vi.mock('@/hooks/useInstalledAgentSkills', () => ({
 
 vi.mock('@/components/settings/CliSkillRuntimeSetup', () => ({
   buildSkillCommandForRuntime: (command: string) => command,
+  buildSkillSetupTerminalCommand: (command: string) => command,
   ensureWslCliAvailableForAgentSkillTerminal: vi.fn(),
   getWslCliDistroRequest: () => undefined
 }))

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -5,6 +5,7 @@ import { IntegrationStatusPill } from '../integration-status-pill'
 import { SkillFreshnessStatusPill } from '../skills/SkillFreshnessStatusPill'
 import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
 import { AgentSkillSetupFailureNotice } from './AgentSkillSetupFailureNotice'
+import { buildSkillSetupTerminalCommand } from './CliSkillRuntimeSetup'
 import type { AgentSkillSetupPanelProps } from './agent-skill-setup-panel-props'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
@@ -386,10 +387,11 @@ export function AgentSkillSetupPanel({
               </TooltipContent>
             </Tooltip>
           </div>
+          {/* The copied string above stays as built; only what we run is adapted. */}
           <OnboardingInlineCommandTerminal
             key={terminalAttempt}
             worktreeId={terminalWorktreeId}
-            command={openTerminalCommand}
+            command={buildSkillSetupTerminalCommand(openTerminalCommand, terminalShellOverride)}
             title={terminalTitle}
             description={translate(
               'auto.components.settings.AgentSkillSetupPanel.runCommandDescription',

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -10,6 +10,7 @@ import { useAppStore } from '@/store'
 import {
   buildSkillCommandForRuntime,
   buildSkillInstallCommandForRuntime,
+  buildSkillSetupTerminalCommand,
   getAgentSkillTerminalShellOverride,
   getSelectedAgentRuntime,
   getSkillDiscoveryTargetForRuntime
@@ -270,6 +271,60 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     } finally {
       useAppStore.setState({ settings: previous.settings })
     }
+  })
+
+  it('keeps the npx preflight in the PowerShell-forced setup terminal', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const windowsHost = { runtime: 'host', label: 'Windows' } as const
+    const previous = useAppStore.getState()
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell: 'git-bash' }
+    })
+
+    try {
+      const copied = buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')
+      expect(copied).toBe(installCommand)
+      // Orca forces its own setup terminal to powershell.exe, where cmd.exe works.
+      expect(buildSkillSetupTerminalCommand(copied, 'powershell.exe', 'win32')).toBe(
+        `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`
+      )
+    } finally {
+      useAppStore.setState({ settings: previous.settings })
+    }
+  })
+
+  it('does not re-wrap the setup terminal command when no shell override applies', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const previous = useAppStore.getState()
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell: 'cmd.exe' }
+    })
+
+    try {
+      const copied = buildSkillCommandForRuntime(
+        installCommand,
+        { runtime: 'host', label: 'Windows' },
+        'win32'
+      )
+      expect(buildSkillSetupTerminalCommand(copied, undefined, 'win32')).toBe(copied)
+      // An already-wrapped command must not gain a second preflight.
+      expect(buildSkillSetupTerminalCommand(copied, 'powershell.exe', 'win32')).toBe(copied)
+    } finally {
+      useAppStore.setState({ settings: previous.settings })
+    }
+  })
+
+  it('leaves WSL and non-Windows setup terminal commands untouched', () => {
+    const wslCommand = buildSkillCommandForRuntime(
+      'npx skills add orchestration --global',
+      { runtime: 'wsl', wslDistro: 'Ubuntu', label: 'WSL Ubuntu' },
+      'win32'
+    )
+
+    expect(buildSkillSetupTerminalCommand(wslCommand, 'powershell.exe', 'win32')).toBe(wslCommand)
+    expect(
+      buildSkillSetupTerminalCommand('npx skills add orchestration --global', undefined, 'linux')
+    ).toBe('npx skills add orchestration --global')
   })
 
   it('keeps the bare reinstall rewrite for POSIX-family Windows skill updates', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -89,7 +89,11 @@ export function buildSkillCommandForRuntime(
     currentPlatform
   )
   if (resolvedRuntime.runtime !== 'wsl') {
-    return wrapWindowsSkillCommandWithNpxPrerequisite(normalizedCommand, currentPlatform)
+    return wrapWindowsSkillCommandWithNpxPrerequisite(
+      normalizedCommand,
+      currentPlatform,
+      'copied-command'
+    )
   }
 
   const distroArg = resolvedRuntime.wslDistro?.trim()
@@ -127,9 +131,43 @@ function normalizeWindowsSkillUpdateCommand(
   return buildAgentFeatureSkillInstallCommand([updateMatch[1]])
 }
 
+/**
+ * Where a built skill command is going: the user's clipboard (their own shell)
+ * or the setup terminal Orca spawns itself.
+ */
+type SkillCommandTarget = 'copied-command' | 'orca-setup-terminal'
+
+/**
+ * Re-adds the npx preflight for Orca's own setup terminal, which
+ * `getAgentSkillTerminalShellOverride` forces onto powershell.exe. The copied
+ * string stays bare for POSIX-family shells; only the executed one is wrapped.
+ */
+export function buildSkillSetupTerminalCommand(
+  copiedCommand: string,
+  terminalShellOverride: string | undefined,
+  currentPlatform = getSkillCommandPlatform()
+): string {
+  if (!isSetupTerminalForcedToPowerShell(terminalShellOverride)) {
+    return copiedCommand
+  }
+  return wrapWindowsSkillCommandWithNpxPrerequisite(
+    copiedCommand,
+    currentPlatform,
+    'orca-setup-terminal'
+  )
+}
+
+function isSetupTerminalForcedToPowerShell(terminalShellOverride: string | undefined): boolean {
+  const trimmedOverride = terminalShellOverride?.trim()
+  return (
+    Boolean(trimmedOverride) && resolveWindowsShellStartupFamily(trimmedOverride) === 'powershell'
+  )
+}
+
 function wrapWindowsSkillCommandWithNpxPrerequisite(
   command: string,
-  currentPlatform: NodeJS.Platform
+  currentPlatform: NodeJS.Platform,
+  target: SkillCommandTarget
 ): string {
   const trimmedCommand = command.trim()
   if (
@@ -140,7 +178,7 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
     // Why: the copied command lands in the user's configured shell, and MSYS
     // shells rewrite cmd.exe's leading /d /s /c switches into drive paths,
     // starting an interactive cmd session instead of running the payload.
-    isPosixFamilyWindowsShellConfigured() ||
+    (target === 'copied-command' && isPosixFamilyWindowsShellConfigured()) ||
     !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
   ) {
     return command

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -170,7 +170,11 @@ describe('AgentSkillSetupPanel installed-command call sites', () => {
     )
 
     expect(source).toContain('buildSkillCommandForRuntime(')
-    expect(source).toContain('command={skillCommand}')
+    // The copied string stays bare for POSIX-family shells; the forced-PowerShell
+    // setup terminal keeps the npx preflight.
+    expect(source).toContain('writeClipboardText(skillCommand)')
+    expect(source).toContain('buildSkillSetupTerminalCommand(')
+    expect(source).toContain('command={setupTerminalCommand}')
     expect(source).toContain('shellOverride={activeSkillRuntime.terminalShellOverride}')
     expect(source).not.toContain('command={ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND}')
     // This terminal auto-pastes with no install gate, so a repair-required runtime


### PR DESCRIPTION
## Summary

Follow-on to #11599, found by the `v1.4.163-rc.1..v1.4.163-rc.3` production release scan.

Two guards fire on the *same* condition and cancel each other out, so Windows users with Git Bash or WSL configured as their terminal shell lose the npx preflight in Orca's own skill-setup terminal.

### The collision

**Guard 1 — Orca overrides the setup terminal's shell** (`src/renderer/src/lib/project-skill-runtime.ts:41`):

```ts
// Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
// Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.
return resolveWindowsShellStartupFamily(settings?.terminalWindowsShell) === 'posix'
  ? 'powershell.exe'
  : undefined
```

So: user's shell is POSIX-family → **force the setup terminal onto PowerShell**.

**Guard 2 — #11599 drops the npx preflight** (`CliSkillRuntimeSetup.tsx:143`):

```ts
// Why: the copied command lands in the user's configured shell, and MSYS
// shells rewrite cmd.exe's leading /d /s /c switches into drive paths,
// starting an interactive cmd session instead of running the payload.
isPosixFamilyWindowsShellConfigured() ||
```

So: user's shell is POSIX-family → **strip the `cmd.exe` npx preflight wrapper**.

Both read the same setting. On a Windows box configured for Git Bash, guard 1 says "this command will run in PowerShell, not their shell" and guard 2 says "this command will run in their shell, so don't wrap it". Guard 2's stated premise — *"the copied command lands in the user's configured shell"* — is true for the clipboard, and false for the terminal Orca spawns itself, precisely because guard 1 just redirected it.

**Result:** clicking "Set up in terminal" runs a bare `npx skills add …` in PowerShell. If Node/npx is not on `PATH`, the user sees PowerShell's raw

```
The term 'npx' is not recognized as the name of a cmdlet, function, script file, or operable program.
```

instead of #11599's guidance ("Install Node.js LTS from https://nodejs.org/ … then close this terminal and start skill setup again — a new terminal picks up the updated PATH"). The users who hit this are exactly the ones most likely to have a PATH that differs between shells.

### Fix

The wrapper now knows where the command is going, instead of assuming.

- `CliSkillRuntimeSetup.tsx:134` — new `SkillCommandTarget = 'copied-command' | 'orca-setup-terminal'`.
- `CliSkillRuntimeSetup.tsx:181` — the POSIX bypass is narrowed to `target === 'copied-command' && isPosixFamilyWindowsShellConfigured()`. #11599's actual fix is fully preserved for the clipboard path, which is what it was about.
- `CliSkillRuntimeSetup.tsx:141` — new exported `buildSkillSetupTerminalCommand(copiedCommand, terminalShellOverride, currentPlatform?)`. It re-applies the preflight **only when `resolveWindowsShellStartupFamily(terminalShellOverride) === 'powershell'`** — that is, only when the override actually resolved to a PowerShell-family shell. It does not assume; it checks.
- `AgentSkillSetupPanel.tsx:393` and `feature-tips/CliSkillSetupTerminal.tsx:25` — the spawned terminal gets the wrapped command. The `<code>` block shown on screen and the "Copy" button both keep the bare command.

All the other conditions in `wrapWindowsSkillCommandWithNpxPrerequisite` are untouched: non-Windows, a focused remote runtime environment, and a non-`npx skills add|update` command still bypass the wrapper exactly as before.

**Left alone deliberately:** `FeatureSetupInlineTerminal` passes no shell override, so `isSetupTerminalForcedToPowerShell` returns false and it correctly keeps the bare command. WSL runtimes take an earlier return in `buildSkillCommandForRuntime` and are unaffected.

## ELI5

Orca can install a "skill" for you by running one command. On Windows there is a wrinkle: if that command can't find `npx`, the error you get is cryptic, so Orca wraps the command in a little check that says "npx is missing — here's how to install Node.js" instead.

Some Windows users run Git Bash or WSL as their terminal. That wrapper is written in Windows `cmd` syntax, which Git Bash mangles — so Orca has two separate protections for those users:

1. When Orca opens its *own* setup terminal, it quietly switches to PowerShell so the syntax works.
2. When Orca gives you the command to *copy and paste*, it removes the wrapper so it doesn't break in your Git Bash window.

The bug is that protection 2 was also being applied to the terminal from protection 1. Orca switched to PowerShell to make the wrapper safe to use, and then removed the wrapper anyway. So Git Bash users got the raw `npx` command in PowerShell with no safety net, and if npx wasn't installed they saw PowerShell's unhelpful "'npx' is not recognized" instead of the install instructions.

Now Orca tells the two paths apart: the thing you copy stays plain, and the thing Orca runs itself keeps the safety net.

## Screenshots

**No visual change.** The `<code>` block rendered on screen and the "Copy" button both continue to show and copy the bare command — verified in the diff: `AgentSkillSetupPanel.tsx:364` and `copyActiveCommand` at `:186` still read `openTerminalCommand`, and only the `command` prop handed to `OnboardingInlineCommandTerminal` at `:394` is wrapped. What changed is the string executed inside the spawned PTY.

## Proof of fix

With `CliSkillRuntimeSetup.tsx`, `AgentSkillSetupPanel.tsx` and `CliSkillSetupTerminal.tsx` reverted to `origin/main` and the tests kept:

```
 × keeps the npx preflight in the PowerShell-forced setup terminal
 × does not re-wrap the setup terminal command when no shell override applies
 × leaves WSL and non-Windows setup terminal commands untouched
 × routes the combined feature-tip install through runtime command setup

TypeError: buildSkillSetupTerminalCommand is not a function
AssertionError: expected 'import { Copy } from \'lucide-react\'…' to contain 'buildSkillSetupTerminalCommand('

 Test Files  2 failed (2)
      Tests  4 failed | 24 passed (28)
```

With the fix restored: **3 files / 30 tests passed**.

New coverage in `CliSkillRuntimeSetup.test.tsx`:
- Windows + PowerShell-resolved override → the setup-terminal command **is** wrapped with the `where.exe npx` preflight.
- No shell override → command passes through untouched (the non-POSIX Windows user already got the wrapper from `buildSkillCommandForRuntime`; re-wrapping would double it).
- WSL and non-Windows → untouched.
- The copied command on a POSIX-family Windows shell is still bare, i.e. #11599 is not regressed.

`agent-skill-installed-command-callers.test.ts` is a source-guard test that pins which call sites use which builder; it now encodes the copy/execute split, so a future caller that runs the bare command in a forced-PowerShell terminal fails CI.

## Proof of no regression

- Targeted suite at branch tip: **3 files / 30 tests passed**.
- Full desktop suite on the merged tree containing all eight scan fixes: **359 files / 3830 tests passed**.
- `npx oxfmt --check` and `npx oxlint` clean.
- `FloatingTerminalOrchestrationDialog.freshness.test.tsx` changed by exactly one line: its `vi.mock` factory for `CliSkillRuntimeSetup` needed the newly-exported symbol. No assertion changed.
- #11599's own scenario is explicitly re-asserted rather than assumed: the copied command on a POSIX-family Windows shell is still unwrapped.

## Testing

- [x] `pnpm lint` — clean (oxlint, type-aware audit, reliability gates, max-lines ratchet, localization catalog/extraction/coverage); `oxfmt --check` clean via lint-staged
- [x] `pnpm typecheck` — clean (tsc: node + cli + web)
- [x] `pnpm test` (targeted at tip + full desktop suite on the combined tree)
- [ ] `pnpm build` — not run; no build-graph, packaging, or dependency change
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed by Claude Opus 5 as part of a 45-agent release scan with adversarial refutation. Risks checked:

- **Cross-platform — the core of this PR.** The change is Windows-only by construction: `buildSkillSetupTerminalCommand` returns early unless the shell override resolves to a PowerShell family, and `getProjectAgentSkillTerminalShellOverride` returns `undefined` for every non-`win32` platform. macOS and Linux take the identical code path they did before. Verified all four Windows shell families (PowerShell, cmd, Git Bash/MSYS, wsl.exe) plus the WSL-runtime and remote-runtime branches.
- **Double-wrapping.** The main risk of the fix. A non-POSIX Windows user already receives a wrapped command from `buildSkillCommandForRuntime`; `isSetupTerminalForcedToPowerShell` returns false for them (no override is set), so no second wrap occurs. Pinned by a test.
- **SSH / remote runtime.** `isRemoteRuntimeEnvironmentFocused()` is unchanged and still short-circuits the wrapper, so a Windows client never hands a `cmd.exe` command to a remote host.
- **Provider neutrality:** not applicable; no git or provider code touched.

## Security Audit

- No new dependencies, no lockfile change, no install hooks.
- **Command construction is the relevant surface.** No new command text is introduced by this PR — `wrapWindowsSkillCommandWithNpxPrerequisite` and its `cmd.exe /d /s /c "…"` payload are byte-for-byte unchanged from `origin/main`. The change is purely *which* of two existing strings a given call site receives.
- The regex gate `/^npx\s+skills\s+(?:add|update)\b/i` still runs before any wrapping, so only Orca's own generated skill-install commands are ever wrapped.
- The command being wrapped is built by `buildAgentFeatureSkillInstallCommand` from Orca's own constants, not from user free-text.
- No auth, secrets, path handling, or IPC changes.

## Notes

- The bug is invisible on macOS and Linux, and invisible on Windows unless the user has explicitly configured Git Bash or WSL as their terminal shell **and** npx is missing from PATH — which is why it shipped.
- `buildSkillSetupTerminalCommand` checks the resolved shell family rather than trusting that the override is always `powershell.exe`. Today `getProjectAgentSkillTerminalShellOverride` only ever returns `'powershell.exe'`, but tying the behaviour to the resolved family means a future override value cannot silently reintroduce this bug.

Made with [Orca](https://github.com/stablyai/orca) 🐋
