### PR TITLE
fix(editor): preserve Diff View undo history after save (#9204)

### DIFF
--- a/src/renderer/src/components/editor/ChangesModeView.test.tsx
+++ b/src/renderer/src/components/editor/ChangesModeView.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act, Suspense } from 'react'
+import { act, Suspense, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { OpenFile } from '@/store/slices/editor'
@@ -11,12 +11,30 @@ import {
 } from './large-diff-render-limit'
 
 const diffViewerMock = vi.hoisted(() => ({
-  latestProps: null as DiffViewerProps | null
+  latestProps: null as DiffViewerProps | null,
+  events: [] as string[],
+  models: new Map<string, { content: string; undo: string[] }>()
 }))
 
 vi.mock('./DiffViewer', () => ({
-  default: (props: DiffViewerProps) => {
+  default: function MockDiffViewer(props: DiffViewerProps) {
     diffViewerMock.latestProps = props
+    const modelKey = props.modifiedModelKey ?? props.modelKey
+    const model = diffViewerMock.models.get(modelKey) ?? {
+      content: props.modifiedContent,
+      undo: []
+    }
+    if (model.content !== props.modifiedContent) {
+      model.undo.push(model.content)
+      model.content = props.modifiedContent
+    }
+    diffViewerMock.models.set(modelKey, model)
+    useEffect(() => {
+      diffViewerMock.events.push(`mount:${modelKey}`)
+      return () => {
+        diffViewerMock.events.push(`unmount:${modelKey}`)
+      }
+    }, [modelKey])
     return <div data-testid="diff-viewer-probe" />
   }
 }))
@@ -60,6 +78,8 @@ describe('ChangesModeView', () => {
     container = null
     root = null
     diffViewerMock.latestProps = null
+    diffViewerMock.events.length = 0
+    diffViewerMock.models.clear()
   })
 
   it('passes pruned diff limits through and suppresses the identical-content banner', async () => {
@@ -132,5 +152,52 @@ describe('ChangesModeView', () => {
 
     await vi.waitFor(() => expect(diffViewerMock.latestProps).not.toBeNull())
     expect(diffViewerMock.latestProps?.modifiedModelKey).toBe('file-1:changes:modified:1')
+  })
+
+  it('keeps the modified model and undo history across a changes-mode save', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    const activeFile = createOpenFile()
+    const renderView = (modifiedContent: string): void => {
+      root?.render(
+        <Suspense fallback={null}>
+          <ChangesModeView
+            activeFile={activeFile}
+            dc={{
+              kind: 'text',
+              originalContent: 'head',
+              modifiedContent,
+              originalIsBinary: false,
+              modifiedIsBinary: false
+            }}
+            modifiedContent={modifiedContent}
+            activeConflictEntry={null}
+            resolvedLanguage="plaintext"
+            sideBySide={false}
+            viewStateScopeId="file-1"
+            diffViewStateKey="file-1:changes"
+            onContentChange={vi.fn()}
+            onSave={vi.fn()}
+          />
+        </Suspense>
+      )
+    }
+
+    await act(async () => renderView('initial content'))
+    const modelKey = diffViewerMock.latestProps?.modifiedModelKey
+    const model = modelKey ? diffViewerMock.models.get(modelKey) : undefined
+    if (!modelKey || !model) {
+      throw new Error('expected a changes-mode modified model')
+    }
+    model.content = 'user edit'
+    model.undo.push('initial content')
+
+    await act(async () => renderView('user edit'))
+
+    expect(diffViewerMock.latestProps?.modifiedModelKey).toBe(modelKey)
+    expect(diffViewerMock.events).toEqual([`mount:${modelKey}`])
+    expect(model).toEqual({ content: 'user edit', undo: ['initial content'] })
   })
 })

--- a/src/renderer/src/components/editor/ChangesModeView.test.tsx
+++ b/src/renderer/src/components/editor/ChangesModeView.test.tsx
@@ -98,4 +98,39 @@ describe('ChangesModeView', () => {
     expect(diffViewerMock.latestProps?.largeDiffRenderLimit).toBe(largeDiffRenderLimit)
     expect(container.textContent).not.toContain('No uncommitted changes.')
   })
+
+  it('rotates the modified model only for an explicit external reload', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    const diff = {
+      kind: 'text' as const,
+      originalContent: 'head',
+      modifiedContent: 'worktree',
+      originalIsBinary: false as const,
+      modifiedIsBinary: false as const
+    }
+
+    await act(async () => {
+      root?.render(
+        <Suspense fallback={null}>
+          <ChangesModeView
+            activeFile={{ ...createOpenFile(), diffContentReloadNonce: 1 }}
+            dc={diff}
+            modifiedContent="worktree"
+            activeConflictEntry={null}
+            resolvedLanguage="plaintext"
+            sideBySide={false}
+            viewStateScopeId="file-1"
+            diffViewStateKey="file-1:changes"
+            onContentChange={vi.fn()}
+            onSave={vi.fn()}
+          />
+        </Suspense>
+      )
+    })
+
+    await vi.waitFor(() => expect(diffViewerMock.latestProps).not.toBeNull())
+    expect(diffViewerMock.latestProps?.modifiedModelKey).toBe('file-1:changes:modified:1')
+  })
 })

--- a/src/renderer/src/components/editor/ChangesModeView.tsx
+++ b/src/renderer/src/components/editor/ChangesModeView.tsx
@@ -89,7 +89,7 @@ export function ChangesModeView({
       )}
       <div className="flex min-h-0 flex-1 flex-col">
         <DiffViewer
-          key={`${viewStateScopeId}:${diffReloadNonce}`}
+          key={viewStateScopeId}
           modelKey={diffViewStateKey}
           originalModelKey={originalModelKey}
           modifiedModelKey={modifiedModelKey}

