### PR TITLE
[P2] fix(mobile): put the PR sidebar and branch chip on the shared check classifier

### DIFF
--- a/mobile/src/components/pr-sidebar/pr-checks-presentation.test.ts
+++ b/mobile/src/components/pr-sidebar/pr-checks-presentation.test.ts
@@ -21,8 +21,8 @@ function check(over: Partial<PRCheckDetail>): PRCheckDetail {
 }
 
 describe('checkOutcome', () => {
-  it('treats a completed null-conclusion check as pending, not failure', () => {
-    expect(checkOutcome(check({ status: 'completed', conclusion: null }))).toBe('pending')
+  it('treats a completed null-conclusion check as neutral, not failure', () => {
+    expect(checkOutcome(check({ status: 'completed', conclusion: null }))).toBe('neutral')
   })
   it('treats queued/in_progress as pending', () => {
     expect(checkOutcome(check({ status: 'queued', conclusion: null }))).toBe('pending')
@@ -33,9 +33,12 @@ describe('checkOutcome', () => {
     expect(checkOutcome(check({ conclusion: 'cancelled' }))).toBe('failure')
     expect(checkOutcome(check({ conclusion: 'timed_out' }))).toBe('failure')
   })
-  it('maps neutral/skipped to neutral (non-blocking)', () => {
+  it('maps a merge-blocking action_required gate to failure', () => {
+    expect(checkOutcome(check({ conclusion: 'action_required' }))).toBe('failure')
+  })
+  it('maps skipped to success and neutral to neutral (desktop parity)', () => {
+    expect(checkOutcome(check({ conclusion: 'skipped' }))).toBe('success')
     expect(checkOutcome(check({ conclusion: 'neutral' }))).toBe('neutral')
-    expect(checkOutcome(check({ conclusion: 'skipped' }))).toBe('neutral')
   })
 })
 
@@ -112,7 +115,7 @@ describe('summarizePRChecks', () => {
   it('reports a neutral-only set as neutral with a labeled count (not empty success)', () => {
     const summary = summarizePRChecks([
       check({ conclusion: 'neutral' }),
-      check({ conclusion: 'skipped' })
+      check({ conclusion: 'neutral' })
     ])
     expect(summary).toMatchObject({
       total: 2,
@@ -122,6 +125,15 @@ describe('summarizePRChecks', () => {
       outcome: 'neutral'
     })
     expect(summary.label).toBe('2 neutral')
+  })
+  it('counts skipped as passed so the sidebar matches desktop and the tasks grid', () => {
+    const summary = summarizePRChecks([
+      check({ conclusion: 'success' }),
+      check({ conclusion: 'success' }),
+      check({ conclusion: 'skipped' })
+    ])
+    expect(summary).toMatchObject({ total: 3, passed: 3, outcome: 'success' })
+    expect(summary.label).toBe('3 passed')
   })
 })
 

--- a/mobile/src/components/pr-sidebar/pr-checks-presentation.ts
+++ b/mobile/src/components/pr-sidebar/pr-checks-presentation.ts
@@ -1,4 +1,9 @@
-import type { PRCheckDetail, PRState } from '../../../../src/shared/types'
+import type { PRCheckDetail, PRState, ProviderCheckSummary } from '../../../../src/shared/types'
+import {
+  classifyCheckOutcome,
+  summarizeProviderChecks,
+  type CheckOutcome as SharedCheckOutcome
+} from '../../../../src/shared/provider-check-summary'
 import { prStateToken } from '../pr-state-token'
 
 // Pure presentation logic for the PR sidebar's checks + state badge. No React /
@@ -18,31 +23,18 @@ export type MobileStatusToken =
 
 export type CheckOutcome = 'success' | 'pending' | 'failure' | 'neutral'
 
-const FAILURE_CONCLUSIONS = new Set<PRCheckDetail['conclusion']>([
-  'failure',
-  'cancelled',
-  'timed_out'
-])
+const OUTCOME_BY_SHARED: Record<SharedCheckOutcome, CheckOutcome> = {
+  passed: 'success',
+  failed: 'failure',
+  pending: 'pending',
+  neutral: 'neutral'
+}
 
-const SUCCESS_CONCLUSIONS = new Set<PRCheckDetail['conclusion']>(['success'])
-
-// Why: a check that is queued/in_progress, or completed with a null/`pending`
-// conclusion, is still pending — never render it as a failure (U5 edge case).
+// Why: delegate to the one shared classifier — a second copy here is what made mobile call a
+// `skipped` check unresolved and an `action_required` gate pending while desktop called them
+// green and red for the same PR.
 export function checkOutcome(check: PRCheckDetail): CheckOutcome {
-  if (check.status !== 'completed') {
-    return 'pending'
-  }
-  if (check.conclusion === null || check.conclusion === 'pending') {
-    return 'pending'
-  }
-  if (FAILURE_CONCLUSIONS.has(check.conclusion)) {
-    return 'failure'
-  }
-  if (SUCCESS_CONCLUSIONS.has(check.conclusion)) {
-    return 'success'
-  }
-  // neutral / skipped are non-blocking — treat as neutral, not failure.
-  return 'neutral'
+  return OUTCOME_BY_SHARED[classifyCheckOutcome(check)]
 }
 
 // Sort order: failures first (most actionable), then pending, then success /
@@ -71,38 +63,21 @@ export type PRChecksSummary = {
   label: string
 }
 
+const OUTCOME_BY_STATE: Record<ProviderCheckSummary['state'], CheckOutcome | 'none'> = {
+  success: 'success',
+  failure: 'failure',
+  pending: 'pending',
+  neutral: 'neutral',
+  none: 'none'
+}
+
 export function summarizePRChecks(checks: readonly PRCheckDetail[]): PRChecksSummary {
   if (checks.length === 0) {
     return { total: 0, passed: 0, pending: 0, failed: 0, outcome: 'none', label: 'No checks' }
   }
-  let passed = 0
-  let pending = 0
-  let failed = 0
-  let neutral = 0
-  for (const check of checks) {
-    const outcome = checkOutcome(check)
-    if (outcome === 'failure') {
-      failed += 1
-    } else if (outcome === 'pending') {
-      pending += 1
-    } else if (outcome === 'success') {
-      passed += 1
-    } else {
-      neutral += 1
-    }
-  }
-  // Worst-case wins so a single failure colors the summary red even if others passed.
-  // A neutral-only set reads as neutral (not success) with a non-empty label.
-  const outcome: CheckOutcome | 'none' =
-    failed > 0
-      ? 'failure'
-      : pending > 0
-        ? 'pending'
-        : passed > 0
-          ? 'success'
-          : neutral > 0
-            ? 'neutral'
-            : 'none'
+  // Counts and the worst-case rollup come from the shared summarizer; only the label wording is mobile's.
+  const { total, passed, pending, failed, neutral, state } = summarizeProviderChecks(checks)
+  const outcome = OUTCOME_BY_STATE[state]
   const parts: string[] = []
   if (failed > 0) {
     parts.push(`${failed} failing`)
@@ -117,7 +92,7 @@ export function summarizePRChecks(checks: readonly PRCheckDetail[]): PRChecksSum
     parts.push(`${neutral} neutral`)
   }
   return {
-    total: checks.length,
+    total,
     passed,
     pending,
     failed,
@@ -141,6 +116,8 @@ export function checkStatusLabel(check: PRCheckDetail): string {
       return 'Cancelled'
     case 'timed_out':
       return 'Timed out'
+    case 'action_required':
+      return 'Action required'
     case 'neutral':
       return 'Neutral'
     case 'skipped':

--- a/mobile/src/session/github-pr-value-readers.test.ts
+++ b/mobile/src/session/github-pr-value-readers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { readRepoIdentity } from './github-pr-value-readers'
+import { classifyCheckOutcome } from '../../../src/shared/provider-check-summary'
+import { readCheckRunConclusion, readRepoIdentity } from './github-pr-value-readers'
 
 describe('readRepoIdentity', () => {
   it('parses a valid owner/repo identity', () => {
@@ -30,5 +31,25 @@ describe('readRepoIdentity', () => {
   it('drops an empty owner or repo as malformed', () => {
     expect(readRepoIdentity({ owner: '', repo: 'orca' })).toBeUndefined()
     expect(readRepoIdentity({ owner: 'octo', repo: '' })).toBeUndefined()
+  })
+})
+
+describe('readCheckRunConclusion', () => {
+  it('keeps every conclusion the shared classifier can act on', () => {
+    for (const conclusion of ['success', 'failure', 'cancelled', 'timed_out', 'skipped']) {
+      expect(readCheckRunConclusion(conclusion)).toBe(conclusion)
+    }
+  })
+
+  // Why: dropping this made a merge-blocking approval gate render as a harmless pending check.
+  it('keeps action_required so it still classifies as a failure', () => {
+    const conclusion = readCheckRunConclusion('action_required')
+    expect(conclusion).toBe('action_required')
+    expect(classifyCheckOutcome({ status: 'completed', conclusion })).toBe('failed')
+  })
+
+  it('drops an unknown conclusion', () => {
+    expect(readCheckRunConclusion('wat')).toBeNull()
+    expect(readCheckRunConclusion(null)).toBeNull()
   })
 })

--- a/mobile/src/session/github-pr-value-readers.ts
+++ b/mobile/src/session/github-pr-value-readers.ts
@@ -82,11 +82,14 @@ export function readCheckRunStatus(value: unknown): PRCheckDetail['status'] | nu
   return value === 'queued' || value === 'in_progress' || value === 'completed' ? value : null
 }
 
+// Why: dropping `action_required` here rendered a merge-blocking approval gate as a pending
+// check; the shared classifier counts it as a failure, so it must survive parsing.
 export function readCheckRunConclusion(value: unknown): PRCheckDetail['conclusion'] {
   return value === 'success' ||
     value === 'failure' ||
     value === 'cancelled' ||
     value === 'timed_out' ||
+    value === 'action_required' ||
     value === 'neutral' ||
     value === 'skipped' ||
     value === 'pending'

--- a/mobile/src/source-control/mobile-pr-chip-summary.test.ts
+++ b/mobile/src/source-control/mobile-pr-chip-summary.test.ts
@@ -52,14 +52,37 @@ describe('buildMobilePrChipSummary', () => {
     expect(summary.stateLabel).toBe('Draft')
   })
 
-  it('rolls up passed checks as passed/total', () => {
+  // Why: a skipped job is a deliberate "not applicable" — desktop and the tasks grid call this 3/3.
+  it('rolls up passed checks as passed/total, counting skipped as passed', () => {
     const summary = buildMobilePrChipSummary(
       ready(pr(), [check('success'), check('success'), check('skipped')])
     )
     if (summary.kind !== 'ready') {
       throw new Error('expected ready')
     }
-    expect(summary.rollup).toEqual({ kind: 'passed', text: '2/3', token: 'statusGreen' })
+    expect(summary.rollup).toEqual({ kind: 'passed', text: '3/3', token: 'statusGreen' })
+  })
+
+  it('treats a merge-blocking action_required gate as failing, not passing', () => {
+    const summary = buildMobilePrChipSummary(
+      ready(pr(), [check('success'), check('action_required')])
+    )
+    if (summary.kind !== 'ready') {
+      throw new Error('expected ready')
+    }
+    expect(summary.rollup).toEqual({ kind: 'failing', text: '1 failing', token: 'statusRed' })
+  })
+
+  it('distinguishes checks that resolved to nothing actionable from having no checks', () => {
+    const summary = buildMobilePrChipSummary(ready(pr(), [check('neutral')]))
+    if (summary.kind !== 'ready') {
+      throw new Error('expected ready')
+    }
+    expect(summary.rollup).toEqual({
+      kind: 'none',
+      text: 'Unresolved checks',
+      token: 'textSecondary'
+    })
   })
 
   it('prefers failing over running and passing', () => {

--- a/mobile/src/source-control/mobile-pr-chip-summary.ts
+++ b/mobile/src/source-control/mobile-pr-chip-summary.ts
@@ -1,8 +1,8 @@
 import type { PRComment } from '../../../src/shared/types'
 import type { PrSidebarState } from '../session/mobile-pr-sidebar-state'
+import { summarizeProviderChecks } from '../../../src/shared/provider-check-summary'
 import {
   prStateBadge,
-  summarizePRChecks,
   type MobileStatusToken
 } from '../components/pr-sidebar/pr-checks-presentation'
 
@@ -90,7 +90,8 @@ function buildChipRollup(state: Extract<PrSidebarState, { kind: 'ready' }>): Mob
   if (state.data.pr.mergeable === 'CONFLICTING') {
     return { kind: 'conflict', text: 'Conflicts', token: 'statusAmber' }
   }
-  const checks = summarizePRChecks(state.data.checks)
+  // Shared classifier so the chip, the Checks list and the tasks grid never disagree about the same PR.
+  const checks = summarizeProviderChecks(state.data.checks)
   if (checks.failed > 0) {
     return { kind: 'failing', text: `${checks.failed} failing`, token: 'statusRed' }
   }
@@ -100,5 +101,10 @@ function buildChipRollup(state: Extract<PrSidebarState, { kind: 'ready' }>): Mob
   if (checks.passed > 0) {
     return { kind: 'passed', text: `${checks.passed}/${checks.total}`, token: 'statusGreen' }
   }
-  return { kind: 'none', text: 'No checks', token: 'textSecondary' }
+  // Checks that exist but resolved to nothing actionable are not "no checks".
+  return {
+    kind: 'none',
+    text: checks.total === 0 ? 'No checks' : 'Unresolved checks',
+    token: 'textSecondary'
+  }
 }


### PR DESCRIPTION
## Summary

Follow-on to #11700, found by the `v1.4.163-rc.1..v1.4.163-rc.3` production release scan (independently corroborated by an external scan, then verified against the source at the target ref).

#11700 moved every **desktop** check surface onto one shared classifier and left mobile behind. Mobile kept a second copy of the rules, so the same PR reads differently depending on which mobile surface you look at — and one mobile surface contradicts another.

### Three concrete defects

**1. `skipped` counts as unresolved on mobile, passed on desktop.** `pr-checks-presentation.ts` had its own `SUCCESS_CONCLUSIONS = new Set(['success'])`, while the shared classifier is `new Set(['success', 'skipped'])`. A PR with 2 successes and 1 skipped check renders **`2/3`** on the mobile branch chip and **`3/3`** in the desktop header and the mobile tasks grid.

**2. A PR whose checks all resolved to nothing renders as "No checks".** `buildChipRollup` fell through to `{ text: 'No checks' }` whenever `passed`, `pending` and `failed` were all zero — which is also true when there *are* checks and they all came back neutral. That is a different fact being reported as the same fact. With the shared classifier a 2-skipped PR now reads `2/2`, and a genuinely all-neutral PR reads "Unresolved checks".

**3. `action_required` is dropped at the parsing boundary.** `readCheckRunConclusion` in `github-pr-value-readers.ts` did not list `action_required` among the accepted values, so it returned `null`. `PRCheckDetail['conclusion']` allows it (`src/shared/types.ts:1400`), the host emits it (`src/main/github/mappers.ts:26`), and the host synthesizes suites carrying it (`src/main/github/client.ts:3425`, `:3551`). The shared classifier treats it as a **failure**, because it blocks merge.

Defect 3 is the sharpest: a merge-blocking approval gate arrived as a `null` conclusion, was read as "still pending", and — with a passing check alongside it — the chip rendered **green `1/2`** for a PR that desktop correctly showed as **failing**.

### Fix

- `pr-checks-presentation.ts:2-37` — deleted the local `SUCCESS_CONCLUSIONS` / `FAILURE_CONCLUSIONS` sets; `checkOutcome` now delegates to `classifyCheckOutcome` through a `passed|failed|pending|neutral` → `success|failure|pending|neutral` name map. Mobile's own outcome vocabulary is preserved; only the rules move.
- `pr-checks-presentation.ts:66-102` — `summarizePRChecks` takes its counts and its worst-case rollup from `summarizeProviderChecks`. Only the label *wording* stays mobile's.
- `pr-checks-presentation.ts:119` — added `case 'action_required': return 'Action required'` to `checkStatusLabel`, so the per-check row has a name for it.
- `mobile-pr-chip-summary.ts:94` — the branch chip reads `summarizeProviderChecks` directly, and distinguishes "no checks" from "checks that resolved to nothing actionable".
- `github-pr-value-readers.ts:85` — `action_required` accepted.

## ELI5

Your PR has a list of automated checks, and Orca shows you a little summary badge. Desktop and mobile were reading that list with two different rulebooks, so they gave different answers about the *same* PR:

- Desktop counts a **skipped** check as fine — skipping is a deliberate "not needed here". Mobile counted it as not-fine, so a perfectly green PR showed `2/3` on your phone and `3/3` on your laptop. Worse, mobile disagreed with *itself*: the tasks grid said `2/2 passed` while the branch card said "No checks", for one PR.
- If every check came back inconclusive, mobile said **"No checks"** — but there *were* checks; they just didn't decide anything. Those are two different situations and you should be able to tell them apart.
- Worst one: GitHub has a check type that means **"a human has to approve this before it can merge"**. Mobile's reader didn't recognise it, threw it away, and treated it as "still running". So a PR that was actually blocked showed a green badge on your phone.

This PR deletes mobile's private rulebook and points it at the shared one, so both devices describe the same PR the same way.

## Screenshots

**Not captured.** These surfaces are React Native (`mobile/`), not the Electron renderer, so the `/electron` CDP screenshot workflow does not reach them and the desktop dev build cannot render them. Rather than substitute a recreated or mocked image, the visible change is stated exactly and pinned by assertions on the rendered chip objects:

| Scenario | Before | After |
|---|---|---|
| 2 success + 1 skipped | `{ kind: 'passed', text: '2/3' }` | `{ kind: 'passed', text: '3/3' }` |
| 1 success + 1 `action_required` | `{ kind: 'passed', text: '1/2' }` green | `{ kind: 'failing', … }` red |
| 2 checks, both neutral | `{ kind: 'none', text: 'No checks' }` | `{ kind: 'none', text: 'Unresolved checks' }` |

These are the literal `expected`/`actual` values from the test run below, not a description of them.

## Proof of fix

With the three production files reverted to `origin/main` and the tests kept — `npx vitest run --config mobile/vitest.config.ts`:

```
 × counts skipped as passed so the sidebar matches desktop and the tasks grid
 × rolls up passed checks as passed/total, counting skipped as passed
 × treats a merge-blocking action_required gate as failing, not passing
 × maps a merge-blocking action_required gate to failure
 × maps skipped to success and neutral to neutral (desktop parity)
 × distinguishes checks that resolved to nothing actionable from having no checks
 × treats a completed null-conclusion check as neutral, not failure
 × keeps action_required so it still classifies as a failure

AssertionError: expected { kind: 'passed', text: '2/3', …(1) } to deeply equal { kind: 'passed', text: '3/3', …(1) }
AssertionError: expected { kind: 'passed', text: '1/2', …(1) } to deeply equal { kind: 'failing', …(2) }
AssertionError: expected { kind: 'none', …(2) } to deeply equal { kind: 'none', …(2) }
AssertionError: expected null to be 'action_required' // Object.is equality
AssertionError: expected 'pending' to be 'neutral' // Object.is equality
AssertionError: expected 'neutral' to be 'failure' // Object.is equality
AssertionError: expected 'neutral' to be 'success' // Object.is equality
AssertionError: expected { total: 3, passed: 2, …(4) } to match object { total: 3, passed: 3, …(1) }

 Test Files  3 failed (3)
      Tests  8 failed | 33 passed (41)
```

Every one of the three defects reproduces as a distinct assertion. With the fix restored: **3 files / 41 tests passed**.

## Proof of no regression

- Targeted mobile suite at branch tip: **3 files / 41 tests passed**.
- Full desktop suite on the merged tree containing all eight scan fixes: **359 files / 3830 tests passed** (this PR touches no desktop production file, but it imports `src/shared/provider-check-summary.ts`, so the desktop consumers of that module were re-run).
- `npx oxfmt --check` and `npx oxlint` clean.
- No `max-lines` disable or `mobile/.oxlintrc.json` bump added; `pr-checks-presentation.ts` gets **shorter** (−34 net), since the local classifier is deleted rather than added to.
- No persisted state, schema, migration, or wire contract is touched — this is presentation logic over data the client already receives, so there is no mobile back-compat or rollback exposure.

### Visible mobile behaviour changes beyond the reported bug — disclosed

Delegating to the shared classifier necessarily changes three more things, all of which are the shared rulebook's existing, deliberate answers:

1. **A completed check with a `null` conclusion** now reads **neutral** (grey) instead of **pending** (amber). Mobile previously called it pending; it is finished, so it is not pending.
2. **`skipped` sorts to the bottom** of the checks list with the other non-blocking outcomes, rather than among successes.
3. **An all-neutral PR** reads **"Unresolved checks"** rather than "No checks" (defect 2 above).

## Testing

- [x] `pnpm lint` — clean (oxlint, type-aware audit, reliability gates, max-lines ratchet, localization catalog/extraction/coverage); `oxfmt --check` clean via lint-staged
- [x] `pnpm typecheck` (desktop) — clean (tsc: node + cli + web); covers `src/shared/provider-check-summary.ts`, the module this PR newly depends on
- [ ] `mobile/` `tsc --noEmit` — **not run.** `mobile/node_modules` is empty in this worktree, so the mobile TypeScript program cannot resolve `expo`, `react-native`, or its other types. Needs CI or a `pnpm install` in `mobile/` to be meaningful; saying it passed would be a fabrication
- [x] `pnpm test` — mobile targeted files, plus the full desktop suite for shared-module consumers
- [ ] `pnpm build` — not run; no build-graph, packaging, or dependency change
- [x] Added or updated high-quality tests that would catch regressions

**Mobile test environment caveat, stated plainly:** `mobile/node_modules` is empty in this worktree, so `mobile/vitest.config.ts` cannot resolve `expo/tsconfig.base.json`. The three files above were run by temporarily stubbing that single file and removing the stub afterwards; the worktree was left exactly as found. A full `mobile/` suite run in this worktree produces 82 file-level failures, all `Cannot find module` for uninstalled packages, plus one genuine test failure in `mobile/src/mock-server-key-pair.test.ts` ("makes concurrent creators converge on the persisted winner"). That failure was proven **pre-existing and unrelated** by stashing `mobile/src` and re-running: it still fails. Neither is caused by this PR, and both should be confirmed against CI's installed environment.

## AI Review Report

Reviewed by Claude Opus 5 as part of a 45-agent release scan with adversarial refutation. Two independent verifiers initially split on the severity of the `action_required` defect and an adjudicator settled it. Risks checked:

- **Provider neutrality:** GitLab reaches these surfaces through the same `PRCheckDetail` shape, and GitLab `manual` gates map to `neutral`. Delegating to the shared classifier means the mobile chip now agrees with desktop on blocked GitLab pipelines as well.
- **Mobile back-compat:** applied `mobile-backcompat-review`. No persisted state, cached schema, settings key, or relay wire contract is touched; a rollback to a prior mobile build simply restores the old presentation of the same server data. No migration needed.
- **Cross-platform:** iOS and Android share this TypeScript; no native module, platform branch, or path handling involved.
- **Blast radius of the deleted local classifier:** all callers of `checkOutcome` and `summarizePRChecks` were traced. `mobile-pr-chip-summary.ts` was the one that needed a corresponding change (it now calls `summarizeProviderChecks` directly rather than going through `summarizePRChecks`, since it only needs the counts); the checks-list rows and the sort order follow from `checkOutcome` and were re-asserted.
- **Merge affordances are unaffected.** `buildChipRollup` feeds a label and a colour token only; mobile merge gating lives in `pr-auto-merge-availability.ts`, which does not read it. That is why these are P2 and not P1 — the wrong badge misinforms, it does not enable a bad merge.

## Security Audit

- No new dependencies, no lockfile change, no install hooks.
- No shell execution, no `eval`, no path handling, no auth, no secrets.
- **The one input-handling change is a widening**, so it was checked directly: `readCheckRunConclusion` now accepts one additional literal, `'action_required'`. It remains an exact-match allowlist against a closed set of string literals with a `null` fallback for everything else — the parser is not loosened structurally, and no untrusted value can now reach a wider code path than before. The value is only ever compared against sets and used to pick a label and a colour token.
- Data flows from the GitHub/GitLab API through the relay to the mobile client; this PR does not change what is fetched, stored, or transmitted.

## Notes

- This is presentation-only. It changes what the user is told about a PR, not what Orca will let them do to it.
- Scope grew beyond the reported symptom: the external scan reported the `2/3` arithmetic and the dropped `action_required`. Both turned out to be instances of the same root cause — a duplicated classifier — so the fix removes the duplicate rather than patching the two symptoms, which also resolved the "No checks" mislabel that neither scan had flagged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
