### PR TITLE
[P1] fix(routing): keep the paired-HUB owner for the active workspace selection

### DIFF
--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -241,6 +241,98 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
+  describe('active workspace host selection', () => {
+    it('keeps the HUB transport when the paired SSH worktree is the active workspace', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            activeWorktreeId: WORKTREE_ID,
+            activeWorkspaceExecutionHostId: 'ssh:hub-private-target',
+            worktreesByRepo: { 'repo-1': [worktree('ssh:hub-private-target', 'hub-a')] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:hub-private-target', runtimeEnvironmentId: 'hub-a' }
+      })
+    })
+
+    it('recovers the HUB transport from the repo for an active mixed-version SSH publication', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            activeWorktreeId: WORKTREE_ID,
+            activeWorkspaceExecutionHostId: 'ssh:hub-private-target',
+            repos: [
+              {
+                id: 'repo-1',
+                connectionId: 'hub-private-target',
+                executionHostId: 'runtime:hub-a'
+              }
+            ],
+            detectedWorktreesByRepo: {
+              'repo-1': { worktrees: [worktree('ssh:hub-private-target')] }
+            }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:hub-private-target', runtimeEnvironmentId: 'hub-a' }
+      })
+    })
+
+    it('keeps the selected host authoritative when the same ID exists on two hosts', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            activeWorktreeId: WORKTREE_ID,
+            activeWorkspaceExecutionHostId: 'runtime:hub-a',
+            worktreesByRepo: { 'repo-1': [worktree('local'), worktree('runtime:hub-a')] }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'runtime:hub-a', runtimeEnvironmentId: 'hub-a' }
+      })
+    })
+
+    it('drops the HUB transport when two HUBs project the active SSH worktree', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          {
+            activeWorktreeId: WORKTREE_ID,
+            activeWorkspaceExecutionHostId: 'ssh:same-private-target',
+            worktreesByRepo: {
+              'repo-1': [
+                worktree('ssh:same-private-target', 'hub-a'),
+                worktree('ssh:same-private-target', 'hub-b')
+              ]
+            }
+          },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:same-private-target', runtimeEnvironmentId: null }
+      })
+    })
+
+    it('keeps an unknown active worktree on its selected host', () => {
+      expect(
+        resolveWorktreeOperationRouteResult(
+          { activeWorktreeId: WORKTREE_ID, activeWorkspaceExecutionHostId: 'ssh:ssh-1' },
+          WORKTREE_ID
+        )
+      ).toEqual({
+        kind: 'resolved',
+        route: { executionHostId: 'ssh:ssh-1', runtimeEnvironmentId: null }
+      })
+    })
+  })
+
   describe('folder workspaces', () => {
     const FOLDER_WORKSPACE_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
     const FOLDER_KEY = `folder:${FOLDER_WORKSPACE_ID}`

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -2,11 +2,11 @@ import type { AppState } from '@/store/types'
 import {
   getRepoExecutionHostId,
   parseExecutionHostId,
-  toSshExecutionHostId,
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
+import { addRoute, resolveExactWorktreeRoute, routeForOwner } from './worktree-owner-route'
 import { resolveIndexedWorktreeOwner } from './worktree-runtime-owner-index'
 import {
   findFolderWorkspaceOwner,
@@ -24,7 +24,7 @@ export type WorktreeOperationRouteResolution =
   | { kind: 'ambiguous' }
   | { kind: 'missing' }
 
-type WorktreeOperationOwnerRecord = {
+export type WorktreeOperationOwnerRecord = {
   id: string
   repoId: string
   hostId?: ExecutionHostId
@@ -32,7 +32,7 @@ type WorktreeOperationOwnerRecord = {
 }
 
 // settings/runtimeEnvironments come from FolderWorkspaceRuntimeOwnerState's legacy-owner base.
-type WorktreeOperationRouteState = FolderWorkspaceRuntimeOwnerState & {
+export type WorktreeOperationRouteState = FolderWorkspaceRuntimeOwnerState & {
   repos?: readonly Pick<AppState['repos'][number], 'id' | 'connectionId' | 'executionHostId'>[]
   worktreesByRepo?: Record<string, readonly WorktreeOperationOwnerRecord[]>
   detectedWorktreesByRepo?: Record<string, { worktrees: readonly WorktreeOperationOwnerRecord[] }>
@@ -45,81 +45,65 @@ const repoOperationRouteIndexCache = new WeakMap<
   ReadonlyMap<string, WorktreeOperationRouteResolution>
 >()
 
-function routeForOwner(owner: {
-  hostId?: ExecutionHostId
-  runtimeOwnerEnvironmentId?: string
-}): WorktreeOperationRoute | null {
-  const runtimeOwnerEnvironmentId = owner.runtimeOwnerEnvironmentId?.trim()
-  if (!owner.hostId && !runtimeOwnerEnvironmentId) {
+function ownerRecordsOnHost(
+  state: WorktreeOperationRouteState,
+  worktreeId: string,
+  executionHostId: ExecutionHostId
+): WorktreeOperationOwnerRecord[] {
+  const owners: WorktreeOperationOwnerRecord[] = []
+  const catalogs = [
+    ...Object.values(state.worktreesByRepo ?? {}),
+    ...Object.values(state.detectedWorktreesByRepo ?? {}).map((result) => result.worktrees)
+  ]
+  for (const worktrees of catalogs) {
+    for (const worktree of worktrees) {
+      if (
+        worktree.id === worktreeId &&
+        parseExecutionHostId(worktree.hostId)?.id === executionHostId
+      ) {
+        owners.push(worktree)
+      }
+    }
+  }
+  return owners
+}
+
+/**
+ * The active workspace's host selection is authoritative identity, but it carries no transport:
+ * an `ssh:` host reached through a paired HUB names the target, not the HUB that proxies it. Keep
+ * the selected host and recover the runtime owner from the matching owner rows (#11346).
+ */
+export function resolveActiveWorkspaceRoute(
+  state: WorktreeOperationRouteState,
+  worktreeId: string
+): WorktreeOperationRoute | null {
+  const activeHost =
+    state.activeWorktreeId === worktreeId
+      ? parseExecutionHostId(state.activeWorkspaceExecutionHostId)
+      : null
+  if (!activeHost) {
     return null
   }
-  const parsedHost = parseExecutionHostId(owner.hostId)
+  if (activeHost.kind === 'runtime') {
+    return { executionHostId: activeHost.id, runtimeEnvironmentId: activeHost.environmentId }
+  }
+  // Why: only an `ssh:` selection can hide a paired HUB owner, so local stays an O(1) hot path.
+  if (activeHost.kind !== 'ssh') {
+    return { executionHostId: activeHost.id, runtimeEnvironmentId: null }
+  }
+  const environmentIds = new Set<string>()
+  for (const owner of ownerRecordsOnHost(state, worktreeId, activeHost.id)) {
+    const resolution = resolveExactWorktreeRoute(state, owner)
+    if (resolution.kind === 'resolved' && resolution.route.runtimeEnvironmentId) {
+      environmentIds.add(resolution.route.runtimeEnvironmentId)
+    }
+  }
+  const environmentId = environmentIds.values().next().value
   return {
-    executionHostId: owner.hostId ?? null,
-    runtimeEnvironmentId:
-      runtimeOwnerEnvironmentId ||
-      (parsedHost?.kind === 'runtime' ? parsedHost.environmentId : null)
+    executionHostId: activeHost.id,
+    // Why: rival HUBs projecting the same host cannot be disambiguated by the host selection alone.
+    runtimeEnvironmentId: environmentIds.size === 1 && environmentId ? environmentId : null
   }
-}
-
-function addRoute(
-  routes: Map<string, WorktreeOperationRoute>,
-  route: WorktreeOperationRoute | null
-): void {
-  if (!route) {
-    return
-  }
-  routes.set(JSON.stringify(route), route)
-}
-
-function resolveRepoRouteForSshOwner(
-  repos: WorktreeOperationRouteState['repos'],
-  owner: WorktreeOperationOwnerRecord
-): WorktreeOperationRouteResolution {
-  if (!repos || !owner.hostId) {
-    return { kind: 'missing' }
-  }
-  const routes = new Map<string, WorktreeOperationRoute>()
-  for (const repo of repos) {
-    if (repo.id !== owner.repoId) {
-      continue
-    }
-    const connectionHostId = repo.connectionId ? toSshExecutionHostId(repo.connectionId) : null
-    if (getRepoExecutionHostId(repo) !== owner.hostId && connectionHostId !== owner.hostId) {
-      continue
-    }
-    addRoute(routes, routeForOwner({ hostId: getRepoExecutionHostId(repo) }))
-  }
-  const route = routes.values().next().value
-  if (routes.size === 1 && route) {
-    return { kind: 'resolved', route }
-  }
-  return routes.size > 1 ? { kind: 'ambiguous' } : { kind: 'missing' }
-}
-
-function resolveExactWorktreeRoute(
-  state: WorktreeOperationRouteState,
-  owner: WorktreeOperationOwnerRecord
-): WorktreeOperationRouteResolution {
-  const route = routeForOwner(owner)
-  if (!route) {
-    return { kind: 'missing' }
-  }
-  if (route.runtimeEnvironmentId || parseExecutionHostId(route.executionHostId)?.kind !== 'ssh') {
-    return { kind: 'resolved', route }
-  }
-  // Recover an optional HUB transport only from the repo setup matching the worktree's SSH host.
-  const repoRoute = resolveRepoRouteForSshOwner(state.repos, owner)
-  if (repoRoute.kind === 'ambiguous') {
-    return repoRoute
-  }
-  if (repoRoute.kind === 'resolved' && repoRoute.route.runtimeEnvironmentId) {
-    return {
-      kind: 'resolved',
-      route: { ...route, runtimeEnvironmentId: repoRoute.route.runtimeEnvironmentId }
-    }
-  }
-  return { kind: 'resolved', route }
 }
 
 export function resolveWorktreeOperationRoute(
@@ -134,18 +118,9 @@ export function resolveWorktreeOperationRouteResult(
   state: WorktreeOperationRouteState,
   worktreeId: string
 ): WorktreeOperationRouteResolution {
-  const activeHost =
-    state.activeWorktreeId === worktreeId
-      ? parseExecutionHostId(state.activeWorkspaceExecutionHostId)
-      : null
-  if (activeHost) {
-    return {
-      kind: 'resolved',
-      route: {
-        executionHostId: activeHost.id,
-        runtimeEnvironmentId: activeHost.kind === 'runtime' ? activeHost.environmentId : null
-      }
-    }
+  const activeRoute = resolveActiveWorkspaceRoute(state, worktreeId)
+  if (activeRoute) {
+    return { kind: 'resolved', route: activeRoute }
   }
   // Why: folder workspaces are not Git worktrees — they never appear in the worktree/repo
   // catalogs scanned below, so without this branch a plain local folder workspace reads as an

--- a/src/renderer/src/lib/worktree-owner-route.ts
+++ b/src/renderer/src/lib/worktree-owner-route.ts
@@ -1,0 +1,89 @@
+import {
+  getRepoExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId
+} from '../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import type {
+  WorktreeOperationOwnerRecord,
+  WorktreeOperationRoute,
+  WorktreeOperationRouteResolution,
+  WorktreeOperationRouteState
+} from './worktree-operation-route'
+
+export function routeForOwner(owner: {
+  hostId?: ExecutionHostId
+  runtimeOwnerEnvironmentId?: string
+}): WorktreeOperationRoute | null {
+  const runtimeOwnerEnvironmentId = owner.runtimeOwnerEnvironmentId?.trim()
+  if (!owner.hostId && !runtimeOwnerEnvironmentId) {
+    return null
+  }
+  const parsedHost = parseExecutionHostId(owner.hostId)
+  return {
+    executionHostId: owner.hostId ?? null,
+    runtimeEnvironmentId:
+      runtimeOwnerEnvironmentId ||
+      (parsedHost?.kind === 'runtime' ? parsedHost.environmentId : null)
+  }
+}
+
+export function addRoute(
+  routes: Map<string, WorktreeOperationRoute>,
+  route: WorktreeOperationRoute | null
+): void {
+  if (!route) {
+    return
+  }
+  routes.set(JSON.stringify(route), route)
+}
+
+function resolveRepoRouteForSshOwner(
+  repos: WorktreeOperationRouteState['repos'],
+  owner: WorktreeOperationOwnerRecord
+): WorktreeOperationRouteResolution {
+  if (!repos || !owner.hostId) {
+    return { kind: 'missing' }
+  }
+  const routes = new Map<string, WorktreeOperationRoute>()
+  for (const repo of repos) {
+    if (repo.id !== owner.repoId) {
+      continue
+    }
+    const connectionHostId = repo.connectionId ? toSshExecutionHostId(repo.connectionId) : null
+    if (getRepoExecutionHostId(repo) !== owner.hostId && connectionHostId !== owner.hostId) {
+      continue
+    }
+    addRoute(routes, routeForOwner({ hostId: getRepoExecutionHostId(repo) }))
+  }
+  const route = routes.values().next().value
+  if (routes.size === 1 && route) {
+    return { kind: 'resolved', route }
+  }
+  return routes.size > 1 ? { kind: 'ambiguous' } : { kind: 'missing' }
+}
+
+export function resolveExactWorktreeRoute(
+  state: WorktreeOperationRouteState,
+  owner: WorktreeOperationOwnerRecord
+): WorktreeOperationRouteResolution {
+  const route = routeForOwner(owner)
+  if (!route) {
+    return { kind: 'missing' }
+  }
+  if (route.runtimeEnvironmentId || parseExecutionHostId(route.executionHostId)?.kind !== 'ssh') {
+    return { kind: 'resolved', route }
+  }
+  // Recover an optional HUB transport only from the repo setup matching the worktree's SSH host.
+  const repoRoute = resolveRepoRouteForSshOwner(state.repos, owner)
+  if (repoRoute.kind === 'ambiguous') {
+    return repoRoute
+  }
+  if (repoRoute.kind === 'resolved' && repoRoute.route.runtimeEnvironmentId) {
+    return {
+      kind: 'resolved',
+      route: { ...route, runtimeEnvironmentId: repoRoute.route.runtimeEnvironmentId }
+    }
+  }
+  return { kind: 'resolved', route }
+}

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -579,3 +579,34 @@ describe('getRuntimeSessionMirrorEnvironmentIds', () => {
     expect(getRuntimeSessionMirrorEnvironmentIds(localOnlyState)).toEqual([])
   })
 })
+
+describe('active workspace host selection', () => {
+  const PAIRED_HUB_WORKTREE_ID = 'hub-repo::wt-paired'
+  const pairedHubState: WorktreeRuntimeOwnerState = {
+    activeWorktreeId: PAIRED_HUB_WORKTREE_ID,
+    activeWorkspaceExecutionHostId: 'ssh:hub-private-target',
+    worktreesByRepo: {
+      'hub-repo': [
+        {
+          id: PAIRED_HUB_WORKTREE_ID,
+          repoId: 'hub-repo',
+          hostId: 'ssh:hub-private-target',
+          runtimeOwnerEnvironmentId: 'hub-a'
+        }
+      ]
+    }
+  }
+
+  it('keeps the HUB transport for the active paired SSH worktree', () => {
+    expect(getRuntimeEnvironmentIdForWorktree(pairedHubState, PAIRED_HUB_WORKTREE_ID)).toBe('hub-a')
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(pairedHubState, PAIRED_HUB_WORKTREE_ID)).toBe(
+      'hub-a'
+    )
+  })
+
+  it('keeps the selected host authoritative for the active worktree', () => {
+    expect(getExecutionHostIdForWorktree(pairedHubState, PAIRED_HUB_WORKTREE_ID)).toBe(
+      'ssh:hub-private-target'
+    )
+  })
+})

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -17,6 +17,7 @@ import {
   getRuntimeEnvironmentIdForFolderWorkspace
 } from './folder-workspace-runtime-owner'
 import {
+  resolveActiveWorkspaceRoute,
   resolveExplicitWorktreeOperationRouteResult,
   resolveWorktreeOperationRouteResult
 } from './worktree-operation-route'
@@ -62,9 +63,9 @@ export function getRuntimeEnvironmentIdForWorktree(
   if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
     return null
   }
-  const activeHost = parseExecutionHostId(getActiveWorkspaceExecutionHostId(state, worktreeId))
-  if (activeHost) {
-    return activeHost.kind === 'runtime' ? activeHost.environmentId : null
+  const activeRoute = resolveActiveWorkspaceRoute(state, worktreeId)
+  if (activeRoute) {
+    return activeRoute.runtimeEnvironmentId
   }
   const workspaceScope = parseWorkspaceKey(worktreeId)
   if (workspaceScope?.type === 'folder') {
@@ -113,9 +114,9 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
   if (!worktreeId) {
     return null
   }
-  const activeHost = parseExecutionHostId(getActiveWorkspaceExecutionHostId(state, worktreeId))
-  if (activeHost) {
-    return activeHost.kind === 'runtime' ? activeHost.environmentId : null
+  const activeRoute = resolveActiveWorkspaceRoute(state, worktreeId)
+  if (activeRoute) {
+    return activeRoute.runtimeEnvironmentId
   }
   const workspaceScope = parseWorkspaceKey(worktreeId)
   if (workspaceScope?.type === 'folder') {

--- a/src/renderer/src/store/selectors.test.ts
+++ b/src/renderer/src/store/selectors.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { Repo, TerminalTab, Worktree } from '../../../shared/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
-import { toRuntimeExecutionHostId } from '../../../shared/execution-host'
+import { toRuntimeExecutionHostId, toSshExecutionHostId } from '../../../shared/execution-host'
+import { isGitRepoKind } from '../../../shared/repo-kind'
 import type { AppState } from './types'
 import {
   getAllWorktreesFromState,
@@ -285,6 +286,100 @@ describe('store selectors', () => {
     ).toBe(runtime)
     expect(
       selectRepoByIdForActiveWorkspace({ ...activeState, repos: [local] }, 'same-repo')
+    ).toBeNull()
+  })
+
+  it('keeps the repo when a paired-hub worktree reports a different execution host', () => {
+    // Why: withRepoHostOwnership deliberately keeps an SSH worktree's own host while its repo stays hub-owned.
+    const repo = makeRepo({
+      id: 'hub-repo',
+      path: '/hub/repo',
+      displayName: 'hub',
+      executionHostId: toRuntimeExecutionHostId('hub-a')
+    })
+
+    expect(
+      selectRepoByIdForActiveWorkspace(
+        {
+          repos: [repo],
+          activeRepoId: 'hub-repo',
+          activeWorkspaceExecutionHostId: toSshExecutionHostId('hub-private-target')
+        },
+        'hub-repo'
+      )
+    ).toBe(repo)
+    // Why: useGitStatusPolling gates every lane on this exact expression, so a null repo silently stops polling.
+    const activeRepo = selectRepoByIdForActiveWorkspace(
+      {
+        repos: [repo],
+        activeRepoId: 'hub-repo',
+        activeWorkspaceExecutionHostId: toSshExecutionHostId('hub-private-target')
+      },
+      'hub-repo'
+    )
+    expect(activeRepo ? isGitRepoKind(activeRepo) : false).toBe(true)
+  })
+
+  it('still prefers the host-matching row when one repo ID spans hosts', () => {
+    const hub = makeRepo({
+      id: 'shared-repo',
+      path: '/hub/repo',
+      displayName: 'hub',
+      executionHostId: toRuntimeExecutionHostId('hub-a')
+    })
+    const ssh = makeRepo({
+      id: 'shared-repo',
+      path: '/ssh/repo',
+      displayName: 'ssh',
+      executionHostId: toSshExecutionHostId('hub-private-target')
+    })
+
+    expect(
+      selectRepoByIdForActiveWorkspace(
+        {
+          repos: [hub, ssh],
+          activeRepoId: 'shared-repo',
+          activeWorkspaceExecutionHostId: toSshExecutionHostId('hub-private-target')
+        },
+        'shared-repo'
+      )
+    ).toBe(ssh)
+  })
+
+  it('keeps every non-paired-hub host mismatch failing closed', () => {
+    // Why: the paired-hub exemption is ssh-selection-over-runtime-repo only; anything else is a wrong host.
+    const runtime = makeRepo({
+      id: 'same-repo',
+      path: '/runtime/repo',
+      displayName: 'runtime',
+      executionHostId: toRuntimeExecutionHostId('env-1')
+    })
+    const ssh = makeRepo({
+      id: 'ssh-repo',
+      path: '/ssh/repo',
+      displayName: 'ssh',
+      executionHostId: toSshExecutionHostId('target-1')
+    })
+
+    expect(
+      selectRepoByIdForActiveWorkspace(
+        {
+          repos: [runtime],
+          activeRepoId: 'same-repo',
+          activeWorkspaceExecutionHostId: toRuntimeExecutionHostId('env-2')
+        },
+        'same-repo'
+      )
+    ).toBeNull()
+    expect(
+      selectRepoByIdForActiveWorkspace(
+        {
+          repos: [ssh],
+          activeRepoId: 'ssh-repo',
+          activeWorkspaceExecutionHostId: toSshExecutionHostId('target-2')
+        },
+        'ssh-repo'
+      )
     ).toBeNull()
   })
 

--- a/src/renderer/src/store/selectors.test.ts
+++ b/src/renderer/src/store/selectors.test.ts
@@ -297,27 +297,47 @@ describe('store selectors', () => {
       displayName: 'hub',
       executionHostId: toRuntimeExecutionHostId('hub-a')
     })
+    const local = makeRepo({
+      id: 'hub-repo',
+      path: '/local/repo',
+      displayName: 'local',
+      executionHostId: 'local'
+    })
+    const activeState = {
+      activeRepoId: 'hub-repo',
+      activeWorkspaceExecutionHostId: toSshExecutionHostId('hub-private-target')
+    }
+
+    for (const repos of [[repo], [local, repo], [repo, local]]) {
+      expect(selectRepoByIdForActiveWorkspace({ ...activeState, repos }, 'hub-repo')).toBe(repo)
+    }
+    // Why: useGitStatusPolling gates every lane on this exact expression, so a null repo silently stops polling.
+    const activeRepo = selectRepoByIdForActiveWorkspace(
+      { ...activeState, repos: [repo] },
+      'hub-repo'
+    )
+    expect(activeRepo ? isGitRepoKind(activeRepo) : false).toBe(true)
+  })
+
+  it('fails a paired-hub repo fallback closed when rival HUB rows share the repo ID', () => {
+    const repoForHub = (environmentId: string) =>
+      makeRepo({
+        id: 'hub-repo',
+        path: `/hub/${environmentId}/repo`,
+        displayName: environmentId,
+        executionHostId: toRuntimeExecutionHostId(environmentId)
+      })
 
     expect(
       selectRepoByIdForActiveWorkspace(
         {
-          repos: [repo],
+          repos: [repoForHub('hub-a'), repoForHub('hub-b')],
           activeRepoId: 'hub-repo',
-          activeWorkspaceExecutionHostId: toSshExecutionHostId('hub-private-target')
+          activeWorkspaceExecutionHostId: toSshExecutionHostId('shared-private-target')
         },
         'hub-repo'
       )
-    ).toBe(repo)
-    // Why: useGitStatusPolling gates every lane on this exact expression, so a null repo silently stops polling.
-    const activeRepo = selectRepoByIdForActiveWorkspace(
-      {
-        repos: [repo],
-        activeRepoId: 'hub-repo',
-        activeWorkspaceExecutionHostId: toSshExecutionHostId('hub-private-target')
-      },
-      'hub-repo'
-    )
-    expect(activeRepo ? isGitRepoKind(activeRepo) : false).toBe(true)
+    ).toBeNull()
   })
 
   it('still prefers the host-matching row when one repo ID spans hosts', () => {

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -3,7 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import type { Repo, Worktree, TerminalTab } from '../../../shared/types'
 import type { AppState } from './types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
-import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
 import { getProjectHostSetupProjectionFromState } from './project-host-setup-selector'
 import {
   getIndexedAllWorktrees as getCachedAllWorktrees,
@@ -181,16 +181,26 @@ export function selectRepoByIdForActiveWorkspace(
   if (!repoId) {
     return null
   }
+  const repo = getCachedRepoMap(state.repos).get(repoId) ?? null
   if (repoId === state.activeRepoId && state.activeWorkspaceExecutionHostId) {
-    return (
-      state.repos.find(
-        (repo) =>
-          repo.id === repoId &&
-          getRepoExecutionHostId(repo) === state.activeWorkspaceExecutionHostId
-      ) ?? null
+    const hostMatch = state.repos.find(
+      (candidate) =>
+        candidate.id === repoId &&
+        getRepoExecutionHostId(candidate) === state.activeWorkspaceExecutionHostId
     )
+    if (hostMatch) {
+      return hostMatch
+    }
+    // Why: withRepoHostOwnership keeps a paired-hub worktree on its own SSH host while the repo
+    // stays hub-owned, so that one mismatch still names the right repo; every other stays closed.
+    const isPairedHubRepo =
+      parseExecutionHostId(state.activeWorkspaceExecutionHostId)?.kind === 'ssh' &&
+      parseExecutionHostId(repo ? getRepoExecutionHostId(repo) : undefined)?.kind === 'runtime'
+    if (!isPairedHubRepo) {
+      return null
+    }
   }
-  return getCachedRepoMap(state.repos).get(repoId) ?? null
+  return repo
 }
 
 export const useRepoById = (repoId: string | null) =>

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -183,22 +183,22 @@ export function selectRepoByIdForActiveWorkspace(
   }
   const repo = getCachedRepoMap(state.repos).get(repoId) ?? null
   if (repoId === state.activeRepoId && state.activeWorkspaceExecutionHostId) {
-    const hostMatch = state.repos.find(
-      (candidate) =>
-        candidate.id === repoId &&
-        getRepoExecutionHostId(candidate) === state.activeWorkspaceExecutionHostId
+    const repoCandidates = state.repos.filter((candidate) => candidate.id === repoId)
+    const hostMatch = repoCandidates.find(
+      (candidate) => getRepoExecutionHostId(candidate) === state.activeWorkspaceExecutionHostId
     )
     if (hostMatch) {
       return hostMatch
     }
     // Why: withRepoHostOwnership keeps a paired-hub worktree on its own SSH host while the repo
     // stays hub-owned, so that one mismatch still names the right repo; every other stays closed.
-    const isPairedHubRepo =
-      parseExecutionHostId(state.activeWorkspaceExecutionHostId)?.kind === 'ssh' &&
-      parseExecutionHostId(repo ? getRepoExecutionHostId(repo) : undefined)?.kind === 'runtime'
-    if (!isPairedHubRepo) {
+    if (parseExecutionHostId(state.activeWorkspaceExecutionHostId)?.kind !== 'ssh') {
       return null
     }
+    const pairedHubRepos = repoCandidates.filter(
+      (candidate) => parseExecutionHostId(getRepoExecutionHostId(candidate))?.kind === 'runtime'
+    )
+    return pairedHubRepos.length === 1 ? pairedHubRepos[0] : null
   }
   return repo
 }


### PR DESCRIPTION
## Summary

Both **P1s** from the `v1.4.163-rc.1..v1.4.163-rc.3` production release scan. Both are regressions introduced by #11346 (`60d2493bbb`), both live in the same topology, and neither is survivable alone — so they ship together.

**The topology.** A project reached *through* a paired runtime HUB has two owners at once. `withRepoHostOwnership` says so in as many words (`src/renderer/src/store/slices/worktrees.ts:423`):

```ts
// Why: an SSH worktree reached through a paired HUB has two owners; retain the SSH execution host and stamp the HUB transport separately.
const nextHostId =
  hostId === LOCAL_EXECUTION_HOST_ID ||
  (runtimeOwnerEnvironmentId !== undefined && worktreeHost?.kind === 'ssh')
    ? worktree.hostId
    : hostId
```

So the worktree carries `hostId: ssh:<target>` **and** `runtimeOwnerEnvironmentId: <hub>`, while its repo row stays `runtime:<hub>`. And activation stamps the *worktree's* host onto the store (`src/renderer/src/components/sidebar/WorktreeCard.tsx:876`):

```ts
void activateWorktreeFromSidebar(
  worktree.id,
  worktree.hostId ?? (repo ? getRepoExecutionHostId(repo) : undefined)
)
```

which lands in `activeWorkspaceExecutionHostId` at `worktrees.ts:5412`. So for this one topology, **`activeWorkspaceExecutionHostId` is `ssh:<target>` while the repo is `runtime:<hub>` — by design.** #11346 added two short-circuits that both assume they can't diverge.

Local-only and runtime-only topologies are unaffected by either bug.

### P1-1 — the active workspace loses its HUB transport

`resolveWorktreeOperationRouteResult` short-circuits on the active host selection before any owner lookup happens (`worktree-operation-route.ts:137-149` on `origin/main`):

```ts
const activeHost =
  state.activeWorktreeId === worktreeId
    ? parseExecutionHostId(state.activeWorkspaceExecutionHostId)
    : null
if (activeHost) {
  return {
    kind: 'resolved',
    route: {
      executionHostId: activeHost.id,
      runtimeEnvironmentId: activeHost.kind === 'runtime' ? activeHost.environmentId : null
    }
  }
}
```

The branch has **no access to the owner record at all** — only the parsed host id — so `runtimeOwnerEnvironmentId` is structurally unreachable from it. An `ssh:` selection therefore always yields `runtimeEnvironmentId: null`, and the whole HUB-recovery path in `resolveExactWorktreeRoute` (which exists precisely to recover it) is skipped. Every owner-routed terminal, git, and filesystem operation on the **active** workspace loses the HUB that proxies the SSH target. The same short-circuit is duplicated in `getRuntimeEnvironmentIdForWorktree` and `getExplicitRuntimeEnvironmentIdForWorktree`.

### P1-2 — the active repo reads as `null`, and git status polling stops

`selectRepoByIdForActiveWorkspace` filters `state.repos` by the selected host with no fallback (`selectors.ts:181-193` on `origin/main`):

```ts
if (repoId === state.activeRepoId && state.activeWorkspaceExecutionHostId) {
  return (
    state.repos.find(
      (repo) =>
        repo.id === repoId &&
        getRepoExecutionHostId(repo) === state.activeWorkspaceExecutionHostId
    ) ?? null                        // ← no fallback
  )
}
```

For the paired-hub topology the selected host is `ssh:<target>` and the repo row is `runtime:<hub>`, so the `find` misses and the active repo is `null`. That this is a regression is not an inference — `git show 60d2493bbb -- src/renderer/src/store/selectors.ts` shows both selectors were unconditional lookups before:

```ts
export const useActiveRepo = () =>
  useAppStore(useShallow((s) => s.repos.find((r) => r.id === s.activeRepoId) ?? null))
export const useRepoById = (repoId: string | null) =>
  useAppStore((s) => (repoId ? (getCachedRepoMap(s.repos).get(repoId) ?? null) : null))
```

`useRepoById` is what `useGitStatusPolling` gates on (`useGitStatusPolling.ts:61-82`):

```ts
const activeRepo = useRepoById(activeRepoId)
const activeRepoSupportsGit = activeRepo ? isGitRepoKind(activeRepo) : false
...
const canFetchActiveWorktreeGitStatus =
  enabled && !!activeWorktreeId && !!worktreePath && activeRepoSupportsGit && ...
```

A `null` repo silently switches off git status polling for the entire workspace. Fourteen non-test modules read `useRepoById`/`useActiveRepo`.

### Fix

- **`worktree-operation-route.ts`** — the active-host branch becomes `resolveActiveWorkspaceRoute`. The host selection stays authoritative for *identity*; the HUB owner is recovered from the owner rows sitting on that host, via the existing `resolveExactWorktreeRoute`. Where **rival HUBs project the same SSH host**, the transport is dropped to `null` rather than guessed — the host selection genuinely cannot disambiguate them.
- **`worktree-runtime-owner.ts`** — both duplicated short-circuits now call `resolveActiveWorkspaceRoute`, so the three entry points cannot drift apart again.
- **`selectors.ts`** — host-exact match still wins. On a miss, exactly one hole opens in #11346's fail-closed rule: an `ssh:` selection over a `runtime:` repo row, which is the paired-hub shape and nothing else. Every other host mismatch still returns `null`.
- **`worktree-owner-route.ts`** — a pure extraction of `routeForOwner` / `addRoute` / `resolveExactWorktreeRoute` / `resolveRepoRouteForSshOwner`. No behavior moved with it; the functions are byte-identical to their previous bodies.

## ELI5

Some projects live on a machine you can't reach directly. Orca gets there by going *through* a second machine — a "hub" — the way you'd SSH through a bastion. So the project has two addresses at once: **where it is** (the target) and **how you get there** (the hub).

A recent change taught Orca to remember which host the workspace you're looking at is on, so that two projects with the same ID on two different machines don't get confused. Good idea. But it only remembered the *first* of those two addresses — where the project is — and threw away the second — how to get there.

Two things broke, both only for hub-routed projects:

1. **Orca knew where your files were but not how to reach them.** Every terminal, every git command, every file read on the workspace you were actually looking at went out without the hub. As soon as you clicked away to another workspace, the same operations worked again — because the "remember the active host" shortcut only applies to the active one.
2. **Orca decided your project didn't exist.** It looked for a project registered at the target address, but the project is registered at the *hub's* address, so it found nothing and returned "no project". Everything downstream that asks "is there a repo here?" got told no — including the thing that refreshes your git status, which just quietly stopped.

This PR keeps the "remember the active host" idea intact and adds back the second address, by looking it up from the workspace's own record instead of trying to read it out of the host name — where it was never stored. When two different hubs both claim the same target and Orca genuinely can't tell which one you meant, it says so by returning nothing rather than picking one.

## Screenshots

**None.** Neither defect renders. P1-1 is a routing argument on IPC calls; P1-2 is a selector returning `null`, whose visible effect is the *absence* of a git-status refresh. Reproducing either on screen needs a live paired-HUB runtime plus an SSH target behind it, which is not something this workstation can stand up — and a screenshot of a sidebar that looks normal but has stopped polling would be evidence of nothing.

The behavior is pinned by assertions on the literal resolved routes instead, reproduced below.

## Proof of fix

With **only the four production files reverted to `origin/main`** and every test kept, `npx vitest run --config config/vitest.config.ts` over the five affected suites:

```
       × keeps the HUB transport when the paired SSH worktree is the active workspace 3ms
       × recovers the HUB transport from the repo for an active mixed-version SSH publication 1ms
     × keeps the HUB transport for the active paired SSH worktree 2ms
     × keeps the repo when a paired-hub worktree reports a different execution host 2ms

AssertionError: expected { kind: 'resolved', route: { …(2) } } to deeply equal { kind: 'resolved', route: { …(2) } }
AssertionError: expected { kind: 'resolved', route: { …(2) } } to deeply equal { kind: 'resolved', route: { …(2) } }
AssertionError: expected null to be 'hub-a' // Object.is equality
AssertionError: expected null to be { badgeColor: '#737373', …(6) } // Object.is equality

 Test Files  3 failed | 2 passed (5)
      Tests  4 failed | 75 passed (79)
```

Each defect reproduces as a distinct assertion: the two route resolutions and `expected null to be 'hub-a'` are P1-1 across its three entry points; `expected null to be { badgeColor … }` is P1-2 — the selector returning `null` where the repo object belongs.

With the fix restored: **5 files / 79 tests passed.**

New coverage:

| Test | Pins |
|---|---|
| `keeps the HUB transport when the paired SSH worktree is the active workspace` | P1-1, owner row carries `runtimeOwnerEnvironmentId` |
| `recovers the HUB transport from the repo for an active mixed-version SSH publication` | P1-1 via the repo-setup recovery path, for runtimes that publish no owner field |
| `keeps the selected host authoritative when the same ID exists on two hosts` | #11346's actual purpose — **not** weakened |
| `drops the HUB transport when two HUBs project the active SSH worktree` | the deliberate ambiguity bail-out |
| `keeps an unknown active worktree on its selected host` | no owner rows at all still resolves |
| `keeps the HUB transport for the active paired SSH worktree` | P1-1 through `worktree-runtime-owner`'s two entry points |
| `keeps the repo when a paired-hub worktree reports a different execution host` | P1-2, including the exact `useGitStatusPolling` gate expression |
| `still prefers the host-matching row when one repo ID spans hosts` | host-exact match still wins |
| `keeps every non-paired-hub host mismatch failing closed` | the new hole is *only* ssh-over-runtime |

## Proof of no regression

- **#11346's own test suites are unmodified and still pass.** `selected-host-active-workspace-identity.test.ts` and `repos-selected-owner-routing.test.ts` are untouched by this PR.
- **The one test that asserts the old `null`** — `does not fall back to a same-ID local repo when the active runtime row is absent` (`selectors.test.ts:266`) — is **unmodified** and still passes. It is the reason the selector fix is a narrow exemption rather than a revert: a `local` row shadowing an absent runtime row must still fail closed.
- Full desktop suite on this branch: **4013 files / 42515 tests passed** (12 files / 77 tests skipped, exit 0).
- `pnpm typecheck` — clean (tsc: node + cli + web).
- `oxfmt --check` and `oxlint` clean; no `max-lines` disable added, and `worktree-operation-route.ts` is **net −7 lines** after the extraction.

### Behavior changes beyond the two bugs — disclosed

1. **A local active selection is now an explicit early return** rather than falling into the owner scan. It resolves identically (`{ executionHostId: 'local', runtimeEnvironmentId: null }`), and this keeps the hot path O(1) — only an `ssh:` selection can hide a paired HUB owner, so only `ssh:` pays for the lookup.
2. **Rival HUBs projecting the same SSH host now resolve to `runtimeEnvironmentId: null`** instead of picking one. Previously the active-host branch also produced `null` here, so this is not a change in *outcome* — but it is now a deliberate, tested decision rather than a side effect of never looking.
3. **`WorktreeOperationOwnerRecord` and `WorktreeOperationRouteState` are now exported** so the extracted module can type against them. Type-only; no runtime surface.

## Testing

- [x] `pnpm lint` — clean (oxlint, native + type-aware code-quality audits, reliability-gate manifest, max-lines ratchet, bundled skill guides, skill-bundle manifest, localization catalog/extraction/coverage); `oxfmt` clean via lint-staged
- [x] `pnpm typecheck` — clean (tsc: node + cli + web)
- [x] `pnpm test` — five affected suites at tip (79 passed) plus the full desktop suite
- [x] **#11346's own reliability gate — run, both projects, both pass.** `pnpm run ensure:electron-runtime && npx playwright test tests/e2e/pr11346-selected-runtime-add.spec.ts --config tests/playwright.config.ts --project <p> --workers=1 --reporter=line`:
  - `electron-headless` → `routes … in hidden-window desktop parity` — **1 passed (22.3s)**
  - `electron-headful` → `routes every Add Project path to a selected non-default headed runtime @headful` — **1 passed (21.1s)**
- [ ] `pnpm build` — not run; no build-graph, packaging, or dependency change
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed by Claude Opus 5 as part of a 45-agent release scan with adversarial refutation, then re-verified against `origin/main` before any code was written. Risks checked:

- **Is #11346 weakened?** No. Its purpose — the same repo/worktree ID existing on two hosts must not resolve to the wrong one — is preserved and newly tested from both directions (`keeps the selected host authoritative when the same ID exists on two hosts`, `still prefers the host-matching row when one repo ID spans hosts`). The selected host still decides *identity*; only the *transport* is recovered separately, and only for the one shape where identity provably cannot carry it.
- **Symmetry with the worktree side — checked, and it cut against the first draft of this argument.** `findKnownWorktreeById` (`worktrees.ts:826-873`) also fails closed on host mismatch rather than falling back host-agnostically. So the repo selector was *consistent* with the worktree lookup, not an outlier; the fix is justified by the paired-hub topology being real, not by an inconsistency. Stating that plainly because the opposite would have been a stronger-sounding and wrong argument.
- **Reliability gate.** #11346 registered a blocking Playwright gate (`config/reliability-gates.jsonc:2244-2449`, headful + headless) over exactly this behavior, and it reads `activeWorkspaceExecutionHostId` directly at three points. `pnpm run check:reliability-gates` is only a manifest schema validator, so `pnpm lint` does **not** re-run it. Both gate projects were therefore run deliberately for this PR, and both pass — see the testing checklist.
- **SSH:** this PR is *about* the SSH case. The bug does not exist for local or runtime-only topologies.
- **Folder workspaces:** the folder branch sits after the active-host short-circuit and is unchanged. Folder workspaces set `activeRepoId: null` on activation (`worktrees.ts:5592`), so the selector's active branch never applies to them.
- **Provider neutrality / Git version / cross-platform:** no git command, provider API, path, or keyboard handling is touched. This is store-level routing resolution.
- **Perf:** the added owner scan is gated to `ssh:` selections; `local` and `runtime:` return in constant time as before. The non-active path already did a full-catalog scan (`worktree-operation-route.ts:133-139`), so the scan shape is not new to this module.

## Security Audit

- No new dependencies, no lockfile change, no install hooks.
- No shell execution, no `eval`, no path construction, no auth, no secrets, no IPC surface added.
- **The change widens which host a routed operation can target, so that was checked directly.** It cannot broaden the *execution host*: `executionHostId` is still taken verbatim from the active selection in every branch. Only `runtimeEnvironmentId` — the HUB transport — is added, and only from an owner row whose own `hostId` already parses to the selected host. A row on a different host cannot contribute one.
- **The ambiguity bail-out is the security-relevant case**, and it fails closed: when two HUBs claim the same SSH host, the transport is dropped rather than resolved to whichever row was scanned first. Picking one would mean routing a user's terminal through a HUB they did not select.
- The selector fix returns an existing `Repo` object from the store or `null`; it constructs nothing and grants no capability the store did not already hold.

## Notes

- **These ship together on purpose.** Fixing only P1-1 leaves the workspace with no repo, so git status stays dead; fixing only P1-2 leaves every operation on that repo missing its HUB. A reviewer needs both to judge whether the topology is handled.
- Both are P1 rather than P0 because they are confined to the paired-HUB-over-SSH topology and are escapable by switching to another workspace and back — the short-circuits only apply to the *active* one, so the non-active paths still resolve correctly today.

Made with [Orca](https://github.com/stablyai/orca) 🐋