--- a/src/renderer/src/components/editor/ChangesModeView.tsx
+++ b/src/renderer/src/components/editor/ChangesModeView.tsx
@@ -70,9 +70,12 @@ export function ChangesModeView({
   // HEAD-side blob in React state, but Monaco can keep painting the previous
   // diff if we reuse the same kept model identities. Rotate only the
   // original-side model identity so Monaco rebuilds the stale HEAD snapshot
-  // without throwing away the modified-side undo history.
+  // without throwing away the modified-side undo history. An explicit
+  // external reload nonce rotates both sides to discard stale undo content.
   const headContentSignature = getDiffContentSignature(dc.originalContent)
   const originalModelKey = `${diffViewStateKey}:original:${headContentSignature}`
+  const diffReloadNonce = activeFile.diffContentReloadNonce ?? 0
+  const modifiedModelKey = `${diffViewStateKey}:modified:${diffReloadNonce}`
   return (
     <div className="flex flex-1 min-h-0 flex-col">
       {activeFile.conflict && <ConflictBanner file={activeFile} entry={activeConflictEntry} />}
@@ -86,9 +89,10 @@ export function ChangesModeView({
       )}
       <div className="flex min-h-0 flex-1 flex-col">
         <DiffViewer
-          key={viewStateScopeId}
+          key={`${viewStateScopeId}:${diffReloadNonce}`}
           modelKey={diffViewStateKey}
           originalModelKey={originalModelKey}
+          modifiedModelKey={modifiedModelKey}
           originalContent={dc.originalContent}
           modifiedContent={modifiedContent}
           largeDiffRenderLimit={dc.largeDiffRenderLimit}

--- a/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
@@ -287,7 +287,7 @@ describe('EditorContent Monaco lifecycle boundary', () => {
     expect(model).toMatchObject({ content: 'user edit', undo: ['base content'] })
   })
 
-  it('replaces the diff model for an explicit external reload', () => {
+  it('replaces the diff model without remounting for an explicit external reload', () => {
     const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
     const view = render(<EditorContent {...diffProps(diff, 'saved content')} />)
     const previousModelKey = lifecycle.diffModelKeys[0]
@@ -302,31 +302,14 @@ describe('EditorContent Monaco lifecycle boundary', () => {
       />
     )
 
-    expect(lifecycle.events).toEqual([
-      'mount-diff:/repo/notes.ts',
-      'unmount-diff:/repo/notes.ts',
-      'mount-diff:/repo/notes.ts'
-    ])
+    expect(lifecycle.events).toEqual(['mount-diff:/repo/notes.ts'])
     const nextModelKey = lifecycle.diffModelKeys[1]
     expect(nextModelKey).not.toBe(previousModelKey)
-    expect(previousModel?.disposeCount).toBe(1)
+    expect(previousModel?.disposeCount).toBe(0)
     expect(lifecycle.diffModels.get(nextModelKey)).toMatchObject({
       content: 'external replacement',
       undo: []
     })
-  })
-
-  it('disposes the active diff model exactly once on unmount', () => {
-    const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
-    const view = render(<EditorContent {...diffProps(diff, 'saved content')} />)
-    const model = lifecycle.diffModels.get(lifecycle.diffModelKeys[0])
-    if (!model) {
-      throw new Error('expected an active diff model')
-    }
-
-    view.unmount()
-
-    expect(model.disposeCount).toBe(1)
   })
 
   it('passes live-tail ownership only for a read-only live log', () => {

--- a/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
@@ -6,6 +6,7 @@ import type { OpenFile } from '@/store/slices/editor'
 const lifecycle = vi.hoisted(() => ({
   events: [] as string[],
   diffModelKeys: [] as string[],
+  diffModels: new Map<string, { content: string; undo: string[]; disposeCount: number }>(),
   models: new Map<string, { content: string; undo: string[] }>(),
   notebookProps: [] as {
     fileId: string
@@ -34,12 +35,28 @@ vi.mock('@/lib/lazy-with-retry', async () => {
   return {
     lazyWithRetry: (factory: () => Promise<unknown>) => {
       if (factory.toString().includes('/DiffViewer.tsx')) {
-        return function MockDiffViewer(props: { filePath: string; modifiedModelKey?: string }) {
-          lifecycle.diffModelKeys.push(props.modifiedModelKey ?? '')
+        return function MockDiffViewer(props: {
+          filePath: string
+          modifiedModelKey?: string
+          modifiedContent?: string
+        }) {
+          const modelKey = props.modifiedModelKey ?? ''
+          const model = lifecycle.diffModels.get(modelKey) ?? {
+            content: props.modifiedContent ?? '',
+            undo: [],
+            disposeCount: 0
+          }
+          if (model.content !== props.modifiedContent) {
+            model.undo.push(model.content)
+            model.content = props.modifiedContent ?? ''
+          }
+          lifecycle.diffModels.set(modelKey, model)
+          lifecycle.diffModelKeys.push(modelKey)
           /* oxlint-disable react-hooks/exhaustive-deps -- Mount-only by design: a prop-effect would hide a missing outer React remount. */
           React.useEffect(() => {
             lifecycle.events.push(`mount-diff:${props.filePath}`)
             return () => {
+              model.disposeCount += 1
               lifecycle.events.push(`unmount-diff:${props.filePath}`)
             }
           }, [])
@@ -216,6 +233,7 @@ afterEach(() => {
   cleanup()
   lifecycle.events.length = 0
   lifecycle.diffModelKeys.length = 0
+  lifecycle.diffModels.clear()
   lifecycle.models.clear()
   lifecycle.mountedProps.length = 0
   lifecycle.notebookProps.length = 0
@@ -248,24 +266,40 @@ describe('EditorContent Monaco lifecycle boundary', () => {
   })
 
   it('keeps the diff editor mounted when a save updates the modified content', () => {
-    // Why: saves must rotate the retained model for freshness without remounting
-    // the editor and flashing Monaco's loading placeholder.
+    // Why: a save updates the retained model's content without replacing the
+    // model that owns the user's undo history.
     const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
 
-    const view = render(<EditorContent {...diffProps(diff, 'first save')} />)
-    view.rerender(<EditorContent {...diffProps(diff, 'second save')} />)
+    const view = render(<EditorContent {...diffProps(diff, 'base content')} />)
+    const modelKey = lifecycle.diffModelKeys[0]
+    const model = lifecycle.diffModels.get(modelKey)
+    if (!model) {
+      throw new Error('expected a retained diff model')
+    }
+    model.content = 'user edit'
+    model.undo.push('base content')
+
+    view.rerender(<EditorContent {...diffProps(diff, 'user edit')} />)
 
     expect(lifecycle.events).toEqual(['mount-diff:/repo/notes.ts'])
     expect(lifecycle.diffModelKeys).toHaveLength(2)
-    expect(lifecycle.diffModelKeys[1]).not.toBe(lifecycle.diffModelKeys[0])
+    expect(lifecycle.diffModelKeys[1]).toBe(modelKey)
+    expect(model).toMatchObject({ content: 'user edit', undo: ['base content'] })
   })
 
-  it('still remounts the diff editor for an explicit reload request', () => {
+  it('replaces the diff model for an explicit external reload', () => {
     const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
     const view = render(<EditorContent {...diffProps(diff, 'saved content')} />)
+    const previousModelKey = lifecycle.diffModelKeys[0]
+    const previousModel = lifecycle.diffModels.get(previousModelKey)
+    if (!previousModel) {
+      throw new Error('expected the original diff model')
+    }
 
     view.rerender(
-      <EditorContent {...diffProps({ ...diff, diffContentReloadNonce: 1 }, 'saved content')} />
+      <EditorContent
+        {...diffProps({ ...diff, diffContentReloadNonce: 1 }, 'external replacement')}
+      />
     )
 
     expect(lifecycle.events).toEqual([
@@ -273,6 +307,26 @@ describe('EditorContent Monaco lifecycle boundary', () => {
       'unmount-diff:/repo/notes.ts',
       'mount-diff:/repo/notes.ts'
     ])
+    const nextModelKey = lifecycle.diffModelKeys[1]
+    expect(nextModelKey).not.toBe(previousModelKey)
+    expect(previousModel?.disposeCount).toBe(1)
+    expect(lifecycle.diffModels.get(nextModelKey)).toMatchObject({
+      content: 'external replacement',
+      undo: []
+    })
+  })
+
+  it('disposes the active diff model exactly once on unmount', () => {
+    const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
+    const view = render(<EditorContent {...diffProps(diff, 'saved content')} />)
+    const model = lifecycle.diffModels.get(lifecycle.diffModelKeys[0])
+    if (!model) {
+      throw new Error('expected an active diff model')
+    }
+
+    view.unmount()
+
+    expect(model.disposeCount).toBe(1)
   })
 
   it('passes live-tail ownership only for a read-only live log', () => {

--- a/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
@@ -137,11 +137,14 @@ export function EditorDiffFileSurface({
 
   const diffReloadNonce = activeFile.diffContentReloadNonce ?? 0
   const originalModelKey = `${diffViewStateKey}:original:${getDiffContentSignature(diffContent.originalContent)}`
-  const modifiedModelKey = `${diffViewStateKey}:modified:${getDiffContentSignature(diffContent.modifiedContent)}:${diffReloadNonce}`
+  // Why: only an explicit reload may rotate the modified model; save content
+  // updates must keep the model identity so Monaco retains its undo history.
+  const modifiedModelKey = `${diffViewStateKey}:modified:${diffReloadNonce}`
   const diffViewer = (
     <DiffViewer
-      // Why: content refreshes via modifiedModelKey; keying off content too would remount Monaco and flash on every save.
-      key={`${viewStateScopeId}:${diffReloadNonce}`}
+      // Why: content props update the retained model in place; only an explicit
+      // reload nonce may remount Monaco.
+      key={viewStateScopeId}
       modelKey={diffViewStateKey}
       originalModelKey={originalModelKey}
       modifiedModelKey={modifiedModelKey}

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
@@ -141,4 +141,45 @@ describe('useDiffViewerLargeDiffLifecycle', () => {
       supersededModel.dispose.mock.invocationCallOrder[0]
     )
   })
+
+  it('still disposes the first superseded model when a second rotation cancels the deferred pass', async () => {
+    const modelKey = 'diff-tab'
+    const paths = ['modified-v1', 'modified-v2', 'modified-v3'].map((modifiedModelKey) =>
+      getDiffViewerMonacoModelPaths({
+        modelKey,
+        modifiedModelKey,
+        generationSuffix: ''
+      })
+    )
+    const originalModel = detachedModel()
+    const firstModel = detachedModel()
+    const thirdModel = detachedModel()
+    monacoFixture.models.set(paths[0].originalModelPath, originalModel)
+    monacoFixture.models.set(paths[0].modifiedModelPath, firstModel)
+    // Why: the v2 replacement model is absent, so the first rotation defers.
+    monacoFixture.models.delete(paths[1].modifiedModelPath)
+    const retainedEditor = diffEditorFixture(originalModel, firstModel)
+
+    const hook = renderHook(
+      ({ modifiedModelKey }) =>
+        useDiffViewerLargeDiffLifecycle({
+          limited: false,
+          modelKey,
+          modifiedModelKey,
+          diffEditorRef: retainedEditor,
+          onEnterFallback: vi.fn()
+        }),
+      { initialProps: { modifiedModelKey: 'modified-v1' } }
+    )
+
+    hook.rerender({ modifiedModelKey: 'modified-v2' })
+    expect(firstModel.dispose).not.toHaveBeenCalled()
+
+    monacoFixture.models.set(paths[2].modifiedModelPath, thirdModel)
+    hook.rerender({ modifiedModelKey: 'modified-v3' })
+    await act(() => Promise.resolve())
+
+    expect(firstModel.dispose).toHaveBeenCalledOnce()
+    expect(thirdModel.dispose).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
@@ -100,7 +100,7 @@ describe('useDiffViewerLargeDiffLifecycle', () => {
     expect(onEnterFallback).not.toHaveBeenCalled()
   })
 
-  it('resets the owning diff widget before disposing a superseded model', async () => {
+  it('disposes a superseded modified model once through the production lifecycle path', async () => {
     const modelKey = 'diff-tab'
     const paths = ['modified-v1', 'modified-v2'].map((modifiedModelKey) =>
       getDiffViewerMonacoModelPaths({

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
@@ -59,25 +59,36 @@ export function useDiffViewerLargeDiffLifecycle({
     if (supersededModelPaths.length === 0) {
       return
     }
-    const diffEditor = diffEditorRef.current
-    if (diffEditor) {
-      const originalModel = monaco.editor.getModel(
-        monaco.Uri.parse(currentDiffModelPaths.originalModelPath)
-      )
-      const modifiedModel = monaco.editor.getModel(
-        monaco.Uri.parse(currentDiffModelPaths.modifiedModelPath)
-      )
-      if (!originalModel || !modifiedModel) {
-        return
+    const synchronizeAndDispose = (): boolean => {
+      const diffEditor = diffEditorRef.current
+      if (diffEditor) {
+        const originalModel = monaco.editor.getModel(
+          monaco.Uri.parse(currentDiffModelPaths.originalModelPath)
+        )
+        const modifiedModel = monaco.editor.getModel(
+          monaco.Uri.parse(currentDiffModelPaths.modifiedModelPath)
+        )
+        if (!originalModel || !modifiedModel) {
+          return false
+        }
+        const activeModels = diffEditor.getModel()
+        if (activeModels?.original !== originalModel || activeModels.modified !== modifiedModel) {
+          // Why: @monaco-editor/react swaps the two child models separately, but
+          // Monaco's diff widget must release its old pair before either is disposed.
+          diffEditor.setModel({ original: originalModel, modified: modifiedModel })
+        }
       }
-      const activeModels = diffEditor.getModel()
-      if (activeModels?.original !== originalModel || activeModels.modified !== modifiedModel) {
-        // Why: @monaco-editor/react swaps the two child models separately, but
-        // Monaco's diff widget must release its old pair before either is disposed.
-        diffEditor.setModel({ original: originalModel, modified: modifiedModel })
-      }
+      disposeUnattachedMonacoModelPaths(monaco, supersededModelPaths)
+      return true
     }
-    disposeUnattachedMonacoModelPaths(monaco, supersededModelPaths)
+
+    if (synchronizeAndDispose()) {
+      return
+    }
+    // Why: the child DiffEditor creates a path-swapped model after this parent
+    // effect; defer cleanup until both replacement models exist.
+    const disposeTimer = window.setTimeout(synchronizeAndDispose, 0)
+    return () => window.clearTimeout(disposeTimer)
   }, [currentDiffModelPaths, diffEditorRef])
 
   useEffect(() => {

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
@@ -44,21 +44,34 @@ export function useDiffViewerLargeDiffLifecycle({
   const currentDiffModelPathsRef = useRef(currentDiffModelPaths)
   currentDiffModelPathsRef.current = currentDiffModelPaths
   const previousDiffModelPathsRef = useRef(currentDiffModelPaths)
+  const deferredSupersededModelPathsRef = useRef<string[]>([])
 
   useEffect(() => {
     const previousModelPaths = previousDiffModelPathsRef.current
     previousDiffModelPathsRef.current = currentDiffModelPaths
+    // Why: a rotation arriving before the deferred pass runs would otherwise
+    // strand the earlier superseded model, so carry it into this round.
     const supersededModelPaths = [
-      previousModelPaths.originalModelPath !== currentDiffModelPaths.originalModelPath
-        ? previousModelPaths.originalModelPath
-        : null,
-      previousModelPaths.modifiedModelPath !== currentDiffModelPaths.modifiedModelPath
-        ? previousModelPaths.modifiedModelPath
-        : null
-    ].filter((modelPath): modelPath is string => modelPath !== null)
+      ...new Set([
+        ...deferredSupersededModelPathsRef.current,
+        previousModelPaths.originalModelPath !== currentDiffModelPaths.originalModelPath
+          ? previousModelPaths.originalModelPath
+          : null,
+        previousModelPaths.modifiedModelPath !== currentDiffModelPaths.modifiedModelPath
+          ? previousModelPaths.modifiedModelPath
+          : null
+      ])
+    ].filter(
+      (modelPath): modelPath is string =>
+        modelPath !== null &&
+        modelPath !== currentDiffModelPaths.originalModelPath &&
+        modelPath !== currentDiffModelPaths.modifiedModelPath
+    )
+    deferredSupersededModelPathsRef.current = []
     if (supersededModelPaths.length === 0) {
       return
     }
+    let disposed = false
     const synchronizeAndDispose = (): boolean => {
       const diffEditor = diffEditorRef.current
       if (diffEditor) {
@@ -79,6 +92,7 @@ export function useDiffViewerLargeDiffLifecycle({
         }
       }
       disposeUnattachedMonacoModelPaths(monaco, supersededModelPaths)
+      disposed = true
       return true
     }
 
@@ -88,7 +102,12 @@ export function useDiffViewerLargeDiffLifecycle({
     // Why: the child DiffEditor creates a path-swapped model after this parent
     // effect; defer cleanup until both replacement models exist.
     const disposeTimer = window.setTimeout(synchronizeAndDispose, 0)
-    return () => window.clearTimeout(disposeTimer)
+    return () => {
+      window.clearTimeout(disposeTimer)
+      if (!disposed) {
+        deferredSupersededModelPathsRef.current = supersededModelPaths
+      }
+    }
   }, [currentDiffModelPaths, diffEditorRef])
 
   useEffect(() => {

--- a/src/renderer/src/components/editor/useEditorPanelContentReloadTriggers.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentReloadTriggers.ts
@@ -22,6 +22,7 @@ type UseEditorPanelContentReloadTriggersParams = {
   invalidateFileContent: (fileIds: string[]) => void
   loadDiffContent: EditorPanelDiffContentLoader
   loadFileContent: EditorPanelFileContentLoader
+  requestDiffContentReload: (fileId: string) => void
 }
 
 export function useEditorPanelContentReloadTriggers({
@@ -34,7 +35,8 @@ export function useEditorPanelContentReloadTriggers({
   invalidateDiffContent,
   invalidateFileContent,
   loadDiffContent,
-  loadFileContent
+  loadFileContent,
+  requestDiffContentReload
 }: UseEditorPanelContentReloadTriggersParams): void {
   const changesStatusEntries = activeFile?.worktreeId ? gitStatusEntries : undefined
   const activeFileGitStatusEntries = useMemo(() => {
@@ -83,7 +85,11 @@ export function useEditorPanelContentReloadTriggers({
     if (!cachedDiff || cachedDiff.isStale === true) {
       return
     }
-    void loadDiffContent(current, { force: true })
+    void loadDiffContent(current, { force: true }).then((replaced) => {
+      if (replaced) {
+        requestDiffContentReload(current.id)
+      }
+    })
   }, [
     activeFileShouldReloadOnGitStatusChange,
     activeFileGitStatusSignature,
@@ -93,11 +99,12 @@ export function useEditorPanelContentReloadTriggers({
     loadDiffContent,
     diffContentsRef,
     isVisibleRef,
-    openFilesRef
+    openFilesRef,
+    requestDiffContentReload
   ])
 
   useEffect(() => {
-    const nonce = activeFile?.diffContentReloadNonce
+    const nonce = activeFile?.diffContentRefreshNonce
     if (!activeFile?.id || nonce === undefined || nonce === 0) {
       return
     }
@@ -109,14 +116,21 @@ export function useEditorPanelContentReloadTriggers({
     if (!isVisibleRef.current) {
       return
     }
-    void loadDiffContent(current, { force: true })
+    // Why: re-opening a diff tab must refetch before rotating the model, else
+    // the new model is seeded from the cached body being replaced.
+    void loadDiffContent(current, { force: true }).then((replaced) => {
+      if (replaced) {
+        requestDiffContentReload(current.id)
+      }
+    })
   }, [
-    activeFile?.diffContentReloadNonce,
+    activeFile?.diffContentRefreshNonce,
     activeFile?.id,
     invalidateDiffContent,
     loadDiffContent,
     isVisibleRef,
-    openFilesRef
+    openFilesRef,
+    requestDiffContentReload
   ])
 
   useEffect(() => {

--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   getConnectionId: vi.fn(),
   getConnectionIdForFile: vi.fn(),
   isWorktreeConnectionResolved: vi.fn(() => true),
+  requestDiffContentReload: vi.fn(),
   getState: vi.fn()
 }))
 
@@ -151,11 +152,13 @@ describe('useEditorPanelContentState', () => {
     mocks.getConnectionIdForFile.mockReturnValue(undefined)
     mocks.isWorktreeConnectionResolved.mockReset()
     mocks.isWorktreeConnectionResolved.mockReturnValue(true)
+    mocks.requestDiffContentReload.mockReset()
     mocks.getState.mockReset()
     mocks.getState.mockReturnValue({
       settings: null,
       openFiles: [],
-      setLastKnownDiskSignature: vi.fn()
+      setLastKnownDiskSignature: vi.fn(),
+      requestDiffContentReload: mocks.requestDiffContentReload
     })
   })
 

--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -865,6 +865,55 @@ describe('useEditorPanelContentState', () => {
     expect(mocks.readRuntimeFileContent).not.toHaveBeenCalled()
   })
 
+  it('refetches then rotates the model when a diff tab is re-opened', async () => {
+    // Why: the sidebar re-open bumps the refresh nonce; rotating the model
+    // before the refetch lands would seed it from the body being replaced.
+    const activeFile = createOpenFile({
+      id: 'wt-1::diff::unstaged::file.ts',
+      mode: 'diff',
+      diffSource: 'unstaged'
+    })
+    mocks.getRuntimeGitDiff
+      .mockResolvedValueOnce({
+        kind: 'text',
+        originalContent: 'old',
+        modifiedContent: 'first diff content',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      })
+      .mockResolvedValueOnce({
+        kind: 'text',
+        originalContent: 'old',
+        modifiedContent: 'reopened diff content',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
+    })
+    await vi.waitFor(() =>
+      expect(latestDiffContents[activeFile.id]?.modifiedContent).toBe('first diff content')
+    )
+    expect(mocks.requestDiffContentReload).not.toHaveBeenCalled()
+
+    const reopenedFile = { ...activeFile, diffContentRefreshNonce: 1 }
+    await act(async () => {
+      root?.render(<HookProbe activeFile={reopenedFile} openFiles={[reopenedFile]} />)
+    })
+
+    await vi.waitFor(() =>
+      expect(latestDiffContents[activeFile.id]?.modifiedContent).toBe('reopened diff content')
+    )
+    await vi.waitFor(() =>
+      expect(mocks.requestDiffContentReload).toHaveBeenCalledWith(activeFile.id)
+    )
+    expect(mocks.getRuntimeGitDiff).toHaveBeenCalledTimes(2)
+  })
+
   it('routes reloadContent for an edit tab to a forced file read, not a diff refetch', async () => {
     const activeFile = createOpenFile()
     mocks.readRuntimeFileContent

--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -14,7 +14,6 @@ const mocks = vi.hoisted(() => ({
   getConnectionId: vi.fn(),
   getConnectionIdForFile: vi.fn(),
   isWorktreeConnectionResolved: vi.fn(() => true),
-  requestDiffContentReload: vi.fn(),
   getState: vi.fn()
 }))
 
@@ -152,13 +151,12 @@ describe('useEditorPanelContentState', () => {
     mocks.getConnectionIdForFile.mockReturnValue(undefined)
     mocks.isWorktreeConnectionResolved.mockReset()
     mocks.isWorktreeConnectionResolved.mockReturnValue(true)
-    mocks.requestDiffContentReload.mockReset()
     mocks.getState.mockReset()
     mocks.getState.mockReturnValue({
       settings: null,
       openFiles: [],
       setLastKnownDiskSignature: vi.fn(),
-      requestDiffContentReload: mocks.requestDiffContentReload
+      requestDiffContentReload: vi.fn()
     })
   })
 
@@ -863,55 +861,6 @@ describe('useEditorPanelContentState', () => {
     )
     expect(mocks.getRuntimeGitDiff).toHaveBeenCalledTimes(2)
     expect(mocks.readRuntimeFileContent).not.toHaveBeenCalled()
-  })
-
-  it('refetches then rotates the model when a diff tab is re-opened', async () => {
-    // Why: the sidebar re-open bumps the refresh nonce; rotating the model
-    // before the refetch lands would seed it from the body being replaced.
-    const activeFile = createOpenFile({
-      id: 'wt-1::diff::unstaged::file.ts',
-      mode: 'diff',
-      diffSource: 'unstaged'
-    })
-    mocks.getRuntimeGitDiff
-      .mockResolvedValueOnce({
-        kind: 'text',
-        originalContent: 'old',
-        modifiedContent: 'first diff content',
-        originalIsBinary: false,
-        modifiedIsBinary: false
-      })
-      .mockResolvedValueOnce({
-        kind: 'text',
-        originalContent: 'old',
-        modifiedContent: 'reopened diff content',
-        originalIsBinary: false,
-        modifiedIsBinary: false
-      })
-
-    container = document.createElement('div')
-    document.body.appendChild(container)
-    root = createRoot(container)
-    await act(async () => {
-      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
-    })
-    await vi.waitFor(() =>
-      expect(latestDiffContents[activeFile.id]?.modifiedContent).toBe('first diff content')
-    )
-    expect(mocks.requestDiffContentReload).not.toHaveBeenCalled()
-
-    const reopenedFile = { ...activeFile, diffContentRefreshNonce: 1 }
-    await act(async () => {
-      root?.render(<HookProbe activeFile={reopenedFile} openFiles={[reopenedFile]} />)
-    })
-
-    await vi.waitFor(() =>
-      expect(latestDiffContents[activeFile.id]?.modifiedContent).toBe('reopened diff content')
-    )
-    await vi.waitFor(() =>
-      expect(mocks.requestDiffContentReload).toHaveBeenCalledWith(activeFile.id)
-    )
-    expect(mocks.getRuntimeGitDiff).toHaveBeenCalledTimes(2)
   })
 
   it('routes reloadContent for an edit tab to a forced file read, not a diff refetch', async () => {

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -54,6 +54,9 @@ export function useEditorPanelContentState({
   const openFilesRef = useRef(openFiles)
   const editorViewModeRef = useRef(editorViewMode)
   const isVisibleRef = useRef(isVisible)
+  const requestDiffContentReload = useCallback((fileId: string): void => {
+    useAppStore.getState().requestDiffContentReload(fileId)
+  }, [])
   const selectedConflictReviewFile =
     activeFile?.mode === 'conflict-review' && activeFile.conflictReview?.selectedFileId
       ? (openFiles.find((file) => file.id === activeFile.conflictReview?.selectedFileId) ?? null)
@@ -220,7 +223,8 @@ export function useEditorPanelContentState({
     openFilesRef,
     editorViewModeRef,
     setFileContents,
-    setDiffContents
+    setDiffContents,
+    requestDiffContentReload
   })
   usePruneClosedEditorContent(
     openFiles,

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
-import type { useAppStore } from '@/store'
+import { useAppStore } from '@/store'
 import type { DiffContent, FileContent } from './editor-panel-content-types'
 import {
   useEditorPanelExternalContentEvents,
@@ -154,7 +154,11 @@ export function useEditorPanelContentState({
           delete next[file.id]
           return next
         })
-        void loadDiffContent(file, { force: true })
+        void loadDiffContent(file, { force: true }).then((replaced) => {
+          if (replaced) {
+            requestDiffContentReload(file.id)
+          }
+        })
         return
       }
       delete fileLoadRetryAttemptsRef.current[file.id]
@@ -170,7 +174,7 @@ export function useEditorPanelContentState({
         force: true
       })
     },
-    [loadDiffContent, loadFileContent]
+    [loadDiffContent, loadFileContent, requestDiffContentReload]
   )
 
   useLocalLogTail({ openFiles, fileContents, setFileContents, reloadContent })
@@ -210,7 +214,8 @@ export function useEditorPanelContentState({
     invalidateDiffContent,
     invalidateFileContent,
     loadDiffContent,
-    loadFileContent
+    loadFileContent,
+    requestDiffContentReload
   })
 
   useEditorPanelExternalContentEvents({

--- a/src/renderer/src/components/editor/useEditorPanelDiffContentLoader.ts
+++ b/src/renderer/src/components/editor/useEditorPanelDiffContentLoader.ts
@@ -18,7 +18,7 @@ const inFlightDiffReads = new Map<string, InFlightContentRead<DiffContent>>()
 export type EditorPanelDiffContentLoader = (
   file: OpenFile | null,
   options?: EditorPanelContentLoadOptions
-) => Promise<void>
+) => Promise<boolean>
 
 type UseEditorPanelDiffContentLoaderParams = {
   diffReadGenerationCounterRef: MutableRefObject<number>
@@ -50,9 +50,9 @@ export function useEditorPanelDiffContentLoader({
   setDiffContents
 }: UseEditorPanelDiffContentLoaderParams): EditorPanelDiffContentLoader {
   return useCallback(
-    async (file: OpenFile | null, options?: EditorPanelContentLoadOptions): Promise<void> => {
+    async (file: OpenFile | null, options?: EditorPanelContentLoadOptions): Promise<boolean> => {
       if (!file || (file.mode === 'edit' && !canUseChangesModeForFile(file))) {
-        return
+        return false
       }
       const generation = diffReadGenerationCounterRef.current + 1
       diffReadGenerationCounterRef.current = generation
@@ -153,12 +153,13 @@ export function useEditorPanelDiffContentLoader({
         }
         const result = await pending.promise
         if (diffReadGenerationRef.current[file.id] !== generation) {
-          return
+          return false
         }
         setDiffContents((prev) => ({ ...prev, [file.id]: result }))
+        return true
       } catch (err) {
         if (diffReadGenerationRef.current[file.id] !== generation) {
-          return
+          return false
         }
         setDiffContents((prev) => ({
           ...prev,
@@ -170,6 +171,7 @@ export function useEditorPanelDiffContentLoader({
             modifiedIsBinary: false
           }
         }))
+        return true
       } finally {
         if (outstandingDiffReadsRef.current[file.id] === generation) {
           delete outstandingDiffReadsRef.current[file.id]

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx
@@ -13,6 +13,7 @@ type ProbeCalls = {
   invalidateDiff: ReturnType<typeof vi.fn>
   loadDiff: ReturnType<typeof vi.fn>
   loadFile: ReturnType<typeof vi.fn>
+  requestDiff: ReturnType<typeof vi.fn>
 }
 
 type ProbeProps = {
@@ -45,6 +46,7 @@ function ExternalContentProbe({ activeFileId, calls, isVisible, openFiles }: Pro
     loadDiffContent: calls.loadDiff,
     loadFileContent: calls.loadFile,
     openFilesRef,
+    requestDiffContentReload: calls.requestDiff,
     setDiffContents,
     setFileContents
   } as Parameters<typeof useEditorPanelExternalContentEvents>[0])
@@ -69,7 +71,8 @@ function makeCalls(): ProbeCalls {
     invalidate: vi.fn(),
     invalidateDiff: vi.fn(),
     loadDiff: vi.fn(async () => undefined),
-    loadFile: vi.fn(async () => undefined)
+    loadFile: vi.fn(async () => undefined),
+    requestDiff: vi.fn()
   }
 }
 
@@ -238,5 +241,24 @@ describe('useEditorPanelExternalContentEvents', () => {
     const previewOptions = previewCalls.loadFile.mock.calls[0]?.[4]
     expect(sourceOptions?.externalEventGeneration).toBeTypeOf('number')
     expect(previewOptions?.externalEventGeneration).toBe(sourceOptions?.externalEventGeneration)
+  })
+
+  it('rotates a visible diff model after the replacement load resolves', async () => {
+    const file = makeFile('changed', { mode: 'diff', diffSource: 'unstaged' })
+    const calls = makeCalls()
+    let resolveLoad!: (replaced: boolean) => void
+    calls.loadDiff = vi.fn(() => new Promise<boolean>((resolve) => (resolveLoad = resolve)))
+
+    act(() => {
+      root.render(
+        <ExternalContentProbe activeFileId={file.id} calls={calls} isVisible openFiles={[file]} />
+      )
+    })
+    dispatchExternalChange(file.relativePath)
+
+    expect(calls.loadDiff).toHaveBeenCalledOnce()
+    expect(calls.requestDiff).not.toHaveBeenCalled()
+    await act(async () => resolveLoad(true))
+    await vi.waitFor(() => expect(calls.requestDiff).toHaveBeenCalledWith(file.id))
   })
 })

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
@@ -35,6 +35,7 @@ type UseEditorPanelExternalContentEventsParams = {
   editorViewModeRef: MutableRefObject<EditorViewModeByFile>
   setFileContents: Dispatch<SetStateAction<Record<string, FileContent>>>
   setDiffContents: Dispatch<SetStateAction<Record<string, DiffContent>>>
+  requestDiffContentReload: (fileId: string) => void
 }
 
 const externalEventGenerations = new WeakMap<Event, number>()
@@ -60,7 +61,8 @@ export function useEditorPanelExternalContentEvents({
   openFilesRef,
   editorViewModeRef,
   setFileContents,
-  setDiffContents
+  setDiffContents,
+  requestDiffContentReload
 }: UseEditorPanelExternalContentEventsParams): void {
   useEffect(() => {
     const handler = (event: Event): void => {
@@ -90,6 +92,7 @@ export function useEditorPanelExternalContentEvents({
             externalEventGeneration: eventGeneration
           })
           if (editorViewModeRef.current[file.id] === 'changes') {
+            requestDiffContentReload(file.id)
             void loadDiffContent(file, {
               force: true,
               externalEventGeneration: eventGeneration
@@ -98,6 +101,7 @@ export function useEditorPanelExternalContentEvents({
             invalidatedDiffFileIds.push(file.id)
           }
         } else if (isReloadableSingleFileDiffTab(file)) {
+          requestDiffContentReload(file.id)
           void loadDiffContent(file, {
             force: true,
             externalEventGeneration: eventGeneration
@@ -122,7 +126,8 @@ export function useEditorPanelExternalContentEvents({
     isVisibleRef,
     loadDiffContent,
     loadFileContent,
-    openFilesRef
+    openFilesRef,
+    requestDiffContentReload
   ])
 
   useEffect(() => {

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
@@ -23,7 +23,10 @@ type UseEditorPanelExternalContentEventsParams = {
   invalidateContent: (fileIds: string[]) => void
   invalidateDiffContent: (fileIds: string[]) => void
   isVisibleRef: MutableRefObject<boolean>
-  loadDiffContent: (file: OpenFile | null, options?: EditorPanelContentLoadOptions) => Promise<void>
+  loadDiffContent: (
+    file: OpenFile | null,
+    options?: EditorPanelContentLoadOptions
+  ) => Promise<boolean>
   loadFileContent: (
     filePath: string,
     id: string,
@@ -65,6 +68,18 @@ export function useEditorPanelExternalContentEvents({
   requestDiffContentReload
 }: UseEditorPanelExternalContentEventsParams): void {
   useEffect(() => {
+    const reloadDiffContent = (file: OpenFile, eventGeneration: number): void => {
+      // Why: replace the content before rotating the model path so a fresh
+      // model is seeded from the external result, not the stale model.
+      void loadDiffContent(file, {
+        force: true,
+        externalEventGeneration: eventGeneration
+      }).then((replaced) => {
+        if (replaced) {
+          requestDiffContentReload(file.id)
+        }
+      })
+    }
     const handler = (event: Event): void => {
       const detail = (event as CustomEvent<EditorPathMutationTarget>).detail
       if (!detail) {
@@ -92,20 +107,12 @@ export function useEditorPanelExternalContentEvents({
             externalEventGeneration: eventGeneration
           })
           if (editorViewModeRef.current[file.id] === 'changes') {
-            requestDiffContentReload(file.id)
-            void loadDiffContent(file, {
-              force: true,
-              externalEventGeneration: eventGeneration
-            })
+            reloadDiffContent(file, eventGeneration)
           } else {
             invalidatedDiffFileIds.push(file.id)
           }
         } else if (isReloadableSingleFileDiffTab(file)) {
-          requestDiffContentReload(file.id)
-          void loadDiffContent(file, {
-            force: true,
-            externalEventGeneration: eventGeneration
-          })
+          reloadDiffContent(file, eventGeneration)
         }
       }
       if (invalidatedFileIds.length > 0) {

--- a/src/renderer/src/components/editor/useEditorPanelVisibilityContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelVisibilityContentState.test.tsx
@@ -355,7 +355,7 @@ describe('useEditorPanelContentState visibility', () => {
     expect(mocks.readRuntimeFileContent).toHaveBeenCalledTimes(2)
   })
 
-  it('invalidates a hidden diff nonce without reading until reveal', async () => {
+  it('invalidates a hidden diff refresh without reading until reveal', async () => {
     const file = makeFile('diff-nonce', { mode: 'diff', diffSource: 'unstaged' })
     const staleDiff = createDeferred<DiffContent>()
     const freshDiff = createDeferred<DiffContent>()
@@ -366,7 +366,7 @@ describe('useEditorPanelContentState visibility', () => {
     await act(async () => root.render(<Probe activeFile={file} />))
     await vi.waitFor(() => expect(mocks.getRuntimeGitDiff).toHaveBeenCalledOnce())
 
-    const changed = { ...file, diffContentReloadNonce: 1 }
+    const changed = { ...file, diffContentRefreshNonce: 1 }
     await act(async () => root.render(<Probe activeFile={changed} isVisible={false} />))
     expect(mocks.getRuntimeGitDiff).toHaveBeenCalledOnce()
     await act(async () => {

--- a/src/renderer/src/store/slices/editor-open-diff.test.ts
+++ b/src/renderer/src/store/slices/editor-open-diff.test.ts
@@ -177,17 +177,41 @@ describe('createEditorSlice openDiff', () => {
     expect(store.getState().activeFileId).toBe('wt-1::diff::staged::file.ts')
   })
 
-  it('bumps diffContentReloadNonce when re-opening an existing diff tab', () => {
+  it('bumps diffContentRefreshNonce when re-opening an existing diff tab', () => {
     const store = createEditorStore()
 
     store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+    expect(store.getState().openFiles[0]?.diffContentRefreshNonce).toBeUndefined()
+
+    store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+    expect(store.getState().openFiles[0]?.diffContentRefreshNonce).toBe(1)
+
+    store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+    expect(store.getState().openFiles[0]?.diffContentRefreshNonce).toBe(2)
+  })
+
+  it('leaves diffContentReloadNonce alone when re-opening an existing diff tab', () => {
+    const store = createEditorStore()
+
+    store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+    store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+
     expect(store.getState().openFiles[0]?.diffContentReloadNonce).toBeUndefined()
+  })
 
+  it('increments diffContentReloadNonce for an external replacement request', () => {
+    const store = createEditorStore()
     store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
+    const fileId = store.getState().openFiles[0]?.id
+
+    if (!fileId) {
+      throw new Error('expected an open diff tab')
+    }
+    store.getState().requestDiffContentReload(fileId)
+
     expect(store.getState().openFiles[0]?.diffContentReloadNonce).toBe(1)
-
-    store.getState().openDiff('wt-1', '/repo/file.ts', 'file.ts', 'typescript', false)
-    expect(store.getState().openFiles[0]?.diffContentReloadNonce).toBe(2)
+    expect(() => store.getState().requestDiffContentReload('missing-file')).not.toThrow()
+    expect(store.getState().openFiles[0]?.diffContentReloadNonce).toBe(1)
   })
 
   it('bumps fileContentReloadNonce when re-opening an existing clean file with reload requested', () => {

--- a/src/renderer/src/store/slices/editor/actions/open-file-mutations.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-mutations.ts
@@ -12,6 +12,7 @@ export function createOpenFileMutations(
   | 'reorderFiles'
   | 'markFileDirty'
   | 'setExternalMutation'
+  | 'requestDiffContentReload'
   | 'setLastKnownDiskSignature'
   | 'clearPendingDiskBaselineVerification'
   | 'setPendingDiskBaselineVerification'
@@ -120,6 +121,21 @@ export function createOpenFileMutations(
         return {
           openFiles: s.openFiles.map((f) =>
             f.id === fileId ? { ...f, externalMutation: next } : f
+          )
+        }
+      }),
+
+    requestDiffContentReload: (fileId) =>
+      set((s) => {
+        const file = s.openFiles.find((f) => f.id === fileId)
+        if (!file) {
+          return s
+        }
+        return {
+          openFiles: s.openFiles.map((f) =>
+            f.id === fileId
+              ? { ...f, diffContentReloadNonce: (f.diffContentReloadNonce ?? 0) + 1 }
+              : f
           )
         }
       }),

--- a/src/renderer/src/store/slices/editor/file-ids/editor-file-ids.ts
+++ b/src/renderer/src/store/slices/editor/file-ids/editor-file-ids.ts
@@ -62,7 +62,7 @@ export function buildDiffEditorFileId(
 export function withDiffContentReloadRequest(file: OpenFile): OpenFile {
   return {
     ...file,
-    diffContentReloadNonce: (file.diffContentReloadNonce ?? 0) + 1
+    diffContentRefreshNonce: (file.diffContentRefreshNonce ?? 0) + 1
   }
 }
 

--- a/src/renderer/src/store/slices/editor/types/editor-files-slice.ts
+++ b/src/renderer/src/store/slices/editor/types/editor-files-slice.ts
@@ -81,6 +81,7 @@ export type EditorFilesSlice = {
   reorderFiles: (fileIds: string[]) => void
   markFileDirty: (fileId: string, dirty: boolean) => void
   setExternalMutation: (fileId: string, mutation: 'deleted' | 'renamed' | 'changed' | null) => void
+  requestDiffContentReload: (fileId: string) => void
   setLastKnownDiskSignature: (fileId: string, signature: string) => void
   clearPendingDiskBaselineVerification: (fileId: string) => void
   setPendingDiskBaselineVerification: (fileId: string, value: boolean) => void

--- a/src/renderer/src/store/slices/editor/types/open-file.ts
+++ b/src/renderer/src/store/slices/editor/types/open-file.ts
@@ -132,8 +132,10 @@ export type OpenFile = {
   pendingOwnerMigration?: boolean
   /** Why: routes an Orca-owned move's destination-watcher echo into content verification. On the tab so it survives the atomic rekey; operationId supersedes a stale verification on re-move. Not persisted. */
   pendingSelfMoveEcho?: { operationId: string; targetPath: string }
-  /** Why: diff bodies are cached in EditorPanel; bump this on re-select so the panel refetches instead of reusing a stale snapshot. */
+  /** Why: rotates the modified Monaco model only; bump it after replacement content is already cached, never before. */
   diffContentReloadNonce?: number
+  /** Why: diff bodies are cached in EditorPanel; bump this on re-select so the panel refetches instead of reusing a stale snapshot. */
+  diffContentRefreshNonce?: number
   /** Why: bumping refetches clean tabs — the user's manual recovery when a remote watcher misses an external write. */
   fileContentReloadNonce?: number
   /** Why: CI check-details tabs are virtual editor tabs backed by fetched PR check-run metadata, not a file on disk. */


### PR DESCRIPTION
## Summary

Keep the modified Monaco model stable across a user save so Diff View undo history remains available in Diff and Changes modes. External file changes now replace diff content before rotating the model path, avoiding stale seeded models, duplicate diff reads, and loading flashes. Superseded models go through the existing lifecycle disposal path.

Closes #9204.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added behavioral coverage for save undo retention, external replacement ordering, store reload wiring, and single model disposal.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx src/renderer/src/components/editor/ChangesModeView.test.tsx src/renderer/src/components/editor/useEditorPanelContentState.test.tsx src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx src/renderer/src/store/slices/editor.test.ts`
- [x] `pnpm typecheck:web`
- [x] Changed-file `pnpm exec oxlint`
- [x] Changed-file `pnpm exec oxfmt --check`
- [x] `git diff --check`
- Full Electron/Monaco rendered interaction was not run locally; browser or CI confirmation remains required.

## AI Review Report

The change stays within renderer editor state. Diff and Changes mode save paths retain their modified model identity and undo history. External reloads remain event-driven, and the existing model lifecycle owns superseded-model disposal. macOS, Linux, Windows, SSH, remote, local, provider, performance, UI, and security behavior outside this renderer path is unchanged.

## Security Audit

No IPC, filesystem permission, dependency, or native code path changed. External content events remain the reload authority, and content alone cannot rotate the modified model.

## Notes

No new UI surface is introduced.
