### PR TITLE
fix(agent-status): preserve Claude background work

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -3006,6 +3006,48 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('does not apply Claude background evidence from a rejected local status', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postClaudeHook = async (payload: Record<string, unknown>): Promise<void> => {
+        const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+        expect(response.status).toBe(204)
+      }
+
+      await postClaudeHook({
+        hook_event_name: 'PermissionRequest',
+        prompt: 'approve shell',
+        tool_name: 'Bash',
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }],
+        session_crons: [{ id: 'cron-1', status: 'running' }]
+      })
+      const waiting = server.getStatusSnapshot()[0]
+
+      await postClaudeHook({
+        hook_event_name: 'PreToolUse',
+        prompt: 'approve shell',
+        tool_name: 'OtherTool',
+        background_tasks: [],
+        session_crons: []
+      })
+
+      expect(server.getStatusSnapshot()[0]).toEqual(waiting)
+      expect(server._getStateForTests().claudeRunningNonAgentTaskPaneKeys.has(PANE)).toBe(true)
+      expect(server._getStateForTests().claudeActiveSessionCronPaneKeys.has(PANE)).toBe(true)
+    } finally {
+      server.stop()
+    }
+  })
+
   it('maps registered legacy numeric HTTP pane keys to stable pane keys', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -445,7 +445,7 @@ describe('AgentHookServer listener replay', () => {
           tabId: 'tab-1',
           worktreeId: 'wt-1',
           isReplay: true,
-          claudeRunningShellOrMonitor: true,
+          claudeRunningNonAgentTask: true,
           payload: { state: 'working', prompt: 'stale replay', agentType: 'claude' }
         },
         'conn-1'

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -607,6 +607,43 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('does not apply Claude background metadata from a rejected remote status', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'PermissionRequest',
+        claudeRunningNonAgentTask: true,
+        payload: {
+          state: 'waiting',
+          prompt: 'approve shell',
+          agentType: 'claude',
+          toolName: 'Bash'
+        }
+      },
+      'conn-1'
+    )
+    const waiting = server.getStatusSnapshot()[0]
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'PreToolUse',
+        claudeRunningNonAgentTask: false,
+        payload: {
+          state: 'working',
+          prompt: 'approve shell',
+          agentType: 'claude',
+          toolName: 'OtherTool'
+        }
+      },
+      'conn-1'
+    )
+
+    expect(server.getStatusSnapshot()[0]).toEqual(waiting)
+    expect(server._getStateForTests().claudeRunningNonAgentTaskPaneKeys.has(PANE)).toBe(true)
+  })
+
   it('carries idle subagent rows through an inferred interrupt', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -402,20 +402,17 @@ describe('AgentHookServer listener replay', () => {
     vi.setSystemTime(1_000)
     try {
       const server = new AgentHookServer()
-      const state = server._getStateForTests()
-      const send = (payload: Record<string, unknown>): void => {
-        const event = normalizeHookPayload(state, 'claude', buildBody(payload), 'production')
-        if (!event) {
-          throw new Error('normalizeHookPayload rejected a known-good Claude fixture')
-        }
-        server.ingestRemote(event, 'conn-1')
-      }
-      send({ hook_event_name: 'UserPromptSubmit', prompt: 'run in background' })
-      send({
-        hook_event_name: 'Stop',
-        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
-      })
-      const baseline = server.getStatusSnapshot()[0]
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          claudeRunningNonAgentTask: true,
+          payload: { state: 'working', prompt: 'run in background', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      let baseline = server.getStatusSnapshot()[0]
 
       vi.setSystemTime(1_500)
       expect(
@@ -429,6 +426,31 @@ describe('AgentHookServer listener replay', () => {
         })
       ).toBe(false)
       expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'working' })
+
+      vi.setSystemTime(2_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          claudeRunningNonAgentTask: false,
+          payload: { state: 'working', prompt: 'run in background', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(2_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'run in background',
+          baselineAgentType: 'claude',
+          intent: 'plain-escape'
+        })
+      ).toBe(true)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -56,6 +56,7 @@ const GOOD_PANE = makePaneKey('tab-good', LEAF_2)
 const OLD_PANE = makePaneKey('tab-old', LEAF_3)
 const FRESH_PANE = makePaneKey('tab-fresh', LEAF_4)
 const TAB_A_PANE = makePaneKey('tab-A', LEAF_5)
+const RUNNING_SHELL = { id: 'shell-1', type: 'shell', status: 'running' }
 
 type Body = {
   paneKey: string
@@ -456,7 +457,46 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
-  it('does not treat replayed Claude background metadata as live evidence', () => {
+  it('blocks local HTTP interrupt inference without exposing transport metadata', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await expect(
+        postHook({ hook_event_name: 'UserPromptSubmit', prompt: 'run in background' })
+      ).resolves.toMatchObject({ status: 204 })
+      await expect(
+        postHook({ hook_event_name: 'Stop', background_tasks: [RUNNING_SHELL] })
+      ).resolves.toMatchObject({ status: 204 })
+      const baseline = server.getStatusSnapshot()[0]
+
+      expect(baseline).not.toHaveProperty('claudeRunningNonAgentTask')
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'run in background',
+          baselineAgentType: 'claude',
+          intent: 'plain-escape'
+        })
+      ).toBe(false)
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('uses replayed Claude background metadata only before a live observation', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     try {
@@ -480,6 +520,43 @@ describe('AgentHookServer listener replay', () => {
           paneKey: PANE,
           baselineUpdatedAt: baseline.receivedAt,
           baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'stale replay',
+          baselineAgentType: 'claude',
+          intent: 'ctrl-c'
+        })
+      ).toBe(false)
+
+      vi.setSystemTime(1_500)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          claudeRunningNonAgentTask: false,
+          payload: { state: 'working', prompt: 'stale replay', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      vi.setSystemTime(2_000)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          isReplay: true,
+          claudeRunningNonAgentTask: true,
+          payload: { state: 'working', prompt: 'stale replay', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      const liveBaseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(2_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: liveBaseline.receivedAt,
+          baselineStateStartedAt: liveBaseline.stateStartedAt,
           baselinePrompt: 'stale replay',
           baselineAgentType: 'claude',
           intent: 'ctrl-c'
@@ -6400,6 +6477,13 @@ describe('Last-status persistence', () => {
           { launchToken: 'launch-bearer-must-not-persist' }
         )
       )
+      await postHookEvent(
+        server,
+        buildBody(
+          { hook_event_name: 'Stop', background_tasks: [RUNNING_SHELL] },
+          { launchToken: 'launch-bearer-must-not-persist' }
+        )
+      )
       // Synchronous flush via stop() captures the trailing-debounced write.
       server.flushStatusPersistSync()
       expect(existsSync(lastStatusPath())).toBe(true)
@@ -6417,6 +6501,8 @@ describe('Last-status persistence', () => {
       expect(file.entries[PANE].launchTokenHash).toBe(
         createHash('sha256').update('launch-bearer-must-not-persist').digest('hex')
       )
+      expect(file.entries[PANE].claudeRunningNonAgentTask).toBeUndefined()
+      expect(readFileSync(lastStatusPath(), 'utf8')).not.toContain('claudeRunningNonAgentTask')
       expect(readFileSync(lastStatusPath(), 'utf8')).not.toContain('launch-bearer-must-not-persist')
     } finally {
       server.stop()

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -434,6 +434,40 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('does not treat replayed Claude background metadata as live evidence', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          isReplay: true,
+          claudeRunningShellOrMonitor: true,
+          payload: { state: 'working', prompt: 'stale replay', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'stale replay',
+          baselineAgentType: 'claude',
+          intent: 'ctrl-c'
+        })
+      ).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('carries idle subagent rows through an inferred interrupt', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -497,7 +497,7 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
-  it('blocks local HTTP interrupt inference without exposing transport metadata', async () => {
+  it('blocks local HTTP interrupt inference for provider-owned work without exposing transport metadata', async () => {
     const server = new AgentHookServer()
     await server.start({ env: 'production' })
     try {
@@ -529,6 +529,26 @@ describe('AgentHookServer listener replay', () => {
           baselinePrompt: 'run in background',
           baselineAgentType: 'claude',
           intent: 'plain-escape'
+        })
+      ).toBe(false)
+
+      await expect(
+        postHook({
+          hook_event_name: 'Stop',
+          background_tasks: [],
+          session_crons: [{ id: 'cron-1' }]
+        })
+      ).resolves.toMatchObject({ status: 204 })
+      const cronBaseline = server.getStatusSnapshot()[0]
+      expect(server._getStateForTests().claudeActiveSessionCronPaneKeys.has(PANE)).toBe(true)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: cronBaseline.receivedAt,
+          baselineStateStartedAt: cronBaseline.stateStartedAt,
+          baselinePrompt: 'run in background',
+          baselineAgentType: 'claude',
+          intent: 'ctrl-c'
         })
       ).toBe(false)
     } finally {

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -397,6 +397,43 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('does not infer an interrupt while Claude reports a background shell', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      const state = server._getStateForTests()
+      const send = (payload: Record<string, unknown>): void => {
+        const event = normalizeHookPayload(state, 'claude', buildBody(payload), 'production')
+        if (!event) {
+          throw new Error('normalizeHookPayload rejected a known-good Claude fixture')
+        }
+        server.ingestRemote(event, 'conn-1')
+      }
+      send({ hook_event_name: 'UserPromptSubmit', prompt: 'run in background' })
+      send({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+      })
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'run in background',
+          baselineAgentType: 'claude',
+          intent: 'plain-escape'
+        })
+      ).toBe(false)
+      expect(server.getStatusSnapshot()[0]).toMatchObject({ state: 'working' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('carries idle subagent rows through an inferred interrupt', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -234,6 +234,46 @@ describe('AgentHookServer listener replay', () => {
     expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
   })
 
+  it('does not carry Claude background work across connection cleanup', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          claudeRunningNonAgentTask: true,
+          payload: { state: 'working', prompt: 'old host', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      server.clearStatusEntriesForConnection('conn-1')
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          payload: { state: 'working', prompt: 'new host', agentType: 'claude' }
+        },
+        'conn-2'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+      vi.setSystemTime(1_500)
+
+      expect(
+        server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'new host',
+          baselineAgentType: 'claude',
+          intent: 'plain-escape'
+        })
+      ).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('retains root Codex identity when relay child events omit it', () => {
     const server = new AgentHookServer()
     const providerSession = { key: 'session_id' as const, id: 'root-session' }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -87,7 +87,7 @@ type EnrichedAgentHookEventPayload = AgentHookEventPayload & {
 
 type PersistedAgentHookEventPayload = Omit<
   EnrichedAgentHookEventPayload,
-  'launchToken' | 'promptInteractionKey'
+  'claudeRunningShellOrMonitor' | 'launchToken' | 'promptInteractionKey'
 > & {
   launchTokenHash?: string
 }
@@ -750,6 +750,13 @@ export class AgentHookServer {
     }
     // Why: a 'working' pane can be child-driven; Ctrl+C doesn't stop background children, so inferring done would retire live child rows.
     if (payload.subagents?.some((subagent) => subagent.state !== 'idle')) {
+      return false
+    }
+    // Why: Escape/Ctrl+C at Claude's idle prompt does not stop provider-owned background shells.
+    if (
+      agentType === 'claude' &&
+      this.state.claudeRunningShellOrMonitorPaneKeys.has(existing.paneKey)
+    ) {
       return false
     }
 
@@ -1720,6 +1727,7 @@ export class AgentHookServer {
       isReplay?: boolean
       /** Payload fields the relay dropped to fit an oversized frame; validated below. */
       shedFields?: unknown
+      claudeRunningShellOrMonitor?: unknown
       payload: unknown
     },
     connectionId: string
@@ -1814,6 +1822,16 @@ export class AgentHookServer {
     ) {
       return
     }
+    if (
+      normalizedPayload.agentType === 'claude' &&
+      typeof envelope.claudeRunningShellOrMonitor === 'boolean'
+    ) {
+      if (envelope.claudeRunningShellOrMonitor) {
+        this.state.claudeRunningShellOrMonitorPaneKeys.add(paneKey)
+      } else {
+        this.state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
+      }
+    }
     // Why: run the HTTP path's warn-once version/env-mismatch diagnostics with this.env as expected.
     warnOnHookEnvOrVersionMismatch(this.state, {
       version: envelope.version,
@@ -1835,6 +1853,10 @@ export class AgentHookServer {
       providerSession,
       providerSessionOnly: envelope.providerSessionOnly === true ? true : undefined,
       isReplay: envelope.isReplay === true ? true : undefined,
+      claudeRunningShellOrMonitor:
+        typeof envelope.claudeRunningShellOrMonitor === 'boolean'
+          ? envelope.claudeRunningShellOrMonitor
+          : undefined,
       payload: normalizedPayload
     }
     this.recordCurrentAuthorityObservation(event)
@@ -2503,6 +2525,7 @@ export class AgentHookServer {
         continue
       }
       const {
+        claudeRunningShellOrMonitor: _claudeRunningShellOrMonitor,
         promptInteractionKey: _promptInteractionKey,
         launchToken,
         ...persistedPayload

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1824,8 +1824,9 @@ export class AgentHookServer {
     }
     if (
       normalizedPayload.agentType === 'claude' &&
-      envelope.isReplay !== true &&
-      typeof envelope.claudeRunningNonAgentTask === 'boolean'
+      typeof envelope.claudeRunningNonAgentTask === 'boolean' &&
+      // Why: reconnect replay may seed a restarted listener, but cannot override any observation made by this runtime.
+      (envelope.isReplay !== true || !this.runtimeObservedStatusPaneKeys.has(paneKey))
     ) {
       if (envelope.claudeRunningNonAgentTask) {
         this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -2049,6 +2049,10 @@ export class AgentHookServer {
           // Why: a replacement remote process may reuse the pane; don't merge it with the lost connection's children.
           this.state.codexSubagentRosterByPaneKey.delete(paneKey)
           this.state.codexLeadStateByPaneKey.delete(paneKey)
+        } else if (deleted.payload.agentType === 'claude') {
+          this.state.claudeSubagentRosterByPaneKey.delete(paneKey)
+          this.state.claudeLeadStateByPaneKey.delete(paneKey)
+          this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
         }
       }
     }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -755,7 +755,8 @@ export class AgentHookServer {
     // Why: Escape/Ctrl+C at Claude's idle prompt does not stop provider-owned background shells.
     if (
       agentType === 'claude' &&
-      this.state.claudeRunningNonAgentTaskPaneKeys.has(existing.paneKey)
+      (this.state.claudeRunningNonAgentTaskPaneKeys.has(existing.paneKey) ||
+        this.state.claudeActiveSessionCronPaneKeys.has(existing.paneKey))
     ) {
       return false
     }
@@ -1037,7 +1038,10 @@ export class AgentHookServer {
     }
   }
 
-  private applyNormalizedStatus(payload: AgentHookEventPayload): EnrichedAgentHookEventPayload {
+  private applyNormalizedStatus(
+    payload: AgentHookEventPayload,
+    onAccepted?: () => void
+  ): EnrichedAgentHookEventPayload {
     const previous = this.state.lastStatusByPaneKey.get(payload.paneKey) as
       | EnrichedAgentHookEventPayload
       | undefined
@@ -1051,6 +1055,7 @@ export class AgentHookServer {
     }
     if (payload.providerSessionOnly) {
       // Why: Pi session_start replaces stale turn state and survives replay, but must not emit prompt telemetry or a fabricated status.
+      onAccepted?.()
       const enriched = this.attachStatusTiming(payload, now)
       this.clearAssistantMessageRetry(enriched.paneKey)
       this.runtimeObservedStatusPaneKeys.delete(enriched.paneKey)
@@ -1161,6 +1166,7 @@ export class AgentHookServer {
     ) {
       this.clearAssistantMessageRetry(effectivePayload.paneKey)
     }
+    onAccepted?.()
     if (!identity.inheritedFromActivePane) {
       this.maybeTrackAgentPromptSent(effectivePayload, previous)
     }
@@ -1822,18 +1828,11 @@ export class AgentHookServer {
     ) {
       return
     }
-    if (
+    const applyClaudeBackgroundWork =
       normalizedPayload.agentType === 'claude' &&
       typeof envelope.claudeRunningNonAgentTask === 'boolean' &&
       // Why: reconnect replay may seed a restarted listener, but cannot override any observation made by this runtime.
       (envelope.isReplay !== true || !this.runtimeObservedStatusPaneKeys.has(paneKey))
-    ) {
-      if (envelope.claudeRunningNonAgentTask) {
-        this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
-      } else {
-        this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
-      }
-    }
     // Why: run the HTTP path's warn-once version/env-mismatch diagnostics with this.env as expected.
     warnOnHookEnvOrVersionMismatch(this.state, {
       version: envelope.version,
@@ -1862,7 +1861,18 @@ export class AgentHookServer {
       payload: normalizedPayload
     }
     this.recordCurrentAuthorityObservation(event)
-    this.applyNormalizedStatus(event)
+    this.applyNormalizedStatus(
+      event,
+      applyClaudeBackgroundWork
+        ? () => {
+            if (envelope.claudeRunningNonAgentTask) {
+              this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
+            } else {
+              this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+            }
+          }
+        : undefined
+    )
   }
 
   async start(options?: {
@@ -2053,6 +2063,7 @@ export class AgentHookServer {
           this.state.claudeSubagentRosterByPaneKey.delete(paneKey)
           this.state.claudeLeadStateByPaneKey.delete(paneKey)
           this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+          this.state.claudeActiveSessionCronPaneKeys.delete(paneKey)
         }
       }
     }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1824,6 +1824,7 @@ export class AgentHookServer {
     }
     if (
       normalizedPayload.agentType === 'claude' &&
+      envelope.isReplay !== true &&
       typeof envelope.claudeRunningShellOrMonitor === 'boolean'
     ) {
       if (envelope.claudeRunningShellOrMonitor) {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -752,7 +752,7 @@ export class AgentHookServer {
     if (payload.subagents?.some((subagent) => subagent.state !== 'idle')) {
       return false
     }
-    // Why: Escape/Ctrl+C at Claude's idle prompt does not stop provider-owned background shells.
+    // Why: Escape/Ctrl+C at Claude's idle prompt does not stop provider-owned shells or session crons.
     if (
       agentType === 'claude' &&
       (this.state.claudeRunningNonAgentTaskPaneKeys.has(existing.paneKey) ||

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -85,6 +85,11 @@ type EnrichedAgentHookEventPayload = AgentHookEventPayload & {
   stateStartedAt: number
 }
 
+type NormalizedLocalHook = {
+  event: AgentHookEventPayload | null
+  onAccepted?: () => void
+}
+
 type PersistedAgentHookEventPayload = Omit<
   EnrichedAgentHookEventPayload,
   'claudeRunningNonAgentTask' | 'launchToken' | 'promptInteractionKey'
@@ -1308,13 +1313,13 @@ export class AgentHookServer {
     ) {
       return
     }
-    const normalized = normalizeHookPayload(this.state, source, body, this.env)
-    if (!normalized?.payload.lastAssistantMessage) {
+    const normalized = this.normalizeLocalHookPayload(source, body)
+    if (!normalized.event?.payload.lastAssistantMessage) {
       this.scheduleAssistantMessageRetry(source, body, original, nextAttempt, requireExactOriginal)
       return
     }
     // Why: some agents POST Stop before their transcript line is flushed; discovery is event-driven, later content retries stay timed.
-    this.applyNormalizedStatus(normalized)
+    this.applyNormalizedStatus(normalized.event, normalized.onAccepted)
   }
 
   setPaneKeyAliasPersistenceListener(listener: PaneKeyAliasPersistenceListener | null): void {
@@ -1635,6 +1640,48 @@ export class AgentHookServer {
     return { ...record, paneKey: stablePaneKey, tabId: parsePaneKey(stablePaneKey)?.tabId }
   }
 
+  private normalizeLocalHookPayload(source: AgentHookSource, body: unknown): NormalizedLocalHook {
+    if (source !== 'claude' || typeof body !== 'object' || body === null) {
+      return { event: normalizeHookPayload(this.state, source, body, this.env) }
+    }
+    const rawPaneKey = (body as Record<string, unknown>).paneKey
+    const paneKey = typeof rawPaneKey === 'string' ? rawPaneKey.trim() : ''
+    if (!paneKey) {
+      return { event: normalizeHookPayload(this.state, source, body, this.env) }
+    }
+    const previousRunningTask = this.state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
+    const previousActiveCron = this.state.claudeActiveSessionCronPaneKeys.has(paneKey)
+    const event = normalizeHookPayload(this.state, source, body, this.env)
+    const nextRunningTask = this.state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
+    const nextActiveCron = this.state.claudeActiveSessionCronPaneKeys.has(paneKey)
+    this.setClaudeBackgroundEvidence(paneKey, previousRunningTask, previousActiveCron)
+    if (!event || event.paneKey !== paneKey) {
+      return { event }
+    }
+    // Why: nested CLIs may inherit the pane key; only accepted statuses may mutate its background-work gate.
+    return {
+      event,
+      onAccepted: () => this.setClaudeBackgroundEvidence(paneKey, nextRunningTask, nextActiveCron)
+    }
+  }
+
+  private setClaudeBackgroundEvidence(
+    paneKey: string,
+    hasRunningTask: boolean,
+    hasActiveCron: boolean
+  ): void {
+    if (hasRunningTask) {
+      this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
+    } else {
+      this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    }
+    if (hasActiveCron) {
+      this.state.claudeActiveSessionCronPaneKeys.add(paneKey)
+    } else {
+      this.state.claudeActiveSessionCronPaneKeys.delete(paneKey)
+    }
+  }
+
   ingestTerminalStatus(event: {
     paneKey: string
     tabId?: string
@@ -1942,10 +1989,10 @@ export class AgentHookServer {
 
         trackEmptyPaneKeyHook(body)
         const aliasedBody = this.normalizeHookBodyPaneKeyAlias(body)
-        const normalized = normalizeHookPayload(this.state, source, aliasedBody, this.env)
-        if (normalized && !this.shouldSuppressClosedTabStatus(normalized.paneKey)) {
-          this.recordCurrentAuthorityObservation(normalized)
-          const enriched = this.applyNormalizedStatus(normalized)
+        const normalized = this.normalizeLocalHookPayload(source, aliasedBody)
+        if (normalized.event && !this.shouldSuppressClosedTabStatus(normalized.event.paneKey)) {
+          this.recordCurrentAuthorityObservation(normalized.event)
+          const enriched = this.applyNormalizedStatus(normalized.event, normalized.onAccepted)
           this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
           this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
         }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -87,7 +87,7 @@ type EnrichedAgentHookEventPayload = AgentHookEventPayload & {
 
 type PersistedAgentHookEventPayload = Omit<
   EnrichedAgentHookEventPayload,
-  'claudeRunningShellOrMonitor' | 'launchToken' | 'promptInteractionKey'
+  'claudeRunningNonAgentTask' | 'launchToken' | 'promptInteractionKey'
 > & {
   launchTokenHash?: string
 }
@@ -755,7 +755,7 @@ export class AgentHookServer {
     // Why: Escape/Ctrl+C at Claude's idle prompt does not stop provider-owned background shells.
     if (
       agentType === 'claude' &&
-      this.state.claudeRunningShellOrMonitorPaneKeys.has(existing.paneKey)
+      this.state.claudeRunningNonAgentTaskPaneKeys.has(existing.paneKey)
     ) {
       return false
     }
@@ -1727,7 +1727,7 @@ export class AgentHookServer {
       isReplay?: boolean
       /** Payload fields the relay dropped to fit an oversized frame; validated below. */
       shedFields?: unknown
-      claudeRunningShellOrMonitor?: unknown
+      claudeRunningNonAgentTask?: unknown
       payload: unknown
     },
     connectionId: string
@@ -1825,12 +1825,12 @@ export class AgentHookServer {
     if (
       normalizedPayload.agentType === 'claude' &&
       envelope.isReplay !== true &&
-      typeof envelope.claudeRunningShellOrMonitor === 'boolean'
+      typeof envelope.claudeRunningNonAgentTask === 'boolean'
     ) {
-      if (envelope.claudeRunningShellOrMonitor) {
-        this.state.claudeRunningShellOrMonitorPaneKeys.add(paneKey)
+      if (envelope.claudeRunningNonAgentTask) {
+        this.state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
       } else {
-        this.state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
+        this.state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
       }
     }
     // Why: run the HTTP path's warn-once version/env-mismatch diagnostics with this.env as expected.
@@ -1854,9 +1854,9 @@ export class AgentHookServer {
       providerSession,
       providerSessionOnly: envelope.providerSessionOnly === true ? true : undefined,
       isReplay: envelope.isReplay === true ? true : undefined,
-      claudeRunningShellOrMonitor:
-        typeof envelope.claudeRunningShellOrMonitor === 'boolean'
-          ? envelope.claudeRunningShellOrMonitor
+      claudeRunningNonAgentTask:
+        typeof envelope.claudeRunningNonAgentTask === 'boolean'
+          ? envelope.claudeRunningNonAgentTask
           : undefined,
       payload: normalizedPayload
     }
@@ -2526,7 +2526,7 @@ export class AgentHookServer {
         continue
       }
       const {
-        claudeRunningShellOrMonitor: _claudeRunningShellOrMonitor,
+        claudeRunningNonAgentTask: _claudeRunningNonAgentTask,
         promptInteractionKey: _promptInteractionKey,
         launchToken,
         ...persistedPayload

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -481,6 +481,7 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
         toolUseId: 'toolu-1',
         toolAgentId: 'agent-subagent-a',
         toolAgentType: 'Review',
+        claudeRunningShellOrMonitor: true,
         providerSessionOnly: true,
         providerSession: {
           key: 'session_id',
@@ -503,6 +504,7 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
           toolUseId: 'toolu-1',
           toolAgentId: 'agent-subagent-a',
           toolAgentType: 'Review',
+          claudeRunningShellOrMonitor: true,
           providerSessionOnly: true,
           providerSession: {
             key: 'session_id',

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -481,7 +481,7 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
         toolUseId: 'toolu-1',
         toolAgentId: 'agent-subagent-a',
         toolAgentType: 'Review',
-        claudeRunningShellOrMonitor: true,
+        claudeRunningNonAgentTask: true,
         providerSessionOnly: true,
         providerSession: {
           key: 'session_id',
@@ -504,7 +504,7 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
           toolUseId: 'toolu-1',
           toolAgentId: 'agent-subagent-a',
           toolAgentType: 'Review',
-          claudeRunningShellOrMonitor: true,
+          claudeRunningNonAgentTask: true,
           providerSessionOnly: true,
           providerSession: {
             key: 'session_id',

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1139,6 +1139,7 @@ export class SshRelaySession {
         providerSession?: unknown
         providerSessionOnly?: unknown
         shedFields?: unknown
+        claudeRunningShellOrMonitor?: unknown
         payload?: unknown
       }
       if (typeof envelope.paneKey !== 'string') {
@@ -1169,6 +1170,10 @@ export class SshRelaySession {
           providerSessionOnly: envelope.providerSessionOnly === true ? true : undefined,
           // Why: names the fields the relay dropped to fit the frame; ingestRemote restores them.
           shedFields: envelope.shedFields,
+          claudeRunningShellOrMonitor:
+            typeof envelope.claudeRunningShellOrMonitor === 'boolean'
+              ? envelope.claudeRunningShellOrMonitor
+              : undefined,
           payload: envelope.payload
         },
         this.targetId

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1139,7 +1139,7 @@ export class SshRelaySession {
         providerSession?: unknown
         providerSessionOnly?: unknown
         shedFields?: unknown
-        claudeRunningShellOrMonitor?: unknown
+        claudeRunningNonAgentTask?: unknown
         payload?: unknown
       }
       if (typeof envelope.paneKey !== 'string') {
@@ -1170,9 +1170,9 @@ export class SshRelaySession {
           providerSessionOnly: envelope.providerSessionOnly === true ? true : undefined,
           // Why: names the fields the relay dropped to fit the frame; ingestRemote restores them.
           shedFields: envelope.shedFields,
-          claudeRunningShellOrMonitor:
-            typeof envelope.claudeRunningShellOrMonitor === 'boolean'
-              ? envelope.claudeRunningShellOrMonitor
+          claudeRunningNonAgentTask:
+            typeof envelope.claudeRunningNonAgentTask === 'boolean'
+              ? envelope.claudeRunningNonAgentTask
               : undefined,
           payload: envelope.payload
         },

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -65,10 +65,41 @@ describe('RelayAgentHookServer', () => {
       expect(envelope.connectionId).toBeNull()
       expect(envelope.payload.state).toBe('working')
       expect(envelope.payload.prompt).toBe('hi')
+      expect(envelope.claudeRunningShellOrMonitor).toBe(false)
       // Why: the relay forwards body env/version so Orca's warn-once
       // protocol diagnostics and remote-location marker survive the wire.
       expect(envelope.env).toBe('remote')
       expect(envelope.version).toBe('1')
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('forwards Claude background-work evidence with the normalized status', async () => {
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = new RelayAgentHookServer({ endpointDir: dir, forward })
+    await server.start()
+    try {
+      const { port, token } = server.getCoordinates()
+      await fetch(`http://127.0.0.1:${port}/hook/claude`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': token
+        },
+        body: JSON.stringify({
+          paneKey: PANE_KEY,
+          payload: {
+            hook_event_name: 'Stop',
+            background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+          }
+        })
+      })
+
+      expect(forward.mock.calls[0][0]).toMatchObject({
+        claudeRunningShellOrMonitor: true,
+        payload: { state: 'working', agentType: 'claude' }
+      })
     } finally {
       server.stop()
     }

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -65,7 +65,7 @@ describe('RelayAgentHookServer', () => {
       expect(envelope.connectionId).toBeNull()
       expect(envelope.payload.state).toBe('working')
       expect(envelope.payload.prompt).toBe('hi')
-      expect(envelope.claudeRunningShellOrMonitor).toBe(false)
+      expect(envelope.claudeRunningNonAgentTask).toBe(false)
       // Why: the relay forwards body env/version so Orca's warn-once
       // protocol diagnostics and remote-location marker survive the wire.
       expect(envelope.env).toBe('remote')
@@ -97,7 +97,7 @@ describe('RelayAgentHookServer', () => {
       })
 
       expect(forward.mock.calls[0][0]).toMatchObject({
-        claudeRunningShellOrMonitor: true,
+        claudeRunningNonAgentTask: true,
         payload: { state: 'working', agentType: 'claude' }
       })
     } finally {

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -316,6 +316,7 @@ export class RelayAgentHookServer {
       toolUseId: event.toolUseId,
       toolAgentId: event.toolAgentId,
       toolAgentType: event.toolAgentType,
+      claudeRunningShellOrMonitor: event.claudeRunningShellOrMonitor,
       ...(event.providerSession ? { providerSession: event.providerSession } : {}),
       ...(event.providerSessionOnly ? { providerSessionOnly: true } : {}),
       isReplay: options.isReplay === true ? true : undefined,

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -316,7 +316,7 @@ export class RelayAgentHookServer {
       toolUseId: event.toolUseId,
       toolAgentId: event.toolAgentId,
       toolAgentType: event.toolAgentType,
-      claudeRunningShellOrMonitor: event.claudeRunningShellOrMonitor,
+      claudeRunningNonAgentTask: event.claudeRunningNonAgentTask,
       ...(event.providerSession ? { providerSession: event.providerSession } : {}),
       ...(event.providerSessionOnly ? { providerSessionOnly: true } : {}),
       isReplay: options.isReplay === true ? true : undefined,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -116,8 +116,10 @@ export type HookListenerState = {
   claudeSubagentRosterByPaneKey: Map<string, ClaudeSubagentRoster>
   /** Last state from the LEAD session's own events (subagent events carry agent_id, excluded), so a SubagentStop can re-emit pane status; `interrupted` persists so the eventual done still carries it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
-  /** Panes whose latest complete Claude task inventory still has running non-agent work. */
+  /** Panes whose latest authoritative Claude task inventory still has running non-agent work. */
   claudeRunningNonAgentTaskPaneKeys: Set<string>
+  /** Panes whose latest authoritative Claude cron inventory still has a scheduled job. */
+  claudeActiveSessionCronPaneKeys: Set<string>
   /** Live thread-spawn children per Codex pane. */
   codexSubagentRosterByPaneKey: Map<string, CodexSubagentRoster>
   /** Incremental parent/child rollout cursors for Codex collaboration v2. */
@@ -152,6 +154,7 @@ export function createHookListenerState(): HookListenerState {
     claudeSubagentRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map(),
     claudeRunningNonAgentTaskPaneKeys: new Set(),
+    claudeActiveSessionCronPaneKeys: new Set(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
     codexLeadStateByPaneKey: new Map()
@@ -167,6 +170,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
   state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+  state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   state.codexSubagentRosterByPaneKey.delete(paneKey)
   state.codexSubagentTranscriptByPaneKey.delete(paneKey)
   state.codexLeadStateByPaneKey.delete(paneKey)
@@ -212,6 +216,7 @@ export function movePaneCacheState(
   movePaneScopedMapEntries(state.claudeSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeLeadStateByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedSetEntries(state.claudeRunningNonAgentTaskPaneKeys, fromPaneKey, toPaneKey)
+  movePaneScopedSetEntries(state.claudeActiveSessionCronPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentTranscriptByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexLeadStateByPaneKey, fromPaneKey, toPaneKey)
@@ -255,6 +260,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
   state.claudeRunningNonAgentTaskPaneKeys.clear()
+  state.claudeActiveSessionCronPaneKeys.clear()
   state.codexSubagentRosterByPaneKey.clear()
   state.codexSubagentTranscriptByPaneKey.clear()
   state.codexLeadStateByPaneKey.clear()
@@ -2450,7 +2456,9 @@ function resolveClaudePaneState(
   }
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   return claudeRosterHasWorkingSubagent(roster) ||
-    (!lead.interrupted && state.claudeRunningNonAgentTaskPaneKeys.has(paneKey))
+    (!lead.interrupted &&
+      (state.claudeRunningNonAgentTaskPaneKeys.has(paneKey) ||
+        state.claudeActiveSessionCronPaneKeys.has(paneKey)))
     ? 'working'
     : 'done'
 }
@@ -2498,6 +2506,7 @@ function normalizeClaudeSubagentLifecycleEvent(
 export function markClaudeLeadTurnInterrupted(state: HookListenerState, paneKey: string): void {
   state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done', interrupted: true })
   state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+  state.claudeActiveSessionCronPaneKeys.delete(paneKey)
 }
 
 /** Rebuild a pane's working roster from a persisted snapshot; live activity confirms a seed, a complete task inventory may reap an unconfirmed one whose finish hook arrived while Orca was offline. */
@@ -2627,6 +2636,9 @@ function normalizeClaudeEvent(
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
+  const sessionCrons = hookPayload['session_crons']
+  const sessionCronInventoryPresent = Array.isArray(sessionCrons)
+  const hasActiveSessionCron = sessionCronInventoryPresent && sessionCrons.length > 0
   if (backgroundTasks.present && eventAgentId === undefined) {
     updateClaudeRunningNonAgentTask(
       state,
@@ -2634,6 +2646,13 @@ function normalizeClaudeEvent(
       backgroundTasks.hasRunningNonAgentTask,
       interrupted === true
     )
+  }
+  if (sessionCronInventoryPresent && eventAgentId === undefined) {
+    if (hasActiveSessionCron && interrupted !== true) {
+      state.claudeActiveSessionCronPaneKeys.add(paneKey)
+    } else {
+      state.claudeActiveSessionCronPaneKeys.delete(paneKey)
+    }
   }
 
   // Why: Claude's auto-allowed AskUserQuestion emits PreToolUse (not PermissionRequest; its Notification hook isn't registered) while blocked on a human answer.
@@ -2655,12 +2674,6 @@ function normalizeClaudeEvent(
   if (!reportedStateName) {
     return null
   }
-  const sessionCrons = hookPayload['session_crons']
-  const hasActiveSessionCron =
-    (eventName === 'Stop' || eventName === 'StopFailure') &&
-    Array.isArray(sessionCrons) &&
-    sessionCrons.length > 0
-
   const stateName = reportedStateName
 
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
@@ -2733,13 +2746,13 @@ function normalizeClaudeEvent(
 
   if (interrupted && eventAgentId === undefined) {
     state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   }
 
-  // Why: preserve upstream cron gating while the pane cache carries task evidence across child lifecycle events.
-  const effectiveState =
-    stateName === 'done' && hasActiveSessionCron && interrupted !== true
-      ? 'working'
-      : resolveClaudePaneState(state, paneKey, { state: stateName, interrupted })
+  const effectiveState = resolveClaudePaneState(state, paneKey, {
+    state: stateName,
+    interrupted
+  })
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,
@@ -4133,7 +4146,9 @@ export function normalizeHookPayload(
         toolAgentType: readString(hookPayloadRecord, 'agent_type'),
         ...(source === 'claude'
           ? {
-              claudeRunningNonAgentTask: state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
+              claudeRunningNonAgentTask:
+                state.claudeRunningNonAgentTaskPaneKeys.has(paneKey) ||
+                state.claudeActiveSessionCronPaneKeys.has(paneKey)
             }
           : {}),
         ...(providerSession ? { providerSession } : {}),

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2710,7 +2710,7 @@ function normalizeClaudeEvent(
     return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
-  if (eventName === 'Stop' || eventName === 'StopFailure') {
+  if ((eventName === 'Stop' || eventName === 'StopFailure') && eventAgentId === undefined) {
     // Why: background_tasks is trusted only where unambiguous (see foldClaudeBackgroundTasksIntoRoster) — teammates report "running" here even while idle.
     // Older Claude builds without the field keep the incrementally tracked roster.
     if (backgroundTasks.present) {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2432,11 +2432,12 @@ function updateClaudeRunningShellOrMonitor(
   state: HookListenerState,
   paneKey: string,
   hasRunningShellOrMonitor: boolean,
-  interrupted: boolean
+  interrupted: boolean,
+  inventoryCanClear: boolean
 ): void {
   if (hasRunningShellOrMonitor && !interrupted) {
     state.claudeRunningShellOrMonitorPaneKeys.add(paneKey)
-  } else {
+  } else if (interrupted || inventoryCanClear) {
     state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
   }
 }
@@ -2611,12 +2612,17 @@ function normalizeClaudeEvent(
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
-  const startsUserTurn =
-    eventName === 'UserPromptSubmit' && !isKnownHarnessInjectedUserTurnText(promptText)
+  const eventAgentId = readString(hookPayload, 'agent_id')
+  const preservesInterruptedBoundary =
+    eventName === 'Stop' ||
+    eventName === 'StopFailure' ||
+    eventName === 'SubagentStart' ||
+    eventName === 'SubagentStop' ||
+    eventName === 'TeammateIdle'
   const interrupted =
     ((eventName === 'Stop' || eventName === 'StopFailure') &&
       hookPayload['is_interrupt'] === true) ||
-    (previousLead?.interrupted === true && !startsUserTurn)
+    (previousLead?.interrupted === true && preservesInterruptedBoundary)
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
@@ -2625,7 +2631,8 @@ function normalizeClaudeEvent(
       state,
       paneKey,
       backgroundTasks.hasRunningShellOrMonitor,
-      interrupted === true
+      interrupted === true,
+      eventAgentId === undefined
     )
   }
 
@@ -2660,13 +2667,11 @@ function normalizeClaudeEvent(
     (eventName === 'Stop' || eventName === 'StopFailure') &&
     hasActiveClaudeNonAgentBackgroundWork(hookPayload)
 
-  // Why: after cancellation, delayed bookkeeping cannot revive the turn; only a genuine user prompt starts a new one.
-  const stateName = interrupted ? 'done' : reportedStateName
+  const stateName = reportedStateName
 
-  const eventAgentId = readString(hookPayload, 'agent_id')
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
   // Two exceptions take the full path below: waiting-inducing events (a child needs human attention on this pane) and the blocked child's own next tool event (approval granted — clear the wait as for the lead).
-  const isWaitingInducing = reportedStateName === 'waiting' && !interrupted
+  const isWaitingInducing = reportedStateName === 'waiting'
   const subagentOriginId =
     !isWaitingInducing &&
     (eventName === 'PreToolUse' ||

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2639,21 +2639,6 @@ function normalizeClaudeEvent(
   const sessionCrons = hookPayload['session_crons']
   const sessionCronInventoryPresent = Array.isArray(sessionCrons)
   const hasActiveSessionCron = sessionCronInventoryPresent && sessionCrons.length > 0
-  if (backgroundTasks.present && eventAgentId === undefined) {
-    updateClaudeRunningNonAgentTask(
-      state,
-      paneKey,
-      backgroundTasks.hasRunningNonAgentTask,
-      interrupted === true
-    )
-  }
-  if (sessionCronInventoryPresent && eventAgentId === undefined) {
-    if (hasActiveSessionCron && interrupted !== true) {
-      state.claudeActiveSessionCronPaneKeys.add(paneKey)
-    } else {
-      state.claudeActiveSessionCronPaneKeys.delete(paneKey)
-    }
-  }
 
   // Why: Claude's auto-allowed AskUserQuestion emits PreToolUse (not PermissionRequest; its Notification hook isn't registered) while blocked on a human answer.
   // Treat that PreToolUse as waiting so the sidebar shows amber attention, not a spinner that decays to grey. Mirrors normalizeKimiEvent.
@@ -2673,6 +2658,21 @@ function normalizeClaudeEvent(
 
   if (!reportedStateName) {
     return null
+  }
+  if (backgroundTasks.present && eventAgentId === undefined) {
+    updateClaudeRunningNonAgentTask(
+      state,
+      paneKey,
+      backgroundTasks.hasRunningNonAgentTask,
+      interrupted === true
+    )
+  }
+  if (sessionCronInventoryPresent && eventAgentId === undefined) {
+    if (hasActiveSessionCron && interrupted !== true) {
+      state.claudeActiveSessionCronPaneKeys.add(paneKey)
+    } else {
+      state.claudeActiveSessionCronPaneKeys.delete(paneKey)
+    }
   }
   const stateName = reportedStateName
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -31,7 +31,6 @@ import {
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
-  hasActiveClaudeNonAgentBackgroundWork,
   idleClaudeTeammateByName,
   readClaudeBackgroundAgentTasks,
   reapRestoredClaudeSubagentsWithoutLiveAgent,
@@ -2610,14 +2609,16 @@ function normalizeClaudeEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
-  const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
   const eventAgentId = readString(hookPayload, 'agent_id')
-  const preservesInterruptedBoundary =
-    eventName === 'Stop' ||
-    eventName === 'StopFailure' ||
+  if (
     eventName === 'SubagentStart' ||
     eventName === 'SubagentStop' ||
     eventName === 'TeammateIdle'
+  ) {
+    return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
+  }
+  const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
+  const preservesInterruptedBoundary = eventName === 'Stop' || eventName === 'StopFailure'
   const interrupted =
     ((eventName === 'Stop' || eventName === 'StopFailure') &&
       eventAgentId === undefined &&
@@ -2626,14 +2627,6 @@ function normalizeClaudeEvent(
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
-
-  if (
-    eventName === 'SubagentStart' ||
-    eventName === 'SubagentStop' ||
-    eventName === 'TeammateIdle'
-  ) {
-    return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
-  }
   if (backgroundTasks.present && eventAgentId === undefined) {
     updateClaudeRunningNonAgentTask(
       state,
@@ -2662,9 +2655,11 @@ function normalizeClaudeEvent(
   if (!reportedStateName) {
     return null
   }
-  const hasActiveNonAgentBackgroundWork =
+  const sessionCrons = hookPayload['session_crons']
+  const hasActiveSessionCron =
     (eventName === 'Stop' || eventName === 'StopFailure') &&
-    hasActiveClaudeNonAgentBackgroundWork(hookPayload)
+    Array.isArray(sessionCrons) &&
+    sessionCrons.length > 0
 
   const stateName = reportedStateName
 
@@ -2742,7 +2737,7 @@ function normalizeClaudeEvent(
 
   // Why: preserve upstream cron gating while the pane cache carries task evidence across child lifecycle events.
   const effectiveState =
-    stateName === 'done' && hasActiveNonAgentBackgroundWork
+    stateName === 'done' && hasActiveSessionCron
       ? 'working'
       : resolveClaudePaneState(state, paneKey, { state: stateName, interrupted })
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -32,12 +32,12 @@ import {
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
   idleClaudeTeammateByName,
-  readClaudeBackgroundAgentTasks,
   reapRestoredClaudeSubagentsWithoutLiveAgent,
   stopClaudeSubagent,
   upsertWorkingClaudeSubagent,
   type ClaudeSubagentRoster
 } from './claude-subagent-roster'
+import { readClaudeBackgroundAgentTasks } from './claude-background-task-inventory'
 import {
   codexRosterEffectiveState,
   codexRosterToSnapshots,
@@ -2737,7 +2737,7 @@ function normalizeClaudeEvent(
 
   // Why: preserve upstream cron gating while the pane cache carries task evidence across child lifecycle events.
   const effectiveState =
-    stateName === 'done' && hasActiveSessionCron
+    stateName === 'done' && hasActiveSessionCron && interrupted !== true
       ? 'working'
       : resolveClaudePaneState(state, paneKey, { state: stateName, interrupted })
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2627,12 +2627,12 @@ function normalizeClaudeEvent(
     return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
   }
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
-  const preservesInterruptedBoundary = eventName === 'Stop' || eventName === 'StopFailure'
+  // Why: only a turn boundary may declare an interrupt or carry a prior one forward; any other event starts a fresh turn and drops it.
+  const isTurnBoundary = eventName === 'Stop' || eventName === 'StopFailure'
   const interrupted =
-    ((eventName === 'Stop' || eventName === 'StopFailure') &&
-      eventAgentId === undefined &&
-      hookPayload['is_interrupt'] === true) ||
-    (previousLead?.interrupted === true && preservesInterruptedBoundary)
+    isTurnBoundary &&
+    ((eventAgentId === undefined && hookPayload['is_interrupt'] === true) ||
+      previousLead?.interrupted === true)
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
@@ -2652,7 +2652,7 @@ function normalizeClaudeEvent(
       ? 'working'
       : eventName === 'PermissionRequest' || isAskUserQuestion
         ? 'waiting'
-        : eventName === 'Stop' || eventName === 'StopFailure'
+        : isTurnBoundary
           ? 'done'
           : null
 
@@ -2673,15 +2673,10 @@ function normalizeClaudeEvent(
     } else {
       state.claudeActiveSessionCronPaneKeys.delete(paneKey)
     }
-  } else if (
-    eventAgentId === undefined &&
-    (eventName === 'Stop' || eventName === 'StopFailure') &&
-    backgroundTasks.present
-  ) {
+  } else if (eventAgentId === undefined && isTurnBoundary && backgroundTasks.present) {
     // Why: current Claude may omit an empty cron inventory while still emitting background_tasks.
     state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   }
-  const stateName = reportedStateName
 
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
   // Two exceptions take the full path below: waiting-inducing events (a child needs human attention on this pane) and the blocked child's own next tool event (approval granted — clear the wait as for the lead).
@@ -2722,7 +2717,7 @@ function normalizeClaudeEvent(
     return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
-  if ((eventName === 'Stop' || eventName === 'StopFailure') && eventAgentId === undefined) {
+  if (isTurnBoundary && eventAgentId === undefined) {
     // Why: background_tasks is trusted only where unambiguous (see foldClaudeBackgroundTasksIntoRoster) — teammates report "running" here even while idle.
     // Older Claude builds without the field keep the incrementally tracked roster.
     if (backgroundTasks.present) {
@@ -2745,7 +2740,7 @@ function normalizeClaudeEvent(
           }
       : undefined
   state.claudeLeadStateByPaneKey.set(paneKey, {
-    state: stateName,
+    state: reportedStateName,
     ...(interrupted ? { interrupted } : {}),
     ...(isWaitingInducing && eventAgentId ? { waitingAgentId: eventAgentId } : {}),
     ...(stateBeforeWait ? { stateBeforeWait } : {})
@@ -2757,7 +2752,7 @@ function normalizeClaudeEvent(
   }
 
   const effectiveState = resolveClaudePaneState(state, paneKey, {
-    state: stateName,
+    state: reportedStateName,
     interrupted
   })
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -118,7 +118,7 @@ export type HookListenerState = {
   /** Last state from the LEAD session's own events (subagent events carry agent_id, excluded), so a SubagentStop can re-emit pane status; `interrupted` persists so the eventual done still carries it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
   /** Panes whose latest complete Claude task inventory still has a running shell or monitor. */
-  claudeRunningShellOrMonitorByPaneKey: Map<string, true>
+  claudeRunningShellOrMonitorPaneKeys: Set<string>
   /** Live thread-spawn children per Codex pane. */
   codexSubagentRosterByPaneKey: Map<string, CodexSubagentRoster>
   /** Incremental parent/child rollout cursors for Codex collaboration v2. */
@@ -152,7 +152,7 @@ export function createHookListenerState(): HookListenerState {
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map(),
-    claudeRunningShellOrMonitorByPaneKey: new Map(),
+    claudeRunningShellOrMonitorPaneKeys: new Set(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
     codexLeadStateByPaneKey: new Map()
@@ -167,7 +167,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
-  state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
+  state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
   state.codexSubagentRosterByPaneKey.delete(paneKey)
   state.codexSubagentTranscriptByPaneKey.delete(paneKey)
   state.codexLeadStateByPaneKey.delete(paneKey)
@@ -212,7 +212,7 @@ export function movePaneCacheState(
   movePaneScopedSetEntries(state.ampCompletedCacheKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeLeadStateByPaneKey, fromPaneKey, toPaneKey)
-  movePaneScopedMapEntries(state.claudeRunningShellOrMonitorByPaneKey, fromPaneKey, toPaneKey)
+  movePaneScopedSetEntries(state.claudeRunningShellOrMonitorPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentTranscriptByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexLeadStateByPaneKey, fromPaneKey, toPaneKey)
@@ -255,7 +255,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
-  state.claudeRunningShellOrMonitorByPaneKey.clear()
+  state.claudeRunningShellOrMonitorPaneKeys.clear()
   state.codexSubagentRosterByPaneKey.clear()
   state.codexSubagentTranscriptByPaneKey.clear()
   state.codexLeadStateByPaneKey.clear()
@@ -317,6 +317,8 @@ export type AgentHookEventPayload = {
   providerSessionOnly?: boolean
   /** True when this event is a relay cache replay rather than a live hook. */
   isReplay?: boolean
+  /** Transport-only Claude background-work evidence used to reject false input-based interrupts. */
+  claudeRunningShellOrMonitor?: boolean
   payload: ParsedAgentStatusPayload
 }
 
@@ -2429,15 +2431,13 @@ function getOrCreateClaudeSubagentRoster(
 function updateClaudeRunningShellOrMonitor(
   state: HookListenerState,
   paneKey: string,
-  hasRunningShellOrMonitor: boolean
+  hasRunningShellOrMonitor: boolean,
+  interrupted: boolean
 ): void {
-  if (
-    hasRunningShellOrMonitor &&
-    state.claudeLeadStateByPaneKey.get(paneKey)?.interrupted !== true
-  ) {
-    state.claudeRunningShellOrMonitorByPaneKey.set(paneKey, true)
+  if (hasRunningShellOrMonitor && !interrupted) {
+    state.claudeRunningShellOrMonitorPaneKeys.add(paneKey)
   } else {
-    state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
+    state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
   }
 }
 
@@ -2451,7 +2451,7 @@ function resolveClaudePaneState(
   }
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   return claudeRosterHasWorkingSubagent(roster) ||
-    (!lead.interrupted && state.claudeRunningShellOrMonitorByPaneKey.has(paneKey))
+    (!lead.interrupted && state.claudeRunningShellOrMonitorPaneKeys.has(paneKey))
     ? 'working'
     : 'done'
 }
@@ -2486,10 +2486,6 @@ function normalizeClaudeSubagentLifecycleEvent(
         Date.now()
       )
     } else {
-      const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
-      if (backgroundTasks.present) {
-        updateClaudeRunningShellOrMonitor(state, paneKey, backgroundTasks.hasRunningShellOrMonitor)
-      }
       // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
       stopClaudeSubagent(roster, agentId)
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
@@ -2502,7 +2498,7 @@ function normalizeClaudeSubagentLifecycleEvent(
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
 export function markClaudeLeadTurnInterrupted(state: HookListenerState, paneKey: string): void {
   state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done', interrupted: true })
-  state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
+  state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
 }
 
 /** Rebuild a pane's working roster from a persisted snapshot; live activity confirms a seed, a complete task inventory may reap an unconfirmed one whose finish hook arrived while Orca was offline. */
@@ -2614,6 +2610,25 @@ function normalizeClaudeEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
+  const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
+  const startsUserTurn =
+    eventName === 'UserPromptSubmit' && !isKnownHarnessInjectedUserTurnText(promptText)
+  const interrupted =
+    ((eventName === 'Stop' || eventName === 'StopFailure') &&
+      hookPayload['is_interrupt'] === true) ||
+    (previousLead?.interrupted === true && !startsUserTurn)
+      ? true
+      : undefined
+  const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
+  if (backgroundTasks.present) {
+    updateClaudeRunningShellOrMonitor(
+      state,
+      paneKey,
+      backgroundTasks.hasRunningShellOrMonitor,
+      interrupted === true
+    )
+  }
+
   if (
     eventName === 'SubagentStart' ||
     eventName === 'SubagentStop' ||
@@ -2626,7 +2641,7 @@ function normalizeClaudeEvent(
   // Treat that PreToolUse as waiting so the sidebar shows amber attention, not a spinner that decays to grey. Mirrors normalizeKimiEvent.
   const isAskUserQuestion =
     eventName === 'PreToolUse' && isAskUserQuestionTool(readString(hookPayload, 'tool_name'))
-  const stateName =
+  const reportedStateName =
     eventName === 'UserPromptSubmit' ||
     eventName === 'PostToolUse' ||
     eventName === 'PostToolUseFailure' ||
@@ -2638,17 +2653,20 @@ function normalizeClaudeEvent(
           ? 'done'
           : null
 
-  if (!stateName) {
+  if (!reportedStateName) {
     return null
   }
   const hasActiveNonAgentBackgroundWork =
     (eventName === 'Stop' || eventName === 'StopFailure') &&
     hasActiveClaudeNonAgentBackgroundWork(hookPayload)
 
+  // Why: after cancellation, delayed bookkeeping cannot revive the turn; only a genuine user prompt starts a new one.
+  const stateName = interrupted ? 'done' : reportedStateName
+
   const eventAgentId = readString(hookPayload, 'agent_id')
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
   // Two exceptions take the full path below: waiting-inducing events (a child needs human attention on this pane) and the blocked child's own next tool event (approval granted — clear the wait as for the lead).
-  const isWaitingInducing = stateName === 'waiting'
+  const isWaitingInducing = reportedStateName === 'waiting' && !interrupted
   const subagentOriginId =
     !isWaitingInducing &&
     (eventName === 'PreToolUse' ||
@@ -2692,9 +2710,7 @@ function normalizeClaudeEvent(
   if (eventName === 'Stop' || eventName === 'StopFailure') {
     // Why: background_tasks is trusted only where unambiguous (see foldClaudeBackgroundTasksIntoRoster) — teammates report "running" here even while idle.
     // Older Claude builds without the field keep the incrementally tracked roster.
-    const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
     if (backgroundTasks.present) {
-      updateClaudeRunningShellOrMonitor(state, paneKey, backgroundTasks.hasRunningShellOrMonitor)
       foldClaudeBackgroundTasksIntoRoster(
         getOrCreateClaudeSubagentRoster(state, paneKey),
         backgroundTasks.tasks,
@@ -2703,10 +2719,7 @@ function normalizeClaudeEvent(
       )
     }
   }
-  const interrupted =
-    eventName === 'Stop' && hookPayload['is_interrupt'] === true ? true : undefined
   // Why: a child-induced wait displaces the lead state; stash it so clearing restores reality (lead may be done). A 2nd child wait carries the ORIGINAL stash, not the intermediate waiting state.
-  const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
   const stateBeforeWait =
     isWaitingInducing && eventAgentId && previousLead
       ? previousLead.state === 'waiting'
@@ -2724,7 +2737,7 @@ function normalizeClaudeEvent(
   })
 
   if (interrupted) {
-    state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
+    state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
   }
 
   // Why: preserve upstream cron gating while the pane cache carries task evidence across child lifecycle events.
@@ -4123,6 +4136,11 @@ export function normalizeHookPayload(
         toolUseId: readFirstString(hookPayloadRecord, ['tool_use_id', 'toolUseId']),
         toolAgentId: readFirstString(hookPayloadRecord, ['agent_id', 'agentId']),
         toolAgentType: readString(hookPayloadRecord, 'agent_type'),
+        ...(source === 'claude'
+          ? {
+              claudeRunningShellOrMonitor: state.claudeRunningShellOrMonitorPaneKeys.has(paneKey)
+            }
+          : {}),
         ...(providerSession ? { providerSession } : {}),
         ...(providerSessionOnly ? { providerSessionOnly: true } : {}),
         payload: transportPayload

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -117,6 +117,8 @@ export type HookListenerState = {
   claudeSubagentRosterByPaneKey: Map<string, ClaudeSubagentRoster>
   /** Last state from the LEAD session's own events (subagent events carry agent_id, excluded), so a SubagentStop can re-emit pane status; `interrupted` persists so the eventual done still carries it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
+  /** Panes whose latest complete Claude task inventory still has a running shell or monitor. */
+  claudeRunningShellOrMonitorByPaneKey: Map<string, true>
   /** Live thread-spawn children per Codex pane. */
   codexSubagentRosterByPaneKey: Map<string, CodexSubagentRoster>
   /** Incremental parent/child rollout cursors for Codex collaboration v2. */
@@ -150,6 +152,7 @@ export function createHookListenerState(): HookListenerState {
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map(),
+    claudeRunningShellOrMonitorByPaneKey: new Map(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
     codexLeadStateByPaneKey: new Map()
@@ -164,6 +167,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
+  state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
   state.codexSubagentRosterByPaneKey.delete(paneKey)
   state.codexSubagentTranscriptByPaneKey.delete(paneKey)
   state.codexLeadStateByPaneKey.delete(paneKey)
@@ -208,6 +212,7 @@ export function movePaneCacheState(
   movePaneScopedSetEntries(state.ampCompletedCacheKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeLeadStateByPaneKey, fromPaneKey, toPaneKey)
+  movePaneScopedMapEntries(state.claudeRunningShellOrMonitorByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentTranscriptByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexLeadStateByPaneKey, fromPaneKey, toPaneKey)
@@ -250,6 +255,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
+  state.claudeRunningShellOrMonitorByPaneKey.clear()
   state.codexSubagentRosterByPaneKey.clear()
   state.codexSubagentTranscriptByPaneKey.clear()
   state.codexLeadStateByPaneKey.clear()
@@ -2420,6 +2426,36 @@ function getOrCreateClaudeSubagentRoster(
   return roster
 }
 
+function updateClaudeRunningShellOrMonitor(
+  state: HookListenerState,
+  paneKey: string,
+  hasRunningShellOrMonitor: boolean
+): void {
+  if (
+    hasRunningShellOrMonitor &&
+    state.claudeLeadStateByPaneKey.get(paneKey)?.interrupted !== true
+  ) {
+    state.claudeRunningShellOrMonitorByPaneKey.set(paneKey, true)
+  } else {
+    state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
+  }
+}
+
+function resolveClaudePaneState(
+  state: HookListenerState,
+  paneKey: string,
+  lead: Pick<ClaudeLeadTurnState, 'state' | 'interrupted'>
+): AgentStatusState {
+  if (lead.state !== 'done') {
+    return lead.state
+  }
+  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  return claudeRosterHasWorkingSubagent(roster) ||
+    (!lead.interrupted && state.claudeRunningShellOrMonitorByPaneKey.has(paneKey))
+    ? 'working'
+    : 'done'
+}
+
 /** SubagentStart/Stop/TeammateIdle update the roster and re-emit the lead's last known state with the fresh child list, so the sidebar reflects spawn/finish even when a background child outlives the lead turn with no other hook traffic. */
 function normalizeClaudeSubagentLifecycleEvent(
   state: HookListenerState,
@@ -2450,6 +2486,10 @@ function normalizeClaudeSubagentLifecycleEvent(
         Date.now()
       )
     } else {
+      const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
+      if (backgroundTasks.present) {
+        updateClaudeRunningShellOrMonitor(state, paneKey, backgroundTasks.hasRunningShellOrMonitor)
+      }
       // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
       stopClaudeSubagent(roster, agentId)
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
@@ -2462,6 +2502,7 @@ function normalizeClaudeSubagentLifecycleEvent(
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
 export function markClaudeLeadTurnInterrupted(state: HookListenerState, paneKey: string): void {
   state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done', interrupted: true })
+  state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
 }
 
 /** Rebuild a pane's working roster from a persisted snapshot; live activity confirms a seed, a complete task inventory may reap an unconfirmed one whose finish hook arrived while Orca was offline. */
@@ -2542,10 +2583,8 @@ export function clearClaudeAnsweredQuestionWait(
       ? { lastAssistantMessage: previousTool.lastAssistantMessage }
       : {}
   )
-  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
-  return restored.state === 'done' && claudeRosterHasWorkingSubagent(roster)
-    ? { state: 'working' }
-    : restored
+  const effectiveState = resolveClaudePaneState(state, paneKey, restored)
+  return effectiveState === restored.state ? restored : { state: effectiveState }
 }
 
 /** Re-emit the lead's cached state on child activity — gated up to 'working' while a child works — without touching the lead's tool/prompt caches, so a live card or permission wait survives child churn. */
@@ -2558,10 +2597,11 @@ function buildClaudeChildDrivenStatusPayload(
   // Why: default 'working' — a spawn proves activity even before the lead's first state-bearing event (e.g. Orca restarted mid-session).
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
   const leadState = lead?.state ?? 'working'
-  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
-    stateName:
-      leadState === 'done' && claudeRosterHasWorkingSubagent(roster) ? 'working' : leadState,
+    stateName: resolveClaudePaneState(state, paneKey, {
+      state: leadState,
+      interrupted: lead?.interrupted
+    }),
     updateToolSnapshot: false,
     interrupted: lead?.interrupted
   })
@@ -2633,12 +2673,8 @@ function normalizeClaudeEvent(
     // Restore the stashed lead state, not this child's 'working': the lead may already be done, and the done-gate never upgrades working back to done once the roster drains.
     const restored = lead.stateBeforeWait ?? { state: 'working' as const }
     state.claudeLeadStateByPaneKey.set(paneKey, restored)
-    const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
-      stateName:
-        restored.state === 'done' && claudeRosterHasWorkingSubagent(roster)
-          ? 'working'
-          : restored.state,
+      stateName: resolveClaudePaneState(state, paneKey, restored),
       updateToolSnapshot: true,
       interrupted: restored.interrupted
     })
@@ -2658,6 +2694,7 @@ function normalizeClaudeEvent(
     // Older Claude builds without the field keep the incrementally tracked roster.
     const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
     if (backgroundTasks.present) {
+      updateClaudeRunningShellOrMonitor(state, paneKey, backgroundTasks.hasRunningShellOrMonitor)
       foldClaudeBackgroundTasksIntoRoster(
         getOrCreateClaudeSubagentRoster(state, paneKey),
         backgroundTasks.tasks,
@@ -2686,13 +2723,15 @@ function normalizeClaudeEvent(
     ...(stateBeforeWait ? { stateBeforeWait } : {})
   })
 
-  // Why: a lead Stop isn't done while children, shells, or crons remain live; a later drained Stop resolves it.
-  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  if (interrupted) {
+    state.claudeRunningShellOrMonitorByPaneKey.delete(paneKey)
+  }
+
+  // Why: preserve upstream cron gating while the pane cache carries task evidence across child lifecycle events.
   const effectiveState =
-    stateName === 'done' &&
-    (hasActiveNonAgentBackgroundWork || claudeRosterHasWorkingSubagent(roster))
+    stateName === 'done' && hasActiveNonAgentBackgroundWork
       ? 'working'
-      : stateName
+      : resolveClaudePaneState(state, paneKey, { state: stateName, interrupted })
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -117,8 +117,8 @@ export type HookListenerState = {
   claudeSubagentRosterByPaneKey: Map<string, ClaudeSubagentRoster>
   /** Last state from the LEAD session's own events (subagent events carry agent_id, excluded), so a SubagentStop can re-emit pane status; `interrupted` persists so the eventual done still carries it. */
   claudeLeadStateByPaneKey: Map<string, ClaudeLeadTurnState>
-  /** Panes whose latest complete Claude task inventory still has a running shell or monitor. */
-  claudeRunningShellOrMonitorPaneKeys: Set<string>
+  /** Panes whose latest complete Claude task inventory still has running non-agent work. */
+  claudeRunningNonAgentTaskPaneKeys: Set<string>
   /** Live thread-spawn children per Codex pane. */
   codexSubagentRosterByPaneKey: Map<string, CodexSubagentRoster>
   /** Incremental parent/child rollout cursors for Codex collaboration v2. */
@@ -152,7 +152,7 @@ export function createHookListenerState(): HookListenerState {
     ampCompletedCacheKeys: new Set(),
     claudeSubagentRosterByPaneKey: new Map(),
     claudeLeadStateByPaneKey: new Map(),
-    claudeRunningShellOrMonitorPaneKeys: new Set(),
+    claudeRunningNonAgentTaskPaneKeys: new Set(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
     codexLeadStateByPaneKey: new Map()
@@ -167,7 +167,7 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   deletePaneScopedSetEntry(state.ampCompletedCacheKeys, paneKey)
   state.claudeSubagentRosterByPaneKey.delete(paneKey)
   state.claudeLeadStateByPaneKey.delete(paneKey)
-  state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
+  state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
   state.codexSubagentRosterByPaneKey.delete(paneKey)
   state.codexSubagentTranscriptByPaneKey.delete(paneKey)
   state.codexLeadStateByPaneKey.delete(paneKey)
@@ -212,7 +212,7 @@ export function movePaneCacheState(
   movePaneScopedSetEntries(state.ampCompletedCacheKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.claudeLeadStateByPaneKey, fromPaneKey, toPaneKey)
-  movePaneScopedSetEntries(state.claudeRunningShellOrMonitorPaneKeys, fromPaneKey, toPaneKey)
+  movePaneScopedSetEntries(state.claudeRunningNonAgentTaskPaneKeys, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentTranscriptByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexLeadStateByPaneKey, fromPaneKey, toPaneKey)
@@ -255,7 +255,7 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.warnedEnvs.clear()
   state.claudeSubagentRosterByPaneKey.clear()
   state.claudeLeadStateByPaneKey.clear()
-  state.claudeRunningShellOrMonitorPaneKeys.clear()
+  state.claudeRunningNonAgentTaskPaneKeys.clear()
   state.codexSubagentRosterByPaneKey.clear()
   state.codexSubagentTranscriptByPaneKey.clear()
   state.codexLeadStateByPaneKey.clear()
@@ -318,7 +318,7 @@ export type AgentHookEventPayload = {
   /** True when this event is a relay cache replay rather than a live hook. */
   isReplay?: boolean
   /** Transport-only Claude background-work evidence used to reject false input-based interrupts. */
-  claudeRunningShellOrMonitor?: boolean
+  claudeRunningNonAgentTask?: boolean
   payload: ParsedAgentStatusPayload
 }
 
@@ -2428,17 +2428,16 @@ function getOrCreateClaudeSubagentRoster(
   return roster
 }
 
-function updateClaudeRunningShellOrMonitor(
+function updateClaudeRunningNonAgentTask(
   state: HookListenerState,
   paneKey: string,
-  hasRunningShellOrMonitor: boolean,
-  interrupted: boolean,
-  inventoryCanClear: boolean
+  hasRunningNonAgentTask: boolean,
+  interrupted: boolean
 ): void {
-  if (hasRunningShellOrMonitor && !interrupted) {
-    state.claudeRunningShellOrMonitorPaneKeys.add(paneKey)
-  } else if (interrupted || inventoryCanClear) {
-    state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
+  if (hasRunningNonAgentTask && !interrupted) {
+    state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
+  } else {
+    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
   }
 }
 
@@ -2452,7 +2451,7 @@ function resolveClaudePaneState(
   }
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   return claudeRosterHasWorkingSubagent(roster) ||
-    (!lead.interrupted && state.claudeRunningShellOrMonitorPaneKeys.has(paneKey))
+    (!lead.interrupted && state.claudeRunningNonAgentTaskPaneKeys.has(paneKey))
     ? 'working'
     : 'done'
 }
@@ -2499,7 +2498,7 @@ function normalizeClaudeSubagentLifecycleEvent(
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
 export function markClaudeLeadTurnInterrupted(state: HookListenerState, paneKey: string): void {
   state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done', interrupted: true })
-  state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
+  state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
 }
 
 /** Rebuild a pane's working roster from a persisted snapshot; live activity confirms a seed, a complete task inventory may reap an unconfirmed one whose finish hook arrived while Orca was offline. */
@@ -2626,13 +2625,12 @@ function normalizeClaudeEvent(
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
-  if (backgroundTasks.present) {
-    updateClaudeRunningShellOrMonitor(
+  if (backgroundTasks.present && eventAgentId === undefined) {
+    updateClaudeRunningNonAgentTask(
       state,
       paneKey,
-      backgroundTasks.hasRunningShellOrMonitor,
-      interrupted === true,
-      eventAgentId === undefined
+      backgroundTasks.hasRunningNonAgentTask,
+      interrupted === true
     )
   }
 
@@ -2742,7 +2740,7 @@ function normalizeClaudeEvent(
   })
 
   if (interrupted) {
-    state.claudeRunningShellOrMonitorPaneKeys.delete(paneKey)
+    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
   }
 
   // Why: preserve upstream cron gating while the pane cache carries task evidence across child lifecycle events.
@@ -4143,7 +4141,7 @@ export function normalizeHookPayload(
         toolAgentType: readString(hookPayloadRecord, 'agent_type'),
         ...(source === 'claude'
           ? {
-              claudeRunningShellOrMonitor: state.claudeRunningShellOrMonitorPaneKeys.has(paneKey)
+              claudeRunningNonAgentTask: state.claudeRunningNonAgentTaskPaneKeys.has(paneKey)
             }
           : {}),
         ...(providerSession ? { providerSession } : {}),

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2673,6 +2673,13 @@ function normalizeClaudeEvent(
     } else {
       state.claudeActiveSessionCronPaneKeys.delete(paneKey)
     }
+  } else if (
+    eventAgentId === undefined &&
+    (eventName === 'Stop' || eventName === 'StopFailure') &&
+    backgroundTasks.present
+  ) {
+    // Why: current Claude may omit an empty cron inventory while still emitting background_tasks.
+    state.claudeActiveSessionCronPaneKeys.delete(paneKey)
   }
   const stateName = reportedStateName
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2625,14 +2625,6 @@ function normalizeClaudeEvent(
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
-  if (backgroundTasks.present && eventAgentId === undefined) {
-    updateClaudeRunningNonAgentTask(
-      state,
-      paneKey,
-      backgroundTasks.hasRunningNonAgentTask,
-      interrupted === true
-    )
-  }
 
   if (
     eventName === 'SubagentStart' ||
@@ -2640,6 +2632,14 @@ function normalizeClaudeEvent(
     eventName === 'TeammateIdle'
   ) {
     return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
+  }
+  if (backgroundTasks.present && eventAgentId === undefined) {
+    updateClaudeRunningNonAgentTask(
+      state,
+      paneKey,
+      backgroundTasks.hasRunningNonAgentTask,
+      interrupted === true
+    )
   }
 
   // Why: Claude's auto-allowed AskUserQuestion emits PreToolUse (not PermissionRequest; its Notification hook isn't registered) while blocked on a human answer.

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2620,6 +2620,7 @@ function normalizeClaudeEvent(
     eventName === 'TeammateIdle'
   const interrupted =
     ((eventName === 'Stop' || eventName === 'StopFailure') &&
+      eventAgentId === undefined &&
       hookPayload['is_interrupt'] === true) ||
     (previousLead?.interrupted === true && preservesInterruptedBoundary)
       ? true
@@ -2701,12 +2702,8 @@ function normalizeClaudeEvent(
     })
   }
 
-  // Why: lead events never carry agent_id, so a known child's id on a turn-boundary event must not retire/resurrect the pane as if the lead spoke — re-emit as child activity.
-  if (
-    eventAgentId &&
-    !isWaitingInducing &&
-    state.claudeSubagentRosterByPaneKey.get(paneKey)?.has(eventAgentId)
-  ) {
+  // Why: lead events never carry agent_id; even a child missed by lifecycle tracking cannot own the lead turn or its background-work evidence.
+  if (eventAgentId && !isWaitingInducing) {
     return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
@@ -2739,7 +2736,7 @@ function normalizeClaudeEvent(
     ...(stateBeforeWait ? { stateBeforeWait } : {})
   })
 
-  if (interrupted) {
+  if (interrupted && eventAgentId === undefined) {
     state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
   }
 

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -88,7 +88,7 @@ export type AgentHookRelayEnvelope = {
   /** True when the relay is replaying its cache after Orca reconnects. */
   isReplay?: boolean
   /** Claude background-work evidence for input-interrupt inference on the receiving host. */
-  claudeRunningShellOrMonitor?: boolean
+  claudeRunningNonAgentTask?: boolean
   /** Forwarded from the agent CLI POST body. The relay default is `remote`,
    *  which marks transport location rather than dev/prod build env. */
   env?: string

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -87,6 +87,8 @@ export type AgentHookRelayEnvelope = {
   providerSessionOnly?: boolean
   /** True when the relay is replaying its cache after Orca reconnects. */
   isReplay?: boolean
+  /** Claude background-work evidence for input-interrupt inference on the receiving host. */
+  claudeRunningShellOrMonitor?: boolean
   /** Forwarded from the agent CLI POST body. The relay default is `remote`,
    *  which marks transport location rather than dev/prod build env. */
   env?: string

--- a/src/shared/claude-background-task-inventory.ts
+++ b/src/shared/claude-background-task-inventory.ts
@@ -54,6 +54,7 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
   for (const item of raw) {
     if (typeof item !== 'object' || item === null) {
       truncated = true
+      hasRunningNonAgentTask = true
       continue
     }
     const obj = item as Record<string, unknown>

--- a/src/shared/claude-background-task-inventory.ts
+++ b/src/shared/claude-background-task-inventory.ts
@@ -2,8 +2,21 @@ import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
 
 const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
   'idle',
+  'done',
+  'success',
+  'succeeded',
+  'complete',
   'completed',
+  'finished',
   'failed',
+  'error',
+  'stopped',
+  'terminated',
+  'exited',
+  'aborted',
+  'expired',
+  'skipped',
+  'crashed',
   'killed',
   'cancelled',
   'canceled',
@@ -21,27 +34,6 @@ export type ClaudeBackgroundAgentTask = {
    *  agent_ids and they report "running" permanently — even after the named
    *  agent finished — so they carry no per-agent state at all. */
   teammate: boolean
-}
-
-/** Shell tasks and session crons outlive a lead Stop but do not belong in the agent roster. */
-export function hasActiveClaudeNonAgentBackgroundWork(
-  hookPayload: Record<string, unknown>
-): boolean {
-  const sessionCrons = hookPayload['session_crons']
-  if (Array.isArray(sessionCrons) && sessionCrons.length > 0) {
-    return true
-  }
-  const backgroundTasks = hookPayload['background_tasks']
-  return (
-    Array.isArray(backgroundTasks) &&
-    backgroundTasks.some((item) => {
-      if (typeof item !== 'object' || item === null) {
-        return false
-      }
-      const task = item as Record<string, unknown>
-      return task.status === 'running' && task.type !== 'subagent' && task.type !== 'teammate'
-    })
-  )
 }
 
 /** Read the agent-typed entries of a hook payload's `background_tasks` field.

--- a/src/shared/claude-background-task-inventory.ts
+++ b/src/shared/claude-background-task-inventory.ts
@@ -1,0 +1,105 @@
+import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
+
+const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
+  'idle',
+  'completed',
+  'failed',
+  'killed',
+  'cancelled',
+  'canceled',
+  'timed_out'
+])
+
+/** One agent entry from the `background_tasks` array Claude attaches to Stop
+ *  (and SubagentStop) hook payloads. Non-agent tasks do not become rows. */
+export type ClaudeBackgroundAgentTask = {
+  id: string
+  agentType?: string
+  description?: string
+  running: boolean
+  /** True for `type: "teammate"` entries. Their ids never match lifecycle
+   *  agent_ids and they report "running" permanently — even after the named
+   *  agent finished — so they carry no per-agent state at all. */
+  teammate: boolean
+}
+
+/** Shell tasks and session crons outlive a lead Stop but do not belong in the agent roster. */
+export function hasActiveClaudeNonAgentBackgroundWork(
+  hookPayload: Record<string, unknown>
+): boolean {
+  const sessionCrons = hookPayload['session_crons']
+  if (Array.isArray(sessionCrons) && sessionCrons.length > 0) {
+    return true
+  }
+  const backgroundTasks = hookPayload['background_tasks']
+  return (
+    Array.isArray(backgroundTasks) &&
+    backgroundTasks.some((item) => {
+      if (typeof item !== 'object' || item === null) {
+        return false
+      }
+      const task = item as Record<string, unknown>
+      return task.status === 'running' && task.type !== 'subagent' && task.type !== 'teammate'
+    })
+  )
+}
+
+/** Read the agent-typed entries of a hook payload's `background_tasks` field.
+ *  `present: false` means the field was absent/malformed (older Claude builds),
+ *  so callers must keep their tracked roster instead of clearing it. */
+export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unknown>): {
+  present: boolean
+  tasks: ClaudeBackgroundAgentTask[]
+  truncated: boolean
+  hasRunningNonAgentTask: boolean
+} {
+  const raw = hookPayload['background_tasks']
+  if (!Array.isArray(raw)) {
+    return { present: false, tasks: [], truncated: false, hasRunningNonAgentTask: false }
+  }
+  const tasks: ClaudeBackgroundAgentTask[] = []
+  let truncated = false
+  let hasRunningNonAgentTask = false
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) {
+      truncated = true
+      continue
+    }
+    const obj = item as Record<string, unknown>
+    const taskType = typeof obj.type === 'string' ? obj.type.trim().toLowerCase() : ''
+    const taskStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : ''
+    const isTerminal =
+      taskStatus.length > 0 && CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus)
+    if (taskType.length === 0) {
+      truncated = true
+      hasRunningNonAgentTask ||= !isTerminal
+      continue
+    }
+    const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
+    // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
+    if (!isAgentTask && !isTerminal) {
+      hasRunningNonAgentTask = true
+    }
+    if (!isAgentTask) {
+      continue
+    }
+    if (typeof obj.id !== 'string' || obj.id.trim().length === 0) {
+      truncated = true
+      continue
+    }
+    if (tasks.length >= AGENT_STATUS_MAX_SUBAGENTS) {
+      // Why: a capped inventory cannot prove a tracked id is absent; callers
+      // must retain unlisted rows rather than deleting live overflow tasks.
+      truncated = true
+      continue
+    }
+    tasks.push({
+      id: obj.id.trim(),
+      agentType: typeof obj.agent_type === 'string' ? obj.agent_type : undefined,
+      description: typeof obj.description === 'string' ? obj.description : undefined,
+      running: !isTerminal,
+      teammate: taskType === 'teammate'
+    })
+  }
+  return { present: true, tasks, truncated, hasRunningNonAgentTask }
+}

--- a/src/shared/claude-background-task-inventory.ts
+++ b/src/shared/claude-background-task-inventory.ts
@@ -10,7 +10,6 @@ const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
   'finished',
   'failed',
   'error',
-  'stopped',
   'terminated',
   'exited',
   'aborted',

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createHookListenerState,
+  movePaneCacheState,
+  normalizeHookPayload,
+  type HookListenerState
+} from './agent-hook-listener'
+import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
+import { readClaudeBackgroundAgentTasks } from './claude-subagent-roster'
+import { makePaneKey } from './stable-pane-id'
+
+const SOURCE_PANE = makePaneKey('tab-source', '11111111-1111-4111-8111-111111111111')
+const TARGET_PANE = makePaneKey('tab-target', '22222222-2222-4222-8222-222222222222')
+const RUNNING_SHELL = {
+  id: 'b8rs2wmxg',
+  type: 'shell',
+  status: 'running',
+  description: 'Sleep for 15 seconds',
+  command: 'sleep 15'
+}
+
+function claudeEvent(state: HookListenerState, paneKey: string, payload: Record<string, unknown>) {
+  return normalizeHookPayload(state, 'claude', { paneKey, payload }, 'production')?.payload
+}
+
+describe('Claude background task status', () => {
+  it('finds pending monitor work after the visible child-row cap', () => {
+    const agentTasks = Array.from({ length: AGENT_STATUS_MAX_SUBAGENTS + 1 }, (_, index) => ({
+      id: `agent-${index}`,
+      type: 'subagent',
+      status: 'running'
+    }))
+    const result = readClaudeBackgroundAgentTasks({
+      background_tasks: [...agentTasks, { id: 'monitor-1', type: 'monitor', status: 'pending' }]
+    })
+
+    expect(result).toMatchObject({ truncated: true, hasRunningShellOrMonitor: true })
+    expect(result.tasks).toHaveLength(AGENT_STATUS_MAX_SUBAGENTS)
+  })
+
+  it('stays working through Claude 2.1.220 Stop and SubagentStop until the shell finishes', () => {
+    const state = createHookListenerState()
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'run a background sleep'
+      })?.state
+    ).toBe('working')
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: [RUNNING_SHELL]
+      })?.state
+    ).toBe('working')
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a70fdf2986e38302b',
+        background_tasks: [RUNNING_SHELL]
+      })?.state
+    ).toBe('working')
+
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: '<task-notification><status>completed</status></task-notification>'
+    })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: []
+      })?.state
+    ).toBe('done')
+  })
+
+  it('keeps pending task state when pane authority moves', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    movePaneCacheState(state, SOURCE_PANE, TARGET_PANE)
+
+    expect(
+      claudeEvent(state, TARGET_PANE, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a70fdf2986e38302b'
+      })?.state
+    ).toBe('working')
+  })
+
+  it('keeps an interrupted Stop terminal even when its task inventory is still running', () => {
+    const state = createHookListenerState()
+    const interrupted = claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      is_interrupt: true,
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(interrupted).toMatchObject({ state: 'done', interrupted: true })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a70fdf2986e38302b',
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+  })
+})

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  clearAllListenerCaches,
+  clearPaneCacheState,
   createHookListenerState,
+  markClaudeLeadTurnInterrupted,
   movePaneCacheState,
   normalizeHookPayload,
   type HookListenerState
@@ -36,6 +39,34 @@ describe('Claude background task status', () => {
 
     expect(result).toMatchObject({ truncated: true, hasRunningShellOrMonitor: true })
     expect(result.tasks).toHaveLength(AGENT_STATUS_MAX_SUBAGENTS)
+
+    const state = createHookListenerState()
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: [...agentTasks, { id: 'monitor-1', type: 'monitor', status: 'pending' }]
+      })?.state
+    ).toBe('working')
+  })
+
+  it('fails future task statuses active but ignores terminal and malformed entries', () => {
+    expect(
+      readClaudeBackgroundAgentTasks({
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'queued' }]
+      }).hasRunningShellOrMonitor
+    ).toBe(true)
+
+    for (const backgroundTasks of [
+      [{ id: 'shell-1', type: 'shell', status: 'completed' }],
+      [{ id: 'shell-1', type: 'shell' }],
+      [null, 'shell'],
+      { id: 'shell-1', type: 'shell', status: 'running' }
+    ]) {
+      expect(
+        readClaudeBackgroundAgentTasks({ background_tasks: backgroundTasks })
+          .hasRunningShellOrMonitor
+      ).toBe(false)
+    }
   })
 
   it('stays working through Claude 2.1.220 Stop and SubagentStop until the shell finishes', () => {
@@ -61,10 +92,12 @@ describe('Claude background task status', () => {
       })?.state
     ).toBe('working')
 
-    claudeEvent(state, SOURCE_PANE, {
-      hook_event_name: 'UserPromptSubmit',
-      prompt: '<task-notification><status>completed</status></task-notification>'
-    })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '<task-notification><status>completed</status></task-notification>'
+      })?.state
+    ).toBe('working')
     expect(
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'Stop',
@@ -106,5 +139,120 @@ describe('Claude background task status', () => {
         background_tasks: [RUNNING_SHELL]
       })
     ).toMatchObject({ state: 'done', interrupted: true })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a8ab60ba5d4410c47',
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+  })
+
+  it('treats an interrupted StopFailure as terminal', () => {
+    const state = createHookListenerState()
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'StopFailure',
+        is_interrupt: true,
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
+  })
+
+  it('starts background gating again only on a genuine user turn', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      is_interrupt: true,
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '<task-notification><status>completed</status></task-notification>',
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'start another task',
+        background_tasks: [RUNNING_SHELL]
+      })?.state
+    ).toBe('working')
+  })
+
+  it('reconciles an authoritative inventory before returning child-attributed events', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'child-1'
+    })
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL, { id: 'child-1', type: 'subagent', status: 'running' }]
+    })
+
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      agent_id: 'child-1',
+      background_tasks: []
+    })
+    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
+  })
+
+  it('clears background gating from an empty SubagentStop inventory', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'child-1',
+        background_tasks: []
+      })?.state
+    ).toBe('done')
+  })
+
+  it('preserves authoritative work across partial inventories and clears it on teardown', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop' })?.state).toBe('working')
+    clearPaneCacheState(state, SOURCE_PANE)
+    expect(state.claudeRunningShellOrMonitorPaneKeys.size).toBe(0)
+
+    claudeEvent(state, TARGET_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+    clearAllListenerCaches(state)
+    expect(state.claudeRunningShellOrMonitorPaneKeys.size).toBe(0)
+  })
+
+  it('clears background gating when the server infers an interruption', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    markClaudeLeadTurnInterrupted(state, SOURCE_PANE)
+    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 })

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -62,6 +62,15 @@ describe('Claude background task status', () => {
         background_tasks: [{ id: 'task-1', type: 'background_shell', status: 'starting' }]
       }).hasRunningNonAgentTask
     ).toBe(true)
+    for (const task of [
+      { id: 'task-1', status: 'running' },
+      { id: 'task-1', type: 42, status: 'running' },
+      { id: 'task-1', type: ' ', status: 'running' }
+    ]) {
+      expect(
+        readClaudeBackgroundAgentTasks({ background_tasks: [task] }).hasRunningNonAgentTask
+      ).toBe(true)
+    }
 
     for (const backgroundTasks of [
       [{ id: 'shell-1', type: 'shell', status: 'completed' }],
@@ -245,6 +254,31 @@ describe('Claude background task status', () => {
         background_tasks: []
       })?.state
     ).toBe('working')
+  })
+
+  it('ignores TeammateIdle inventories for lead-owned background work', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'TeammateIdle',
+        teammate_name: 'reviewer',
+        background_tasks: []
+      })?.state
+    ).toBe('working')
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', background_tasks: [] })
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'TeammateIdle',
+      teammate_name: 'reviewer',
+      background_tasks: [RUNNING_SHELL]
+    })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
   it('shows a child permission wait after the lead turn is interrupted', () => {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -37,7 +37,7 @@ describe('Claude background task status', () => {
       background_tasks: [...agentTasks, { id: 'monitor-1', type: 'monitor', status: 'pending' }]
     })
 
-    expect(result).toMatchObject({ truncated: true, hasRunningShellOrMonitor: true })
+    expect(result).toMatchObject({ truncated: true, hasRunningNonAgentTask: true })
     expect(result.tasks).toHaveLength(AGENT_STATUS_MAX_SUBAGENTS)
 
     const state = createHookListenerState()
@@ -54,20 +54,26 @@ describe('Claude background task status', () => {
       expect(
         readClaudeBackgroundAgentTasks({
           background_tasks: [{ id: 'shell-1', type: 'shell', status }]
-        }).hasRunningShellOrMonitor
+        }).hasRunningNonAgentTask
       ).toBe(true)
     }
+    expect(
+      readClaudeBackgroundAgentTasks({
+        background_tasks: [{ id: 'task-1', type: 'background_shell', status: 'starting' }]
+      }).hasRunningNonAgentTask
+    ).toBe(true)
 
     for (const backgroundTasks of [
       [{ id: 'shell-1', type: 'shell', status: 'completed' }],
+      [{ id: 'shell-1', type: 'shell', status: ' Completed ' }],
       [{ id: 'shell-1', type: 'shell', status: 'canceled' }],
       [{ id: 'shell-1', type: 'shell', status: 'timed_out' }],
+      [{ id: 'agent-1', type: ' Subagent ', status: 'running' }],
       [null, 'shell'],
       { id: 'shell-1', type: 'shell', status: 'running' }
     ]) {
       expect(
-        readClaudeBackgroundAgentTasks({ background_tasks: backgroundTasks })
-          .hasRunningShellOrMonitor
+        readClaudeBackgroundAgentTasks({ background_tasks: backgroundTasks }).hasRunningNonAgentTask
       ).toBe(false)
     }
   })
@@ -167,7 +173,7 @@ describe('Claude background task status', () => {
         background_tasks: [RUNNING_SHELL]
       })
     ).toMatchObject({ state: 'done', interrupted: true })
-    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
   it('resumes on task notifications and user slash commands after interruption', () => {
@@ -201,23 +207,28 @@ describe('Claude background task status', () => {
     ).toBe('working')
   })
 
-  it('does not let a child-attributed inventory clear lead-owned background work', () => {
+  it('ignores child-attributed inventories for lead-owned background work', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
-      hook_event_name: 'SubagentStart',
-      agent_id: 'child-1'
+      hook_event_name: 'SubagentStop',
+      agent_id: 'child-1',
+      background_tasks: [RUNNING_SHELL]
     })
-    claudeEvent(state, SOURCE_PANE, {
-      hook_event_name: 'Stop',
-      background_tasks: [RUNNING_SHELL, { id: 'child-1', type: 'subagent', status: 'running' }]
-    })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
 
     claudeEvent(state, SOURCE_PANE, {
       hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'SubagentStop',
       agent_id: 'child-1',
       background_tasks: []
     })
-    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(true)
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', background_tasks: [] })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
   it('keeps background gating through an empty child SubagentStop inventory', () => {
@@ -263,14 +274,14 @@ describe('Claude background task status', () => {
 
     expect(claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop' })?.state).toBe('working')
     clearPaneCacheState(state, SOURCE_PANE)
-    expect(state.claudeRunningShellOrMonitorPaneKeys.size).toBe(0)
+    expect(state.claudeRunningNonAgentTaskPaneKeys.size).toBe(0)
 
     claudeEvent(state, TARGET_PANE, {
       hook_event_name: 'Stop',
       background_tasks: [RUNNING_SHELL]
     })
     clearAllListenerCaches(state)
-    expect(state.claudeRunningShellOrMonitorPaneKeys.size).toBe(0)
+    expect(state.claudeRunningNonAgentTaskPaneKeys.size).toBe(0)
   })
 
   it('clears background gating when the server infers an interruption', () => {
@@ -281,6 +292,6 @@ describe('Claude background task status', () => {
     })
 
     markClaudeLeadTurnInterrupted(state, SOURCE_PANE)
-    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 })

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -240,6 +240,49 @@ describe('Claude background task status', () => {
     expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
+  it('retains live child rows when an agent inventory is partial or has a future status', () => {
+    for (const backgroundTask of [
+      { id: 'child-1', type: 'subagent', status: 'in_progress' },
+      { id: 'child-1', type: 'subagent' },
+      { task_id: 'child-1', type: 'subagent', status: 'running' }
+    ]) {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStart',
+        agent_id: 'child-1'
+      })
+
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Stop',
+          background_tasks: [backgroundTask]
+        })
+      ).toMatchObject({
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'child-1', state: 'working' })]
+      })
+    }
+  })
+
+  it('does not fold a Stop inventory attributed to an unknown child', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'child-1'
+    })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        agent_id: 'unknown-child',
+        background_tasks: []
+      })
+    ).toMatchObject({
+      state: 'working',
+      subagents: [expect.objectContaining({ id: 'child-1', state: 'working' })]
+    })
+  })
+
   it('keeps background gating through an empty child SubagentStop inventory', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -49,16 +49,19 @@ describe('Claude background task status', () => {
     ).toBe('working')
   })
 
-  it('fails future task statuses active but ignores terminal and malformed entries', () => {
-    expect(
-      readClaudeBackgroundAgentTasks({
-        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'queued' }]
-      }).hasRunningShellOrMonitor
-    ).toBe(true)
+  it('fails unknown or partial task statuses active but ignores terminal and malformed entries', () => {
+    for (const status of ['queued', undefined]) {
+      expect(
+        readClaudeBackgroundAgentTasks({
+          background_tasks: [{ id: 'shell-1', type: 'shell', status }]
+        }).hasRunningShellOrMonitor
+      ).toBe(true)
+    }
 
     for (const backgroundTasks of [
       [{ id: 'shell-1', type: 'shell', status: 'completed' }],
-      [{ id: 'shell-1', type: 'shell' }],
+      [{ id: 'shell-1', type: 'shell', status: 'canceled' }],
+      [{ id: 'shell-1', type: 'shell', status: 'timed_out' }],
       [null, 'shell'],
       { id: 'shell-1', type: 'shell', status: 'running' }
     ]) {
@@ -167,7 +170,7 @@ describe('Claude background task status', () => {
     expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
-  it('starts background gating again only on a genuine user turn', () => {
+  it('resumes on task notifications and user slash commands after interruption', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
       hook_event_name: 'Stop',
@@ -181,17 +184,24 @@ describe('Claude background task status', () => {
         prompt: '<task-notification><status>completed</status></task-notification>',
         background_tasks: [RUNNING_SHELL]
       })
+    ).toMatchObject({ state: 'working' })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        is_interrupt: true,
+        background_tasks: [RUNNING_SHELL]
+      })
     ).toMatchObject({ state: 'done', interrupted: true })
     expect(
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'UserPromptSubmit',
-        prompt: 'start another task',
+        prompt: '<command-message>review</command-message><command-name>/review</command-name>',
         background_tasks: [RUNNING_SHELL]
       })?.state
     ).toBe('working')
   })
 
-  it('reconciles an authoritative inventory before returning child-attributed events', () => {
+  it('does not let a child-attributed inventory clear lead-owned background work', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
       hook_event_name: 'SubagentStart',
@@ -207,10 +217,10 @@ describe('Claude background task status', () => {
       agent_id: 'child-1',
       background_tasks: []
     })
-    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(false)
+    expect(state.claudeRunningShellOrMonitorPaneKeys.has(SOURCE_PANE)).toBe(true)
   })
 
-  it('clears background gating from an empty SubagentStop inventory', () => {
+  it('keeps background gating through an empty child SubagentStop inventory', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
       hook_event_name: 'Stop',
@@ -223,7 +233,25 @@ describe('Claude background task status', () => {
         agent_id: 'child-1',
         background_tasks: []
       })?.state
-    ).toBe('done')
+    ).toBe('working')
+  })
+
+  it('shows a child permission wait after the lead turn is interrupted', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'SubagentStart',
+      agent_id: 'child-1'
+    })
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', is_interrupt: true })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'PermissionRequest',
+        agent_id: 'child-1',
+        tool_name: 'Bash',
+        tool_input: { command: 'git status' }
+      })
+    ).toMatchObject({ state: 'waiting', toolName: 'Bash' })
   })
 
   it('preserves authoritative work across partial inventories and clears it on teardown', () => {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -49,7 +49,7 @@ describe('Claude background task status', () => {
     ).toBe('working')
   })
 
-  it('fails unknown or partial task statuses active but ignores terminal and malformed entries', () => {
+  it('fails unknown, partial, or malformed task entries active but ignores terminal entries', () => {
     for (const status of ['queued', undefined]) {
       expect(
         readClaudeBackgroundAgentTasks({
@@ -72,6 +72,9 @@ describe('Claude background task status', () => {
         hasRunningNonAgentTask: true
       })
     }
+    expect(
+      readClaudeBackgroundAgentTasks({ background_tasks: [null, 'shell'] }).hasRunningNonAgentTask
+    ).toBe(true)
 
     for (const backgroundTasks of [
       [{ id: 'shell-1', type: 'shell', status: 'completed' }],
@@ -93,7 +96,6 @@ describe('Claude background task status', () => {
       [{ id: 'shell-1', type: 'shell', status: 'canceled' }],
       [{ id: 'shell-1', type: 'shell', status: 'timed_out' }],
       [{ id: 'agent-1', type: ' Subagent ', status: 'running' }],
-      [null, 'shell'],
       { id: 'shell-1', type: 'shell', status: 'running' }
     ]) {
       expect(
@@ -218,7 +220,7 @@ describe('Claude background task status', () => {
     expect(
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'Stop',
-        session_crons: []
+        background_tasks: []
       })?.state
     ).toBe('done')
     expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
@@ -271,25 +273,35 @@ describe('Claude background task status', () => {
   it('ignores child-attributed inventories for lead-owned background work', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
-      hook_event_name: 'SubagentStop',
+      hook_event_name: 'Stop',
       agent_id: 'child-1',
-      background_tasks: [RUNNING_SHELL]
+      background_tasks: [RUNNING_SHELL],
+      session_crons: [{ id: 'cron-1' }]
     })
     expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
 
     claudeEvent(state, SOURCE_PANE, {
       hook_event_name: 'Stop',
-      background_tasks: [RUNNING_SHELL]
+      background_tasks: [RUNNING_SHELL],
+      session_crons: [{ id: 'cron-1' }]
     })
     claudeEvent(state, SOURCE_PANE, {
-      hook_event_name: 'SubagentStop',
+      hook_event_name: 'Stop',
       agent_id: 'child-1',
-      background_tasks: []
+      background_tasks: [],
+      session_crons: []
     })
     expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
 
-    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', background_tasks: [] })
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [],
+      session_crons: []
+    })
     expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
   it('retains live child rows when an agent inventory is partial or has a future status', () => {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -226,6 +226,31 @@ describe('Claude background task status', () => {
     expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
+  it('only infers an omitted cron inventory is drained from modern lead Stop payloads', () => {
+    const createCronState = (): HookListenerState => {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        session_crons: [{ id: 'cron-1' }]
+      })
+      return state
+    }
+
+    const midTurnState = createCronState()
+    claudeEvent(midTurnState, SOURCE_PANE, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'continue',
+      background_tasks: []
+    })
+    expect(midTurnState.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
+
+    const legacyStopState = createCronState()
+    expect(claudeEvent(legacyStopState, SOURCE_PANE, { hook_event_name: 'Stop' })?.state).toBe(
+      'working'
+    )
+    expect(legacyStopState.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
+  })
+
   it('treats an interrupted StopFailure as terminal', () => {
     const state = createHookListenerState()
 

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -9,7 +9,7 @@ import {
   type HookListenerState
 } from './agent-hook-listener'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
-import { readClaudeBackgroundAgentTasks } from './claude-subagent-roster'
+import { readClaudeBackgroundAgentTasks } from './claude-background-task-inventory'
 import { makePaneKey } from './stable-pane-id'
 
 const SOURCE_PANE = makePaneKey('tab-source', '11111111-1111-4111-8111-111111111111')
@@ -76,6 +76,21 @@ describe('Claude background task status', () => {
     for (const backgroundTasks of [
       [{ id: 'shell-1', type: 'shell', status: 'completed' }],
       [{ id: 'shell-1', type: 'shell', status: ' Completed ' }],
+      ...[
+        'done',
+        'success',
+        'succeeded',
+        'complete',
+        'finished',
+        'error',
+        'stopped',
+        'terminated',
+        'exited',
+        'aborted',
+        'expired',
+        'skipped',
+        'crashed'
+      ].map((status) => [{ id: 'shell-1', type: 'shell', status }]),
       [{ id: 'shell-1', type: 'shell', status: 'canceled' }],
       [{ id: 'shell-1', type: 'shell', status: 'timed_out' }],
       [{ id: 'agent-1', type: ' Subagent ', status: 'running' }],
@@ -169,6 +184,18 @@ describe('Claude background task status', () => {
         hook_event_name: 'SubagentStop',
         agent_id: 'a8ab60ba5d4410c47',
         background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+  })
+
+  it('keeps an interrupted Stop terminal while a session cron remains', () => {
+    const state = createHookListenerState()
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        is_interrupt: true,
+        session_crons: [{ id: 'cron-1' }]
       })
     ).toMatchObject({ state: 'done', interrupted: true })
   })

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -67,9 +67,10 @@ describe('Claude background task status', () => {
       { id: 'task-1', type: 42, status: 'running' },
       { id: 'task-1', type: ' ', status: 'running' }
     ]) {
-      expect(
-        readClaudeBackgroundAgentTasks({ background_tasks: [task] }).hasRunningNonAgentTask
-      ).toBe(true)
+      expect(readClaudeBackgroundAgentTasks({ background_tasks: [task] })).toMatchObject({
+        truncated: true,
+        hasRunningNonAgentTask: true
+      })
     }
 
     for (const backgroundTasks of [
@@ -264,6 +265,26 @@ describe('Claude background task status', () => {
     }
   })
 
+  it('retains live child rows when inventory entries cannot be classified', () => {
+    for (const backgroundTasks of [[{ id: 'child-1', status: 'running' }], [null, 'shell', 42]]) {
+      const state = createHookListenerState()
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStart',
+        agent_id: 'child-1'
+      })
+
+      expect(
+        claudeEvent(state, SOURCE_PANE, {
+          hook_event_name: 'Stop',
+          background_tasks: backgroundTasks
+        })
+      ).toMatchObject({
+        state: 'working',
+        subagents: [expect.objectContaining({ id: 'child-1', state: 'working' })]
+      })
+    }
+  })
+
   it('does not fold a Stop inventory attributed to an unknown child', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
@@ -281,6 +302,27 @@ describe('Claude background task status', () => {
       state: 'working',
       subagents: [expect.objectContaining({ id: 'child-1', state: 'working' })]
     })
+  })
+
+  it('does not let an unknown child interrupt lead-owned background work', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      background_tasks: [RUNNING_SHELL]
+    })
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'continue lead work'
+    })
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        agent_id: 'unknown-child',
+        is_interrupt: true
+      })
+    ).toMatchObject({ state: 'working' })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
   })
 
   it('keeps background gating through an empty child SubagentStop inventory', () => {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -83,7 +83,6 @@ describe('Claude background task status', () => {
         'complete',
         'finished',
         'error',
-        'stopped',
         'terminated',
         'exited',
         'aborted',
@@ -198,6 +197,31 @@ describe('Claude background task status', () => {
         session_crons: [{ id: 'cron-1' }]
       })
     ).toMatchObject({ state: 'done', interrupted: true })
+  })
+
+  it('keeps a session cron working through child lifecycle events until a drained inventory', () => {
+    const state = createHookListenerState()
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        session_crons: [{ id: 'cron-1' }]
+      })?.state
+    ).toBe('working')
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'SubagentStop',
+        agent_id: 'child-1'
+      })?.state
+    ).toBe('working')
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        session_crons: []
+      })?.state
+    ).toBe('done')
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
   it('treats an interrupted StopFailure as terminal', () => {

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -264,6 +264,39 @@ describe('Claude background task status', () => {
     expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
+  it('keeps a failed turn working while its background shell runs', () => {
+    const state = createHookListenerState()
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'StopFailure',
+        background_tasks: [RUNNING_SHELL]
+      })?.state
+    ).toBe('working')
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'StopFailure',
+        background_tasks: []
+      })?.state
+    ).toBe('done')
+  })
+
+  it('drops interrupted state on a mid-turn lead event with no prompt submit', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', is_interrupt: true })
+
+    // Why: a resumed turn can start at a tool event; the next Stop must not inherit the old interrupt and discard live work.
+    expect(claudeEvent(state, SOURCE_PANE, { hook_event_name: 'PreToolUse' })?.state).toBe(
+      'working'
+    )
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'working', interrupted: undefined })
+  })
+
   it('resumes on task notifications and user slash commands after interruption', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {

--- a/src/shared/claude-subagent-roster.test.ts
+++ b/src/shared/claude-subagent-roster.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
+import { readClaudeBackgroundAgentTasks } from './claude-background-task-inventory'
 import {
   claudeRosterHasWorkingSubagent,
   claudeRosterToSnapshots,
   claudeTeammateIdMatchesName,
   foldClaudeBackgroundTasksIntoRoster,
-  hasActiveClaudeNonAgentBackgroundWork,
   idleClaudeTeammateByName,
-  readClaudeBackgroundAgentTasks,
   reapRestoredClaudeSubagentsWithoutLiveAgent,
   stopClaudeSubagent,
   upsertWorkingClaudeSubagent,
@@ -201,27 +200,6 @@ describe('claude-subagent-roster', () => {
         teammate: true
       }
     ])
-  })
-
-  it('detects live non-agent background work without treating agent tasks as shell work', () => {
-    expect(
-      hasActiveClaudeNonAgentBackgroundWork({
-        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
-      })
-    ).toBe(true)
-    expect(hasActiveClaudeNonAgentBackgroundWork({ session_crons: [{ id: 'cron-1' }] })).toBe(true)
-    expect(
-      hasActiveClaudeNonAgentBackgroundWork({
-        background_tasks: [
-          { id: 'agent-1', type: 'subagent', status: 'running' },
-          { id: 'team-1', type: 'teammate', status: 'running' }
-        ]
-      })
-    ).toBe(false)
-    expect(hasActiveClaudeNonAgentBackgroundWork({ background_tasks: [], session_crons: [] })).toBe(
-      false
-    )
-    expect(hasActiveClaudeNonAgentBackgroundWork({})).toBe(false)
   })
 
   it('reports background_tasks as absent when missing or malformed', () => {

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -52,8 +52,7 @@ export type TrackedClaudeSubagent = {
 }
 
 /** One agent entry from the `background_tasks` array Claude attaches to Stop
- *  (and SubagentStop) hook payloads. Non-agent task types (background shells,
- *  crons) are filtered out at read time. */
+ *  (and SubagentStop) hook payloads. Non-agent tasks do not become rows. */
 export type ClaudeBackgroundAgentTask = {
   id: string
   agentType?: string
@@ -170,18 +169,26 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
   present: boolean
   tasks: ClaudeBackgroundAgentTask[]
   truncated: boolean
+  hasRunningShellOrMonitor: boolean
 } {
   const raw = hookPayload['background_tasks']
   if (!Array.isArray(raw)) {
-    return { present: false, tasks: [], truncated: false }
+    return { present: false, tasks: [], truncated: false, hasRunningShellOrMonitor: false }
   }
   const tasks: ClaudeBackgroundAgentTask[] = []
   let truncated = false
+  let hasRunningShellOrMonitor = false
   for (const item of raw) {
     if (typeof item !== 'object' || item === null) {
       continue
     }
     const obj = item as Record<string, unknown>
+    if (
+      (obj.type === 'shell' || obj.type === 'monitor') &&
+      (obj.status === 'running' || obj.status === 'pending')
+    ) {
+      hasRunningShellOrMonitor = true
+    }
     if (obj.type !== 'subagent' && obj.type !== 'teammate') {
       continue
     }
@@ -192,7 +199,7 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       // Why: a capped inventory cannot prove a tracked id is absent; callers
       // must retain unlisted rows rather than deleting live overflow tasks.
       truncated = true
-      break
+      continue
     }
     tasks.push({
       id: obj.id,
@@ -202,7 +209,7 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       teammate: obj.type === 'teammate'
     })
   }
-  return { present: true, tasks, truncated }
+  return { present: true, tasks, truncated, hasRunningShellOrMonitor }
 }
 
 /** Fold a lead Stop's `background_tasks` into the lifecycle-tracked roster.

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -195,7 +195,6 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
     const taskStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : ''
     // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
     if (
-      taskType.length > 0 &&
       taskType !== 'subagent' &&
       taskType !== 'teammate' &&
       (taskStatus.length === 0 || !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus))
@@ -215,7 +214,7 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       continue
     }
     tasks.push({
-      id: obj.id,
+      id: obj.id.trim(),
       agentType: typeof obj.agent_type === 'string' ? obj.agent_type : undefined,
       description: typeof obj.description === 'string' ? obj.description : undefined,
       running: taskStatus === 'running',

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -1,18 +1,15 @@
 import { AGENT_STATUS_MAX_SUBAGENTS, type AgentSubagentSnapshot } from './agent-status-types'
+import type { ClaudeBackgroundAgentTask } from './claude-background-task-inventory'
+
+export {
+  hasActiveClaudeNonAgentBackgroundWork,
+  readClaudeBackgroundAgentTasks
+} from './claude-background-task-inventory'
 
 /** Mirrors the wire-normalization id cap in agent-status-types. Enforced at
  *  upsert so an over-long id can't gate the pane 'working' while being
  *  invisible in the emitted snapshots (which drop such ids). */
 const CLAUDE_SUBAGENT_ID_MAX_LENGTH = 64
-const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
-  'idle',
-  'completed',
-  'failed',
-  'killed',
-  'cancelled',
-  'canceled',
-  'timed_out'
-])
 
 /** Live subagents/teammates tracked for one Claude pane, keyed by the
  *  provider-assigned `agent_id` from SubagentStart/SubagentStop payloads.
@@ -58,19 +55,6 @@ export type TrackedClaudeSubagent = {
    *  teammate-shaped. Never cleared: the listing mode of an id can't change
    *  mid-life. */
   listedAsSubagentTask?: true
-}
-
-/** One agent entry from the `background_tasks` array Claude attaches to Stop
- *  (and SubagentStop) hook payloads. Non-agent tasks do not become rows. */
-export type ClaudeBackgroundAgentTask = {
-  id: string
-  agentType?: string
-  description?: string
-  running: boolean
-  /** True for `type: "teammate"` entries. Their ids never match lifecycle
-   *  agent_ids and they report "running" permanently — even after the named
-   *  agent finished — so they carry no per-agent state at all. */
-  teammate: boolean
 }
 
 /** Agent-team/named-agent lifecycle ids are `a<name>-<hex>` while one-shot
@@ -148,87 +132,6 @@ export function stopClaudeSubagent(roster: ClaudeSubagentRoster, id: string): vo
     return
   }
   tracked.state = 'idle'
-}
-
-/** Shell tasks and session crons outlive a lead Stop but do not belong in the agent roster. */
-export function hasActiveClaudeNonAgentBackgroundWork(
-  hookPayload: Record<string, unknown>
-): boolean {
-  const sessionCrons = hookPayload['session_crons']
-  if (Array.isArray(sessionCrons) && sessionCrons.length > 0) {
-    return true
-  }
-  const backgroundTasks = hookPayload['background_tasks']
-  return (
-    Array.isArray(backgroundTasks) &&
-    backgroundTasks.some((item) => {
-      if (typeof item !== 'object' || item === null) {
-        return false
-      }
-      const task = item as Record<string, unknown>
-      return task.status === 'running' && task.type !== 'subagent' && task.type !== 'teammate'
-    })
-  )
-}
-
-/** Read the agent-typed entries of a hook payload's `background_tasks` field.
- *  `present: false` means the field was absent/malformed (older Claude builds),
- *  so callers must keep their tracked roster instead of clearing it. */
-export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unknown>): {
-  present: boolean
-  tasks: ClaudeBackgroundAgentTask[]
-  truncated: boolean
-  hasRunningNonAgentTask: boolean
-} {
-  const raw = hookPayload['background_tasks']
-  if (!Array.isArray(raw)) {
-    return { present: false, tasks: [], truncated: false, hasRunningNonAgentTask: false }
-  }
-  const tasks: ClaudeBackgroundAgentTask[] = []
-  let truncated = false
-  let hasRunningNonAgentTask = false
-  for (const item of raw) {
-    if (typeof item !== 'object' || item === null) {
-      truncated = true
-      continue
-    }
-    const obj = item as Record<string, unknown>
-    const taskType = typeof obj.type === 'string' ? obj.type.trim().toLowerCase() : ''
-    const taskStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : ''
-    const isTerminal =
-      taskStatus.length > 0 && CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus)
-    if (taskType.length === 0) {
-      truncated = true
-      hasRunningNonAgentTask ||= !isTerminal
-      continue
-    }
-    const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
-    // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
-    if (!isAgentTask && !isTerminal) {
-      hasRunningNonAgentTask = true
-    }
-    if (!isAgentTask) {
-      continue
-    }
-    if (typeof obj.id !== 'string' || obj.id.trim().length === 0) {
-      truncated = true
-      continue
-    }
-    if (tasks.length >= AGENT_STATUS_MAX_SUBAGENTS) {
-      // Why: a capped inventory cannot prove a tracked id is absent; callers
-      // must retain unlisted rows rather than deleting live overflow tasks.
-      truncated = true
-      continue
-    }
-    tasks.push({
-      id: obj.id.trim(),
-      agentType: typeof obj.agent_type === 'string' ? obj.agent_type : undefined,
-      description: typeof obj.description === 'string' ? obj.description : undefined,
-      running: !isTerminal,
-      teammate: taskType === 'teammate'
-    })
-  }
-  return { present: true, tasks, truncated, hasRunningNonAgentTask }
 }
 
 /** Fold a lead Stop's `background_tasks` into the lifecycle-tracked roster.

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -4,6 +4,12 @@ import { AGENT_STATUS_MAX_SUBAGENTS, type AgentSubagentSnapshot } from './agent-
  *  upsert so an over-long id can't gate the pane 'working' while being
  *  invisible in the emitted snapshots (which drop such ids). */
 const CLAUDE_SUBAGENT_ID_MAX_LENGTH = 64
+const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
+  'completed',
+  'failed',
+  'killed',
+  'cancelled'
+])
 
 /** Live subagents/teammates tracked for one Claude pane, keyed by the
  *  provider-assigned `agent_id` from SubagentStart/SubagentStop payloads.
@@ -183,9 +189,12 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       continue
     }
     const obj = item as Record<string, unknown>
+    // Why: future nonterminal labels must fail active; only explicit terminal states can safely retire work.
     if (
       (obj.type === 'shell' || obj.type === 'monitor') &&
-      (obj.status === 'running' || obj.status === 'pending')
+      typeof obj.status === 'string' &&
+      obj.status.length > 0 &&
+      !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(obj.status)
     ) {
       hasRunningShellOrMonitor = true
     }

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -5,6 +5,7 @@ import { AGENT_STATUS_MAX_SUBAGENTS, type AgentSubagentSnapshot } from './agent-
  *  invisible in the emitted snapshots (which drop such ids). */
 const CLAUDE_SUBAGENT_ID_MAX_LENGTH = 64
 const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
+  'idle',
   'completed',
   'failed',
   'killed',
@@ -193,18 +194,18 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
     const obj = item as Record<string, unknown>
     const taskType = typeof obj.type === 'string' ? obj.type.trim().toLowerCase() : ''
     const taskStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : ''
+    const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
+    const isTerminal =
+      taskStatus.length > 0 && CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus)
     // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
-    if (
-      taskType !== 'subagent' &&
-      taskType !== 'teammate' &&
-      (taskStatus.length === 0 || !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus))
-    ) {
+    if (!isAgentTask && !isTerminal) {
       hasRunningNonAgentTask = true
     }
-    if (taskType !== 'subagent' && taskType !== 'teammate') {
+    if (!isAgentTask) {
       continue
     }
     if (typeof obj.id !== 'string' || obj.id.trim().length === 0) {
+      truncated = true
       continue
     }
     if (tasks.length >= AGENT_STATUS_MAX_SUBAGENTS) {
@@ -217,7 +218,7 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       id: obj.id.trim(),
       agentType: typeof obj.agent_type === 'string' ? obj.agent_type : undefined,
       description: typeof obj.description === 'string' ? obj.description : undefined,
-      running: taskStatus === 'running',
+      running: !isTerminal,
       teammate: taskType === 'teammate'
     })
   }

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -8,7 +8,9 @@ const CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES = new Set([
   'completed',
   'failed',
   'killed',
-  'cancelled'
+  'cancelled',
+  'canceled',
+  'timed_out'
 ])
 
 /** Live subagents/teammates tracked for one Claude pane, keyed by the
@@ -192,9 +194,9 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
     // Why: future nonterminal labels must fail active; only explicit terminal states can safely retire work.
     if (
       (obj.type === 'shell' || obj.type === 'monitor') &&
-      typeof obj.status === 'string' &&
-      obj.status.length > 0 &&
-      !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(obj.status)
+      (typeof obj.status !== 'string' ||
+        obj.status.length === 0 ||
+        !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(obj.status))
     ) {
       hasRunningShellOrMonitor = true
     }

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -177,30 +177,32 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
   present: boolean
   tasks: ClaudeBackgroundAgentTask[]
   truncated: boolean
-  hasRunningShellOrMonitor: boolean
+  hasRunningNonAgentTask: boolean
 } {
   const raw = hookPayload['background_tasks']
   if (!Array.isArray(raw)) {
-    return { present: false, tasks: [], truncated: false, hasRunningShellOrMonitor: false }
+    return { present: false, tasks: [], truncated: false, hasRunningNonAgentTask: false }
   }
   const tasks: ClaudeBackgroundAgentTask[] = []
   let truncated = false
-  let hasRunningShellOrMonitor = false
+  let hasRunningNonAgentTask = false
   for (const item of raw) {
     if (typeof item !== 'object' || item === null) {
       continue
     }
     const obj = item as Record<string, unknown>
-    // Why: future nonterminal labels must fail active; only explicit terminal states can safely retire work.
+    const taskType = typeof obj.type === 'string' ? obj.type.trim().toLowerCase() : ''
+    const taskStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : ''
+    // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
     if (
-      (obj.type === 'shell' || obj.type === 'monitor') &&
-      (typeof obj.status !== 'string' ||
-        obj.status.length === 0 ||
-        !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(obj.status))
+      taskType.length > 0 &&
+      taskType !== 'subagent' &&
+      taskType !== 'teammate' &&
+      (taskStatus.length === 0 || !CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus))
     ) {
-      hasRunningShellOrMonitor = true
+      hasRunningNonAgentTask = true
     }
-    if (obj.type !== 'subagent' && obj.type !== 'teammate') {
+    if (taskType !== 'subagent' && taskType !== 'teammate') {
       continue
     }
     if (typeof obj.id !== 'string' || obj.id.trim().length === 0) {
@@ -216,11 +218,11 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       id: obj.id,
       agentType: typeof obj.agent_type === 'string' ? obj.agent_type : undefined,
       description: typeof obj.description === 'string' ? obj.description : undefined,
-      running: obj.status === 'running',
-      teammate: obj.type === 'teammate'
+      running: taskStatus === 'running',
+      teammate: taskType === 'teammate'
     })
   }
-  return { present: true, tasks, truncated, hasRunningShellOrMonitor }
+  return { present: true, tasks, truncated, hasRunningNonAgentTask }
 }
 
 /** Fold a lead Stop's `background_tasks` into the lifecycle-tracked roster.

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -1,11 +1,6 @@
 import { AGENT_STATUS_MAX_SUBAGENTS, type AgentSubagentSnapshot } from './agent-status-types'
 import type { ClaudeBackgroundAgentTask } from './claude-background-task-inventory'
 
-export {
-  hasActiveClaudeNonAgentBackgroundWork,
-  readClaudeBackgroundAgentTasks
-} from './claude-background-task-inventory'
-
 /** Mirrors the wire-normalization id cap in agent-status-types. Enforced at
  *  upsert so an over-long id can't gate the pane 'working' while being
  *  invisible in the emitted snapshots (which drop such ids). */

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -189,14 +189,20 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
   let hasRunningNonAgentTask = false
   for (const item of raw) {
     if (typeof item !== 'object' || item === null) {
+      truncated = true
       continue
     }
     const obj = item as Record<string, unknown>
     const taskType = typeof obj.type === 'string' ? obj.type.trim().toLowerCase() : ''
     const taskStatus = typeof obj.status === 'string' ? obj.status.trim().toLowerCase() : ''
-    const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
     const isTerminal =
       taskStatus.length > 0 && CLAUDE_TERMINAL_BACKGROUND_TASK_STATUSES.has(taskStatus)
+    if (taskType.length === 0) {
+      truncated = true
+      hasRunningNonAgentTask ||= !isTerminal
+      continue
+    }
+    const isAgentTask = taskType === 'subagent' || taskType === 'teammate'
     // Why: future non-agent types and nonterminal labels must fail active; only typed agent rows or explicit terminal states can safely retire work.
     if (!isAgentTask && !isTerminal) {
       hasRunningNonAgentTask = true


### PR DESCRIPTION
## Summary

Keep Claude Code's Orca status `working` while Claude still reports provider-owned background work, and settle to `done` only when the lead session reports that work is gone.

This fixes the observed mismatch where Claude's footer says `1 shell still running` while Orca's sidebar and `orca worktree ps` already say `done` and remove the spinner.

Addresses the background-task portion of #10997. Related prior attempts: #8853 and #10998.

## Reproduction and root cause

Reproduced before the change with:

- Orca `1.4.163`
- Claude Code `2.1.220`
- macOS, local worktree
- a background `sleep` that outlived the lead turn

Observed simultaneously:

```text
Claude footer: 1 shell still running
Claude title:  ✳ Run background sleep command
Orca agent row: state: "done"
```

The installed Claude binary emitted this exact sequence:

```json
{"event":"Stop","background_tasks":[{"id":"b8rs2wmxg","type":"shell","status":"running","description":"Sleep for 15 seconds","command":"sleep 15"}]}
{"event":"SubagentStop","agent_id":"a70fdf2986e38302b","background_tasks":[{"id":"b8rs2wmxg","type":"shell","status":"running","description":"Sleep for 15 seconds","command":"sleep 15"}]}
```

When the shell finished, Claude emitted its completion notification and then:

```json
{"event":"Stop","background_tasks":[]}
{"event":"SubagentStop","agent_id":"a8ab60ba5d4410c47","background_tasks":[]}
```

Orca previously extracted only `subagent` and `teammate` rows from `background_tasks`. It discarded the shell, stored the lead as `done`, and let the following child lifecycle event re-emit that cached state. A one-event special case was insufficient because the immediate `SubagentStop` could overwrite it.

Binary inspection of Claude Code `2.1.220` confirmed that the wire inventory includes running/pending work and currently maps these provider task families: `subagent`, `teammate`, `workflow`, `shell`, `monitor`, `MCP task`, `dream`, `auto-mode scan`, and `cloud session`.

## What changed

- Parse the complete Claude background-task inventory into two independent signals:
  - bounded visible `subagent`/`teammate` rows;
  - a pane-level boolean for any running non-agent task.
- Keep the lead status effectively `working` while that boolean is set, including across Claude's follow-up child lifecycle hooks.
- Give only lead-attributed inventories pane-level authority. Any hook carrying `agent_id`, plus `SubagentStart`, `SubagentStop`, and `TeammateIdle`, is child-owned and cannot assert, clear, interrupt, or fold lead background evidence.
- Treat unknown task types/statuses and partial/unclassifiable inventories conservatively:
  - future non-agent types and nonterminal statuses fail active;
  - malformed or capped agent inventories are incomplete and cannot reap live child rows;
  - explicit terminal states, including teammate `idle`, remain non-running.
- Preserve an authoritative value when `background_tasks` is absent, but clear it when the lead provides a present empty inventory.
- Carry the boolean through relay, SSH, and WSL envelopes with boolean validation at trust boundaries.
- Let reconnect replay seed a cold runtime, then make live observations authoritative so a later stale replay cannot re-arm the gate.
- Block Escape/Ctrl+C fallback inference while Claude-owned background work is live.
- Keep the field transport-only: it is excluded from renderer IPC and persisted status files.
- Move and clear the pane-scoped state with existing cache transfer, pane teardown, inferred interruption, and listener teardown paths.
- Preserve session-cron evidence across child lifecycle hooks, but let a modern authoritative lead Stop drain it when Claude omits an empty `session_crons` array.

## ELI5

Claude can say, “I’m done talking,” while a job it started is still running in the background. Orca used to hear only “I’m done” and turn off the working light.

Now Orca also checks Claude's attached job list. If a background job is still alive, the working light stays on. Only Claude's main session may update that shared job-list signal, so a child agent's bookkeeping message cannot accidentally turn the light off—or turn it on. When the main session later sends an empty list, Orca marks the work finished.

## Proof of fix

The production normalizer regression test replays the captured Claude `2.1.220` order:

```text
UserPromptSubmit                       -> working
Stop + running shell                  -> working
SubagentStop + same running shell     -> working
task completion notification          -> working
Stop + empty background_tasks         -> done
```

End-to-end transport tests additionally prove:

- a real local `POST /hook/claude` with a running shell blocks false Escape inference;
- live remote `true` blocks inference and live `false` restores it;
- cold-runtime replay can seed evidence, but replay cannot override a later live observation;
- relay and SSH session forwarding preserve the boolean;
- the boolean is absent from renderer-facing snapshots and persisted JSON.

Parser/lifecycle tests prove:

- work after the visible child-row cap is still detected;
- state follows pane authority transfer and clears on teardown;
- `SubagentStart`, `SubagentStop`, and `TeammateIdle` inventories cannot assert or retract lead evidence;
- even an unknown child carrying `is_interrupt` cannot clear lead evidence;
- lead empty inventories clear the gate, while absent or partial inventories retain safe state;
- pending/future statuses remain active, known terminal/idle statuses do not;
- malformed, untyped, or unparseable rows cannot incorrectly reap live child state;
- explicit lead interruption remains terminal where that compatibility path applies.

These tests are load-bearing: without the change, the captured post-`Stop`/`SubagentStop` state is `done`, matching the installed-app reproduction.

## Proof of no regression

Final coordinator verification at `8a922e3997`, rebased onto `origin/main` at `8ab85c9bfc`:

- Complete shared suite from the adversarial hardening cycle: **390 files passed, 3 skipped; 3,627 tests passed, 15 skipped**.
- Main server/relay/SSH integration suite from that cycle: **3 files passed; 280 tests passed**.
- Latest merge-conflict integration suite: **10 files passed; 505 tests passed**, covering listener state, inventories, main ingest, relay frame shedding/publication, SSH forwarding, WSL forwarding, and cleanup.
- Final Opus confirmation recorded **5,247 passing tests** and killed **8/8 targeted mutants** before the latest rebase; the rebased implementation preserves every reviewed behavior.
- `pnpm typecheck`: **passed** for node, CLI, and web TypeScript projects on the latest head.
- Repository oxlint, native focused audit, type-aware audit, and changed-code quality gate: **passed with zero findings**.
- `pnpm exec oxfmt --check` on all **12 changed files**: **passed**.
- `pnpm run check:max-lines-ratchet`: **passed**, no new bypasses.
- Reliability gates, React Doctor changed-line review, localization checks, feature-wall asset budget, macOS entitlements, the root-directory guard, and `git diff --check`: **passed**.
- `pnpm run build:electron-vite`: **passed** for main, preload, and renderer production bundles during the hardening cycle.
- Final `git range-diff` marks **12/15 commits as exact equivalents**. The other three intentionally integrate newly merged relay frame-shedding metadata/tests alongside this PR’s Claude background-work transport field; no PR behavior was dropped.

The only textual conflicts were in `server.ts`, `ssh-relay-session.ts`, and adjacent `server.test.ts` coverage. Resolution preserves both upstream `shedFields` restoration and this PR’s validated `claudeRunningNonAgentTask` forwarding, plus both upstream roster-shedding tests and the PR’s connection-cleanup test. No conflict markers or uncommitted changes remain.

 Performance evidence

Synthetic worst-case benchmark: 200 hook events, each carrying a 10,000-row `background_tasks` inventory. Timings are local wall-clock measurements and are intended to expose relative hot-path work, not claim production latency.

- Rebase merge before cleanup, with duplicate full scan: **58.55 ms**.
- Parser-only baseline: **41.99 ms**.
- After duplicate-scan removal: **45.68 ms**.
- `SubagentStop` lifecycle path before early return: **51.01 ms**.
- `SubagentStop` lifecycle path after early return: **0.29 ms median** across seven samples (**~176x faster; ~99.4% less time**).

The optimized lifecycle path is correct because `SubagentStart`, `SubagentStop`, and `TeammateIdle` do not own pane-wide inventory authority; they update only the bounded roster and reuse pane-cached lead evidence. The retained lead path still performs one complete scan so capped or future task kinds cannot be missed.

## Adversarial AI review report

Review was coordinated through Orca orchestration Run `run_04348f604e05`. Each round used a fresh `claude --model opus` session, reviewed the complete `origin/main...HEAD` diff, was review-only, and was required to provide concrete reproductions or an explicit `CLEAN` verdict.

1. **Round 1 — not clean:** found interruption state reopening, missing Escape/Ctrl+C protection, ambiguous child inventory ownership, and StopFailure asymmetry. Fixed lifecycle ordering, interruption handling, server inference, and cache representation.
2. **Round 2 — not clean:** found child permission waits hidden after interruption, resumed turns remaining interrupted, child inventories clearing lead state, and replay overriding live authority. Fixed precedence, bounded resume behavior, lead ownership, and replay suppression.
3. **Round 3 — not clean:** found child inventories able to assert pane work, case/whitespace-sensitive statuses, and a fail-inactive task-type allowlist. Switched to lead-only authority, normalized statuses/types, and made future non-agent kinds fail active.
4. **Round 4 — not clean:** found `TeammateIdle` bypassing the child check via `teammate_name`, insufficient remote-ingest coverage, and missing/non-string task types failing inactive. Moved lifecycle handling ahead of inventory authority, hardened parsing, and tested the public remote path in both directions.
5. **Round 5 — not clean:** found agent rows with future/omitted statuses being reaped, unknown-child roster folding, no cold-runtime replay recovery, and missing local HTTP/persistence/IPC coverage. Made agent inventories fail active/incomplete, aligned lead scoping, added replay-before-live precedence, and added end-to-end proof.
6. **Round 6 — not clean:** found unknown-child interrupted Stops clearing lead evidence and fully unclassifiable rows still permitting authoritative reap. Made every `agent_id` event child-owned and marked every unclassifiable inventory incomplete.
7. **Round 7 — `CLEAN`:** no actionable defects. Opus revalidated all previous areas, inspected the shipped Claude `2.1.220` binary for wire-schema ground truth, reran tests/typecheck/lint, and confirmed the worktree was unchanged.

Final Opus verdict:

> **CLEAN. No actionable defects.**

Non-blocking suggestions were limited to cleanup/documentation and future product-policy choices (dead condition members, long-lived background-task presentation, and possible SessionEnd handling); none changes the correctness or merge readiness of this fix.

## Fresh post-rebase Opus review

Orca orchestration Run `run_5b6490fd4e9a` coordinated eight fresh review-only rounds with `claude --model opus`. Every round re-read the complete relevant diff and had to return concrete actionable findings or an explicit clean verdict.

1. **Round 1:** eight findings; fixed the substantive lifecycle, ownership, and transport issues.
2. **Round 2:** three findings; fixed remote-evidence acceptance ordering, independent cron state, and ambiguous status handling.
3. **Round 3:** one low policy/test gap; pinned interruption semantics and hardened intake.
4. **Round 4:** no implementation defect at the reviewed head.
5. **Post-CI cleanup round:** found three low hardening/coverage gaps. Malformed entries now fail active, child inventory authority is non-vacuously tested, and omitted empty cron inventories drain safely.
6. **Hardening re-review:** all three fixes passed mutation checks; one remaining test-only guard gap was found and pinned.
7. **Clean confirmation:** **8/8 targeted mutants killed**, **5,247 tests passed**, all static gates passed, and no actionable finding remained.
8. **Final post-rebase confirmation — `CLEAN`:** verified all 14 commits as exact equivalents, proved the dropped lint patch is byte-identical upstream, checked the three new upstream commits for interaction, reran 337 focused tests and all static gates, and found no actionable issue.

Final Opus verdict at `6a55cd6fba`:

> **CLEAN with no actionable findings.**

The reviewer explicitly found no correctness, security, performance, lifecycle/memory, transport, or Windows/Linux/macOS/WSL/SSH/relay/mobile/folder-workspace/git-worktree regression.


## Independent review round at `0d9f04e4be`

A fresh adversarial pass over the full `origin/main...HEAD` diff found no correctness, lifecycle, transport, or security defect. Areas re-derived from source rather than from the log above: pane-key identity across `ingestRemote`'s alias resolution and `inferInterrupt`'s lookup; the accepted-evidence gate against every early return in `applyNormalizedStatus`; replay seeding against the relay's one-entry-per-pane cache; `movePaneScopedSetEntries` on plain (non-composite) pane keys; and the absence of any renderer-side optimistic interrupt path that could bypass the main-process gate.

Two maintainability findings were fixed:

- The Stop/StopFailure predicate was written inline five times and `stateName` was a bare alias of `reportedStateName`, with both names used interchangeably in one function. Collapsed to a single `isTurnBoundary` constant and one state name — behavior-preserving, confirmed by the full related suite.
- Only the *interrupted* `StopFailure` path was pinned. Added two tests: a non-interrupted `StopFailure` keeps gating on live background work, and interrupted state does not survive a mid-turn lead event with no prompt submit. Both were mutation-checked — narrowing `isTurnBoundary` to `Stop` kills the first, and letting `interrupted` escape the turn boundary kills the second.

Gates at this head: **1,822 related tests passed** (3 skipped), `pnpm typecheck` passed for node/CLI/web, oxlint and oxfmt clean on all changed files, and `check:max-lines-ratchet` reported no new bypasses.

## Cross-platform and workspace assessment

- **Windows / Linux / macOS / WSL:** the change is transport-agnostic TypeScript and adds no OS-specific path, shortcut, shell, native module, or Git behavior. Named-pipe and socket transports continue to carry ordinary JSON; the new field is an optional boolean.
- **SSH / relay:** ingress accepts the field only when its runtime type is boolean; cold replay may seed a restarted runtime, while any live observation wins over later stale replay. The focused SSH integration suite passes.
- **Mobile / renderer:** mobile and desktop both consume the same normalized `AgentStatusIpcPayload` from `getStatusSnapshot()`. The transport-only boolean is stripped before IPC, snapshots, and persistence, so no protocol or mobile schema change is required.
- **Folder workspaces / git worktrees:** evidence is keyed only by stable pane identity, not repository metadata. Move, pane-clear, listener-clear, and teardown paths are covered.
- **Memory / lifecycle:** storage uses two O(1) pane-key `Set`s, bounded by live panes and cleared through existing lifecycle cleanup. Visible child rows remain capped by `AGENT_STATUS_MAX_SUBAGENTS`.

No platform-specific fallback is required.

## Security audit

- No new command execution, process launch, filesystem access, IPC endpoint, authentication flow, secret, dependency, or external network behavior.
- Existing request-size and structural normalization limits still bound hook payload work.
- Relay/SSH ingress accepts the new field only when `typeof value === 'boolean'`.
- The derived boolean contains no user content and is stripped before renderer IPC and disk persistence.
- Memory remains bounded to one Set entry per live pane and existing child-row caps; move/clear/teardown paths are covered.
- A compromised relay already controls the pane status payload; this boolean does not expand that trust boundary.

No security follow-up is required.

## Notes and trade-offs

- Long-lived Claude-owned tasks such as monitors or dev servers intentionally keep the working indicator active. That is preferable to reporting completion while Claude itself reports live work.
- A missing inventory retains the last authoritative value for compatibility with older or partial hooks; a present empty lead inventory clears it.
- Existing 30-minute status freshness still bounds stale presentation.
- This PR intentionally does not broaden into the separate permission/plan-mode cases in #10997, which have different precedence and clearing semantics.
- No screenshot is included because there is no component or layout change; the exact before-state, raw provider payloads, and production-path after-state are recorded above.

## Final exact-head merge gate

- Merge candidate: `27062e709968c822cf5bd26a9884d6ef2c663b12` on `origin/main` `4f963fd279ceeed031b7c0495f62ba920b774588`.
- Final rebase was conflict-free. `git range-diff` marks all **16/16 commits as exact equivalents**; the three latest upstream commits touch zero PR files.
- Final Opus feedback loop found one local-HTTP acceptance-ordering gap. Commit `27062e7099` defers both Claude background-task and session-cron evidence until the normalized status is accepted.
- The new regression test is non-vacuous: copied onto the pre-fix parent it fails while the rejected status itself remains unchanged; on the fixed head it passes.
- Final exact-head Opus review via Orca orchestration Run `run_5b6490fd4e9a`: **CLEAN with no actionable findings**. It independently confirmed 16/16 range-diff equivalence, zero upstream overlap, 342/342 focused tests, node/CLI/web typecheck, oxlint, max-lines, and 61/61 reliability gates.
- Coordinator post-rebase proof: 305/305 focused listener/server/relay/SSH tests, full typecheck, lint, formatting, max-lines, and `git diff --check` passed.
- Final GitHub Actions run `30731878819`: every Node 24/26 shard, Git compatibility, Windows packaging, static analysis, typecheck, shell contracts, root guard, and aggregate `verify` passed; E2E was intentionally skipped because no changed E2E specs were detected. The latest Greptile review on the exact-equivalent pre-rebase head also passed.
- Cross-platform review remains clean for Windows, Linux, macOS, WSL, SSH/relay, mobile, folder workspaces, and git worktrees. The final fix is synchronous in-memory Set gating and adds no platform-specific path, shell, Git, native-module, renderer, or mobile behavior.
- The final additional upstream commit, `fix(browser): remove unsafe window close bypass (#12040)`, changes only browser/window/session code and has zero overlap with the PR's agent-hook files; the last rebase remains 16/16 exact-equivalent.