### PR TITLE
fix(codex): promote only newer marketplace metadata (#11770)

### DIFF
--- a/src/main/codex/config-marketplace-refresh-promotion.test.ts
+++ b/src/main/codex/config-marketplace-refresh-promotion.test.ts
@@ -187,6 +187,24 @@ describe('Codex marketplace refresh promotion through the config mirror', () => 
     expect(readRuntimeConfig()).toContain('source = "https://github.com/example/demo.git"')
   })
 
+  it('inserts last_revision after last_updated when the canonical marketplace lacks it', () => {
+    writeSystemConfig(MARKETPLACE_CONFIG.replace('last_revision = "canonical-revision"\r\n', ''))
+    syncSystemConfigIntoManagedCodexHome()
+    expect(existsSync(runtimeConfigPath())).toBe(true)
+    writeRuntimeConfig(
+      readRuntimeConfig().replace(
+        /last_updated = .*\r?\n/,
+        'last_updated = "2026-07-02T00:00:00Z"\r\nlast_revision = "runtime-revision"\r\n'
+      )
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).toContain(
+      'last_updated = "2026-07-02T00:00:00Z" # keep this comment\r\nlast_revision = "runtime-revision"\r\nenabled = true'
+    )
+  })
+
   it('does not restore a runtime-only marketplace or a removed canonical marketplace', () => {
     seedMirroredConfig()
     writeRuntimeConfig(

--- a/src/main/codex/config-marketplace-refresh-promotion.test.ts
+++ b/src/main/codex/config-marketplace-refresh-promotion.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import type * as NodeOs from 'node:os'
+import { join } from 'node:path'
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: getPathMock
+  }
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+
+const MARKETPLACE_CONFIG = [
+  '# canonical config',
+  'model = "gpt-5"',
+  '',
+  '[marketplaces.demo]',
+  'source_type = "git"',
+  'source = "https://github.com/example/demo.git"',
+  'ref = "main"',
+  'sparse_paths = ["plugins"]',
+  'last_updated = "2026-07-01T00:00:00Z" # keep this comment',
+  'last_revision = "canonical-revision"',
+  'enabled = true',
+  '',
+  '[features]',
+  'hooks = true',
+  ''
+].join('\r\n')
+
+let fakeHomeDir: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+
+beforeEach(() => {
+  fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-marketplace-home-'))
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-marketplace-user-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+  getPathMock.mockImplementation((name: string) => {
+    if (name === 'userData') {
+      return userDataDir
+    }
+    throw new Error(`unexpected app.getPath(${name})`)
+  })
+  mkdirSync(systemHomeDir(), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(fakeHomeDir, { recursive: true, force: true })
+  rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+function systemHomeDir(): string {
+  return join(fakeHomeDir, '.codex')
+}
+
+function systemConfigPath(): string {
+  return join(systemHomeDir(), 'config.toml')
+}
+
+function runtimeConfigPath(): string {
+  return join(userDataDir, 'codex-runtime-home', 'home', 'config.toml')
+}
+
+function writeSystemConfig(content: string): void {
+  writeFileSync(systemConfigPath(), content, 'utf-8')
+}
+
+function readSystemConfig(): string {
+  return readFileSync(systemConfigPath(), 'utf-8')
+}
+
+function readRuntimeConfig(): string {
+  return readFileSync(runtimeConfigPath(), 'utf-8')
+}
+
+function writeRuntimeConfig(content: string): void {
+  mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+  writeFileSync(runtimeConfigPath(), content, 'utf-8')
+}
+
+function seedMirroredConfig(): void {
+  writeSystemConfig(MARKETPLACE_CONFIG)
+  syncSystemConfigIntoManagedCodexHome()
+  expect(existsSync(runtimeConfigPath())).toBe(true)
+}
+
+function setRuntimeMarketplaceMetadata(
+  timestamp: string | null,
+  revision = 'runtime-revision',
+  source = 'https://github.com/example/demo.git'
+): void {
+  let config = readRuntimeConfig().replace(
+    'source = "https://github.com/example/demo.git"',
+    `source = "${source}"`
+  )
+  config = config.replace(
+    /last_updated = .*\r?\n/,
+    timestamp ? `last_updated = "${timestamp}"\r\n` : ''
+  )
+  config = config.replace(/last_revision = .*\r?\n/, `last_revision = "${revision}"\r\n`)
+  writeRuntimeConfig(config)
+}
+
+describe('Codex marketplace refresh promotion through the config mirror', () => {
+  it('promotes newer matching metadata, keeps unrelated fields, and is idempotent', () => {
+    seedMirroredConfig()
+    setRuntimeMarketplaceMetadata('2026-07-02T00:00:00Z')
+    writeRuntimeConfig(readRuntimeConfig().replace('enabled = true', 'enabled = false'))
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const promoted = readSystemConfig()
+    expect(promoted).toContain('last_updated = "2026-07-02T00:00:00Z" # keep this comment')
+    expect(promoted).toContain('last_revision = "runtime-revision"')
+    expect(promoted).toContain('source = "https://github.com/example/demo.git"')
+    expect(promoted).toContain('enabled = true')
+    expect(promoted).toContain('model = "gpt-5"')
+    expect(promoted).toContain('[features]\r\nhooks = true')
+
+    const settledSystem = readSystemConfig()
+    const settledRuntime = readRuntimeConfig()
+    syncSystemConfigIntoManagedCodexHome()
+    expect(readSystemConfig()).toBe(settledSystem)
+    expect(readRuntimeConfig()).toBe(settledRuntime)
+  })
+
+  it.each([
+    ['equal', '2026-07-01T00:00:00Z'],
+    ['older', '2026-06-30T00:00:00Z'],
+    ['malformed', 'not-a-timestamp']
+  ])('preserves canonical metadata for an %s runtime timestamp', (_label, timestamp) => {
+    seedMirroredConfig()
+    const before = readSystemConfig()
+    setRuntimeMarketplaceMetadata(timestamp)
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).toBe(before)
+  })
+
+  it('preserves canonical metadata when the runtime timestamp is missing', () => {
+    seedMirroredConfig()
+    const before = readSystemConfig()
+    setRuntimeMarketplaceMetadata(null)
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).toBe(before)
+  })
+
+  it('preserves canonical metadata when the marketplace identity changes', () => {
+    seedMirroredConfig()
+    const before = readSystemConfig()
+    setRuntimeMarketplaceMetadata(
+      '2026-07-02T00:00:00Z',
+      'runtime-revision',
+      'https://example.com/other.git'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).toBe(before)
+    expect(readRuntimeConfig()).toContain('source = "https://github.com/example/demo.git"')
+  })
+
+  it('does not restore a runtime-only marketplace or a removed canonical marketplace', () => {
+    seedMirroredConfig()
+    writeRuntimeConfig(
+      `${readRuntimeConfig()}\r\n[marketplaces.runtime_only]\r\nsource_type = "git"\r\nsource = "https://github.com/example/runtime.git"\r\nlast_updated = "2026-07-02T00:00:00Z"\r\nlast_revision = "runtime-only"\r\n`
+    )
+    writeSystemConfig(
+      MARKETPLACE_CONFIG.replace(
+        /\r?\n\[marketplaces\.demo\][\s\S]*?\r?\n\[features\]/,
+        '\r\n[features]'
+      )
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).not.toContain('[marketplaces.')
+    expect(readRuntimeConfig()).not.toContain('[marketplaces.')
+  })
+})

--- a/src/main/codex/config-marketplace-refresh-promotion.ts
+++ b/src/main/codex/config-marketplace-refresh-promotion.ts
@@ -1,0 +1,326 @@
+import {
+  createTomlLineScanState,
+  isTomlStructuralLine,
+  parseTomlSingleLineStringValue,
+  updateTomlLineScanState
+} from './config-toml-line-scan'
+import { parseTomlKeyPath, parseTomlTableHeaderPath } from './config-toml-key-path'
+import {
+  extractOrdinaryCodexSettings,
+  getTomlSections,
+  joinTomlBlocks,
+  type TomlSection
+} from './config-toml-runtime-owned-sections'
+import { upsertPromotedSettingsInContent } from './codex-config-settings-upsert'
+
+type MarketplaceField = {
+  lineIndex: number
+  stringValue: { value: string; rawValue: string } | null
+  stringArrayValue: string[] | null
+  leadingWhitespace: string
+  trailingText: string
+  lineEnding: string
+}
+
+type MarketplaceTable = {
+  name: string
+  fields: ReadonlyMap<string, MarketplaceField>
+}
+
+const MARKETPLACE_IDENTITY_KEYS = ['source_type', 'source', 'ref', 'sparse_paths'] as const
+
+export function prepareSystemConfigForPromotion(
+  systemConfig: string | null,
+  runtimeConfig: string,
+  updates: Map<string, string>
+): string | null {
+  if (systemConfig === null && updates.size === 0) {
+    return null
+  }
+  const ordinaryConfig =
+    systemConfig ?? stripMarketplaceTomlSections(extractOrdinaryCodexSettings(runtimeConfig))
+  const configWithRefresh =
+    systemConfig === null
+      ? ordinaryConfig
+      : promoteMarketplaceRefreshMetadata(ordinaryConfig, runtimeConfig)
+  return upsertPromotedSettingsInContent(configWithRefresh, updates)
+}
+
+/**
+ * Promotes Codex-owned refresh metadata from a managed home into the canonical
+ * config only when the canonical marketplace still describes the same source.
+ */
+export function promoteMarketplaceRefreshMetadata(
+  systemConfig: string,
+  runtimeConfig: string
+): string {
+  const systemTables = getMarketplaceTables(systemConfig)
+  const runtimeTables = getMarketplaceTables(runtimeConfig)
+  const lines = systemConfig.split('\n')
+  let changed = false
+
+  const matchingTables = [...systemTables.values()]
+    .map((systemTable) => ({
+      systemTable,
+      runtimeTable: runtimeTables.get(systemTable.name)
+    }))
+    .filter(
+      (
+        candidate
+      ): candidate is {
+        systemTable: MarketplaceTable
+        runtimeTable: MarketplaceTable
+      } => candidate.runtimeTable !== undefined
+    )
+    .filter(({ systemTable, runtimeTable }) =>
+      marketplaceIdentityMatches(systemTable, runtimeTable)
+    )
+    .filter(({ systemTable, runtimeTable }) =>
+      marketplaceTimestampIsNewer(systemTable, runtimeTable)
+    )
+    .sort((left, right) => getTableStart(right.systemTable) - getTableStart(left.systemTable))
+
+  for (const { systemTable, runtimeTable } of matchingTables) {
+    const systemTimestamp = systemTable.fields.get('last_updated')
+    const runtimeTimestamp = runtimeTable.fields.get('last_updated')
+    if (!systemTimestamp || !runtimeTimestamp || !runtimeTimestamp.stringValue) {
+      continue
+    }
+    lines[systemTimestamp.lineIndex] = replaceFieldValue(
+      lines[systemTimestamp.lineIndex] ?? '',
+      systemTimestamp,
+      runtimeTimestamp.stringValue.rawValue
+    )
+    const runtimeRevision = runtimeTable.fields.get('last_revision')
+    if (runtimeRevision?.stringValue) {
+      const systemRevision = systemTable.fields.get('last_revision')
+      if (systemRevision) {
+        lines[systemRevision.lineIndex] = replaceFieldValue(
+          lines[systemRevision.lineIndex] ?? '',
+          systemRevision,
+          runtimeRevision.stringValue.rawValue
+        )
+      } else {
+        const line = lines[systemTimestamp.lineIndex] ?? ''
+        const indentation = /^\s*/.exec(line)?.[0] ?? ''
+        lines.splice(
+          systemTimestamp.lineIndex + 1,
+          0,
+          `${indentation}last_revision = ${runtimeRevision.stringValue.rawValue}${
+            systemTimestamp.lineEnding
+          }`
+        )
+      }
+    }
+    changed = true
+  }
+
+  return changed ? lines.join('\n') : systemConfig
+}
+
+/** Removes runtime-only marketplace tables before seeding a new canonical config. */
+export function stripMarketplaceTomlSections(config: string): string {
+  const sections = getTomlSections(config)
+  const firstSectionIndex = sections[0]?.start ?? -1
+  const lines = config.split('\n')
+  const preamble = firstSectionIndex === -1 ? config : lines.slice(0, firstSectionIndex).join('\n')
+  return joinTomlBlocks([
+    preamble,
+    ...sections.filter((section) => !isMarketplaceSection(section)).map((section) => section.block)
+  ])
+}
+
+function getMarketplaceTables(config: string): Map<string, MarketplaceTable> {
+  const tables = new Map<string, MarketplaceTable>()
+  for (const section of getTomlSections(config)) {
+    const header = parseTomlTableHeaderPath(section.header)
+    if (
+      !header ||
+      header.isArray ||
+      header.segments.length !== 2 ||
+      header.segments[0] !== 'marketplaces'
+    ) {
+      continue
+    }
+    tables.set(header.segments[1]!, {
+      name: header.segments[1]!,
+      fields: getMarketplaceFields(section)
+    })
+  }
+  return tables
+}
+
+function getMarketplaceFields(section: TomlSection): Map<string, MarketplaceField> {
+  const fields = new Map<string, MarketplaceField>()
+  const lines = section.block.split('\n')
+  let scanState = createTomlLineScanState()
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (isTomlStructuralLine(scanState)) {
+      const parsed = parseTomlKeyPath(line)
+      const key = parsed?.segments.length === 1 ? parsed.segments[0] : null
+      if (parsed && key && line[parsed.end] === '=' && isMarketplaceField(key)) {
+        const valueArea = line.slice(parsed.end + 1)
+        const trimmedValueArea = valueArea.trim()
+        const stringValue = parseStringValue(trimmedValueArea)
+        const stringArrayValue = parseStringArrayValue(trimmedValueArea)
+        const valueEnd = stringValue ? stringValue.end : stringArrayValue ? stringArrayValue.end : 0
+        const leadingWhitespace = valueArea.slice(
+          0,
+          valueArea.length - valueArea.trimStart().length
+        )
+        const lineEnding = line.endsWith('\r') ? '\r' : ''
+        fields.set(key, {
+          lineIndex: section.start + index,
+          stringValue: stringValue
+            ? { value: stringValue.value, rawValue: trimmedValueArea.slice(0, stringValue.end) }
+            : null,
+          stringArrayValue: stringArrayValue?.value ?? null,
+          leadingWhitespace,
+          trailingText: trimmedValueArea.slice(valueEnd),
+          lineEnding
+        })
+      }
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+  }
+  return fields
+}
+
+function isMarketplaceField(key: string): boolean {
+  return (
+    key === 'last_updated' ||
+    key === 'last_revision' ||
+    (MARKETPLACE_IDENTITY_KEYS as readonly string[]).includes(key)
+  )
+}
+
+function marketplaceIdentityMatches(
+  systemTable: MarketplaceTable,
+  runtimeTable: MarketplaceTable
+): boolean {
+  for (const key of ['source_type', 'source'] as const) {
+    const systemField = systemTable.fields.get(key)
+    const runtimeField = runtimeTable.fields.get(key)
+    if (!systemField || !runtimeField) {
+      return false
+    }
+    if (
+      systemField.stringValue === null ||
+      runtimeField.stringValue === null ||
+      systemField.stringValue.value !== runtimeField.stringValue.value
+    ) {
+      return false
+    }
+  }
+  for (const key of ['ref', 'sparse_paths'] as const) {
+    const systemField = systemTable.fields.get(key)
+    const runtimeField = runtimeTable.fields.get(key)
+    if (!systemField && !runtimeField) {
+      continue
+    }
+    if (!systemField || !runtimeField) {
+      return false
+    }
+    if (key === 'sparse_paths') {
+      if (
+        systemField.stringArrayValue === null ||
+        runtimeField.stringArrayValue === null ||
+        !arraysEqual(systemField.stringArrayValue, runtimeField.stringArrayValue)
+      ) {
+        return false
+      }
+      continue
+    }
+    if (systemField.stringValue === null || runtimeField.stringValue === null) {
+      return false
+    }
+    if (systemField.stringValue.value !== runtimeField.stringValue.value) {
+      return false
+    }
+  }
+  return true
+}
+
+function marketplaceTimestampIsNewer(
+  systemTable: MarketplaceTable,
+  runtimeTable: MarketplaceTable
+): boolean {
+  const systemTimestamp = systemTable.fields.get('last_updated')?.stringValue?.value
+  const runtimeTimestamp = runtimeTable.fields.get('last_updated')?.stringValue?.value
+  if (!systemTimestamp || !runtimeTimestamp) {
+    return false
+  }
+  const systemTime = Date.parse(systemTimestamp)
+  const runtimeTime = Date.parse(runtimeTimestamp)
+  return Number.isFinite(systemTime) && Number.isFinite(runtimeTime) && runtimeTime > systemTime
+}
+
+function replaceFieldValue(line: string, field: MarketplaceField, rawValue: string): string {
+  return `${line.slice(0, line.indexOf('=') + 1)}${field.leadingWhitespace}${rawValue}${field.trailingText}${field.lineEnding}`
+}
+
+function isMarketplaceSection(section: TomlSection): boolean {
+  const header = parseTomlTableHeaderPath(section.header)
+  return Boolean(
+    header &&
+    !header.isArray &&
+    header.segments.length === 2 &&
+    header.segments[0] === 'marketplaces'
+  )
+}
+
+function getTableStart(table: MarketplaceTable): number {
+  return table.fields.values().next().value?.lineIndex ?? -1
+}
+
+function parseStringValue(raw: string): { value: string; end: number } | null {
+  const parsed = parseTomlSingleLineStringValue(raw, 0)
+  if (!parsed || !isTomlCommentOrWhitespace(raw.slice(parsed.end))) {
+    return null
+  }
+  return parsed
+}
+
+function parseStringArrayValue(raw: string): { value: string[]; end: number } | null {
+  if (!raw.startsWith('[')) {
+    return null
+  }
+  const values: string[] = []
+  let index = 1
+  while (index < raw.length) {
+    while (raw[index] === ' ' || raw[index] === '\t') {
+      index += 1
+    }
+    if (raw[index] === ']') {
+      return { value: values, end: index + 1 }
+    }
+    const parsed = parseTomlSingleLineStringValue(raw, index)
+    if (!parsed) {
+      return null
+    }
+    values.push(parsed.value)
+    index = parsed.end
+    while (raw[index] === ' ' || raw[index] === '\t') {
+      index += 1
+    }
+    if (raw[index] === ',') {
+      index += 1
+      continue
+    }
+    if (raw[index] === ']') {
+      return { value: values, end: index + 1 }
+    }
+    return null
+  }
+  return null
+}
+
+function isTomlCommentOrWhitespace(value: string): boolean {
+  const trimmed = value.trim()
+  return trimmed === '' || trimmed.startsWith('#')
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}

--- a/src/main/codex/config-marketplace-refresh-promotion.ts
+++ b/src/main/codex/config-marketplace-refresh-promotion.ts
@@ -223,6 +223,7 @@ function marketplaceIdentityMatches(
       return false
     }
     if (key === 'sparse_paths') {
+      // Why: an unparsed array (multi-line) can't prove identity, so fail closed rather than promote across a source change.
       if (
         systemField.stringArrayValue === null ||
         runtimeField.stringArrayValue === null ||

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -246,17 +246,17 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
     conflicts,
     runtimeValuesToPreserve
   })
-  // Why: a fresh host has no ~/.codex; create it owner-only (holds auth.json) or the atomic write ENOENTs and the mirror wipes it.
-  mkdirSync(systemHomePath, { recursive: true, mode: 0o700 })
   const writeTarget = resolvePromotionWriteTarget(systemTomlPath)
-  // Why: a dangling symlink may target an unmade dir tree; create its real parent so the atomic temp write has a home.
-  mkdirSync(dirname(writeTarget.path), { recursive: true, mode: 0o700 })
   const targetExists = existsSync(writeTarget.path)
   const systemContent = targetExists ? readAgentStateFileSync(writeTarget.path) : null
   const nextContent = prepareSystemConfigForPromotion(systemContent, runtimeConfig, updates)
   if (nextContent === null || (targetExists && nextContent === systemContent)) {
     return { conflicts, runtimeValuesToPreserve }
   }
+  // Why: a fresh host has no ~/.codex; create it owner-only (holds auth.json) or the atomic write ENOENTs and the mirror wipes it.
+  mkdirSync(systemHomePath, { recursive: true, mode: 0o700 })
+  // Why: a dangling symlink may target an unmade dir tree; create its real parent so the atomic temp write has a home.
+  mkdirSync(dirname(writeTarget.path), { recursive: true, mode: 0o700 })
   if (targetExists && parseWslUncPath(writeTarget.path)) {
     // Why: \\wsl$ 9P symlink metadata is unreliable; write through the existing file to preserve the WSL-side inode.
     writeFileSync(writeTarget.path, nextContent, 'utf-8')

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -19,7 +19,7 @@ import {
   updateTomlLineScanState
 } from './config-toml-line-scan'
 import { parseTomlKeyPath, parseTomlTableHeaderPath } from './config-toml-key-path'
-import { tuiStructuredKey, upsertPromotedSettingsInContent } from './codex-config-settings-upsert'
+import { tuiStructuredKey } from './codex-config-settings-upsert'
 import {
   readCodexSettingsBaseline,
   writeCodexSettingsBaseline,
@@ -27,7 +27,7 @@ import {
   type CodexSettingsConflict
 } from './config-settings-baseline'
 import { resolveUntrackedCodexSetting } from './config-settings-conflict-resolution'
-import { extractOrdinaryCodexSettings } from './config-toml-runtime-owned-sections'
+import { prepareSystemConfigForPromotion } from './config-marketplace-refresh-promotion'
 
 // Why: the mirror reverts in-Codex config changes each launch; promotion salvages them by diffing the last baseline.
 
@@ -234,6 +234,7 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
   }
   const runtimeValues = readPromotedSettingValues(runtimeTomlPath)
   const systemValues = readPromotedSettingValues(systemTomlPath)
+  const runtimeConfig = readAgentStateFileSync(runtimeTomlPath)
   const updates = new Map<string, string>()
   const conflicts = new Map<string, CodexSettingsConflict>()
   const runtimeValuesToPreserve = new Map<string, string | null>()
@@ -245,24 +246,15 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
     conflicts,
     runtimeValuesToPreserve
   })
-  if (updates.size === 0) {
-    return { conflicts, runtimeValuesToPreserve }
-  }
   // Why: a fresh host has no ~/.codex; create it owner-only (holds auth.json) or the atomic write ENOENTs and the mirror wipes it.
   mkdirSync(systemHomePath, { recursive: true, mode: 0o700 })
   const writeTarget = resolvePromotionWriteTarget(systemTomlPath)
   // Why: a dangling symlink may target an unmade dir tree; create its real parent so the atomic temp write has a home.
   mkdirSync(dirname(writeTarget.path), { recursive: true, mode: 0o700 })
   const targetExists = existsSync(writeTarget.path)
-  // Why: seeding a brand-new ~/.codex/config.toml from the promoted keys alone
-  // would leave a skeleton the next mirror treats as authoritative, deleting
-  // every other runtime setting (mcp_servers, features). With no system config
-  // the runtime IS the user's config, so carry its ordinary settings across.
-  const systemContent = targetExists
-    ? readAgentStateFileSync(writeTarget.path)
-    : extractOrdinaryCodexSettings(readAgentStateFileSync(runtimeTomlPath))
-  const nextContent = upsertPromotedSettingsInContent(systemContent, updates)
-  if (nextContent === systemContent) {
+  const systemContent = targetExists ? readAgentStateFileSync(writeTarget.path) : null
+  const nextContent = prepareSystemConfigForPromotion(systemContent, runtimeConfig, updates)
+  if (nextContent === null || (targetExists && nextContent === systemContent)) {
     return { conflicts, runtimeValuesToPreserve }
   }
   if (targetExists && parseWslUncPath(writeTarget.path)) {


### PR DESCRIPTION
## Summary

- Promote Codex marketplace refresh metadata only when the canonical and managed tables have the same source identity and the managed timestamp is newer.
- Preserve canonical marketplace settings, unrelated configuration, and existing non-marketplace promotion behavior.

Closes #11770.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-config-mirror.test.ts src/main/codex/config-settings-promotion.test.ts src/main/codex/config-marketplace-refresh-promotion.test.ts`
- [x] `pnpm typecheck:node`
- [x] `pnpm exec oxlint src/main/codex/config-marketplace-refresh-promotion.ts src/main/codex/config-marketplace-refresh-promotion.test.ts src/main/codex/config-settings-promotion.ts`
- [x] `pnpm exec oxfmt --check src/main/codex/config-marketplace-refresh-promotion.ts src/main/codex/config-marketplace-refresh-promotion.test.ts src/main/codex/config-settings-promotion.ts`
- [x] `git diff --check`

The base reproduction failed before the fix, and the focused head suite passed with 97 tests and 4 intentional skips. Full lint, test, and build remain CI-gated.

## AI Review Report

The final diff is limited to Codex config promotion and its production-composed tests. It compares marketplace source identity and strict timestamp ordering, preserves canonical fields and unrelated settings, and leaves the existing managed-home mirror path in place. No UI, provider, local/remote transport, or new filesystem authority changed.

## Security Audit

The change only copies two already-parsed metadata values from a matching managed table into the canonical config. It accepts no new URL, credential, command, or filesystem authority.

## Notes

Related config PRs https://github.com/stablyai/orca/pull/6577, https://github.com/stablyai/orca/pull/9501, and https://github.com/stablyai/orca/pull/10221 do not own this marketplace freshness slice.
