### PR TITLE
fix(workspaces): guarantee Korean flag :kr: shortcode

### DIFF
--- a/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
@@ -11,10 +11,8 @@ describe('workspace emoji shortcodes', () => {
     expect(searchWorkspaceEmojiShortcodes('wink', 1)).toEqual([{ emoji: '😉', shortcode: 'wink' }])
   })
 
-  it('finds the Korean flag by workspace shortcode', () => {
-    expect(searchWorkspaceEmojiShortcodes('flag_kr', 1)).toEqual([
-      { emoji: '🇰🇷', shortcode: 'flag_kr' }
-    ])
+  it('finds the Korean flag by kr shortcode', () => {
+    expect(searchWorkspaceEmojiShortcodes('kr', 1)).toEqual([{ emoji: '🇰🇷', shortcode: 'kr' }])
   })
 
   it('ranks an exact shortcode before longer aliases', () => {
@@ -45,8 +43,8 @@ describe('workspace emoji shortcodes', () => {
     })
   })
 
-  it('replaces the completed Korean flag shortcode', () => {
-    expect(replaceCompletedWorkspaceEmojiShortcode(':flag_kr:', 9)).toEqual({
+  it('replaces the completed kr shortcode', () => {
+    expect(replaceCompletedWorkspaceEmojiShortcode(':kr:', 4)).toEqual({
       value: '🇰🇷',
       cursor: 4
     })

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -17,7 +17,7 @@ export type WorkspaceEmojiReplacement = {
 }
 
 const WORKSPACE_EMOJI_SHORTCODE_ADDITIONS: readonly WorkspaceEmojiSuggestion[] = [
-  { emoji: '🇰🇷', shortcode: 'flag_kr' }
+  { emoji: '🇰🇷', shortcode: 'kr' }
 ]
 
 const SHORTCODE_ENTRIES = [

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -190,7 +190,7 @@ test.describe('Create Workspace', () => {
     }
   })
 
-  test('enters the Korean flag with a workspace shortcode suggestion', async ({ orcaPage }) => {
+  test('enters the Korean flag with the kr shortcode suggestion', async ({ orcaPage }) => {
     try {
       await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
 
@@ -198,11 +198,11 @@ test.describe('Create Workspace', () => {
       const nameInput = dialog.getByPlaceholder(/Type a name/i)
       await expect(nameInput).toBeVisible()
 
-      await nameInput.pressSequentially('Launch :flag_kr', { delay: 100 })
+      await nameInput.pressSequentially('Launch :kr', { delay: 100 })
       const emojiSuggestions = orcaPage.locator('[data-workspace-emoji-suggestions="true"]')
       const sourceSuggestions = orcaPage.locator('[data-workspace-source-suggestions="true"]')
       await expect(emojiSuggestions).toBeVisible()
-      await expect(emojiSuggestions.getByRole('option', { name: ':flag_kr:' })).toBeVisible()
+      await expect(emojiSuggestions.getByRole('option', { name: ':kr:' })).toBeVisible()
       await expect(emojiSuggestions).toHaveAttribute('data-side', 'top')
       await expect(sourceSuggestions).toBeVisible()
       await expect(sourceSuggestions).toHaveAttribute('data-side', 'bottom')
@@ -211,7 +211,7 @@ test.describe('Create Workspace', () => {
 
       await nameInput.pressSequentially(':')
       await expect(nameInput).toHaveValue('Launch 🇰🇷')
-      await expect(orcaPage.getByRole('option', { name: /:flag_kr:/i })).toHaveCount(0)
+      await expect(orcaPage.getByRole('option', { name: /:kr:/i })).toHaveCount(0)
       await nameInput.pressSequentially(' experiment')
       await expect(nameInput).toHaveValue('Launch 🇰🇷 experiment')
       // Keep the asserted result visible in retained proof recordings.


### PR DESCRIPTION
## Summary

- make `:kr:` an explicit workspace emoji shortcode for 🇰🇷
- remove the unnecessary `:flag_kr:` workspace addition
- cover `:kr:` suggestion and replacement in unit and packaged Electron tests

## Validation

- packaged Electron E2E: `:kr:` appears visibly and resolves to 🇰🇷
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (42,643 passed; 78 skipped)