### PR TITLE
fix(renderer): resume floating AI Vault workspaces (#11640)

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -6,10 +6,7 @@ import {
   type AiVaultResumeStartup
 } from '@/lib/ai-vault-resume-command'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
-import {
-  activateAndRevealFolderWorkspace,
-  activateAndRevealWorktree
-} from '@/lib/worktree-activation'
+import { activateAiVaultResumeWorkspace } from './ai-vault-session-resume-activation'
 import { useAppStore } from '@/store'
 import {
   canResumeAiVaultSessionOnTarget,
@@ -306,13 +303,4 @@ function aiVaultResumeUnsupportedMessage(
     'auto.components.right.sidebar.AiVaultPanel.openSupportedWorkspace',
     'Open a workspace before resuming a session.'
   )
-}
-
-function activateAiVaultResumeWorkspace(workspaceId: string): void {
-  const workspaceScope = parseWorkspaceKey(workspaceId)
-  if (workspaceScope?.type === 'folder') {
-    activateAndRevealFolderWorkspace(workspaceScope.folderWorkspaceId)
-    return
-  }
-  activateAndRevealWorktree(workspaceId)
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume-activation.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume-activation.ts
@@ -1,0 +1,26 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
+import { isFloatingWorkspacePanelVisible } from '@/lib/floating-workspace-terminal-actions'
+import {
+  activateAndRevealFolderWorkspace,
+  activateAndRevealWorktree
+} from '@/lib/worktree-activation'
+
+export function activateAiVaultResumeWorkspace(workspaceId: string): void {
+  const workspaceScope = parseWorkspaceKey(workspaceId)
+  if (workspaceScope?.type === 'folder') {
+    activateAndRevealFolderWorkspace(workspaceScope.folderWorkspaceId)
+    return
+  }
+
+  const worktreeId = workspaceScope?.type === 'worktree' ? workspaceScope.worktreeId : workspaceId
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    if (typeof window !== 'undefined' && !isFloatingWorkspacePanelVisible()) {
+      window.dispatchEvent(new Event(TOGGLE_FLOATING_TERMINAL_EVENT))
+    }
+    return
+  }
+
+  activateAndRevealWorktree(worktreeId)
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Repo, Worktree } from '../../../../shared/types'
 import type { AiVaultSessionWorktreeInfo } from './ai-vault-session-worktree'
 import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { resolveAiVaultSessionLaunchTarget } from './ai-vault-session-launch-actions'
+import { activateAiVaultResumeWorkspace } from './ai-vault-session-resume-activation'
 import {
   aiVaultSessionResumeLabel,
   aiVaultSessionRowResumeGating,
@@ -10,6 +12,21 @@ import {
   resolveAiVaultSessionResumeActions,
   resolveAiVaultSessionResumeState
 } from './ai-vault-session-resume'
+
+const activationMocks = vi.hoisted(() => ({
+  activateFolder: vi.fn(),
+  activateWorktree: vi.fn(),
+  isFloatingWorkspacePanelVisible: vi.fn()
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealFolderWorkspace: activationMocks.activateFolder,
+  activateAndRevealWorktree: activationMocks.activateWorktree
+}))
+
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  isFloatingWorkspacePanelVisible: activationMocks.isFloatingWorkspacePanelVisible
+}))
 
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
   return {
@@ -506,6 +523,19 @@ describe('resolveAiVaultSessionResumeActions', () => {
 })
 
 describe('resolveAiVaultSessionLaunchTarget', () => {
+  it('allows direct resume into the synthetic floating workspace', () => {
+    expect(
+      resolveAiVaultSessionLaunchTarget({
+        sessionFilePath: HOST_SESSION_FILE,
+        activeWorktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+        targetState: makeTargetState()
+      })
+    ).toEqual({
+      status: 'ready',
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID
+    })
+  })
+
   it('allows direct resume into an active SSH folder workspace', () => {
     expect(
       resolveAiVaultSessionLaunchTarget({
@@ -558,6 +588,63 @@ describe('resolveAiVaultSessionLaunchTarget', () => {
       status: 'unsupported',
       targetStatus: 'runtime'
     })
+  })
+
+  it('allows direct resume into a normal local worktree', () => {
+    expect(
+      resolveAiVaultSessionLaunchTarget({
+        sessionFilePath: HOST_SESSION_FILE,
+        activeWorktreeId: 'repo-1::/repo/orca',
+        targetState: makeTargetState({
+          repos: [makeRepo()],
+          worktreesByRepo: { 'repo-1': [makeWorktree()] }
+        })
+      })
+    ).toEqual({
+      status: 'ready',
+      worktreeId: 'repo-1::/repo/orca'
+    })
+  })
+
+  it('rejects an unknown target without activating a workspace', () => {
+    expect(
+      resolveAiVaultSessionLaunchTarget({
+        sessionFilePath: HOST_SESSION_FILE,
+        activeWorktreeId: 'missing-workspace',
+        targetState: makeTargetState()
+      })
+    ).toEqual({ status: 'missing' })
+  })
+})
+
+describe('activateAiVaultResumeWorkspace', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('opens the floating workspace once and leaves an already-open panel alone', () => {
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal('window', { dispatchEvent })
+    activationMocks.isFloatingWorkspacePanelVisible.mockReturnValue(false)
+
+    activateAiVaultResumeWorkspace(FLOATING_TERMINAL_WORKTREE_ID)
+    expect(dispatchEvent).toHaveBeenCalledTimes(1)
+    expect((dispatchEvent.mock.calls[0][0] as Event).type).toBe('orca-toggle-floating-terminal')
+
+    activationMocks.isFloatingWorkspacePanelVisible.mockReturnValue(true)
+    activateAiVaultResumeWorkspace(FLOATING_TERMINAL_WORKTREE_ID)
+    expect(dispatchEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves folder and normal worktree activation', () => {
+    vi.stubGlobal('window', { dispatchEvent: vi.fn() })
+
+    activateAiVaultResumeWorkspace(folderWorkspaceKey('folder-1'))
+    activateAiVaultResumeWorkspace('repo-1::/repo/orca')
+
+    expect(activationMocks.activateFolder).toHaveBeenCalledWith('folder-1')
+    expect(activationMocks.activateWorktree).toHaveBeenCalledWith('repo-1::/repo/orca')
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -1,4 +1,5 @@
 import type { Repo, Worktree } from '../../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
   canResumeAiVaultSessionOnTarget,
   getAiVaultResumeWorkspaceExecutionHostId,
@@ -139,6 +140,12 @@ export function isKnownAiVaultResumeWorkspaceTarget(
   }
 
   const workspaceKey = parseWorkspaceKey(workspaceId)
+  if (
+    workspaceId === FLOATING_TERMINAL_WORKTREE_ID ||
+    (workspaceKey?.type === 'worktree' && workspaceKey.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)
+  ) {
+    return true
+  }
   if (workspaceKey?.type === 'folder') {
     return state.folderWorkspaces.some(
       (workspace) => workspace.id === workspaceKey.folderWorkspaceId

--- a/src/renderer/src/lib/ai-vault-resume-target.ts
+++ b/src/renderer/src/lib/ai-vault-resume-target.ts
@@ -7,6 +7,7 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import type { Repo } from '../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { isWslUncPath } from '../../../shared/wsl-paths'
@@ -157,6 +158,9 @@ export function getAiVaultResumeWorkspaceTargetStatus(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return 'local'
+  }
   const worktree = getIndexedWorktreeMap(state.worktreesByRepo ?? {}).get(worktreeId)
   const worktreeHost = getAiVaultResumeExecutionHostTargetStatus(worktree?.hostId)
   if (worktreeHost !== 'unknown') {


### PR DESCRIPTION
## Summary

- Recognize the synthetic floating workspace as a valid AI Vault resume target.
- Activate and focus it idempotently while preserving folder, worktree, and unknown-target behavior.

Closes #11640.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts src/renderer/src/lib/ai-vault-resume-target.test.ts`
- `pnpm typecheck:web`
- Changed-file `pnpm exec oxlint`
- Changed-file `pnpm exec oxfmt --check`
- `git diff --check`

The focused Vitest run passed 55 tests across the resume and target-status suites. The base regression returned `status: 'missing'` for `global-floating-terminal`; the head accepts it and opens the existing floating panel through the renderer event bridge. Folder and normal worktree activation remain unchanged, and unknown targets remain rejected.

## AI Review Report

The change is limited to renderer target classification and activation. Repeated resume is guarded by the existing panel visibility check, folder and normal worktree activation retain their existing helpers, and malformed targets are rejected before activation. The implementation is platform-neutral; Electron focus timing remains covered by the existing floating panel lifecycle and should be confirmed by CI/browser execution on macOS, Linux, and Windows.

## Security Audit

The change uses the existing renderer activation commands and an explicit synthetic identifier. Unknown target data still fails target validation, no path is inferred from the session, and no IPC or filesystem boundary changes were added.

## Notes

Automatic historical session-to-floating-workspace provenance remains a separate follow-up because the current session model records no workspace owner.
