### PR TITLE
fix(orchestration): deliver Run mailbox messages to current coordinators (#11787)

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17315,10 +17315,11 @@ describe('OrcaRuntimeService', () => {
 
       runtime.deliverPendingMessagesForHandle(terminal.handle)
 
-      const payload = write.mock.calls.find(
-        ([, text]) => typeof text === 'string' && text.includes('Subject: worker done')
-      )?.[1]
-      expect(payload).toEqual(expect.stringContaining('Subject: terminal status'))
+      const written = write.mock.calls
+        .map(([, text]) => (typeof text === 'string' ? text : ''))
+        .join('')
+      expect(written).toContain('Subject: worker done')
+      expect(written).toContain('Subject: terminal status')
       await vi.advanceTimersByTimeAsync(500)
       expect(write).toHaveBeenCalledWith('pty-1', '\r')
       expect(db.getMessageById(runMessage.id)).toMatchObject({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17277,6 +17277,65 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('delivers current Run-mailbox and direct terminal mail through the idle runtime path', async () => {
+    vi.useFakeTimers()
+    const db = new OrchestrationDb(':memory:')
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const write = vi.fn().mockReturnValue(true)
+      runtime.setOrchestrationDb(db)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+      const run = db.createRun({
+        objective: 'Runtime Run mailbox delivery',
+        coordinatorHandle: terminal.handle,
+        coordinatorPaneKey: 'tab-1:pane:1'
+      })
+      const runMessage = db.insertMessage({
+        from: 'term_worker',
+        to: `run:${run.id}`,
+        subject: 'worker done',
+        type: 'worker_done',
+        runId: run.id
+      })
+      const terminalMessage = db.insertMessage({
+        from: 'term_sender',
+        to: terminal.handle,
+        subject: 'terminal status',
+        runId: run.id
+      })
+
+      runtime.deliverPendingMessagesForHandle(terminal.handle)
+
+      const payload = write.mock.calls.find(
+        ([, text]) => typeof text === 'string' && text.includes('Subject: worker done')
+      )?.[1]
+      expect(payload).toEqual(expect.stringContaining('Subject: terminal status'))
+      await vi.advanceTimersByTimeAsync(500)
+      expect(write).toHaveBeenCalledWith('pty-1', '\r')
+      expect(db.getMessageById(runMessage.id)).toMatchObject({
+        read: 0,
+        delivered_at: expect.any(String)
+      })
+      expect(db.getMessageById(terminalMessage.id)).toMatchObject({
+        read: 0,
+        delivered_at: expect.any(String)
+      })
+      expect(db.getUndeliveredUnreadMessages(terminal.handle)).toEqual([])
+    } finally {
+      db.close()
+      vi.useRealTimers()
+    }
+  })
+
   it('injects pending orchestration messages into the active coordinator without auto-submitting', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -3408,28 +3408,38 @@ export class OrchestrationDb {
 
   // Why: delivered_at IS NULL filter — push-on-idle delivers each row at most once; read (set only by check) wouldn't prevent replay.
   getUndeliveredUnreadMessages(toHandle: string, types?: MessageType[]): MessageRow[] {
+    // Why: a current Run mailbox is lifecycle-owned by its bound coordinator; direct terminal mail remains handle-owned.
+    const recipientPredicate = `(
+      m.to_handle = ? OR (
+        m.to_handle = 'run:' || r.id
+        AND r.legacy = 0
+        AND r.coordinator_handle = ?
+      )
+    )`
     if (types && types.length > 0) {
       const placeholders = types.map(() => '?').join(',')
       return exposeMessageListTimestamps(
         this.db
           .prepare(
-            `SELECT * FROM messages
-             WHERE to_handle = ? AND read = 0 AND delivered_at IS NULL
-               AND delivery_contract = 'current_delivery'
-               AND type IN (${placeholders}) ORDER BY sequence`
+            `SELECT m.* FROM messages m
+             LEFT JOIN runs r ON r.id = m.run_id
+             WHERE ${recipientPredicate} AND m.read = 0 AND m.delivered_at IS NULL
+               AND m.delivery_contract = 'current_delivery'
+               AND m.type IN (${placeholders}) ORDER BY m.sequence`
           )
-          .all(toHandle, ...types) as MessageRow[]
+          .all(toHandle, toHandle, ...types) as MessageRow[]
       )
     }
     return exposeMessageListTimestamps(
       this.db
         .prepare(
-          `SELECT * FROM messages
-           WHERE to_handle = ? AND read = 0 AND delivered_at IS NULL
-             AND delivery_contract = 'current_delivery'
-           ORDER BY sequence`
+          `SELECT m.* FROM messages m
+           LEFT JOIN runs r ON r.id = m.run_id
+           WHERE ${recipientPredicate} AND m.read = 0 AND m.delivered_at IS NULL
+             AND m.delivery_contract = 'current_delivery'
+           ORDER BY m.sequence`
         )
-        .all(toHandle) as MessageRow[]
+        .all(toHandle, toHandle) as MessageRow[]
     )
   }
 

--- a/src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts
@@ -87,8 +87,9 @@ describe('OrchestrationDb Run state', () => {
     it('keeps delivered Run mail suppressed after database restart without changing read state', () => {
       const dir = mkdtempSync(join(tmpdir(), 'orca-run-push-'))
       const dbPath = join(dir, 'orchestration.db')
+      let firstDb: OrchestrationDb | undefined
       try {
-        const firstDb = new OrchestrationDb(dbPath)
+        firstDb = new OrchestrationDb(dbPath)
         const run = firstDb.createRun({
           objective: 'Restart delivery',
           coordinatorHandle: 'term_coord',
@@ -104,6 +105,7 @@ describe('OrchestrationDb Run state', () => {
         firstDb.markAsDelivered([message.id])
         expect(firstDb.getMessageById(message.id)).toMatchObject({ read: 0 })
         firstDb.close()
+        firstDb = undefined
 
         const reopened = new OrchestrationDb(dbPath)
         db = reopened
@@ -112,6 +114,7 @@ describe('OrchestrationDb Run state', () => {
           { id: message.id, read: 0 }
         ])
       } finally {
+        firstDb?.close()
         db?.close()
         db = undefined
         rmSync(dir, { recursive: true, force: true })

--- a/src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts
@@ -25,6 +25,99 @@ describe('OrchestrationDb Run state', () => {
   }
 
   describe('Run deliveries', () => {
+    it('resolves current Run mail to its coordinator while preserving direct terminal mail', () => {
+      const d = createDb()
+      const run = createBoundRun(d)
+      const runMessage = d.insertMessage({
+        from: 'term_worker',
+        to: `run:${run.id}`,
+        subject: 'worker done',
+        type: 'worker_done',
+        runId: run.id
+      })
+      const terminalMessage = d.insertMessage({
+        from: 'term_sender',
+        to: 'term_coord',
+        subject: 'direct terminal mail',
+        runId: run.id
+      })
+      const otherRun = d.createRun({
+        objective: 'Other Run',
+        coordinatorHandle: 'term_other',
+        coordinatorPaneKey: 'tab_other:44444444-4444-4444-8444-444444444444'
+      })
+      d.insertMessage({
+        from: 'term_worker',
+        to: `run:${otherRun.id}`,
+        subject: 'other terminal',
+        type: 'escalation',
+        runId: otherRun.id
+      })
+
+      expect(d.getUndeliveredUnreadMessages('term_coord').map((message) => message.id)).toEqual([
+        runMessage.id,
+        terminalMessage.id
+      ])
+    })
+
+    it('leaves Run mail pending when its coordinator binding is gone', () => {
+      const d = createDb()
+      const paneKey = 'tab_coord:22222222-2222-4222-9222-222222222222'
+      const run = d.createRun({
+        objective: 'Unbound Run mail',
+        coordinatorHandle: 'term_old',
+        coordinatorPaneKey: paneKey
+      })
+      const message = d.insertMessage({
+        from: 'term_worker',
+        to: `run:${run.id}`,
+        subject: 'pending',
+        runId: run.id
+      })
+      d.createRun({
+        objective: 'Replacement Run',
+        coordinatorHandle: 'term_new',
+        coordinatorPaneKey: paneKey
+      })
+
+      expect(d.getUndeliveredUnreadMessages('term_old')).toEqual([])
+      expect(d.getMessageById(message.id)).toMatchObject({ read: 0, delivered_at: null })
+    })
+
+    it('keeps delivered Run mail suppressed after database restart without changing read state', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'orca-run-push-'))
+      const dbPath = join(dir, 'orchestration.db')
+      try {
+        const firstDb = new OrchestrationDb(dbPath)
+        const run = firstDb.createRun({
+          objective: 'Restart delivery',
+          coordinatorHandle: 'term_coord',
+          coordinatorPaneKey: 'tab_coord:33333333-3333-4333-8333-333333333333'
+        })
+        const message = firstDb.insertMessage({
+          from: 'term_worker',
+          to: `run:${run.id}`,
+          subject: 'once',
+          runId: run.id
+        })
+        expect(firstDb.getUndeliveredUnreadMessages('term_coord')).toHaveLength(1)
+        firstDb.markAsDelivered([message.id])
+        expect(firstDb.getMessageById(message.id)).toMatchObject({ read: 0 })
+        firstDb.close()
+
+        const reopened = new OrchestrationDb(dbPath)
+        db = reopened
+        expect(reopened.getUndeliveredUnreadMessages('term_coord')).toEqual([])
+        expect(reopened.getUnreadMessages(`run:${run.id}`)).toMatchObject([
+          { id: message.id, read: 0 }
+        ])
+      } finally {
+        db?.close()
+        db = undefined
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
     it('returns one bounded FIFO batch and replays it until acknowledgment', () => {
       const d = createDb()
       const run = createBoundRun(d)


### PR DESCRIPTION
## Summary

- Resolve current `run:<runId>` mailbox recipients to the bound coordinator during push-on-idle delivery.
- Preserve direct terminal recipients, `delivered_at` replay suppression, and explicit read/ack behavior.

Closes #11787.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/db.test.ts src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts src/main/runtime/orca-runtime.test.ts` (3 files, 1038 tests passed)
- [x] `pnpm exec oxlint src/main/runtime/orchestration/db.ts src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts src/main/runtime/orca-runtime.test.ts`
- [x] `pnpm exec oxfmt --check src/main/runtime/orchestration/db.ts src/main/runtime/orchestration/orchestration-run-delivery-db.test.ts src/main/runtime/orca-runtime.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `git diff --check`

The constructed base probe failed because the terminal-only query returned the direct message without the Run message. The same regression passed on this branch after the query joined the persisted current Run coordinator binding.

## AI Review Report

Separate AI review was not run during coding. The final diff is limited to Run recipient resolution, production runtime/database regressions, and existing delivery-path assertions; review scope covers Run and direct terminal recipients, coordinator binding changes, idle delivery, local/SSH/remote PTYs, supported agents, retries, and duplicate suppression.

## Security Audit

No new auth, IPC, command, or delivery authority was introduced. The query requires the persisted current non-legacy Run row and exact coordinator handle; direct terminal mail keeps its existing handle match. Explicit `check` continues to own `read` and Run acknowledgment.

## Notes

PR https://github.com/stablyai/orca/pull/8057 covers synthetic background-PTY delivery, not Run-mailbox resolution. Issue #11786 covers the concurrent duplicate window and remains out of scope. Legacy Run formats remain out of scope unless their current persistence contract proves compatible.
