### PR TITLE
fix(github): target upstream when creating PRs from forks (#8843)

### DIFF
--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -6,6 +6,7 @@ const {
   getOwnerRepoMock,
   getOwnerRepoForRemoteMock,
   getEnterpriseGitHubRepoSlugMock,
+  getEnterpriseGitHubRepoSlugForRemoteMock,
   extractExecErrorMock,
   acquireMock,
   releaseMock,
@@ -15,6 +16,7 @@ const {
   getOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   getEnterpriseGitHubRepoSlugMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugForRemoteMock: vi.fn(),
   extractExecErrorMock: vi.fn((error: unknown) => {
     const value = error as { stderr?: string; stdout?: string; message?: string }
     return {
@@ -58,6 +60,7 @@ vi.mock('../git/runner', () => ({
 
 vi.mock('./github-enterprise-repository', () => ({
   getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock,
+  getEnterpriseGitHubRepoSlugForRemote: getEnterpriseGitHubRepoSlugForRemoteMock,
   isGitHubHostAuthenticated: vi.fn().mockResolvedValue(true)
 }))
 
@@ -85,6 +88,8 @@ describe('createGitHubPullRequest', () => {
     )
     getEnterpriseGitHubRepoSlugMock.mockReset()
     getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugForRemoteMock.mockReset()
+    getEnterpriseGitHubRepoSlugForRemoteMock.mockResolvedValue(null)
     extractExecErrorMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
@@ -92,8 +97,15 @@ describe('createGitHubPullRequest', () => {
     acquireMock.mockResolvedValue(undefined)
   })
 
+  const mockNonForkRepository = () => {
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ isFork: false, parent: null })
+    })
+  }
+
   it('creates a GitHub pull request with normalized refs and a body file', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 42,
@@ -116,7 +128,7 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.com/acme/widgets/pull/42'
     })
 
-    const [args, options] = ghExecFileAsyncMock.mock.calls[0]
+    const [args, options] = ghExecFileAsyncMock.mock.calls[1]
     expect(args).toEqual(
       expect.arrayContaining([
         'pr',
@@ -138,14 +150,33 @@ describe('createGitHubPullRequest', () => {
       timeout: 60_000,
       idempotent: false
     })
-    expect(acquireMock).toHaveBeenCalledOnce()
-    expect(releaseMock).toHaveBeenCalledOnce()
+    expect(acquireMock).toHaveBeenCalledTimes(2)
+    expect(releaseMock).toHaveBeenCalledTimes(2)
   })
 
-  it('targets the origin fork (not the upstream parent) on a fork checkout (#7331)', async () => {
-    // Fork checkout: origin is the personal fork, upstream is the parent. The
-    // head branch is unqualified and lives on the fork, so `gh pr create` must
-    // run with --repo <fork> even though PR reads prefer upstream since #7331.
+  it('keeps the target and head in one repository when upstream matches origin', async () => {
+    getOwnerRepoForRemoteMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ number: 4, url: 'https://github.com/acme/widgets/pull/4' })
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/same-repository',
+        title: 'Same repository'
+      })
+    ).resolves.toMatchObject({ ok: true, number: 4 })
+
+    const [args] = ghExecFileAsyncMock.mock.calls[1]
+    expect(args[args.indexOf('--repo') + 1]).toBe('acme/widgets')
+    expect(args[args.indexOf('--head') + 1]).toBe('feature/same-repository')
+  })
+
+  it('targets the upstream parent and qualifies the fork head on a fork checkout', async () => {
+    // The target and head repositories are separate GitHub PR topology values.
     getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
       remoteName === 'origin'
         ? { owner: 'fsdwen', repo: 'orca' }
@@ -172,19 +203,43 @@ describe('createGitHubPullRequest', () => {
     })
 
     const [args] = ghExecFileAsyncMock.mock.calls[0]
-    expect(args[args.indexOf('--repo') + 1]).toBe('fsdwen/orca')
-    expect(args[args.indexOf('--head') + 1]).toBe('my-branch')
+    expect(args[args.indexOf('--repo') + 1]).toBe('stablyai/orca')
+    expect(args[args.indexOf('--head') + 1]).toBe('fsdwen:my-branch')
+  })
+
+  it('falls back to the origin repository when no upstream is available', async () => {
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin' ? { owner: 'acme', repo: 'widgets' } : null
+    )
+    mockNonForkRepository()
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ number: 6, url: 'https://github.com/acme/widgets/pull/6' })
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/no-upstream',
+        title: 'Origin fallback'
+      })
+    ).resolves.toMatchObject({ ok: true, number: 6 })
+
+    const [args] = ghExecFileAsyncMock.mock.calls[1]
+    expect(args[args.indexOf('--repo') + 1]).toBe('acme/widgets')
+    expect(args[args.indexOf('--head') + 1]).toBe('feature/no-upstream')
   })
 
   it('routes --repo to the Enterprise server via options.host for a GHES remote (#8312)', async () => {
     // github.com-only slug parsing misses GHES, so creation comes from the
     // enterprise resolver, which carries the host.
-    getOwnerRepoMock.mockResolvedValueOnce(null)
+    getOwnerRepoMock.mockResolvedValue(null)
     getEnterpriseGitHubRepoSlugMock.mockResolvedValueOnce({
       owner: 'team',
       repo: 'orca',
       host: 'github.acme-corp.com'
     })
+    mockNonForkRepository()
     // gh prints the PR URL (not JSON); the GHES host must still parse directly.
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: 'https://github.acme-corp.com/team/orca/pull/7\n'
@@ -203,7 +258,7 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.acme-corp.com/team/orca/pull/7'
     })
 
