### PR TITLE
Revert Slack emoji alias expansion

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -269,13 +269,13 @@ describe('SmartWorkspaceNameField emoji shortcodes', () => {
     act(() => {
       Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
         input,
-        'Launch :flag-kr: experiment'
+        'Launch :wink: experiment'
       )
-      input.setSelectionRange(16, 16)
+      input.setSelectionRange(13, 13)
       input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }))
     })
 
-    expect(onValueChange).toHaveBeenCalledWith('Launch 🇰🇷 experiment')
+    expect(onValueChange).toHaveBeenCalledWith('Launch 😉 experiment')
   })
 
   it('accepts the highlighted shortcode suggestion with Enter', () => {

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
@@ -11,19 +11,6 @@ describe('workspace emoji shortcodes', () => {
     expect(searchWorkspaceEmojiShortcodes('wink', 1)).toEqual([{ emoji: '😉', shortcode: 'wink' }])
   })
 
-  it('finds Slack flag aliases', () => {
-    expect(searchWorkspaceEmojiShortcodes('kr', 1)).toEqual([{ emoji: '🇰🇷', shortcode: 'kr' }])
-    expect(searchWorkspaceEmojiShortcodes('flag-kr', 1)).toEqual([
-      { emoji: '🇰🇷', shortcode: 'flag-kr' }
-    ])
-  })
-
-  it('finds Slack aliases absent from the GitHub catalog', () => {
-    expect(searchWorkspaceEmojiShortcodes('mostly_sunny', 1)).toEqual([
-      { emoji: '🌤', shortcode: 'mostly_sunny' }
-    ])
-  })
-
   it('ranks an exact shortcode before longer aliases', () => {
     expect(searchWorkspaceEmojiShortcodes('heart', 3)[0]).toMatchObject({
       shortcode: 'heart'
@@ -49,27 +36,6 @@ describe('workspace emoji shortcodes', () => {
     expect(replaceCompletedWorkspaceEmojiShortcode('Ship :wink: today', 11)).toEqual({
       value: 'Ship 😉 today',
       cursor: 7
-    })
-  })
-
-  it('replaces a completed Slack-only flag alias', () => {
-    expect(replaceCompletedWorkspaceEmojiShortcode('Ship :flag-kr:', 14)).toEqual({
-      value: 'Ship 🇰🇷',
-      cursor: 9
-    })
-  })
-
-  it('supports the longest Slack aliases', () => {
-    const shortcode = 'smiling_face_with_smiling_eyes_and_hand_covering_mouth'
-    const completed = `:${shortcode}:`
-    expect(getActiveWorkspaceEmojiShortcode(`:${shortcode}`, shortcode.length + 1)).toEqual({
-      start: 0,
-      end: shortcode.length + 1,
-      query: shortcode
-    })
-    expect(replaceCompletedWorkspaceEmojiShortcode(completed, completed.length)).toEqual({
-      value: '🤭',
-      cursor: 2
     })
   })
 

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -17,15 +17,6 @@ export type WorkspaceEmojiReplacement = {
 }
 
 const SHORTCODE_ENTRIES = STANDARD_EMOJI_SHORTCODE_ENTRIES
-const MAX_SHORTCODE_LENGTH = 64
-const ACTIVE_SHORTCODE_PATTERN = new RegExp(
-  `(^|\\s):([a-z0-9_+-]{1,${MAX_SHORTCODE_LENGTH}})$`,
-  'i'
-)
-const COMPLETED_SHORTCODE_PATTERN = new RegExp(
-  `(^|\\s):([a-z0-9_+-]{1,${MAX_SHORTCODE_LENGTH}}):$`,
-  'i'
-)
 
 const EXACT_SHORTCODE = new Map(
   SHORTCODE_ENTRIES.map(({ emoji, shortcode }) => [shortcode, { emoji, shortcode }])
@@ -70,7 +61,7 @@ export function getActiveWorkspaceEmojiShortcode(
   if (cursor === null || cursor < 0 || cursor > value.length) {
     return null
   }
-  const match = value.slice(0, cursor).match(ACTIVE_SHORTCODE_PATTERN)
+  const match = value.slice(0, cursor).match(/(^|\s):([a-z0-9_+-]{1,40})$/i)
   if (!match) {
     return null
   }
@@ -88,7 +79,7 @@ export function replaceCompletedWorkspaceEmojiShortcode(
   if (cursor === null || cursor < 0 || cursor > value.length) {
     return null
   }
-  const match = value.slice(0, cursor).match(COMPLETED_SHORTCODE_PATTERN)
+  const match = value.slice(0, cursor).match(/(^|\s):([a-z0-9_+-]{1,40}):$/i)
   if (!match) {
     return null
   }

--- a/src/shared/emoji-shortcode-catalog.ts
+++ b/src/shared/emoji-shortcode-catalog.ts
@@ -1,39 +1,24 @@
-import githubEmojiShortcodes from 'emojibase-data/en/shortcodes/github.json'
-import slackEmojiShortcodes from 'emojibase-data/en/shortcodes/iamcal.json'
+import emojiShortcodes from 'emojibase-data/en/shortcodes/github.json'
 
 export type StandardEmojiShortcodeEntry = {
   emoji: string
   shortcode: string
 }
 
-const GITHUB_EMOJI_SHORTCODE_ENTRIES = toEmojiShortcodeEntries(githubEmojiShortcodes)
-const GITHUB_SHORTCODES = new Set(GITHUB_EMOJI_SHORTCODE_ENTRIES.map(({ shortcode }) => shortcode))
-
-// Emojibase's iamcal preset backs its Slack shortcode catalog.
-const SLACK_EMOJI_SHORTCODE_ENTRIES = toEmojiShortcodeEntries(slackEmojiShortcodes)
-
-export const STANDARD_EMOJI_SHORTCODE_ENTRIES: readonly StandardEmojiShortcodeEntry[] = [
-  ...GITHUB_EMOJI_SHORTCODE_ENTRIES,
-  ...SLACK_EMOJI_SHORTCODE_ENTRIES.filter(({ shortcode }) => !GITHUB_SHORTCODES.has(shortcode))
-]
+export const STANDARD_EMOJI_SHORTCODE_ENTRIES: readonly StandardEmojiShortcodeEntry[] =
+  Object.entries(emojiShortcodes).flatMap(([hexcode, value]) => {
+    const shortcodes = typeof value === 'string' ? [value] : value
+    const emoji = hexcodeToEmoji(hexcode)
+    return shortcodes.map((shortcode) => ({ emoji, shortcode }))
+  })
 
 const PRIMARY_SHORTCODE_BY_EMOJI = new Map(
-  Object.entries(githubEmojiShortcodes).map(([hexcode, value]) => {
+  Object.entries(emojiShortcodes).map(([hexcode, value]) => {
     const shortcodes = typeof value === 'string' ? [value] : value
     const shortcode = shortcodes.find((candidate) => /^[a-z]/i.test(candidate)) ?? shortcodes[0]
     return [normalizeEmojiLookup(hexcodeToEmoji(hexcode)), shortcode]
   })
 )
-
-function toEmojiShortcodeEntries(
-  catalog: Record<string, string | string[]>
-): StandardEmojiShortcodeEntry[] {
-  return Object.entries(catalog).flatMap(([hexcode, value]) => {
-    const shortcodes = typeof value === 'string' ? [value] : value
-    const emoji = hexcodeToEmoji(hexcode)
-    return shortcodes.map((shortcode) => ({ emoji, shortcode }))
-  })
-}
 
 const EMOJI_SEGMENTER = new Intl.Segmenter('en', { granularity: 'grapheme' })
 


### PR DESCRIPTION
## Summary

Revert #11837 in full. A narrower replacement will handle Korean flag entry without adding Slack-specific shortcode coverage.

## Screenshots

No visual change.

## Testing

- [ ] pnpm lint
- [ ] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [x] Focused workspace emoji tests (14 passed)

## AI Review Report

Verified this is an exact revert of #11837 and restores the previously tested GitHub shortcode catalog and parser behavior. No platform-specific shortcuts, paths, shell behavior, SSH behavior, or Electron integrations are changed.

## Security Audit

No new input, command, path, auth, secret, dependency, network, or IPC behavior is introduced.

## Notes

A separate focused PR will add Korean flag support using Orca current shortcode convention.