### PR TITLE
fix(rate-limits): pass configured proxies to Codex fetchers (#11752)

### DIFF
--- a/src/main/rate-limits/codex-fetcher-proxy-env.test.ts
+++ b/src/main/rate-limits/codex-fetcher-proxy-env.test.ts
@@ -1,0 +1,157 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, ptySpawnMock, resolveCodexCommandMock, readFileMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  ptySpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
+vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
+vi.mock('node-pty', () => ({ spawn: ptySpawnMock }))
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: resolveCodexCommandMock }))
+vi.mock('./codex-auth-presence', () => ({ probeCodexAuthPresence: vi.fn(() => 'present') }))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+const proxyEnvKeys = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'NO_PROXY',
+  'no_proxy'
+] as const
+const originalProxyEnv = Object.fromEntries(
+  proxyEnvKeys.map((key) => [key, process.env[key]])
+) as Record<(typeof proxyEnvKeys)[number], string | undefined>
+
+function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: { write: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = { write: vi.fn() }
+  child.kill = vi.fn()
+  return child
+}
+
+function makePtyTerm() {
+  let exitHandler: (() => void) | null = null
+  return {
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onExit: vi.fn((callback: () => void) => {
+      exitHandler = callback
+      return { dispose: vi.fn() }
+    }),
+    write: vi.fn(),
+    kill: vi.fn(),
+    emitExit: () => exitHandler?.()
+  }
+}
+
+describe('Codex rate-limit proxy subprocess environments', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveCodexCommandMock.mockReturnValue('codex')
+    readFileMock.mockRejectedValue(new Error('no auth fixture'))
+  })
+
+  afterEach(() => {
+    for (const key of proxyEnvKeys) {
+      const value = originalProxyEnv[key]
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+    vi.useRealTimers()
+  })
+
+  it('merges configured proxy values over inherited RPC environment values', async () => {
+    process.env.HTTP_PROXY = 'http://parent.example:8080'
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({
+      allowPtyFallback: false,
+      networkProxySettings: {
+        httpProxyUrl: 'http://configured.example:9090',
+        httpProxyBypassRules: 'localhost, *.internal'
+      }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const spawnEnv = childSpawnMock.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv).toMatchObject({
+      HTTP_PROXY: 'http://configured.example:9090',
+      HTTPS_PROXY: 'http://configured.example:9090',
+      ALL_PROXY: 'http://configured.example:9090',
+      http_proxy: 'http://configured.example:9090',
+      https_proxy: 'http://configured.example:9090',
+      all_proxy: 'http://configured.example:9090',
+      NO_PROXY: 'localhost,*.internal',
+      no_proxy: 'localhost,*.internal'
+    })
+    expect(spawnEnv.PATH).toBe(process.env.PATH)
+    expect(process.env.HTTP_PROXY).toBe('http://parent.example:8080')
+
+    rpcChild.emit('close')
+    await resultPromise
+  })
+
+  it('preserves inherited proxy values and does not inject empty config', async () => {
+    process.env.HTTP_PROXY = 'http://parent.example:8080'
+    delete process.env.NO_PROXY
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({
+      allowPtyFallback: false,
+      networkProxySettings: { httpProxyUrl: '' }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const spawnEnv = childSpawnMock.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv.HTTP_PROXY).toBe('http://parent.example:8080')
+    expect(spawnEnv.NO_PROXY).toBeUndefined()
+    expect(process.env.HTTP_PROXY).toBe('http://parent.example:8080')
+
+    rpcChild.emit('close')
+    await resultPromise
+  })
+
+  it('passes configured proxy values to the PTY child environment', async () => {
+    const term = makePtyTerm()
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchCodexRateLimits({
+      networkProxySettings: { httpProxyUrl: 'http://configured.example:9090' }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const spawnEnv = ptySpawnMock.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv).toMatchObject({
+      HTTP_PROXY: 'http://configured.example:9090',
+      HTTPS_PROXY: 'http://configured.example:9090',
+      ALL_PROXY: 'http://configured.example:9090',
+      TERM: 'xterm-256color'
+    })
+
+    term.emitExit()
+    await resultPromise
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -655,7 +655,8 @@ describe('fetchCodexRateLimits', () => {
 
     try {
       const resultPromise = fetchCodexRateLimits({
-        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home'
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home',
+        networkProxySettings: { httpProxyUrl: 'http://proxy.example:8080' }
       })
       await vi.advanceTimersByTimeAsync(1)
       await vi.advanceTimersByTimeAsync(1)
@@ -675,6 +676,7 @@ describe('fetchCodexRateLimits', () => {
       expect(shellCommand).toContain(
         "export CODEX_HOME='\\''/home/alice/.local/share/orca/account/home'\\''"
       )
+      expect(shellCommand).toContain("export HTTP_PROXY='\\''http://proxy.example:8080'\\''")
       expect(shellCommand).toContain(
         "exec codex '\\''-s'\\'' '\\''read-only'\\'' '\\''-a'\\'' '\\''untrusted'\\'' '\\''app-server'\\'' <&3 >&4 3<&- 4>&-"
       )
@@ -776,7 +778,8 @@ describe('fetchCodexRateLimits', () => {
 
     try {
       const resultPromise = fetchCodexRateLimits({
-        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home'
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home',
+        networkProxySettings: { httpProxyUrl: 'http://proxy.example:8080' }
       })
       await vi.advanceTimersByTimeAsync(0)
       rpcChild.emit('close')
@@ -797,6 +800,7 @@ describe('fetchCodexRateLimits', () => {
       expect(shellCommand).toContain(
         "export CODEX_HOME='\\''/home/alice/.local/share/orca/account/home'\\''"
       )
+      expect(shellCommand).toContain("export HTTP_PROXY='\\''http://proxy.example:8080'\\''")
       expect(shellCommand).toContain('exec codex ')
       expect(shellCommand).not.toContain('_orca_codex')
       expect(shellCommand).not.toContain('wsl-codex-path')

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -36,6 +36,7 @@ import {
   createAuthFilesystemOperation,
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
+import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared/network-proxy'
 
 const RPC_TIMEOUT_MS = 10_000
 const WSL_RPC_TIMEOUT_MS = 25_000
@@ -57,6 +58,7 @@ const MAX_DIAGNOSTIC_OUTPUT_LENGTH = 100_000
 export type FetchCodexRateLimitsOptions = {
   codexHomePath?: string | null
   allowPtyFallback?: boolean
+  networkProxySettings?: NetworkProxySettings | null
   signal?: AbortSignal
 }
 
@@ -152,7 +154,7 @@ function shellQuote(value: string): string {
 function buildWslCodexCommand(
   codexHomePath: string,
   args: string[],
-  options?: { isolateRpcStdio?: boolean }
+  options?: { isolateRpcStdio?: boolean; proxyEnv?: Record<string, string> }
 ): {
   command: string
   args: string[]
@@ -163,6 +165,9 @@ function buildWslCodexCommand(
   }
   const setupCommands = [
     ...getHiddenRateLimitWslCwdSetupCommands(),
+    ...Object.entries(options?.proxyEnv ?? {}).map(
+      ([key, value]) => `export ${key}=${shellQuote(value)}`
+    ),
     `export CODEX_HOME=${shellQuote(wslInfo.linuxPath)}`
   ].join(' && ')
   const execSuffix = `${args.map(shellQuote).join(' ')}${
@@ -186,6 +191,19 @@ function cloneProcessEnvWithoutCodexHome(): NodeJS.ProcessEnv {
   const env = { ...process.env }
   delete env.CODEX_HOME
   return env
+}
+
+function buildCodexChildEnv(
+  options: FetchCodexRateLimitsOptions | undefined,
+  isWsl: boolean,
+  extraEnv?: Record<string, string>
+): NodeJS.ProcessEnv {
+  return {
+    ...(isWsl ? cloneProcessEnvWithoutCodexHome() : process.env),
+    ...buildConfiguredProxyEnv(options?.networkProxySettings),
+    ...(options?.codexHomePath && !isWsl ? { CODEX_HOME: options.codexHomePath } : {}),
+    ...extraEnv
+  }
 }
 
 function buildRpcMessage(id: number, method: string, params?: unknown): string {
@@ -616,8 +634,12 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     let rpcId = 0
 
     const codexArgs = ['-s', 'read-only', '-a', 'untrusted', 'app-server']
+    const proxyEnv = buildConfiguredProxyEnv(options?.networkProxySettings)
     const wslCodex = options?.codexHomePath
-      ? buildWslCodexCommand(options.codexHomePath, codexArgs, { isolateRpcStdio: true })
+      ? buildWslCodexCommand(options.codexHomePath, codexArgs, {
+          isolateRpcStdio: true,
+          proxyEnv
+        })
       : null
     // Why: cold WSL startup + app-server init can exceed the host RPC budget, causing a false "unavailable" on launch.
     const rpcTimeoutMs = wslCodex ? WSL_RPC_TIMEOUT_MS : RPC_TIMEOUT_MS
@@ -632,10 +654,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       // Why: scope the selected account to this subprocess only; never mutate process.env globally.
       // Why windowsHide: without it, background cmd.exe /c polls flash a console window on Windows.
       windowsHide: true,
-      env: {
-        ...(wslCodex ? cloneProcessEnvWithoutCodexHome() : process.env),
-        ...(options?.codexHomePath && !wslCodex ? { CODEX_HOME: options.codexHomePath } : {})
-      }
+      env: buildCodexChildEnv(options, Boolean(wslCodex))
     })
 
     let timeout: ReturnType<typeof setTimeout> | null = null
@@ -906,7 +925,10 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
   if (options?.signal?.aborted) {
     return abortedCodexRateLimitResult()
   }
-  const wslCodex = options?.codexHomePath ? buildWslCodexCommand(options.codexHomePath, []) : null
+  const proxyEnv = buildConfiguredProxyEnv(options?.networkProxySettings)
+  const wslCodex = options?.codexHomePath
+    ? buildWslCodexCommand(options.codexHomePath, [], { proxyEnv })
+    : null
   const codexCommand = wslCodex ? 'codex' : resolveCodexCommand()
 
   // Why: on win32 route through cmd.exe (even bare 'codex') so PATHEXT resolves codex.cmd under a minimal Electron PATH.
@@ -926,11 +948,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       cols: 120,
       rows: 40,
       cwd: resolveHiddenRateLimitPtyCwd(),
-      env: {
-        ...(wslCodex ? cloneProcessEnvWithoutCodexHome() : process.env),
-        TERM: 'xterm-256color',
-        ...(options?.codexHomePath && !wslCodex ? { CODEX_HOME: options.codexHomePath } : {})
-      }
+      env: buildCodexChildEnv(options, Boolean(wslCodex), { TERM: 'xterm-256color' })
     })
     const termDisposables: { dispose: () => void }[] = [registerHiddenRateLimitPty(term)]
 

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -634,11 +634,10 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     let rpcId = 0
 
     const codexArgs = ['-s', 'read-only', '-a', 'untrusted', 'app-server']
-    const proxyEnv = buildConfiguredProxyEnv(options?.networkProxySettings)
     const wslCodex = options?.codexHomePath
       ? buildWslCodexCommand(options.codexHomePath, codexArgs, {
           isolateRpcStdio: true,
-          proxyEnv
+          proxyEnv: buildConfiguredProxyEnv(options?.networkProxySettings)
         })
       : null
     // Why: cold WSL startup + app-server init can exceed the host RPC budget, causing a false "unavailable" on launch.

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1404,10 +1404,14 @@ describe('RateLimitService', () => {
         authPreparation: undefined,
         allowPtyFallback: false,
         allowUsagePanelSupplement: true,
+        networkProxySettings,
         signal: expect.any(AbortSignal)
       })
     )
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchCodexRateLimits).toHaveBeenCalledWith(
+      expect.objectContaining({ networkProxySettings })
+    )
     expect(fetchGeminiRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchGeminiRateLimits).toHaveBeenCalledWith(true)
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledTimes(1)

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -631,6 +631,7 @@ export class RateLimitService {
           const fresh = await fetchCodexRateLimits({
             codexHomePath: account.managedHomePath,
             allowPtyFallback: false,
+            networkProxySettings: this.networkProxySettingsResolver?.(),
             signal
           })
           if (
@@ -1263,6 +1264,7 @@ export class RateLimitService {
       fresh = await fetchCodexRateLimits({
         codexHomePath,
         allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+        networkProxySettings: this.networkProxySettingsResolver?.(),
         signal: controller.signal
       })
     } catch (error) {
@@ -1611,6 +1613,7 @@ export class RateLimitService {
           fetchCodexRateLimits({
             codexHomePath,
             allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
             signal
           }),
         fetchGeminiRateLimits(geminiCliOAuthEnabled),
@@ -1825,6 +1828,7 @@ export class RateLimitService {
         : fetchCodexRateLimits({
             codexHomePath,
             allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
             signal
           })
     ).catch(


### PR DESCRIPTION
## Summary

- Codex rate-limit RPC and PTY subprocesses now receive the configured proxy environment.
- The provider clones inherited variables, gives explicit settings precedence, preserves `CODEX_HOME` and `TERM`, exports proxy values inside WSL, and leaves the parent environment unchanged.

Closes #11752.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation run in this session:

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/codex-fetcher.test.ts src/main/rate-limits/codex-fetcher-proxy-env.test.ts src/shared/network-proxy.test.ts` (30 passed)
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/main/rate-limits/codex-fetcher.ts src/main/rate-limits/codex-fetcher.test.ts src/main/rate-limits/codex-fetcher-proxy-env.test.ts src/main/rate-limits/service.ts src/main/rate-limits/service.test.ts`
- [x] `pnpm exec oxfmt --check src/main/rate-limits/codex-fetcher.ts src/main/rate-limits/codex-fetcher.test.ts src/main/rate-limits/codex-fetcher-proxy-env.test.ts src/main/rate-limits/service.ts src/main/rate-limits/service.test.ts`
- [x] `pnpm run check:max-lines-ratchet`
- [x] `git diff --check`
- `src/main/rate-limits/service.test.ts` was also run; seven existing Claude PTY expectation cases fail on Windows because the test expects Linux values (`allowUsagePanelSupplement: true`), while the unchanged production guard correctly returns false on `win32`.

## AI Review Report

The change is limited to Codex rate-limit subprocess environment construction and service wiring. RPC and PTY use the same inherited-environment clone and configured proxy merge. WSL receives the proxy through the existing shell-quoting path; host `CODEX_HOME` stripping and PTY `TERM` behavior remain intact. No UI, network client, provider selection, or new subprocess path changed.

## Security Audit

Configured proxy values pass through the existing normalized proxy helper, which preserves credential handling and bypass normalization. Values are shell-quoted for WSL and are not logged. The parent `process.env` is never mutated, and no new network or credential source is introduced.

## Notes

Validated against `origin/main` at `a53c5d3fb07ef00bbe42e75609310436ed95a541`. The base regression run failed the configured RPC and PTY proxy assertions; the head run passed all 30 focused tests. Related PR https://github.com/stablyai/orca/pull/11662 covers invalid RPC fallback, not proxy environment merging.