-    const [args, options] = ghExecFileAsyncMock.mock.calls[0]
+    const [args, options] = ghExecFileAsyncMock.mock.calls[1]
     // The runner host-qualifies argv at spawn time from options.host, so the
     // mocked call sees a bare owner/repo plus the host in exec options.
     expect(args[args.indexOf('--repo') + 1]).toBe('team/orca')
@@ -217,6 +272,7 @@ describe('createGitHubPullRequest', () => {
       repo: 'orca',
       host: 'github.acme-corp.com'
     })
+    mockNonForkRepository()
     // Create reports "already exists", forcing the pr-list fallback.
     ghExecFileAsyncMock
       .mockRejectedValueOnce(
@@ -244,14 +300,15 @@ describe('createGitHubPullRequest', () => {
       existingReview: { number: 9, url: 'https://github.acme-corp.com/team/orca/pull/9' }
     })
 
-    const [listArgs, listOptions] = ghExecFileAsyncMock.mock.calls[1]
+    const [listArgs, listOptions] = ghExecFileAsyncMock.mock.calls[2]
     expect(listArgs).toEqual(expect.arrayContaining(['pr', 'list']))
     expect(listArgs[listArgs.indexOf('--repo') + 1]).toBe('team/orca')
     expect(listOptions).toMatchObject({ host: 'github.acme-corp.com' })
   })
 
   it('runs local WSL project pull request creation through the selected distro', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 43,
@@ -277,7 +334,7 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.com/acme/widgets/pull/43'
     })
 
