### PR TITLE
fix(terminal): restore live background terminal projections

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -8840,6 +8840,184 @@ describe('Store', () => {
     expect(session.tabsByWorktree.wt1[0].ptyId).toBe('remote-pty')
   })
 
+  it('sync-persists a fresh background binding without constructing renderer projection', async () => {
+    const store = await createStore()
+    const foregroundWorktreeId = 'repo::/foreground'
+    const targetWorktreeId = 'repo::/background'
+    const foregroundTab = makeTerminalTab({
+      id: 'foreground-tab',
+      worktreeId: foregroundWorktreeId,
+      ptyId: 'foreground-pty',
+      title: 'Foreground terminal',
+      createdAt: 10
+    })
+    const existingTargetTab = makeTerminalTab({
+      id: 'target-tab',
+      worktreeId: targetWorktreeId,
+      ptyId: 'target-pty',
+      title: 'Background terminal',
+      createdAt: 20
+    })
+    store.setWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: 'repo',
+      activeWorktreeId: foregroundWorktreeId,
+      activeTabId: foregroundTab.id,
+      activeTabIdByWorktree: {
+        [foregroundWorktreeId]: foregroundTab.id,
+        [targetWorktreeId]: existingTargetTab.id
+      },
+      tabsByWorktree: {
+        [foregroundWorktreeId]: [foregroundTab],
+        [targetWorktreeId]: [existingTargetTab]
+      },
+      terminalLayoutsByTabId: {
+        [existingTargetTab.id]: {
+          root: { type: 'leaf', leafId: TEST_LEAF_2 },
+          activeLeafId: TEST_LEAF_2,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_2]: 'target-pty' }
+        }
+      },
+      unifiedTabs: {
+        [foregroundWorktreeId]: [
+          {
+            id: foregroundTab.id,
+            entityId: foregroundTab.id,
+            groupId: 'foreground-group',
+            worktreeId: foregroundWorktreeId,
+            contentType: 'terminal',
+            label: foregroundTab.title,
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: foregroundTab.createdAt
+          }
+        ]
+      },
+      tabGroups: {
+        [foregroundWorktreeId]: [
+          {
+            id: 'foreground-group',
+            worktreeId: foregroundWorktreeId,
+            activeTabId: foregroundTab.id,
+            tabOrder: [foregroundTab.id]
+          }
+        ]
+      },
+      tabGroupLayouts: {
+        [foregroundWorktreeId]: { type: 'leaf', groupId: 'foreground-group' }
+      },
+      activeGroupIdByWorktree: { [foregroundWorktreeId]: 'foreground-group' },
+      terminalTopologyRevisionByRepoId: { repo: 4 }
+    })
+    const projectionBytes = (session: WorkspaceSessionState): string =>
+      JSON.stringify({
+        unifiedTabs: session.unifiedTabs,
+        tabGroups: session.tabGroups,
+        tabGroupLayouts: session.tabGroupLayouts,
+        activeGroupIdByWorktree: session.activeGroupIdByWorktree
+      })
+    const projectionBefore = projectionBytes(store.getWorkspaceSession())
+    expect(store.getWorkspaceSession().unifiedTabs?.[foregroundWorktreeId]).toHaveLength(1)
+    const binding = {
+      worktreeId: targetWorktreeId,
+      tabId: 'fresh-tab',
+      leafId: TEST_LEAF_1,
+      ptyId: 'fresh-pty'
+    }
+
+    store.persistPtyBinding(binding)
+
+    const admitted = structuredClone(store.getWorkspaceSession())
+    expect(projectionBytes(admitted)).toBe(projectionBefore)
+    expect(admitted.unifiedTabs?.[targetWorktreeId]).toBeUndefined()
+    expect(admitted.tabGroups?.[targetWorktreeId]).toBeUndefined()
+    expect(admitted.tabGroupLayouts?.[targetWorktreeId]).toBeUndefined()
+    expect(admitted.activeGroupIdByWorktree?.[targetWorktreeId]).toBeUndefined()
+    expect(admitted.activeWorktreeId).toBe(foregroundWorktreeId)
+    expect(admitted.activeTabId).toBe(foregroundTab.id)
+    expect(admitted.activeTabIdByWorktree?.[targetWorktreeId]).toBe(existingTargetTab.id)
+
+    const freshTab = admitted.tabsByWorktree[targetWorktreeId][1]
+    expect(freshTab).toMatchObject({
+      id: binding.tabId,
+      worktreeId: targetWorktreeId,
+      ptyId: binding.ptyId,
+      title: 'Terminal 2',
+      defaultTitle: 'Terminal 2',
+      customTitle: null,
+      color: null,
+      sortOrder: 1,
+      pendingActivationSpawn: true
+    })
+    expect(freshTab.createdAt).toBeGreaterThan(existingTargetTab.createdAt)
+    expect(admitted.terminalLayoutsByTabId[binding.tabId]).toEqual({
+      root: { type: 'leaf', leafId: TEST_LEAF_1 },
+      activeLeafId: TEST_LEAF_1,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [TEST_LEAF_1]: binding.ptyId }
+    })
+    expect(admitted.terminalTopologyRevisionByRepoId?.repo).toBe(5)
+
+    const flushed = (readDataFile() as PersistedState).workspaceSession
+    const { pendingActivationSpawn: _flushedTransientSpawn, ...flushedDurableTab } =
+      flushed.tabsByWorktree[targetWorktreeId][1]
+    const { pendingActivationSpawn: _admittedTransientSpawn, ...admittedDurableTab } = freshTab
+    expect(flushedDurableTab).toEqual(admittedDurableTab)
+    expect(flushed.terminalLayoutsByTabId[binding.tabId]).toEqual(
+      admitted.terminalLayoutsByTabId[binding.tabId]
+    )
+    expect(projectionBytes(flushed)).toBe(projectionBefore)
+
+    const admittedBytes = JSON.stringify(admitted)
+    store.persistPtyBinding(binding)
+    expect(JSON.stringify(store.getWorkspaceSession())).toBe(admittedBytes)
+    expect(store.getWorkspaceSession().terminalTopologyRevisionByRepoId?.repo).toBe(5)
+
+    const reloaded = await createStore()
+    const reloadedSession = reloaded.getWorkspaceSession()
+    const reloadedFreshTab = reloadedSession.tabsByWorktree[targetWorktreeId][1]
+    expect(projectionBytes(reloadedSession)).toBe(projectionBefore)
+    expect(reloadedSession.unifiedTabs?.[targetWorktreeId]).toBeUndefined()
+    expect(reloadedSession.tabGroups?.[targetWorktreeId]).toBeUndefined()
+    expect(reloadedSession.tabGroupLayouts?.[targetWorktreeId]).toBeUndefined()
+    expect(reloadedSession.activeGroupIdByWorktree?.[targetWorktreeId]).toBeUndefined()
+    expect(reloadedSession.tabsByWorktree[targetWorktreeId]).toHaveLength(2)
+    expect(reloadedFreshTab).toMatchObject({
+      id: binding.tabId,
+      worktreeId: targetWorktreeId,
+      ptyId: binding.ptyId,
+      title: 'Terminal 2',
+      defaultTitle: 'Terminal 2',
+      sortOrder: 1,
+      createdAt: freshTab.createdAt
+    })
+    // Why: pendingActivationSpawn is an in-memory handoff flag and is intentionally absent after schema reload.
+    expect(reloadedFreshTab.pendingActivationSpawn).toBeUndefined()
+    expect(reloadedSession.terminalLayoutsByTabId[binding.tabId]).toEqual(
+      admitted.terminalLayoutsByTabId[binding.tabId]
+    )
+    expect(reloadedSession.terminalTopologyRevisionByRepoId?.repo).toBe(5)
+  })
+
+  it('seeds global and target terminal selection when a fresh binding has none', async () => {
+    const store = await createStore()
+    const targetWorktreeId = 'repo::/background'
+
+    store.persistPtyBinding({
+      worktreeId: targetWorktreeId,
+      tabId: 'fresh-tab',
+      leafId: TEST_LEAF_1,
+      ptyId: 'fresh-pty'
+    })
+
+    const session = store.getWorkspaceSession()
+    expect(session.activeWorktreeId).toBe(targetWorktreeId)
+    expect(session.activeTabId).toBe('fresh-tab')
+    expect(session.activeTabIdByWorktree?.[targetWorktreeId]).toBe('fresh-tab')
+  })
+
   it('promotes an empty tab layout to a durable UUID root when persisting the first PTY binding', async () => {
     const store = await createStore()
     store.setWorkspaceSession({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -6327,7 +6327,8 @@ export class Store {
       tab.ptyId = args.ptyId
     } else {
       terminalMembershipChanged = true
-      // Why: pty:spawn can beat the debounced writer; persist a minimal tab so hydration won't prune the binding as orphaned.
+      // Why: pty:spawn can beat the renderer's debounced writer; main sync-persists only
+      // legacy backing/binding/layout so hydration cannot prune it, while renderer alone owns projection.
       const nextTabs = [
         ...(tabs ?? []),
         createMinimalPersistedTerminalTab({

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1285,7 +1285,6 @@ function App(): React.JSX.Element {
         const state = useAppStore.getState()
         // Why: route each host's worktree-scoped slice to its own partition; return the local write so the remote-workspace upload chain below keeps its ordering.
         const localWrite = patchWorkspaceSessionByHost(window.api.session, patch, state)
-        void localWrite
         const hydratedTargetIds = Array.from(state.remoteWorkspaceHydratedTargetIds).filter(
           (targetId) => state.remoteWorkspaceSyncStatusByTargetId[targetId]?.phase !== 'conflict'
         )
@@ -1307,6 +1306,7 @@ function App(): React.JSX.Element {
               }
             })
         }
+        return localWrite
       }
     })
   }, [])

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -123,6 +123,7 @@ import {
   shouldPersistWorkspaceSession
 } from './lib/workspace-session'
 import { createSessionWriteSubscriber } from './lib/session-write-subscriber'
+import { repairLiveTerminalTabProjections } from './lib/terminal-tab-projection-repair'
 import { buildActiveViewUnloadPatch } from './lib/active-view-persist'
 import {
   buildWorkspaceSessionHostSnapshots,
@@ -1081,6 +1082,41 @@ function App(): React.JSX.Element {
           await timeRendererStartupStep('recover-legacy-worker-terminals-post-reconnect', () =>
             window.api.app.recoverLegacyWorkerTerminalsForRendererStartup()
           )
+          try {
+            const projectionRepair = await timeRendererStartupStep(
+              'repair-live-terminal-tab-projections',
+              () =>
+                repairLiveTerminalTabProjections({
+                  store: useAppStore,
+                  hasPty: (ptyId) => window.api.pty.hasPty(ptyId),
+                  signal: abortController.signal
+                })
+            )
+            const livenessAttemptCount =
+              projectionRepair.probedPtyCount + projectionRepair.deadlineSuppressedPtyCount
+            const inconclusiveProbeCount =
+              projectionRepair.unknownPtyCount +
+              projectionRepair.probeFailureCount +
+              projectionRepair.timedOutPtyCount +
+              projectionRepair.deadlineSuppressedPtyCount
+            if (livenessAttemptCount > 0 && inconclusiveProbeCount === livenessAttemptCount) {
+              console.error(
+                '[startup] Every live terminal projection liveness probe was inconclusive:',
+                projectionRepair
+              )
+            }
+            if (
+              projectionRepair.ready === false ||
+              projectionRepair.repairedTabCount > 0 ||
+              projectionRepair.unchangedTabCount > 0 ||
+              projectionRepair.skippedTabCount > 0
+            ) {
+              logRendererStartupDiagnostic('live-terminal-tab-projection-repair', projectionRepair)
+            }
+          } catch (error) {
+            // Why: projection chrome is recoverable on the next reveal/startup; never turn a live PTY restore into degraded no-save mode.
+            console.error('[startup] Live terminal tab projection repair failed:', error)
+          }
           syncZoomCSSVar()
           // Why (issue #1158): unlock the session writer only after hydration and all dependent steps succeeded, so a mid-startup throw can't serialize partially-mutated state to disk.
           actions.setHydrationSucceeded(true)

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -132,26 +132,58 @@ describe('renderer startup runtime routing', () => {
     )
   })
 
-  it('waits for first-window startup services before terminal reconnect', () => {
+  it('waits for startup services and reconnect before repairing terminal projections', () => {
     const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
-    const servicesIndex = source.indexOf('await window.api.app.awaitFirstWindowStartupServices()')
+    const servicesIndex = source.indexOf("'first-window-services-await'")
     const preReconnectRecoveryIndex = source.indexOf(
-      'window.api.app.recoverLegacyWorkerTerminalsForRendererStartup()',
+      "'recover-legacy-worker-terminals-pre-reconnect'",
       servicesIndex
     )
-    const reconnectIndex = source.indexOf(
-      'actions.reconnectPersistedTerminals(abortController.signal)',
-      preReconnectRecoveryIndex
-    )
+    const reconnectIndex = source.indexOf("'reconnect-terminals'", preReconnectRecoveryIndex)
     const postReconnectRecoveryIndex = source.indexOf(
-      'window.api.app.recoverLegacyWorkerTerminalsForRendererStartup()',
+      "'recover-legacy-worker-terminals-post-reconnect'",
       reconnectIndex
+    )
+    const projectionRepairIndex = source.indexOf("'repair-live-terminal-tab-projections'")
+    const hydrationSuccessIndex = source.indexOf(
+      'actions.setHydrationSucceeded(true)',
+      projectionRepairIndex
+    )
+    const localFailureIndex = source.indexOf(
+      '[startup] Live terminal tab projection repair failed:',
+      projectionRepairIndex
     )
 
     expect(servicesIndex).toBeGreaterThanOrEqual(0)
     expect(preReconnectRecoveryIndex).toBeGreaterThan(servicesIndex)
     expect(reconnectIndex).toBeGreaterThan(preReconnectRecoveryIndex)
     expect(postReconnectRecoveryIndex).toBeGreaterThan(reconnectIndex)
+    expect(projectionRepairIndex).toBeGreaterThan(postReconnectRecoveryIndex)
+    expect(localFailureIndex).toBeGreaterThan(projectionRepairIndex)
+    expect(localFailureIndex).toBeLessThan(hydrationSuccessIndex)
+    expect(projectionRepairIndex).toBeLessThan(hydrationSuccessIndex)
+    expect(source.slice(servicesIndex, preReconnectRecoveryIndex)).toContain(
+      'window.api.app.awaitFirstWindowStartupServices()'
+    )
+    expect(source.slice(preReconnectRecoveryIndex, reconnectIndex)).toContain(
+      'window.api.app.recoverLegacyWorkerTerminalsForRendererStartup()'
+    )
+    expect(source.slice(reconnectIndex, postReconnectRecoveryIndex)).toContain(
+      'actions.reconnectPersistedTerminals(abortController.signal)'
+    )
+    expect(source.slice(postReconnectRecoveryIndex, projectionRepairIndex)).toContain(
+      'window.api.app.recoverLegacyWorkerTerminalsForRendererStartup()'
+    )
+    const repairBlock = source.slice(projectionRepairIndex, hydrationSuccessIndex)
+    expect(repairBlock).toContain('signal: abortController.signal')
+    expect(repairBlock).toContain('window.api.pty.hasPty(')
+    expect(repairBlock).toContain('repairLiveTerminalTabProjections({')
+    expect(repairBlock).toContain('store: useAppStore')
+    expect(repairBlock).toContain('projectionRepair.deadlineSuppressedPtyCount')
+    expect(repairBlock).toContain('projectionRepair.unchangedTabCount > 0')
+    expect(repairBlock).not.toContain('reconcileWorktreeTabModel')
+    expect(repairBlock).not.toContain('setActiveWorktree')
+    expect(repairBlock).not.toContain('activeWorktreeId')
   })
 
   it('keeps the persisted Automations view from starting its own bootstrap worktree scan', () => {

--- a/src/renderer/src/hooks/ipc-events-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-test-harness.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import type * as ReactModule from 'react'
 import type { TerminalPaneLayoutNode } from '../../../shared/types'
+import type { EnsureTerminalTabProjectionResult } from '@/store/slices/terminal-tab-projection'
 
 export type CreateTerminalRequest = {
   requestId?: string
@@ -44,6 +45,13 @@ export function createHarnessStoreState(
 ): HarnessStoreState {
   const state: HarnessStoreState = {
     createTab: vi.fn(() => ({ id: 'tab-minted' })),
+    ensureTerminalTabProjection: vi.fn(
+      (_worktreeId: string, tabId: string): EnsureTerminalTabProjectionResult => ({
+        status: 'unchanged',
+        tabId,
+        groupId: 'group-existing'
+      })
+    ),
     setActiveView: vi.fn(),
     setActiveWorktree: vi.fn(),
     markWorktreeVisited: vi.fn(),

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -25,6 +25,7 @@ import {
   FLOATING_WORKSPACE_GUEST_CLOSE_EVENT,
   FLOATING_WORKSPACE_GUEST_SELECT_INDEX_EVENT
 } from '@/lib/floating-workspace-guest-bridge'
+import type { EnsureTerminalTabProjectionResult } from '@/store/slices/terminal-tab-projection'
 
 const { closeTerminalTabMock } = vi.hoisted(() => ({
   closeTerminalTabMock: vi.fn()
@@ -1798,6 +1799,15 @@ describe('useIpcEvents updater integration', () => {
         id: options?.id ?? 'tab-new'
       })
     )
+    const ensureTerminalTabProjection = vi.fn(
+      (_worktreeId: string, tabId: string): EnsureTerminalTabProjectionResult => ({
+        status: 'repaired',
+        tabId,
+        groupId: 'group-1',
+        removedProjectionCount: 0,
+        removedOrderOccurrenceCount: 0
+      })
+    )
     const setActiveView = vi.fn()
     const setActiveWorktree = vi.fn()
     const markWorktreeVisited = vi.fn()
@@ -1825,6 +1835,7 @@ describe('useIpcEvents updater integration', () => {
     const storeState = {
       setUpdateStatus: vi.fn(),
       createTab,
+      ensureTerminalTabProjection,
       setActiveView,
       setActiveWorktree,
       markWorktreeVisited,
@@ -2854,6 +2865,7 @@ describe('useIpcEvents updater integration', () => {
     focusRuntimeTerminalSurface.mockClear()
     focusTerminalTabSurface.mockClear()
     replyTerminalCreate.mockClear()
+    ensureTerminalTabProjection.mockClear()
     createTerminalListenerRef.current({
       requestId: 'req-adopt-pending',
       worktreeId: 'wt-2',
@@ -2875,6 +2887,13 @@ describe('useIpcEvents updater integration', () => {
         [pendingLeafId]: 'serve-cf39bedb-a33a-417c-9ab6-f304dc27a6c0'
       }
     })
+    expect(ensureTerminalTabProjection).toHaveBeenCalledWith('wt-2', pendingTabId)
+    expect(setTabLayout.mock.invocationCallOrder[0]).toBeLessThan(
+      ensureTerminalTabProjection.mock.invocationCallOrder[0]
+    )
+    expect(ensureTerminalTabProjection.mock.invocationCallOrder[0]).toBeLessThan(
+      replyTerminalCreate.mock.invocationCallOrder[0]
+    )
     expect(setActiveTab).not.toHaveBeenCalled()
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith('wt-2')
     expect(focusRuntimeTerminalSurface).toHaveBeenCalledWith(pendingTabId, pendingLeafId)
@@ -2890,6 +2909,66 @@ describe('useIpcEvents updater integration', () => {
         ptyId: 'serve-cf39bedb-a33a-417c-9ab6-f304dc27a6c0'
       }
     })
+    const projectionError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ensureTerminalTabProjection.mockImplementationOnce(() => ({
+      status: 'skipped',
+      tabId: pendingTabId,
+      reason: 'duplicate-backing-tab'
+    }))
+    replyTerminalCreate.mockClear()
+    createTerminalListenerRef.current({
+      requestId: 'req-projection-skipped',
+      worktreeId: 'wt-2',
+      ptyId: 'serve-cf39bedb-a33a-417c-9ab6-f304dc27a6c0',
+      tabId: pendingTabId,
+      leafId: pendingLeafId
+    })
+    expect(projectionError).toHaveBeenCalledWith(
+      '[onCreateTerminal] Terminal projection repair skipped',
+      expect.objectContaining({
+        worktreeId: 'wt-2',
+        tabId: pendingTabId,
+        reason: 'duplicate-backing-tab'
+      })
+    )
+    expect(replyTerminalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req-projection-skipped',
+        tabId: pendingTabId,
+        title: 'Terminal 3'
+      })
+    )
+    expect(replyTerminalCreate).toHaveBeenCalledTimes(1)
+
+    projectionError.mockClear()
+    ensureTerminalTabProjection.mockImplementationOnce(() => {
+      throw new Error('projection unavailable')
+    })
+    replyTerminalCreate.mockClear()
+    createTerminalListenerRef.current({
+      requestId: 'req-projection-diagnostic',
+      worktreeId: 'wt-2',
+      ptyId: 'serve-cf39bedb-a33a-417c-9ab6-f304dc27a6c0',
+      tabId: pendingTabId,
+      leafId: pendingLeafId
+    })
+    expect(replyTerminalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'req-projection-diagnostic',
+        tabId: pendingTabId,
+        title: 'Terminal 3'
+      })
+    )
+    expect(replyTerminalCreate).toHaveBeenCalledTimes(1)
+    expect(projectionError).toHaveBeenCalledWith(
+      '[onCreateTerminal] Terminal projection repair failed',
+      expect.objectContaining({
+        worktreeId: 'wt-2',
+        tabId: pendingTabId,
+        error: 'projection unavailable'
+      })
+    )
+    projectionError.mockRestore()
 
     storeState.tabsByWorktree = {
       'wt-2': [{ id: 'tab-existing', ptyId: 'pty-bg', title: 'Terminal 1' }]

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1577,6 +1577,23 @@ export function useIpcEvents(): void {
                 }
               }
             }
+            try {
+              const projectionResult = store.ensureTerminalTabProjection(worktreeId, tab.id)
+              if (projectionResult.status === 'skipped') {
+                console.error('[onCreateTerminal] Terminal projection repair skipped', {
+                  worktreeId,
+                  tabId: tab.id,
+                  reason: projectionResult.reason
+                })
+              }
+            } catch (error) {
+              // Why: the PTY is already host-bound; optional chrome repair must not turn a successful CLI spawn into an error reply.
+              console.error('[onCreateTerminal] Terminal projection repair failed', {
+                worktreeId,
+                tabId: tab.id,
+                error: error instanceof Error ? error.message : 'unknown'
+              })
+            }
             if (command) {
               store.queueTabStartupCommand(tab.id, {
                 command,

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -69,6 +69,7 @@ describe('createSessionWriteSubscriber', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
     useAppStore.setState(initialState, true)
   })
@@ -542,6 +543,159 @@ describe('createSessionWriteSubscriber', () => {
     expect(persist.mock.calls[0][0].patch.activeTabId).toBe('tab-1')
     cleanup()
   })
+  it('flushes retained fields when suppression lifts without another store notification', async () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let shouldSchedule = false
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule,
+      debounceMs: 100
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'self-scheduled-tab'
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('self-scheduled-tab')
+    cleanup()
+  })
+
+  it('restores the captured batch and retries after a synchronous persist failure', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const persist = vi
+      .fn<(payload: WorkspaceSessionWrite) => void>()
+      .mockImplementationOnce(() => {
+        throw new Error('disk unavailable')
+      })
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      debounceMs: 100
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'sync-retry-tab'
+    })
+    vi.advanceTimersByTime(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1_000)
+
+    expect(persist).toHaveBeenCalledTimes(2)
+    expect(persist.mock.calls[1][0].patch.activeTabId).toBe('sync-retry-tab')
+    expect(consoleError).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('restores the captured batch and retries after an async persist rejection', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const persist = vi
+      .fn<(payload: WorkspaceSessionWrite) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('ipc unavailable'))
+      .mockResolvedValue(undefined)
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      debounceMs: 100
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'async-retry-tab'
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(persist).toHaveBeenCalledTimes(2)
+    expect(persist.mock.calls[1][0].patch.activeTabId).toBe('async-retry-tab')
+    expect(consoleError).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
+
+  it('does not retry or report an async rejection after cleanup', async () => {
+    let rejectPersist!: (reason?: unknown) => void
+    const persist = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectPersist = reject
+        })
+    )
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      debounceMs: 100
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'disposed-retry-tab'
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    rejectPersist(new Error('late rejection'))
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('unions fresh changes into a failed in-flight batch without delaying their timer', async () => {
+    let rejectFirstPersist!: (reason?: unknown) => void
+    const firstPersist = new Promise<void>((_resolve, reject) => {
+      rejectFirstPersist = reject
+    })
+    const persist = vi
+      .fn<(payload: WorkspaceSessionWrite) => Promise<void>>()
+      .mockImplementationOnce(() => firstPersist)
+      .mockResolvedValue(undefined)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      debounceMs: 100
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'in-flight-tab'
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    useAppStore.setState({ activeRepoId: 'repo-during-write' })
+    rejectFirstPersist(new Error('first write failed'))
+    await vi.advanceTimersByTimeAsync(99)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(persist).toHaveBeenCalledTimes(2)
+    expect(persist.mock.calls[1][0].patch).toMatchObject({
+      activeTabId: 'in-flight-tab',
+      activeRepoId: 'repo-during-write'
+    })
+    expect(consoleError).toHaveBeenCalledTimes(1)
+    cleanup()
+  })
 
   it('persists a coherent projection bundle after the first eligible write is dropped', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
@@ -703,13 +857,13 @@ describe('createSessionWriteSubscriber', () => {
     vi.advanceTimersByTime(200)
     shouldSchedule = true
     useAppStore.getState().setCacheTimerStartedAt('pending-replay', 1)
-    vi.advanceTimersByTime(100)
+    vi.advanceTimersByTime(50)
 
     useAppStore.setState({ activeTabId: 'new-relevant-tab' })
-    vi.advanceTimersByTime(60)
+    vi.advanceTimersByTime(149)
     expect(persist).not.toHaveBeenCalled()
 
-    vi.advanceTimersByTime(100)
+    vi.advanceTimersByTime(1)
     expect(persist).toHaveBeenCalledTimes(1)
     expect(persist.mock.calls[0][0].patch.activeTabId).toBe('new-relevant-tab')
     cleanup()

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -521,7 +521,7 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
-  it('updates its baseline without scheduling when shouldSchedulePersist returns false', () => {
+  it('retains its baseline while scheduling is suppressed', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = false
     const cleanup = createSessionWriteSubscriber({
@@ -537,11 +537,76 @@ describe('createSessionWriteSubscriber', () => {
     shouldSchedule = true
     useAppStore.setState({ activeTabId: 'tab-1' })
     vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('tab-1')
+    cleanup()
+  })
+
+  it('persists a coherent projection bundle after the first eligible write is dropped', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let shouldSchedule = false
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: false,
+      ...makeTerminalSessionState('Terminal 1')
+    })
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({ hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    useAppStore.getState().setCacheTimerStartedAt('projection-replay', 1)
+    vi.advanceTimersByTime(100)
+    useAppStore.getState().setCacheTimerStartedAt('projection-replay', 2)
+    vi.advanceTimersByTime(60)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    const patch = persist.mock.calls[0][0].patch
+    expect(patch).toEqual(
+      expect.objectContaining({
+        unifiedTabs: expect.objectContaining({ 'wt-1': expect.any(Array) }),
+        tabGroups: expect.objectContaining({ 'wt-1': expect.any(Array) }),
+        tabGroupLayouts: expect.objectContaining({ 'wt-1': expect.any(Object) }),
+        activeGroupIdByWorktree: expect.objectContaining({ 'wt-1': 'group-1' })
+      })
+    )
+    expect(patch.unifiedTabs).toBeDefined()
+    expect(patch.tabGroups).toBeDefined()
+    expect(patch.tabGroupLayouts).toBeDefined()
+    expect(patch.activeGroupIdByWorktree).toBeDefined()
+    const persistedTab = patch.unifiedTabs!['wt-1'][0]
+    const persistedGroup = patch.tabGroups!['wt-1'][0]
+    expect(persistedTab).toMatchObject({
+      id: 'tab-1',
+      entityId: 'tab-1',
+      groupId: 'group-1',
+      label: 'Terminal 1'
+    })
+    expect(persistedGroup).toMatchObject({
+      id: 'group-1',
+      activeTabId: 'tab-1',
+      tabOrder: ['tab-1']
+    })
+    expect(patch.tabGroupLayouts!['wt-1']).toEqual({
+      type: 'leaf',
+      groupId: persistedGroup.id
+    })
+    expect(patch.activeGroupIdByWorktree!['wt-1']).toBe(persistedGroup.id)
+
+    useAppStore.getState().setCacheTimerStartedAt('projection-replay', 3)
+    vi.advanceTimersByTime(200)
     expect(persist).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
-  it('cancels a pending debounce when shouldSchedulePersist returns false', () => {
+  it('retains pending fields when suppression cancels an armed debounce', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = true
     const cleanup = createSessionWriteSubscriber({
@@ -550,17 +615,54 @@ describe('createSessionWriteSubscriber', () => {
       shouldSchedulePersist: () => shouldSchedule
     })
 
-    useAppStore.setState({ workspaceSessionReady: true })
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
     vi.advanceTimersByTime(50)
     shouldSchedule = false
     useAppStore.setState({ activeTabId: 'remote-tab' })
     vi.advanceTimersByTime(200)
-
     expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    useAppStore.getState().setCacheTimerStartedAt('cancelled-debounce-replay', 1)
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('remote-tab')
+    cleanup()
+  })
+  it('unions distinct relevant fields across one suppression window', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let shouldSchedule = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    shouldSchedule = false
+    useAppStore.setState({ activeRepoId: 'repo-during-suppression' })
+    vi.advanceTimersByTime(200)
+    useAppStore.setState({ activeWorktreeId: 'worktree-during-suppression' })
+    vi.advanceTimersByTime(200)
+    expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    useAppStore.getState().setCacheTimerStartedAt('union-replay', 1)
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch).toMatchObject({
+      activeRepoId: 'repo-during-suppression',
+      activeWorktreeId: 'worktree-during-suppression'
+    })
     cleanup()
   })
 
-  it('re-checks shouldSchedulePersist when a pending debounce fires', () => {
+  it('retains pending fields when suppression begins as the debounce fires', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = true
     const cleanup = createSessionWriteSubscriber({
@@ -577,8 +679,39 @@ describe('createSessionWriteSubscriber', () => {
     vi.advanceTimersByTime(50)
     shouldSchedule = false
     vi.advanceTimersByTime(200)
-
     expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    useAppStore.getState().setCacheTimerStartedAt('expired-debounce-replay', 1)
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeWorktreeId).toBe('wt-before-remote-pull')
+    cleanup()
+  })
+
+  it('restarts a pending replay debounce only for a new relevant change', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let shouldSchedule = false
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+    shouldSchedule = true
+    useAppStore.getState().setCacheTimerStartedAt('pending-replay', 1)
+    vi.advanceTimersByTime(100)
+
+    useAppStore.setState({ activeTabId: 'new-relevant-tab' })
+    vi.advanceTimersByTime(60)
+    expect(persist).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('new-relevant-tab')
     cleanup()
   })
 

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -100,16 +100,26 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
-  it('re-checks the hydration gate when a pending debounce fires', () => {
+  it('retains a pending batch while the hydration gate closes and reopens', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
 
-    useAppStore.setState({ workspaceSessionReady: true, hydrationSucceeded: true })
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'retained-through-gate'
+    })
     vi.advanceTimersByTime(50)
     useAppStore.setState({ hydrationSucceeded: false })
     vi.advanceTimersByTime(200)
 
     expect(persist).not.toHaveBeenCalled()
+
+    useAppStore.setState({ hydrationSucceeded: true })
+    vi.advanceTimersByTime(200)
+
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.activeTabId).toBe('retained-through-gate')
     cleanup()
   })
 
@@ -626,6 +636,43 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
+  it('serializes an in-flight write before flushing newer pending state', async () => {
+    let resolveFirstPersist!: () => void
+    const firstPersist = new Promise<void>((resolve) => {
+      resolveFirstPersist = resolve
+    })
+    const persist = vi
+      .fn<(payload: WorkspaceSessionWrite) => Promise<void>>()
+      .mockImplementationOnce(() => firstPersist)
+      .mockResolvedValue(undefined)
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      debounceMs: 100
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      activeTabId: 'first-write-tab'
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    useAppStore.setState({ activeRepoId: 'repo-after-first-write' })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    resolveFirstPersist()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(persist).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(persist).toHaveBeenCalledTimes(2)
+    expect(persist.mock.calls[1][0].patch.activeRepoId).toBe('repo-after-first-write')
+    cleanup()
+  })
   it('does not retry or report an async rejection after cleanup', async () => {
     let rejectPersist!: (reason?: unknown) => void
     const persist = vi.fn(

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -165,6 +165,7 @@ export function createSessionWriteSubscriber({
   let timer: ReturnType<typeof setTimeout> | null = null
   let disposed = false
   let persistFailureReported = false
+  let persistInFlight = false
   // Why: the subscriber fires on every store update (agent status, usage
   // refreshes, runtime title ticks, …). Without this gate each fire reset
   // the debounce, and when it finally expired buildWorkspaceSessionPayload
@@ -223,7 +224,8 @@ export function createSessionWriteSubscriber({
     // stale values for that field.
     const fresh = store.getState()
     if (!shouldPersistWorkspaceSession(fresh)) {
-      pendingChangedFields.clear()
+      // Why: readiness/hydration reopening is itself a store update. Keep the
+      // observed batch so that update can schedule one fresh write.
       return
     }
     if (shouldSchedulePersist && !shouldSchedulePersist()) {
@@ -231,6 +233,11 @@ export function createSessionWriteSubscriber({
       // the gate with one owned timer guarantees the retained batch eventually
       // flushes after suppression lifts instead of depending on incidental UI work.
       scheduleFlush(suppressionRetryMs, false)
+      return
+    }
+    if (persistInFlight) {
+      // Why: IPC patch promises can settle out of order. Completion owns scheduling
+      // the next fresh batch so session partition writes stay serialized.
       return
     }
 
@@ -246,19 +253,30 @@ export function createSessionWriteSubscriber({
       pendingChangedFields.delete(field)
     }
 
+    persistInFlight = true
     let result: void | Promise<void>
     try {
       result = persist({ patch })
     } catch (error) {
+      persistInFlight = false
       // Why: synchronous adapters and async IPC writes share the same retry contract.
       restoreFailedBatch(changed, error)
       return
     }
-    void Promise.resolve(result).then(
+    if (result === undefined) {
+      persistInFlight = false
+      persistFailureReported = false
+      scheduleFlush(debounceMs, false)
+      return
+    }
+    void result.then(
       () => {
+        persistInFlight = false
         persistFailureReported = false
+        scheduleFlush(debounceMs, false)
       },
       (error) => {
+        persistInFlight = false
         // Why: the local IPC write owns durability. Restore the exact captured batch
         // on rejection so a transient failure cannot silently acknowledge lost state.
         restoreFailedBatch(changed, error)

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -145,7 +145,7 @@ export type SessionWriteSubscriberDeps = {
     subscribe: (listener: (state: AppState) => void) => () => void
     getState: () => AppState
   }
-  persist: (payload: WorkspaceSessionWrite) => void
+  persist: (payload: WorkspaceSessionWrite) => void | Promise<void>
   shouldSchedulePersist?: () => boolean
   debounceMs?: number
 }
@@ -163,6 +163,8 @@ export function createSessionWriteSubscriber({
   debounceMs = 150
 }: SessionWriteSubscriberDeps): () => void {
   let timer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+  let persistFailureReported = false
   // Why: the subscriber fires on every store update (agent status, usage
   // refreshes, runtime title ticks, …). Without this gate each fire reset
   // the debounce, and when it finally expired buildWorkspaceSessionPayload
@@ -172,6 +174,97 @@ export function createSessionWriteSubscriber({
   // sentinel guarantees the very first fire always proceeds.
   let prev: Record<string, unknown> | null = null
   const pendingChangedFields = new Set<SessionRelevantField>()
+  const suppressionRetryMs = Math.max(debounceMs, 50)
+  const persistFailureRetryMs = Math.max(debounceMs, 1_000)
+
+  function scheduleFlush(delayMs: number, resetTimer: boolean): void {
+    if (disposed || pendingChangedFields.size === 0) {
+      return
+    }
+    if (timer !== null) {
+      if (!resetTimer) {
+        return
+      }
+      clearTimeout(timer)
+    }
+    timer = setTimeout(flushPending, delayMs)
+  }
+
+  function restoreFailedBatch(
+    changed: ReadonlySet<SessionRelevantField>,
+    error: unknown
+  ): void {
+    if (disposed) {
+      return
+    }
+    if (!persistFailureReported) {
+      persistFailureReported = true
+      console.error('[session] Workspace session write failed; retrying:', error)
+    }
+    for (const field of changed) {
+      pendingChangedFields.add(field)
+    }
+    scheduleFlush(persistFailureRetryMs, false)
+  }
+
+  function flushPending(): void {
+    timer = null
+    if (disposed || pendingChangedFields.size === 0) {
+      return
+    }
+
+    // Why: rebuild from the freshest store state rather than the snapshot
+    // captured when this timer was scheduled. Today this is equivalent
+    // because buildWorkspaceSessionPayload reads only SESSION_RELEVANT_FIELDS
+    // (the same fields gating the timer reset), so the captured `state` is
+    // already current for those fields. Calling getState() guards against a
+    // future refactor that adds a non-relevant field read to the payload
+    // builder — without this, such a change would silently start emitting
+    // stale values for that field.
+    const fresh = store.getState()
+    if (!shouldPersistWorkspaceSession(fresh)) {
+      pendingChangedFields.clear()
+      return
+    }
+    if (shouldSchedulePersist && !shouldSchedulePersist()) {
+      // Why: remote-session apply can end without another Zustand update. Polling
+      // the gate with one owned timer guarantees the retained batch eventually
+      // flushes after suppression lifts instead of depending on incidental UI work.
+      scheduleFlush(suppressionRetryMs, false)
+      return
+    }
+
+    const changed = new Set(pendingChangedFields)
+    const patch = buildWorkspaceSessionPatch(fresh, changed)
+    if (Object.keys(patch).length === 0) {
+      for (const field of changed) {
+        pendingChangedFields.delete(field)
+      }
+      return
+    }
+    for (const field of changed) {
+      pendingChangedFields.delete(field)
+    }
+
+    let result: void | Promise<void>
+    try {
+      result = persist({ patch })
+    } catch (error) {
+      // Why: synchronous adapters and async IPC writes share the same retry contract.
+      restoreFailedBatch(changed, error)
+      return
+    }
+    void Promise.resolve(result).then(
+      () => {
+        persistFailureReported = false
+      },
+      (error) => {
+        // Why: the local IPC write owns durability. Restore the exact captured batch
+        // on rejection so a transient failure cannot silently acknowledge lost state.
+        restoreFailedBatch(changed, error)
+      }
+    )
+  }
 
   const unsub = store.subscribe((state) => {
     if (!shouldPersistWorkspaceSession(state)) {
@@ -203,65 +296,18 @@ export function createSessionWriteSubscriber({
     }
 
     if (shouldSchedulePersist && !shouldSchedulePersist()) {
-      if (timer !== null) {
-        clearTimeout(timer)
-        timer = null
-      }
-      // Why: remote-session apply suppresses scheduling temporarily; retaining the field set
-      // lets the next eligible store fire persist the coherent state without replaying mutations.
+      scheduleFlush(suppressionRetryMs, false)
       return
     }
-    if (timer !== null) {
-      if (!hasNewRelevantChanges) {
-        return
-      }
-      clearTimeout(timer)
-    }
-    timer = setTimeout(() => {
-      timer = null
-      // Why: rebuild from the freshest store state rather than the snapshot
-      // captured when this timer was scheduled. Today this is equivalent
-      // because buildWorkspaceSessionPayload reads only SESSION_RELEVANT_FIELDS
-      // (the same fields gating the timer reset), so the captured `state` is
-      // already current for those fields. Calling getState() guards against a
-      // future refactor that adds a non-relevant field read to the payload
-      // builder — without this, such a change would silently start emitting
-      // stale values for that field.
-      const fresh = store.getState()
-      if (!shouldPersistWorkspaceSession(fresh)) {
-        pendingChangedFields.clear()
-        return
-      }
-      if (shouldSchedulePersist && !shouldSchedulePersist()) {
-        // Why: the suppression window can outlive the debounce; keep pending work so a
-        // later unrelated store fire can arm one fresh timer without losing the change.
-        return
-      }
-      const changed = new Set(pendingChangedFields)
-      const patch = buildWorkspaceSessionPatch(fresh, changed)
-      if (Object.keys(patch).length === 0) {
-        pendingChangedFields.clear()
-        return
-      }
-      for (const field of changed) {
-        pendingChangedFields.delete(field)
-      }
-      try {
-        persist({ patch })
-      } catch (error) {
-        // Why: a synchronous persist failure must leave this exact field batch retryable.
-        for (const field of changed) {
-          pendingChangedFields.add(field)
-        }
-        throw error
-      }
-    }, debounceMs)
+    scheduleFlush(debounceMs, hasNewRelevantChanges)
   })
 
   return () => {
+    disposed = true
     unsub()
     if (timer !== null) {
       clearTimeout(timer)
+      timer = null
     }
     pendingChangedFields.clear()
   }

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -187,26 +187,34 @@ export function createSessionWriteSubscriber({
         }
       }
     }
-    if (changedFields.length === 0) {
+    const hasNewRelevantChanges = changedFields.length > 0
+    if (!hasNewRelevantChanges && pendingChangedFields.size === 0) {
       return
     }
-    const next: Record<string, unknown> = {}
-    for (const key of SESSION_RELEVANT_FIELDS) {
-      next[key] = state[key]
+    if (hasNewRelevantChanges) {
+      const next: Record<string, unknown> = {}
+      for (const key of SESSION_RELEVANT_FIELDS) {
+        next[key] = state[key]
+      }
+      prev = next
+      for (const field of changedFields) {
+        pendingChangedFields.add(field)
+      }
     }
-    prev = next
-    for (const field of changedFields) {
-      pendingChangedFields.add(field)
-    }
+
     if (shouldSchedulePersist && !shouldSchedulePersist()) {
       if (timer !== null) {
         clearTimeout(timer)
         timer = null
       }
-      pendingChangedFields.clear()
+      // Why: remote-session apply suppresses scheduling temporarily; retaining the field set
+      // lets the next eligible store fire persist the coherent state without replaying mutations.
       return
     }
     if (timer !== null) {
+      if (!hasNewRelevantChanges) {
+        return
+      }
       clearTimeout(timer)
     }
     timer = setTimeout(() => {
@@ -225,16 +233,28 @@ export function createSessionWriteSubscriber({
         return
       }
       if (shouldSchedulePersist && !shouldSchedulePersist()) {
-        pendingChangedFields.clear()
+        // Why: the suppression window can outlive the debounce; keep pending work so a
+        // later unrelated store fire can arm one fresh timer without losing the change.
         return
       }
       const changed = new Set(pendingChangedFields)
-      pendingChangedFields.clear()
       const patch = buildWorkspaceSessionPatch(fresh, changed)
       if (Object.keys(patch).length === 0) {
+        pendingChangedFields.clear()
         return
       }
-      persist({ patch })
+      for (const field of changed) {
+        pendingChangedFields.delete(field)
+      }
+      try {
+        persist({ patch })
+      } catch (error) {
+        // Why: a synchronous persist failure must leave this exact field batch retryable.
+        for (const field of changed) {
+          pendingChangedFields.add(field)
+        }
+        throw error
+      }
     }, debounceMs)
   })
 

--- a/src/renderer/src/lib/terminal-tab-projection-repair.test.ts
+++ b/src/renderer/src/lib/terminal-tab-projection-repair.test.ts
@@ -1,0 +1,515 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup, TerminalTab } from '../../../shared/types'
+import {
+  ensureTerminalTabProjection,
+  hasTerminalTabProjectionInvariant
+} from '@/store/slices/terminal-tab-projection'
+import {
+  repairLiveTerminalTabProjections,
+  type TerminalTabProjectionRepairStore
+} from './terminal-tab-projection-repair'
+
+type RepairState = ReturnType<TerminalTabProjectionRepairStore['getState']>
+
+function makeBackingTab(worktreeId: string, id: string, ptyId: string | null): TerminalTab {
+  return {
+    id,
+    ptyId,
+    worktreeId,
+    title: `Terminal ${id}`,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    pendingActivationSpawn: true
+  }
+}
+
+function createRepairStore(overrides: Partial<RepairState> = {}): {
+  store: TerminalTabProjectionRepairStore
+  getState: () => RepairState
+  setState: (patch: Partial<RepairState>) => void
+} {
+  let state: RepairState
+  const ensure = (worktreeId: string, tabId: string, targetGroupId?: string) => {
+    const outcome = ensureTerminalTabProjection(
+      state,
+      worktreeId,
+      tabId,
+      targetGroupId,
+      () => `group-${tabId}`
+    )
+    state = { ...state, ...outcome.patch, ensureTerminalTabProjection: ensure }
+    return outcome.result
+  }
+  state = {
+    workspaceSessionReady: true,
+    tabsByWorktree: {},
+    ptyIdsByTabId: {},
+    terminalLayoutsByTabId: {},
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    layoutByWorktree: {},
+    activeTabIdByWorktree: {},
+    ensureTerminalTabProjection: ensure,
+    ...overrides
+  }
+  return {
+    store: { getState: () => state },
+    getState: () => state,
+    setState: (patch) => {
+      state = { ...state, ...patch, ensureTerminalTabProjection: ensure }
+    }
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('repairLiveTerminalTabProjections', () => {
+  it('repairs every provider-confirmed live background tab without filtering by active workspace', async () => {
+    const first = makeBackingTab('workspace-b', 'tab-b', 'pty-b')
+    const second = makeBackingTab('folder:workspace-a', 'tab-a', null)
+    const floating = makeBackingTab('__floating-terminal__', 'tab-floating', 'pty-floating')
+    const availableSsh = makeBackingTab(
+      'ssh:available:host:/repo',
+      'tab-available-ssh',
+      'pty-available-ssh'
+    )
+    const foregroundGroups = [
+      {
+        id: 'foreground-group',
+        worktreeId: 'foreground',
+        activeTabId: null,
+        tabOrder: []
+      }
+    ]
+    const harness = createRepairStore({
+      tabsByWorktree: {
+        'workspace-b': [first],
+        'folder:workspace-a': [second],
+        '__floating-terminal__': [floating],
+        'ssh:available:host:/repo': [availableSsh]
+      },
+      ptyIdsByTabId: {
+        'tab-b': ['pty-b'],
+        'tab-a': [],
+        'tab-floating': ['pty-floating'],
+        'tab-available-ssh': ['pty-available-ssh']
+      },
+      terminalLayoutsByTabId: {
+        'tab-a': {
+          root: { type: 'leaf', leafId: 'leaf-a' },
+          activeLeafId: 'leaf-a',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-a': 'pty-a-layout' }
+        }
+      },
+      groupsByWorktree: { foreground: foregroundGroups },
+      activeGroupIdByWorktree: { foreground: 'foreground-group' },
+      layoutByWorktree: {
+        foreground: { type: 'leaf', groupId: 'foreground-group' }
+      }
+    })
+    const hasPty = vi.fn(async () => true)
+
+    const summary = await repairLiveTerminalTabProjections({ store: harness.store, hasPty })
+    const state = harness.getState()
+
+    expect(summary).toMatchObject({
+      ready: true,
+      examinedTabCount: 4,
+      candidateTabCount: 4,
+      probedPtyCount: 4,
+      livePtyCount: 4,
+      confirmedLiveTabCount: 4,
+      repairedTabCount: 4,
+      skippedTabCount: 0
+    })
+    expect(hasTerminalTabProjectionInvariant(state, 'workspace-b', 'tab-b')).toBe(true)
+    expect(hasTerminalTabProjectionInvariant(state, 'folder:workspace-a', 'tab-a')).toBe(true)
+    expect(hasTerminalTabProjectionInvariant(state, '__floating-terminal__', 'tab-floating')).toBe(
+      true
+    )
+    expect(
+      hasTerminalTabProjectionInvariant(state, 'ssh:available:host:/repo', 'tab-available-ssh')
+    ).toBe(true)
+    await expect(
+      repairLiveTerminalTabProjections({ store: harness.store, hasPty })
+    ).resolves.toMatchObject({
+      examinedTabCount: 4,
+      candidateTabCount: 0,
+      probedPtyCount: 0,
+      repairedTabCount: 0,
+      skippedTabCount: 0
+    })
+    expect(hasPty).toHaveBeenCalledTimes(4)
+    expect(state.activeGroupIdByWorktree.foreground).toBe('foreground-group')
+    expect(state.groupsByWorktree.foreground).toBe(foregroundGroups)
+  })
+
+  it('deduplicates candidate ids and rechecks the binding after an async liveness probe', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-shared')
+    let resolveProbe!: (value: boolean) => void
+    const hasPty = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveProbe = resolve
+        })
+    )
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [tab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-shared', 'pty-shared'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: 'leaf' },
+          activeLeafId: 'leaf',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { leaf: 'pty-shared' }
+        }
+      }
+    })
+
+    const pending = repairLiveTerminalTabProjections({ store: harness.store, hasPty })
+    await Promise.resolve()
+    expect(hasPty).toHaveBeenCalledTimes(1)
+    harness.setState({ tabsByWorktree: { workspace: [] } })
+    resolveProbe(true)
+
+    await expect(pending).resolves.toMatchObject({
+      probedPtyCount: 1,
+      livePtyCount: 1,
+      confirmedLiveTabCount: 0,
+      repairedTabCount: 0,
+      skippedTabCount: 1
+    })
+  })
+  it('skips a backing tab rebound while its prior PTY probe is in flight', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-old')
+    let resolveProbe!: (value: boolean) => void
+    const hasPty = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveProbe = resolve
+        })
+    )
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [tab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-old'] }
+    })
+
+    const pending = repairLiveTerminalTabProjections({ store: harness.store, hasPty })
+    await Promise.resolve()
+    harness.setState({
+      tabsByWorktree: {
+        workspace: [{ ...tab, ptyId: 'pty-new' }]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-new'] }
+    })
+    resolveProbe(true)
+
+    await expect(pending).resolves.toMatchObject({
+      probedPtyCount: 1,
+      livePtyCount: 1,
+      confirmedLiveTabCount: 0,
+      repairedTabCount: 0,
+      skippedTabCount: 1
+    })
+    expect(harness.getState().unifiedTabsByWorktree.workspace).toBeUndefined()
+  })
+
+  it('fails closed for false, unknown, rejected, and timed-out probes', async () => {
+    vi.useFakeTimers()
+    const tabs = ['false', 'unknown', 'rejected', 'timeout', 'live'].map((suffix, index) => ({
+      ...makeBackingTab('workspace', `tab-${suffix}`, `pty-${suffix}`),
+      sortOrder: index
+    }))
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: tabs },
+      ptyIdsByTabId: Object.fromEntries(tabs.map((tab) => [tab.id, [tab.ptyId as string]]))
+    })
+    const hasPty = vi.fn((ptyId: string): Promise<boolean | null> => {
+      if (ptyId === 'pty-false') {
+        return Promise.resolve(false)
+      }
+      if (ptyId === 'pty-unknown') {
+        return Promise.resolve(null)
+      }
+      if (ptyId === 'pty-rejected') {
+        return Promise.reject(new Error('provider unavailable'))
+      }
+      if (ptyId === 'pty-live') {
+        return Promise.resolve(true)
+      }
+      return new Promise(() => {})
+    })
+
+    const pending = repairLiveTerminalTabProjections({
+      store: harness.store,
+      hasPty,
+      probeTimeoutMs: 20,
+      deadlineMs: 50
+    })
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(pending).resolves.toMatchObject({
+      candidateTabCount: 5,
+      probedPtyCount: 5,
+      livePtyCount: 1,
+      deadPtyCount: 1,
+      unknownPtyCount: 1,
+      probeFailureCount: 1,
+      timedOutPtyCount: 1,
+      firstProbeError: 'provider unavailable',
+      confirmedLiveTabCount: 1,
+      repairedTabCount: 1,
+      skippedTabCount: 4
+    })
+    expect(hasTerminalTabProjectionInvariant(harness.getState(), 'workspace', 'tab-live')).toBe(
+      true
+    )
+  })
+
+  it('reports deadline-suppressed probes without calling the provider', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-1')
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [tab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    const hasPty = vi.fn(async () => true)
+
+    await expect(
+      repairLiveTerminalTabProjections({
+        store: harness.store,
+        hasPty,
+        deadlineMs: 0
+      })
+    ).resolves.toMatchObject({
+      candidateTabCount: 1,
+      probedPtyCount: 0,
+      deadlineSuppressedPtyCount: 1,
+      repairedTabCount: 0,
+      skippedTabCount: 1
+    })
+    expect(hasPty).not.toHaveBeenCalled()
+  })
+  it('does not probe or mutate when startup is already aborted', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-1')
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [tab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    const hasPty = vi.fn(async () => true)
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      repairLiveTerminalTabProjections({
+        store: harness.store,
+        hasPty,
+        signal: controller.signal
+      })
+    ).resolves.toMatchObject({
+      candidateTabCount: 1,
+      probedPtyCount: 0,
+      repairedTabCount: 0,
+      skippedTabCount: 1
+    })
+    expect(hasPty).not.toHaveBeenCalled()
+    expect(harness.getState().unifiedTabsByWorktree.workspace).toBeUndefined()
+  })
+
+  it('does not mutate after an in-flight live probe is aborted', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-1')
+    let resolveProbe!: (value: boolean) => void
+    const hasPty = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveProbe = resolve
+        })
+    )
+    const ensureProjection = vi.fn((_worktreeId: string, tabId: string) => ({
+      status: 'skipped' as const,
+      tabId,
+      reason: 'missing-backing-tab' as const
+    }))
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [tab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      ensureTerminalTabProjection: ensureProjection
+    })
+    const controller = new AbortController()
+
+    const pending = repairLiveTerminalTabProjections({
+      store: harness.store,
+      hasPty,
+      signal: controller.signal
+    })
+    await Promise.resolve()
+    controller.abort()
+    resolveProbe(true)
+
+    await expect(pending).resolves.toMatchObject({
+      probedPtyCount: 1,
+      livePtyCount: 1,
+      confirmedLiveTabCount: 0,
+      repairedTabCount: 0,
+      skippedTabCount: 1
+    })
+    expect(ensureProjection).not.toHaveBeenCalled()
+    expect(harness.getState().unifiedTabsByWorktree.workspace).toBeUndefined()
+  })
+
+  it('applies pooled live-probe results in candidate order despite reversed completion', async () => {
+    const first = makeBackingTab('workspace', 'tab-1', 'pty-1')
+    const second = { ...makeBackingTab('workspace', 'tab-2', 'pty-2'), sortOrder: 1 }
+    const third = { ...makeBackingTab('workspace', 'tab-3', 'pty-3'), sortOrder: 2 }
+    const primaryGroup: TabGroup = {
+      id: 'group-primary',
+      worktreeId: 'workspace',
+      activeTabId: 'editor-1',
+      tabOrder: ['editor-1']
+    }
+    const siblingGroup: TabGroup = {
+      id: 'group-sibling',
+      worktreeId: 'workspace',
+      activeTabId: 'editor-2',
+      tabOrder: ['editor-2']
+    }
+    const primaryEditor: Tab = {
+      id: 'editor-1',
+      entityId: '/tmp/one.ts',
+      groupId: primaryGroup.id,
+      worktreeId: 'workspace',
+      contentType: 'editor',
+      label: 'one.ts',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const siblingEditor: Tab = {
+      ...primaryEditor,
+      id: 'editor-2',
+      entityId: '/tmp/two.ts',
+      groupId: siblingGroup.id,
+      label: 'two.ts',
+      sortOrder: 1,
+      createdAt: 2
+    }
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [first, second, third] },
+      ptyIdsByTabId: {
+        'tab-1': ['pty-1'],
+        'tab-2': ['pty-2'],
+        'tab-3': ['pty-3']
+      },
+      unifiedTabsByWorktree: { workspace: [primaryEditor, siblingEditor] },
+      groupsByWorktree: { workspace: [primaryGroup, siblingGroup] },
+      activeGroupIdByWorktree: { workspace: primaryGroup.id },
+      layoutByWorktree: {
+        workspace: {
+          type: 'split',
+          direction: 'horizontal',
+          ratio: 0.5,
+          first: { type: 'leaf', groupId: primaryGroup.id },
+          second: { type: 'leaf', groupId: siblingGroup.id }
+        }
+      }
+    })
+
+    // Why: with three candidates and concurrency two, pty-2 and pty-3 settle before
+    // pty-1. Projection order must still follow the collected candidate order.
+    let resolveFirstProbe!: (value: boolean) => void
+    const firstProbe = new Promise<boolean>((resolve) => {
+      resolveFirstProbe = resolve
+    })
+    let resolveThirdProbeStarted!: () => void
+    const thirdProbeStarted = new Promise<void>((resolve) => {
+      resolveThirdProbeStarted = resolve
+    })
+    const startedPtyIds: string[] = []
+    const hasPty = vi.fn((ptyId: string) => {
+      startedPtyIds.push(ptyId)
+      if (ptyId === 'pty-3') {
+        resolveThirdProbeStarted()
+      }
+      return ptyId === 'pty-1' ? firstProbe : Promise.resolve(true)
+    })
+    const pending = repairLiveTerminalTabProjections({
+      store: harness.store,
+      hasPty,
+      concurrency: 2,
+      probeTimeoutMs: 30_000,
+      deadlineMs: 30_000
+    })
+    expect(startedPtyIds).toEqual(['pty-1', 'pty-2'])
+    await thirdProbeStarted
+    expect(startedPtyIds).toEqual(['pty-1', 'pty-2', 'pty-3'])
+    resolveFirstProbe(true)
+    const summary = await pending
+    const state = harness.getState()
+    const groups = state.groupsByWorktree.workspace
+
+    expect(summary).toMatchObject({
+      examinedTabCount: 3,
+      candidateTabCount: 3,
+      livePtyCount: 3,
+      confirmedLiveTabCount: 3,
+      repairedTabCount: 3,
+      unchangedTabCount: 0,
+      skippedTabCount: 0
+    })
+    expect(groups).toHaveLength(2)
+    expect(groups[0].tabOrder).toEqual(['editor-1', 'tab-1', 'tab-2', 'tab-3'])
+    expect(hasTerminalTabProjectionInvariant(state, 'workspace', 'tab-1')).toBe(true)
+    expect(hasTerminalTabProjectionInvariant(state, 'workspace', 'tab-2')).toBe(true)
+    expect(hasTerminalTabProjectionInvariant(state, 'workspace', 'tab-3')).toBe(true)
+  })
+
+  it('retains the exact structural reason when a confirmed-live projection is skipped', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-1')
+    const ensureProjection = vi.fn((_worktreeId: string, tabId: string) => ({
+      status: 'skipped' as const,
+      tabId,
+      reason: 'duplicate-backing-tab' as const
+    }))
+    const harness = createRepairStore({
+      tabsByWorktree: { workspace: [tab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      ensureTerminalTabProjection: ensureProjection
+    })
+
+    const summary = await repairLiveTerminalTabProjections({
+      store: harness.store,
+      hasPty: vi.fn(async () => true)
+    })
+
+    expect(summary).toMatchObject({
+      candidateTabCount: 1,
+      confirmedLiveTabCount: 1,
+      repairedTabCount: 0,
+      unchangedTabCount: 0,
+      skippedTabCount: 1,
+      projectionSkipReasons: { 'duplicate-backing-tab': 1 }
+    })
+    expect(summary.repairedTabCount + summary.unchangedTabCount + summary.skippedTabCount).toBe(
+      summary.candidateTabCount
+    )
+  })
+  it('does not probe before the workspace session is ready', async () => {
+    const tab = makeBackingTab('workspace', 'tab-1', 'pty-1')
+    const harness = createRepairStore({
+      workspaceSessionReady: false,
+      tabsByWorktree: { workspace: [tab] }
+    })
+    const hasPty = vi.fn(async () => true)
+
+    await expect(
+      repairLiveTerminalTabProjections({ store: harness.store, hasPty })
+    ).resolves.toMatchObject({ ready: false, candidateTabCount: 1, skippedTabCount: 1 })
+    expect(hasPty).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/terminal-tab-projection-repair.ts
+++ b/src/renderer/src/lib/terminal-tab-projection-repair.ts
@@ -1,0 +1,277 @@
+import type { AppState } from '@/store'
+import type { TerminalTab } from '../../../shared/types'
+import { mapWithConcurrency } from '../../../shared/map-with-concurrency'
+import {
+  hasTerminalTabProjectionInvariant,
+  type EnsureTerminalTabProjectionSkipReason
+} from '@/store/slices/terminal-tab-projection'
+
+type ProjectionRepairState = Pick<
+  AppState,
+  | 'workspaceSessionReady'
+  | 'tabsByWorktree'
+  | 'ptyIdsByTabId'
+  | 'terminalLayoutsByTabId'
+  | 'unifiedTabsByWorktree'
+  | 'groupsByWorktree'
+  | 'activeGroupIdByWorktree'
+  | 'layoutByWorktree'
+  | 'activeTabIdByWorktree'
+  | 'ensureTerminalTabProjection'
+>
+
+export type TerminalTabProjectionRepairStore = {
+  getState: () => ProjectionRepairState
+}
+
+export type TerminalTabProjectionRepairSummary = {
+  ready: boolean
+  examinedTabCount: number
+  candidateTabCount: number
+  probedPtyCount: number
+  livePtyCount: number
+  deadPtyCount: number
+  unknownPtyCount: number
+  probeFailureCount: number
+  timedOutPtyCount: number
+  deadlineSuppressedPtyCount: number
+  firstProbeError: string | null
+  confirmedLiveTabCount: number
+  repairedTabCount: number
+  unchangedTabCount: number
+  skippedTabCount: number
+  projectionSkipReasons: Partial<Record<EnsureTerminalTabProjectionSkipReason, number>>
+}
+
+type RepairCandidate = {
+  worktreeId: string
+  tabId: string
+  ptyIds: string[]
+}
+
+type ProbeOutcome =
+  | { status: 'live' }
+  | { status: 'dead' }
+  | { status: 'unknown' }
+  | { status: 'error'; error: string }
+  | { status: 'timeout' }
+  | { status: 'deadline' }
+
+type RepairOptions = {
+  store: TerminalTabProjectionRepairStore
+  hasPty: (ptyId: string) => Promise<boolean | null>
+  signal?: AbortSignal
+  concurrency?: number
+  probeTimeoutMs?: number
+  deadlineMs?: number
+}
+
+const DEFAULT_CONCURRENCY = 8
+const DEFAULT_PROBE_TIMEOUT_MS = 1_000
+const DEFAULT_DEADLINE_MS = 5_000
+
+function collectCandidatePtyIds(state: ProjectionRepairState, tab: TerminalTab): string[] {
+  const ids = [
+    ...(state.ptyIdsByTabId[tab.id] ?? []),
+    tab.ptyId,
+    ...Object.values(state.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId ?? {})
+  ]
+  return [...new Set(ids.filter((id): id is string => typeof id === 'string' && id.length > 0))]
+}
+
+function collectRepairCandidates(state: ProjectionRepairState): {
+  examinedTabCount: number
+  candidates: RepairCandidate[]
+} {
+  let examinedTabCount = 0
+  const candidates: RepairCandidate[] = []
+  for (const worktreeId of Object.keys(state.tabsByWorktree).sort()) {
+    const tabs = [...(state.tabsByWorktree[worktreeId] ?? [])].sort(
+      (left, right) =>
+        left.sortOrder - right.sortOrder ||
+        left.createdAt - right.createdAt ||
+        left.id.localeCompare(right.id)
+    )
+    for (const tab of tabs) {
+      examinedTabCount += 1
+      if (hasTerminalTabProjectionInvariant(state, worktreeId, tab.id)) {
+        continue
+      }
+      candidates.push({
+        worktreeId,
+        tabId: tab.id,
+        ptyIds: collectCandidatePtyIds(state, tab)
+      })
+    }
+  }
+  return { examinedTabCount, candidates }
+}
+
+function formatProbeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function probePtyWithTimeout(
+  ptyId: string,
+  hasPty: RepairOptions['hasPty'],
+  timeoutMs: number
+): Promise<ProbeOutcome> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    let providerResult: Promise<boolean | null>
+    try {
+      providerResult = hasPty(ptyId)
+    } catch (error) {
+      return { status: 'error', error: formatProbeError(error) }
+    }
+    const providerOutcome = Promise.resolve(providerResult)
+      .then<ProbeOutcome>((result) =>
+        result === true
+          ? { status: 'live' }
+          : result === false
+            ? { status: 'dead' }
+            : { status: 'unknown' }
+      )
+      .catch<ProbeOutcome>((error) => ({ status: 'error', error: formatProbeError(error) }))
+    return await Promise.race([
+      providerOutcome,
+      new Promise<ProbeOutcome>((resolve) => {
+        timer = setTimeout(() => resolve({ status: 'timeout' }), timeoutMs)
+      })
+    ])
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer)
+    }
+  }
+}
+
+function recordProbeOutcome(
+  summary: TerminalTabProjectionRepairSummary,
+  outcome: ProbeOutcome
+): void {
+  if (outcome.status === 'live') {
+    summary.livePtyCount += 1
+  } else if (outcome.status === 'dead') {
+    summary.deadPtyCount += 1
+  } else if (outcome.status === 'unknown') {
+    summary.unknownPtyCount += 1
+  } else if (outcome.status === 'error') {
+    summary.probeFailureCount += 1
+    summary.firstProbeError ??= outcome.error
+  } else if (outcome.status === 'timeout') {
+    summary.timedOutPtyCount += 1
+  }
+}
+
+export async function repairLiveTerminalTabProjections({
+  store,
+  hasPty,
+  signal,
+  concurrency = DEFAULT_CONCURRENCY,
+  probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+  deadlineMs = DEFAULT_DEADLINE_MS
+}: RepairOptions): Promise<TerminalTabProjectionRepairSummary> {
+  const initial = store.getState()
+  const collected = collectRepairCandidates(initial)
+  const summary: TerminalTabProjectionRepairSummary = {
+    ready: initial.workspaceSessionReady,
+    examinedTabCount: collected.examinedTabCount,
+    candidateTabCount: collected.candidates.length,
+    probedPtyCount: 0,
+    livePtyCount: 0,
+    deadPtyCount: 0,
+    unknownPtyCount: 0,
+    probeFailureCount: 0,
+    timedOutPtyCount: 0,
+    deadlineSuppressedPtyCount: 0,
+    firstProbeError: null,
+    confirmedLiveTabCount: 0,
+    repairedTabCount: 0,
+    unchangedTabCount: 0,
+    skippedTabCount: 0,
+    projectionSkipReasons: {}
+  }
+  if (!initial.workspaceSessionReady || signal?.aborted) {
+    summary.skippedTabCount = collected.candidates.length
+    return summary
+  }
+
+  const deadlineAt = Date.now() + Math.max(0, deadlineMs)
+  const probeCache = new Map<string, Promise<ProbeOutcome>>()
+  const probe = (ptyId: string): Promise<ProbeOutcome> => {
+    const existing = probeCache.get(ptyId)
+    if (existing) {
+      return existing
+    }
+    const timeoutMs = Math.min(probeTimeoutMs, Math.max(0, deadlineAt - Date.now()))
+    if (timeoutMs === 0) {
+      summary.deadlineSuppressedPtyCount += 1
+      const deadline = Promise.resolve<ProbeOutcome>({ status: 'deadline' })
+      probeCache.set(ptyId, deadline)
+      return deadline
+    }
+
+    summary.probedPtyCount += 1
+    const pending = probePtyWithTimeout(ptyId, hasPty, timeoutMs).then((outcome) => {
+      recordProbeOutcome(summary, outcome)
+      return outcome
+    })
+    probeCache.set(ptyId, pending)
+    return pending
+  }
+
+  const probedCandidates = await mapWithConcurrency(
+    collected.candidates,
+    concurrency,
+    async (candidate) => {
+      if (signal?.aborted || candidate.ptyIds.length === 0) {
+        return { candidate, livePtyIds: new Set<string>() }
+      }
+      const liveness = await Promise.all(
+        candidate.ptyIds.map(async (ptyId) => ({ ptyId, outcome: await probe(ptyId) }))
+      )
+      return {
+        candidate,
+        livePtyIds: new Set(
+          liveness.filter((item) => item.outcome.status === 'live').map((item) => item.ptyId)
+        )
+      }
+    }
+  )
+
+  // Why: liveness probes may finish out of order, but projection insertion order is persisted UI.
+  // Apply the ordered results synchronously so completion timing cannot reorder same-worktree tabs.
+  for (const { candidate, livePtyIds } of probedCandidates) {
+    if (livePtyIds.size === 0 || signal?.aborted) {
+      summary.skippedTabCount += 1
+      continue
+    }
+
+    const fresh = store.getState()
+    const currentBackingTabs = (fresh.tabsByWorktree[candidate.worktreeId] ?? []).filter(
+      (tab) => tab.id === candidate.tabId
+    )
+    if (
+      currentBackingTabs.length !== 1 ||
+      !collectCandidatePtyIds(fresh, currentBackingTabs[0]).some((ptyId) => livePtyIds.has(ptyId))
+    ) {
+      summary.skippedTabCount += 1
+      continue
+    }
+
+    summary.confirmedLiveTabCount += 1
+    const result = fresh.ensureTerminalTabProjection(candidate.worktreeId, candidate.tabId)
+    if (result.status === 'repaired') {
+      summary.repairedTabCount += 1
+    } else if (result.status === 'unchanged') {
+      summary.unchangedTabCount += 1
+    } else {
+      summary.skippedTabCount += 1
+      summary.projectionSkipReasons[result.reason] =
+        (summary.projectionSkipReasons[result.reason] ?? 0) + 1
+    }
+  }
+
+  return summary
+}

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -2048,6 +2048,35 @@ describe('TabsSlice', () => {
       expect(reconciled.activeGroupIdByWorktree[WT]).toBe(repairedActiveGroup)
       expect(reconciled.groupsByWorktree[WT][0].tabOrder).toEqual(['legacy-live-tab'])
     })
+    it('does not notify subscribers for unchanged or skipped projections', () => {
+      const tab = makeTab({
+        id: 'already-projected-tab',
+        worktreeId: WT,
+        ptyId: 'pty-live',
+        title: 'Terminal 1',
+        sortOrder: 0,
+        createdAt: 10
+      })
+      store.setState({
+        tabsByWorktree: { [WT]: [tab] },
+        unifiedTabsByWorktree: {},
+        groupsByWorktree: {},
+        activeGroupIdByWorktree: {},
+        layoutByWorktree: {}
+      })
+      expect(store.getState().ensureTerminalTabProjection(WT, tab.id).status).toBe('repaired')
+
+      const listener = vi.fn()
+      const unsubscribe = store.subscribe(listener)
+
+      expect(store.getState().ensureTerminalTabProjection(WT, tab.id).status).toBe('unchanged')
+      expect(store.getState().ensureTerminalTabProjection(WT, 'missing-tab')).toMatchObject({
+        status: 'skipped',
+        reason: 'missing-backing-tab'
+      })
+      expect(listener).not.toHaveBeenCalled()
+      unsubscribe()
+    })
   })
 
   describe('reconcileWorktreeTabModel', () => {

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -107,6 +107,7 @@ globalThis.window = { api: mockApi }
 import {
   createTestStore,
   makeOpenFile,
+  makeTab,
   makeTabGroup,
   makeUnifiedTab,
   makeWorktree
@@ -1983,6 +1984,69 @@ describe('TabsSlice', () => {
       store.getState().reorderUnifiedTabs(groupId, [second.id, first.id, second.id, first.id])
 
       expect(store.getState().groupsByWorktree[WT][0].tabOrder).toEqual([second.id, first.id])
+    })
+  })
+  describe('ensureTerminalTabProjection', () => {
+    it('preserves live backing state and survives the destructive activation reconcile path', () => {
+      const tab = makeTab({
+        id: 'legacy-live-tab',
+        worktreeId: WT,
+        ptyId: 'pty-live',
+        title: 'Terminal 3',
+        sortOrder: 2,
+        createdAt: 30,
+        pendingActivationSpawn: true
+      })
+      const terminalLayout = {
+        root: { type: 'leaf' as const, leafId: 'leaf-live' },
+        activeLeafId: 'leaf-live',
+        expandedLeafId: null,
+        ptyIdsByLeafId: { 'leaf-live': 'pty-live' }
+      }
+      store.setState({
+        activeView: 'settings',
+        activeWorktreeId: 'foreground-worktree',
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: WT, repoId: 'repo1' })]
+        },
+        tabsByWorktree: { [WT]: [tab] },
+        ptyIdsByTabId: { 'legacy-live-tab': ['pty-live'] },
+        terminalLayoutsByTabId: { 'legacy-live-tab': terminalLayout },
+        activeTabIdByWorktree: { [WT]: 'legacy-live-tab' },
+        unifiedTabsByWorktree: {},
+        groupsByWorktree: {},
+        activeGroupIdByWorktree: {},
+        layoutByWorktree: {}
+      })
+
+      const beforeBacking = store.getState().tabsByWorktree
+      const beforePtyIds = store.getState().ptyIdsByTabId
+      const beforeTerminalLayouts = store.getState().terminalLayoutsByTabId
+      expect(store.getState().ensureTerminalTabProjection(WT, 'legacy-live-tab').status).toBe(
+        'repaired'
+      )
+
+      const repaired = store.getState()
+      expect(repaired.unifiedTabsByWorktree[WT].map((item) => item.entityId)).toContain(
+        'legacy-live-tab'
+      )
+      expect(repaired.tabsByWorktree).toBe(beforeBacking)
+      expect(repaired.ptyIdsByTabId).toBe(beforePtyIds)
+      expect(repaired.terminalLayoutsByTabId).toBe(beforeTerminalLayouts)
+      expect(repaired.tabsByWorktree[WT][0].pendingActivationSpawn).toBe(true)
+      const repairedTabs = repaired.unifiedTabsByWorktree[WT]
+      const repairedGroups = repaired.groupsByWorktree[WT]
+      const repairedLayout = repaired.layoutByWorktree[WT]
+      const repairedActiveGroup = repaired.activeGroupIdByWorktree[WT]
+
+      repaired.setActiveWorktree(WT)
+
+      const reconciled = store.getState()
+      expect(reconciled.unifiedTabsByWorktree[WT]).toBe(repairedTabs)
+      expect(reconciled.groupsByWorktree[WT]).toBe(repairedGroups)
+      expect(reconciled.layoutByWorktree[WT]).toBe(repairedLayout)
+      expect(reconciled.activeGroupIdByWorktree[WT]).toBe(repairedActiveGroup)
+      expect(reconciled.groupsByWorktree[WT][0].tabOrder).toEqual(['legacy-live-tab'])
     })
   })
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -32,6 +32,10 @@ import {
   getOrphanTerminalIds,
   terminalTabHasReconnectablePty
 } from './terminal-orphan-helpers'
+import {
+  ensureTerminalTabProjection as buildTerminalTabProjectionPatch,
+  type EnsureTerminalTabProjectionResult
+} from './terminal-tab-projection'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
@@ -187,6 +191,11 @@ export type TabsSlice = {
   ) => Tab | null
   mergeGroupIntoSibling: (worktreeId: string, groupId: string) => string | null
   setTabGroupSplitRatio: (worktreeId: string, nodePath: string, ratio: number) => void
+  ensureTerminalTabProjection: (
+    worktreeId: string,
+    tabId: string,
+    targetGroupId?: string
+  ) => EnsureTerminalTabProjectionResult
   reconcileWorktreeTabModel: (worktreeId: string) => {
     renderableTabCount: number
     activeRenderableTabId: string | null
@@ -622,6 +631,21 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
   groupsByWorktree: {},
   activeGroupIdByWorktree: {},
   layoutByWorktree: {},
+  ensureTerminalTabProjection: (worktreeId, tabId, targetGroupId) => {
+    let result!: EnsureTerminalTabProjectionResult
+    set((state) => {
+      const outcome = buildTerminalTabProjectionPatch(
+        state,
+        worktreeId,
+        tabId,
+        targetGroupId,
+        createBrowserUuid
+      )
+      result = outcome.result
+      return outcome.patch
+    })
+    return result
+  },
 
   createUnifiedTab: (worktreeId, contentType, init) => {
     const id = init?.id ?? createBrowserUuid()

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -632,19 +632,17 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
   activeGroupIdByWorktree: {},
   layoutByWorktree: {},
   ensureTerminalTabProjection: (worktreeId, tabId, targetGroupId) => {
-    let result!: EnsureTerminalTabProjectionResult
-    set((state) => {
-      const outcome = buildTerminalTabProjectionPatch(
-        state,
-        worktreeId,
-        tabId,
-        targetGroupId,
-        createBrowserUuid
-      )
-      result = outcome.result
-      return outcome.patch
-    })
-    return result
+    const outcome = buildTerminalTabProjectionPatch(
+      get(),
+      worktreeId,
+      tabId,
+      targetGroupId,
+      createBrowserUuid
+    )
+    if (Object.keys(outcome.patch).length > 0) {
+      set(outcome.patch)
+    }
+    return outcome.result
   },
 
   createUnifiedTab: (worktreeId, contentType, init) => {

--- a/src/renderer/src/store/slices/terminal-tab-projection-invariant.ts
+++ b/src/renderer/src/store/slices/terminal-tab-projection-invariant.ts
@@ -1,0 +1,69 @@
+import type { AppState } from '../types'
+import type { TabGroup, TabGroupLayoutNode } from '../../../../shared/types'
+
+export type TerminalTabProjectionState = Pick<
+  AppState,
+  | 'tabsByWorktree'
+  | 'unifiedTabsByWorktree'
+  | 'groupsByWorktree'
+  | 'activeGroupIdByWorktree'
+  | 'layoutByWorktree'
+  | 'activeTabIdByWorktree'
+>
+
+function collectLayoutGroupIds(node: TabGroupLayoutNode | undefined, ids: string[]): void {
+  if (!node) {
+    return
+  }
+  if (node.type === 'leaf') {
+    ids.push(node.groupId)
+    return
+  }
+  collectLayoutGroupIds(node.first, ids)
+  collectLayoutGroupIds(node.second, ids)
+}
+
+export function layoutExactlyCoversGroups(
+  layout: TabGroupLayoutNode | undefined,
+  groups: readonly TabGroup[]
+): boolean {
+  if (!layout) {
+    return false
+  }
+  const layoutGroupIds: string[] = []
+  collectLayoutGroupIds(layout, layoutGroupIds)
+  const groupIds = new Set(groups.map((group) => group.id))
+  return (
+    layoutGroupIds.length === groups.length &&
+    new Set(layoutGroupIds).size === layoutGroupIds.length &&
+    layoutGroupIds.every((groupId) => groupIds.has(groupId))
+  )
+}
+
+export function hasTerminalTabProjectionInvariant(
+  state: TerminalTabProjectionState,
+  worktreeId: string,
+  tabId: string
+): boolean {
+  const backingTabs = (state.tabsByWorktree[worktreeId] ?? []).filter((tab) => tab.id === tabId)
+  if (backingTabs.length !== 1) {
+    return false
+  }
+  const projections = (state.unifiedTabsByWorktree[worktreeId] ?? []).filter(
+    (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+  )
+  if (projections.length !== 1) {
+    return false
+  }
+  const projection = projections[0]
+  const groups = state.groupsByWorktree[worktreeId] ?? []
+  const owningGroup = groups.find((group) => group.id === projection.groupId)
+  if (!owningGroup || !layoutExactlyCoversGroups(state.layoutByWorktree[worktreeId], groups)) {
+    return false
+  }
+  let orderOccurrences = 0
+  for (const group of groups) {
+    orderOccurrences += group.tabOrder.filter((id) => id === projection.id).length
+  }
+  return orderOccurrences === 1 && owningGroup.tabOrder.includes(projection.id)
+}

--- a/src/renderer/src/store/slices/terminal-tab-projection.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-projection.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
+import {
+  ensureTerminalTabProjection,
+  hasTerminalTabProjectionInvariant,
+  type EnsureTerminalTabProjectionOutcome,
+  type EnsureTerminalTabProjectionSkipReason
+} from './terminal-tab-projection'
+
+type ProjectionState = Parameters<typeof ensureTerminalTabProjection>[0]
+
+const WORKTREE_ID = 'repo::/tmp/background'
+
+function makeBackingTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'terminal-1',
+    ptyId: 'pty-live',
+    worktreeId: WORKTREE_ID,
+    title: 'Terminal 3',
+    generatedTitle: 'Fix the projection',
+    quickCommandLabel: 'Claude',
+    customTitle: null,
+    color: '#00ff00',
+    isPinned: true,
+    viewMode: 'chat',
+    sortOrder: 2,
+    createdAt: 30,
+    pendingActivationSpawn: true,
+    ...overrides
+  }
+}
+
+function makeState(overrides: Partial<ProjectionState> = {}): ProjectionState {
+  return {
+    tabsByWorktree: { [WORKTREE_ID]: [makeBackingTab()] },
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    layoutByWorktree: {},
+    activeTabIdByWorktree: {},
+    ...overrides
+  }
+}
+
+function applyOutcome(
+  state: ProjectionState,
+  patch: EnsureTerminalTabProjectionOutcome['patch']
+): ProjectionState {
+  return { ...state, ...patch }
+}
+
+function makeEditorTab(groupId: string): Tab {
+  return {
+    id: 'editor-1',
+    entityId: '/tmp/background/file.ts',
+    groupId,
+    worktreeId: WORKTREE_ID,
+    contentType: 'editor',
+    label: 'file.ts',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 10
+  }
+}
+
+function makeGroup(overrides: Partial<TabGroup> = {}): TabGroup {
+  return {
+    id: 'group-1',
+    worktreeId: WORKTREE_ID,
+    activeTabId: 'editor-1',
+    tabOrder: ['editor-1'],
+    recentTabIds: ['editor-1'],
+    ...overrides
+  }
+}
+
+describe('ensureTerminalTabProjection', () => {
+  it('adds a missing terminal projection without changing the selected foreground tab', () => {
+    const group = makeGroup()
+    const editor = makeEditorTab(group.id)
+    const state = makeState({
+      unifiedTabsByWorktree: { [WORKTREE_ID]: [editor] },
+      groupsByWorktree: { [WORKTREE_ID]: [group] },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: group.id },
+      layoutByWorktree: { [WORKTREE_ID]: { type: 'leaf', groupId: group.id } },
+      activeTabIdByWorktree: { [WORKTREE_ID]: 'terminal-1' }
+    })
+
+    const outcome = ensureTerminalTabProjection(
+      state,
+      WORKTREE_ID,
+      'terminal-1',
+      undefined,
+      () => 'unused-group'
+    )
+    const repaired = applyOutcome(state, outcome.patch)
+
+    expect(outcome.result.status).toBe('repaired')
+    expect(hasTerminalTabProjectionInvariant(repaired, WORKTREE_ID, 'terminal-1')).toBe(true)
+    expect(repaired.unifiedTabsByWorktree[WORKTREE_ID][0]).toBe(editor)
+    expect(repaired.groupsByWorktree[WORKTREE_ID][0]).toMatchObject({
+      activeTabId: 'editor-1',
+      tabOrder: ['editor-1', 'terminal-1'],
+      recentTabIds: ['editor-1']
+    })
+    expect(repaired.activeGroupIdByWorktree[WORKTREE_ID]).toBe(group.id)
+    expect(repaired.tabsByWorktree).toBe(state.tabsByWorktree)
+
+    const replay = ensureTerminalTabProjection(
+      repaired,
+      WORKTREE_ID,
+      'terminal-1',
+      undefined,
+      () => 'unused-group'
+    )
+    expect(replay).toEqual({
+      result: { status: 'unchanged', tabId: 'terminal-1', groupId: group.id },
+      patch: {}
+    })
+  })
+
+  it('creates one root group and copies stable terminal presentation metadata', () => {
+    const state = makeState()
+    const outcome = ensureTerminalTabProjection(
+      state,
+      WORKTREE_ID,
+      'terminal-1',
+      undefined,
+      () => 'root-group'
+    )
+    const repaired = applyOutcome(state, outcome.patch)
+    const projection = repaired.unifiedTabsByWorktree[WORKTREE_ID][0]
+
+    expect(projection).toMatchObject({
+      id: 'terminal-1',
+      entityId: 'terminal-1',
+      groupId: 'root-group',
+      label: 'Terminal 3',
+      generatedLabel: 'Fix the projection',
+      quickCommandLabel: 'Claude',
+      color: '#00ff00',
+      isPinned: true,
+      viewMode: 'chat',
+      sortOrder: 2,
+      createdAt: 30
+    })
+    expect(repaired.groupsByWorktree[WORKTREE_ID]).toEqual([
+      {
+        id: 'root-group',
+        worktreeId: WORKTREE_ID,
+        activeTabId: 'terminal-1',
+        tabOrder: ['terminal-1']
+      }
+    ])
+    expect(repaired.layoutByWorktree[WORKTREE_ID]).toEqual({
+      type: 'leaf',
+      groupId: 'root-group'
+    })
+    expect(repaired.activeGroupIdByWorktree[WORKTREE_ID]).toBe('root-group')
+  })
+
+  it('canonicalizes duplicate aliases and order occurrences for only the target terminal', () => {
+    const group = makeGroup({
+      activeTabId: 'terminal-alias-2',
+      tabOrder: ['editor-1', 'terminal-alias-1', 'terminal-alias-1', 'terminal-alias-2'],
+      recentTabIds: ['editor-1', 'terminal-alias-1', 'terminal-alias-2']
+    })
+    const editor = makeEditorTab(group.id)
+    const aliases: Tab[] = ['terminal-alias-1', 'terminal-alias-2'].map((id, index) => ({
+      id,
+      entityId: 'terminal-1',
+      groupId: group.id,
+      worktreeId: WORKTREE_ID,
+      contentType: 'terminal',
+      label: `Alias ${index + 1}`,
+      customLabel: null,
+      color: null,
+      sortOrder: index + 1,
+      createdAt: index + 20
+    }))
+    const state = makeState({
+      unifiedTabsByWorktree: { [WORKTREE_ID]: [editor, ...aliases] },
+      groupsByWorktree: { [WORKTREE_ID]: [group] },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: group.id },
+      layoutByWorktree: { [WORKTREE_ID]: { type: 'leaf', groupId: group.id } }
+    })
+
+    const outcome = ensureTerminalTabProjection(
+      state,
+      WORKTREE_ID,
+      'terminal-1',
+      undefined,
+      () => 'unused-group'
+    )
+    const repaired = applyOutcome(state, outcome.patch)
+
+    expect(outcome.result).toMatchObject({
+      status: 'repaired',
+      removedProjectionCount: 1,
+      removedOrderOccurrenceCount: 2
+    })
+    expect(repaired.unifiedTabsByWorktree[WORKTREE_ID].map((tab) => tab.id)).toEqual([
+      'editor-1',
+      'terminal-alias-2'
+    ])
+    expect(repaired.groupsByWorktree[WORKTREE_ID][0]).toMatchObject({
+      activeTabId: 'terminal-alias-2',
+      tabOrder: ['editor-1', 'terminal-alias-2'],
+      recentTabIds: ['editor-1', 'terminal-alias-2']
+    })
+    expect(hasTerminalTabProjectionInvariant(repaired, WORKTREE_ID, 'terminal-1')).toBe(true)
+  })
+  it('keeps a populated sibling group selected while removing its stale target pointer', () => {
+    const primaryGroup = makeGroup()
+    const siblingGroup = makeGroup({
+      id: 'group-2',
+      activeTabId: 'terminal-1',
+      tabOrder: ['editor-2'],
+      recentTabIds: ['terminal-1', 'editor-2']
+    })
+    const primaryEditor = makeEditorTab(primaryGroup.id)
+    const siblingEditor: Tab = {
+      ...makeEditorTab(siblingGroup.id),
+      id: 'editor-2',
+      entityId: '/tmp/background/other.ts',
+      label: 'other.ts'
+    }
+    const state = makeState({
+      unifiedTabsByWorktree: { [WORKTREE_ID]: [primaryEditor, siblingEditor] },
+      groupsByWorktree: { [WORKTREE_ID]: [primaryGroup, siblingGroup] },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: primaryGroup.id },
+      layoutByWorktree: {
+        [WORKTREE_ID]: {
+          type: 'split',
+          direction: 'horizontal',
+          ratio: 0.5,
+          first: { type: 'leaf', groupId: primaryGroup.id },
+          second: { type: 'leaf', groupId: siblingGroup.id }
+        }
+      },
+      activeTabIdByWorktree: { [WORKTREE_ID]: 'terminal-1' }
+    })
+
+    const outcome = ensureTerminalTabProjection(
+      state,
+      WORKTREE_ID,
+      'terminal-1',
+      undefined,
+      () => 'unused-group'
+    )
+    const repaired = applyOutcome(state, outcome.patch)
+
+    expect(outcome.result.status).toBe('repaired')
+    expect(repaired.groupsByWorktree[WORKTREE_ID][1]).toMatchObject({
+      activeTabId: 'editor-2',
+      tabOrder: ['editor-2'],
+      recentTabIds: ['editor-2']
+    })
+    expect(hasTerminalTabProjectionInvariant(repaired, WORKTREE_ID, 'terminal-1')).toBe(true)
+  })
+  it('honors an explicit rendered target group without changing the active group', () => {
+    const primaryGroup = makeGroup()
+    const targetGroup = makeGroup({
+      id: 'group-2',
+      activeTabId: 'editor-2',
+      tabOrder: ['editor-2'],
+      recentTabIds: ['editor-2']
+    })
+    const primaryEditor = makeEditorTab(primaryGroup.id)
+    const targetEditor: Tab = {
+      ...makeEditorTab(targetGroup.id),
+      id: 'editor-2',
+      entityId: '/tmp/background/target.ts',
+      label: 'target.ts'
+    }
+    const state = makeState({
+      unifiedTabsByWorktree: { [WORKTREE_ID]: [primaryEditor, targetEditor] },
+      groupsByWorktree: { [WORKTREE_ID]: [primaryGroup, targetGroup] },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: primaryGroup.id },
+      layoutByWorktree: {
+        [WORKTREE_ID]: {
+          type: 'split',
+          direction: 'horizontal',
+          ratio: 0.5,
+          first: { type: 'leaf', groupId: primaryGroup.id },
+          second: { type: 'leaf', groupId: targetGroup.id }
+        }
+      }
+    })
+
+    const outcome = ensureTerminalTabProjection(
+      state,
+      WORKTREE_ID,
+      'terminal-1',
+      targetGroup.id,
+      () => 'unused-group'
+    )
+    const repaired = applyOutcome(state, outcome.patch)
+
+    expect(outcome.result).toMatchObject({ status: 'repaired', groupId: targetGroup.id })
+    expect(repaired.activeGroupIdByWorktree[WORKTREE_ID]).toBe(primaryGroup.id)
+    expect(repaired.groupsByWorktree[WORKTREE_ID][1]).toMatchObject({
+      activeTabId: 'editor-2',
+      tabOrder: ['editor-2', 'terminal-1']
+    })
+    expect(hasTerminalTabProjectionInvariant(repaired, WORKTREE_ID, 'terminal-1')).toBe(true)
+  })
+
+  it('fails closed without mutating state for structural projection conflicts', () => {
+    const aliasProjection = (id: string, groupId: string): Tab => ({
+      id,
+      entityId: 'terminal-1',
+      groupId,
+      worktreeId: WORKTREE_ID,
+      contentType: 'terminal',
+      label: id,
+      customLabel: null,
+      color: null,
+      sortOrder: 1,
+      createdAt: 20
+    })
+    const conflictCases: {
+      reason: EnsureTerminalTabProjectionSkipReason
+      state: ProjectionState
+      createGroupId?: () => string
+    }[] = [
+      {
+        reason: 'missing-backing-tab',
+        state: makeState({ tabsByWorktree: { [WORKTREE_ID]: [] } })
+      },
+      {
+        reason: 'duplicate-backing-tab',
+        state: makeState({
+          tabsByWorktree: {
+            [WORKTREE_ID]: [makeBackingTab(), makeBackingTab({ title: 'Duplicate' })]
+          }
+        })
+      },
+      {
+        reason: 'duplicate-unified-id',
+        state: makeState({
+          unifiedTabsByWorktree: {
+            [WORKTREE_ID]: [{ ...makeEditorTab('group-1'), id: 'terminal-1' }]
+          }
+        })
+      },
+      {
+        reason: 'duplicate-unified-id',
+        state: makeState({
+          unifiedTabsByWorktree: {
+            [WORKTREE_ID]: [
+              aliasProjection('shared-alias', 'group-1'),
+              { ...aliasProjection('shared-alias', 'group-1'), label: 'Duplicate alias id' }
+            ]
+          }
+        })
+      },
+      {
+        reason: 'ambiguous-active-aliases',
+        state: makeState({
+          unifiedTabsByWorktree: {
+            [WORKTREE_ID]: [
+              aliasProjection('terminal-alias-1', 'group-1'),
+              aliasProjection('terminal-alias-2', 'group-2')
+            ]
+          },
+          groupsByWorktree: {
+            [WORKTREE_ID]: [
+              makeGroup({
+                id: 'group-1',
+                activeTabId: 'terminal-alias-1',
+                tabOrder: ['terminal-alias-1']
+              }),
+              makeGroup({
+                id: 'group-2',
+                activeTabId: 'terminal-alias-2',
+                tabOrder: ['terminal-alias-2']
+              })
+            ]
+          }
+        })
+      },
+      {
+        reason: 'group-id-collision',
+        state: makeState({
+          unifiedTabsByWorktree: {
+            [WORKTREE_ID]: [aliasProjection('terminal-alias', 'colliding-group')]
+          }
+        }),
+        createGroupId: () => 'colliding-group'
+      }
+    ]
+
+    for (const { reason, state, createGroupId = () => 'unused-group' } of conflictCases) {
+      const before = JSON.stringify(state)
+      const outcome = ensureTerminalTabProjection(
+        state,
+        WORKTREE_ID,
+        'terminal-1',
+        undefined,
+        createGroupId
+      )
+
+      expect(outcome).toEqual({
+        result: { status: 'skipped', tabId: 'terminal-1', reason },
+        patch: {}
+      })
+      expect(JSON.stringify(state)).toBe(before)
+    }
+  })
+
+  it('leaves ambiguous multi-group topology byte-equivalent', () => {
+    const groups = [makeGroup(), makeGroup({ id: 'group-2', activeTabId: null, tabOrder: [] })]
+    const state = makeState({
+      unifiedTabsByWorktree: { [WORKTREE_ID]: [makeEditorTab('group-1')] },
+      groupsByWorktree: { [WORKTREE_ID]: groups },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: 'group-1' }
+    })
+
+    const before = JSON.stringify(state)
+    const outcome = ensureTerminalTabProjection(
+      state,
+      WORKTREE_ID,
+      'terminal-1',
+      undefined,
+      () => 'unused-group'
+    )
+
+    expect(outcome).toEqual({
+      result: {
+        status: 'skipped',
+        tabId: 'terminal-1',
+        reason: 'ambiguous-group-topology'
+      },
+      patch: {}
+    })
+    expect(JSON.stringify(state)).toBe(before)
+  })
+})

--- a/src/renderer/src/store/slices/terminal-tab-projection.ts
+++ b/src/renderer/src/store/slices/terminal-tab-projection.ts
@@ -1,0 +1,310 @@
+import type { AppState } from '../types'
+import type { Tab, TabGroup, TerminalTab } from '../../../../shared/types'
+import {
+  layoutExactlyCoversGroups,
+  type TerminalTabProjectionState as ProjectionState
+} from './terminal-tab-projection-invariant'
+export { hasTerminalTabProjectionInvariant } from './terminal-tab-projection-invariant'
+
+type ProjectionPatch = Partial<
+  Pick<
+    AppState,
+    'unifiedTabsByWorktree' | 'groupsByWorktree' | 'activeGroupIdByWorktree' | 'layoutByWorktree'
+  >
+>
+
+export type EnsureTerminalTabProjectionSkipReason =
+  | 'missing-backing-tab'
+  | 'duplicate-backing-tab'
+  | 'duplicate-unified-id'
+  | 'ambiguous-active-aliases'
+  | 'ambiguous-group-topology'
+  | 'group-id-collision'
+
+export type EnsureTerminalTabProjectionResult =
+  | { status: 'unchanged'; tabId: string; groupId: string }
+  | {
+      status: 'repaired'
+      tabId: string
+      groupId: string
+      removedProjectionCount: number
+      removedOrderOccurrenceCount: number
+    }
+  | { status: 'skipped'; tabId: string; reason: EnsureTerminalTabProjectionSkipReason }
+
+export type EnsureTerminalTabProjectionOutcome = {
+  result: EnsureTerminalTabProjectionResult
+  patch: ProjectionPatch
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function dedupeKeepingLast(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const reversed: string[] = []
+  for (let index = values.length - 1; index >= 0; index--) {
+    const value = values[index]
+    if (!seen.has(value)) {
+      seen.add(value)
+      reversed.push(value)
+    }
+  }
+  return reversed.toReversed()
+}
+
+function buildTerminalProjection(
+  backingTab: TerminalTab,
+  worktreeId: string,
+  groupId: string
+): Tab {
+  return {
+    id: backingTab.id,
+    entityId: backingTab.id,
+    groupId,
+    worktreeId,
+    contentType: 'terminal',
+    label: backingTab.title,
+    ...(backingTab.generatedTitle?.trim()
+      ? { generatedLabel: backingTab.generatedTitle.trim() }
+      : {}),
+    ...(backingTab.quickCommandLabel?.trim()
+      ? { quickCommandLabel: backingTab.quickCommandLabel.trim() }
+      : {}),
+    customLabel: backingTab.customTitle,
+    color: backingTab.color,
+    sortOrder: backingTab.sortOrder,
+    createdAt: backingTab.createdAt,
+    ...(backingTab.isPinned !== undefined ? { isPinned: backingTab.isPinned } : {}),
+    ...(backingTab.viewMode !== undefined ? { viewMode: backingTab.viewMode } : {})
+  }
+}
+
+function countTargetOrderOccurrences(
+  groups: readonly TabGroup[],
+  targetIds: ReadonlySet<string>
+): number {
+  let count = 0
+  for (const group of groups) {
+    for (const tabId of group.tabOrder) {
+      if (targetIds.has(tabId)) {
+        count += 1
+      }
+    }
+  }
+  return count
+}
+
+export function ensureTerminalTabProjection(
+  state: ProjectionState,
+  worktreeId: string,
+  tabId: string,
+  targetGroupId: string | undefined,
+  createGroupId: () => string
+): EnsureTerminalTabProjectionOutcome {
+  const backingMatches = (state.tabsByWorktree[worktreeId] ?? []).filter((tab) => tab.id === tabId)
+  if (backingMatches.length === 0) {
+    return { result: { status: 'skipped', tabId, reason: 'missing-backing-tab' }, patch: {} }
+  }
+  if (backingMatches.length > 1) {
+    return { result: { status: 'skipped', tabId, reason: 'duplicate-backing-tab' }, patch: {} }
+  }
+
+  const backingTab = backingMatches[0]
+  const currentTabs = state.unifiedTabsByWorktree[worktreeId] ?? []
+  const targetProjections = currentTabs.filter(
+    (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+  )
+  const targetProjectionSet = new Set(targetProjections)
+  const unifiedIdCounts = new Map<string, number>()
+  for (const tab of currentTabs) {
+    unifiedIdCounts.set(tab.id, (unifiedIdCounts.get(tab.id) ?? 0) + 1)
+  }
+  if (
+    targetProjections.some((tab) => (unifiedIdCounts.get(tab.id) ?? 0) > 1) ||
+    (targetProjections.length === 0 && currentTabs.some((tab) => tab.id === tabId))
+  ) {
+    return { result: { status: 'skipped', tabId, reason: 'duplicate-unified-id' }, patch: {} }
+  }
+
+  const currentGroups = state.groupsByWorktree[worktreeId] ?? []
+  if (new Set(currentGroups.map((group) => group.id)).size !== currentGroups.length) {
+    return { result: { status: 'skipped', tabId, reason: 'ambiguous-group-topology' }, patch: {} }
+  }
+  const activelySelectedTargets = targetProjections.filter((tab) =>
+    currentGroups.some((group) => group.id === tab.groupId && group.activeTabId === tab.id)
+  )
+  if (new Set(activelySelectedTargets.map((tab) => tab.groupId)).size > 1) {
+    return { result: { status: 'skipped', tabId, reason: 'ambiguous-active-aliases' }, patch: {} }
+  }
+
+  const canonicalProjection =
+    activelySelectedTargets[0] ??
+    targetProjections.find((tab) => tab.id === tabId) ??
+    targetProjections[0] ??
+    null
+
+  let nextGroups = currentGroups
+  let nextLayout = state.layoutByWorktree[worktreeId]
+  let groupsCreated = false
+  if (currentGroups.length === 0) {
+    if (currentTabs.some((tab) => !targetProjectionSet.has(tab))) {
+      return { result: { status: 'skipped', tabId, reason: 'ambiguous-group-topology' }, patch: {} }
+    }
+    const groupId = createGroupId()
+    if (currentTabs.some((tab) => tab.groupId === groupId)) {
+      return { result: { status: 'skipped', tabId, reason: 'group-id-collision' }, patch: {} }
+    }
+    nextGroups = [{ id: groupId, worktreeId, activeTabId: null, tabOrder: [] }]
+    nextLayout = { type: 'leaf', groupId }
+    groupsCreated = true
+  } else if (currentGroups.length === 1) {
+    if (!layoutExactlyCoversGroups(nextLayout, currentGroups)) {
+      nextLayout = { type: 'leaf', groupId: currentGroups[0].id }
+    }
+  } else if (!layoutExactlyCoversGroups(nextLayout, currentGroups)) {
+    return { result: { status: 'skipped', tabId, reason: 'ambiguous-group-topology' }, patch: {} }
+  }
+
+  const activeGroupId = state.activeGroupIdByWorktree[worktreeId]
+  const chosenGroup =
+    (canonicalProjection
+      ? nextGroups.find((group) => group.id === canonicalProjection.groupId)
+      : undefined) ??
+    (targetGroupId ? nextGroups.find((group) => group.id === targetGroupId) : undefined) ??
+    nextGroups.find((group) => group.id === activeGroupId) ??
+    nextGroups[0]
+  if (!chosenGroup) {
+    return { result: { status: 'skipped', tabId, reason: 'ambiguous-group-topology' }, patch: {} }
+  }
+
+  const canonicalTab = canonicalProjection
+    ? canonicalProjection.groupId === chosenGroup.id
+      ? canonicalProjection
+      : { ...canonicalProjection, groupId: chosenGroup.id }
+    : buildTerminalProjection(backingTab, worktreeId, chosenGroup.id)
+  const targetIds = new Set(targetProjections.map((tab) => tab.id))
+  targetIds.add(canonicalTab.id)
+  const priorOrderOccurrenceCount = countTargetOrderOccurrences(currentGroups, targetIds)
+
+  const firstProjectionIndex = currentTabs.findIndex((tab) => targetProjectionSet.has(tab))
+  const tabsWithoutTarget = currentTabs.filter((tab) => !targetProjectionSet.has(tab))
+  const tabInsertIndex =
+    firstProjectionIndex < 0
+      ? tabsWithoutTarget.length
+      : currentTabs.slice(0, firstProjectionIndex).filter((tab) => !targetProjectionSet.has(tab))
+          .length
+  const projectedTabs = tabsWithoutTarget.toSpliced(tabInsertIndex, 0, canonicalTab)
+  const tabsChanged =
+    projectedTabs.length !== currentTabs.length ||
+    projectedTabs.some((tab, index) => tab !== currentTabs[index])
+
+  let groupsChanged = groupsCreated
+  const projectedGroups = nextGroups.map((group) => {
+    const firstTargetIndex = group.tabOrder.findIndex((id) => targetIds.has(id))
+    const orderWithoutTarget = group.tabOrder.filter((id) => !targetIds.has(id))
+    const nextOrder =
+      group.id === chosenGroup.id
+        ? orderWithoutTarget.toSpliced(
+            firstTargetIndex < 0
+              ? orderWithoutTarget.length
+              : group.tabOrder.slice(0, firstTargetIndex).filter((id) => !targetIds.has(id)).length,
+            0,
+            canonicalTab.id
+          )
+        : orderWithoutTarget
+    const nextActiveTabId = targetIds.has(group.activeTabId ?? '')
+      ? group.id === chosenGroup.id
+        ? canonicalTab.id
+        : (nextOrder[0] ?? null)
+      : group.activeTabId === null &&
+          group.id === chosenGroup.id &&
+          (group.tabOrder.length === 0 || state.activeTabIdByWorktree[worktreeId] === tabId)
+        ? canonicalTab.id
+        : group.activeTabId
+    const mappedRecent = (group.recentTabIds ?? [])
+      .map((id) => (targetIds.has(id) && group.id === chosenGroup.id ? canonicalTab.id : id))
+      .filter((id) => !targetIds.has(id) || id === canonicalTab.id)
+      .filter((id) => nextOrder.includes(id))
+    const nextRecent = dedupeKeepingLast(mappedRecent)
+    const recentUnchanged =
+      group.recentTabIds === undefined
+        ? nextRecent.length === 0
+        : arraysEqual(group.recentTabIds, nextRecent)
+    if (
+      arraysEqual(group.tabOrder, nextOrder) &&
+      group.activeTabId === nextActiveTabId &&
+      recentUnchanged
+    ) {
+      return group
+    }
+    groupsChanged = true
+    return {
+      ...group,
+      activeTabId: nextActiveTabId,
+      tabOrder: nextOrder,
+      ...(group.recentTabIds !== undefined || nextRecent.length > 0
+        ? { recentTabIds: nextRecent }
+        : {})
+    }
+  })
+
+  const currentLayout = state.layoutByWorktree[worktreeId]
+  const layoutChanged = nextLayout !== currentLayout
+  const nextActiveGroupId = nextGroups.some((group) => group.id === activeGroupId)
+    ? activeGroupId
+    : chosenGroup.id
+  const activeGroupChanged = nextActiveGroupId !== activeGroupId
+  const patch: ProjectionPatch = {
+    ...(tabsChanged
+      ? {
+          unifiedTabsByWorktree: {
+            ...state.unifiedTabsByWorktree,
+            [worktreeId]: projectedTabs
+          }
+        }
+      : {}),
+    ...(groupsChanged
+      ? {
+          groupsByWorktree: {
+            ...state.groupsByWorktree,
+            [worktreeId]: projectedGroups
+          }
+        }
+      : {}),
+    ...(activeGroupChanged
+      ? {
+          activeGroupIdByWorktree: {
+            ...state.activeGroupIdByWorktree,
+            [worktreeId]: nextActiveGroupId
+          }
+        }
+      : {}),
+    ...(layoutChanged && nextLayout
+      ? {
+          layoutByWorktree: {
+            ...state.layoutByWorktree,
+            [worktreeId]: nextLayout
+          }
+        }
+      : {})
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return {
+      result: { status: 'unchanged', tabId, groupId: chosenGroup.id },
+      patch
+    }
+  }
+  return {
+    result: {
+      status: 'repaired',
+      tabId,
+      groupId: chosenGroup.id,
+      removedProjectionCount: Math.max(0, targetProjections.length - 1),
+      removedOrderOccurrenceCount: Math.max(0, priorOrderOccurrenceCount - 1)
+    },
+    patch
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a renderer state-synchronization race that could make existing live terminal sessions disappear from Orca after a background/non-focus CLI terminal was created.

The main process can durably create the terminal backing row and PTY binding before the renderer session writer runs. When the renderer subsequently adopted that row, it could skip tab creation and leave the renderer-owned `unifiedTabs` / tab-group projection missing. The PTY remained alive, but the UI no longer had a renderable projection.

This change:

- adds an idempotent exact-one terminal projection repair owned by the renderer
- repairs the projection immediately after IPC terminal adoption and during startup after recovery/reconnect
- only repairs bindings confirmed live by the existing PTY provider and rechecks fresh state before mutation
- preserves background/non-focus behavior, active worktree/tab/group state, backing rows, PTY bindings, and layouts
- keeps concurrent liveness probes bounded while applying projection updates in deterministic candidate order
- retains coherent projection fields across temporary session-write suppression
- pins the main process as backing/binding/layout-only rather than a second projection writer

## Screenshots

No visual styling change. This restores terminal tabs that should already be visible. Native Electron automation verifies exact-one projection recovery, unchanged foreground state, PTY survival, and buffered output replay on first visible mount.

## Testing

- [ ] `pnpm lint` — not run; `pnpm check:code-quality:changed` passed with 0 new findings across all 16 changed files
- [x] `pnpm typecheck`
- [ ] `pnpm test` — final branch used the focused suite below rather than the entire repository suite
- [ ] `pnpm build` — not invoked directly; the Electron Playwright run completed its application and bundled CLI build successfully
- [x] Added or updated high-quality tests that would catch regressions

Focused verification on current `origin/main`:

- 59 suites / 686 tests passed across persistence, startup routing, IPC adoption, projection repair, tab reconciliation, delayed session persistence, suppression recovery, readiness-gate retention, serialized writes, and sync/async persistence retries
- deterministic pooled-probe reversed-completion regression passed
- Electron headless hidden-terminal first-visible-mount scenario: 1 passed, 0 unexpected, 0 flaky
- `pnpm check:code-quality:changed` passed
- `pnpm check:max-lines-ratchet` passed
- `git diff --check origin/main...HEAD` passed

## AI Review Report

The review covered architecture, product behavior, and code quality against the approved repair contract. It checked renderer/main ownership, exact-one projection invariants, focus preservation, startup ordering, IPC reply semantics, liveness failure handling, stale-binding races, destructive reconciliation, writer suppression, and native Electron behavior.

An independent red-team pass found a real deterministic-order blocker in the first implementation: sorted candidates were being applied in PTY probe completion order. The implementation was changed to collect bounded concurrent probe results first and then apply projection mutations synchronously in deterministic candidate order. A three-candidate/concurrency-two reversed-completion regression now pins both the pool boundary and final tab order. Final architecture review returned CLEAR/APPROVE and final red-team QA passed with no blockers.

GitHub automated review then identified three additional gaps: empty projection patches still notified Zustand subscribers, suppression recovery still depended on a later store mutation, and rejected local session writes could lose their captured field batch. The follow-up commit skips no-op `set()` calls, self-schedules retained work until suppression lifts, returns and handles the local persistence Promise, restores and retries both synchronous and asynchronous failures, reports the first failure without log spam, and adds regressions for cleanup and concurrent in-flight changes.

A second automated pass found that a retained batch could still be cleared if the hydration gate closed while its timer fired, and that multiple asynchronous local patches could overlap. The final follow-up keeps batches across gate closure and serializes Promise-backed writes; dedicated regressions cover gate-only reopen and deferred first-write completion.

Cross-platform compatibility was explicitly reviewed for macOS, Linux, and Windows. The change adds no shortcuts, labels, platform paths, shell commands, or OS-specific branches. It uses existing Electron IPC/store APIs and platform-neutral Promise/timer behavior; no platform-specific follow-up is required.

## Security Audit

- No dependency, authentication, secret, network endpoint, or command-execution changes
- No new IPC channel; the repair uses the existing `pty.hasPty` contract
- Only literal `true` liveness results can create UI projection state; `false`, `null`, rejection, timeout, deadline exhaustion, and abort all fail closed
- Probe concurrency and total startup time are bounded
- Fresh backing/binding state is rechecked after asynchronous probes to reject stale or rebound PTYs
- The projector is structurally limited to the four renderer projection fields and cannot kill PTYs, rewrite backing rows, navigate, reveal, or steal focus

No security blocker or follow-up was identified.

## Notes

The affected sessions were not terminated; they became invisible because their renderer projection was absent. This PR repairs that projection while retaining the existing PTY lifecycle and main/renderer ownership boundary.
