### PR TITLE
Improve disconnected server recovery copy

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -325,7 +325,10 @@
         },
         "runtime": {
           "status": {
-            "runtimeHostDisconnectedDescription": "Workspaces and terminals on this server are unavailable."
+            "runtimeHostDisconnectedDescription": "Check that Orca is running on this server and that your network connection is working, then try again.",
+            "runtimeHostUnreachableNamed": "Can't reach {{hostName}}",
+            "runtimeHostUnreachable": "Can't reach Orca server",
+            "tryAgain": "Try again"
           }
         }
       }

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -189,11 +189,12 @@ describe('runtime-status slice', () => {
 
     expect(toast.warning).toHaveBeenCalledTimes(1)
     expect(toast.warning).toHaveBeenCalledWith(
-      'Dev Box disconnected',
+      "Can't reach Dev Box",
       expect.objectContaining({
         id: 'runtime-environment-disconnected:env-a',
-        description: 'Workspaces and terminals on this server are unavailable.',
-        action: expect.objectContaining({ label: 'Retry' })
+        description:
+          'Check that Orca is running on this server and that your network connection is working, then try again.',
+        action: expect.objectContaining({ label: 'Try again' })
       })
     )
   })

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -76,13 +76,13 @@ function showRuntimeDisconnectedToast(environmentId: string, getState: () => App
   const activation = Symbol(toastId)
   const title = environment?.name
     ? translate(
-        'auto.components.sidebar.WorktreeCard.runtimeHostDisconnectedNamed',
-        '{{hostName}} disconnected',
+        'auto.store.slices.runtime.status.runtimeHostUnreachableNamed',
+        "Can't reach {{hostName}}",
         { hostName: environment.name }
       )
     : translate(
-        'auto.components.sidebar.WorktreeCard.runtimeHostDisconnected',
-        'Server disconnected'
+        'auto.store.slices.runtime.status.runtimeHostUnreachable',
+        "Can't reach Orca server"
       )
   activeRuntimeDisconnectedToasts.set(toastId, activation)
   const clearActiveToast = (): void => {
@@ -96,11 +96,11 @@ function showRuntimeDisconnectedToast(environmentId: string, getState: () => App
       id: toastId,
       description: translate(
         'auto.store.slices.runtime.status.runtimeHostDisconnectedDescription',
-        'Workspaces and terminals on this server are unavailable.'
+        'Check that Orca is running on this server and that your network connection is working, then try again.'
       ),
       duration,
       action: {
-        label: translate('browser.loadFailure.retry', 'Retry'),
+        label: translate('auto.store.slices.runtime.status.tryAgain', 'Try again'),
         onClick: (event) => {
           // Why: Sonner otherwise deletes the keyed toast after the action callback.
           event.preventDefault()


### PR DESCRIPTION
## Summary

- Change the outage toast to say “Can’t reach <server>” without overclaiming the cause.
- Tell users to check that Orca is running on the server and that their network connection works.
- Rename the action from “Retry” to “Try again.”

## User-facing copy

Title: “Can’t reach QA Server”

Message: “Check that Orca is running on this server and that your network connection is working, then try again.”

Action: “Try again”

## Validation

- 25 focused runtime-status tests passed
- Web typecheck passed
- Focused lint and formatting passed
- Localization catalog and extraction checks passed
- Whitespace validation passed