-    const [, options] = ghExecFileAsyncMock.mock.calls[0]
+    const [, options] = ghExecFileAsyncMock.mock.calls[1]
     expect(options).toMatchObject({
       cwd: '/repo-root',
       wslDistro: 'Ubuntu',
@@ -287,7 +344,8 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('creates SSH-backed pull requests without using the remote path as a local cwd', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         number: 45,
@@ -318,7 +376,7 @@ describe('createGitHubPullRequest', () => {
       'ssh-1',
       {}
     )
-    const [args, options] = ghExecFileAsyncMock.mock.calls[0]
+    const [args, options] = ghExecFileAsyncMock.mock.calls[1]
     expect(args).toEqual(
       expect.arrayContaining([
         'pr',
@@ -369,7 +427,8 @@ describe('createGitHubPullRequest', () => {
         throw new Error('missing template')
       })
       getSshFilesystemProviderMock.mockReturnValue({ readFile: readRemoteFile })
-      getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+      getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+      mockNonForkRepository()
       const writtenBodies: string[] = []
       ghExecFileAsyncMock.mockImplementationOnce(async (args: string[]) => {
         const bodyPath = args[args.indexOf('--body-file') + 1]
@@ -409,7 +468,8 @@ describe('createGitHubPullRequest', () => {
   )
 
   it('falls back to parsing the PR URL for older gh output', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: 'https://github.com/acme/widgets/pull/43\n'
     })
@@ -429,7 +489,8 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('returns the existing PR when gh reports an already-open pull request', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
     ghExecFileAsyncMock
       .mockRejectedValueOnce({ stderr: 'a pull request already exists for feature/existing' })
       .mockResolvedValueOnce({
@@ -458,7 +519,7 @@ describe('createGitHubPullRequest', () => {
       }
     })
 
-    expect(ghExecFileAsyncMock.mock.calls[1]).toEqual([
+    expect(ghExecFileAsyncMock.mock.calls[2]).toEqual([
       [
         'pr',
         'list',
@@ -482,7 +543,8 @@ describe('createGitHubPullRequest', () => {
   })
 
   it('validates base, head, and title before invoking gh', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    mockNonForkRepository()
 
     await expect(
       createGitHubPullRequest('/repo-root', {

--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -184,6 +184,12 @@ describe('createGitHubPullRequest', () => {
     )
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
+        isFork: true,
+        parent: { name: 'orca', owner: { login: 'stablyai' } }
+      })
+    })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
         number: 5,
         url: 'https://github.com/fsdwen/orca/pull/5'
       })
@@ -202,9 +208,95 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.com/fsdwen/orca/pull/5'
     })
 
-    const [args] = ghExecFileAsyncMock.mock.calls[0]
+    const [args] = ghExecFileAsyncMock.mock.calls[1]
     expect(args[args.indexOf('--repo') + 1]).toBe('stablyai/orca')
     expect(args[args.indexOf('--head') + 1]).toBe('fsdwen:my-branch')
+  })
+
+  it('uses the GitHub parent for a plain clone of a fork', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'fsdwen', repo: 'orca' })
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin' ? { owner: 'fsdwen', repo: 'orca' } : null
+    )
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        isFork: true,
+        parent: { name: 'orca', owner: { login: 'stablyai' } }
+      })
+    })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ number: 8, url: 'https://github.com/stablyai/orca/pull/8' })
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Plain clone fork PR'
+      })
+    ).resolves.toMatchObject({ ok: true, number: 8 })
+
+    const [args] = ghExecFileAsyncMock.mock.calls[1]
+    expect(args[args.indexOf('--repo') + 1]).toBe('stablyai/orca')
+    expect(args[args.indexOf('--head') + 1]).toBe('fsdwen:my-branch')
+  })
+
+  it('looks up an existing fork PR through the REST head filter', async () => {
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin'
+        ? { owner: 'fsdwen', repo: 'orca' }
+        : { owner: 'stablyai', repo: 'orca' }
+    )
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        isFork: true,
+        parent: { name: 'orca', owner: { login: 'stablyai' } }
+      })
+    })
+    ghExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('already exists'), {
+        stderr: 'a pull request for branch "my-branch" already exists'
+      })
+    )
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([{ number: 9, html_url: 'https://github.com/stablyai/orca/pull/9' }])
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Existing fork PR'
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'already_exists',
+      existingReview: { number: 9, url: 'https://github.com/stablyai/orca/pull/9' }
+    })
+
+    const [lookupArgs] = ghExecFileAsyncMock.mock.calls[2]
+    expect(lookupArgs[0]).toBe('api')
+    expect(lookupArgs[1]).toContain('head=fsdwen%3Amy-branch')
+    expect(lookupArgs[1]).toContain('base=main')
+    expect(ghExecFileAsyncMock.mock.calls[2][0]).not.toContain('pr')
+  })
+
+  it('fails closed when fork ownership cannot be verified', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'fsdwen', repo: 'orca' })
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('temporary GitHub failure'))
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Unverified fork PR'
+      })
+    ).resolves.toMatchObject({ ok: false, code: 'validation' })
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to the origin repository when no upstream is available', async () => {

