### PR TITLE
fix(ssh): restore relay ownership after app restart

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -273,6 +273,9 @@ describe('SSH IPC handlers', () => {
   const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
   const mockStore = {
     getRepos: () => [],
+    getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
+    upsertSshPtyConsumerRecovery: vi.fn(),
+    removeSshPtyConsumerRecovery: vi.fn(),
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6799,6 +6799,7 @@ describe('Store', () => {
 
   it('durably encrypts SSH PTY consumer ownership for process restart recovery', async () => {
     const store = await createStore()
+    store.setGitHubCache({ pr: { 'o/r#1': { fetchedAt: 1 } as never }, issue: {} })
     store.upsertSshPtyConsumerRecovery({
       targetId: 'ssh-1',
       clientInstanceId: 'client-1',
@@ -6813,6 +6814,7 @@ describe('Store', () => {
       sshPtyConsumerRecoveries: { ownerLease: string }[]
     }
     expect(persisted.sshPtyConsumerRecoveries[0]?.ownerLease).not.toBe('secret-owner-lease')
+    expect(existsSync(join(testState.dir, 'orca-github-cache.json'))).toBe(false)
 
     const reloaded = await createStore()
     expect(reloaded.getSshPtyConsumerRecovery('ssh-1')).toEqual({
@@ -6824,6 +6826,27 @@ describe('Store', () => {
       ownerLease: 'secret-owner-lease',
       outputFlowControl: { version: 1, windowSu: 256 * 1024 }
     })
+  })
+
+  it('drops decrypted SSH PTY owner leases that exceed the relay protocol bound', async () => {
+    const oversizedLease = 'x'.repeat(513)
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      sshPtyConsumerRecoveries: [
+        {
+          targetId: 'ssh-1',
+          clientInstanceId: 'client-1',
+          serverBuildId: 'relay-build-1',
+          clientGeneration: 3,
+          ownerGeneration: 5,
+          ownerLease: Buffer.from(`encrypted:${oversizedLease}`, 'utf-8').toString('base64')
+        }
+      ]
+    })
+
+    const store = await createStore()
+
+    expect(store.getSshPtyConsumerRecovery('ssh-1')).toBeNull()
   })
 
   it('removes persisted SSH PTY consumer ownership with its target', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6797,6 +6797,58 @@ describe('Store', () => {
     expect(reloaded.getUI().browserKagiSessionLink).toBe(sessionLink)
   })
 
+  it('durably encrypts SSH PTY consumer ownership for process restart recovery', async () => {
+    const store = await createStore()
+    store.upsertSshPtyConsumerRecovery({
+      targetId: 'ssh-1',
+      clientInstanceId: 'client-1',
+      serverBuildId: 'relay-build-1',
+      clientGeneration: 3,
+      ownerGeneration: 5,
+      ownerLease: 'secret-owner-lease',
+      outputFlowControl: { version: 1, windowSu: 256 * 1024 }
+    })
+
+    const persisted = readDataFile() as {
+      sshPtyConsumerRecoveries: { ownerLease: string }[]
+    }
+    expect(persisted.sshPtyConsumerRecoveries[0]?.ownerLease).not.toBe('secret-owner-lease')
+
+    const reloaded = await createStore()
+    expect(reloaded.getSshPtyConsumerRecovery('ssh-1')).toEqual({
+      targetId: 'ssh-1',
+      clientInstanceId: 'client-1',
+      serverBuildId: 'relay-build-1',
+      clientGeneration: 3,
+      ownerGeneration: 5,
+      ownerLease: 'secret-owner-lease',
+      outputFlowControl: { version: 1, windowSu: 256 * 1024 }
+    })
+  })
+
+  it('removes persisted SSH PTY consumer ownership with its target', async () => {
+    const store = await createStore()
+    store.addSshTarget({
+      id: 'ssh-1',
+      label: 'SSH 1',
+      host: 'example.test',
+      port: 22,
+      username: 'orca'
+    })
+    store.upsertSshPtyConsumerRecovery({
+      targetId: 'ssh-1',
+      clientInstanceId: 'client-1',
+      serverBuildId: 'relay-build-1',
+      clientGeneration: 3,
+      ownerGeneration: 5,
+      ownerLease: 'secret-owner-lease'
+    })
+
+    store.removeSshTarget('ssh-1')
+
+    expect(store.getSshPtyConsumerRecovery('ssh-1')).toBeNull()
+  })
+
   it('keeps plaintext Kagi session links readable for migration from older builds', async () => {
     const sessionLink = 'https://kagi.com/search?token=secret'
     writeDataFile({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -97,6 +97,7 @@ import { hardenExistingSecureFile } from '../shared/secure-file'
 import {
   LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS,
   type RemovedSshTargetTombstone,
+  type SshPtyConsumerRecovery,
   type SshRemotePtyLease,
   type SshTarget
 } from '../shared/ssh-types'
@@ -1590,6 +1591,51 @@ function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | null {
   }
 }
 
+function normalizeSshPtyConsumerRecovery(value: unknown): SshPtyConsumerRecovery | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const raw = value as Partial<SshPtyConsumerRecovery>
+  const clientGeneration = raw.clientGeneration
+  const ownerGeneration = raw.ownerGeneration
+  if (
+    typeof raw.targetId !== 'string' ||
+    raw.targetId.length === 0 ||
+    raw.targetId.length > 512 ||
+    typeof raw.clientInstanceId !== 'string' ||
+    raw.clientInstanceId.length === 0 ||
+    raw.clientInstanceId.length > 512 ||
+    typeof raw.serverBuildId !== 'string' ||
+    raw.serverBuildId.length === 0 ||
+    raw.serverBuildId.length > 512 ||
+    typeof clientGeneration !== 'number' ||
+    !Number.isSafeInteger(clientGeneration) ||
+    clientGeneration <= 0 ||
+    typeof ownerGeneration !== 'number' ||
+    !Number.isSafeInteger(ownerGeneration) ||
+    ownerGeneration <= 0 ||
+    typeof raw.ownerLease !== 'string' ||
+    raw.ownerLease.length === 0 ||
+    raw.ownerLease.length > 4096
+  ) {
+    return null
+  }
+  const flow = raw.outputFlowControl
+  const outputFlowControl =
+    flow?.version === 1 && Number.isSafeInteger(flow.windowSu) && flow.windowSu > 0
+      ? { version: 1 as const, windowSu: flow.windowSu }
+      : undefined
+  return {
+    targetId: raw.targetId,
+    clientInstanceId: raw.clientInstanceId,
+    serverBuildId: raw.serverBuildId,
+    clientGeneration,
+    ownerGeneration,
+    ownerLease: raw.ownerLease,
+    ...(outputFlowControl ? { outputFlowControl } : {})
+  }
+}
+
 type LayoutLeafNormalization = {
   snapshot: TerminalLayoutSnapshot
   changed: boolean
@@ -2936,6 +2982,12 @@ export class Store {
         if (parsed.ui?.browserKagiSessionLink) {
           parsed.ui.browserKagiSessionLink = decryptOptionalSecret(parsed.ui.browserKagiSessionLink)
         }
+        parsed.sshPtyConsumerRecoveries = (
+          Array.isArray(parsed.sshPtyConsumerRecoveries) ? parsed.sshPtyConsumerRecoveries : []
+        )
+          .map(normalizeSshPtyConsumerRecovery)
+          .filter((record): record is SshPtyConsumerRecovery => record !== null)
+          .map((record) => ({ ...record, ownerLease: decrypt(record.ownerLease) }))
 
         // Merge with defaults in case new fields were added
         const homeDir = homedir()
@@ -3495,6 +3547,7 @@ export class Store {
           sshRemotePtyLeases: (parsed.sshRemotePtyLeases ?? [])
             .map(normalizeSshRemotePtyLease)
             .filter((lease): lease is SshRemotePtyLease => lease !== null),
+          sshPtyConsumerRecoveries: parsed.sshPtyConsumerRecoveries,
           claudeLivePtySessionIds: normalizeClaudeLivePtySessionIds(parsed.claudeLivePtySessionIds),
           migrationUnsupportedPtyEntries: normalizeMigrationUnsupportedPtyEntries(
             parsed.migrationUnsupportedPtyEntries
@@ -3747,6 +3800,10 @@ export class Store {
     // Why: clone before encrypting secrets so in-memory this.state stays plaintext.
     const stateToSave = {
       ...this.getDurableState(),
+      sshPtyConsumerRecoveries: (this.state.sshPtyConsumerRecoveries ?? []).map((record) => ({
+        ...record,
+        ownerLease: encryptToSentinel(record.ownerLease)
+      })),
       settings: {
         ...this.state.settings,
         opencodeSessionCookie: encryptToSentinel(this.state.settings.opencodeSessionCookie),
@@ -6440,10 +6497,15 @@ export class Store {
   }
 
   removeSshTarget(id: string): void {
-    if (!this.state.sshTargets) {
+    const targets = this.state.sshTargets ?? []
+    const recoveries = this.state.sshPtyConsumerRecoveries ?? []
+    const nextTargets = targets.filter((target) => target.id !== id)
+    const nextRecoveries = recoveries.filter((record) => record.targetId !== id)
+    if (nextTargets.length === targets.length && nextRecoveries.length === recoveries.length) {
       return
     }
-    this.state.sshTargets = this.state.sshTargets.filter((t) => t.id !== id)
+    this.state.sshTargets = nextTargets
+    this.state.sshPtyConsumerRecoveries = nextRecoveries
     this.scheduleSave()
   }
 
@@ -6590,6 +6652,12 @@ export class Store {
         carrierChanged = true
       }
     }
+    const recoveries = this.state.sshPtyConsumerRecoveries ?? []
+    const retainedRecoveries = recoveries.filter((record) => record.targetId !== oldTargetId)
+    if (retainedRecoveries.length !== recoveries.length) {
+      this.state.sshPtyConsumerRecoveries = retainedRecoveries
+      carrierChanged = true
+    }
     let setupsChanged = false
     const keptSetups: ProjectHostSetup[] = []
     for (const setup of this.state.projectHostSetups) {
@@ -6622,6 +6690,38 @@ export class Store {
       this.scheduleSave()
     }
     return [...repoIds]
+  }
+
+  // ── SSH PTY Consumer Recovery ──────────────────────────────────────
+
+  getSshPtyConsumerRecovery(targetId: string): SshPtyConsumerRecovery | null {
+    const record = (this.state.sshPtyConsumerRecoveries ?? []).find(
+      (candidate) => candidate.targetId === targetId
+    )
+    return record ? structuredClone(record) : null
+  }
+
+  upsertSshPtyConsumerRecovery(record: SshPtyConsumerRecovery): void {
+    const normalized = normalizeSshPtyConsumerRecovery(record)
+    if (!normalized) {
+      throw new Error('Invalid SSH PTY consumer recovery record')
+    }
+    const recoveries = this.state.sshPtyConsumerRecoveries ?? []
+    this.state.sshPtyConsumerRecoveries = [
+      ...recoveries.filter((candidate) => candidate.targetId !== normalized.targetId),
+      normalized
+    ]
+    this.flush()
+  }
+
+  removeSshPtyConsumerRecovery(targetId: string): void {
+    const recoveries = this.state.sshPtyConsumerRecoveries ?? []
+    const next = recoveries.filter((record) => record.targetId !== targetId)
+    if (next.length === recoveries.length) {
+      return
+    }
+    this.state.sshPtyConsumerRecoveries = next
+    this.flush()
   }
 
   // ── SSH Remote PTY Leases ──────────────────────────────────────────

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1591,7 +1591,13 @@ function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | null {
   }
 }
 
-function normalizeSshPtyConsumerRecovery(value: unknown): SshPtyConsumerRecovery | null {
+const SSH_PTY_OWNER_LEASE_MAX_LENGTH = 512
+const ENCRYPTED_SSH_PTY_OWNER_LEASE_MAX_LENGTH = 4096
+
+function normalizeSshPtyConsumerRecovery(
+  value: unknown,
+  ownerLeaseMaxLength = SSH_PTY_OWNER_LEASE_MAX_LENGTH
+): SshPtyConsumerRecovery | null {
   if (!value || typeof value !== 'object') {
     return null
   }
@@ -1616,7 +1622,7 @@ function normalizeSshPtyConsumerRecovery(value: unknown): SshPtyConsumerRecovery
     ownerGeneration <= 0 ||
     typeof raw.ownerLease !== 'string' ||
     raw.ownerLease.length === 0 ||
-    raw.ownerLease.length > 4096
+    raw.ownerLease.length > ownerLeaseMaxLength
   ) {
     return null
   }
@@ -2985,9 +2991,13 @@ export class Store {
         parsed.sshPtyConsumerRecoveries = (
           Array.isArray(parsed.sshPtyConsumerRecoveries) ? parsed.sshPtyConsumerRecoveries : []
         )
-          .map(normalizeSshPtyConsumerRecovery)
+          .map((record) =>
+            normalizeSshPtyConsumerRecovery(record, ENCRYPTED_SSH_PTY_OWNER_LEASE_MAX_LENGTH)
+          )
           .filter((record): record is SshPtyConsumerRecovery => record !== null)
           .map((record) => ({ ...record, ownerLease: decrypt(record.ownerLease) }))
+          .map((record) => normalizeSshPtyConsumerRecovery(record))
+          .filter((record): record is SshPtyConsumerRecovery => record !== null)
 
         // Merge with defaults in case new fields were added
         const homeDir = homedir()
@@ -6711,7 +6721,7 @@ export class Store {
       ...recoveries.filter((candidate) => candidate.targetId !== normalized.targetId),
       normalized
     ]
-    this.flush()
+    this.flushSshPtyConsumerRecovery()
   }
 
   removeSshPtyConsumerRecovery(targetId: string): void {
@@ -6721,7 +6731,16 @@ export class Store {
       return
     }
     this.state.sshPtyConsumerRecoveries = next
-    this.flush()
+    this.flushSshPtyConsumerRecovery()
+  }
+
+  private flushSshPtyConsumerRecovery(): void {
+    try {
+      // Why: ownership must be durable before relay setup continues, but active-view and GitHub sidecars are unrelated startup work.
+      this.flushOrThrow()
+    } catch (err) {
+      console.error('[persistence] Failed to flush SSH PTY consumer recovery:', err)
+    }
   }
 
   // ── SSH Remote PTY Leases ──────────────────────────────────────────

--- a/src/main/ssh/ssh-pty-consumer-recovery.ts
+++ b/src/main/ssh/ssh-pty-consumer-recovery.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from 'node:crypto'
+import type { SshPtyConsumerRecovery as PersistedRecovery } from '../../shared/ssh-types'
+import type { SshPtyAcceptedSourceCheckpoint } from '../ipc/ssh-pty-output-source-obligations'
+import type { SshPtyOutputMigrationResult } from '../ipc/ssh-pty-output-model-migration'
+import type { Store } from '../persistence'
+import type { SshPtyConsumerOwnerState } from './ssh-pty-consumer-session'
+
+export type SshPtyConsumerRecoveryState = {
+  clientInstanceId: string
+  detached: boolean
+  serverBuildId?: string
+  owner?: SshPtyConsumerOwnerState
+  checkpointsByAppPtyId: Map<string, SshPtyAcceptedSourceCheckpoint>
+  modelMigrationsByAppPtyId: Map<string, Promise<SshPtyOutputMigrationResult>>
+}
+
+const recoveryByTarget = new Map<string, SshPtyConsumerRecoveryState>()
+
+function ownerFromPersisted(record: PersistedRecovery): SshPtyConsumerOwnerState {
+  return {
+    mode: 'negotiated',
+    clientInstanceId: record.clientInstanceId,
+    clientGeneration: record.clientGeneration,
+    ownerGeneration: record.ownerGeneration,
+    ownerLease: record.ownerLease,
+    ...(record.outputFlowControl ? { outputFlowControl: record.outputFlowControl } : {})
+  }
+}
+
+export function claimSshPtyConsumerRecovery(
+  targetId: string,
+  store: Store
+): SshPtyConsumerRecoveryState {
+  const current = recoveryByTarget.get(targetId)
+  if (current?.detached) {
+    current.detached = false
+    return current
+  }
+  const persisted = current ? null : store.getSshPtyConsumerRecovery(targetId)
+  const created: SshPtyConsumerRecoveryState = {
+    clientInstanceId: persisted?.clientInstanceId ?? randomUUID(),
+    detached: false,
+    ...(persisted
+      ? { serverBuildId: persisted.serverBuildId, owner: ownerFromPersisted(persisted) }
+      : {}),
+    checkpointsByAppPtyId: new Map(),
+    modelMigrationsByAppPtyId: new Map()
+  }
+  recoveryByTarget.set(targetId, created)
+  return created
+}
+
+export function getSshPtyConsumerRecovery(
+  targetId: string
+): SshPtyConsumerRecoveryState | undefined {
+  return recoveryByTarget.get(targetId)
+}
+
+export function rememberSshPtyConsumerRecovery(args: {
+  targetId: string
+  clientInstanceId: string
+  serverBuildId: string
+  owner: SshPtyConsumerOwnerState
+  store: Store
+}): void {
+  const current = recoveryByTarget.get(args.targetId)
+  if (current?.clientInstanceId !== args.clientInstanceId) {
+    return
+  }
+  current.detached = false
+  current.serverBuildId = args.serverBuildId
+  current.owner = args.owner
+  args.store.upsertSshPtyConsumerRecovery({
+    targetId: args.targetId,
+    clientInstanceId: args.clientInstanceId,
+    serverBuildId: args.serverBuildId,
+    clientGeneration: args.owner.clientGeneration,
+    ownerGeneration: args.owner.ownerGeneration,
+    ownerLease: args.owner.ownerLease,
+    ...(args.owner.outputFlowControl ? { outputFlowControl: args.owner.outputFlowControl } : {})
+  })
+}
+
+export function removeSshPtyConsumerOwnerRecovery(
+  targetId: string,
+  clientInstanceId: string,
+  store: Store
+): void {
+  const persisted = store.getSshPtyConsumerRecovery(targetId)
+  if (persisted?.clientInstanceId === clientInstanceId) {
+    store.removeSshPtyConsumerRecovery(targetId)
+  }
+}
+
+export function detachSshPtyConsumerRecovery(targetId: string, clientInstanceId: string): void {
+  const current = recoveryByTarget.get(targetId)
+  if (current?.clientInstanceId === clientInstanceId) {
+    current.detached = true
+  }
+}
+
+export function forgetSshPtyConsumerRecovery(
+  targetId: string,
+  clientInstanceId: string,
+  store: Store
+): void {
+  const current = recoveryByTarget.get(targetId)
+  if (current?.clientInstanceId === clientInstanceId) {
+    recoveryByTarget.delete(targetId)
+  }
+  removeSshPtyConsumerOwnerRecovery(targetId, clientInstanceId, store)
+}

--- a/src/main/ssh/ssh-pty-consumer-session.test.ts
+++ b/src/main/ssh/ssh-pty-consumer-session.test.ts
@@ -75,6 +75,17 @@ describe('openSshPtyConsumerSession', () => {
     ).rejects.toThrow('session contract mismatch')
   })
 
+  it('rejects an owner lease that cannot be resumed through the relay protocol', async () => {
+    const { mux } = muxReturning(legacyOwnerGrant({ ownerLease: 'x'.repeat(513) }))
+
+    await expect(
+      openSshPtyConsumerSession(mux, {
+        clientInstanceId: 'client-a',
+        expectedServerBuildId: 'build-a'
+      })
+    ).rejects.toThrow('did not grant')
+  })
+
   it('does not silently downgrade when V1 was offered', async () => {
     const { mux } = muxReturning(legacyOwnerGrant())
 

--- a/src/main/ssh/ssh-pty-consumer-session.ts
+++ b/src/main/ssh/ssh-pty-consumer-session.ts
@@ -64,7 +64,8 @@ function validateGrant(
     !Number.isSafeInteger(grant.ownerGeneration) ||
     grant.ownerGeneration! <= 0 ||
     typeof grant.ownerLease !== 'string' ||
-    grant.ownerLease.length === 0
+    grant.ownerLease.length === 0 ||
+    grant.ownerLease.length > 512
   ) {
     throw new Error('Remote relay did not grant an authenticated PTY session owner')
   }

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -149,6 +149,9 @@ function createFakeRelay(): FakeRelay {
 function createSession(targetId: string): InstanceType<typeof SshRelaySession> {
   const store = {
     getRepos: vi.fn().mockReturnValue([]),
+    getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
+    upsertSshPtyConsumerRecovery: vi.fn(),
+    removeSshPtyConsumerRecovery: vi.fn(),
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn()

--- a/src/main/ssh/ssh-relay-session-data-delivery.test.ts
+++ b/src/main/ssh/ssh-relay-session-data-delivery.test.ts
@@ -303,6 +303,45 @@ describe('SshRelaySession data delivery', () => {
     fresh.dispose()
   })
 
+  it('resumes authenticated ownership from a persisted main-process recovery record', async () => {
+    const targetId = 'persisted-recovery-target'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.getSshPtyConsumerRecovery).mockReturnValue({
+      targetId,
+      clientInstanceId: 'persisted-client',
+      serverBuildId: 'test-relay-build',
+      clientGeneration: 7,
+      ownerGeneration: 11,
+      ownerLease: 'persisted-owner-lease',
+      outputFlowControl: { version: 1, windowSu: 256 * 1024 }
+    })
+    vi.mocked(deployAndLaunchRelay).mockResolvedValue({
+      transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
+      platform: 'linux-x64',
+      serverBuildId: 'test-relay-build'
+    })
+
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(openConsumerSessionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        clientInstanceId: 'persisted-client',
+        resume: { ownerGeneration: 11, ownerLease: 'persisted-owner-lease' }
+      })
+    )
+    expect(mockStore.upsertSshPtyConsumerRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetId,
+        clientInstanceId: 'persisted-client',
+        ownerLease: 'test-owner-lease'
+      })
+    )
+    session.dispose()
+    expect(mockStore.removeSshPtyConsumerRecovery).toHaveBeenCalledWith(targetId)
+  })
+
   it('clears stale owner recovery and retries a fresh same-build relay once without resume', async () => {
     const targetId = 'fresh-relay-retry'
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -100,6 +100,9 @@ function createMockDeps(): {
   const mockConn = {} as SshConnection
   const mockStore = {
     getRepos: vi.fn().mockReturnValue([]),
+    getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
+    upsertSshPtyConsumerRecovery: vi.fn(),
+    removeSshPtyConsumerRecovery: vi.fn(),
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn()

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -18,6 +18,9 @@ export function createMockDeps(): SshRelaySessionTestDeps {
   const mockConn = {} as SshConnection
   const mockStore = {
     getRepos: vi.fn().mockReturnValue([]),
+    getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
+    upsertSshPtyConsumerRecovery: vi.fn(),
+    removeSshPtyConsumerRecovery: vi.fn(),
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -55,8 +55,6 @@ import {
   installSshPtySourceAckPublisher,
   installSshPtySourceCancellationPublisher
 } from '../ipc/ssh-pty-output-intake-registry'
-import type { SshPtyAcceptedSourceCheckpoint } from '../ipc/ssh-pty-output-source-obligations'
-import type { SshPtyOutputMigrationResult } from '../ipc/ssh-pty-output-model-migration'
 import {
   registerSshFilesystemProvider,
   unregisterSshFilesystemProvider,
@@ -102,6 +100,14 @@ import type {
 } from '../../shared/pty-source-recovery-contract'
 import { SshPtyRecoveryRetentionBudget } from './ssh-pty-recovery-retention-budget'
 import { SshPtyRetiredSourceDeliveries } from './ssh-pty-retired-source-deliveries'
+import {
+  claimSshPtyConsumerRecovery,
+  detachSshPtyConsumerRecovery,
+  forgetSshPtyConsumerRecovery,
+  getSshPtyConsumerRecovery,
+  rememberSshPtyConsumerRecovery,
+  removeSshPtyConsumerOwnerRecovery
+} from './ssh-pty-consumer-recovery'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
 
@@ -227,33 +233,6 @@ function normalizeRelayGracePeriodSeconds(graceTimeSeconds: number | undefined):
       )
 }
 
-type PtyConsumerRecovery = {
-  clientInstanceId: string
-  detached: boolean
-  serverBuildId?: string
-  owner?: SshPtyConsumerOwnerState
-  checkpointsByAppPtyId: Map<string, SshPtyAcceptedSourceCheckpoint>
-  modelMigrationsByAppPtyId: Map<string, Promise<SshPtyOutputMigrationResult>>
-}
-
-const ptyConsumerRecoveryByTarget = new Map<string, PtyConsumerRecovery>()
-
-function ptyConsumerRecoveryForTarget(targetId: string): PtyConsumerRecovery {
-  const current = ptyConsumerRecoveryByTarget.get(targetId)
-  if (current?.detached) {
-    current.detached = false
-    return current
-  }
-  const created = {
-    clientInstanceId: randomUUID(),
-    detached: false,
-    checkpointsByAppPtyId: new Map<string, SshPtyAcceptedSourceCheckpoint>(),
-    modelMigrationsByAppPtyId: new Map<string, Promise<SshPtyOutputMigrationResult>>()
-  }
-  ptyConsumerRecoveryByTarget.set(targetId, created)
-  return created
-}
-
 export class SshRelaySession {
   private _state: RelaySessionState = 'idle'
   private mux: SshChannelMultiplexer | null = null
@@ -305,7 +284,7 @@ export class SshRelaySession {
       platform: string
     ) => void
   ) {
-    this.ptyConsumerClientInstanceId = ptyConsumerRecoveryForTarget(targetId).clientInstanceId
+    this.ptyConsumerClientInstanceId = claimSshPtyConsumerRecovery(targetId, store).clientInstanceId
   }
 
   refreshEnvironment(
@@ -654,7 +633,7 @@ export class SshRelaySession {
     this.store.markSshRemotePtyLeases(this.targetId, 'terminated')
     this.currentConnection = null
     this._state = 'disposed'
-    ptyConsumerRecoveryByTarget.delete(this.targetId)
+    forgetSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId, this.store)
   }
 
   detach(): void {
@@ -669,10 +648,7 @@ export class SshRelaySession {
     this.store.markSshRemotePtyLeases(this.targetId, 'detached')
     this.currentConnection = null
     this._state = 'disposed'
-    const recovery = ptyConsumerRecoveryByTarget.get(this.targetId)
-    if (recovery?.clientInstanceId === this.ptyConsumerClientInstanceId) {
-      recovery.detached = true
-    }
+    detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
   }
 
   // ── Private ───────────────────────────────────────────────────────
@@ -729,7 +705,7 @@ export class SshRelaySession {
       this.remoteCliBridgeEnv ?? undefined,
       providerGeneration
     )
-    const consumerOwnerState = this.negotiatedPtyConsumerOwner()
+    const consumerOwnerState = this.activePtyConsumerOwner()
     if (consumerOwnerState) {
       ptyProvider.setPtyDeliveryPauseAdapter?.(({ id, providerGeneration: generation, paused }) => {
         if (
@@ -836,13 +812,20 @@ export class SshRelaySession {
     return true
   }
 
-  private negotiatedPtyConsumerOwner(serverBuildId?: string): SshPtyConsumerOwnerState | null {
+  private activePtyConsumerOwner(): SshPtyConsumerOwnerState | null {
     const state = this.ptyConsumerSessionState
-    if (state && state.mode !== 'legacy-fallback') {
-      return state as SshPtyConsumerOwnerState
+    return state && state.mode !== 'legacy-fallback' ? state : null
+  }
+
+  private recoverablePtyConsumerOwner(
+    serverBuildId: string | undefined
+  ): SshPtyConsumerOwnerState | null {
+    const active = this.activePtyConsumerOwner()
+    if (active) {
+      return active
     }
-    const recovery = ptyConsumerRecoveryByTarget.get(this.targetId)
-    return !serverBuildId || recovery?.serverBuildId === serverBuildId
+    const recovery = getSshPtyConsumerRecovery(this.targetId)
+    return serverBuildId && recovery?.serverBuildId === serverBuildId
       ? (recovery?.owner ?? null)
       : null
   }
@@ -851,7 +834,7 @@ export class SshRelaySession {
     mux: SshChannelMultiplexer,
     serverBuildId: string | undefined
   ): Promise<SshPtyConsumerSessionState> {
-    const previousOwner = this.negotiatedPtyConsumerOwner(serverBuildId)
+    const previousOwner = this.recoverablePtyConsumerOwner(serverBuildId)
     const options = {
       clientInstanceId: this.ptyConsumerClientInstanceId,
       expectedServerBuildId: serverBuildId,
@@ -877,7 +860,7 @@ export class SshRelaySession {
       ) {
         throw error
       }
-      const recovery = ptyConsumerRecoveryByTarget.get(this.targetId)
+      const recovery = getSshPtyConsumerRecovery(this.targetId)
       if (recovery) {
         delete recovery.owner
         recovery.checkpointsByAppPtyId.clear()
@@ -893,27 +876,23 @@ export class SshRelaySession {
           )
         }
       }
+      removeSshPtyConsumerOwnerRecovery(this.targetId, this.ptyConsumerClientInstanceId, this.store)
       this.ptyConsumerSessionState = null
       return openSshPtyConsumerSession(mux, options)
     }
   }
 
   private rememberPtyConsumerRecovery(serverBuildId: string | undefined): void {
-    const owner = this.negotiatedPtyConsumerOwner()
+    const owner = this.activePtyConsumerOwner()
     if (!owner || !serverBuildId) {
       return
     }
-    const previous = ptyConsumerRecoveryByTarget.get(this.targetId)
-    ptyConsumerRecoveryByTarget.set(this.targetId, {
+    rememberSshPtyConsumerRecovery({
+      targetId: this.targetId,
       clientInstanceId: this.ptyConsumerClientInstanceId,
-      detached: false,
       serverBuildId,
       owner,
-      checkpointsByAppPtyId:
-        previous?.checkpointsByAppPtyId ?? new Map<string, SshPtyAcceptedSourceCheckpoint>(),
-      modelMigrationsByAppPtyId:
-        previous?.modelMigrationsByAppPtyId ??
-        new Map<string, Promise<SshPtyOutputMigrationResult>>()
+      store: this.store
     })
   }
 
@@ -1228,7 +1207,7 @@ export class SshRelaySession {
     this.ptyRecoveryNotificationCleanups = []
     if (this.activePtyProviderGeneration !== null) {
       const providerGeneration = this.activePtyProviderGeneration
-      if (reason === 'connection_lost' && this.negotiatedPtyConsumerOwner()?.outputFlowControl) {
+      if (reason === 'connection_lost' && this.activePtyConsumerOwner()?.outputFlowControl) {
         this.beginPtyModelMigration(providerGeneration, outputGenerationReason)
       } else {
         closeSshPtyOutputGeneration(providerGeneration, outputGenerationReason)
@@ -1361,7 +1340,7 @@ export class SshRelaySession {
         return
       }
       const pending = this.pendingPtyReattaches.get(payload.id)
-      if (pending && this.negotiatedPtyConsumerOwner()?.outputFlowControl) {
+      if (pending && this.activePtyConsumerOwner()?.outputFlowControl) {
         if (pending.livePassthrough) {
           void this.acceptPtyData(payload).catch(() => {})
           return
@@ -1403,7 +1382,7 @@ export class SshRelaySession {
   }
 
   private acceptPtyData(payload: SshPtyDataPayload): Promise<unknown> {
-    const consumerOwner = this.negotiatedPtyConsumerOwner()
+    const consumerOwner = this.activePtyConsumerOwner()
     const offeredSource = payload.source
     if (
       offeredSource &&
@@ -1677,10 +1656,10 @@ export class SshRelaySession {
     this.retiredSourceDeliveries.activate(relayPtyId)
     clearProviderPtyState(payload.id)
     deletePtyOwnership(payload.id)
-    ptyConsumerRecoveryByTarget.get(this.targetId)?.checkpointsByAppPtyId.delete(payload.id)
-    ptyConsumerRecoveryByTarget
-      .get(this.targetId)
-      ?.checkpointsByAppPtyId.delete(toRelaySshPtyId(this.targetId, payload.id))
+    getSshPtyConsumerRecovery(this.targetId)?.checkpointsByAppPtyId.delete(payload.id)
+    getSshPtyConsumerRecovery(this.targetId)?.checkpointsByAppPtyId.delete(
+      toRelaySshPtyId(this.targetId, payload.id)
+    )
     this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'terminated')
     if (deliveryHandled) {
       return
@@ -2103,10 +2082,10 @@ export class SshRelaySession {
   private async sourceRecoveryRequest(
     appPtyId: string
   ): Promise<PtySourceRecoveryRequest | undefined> {
-    if (!this.negotiatedPtyConsumerOwner()?.outputFlowControl) {
+    if (!this.activePtyConsumerOwner()?.outputFlowControl) {
       return undefined
     }
-    const recovery = ptyConsumerRecoveryByTarget.get(this.targetId)
+    const recovery = getSshPtyConsumerRecovery(this.targetId)
     const migration = recovery?.modelMigrationsByAppPtyId.get(appPtyId)
     if (migration) {
       const outcome = await migration
@@ -2136,7 +2115,7 @@ export class SshRelaySession {
   }
 
   private beginPtyModelMigration(providerGeneration: number, closeReason: string): void {
-    const recovery = ptyConsumerRecoveryByTarget.get(this.targetId)
+    const recovery = getSshPtyConsumerRecovery(this.targetId)
     if (!recovery) {
       closeSshPtyOutputGeneration(providerGeneration, closeReason)
       return
@@ -2150,7 +2129,7 @@ export class SshRelaySession {
       const fence = previous ? previous.then(() => result) : result
       recovery.modelMigrationsByAppPtyId.set(ptyId, fence)
       void fence.then((outcome) => {
-        const current = ptyConsumerRecoveryByTarget.get(this.targetId)
+        const current = getSshPtyConsumerRecovery(this.targetId)
         if (current?.modelMigrationsByAppPtyId.get(ptyId) !== fence) {
           return
         }
@@ -2179,7 +2158,7 @@ export class SshRelaySession {
   ): Promise<boolean> {
     const recovery = attachResult.sourceRecovery
     const pendingRecovery = recovery?.status === 'pending' ? recovery : undefined
-    const owner = this.negotiatedPtyConsumerOwner()
+    const owner = this.activePtyConsumerOwner()
     if (
       !owner?.outputFlowControl ||
       !pendingRecovery ||
@@ -2277,7 +2256,7 @@ export class SshRelaySession {
     )
     // Why: checkpoints are app-id keyed; a relay-id entry here would be shadowed
     // by a staler app-id entry on the next sourceRecoveryRequest lookup.
-    ptyConsumerRecoveryByTarget.get(this.targetId)?.checkpointsByAppPtyId.set(
+    getSshPtyConsumerRecovery(this.targetId)?.checkpointsByAppPtyId.set(
       appPtyId,
       Object.freeze({
         id: appPtyId,
@@ -2417,8 +2396,8 @@ export class SshRelaySession {
     if (!identity || !recovery || this.sameSourceDelivery(identity, recovery)) {
       this.sourceIdentityByRelayPtyId.delete(relayPtyId)
     }
-    ptyConsumerRecoveryByTarget.get(this.targetId)?.checkpointsByAppPtyId.delete(appPtyId)
-    ptyConsumerRecoveryByTarget.get(this.targetId)?.checkpointsByAppPtyId.delete(relayPtyId)
+    getSshPtyConsumerRecovery(this.targetId)?.checkpointsByAppPtyId.delete(appPtyId)
+    getSshPtyConsumerRecovery(this.targetId)?.checkpointsByAppPtyId.delete(relayPtyId)
     this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'detached')
   }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -438,6 +438,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
     sshTargets: [],
     deletedSshConfigAliases: [],
     sshRemotePtyLeases: [],
+    sshPtyConsumerRecoveries: [],
     claudeLivePtySessionIds: [],
     migrationUnsupportedPtyEntries: [],
     legacyPaneKeyAliasEntries: [],

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -157,6 +157,20 @@ export type SshRemotePtyLease = {
   lastDetachedAt?: number
 }
 
+/** Main-owned relay lease needed to reclaim PTY delivery after a desktop restart. */
+export type SshPtyConsumerRecovery = {
+  targetId: string
+  clientInstanceId: string
+  serverBuildId: string
+  clientGeneration: number
+  ownerGeneration: number
+  ownerLease: string
+  outputFlowControl?: {
+    version: 1
+    windowSu: number
+  }
+}
+
 // ─── Port Forwarding Types ─────────────────────────────────────────
 
 export type PortForwardEntry = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,6 +1,11 @@
 /* eslint-disable max-lines */
 import type { ExecutionHostId } from './execution-host'
-import type { RemovedSshTargetTombstone, SshRemotePtyLease, SshTarget } from './ssh-types'
+import type {
+  RemovedSshTargetTombstone,
+  SshPtyConsumerRecovery,
+  SshRemotePtyLease,
+  SshTarget
+} from './ssh-types'
 import type { Automation, AutomationExecutionTargetType, AutomationRun } from './automations-types'
 import type { WorkspaceSource } from './workspace-source'
 import type { ReleaseBuild, ReleaseChannel } from './release-channel'
@@ -3595,6 +3600,8 @@ export type PersistedState = {
   /** Identity records for removed SSH targets so a re-added host can re-adopt workspaces orphaned on the old target id. */
   removedSshTargetTombstones?: RemovedSshTargetTombstone[]
   sshRemotePtyLeases: SshRemotePtyLease[]
+  /** Main-owned authenticated relay recovery records; never expose through renderer settings APIs. */
+  sshPtyConsumerRecoveries?: SshPtyConsumerRecovery[]
   /** Live local Claude daemon session ids; seeds the live-PTY gate so early OAuth refresh can't rotate the single-use refresh token out from under a running daemon. */
   claudeLivePtySessionIds?: string[]
   migrationUnsupportedPtyEntries: MigrationUnsupportedPtyEntry[]

--- a/tests/e2e/ssh-cold-activation-restore.spec.ts
+++ b/tests/e2e/ssh-cold-activation-restore.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@stablyai/playwright-test'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
@@ -14,6 +14,7 @@ import {
   type DockerSshRelayTarget
 } from './helpers/docker-ssh-relay-target'
 import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import { createRestartSession } from './helpers/orca-restart'
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 const TAB_COUNT = 6
@@ -52,6 +53,14 @@ async function readRemoteTerminalTabs(
       })),
     worktreeId
   )
+}
+
+function readRemoteProof(target: DockerSshRelayTarget, path: string): string | null {
+  try {
+    return execDockerSshRelayTargetCommand(target, `cat ${path}`)
+  } catch {
+    return null
+  }
 }
 
 test.describe('SSH cold activation restore', () => {
@@ -197,6 +206,105 @@ test.describe('SSH cold activation restore', () => {
       ).toContainText(marker, { timeout: 30_000 })
       expect(execDockerSshRelayTargetCommand(target, `cat ${proofFile}`)).toBe(marker)
     } finally {
+      cleanupDockerSshRelayTarget(target)
+    }
+  })
+
+  test('reclaims the authenticated PTY owner immediately after a full app restart', async (// oxlint-disable-next-line no-empty-pattern -- This restart test owns both Electron launches.
+  {}, testInfo) => {
+    test.setTimeout(300_000)
+    const restart = createRestartSession(testInfo)
+    let target: DockerSshRelayTarget | null = null
+    let firstApp: ElectronApplication | null = null
+    let secondApp: ElectronApplication | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      const firstLaunch = await restart.launch()
+      firstApp = firstLaunch.app
+      await waitForSessionReady(firstLaunch.page)
+      const remote = await connectDockerSshRelayTarget(firstLaunch.page, target)
+      await expect
+        .poll(() => waitForActiveWorktree(firstLaunch.page), { timeout: 30_000 })
+        .toBe(remote.worktreeId)
+      await waitForActiveTerminalManager(firstLaunch.page, 60_000)
+      const firstPtyId = await waitForActivePanePtyId(firstLaunch.page, 60_000)
+      const token = `SSH_PROCESS_RESTART_${Date.now()}`
+      const beforeProofPath = `/tmp/orca-ssh-restart-before-${Date.now()}`
+      const afterProofPath = `/tmp/orca-ssh-restart-after-${Date.now()}`
+
+      await focusActiveTerminalInput(firstLaunch.page)
+      await firstLaunch.page.keyboard.type(
+        `export ORCA_RESTART_TOKEN=${token}; cd /tmp; (while :; do sleep 60; done) & export ORCA_BG_PID=$!; printf '%s|%s|%s|%s\\n' "$$" "$ORCA_BG_PID" "$ORCA_RESTART_TOKEN" "$PWD" > ${beforeProofPath}`
+      )
+      await firstLaunch.page.keyboard.press('Enter')
+      await expect.poll(() => readRemoteProof(target!, beforeProofPath)).not.toBeNull()
+      const beforeProof = readRemoteProof(target, beforeProofPath)
+      expect(beforeProof).toMatch(/^\d+\|\d+\|SSH_PROCESS_RESTART_\d+\|\/tmp$/)
+
+      const beforeTabs = await readRemoteTerminalTabs(firstLaunch.page, remote.worktreeId)
+      const restoredTabId = beforeTabs.find((tab) => tab.ptyId === firstPtyId)?.id
+      if (!restoredTabId) {
+        throw new Error('Active SSH terminal was not persisted in its worktree')
+      }
+      await firstLaunch.page.evaluate(() => window.dispatchEvent(new Event('beforeunload')))
+      await expect
+        .poll(
+          () =>
+            firstLaunch.page.evaluate(
+              async ({ targetId, worktreeId, tabId }) => {
+                const persisted = await window.api.session.get()
+                return (
+                  persisted.activeConnectionIdsAtShutdown?.includes(targetId) === true &&
+                  persisted.tabsByWorktree[worktreeId]?.some((tab) => tab.id === tabId) === true
+                )
+              },
+              { targetId: remote.targetId, worktreeId: remote.worktreeId, tabId: restoredTabId }
+            ),
+          { timeout: 10_000, message: 'SSH restart state was not persisted before quit' }
+        )
+        .toBe(true)
+
+      await restart.close(firstApp)
+      firstApp = null
+
+      const secondLaunch = await restart.launch()
+      secondApp = secondLaunch.app
+      await waitForSessionReady(secondLaunch.page, 60_000)
+      await expect
+        .poll(() => waitForActiveWorktree(secondLaunch.page), { timeout: 60_000 })
+        .toBe(remote.worktreeId)
+      await waitForActiveTerminalManager(secondLaunch.page, 60_000)
+      expect(await waitForActivePanePtyId(secondLaunch.page, 60_000)).toBe(firstPtyId)
+      await secondLaunch.page.evaluate((tabId) => {
+        const manager = window.__paneManagers?.get(tabId)
+        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+        if (!pane) {
+          throw new Error('Restored SSH pane unavailable')
+        }
+        pane.terminal.options.screenReaderMode = true
+        pane.terminal.refresh(0, pane.terminal.rows - 1)
+      }, restoredTabId)
+
+      const restoredMarker = `SSH_OWNER_RESTORED_${Date.now()}`
+      await focusActiveTerminalInput(secondLaunch.page)
+      await secondLaunch.page.keyboard.type(
+        `printf '%s|%s|%s|%s\\n' "$$" "$ORCA_BG_PID" "$ORCA_RESTART_TOKEN" "$PWD" > ${afterProofPath}; printf '${restoredMarker}\\n'`
+      )
+      await secondLaunch.page.keyboard.press('Enter')
+      await expect(
+        secondLaunch.page.locator(
+          `[data-terminal-tab-id=${JSON.stringify(restoredTabId)}] .xterm-accessibility-tree`
+        )
+      ).toContainText(restoredMarker, { timeout: 30_000 })
+      await expect.poll(() => readRemoteProof(target!, afterProofPath)).toBe(beforeProof)
+    } finally {
+      if (secondApp) {
+        await restart.close(secondApp)
+      }
+      if (firstApp) {
+        await restart.close(firstApp)
+      }
+      await restart.dispose()
       cleanupDockerSshRelayTarget(target)
     }
   })


### PR DESCRIPTION
## Summary

- Persist the authenticated SSH PTY consumer identity and owner lease so a newly launched Electron main process can reclaim the existing relay session immediately.
- Encrypt the owner lease through the existing `safeStorage` persistence pipeline, validate persisted records, and clear them on stale recovery, target removal, or target re-adoption.
- Keep the relay ownership fence intact: recovery still requires the exact client identity, owner generation, lease, build, authenticated endpoint, and SSH principal.
- Add a true quit/relaunch E2E that preserves the same PTY, shell PID, background PID, environment token, and working directory inside the former 30-second failure window.

Fixes #11729

## Manual Electron reproduction

Reproduced on the then-current `main` from the issue worktree using an isolated Electron dev profile and CDP, connected over real SSH to Rocky Linux 9.4/aarch64 with Node 20.20.2 and the real `stablyai/demo-project` repository.

- A manual disconnect/reconnect succeeded and retained PTY `ssh:ssh-1785540514218-6mrb55@@pty-1`, shell PID `2415`, background PID `2497`, token `ROCKY_RESTORE_178554`, and CWD `/tmp`.
- An immediate full Electron quit/relaunch failed: the SSH target remained disconnected, the UI showed “SSH connection required,” the PTY ID became null, and the app reported `Remote relay did not grant an authenticated PTY session owner`. The remote shell and background processes remained alive.
- Waiting more than 30 seconds before relaunch succeeded with the same PTY, PIDs, token, and CWD, isolating the regression to immediate ownership recovery after the Electron main process exited.
- With this fix, an immediate full Electron restart succeeds inside that former 30-second failure window.

The regression test launches two distinct Electron main processes with the same `userDataDir`; it is not a renderer `page.reload`. Orca v1.4.162 predates the PTY consumer protocol involved in this current-main regression.

## Screenshots

Final commit `d411ff24e5`, full-window Electron evidence from the passing Docker-backed SSH restart oracle.

### Before restart

![Before restart: remote shell, background process, environment token, and /tmp cwd](https://github.com/user-attachments/assets/6768e844-33d3-4983-ab96-4832a3b22e88)

### After restart

![After restart: the same shell PID, background PID, environment token, and /tmp cwd](https://github.com/user-attachments/assets/bf9a2d9f-3654-4b8e-8b44-5d52dcf786cc)

The rendered terminal shows the same shell PID `808`, background PID `825`, token `SSH_PROCESS_RESTART_1785546258538`, and `/tmp` working directory before and after the full Electron process restart. The second process also printed `SSH_OWNER_RESTORED_1785546268310` through the restored PTY.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused Vitest coverage passed: 513 tests across persistence, relay ownership/data delivery, terminal errors, agent hooks, and SSH IPC
- [ ] `pnpm build` — `pnpm build:relay` and `pnpm exec electron-vite build --mode e2e` passed
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- [x] `ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-cold-activation-restore.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` — 2 passed
- [x] Final `d411ff24e5`: persistence + consumer-session Vitest — 445 passed
- [x] Final `d411ff24e5`: focused Docker SSH full-restart oracle — 1 passed in 35.2s
- [x] Final `d411ff24e5`: headful Electron evidence run — 1 passed in 37.4s

## AI Review Report

Reviewed the full recovery lifecycle: initial grant, manual detach/reconnect, complete main-process restart, stale lease fallback, relay build mismatch, legacy relay fallback, target deletion/re-adoption, and competing in-process session fencing. The review caught that a legacy-fallback session could otherwise read a retained negotiated owner; active negotiated ownership is now separated from pre-open recovery state.

Cross-platform review covered macOS, Linux, and Windows. Product code adds no platform-specific paths, shell commands, shortcuts, labels, or native dependencies. It uses the existing cross-platform profile store and Electron `safeStorage`. The Docker E2E intentionally uses POSIX SSH tooling and remains skipped on Windows; persistence and relay unit coverage is platform-neutral. Folder workspaces and git worktrees share the same target-scoped recovery path and neither is assumed by the implementation.

Post-fix same-model review returned **CLEAN** after commit `d411ff24e5`, focused regression coverage, lint, typecheck, and relay/recovery suites.

## Reliability Gate

- **Invariant / gate:** `terminal-provider.ssh-remote-reattach-contract`. A restarted Electron main process may reclaim only the exact authenticated SSH PTY owner tuple, and must preserve the same PTY, shell, background process, environment, and working directory without waiting for lease expiry.
- **Failure source:** #11729 and the reproduced immediate-relaunch failure inside the prior 30-second ownership window.
- **Oracle:** the two-launch Docker SSH test uses one persisted profile, gracefully closes the first Electron app, starts a distinct second Electron process, asserts the same PTY ID, sends live input, and byte-compares `shell PID|background PID|token|cwd` before and after restart.
- **Provider/platform coverage:** macOS Electron to Linux SSH is covered here; the earlier manual run used Rocky Linux 9.4. Folder workspaces and git worktrees share the same target-scoped recovery path. Platform-neutral unit coverage and Windows packaging pass; a live Windows/WSL restart was not run.
- **Performance budget:** recovery adds no polling, provider listing, subprocess fanout, or hot-path scans. Owner grants are length-bounded and perform one main-state durability write only at ownership lifecycle boundaries; the regression test proves zero unrelated GitHub-cache sidecar writes.
- **Diagnostics:** existing SSH relay lifecycle logs expose build identity, owner admission, stale recovery, and cleanup; malformed persisted or granted leases fail closed.
- **Residual gaps:** the final post-review live rerun used the Linux Docker fixture rather than another Rocky host, and no live Windows/WSL restart was exercised.

## Security Audit

The owner lease is a bearer recovery secret, so it is main-owned, size/type validated on load, encrypted when `safeStorage` is available, and never added to renderer settings APIs. Recovery does not weaken server admission or promote subscribers: the relay still verifies the exact client ID, generation, lease, authenticated endpoint credential, and SSH principal. Conditional cleanup prevents an obsolete local session from deleting a newer owner's durable record.

No new IPC methods, network endpoints, command execution paths, dependencies, or user-controlled filesystem paths were added. Existing secure profile-file handling remains the fallback protection on platforms where OS encryption is unavailable.

## Notes

The PTY consumer protocol was introduced after Orca 1.4.162. This fixes the current-main full-restart failure reproduced under the issue scenario; users on 1.4.162 need to upgrade to receive it.
