### PR TITLE
feat(workspaces): add Korean flag shortcode

### DIFF
--- a/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
@@ -7,8 +7,14 @@ import {
 } from './workspace-emoji-shortcodes'
 
 describe('workspace emoji shortcodes', () => {
-  it('finds standard emoji by Slack-style shortcode', () => {
+  it('finds standard emoji by shortcode', () => {
     expect(searchWorkspaceEmojiShortcodes('wink', 1)).toEqual([{ emoji: '😉', shortcode: 'wink' }])
+  })
+
+  it('finds the Korean flag by workspace shortcode', () => {
+    expect(searchWorkspaceEmojiShortcodes('flag_kr', 1)).toEqual([
+      { emoji: '🇰🇷', shortcode: 'flag_kr' }
+    ])
   })
 
   it('ranks an exact shortcode before longer aliases', () => {
@@ -36,6 +42,13 @@ describe('workspace emoji shortcodes', () => {
     expect(replaceCompletedWorkspaceEmojiShortcode('Ship :wink: today', 11)).toEqual({
       value: 'Ship 😉 today',
       cursor: 7
+    })
+  })
+
+  it('replaces the completed Korean flag shortcode', () => {
+    expect(replaceCompletedWorkspaceEmojiShortcode(':flag_kr:', 9)).toEqual({
+      value: '🇰🇷',
+      cursor: 4
     })
   })
 

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -16,7 +16,14 @@ export type WorkspaceEmojiReplacement = {
   value: string
 }
 
-const SHORTCODE_ENTRIES = STANDARD_EMOJI_SHORTCODE_ENTRIES
+const WORKSPACE_EMOJI_SHORTCODE_ADDITIONS: readonly WorkspaceEmojiSuggestion[] = [
+  { emoji: '🇰🇷', shortcode: 'flag_kr' }
+]
+
+const SHORTCODE_ENTRIES = [
+  ...STANDARD_EMOJI_SHORTCODE_ENTRIES,
+  ...WORKSPACE_EMOJI_SHORTCODE_ADDITIONS
+]
 
 const EXACT_SHORTCODE = new Map(
   SHORTCODE_ENTRIES.map(({ emoji, shortcode }) => [shortcode, { emoji, shortcode }])

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -190,7 +190,7 @@ test.describe('Create Workspace', () => {
     }
   })
 
-  test('enters emoji with Slack-style shortcode suggestions', async ({ orcaPage }) => {
+  test('enters the Korean flag with a workspace shortcode suggestion', async ({ orcaPage }) => {
     try {
       await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
 
@@ -198,11 +198,11 @@ test.describe('Create Workspace', () => {
       const nameInput = dialog.getByPlaceholder(/Type a name/i)
       await expect(nameInput).toBeVisible()
 
-      await nameInput.pressSequentially('Launch :wink', { delay: 100 })
+      await nameInput.pressSequentially('Launch :flag_kr', { delay: 100 })
       const emojiSuggestions = orcaPage.locator('[data-workspace-emoji-suggestions="true"]')
       const sourceSuggestions = orcaPage.locator('[data-workspace-source-suggestions="true"]')
       await expect(emojiSuggestions).toBeVisible()
-      await expect(emojiSuggestions.getByRole('option', { name: ':wink:' })).toBeVisible()
+      await expect(emojiSuggestions.getByRole('option', { name: ':flag_kr:' })).toBeVisible()
       await expect(emojiSuggestions).toHaveAttribute('data-side', 'top')
       await expect(sourceSuggestions).toBeVisible()
       await expect(sourceSuggestions).toHaveAttribute('data-side', 'bottom')
@@ -210,10 +210,10 @@ test.describe('Create Workspace', () => {
       await orcaPage.waitForTimeout(750)
 
       await nameInput.pressSequentially(':')
-      await expect(nameInput).toHaveValue('Launch 😉')
-      await expect(orcaPage.getByRole('option', { name: /:wink:/i })).toHaveCount(0)
+      await expect(nameInput).toHaveValue('Launch 🇰🇷')
+      await expect(orcaPage.getByRole('option', { name: /:flag_kr:/i })).toHaveCount(0)
       await nameInput.pressSequentially(' experiment')
-      await expect(nameInput).toHaveValue('Launch 😉 experiment')
+      await expect(nameInput).toHaveValue('Launch 🇰🇷 experiment')
       // Keep the asserted result visible in retained proof recordings.
       await orcaPage.waitForTimeout(750)
     } finally {


### PR DESCRIPTION
## Summary

- add `:flag_kr:` as a focused workspace emoji shortcode for 🇰🇷
- cover shortcode search and completed replacement
- verify the full picker flow in packaged Electron

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (42,643 passed; 78 skipped)
- packaged Electron E2E for the Korean flag shortcode