### PR TITLE
fix(runtime): rebind terminal sends after host identity changes (#11191)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -6592,6 +6592,7 @@
       "invariant": "A guarded note send writes only to the exact PTY binding checked by the guard and only while permission/wait evidence allows input; fresh hook state conflicting with an ordinary shell foreground requires fresh provider confirmation of a recognized agent in that PTY.",
       "oracle": "Fresh explicit state plus ordinary PowerShell plus confirmed recognized agent is sendable on the same PTY. Confirmed shell/non-agent, unavailable confirmation, PTY exit, handle rebind, or a callback PTY mismatch returns a refusal or not-writable result and writes zero bytes.",
       "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/ipc/pty.test.ts src/main/providers/agent-foreground-process.test.ts src/main/providers/local-pty-provider.test.ts src/main/providers/windows-conpty-process-membership.test.ts src/main/daemon/daemon-foreground-confirmation-protocol.test.ts src/main/daemon/pty-subprocess.test.ts src/renderer/src/lib/active-agent-note-send.test.ts src/renderer/src/lib/active-agent-note-terminal-binding.test.ts src/renderer/src/components/browser-pane/BrowserAnnotationSendMenuContent.test.tsx",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/rpc/terminal-send.test.ts src/main/ipc/pty.test.ts src/main/providers/agent-foreground-process.test.ts src/main/providers/local-pty-provider.test.ts src/main/providers/windows-conpty-process-membership.test.ts src/main/daemon/daemon-foreground-confirmation-protocol.test.ts src/main/daemon/pty-subprocess.test.ts src/renderer/src/lib/active-agent-note-send.test.ts src/renderer/src/components/browser-pane/BrowserAnnotationSendMenuContent.test.tsx"
       ],
       "testFiles": [
@@ -6604,6 +6605,7 @@
         "src/main/daemon/daemon-foreground-confirmation-protocol.test.ts",
         "src/main/daemon/pty-subprocess.test.ts",
         "src/renderer/src/lib/active-agent-note-send.test.ts",
+        "src/renderer/src/lib/active-agent-note-terminal-binding.test.ts",
         "src/renderer/src/components/browser-pane/BrowserAnnotationSendMenuContent.test.tsx"
       ],
       "assertionRefs": [
@@ -6663,7 +6665,17 @@
         },
         {
           "file": "src/renderer/src/lib/active-agent-note-send.test.ts",
-          "assertions": ["selected active-agent note sends retain guarded paste and submit routing"]
+          "assertions": [
+            "selected active-agent note sends retain guarded paste and submit routing",
+            "a host restart before the first accepted write remints once, while a restart after an accepted paste never replays prompt bytes"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/active-agent-note-terminal-binding.test.ts",
+          "assertions": [
+            "direct and paired SSH reconnect generations invalidate only the affected folder or worktree pane binding",
+            "retained pane bindings remain bounded under worktree churn"
+          ]
         },
         {
           "file": "src/renderer/src/components/browser-pane/BrowserAnnotationSendMenuContent.test.tsx",

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2745,6 +2745,56 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('remints a terminal handle when a replacement runtime owns the same pane', async () => {
+    const tabId = 'tab-runtime-rebind'
+    const leafId = HEADLESS_LEAF_ID
+    const graph = {
+      tabs: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Codex',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-runtime-rebind'
+        }
+      ]
+    } satisfies RuntimeSyncWindowGraph
+
+    const oldRuntime = new OrcaRuntimeService(store)
+    oldRuntime.attachWindow(1)
+    oldRuntime.syncWindowGraph(1, graph)
+    const oldHandle = (await oldRuntime.listTerminals(`id:${TEST_WORKTREE_ID}`)).terminals[0]
+      ?.handle
+    expect(oldHandle).toBeTruthy()
+
+    const replacementRuntime = new OrcaRuntimeService(store)
+    replacementRuntime.attachWindow(1)
+    replacementRuntime.syncWindowGraph(1, graph)
+    const replacement = await replacementRuntime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    const newHandle = replacement.terminals[0]?.handle
+    expect(newHandle).toBeTruthy()
+    expect(newHandle).not.toBe(oldHandle)
+
+    await expect(replacementRuntime.showTerminal(oldHandle!)).rejects.toThrow(
+      'terminal_handle_stale'
+    )
+    await expect(replacementRuntime.showTerminal(newHandle!)).resolves.toMatchObject({
+      handle: newHandle,
+      tabId,
+      leafId,
+      ptyId: 'pty-runtime-rebind'
+    })
+  })
+
   it('rejects pane resolution when leaf and PTY ownership disagree', () => {
     const runtime = new OrcaRuntimeService(store)
     const tabId = 'tab-1'

--- a/src/renderer/src/lib/active-agent-note-send.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send.test.ts
@@ -8,6 +8,7 @@ import {
   probeActiveAgentNoteTarget,
   sendNotesToActiveAgentSession
 } from './active-agent-note-send'
+import { clearActiveAgentTerminalBindingCacheForTests } from './active-agent-note-terminal-binding'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../shared/types'
@@ -90,6 +91,7 @@ vi.mock('@/runtime/runtime-rpc-client', () => ({
 
 describe('active agent note send', () => {
   beforeEach(() => {
+    clearActiveAgentTerminalBindingCacheForTests()
     testState.appState = {
       activeWorktreeId: 'wt-1',
       activeTabType: 'terminal',
@@ -372,6 +374,74 @@ describe('active agent note send', () => {
       },
       { timeoutMs: 15000 }
     )
+  })
+
+  it('clears a stale pane binding and re-resolves the reminted handle once', async () => {
+    let listCount = 0
+    const methods: string[] = []
+    testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
+      methods.push(method)
+      if (method === 'terminal.list') {
+        listCount += 1
+        return {
+          terminals: [
+            {
+              handle: listCount === 1 ? 'term-old-runtime' : 'term-new-runtime',
+              worktreeId: 'wt-1',
+              worktreePath: '/repo',
+              branch: 'main',
+              tabId: 'tab-9',
+              leafId: OTHER_LEAF_ID,
+              title: 'Codex',
+              connected: true,
+              writable: true,
+              lastOutputAt: 1,
+              preview: ''
+            }
+          ],
+          totalCount: 1,
+          truncated: false
+        }
+      }
+      if (method === 'terminal.agentStatus') {
+        if (params.terminal === 'term-old-runtime') {
+          throw new testState.RuntimeRpcCallError({
+            error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
+          })
+        }
+        return { agentStatus: { handle: 'term-new-runtime', isRunningAgent: true, status: null } }
+      }
+      if (method === 'terminal.send') {
+        expect(params.terminal).toBe('term-new-runtime')
+        return {
+          send: {
+            handle: 'term-new-runtime',
+            accepted: true,
+            bytesWritten: typeof params.text === 'string' ? params.text.length : 1
+          }
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      sendNotesToActiveAgentSession({
+        worktreeId: 'wt-1',
+        prompt: 'notes',
+        noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
+      })
+    ).resolves.toEqual({ status: 'sent' })
+
+    expect(listCount).toBe(2)
+    expect(methods).toEqual([
+      'terminal.list',
+      'terminal.agentStatus',
+      'terminal.list',
+      'terminal.agentStatus',
+      'terminal.send',
+      'terminal.agentStatus',
+      'terminal.send'
+    ])
   })
 
   it('maps active-focused guarded paste permission refusal to permission', async () => {
@@ -1068,7 +1138,7 @@ describe('active agent note send', () => {
         noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
       })
     ).resolves.toEqual({ status: 'no-agent' })
-    expect(methods).toEqual(['terminal.list', 'terminal.agentStatus', 'terminal.send'])
+    expect(methods).toEqual(['terminal.agentStatus', 'terminal.send'])
   })
 
   it('maps explicit target first-write refusal to not-writable', async () => {

--- a/src/renderer/src/lib/active-agent-note-send.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send.test.ts
@@ -18,6 +18,7 @@ const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
 const NOW = 1_700_000_000_000
 const PASTE_BEGIN = '\x1b[200~'
 const PASTE_END = '\x1b[201~'
+type TestRuntimeTarget = { kind: 'local' } | { kind: 'environment'; environmentId: string }
 
 const testState = vi.hoisted(() => ({
   appState: {
@@ -60,7 +61,7 @@ const testState = vi.hoisted(() => ({
     settings: Record<string, unknown>
   },
   callRuntimeRpc: vi.fn(),
-  getActiveRuntimeTarget: vi.fn(() => ({ kind: 'local' })),
+  getActiveRuntimeTarget: vi.fn<() => TestRuntimeTarget>(() => ({ kind: 'local' })),
   RuntimeRpcCallError: class RuntimeRpcCallError extends Error {
     readonly code: string
     readonly response: unknown
@@ -516,8 +517,10 @@ describe('active agent note send', () => {
   it('does not replay an accepted paste when the host changes before submit', async () => {
     let listCount = 0
     let oldHandleStatusCount = 0
+    const methods: string[] = []
     const pasteHandles: string[] = []
     testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
+      methods.push(method)
       if (method === 'terminal.list') {
         listCount += 1
         const handle = listCount === 1 ? 'term-old-runtime' : 'term-new-runtime'
@@ -544,7 +547,7 @@ describe('active agent note send', () => {
       if (method === 'terminal.agentStatus') {
         if (params.terminal === 'term-old-runtime') {
           oldHandleStatusCount += 1
-          if (oldHandleStatusCount === 2) {
+          if (oldHandleStatusCount >= 2) {
             throw new testState.RuntimeRpcCallError({
               error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
             })
@@ -577,6 +580,18 @@ describe('active agent note send', () => {
 
     expect(listCount).toBe(1)
     expect(pasteHandles).toEqual(['term-old-runtime'])
+
+    methods.length = 0
+    await expect(
+      sendNotesToActiveAgentSession({
+        worktreeId: 'wt-1',
+        prompt: 'next notes',
+        noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
+      })
+    ).resolves.toEqual({ status: 'sent' })
+
+    expect(methods[0]).toBe('terminal.list')
+    expect(pasteHandles).toEqual(['term-old-runtime', 'term-new-runtime'])
   })
 
   it('maps active-focused guarded paste permission refusal to permission', async () => {

--- a/src/renderer/src/lib/active-agent-note-send.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send.test.ts
@@ -444,6 +444,141 @@ describe('active agent note send', () => {
     ])
   })
 
+  it('re-resolves through the current host after a stale pre-write handle', async () => {
+    const targets: unknown[] = []
+    testState.getActiveRuntimeTarget
+      .mockReturnValueOnce({ kind: 'environment', environmentId: 'host-before-restart' })
+      .mockReturnValue({ kind: 'environment', environmentId: 'host-after-restart' })
+    testState.callRuntimeRpc.mockImplementation(async (target, method, params) => {
+      targets.push(target)
+      const environmentId = target.kind === 'environment' ? target.environmentId : 'local'
+      const handle =
+        environmentId === 'host-before-restart' ? 'term-old-runtime' : 'term-new-runtime'
+      if (method === 'terminal.list') {
+        return {
+          terminals: [
+            {
+              handle,
+              worktreeId: 'wt-1',
+              worktreePath: '/repo',
+              branch: 'main',
+              tabId: 'tab-9',
+              leafId: OTHER_LEAF_ID,
+              title: 'Codex',
+              connected: true,
+              writable: true,
+              lastOutputAt: 1,
+              preview: ''
+            }
+          ],
+          totalCount: 1,
+          truncated: false
+        }
+      }
+      if (method === 'terminal.agentStatus') {
+        if (handle === 'term-old-runtime') {
+          throw new testState.RuntimeRpcCallError({
+            error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
+          })
+        }
+        return { agentStatus: { handle, isRunningAgent: true, status: null } }
+      }
+      if (method === 'terminal.send') {
+        return {
+          send: {
+            handle,
+            accepted: true,
+            bytesWritten: typeof params.text === 'string' ? params.text.length : 1
+          }
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      sendNotesToActiveAgentSession({
+        worktreeId: 'wt-1',
+        prompt: 'notes',
+        noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
+      })
+    ).resolves.toEqual({ status: 'sent' })
+
+    expect(targets).toContainEqual({
+      kind: 'environment',
+      environmentId: 'host-before-restart'
+    })
+    expect(targets).toContainEqual({
+      kind: 'environment',
+      environmentId: 'host-after-restart'
+    })
+  })
+
+  it('does not replay an accepted paste when the host changes before submit', async () => {
+    let listCount = 0
+    let oldHandleStatusCount = 0
+    const pasteHandles: string[] = []
+    testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
+      if (method === 'terminal.list') {
+        listCount += 1
+        const handle = listCount === 1 ? 'term-old-runtime' : 'term-new-runtime'
+        return {
+          terminals: [
+            {
+              handle,
+              worktreeId: 'wt-1',
+              worktreePath: '/repo',
+              branch: 'main',
+              tabId: 'tab-9',
+              leafId: OTHER_LEAF_ID,
+              title: 'Codex',
+              connected: true,
+              writable: true,
+              lastOutputAt: 1,
+              preview: ''
+            }
+          ],
+          totalCount: 1,
+          truncated: false
+        }
+      }
+      if (method === 'terminal.agentStatus') {
+        if (params.terminal === 'term-old-runtime') {
+          oldHandleStatusCount += 1
+          if (oldHandleStatusCount === 2) {
+            throw new testState.RuntimeRpcCallError({
+              error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
+            })
+          }
+        }
+        return { agentStatus: { handle: params.terminal, isRunningAgent: true, status: null } }
+      }
+      if (method === 'terminal.send') {
+        if (typeof params.text === 'string') {
+          pasteHandles.push(params.terminal)
+        }
+        return {
+          send: {
+            handle: params.terminal,
+            accepted: true,
+            bytesWritten: typeof params.text === 'string' ? params.text.length : 1
+          }
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      sendNotesToActiveAgentSession({
+        worktreeId: 'wt-1',
+        prompt: 'notes',
+        noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
+      })
+    ).resolves.toEqual({ status: 'partial-submit-failed' })
+
+    expect(listCount).toBe(1)
+    expect(pasteHandles).toEqual(['term-old-runtime'])
+  })
+
   it('maps active-focused guarded paste permission refusal to permission', async () => {
     testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
       if (method === 'terminal.list') {

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -3,10 +3,13 @@ import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
 import {
-  findActiveRuntimeTerminal,
   getActiveTerminalNoteTarget,
   type ActiveTerminalNoteTarget
 } from './active-agent-note-target'
+import {
+  clearActiveAgentTerminalBinding,
+  resolveActiveAgentTerminal
+} from './active-agent-note-terminal-binding'
 import {
   BRACKETED_PASTE_BEGIN,
   BRACKETED_PASTE_END,
@@ -18,10 +21,10 @@ import {
   ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS,
   getTerminalAgentSendReadiness,
   isRuntimeTerminalNotWritable,
+  isRuntimeTerminalStale,
   isRuntimeTerminalUnavailable,
   isRuntimeTimeout
 } from './active-agent-terminal-send-readiness'
-
 export {
   getActiveAgentNoteTarget,
   getActiveAgentRuntimeProbeDescriptor,
@@ -34,7 +37,6 @@ export {
   type ActiveAgentNotesSendResult,
   type ActiveAgentNotesSendStatus
 } from './active-agent-note-send-result'
-
 const ACTIVE_AGENT_SEND_TIMEOUT_MS = 8000
 const ORCA_DESKTOP_TERMINAL_CLIENT = { id: 'orca-desktop', type: 'desktop' as const }
 
@@ -53,6 +55,22 @@ export async function sendNotesToActiveAgentSession({
   if (!trimmedPrompt) {
     return { status: 'empty' }
   }
+  return await sendNotesToActiveAgentSessionAttempt(
+    { worktreeId, prompt: trimmedPrompt, noteTarget: explicitNoteTarget, timeoutMs },
+    0
+  )
+}
+
+async function sendNotesToActiveAgentSessionAttempt(
+  args: {
+    worktreeId: string
+    prompt: string
+    noteTarget?: ActiveTerminalNoteTarget
+    timeoutMs?: number
+  },
+  staleRetryCount: number
+): Promise<ActiveAgentNotesSendResult> {
+  const { worktreeId, prompt, noteTarget: explicitNoteTarget, timeoutMs } = args
 
   const state = useAppStore.getState()
   // Why: an explicit target lets the notes dropdown address ANY running agent of
@@ -68,71 +86,75 @@ export async function sendNotesToActiveAgentSession({
   const runtimeTarget = getActiveRuntimeTarget(
     getSettingsForWorktreeRuntimeOwner(state, worktreeId)
   )
-  const terminal = await findActiveRuntimeTerminal(
-    runtimeTarget,
-    worktreeId,
-    noteTarget,
-    ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS
-  )
+  const terminal = await resolveActiveAgentTerminal(state, runtimeTarget, worktreeId, noteTarget)
   if (!terminal) {
     return { status: 'no-active-terminal' }
   }
-
-  if (explicitNoteTarget) {
-    return await sendPromptToExplicitAgentTarget(runtimeTarget, terminal.handle, trimmedPrompt)
-  }
-
-  const effectiveTimeoutMs = timeoutMs ?? ACTIVE_AGENT_SEND_TIMEOUT_MS
-  const initialAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminal.handle, {
-    allowLegacyFallback: true
-  })
-  if (initialAgentStatus.status !== 'sendable') {
-    return { status: initialAgentStatus.status }
-  }
-
   try {
-    const { wait } = await callRuntimeRpc<{ wait: RuntimeTerminalWait }>(
-      runtimeTarget,
-      'terminal.wait',
-      { terminal: terminal.handle, for: 'tui-idle', timeoutMs: effectiveTimeoutMs },
-      { timeoutMs: effectiveTimeoutMs + 5000 }
-    )
-    if (wait.status !== 'running') {
-      return { status: 'no-active-terminal' }
+    if (explicitNoteTarget) {
+      return await sendPromptToExplicitAgentTarget(runtimeTarget, terminal.handle, prompt)
     }
-    if (wait.blockedReason) {
-      return { status: 'permission' }
-    }
-    if (!wait.satisfied) {
-      return { status: 'not-ready' }
-    }
-  } catch (error) {
-    if (isRuntimeTerminalUnavailable(error)) {
-      return { status: 'no-active-terminal' }
-    }
-    if (isRuntimeTimeout(error)) {
-      return { status: 'not-ready' }
-    }
-    throw error
-  }
-
-  const finalAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminal.handle, {
-    allowLegacyFallback: true
-  })
-  if (finalAgentStatus.status !== 'sendable') {
-    return { status: finalAgentStatus.status }
-  }
-
-  if (finalAgentStatus.supportsGuardedSend) {
-    return await sendPromptWithGuardedPasteAndEnter(runtimeTarget, terminal.handle, trimmedPrompt, {
-      allowLegacyFallback: false
+    const effectiveTimeoutMs = timeoutMs ?? ACTIVE_AGENT_SEND_TIMEOUT_MS
+    const initialAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminal.handle, {
+      allowLegacyFallback: true
     })
-  }
+    if (initialAgentStatus.status !== 'sendable') {
+      return { status: initialAgentStatus.status }
+    }
+    try {
+      const { wait } = await callRuntimeRpc<{ wait: RuntimeTerminalWait }>(
+        runtimeTarget,
+        'terminal.wait',
+        { terminal: terminal.handle, for: 'tui-idle', timeoutMs: effectiveTimeoutMs },
+        { timeoutMs: effectiveTimeoutMs + 5000 }
+      )
+      if (wait.status !== 'running') {
+        return { status: 'no-active-terminal' }
+      }
+      if (wait.blockedReason) {
+        return { status: 'permission' }
+      }
+      if (!wait.satisfied) {
+        return { status: 'not-ready' }
+      }
+    } catch (error) {
+      if (isRuntimeTerminalStale(error)) {
+        throw error
+      }
+      if (isRuntimeTerminalUnavailable(error)) {
+        return { status: 'no-active-terminal' }
+      }
+      if (isRuntimeTimeout(error)) {
+        return { status: 'not-ready' }
+      }
+      throw error
+    }
+    const finalAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminal.handle, {
+      allowLegacyFallback: true
+    })
+    if (finalAgentStatus.status !== 'sendable') {
+      return { status: finalAgentStatus.status }
+    }
+    if (finalAgentStatus.supportsGuardedSend) {
+      return await sendPromptWithGuardedPasteAndEnter(runtimeTarget, terminal.handle, prompt, {
+        allowLegacyFallback: false
+      })
+    }
 
-  // Why: protocol-compatible older SSH runtimes do not know the guarded send
-  // option. They already passed terminal.wait + legacy isRunningAgent checks,
-  // so preserve the old active-focused send path for remote compatibility.
-  return await sendPromptWithLegacyCombinedSend(runtimeTarget, terminal.handle, trimmedPrompt)
+    // Why: protocol-compatible older SSH runtimes do not know the guarded send
+    // option. They already passed terminal.wait + legacy isRunningAgent checks,
+    // so preserve the old active-focused send path for remote compatibility.
+    return await sendPromptWithLegacyCombinedSend(runtimeTarget, terminal.handle, prompt)
+  } catch (error) {
+    if (!isRuntimeTerminalStale(error)) {
+      throw error
+    }
+    clearActiveAgentTerminalBinding(worktreeId, noteTarget, runtimeTarget)
+    if (staleRetryCount > 0) {
+      return { status: 'no-active-terminal' }
+    }
+    return await sendNotesToActiveAgentSessionAttempt(args, staleRetryCount + 1)
+  }
 }
 
 async function sendPromptWithLegacyCombinedSend(
@@ -154,6 +176,9 @@ async function sendPromptWithLegacyCombinedSend(
     )
     return send.accepted ? { status: 'sent' } : { status: 'not-writable' }
   } catch (error) {
+    if (isRuntimeTerminalStale(error)) {
+      throw error
+    }
     if (isRuntimeTerminalUnavailable(error)) {
       return { status: 'no-active-terminal' }
     }
@@ -205,6 +230,9 @@ async function sendPromptWithGuardedPasteAndEnter(
       return { status: 'not-writable' }
     }
   } catch (error) {
+    if (isRuntimeTerminalStale(error)) {
+      throw error
+    }
     if (isRuntimeTerminalUnavailable(error)) {
       return { status: 'no-active-terminal' }
     }
@@ -227,6 +255,9 @@ async function sendPromptWithGuardedPasteAndEnter(
       return { status: 'partial-submit-failed' }
     }
   } catch (error) {
+    if (isRuntimeTerminalStale(error)) {
+      throw error
+    }
     if (isRuntimeTerminalUnavailable(error)) {
       return { status: 'partial-submit-failed' }
     }
@@ -247,6 +278,9 @@ async function sendPromptWithGuardedPasteAndEnter(
     )
     return send.accepted ? { status: 'sent' } : { status: 'partial-submit-failed' }
   } catch (error) {
+    if (isRuntimeTerminalStale(error)) {
+      throw error
+    }
     if (isRuntimeTerminalUnavailable(error) || isRuntimeTerminalNotWritable(error)) {
       return { status: 'partial-submit-failed' }
     }

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -39,6 +39,7 @@ export {
 } from './active-agent-note-send-result'
 const ACTIVE_AGENT_SEND_TIMEOUT_MS = 8000
 const ORCA_DESKTOP_TERMINAL_CLIENT = { id: 'orca-desktop', type: 'desktop' as const }
+class ActiveAgentPostPasteStaleError extends Error {}
 
 export async function sendNotesToActiveAgentSession({
   worktreeId,
@@ -146,6 +147,10 @@ async function sendNotesToActiveAgentSessionAttempt(
     // so preserve the old active-focused send path for remote compatibility.
     return await sendPromptWithLegacyCombinedSend(runtimeTarget, terminal.handle, prompt)
   } catch (error) {
+    if (error instanceof ActiveAgentPostPasteStaleError) {
+      clearActiveAgentTerminalBinding(worktreeId, noteTarget, runtimeTarget)
+      return { status: 'partial-submit-failed' }
+    }
     if (!isRuntimeTerminalStale(error)) {
       throw error
     }
@@ -256,7 +261,7 @@ async function sendPromptWithGuardedPasteAndEnter(
     }
   } catch (error) {
     if (isRuntimeTerminalStale(error)) {
-      throw error
+      throw new ActiveAgentPostPasteStaleError()
     }
     if (isRuntimeTerminalUnavailable(error)) {
       return { status: 'partial-submit-failed' }
@@ -279,7 +284,7 @@ async function sendPromptWithGuardedPasteAndEnter(
     return send.accepted ? { status: 'sent' } : { status: 'partial-submit-failed' }
   } catch (error) {
     if (isRuntimeTerminalStale(error)) {
-      throw error
+      throw new ActiveAgentPostPasteStaleError()
     }
     if (isRuntimeTerminalUnavailable(error) || isRuntimeTerminalNotWritable(error)) {
       return { status: 'partial-submit-failed' }

--- a/src/renderer/src/lib/active-agent-note-terminal-binding.test.ts
+++ b/src/renderer/src/lib/active-agent-note-terminal-binding.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearActiveAgentTerminalBindingCacheForTests,
+  getActiveAgentTerminalBindingCacheSizeForTests,
+  resolveActiveAgentTerminal
+} from './active-agent-note-terminal-binding'
+
+const testState = vi.hoisted(() => ({
+  findActiveRuntimeTerminal: vi.fn(),
+  directSshGeneration: 0,
+  environmentGeneration: 0,
+  environmentSshGeneration: 0,
+  nestedSshGeneration: 0
+}))
+
+vi.mock('./active-agent-note-target', () => ({
+  findActiveRuntimeTerminal: testState.findActiveRuntimeTerminal
+}))
+
+vi.mock('@/store/slices/ssh', () => ({
+  getLocalSshTargetConnectionGeneration: () => testState.directSshGeneration
+}))
+
+vi.mock('@/store/slices/runtime-status', () => ({
+  getRuntimeEnvironmentConnectionGeneration: () => testState.environmentGeneration
+}))
+
+vi.mock('@/store/slices/runtime-environment-ssh', () => ({
+  getEnvironmentSshStateGeneration: () => testState.environmentSshGeneration,
+  getEnvironmentSshTargetConnectionGeneration: () => testState.nestedSshGeneration
+}))
+
+vi.mock('@/runtime/runtime-environment-revision', () => ({
+  getRuntimeEnvironmentRevision: () => 0
+}))
+
+describe('active agent note terminal binding', () => {
+  beforeEach(() => {
+    clearActiveAgentTerminalBindingCacheForTests()
+    testState.directSshGeneration = 0
+    testState.environmentGeneration = 0
+    testState.environmentSshGeneration = 0
+    testState.nestedSshGeneration = 0
+    testState.findActiveRuntimeTerminal.mockReset()
+    testState.findActiveRuntimeTerminal.mockImplementation(
+      async (_runtimeTarget, worktreeId, noteTarget) => ({
+        handle: `term-${worktreeId}`,
+        ptyId: `pty-${worktreeId}`,
+        worktreeId,
+        worktreePath: '/repo',
+        branch: 'main',
+        tabId: noteTarget.tabId,
+        leafId: noteTarget.leafId,
+        title: 'Codex',
+        connected: true,
+        writable: true,
+        lastOutputAt: 1,
+        preview: ''
+      })
+    )
+  })
+
+  it('bounds retained pane bindings and evicts the oldest entry', async () => {
+    const state = {} as Parameters<typeof resolveActiveAgentTerminal>[0]
+    const runtimeTarget = { kind: 'local' } as const
+    const resolve = async (index: number): Promise<void> => {
+      await resolveActiveAgentTerminal(state, runtimeTarget, `worktree-${index}`, {
+        tabId: `tab-${index}`,
+        leafId: `leaf-${index}`
+      })
+    }
+
+    for (let index = 0; index < 129; index += 1) {
+      await resolve(index)
+    }
+
+    expect(getActiveAgentTerminalBindingCacheSizeForTests()).toBe(128)
+    expect(testState.findActiveRuntimeTerminal).toHaveBeenCalledTimes(129)
+
+    await resolve(0)
+    await resolve(128)
+
+    expect(getActiveAgentTerminalBindingCacheSizeForTests()).toBe(128)
+    expect(testState.findActiveRuntimeTerminal).toHaveBeenCalledTimes(130)
+  })
+
+  it('invalidates a folder binding when its direct SSH authority reconnects', async () => {
+    const worktreeId = 'folder:ssh-folder'
+    const state = {
+      activeWorktreeId: worktreeId,
+      activeWorkspaceExecutionHostId: 'ssh:ssh-a'
+    } as Parameters<typeof resolveActiveAgentTerminal>[0]
+    const resolve = async (): Promise<void> => {
+      await resolveActiveAgentTerminal(state, { kind: 'local' }, worktreeId, {
+        tabId: 'tab-folder',
+        leafId: 'leaf-folder'
+      })
+    }
+
+    await resolve()
+    await resolve()
+    testState.directSshGeneration += 1
+    await resolve()
+
+    expect(testState.findActiveRuntimeTerminal).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates a nested SSH binding when its paired host reconnects', async () => {
+    const worktreeId = 'repo-a::worktree-a'
+    const state = {
+      activeWorktreeId: worktreeId,
+      activeWorkspaceExecutionHostId: 'ssh:ssh-a',
+      worktreesByRepo: {
+        'repo-a': [
+          {
+            id: worktreeId,
+            repoId: 'repo-a',
+            hostId: 'ssh:ssh-a',
+            runtimeOwnerEnvironmentId: 'environment-a'
+          }
+        ]
+      }
+    } as Parameters<typeof resolveActiveAgentTerminal>[0]
+    const runtimeTarget = { kind: 'environment', environmentId: 'environment-a' } as const
+    const resolve = async (): Promise<void> => {
+      await resolveActiveAgentTerminal(state, runtimeTarget, worktreeId, {
+        tabId: 'tab-nested',
+        leafId: 'leaf-nested'
+      })
+    }
+
+    await resolve()
+    await resolve()
+    testState.nestedSshGeneration += 1
+    await resolve()
+
+    expect(testState.findActiveRuntimeTerminal).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/lib/active-agent-note-terminal-binding.ts
+++ b/src/renderer/src/lib/active-agent-note-terminal-binding.ts
@@ -14,7 +14,22 @@ type ActiveAgentTerminalBinding = {
   terminal: RuntimeTerminalListResult['terminals'][number]
 }
 
+const ACTIVE_AGENT_TERMINAL_BINDING_CACHE_MAX = 128
 const activeAgentTerminalBindings = new Map<string, ActiveAgentTerminalBinding>()
+
+function rememberActiveAgentTerminalBinding(
+  key: string,
+  binding: ActiveAgentTerminalBinding
+): void {
+  activeAgentTerminalBindings.set(key, binding)
+  while (activeAgentTerminalBindings.size > ACTIVE_AGENT_TERMINAL_BINDING_CACHE_MAX) {
+    const oldestKey = activeAgentTerminalBindings.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    activeAgentTerminalBindings.delete(oldestKey)
+  }
+}
 
 function getRuntimeBindingAuthority(
   state: Parameters<typeof resolveWorktreeOperationRoute>[0],
@@ -69,7 +84,7 @@ export async function resolveActiveAgentTerminal(
     ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS
   )
   if (terminal) {
-    activeAgentTerminalBindings.set(key, { authority, terminal })
+    rememberActiveAgentTerminalBinding(key, { authority, terminal })
   }
   return terminal
 }
@@ -84,4 +99,8 @@ export function clearActiveAgentTerminalBinding(
 
 export function clearActiveAgentTerminalBindingCacheForTests(): void {
   activeAgentTerminalBindings.clear()
+}
+
+export function getActiveAgentTerminalBindingCacheSizeForTests(): number {
+  return activeAgentTerminalBindings.size
 }

--- a/src/renderer/src/lib/active-agent-note-terminal-binding.ts
+++ b/src/renderer/src/lib/active-agent-note-terminal-binding.ts
@@ -25,6 +25,7 @@ function getRuntimeBindingAuthority(
   if (route) {
     return JSON.stringify(captureWorktreeOperationGenerationSnapshot(route))
   }
+  // Why: only environment targets carry a connection generation; other targets rely on the terminal_handle_stale path to drop a rebound handle.
   const generation =
     runtimeTarget.kind === 'environment'
       ? getRuntimeEnvironmentConnectionGeneration(runtimeTarget.environmentId)

--- a/src/renderer/src/lib/active-agent-note-terminal-binding.ts
+++ b/src/renderer/src/lib/active-agent-note-terminal-binding.ts
@@ -1,0 +1,86 @@
+import type { RuntimeTerminalListResult } from '../../../shared/runtime-types'
+import type { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { getRuntimeEnvironmentConnectionGeneration } from '@/store/slices/runtime-status'
+import { captureWorktreeOperationGenerationSnapshot } from './worktree-operation-generation'
+import { resolveWorktreeOperationRoute } from './worktree-operation-route'
+import {
+  findActiveRuntimeTerminal,
+  type ActiveTerminalNoteTarget
+} from './active-agent-note-target'
+import { ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS } from './active-agent-terminal-send-readiness'
+
+type ActiveAgentTerminalBinding = {
+  authority: string
+  terminal: RuntimeTerminalListResult['terminals'][number]
+}
+
+const activeAgentTerminalBindings = new Map<string, ActiveAgentTerminalBinding>()
+
+function getRuntimeBindingAuthority(
+  state: Parameters<typeof resolveWorktreeOperationRoute>[0],
+  worktreeId: string,
+  runtimeTarget: ReturnType<typeof getActiveRuntimeTarget>
+): string {
+  const route = resolveWorktreeOperationRoute(state, worktreeId)
+  if (route) {
+    return JSON.stringify(captureWorktreeOperationGenerationSnapshot(route))
+  }
+  const generation =
+    runtimeTarget.kind === 'environment'
+      ? getRuntimeEnvironmentConnectionGeneration(runtimeTarget.environmentId)
+      : 0
+  return JSON.stringify({ runtimeTarget, generation })
+}
+
+function getBindingKey(
+  worktreeId: string,
+  noteTarget: ActiveTerminalNoteTarget,
+  runtimeTarget: ReturnType<typeof getActiveRuntimeTarget>
+): string {
+  return JSON.stringify({
+    runtimeTarget,
+    worktreeId,
+    tabId: noteTarget.tabId,
+    leafId: noteTarget.leafId
+  })
+}
+
+export async function resolveActiveAgentTerminal(
+  state: Parameters<typeof resolveWorktreeOperationRoute>[0],
+  runtimeTarget: ReturnType<typeof getActiveRuntimeTarget>,
+  worktreeId: string,
+  noteTarget: ActiveTerminalNoteTarget
+): Promise<RuntimeTerminalListResult['terminals'][number] | null> {
+  const key = getBindingKey(worktreeId, noteTarget, runtimeTarget)
+  const authority = getRuntimeBindingAuthority(state, worktreeId, runtimeTarget)
+  const cached = activeAgentTerminalBindings.get(key)
+  if (cached) {
+    if (cached.authority === authority) {
+      return cached.terminal
+    }
+    activeAgentTerminalBindings.delete(key)
+  }
+
+  const terminal = await findActiveRuntimeTerminal(
+    runtimeTarget,
+    worktreeId,
+    noteTarget,
+    ACTIVE_AGENT_SEND_RPC_TIMEOUT_MS
+  )
+  if (terminal) {
+    activeAgentTerminalBindings.set(key, { authority, terminal })
+  }
+  return terminal
+}
+
+export function clearActiveAgentTerminalBinding(
+  worktreeId: string,
+  noteTarget: ActiveTerminalNoteTarget,
+  runtimeTarget: ReturnType<typeof getActiveRuntimeTarget>
+): void {
+  activeAgentTerminalBindings.delete(getBindingKey(worktreeId, noteTarget, runtimeTarget))
+}
+
+export function clearActiveAgentTerminalBindingCacheForTests(): void {
+  activeAgentTerminalBindings.clear()
+}

--- a/src/renderer/src/lib/active-agent-terminal-send-readiness.ts
+++ b/src/renderer/src/lib/active-agent-terminal-send-readiness.ts
@@ -36,6 +36,9 @@ export async function getTerminalAgentSendReadiness(
     }
     return { status: 'sendable', supportsGuardedSend: true }
   } catch (error) {
+    if (isRuntimeTerminalStale(error)) {
+      throw error
+    }
     if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
       if (!options.allowLegacyFallback) {
         // Why: selected-target sends are immediate; without terminal.agentStatus
@@ -69,6 +72,9 @@ async function getLegacyTerminalAgentSendStatus(
     )
     return isRunningAgent ? 'sendable' : 'no-agent'
   } catch (error) {
+    if (isRuntimeTerminalStale(error)) {
+      throw error
+    }
     if (isRuntimeTerminalUnavailable(error)) {
       return 'no-active-terminal'
     }
@@ -84,11 +90,15 @@ export function isRuntimeTimeout(error: unknown): boolean {
 export function isRuntimeTerminalUnavailable(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return (
-    message.includes('terminal_handle_stale') ||
     message.includes('terminal_exited') ||
     message.includes('terminal_gone') ||
     message.includes('no_active_terminal')
   )
+}
+
+export function isRuntimeTerminalStale(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('terminal_handle_stale')
 }
 
 export function isRuntimeTerminalNotWritable(error: unknown): boolean {


### PR DESCRIPTION
## Summary

- Invalidate renderer terminal bindings when runtime connection identity changes.
- When a runtime replacement races the first terminal operation after `terminal.list`, re-resolve through the current runtime authority once, preserving same-generation sends and existing server reminting.

Related to #11191.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/active-agent-note-send.test.ts`, 35 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "stale terminal handles|remints a terminal handle"`, 2 tests passed.
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- Changed-file `pnpm exec oxlint` and `pnpm exec oxfmt --check`
- `git diff --check`

The complete renderer and runtime test-file run passed 1,000 tests; one existing runtime fixture failed on Windows because it creates a `/tmp` directory. The focused tests for this change pass.

## AI Review Report

The renderer binding is keyed by the existing worktree route and connection-generation authority. A stale handle clears the pane-key binding and permits one remint lookup, then stops. Same-generation sends reuse the binding, local/SSH/paired routing remains owner-derived, and the existing legacy runtime fallback remains unchanged. The runtime test confirms that a replacement runtime rejects the old handle and accepts its reminted handle.

## Security Audit

The change prevents sends to stale runtime identities. Re-resolution uses the existing owner route and terminal list, cannot infer a host from handle text, and adds no IPC or credential path.

## Notes

Independent verification found that the completed-restart-then-send sequence described in #11191 already succeeds on the PR base and v1.4.159, so this PR does not close that issue. This change addresses the narrower race where the runtime is replaced after `terminal.list` but before the first terminal operation. #11191 remains open for the original report.

PR https://github.com/stablyai/orca/pull/11742 covers server-side tmuxCompat reminting only. No visual change.

