### PR TITLE
fix(i18n): localize status labels in settings and stats

### DIFF
--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -120,11 +120,16 @@ export function ComputerUsePane(): React.JSX.Element {
             'auto.components.settings.computerUseSummary.readyDescription',
             'Agents can inspect and operate app windows when you ask.'
           )
-        : translate(
-            'auto.components.settings.computerUseSummary.permissionsRequired',
-            '{{value0}} permission{{value1}} required before agents can operate app windows.',
-            { value0: missingCount, value1: missingCount === 1 ? '' : 's' }
-          )
+        : missingCount === 1
+          ? translate(
+              'auto.components.settings.computerUseSummary.permissionsRequired_one',
+              '1 permission required before agents can operate app windows.'
+            )
+          : translate(
+              'auto.components.settings.computerUseSummary.permissionsRequired_other',
+              '{{value0}} permissions required before agents can operate app windows.',
+              { value0: missingCount }
+            )
 
   useEffect(() => {
     mountedRef.current = true

--- a/src/renderer/src/components/settings/ComputerUsePane.tsx
+++ b/src/renderer/src/components/settings/ComputerUsePane.tsx
@@ -44,12 +44,12 @@ const PERMISSIONS: PermissionDefinition[] = [
 function statusLabel(status: ComputerUsePermissionStatus | undefined): string {
   switch (status) {
     case 'granted':
-      return 'Granted'
+      return translate('auto.components.settings.ComputerUsePane.statusGranted', 'Granted')
     case 'unsupported':
-      return 'macOS only'
+      return translate('auto.components.settings.ComputerUsePane.statusUnsupported', 'macOS only')
     case 'not-granted':
     case undefined:
-      return 'Not enabled'
+      return translate('auto.components.settings.ComputerUsePane.statusNotEnabled', 'Not enabled')
   }
 }
 
@@ -85,21 +85,46 @@ export function ComputerUsePane(): React.JSX.Element {
   const resetAccessDisabled =
     resetting || loading || states.length === 0 || pendingId !== null || setupUnavailable
   const summaryTitle = checking
-    ? 'Checking Computer Use access.'
+    ? translate(
+        'auto.components.settings.computerUseSummary.checkingTitle',
+        'Checking Computer Use access.'
+      )
     : setupUnavailable
-      ? 'Computer Use is unavailable.'
+      ? translate(
+          'auto.components.settings.computerUseSummary.unavailableTitle',
+          'Computer Use is unavailable.'
+        )
       : allGranted
-        ? 'Computer Use is ready.'
-        : 'Finish setup to use local apps.'
+        ? translate(
+            'auto.components.settings.computerUseSummary.readyTitle',
+            'Computer Use is ready.'
+          )
+        : translate(
+            'auto.components.settings.computerUseSummary.permissionsTitle',
+            'Finish setup to use local apps.'
+          )
+  const missingCount = PERMISSIONS.length - grantedCount
   const summaryDescription = checking
-    ? 'Orca is checking macOS privacy permissions for the Computer Use helper.'
+    ? translate(
+        'auto.components.settings.computerUseSummary.checkingDescription',
+        'Orca is checking macOS privacy permissions for the Computer Use helper.'
+      )
     : setupUnavailable
-      ? `Computer Use permissions are unavailable because ${helperUnavailableReason}.`
+      ? translate(
+          'auto.components.settings.computerUseSummary.unavailableDescription',
+          'Computer Use permissions are unavailable because {{value0}}.',
+          { value0: helperUnavailableReason }
+        )
       : allGranted
-        ? 'Agents can inspect and operate app windows when you ask.'
-        : `${PERMISSIONS.length - grantedCount} permission${
-            PERMISSIONS.length - grantedCount === 1 ? '' : 's'
-          } required before agents can operate app windows.`
+        ? translate(
+            'auto.components.settings.computerUseSummary.readyDescription',
+            'Agents can inspect and operate app windows when you ask.'
+          )
+        : translate(
+            'auto.components.settings.computerUseSummary.permissionsRequired',
+            '{{value0}} permission{{value1}} required before agents can operate app windows.',
+            { value0: missingCount, value1: missingCount === 1 ? '' : 's' }
+          )
 
   useEffect(() => {
     mountedRef.current = true

--- a/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
+++ b/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
@@ -16,11 +16,14 @@ import {
 import { toast } from 'sonner'
 import type {
   DeveloperPermissionId,
-  DeveloperPermissionState,
-  DeveloperPermissionStatus
+  DeveloperPermissionState
 } from '../../../../shared/developer-permissions-types'
 import { Button } from '../ui/button'
 import { translate } from '@/i18n/i18n'
+import {
+  developerPermissionStatusClass,
+  developerPermissionStatusLabel
+} from './developer-permission-status'
 export { getDeveloperPermissionsPaneSearchEntries } from './developer-permissions-search'
 
 type DeveloperPermissionsPaneProps = {
@@ -47,7 +50,9 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Voice input, transcription, audio recording, sox, ffmpeg, and Whisper CLIs.'
       )
     },
-    actionLabel: 'Request',
+    get actionLabel() {
+      return translate('auto.components.settings.DeveloperPermissionsPane.actionRequest', 'Request')
+    },
     icon: <Mic className="size-4" />
   },
   {
@@ -61,7 +66,9 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Webcam capture and camera-driven local test apps.'
       )
     },
-    actionLabel: 'Request',
+    get actionLabel() {
+      return translate('auto.components.settings.DeveloperPermissionsPane.actionRequest', 'Request')
+    },
     icon: <Camera className="size-4" />
   },
   {
@@ -78,7 +85,12 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Screenshot, visual automation, and UI inspection tools.'
       )
     },
-    actionLabel: 'Open Settings',
+    get actionLabel() {
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.actionOpenSettings',
+        'Open Settings'
+      )
+    },
     icon: <MonitorUp className="size-4" />
   },
   {
@@ -95,7 +107,9 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Keystroke injection, window control, and UI automation tools.'
       )
     },
