### PR TITLE
Add Slack emoji aliases to worktree creation

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -269,13 +269,13 @@ describe('SmartWorkspaceNameField emoji shortcodes', () => {
     act(() => {
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
         input,
-        'Launch :wink: experiment'
+        'Launch :flag-kr: experiment'
       )
-      input.setSelectionRange(13, 13)
+      input.setSelectionRange(16, 16)
       input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }))
     })
 
-    expect(onValueChange).toHaveBeenCalledWith('Launch 😉 experiment')
+    expect(onValueChange).toHaveBeenCalledWith('Launch 🇰🇷 experiment')
   })
 
   it('accepts the highlighted shortcode suggestion with Enter', () => {

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
@@ -11,6 +11,19 @@ describe('workspace emoji shortcodes', () => {
     expect(searchWorkspaceEmojiShortcodes('wink', 1)).toEqual([{ emoji: '😉', shortcode: 'wink' }])
   })
 
+  it('finds Slack flag aliases', () => {
+    expect(searchWorkspaceEmojiShortcodes('kr', 1)).toEqual([{ emoji: '🇰🇷', shortcode: 'kr' }])
+    expect(searchWorkspaceEmojiShortcodes('flag-kr', 1)).toEqual([
+      { emoji: '🇰🇷', shortcode: 'flag-kr' }
+    ])
+  })
+
+  it('finds Slack aliases absent from the GitHub catalog', () => {
+    expect(searchWorkspaceEmojiShortcodes('mostly_sunny', 1)).toEqual([
+      { emoji: '🌤', shortcode: 'mostly_sunny' }
+    ])
+  })
+
   it('ranks an exact shortcode before longer aliases', () => {
     expect(searchWorkspaceEmojiShortcodes('heart', 3)[0]).toMatchObject({
       shortcode: 'heart'
@@ -36,6 +49,27 @@ describe('workspace emoji shortcodes', () => {
     expect(replaceCompletedWorkspaceEmojiShortcode('Ship :wink: today', 11)).toEqual({
       value: 'Ship 😉 today',
       cursor: 7
+    })
+  })
+
+  it('replaces a completed Slack-only flag alias', () => {
+    expect(replaceCompletedWorkspaceEmojiShortcode('Ship :flag-kr:', 14)).toEqual({
+      value: 'Ship 🇰🇷',
+      cursor: 9
+    })
+  })
+
+  it('supports the longest Slack aliases', () => {
+    const shortcode = 'smiling_face_with_smiling_eyes_and_hand_covering_mouth'
+    const completed = `:${shortcode}:`
+    expect(getActiveWorkspaceEmojiShortcode(`:${shortcode}`, shortcode.length + 1)).toEqual({
+      start: 0,
+      end: shortcode.length + 1,
+      query: shortcode
+    })
+    expect(replaceCompletedWorkspaceEmojiShortcode(completed, completed.length)).toEqual({
+      value: '🤭',
+      cursor: 2
     })
   })
 

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -17,6 +17,15 @@ export type WorkspaceEmojiReplacement = {
 }
 
 const SHORTCODE_ENTRIES = STANDARD_EMOJI_SHORTCODE_ENTRIES
+const MAX_SHORTCODE_LENGTH = 64
+const ACTIVE_SHORTCODE_PATTERN = new RegExp(
+  `(^|\\s):([a-z0-9_+-]{1,${MAX_SHORTCODE_LENGTH}})$`,
+  'i'
+)
+const COMPLETED_SHORTCODE_PATTERN = new RegExp(
+  `(^|\\s):([a-z0-9_+-]{1,${MAX_SHORTCODE_LENGTH}}):$`,
+  'i'
+)
 
 const EXACT_SHORTCODE = new Map(
   SHORTCODE_ENTRIES.map(({ emoji, shortcode }) => [shortcode, { emoji, shortcode }])
@@ -61,7 +70,7 @@ export function getActiveWorkspaceEmojiShortcode(
   if (cursor === null || cursor < 0 || cursor > value.length) {
     return null
   }
-  const match = value.slice(0, cursor).match(/(^|\s):([a-z0-9_+-]{1,40})$/i)
+  const match = value.slice(0, cursor).match(ACTIVE_SHORTCODE_PATTERN)
   if (!match) {
     return null
   }
@@ -79,7 +88,7 @@ export function replaceCompletedWorkspaceEmojiShortcode(
   if (cursor === null || cursor < 0 || cursor > value.length) {
     return null
   }
-  const match = value.slice(0, cursor).match(/(^|\s):([a-z0-9_+-]{1,40}):$/i)
+  const match = value.slice(0, cursor).match(COMPLETED_SHORTCODE_PATTERN)
   if (!match) {
     return null
   }

--- a/src/shared/emoji-shortcode-catalog.ts
+++ b/src/shared/emoji-shortcode-catalog.ts
@@ -1,24 +1,39 @@
-import emojiShortcodes from 'emojibase-data/en/shortcodes/github.json'
+import githubEmojiShortcodes from 'emojibase-data/en/shortcodes/github.json'
+import slackEmojiShortcodes from 'emojibase-data/en/shortcodes/iamcal.json'
 
 export type StandardEmojiShortcodeEntry = {
   emoji: string
   shortcode: string
 }
 
-export const STANDARD_EMOJI_SHORTCODE_ENTRIES: readonly StandardEmojiShortcodeEntry[] =
-  Object.entries(emojiShortcodes).flatMap(([hexcode, value]) => {
-    const shortcodes = typeof value === 'string' ? [value] : value
-    const emoji = hexcodeToEmoji(hexcode)
-    return shortcodes.map((shortcode) => ({ emoji, shortcode }))
-  })
+const GITHUB_EMOJI_SHORTCODE_ENTRIES = toEmojiShortcodeEntries(githubEmojiShortcodes)
+const GITHUB_SHORTCODES = new Set(GITHUB_EMOJI_SHORTCODE_ENTRIES.map(({ shortcode }) => shortcode))
+
+// Emojibase's iamcal preset backs its Slack shortcode catalog.
+const SLACK_EMOJI_SHORTCODE_ENTRIES = toEmojiShortcodeEntries(slackEmojiShortcodes)
+
+export const STANDARD_EMOJI_SHORTCODE_ENTRIES: readonly StandardEmojiShortcodeEntry[] = [
+  ...GITHUB_EMOJI_SHORTCODE_ENTRIES,
+  ...SLACK_EMOJI_SHORTCODE_ENTRIES.filter(({ shortcode }) => !GITHUB_SHORTCODES.has(shortcode))
+]
 
 const PRIMARY_SHORTCODE_BY_EMOJI = new Map(
-  Object.entries(emojiShortcodes).map(([hexcode, value]) => {
+  Object.entries(githubEmojiShortcodes).map(([hexcode, value]) => {
     const shortcodes = typeof value === 'string' ? [value] : value
     const shortcode = shortcodes.find((candidate) => /^[a-z]/i.test(candidate)) ?? shortcodes[0]
     return [normalizeEmojiLookup(hexcodeToEmoji(hexcode)), shortcode]
   })
 )
+
+function toEmojiShortcodeEntries(
+  catalog: Record<string, string | string[]>
+): StandardEmojiShortcodeEntry[] {
+  return Object.entries(catalog).flatMap(([hexcode, value]) => {
+    const shortcodes = typeof value === 'string' ? [value] : value
+    const emoji = hexcodeToEmoji(hexcode)
+    return shortcodes.map((shortcode) => ({ emoji, shortcode }))
+  })
+}
 
 const EMOJI_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' })
 


### PR DESCRIPTION
## Summary

- Extend worktree-name emoji autocomplete with 624 non-conflicting aliases from the Emojibase Slack catalog.
- Preserve existing GitHub shortcode meanings when the catalogs disagree.
- Raise the bounded shortcode parser limit from 40 to 64 characters so every merged alias is reachable.

## Screenshots

No visual change.

## Testing

- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test (42,624 passed; 80 skipped)
- [ ] pnpm build (not run; data and parser-only change)
- [x] Added focused catalog, completion, parser-boundary, and component-level regression coverage

## AI Review Report

Reviewed catalog collision behavior, autocomplete and exact-completion paths, parser constraints, and the existing branch-name derivation behavior. Review flagged that nine Slack aliases exceeded the prior 40-character parser cap; the cap is now 64 and the longest current 54-character alias has active/completion coverage.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This change is platform-neutral Unicode/catalog parsing and does not alter shortcuts, labels, paths, shell behavior, SSH/folder-workspace behavior, or Electron platform integrations.

## Security Audit

The catalog remains static bundled data and the user-input regex remains length-bounded. No command execution, path handling, authentication, secrets, dependency versions, network access, or IPC surfaces changed. Existing GitHub mappings remain the source for branch-name derivation, avoiding unexpected branch/path renames.

## Notes

The current GitHub catalog already includes :kr:, and that path passes focused tests on main. This PR adds Slack-only alternatives such as :flag-kr: and :mostly_sunny: plus 622 others; it does not claim to fix a reproducible failure of the pre-existing :kr: alias.