### PR TITLE
fix(codex): restore managed credentials after failed reauthentication (#10795)

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1637,6 +1637,103 @@ describe('CodexAccountService config sync', () => {
     }
   })
 
+  it('restores WSL managed home auth.json when reauthentication fails', async () => {
+    vi.resetModules()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    const wslManagedHomePath = join(testState.userDataDir, 'wsl-account', 'home')
+    const wslLinuxHomePath = '/home/alice/.local/share/orca/codex-accounts/account-1/home'
+    const wslAuthPath = join(wslManagedHomePath, 'auth.json')
+    const originalAuthJson = JSON.stringify({
+      tokens: {
+        id_token: `header.${Buffer.from(JSON.stringify({ email: 'old@example.com' })).toString(
+          'base64url'
+        )}.signature`
+      }
+    })
+    mkdirSync(wslManagedHomePath, { recursive: true })
+    writeFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'account-1\n', 'utf-8')
+    writeFileSync(wslAuthPath, originalAuthJson, 'utf-8')
+
+    const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
+      const script = decodeEncodedWslBashCommand(String(args.at(-1)))
+      if (script.includes('readlink -f')) {
+        return `${wslLinuxHomePath}\n`
+      }
+      return ''
+    })
+    const spawnMock = vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough
+        stderr: PassThrough
+        kill: () => void
+      }
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.kill = vi.fn()
+      writeFileSync(wslAuthPath, '{"tokens":{"id_token":"partial"}}', 'utf-8')
+      queueMicrotask(() => child.emit('close', 1))
+      return child
+    })
+
+    vi.doMock('node:child_process', () => ({
+      execFileSync: execFileSyncMock,
+      spawn: spawnMock
+    }))
+    vi.doMock('../../shared/wsl-paths', () => ({
+      parseWslUncPath: (path: string) =>
+        path === wslManagedHomePath ? { distro: 'Ubuntu', linuxPath: wslLinuxHomePath } : null
+    }))
+    vi.doMock('../wsl', () => ({
+      toWindowsWslPath: () => wslManagedHomePath
+    }))
+
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'old@example.com',
+          managedHomePath: wslManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: null,
+      activeCodexManagedAccountIdsByRuntime: {
+        host: null,
+        wsl: { Ubuntu: 'account-1' }
+      }
+    })
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(settings) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      await expect(service.reauthenticateAccount('account-1')).rejects.toThrow('Codex login')
+      expect(readFileSync(wslAuthPath, 'utf-8')).toBe(originalAuthJson)
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
   it('recreates the expected missing WSL managed home before reauthenticating', async () => {
     vi.resetModules()
     const originalPlatform = process.platform
@@ -3263,7 +3360,7 @@ describe('CodexAccountService config sync', () => {
       )
       const loginPromise = (
         service as unknown as {
-          runCodexLogin(managedHomePath: string): Promise<void>
+          runCodexLogin(managedHomePath: string): Promise<unknown>
         }
       ).runCodexLogin(testState.fakeHomeDir)
       const rejection = expect(loginPromise).rejects.toThrow(
@@ -3286,6 +3383,133 @@ describe('CodexAccountService config sync', () => {
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
       expect(child.listenerCount('close')).toBe(0)
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('rejects a timed-out Codex login when the child never emits close', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: () => void
+    }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn()
+    const authPath = join(testState.fakeHomeDir, 'auth.json')
+    const originalAuthJson = createCodexAuthJson('user@example.com', 'provider-1', 'old-token')
+    writeFileSync(authPath, originalAuthJson, 'utf-8')
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: vi.fn(() => child)
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+      const loginPromise = (
+        service as unknown as {
+          runCodexLogin(managedHomePath: string): Promise<unknown>
+        }
+      ).runCodexLogin(testState.fakeHomeDir)
+      const rejection = expect(loginPromise).rejects.toThrow(
+        'Codex sign-in took too long to finish.'
+      )
+
+      writeFileSync(
+        authPath,
+        createCodexAuthJson('user@example.com', 'provider-1', 'half-written'),
+        'utf-8'
+      )
+      await vi.advanceTimersByTimeAsync(120_000)
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await rejection
+      expect(readFileSync(authPath, 'utf-8')).toBe(originalAuthJson)
+      expect(child.listenerCount('close')).toBe(0)
+
+      // A close arriving after the forced settlement must not restore a second time.
+      writeFileSync(authPath, 'sentinel', 'utf-8')
+      child.emit('close', 1)
+      expect(readFileSync(authPath, 'utf-8')).toBe('sentinel')
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('keeps a post-auth killed Windows login successful after the timeout fires', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: () => void
+      pid: number
+      exitCode: number | null
+      signalCode: string | null
+    }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn()
+    child.pid = 4444
+    child.exitCode = null
+    child.signalCode = null
+    const authPath = join(testState.fakeHomeDir, 'auth.json')
+    writeFileSync(
+      authPath,
+      createCodexAuthJson('user@example.com', 'provider-1', 'old-token'),
+      'utf-8'
+    )
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: vi.fn(() => child)
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+      const loginPromise = (
+        service as unknown as {
+          runCodexLogin(managedHomePath: string): Promise<unknown>
+        }
+      ).runCodexLogin(testState.fakeHomeDir)
+
+      const newAuthJson = createCodexAuthJson('user@example.com', 'provider-1', 'new-token')
+      writeFileSync(authPath, newAuthJson, 'utf-8')
+      // Auth watch sees the new bytes, then the post-auth grace kills a tree that never closes.
+      await vi.advanceTimersByTimeAsync(6_000)
+      await vi.advanceTimersByTimeAsync(120_000)
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(loginPromise).resolves.toBeDefined()
+      expect(readFileSync(authPath, 'utf-8')).toBe(newAuthJson)
     } finally {
       Object.defineProperty(process, 'platform', originalPlatform)
       vi.useRealTimers()
@@ -3336,7 +3560,7 @@ describe('CodexAccountService config sync', () => {
       )
       const loginPromise = (
         service as unknown as {
-          runCodexLogin(managedHomePath: string): Promise<void>
+          runCodexLogin(managedHomePath: string): Promise<unknown>
         }
       ).runCodexLogin(testState.fakeHomeDir)
 
@@ -3359,7 +3583,7 @@ describe('CodexAccountService config sync', () => {
 
       // The forced non-zero exit still counts as a successful login.
       child.emit('close', 1)
-      await expect(loginPromise).resolves.toBeUndefined()
+      await expect(loginPromise).resolves.toBeDefined()
       expect(readFileSync(authPath, 'utf-8')).toBe(
         createCodexAuthJson('user@example.com', 'provider-account-1', 'refresh-token')
       )
@@ -3411,7 +3635,7 @@ describe('CodexAccountService config sync', () => {
         createRuntimeHome() as never
       )
       const loginPromise = (
-        service as unknown as { runCodexLogin(managedHomePath: string): Promise<void> }
+        service as unknown as { runCodexLogin(managedHomePath: string): Promise<unknown> }
       ).runCodexLogin(testState.fakeHomeDir)
 
       await vi.advanceTimersByTimeAsync(6_000)
@@ -3430,7 +3654,7 @@ describe('CodexAccountService config sync', () => {
       )
 
       child.emit('close', 1)
-      await expect(loginPromise).resolves.toBeUndefined()
+      await expect(loginPromise).resolves.toBeDefined()
     } finally {
       Object.defineProperty(process, 'platform', originalPlatform)
       vi.useRealTimers()

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1019,8 +1019,15 @@ describe('CodexAccountService config sync', () => {
       label: 'a login that fails',
       accountId: 'account-1',
       outcome: 'login-failure',
-      expectedActiveAccountId: null,
-      expectedUpdateCount: 1
+      expectedActiveAccountId: 'account-1',
+      expectedUpdateCount: 2
+    },
+    {
+      label: 'login output that is malformed',
+      accountId: 'account-1',
+      outcome: 'malformed-output',
+      expectedActiveAccountId: 'account-1',
+      expectedUpdateCount: 2
     },
     {
       label: 'credentials rejected by runtime validation',
@@ -1100,6 +1107,11 @@ describe('CodexAccountService config sync', () => {
           queueMicrotask(() => child.emit('close', 1))
           return child
         }
+        if (testCase.outcome === 'malformed-output') {
+          writeFileSync(join(options.env.CODEX_HOME!, 'auth.json'), 'not-json', 'utf-8')
+          queueMicrotask(() => child.emit('close', 0))
+          return child
+        }
         writeFileSync(
           join(options.env.CODEX_HOME!, 'auth.json'),
           createCodexAuthJson('reauthenticated@example.com', 'provider-new', 'refresh-new'),
@@ -1139,16 +1151,18 @@ describe('CodexAccountService config sync', () => {
     )
 
     let result: CodexRateLimitAccountsState | null = null
-    if (testCase.outcome === 'login-failure') {
+    if (testCase.outcome === 'login-failure' || testCase.outcome === 'malformed-output') {
       await expect(service.reauthenticateAccount(testCase.accountId)).rejects.toThrow(
-        'Codex login exited with code 1.'
+        testCase.outcome === 'login-failure'
+          ? 'Codex login exited with code 1.'
+          : 'Codex auth.json is corrupt or not valid JSON'
       )
     } else {
       result = await service.reauthenticateAccount(testCase.accountId)
     }
 
-    expect(result?.activeAccountId ?? null).toBe(testCase.expectedActiveAccountId)
     if (result) {
+      expect(result.activeAccountId ?? null).toBe(testCase.expectedActiveAccountId)
       expect(result.activeAccountIdsByRuntime).toEqual({
         host: testCase.expectedActiveAccountId,
         wsl: { Ubuntu: null }
@@ -1158,10 +1172,14 @@ describe('CodexAccountService config sync', () => {
       activeCodexManagedAccountId: testCase.expectedActiveAccountId,
       activeCodexManagedAccountIdsByRuntime: {
         host: testCase.expectedActiveAccountId,
-        wsl: { Ubuntu: null }
+        wsl: {
+          Ubuntu: ['login-failure', 'malformed-output'].includes(testCase.outcome)
+            ? 'account-wsl'
+            : null
+        }
       }
     })
-    const completedLogin = testCase.outcome !== 'login-failure'
+    const completedLogin = !['login-failure', 'malformed-output'].includes(testCase.outcome)
     expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(completedLogin ? 1 : 0)
     if (completedLogin) {
       expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledWith({ runtime: 'host' })
@@ -1171,6 +1189,19 @@ describe('CodexAccountService config sync', () => {
     }
     expect(rateLimits.refreshForCodexAccountChange).toHaveBeenCalledTimes(completedLogin ? 1 : 0)
     expect(store.updateSettings).toHaveBeenCalledTimes(testCase.expectedUpdateCount)
+    for (const entry of hostAccounts) {
+      expect(readFileSync(join(entry.managedHomePath, 'auth.json'), 'utf-8')).toBe(
+        testCase.outcome !== 'login-failure' &&
+          testCase.outcome !== 'malformed-output' &&
+          entry.id === testCase.accountId
+          ? createCodexAuthJson('reauthenticated@example.com', 'provider-new', 'refresh-new')
+          : createCodexAuthJson(
+              `${entry.id}@example.com`,
+              `provider-${entry.id}`,
+              `refresh-${entry.id}`
+            )
+      )
+    }
   })
 
   it('does not recreate a missing managed home at a different account path', async () => {
@@ -3199,6 +3230,8 @@ describe('CodexAccountService config sync', () => {
   it('removes command listeners when Codex login times out', async () => {
     vi.resetModules()
     vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
     const child = new EventEmitter() as EventEmitter & {
       stdout: PassThrough
       stderr: PassThrough
@@ -3207,6 +3240,7 @@ describe('CodexAccountService config sync', () => {
     child.stdout = new PassThrough()
     child.stderr = new PassThrough()
     child.kill = vi.fn()
+    const authPath = join(testState.fakeHomeDir, 'auth.json')
     const spawnMock = vi.fn(() => child)
     vi.doMock('node:child_process', () => ({
       execFileSync: vi.fn(),
@@ -3236,15 +3270,24 @@ describe('CodexAccountService config sync', () => {
         'Codex sign-in took too long to finish.'
       )
 
+      writeFileSync(
+        authPath,
+        createCodexAuthJson('new@example.com', 'new-account', 'new-token'),
+        'utf-8'
+      )
       await vi.advanceTimersByTimeAsync(120_000)
+      expect(readFileSync(authPath, 'utf-8')).toContain('new-token')
+      child.emit('close', 1)
 
       await rejection
       expect(child.kill).toHaveBeenCalledTimes(1)
+      expect(existsSync(authPath)).toBe(false)
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
       expect(child.listenerCount('close')).toBe(0)
     } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
       vi.useRealTimers()
       vi.doUnmock('node:child_process')
       vi.doUnmock('../codex-cli/command')
@@ -3271,6 +3314,7 @@ describe('CodexAccountService config sync', () => {
     child.exitCode = null
     child.signalCode = null
     const execFileSyncMock = vi.fn()
+    const authPath = join(testState.fakeHomeDir, 'auth.json')
     const spawnMock = vi.fn(() => child)
     vi.doMock('node:child_process', () => ({
       execFileSync: execFileSyncMock,
@@ -3316,6 +3360,9 @@ describe('CodexAccountService config sync', () => {
       // The forced non-zero exit still counts as a successful login.
       child.emit('close', 1)
       await expect(loginPromise).resolves.toBeUndefined()
+      expect(readFileSync(authPath, 'utf-8')).toBe(
+        createCodexAuthJson('user@example.com', 'provider-account-1', 'refresh-token')
+      )
     } finally {
       Object.defineProperty(process, 'platform', originalPlatform)
       vi.useRealTimers()

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1728,6 +1728,9 @@ describe('CodexAccountService config sync', () => {
       await expect(service.reauthenticateAccount('account-1')).rejects.toThrow('Codex login')
       expect(readFileSync(wslAuthPath, 'utf-8')).toBe(originalAuthJson)
     } finally {
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../../shared/wsl-paths')
+      vi.doUnmock('../wsl')
       Object.defineProperty(process, 'platform', {
         configurable: true,
         value: originalPlatform
@@ -1837,6 +1840,9 @@ describe('CodexAccountService config sync', () => {
       expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
     } finally {
       warnSpy.mockRestore()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../../shared/wsl-paths')
+      vi.doUnmock('../wsl')
       Object.defineProperty(process, 'platform', {
         configurable: true,
         value: originalPlatform

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  unlinkSync,
   utimesSync,
   writeFileSync
 } from 'node:fs'
@@ -3417,6 +3418,132 @@ describe('CodexAccountService config sync', () => {
 
     try {
       const { CodexAccountService } = await import('./service')
+      const store = createStore(createSettings({ activeCodexManagedAccountId: 'account-1' }))
+      const service = new CodexAccountService(
+        store as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+      const loginPromise = (
+        service as unknown as {
+          runCodexLogin(managedHomePath: string): Promise<unknown>
+        }
+      ).runCodexLogin(testState.fakeHomeDir)
+      const rejection = expect(loginPromise).rejects.toThrow(
+        'Codex sign-in took too long to finish.'
+      )
+
+      // The login clears the selection and then hangs without writing credentials.
+      store.updateSettings({ activeCodexManagedAccountId: null })
+      unlinkSync(authPath)
+      await vi.advanceTimersByTimeAsync(120_000)
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await rejection
+      expect(readFileSync(authPath, 'utf-8')).toBe(originalAuthJson)
+      expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+      expect(child.listenerCount('close')).toBe(0)
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('keeps credentials the auth watch saw in the same tick the login timeout fired', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: () => void
+      pid: number
+      exitCode: number | null
+      signalCode: string | null
+    }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn()
+    child.pid = 4545
+    child.exitCode = null
+    child.signalCode = null
+    const authPath = join(testState.fakeHomeDir, 'auth.json')
+    writeFileSync(
+      authPath,
+      createCodexAuthJson('user@example.com', 'provider-1', 'old-token'),
+      'utf-8'
+    )
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: vi.fn(() => child)
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        createStore(createSettings()) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+      const loginPromise = (
+        service as unknown as {
+          runCodexLogin(managedHomePath: string): Promise<unknown>
+        }
+      ).runCodexLogin(testState.fakeHomeDir)
+
+      // Credentials land inside the last poll window, so the timeout fires before the post-auth kill is scheduled.
+      const newAuthJson = createCodexAuthJson('user@example.com', 'provider-1', 'new-token')
+      await vi.advanceTimersByTimeAsync(119_500)
+      writeFileSync(authPath, newAuthJson, 'utf-8')
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(loginPromise).resolves.toBeDefined()
+      expect(readFileSync(authPath, 'utf-8')).toBe(newAuthJson)
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('keeps the timeout message when killing the login tree emits an error', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: () => void
+    }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn(() => {
+      child.emit('error', Object.assign(new Error('kill EPERM'), { code: 'EPERM' }))
+    })
+    writeFileSync(
+      join(testState.fakeHomeDir, 'auth.json'),
+      createCodexAuthJson('user@example.com', 'provider-1', 'old-token'),
+      'utf-8'
+    )
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: vi.fn(() => child)
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    try {
+      const { CodexAccountService } = await import('./service')
       const service = new CodexAccountService(
         createStore(createSettings()) as never,
         createRateLimits() as never,
@@ -3431,22 +3558,9 @@ describe('CodexAccountService config sync', () => {
         'Codex sign-in took too long to finish.'
       )
 
-      writeFileSync(
-        authPath,
-        createCodexAuthJson('user@example.com', 'provider-1', 'half-written'),
-        'utf-8'
-      )
       await vi.advanceTimersByTimeAsync(120_000)
       await vi.advanceTimersByTimeAsync(5_000)
-
       await rejection
-      expect(readFileSync(authPath, 'utf-8')).toBe(originalAuthJson)
-      expect(child.listenerCount('close')).toBe(0)
-
-      // A close arriving after the forced settlement must not restore a second time.
-      writeFileSync(authPath, 'sentinel', 'utf-8')
-      child.emit('close', 1)
-      expect(readFileSync(authPath, 'utf-8')).toBe('sentinel')
     } finally {
       Object.defineProperty(process, 'platform', originalPlatform)
       vi.useRealTimers()

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -68,6 +68,7 @@ const WINDOWS_RM_MAX_RETRIES = 8
 const WINDOWS_RM_RETRY_DELAY_MS = 150
 const WINDOWS_LOGIN_AUTH_POLL_INTERVAL_MS = 500
 const WINDOWS_LOGIN_POST_AUTH_EXIT_GRACE_MS = 5_000
+const LOGIN_TIMEOUT_CLOSE_GRACE_MS = 5_000
 const WINDOWS_LOGIN_TREE_KILL_TIMEOUT_MS = 5_000
 
 type CodexOAuthCredentials = {
@@ -82,10 +83,14 @@ type ResolvedCodexIdentity = {
   workspaceAccountId: string | null
 }
 
-type CodexLoginSnapshot = {
-  authJson: string | null | undefined
+type CodexSelectionSnapshot = {
   activeCodexManagedAccountId: GlobalSettings['activeCodexManagedAccountId']
   activeCodexManagedAccountIdsByRuntime: GlobalSettings['activeCodexManagedAccountIdsByRuntime']
+}
+
+// Why: undefined means the auth bytes were never captured, so rollback skips the file; null means captured and absent.
+type CodexLoginSnapshot = CodexSelectionSnapshot & {
+  authJson: string | null | undefined
 }
 
 type CanonicalCodexConfig = {
@@ -859,14 +864,14 @@ export class CodexAccountService {
     const account = this.requireAccount(accountId)
     const managedHomePath = this.ensureManagedHomeForReauthentication(account)
     const accountTarget = getCodexSelectionTargetForAccount(account)
-    const loginSnapshot = this.captureLoginSnapshot(managedHomePath)
+    const selectionSnapshot = this.captureSelectionSnapshot()
     const selectedAccountId = getSelectedCodexAccountIdForTarget(
       this.store.getSettings(),
       accountTarget
     )
 
     this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, undefined, account.id)
-    await this.runCodexLogin(managedHomePath, loginSnapshot)
+    const loginSnapshot = await this.runCodexLogin(managedHomePath, selectionSnapshot)
     let identity: ResolvedCodexIdentity
     try {
       identity = this.readIdentityFromHome(managedHomePath, account.id)
@@ -1643,12 +1648,9 @@ export class CodexAccountService {
     }
   }
 
-  private captureLoginSnapshot(managedHomePath: string): CodexLoginSnapshot {
+  private captureSelectionSnapshot(): CodexSelectionSnapshot {
     const settings = this.store.getSettings()
     return {
-      authJson: parseWslUncPath(managedHomePath)
-        ? undefined
-        : readLoginAuthSnapshot(join(managedHomePath, 'auth.json')),
       activeCodexManagedAccountId: settings.activeCodexManagedAccountId,
       activeCodexManagedAccountIdsByRuntime: structuredClone(
         settings.activeCodexManagedAccountIdsByRuntime
@@ -1708,13 +1710,17 @@ export class CodexAccountService {
 
   private async runCodexLogin(
     managedHomePath: string,
-    snapshot?: CodexLoginSnapshot
-  ): Promise<void> {
+    selectionSnapshot?: CodexSelectionSnapshot
+  ): Promise<CodexLoginSnapshot> {
     const wslInfo = parseWslUncPath(managedHomePath)
     if (wslInfo) {
       this.assertWslCodexCliAvailable(wslInfo)
     }
-    const loginSnapshot = snapshot ?? this.captureLoginSnapshot(managedHomePath)
+    // Why: reading a WSL home over UNC before the distro answers can block the main process and report a dead path as an absent file.
+    const loginSnapshot: CodexLoginSnapshot = {
+      ...(selectionSnapshot ?? this.captureSelectionSnapshot()),
+      authJson: readLoginAuthSnapshot(join(managedHomePath, 'auth.json'))
+    }
     // Why: reauthentication starts with an existing auth.json. Only new auth
     // bytes prove this login completed; existence alone would kill the
     // Windows OAuth flow five seconds after it opened.
@@ -1761,6 +1767,7 @@ export class CodexAccountService {
       let timeout: ReturnType<typeof setTimeout> | null = null
       let authWatchInterval: ReturnType<typeof setInterval> | null = null
       let postAuthExitTimeout: ReturnType<typeof setTimeout> | null = null
+      let forceSettleTimeout: ReturnType<typeof setTimeout> | null = null
       let loginTreeKilledAfterAuth = false
       let failureError: Error | null = null
       const authJsonPath = join(managedHomePath, 'auth.json')
@@ -1768,6 +1775,10 @@ export class CodexAccountService {
         if (timeout) {
           clearTimeout(timeout)
           timeout = null
+        }
+        if (forceSettleTimeout) {
+          clearTimeout(forceSettleTimeout)
+          forceSettleTimeout = null
         }
         if (authWatchInterval) {
           clearInterval(authWatchInterval)
@@ -1792,10 +1803,47 @@ export class CodexAccountService {
         callback()
       }
 
+      // Why: the post-auth kill already secured new credentials, so a later failure must not roll them back.
+      const loginSucceededAfterForcedKill = (): boolean =>
+        loginTreeKilledAfterAuth && existsSync(authJsonPath)
+
+      const settleFailure = (error: Error): void => {
+        settle(() => {
+          try {
+            this.restoreLoginSnapshot(managedHomePath, loginSnapshot)
+            rejectPromise(error)
+          } catch (rollbackError) {
+            rejectPromise(
+              new Error(
+                `${error.message} Credential restoration failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+                { cause: error }
+              )
+            )
+          }
+        })
+      }
+
       const timeoutError = new Error('Codex sign-in took too long to finish. Please try again.')
+      // Why: a killed login tree can fail to emit close, which would leave the caller waiting past the timeout unbounded.
+      const armForcedSettle = (): void => {
+        if (settled || forceSettleTimeout) {
+          return
+        }
+        forceSettleTimeout = setTimeout(() => {
+          if (loginSucceededAfterForcedKill()) {
+            settle(() => {
+              resolvePromise()
+            })
+            return
+          }
+          settleFailure(failureError ?? timeoutError)
+        }, LOGIN_TIMEOUT_CLOSE_GRACE_MS)
+      }
+
       timeout = setTimeout(() => {
         failureError = timeoutError
         killLoginProcessTree(child)
+        armForcedSettle()
       }, LOGIN_TIMEOUT_MS)
 
       // Why: on Windows the codex login CLI can linger after writing auth.json,
@@ -1828,40 +1876,29 @@ export class CodexAccountService {
             : 'Codex CLI found but could not run — Node.js may not be in your PATH.'
           : error.message
         failureError = new Error(message)
+        // Why: close normally follows a spawn error, but nothing guarantees it.
+        armForcedSettle()
       }
 
       const onClose = (code: number | null): void => {
-        settle(() => {
-          // Why: the post-auth tree kill is a success path — auth.json already
-          // exists and codex only failed to exit on its own, so the forced
-          // non-zero exit must not surface as a login failure.
-          if (
-            !failureError &&
-            (code === 0 || (loginTreeKilledAfterAuth && existsSync(authJsonPath)))
-          ) {
+        // Why: the post-auth tree kill is a success path — auth.json already
+        // exists and codex only failed to exit on its own, so the forced
+        // non-zero exit must not surface as a login failure.
+        if ((!failureError && code === 0) || loginSucceededAfterForcedKill()) {
+          settle(() => {
             resolvePromise()
-            return
-          }
-          const trimmedOutput = output.trim()
-          const error =
-            failureError ??
+          })
+          return
+        }
+        const trimmedOutput = output.trim()
+        settleFailure(
+          failureError ??
             new Error(
               trimmedOutput
                 ? `Codex login failed: ${trimmedOutput}`
                 : `Codex login exited with code ${code ?? 'unknown'}.`
             )
-          try {
-            this.restoreLoginSnapshot(managedHomePath, loginSnapshot)
-            rejectPromise(error)
-          } catch (rollbackError) {
-            rejectPromise(
-              new Error(
-                `${error.message} Credential restoration failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
-                { cause: error }
-              )
-            )
-          }
-        })
+        )
       }
 
       child.stdout.on('data', appendOutput)
@@ -1869,6 +1906,8 @@ export class CodexAccountService {
       child.on('error', onError)
       child.on('close', onClose)
     })
+
+    return loginSnapshot
   }
 
   private assertWslCodexCliAvailable(wslInfo: { distro: string; linuxPath: string }): void {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -1768,7 +1768,7 @@ export class CodexAccountService {
       let authWatchInterval: ReturnType<typeof setInterval> | null = null
       let postAuthExitTimeout: ReturnType<typeof setTimeout> | null = null
       let forceSettleTimeout: ReturnType<typeof setTimeout> | null = null
-      let loginTreeKilledAfterAuth = false
+      let loginAuthSecured = false
       let failureError: Error | null = null
       const authJsonPath = join(managedHomePath, 'auth.json')
       const cleanupListeners = (): void => {
@@ -1803,9 +1803,10 @@ export class CodexAccountService {
         callback()
       }
 
-      // Why: the post-auth kill already secured new credentials, so a later failure must not roll them back.
-      const loginSucceededAfterForcedKill = (): boolean =>
-        loginTreeKilledAfterAuth && existsSync(authJsonPath)
+      // Why: once the auth watch has seen new credentials the login completed, whether or not a timeout also fired.
+      const loginFinishedBeforeForcedKill = (): boolean =>
+        loginAuthSecured &&
+        loginAuthChanged(initialAuthSnapshot, readLoginAuthSnapshot(authJsonPath))
 
       const settleFailure = (error: Error): void => {
         settle(() => {
@@ -1830,7 +1831,7 @@ export class CodexAccountService {
           return
         }
         forceSettleTimeout = setTimeout(() => {
-          if (loginSucceededAfterForcedKill()) {
+          if (loginFinishedBeforeForcedKill()) {
             settle(() => {
               resolvePromise()
             })
@@ -1855,12 +1856,12 @@ export class CodexAccountService {
           if (!loginAuthChanged(initialAuthSnapshot, readLoginAuthSnapshot(authJsonPath))) {
             return
           }
+          loginAuthSecured = true
           if (authWatchInterval) {
             clearInterval(authWatchInterval)
             authWatchInterval = null
           }
           postAuthExitTimeout = setTimeout(() => {
-            loginTreeKilledAfterAuth = true
             killLoginProcessTree(child)
           }, WINDOWS_LOGIN_POST_AUTH_EXIT_GRACE_MS)
         }, WINDOWS_LOGIN_AUTH_POLL_INTERVAL_MS)
@@ -1875,16 +1876,16 @@ export class CodexAccountService {
             ? 'Codex CLI not found.'
             : 'Codex CLI found but could not run — Node.js may not be in your PATH.'
           : error.message
-        failureError = new Error(message)
+        // Why: a kill that fails after the timeout must not replace the user-facing timeout message with its errno.
+        failureError ??= new Error(message)
         // Why: close normally follows a spawn error, but nothing guarantees it.
         armForcedSettle()
       }
 
       const onClose = (code: number | null): void => {
-        // Why: the post-auth tree kill is a success path — auth.json already
-        // exists and codex only failed to exit on its own, so the forced
-        // non-zero exit must not surface as a login failure.
-        if ((!failureError && code === 0) || loginSucceededAfterForcedKill()) {
+        // Why: a tree we killed after it wrote new credentials succeeded; its
+        // forced non-zero exit must not surface as a login failure.
+        if ((!failureError && code === 0) || loginFinishedBeforeForcedKill()) {
           settle(() => {
             resolvePromise()
           })

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -10,7 +10,8 @@ import type {
   CodexManagedAccount,
   CodexManagedAccountSummary,
   CodexRateLimitAccountsState,
-  CodexSystemDefaultIdentity
+  CodexSystemDefaultIdentity,
+  GlobalSettings
 } from '../../shared/types'
 import type {
   CodexRateLimitResetOutcome,
@@ -79,6 +80,12 @@ type ResolvedCodexIdentity = {
   providerAccountId: string | null
   workspaceLabel: string | null
   workspaceAccountId: string | null
+}
+
+type CodexLoginSnapshot = {
+  authJson: string | null | undefined
+  activeCodexManagedAccountId: GlobalSettings['activeCodexManagedAccountId']
+  activeCodexManagedAccountIdsByRuntime: GlobalSettings['activeCodexManagedAccountIdsByRuntime']
 }
 
 type CanonicalCodexConfig = {
@@ -852,16 +859,27 @@ export class CodexAccountService {
     const account = this.requireAccount(accountId)
     const managedHomePath = this.ensureManagedHomeForReauthentication(account)
     const accountTarget = getCodexSelectionTargetForAccount(account)
+    const loginSnapshot = this.captureLoginSnapshot(managedHomePath)
     const selectedAccountId = getSelectedCodexAccountIdForTarget(
       this.store.getSettings(),
       accountTarget
     )
 
     this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, undefined, account.id)
-    await this.runCodexLogin(managedHomePath)
-    const identity = this.readIdentityFromHome(managedHomePath, account.id)
+    await this.runCodexLogin(managedHomePath, loginSnapshot)
+    let identity: ResolvedCodexIdentity
+    try {
+      identity = this.readIdentityFromHome(managedHomePath, account.id)
+    } catch (error) {
+      this.restoreLoginSnapshotOrThrow(managedHomePath, loginSnapshot, error)
+      throw error
+    }
     if (!identity.email) {
-      throw new Error('Codex login completed, but Orca could not resolve the account email.')
+      const error = new Error(
+        'Codex login completed, but Orca could not resolve the account email.'
+      )
+      this.restoreLoginSnapshotOrThrow(managedHomePath, loginSnapshot, error)
+      throw error
     }
 
     const settings = this.store.getSettings()
@@ -1625,17 +1643,82 @@ export class CodexAccountService {
     }
   }
 
-  private async runCodexLogin(managedHomePath: string): Promise<void> {
+  private captureLoginSnapshot(managedHomePath: string): CodexLoginSnapshot {
+    const settings = this.store.getSettings()
+    return {
+      authJson: parseWslUncPath(managedHomePath)
+        ? undefined
+        : readLoginAuthSnapshot(join(managedHomePath, 'auth.json')),
+      activeCodexManagedAccountId: settings.activeCodexManagedAccountId,
+      activeCodexManagedAccountIdsByRuntime: structuredClone(
+        settings.activeCodexManagedAccountIdsByRuntime
+      )
+    }
+  }
+
+  private restoreLoginSnapshot(managedHomePath: string, snapshot: CodexLoginSnapshot): void {
+    const authJsonPath = join(managedHomePath, 'auth.json')
+    let firstError: unknown
+    if (snapshot.authJson !== undefined) {
+      try {
+        if (snapshot.authJson === null) {
+          rmSync(authJsonPath, { force: true })
+        } else {
+          writeFileAtomically(authJsonPath, snapshot.authJson, { mode: 0o600 })
+        }
+      } catch (error) {
+        firstError = error
+      }
+    }
+
+    try {
+      const settings = this.store.getSettings()
+      if (
+        settings.activeCodexManagedAccountId !== snapshot.activeCodexManagedAccountId ||
+        JSON.stringify(settings.activeCodexManagedAccountIdsByRuntime) !==
+          JSON.stringify(snapshot.activeCodexManagedAccountIdsByRuntime)
+      ) {
+        this.store.updateSettings({
+          activeCodexManagedAccountId: snapshot.activeCodexManagedAccountId,
+          activeCodexManagedAccountIdsByRuntime: snapshot.activeCodexManagedAccountIdsByRuntime
+        })
+      }
+    } catch (error) {
+      firstError ??= error
+    }
+    if (firstError) {
+      throw firstError
+    }
+  }
+
+  private restoreLoginSnapshotOrThrow(
+    managedHomePath: string,
+    snapshot: CodexLoginSnapshot,
+    originalError: unknown
+  ): void {
+    try {
+      this.restoreLoginSnapshot(managedHomePath, snapshot)
+    } catch (rollbackError) {
+      throw new Error(
+        `${originalError instanceof Error ? originalError.message : 'Codex login failed'} Credential restoration failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+        { cause: originalError }
+      )
+    }
+  }
+
+  private async runCodexLogin(
+    managedHomePath: string,
+    snapshot?: CodexLoginSnapshot
+  ): Promise<void> {
     const wslInfo = parseWslUncPath(managedHomePath)
     if (wslInfo) {
       this.assertWslCodexCliAvailable(wslInfo)
     }
+    const loginSnapshot = snapshot ?? this.captureLoginSnapshot(managedHomePath)
     // Why: reauthentication starts with an existing auth.json. Only new auth
     // bytes prove this login completed; existence alone would kill the
     // Windows OAuth flow five seconds after it opened.
-    const initialAuthSnapshot = wslInfo
-      ? null
-      : readLoginAuthSnapshot(join(managedHomePath, 'auth.json'))
+    const initialAuthSnapshot = loginSnapshot.authJson
 
     await new Promise<void>((resolvePromise, rejectPromise) => {
       const spawnConfig = wslInfo
@@ -1679,6 +1762,7 @@ export class CodexAccountService {
       let authWatchInterval: ReturnType<typeof setInterval> | null = null
       let postAuthExitTimeout: ReturnType<typeof setTimeout> | null = null
       let loginTreeKilledAfterAuth = false
+      let failureError: Error | null = null
       const authJsonPath = join(managedHomePath, 'auth.json')
       const cleanupListeners = (): void => {
         if (timeout) {
@@ -1710,10 +1794,8 @@ export class CodexAccountService {
 
       const timeoutError = new Error('Codex sign-in took too long to finish. Please try again.')
       timeout = setTimeout(() => {
+        failureError = timeoutError
         killLoginProcessTree(child)
-        settle(() => {
-          rejectPromise(timeoutError)
-        })
       }, LOGIN_TIMEOUT_MS)
 
       // Why: on Windows the codex login CLI can linger after writing auth.json,
@@ -1737,17 +1819,15 @@ export class CodexAccountService {
       }
 
       const onError = (error: Error): void => {
-        settle(() => {
-          const isEnoent = (error as NodeJS.ErrnoException).code === 'ENOENT'
-          // Why: ENOENT is ambiguous — missing codex binary or missing node in PATH; a resolved full path implies node is missing.
-          const isBareCommand = spawnConfig.codexCommand === 'codex'
-          const message = isEnoent
-            ? isBareCommand
-              ? 'Codex CLI not found.'
-              : 'Codex CLI found but could not run — Node.js may not be in your PATH.'
-            : error.message
-          rejectPromise(new Error(message))
-        })
+        const isEnoent = (error as NodeJS.ErrnoException).code === 'ENOENT'
+        // Why: ENOENT is ambiguous — missing codex binary or missing node in PATH; a resolved full path implies node is missing.
+        const isBareCommand = spawnConfig.codexCommand === 'codex'
+        const message = isEnoent
+          ? isBareCommand
+            ? 'Codex CLI not found.'
+            : 'Codex CLI found but could not run — Node.js may not be in your PATH.'
+          : error.message
+        failureError = new Error(message)
       }
 
       const onClose = (code: number | null): void => {
@@ -1755,18 +1835,32 @@ export class CodexAccountService {
           // Why: the post-auth tree kill is a success path — auth.json already
           // exists and codex only failed to exit on its own, so the forced
           // non-zero exit must not surface as a login failure.
-          if (code === 0 || (loginTreeKilledAfterAuth && existsSync(authJsonPath))) {
+          if (
+            !failureError &&
+            (code === 0 || (loginTreeKilledAfterAuth && existsSync(authJsonPath)))
+          ) {
             resolvePromise()
             return
           }
           const trimmedOutput = output.trim()
-          rejectPromise(
+          const error =
+            failureError ??
             new Error(
               trimmedOutput
                 ? `Codex login failed: ${trimmedOutput}`
                 : `Codex login exited with code ${code ?? 'unknown'}.`
             )
-          )
+          try {
+            this.restoreLoginSnapshot(managedHomePath, loginSnapshot)
+            rejectPromise(error)
+          } catch (rollbackError) {
+            rejectPromise(
+              new Error(
+                `${error.message} Credential restoration failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+                { cause: error }
+              )
+            )
+          }
         })
       }
 


### PR DESCRIPTION
## Summary

- Snapshot managed Codex credentials and active-account selection before login, including WSL managed homes once the distro has answered.
- Restore both when a login times out or fails, with a bounded wait for the login process to close, using the existing atomic write path.

Closes #10795.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/service.test.ts`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/main/codex-accounts/service.ts src/main/codex-accounts/service.test.ts`
- `pnpm exec oxfmt --check src/main/codex-accounts/service.ts src/main/codex-accounts/service.test.ts`
- `git diff --check`

The focused account-service suite passed all 75 tests. The node typecheck, changed-file lint, changed-file format check, and whitespace check passed.

## AI Review Report

The change restores the captured managed auth bytes and runtime selection after timeout, non-zero exit, or malformed successful output. A timed-out sign-in settles within the timeout plus a five second close grace even when the login process never exits, so the caller is never left waiting without a bound. Once the auth watch has observed new credential bytes the login counts as successful, so a timeout arriving in the same window cannot roll back credentials the login just wrote. Successful replacement remains in place, and an unrelated managed account remains unchanged. The existing Windows lingering-login behavior remains covered.

## Security Audit

The snapshot is held only for the login attempt and restoration uses the existing atomic writer. WSL managed homes are covered by the same restore; their auth bytes are read only after the distro availability check succeeds, so a stopped distro cannot block the main process on a UNC read or be mistaken for an absent credential file. The implementation does not log auth contents or add a credential source.

## Notes

Merged PR https://github.com/stablyai/orca/pull/9430 covers lingering Windows login processes, not credential rollback. Full repository lint, full typecheck, full tests, and build were not run locally.
