### PR TITLE
fix(sidebar): show Trae agent status in worktrees (#11643)

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -50,8 +50,8 @@ describe('buildTitleDerivedAgentRows', () => {
       retained: [],
       runtimePaneTitlesByTabId: {
         'tab-1': {
-          1: 'Trae ready',
-          2: '⠋ Trae'
+          1: 'traecli',
+          2: '⠋ traecli'
         }
       },
       ptyIdsByTabId: { 'tab-1': ['pty-idle', 'pty-working'] },
@@ -137,7 +137,23 @@ describe('buildTitleDerivedAgentRows', () => {
       entries: [],
       retained: [],
       runtimePaneTitlesByTabId: {
-        'tab-1': { 1: 'Trae ready' }
+        'tab-1': { 1: '⠋ Codex' }
+      },
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not infer Trae from stale configuration without a live PTY', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'traecli' }
       },
       ptyIdsByTabId: {},
       terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
@@ -153,7 +169,7 @@ describe('buildTitleDerivedAgentRows', () => {
       entries: [],
       retained: [],
       runtimePaneTitlesByTabId: {
-        'tab-1': { 1: 'trae-cli ready' }
+        'tab-1': { 1: 'trae-cli' }
       },
       ptyIdsByTabId: { 'tab-1': ['pty-unknown'] },
       terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -43,6 +43,28 @@ function makeSingleLayout(leafId: string): TerminalLayoutSnapshot {
 }
 
 describe('buildTitleDerivedAgentRows', () => {
+  it('adds idle and working rows for live Trae panes', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: 'Trae ready',
+          2: '⠋ Trae'
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-idle', 'pty-working'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['trae', 'idle', 'Idle'],
+      ['trae', 'working', 'Running']
+    ])
+  })
+
   it('adds title-derived rows for live agent panes that have no hook status yet', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],
@@ -115,10 +137,26 @@ describe('buildTitleDerivedAgentRows', () => {
       entries: [],
       retained: [],
       runtimePaneTitlesByTabId: {
-        'tab-1': { 1: '⠋ Codex' }
+        'tab-1': { 1: 'Trae ready' }
       },
       ptyIdsByTabId: {},
       terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not infer Trae from an unknown similar title', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'trae-cli ready' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-unknown'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
       now: 2000
     })
 

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -38,6 +38,7 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   Cursor: 'cursor',
   Droid: 'droid',
   Hermes: 'hermes',
+  Trae: 'trae',
   Pi: 'pi',
   OMP: 'omp'
 }

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -101,6 +101,26 @@ describe('MiMo title detection', () => {
   )
 })
 
+describe('Trae title detection', () => {
+  it.each([
+    ['Trae', 'idle'],
+    ['Trae ready', 'idle'],
+    ['⠋ Trae', 'working'],
+    ['Trae working', 'working']
+  ] as const)('classifies %s', (title, expectedStatus) => {
+    expect(getAgentLabel(title)).toBe('Trae')
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
+  it.each(['trae-cli ready', 'trae-agent working', '~/trae/working'])(
+    'does not classify a non-Trae title %s',
+    (title) => {
+      expect(getAgentLabel(title)).toBeNull()
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  )
+})
+
 describe('Pi-compatible title detection', () => {
   it.each([
     ['\u280b OMP', 'OMP', 'working'],

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -5,6 +5,7 @@ import {
   extractAllOscTitles,
   extractLastOscTitle,
   getAgentLabel,
+  isClaudeAgent,
   isCursorAgentTitle,
   MAX_OSC_TITLE_CHARS,
   MAX_OSC_TITLES_PER_CHUNK,
@@ -122,6 +123,14 @@ describe('Trae title detection', () => {
 
   it('keeps a Claude task title that mentions Trae classified as Claude', () => {
     expect(getAgentLabel('⠋ fix the trae mapping')).toBe('Claude Code')
+  })
+
+  // Why: the prompt-cache timer and parked-terminal byte watcher call isClaudeAgent
+  // directly, so a Trae working title must not reach Claude-only behavior.
+  it('keeps Trae working titles out of isClaudeAgent', () => {
+    expect(isClaudeAgent('⠋ traecli')).toBe(false)
+    expect(isClaudeAgent('⠋ traecli.exe')).toBe(false)
+    expect(isClaudeAgent('⠋ fix the trae mapping')).toBe(true)
   })
 })
 

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -103,22 +103,26 @@ describe('MiMo title detection', () => {
 
 describe('Trae title detection', () => {
   it.each([
-    ['Trae', 'idle'],
-    ['Trae ready', 'idle'],
-    ['⠋ Trae', 'working'],
-    ['Trae working', 'working']
+    ['traecli', 'idle'],
+    ['traecli.exe', 'idle'],
+    ['⠋ traecli', 'working'],
+    ['⠋ traecli.exe', 'working']
   ] as const)('classifies %s', (title, expectedStatus) => {
     expect(getAgentLabel(title)).toBe('Trae')
     expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
   })
 
-  it.each(['trae-cli ready', 'trae-agent working', '~/trae/working'])(
+  it.each(['trae', 'trae-cli', 'trae-agent', '~/traecli/working'])(
     'does not classify a non-Trae title %s',
     (title) => {
       expect(getAgentLabel(title)).toBeNull()
       expect(detectAgentStatusFromTitle(title)).toBeNull()
     }
   )
+
+  it('keeps a Claude task title that mentions Trae classified as Claude', () => {
+    expect(getAgentLabel('⠋ fix the trae mapping')).toBe('Claude Code')
+  })
 })
 
 describe('Pi-compatible title detection', () => {

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -27,12 +27,17 @@ export const AGENT_NAMES = [
   'aider',
   'grok',
   'devin',
-  'trae'
+  'traecli'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as
 // `openclaude.exe`; still reject arbitrary dotted path fragments.
 const WINDOWS_EXECUTABLE_SUFFIX_RE = String.raw`(?:\.(?:exe|cmd|bat|ps1))`
+
+const TRAE_CLI_TITLE_RE = new RegExp(
+  `^(?:[\\u2800-\\u28ff]+\\s+)?traecli${WINDOWS_EXECUTABLE_SUFFIX_RE}?$`,
+  'i'
+)
 
 export function buildAgentNameRe(name: string): RegExp {
   return new RegExp(
@@ -58,6 +63,11 @@ export function titleHasAgentName(title: string, name: string): boolean {
 /** True when `title` contains any AGENT_NAMES entry as a whole token. */
 export function titleHasAnyLegacyAgentName(title: string): boolean {
   return ANY_LEGACY_AGENT_NAME_RE.test(title)
+}
+
+/** True when the title is the Trae CLI identity, including a Windows suffix. */
+export function isTraeCliTitle(title: string): boolean {
+  return TRAE_CLI_TITLE_RE.test(title.trim())
 }
 
 // Why: `android` contains `droid`; like the legacy names above, Droid must be

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,7 +26,8 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin'
+  'devin',
+  'trae'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -2,12 +2,19 @@ import {
   AGY_AGENT_NAME_RE,
   DROID_AGENT_NAME_RE,
   HERMES_AGENT_NAME_RE,
+  isTraeCliTitle,
   titleHasAgentName,
   titleHasAnyLegacyAgentName
 } from './agent-name-token-match'
 import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
 
-export { AGY_AGENT_NAME_RE, DROID_AGENT_NAME_RE, HERMES_AGENT_NAME_RE, titleHasAgentName }
+export {
+  AGY_AGENT_NAME_RE,
+  DROID_AGENT_NAME_RE,
+  HERMES_AGENT_NAME_RE,
+  isTraeCliTitle,
+  titleHasAgentName
+}
 
 export type AgentStatus = 'working' | 'permission' | 'idle'
 

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -113,6 +113,9 @@ export function getAgentLabel(title: string): string | null {
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
   }
+  if (titleHasAgentName(title, 'trae')) {
+    return 'Trae'
+  }
   if (isClaudeAgent(title)) {
     return 'Claude Code'
   }

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -35,7 +35,7 @@ export function isClaudeAgent(title: string): boolean {
   if (containsBrailleSpinner(title)) {
     // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
     // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
-    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
+    return !isCursorAgentTitle(title) && !isTraeCliTitle(title) && !lower.includes('openclaude')
   }
 
   const trimmedTitle = title.trimStart()

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -8,6 +8,7 @@ import {
   isCursorAgentTitle,
   isGeminiTerminalTitle,
   isPiAgentTitle,
+  isTraeCliTitle,
   titleHasAgentName
 } from './agent-title-core'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
@@ -113,7 +114,7 @@ export function getAgentLabel(title: string): string | null {
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
   }
-  if (titleHasAgentName(title, 'trae')) {
+  if (isTraeCliTitle(title)) {
     return 'Trae'
   }
   if (isClaudeAgent(title)) {

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -47,9 +47,13 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
   })
 
   it('maps Trae titles without accepting similarly named commands', () => {
-    expect(resolveExplicitTerminalTitleAgentType('Trae ready')).toBe('trae')
-    expect(resolveExplicitTerminalTitleAgentType('⠋ Trae')).toBe('trae')
-    expect(resolveExplicitTerminalTitleAgentType('trae-cli ready')).toBeNull()
+    expect(resolveExplicitTerminalTitleAgentType('traecli')).toBe('trae')
+    expect(resolveExplicitTerminalTitleAgentType('⠋ traecli')).toBe('trae')
+    expect(resolveExplicitTerminalTitleAgentType('trae-cli')).toBeNull()
+  })
+
+  it('does not relabel a Claude task that mentions Trae', () => {
+    expect(resolveExplicitTerminalTitleAgentType('⠋ fix the trae mapping')).toBeNull()
   })
 
   it('treats Claude generic status prefixes as activity-only, not identity', () => {

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -46,6 +46,12 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(resolveExplicitTerminalTitleAgentType('OMP')).toBe('omp')
   })
 
+  it('maps Trae titles without accepting similarly named commands', () => {
+    expect(resolveExplicitTerminalTitleAgentType('Trae ready')).toBe('trae')
+    expect(resolveExplicitTerminalTitleAgentType('⠋ Trae')).toBe('trae')
+    expect(resolveExplicitTerminalTitleAgentType('trae-cli ready')).toBeNull()
+  })
+
   it('treats Claude generic status prefixes as activity-only, not identity', () => {
     expect(resolveExplicitTerminalTitleAgentType('✳ investigating startup')).toBeNull()
     expect(resolveExplicitTerminalTitleAgentType('⠸ investigating startup')).toBeNull()

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -144,4 +144,10 @@ describe('isClaudeAgent', () => {
     expect(isClaudeAgent('⠋ preserve cursor visibility across replays')).toBe(true)
     expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
   })
+
+  it('excludes Trae working titles so Claude-only timers stay off them', () => {
+    expect(isClaudeAgent('⠋ traecli')).toBe(false)
+    expect(isClaudeAgent('⠋ traecli.exe')).toBe(false)
+    expect(isClaudeAgent('⠋ fix the trae mapping')).toBe(true)
+  })
 })

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -201,6 +201,9 @@ export function getAgentLabel(title: string): string | null {
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
   }
+  if (titleHasAgentName(title, 'trae')) {
+    return 'Trae'
+  }
   if (isClaudeAgent(title)) {
     return 'Claude Code'
   }
@@ -227,6 +230,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   Cursor: 'cursor',
   Droid: 'droid',
   Hermes: 'hermes',
+  Trae: 'trae',
   Pi: 'pi',
   OMP: 'omp'
 }

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -2,6 +2,7 @@ import {
   AGY_AGENT_NAME_RE,
   DROID_AGENT_NAME_RE,
   HERMES_AGENT_NAME_RE,
+  isTraeCliTitle,
   titleHasAgentName
 } from './agent-name-token-match'
 import { isCursorAgentTitle } from './agent-title-core'
@@ -201,7 +202,7 @@ export function getAgentLabel(title: string): string | null {
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
   }
-  if (titleHasAgentName(title, 'trae')) {
+  if (isTraeCliTitle(title)) {
     return 'Trae'
   }
   if (isClaudeAgent(title)) {

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -102,7 +102,7 @@ export function isClaudeAgent(title: string): boolean {
   if (containsBrailleSpinner(title)) {
     // Why: named non-Claude agents carry braille spinners too. Gate Cursor by its
     // identity title, not the token, so a Claude title mentioning a cursor stays Claude.
-    return !isCursorAgentTitle(title) && !lower.includes('openclaude')
+    return !isCursorAgentTitle(title) && !isTraeCliTitle(title) && !lower.includes('openclaude')
   }
   // Why: permission/action-required Claude titles can omit the usual prefixes.
   // Token-match so cwd/worktree titles like "claude-scratch" do not become


### PR DESCRIPTION
## Summary

- Map the observed `traecli` launcher title through the shared worktree sidebar status pipeline.
- Keep bare `trae` task text from changing the owning agent label.
- Preserve live-PTY guards, existing agent mappings, and resume behavior.

Closes #11643.

## Screenshots

Not captured in this local pass. The issue includes the upstream symptom screenshot; focused tests reach the production row builder, but no Electron sidebar was mounted here. Final rendered-row presence remains a CI/browser check.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that catch regressions

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-process-recognition.test.ts src/shared/agent-detection.test.ts src/shared/terminal-title-agent-type.test.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts` passed: `Test Files 4 passed (4)`, `Tests 116 passed (116)`.
- `pnpm exec oxlint src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/shared/agent-detection.test.ts src/shared/agent-name-token-match.ts src/shared/agent-title-core.ts src/shared/agent-title-identity.ts src/shared/terminal-title-agent-type.test.ts src/shared/terminal-title-agent-type.ts` passed.
- `pnpm exec oxfmt --check src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/shared/agent-detection.test.ts src/shared/agent-name-token-match.ts src/shared/agent-title-core.ts src/shared/agent-title-identity.ts src/shared/terminal-title-agent-type.test.ts src/shared/terminal-title-agent-type.ts` passed.
- `git diff --check`
- `pnpm typecheck:web` passed.
- The focused tests cover the observed `traecli` idle and spinner-working titles, the live-PTY guard, unknown-title rejection, Claude task-title protection, process recognition, and the existing Codex no-live-PTY regression.

## AI Review Report

The diff maps the observed `traecli` launcher title, including Windows executable suffixes and the generic spinner-working form, through both title identity copies and the production sidebar row builder. Bare `trae` task text remains owned by the live Claude title path. The tests use live-PTY inputs, so stale configuration cannot create a row, and the existing Codex no-live-PTY regression remains in place. Full Electron layout rendering was not available in the focused harness; CI or browser review should confirm the final visible row. The change is provider-neutral and contains no resume, hook-service, platform-specific, SSH, IPC, credential, command, or filesystem behavior.

## Security Audit

The change only maps an existing local `traecli` agent identity to a live sidebar row. The focused tests verify that stale configuration cannot fabricate a status, similarly named commands are rejected, and Claude task text mentioning Trae stays Claude-owned. No resume, hook-service, IPC, credential, command, or filesystem path changes are present.

## Notes

Related PR https://github.com/stablyai/orca/pull/11278 covers resume support only. This fix uses the observed title path; a future Trae hook service remains outside this issue if title signals prove insufficient.
