### PR TITLE
fix(scm): keep git-status pacing across scheduler rebuilds

### DIFF
--- a/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.test.ts
@@ -312,6 +312,66 @@ describe('createGitStatusRefreshScheduler', () => {
     expect(task).toHaveBeenCalledTimes(2)
   })
 
+  it('does not let an older disposed run erase replacement backoff', async () => {
+    vi.useFakeTimers()
+    const calls: ReturnType<typeof deferred>[] = []
+    const task = vi.fn(() => {
+      const call = deferred()
+      calls.push(call)
+      return call.promise
+    })
+    const pacing = createGitStatusRefreshPacing()
+
+    const first = createScheduler(task, pacing)
+    first.resumeSafety()
+    first.dispose()
+
+    const second = createScheduler(task, pacing)
+    second.resumeSafety()
+    await vi.advanceTimersByTimeAsync(30_000)
+    calls[1]?.resolve()
+    await flushMicrotasks()
+
+    await vi.advanceTimersByTimeAsync(1)
+    calls[0]?.resolve()
+    await flushMicrotasks()
+    second.signal()
+
+    await vi.advanceTimersByTimeAsync(29_998)
+    expect(task).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(task).toHaveBeenCalledTimes(3)
+  })
+
+  it('lets an aborted old run pace repeated rebuilds until a replacement finishes', async () => {
+    vi.useFakeTimers()
+    const calls: ReturnType<typeof deferred>[] = []
+    const task = vi.fn(() => {
+      const call = deferred()
+      calls.push(call)
+      return call.promise
+    })
+    const pacing = createGitStatusRefreshPacing()
+
+    const first = createScheduler(task, pacing)
+    first.resumeSafety()
+    first.dispose()
+
+    const second = createScheduler(task, pacing)
+    second.resumeSafety()
+    calls[0]?.resolve()
+    await flushMicrotasks()
+    second.dispose()
+
+    const third = createScheduler(task, pacing)
+    third.resumeSafety()
+    expect(task).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(2999)
+    expect(task).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(task).toHaveBeenCalledTimes(3)
+  })
+
   it('cleans up debounce and safety timers on dispose', async () => {
     vi.useFakeTimers()
     const task = vi.fn(async () => {})

--- a/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  createGitStatusRefreshPacing,
   createGitStatusRefreshScheduler,
+  type GitStatusRefreshPacing,
   type GitStatusRefreshReason
 } from './git-status-refresh-scheduler'
 
@@ -19,7 +21,8 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 function createScheduler(
-  task: (request: { reason: GitStatusRefreshReason; signal: AbortSignal }) => Promise<void>
+  task: (request: { reason: GitStatusRefreshReason; signal: AbortSignal }) => Promise<void>,
+  pacing?: GitStatusRefreshPacing
 ) {
   return createGitStatusRefreshScheduler(task, {
     safetyIntervalMs: 60_000,
@@ -29,7 +32,8 @@ function createScheduler(
       idleMultiplier: 5,
       changeSignalMultiplier: 1,
       maxIntervalMs: 5 * 60_000
-    }
+    },
+    ...(pacing ? { pacing } : {})
   })
 }
 
@@ -255,6 +259,56 @@ describe('createGitStatusRefreshScheduler', () => {
     expect(task).toHaveBeenCalledTimes(2)
     await flushMicrotasks()
     await vi.advanceTimersByTimeAsync(120_000)
+    expect(task).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the activity floor across scheduler recreation when pacing is shared', async () => {
+    vi.useFakeTimers()
+    const task = vi.fn(async () => {})
+    const pacing = createGitStatusRefreshPacing()
+
+    const first = createScheduler(task, pacing)
+    first.resumeSafety()
+    await flushMicrotasks()
+    expect(task).toHaveBeenCalledTimes(1)
+    first.dispose()
+
+    // A rebuild (execution-host/push-target change) must not grant a fresh
+    // immediate run; the floor from the previous run still applies.
+    const second = createScheduler(task, pacing)
+    second.resumeSafety()
+    await flushMicrotasks()
+    expect(task).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(2999)
+    expect(task).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(task).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps slow-scan backoff across scheduler recreation when pacing is shared', async () => {
+    vi.useFakeTimers()
+    const calls: ReturnType<typeof deferred>[] = []
+    const task = vi.fn(() => {
+      const call = deferred()
+      calls.push(call)
+      return call.promise
+    })
+    const pacing = createGitStatusRefreshPacing()
+
+    const first = createScheduler(task, pacing)
+    first.resumeSafety()
+    await vi.advanceTimersByTimeAsync(30_000)
+    calls[0]?.resolve()
+    await flushMicrotasks()
+    first.dispose()
+
+    const second = createScheduler(task, pacing)
+    second.resumeSafety()
+    await flushMicrotasks()
+    // The 30s scan duration still paces the next run: max(3s floor, 1x 30s).
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(task).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
     expect(task).toHaveBeenCalledTimes(2)
   })
 

