### PR TITLE
test(e2e): stabilize virtualized marquee start

### DIFF
--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -366,14 +366,35 @@ test.describe('Workspace board lane virtualization', () => {
     const laneCards = lane.locator('[data-workspace-board-card-id]')
     await expect.poll(() => laneCards.count(), { timeout: 15_000 }).toBeGreaterThan(3)
     const laneScroll = lane.locator('[data-workspace-board-lane-scroll]')
+    const laneGrid = orcaPage.locator('[data-workspace-board-lane-grid]')
     const box = await laneScroll.boundingBox()
-    if (!box) {
-      throw new Error('Expected the marquee lane to have a bounding box')
+    const laneBox = await lane.boundingBox()
+    const nextLaneBox = await laneGrid.locator('[data-workspace-status]').nth(1).boundingBox()
+    if (!box || !laneBox || !nextLaneBox) {
+      throw new Error('Expected the marquee lane and its neighboring lane to have bounding boxes')
     }
+    const dragStartX = (laneBox.x + laneBox.width + nextLaneBox.x) / 2
+    const dragStartY = box.y + 4
+    const startsInLaneGap = await orcaPage.evaluate(
+      ({ x, y }) => {
+        const target = document.elementFromPoint(x, y)
+        return Boolean(
+          target?.closest('[data-workspace-board-lane-grid]') &&
+          !target.closest('[data-workspace-status]')
+        )
+      },
+      { x: dragStartX, y: dragStartY }
+    )
+    expect(startsInLaneGap).toBe(true)
 
-    await orcaPage.mouse.move(box.x + 2, box.y + 12)
+    await orcaPage.mouse.move(dragStartX, dragStartY)
     await orcaPage.mouse.down()
-    await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80)
+    await orcaPage.mouse.move(box.x + 18, box.y + 80, { steps: 4 })
+    await expect
+      .poll(() => lane.locator('[data-workspace-board-card-area-selected="true"]').count(), {
+        timeout: 15_000
+      })
+      .toBeGreaterThan(0)
     await laneScroll.evaluate(async (element) => {
       for (let pass = 0; pass < 4; pass++) {
         element.scrollTop = element.scrollHeight
@@ -383,7 +404,7 @@ test.describe('Workspace board lane virtualization', () => {
         })
       }
     })
-    await orcaPage.mouse.move(box.x + box.width - 18, box.y + box.height - 12)
+    await orcaPage.mouse.move(box.x + 18, box.y + box.height - 12)
     await orcaPage.mouse.up()
 
     await expect(


### PR DESCRIPTION
## Problem

The large-lane marquee E2E started on a scroll-container edge. On Linux CI that point did not reach Orca area selection, so Chromium performed native text selection and the test later scrolled without selecting cards. The first attempted board-padding origin was also covered by the sheet edge; the Linux trace made that visible.

## Fix

Compute a guaranteed empty gap between two rendered lanes, prove it resolves to the lane grid rather than a lane or interactive control, start the real mouse drag there, and assert marquee preview selection has begun before programmatically jumping the lane scroll.

## Validation

- Exact focused Electron headless test: 10/10 concurrent passes
- Oxfmt, Oxlint, max-lines ratchet, and git diff --check pass
- Linux CI rerun in progress

CI evidence: https://github.com/stablyai/orca/actions/runs/30671024406/job/91289011868