-    actionLabel: 'Request',
+    get actionLabel() {
+      return translate('auto.components.settings.DeveloperPermissionsPane.actionRequest', 'Request')
+    },
     icon: <Accessibility className="size-4" />
   },
   {
@@ -112,7 +126,12 @@ const PERMISSIONS: PermissionDefinition[] = [
         "macOS names Orca when the agents it runs read other apps' data, because Orca is the responsible process for terminal commands. Grant this to Orca to reduce those prompts. Then quit and reopen Orca."
       )
     },
-    actionLabel: 'Open Settings',
+    get actionLabel() {
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.actionOpenSettings',
+        'Open Settings'
+      )
+    },
     icon: <HardDrive className="size-4" />
   },
   {
@@ -126,7 +145,12 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Apple Events for scripts that control other local apps.'
       )
     },
-    actionLabel: 'Trigger Prompt',
+    get actionLabel() {
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.actionTriggerPrompt',
+        'Trigger Prompt'
+      )
+    },
     icon: <Workflow className="size-4" />
   },
   {
@@ -140,7 +164,12 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Discovery and access for development servers on your network.'
       )
     },
-    actionLabel: 'Trigger Prompt',
+    get actionLabel() {
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.actionTriggerPrompt',
+        'Trigger Prompt'
+      )
+    },
     icon: <Network className="size-4" />
   },
   {
@@ -157,7 +186,12 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Hardware debugging and device tools that talk to USB devices.'
       )
     },
-    actionLabel: 'Open Settings',
+    get actionLabel() {
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.actionOpenSettings',
+        'Open Settings'
+      )
+    },
     icon: <Usb className="size-4" />
   },
   {
@@ -171,40 +205,15 @@ const PERMISSIONS: PermissionDefinition[] = [
         'Bluetooth device tools and local hardware experiments.'
       )
     },
-    actionLabel: 'Open Settings',
+    get actionLabel() {
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.actionOpenSettings',
+        'Open Settings'
+      )
+    },
     icon: <Bluetooth className="size-4" />
   }
 ]