--- a/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.ts
@@ -8,10 +8,17 @@ export type GitStatusRefreshReason = 'activity' | 'safety'
 export type GitStatusRefreshPacing = {
   lastRunEndedAt: number
   lastRunDurationMs: number
+  nextRunId: number
+  latestFinishedRunId: number
 }
 
 export function createGitStatusRefreshPacing(): GitStatusRefreshPacing {
-  return { lastRunEndedAt: -Infinity, lastRunDurationMs: 0 }
+  return {
+    lastRunEndedAt: -Infinity,
+    lastRunDurationMs: 0,
+    nextRunId: 0,
+    latestFinishedRunId: 0
+  }
 }
 
 export type GitStatusRefreshScheduler = {
@@ -133,6 +140,7 @@ export function createGitStatusRefreshScheduler(
     clearSafetyTimer()
     inFlight = true
     const startedAt = Date.now()
+    const runId = ++pacing.nextRunId
     const controller = new AbortController()
     activeController = controller
     let result: Promise<void>
@@ -146,14 +154,17 @@ export function createGitStatusRefreshScheduler(
         // Status refresh errors are transient; the next signal or safety run retries.
       })
       .finally(() => {
-        pacing.lastRunEndedAt = Date.now()
-        // Why: cancelled scans never delivered a useful result, so their wall
-        // time must not stretch the next activity/safety gap. Otherwise hide →
-        // reveal after a slow abort waits out the aborted scan's full duration
-        // before the catch-up refresh can start.
-        pacing.lastRunDurationMs = controller.signal.aborted
-          ? 0
-          : Math.max(0, pacing.lastRunEndedAt - startedAt)
+        if (runId > pacing.latestFinishedRunId) {
+          pacing.latestFinishedRunId = runId
+          pacing.lastRunEndedAt = Date.now()
+          // Why: cancelled scans never delivered a useful result, so their wall
+          // time must not stretch the next activity/safety gap. Otherwise hide →
+          // reveal after a slow abort waits out the aborted scan's full duration
+          // before the catch-up refresh can start.
+          pacing.lastRunDurationMs = controller.signal.aborted
+            ? 0
+            : Math.max(0, pacing.lastRunEndedAt - startedAt)
+        }
         if (activeController === controller) {
           activeController = null
         }

--- a/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh-scheduler.ts
@@ -2,6 +2,18 @@ import { slowTaskRequiredIdleMs, type SlowTaskBackoffOptions } from './coalesced
 
 export type GitStatusRefreshReason = 'activity' | 'safety'
 
+// Why: run pacing must be shareable across scheduler instances — a rebuild
+// (execution-host or push-target change) that resets it lets sustained change
+// signals run git at the bare debounce, bypassing the #7983 floor.
+export type GitStatusRefreshPacing = {
+  lastRunEndedAt: number
+  lastRunDurationMs: number
+}
+
+export function createGitStatusRefreshPacing(): GitStatusRefreshPacing {
+  return { lastRunEndedAt: -Infinity, lastRunDurationMs: 0 }
+}
+
 export type GitStatusRefreshScheduler = {
   resumeSafety: () => void
   pause: () => void
@@ -27,6 +39,7 @@ export function createGitStatusRefreshScheduler(
     // task backoff when the previous scan itself was slow.
     activityMinGapMs: number
     slowTaskBackoff: SlowTaskBackoffOptions
+    pacing?: GitStatusRefreshPacing
   }
 ): GitStatusRefreshScheduler {
   let disposed = false
@@ -37,8 +50,7 @@ export function createGitStatusRefreshScheduler(
   let activityTimerFiresAt = Infinity
   let safetyTimer: ReturnType<typeof setTimeout> | null = null
   let activeController: AbortController | null = null
-  let lastRunEndedAt = -Infinity
-  let lastRunDurationMs = 0
+  const pacing = options.pacing ?? createGitStatusRefreshPacing()
 
   const clearActivityTimer = (): void => {
     if (activityTimer !== null) {
@@ -56,7 +68,7 @@ export function createGitStatusRefreshScheduler(
 
   const requiredActivityIdleMs = (): number =>
     slowTaskRequiredIdleMs(
-      lastRunDurationMs,
+      pacing.lastRunDurationMs,
       options.slowTaskBackoff.changeSignalMultiplier,
       options.activityMinGapMs,
       options.slowTaskBackoff.maxIntervalMs
@@ -68,7 +80,7 @@ export function createGitStatusRefreshScheduler(
     const delay = Math.max(
       options.safetyIntervalMs,
       slowTaskRequiredIdleMs(
-        lastRunDurationMs,
+        pacing.lastRunDurationMs,
         options.slowTaskBackoff.idleMultiplier,
         0,
         options.slowTaskBackoff.maxIntervalMs
@@ -91,7 +103,7 @@ export function createGitStatusRefreshScheduler(
       return
     }
     const now = Date.now()
-    const delay = Math.max(minDelayMs, lastRunEndedAt + requiredActivityIdleMs() - now)
+    const delay = Math.max(minDelayMs, pacing.lastRunEndedAt + requiredActivityIdleMs() - now)
     if (delay <= 0) {
       startRun('activity')
       return
@@ -134,12 +146,14 @@ export function createGitStatusRefreshScheduler(
         // Status refresh errors are transient; the next signal or safety run retries.
       })
       .finally(() => {
-        lastRunEndedAt = Date.now()
+        pacing.lastRunEndedAt = Date.now()
         // Why: cancelled scans never delivered a useful result, so their wall
         // time must not stretch the next activity/safety gap. Otherwise hide →
         // reveal after a slow abort waits out the aborted scan's full duration
         // before the catch-up refresh can start.
-        lastRunDurationMs = controller.signal.aborted ? 0 : Math.max(0, lastRunEndedAt - startedAt)
+        pacing.lastRunDurationMs = controller.signal.aborted
+          ? 0
+          : Math.max(0, pacing.lastRunEndedAt - startedAt)
         if (activeController === controller) {
           activeController = null
         }

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
@@ -172,6 +172,13 @@ describe('useGitStatusPolling rerender stability', () => {
     // Should trigger an immediate poll on the new worktree (total 2 calls)
     // without having to wait for the 3000ms timer.
     expect(refreshMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      useAppStore.setState({ activeWorktreeId: WORKTREE_ID })
+    })
+    await flushMicrotasks()
+
+    expect(refreshMock).toHaveBeenCalledTimes(3)
   })
 
   it('refreshes immediately when Source Control becomes visible', async () => {

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.rerender.test.ts
@@ -241,6 +241,42 @@ describe('useGitStatusPolling rerender stability', () => {
     expect(refreshMock.mock.calls[1]?.[0].request.reuseLineStats).toBe(true)
   })
 
+  it('keeps the activity floor when the execution host flaps for the same worktree', async () => {
+    await renderHook()
+    await flushMicrotasks()
+    // Mount refresh settles and stamps pacing for this worktree.
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+
+    // Flap the resolved execution host back and forth. Each flip rebuilds the
+    // scheduler; pacing must survive or every flip grants an immediate run
+    // (the rc.3 storm: sustained git at the debounce floor).
+    await act(async () => {
+      useAppStore.setState({
+        worktreesByRepo: {
+          [REPO_ID]: [{ ...worktree, hostId: 'runtime:env-2' }],
+          [REPO_ID2]: [worktree2]
+        }
+      })
+    })
+    await flushMicrotasks()
+    await act(async () => {
+      useAppStore.setState({
+        worktreesByRepo: {
+          [REPO_ID]: [worktree],
+          [REPO_ID2]: [worktree2]
+        }
+      })
+    })
+    await flushMicrotasks()
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(2999)
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    await flushMicrotasks()
+    expect(refreshMock).toHaveBeenCalledTimes(2)
+  })
+
   it('aborts and rejects stale work when the execution host changes', async () => {
     let resolveFirst!: () => void
     const firstRefresh = new Promise<void>((resolve) => {

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -15,7 +15,9 @@ import { useGitStatusFileWatchRefresh } from './git-status-file-watch-refresh'
 import { useGitStatusPushSignalRefresh } from './git-status-push-signal-refresh'
 import { useStaleConflictOperationPolling } from './stale-conflict-operation-poll'
 import {
+  createGitStatusRefreshPacing,
   createGitStatusRefreshScheduler,
+  type GitStatusRefreshPacing,
   type GitStatusRefreshReason,
   type GitStatusRefreshScheduler
 } from './git-status-refresh-scheduler'
@@ -162,8 +164,19 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   const statusRefreshGenerationRef = useRef(0)
 
   const statusSchedulerRef = useRef<GitStatusRefreshScheduler | null>(null)
+  // Why: pacing is keyed by worktree, not by scheduler instance — the rebuilds
+  // below (execution-host/push-target changes) must not reset it, or a flapping
+  // host id lets sustained change signals run git at the bare debounce.
+  const statusPacingByWorktreeRef = useRef<Map<string, GitStatusRefreshPacing> | null>(null)
   useEffect(() => {
     const generation = ++statusRefreshGenerationRef.current
+    const pacingByWorktree = (statusPacingByWorktreeRef.current ??= new Map())
+    const pacingKey = `${activeWorktreeId}\0${worktreePath}`
+    let pacing = pacingByWorktree.get(pacingKey)
+    if (!pacing) {
+      pacing = createGitStatusRefreshPacing()
+      pacingByWorktree.set(pacingKey, pacing)
+    }
     const scheduler = createGitStatusRefreshScheduler(
       ({ reason, signal }) =>
         runFetchStatusRef.current({
@@ -179,7 +192,8 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
         safetyIntervalMs: STATUS_SAFETY_INTERVAL_MS,
         activityDebounceMs: STATUS_ACTIVITY_DEBOUNCE_MS,
         activityMinGapMs: STATUS_ACTIVITY_MIN_GAP_MS,
-        slowTaskBackoff: SLOW_GIT_POLL_BACKOFF
+        slowTaskBackoff: SLOW_GIT_POLL_BACKOFF,
+        pacing
       }
     )
     statusSchedulerRef.current = scheduler

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -164,18 +164,21 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
   const statusRefreshGenerationRef = useRef(0)
 
   const statusSchedulerRef = useRef<GitStatusRefreshScheduler | null>(null)
-  // Why: pacing is keyed by worktree, not by scheduler instance — the rebuilds
-  // below (execution-host/push-target changes) must not reset it, or a flapping
-  // host id lets sustained change signals run git at the bare debounce.
-  const statusPacingByWorktreeRef = useRef<Map<string, GitStatusRefreshPacing> | null>(null)
+  // Why: pacing belongs to the current worktree, not to scheduler instances —
+  // execution-host/push-target rebuilds must not reset it, or a flapping host id
+  // lets sustained change signals run git at the bare debounce.
+  const statusPacingRef = useRef<{
+    key: string
+    pacing: GitStatusRefreshPacing
+  } | null>(null)
   useEffect(() => {
     const generation = ++statusRefreshGenerationRef.current
-    const pacingByWorktree = (statusPacingByWorktreeRef.current ??= new Map())
     const pacingKey = `${activeWorktreeId}\0${worktreePath}`
-    let pacing = pacingByWorktree.get(pacingKey)
+    let pacing =
+      statusPacingRef.current?.key === pacingKey ? statusPacingRef.current.pacing : undefined
     if (!pacing) {
       pacing = createGitStatusRefreshPacing()
-      pacingByWorktree.set(pacingKey, pacing)
+      statusPacingRef.current = { key: pacingKey, pacing }
     }
     const scheduler = createGitStatusRefreshScheduler(
       ({ reason, signal }) =>


### PR DESCRIPTION
## Summary

Fixes the git-status refresh storm that makes the app lag badly (typing latency, renderer pegged at 100-160% CPU) when a remote/mobile runtime client is attached while agents are active.

Root cause: #11346 added `activeExecutionHostId` to the git-status scheduler effect's dependency array in `useGitStatusPolling`. The rebuild on host change is intentional (generation bump + in-flight abort), but the scheduler's pacing state (`lastRunEndedAt`, `lastRunDurationMs`) was closure-local, so every rebuild reset it to `-Infinity`. With a connected runtime client the resolved host id flaps (local vs `runtime:<env>` publications overwrite each other in the repoId-keyed store), each flap minted an unthrottled scheduler, and the pre-existing loop (git status rewrites `.git/worktrees/<n>/index` → 2s base-directory poller → status signal) then ran at the bare 125ms debounce instead of the 3s floor + slow-task backoff (#7983).

Measured on the affected machine (1.4.163-rc.3, live trace spans): git spawn rate jumped from 26-35/min (rc.1, same workload) to a sustained 150-283/min, full 5-command status cycles every 1-3s per busy worktree, renderer main thread ~73% busy.

Fix (two commits):
- `6eece0b41e`: pacing becomes a shareable object (`GitStatusRefreshPacing`) owned by the hook and keyed to the current worktree, surviving scheduler rebuilds. Host/push-target changes still dispose the scheduler, abort in-flight scans, and bump the generation — they just no longer forget how recently git ran. Worktree *switches* keep their instant refresh (fresh pacing per worktree).
- `1414b6a239`: hardening — run-id ordering so a stale run from a disposed scheduler that settles late cannot stamp pacing over a newer run's result, and the hook holds a single current-worktree pacing slot instead of an unbounded map.

## Empirical A/B validation

Beyond unit tests, the mechanism and fix were validated in a live dev app with real git subprocesses: two instances from pinned commits differing only by this fix (`cd2b62ed14` = main/broken vs `6eece0b41e` = main+fix), isolated `ORCA_DEV_USER_DATA_PATH` profiles, a fixture repo with 500ms file churn, Source Control active, then a scheduler-dep flip injected every 1s via the exposed store (same dependency array and rebuild path as the production host-id flap). Git spawns measured from each profile's `main.trace.ndjson`:

| | Baseline (churn only) | Under 1s dep-flapping |
|---|---|---|
| main `cd2b62ed14` (broken) | 54 execs/min, status every 3s | **60 status cycles/min at 1s gaps** (floor bypassed, 466 execs) |
| `6eece0b41e` (fix) | 54 execs/min, status every 3s | **20 status cycles/min at exact 3s gaps** (floor holds) |

Baselines are identical, so the fix changes nothing in normal operation; under the storm input, the broken build runs status at the flap rate while the fix build holds the floor.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (targeted suites run locally; full suite left to CI)
- [ ] `pnpm build` (left to CI)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted runs (all green): `git-status-refresh-scheduler.test.ts`, `useGitStatusPolling.rerender.test.ts`, `useGitStatusPolling.test.ts`.

New regression coverage:
- scheduler: shared pacing keeps the 3s activity floor across dispose/recreate
- scheduler: shared pacing keeps slow-scan backoff (30s scan still paces the next run after recreation)
- hook: execution-host flapping for the same worktree cannot bypass the floor (the storm shape)

Plus the live A/B above as end-to-end validation.

## AI Review Report

Reviewed the change against the scheduler's correctness contracts:
- Rebuild semantics preserved: generation bump, in-flight abort, and trailing-refresh behavior are untouched; only pacing continuity changes. The existing tests "aborts and rejects stale work when the execution host changes" and "triggers an immediate poll when the active worktree changes" pass unchanged.
- Out-of-order settle handled: a disposed scheduler's still-running scan that settles after a newer run cannot regress pacing (run-id ordering, second commit).
- Aborted-scan rule preserved: cancelled scans still record duration 0 so hide→reveal catch-up is not stretched.
- Pacing storage is a single current-worktree slot in a ref — no growth, released on unmount.
- `pacing` option is optional; the only factory consumer is `useGitStatusPolling`, and omitting it reproduces the old per-instance behavior.
Cross-platform: renderer-only TypeScript using timers and in-memory state — no shortcuts, labels, paths, shell, or Electron platform APIs touched; behavior identical on macOS/Linux/Windows. Applies equally to SSH-hosted and folder workspaces since the pacing key is the worktree id + path already used by the scheduler effect.

## Security Audit

No input handling, command execution, path construction, auth, secrets, dependency, or IPC changes. The pacing key is built from in-app worktree id/path values and stays in renderer memory; nothing is persisted or transmitted.

## Notes

- This clamps the amplifier regardless of what causes scheduler rebuilds. Follow-ups deliberately out of scope (separate PRs): (1) ~20 `setActiveWorktree` call sites clear `activeWorkspaceExecutionHostId` by omitting the new argument — making it sticky would reduce host-id flapping at the source; (2) `detectedWorktreesByRepo` is keyed by repoId alone, so local and runtime publications of the same repo overwrite each other.
- Related but separate: PR-status polling has no pre-spawn default-branch short-circuit and bypasses its negative cache on `active`/`post-push` reasons, which multiplied `gh` spawns during the storm (~50-100/min). Also a candidate for its own PR.
- Release impact: the regression is only in `v1.4.163-rc.3` (landed between rc.1 and rc.3); it is not in stable v1.4.162. Recommend landing this before promoting 1.4.163 to stable.
