### PR TITLE
[P2] fix(terminal): always close the bracketed-paste frame and hold the pty lock through submit

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-coordinator.test.ts
@@ -40,6 +40,17 @@ function terminalTarget(overrides: Partial<TerminalPasteTarget> = {}): TerminalP
   }
 }
 
+function bracketedChunkedPlan() {
+  return planTerminalPaste({
+    text: '0123456789abcdef',
+    source: 'keyboard',
+    target: terminalTarget(),
+    terminalBracketedPasteMode: true,
+    maxDirectBytes: 4,
+    maxChunkBytes: 4
+  })
+}
+
 function getPastePayloadCorpusText(name: string): string {
   const entry = PASTE_PAYLOAD_CORPUS.find((item) => item.name === name)
   if (!entry) {
@@ -649,6 +660,133 @@ describe('terminal paste coordinator', () => {
       BRACKETED_PASTE_START,
       BRACKETED_PASTE_END
     ])
+  })
+
+  it('closes an opened bracketed paste when a payload write is rejected', async () => {
+    const writes: string[] = []
+    const writePty = vi.fn<(data: string) => boolean>((data) => {
+      writes.push(data)
+      return data === BRACKETED_PASTE_START
+    })
+
+    const result = await executeTerminalPastePlan(bracketedChunkedPlan(), {
+      pasteText: vi.fn(),
+      writePty,
+      isTargetCurrent: () => true,
+      canContinue: () => true,
+      yieldToEventLoop: async () => {}
+    })
+
+    expect(result).toMatchObject({ status: 'cancelled', reason: 'target-disconnected' })
+    expect(writes).toEqual([BRACKETED_PASTE_START, '0123', BRACKETED_PASTE_END])
+  })
+
+  it('closes an opened bracketed paste when a payload write exceeds the safety timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const writePty = vi.fn((data: string) => {
+        writes.push(data)
+        return data === BRACKETED_PASTE_START ? true : new Promise<boolean>(() => {})
+      })
+
+      const execution = executeTerminalPastePlan(bracketedChunkedPlan(), {
+        pasteText: vi.fn(),
+        writePty,
+        isTargetCurrent: () => true,
+        canContinue: () => true,
+        yieldToEventLoop: async () => {},
+        operationTimeoutMs: 25
+      })
+      // Why: the payload write and the best-effort close each burn their own budget.
+      await vi.advanceTimersByTimeAsync(25)
+      await vi.advanceTimersByTimeAsync(25)
+
+      await expect(execution).resolves.toMatchObject({
+        status: 'cancelled',
+        reason: 'operation-timeout'
+      })
+      expect(writes).toEqual([BRACKETED_PASTE_START, '0123', BRACKETED_PASTE_END])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports a timed-out bracketed close on a stale target as an operation timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      let current = true
+      const writes: string[] = []
+      const writePty = vi.fn((data: string) => {
+        writes.push(data)
+        return data === BRACKETED_PASTE_END ? new Promise<boolean>(() => {}) : true
+      })
+
+      const execution = executeTerminalPastePlan(bracketedChunkedPlan(), {
+        pasteText: vi.fn(),
+        writePty,
+        isTargetCurrent: () => current,
+        canContinue: () => true,
+        yieldToEventLoop: async () => {
+          current = false
+        },
+        operationTimeoutMs: 25
+      })
+      await vi.advanceTimersByTimeAsync(25)
+      await vi.advanceTimersByTimeAsync(25)
+
+      await expect(execution).resolves.toMatchObject({
+        status: 'cancelled',
+        reason: 'operation-timeout'
+      })
+      expect(writes).toEqual([BRACKETED_PASTE_START, BRACKETED_PASTE_END])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips the bracketed close when the paste target is already gone', async () => {
+    // Why: canContinue false means the pane/PTY is unmounted, so an end marker has
+    // nowhere to land — the frame dies with the target.
+    let writable = true
+    const writes: string[] = []
+
+    const result = await executeTerminalPastePlan(bracketedChunkedPlan(), {
+      pasteText: vi.fn(),
+      writePty: (data) => {
+        writes.push(data)
+        writable = false
+        return true
+      },
+      isTargetCurrent: () => true,
+      canContinue: () => writable,
+      yieldToEventLoop: async () => {}
+    })
+
+    expect(result).toMatchObject({ status: 'cancelled', reason: 'target-disconnected' })
+    expect(writes).toEqual([BRACKETED_PASTE_START])
+  })
+
+  it('closes an opened bracketed paste when the PTY writer throws', async () => {
+    const writes: string[] = []
+    const writePty = vi.fn<(data: string) => boolean>((data) => {
+      writes.push(data)
+      if (data !== BRACKETED_PASTE_START && data !== BRACKETED_PASTE_END) {
+        throw new Error('writer gone')
+      }
+      return true
+    })
+
+    await expect(
+      executeTerminalPastePlan(bracketedChunkedPlan(), {
+        pasteText: vi.fn(),
+        writePty,
+        isTargetCurrent: () => true,
+        canContinue: () => true,
+        yieldToEventLoop: async () => {}
+      })
+    ).rejects.toThrow('writer gone')
+    expect(writes).toEqual([BRACKETED_PASTE_START, '0123', BRACKETED_PASTE_END])
   })
 
   it('rejects oversized payloads before touching xterm or the PTY', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-paste-executor.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-executor.ts
@@ -76,44 +76,81 @@ async function executeTerminalPastePlanNow(
 
   let chunksWritten = 0
   let bracketedPasteOpen = false
-  for (const chunk of iterateTerminalPastePlanChunks(plan)) {
-    if (isTargetCurrent && !isTargetCurrent()) {
-      if (bracketedPasteOpen && (!canContinue || canContinue())) {
-        const closeResult = await runTerminalPasteOperationWithTimeout(
-          () => writePty(BRACKETED_PASTE_END),
-          operationTimeoutMs
-        )
-        if (closeResult.timedOut) {
-          return finish('cancelled', chunksWritten, 'operation-timeout')
-        }
-        if (closeResult.value) {
-          chunksWritten += 1
-        }
-      }
-      return finish('cancelled', chunksWritten, 'stale-target')
+  // Why: best-effort — a close that hangs or throws must not mask the real exit reason.
+  const closeBracketedPasteFrame = async (): Promise<{ timedOut: boolean }> => {
+    if (!bracketedPasteOpen) {
+      return { timedOut: false }
     }
+    bracketedPasteOpen = false
     if (canContinue && !canContinue()) {
-      return finish('cancelled', chunksWritten, 'target-disconnected')
+      return { timedOut: false }
     }
-    const writeResult = await runTerminalPasteOperationWithTimeout(
-      () => writePty(chunk),
-      operationTimeoutMs
-    )
-    if (writeResult.timedOut) {
-      return finish('cancelled', chunksWritten, 'operation-timeout')
+    try {
+      const closeResult = await runTerminalPasteOperationWithTimeout(
+        () => writePty(BRACKETED_PASTE_END),
+        operationTimeoutMs
+      )
+      if (closeResult.timedOut) {
+        return { timedOut: true }
+      }
+      if (closeResult.value) {
+        chunksWritten += 1
+      }
+    } catch {
+      // The frame stays open only because the writer itself is gone; nothing left to do.
     }
-    if (!writeResult.value) {
-      return finish('cancelled', chunksWritten, 'target-disconnected')
-    }
-    chunksWritten += 1
-    if (chunk === BRACKETED_PASTE_START) {
-      bracketedPasteOpen = true
-    } else if (chunk === BRACKETED_PASTE_END) {
-      bracketedPasteOpen = false
-    }
-    await yieldToEventLoop()
+    return { timedOut: false }
   }
-  return finish('pasted', chunksWritten)
+
+  const writeChunks = async (): Promise<ChunkedPasteOutcome> => {
+    for (const chunk of iterateTerminalPastePlanChunks(plan)) {
+      if (isTargetCurrent && !isTargetCurrent()) {
+        return { status: 'cancelled', reason: 'stale-target' }
+      }
+      if (canContinue && !canContinue()) {
+        return { status: 'cancelled', reason: 'target-disconnected' }
+      }
+      const writeResult = await runTerminalPasteOperationWithTimeout(
+        () => writePty(chunk),
+        operationTimeoutMs
+      )
+      // Why: a failed close chunk is already the close attempt; retrying would emit a stray end.
+      if (writeResult.timedOut) {
+        bracketedPasteOpen = bracketedPasteOpen && chunk !== BRACKETED_PASTE_END
+        return { status: 'cancelled', reason: 'operation-timeout' }
+      }
+      if (!writeResult.value) {
+        bracketedPasteOpen = bracketedPasteOpen && chunk !== BRACKETED_PASTE_END
+        return { status: 'cancelled', reason: 'target-disconnected' }
+      }
+      chunksWritten += 1
+      if (chunk === BRACKETED_PASTE_START) {
+        bracketedPasteOpen = true
+      } else if (chunk === BRACKETED_PASTE_END) {
+        bracketedPasteOpen = false
+      }
+      await yieldToEventLoop()
+    }
+    return { status: 'pasted' }
+  }
+
+  let outcome!: ChunkedPasteOutcome
+  let closeTimedOut = false
+  try {
+    outcome = await writeChunks()
+  } finally {
+    // Why: every exit, including an unexpected writer rejection, must leave the frame closed.
+    closeTimedOut = (await closeBracketedPasteFrame()).timedOut
+  }
+  if (closeTimedOut && outcome.reason === 'stale-target') {
+    return finish('cancelled', chunksWritten, 'operation-timeout')
+  }
+  return finish(outcome.status, chunksWritten, outcome.reason)
+}
+
+type ChunkedPasteOutcome = {
+  status: TerminalPasteExecutionResult['status']
+  reason?: TerminalPasteExecutionReason
 }
 
 export function getTerminalPasteOperationTimeoutMs(plan: TerminalPastePlan): number {

--- a/src/renderer/src/lib/agent-draft-paste-content.ts
+++ b/src/renderer/src/lib/agent-draft-paste-content.ts
@@ -32,7 +32,9 @@ export async function sendAgentDraftPasteContent(
   )
 }
 
-async function sendAgentDraftPasteContentNow(
+// Why: callers that must keep extra PTY writes (e.g. submit Enter) inside the same
+// transaction take the lock themselves; taking it again here would deadlock.
+export async function sendAgentDraftPasteContentNow(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   ptyId: string,
   content: string,

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -8,6 +8,7 @@ import {
   iterateAgentDraftPasteContentChunks,
   pasteDraftToAgentPtyWhenReady,
   pasteDraftWhenAgentReady,
+  POST_PASTE_SUBMIT_DELAY_MS,
   sendAgentDraftPasteContent,
   sendBracketedPasteToRunningAgent,
   submitPromptToAgentPty
@@ -538,6 +539,35 @@ describe('pasteDraftWhenAgentReady', () => {
 
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(2, {}, 'pty-1', '\r')
+  })
+
+  it('holds the PTY transaction across the paste and its submit Enter', async () => {
+    const writes: string[] = []
+    testState.sendRuntimePtyInputVerified.mockImplementation(
+      async (_settings: unknown, _ptyId: string, data: string) => {
+        writes.push(data)
+        return true
+      }
+    )
+
+    const submit = sendBracketedPasteToRunningAgent({ ptyId: 'pty-1', content: ISSUE_URL })
+    await flushMicrotasks()
+    // Competing chunked paste on the same PTY: it must not open a frame the Enter can land in.
+    const competing = sendAgentDraftPasteContent(
+      {},
+      'pty-1',
+      'y'.repeat(AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + 1)
+    )
+    await flushMicrotasks(10)
+    expect(writes).toEqual([PASTED_ISSUE_URL])
+
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS)
+    await expect(submit).resolves.toBe(true)
+    await expect(competing).resolves.toBe(true)
+
+    expect(writes.indexOf('\r')).toBe(1)
+    expect(writes.at(2)).toBe('\x1b[200~')
+    expect(writes.at(-1)).toBe('\x1b[201~')
   })
 
   it('submits to an exact PTY even when it is not the first PTY in the tab', async () => {

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -10,9 +10,10 @@ import {
   BRACKETED_PASTE_START,
   sanitizeTerminalPasteText
 } from '@/components/terminal-pane/terminal-bracketed-paste'
+import { runTerminalPtyInputTransaction } from '@/components/terminal-pane/terminal-pty-input-transaction'
 import { waitForAgentReady } from './agent-ready-wait'
 import { getSettingsForWorktreeRuntimeOwner } from './worktree-runtime-owner'
-import { sendAgentDraftPasteContent } from './agent-draft-paste-content'
+import { sendAgentDraftPasteContentNow } from './agent-draft-paste-content'
 import { agentDeliversDraftViaNativePrefill } from './agent-native-draft-prefill'
 import { waitForAgentDraftInputReady } from './agent-draft-readiness'
 import { isExpectedAgentProcess } from '../../../shared/agent-process-recognition'
@@ -212,19 +213,20 @@ async function sendBracketedPasteToAgent(args: {
 }): Promise<boolean> {
   const { settings = useAppStore.getState().settings, ptyId, content, submit } = args
   try {
-    const pasted = await sendAgentDraftPasteContent(settings, ptyId, content)
-    if (!pasted) {
-      return false
-    }
-    if (!submit) {
-      return true
-    }
+    // Why: paste + Enter must be one transaction, or a concurrent paste on this PTY
+    // can slip between them and submit a half-written prompt.
+    return await runTerminalPtyInputTransaction(ptyId, async () => {
+      const pasted = await sendAgentDraftPasteContentNow(settings, ptyId, content)
+      if (!pasted || !submit) {
+        return pasted
+      }
 
-    // Why: Claude Code can leave a prompt as editable text when paste-end and
-    // Enter arrive in the same PTY write. Split the submit into the next turn so
-    // the TUI processes bracketed-paste termination before handling Enter.
-    await new Promise<void>((resolve) => window.setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
-    return await sendRuntimePtyInputVerified(settings, ptyId, '\r')
+      // Why: Claude Code can leave a prompt as editable text when paste-end and
+      // Enter arrive in the same PTY write. Split the submit into the next turn so
+      // the TUI processes bracketed-paste termination before handling Enter.
+      await new Promise<void>((resolve) => window.setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
+      return await sendRuntimePtyInputVerified(settings, ptyId, '\r')
+    })
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary

Two independent P2s found by the `v1.4.163-rc.1..v1.4.163-rc.3` production release scan, both in the terminal paste path. Both leave the terminal in a state the user cannot easily diagnose or escape.

### Bug A — an aborted chunked paste can leave the PTY stuck in bracketed-paste mode

A large paste (over `TERMINAL_PASTE_DIRECT_MAX_BYTES`, 64 KiB) is written to the PTY as a sequence of chunks: `ESC[200~`, the payload in pieces, then `ESC[201~`. The opening sequence puts the shell or TUI into bracketed-paste mode, where it buffers input as literal text instead of interpreting it. It stays there until the closing sequence arrives.

On `origin/main`, `executeTerminalPastePlanNow` closed that frame on exactly **one** of its four exit paths — the stale-target check. The other three returned immediately with the frame still open:

```ts
if (writeResult.timedOut) {
  return finish('cancelled', chunksWritten, 'operation-timeout')   // frame left open
}
if (!writeResult.value) {
  return finish('cancelled', chunksWritten, 'target-disconnected') // frame left open
}
```

and an exception thrown by `writePty` itself escaped the function without closing anything.

**Impact:** the terminal silently stops responding to input as input. Keystrokes and `Enter` are swallowed as paste payload; the shell never runs anything. There is no error, no indication of the mode, and no obvious recovery short of killing the terminal.

**Fix:** the chunk loop moves into `writeChunks()`, which returns a `ChunkedPasteOutcome` instead of returning from the outer function, and the close is a `finally`:

```ts
try {
  outcome = await writeChunks()
} finally {
  // Why: every exit, including an unexpected writer rejection, must leave the frame closed.
  closeTimedOut = (await closeBracketedPasteFrame()).timedOut
}
```

`closeBracketedPasteFrame` is idempotent (`bracketedPasteOpen` is cleared on entry), still respects `canContinue()`, is itself timeout-wrapped, and is wrapped in `try/catch` so a close failure cannot mask the real exit reason. The `bracketedPasteOpen = bracketedPasteOpen && chunk !== BRACKETED_PASTE_END` lines handle the one case where the *close chunk itself* is what failed — retrying it would emit a stray terminator. The pre-existing stale-target + close-timeout combination keeps reporting `operation-timeout`, so no existing caller sees a changed reason code.

### Bug B — paste and its submit `Enter` were not one transaction

`sendBracketedPasteToAgent` pastes a draft and then, if `submit` is set, waits `POST_PASTE_SUBMIT_DELAY_MS` (50 ms) before sending `\r`. The delay is deliberate and documented: Claude Code can leave the prompt as editable text if paste-end and `Enter` land in the same PTY write.

On `origin/main` the paste took the per-PTY `runTerminalPtyInputTransaction` lock and then **released it**, leaving that 50 ms window unguarded. Anything else writing to the same PTY in that window interleaves between the payload and the `Enter` — so the `Enter` submits whatever is in the prompt at that moment, which is the first draft plus part of a second one.

**Fix:** take the lock once, around both:

```ts
return await runTerminalPtyInputTransaction(ptyId, async () => {
  const pasted = await sendAgentDraftPasteContentNow(settings, ptyId, content)
  if (!pasted || !submit) return pasted
  await new Promise<void>((resolve) => window.setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
  return await sendRuntimePtyInputVerified(settings, ptyId, '\r')
})
```

`runTerminalPtyInputTransaction` is a promise-tail mutex and is **not reentrant** — naively wrapping the existing call would have deadlocked the PTY permanently. `agent-draft-paste-content.ts` therefore exports `sendAgentDraftPasteContentNow`, the non-locking inner variant, following the existing `X` / `XNow` convention in this module. `sendAgentDraftPasteContent` (the locking wrapper) is unchanged for its other callers. The 50 ms delay constant is unchanged — only relocated inside the lock.

## ELI5

**A.** When you paste something big, Orca tells the terminal "everything until I say stop is text you should just sit on, not commands to run". If the paste is interrupted partway — the connection drops, the write times out — Orca was forgetting to say "stop". The terminal keeps waiting, so your typing goes into a void: you press Enter and nothing happens, with no error explaining why. Now the "stop" is sent on every possible way out, including crashes.

**B.** When Orca hands a drafted prompt to a coding agent, it does two things: paste the text, wait a beat, then press Enter. The beat is necessary — press Enter too fast and the agent leaves the text sitting there unsent. But Orca only held the "nobody else write to this terminal" lock for the paste, then let go during the beat. If a second paste started right then, it slipped in before the Enter — and the Enter submitted a mashup of both prompts. Now the lock is held across the whole thing, so nothing can wedge itself in the middle.

## Screenshots

**No visual change.** Neither fix alters any rendered element. Bug A's symptom is an invisible terminal *mode*; bug B's symptom is a corrupted prompt string. Both are exercised through the PTY write stream, which is what the tests below assert on directly.

## Proof of fix

Each fix was reverted independently so neither can take credit for the other.

**Bug A** — `terminal-paste-executor.ts` reverted to `origin/main`, tests kept:

```
 × closes an opened bracketed paste when a payload write is rejected
 × closes an opened bracketed paste when a payload write exceeds the safety timeout
 × closes an opened bracketed paste when the PTY writer throws

AssertionError: expected [ '^[[200~', '0123' ] to deeply equal [ Array(3) ]
AssertionError: expected [ '^[[200~', '0123' ] to deeply equal [ Array(3) ]
AssertionError: expected [ '^[[200~', '0123' ] to deeply equal [ Array(3) ]

 Test Files  1 failed (1)
      Tests  3 failed | 27 passed (30)
```

The `actual` array **is** the bug: the PTY received `ESC[200~` and a payload chunk, and nothing else. The frame was opened and never closed, for all three failure modes.

**Bug B** — `agent-paste-draft.ts` and `agent-draft-paste-content.ts` reverted to `origin/main`, tests kept:

```
 × holds the PTY transaction across the paste and its submit Enter

AssertionError: expected [ …(7) ] to deeply equal [ Array(1) ]

 Test Files  1 failed (1)
      Tests  1 failed | 32 passed (33)
```

The test starts a competing paste on the same PTY during the 50 ms delay and asserts nothing lands between the payload and the `Enter`. Unfixed, the competing paste's **7 writes** all land inside the window.

With both fixes restored: **2 files / 63 tests passed**.

## Proof of no regression

- Targeted suite at branch tip: **2 files / 63 tests passed** (30 in `terminal-paste-coordinator.test.ts`, 33 in `agent-paste-draft.test.ts`), of which 60 are pre-existing and unmodified.
- Full desktop suite on the merged tree containing all eight scan fixes: **359 files / 3830 tests passed**.
- `npx oxfmt --check` and `npx oxlint` clean.
- **Deadlock specifically checked**, since it is the failure mode this refactor invites and a test would hang rather than fail: verified by inspection that `agent-paste-draft.ts:218` is the only lock acquisition on that path and `:219` calls the non-locking `…Now` variant. `sendAgentDraftPasteContent` (the locking wrapper) has no remaining caller inside a transaction.
- `terminal-paste-executor.ts` is **191 lines**, within the 300-line cap. No `max-lines` disable added.
- Existing reason codes are preserved, not just tests: the stale-target-plus-close-timeout path still reports `operation-timeout`, so no caller's error handling changes.

**Deliberately not touched:** `agent-draft-paste-content.ts`'s own chunked-close logic (a separate path, already correct), everything introduced by #11612, and `active-agent-note-send.ts:218` (a different call site that does not submit and therefore has no unguarded window).

## Testing

- [x] `pnpm lint` — clean (oxlint, type-aware audit, reliability gates, max-lines ratchet, localization catalog/extraction/coverage); `oxfmt --check` clean via lint-staged
- [x] `pnpm typecheck` — clean (tsc: node + cli + web)
- [x] `pnpm test` (targeted at tip + full desktop suite on the combined tree)
- [ ] `pnpm build` — not run; no build-graph, packaging, or dependency change
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed by Claude Opus 5 as part of a 45-agent release scan with adversarial refutation. Risks checked:

- **Concurrency / deadlock.** The dominant risk. `runTerminalPtyInputTransaction` is a per-`ptyId` promise-tail mutex with no reentrancy guard, so a double acquisition would wedge that PTY for the lifetime of the session with no error. Handled via the `…Now` split and verified by call-site inspection (a hang cannot be caught by a passing test).
- **Lock hold time.** The critical section grows by `POST_PASTE_SUBMIT_DELAY_MS` (50 ms). That is bounded, applies only when `submit` is true, and is the whole point — the alternative is a submitted prompt containing two drafts. It is far shorter than the chunked-write phase the lock already covered.
- **Cleanup and error paths.** The `finally` runs on the exception path too, which is the case `origin/main` handled worst. `closeBracketedPasteFrame` is idempotent and independently timeout-wrapped so a hung writer cannot make cleanup hang the paste.
- **Cross-platform:** no platform branch, path, or shell handling. The bracketed-paste escape sequences and the PTY write API are identical on macOS, Linux, and Windows.
- **SSH / relay:** both fixes are in the renderer and operate on `ptyId`, above the transport. A remote PTY reaches the same code, and the dropped-connection case (`!writeResult.value` → `target-disconnected`) is precisely the SSH failure mode bug A left the frame open on — so this matters *more* on SSH and relay than locally.

## Security Audit

- No new dependencies, no lockfile change, no install hooks.
- No `eval`, no shell string construction, no path handling, no auth, no secrets, no network.
- **Terminal control sequences are the relevant surface.** The only bytes this PR can newly cause to be written are `BRACKETED_PASTE_END` (`ESC[201~`), from the existing constant, on failure paths that previously wrote nothing. Writing a terminator without a matching opener is checked and prevented: `closeBracketedPasteFrame` returns immediately unless `bracketedPasteOpen`, clears the flag on entry so it cannot double-fire, and the `chunk !== BRACKETED_PASTE_END` guards stop a retry when the close chunk is itself what failed. No user-controlled data is added to the write stream.
- Bug A's fix is a defensive improvement in its own right: leaving a terminal in bracketed-paste mode means subsequent keystrokes — potentially including things the user types believing they are running a command — accumulate in a paste buffer instead.
- Bug B's fix closes a race that could cause an agent to receive and act on a prompt the user never composed. Local-only and not remotely triggerable, but it is an integrity issue rather than a cosmetic one.

## Notes

- Both bugs are hard to reproduce by hand — bug A needs a large paste interrupted mid-flight, bug B needs two pastes within a 50 ms window — and both fail silently rather than loudly, which is why they are worth pinning with tests even at P2.
- Bug B's fix intentionally does **not** change `POST_PASTE_SUBMIT_DELAY_MS`. The delay exists for a real TUI behaviour in Claude Code; shortening it would trade this race for that one. The fix makes the window safe rather than smaller.

Made with [Orca](https://github.com/stablyai/orca) 🐋
