### PR TITLE
Use preview context for OpenCode SQLite sessions

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-continuation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-continuation.test.ts
@@ -64,6 +64,21 @@ describe('buildAgentSessionContinuationPrompt', () => {
     )
     expect(buildAgentSessionContinuationPrompt(source, 'full')).toBeNull()
   })
+
+  it('uses bounded preview context for synthetic OpenCode SQLite paths', () => {
+    const source = {
+      capturedText: 'user: fix the parser\n\nassistant: parser fix is incomplete',
+      sourceAgent: 'opencode' as const,
+      transcriptPath: '/home/u/.local/share/opencode/opencode.db#ses_123',
+      lastPrompt: 'fix the parser'
+    }
+
+    const prompt = buildAgentSessionContinuationPrompt(source, 'focused')
+
+    expect(prompt).toContain('bounded recent terminal capture')
+    expect(prompt).toContain('user: fix the parser')
+    expect(prompt).not.toContain('opencode.db#ses_123')
+  })
 })
 
 describe('prepareAgentSessionContinuationFromPane', () => {

--- a/src/renderer/src/lib/agent-session-continuation.ts
+++ b/src/renderer/src/lib/agent-session-continuation.ts
@@ -31,14 +31,20 @@ function markdownFenceFor(value: string): string {
 }
 
 export function hasFullAgentSessionContext(source: AgentSessionContinuationSource): boolean {
-  return Boolean(source.transcriptPath?.trim())
+  const path = source.transcriptPath?.trim()
+  return Boolean(path && !isSyntheticOpenCodeTranscriptPath(source.sourceAgent, path))
 }
 
 export function buildAgentSessionContinuationPrompt(
   source: AgentSessionContinuationSource,
   mode: AgentSessionContinuationContextMode
 ): string | null {
-  const transcriptPath = source.transcriptPath?.trim() || null
+  const candidateTranscriptPath = source.transcriptPath?.trim() || null
+  const transcriptPath =
+    candidateTranscriptPath &&
+    !isSyntheticOpenCodeTranscriptPath(source.sourceAgent, candidateTranscriptPath)
+      ? candidateTranscriptPath
+      : null
   const capturedTranscript = transcriptPath
     ? null
     : buildBoundedSessionTranscript(source.capturedText)
@@ -79,6 +85,10 @@ export function buildAgentSessionContinuationPrompt(
     '',
     'Briefly state where the previous session stopped. If work remains, continue it. If the prior task appears complete, say so and wait for my next instruction. Ask me only if the session context and workspace do not provide enough information to proceed.'
   ].join('\n')
+}
+
+function isSyntheticOpenCodeTranscriptPath(agent: TuiAgent | null, path: string): boolean {
+  return agent === 'opencode' && path.includes('#')
 }
 
 function buildContextSection(args: {


### PR DESCRIPTION
## Summary
- recognize OpenCode SQLite session paths such as `opencode.db#<sessionId>` as synthetic metadata, not readable transcript files
- fall back to the bounded, sanitized session preview so Continue in New Session actually receives prior context
- keep real transcript paths and existing safe post-ready prompt delivery unchanged

## Root Cause
OpenCode sessions discovered from SQLite use a synthetic `databasePath#sessionId` file path. The continuation prompt treated that value as a real transcript path and asked the new agent to read it, so no prior context was available.

## Validation
- focused affected suite: 4 files, 100 tests passed
- `pnpm run typecheck:web`
- changed-file `oxlint --deny-warnings`
- regression test covers synthetic OpenCode SQLite paths and asserts bounded preview context is embedded instead of the synthetic path
- `opencode --help` confirms the existing interactive prompt support

This PR intentionally does not place transcript-derived text into shell commands or process arguments.