### PR TITLE
fix(github): fetch PR details through the validated Git provider (#10921)

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -194,6 +194,7 @@ vi.mock('../text-generation/commit-message-text-generation', () => ({
 }))
 
 vi.mock('../text-generation/pull-request-context', () => ({
+  createPullRequestGitFetch: vi.fn(() => vi.fn()),
   getPullRequestDraftContext: getPullRequestDraftContextMock
 }))
 
@@ -2268,6 +2269,7 @@ describe('registerFilesystemHandlers', () => {
       const worktreeId = 'repo-1::/remote/repo'
       getSshGitProviderMock.mockReturnValue({
         exec: vi.fn(),
+        fetchRemoteTrackingRef: vi.fn(),
         executeCommitMessagePlan: vi.fn()
       })
       const linkedStore = {
@@ -2289,6 +2291,58 @@ describe('registerFilesystemHandlers', () => {
         params,
         expect.objectContaining({ kind: 'remote' })
       )
+    })
+
+    it('routes SSH pull-request base refreshes through the validated provider RPC', async () => {
+      const worktreeId = 'repo-1::/remote/repo'
+      const exec = vi.fn()
+      const fetchRemoteTrackingRef = vi.fn()
+      getSshGitProviderMock.mockReturnValue({
+        exec,
+        fetchRemoteTrackingRef,
+        executeCommitMessagePlan: vi.fn()
+      })
+      getPullRequestDraftContextMock.mockImplementationOnce(
+        async (_exec, _input, fetchRemoteTrackingRefForContext) => {
+          await fetchRemoteTrackingRefForContext('origin', 'main', 'refs/remotes/origin/main')
+          return PULL_REQUEST_CONTEXT
+        }
+      )
+
+      registerFilesystemHandlers(store as never)
+
+      await expect(
+        handlers.get('git:generatePullRequestFields')!(null, {
+          ...PULL_REQUEST_ARGS,
+          worktreePath: '/remote/repo',
+          worktreeId,
+          connectionId: 'conn-1'
+        })
+      ).resolves.toEqual({ success: true, fields: {} })
+
+      expect(fetchRemoteTrackingRef).toHaveBeenCalledWith(
+        '/remote/repo',
+        'origin',
+        'main',
+        'refs/remotes/origin/main'
+      )
+      expect(exec).not.toHaveBeenCalledWith(expect.arrayContaining(['fetch']), expect.anything())
+    })
+
+    it('preserves the explicit error when the SSH Git provider is unavailable', async () => {
+      registerFilesystemHandlers(store as never)
+
+      await expect(
+        handlers.get('git:generatePullRequestFields')!(null, {
+          ...PULL_REQUEST_ARGS,
+          worktreePath: '/remote/repo',
+          worktreeId: 'repo-1::/remote/repo',
+          connectionId: 'conn-1'
+        })
+      ).resolves.toEqual({
+        success: false,
+        error: 'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+      })
     })
 
     it('ignores a pull-request worktree id that does not own the requested path', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -73,7 +73,10 @@ import {
   type GenerateCommitMessageResult,
   type GeneratePullRequestFieldsResult
 } from '../text-generation/commit-message-text-generation'
-import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
+import {
+  createPullRequestGitFetch,
+  getPullRequestDraftContext
+} from '../text-generation/pull-request-context'
 import { getUpstreamStatus } from '../git/upstream'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
 import { gitSyncForkDefaultBranch } from '../git/fork-sync'
@@ -1612,7 +1615,9 @@ export function registerFilesystemHandlers(
               currentTitle: args.title,
               currentBody,
               currentDraft: args.draft
-            }
+            },
+            (remote, branch, ref) =>
+              provider.fetchRemoteTrackingRef(args.worktreePath, remote, branch, ref)
           )
         } catch (error) {
           return {
@@ -1660,7 +1665,10 @@ export function registerFilesystemHandlers(
             currentTitle: args.title,
             currentBody,
             currentDraft: args.draft
-          }
+          },
+          createPullRequestGitFetch((argv, options) =>
+            gitExecFileAsync(argv, { cwd: worktreePath, ...gitOptions, ...options })
+          )
         )
       } catch (error) {
         return {

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -895,6 +895,20 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('rethrows fetch RPC errors unchanged', async () => {
+    const error = new Error('fatal: could not read from remote repository')
+    mux.request.mockRejectedValueOnce(error)
+
+    await expect(
+      provider.fetchRemoteTrackingRef(
+        '/home/user/repo',
+        'origin',
+        'main',
+        'refs/remotes/origin/main'
+      )
+    ).rejects.toBe(error)
+  })
+
   it('fetchGitLabMergeRequestHead sends the durable-ref git.fetchGitLabMergeRequestHeadRef request', async () => {
     mux.request.mockResolvedValueOnce({
       localRef: 'refs/orca/merge-requests/origin-abc/42'

--- a/src/main/runtime/orca-runtime-git.test.ts
+++ b/src/main/runtime/orca-runtime-git.test.ts
@@ -579,7 +579,8 @@ describe('RuntimeGitCommands', () => {
       expect.any(Function),
       expect.objectContaining({
         currentBody: templateBody
-      })
+      }),
+      expect.any(Function)
     )
   })
 
@@ -820,8 +821,10 @@ describe('RuntimeGitCommands', () => {
     }
     const params = { agentId: 'codex' as const, model: 'gpt-5.5' }
     mocks.generatePullRequestFieldsFromContext.mockResolvedValue({ success: true, fields: {} })
+    const fetchRemoteTrackingRef = vi.fn()
     mocks.getSshGitProvider.mockReturnValue({
       exec: vi.fn(),
+      fetchRemoteTrackingRef,
       executeCommitMessagePlan: vi.fn()
     })
 
@@ -832,7 +835,12 @@ describe('RuntimeGitCommands', () => {
       if (!connectionId) {
         tempDirs.push(worktreePath)
       }
-      mocks.getPullRequestDraftContext.mockResolvedValue(context)
+      mocks.getPullRequestDraftContext.mockImplementation(async (_exec, _input, fetch) => {
+        if (connectionId) {
+          await fetch('origin', 'main', 'refs/remotes/origin/main')
+        }
+        return context
+      })
       const commands = new RuntimeGitCommands({
         resolveRuntimeGitTarget: async () => ({
           worktree: makeWorktree(worktreePath, 55),
@@ -852,6 +860,12 @@ describe('RuntimeGitCommands', () => {
     for (const call of mocks.generatePullRequestFieldsFromContext.mock.calls) {
       expect(call[0]).toEqual({ ...context, linkedIssue: 55 })
     }
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/home/tester/wt',
+      'origin',
+      'main',
+      'refs/remotes/origin/main'
+    )
   })
 
   it('leaves the pull-request context untouched when no issue is linked', async () => {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -77,7 +77,10 @@ import type {
   CommitMessageAgentRuntimeTarget
 } from '../text-generation/commit-message-agent-environment'
 import { prepareLocalCommitMessageAgentEnv } from '../text-generation/commit-message-agent-environment'
-import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
+import {
+  createPullRequestGitFetch,
+  getPullRequestDraftContext
+} from '../text-generation/pull-request-context'
 import { normalizeRuntimeRelativePath } from './runtime-relative-paths'
 import { gitExecFileAsync } from '../git/runner'
 import type { GitRuntimeOptions } from '../git/git-runtime-options'
@@ -732,12 +735,17 @@ export class RuntimeGitCommands {
         useTemplate: input.useTemplate
       })
       context = target.connectionId
-        ? await getPullRequestDraftContext((argv) => provider!.exec(argv, target.worktree.path), {
-            base: input.base,
-            currentTitle: input.title,
-            currentBody,
-            currentDraft: input.draft
-          })
+        ? await getPullRequestDraftContext(
+            (argv) => provider!.exec(argv, target.worktree.path),
+            {
+              base: input.base,
+              currentTitle: input.title,
+              currentBody,
+              currentDraft: input.draft
+            },
+            (remote, branch, ref) =>
+              provider!.fetchRemoteTrackingRef(target.worktree.path, remote, branch, ref)
+          )
         : await getPullRequestDraftContext(
             (argv, options) =>
               gitExecFileAsync(argv, {
@@ -750,7 +758,14 @@ export class RuntimeGitCommands {
               currentTitle: input.title,
               currentBody,
               currentDraft: input.draft
-            }
+            },
+            createPullRequestGitFetch((argv, options) =>
+              gitExecFileAsync(argv, {
+                cwd: target.worktree.path,
+                ...localGitOptionsForTarget(target),
+                ...options
+              })
+            )
           )
     } catch (error) {
       return {

--- a/src/main/text-generation/pull-request-context-errors.test.ts
+++ b/src/main/text-generation/pull-request-context-errors.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getPullRequestDraftContext } from './pull-request-context'
+import {
+  createPullRequestGitFetch,
+  getPullRequestDraftContext,
+  type PullRequestGitFetch
+} from './pull-request-context'
 
 type GitExec = Parameters<typeof getPullRequestDraftContext>[0]
 
@@ -14,6 +18,10 @@ function createContextInput(base = 'main') {
     currentBody: 'Existing body',
     currentDraft: false
   }
+}
+
+function createFetch(execGit: GitExec): PullRequestGitFetch {
+  return createPullRequestGitFetch(execGit)
 }
 
 describe('getPullRequestDraftContext error handling', () => {
@@ -48,7 +56,9 @@ describe('getPullRequestDraftContext error handling', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await expect(getPullRequestDraftContext(execGit, createContextInput())).resolves.toMatchObject({
+    await expect(
+      getPullRequestDraftContext(execGit, createContextInput(), createFetch(execGit))
+    ).resolves.toMatchObject({
       branch: 'feature'
     })
     expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
@@ -73,9 +83,9 @@ describe('getPullRequestDraftContext error handling', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await expect(getPullRequestDraftContext(execGit, createContextInput())).rejects.toThrow(
-      'Fetch before generating PR details failed: fatal: unable to access origin'
-    )
+    await expect(
+      getPullRequestDraftContext(execGit, createContextInput(), createFetch(execGit))
+    ).rejects.toThrow('Fetch before generating PR details failed: fatal: unable to access origin')
   })
 
   it('handles newline-heavy remote state and fetch errors without line-array splitting', async () => {
@@ -95,9 +105,9 @@ describe('getPullRequestDraftContext error handling', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await expect(getPullRequestDraftContext(execGit, createContextInput())).rejects.toThrow(
-      'Fetch before generating PR details failed: fatal: unable to access origin'
-    )
+    await expect(
+      getPullRequestDraftContext(execGit, createContextInput(), createFetch(execGit))
+    ).rejects.toThrow('Fetch before generating PR details failed: fatal: unable to access origin')
 
     const usedLineSplit = splitSpy.mock.calls.some(
       ([separator]) =>
@@ -107,12 +117,36 @@ describe('getPullRequestDraftContext error handling', () => {
     expect(usedLineSplit).toBe(false)
   })
 
+  it('propagates provider validation for malformed remote state without generic-exec fallback', async () => {
+    const execGit = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'remote') {
+        return { stdout: 'origin//main\n', stderr: '' }
+      }
+      if (args[0] === 'for-each-ref') {
+        return { stdout: 'origin//main\n', stderr: '' }
+      }
+      throw new Error(`Unexpected git args: ${args.join(' ')}`)
+    })
+    const fetchRemoteTrackingRef = vi.fn<PullRequestGitFetch>(async (_remote, branch) => {
+      if (branch.startsWith('/')) {
+        throw new Error("fatal: 'refs/heads//main' is not a valid ref name")
+      }
+    })
+
+    await expect(
+      getPullRequestDraftContext(execGit, createContextInput(), fetchRemoteTrackingRef)
+    ).rejects.toThrow(
+      "Fetch before generating PR details failed: fatal: 'refs/heads//main' is not a valid ref name"
+    )
+    expect(execGit.mock.calls.some(([args]) => args[0] === 'fetch')).toBe(false)
+  })
+
   it('returns null without running git when the base is invalid', async () => {
     const execGit = vi.fn<GitExec>()
 
-    await expect(getPullRequestDraftContext(execGit, createContextInput('--main'))).resolves.toBe(
-      null
-    )
+    await expect(
+      getPullRequestDraftContext(execGit, createContextInput('--main'), createFetch(execGit))
+    ).resolves.toBe(null)
     expect(execGit).not.toHaveBeenCalled()
   })
 })

--- a/src/main/text-generation/pull-request-context.test.ts
+++ b/src/main/text-generation/pull-request-context.test.ts
@@ -2,7 +2,11 @@
 // variants; keeping the table of git command mocks together makes regressions
 // easier to audit than splitting the suite by helper.
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getPullRequestDraftContext } from './pull-request-context'
+import {
+  createPullRequestGitFetch,
+  getPullRequestDraftContext,
+  type PullRequestGitFetch
+} from './pull-request-context'
 
 type GitExec = Parameters<typeof getPullRequestDraftContext>[0]
 
@@ -19,11 +23,15 @@ function createContextInput(base = 'main') {
   }
 }
 
+function createFetch(execGit: GitExec): PullRequestGitFetch {
+  return createPullRequestGitFetch(execGit)
+}
+
 describe('getPullRequestDraftContext', () => {
-  it('fetches the resolved remote base before collecting PR context without mutating HEAD', async () => {
+  it('uses the injected fetch authority before collecting PR context without mutating HEAD', async () => {
     const execGit = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'fetch') {
-        return { stdout: '', stderr: '' }
+        throw new Error('generic git.exec must not receive fetch')
       }
       if (args[0] === 'remote') {
         return { stdout: 'origin\nupstream\n', stderr: '' }
@@ -48,8 +56,13 @@ describe('getPullRequestDraftContext', () => {
       }
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
+    const fetchRemoteTrackingRef = vi.fn<PullRequestGitFetch>(async () => undefined)
 
-    const context = await getPullRequestDraftContext(execGit, createContextInput())
+    const context = await getPullRequestDraftContext(
+      execGit,
+      createContextInput(),
+      fetchRemoteTrackingRef
+    )
 
     expect(context).toMatchObject({
       branch: 'feature/pr-details',
@@ -58,10 +71,12 @@ describe('getPullRequestDraftContext', () => {
       commitSummary: '- feat: summarize branch',
       changeSummary: 'M\tsrc/file.ts'
     })
-    expect(execGit).toHaveBeenCalledWith(
-      ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
-      expect.any(Object)
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      'origin',
+      'main',
+      'refs/remotes/origin/main'
     )
+    expect(execGit.mock.calls.some(([args]) => args[0] === 'fetch')).toBe(false)
     expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
     expect(execGit).not.toHaveBeenCalledWith(
       expect.arrayContaining(['rev-parse']),
@@ -99,7 +114,7 @@ describe('getPullRequestDraftContext', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await getPullRequestDraftContext(execGit, createContextInput())
+    await getPullRequestDraftContext(execGit, createContextInput(), createFetch(execGit))
 
     expect(execGit).toHaveBeenCalledWith(
       ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
@@ -139,7 +154,9 @@ describe('getPullRequestDraftContext', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await expect(getPullRequestDraftContext(execGit, createContextInput())).resolves.toMatchObject({
+    await expect(
+      getPullRequestDraftContext(execGit, createContextInput(), createFetch(execGit))
+    ).resolves.toMatchObject({
       branch: 'feature/pr-details'
     })
 
@@ -177,7 +194,7 @@ describe('getPullRequestDraftContext', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    await getPullRequestDraftContext(execGit, createContextInput())
+    await getPullRequestDraftContext(execGit, createContextInput(), createFetch(execGit))
 
     expect(execGit).not.toHaveBeenCalledWith(
       expect.arrayContaining(['contributor-a']),
@@ -216,7 +233,11 @@ describe('getPullRequestDraftContext', () => {
       throw new Error(`Unexpected git args: ${args.join(' ')}`)
     })
 
-    const context = await getPullRequestDraftContext(execGit, createContextInput())
+    const context = await getPullRequestDraftContext(
+      execGit,
+      createContextInput(),
+      createFetch(execGit)
+    )
 
     expect(context?.branchChangedByPreparation).toBe(false)
     expect(execGit).not.toHaveBeenCalledWith(expect.arrayContaining(['rebase']), expect.anything())
@@ -252,7 +273,11 @@ describe('getPullRequestDraftContext', () => {
       return { stdout: '', stderr: '' }
     })
 
-    await getPullRequestDraftContext(execGit, createContextInput('upstream/main'))
+    await getPullRequestDraftContext(
+      execGit,
+      createContextInput('upstream/main'),
+      createFetch(execGit)
+    )
 
     expect(execGit).toHaveBeenCalledWith(
       ['fetch', '--no-tags', 'upstream', '+refs/heads/main:refs/remotes/upstream/main'],

--- a/src/main/text-generation/pull-request-context.ts
+++ b/src/main/text-generation/pull-request-context.ts
@@ -7,6 +7,16 @@ type GitExec = (
   options?: { maxBuffer?: number }
 ) => Promise<{ stdout: string; stderr?: string }>
 
+export type PullRequestGitFetch = (remote: string, branch: string, ref: string) => Promise<void>
+
+export function createPullRequestGitFetch(execGit: GitExec): PullRequestGitFetch {
+  return async (remote, branch, ref) => {
+    await execGit(['fetch', '--no-tags', remote, `+refs/heads/${branch}:${ref}`], {
+      maxBuffer: MAX_PULL_REQUEST_CONTEXT_BYTES
+    })
+  }
+}
+
 export type PullRequestContextInput = {
   base: string
   currentTitle: string
@@ -34,15 +44,6 @@ function summarizeGitError(error: unknown): string {
     }
   }
   return error.message
-}
-
-async function requiredExec(execGit: GitExec, args: string[], label: string): Promise<string> {
-  try {
-    const { stdout } = await execGit(args, { maxBuffer: MAX_PULL_REQUEST_CONTEXT_BYTES })
-    return stdout.trim()
-  } catch (error) {
-    throw new Error(`${label}: ${summarizeGitError(error)}`)
-  }
 }
 
 type RemoteState = {
@@ -179,20 +180,22 @@ function resolveComparisonBase(
   return { comparisonBase: base, fetchTarget: null }
 }
 
-async function fetchComparisonBase(execGit: GitExec, target: RemoteBranch | null): Promise<void> {
+async function fetchComparisonBase(
+  fetchRemoteTrackingRef: PullRequestGitFetch,
+  target: RemoteBranch | null
+): Promise<void> {
   if (!target) {
     return
   }
-  await requiredExec(
-    execGit,
-    [
-      'fetch',
-      '--no-tags',
+  try {
+    await fetchRemoteTrackingRef(
       target.remote,
-      `+refs/heads/${target.branch}:refs/remotes/${target.remote}/${target.branch}`
-    ],
-    'Fetch before generating PR details failed'
-  )
+      target.branch,
+      `refs/remotes/${target.remote}/${target.branch}`
+    )
+  } catch (error) {
+    throw new Error(`Fetch before generating PR details failed: ${summarizeGitError(error)}`)
+  }
 }
 
 type PullRequestBranchPreparation = {
@@ -202,12 +205,13 @@ type PullRequestBranchPreparation = {
 
 async function preparePullRequestBranch(
   execGit: GitExec,
+  fetchRemoteTrackingRef: PullRequestGitFetch,
   base: string
 ): Promise<PullRequestBranchPreparation> {
   const { comparisonBase, fetchTarget } = resolveComparisonBase(base, await getRemoteState(execGit))
   // Why: PR generation only needs the selected base branch. A repo-wide
   // `fetch --all` makes stale contributor fork remotes block unrelated PRs.
-  await fetchComparisonBase(execGit, fetchTarget)
+  await fetchComparisonBase(fetchRemoteTrackingRef, fetchTarget)
   return {
     comparisonBase,
     // Why: Generate must be read-only. Rebasing the live worktree can rewrite
@@ -218,14 +222,19 @@ async function preparePullRequestBranch(
 
 export async function getPullRequestDraftContext(
   execGit: GitExec,
-  input: PullRequestContextInput
+  input: PullRequestContextInput,
+  fetchRemoteTrackingRef: PullRequestGitFetch
 ): Promise<PullRequestDraftContext | null> {
   const base = input.base.trim()
   if (!base || base.startsWith('-')) {
     return null
   }
 
-  const { comparisonBase, branchChanged } = await preparePullRequestBranch(execGit, base)
+  const { comparisonBase, branchChanged } = await preparePullRequestBranch(
+    execGit,
+    fetchRemoteTrackingRef,
+    base
+  )
   const [branch, mergeBase] = await Promise.all([
     safeExec(execGit, ['branch', '--show-current']),
     safeExec(execGit, ['merge-base', comparisonBase, 'HEAD'])

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -1814,6 +1814,15 @@ describe('GitHandler', () => {
           ref: 'refs/remotes/origin/other'
         })
       ).rejects.toThrow('Remote-tracking ref does not match the requested remote and branch.')
+
+      await expect(
+        dispatcher.callRequest('git.fetchRemoteTrackingRef', {
+          worktreePath: tmpDir,
+          remote: 'origin',
+          branch: '-main',
+          ref: 'refs/remotes/origin/-main'
+        })
+      ).rejects.toThrow('Remote-tracking fetch inputs must not start with "-".')
     })
 
     it('fetches GitHub pull request heads through the narrow fetch RPC', async () => {


### PR DESCRIPTION
## Summary

- Route remote PR-detail fetches through the validated Git provider fetch method.
- Preserve local Git, non-fetch operations, SSH validation, and explicit unsupported-provider errors.

Closes #10921.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-git.test.ts src/main/text-generation/pull-request-context.test.ts` passed, 32 tests.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/text-generation/pull-request-context-errors.test.ts src/main/ipc/filesystem.test.ts src/main/providers/ssh-git-provider.test.ts` passed, 201 tests.
- Targeted `src/relay/git-handler.test.ts` remote-tracking validation passed, 1 test.
- `pnpm run typecheck:node` passed.
- Changed-file `pnpm exec oxlint` and `pnpm exec oxfmt --check` passed.
- `git diff --check` passed.

The full relay-handler file was not claimed green; a broad run exposed an unrelated existing `upstreamStatus` expectation. See `orca-PR-TARGET-10921-PROOF.md` for the exact evidence.

## AI Review Report

Focused review completed for SSH/local/remote providers, relay validation, PR context consumers, fetch/non-fetch separation, command execution, and performance. No UI or new subprocesses are involved.

## Security Audit

Remote fetches now use the existing validated provider boundary. Request parameters remain validated by `git.fetchRemoteTrackingRef`; no generic-exec allowlist or new SSH command surface was added. Local fetch and non-fetch behavior remain unchanged.

## Notes

Merged PR https://github.com/stablyai/orca/pull/5320 covers another SSH fetch path. This PR keeps that path unchanged and closes the PR-detail caller bypass.
