### PR TITLE
Restyle voice dictation feature tip

### DIFF
--- a/src/renderer/src/components/feature-tips/FeatureTipActions.tsx
+++ b/src/renderer/src/components/feature-tips/FeatureTipActions.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react'
+import type { JSX, Ref } from 'react'
 import { Loader2 } from 'lucide-react'
 import type { FeatureTip, FeatureTipAction } from '../../../../shared/feature-tips'
 import { Button } from '@/components/ui/button'
@@ -17,7 +17,8 @@ export function FeatureTipActions({
   onPrimaryAction,
   onSkip,
   showSkip = true,
-  fullWidth = false
+  fullWidth = false,
+  primaryButtonRef
 }: {
   currentTip: FeatureTip
   primaryBusy: boolean
@@ -25,6 +26,7 @@ export function FeatureTipActions({
   onSkip: () => void
   showSkip?: boolean
   fullWidth?: boolean
+  primaryButtonRef?: Ref<HTMLButtonElement>
 }): JSX.Element {
   return (
     <>
@@ -34,6 +36,7 @@ export function FeatureTipActions({
         </Button>
       ) : null}
       <Button
+        ref={primaryButtonRef}
         className={fullWidth ? 'w-full' : undefined}
         onClick={onPrimaryAction}
         disabled={primaryBusy}

--- a/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
+++ b/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState, type JSX } from 'react'
-import { Mic } from 'lucide-react'
 import { toast } from 'sonner'
 import { getDefaultVoiceSettings } from '../../../../shared/constants'
-import type { FeatureTip } from '../../../../shared/feature-tips'
 import {
   ORCHESTRATION_ENABLED_STORAGE_KEY,
   ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY,
@@ -19,7 +17,6 @@ import {
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/store'
 import { CliFeatureTipVisual } from './CliFeatureTipVisual'
-import { CmdJPaletteFeatureTipVisual } from './CmdJPaletteFeatureTipVisual'
 import { CmdJPaletteTipDialog } from './CmdJPaletteTipDialog'
 import { CliSkillSetupTerminal } from './CliSkillSetupTerminal'
 import { FeatureTipActions } from './FeatureTipActions'
@@ -33,8 +30,7 @@ import {
 } from './feature-tip-telemetry'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
-
-const WAVEFORM_BAR_HEIGHTS = [30, 60, 90, 70, 100, 50, 80, 35, 65]
+import { VoiceDictationTipDialog } from './VoiceDictationTipDialog'
 
 function WorktreePromptTerm({ children }: { children: string }): JSX.Element {
   return (
@@ -42,37 +38,6 @@ function WorktreePromptTerm({ children }: { children: string }): JSX.Element {
       {children}
     </span>
   )
-}
-
-function FeatureTipVisual({ tip }: { tip: FeatureTip }): JSX.Element {
-  if (tip.action === 'setup-cli') {
-    return <CliFeatureTipVisual />
-  }
-
-  switch (tip.action) {
-    case 'learn-cmd-j-palette':
-      // Kept for type exhaustiveness; the cmd-j tip is rendered via
-      // CmdJPaletteTipDialog and never reaches this function at runtime.
-      return <CmdJPaletteFeatureTipVisual />
-    case 'enable-voice':
-      return (
-        <div className="flex flex-col items-center gap-2.5">
-          <div className="flex size-14 items-center justify-center rounded-full bg-foreground text-background">
-            <Mic className="size-5" />
-          </div>
-          {/* Animated waveform — purely decorative, signals "voice" without copy */}
-          <div className="flex h-6 items-center justify-center gap-1" aria-hidden="true">
-            {WAVEFORM_BAR_HEIGHTS.map((height, i) => (
-              <span
-                key={i}
-                className="block w-[3px] rounded-[2px] bg-foreground/60 animate-waveform"
-                style={{ height: `${height}%`, animationDelay: `${i * 0.1}s` }}
-              />
-            ))}
-          </div>
-        </div>
-      )
-  }
 }
 
 export default function FeatureTipsModal(): JSX.Element | null {
@@ -140,6 +105,13 @@ export default function FeatureTipsModal(): JSX.Element | null {
     markCurrentTipSeen()
     closeModal()
     openSettingsTarget({ pane: 'shortcuts', repoId: null })
+    openSettingsPage()
+  }
+
+  const openVoiceSettings = (): void => {
+    markCurrentTipSeen()
+    closeModal()
+    openSettingsTarget({ pane: 'voice', repoId: null })
     openSettingsPage()
   }
 
@@ -371,7 +343,7 @@ export default function FeatureTipsModal(): JSX.Element | null {
                 skillTerminalOpen ? 'translate-x-full opacity-0' : 'translate-x-0 opacity-100'
               }`}
             >
-              {skillTerminalOpen ? null : <FeatureTipVisual tip={currentTip} />}
+              {skillTerminalOpen ? null : <CliFeatureTipVisual />}
             </div>
           </div>
         </DialogContent>
@@ -394,28 +366,14 @@ export default function FeatureTipsModal(): JSX.Element | null {
   }
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md gap-4 p-7" showCloseButton>
-        <DialogHeader className="items-center gap-4 px-8 text-center sm:text-center">
-          <FeatureTipVisual tip={currentTip} />
-          <DialogTitle className="text-2xl font-semibold tracking-tight">
-            {currentTip.title}
-          </DialogTitle>
-          <DialogDescription className="max-w-sm text-sm leading-relaxed">
-            {currentTip.description}
-          </DialogDescription>
-        </DialogHeader>
-
-        <DialogFooter className="sm:justify-center">
-          <FeatureTipActions
-            currentTip={currentTip}
-            primaryBusy={primaryBusy}
-            onPrimaryAction={() => void handlePrimaryAction()}
-            onSkip={handleSkip}
-            showSkip
-          />
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <VoiceDictationTipDialog
+      open={isOpen}
+      tip={currentTip}
+      primaryBusy={primaryBusy}
+      onOpenChange={handleOpenChange}
+      onPrimaryAction={() => void handlePrimaryAction()}
+      onSkip={handleSkip}
+      onVoiceSettingsClick={openVoiceSettings}
+    />
   )
 }

--- a/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
+++ b/src/renderer/src/components/feature-tips/FeatureTipsModal.tsx
@@ -365,6 +365,11 @@ export default function FeatureTipsModal(): JSX.Element | null {
     )
   }
 
+  if (currentTip.action !== 'enable-voice') {
+    currentTip.action satisfies never
+    return null
+  }
+
   return (
     <VoiceDictationTipDialog
       open={isOpen}

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.test.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.test.tsx
@@ -47,7 +47,7 @@ describe('VoiceDictationFeatureTipVisual', () => {
     expect(prompt?.textContent).toBe('R')
     await act(async () => vi.runAllTimers())
     expect(prompt?.textContent).toBe(
-      'Refactor the voice setup flow and add coverage for the permission states.'
+      'Review this diff for edge cases and add tests for anything you find.'
     )
     expect(vi.getTimerCount()).toBe(0)
 
@@ -69,7 +69,7 @@ describe('VoiceDictationFeatureTipVisual', () => {
     const { container, root } = await renderVisual()
 
     expect(container.textContent).toContain(
-      'Refactor the voice setup flow and add coverage for the permission states.'
+      'Review this diff for edge cases and add tests for anything you find.'
     )
     expect(container.innerHTML).not.toContain('animate-waveform')
     expect(setTimeoutSpy).not.toHaveBeenCalled()

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.test.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.test.tsx
@@ -8,15 +8,13 @@ import { VoiceDictationFeatureTipVisual } from './VoiceDictationFeatureTipVisual
 
 const prefersReducedMotionMock = vi.hoisted(() => vi.fn(() => false))
 const shortcutMock = vi.hoisted(() => vi.fn(() => ({ keys: ['⌘', 'E'], doubleTap: false })))
-const formatShortcutMock = vi.hoisted(() => vi.fn(() => [{ keys: ['⌘', 'E'], doubleTap: false }]))
 
 vi.mock('@/components/feature-wall/feature-wall-modal-helpers', () => ({
   usePrefersReducedMotion: prefersReducedMotionMock
 }))
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
-  useShortcutKeyDetails: shortcutMock,
-  formatShortcutKeyComboDetails: formatShortcutMock
+  useShortcutKeyDetails: shortcutMock
 }))
 
 async function renderVisual(): Promise<{ container: HTMLDivElement; root: Root }> {
@@ -31,7 +29,6 @@ describe('VoiceDictationFeatureTipVisual', () => {
   beforeEach(() => {
     prefersReducedMotionMock.mockReturnValue(false)
     shortcutMock.mockReturnValue({ keys: ['⌘', 'E'], doubleTap: false })
-    formatShortcutMock.mockReturnValue([{ keys: ['⌘', 'E'], doubleTap: false }])
   })
 
   afterEach(() => {
@@ -80,14 +77,12 @@ describe('VoiceDictationFeatureTipVisual', () => {
     await act(async () => root.unmount())
   })
 
-  it('falls back to the default shortcut when the live binding is unassigned', () => {
+  it('does not show a shortcut that the user has unassigned', () => {
     shortcutMock.mockReturnValue({ keys: [], doubleTap: false })
-    formatShortcutMock.mockReturnValue([{ keys: ['Ctrl', 'E'], doubleTap: false }])
 
     const html = renderToStaticMarkup(<VoiceDictationFeatureTipVisual />)
 
-    expect(formatShortcutMock).toHaveBeenCalledWith('voice.dictation')
-    expect(html).toContain('Ctrl')
-    expect(html).toContain('E')
+    expect(html).not.toContain('Start dictation')
+    expect(html).not.toContain('Ctrl')
   })
 })

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.test.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VoiceDictationFeatureTipVisual } from './VoiceDictationFeatureTipVisual'
+
+const prefersReducedMotionMock = vi.hoisted(() => vi.fn(() => false))
+const shortcutMock = vi.hoisted(() => vi.fn(() => ({ keys: ['⌘', 'E'], doubleTap: false })))
+const formatShortcutMock = vi.hoisted(() => vi.fn(() => [{ keys: ['⌘', 'E'], doubleTap: false }]))
+
+vi.mock('@/components/feature-wall/feature-wall-modal-helpers', () => ({
+  usePrefersReducedMotion: prefersReducedMotionMock
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutKeyDetails: shortcutMock,
+  formatShortcutKeyComboDetails: formatShortcutMock
+}))
+
+async function renderVisual(): Promise<{ container: HTMLDivElement; root: Root }> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  await act(async () => root.render(<VoiceDictationFeatureTipVisual />))
+  return { container, root }
+}
+
+describe('VoiceDictationFeatureTipVisual', () => {
+  beforeEach(() => {
+    prefersReducedMotionMock.mockReturnValue(false)
+    shortcutMock.mockReturnValue({ keys: ['⌘', 'E'], doubleTap: false })
+    formatShortcutMock.mockReturnValue([{ keys: ['⌘', 'E'], doubleTap: false }])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('types the dictated prompt once and settles on the complete sentence', async () => {
+    vi.useFakeTimers()
+    const { container, root } = await renderVisual()
+    const prompt = container.querySelector('[data-testid="dictated-prompt"]')
+
+    expect(prompt?.textContent).toBe('')
+    await act(async () => vi.advanceTimersByTime(650))
+    expect(prompt?.textContent).toBe('R')
+    await act(async () => vi.runAllTimers())
+    expect(prompt?.textContent).toBe(
+      'Refactor the voice setup flow and add coverage for the permission states.'
+    )
+    expect(vi.getTimerCount()).toBe(0)
+
+    await act(async () => root.unmount())
+  })
+
+  it('gives the prompt the full remaining row width', () => {
+    const html = renderToStaticMarkup(<VoiceDictationFeatureTipVisual />)
+    const promptClass = html.match(/data-testid="dictated-prompt" class="([^"]+)"/)?.[1]
+
+    expect(promptClass).toContain('min-w-0')
+    expect(promptClass).toContain('flex-1')
+    expect(promptClass).not.toContain('max-w-')
+  })
+
+  it('renders the completed prompt without timers for reduced motion', async () => {
+    prefersReducedMotionMock.mockReturnValue(true)
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout')
+    const { container, root } = await renderVisual()
+
+    expect(container.textContent).toContain(
+      'Refactor the voice setup flow and add coverage for the permission states.'
+    )
+    expect(container.innerHTML).not.toContain('animate-waveform')
+    expect(setTimeoutSpy).not.toHaveBeenCalled()
+
+    await act(async () => root.unmount())
+  })
+
+  it('falls back to the default shortcut when the live binding is unassigned', () => {
+    shortcutMock.mockReturnValue({ keys: [], doubleTap: false })
+    formatShortcutMock.mockReturnValue([{ keys: ['Ctrl', 'E'], doubleTap: false }])
+
+    const html = renderToStaticMarkup(<VoiceDictationFeatureTipVisual />)
+
+    expect(formatShortcutMock).toHaveBeenCalledWith('voice.dictation')
+    expect(html).toContain('Ctrl')
+    expect(html).toContain('E')
+  })
+})

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
@@ -14,7 +14,7 @@ export function VoiceDictationFeatureTipVisual(): JSX.Element {
   const shortcut = useShortcutKeyDetails('voice.dictation')
   const dictatedPrompt = translate(
     'featureTips.voice.demoPrompt',
-    'Refactor the voice setup flow and add coverage for the permission states.'
+    'Review this diff for edge cases and add tests for anything you find.'
   )
   const [typedLength, setTypedLength] = useState(0)
   const effectiveTypedLength = reducedMotion ? dictatedPrompt.length : typedLength

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
@@ -71,7 +71,7 @@ export function VoiceDictationFeatureTipVisual(): JSX.Element {
       <div className="relative mt-4 h-56 w-full max-w-[21rem] overflow-hidden rounded-xl border border-border/80 bg-card text-left shadow-xs">
         <div className="flex h-10 items-center gap-2 border-b border-border px-3 text-[11px] text-muted-foreground">
           <span className="size-2 rounded-full bg-foreground/35" />
-          <span>{translate('featureTips.voice.agentPromptTitle', 'Agent prompt · bonito')}</span>
+          <span>{translate('featureTips.voice.agentPromptTitle', 'Agent prompt')}</span>
         </div>
 
         <div className="absolute inset-x-0 bottom-0 top-10 bg-[var(--editor-surface)] px-4 py-5 font-mono text-xs leading-relaxed">

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState, type JSX } from 'react'
+import { Mic, Square } from 'lucide-react'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { usePrefersReducedMotion } from '@/components/feature-wall/feature-wall-modal-helpers'
+import { formatShortcutKeyComboDetails, useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { translate } from '@/i18n/i18n'
+
+const TYPE_START_DELAY_MS = 650
+const TYPE_INTERVAL_MS = 36
+const WAVEFORM_BAR_HEIGHTS = [38, 70, 100, 58, 82]
+
+export function VoiceDictationFeatureTipVisual(): JSX.Element {
+  const reducedMotion = usePrefersReducedMotion()
+  const shortcut = useShortcutKeyDetails('voice.dictation')
+  const displayShortcut =
+    shortcut.keys.length > 0 ? shortcut : formatShortcutKeyComboDetails('voice.dictation')[0]
+  const dictatedPrompt = translate(
+    'featureTips.voice.demoPrompt',
+    'Refactor the voice setup flow and add coverage for the permission states.'
+  )
+  const [typedLength, setTypedLength] = useState(0)
+  const effectiveTypedLength = reducedMotion ? dictatedPrompt.length : typedLength
+  const typing = !reducedMotion && effectiveTypedLength < dictatedPrompt.length
+
+  useEffect(() => {
+    if (reducedMotion) {
+      return
+    }
+
+    let cancelled = false
+    let timeoutId: number | undefined
+    let nextLength = 0
+    const typeNext = (): void => {
+      if (cancelled) {
+        return
+      }
+      nextLength += 1
+      setTypedLength(nextLength)
+      if (nextLength < dictatedPrompt.length) {
+        timeoutId = window.setTimeout(typeNext, TYPE_INTERVAL_MS)
+      }
+    }
+
+    timeoutId = window.setTimeout(typeNext, TYPE_START_DELAY_MS)
+    return () => {
+      cancelled = true
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId)
+      }
+    }
+  }, [dictatedPrompt, reducedMotion])
+
+  return (
+    <div
+      className="relative flex h-full min-h-[23rem] flex-col items-center justify-center overflow-hidden px-6 py-7"
+      aria-hidden="true"
+    >
+      {displayShortcut && displayShortcut.keys.length > 0 ? (
+        <div className="flex items-center gap-2.5">
+          <ShortcutKeyCombo
+            keys={displayShortcut.keys}
+            doubleTap={displayShortcut.doubleTap}
+            keyCapClassName="h-7 min-w-7 bg-foreground/[0.08] px-2 font-semibold shadow-xs"
+          />
+          <span className="text-[10px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+            {translate('featureTips.voice.startDictation', 'Start dictation')}
+          </span>
+        </div>
+      ) : null}
+
+      <div className="relative mt-4 h-56 w-full max-w-[21rem] overflow-hidden rounded-xl border border-border/80 bg-card text-left shadow-xs">
+        <div className="flex h-10 items-center gap-2 border-b border-border px-3 text-[11px] text-muted-foreground">
+          <span className="size-2 rounded-full bg-foreground/35" />
+          <span>{translate('featureTips.voice.agentPromptTitle', 'Agent prompt · bonito')}</span>
+        </div>
+
+        <div className="absolute inset-x-0 bottom-0 top-10 bg-[var(--editor-surface)] px-4 py-5 font-mono text-xs leading-relaxed">
+          <div className="flex min-w-0 gap-2.5">
+            <span className="shrink-0 text-muted-foreground">›</span>
+            <span
+              data-testid="dictated-prompt"
+              className="min-w-0 flex-1 whitespace-pre-wrap break-words text-foreground"
+            >
+              {dictatedPrompt.slice(0, effectiveTypedLength)}
+              {typing ? (
+                <span className="ml-px inline-block h-3.5 w-px translate-y-0.5 bg-foreground/75" />
+              ) : null}
+            </span>
+          </div>
+        </div>
+
+        <div className="absolute inset-x-3 bottom-3 flex h-10 items-center gap-2 rounded-lg bg-foreground/90 px-3 text-xs font-medium text-background shadow-lg">
+          <Mic className="size-4 shrink-0" />
+          <span className="flex h-4 items-center gap-0.5" aria-hidden="true">
+            {WAVEFORM_BAR_HEIGHTS.map((height, index) => (
+              <span
+                key={height}
+                className={`block w-0.5 rounded-full bg-current ${typing ? 'animate-waveform' : ''}`}
+                style={{ height: `${height}%`, animationDelay: `${index * 0.1}s` }}
+              />
+            ))}
+          </span>
+          <span className="min-w-0 flex-1 truncate">
+            {translate('featureTips.voice.listening', 'Listening...')}
+          </span>
+          <Square className="size-2.5 shrink-0 fill-current opacity-55" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationFeatureTipVisual.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type JSX } from 'react'
 import { Mic, Square } from 'lucide-react'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { usePrefersReducedMotion } from '@/components/feature-wall/feature-wall-modal-helpers'
-import { formatShortcutKeyComboDetails, useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 
 const TYPE_START_DELAY_MS = 650
@@ -12,8 +12,6 @@ const WAVEFORM_BAR_HEIGHTS = [38, 70, 100, 58, 82]
 export function VoiceDictationFeatureTipVisual(): JSX.Element {
   const reducedMotion = usePrefersReducedMotion()
   const shortcut = useShortcutKeyDetails('voice.dictation')
-  const displayShortcut =
-    shortcut.keys.length > 0 ? shortcut : formatShortcutKeyComboDetails('voice.dictation')[0]
   const dictatedPrompt = translate(
     'featureTips.voice.demoPrompt',
     'Refactor the voice setup flow and add coverage for the permission states.'
@@ -55,11 +53,11 @@ export function VoiceDictationFeatureTipVisual(): JSX.Element {
       className="relative flex h-full min-h-[23rem] flex-col items-center justify-center overflow-hidden px-6 py-7"
       aria-hidden="true"
     >
-      {displayShortcut && displayShortcut.keys.length > 0 ? (
+      {shortcut.keys.length > 0 ? (
         <div className="flex items-center gap-2.5">
           <ShortcutKeyCombo
-            keys={displayShortcut.keys}
-            doubleTap={displayShortcut.doubleTap}
+            keys={shortcut.keys}
+            doubleTap={shortcut.doubleTap}
             keyCapClassName="h-7 min-w-7 bg-foreground/[0.08] px-2 font-semibold shadow-xs"
           />
           <span className="text-[10px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">

--- a/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.test.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.test.tsx
@@ -1,17 +1,18 @@
 // @vitest-environment happy-dom
 
-import type { ReactNode } from 'react'
+import { act, type ReactNode, type RefObject } from 'react'
+import { createRoot } from 'react-dom/client'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FEATURE_TIPS, type FeatureTip } from '../../../../shared/feature-tips'
 import { VoiceDictationTipDialog } from './VoiceDictationTipDialog'
 
 const shortcutMock = vi.hoisted(() => vi.fn(() => ({ keys: ['⌘', 'E'], doubleTap: false })))
-const formatShortcutMock = vi.hoisted(() => vi.fn(() => [{ keys: ['⌘', 'E'], doubleTap: false }]))
+const dialogContentPropsMock = vi.hoisted(() => vi.fn())
+const featureTipActionsPropsMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
-  useShortcutKeyDetails: shortcutMock,
-  formatShortcutKeyComboDetails: formatShortcutMock
+  useShortcutKeyDetails: shortcutMock
 }))
 
 vi.mock('./VoiceDictationFeatureTipVisual', () => ({
@@ -20,7 +21,16 @@ vi.mock('./VoiceDictationFeatureTipVisual', () => ({
 
 vi.mock('@/components/ui/dialog', () => ({
   Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode
+    onOpenAutoFocus?: (event: Event) => void
+  }) => {
+    dialogContentPropsMock(props)
+    return <div>{children}</div>
+  },
   DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
   DialogFooter: ({ children }: { children: ReactNode }) => <footer>{children}</footer>,
   DialogHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
@@ -28,7 +38,10 @@ vi.mock('@/components/ui/dialog', () => ({
 }))
 
 vi.mock('./FeatureTipActions', () => ({
-  FeatureTipActions: () => <div data-testid="feature-tip-actions" />
+  FeatureTipActions: (props: { primaryButtonRef?: RefObject<HTMLButtonElement | null> }) => {
+    featureTipActionsPropsMock(props)
+    return <button ref={props.primaryButtonRef}>Primary action</button>
+  }
 }))
 
 function getVoiceTip(): FeatureTip {
@@ -56,7 +69,8 @@ function renderDialog(): string {
 describe('VoiceDictationTipDialog', () => {
   beforeEach(() => {
     shortcutMock.mockReturnValue({ keys: ['⌘', 'E'], doubleTap: false })
-    formatShortcutMock.mockReturnValue([{ keys: ['⌘', 'E'], doubleTap: false }])
+    dialogContentPropsMock.mockClear()
+    featureTipActionsPropsMock.mockClear()
   })
 
   it('uses the established feature-tip layout and durable copy', () => {
@@ -78,13 +92,43 @@ describe('VoiceDictationTipDialog', () => {
     expect(html).toContain('Settings → Voice')
   })
 
-  it('falls back to the platform default shortcut when unassigned', () => {
+  it('uses generic instructions instead of a shortcut the user has unassigned', () => {
     shortcutMock.mockReturnValue({ keys: [], doubleTap: false })
-    formatShortcutMock.mockReturnValue([{ keys: ['Ctrl', 'E'], doubleTap: false }])
 
     const html = renderDialog()
 
-    expect(formatShortcutMock).toHaveBeenCalledWith('voice.dictation')
-    expect(html).toContain('Ctrl')
+    expect(html).toContain(
+      'Assign a dictation shortcut before starting voice dictation in a focused pane.'
+    )
+    expect(html).not.toContain('to start voice dictation. Press')
+    expect(html).not.toContain('Ctrl')
+  })
+
+  it('moves initial focus to the primary action', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <VoiceDictationTipDialog
+          open
+          tip={getVoiceTip()}
+          primaryBusy={false}
+          onOpenChange={vi.fn()}
+          onPrimaryAction={vi.fn()}
+          onSkip={vi.fn()}
+          onVoiceSettingsClick={vi.fn()}
+        />
+      )
+    })
+    const event = { preventDefault: vi.fn() } as unknown as Event
+
+    dialogContentPropsMock.mock.lastCall?.[0].onOpenAutoFocus(event)
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(document.activeElement?.textContent).toBe('Primary action')
+
+    await act(async () => root.unmount())
+    container.remove()
   })
 })

--- a/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.test.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FEATURE_TIPS, type FeatureTip } from '../../../../shared/feature-tips'
+import { VoiceDictationTipDialog } from './VoiceDictationTipDialog'
+
+const shortcutMock = vi.hoisted(() => vi.fn(() => ({ keys: ['⌘', 'E'], doubleTap: false })))
+const formatShortcutMock = vi.hoisted(() => vi.fn(() => [{ keys: ['⌘', 'E'], doubleTap: false }]))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutKeyDetails: shortcutMock,
+  formatShortcutKeyComboDetails: formatShortcutMock
+}))
+
+vi.mock('./VoiceDictationFeatureTipVisual', () => ({
+  VoiceDictationFeatureTipVisual: () => <div data-testid="voice-visual" />
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>
+}))
+
+vi.mock('./FeatureTipActions', () => ({
+  FeatureTipActions: () => <div data-testid="feature-tip-actions" />
+}))
+
+function getVoiceTip(): FeatureTip {
+  const tip = FEATURE_TIPS.find((entry) => entry.id === 'voice-dictation')
+  if (!tip) {
+    throw new Error('Expected voice-dictation feature tip fixture')
+  }
+  return { ...tip }
+}
+
+function renderDialog(): string {
+  return renderToStaticMarkup(
+    <VoiceDictationTipDialog
+      open
+      tip={getVoiceTip()}
+      primaryBusy={false}
+      onOpenChange={vi.fn()}
+      onPrimaryAction={vi.fn()}
+      onSkip={vi.fn()}
+      onVoiceSettingsClick={vi.fn()}
+    />
+  )
+}
+
+describe('VoiceDictationTipDialog', () => {
+  beforeEach(() => {
+    shortcutMock.mockReturnValue({ keys: ['⌘', 'E'], doubleTap: false })
+    formatShortcutMock.mockReturnValue([{ keys: ['⌘', 'E'], doubleTap: false }])
+  })
+
+  it('uses the established feature-tip layout and durable copy', () => {
+    const html = renderDialog()
+
+    expect(html).toContain('TIP')
+    expect(html).toContain('Dictate into any pane')
+    expect(html).toContain('Turn speech into text wherever')
+    expect(html).not.toContain('is here')
+  })
+
+  it('shows the live dictation shortcut and voice settings path', () => {
+    const html = renderDialog()
+
+    expect(html).toContain('⌘')
+    expect(html).toContain('E')
+    expect(html).toContain('Settings → Voice')
+  })
+
+  it('falls back to the platform default shortcut when unassigned', () => {
+    shortcutMock.mockReturnValue({ keys: [], doubleTap: false })
+    formatShortcutMock.mockReturnValue([{ keys: ['Ctrl', 'E'], doubleTap: false }])
+
+    const html = renderDialog()
+
+    expect(formatShortcutMock).toHaveBeenCalledWith('voice.dictation')
+    expect(html).toContain('Ctrl')
+  })
+})

--- a/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.test.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.test.tsx
@@ -64,7 +64,7 @@ describe('VoiceDictationTipDialog', () => {
 
     expect(html).toContain('TIP')
     expect(html).toContain('Dictate into any pane')
-    expect(html).toContain('Turn speech into text wherever')
+    expect(html).not.toContain('Turn speech into text wherever')
     expect(html).not.toContain('is here')
   })
 
@@ -73,6 +73,8 @@ describe('VoiceDictationTipDialog', () => {
 
     expect(html).toContain('⌘')
     expect(html).toContain('E')
+    expect(html).toContain('to start voice dictation. Press')
+    expect(html).toContain('again to stop.')
     expect(html).toContain('Settings → Voice')
   })
 

--- a/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.tsx
@@ -56,7 +56,6 @@ export function VoiceDictationTipDialog({
                 {tip.title}
               </DialogTitle>
               <DialogDescription className="mt-3 max-w-2xl space-y-3 text-sm leading-relaxed">
-                <span className="block">{tip.description}</span>
                 <span className="block">
                   {translate(
                     'featureTips.voice.focusPaneInstruction',
@@ -72,7 +71,21 @@ export function VoiceDictationTipDialog({
                   ) : (
                     translate('featureTips.voice.theShortcut', 'the dictation shortcut')
                   )}{' '}
-                  {translate('featureTips.voice.startStopInstruction', 'to start or stop.')}
+                  {translate(
+                    'featureTips.voice.startInstruction',
+                    'to start voice dictation. Press'
+                  )}{' '}
+                  {displayShortcut && displayShortcut.keys.length > 0 ? (
+                    <ShortcutKeyCombo
+                      keys={displayShortcut.keys}
+                      doubleTap={displayShortcut.doubleTap}
+                      className="mx-1 align-middle"
+                      keyCapClassName="min-w-0 bg-card px-1.5 py-0 text-[11px] text-foreground shadow-none"
+                    />
+                  ) : (
+                    translate('featureTips.voice.theShortcut', 'the dictation shortcut')
+                  )}{' '}
+                  {translate('featureTips.voice.stopInstruction', 'again to stop.')}
                 </span>
                 <span className="block text-muted-foreground">
                   {translate(

--- a/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.tsx
@@ -1,0 +1,115 @@
+import type { JSX } from 'react'
+import type { FeatureTip } from '../../../../shared/feature-tips'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { formatShortcutKeyComboDetails, useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { translate } from '@/i18n/i18n'
+import { FeatureTipActions } from './FeatureTipActions'
+import { VoiceDictationFeatureTipVisual } from './VoiceDictationFeatureTipVisual'
+
+export function VoiceDictationTipDialog({
+  open,
+  tip,
+  primaryBusy,
+  onOpenChange,
+  onPrimaryAction,
+  onSkip,
+  onVoiceSettingsClick
+}: {
+  open: boolean
+  tip: FeatureTip
+  primaryBusy: boolean
+  onOpenChange: (open: boolean) => void
+  onPrimaryAction: () => void
+  onSkip: () => void
+  onVoiceSettingsClick: () => void
+}): JSX.Element {
+  const shortcut = useShortcutKeyDetails('voice.dictation')
+  const displayShortcut =
+    shortcut.keys.length > 0 ? shortcut : formatShortcutKeyComboDetails('voice.dictation')[0]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="!flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden bg-[color-mix(in_srgb,var(--foreground)_8%,var(--background))] p-0 dark:bg-[color-mix(in_srgb,var(--foreground)_16%,var(--background))] sm:max-w-4xl md:!h-[min(27rem,calc(100vh-2rem))] md:!flex-row"
+        showCloseButton
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="scrollbar-sleek flex min-h-0 min-w-0 flex-1 flex-col justify-between overflow-y-auto px-8 py-9 md:shrink-0 md:basis-1/2">
+          <DialogHeader className="gap-4 text-left">
+            <div>
+              <Badge
+                variant="outline"
+                className="mb-3 rounded-md px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                {tip.eyebrow.toUpperCase()}
+              </Badge>
+              <DialogTitle className="text-2xl font-semibold leading-tight tracking-tight md:text-[1.75rem]">
+                {tip.title}
+              </DialogTitle>
+              <DialogDescription className="mt-3 max-w-2xl space-y-3 text-sm leading-relaxed">
+                <span className="block">{tip.description}</span>
+                <span className="block">
+                  {translate(
+                    'featureTips.voice.focusPaneInstruction',
+                    'Focus a terminal, editor, or agent prompt, then press'
+                  )}{' '}
+                  {displayShortcut && displayShortcut.keys.length > 0 ? (
+                    <ShortcutKeyCombo
+                      keys={displayShortcut.keys}
+                      doubleTap={displayShortcut.doubleTap}
+                      className="mx-1 align-middle"
+                      keyCapClassName="min-w-0 bg-card px-1.5 py-0 text-[11px] text-foreground shadow-none"
+                    />
+                  ) : (
+                    translate('featureTips.voice.theShortcut', 'the dictation shortcut')
+                  )}{' '}
+                  {translate('featureTips.voice.startStopInstruction', 'to start or stop.')}
+                </span>
+                <span className="block text-muted-foreground">
+                  {translate(
+                    'featureTips.voice.settingsInstruction',
+                    'Change the model, dictation mode, or shortcut anytime in'
+                  )}{' '}
+                  <button
+                    type="button"
+                    onClick={onVoiceSettingsClick}
+                    className="inline appearance-none border-0 bg-transparent p-0 font-medium text-foreground underline decoration-foreground/30 underline-offset-2 transition-colors hover:decoration-foreground focus-visible:outline-none focus-visible:decoration-foreground"
+                  >
+                    {translate('featureTips.voice.settingsLink', 'Settings → Voice')}
+                  </button>
+                  .
+                </span>
+              </DialogDescription>
+            </div>
+          </DialogHeader>
+
+          <DialogFooter className="mt-8 flex sm:justify-stretch">
+            <FeatureTipActions
+              currentTip={tip}
+              primaryBusy={primaryBusy}
+              onPrimaryAction={onPrimaryAction}
+              onSkip={onSkip}
+              showSkip={false}
+              fullWidth
+            />
+          </DialogFooter>
+        </div>
+
+        <div className="flex min-h-0 min-w-0 shrink-0 self-stretch overflow-hidden bg-muted/60 md:basis-1/2 md:border-l md:border-border/70">
+          <div className="h-full min-h-[23rem] w-full md:w-[29.4rem]">
+            <VoiceDictationFeatureTipVisual />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.tsx
+++ b/src/renderer/src/components/feature-tips/VoiceDictationTipDialog.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react'
+import { useRef, type JSX } from 'react'
 import type { FeatureTip } from '../../../../shared/feature-tips'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { Badge } from '@/components/ui/badge'
@@ -10,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
-import { formatShortcutKeyComboDetails, useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import { FeatureTipActions } from './FeatureTipActions'
 import { VoiceDictationFeatureTipVisual } from './VoiceDictationFeatureTipVisual'
@@ -33,15 +33,17 @@ export function VoiceDictationTipDialog({
   onVoiceSettingsClick: () => void
 }): JSX.Element {
   const shortcut = useShortcutKeyDetails('voice.dictation')
-  const displayShortcut =
-    shortcut.keys.length > 0 ? shortcut : formatShortcutKeyComboDetails('voice.dictation')[0]
+  const primaryButtonRef = useRef<HTMLButtonElement>(null)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="!flex max-h-[calc(100vh-2rem)] flex-col gap-0 overflow-hidden bg-[color-mix(in_srgb,var(--foreground)_8%,var(--background))] p-0 dark:bg-[color-mix(in_srgb,var(--foreground)_16%,var(--background))] sm:max-w-4xl md:!h-[min(27rem,calc(100vh-2rem))] md:!flex-row"
         showCloseButton
-        onOpenAutoFocus={(event) => event.preventDefault()}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          primaryButtonRef.current?.focus()
+        }}
       >
         <div className="scrollbar-sleek flex min-h-0 min-w-0 flex-1 flex-col justify-between overflow-y-auto px-8 py-9 md:shrink-0 md:basis-1/2">
           <DialogHeader className="gap-4 text-left">
@@ -56,37 +58,38 @@ export function VoiceDictationTipDialog({
                 {tip.title}
               </DialogTitle>
               <DialogDescription className="mt-3 max-w-2xl space-y-3 text-sm leading-relaxed">
-                <span className="block">
-                  {translate(
-                    'featureTips.voice.focusPaneInstruction',
-                    'Focus a terminal, editor, or agent prompt, then press'
-                  )}{' '}
-                  {displayShortcut && displayShortcut.keys.length > 0 ? (
+                {shortcut.keys.length > 0 ? (
+                  <span className="block">
+                    {translate(
+                      'featureTips.voice.focusPaneInstruction',
+                      'Focus a terminal, editor, or agent prompt, then press'
+                    )}{' '}
                     <ShortcutKeyCombo
-                      keys={displayShortcut.keys}
-                      doubleTap={displayShortcut.doubleTap}
+                      keys={shortcut.keys}
+                      doubleTap={shortcut.doubleTap}
                       className="mx-1 align-middle"
                       keyCapClassName="min-w-0 bg-card px-1.5 py-0 text-[11px] text-foreground shadow-none"
-                    />
-                  ) : (
-                    translate('featureTips.voice.theShortcut', 'the dictation shortcut')
-                  )}{' '}
-                  {translate(
-                    'featureTips.voice.startInstruction',
-                    'to start voice dictation. Press'
-                  )}{' '}
-                  {displayShortcut && displayShortcut.keys.length > 0 ? (
+                    />{' '}
+                    {translate(
+                      'featureTips.voice.startInstruction',
+                      'to start voice dictation. Press'
+                    )}{' '}
                     <ShortcutKeyCombo
-                      keys={displayShortcut.keys}
-                      doubleTap={displayShortcut.doubleTap}
+                      keys={shortcut.keys}
+                      doubleTap={shortcut.doubleTap}
                       className="mx-1 align-middle"
                       keyCapClassName="min-w-0 bg-card px-1.5 py-0 text-[11px] text-foreground shadow-none"
-                    />
-                  ) : (
-                    translate('featureTips.voice.theShortcut', 'the dictation shortcut')
-                  )}{' '}
-                  {translate('featureTips.voice.stopInstruction', 'again to stop.')}
-                </span>
+                    />{' '}
+                    {translate('featureTips.voice.stopInstruction', 'again to stop.')}
+                  </span>
+                ) : (
+                  <span className="block">
+                    {translate(
+                      'featureTips.voice.unassignedInstruction',
+                      'Assign a dictation shortcut before starting voice dictation in a focused pane.'
+                    )}
+                  </span>
+                )}
                 <span className="block text-muted-foreground">
                   {translate(
                     'featureTips.voice.settingsInstruction',
@@ -113,6 +116,7 @@ export function VoiceDictationTipDialog({
               onSkip={onSkip}
               showSkip={false}
               fullWidth
+              primaryButtonRef={primaryButtonRef}
             />
           </DialogFooter>
         </div>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14691,7 +14691,7 @@
     "voice": {
       "demoPrompt": "Refactor the voice setup flow and add coverage for the permission states.",
       "startDictation": "Start dictation",
-      "agentPromptTitle": "Agent prompt · bonito",
+      "agentPromptTitle": "Agent prompt",
       "listening": "Listening...",
       "focusPaneInstruction": "Focus a terminal, editor, or agent prompt, then press",
       "theShortcut": "the dictation shortcut",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14686,5 +14686,18 @@
         "unknown": "Restart Orca to try again."
       }
     }
+  },
+  "featureTips": {
+    "voice": {
+      "demoPrompt": "Refactor the voice setup flow and add coverage for the permission states.",
+      "startDictation": "Start dictation",
+      "agentPromptTitle": "Agent prompt · bonito",
+      "listening": "Listening...",
+      "focusPaneInstruction": "Focus a terminal, editor, or agent prompt, then press",
+      "theShortcut": "the dictation shortcut",
+      "startStopInstruction": "to start or stop.",
+      "settingsInstruction": "Change the model, dictation mode, or shortcut anytime in",
+      "settingsLink": "Settings → Voice"
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14689,7 +14689,7 @@
   },
   "featureTips": {
     "voice": {
-      "demoPrompt": "Refactor the voice setup flow and add coverage for the permission states.",
+      "demoPrompt": "Review this diff for edge cases and add tests for anything you find.",
       "startDictation": "Start dictation",
       "agentPromptTitle": "Agent prompt",
       "listening": "Listening...",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14695,7 +14695,8 @@
       "listening": "Listening...",
       "focusPaneInstruction": "Focus a terminal, editor, or agent prompt, then press",
       "theShortcut": "the dictation shortcut",
-      "startStopInstruction": "to start or stop.",
+      "startInstruction": "to start voice dictation. Press",
+      "stopInstruction": "again to stop.",
       "settingsInstruction": "Change the model, dictation mode, or shortcut anytime in",
       "settingsLink": "Settings → Voice"
     }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14694,9 +14694,9 @@
       "agentPromptTitle": "Agent prompt",
       "listening": "Listening...",
       "focusPaneInstruction": "Focus a terminal, editor, or agent prompt, then press",
-      "theShortcut": "the dictation shortcut",
       "startInstruction": "to start voice dictation. Press",
       "stopInstruction": "again to stop.",
+      "unassignedInstruction": "Assign a dictation shortcut before starting voice dictation in a focused pane.",
       "settingsInstruction": "Change the model, dictation mode, or shortcut anytime in",
       "settingsLink": "Settings → Voice"
     }

--- a/src/shared/feature-tips.test.ts
+++ b/src/shared/feature-tips.test.ts
@@ -105,6 +105,6 @@ describe('feature tips', () => {
     expect(voiceTip?.eyebrow).toBe('Tip')
     expect(voiceTip?.priority).toBe('unseen')
     expect(voiceTip?.title).toBe('Dictate into any pane')
-    expect(voiceTip?.ctaLabel).toBe('Set up voice')
+    expect(voiceTip?.ctaLabel).toBe('Set up voice dictation')
   })
 })

--- a/src/shared/feature-tips.test.ts
+++ b/src/shared/feature-tips.test.ts
@@ -104,5 +104,7 @@ describe('feature tips', () => {
 
     expect(voiceTip?.eyebrow).toBe('Tip')
     expect(voiceTip?.priority).toBe('unseen')
+    expect(voiceTip?.title).toBe('Dictate into any pane')
+    expect(voiceTip?.ctaLabel).toBe('Set up voice')
   })
 })

--- a/src/shared/feature-tips.ts
+++ b/src/shared/feature-tips.ts
@@ -59,7 +59,7 @@ export const FEATURE_TIPS = [
     title: 'Dictate into any pane',
     description: 'Start voice dictation in any focused pane, then use the shortcut again to stop.',
     action: 'enable-voice',
-    ctaLabel: 'Set up voice',
+    ctaLabel: 'Set up voice dictation',
     completedByFeatureInteractions: ['voice-dictation']
   }
 ] as const satisfies readonly FeatureTip[]

--- a/src/shared/feature-tips.ts
+++ b/src/shared/feature-tips.ts
@@ -56,11 +56,10 @@ export const FEATURE_TIPS = [
     id: 'voice-dictation',
     priority: 'unseen',
     eyebrow: 'Tip',
-    title: 'Voice Dictation is here',
-    description:
-      'Speak into any focused pane and Orca will transcribe it. Press the dictation shortcut to start and stop.',
+    title: 'Dictate into any pane',
+    description: "Turn speech into text wherever you're working.",
     action: 'enable-voice',
-    ctaLabel: 'Set Up Voice',
+    ctaLabel: 'Set up voice',
     completedByFeatureInteractions: ['voice-dictation']
   }
 ] as const satisfies readonly FeatureTip[]

--- a/src/shared/feature-tips.ts
+++ b/src/shared/feature-tips.ts
@@ -57,7 +57,7 @@ export const FEATURE_TIPS = [
     priority: 'unseen',
     eyebrow: 'Tip',
     title: 'Dictate into any pane',
-    description: "Turn speech into text wherever you're working.",
+    description: 'Start voice dictation in any focused pane, then use the shortcut again to stop.',
     action: 'enable-voice',
     ctaLabel: 'Set up voice',
     completedByFeatureInteractions: ['voice-dictation']


### PR DESCRIPTION
## Summary

- restyle the voice dictation education modal to match Orca's newer split feature-tip layout
- demonstrate dictation with a one-shot, character-by-character agent prompt preview
- use the full prompt width before wrapping and respect reduced-motion preferences
- show the live platform shortcut and provide a direct Settings → Voice path

## Validation

- 36 focused feature-tip tests passed
- `pnpm run typecheck:web`
- `pnpm run check:code-quality:changed`
- localization catalog and extraction checks
- max-lines ratchet
- launched the real Electron app from this worktree and attached over CDP
- verified the prompt types to completion, uses the full available line width, and opens Voice settings from the inline link

## Screenshots

### Mid-dictation

![Voice dictation feature tip while the sample prompt is being transcribed](https://github.com/user-attachments/assets/fae1b233-1231-40c8-bb65-05361207af3a)

### Completed prompt

![Voice dictation feature tip after the sample prompt finishes transcribing](https://github.com/user-attachments/assets/1e5eeaf5-a377-4656-b128-27273fd1c572)