-
-function statusLabel(status: DeveloperPermissionStatus | undefined): string {
-  switch (status) {
-    case 'granted':
-      return 'Granted'
-    case 'denied':
-      return 'Denied'
-    case 'not-determined':
-      return 'Not requested'
-    case 'restricted':
-      return 'Restricted'
-    case 'unsupported':
-      return 'macOS only'
-    case 'ready':
-      return 'Entitled'
-    case 'unknown':
-    case undefined:
-      return 'Check manually'
-  }
-}
-
-function statusClass(status: DeveloperPermissionStatus | undefined): string {
-  if (status === 'granted' || status === 'ready') {
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-  }
-  if (status === 'denied' || status === 'restricted') {
-    return 'border-destructive/30 bg-destructive/10 text-destructive'
-  }
-  return 'border-border bg-muted text-muted-foreground'
-}
 
 export function DeveloperPermissionsPane({
   highlightedSettingId = null
@@ -361,11 +370,11 @@ export function DeveloperPermissionsPane({
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="text-sm font-medium">{permission.label}</span>
                     <span
-                      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${statusClass(
+                      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${developerPermissionStatusClass(
                         status
                       )}`}
                     >
-                      {statusLabel(status)}
+                      {developerPermissionStatusLabel(status)}
                     </span>
                   </div>
                   <p className="text-xs text-muted-foreground">{permission.description}</p>

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
@@ -28,11 +28,16 @@ function getAgentCoverageSummary(props: {
     )
   }
   if (fullCoverage) {
-    return translate(
-      'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage',
-      'All {{value0}} detected agents have the skill.',
-      { value0: totalCount }
-    )
+    return totalCount === 1
+      ? translate(
+          'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage_one',
+          'All 1 detected agent has the skill.'
+        )
+      : translate(
+          'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage_other',
+          'All {{value0}} detected agents have the skill.',
+          { value0: totalCount }
+        )
   }
   if (noCoverage) {
     return translate(

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
@@ -16,18 +16,35 @@ function getAgentCoverageSummary(props: {
   const { loading, totalCount, installedCount, fullCoverage, noCoverage } = props
 
   if (loading) {
-    return 'Checking installed agents and skill paths…'
+    return translate(
+      'auto.components.settings.OrchestrationSkillAgentCoverage.checking',
+      'Checking installed agents and skill paths…'
+    )
   }
   if (totalCount === 0) {
-    return 'No agent CLIs detected on PATH. Install agents in Settings → Agents, then re-check.'
+    return translate(
+      'auto.components.settings.OrchestrationSkillAgentCoverage.noAgents',
+      'No agent CLIs detected on PATH. Install agents in Settings → Agents, then re-check.'
+    )
   }
   if (fullCoverage) {
-    return `All ${totalCount} detected agents have the skill.`
+    return translate(
+      'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage',
+      'All {{value0}} detected agents have the skill.',
+      { value0: totalCount }
+    )
   }
   if (noCoverage) {
-    return 'Install the skill above, then re-check.'
+    return translate(
+      'auto.components.settings.OrchestrationSkillAgentCoverage.noCoverage',
+      'Install the skill above, then re-check.'
+    )
   }
-  return `${installedCount} of ${totalCount} detected agents have the skill.`
+  return translate(
+    'auto.components.settings.OrchestrationSkillAgentCoverage.partialCoverage',
+    '{{value0}} of {{value1}} detected agents have the skill.',
+    { value0: installedCount, value1: totalCount }
+  )
 }
 
 function AgentCoverageChip({
@@ -74,7 +91,9 @@ export function OrchestrationSkillAgentCoverage(props: {
   className?: string
 }): React.JSX.Element {
   const { skills, sources, loading: skillsLoading, embedded = false, className } = props
-  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents({ kind: 'local' })
+  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents({
+    kind: 'local'
+  })
   const loading = skillsLoading || agentsLoading || detectedIds === null
   const agentStatuses = getOrchestrationSkillAgentStatuses(skills, detectedIds ?? [], sources)
   const installedCount = agentStatuses.filter((status) => status.installed).length

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -11,6 +11,35 @@ import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
 import { translate } from '@/i18n/i18n'
 
+function integrationStatusLabel(
+  status: 'connected' | 'unavailable' | 'not-installed' | 'not-authenticated' | 'checking'
+): string {
+  switch (status) {
+    case 'connected':
+      return translate(
+        'auto.components.settings.cli.source.control.integration.cards.statusConnected',
+        'Connected'
+      )
+    case 'unavailable':
+      return translate(
+        'auto.components.settings.cli.source.control.integration.cards.statusUnavailable',
+        'Unavailable'
+      )
+    case 'not-installed':
+      return translate(
+        'auto.components.settings.cli.source.control.integration.cards.statusNotInstalled',
+        'Not installed'
+      )
+    case 'not-authenticated':
+      return translate(
+        'auto.components.settings.cli.source.control.integration.cards.statusNotAuthenticated',
+        'Not authenticated'
+      )
+    case 'checking':
+      return ''
+  }
+}
+
 function ProviderAccountScopeDetails({
   children
 }: {
@@ -65,27 +94,7 @@ export function GitHubIntegrationCard(): React.JSX.Element {
       }
       checking={status === 'checking'}
       statusTone={connected ? 'connected' : 'attention'}
-      statusLabel={
-        connected
-          ? translate(
-              'auto.components.settings.cli.source.control.integration.cards.statusConnected',
-              'Connected'
-            )
-          : status === 'unavailable'
-            ? translate(
-                'auto.components.settings.cli.source.control.integration.cards.statusUnavailable',
-                'Unavailable'
-              )
-            : status === 'not-installed'
-              ? translate(
-                  'auto.components.settings.cli.source.control.integration.cards.statusNotInstalled',
-                  'Not installed'
-                )
-              : translate(
-                  'auto.components.settings.cli.source.control.integration.cards.statusNotAuthenticated',
-                  'Not authenticated'
-                )
-      }
+      statusLabel={integrationStatusLabel(status)}
     >
       <ProviderAccountScopeDetails>
         {status !== 'checking' && !connected ? (
@@ -206,27 +215,7 @@ export function GitLabIntegrationCard(): React.JSX.Element {
       }
       checking={status === 'checking'}
       statusTone={connected ? 'connected' : 'attention'}
-      statusLabel={
-        connected
-          ? translate(
-              'auto.components.settings.cli.source.control.integration.cards.statusConnected',
-              'Connected'
-            )
-          : status === 'unavailable'
-            ? translate(
-                'auto.components.settings.cli.source.control.integration.cards.statusUnavailable',
-                'Unavailable'
-              )
-            : status === 'not-installed'
-              ? translate(
-                  'auto.components.settings.cli.source.control.integration.cards.statusNotInstalled',
-                  'Not installed'
-                )
-              : translate(
-                  'auto.components.settings.cli.source.control.integration.cards.statusNotAuthenticated',
-                  'Not authenticated'
-                )
-      }
+      statusLabel={integrationStatusLabel(status)}
     >
       <ProviderAccountScopeDetails>
         {status !== 'checking' && !connected ? (

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -67,12 +67,24 @@ export function GitHubIntegrationCard(): React.JSX.Element {
       statusTone={connected ? 'connected' : 'attention'}
       statusLabel={
         connected
-          ? 'Connected'
+          ? translate(
+              'auto.components.settings.cli.source.control.integration.cards.statusConnected',
+              'Connected'
+            )
           : status === 'unavailable'
-            ? 'Unavailable'
+            ? translate(
+                'auto.components.settings.cli.source.control.integration.cards.statusUnavailable',
+                'Unavailable'
+              )
             : status === 'not-installed'
-              ? 'Not installed'
-              : 'Not authenticated'
+              ? translate(
+                  'auto.components.settings.cli.source.control.integration.cards.statusNotInstalled',
+                  'Not installed'
+                )
+              : translate(
+                  'auto.components.settings.cli.source.control.integration.cards.statusNotAuthenticated',
+                  'Not authenticated'
+                )
       }
     >
       <ProviderAccountScopeDetails>
@@ -196,12 +208,24 @@ export function GitLabIntegrationCard(): React.JSX.Element {
       statusTone={connected ? 'connected' : 'attention'}
       statusLabel={
         connected
-          ? 'Connected'
+          ? translate(
+              'auto.components.settings.cli.source.control.integration.cards.statusConnected',
+              'Connected'
+            )
           : status === 'unavailable'
-            ? 'Unavailable'
+            ? translate(
+                'auto.components.settings.cli.source.control.integration.cards.statusUnavailable',
+                'Unavailable'
+              )
             : status === 'not-installed'
-              ? 'Not installed'
-              : 'Not authenticated'
+              ? translate(
+                  'auto.components.settings.cli.source.control.integration.cards.statusNotInstalled',
+                  'Not installed'
+                )
+              : translate(
+                  'auto.components.settings.cli.source.control.integration.cards.statusNotAuthenticated',
+                  'Not authenticated'
+                )
       }
     >
       <ProviderAccountScopeDetails>

--- a/src/renderer/src/components/settings/developer-permission-status.ts
+++ b/src/renderer/src/components/settings/developer-permission-status.ts
@@ -1,0 +1,52 @@
+import { translate } from '@/i18n/i18n'
+import type { DeveloperPermissionStatus } from '../../../../shared/developer-permissions-types'
+
+/** Status copy and tone for the macOS developer permission rows. */
+export function developerPermissionStatusLabel(
+  status: DeveloperPermissionStatus | undefined
+): string {
+  switch (status) {
+    case 'granted':
+      return translate('auto.components.settings.DeveloperPermissionsPane.statusGranted', 'Granted')
+    case 'denied':
+      return translate('auto.components.settings.DeveloperPermissionsPane.statusDenied', 'Denied')
+    case 'not-determined':
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.statusNotRequested',
+        'Not requested'
+      )
+    case 'restricted':
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.statusRestricted',
+        'Restricted'
+      )
+    case 'unsupported':
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.statusUnsupported',
+        'macOS only'
+      )
+    case 'ready':
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.statusEntitled',
+        'Entitled'
+      )
+    case 'unknown':
+    case undefined:
+      return translate(
+        'auto.components.settings.DeveloperPermissionsPane.statusCheckManually',
+        'Check manually'
+      )
+  }
+}
+
+export function developerPermissionStatusClass(
+  status: DeveloperPermissionStatus | undefined
+): string {
+  if (status === 'granted' || status === 'ready') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+  }
+  if (status === 'denied' || status === 'restricted') {
+    return 'border-destructive/30 bg-destructive/10 text-destructive'
+  }
+  return 'border-border bg-muted text-muted-foreground'
+}

--- a/src/renderer/src/components/stats/StatsPane.tsx
+++ b/src/renderer/src/components/stats/StatsPane.tsx
@@ -43,7 +43,13 @@ function formatTrackingSince(timestamp: number | null): string {
     return ''
   }
   const date = new Date(timestamp)
-  return `Tracking since ${date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`
+  return translate('auto.components.stats.StatsPane.trackingSince', 'Tracking since {{value0}}', {
+    value0: date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    })
+  })
 }
 
 type UsageTab = 'overview' | 'claude' | 'codex' | 'opencode' | 'grok'

--- a/src/renderer/src/components/stats/usage-overview-sections.tsx
+++ b/src/renderer/src/components/stats/usage-overview-sections.tsx
@@ -30,7 +30,10 @@ function formatDayLabel(day: string): string {
   if (Number.isNaN(parsed.getTime())) {
     return day
   }
-  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric'
+  })
 }
 
 export function TokenMixBar({ overview }: { overview: UsageOverviewModel }): React.JSX.Element {
@@ -97,7 +100,10 @@ export function TokenMixBar({ overview }: { overview: UsageOverviewModel }): Rea
                 aria-label={translate(
                   'auto.components.stats.usage.overview.sections.32330a6e66',
                   '{{value0}}: {{value1}} tokens',
-                  { value0: segment.label, value1: segment.value.toLocaleString() }
+                  {
+                    value0: segment.label,
+                    value1: segment.value.toLocaleString()
+                  }
                 )}
               />
             ) : null
@@ -201,7 +207,11 @@ export function ProviderUsageRow({
   onEnable: () => void
 }): React.JSX.Element {
   const share = totalTokens > 0 ? provider.totalTokens / totalTokens : 0
-  const status = provider.enabled ? (provider.isScanning ? 'Scanning' : 'Enabled') : 'Off'
+  const status = provider.enabled
+    ? provider.isScanning
+      ? translate('auto.components.stats.usage.overview.sections.statusScanning', 'Scanning')
+      : translate('auto.components.stats.usage.overview.sections.statusEnabled', 'Enabled')
+    : translate('auto.components.stats.usage.overview.sections.statusOff', 'Off')
   const statusVariant = provider.enabled ? 'secondary' : 'outline'
 
   return (
@@ -246,7 +256,9 @@ export function ProviderUsageRow({
       <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
         <div
           className="h-full rounded-full bg-foreground/75"
-          style={{ width: `${Math.max(share * 100, provider.totalTokens > 0 ? 2 : 0)}%` }}
+          style={{
+            width: `${Math.max(share * 100, provider.totalTokens > 0 ? 2 : 0)}%`
+          }}
         />
       </div>
       {provider.lastScanError ? (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -498,7 +498,12 @@
             "9e37a5b1b3": "Run independent work in parallel",
             "bddc4c09b8": "Run a phased workflow",
             "ab0e9803b7": "Hand off to another worktree",
-            "5e0d489fe1": "Hand off an active task"
+            "5e0d489fe1": "Hand off an active task",
+            "handoffSummary": "Move ownership to another agent with enough context to continue.",
+            "worktreeHandoffSummary": "Move work to an agent that is already running in a different branch.",
+            "childSequenceSummary": "Use child agents one after another when each phase depends on the last.",
+            "childParallelSummary": "Split non-overlapping investigation or implementation tasks across child agents.",
+            "prSplitSummary": "Give each child agent its own worktree so parallel implementation stays reviewable."
           }
         }
       },
@@ -3648,7 +3653,8 @@
           "908c470587": "codex",
           "eb6a066185": "claude",
           "eee19cfade": "overview",
-          "grokUsageTab": "Grok"
+          "grokUsageTab": "Grok",
+          "trackingSince": "Tracking since {{value0}}"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "sessions",
@@ -3736,7 +3742,10 @@
               "6762f6a682": "tokens",
               "a7f937fb29": "{{value0}} sessions - {{value1}} {{value2}}",
               "c8f3a2d1e0b4": "turns",
-              "d9a4b3e2f1c5": "events"
+              "d9a4b3e2f1c5": "events",
+              "statusScanning": "Scanning",
+              "statusEnabled": "Enabled",
+              "statusOff": "Off"
             }
           }
         },
@@ -5705,7 +5714,10 @@
           "6b5a2cd3a5": "Accessibility",
           "6b17602073": "Reset access",
           "506f2acf7a": "Resetting access...",
-          "4b65070096": "darwin"
+          "4b65070096": "darwin",
+          "statusGranted": "Granted",
+          "statusUnsupported": "macOS only",
+          "statusNotEnabled": "Not enabled"
         },
         "DeveloperPermissionsPane": {
           "4c17304beb": "Refresh",
@@ -5734,7 +5746,17 @@
           "e5b5f3d6b9": "Camera",
           "cc8151d9fa": "Voice input, transcription, audio recording, sox, ffmpeg, and Whisper CLIs.",
           "16381e040a": "Microphone",
-          "dac08ec03e": "Working..."
+          "dac08ec03e": "Working...",
+          "actionRequest": "Request",
+          "actionOpenSettings": "Open Settings",
+          "actionTriggerPrompt": "Trigger Prompt",
+          "statusGranted": "Granted",
+          "statusDenied": "Denied",
+          "statusNotRequested": "Not requested",
+          "statusRestricted": "Restricted",
+          "statusUnsupported": "macOS only",
+          "statusEntitled": "Entitled",
+          "statusCheckManually": "Check manually"
         },
         "ExperimentalPane": {
           "9762364929": "Uses APFS clone-copy on macOS when possible, otherwise symlinks configured folders or files into created worktrees.",
@@ -6375,7 +6397,12 @@
         "OrchestrationSkillAgentCoverage": {
           "6dec5ce2d2": "Agent coverage",
           "ffe13e36fb": "Missing",
-          "1e8f8d8fae": "Ready"
+          "1e8f8d8fae": "Ready",
+          "checking": "Checking installed agents and skill paths…",
+          "noAgents": "No agent CLIs detected on PATH. Install agents in Settings → Agents, then re-check.",
+          "fullCoverage": "All {{value0}} detected agents have the skill.",
+          "noCoverage": "Install the skill above, then re-check.",
+          "partialCoverage": "{{value0}} of {{value1}} detected agents have the skill."
         },
         "OrchestrationSkillPromptDialog": {
           "f08d45293d": "Copy command",
@@ -9172,7 +9199,11 @@
                   "6f30fc4216": "GitHub CLI status is not available in this runtime yet.",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "Pull requests, issues, and checks via the",
-                  "account_scope_prefix": "Account scope"
+                  "account_scope_prefix": "Account scope",
+                  "statusConnected": "Connected",
+                  "statusUnavailable": "Unavailable",
+                  "statusNotInstalled": "Not installed",
+                  "statusNotAuthenticated": "Not authenticated"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6400,7 +6400,8 @@
           "1e8f8d8fae": "Ready",
           "checking": "Checking installed agents and skill paths…",
           "noAgents": "No agent CLIs detected on PATH. Install agents in Settings → Agents, then re-check.",
-          "fullCoverage": "All {{value0}} detected agents have the skill.",
+          "fullCoverage_one": "All 1 detected agent has the skill.",
+          "fullCoverage_other": "All {{value0}} detected agents have the skill.",
           "noCoverage": "Install the skill above, then re-check.",
           "partialCoverage": "{{value0}} of {{value1}} detected agents have the skill."
         },
@@ -9297,7 +9298,8 @@
           "readyTitle": "Computer Use is ready.",
           "readyDescription": "Agents can inspect and operate app windows when you ask.",
           "permissionsTitle": "Finish setup to use local apps.",
-          "permissionsRequired": "{{value0}} permission{{value1}} required before agents can operate app windows."
+          "permissionsRequired_one": "1 permission required before agents can operate app windows.",
+          "permissionsRequired_other": "{{value0}} permissions required before agents can operate app windows."
         },
         "providerAccountScope": {
           "remoteServer": "Remote server: {{value0}}",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9201,7 +9201,8 @@
           }
         },
         "computerUseSummary": {
-          "permissionsRequired": "Requiere {{value0}} permiso{{value1}} antes de que los agentes puedan operar ventanas de apps.",
+          "permissionsRequired_one": "Se requiere 1 permiso antes de que los agentes puedan operar ventanas de apps.",
+          "permissionsRequired_other": "Se requieren {{value0}} permisos antes de que los agentes puedan operar ventanas de apps.",
           "checkingTitle": "Comprobando el acceso a Computer Use.",
           "checkingDescription": "Orca está comprobando los permisos de privacidad de macOS para el helper de Computer Use.",
           "unavailableTitle": "Computer Use no está disponible.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9201,7 +9201,8 @@
           }
         },
         "computerUseSummary": {
-          "permissionsRequired": "{{value0}} permission{{value1}} required before agents can operate app windows.",
+          "permissionsRequired_one": "1 permission required before agents can operate app windows.",
+          "permissionsRequired_other": "{{value0}} permissions required before agents can operate app windows.",
           "checkingTitle": "Checking Computer Use access.",
           "checkingDescription": "Orca is checking macOS privacy permissions for the Computer Use helper.",
           "unavailableTitle": "Computer Use is unavailable.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9201,7 +9201,8 @@
           }
         },
         "computerUseSummary": {
-          "permissionsRequired": "agents가 앱 창을 조작하려면 먼저 {{value0}} 권한{{value1}}이 필요합니다.",
+          "permissionsRequired_one": "agents가 앱 창을 조작하려면 먼저 1 권한이 필요합니다.",
+          "permissionsRequired_other": "agents가 앱 창을 조작하려면 먼저 {{value0}} 권한이 필요합니다.",
           "checkingTitle": "Computer Use 액세스 확인 중입니다.",
           "checkingDescription": "Orca가 Computer Use 도우미의 macOS 개인정보 보호 권한을 확인하고 있습니다.",
           "unavailableTitle": "Computer Use를 사용할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9201,7 +9201,8 @@
           }
         },
         "computerUseSummary": {
-          "permissionsRequired": "在智能体可操作应用窗口前需要 {{value0}} 项权限{{value1}}。",
+          "permissionsRequired_one": "在智能体可操作应用窗口前需要 1 项权限。",
+          "permissionsRequired_other": "在智能体可操作应用窗口前需要 {{value0}} 项权限。",
           "checkingTitle": "正在检查计算机控制访问权限。",
           "checkingDescription": "Orca 正在检查计算机控制助手的 macOS 隐私权限。",
           "unavailableTitle": "计算机控制不可用。",

--- a/src/renderer/src/i18n/settings-status-label-localization.test.ts
+++ b/src/renderer/src/i18n/settings-status-label-localization.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Status pills in Settings and Stats used to be built from bare string literals
+ * inside local helper functions, so they stayed English no matter which language
+ * was selected. The coverage audit does not reach them: it inspects JSX
+ * attributes and object properties, not values returned by helpers.
+ *
+ * These assertions pin the catalog contract for those helpers. A future refactor
+ * that drops `translate()` and returns a literal again would leave the key
+ * missing from `en.json` and fail here.
+ */
+import { describe, expect, it } from 'vitest'
+import en from './locales/en.json'
+
+function lookup(key: string): string | undefined {
+  const value = key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
+      en as unknown
+    )
+  return typeof value === 'string' ? value : undefined
+}
+
+const REQUIRED_KEYS: Record<string, string> = {
+  // DeveloperPermissionsPane — macOS permission rows
+  'auto.components.settings.DeveloperPermissionsPane.statusGranted': 'Granted',
+  'auto.components.settings.DeveloperPermissionsPane.statusDenied': 'Denied',
+  'auto.components.settings.DeveloperPermissionsPane.statusNotRequested': 'Not requested',
+  'auto.components.settings.DeveloperPermissionsPane.statusRestricted': 'Restricted',
+  'auto.components.settings.DeveloperPermissionsPane.statusUnsupported': 'macOS only',
+  'auto.components.settings.DeveloperPermissionsPane.statusEntitled': 'Entitled',
+  'auto.components.settings.DeveloperPermissionsPane.statusCheckManually': 'Check manually',
+  'auto.components.settings.DeveloperPermissionsPane.actionRequest': 'Request',
+  'auto.components.settings.DeveloperPermissionsPane.actionTriggerPrompt': 'Trigger Prompt',
+  'auto.components.settings.DeveloperPermissionsPane.actionOpenSettings': 'Open Settings',
+  // ComputerUsePane — permission rows
+  'auto.components.settings.ComputerUsePane.statusGranted': 'Granted',
+  'auto.components.settings.ComputerUsePane.statusUnsupported': 'macOS only',
+  'auto.components.settings.ComputerUsePane.statusNotEnabled': 'Not enabled',
+  // Source-control CLI integration cards
+  'auto.components.settings.cli.source.control.integration.cards.statusConnected': 'Connected',
+  'auto.components.settings.cli.source.control.integration.cards.statusUnavailable': 'Unavailable',
+  'auto.components.settings.cli.source.control.integration.cards.statusNotInstalled':
+    'Not installed',
+  'auto.components.settings.cli.source.control.integration.cards.statusNotAuthenticated':
+    'Not authenticated',
+  // Stats — provider rows
+  'auto.components.stats.usage.overview.sections.statusScanning': 'Scanning',
+  'auto.components.stats.usage.overview.sections.statusEnabled': 'Enabled',
+  'auto.components.stats.usage.overview.sections.statusOff': 'Off'
+}
+
+const INTERPOLATED_KEYS: Record<string, string[]> = {
+  'auto.components.stats.StatsPane.trackingSince': ['{{value0}}'],
+  'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage': ['{{value0}}'],
+  'auto.components.settings.OrchestrationSkillAgentCoverage.partialCoverage': [
+    '{{value0}}',
+    '{{value1}}'
+  ],
+  'auto.components.settings.computerUseSummary.unavailableDescription': ['{{value0}}'],
+  'auto.components.settings.computerUseSummary.permissionsRequired': ['{{value0}}', '{{value1}}']
+}
+
+describe('settings and stats status labels', () => {
+  it.each(Object.entries(REQUIRED_KEYS))('keeps %s in the English catalog', (key, expected) => {
+    expect(lookup(key)).toBe(expected)
+  })
+
+  it.each(Object.entries(INTERPOLATED_KEYS))(
+    'keeps the placeholders of %s intact',
+    (key, placeholders) => {
+      const value = lookup(key)
+      expect(value).toBeDefined()
+      for (const placeholder of placeholders) {
+        expect(value).toContain(placeholder)
+      }
+    }
+  )
+
+  it('keeps the orchestration usage summaries in the catalog', () => {
+    for (const id of [
+      'handoffSummary',
+      'worktreeHandoffSummary',
+      'childSequenceSummary',
+      'childParallelSummary',
+      'prSplitSummary'
+    ]) {
+      expect(lookup(`auto.lib.orchestration.usage.examples.${id}`)).toBeTruthy()
+    }
+  })
+})

--- a/src/renderer/src/i18n/settings-status-label-localization.test.ts
+++ b/src/renderer/src/i18n/settings-status-label-localization.test.ts
@@ -10,16 +10,30 @@
  */
 import { describe, expect, it } from 'vitest'
 import en from './locales/en.json'
+import es from './locales/es.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import zh from './locales/zh.json'
 
-function lookup(key: string): string | undefined {
+const LOCALE_CATALOGS = { es, ja, ko, zh }
+
+function lookupIn(catalog: unknown, key: string): string | undefined {
   const value = key
     .split('.')
     .reduce<unknown>(
       (node, part) =>
         node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
-      en as unknown
+      catalog
     )
   return typeof value === 'string' ? value : undefined
+}
+
+function lookup(key: string): string | undefined {
+  return lookupIn(en, key)
+}
+
+function placeholdersOf(value: string): string[] {
+  return [...new Set(value.match(/\{\{[^}]+\}\}/g) ?? [])].sort()
 }
 
 const REQUIRED_KEYS: Record<string, string> = {
@@ -64,6 +78,25 @@ const INTERPOLATED_KEYS: Record<string, string[]> = {
   ]
 }
 
+// Base keys i18next resolves through CLDR plural categories (`<key>_<suffix>`).
+const PLURAL_KEYS = [
+  'auto.components.settings.computerUseSummary.permissionsRequired',
+  'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage'
+]
+
+function pluralCategories(locale: string): string[] {
+  return [...new Intl.PluralRules(locale).resolvedOptions().pluralCategories]
+}
+
+// A locale owes `_other` plus whichever of its categories English also spells
+// out. Categories English never defines (es `many`, only reached past 1e6) fall
+// back to the English source instead of rendering wrong, so they aren't gated.
+function requiredPluralSuffixes(locale: string, base: string): string[] {
+  return pluralCategories(locale).filter(
+    (category) => category === 'other' || lookup(`${base}_${category}`) !== undefined
+  )
+}
+
 describe('settings and stats status labels', () => {
   it.each(Object.entries(REQUIRED_KEYS))('keeps %s in the English catalog', (key, expected) => {
     expect(lookup(key)).toBe(expected)
@@ -91,4 +124,42 @@ describe('settings and stats status labels', () => {
       expect(lookup(`auto.lib.orchestration.usage.examples.${id}`)).toBeTruthy()
     }
   })
+})
+
+// Translation lands incrementally and a missing key renders the English
+// `translate()` fallback, so absence is fine — a *present* value that drops a
+// placeholder or invents one interpolates to nothing at runtime, and a plural
+// family translated only halfway silently reverts to English for some counts.
+describe('shipped locale catalogs', () => {
+  it.each(Object.entries(LOCALE_CATALOGS))(
+    '%s keeps the English placeholders of every message it translates',
+    (_locale, catalog) => {
+      for (const key of Object.keys(INTERPOLATED_KEYS)) {
+        const localized = lookupIn(catalog, key)
+        if (localized === undefined) {
+          continue
+        }
+        const english = lookup(key)
+        expect(english, `${key} missing from en.json`).toBeDefined()
+        expect(placeholdersOf(localized), `${key} placeholders drifted`).toEqual(
+          placeholdersOf(english ?? '')
+        )
+      }
+    }
+  )
+
+  it.each(Object.entries(LOCALE_CATALOGS))(
+    '%s completes every plural family it translates',
+    (locale, catalog) => {
+      for (const base of PLURAL_KEYS) {
+        const suffixes = [...new Set([...pluralCategories(locale), ...pluralCategories('en')])]
+        if (!suffixes.some((suffix) => lookupIn(catalog, `${base}_${suffix}`))) {
+          continue
+        }
+        for (const suffix of requiredPluralSuffixes(locale, base)) {
+          expect(lookupIn(catalog, `${base}_${suffix}`), `${base}_${suffix} missing`).toBeTruthy()
+        }
+      }
+    }
+  )
 })

--- a/src/renderer/src/i18n/settings-status-label-localization.test.ts
+++ b/src/renderer/src/i18n/settings-status-label-localization.test.ts
@@ -53,13 +53,15 @@ const REQUIRED_KEYS: Record<string, string> = {
 
 const INTERPOLATED_KEYS: Record<string, string[]> = {
   'auto.components.stats.StatsPane.trackingSince': ['{{value0}}'],
-  'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage': ['{{value0}}'],
+  'auto.components.settings.computerUseSummary.permissionsRequired_one': [],
+  'auto.components.settings.computerUseSummary.permissionsRequired_other': ['{{value0}}'],
+  'auto.components.settings.computerUseSummary.unavailableDescription': ['{{value0}}'],
+  'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage_one': [],
+  'auto.components.settings.OrchestrationSkillAgentCoverage.fullCoverage_other': ['{{value0}}'],
   'auto.components.settings.OrchestrationSkillAgentCoverage.partialCoverage': [
     '{{value0}}',
     '{{value1}}'
-  ],
-  'auto.components.settings.computerUseSummary.unavailableDescription': ['{{value0}}'],
-  'auto.components.settings.computerUseSummary.permissionsRequired': ['{{value0}}', '{{value1}}']
+  ]
 }
 
 describe('settings and stats status labels', () => {

--- a/src/renderer/src/lib/orchestration-usage-examples.ts
+++ b/src/renderer/src/lib/orchestration-usage-examples.ts
@@ -6,7 +6,10 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
   {
     id: 'handoff',
     title: translate('auto.lib.orchestration.usage.examples.5e0d489fe1', 'Hand off an active task'),
-    summary: 'Move ownership to another agent with enough context to continue.',
+    summary: translate(
+      'auto.lib.orchestration.usage.examples.handoffSummary',
+      'Move ownership to another agent with enough context to continue.'
+    ),
     prompt:
       'Use /orchestration to hand this billing settings task to the idle Claude agent. Include the goal, current context, and what they should finish next.'
   },
@@ -16,14 +19,20 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.ab0e9803b7',
       'Hand off to another worktree'
     ),
-    summary: 'Move work to an agent that is already running in a different branch.',
+    summary: translate(
+      'auto.lib.orchestration.usage.examples.worktreeHandoffSummary',
+      'Move work to an agent that is already running in a different branch.'
+    ),
     prompt:
       'Use /orchestration to hand this settings cleanup to the agent in the settings-polish worktree. Send the goal, relevant files, and expected result.'
   },
   {
     id: 'child-sequence',
     title: translate('auto.lib.orchestration.usage.examples.bddc4c09b8', 'Run a phased workflow'),
-    summary: 'Use child agents one after another when each phase depends on the last.',
+    summary: translate(
+      'auto.lib.orchestration.usage.examples.childSequenceSummary',
+      'Use child agents one after another when each phase depends on the last.'
+    ),
     prompt:
       'Use /orchestration to run this auth refactor in phases: plan, backend, UI, then tests. Start each child agent after the previous phase is done.'
   },
@@ -33,7 +42,10 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.9e37a5b1b3',
       'Run independent work in parallel'
     ),
-    summary: 'Split non-overlapping investigation or implementation tasks across child agents.',
+    summary: translate(
+      'auto.lib.orchestration.usage.examples.childParallelSummary',
+      'Split non-overlapping investigation or implementation tasks across child agents.'
+    ),
     prompt:
       'Use /orchestration to split this auth refactor across parallel child agents: API contract, backend call sites, UI flow, and test gaps.'
   },
@@ -43,7 +55,10 @@ export const getOrchestrationUsageExamples = createLocalizedCatalog((): SkillUsa
       'auto.lib.orchestration.usage.examples.f91fe27f2a',
       'Split a large change into smaller PRs'
     ),
-    summary: 'Give each child agent its own worktree so parallel implementation stays reviewable.',
+    summary: translate(
+      'auto.lib.orchestration.usage.examples.prSplitSummary',
+      'Give each child agent its own worktree so parallel implementation stays reviewable.'
+    ),
     prompt:
       'Use /orchestration to split this onboarding update into smaller PRs, each in its own child worktree: setup state, settings UI, copy, and tests.'
   }


### PR DESCRIPTION
## Summary

Status pills and summaries in **Settings** and **Stats** were built from bare string literals inside local helper functions, so they stayed English even with a language pack active. Neighbouring copy in the same components already goes through `translate()`, which makes those panes look half-translated.

`ComputerUsePane.tsx` shows the problem inside a single block:

```tsx
{summaryTitle}                                        // literal → English
{translate('…ComputerUsePane.0c29da5805', 'Ready')}   // translated
{summaryDescription}                                  // literal → English
{translate(permission.labelKey, …)}                   // translated
{statusLabel(status)}                                 // literal → English
```

Result in a localized build: `Универсальный доступ  GRANTED`, `GitHub … Connected`, and orchestration cards with translated titles above English summaries.

**Why the coverage gate did not catch it.** `audit-localization-coverage.mjs` inspects JSX attributes and object properties, not values returned by helper functions. `pnpm verify:localization-coverage` passes while the strings ship untranslated. A sweep for helpers named `*Label`/`*Status`/`*Summary` that return literals found **57 such functions across the renderer**; this PR fixes the ones users hit on the Settings and Stats screens and leaves the rest for follow-up.

### What changed

| Area | Strings |
|---|---|
| `DeveloperPermissionsPane` — macOS permission rows | 7 statuses + 3 action labels |
| `ComputerUsePane` — permission rows and summary | 3 statuses + 4 titles + 4 descriptions |
| `cli-source-control-integration-cards` — GitHub/GitLab cards | 4 statuses |
| `OrchestrationSkillAgentCoverage` | 5 coverage states |
| `orchestration-usage-examples` | 5 card summaries |
| `usage-overview-sections`, `StatsPane` | 3 provider statuses + tracking-since |

Notes on the approach:

- `sync:localization-catalog` added **31 keys**; nothing was removed or reworded (11832 → 11863, 0 deletions, 0 value changes).
- `auto.components.settings.computerUseSummary.*` already existed in `en.json` with identical copy — including the `{{value0}}`/`{{value1}}` placeholders — but nothing referenced it. Those keys are now wired up rather than duplicated.
- Keys are stable and semantic (`statusGranted`, `actionRequest`) rather than content hashes, matching the direction in `config/i18n-translation-source.md`: *"a feature developer adds a stable message ID and current English copy once"*.
- Permission status helpers moved to `developer-permission-status.ts` so `DeveloperPermissionsPane.tsx` stays under the 400-line gate.
- Agent `prompt` values in `orchestration-usage-examples.ts` are deliberately left in English: they are payload sent to the agent, not UI copy.

## Screenshots

**No visual change in English** — every string keeps its exact English wording, so an English build renders identically.

The defect is only visible in a localized build. These are from a Russian language pack on current `main`, before this PR:

| Settings → Integrations | Settings → Computer Use |
|---|---|
| ![Integrations](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-integrations.png) | ![Computer Use](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-computer-use.png) |
| `Connected` / `Not installed` sit next to fully translated descriptions. | `Универсальный доступ  GRANTED`, and the heading reads `Computer Use is ready.` in English while the badge next to it is translated. |

| Settings → macOS Permissions | Settings → Orchestration |
|---|---|
| ![macOS Permissions](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-macos-permissions.png) | ![Orchestration](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-orchestration.png) |
| Nine rows of `GRANTED` / `CHECK MANUALLY` / `ENTITLED`, with `Request`, `Trigger Prompt`, `Open Settings` buttons. | Card titles are translated, all five summaries stay English. |

Stats & Usage is affected the same way (`Enabled` / `Off` per provider, `Tracking since …` in the header); that screenshot is omitted because the pane shows account spend.

After this change those strings resolve through the catalog and follow the selected language, falling back to the same English text when a locale has no value.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added `src/renderer/src/i18n/settings-status-label-localization.test.ts` — 26 assertions pinning the catalog contract for these keys, including placeholder integrity for the interpolated ones. Dropping `translate()` for a literal again removes the key from `en.json` and fails the test.

`pnpm test`: 42 550 passed, 78 skipped. Two files fail on this machine — `src/main/ssh/ssh-posix-command-wrapper.test.ts` (3) and `src/relay/agent-exec-handler.test.ts` (2). Both fail identically on a clean `main` with these changes stashed, so they are pre-existing environment failures, not regressions from this PR.

> **Note on CI:** this PR comes from a fork, so `PR Checks` sits at `action_required` until a maintainer approves the workflow run — nothing has failed. The four checks below were run locally against this branch.

## AI Review Report

Reviewed with Claude Opus 5.

- **Cross-platform.** No platform branching added or changed. `macOS only` and `Check manually` stay behind the same `DeveloperPermissionStatus` values as before; the macOS-only panes keep their existing platform guards. No shortcuts, accelerators, labels, or path handling touched.
- **SSH / remote / local.** No process, filesystem, credential, or network path touched. The changed helpers are pure renderer formatting.
- **Agents / integrations / git providers.** `cli-source-control-integration-cards.tsx` is shared by GitHub and GitLab; both call sites were updated together and keep identical status semantics. Agent prompts were intentionally not localized so agent behaviour is unchanged.
- **Performance.** `translate()` calls happen in render paths that already call it for neighbouring copy. The permission definitions use the file's existing lazy-getter pattern, so no `translate()` runs at module scope — the `no-top-level-translate` test covers this.
- **UI quality.** Wording is unchanged, so English layout is identical. Status pills keep their `uppercase` class; a translated value simply uppercases in its own script.
- **Catalog integrity.** Verified programmatically: 31 keys added, 0 removed, 0 existing values modified. `verify:localization-catalog` and `verify:localization-extraction` pass.

The review flagged two things that were fixed before submitting: an unused type import left behind by the helper extraction, and a `default` branch that broke `switch-exhaustiveness-check` — restored as an explicit `case undefined`.

## Security Audit

Reviewed with Claude Opus 5. No new input handling, command execution, path handling, auth, secrets, or IPC surface. The diff converts string literals into catalog lookups; interpolated values (`helperUnavailableReason`, permission counts, provider counts, formatted dates) were already rendered into the same strings and are passed as i18next interpolation parameters, which escape by default in React rendering. No dependency changes. No follow-up needed.

## Notes

- **Follow-up worth considering:** the coverage audit could grow a rule for helper functions that return user-facing literals. The sweep mentioned above found 57 such functions; the remaining ones include `getCheckStatusLabel` (duplicated across `GitHubItemDialog`, `PullRequestPage`, `checks-panel-content`), `agentStateLabel`, `getAutomationRunStatusLabel`, and `getSidebarHostHealthLabel`. Happy to send those as separate PRs if the approach here looks right.
- **How this was found.** While building a full Russian language pack for Orca — [smwbev/orca-russian](https://github.com/smwbev/orca-russian), 11 613 strings, 98.2 % of `en.json`. Translating the whole catalog surfaces exactly the strings that never reach it: everything in this PR was invisible to the catalog, so no amount of translation work could fix it downstream.
- The pack also confirms the plugin path works end to end: `contributes.languagePacks` + a marketplace index, no code execution, English fallback for missing keys.

X: [@silentmegawatt](https://x.com/silentmegawatt) · GitHub: [@smwbev](https://github.com/smwbev)
