### PR TITLE
Fix OpenCode continuation prompt delivery

### DIFF
--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -7,6 +7,7 @@ const mockSetActiveTabType = vi.fn()
 const mockSetTabBarOrder = vi.fn()
 const mockSetAgentStatus = vi.fn()
 const mockPasteDraftWhenAgentReady = vi.fn()
+const mockWaitForAgentReady = vi.fn()
 const mockSeedNativeChatLaunchPrompt = vi.fn()
 const mockSeedNativeChatLaunchDraft = vi.fn()
 const mockMarkNativeChatLaunchPromptFailed = vi.fn()
@@ -111,6 +112,10 @@ vi.mock('@/lib/agent-paste-draft', () => ({
   pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
 }))
 
+vi.mock('@/lib/agent-ready-wait', () => ({
+  waitForAgentReady: mockWaitForAgentReady
+}))
+
 vi.mock('@/lib/telemetry', () => ({
   track: mockTrack,
   tuiAgentToAgentKind: (agent: string) => agent
@@ -170,6 +175,7 @@ describe('launchAgentInNewTab', () => {
     store.ptyIdsByTabId = {}
     mockCreateTab.mockReturnValue({ id: 'tab-1' })
     mockPasteDraftWhenAgentReady.mockResolvedValue(true)
+    mockWaitForAgentReady.mockResolvedValue({ ready: true, reason: 'foreground-match' })
   })
 
   it('stamps the launched agent on the new tab for immediate provider icon bootstrap', async () => {
@@ -219,6 +225,30 @@ describe('launchAgentInNewTab', () => {
       text: 'large generated prompt',
       createdAt: expect.any(Number)
     })
+  })
+
+  it('tracks inline OpenCode continuation delivery until the agent is ready', async () => {
+    const onPromptDelivered = vi.fn()
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'opencode',
+      worktreeId: 'wt-1',
+      prompt: 'Continue from the previous session.',
+      promptDelivery: 'submit-after-ready',
+      onPromptDelivered
+    })
+
+    expect(result?.promptDeliveryResult).toBeDefined()
+    expect(onPromptDelivered).not.toHaveBeenCalled()
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: true,
+      failureNotified: false
+    })
+    expect(mockWaitForAgentReady).toHaveBeenCalledWith('tab-1', 'opencode', {
+      timeoutMs: 8000
+    })
+    expect(onPromptDelivered).toHaveBeenCalledOnce()
   })
 
   it('opens local Grok submit-after-ready launches in native chat', async () => {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -10,6 +10,7 @@ import {
   deliverLaunchPromptToAgentTab,
   seedNativeChatLaunchDraftForAgentTab
 } from '@/lib/agent-launch-prompt-delivery'
+import { waitForAgentReady } from '@/lib/agent-ready-wait'
 import { initialAgentTabViewModeProps } from '@/lib/native-chat-initial-view-mode'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -29,6 +30,8 @@ import type { LaunchSource } from '../../../shared/telemetry-events'
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
+
+const INLINE_PROMPT_DELIVERY_TIMEOUT_MS = 8000
 
 export type LaunchAgentInNewTabArgs = {
   agent: TuiAgent
@@ -214,7 +217,27 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     // and deliverLaunchPromptToAgentTab never seeds. Mirror it into chat here.
     seedNativeChatLaunchDraftForAgentTab({ tabId: tab.id, agent, text: trimmedPrompt })
   }
-  if (pasteDraftAfterLaunch !== null) {
+  if (hasPrompt && promptDelivery === 'submit-after-ready' && pasteDraftAfterLaunch === null) {
+    const timeoutNotice = createPasteReadinessTimeoutNotice({
+      worktreeId,
+      tabId: tab.id,
+      agent,
+      submitted: true
+    })
+    promptDeliveryResult = waitForAgentReady(tab.id, startupPlan.expectedProcess, {
+      timeoutMs: INLINE_PROMPT_DELIVERY_TIMEOUT_MS
+    }).then(({ ready }) => {
+      if (ready) {
+        onPromptDelivered?.()
+      } else {
+        timeoutNotice.onTimeout()
+      }
+      return {
+        delivered: ready,
+        failureNotified: !ready && timeoutNotice.wasNotified()
+      }
+    })
+  } else if (pasteDraftAfterLaunch !== null) {
     const timeoutNotice = createPasteReadinessTimeoutNotice({
       worktreeId,
       tabId: tab.id,

--- a/src/renderer/src/lib/launch-agent-startup-prompt-plan.test.ts
+++ b/src/renderer/src/lib/launch-agent-startup-prompt-plan.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { planLaunchAgentStartupPrompt } from './launch-agent-startup-prompt-plan'
+
+const base = {
+  agent: 'opencode' as const,
+  cmdOverrides: {},
+  platform: 'linux' as const
+}
+
+describe('planLaunchAgentStartupPrompt', () => {
+  it('uses OpenCode prompt submission for a fitting continuation prompt', () => {
+    const result = planLaunchAgentStartupPrompt({
+      base,
+      prompt: 'Continue the previous task from the saved context.',
+      promptDelivery: 'submit-after-ready',
+      isFollowupPath: false
+    })
+
+    expect(result.pasteDraftAfterLaunch).toBeNull()
+    expect(result.submitPastedPrompt).toBe(false)
+    expect(result.startupPlan?.launchCommand).toContain(
+      "opencode --prompt 'Continue the previous task from the saved context.'"
+    )
+  })
+
+  it('keeps post-ready paste for an oversized Windows continuation prompt', () => {
+    const prompt = 'x'.repeat(25_000)
+    const result = planLaunchAgentStartupPrompt({
+      base: { ...base, platform: 'win32' },
+      prompt,
+      promptDelivery: 'submit-after-ready',
+      isFollowupPath: false
+    })
+
+    expect(result.startupPlan?.launchCommand).toBe('opencode')
+    expect(result.pasteDraftAfterLaunch).toBe(prompt)
+    expect(result.submitPastedPrompt).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/launch-agent-startup-prompt-plan.ts
+++ b/src/renderer/src/lib/launch-agent-startup-prompt-plan.ts
@@ -3,6 +3,7 @@ import {
   buildAgentStartupPlan,
   type AgentStartupPlan
 } from '@/lib/tui-agent-startup'
+import { inlineAgentDraftFitsPlatform } from '../../../shared/agent-draft-platform-limit'
 
 type StartupPlanBase = Omit<
   Parameters<typeof buildAgentStartupPlan>[0],
@@ -39,6 +40,27 @@ export function planLaunchAgentStartupPrompt(args: {
   })
 
   if (hasPrompt && promptDelivery === 'submit-after-ready') {
+    if (base.agent === 'opencode') {
+      const inlinePlan = buildAgentStartupPlan({
+        ...base,
+        prompt,
+        allowEmptyPromptLaunch: false
+      })
+      if (
+        inlinePlan &&
+        inlineAgentDraftFitsPlatform({
+          command: inlinePlan.launchCommand,
+          env: inlinePlan.env,
+          platform: base.platform
+        })
+      ) {
+        return {
+          startupPlan: inlinePlan,
+          pasteDraftAfterLaunch: null,
+          submitPastedPrompt: false
+        }
+      }
+    }
     // Why: multi-line generated prompts are too large for a shell argv, so launch clean then paste+submit in the TUI.
     return pasteAfterReady(true)
   }


### PR DESCRIPTION
## Summary
- use OpenCode's supported `--prompt` launch path for normal Continue in New Session handoffs
- retain post-ready paste for prompts that exceed the Windows command budget
- track inline delivery until the OpenCode process is ready instead of reporting success synchronously
- add regression coverage for inline, tracked, and fallback delivery

## Why
The continuation flow always forced OpenCode through the readiness-gated paste path. The installed Orca build still uses that path, so context can fail to reach the new session. OpenCode supports `--prompt`, which avoids the startup paste race for normal-sized handoff prompts. Inline launches now wait for the launched process to become ready before reporting delivery success.

## Validation
- focused affected suite: 5 files, 102 tests passed
- `pnpm run typecheck:web`
- changed-file `oxlint --deny-warnings`
- `opencode --help` confirms `--prompt` support
- red-green regression: inline delivery promise absent before fix, present and readiness-tracked after fix

The full suite previously had 10 unrelated environment/pre-existing failures; details are documented in the task handoff.