--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -299,6 +299,83 @@ describe('createGitHubPullRequest', () => {
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
+  it('fails closed when GitHub returns a fork without parent metadata', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'fsdwen', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ isFork: true, parent: null })
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Malformed fork PR'
+      })
+    ).resolves.toMatchObject({ ok: false, code: 'validation' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects an upstream remote that disagrees with the verified parent', async () => {
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin'
+        ? { owner: 'fsdwen', repo: 'orca' }
+        : { owner: 'other-owner', repo: 'orca' }
+    )
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        isFork: true,
+        parent: { name: 'orca', owner: { login: 'stablyai' } }
+      })
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Mismatched upstream PR'
+      })
+    ).resolves.toMatchObject({ ok: false, code: 'validation' })
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers an existing fork PR after unknown completion', async () => {
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin'
+        ? { owner: 'fsdwen', repo: 'orca' }
+        : { owner: 'stablyai', repo: 'orca' }
+    )
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        isFork: true,
+        parent: { name: 'orca', owner: { login: 'stablyai' } }
+      })
+    })
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('request timed out'))
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify([{ number: 10, html_url: 'https://github.com/stablyai/orca/pull/10' }])
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Unknown completion fork PR'
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'already_exists',
+      existingReview: { number: 10, url: 'https://github.com/stablyai/orca/pull/10' }
+    })
+
+    expect(ghExecFileAsyncMock.mock.calls[2][0]).toEqual([
+      'api',
+      expect.stringContaining('head=fsdwen%3Amy-branch')
+    ])
+  })
+
   it('falls back to the origin repository when no upstream is available', async () => {
     getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
       remoteName === 'origin' ? { owner: 'acme', repo: 'widgets' } : null

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1682,12 +1682,7 @@ async function resolveCreatePRTopology(
     connectionId,
     localGitOptions
   )
-  const { ghOptions } = await resolveGitHubRepoExecution(
-    repoPath,
-    undefined,
-    connectionId,
-    localGitOptions
-  )
+  const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
 
   let data: { isFork?: boolean; parent?: { name?: string; owner?: { login?: string } } | null }
   await acquire()
@@ -1723,7 +1718,8 @@ async function resolveCreatePRTopology(
       return {
         ok: false,
         code: 'validation',
-        error: 'Create PR failed: the upstream remote is not the verified fork parent.'
+        error:
+          'Create PR failed: the upstream remote does not match the verified origin repository.'
       }
     }
     return { ok: true, targetRepo: headRepo }

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1664,6 +1664,95 @@ export async function getRepoUpstream(
   }
 }
 
+type CreatePRTopology =
+  | { ok: true; targetRepo: GitHubApiRepository }
+  | Extract<CreateHostedReviewResult, { ok: false }>
+
+async function resolveCreatePRTopology(
+  repoPath: string,
+  headRepo: GitHubApiRepository,
+  connectionId?: string | null,
+  options: HostedReviewExecutionOptions = {}
+): Promise<CreatePRTopology> {
+  const localGitArgs = hostedReviewLocalGitOptionArgs(options)
+  const localGitOptions = localGitArgs[0] ?? {}
+  const upstreamRemote = await getGitHubApiRepositoryForRemote(
+    repoPath,
+    'upstream',
+    connectionId,
+    localGitOptions
+  )
+  const { ghOptions } = await resolveGitHubRepoExecution(
+    repoPath,
+    undefined,
+    connectionId,
+    localGitOptions
+  )
+
+  let data: { isFork?: boolean; parent?: { name?: string; owner?: { login?: string } } | null }
+  await acquire()
+  try {
+    const { stdout } = await ghExecFileAsync(
+      ['repo', 'view', githubRepositorySlugArg(headRepo), '--json', 'isFork,parent'],
+      {
+        ...ghOptions,
+        ...githubHostExecOptions(headRepo),
+        timeout: 10_000
+      }
+    )
+    data = JSON.parse(stdout) as typeof data
+  } catch {
+    return {
+      ok: false,
+      code: 'validation',
+      error: 'Create PR failed: GitHub fork ownership could not be verified.'
+    }
+  } finally {
+    release()
+  }
+
+  if (typeof data.isFork !== 'boolean') {
+    return {
+      ok: false,
+      code: 'validation',
+      error: 'Create PR failed: GitHub fork ownership could not be verified.'
+    }
+  }
+  if (!data.isFork) {
+    if (upstreamRemote && !sameOwnerRepo(upstreamRemote, headRepo)) {
+      return {
+        ok: false,
+        code: 'validation',
+        error: 'Create PR failed: the upstream remote is not the verified fork parent.'
+      }
+    }
+    return { ok: true, targetRepo: headRepo }
+  }
+
+  const owner = data.parent?.owner?.login
+  const repo = data.parent?.name
+  if (!owner || !repo) {
+    return {
+      ok: false,
+      code: 'validation',
+      error: 'Create PR failed: GitHub returned a fork without a parent repository.'
+    }
+  }
+  const parentRepo: GitHubApiRepository = {
+    owner,
+    repo,
+    ...(headRepo.host ? { host: headRepo.host } : {})
+  }
+  if (upstreamRemote && !sameOwnerRepo(upstreamRemote, parentRepo)) {
+    return {
+      ok: false,
+      code: 'validation',
+      error: 'Create PR failed: the upstream remote does not match the verified fork parent.'
+    }
+  }
+  return { ok: true, targetRepo: parentRepo }
+}
+
 function classifyCreatePRError(error: unknown): CreateHostedReviewResult {
   const { stderr, stdout } = extractExecError(error)
   const message = `${stderr}\n${stdout}`.trim()
@@ -1740,12 +1829,32 @@ function parseCreatePRPayload(stdout: string): { number: number; url: string } |
 async function findOpenPRByHeadBase(args: {
   repoPath: string
   repo: GitHubApiRepository
+  headRepo: GitHubApiRepository
   head: string
   base: string
   connectionId?: string | null
   options?: HostedReviewExecutionOptions
 }): Promise<{ number: number; url: string } | null> {
   const context = githubRepoContext(args.repoPath, args.connectionId)
+  const execOptions = {
+    ...ghRepoExecOptions(context),
+    ...(args.connectionId ? {} : getHostedReviewLocalGitOptions(args.options)),
+    ...githubHostExecOptions(args.repo)
+  }
+  if (!sameOwnerRepo(args.repo, args.headRepo)) {
+    const separator = args.head.indexOf(':')
+    if (separator <= 0 || separator === args.head.length - 1) {
+      return null
+    }
+    const existing = await getRestPRForBranch(
+      args.repo,
+      args.head.slice(0, separator),
+      args.head.slice(separator + 1),
+      execOptions,
+      { base: args.base, state: 'open' }
+    )
+    return existing ? { number: existing.number, url: existing.url } : null
+  }
   const { stdout } = await ghExecFileAsync(
     [
       'pr',
@@ -1763,11 +1872,7 @@ async function findOpenPRByHeadBase(args: {
       '--json',
       'number,url'
     ],
-    {
-      ...ghRepoExecOptions(context),
-      ...(args.connectionId ? {} : getHostedReviewLocalGitOptions(args.options)),
-      ...githubHostExecOptions(args.repo)
-    }
+    execOptions
   )
   const list = JSON.parse(stdout) as { number?: number; url?: string }[]
   if (list.length !== 1 || !list[0]?.number || !list[0]?.url) {
@@ -1856,7 +1961,11 @@ export async function createGitHubPullRequest(
     }
   }
 
-  const targetRepo = (await getRepoUpstream(repoPath, connectionId, options)) ?? headRepo
+  const topology = await resolveCreatePRTopology(repoPath, headRepo, connectionId, options)
+  if (!topology.ok) {
+    return topology
+  }
+  const targetRepo = topology.targetRepo
   const head =
     headRef && !sameOwnerRepo(targetRepo, headRepo) ? `${headRepo.owner}:${headRef}` : headRef
   // The runner host-qualifies --repo from options.host for GHES (#8312).
@@ -1906,6 +2015,7 @@ export async function createGitHubPullRequest(
         ? await findOpenPRByHeadBase({
             repoPath,
             repo: targetRepo,
+            headRepo,
             head,
             base,
             connectionId,
@@ -1930,6 +2040,7 @@ export async function createGitHubPullRequest(
         const existing = await findOpenPRByHeadBase({
           repoPath,
           repo: targetRepo,
+          headRepo,
           head,
           base,
           connectionId,
@@ -2369,11 +2480,17 @@ async function getRestPRForBranch(
   prRepo: GitHubApiRepository,
   headOwner: string,
   branchName: string,
-  ghOptions: ReturnType<typeof ghRepoExecOptions>
+  ghOptions: ReturnType<typeof ghRepoExecOptions>,
+  filters: { base?: string; state?: 'all' | 'open' } = {}
 ): Promise<PullRequestLookupData | null> {
   const head = encodeURIComponent(`${headOwner}:${branchName}`)
+  const base = filters.base ? `&base=${encodeURIComponent(filters.base)}` : ''
+  const state = filters.state ?? 'all'
   const { stdout } = await ghExecFileAsync(
-    ['api', `repos/${prRepo.owner}/${prRepo.repo}/pulls?head=${head}&state=all&per_page=1`],
+    [
+      'api',
+      `repos/${prRepo.owner}/${prRepo.repo}/pulls?head=${head}&state=${state}&per_page=1${base}`
+    ],
     { ...ghOptions, ...githubHostExecOptions(prRepo) }
   )
   const list = JSON.parse(stdout) as RestPullRequest[]

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1825,24 +1825,21 @@ export async function createGitHubPullRequest(
     }
   }
 
-  // Why: creation targets the origin owning the unqualified head branch; the shared resolver preserves its host (#7331, #8312).
-  const ownerRepo = await getOriginGitHubApiRepository(
+  // Why: the origin owns the unqualified head branch; the upstream, when present, owns the PR target (#7331, #8843).
+  const headRepo = await getOriginGitHubApiRepository(
     repoPath,
     connectionId,
     getHostedReviewLocalGitOptions(options)
   )
-  if (!ownerRepo) {
+  if (!headRepo) {
     return {
       ok: false,
       code: 'unsupported_provider',
       error: 'Creating pull requests requires a GitHub remote.'
     }
   }
-  // The runner host-qualifies --repo from options.host for GHES (#8312).
-  const repoArg = `${ownerRepo.owner}/${ownerRepo.repo}`
-
   const base = normalizeHostedReviewBaseRef(input.base)
-  const head = input.head ? normalizeHostedReviewHeadRef(input.head) || undefined : undefined
+  const headRef = input.head ? normalizeHostedReviewHeadRef(input.head) || undefined : undefined
   const title = input.title.trim()
   if (!base || !title) {
     return {
@@ -1851,13 +1848,19 @@ export async function createGitHubPullRequest(
       error: 'Create PR failed: base branch and title are required.'
     }
   }
-  if (head && head.toLowerCase() === base.toLowerCase()) {
+  if (headRef && headRef.toLowerCase() === base.toLowerCase()) {
     return {
       ok: false,
       code: 'validation',
       error: 'Create PR failed: choose a different base branch before creating a pull request.'
     }
   }
+
+  const targetRepo = (await getRepoUpstream(repoPath, connectionId, options)) ?? headRepo
+  const head =
+    headRef && !sameOwnerRepo(targetRepo, headRepo) ? `${headRepo.owner}:${headRef}` : headRef
+  // The runner host-qualifies --repo from options.host for GHES (#8312).
+  const repoArg = `${targetRepo.owner}/${targetRepo.repo}`
 
   const tempDir = await mkdtemp(join(tmpdir(), 'orca-pr-body-'))
   await acquire()
@@ -1891,7 +1894,7 @@ export async function createGitHubPullRequest(
       const { stdout } = await ghExecFileAsync(createArgs, {
         ...ghRepoExecOptions(context),
         ...(connectionId ? {} : getHostedReviewLocalGitOptions(options)),
-        ...githubHostExecOptions(ownerRepo),
+        ...githubHostExecOptions(targetRepo),
         timeout: 60_000,
         idempotent: false
       })
@@ -1902,7 +1905,7 @@ export async function createGitHubPullRequest(
       const found = head
         ? await findOpenPRByHeadBase({
             repoPath,
-            repo: ownerRepo,
+            repo: targetRepo,
             head,
             base,
             connectionId,
@@ -1926,7 +1929,7 @@ export async function createGitHubPullRequest(
       ) {
         const existing = await findOpenPRByHeadBase({
           repoPath,
-          repo: ownerRepo,
+          repo: targetRepo,
           head,
           base,
           connectionId,


### PR DESCRIPTION
## Summary

- Verify the fork parent before creating a GitHub PR.
- Target the verified upstream repository while keeping the fork owner and head branch separate.
- Recover existing cross-repository PRs through GitHub's REST head filter.

Closes #8843.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck:node`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests covering verified fork, plain fork clone, same-repository, missing-upstream, existing-PR lookup, host handling, and normalized branch behavior

Focused validation:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/github/client-create-pr.test.ts src/main/github/client.test.ts`
- [x] `pnpm typecheck:node`
- [x] `pnpm exec oxlint src/main/github/client.ts src/main/github/client-create-pr.test.ts`
- [x] `pnpm exec oxfmt --check src/main/github/client.ts src/main/github/client-create-pr.test.ts`
- [x] `git diff --check`

## AI Review Report

The change is confined to GitHub pull-request creation in `src/main/github/client.ts`. Fork topology is read once through `gh repo view --json isFork,parent` and the result decides the target repository; every unverifiable case fails closed with a validation error rather than falling back to the origin. The execution options for that call are built from the repo context helper the rest of the file uses, so connection-scoped, WSL, and SSH invocations keep the same cwd and host handling as neighbouring GitHub calls. Enterprise hosts stay pinned through `githubHostExecOptions`, so a process-level `GH_HOST` cannot redirect the lookup. The code paths are platform-neutral: no shell strings, path separators, or OS branches were added, and macOS, Linux, and Windows exercise the identical argv.

## Security Audit

The new call only reads repository metadata and never writes. Repository slugs reach `gh` as separate argv entries through the existing exec helper, so an owner or repo name cannot inject arguments. The head branch is qualified as `owner:branch` only when the target and head repositories differ, which keeps a fork branch from being interpreted as a branch on the upstream repository. When the upstream remote disagrees with GitHub's parent metadata, creation stops instead of opening a PR against an unintended repository. No credential, token, or filesystem boundary changed.

## Notes

The creation path now fails closed when the fork parent cannot be verified or when an upstream remote disagrees with GitHub's parent metadata. No UI or release files changed.
