### PR TITLE
fix(mobile): focus Kimi terminal input after touch

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -117,10 +117,10 @@ import { createTerminalLiveAccessoryInput } from '../../../../src/terminal/termi
 import { sendTerminalLiveAccessoryRawBytes } from '../../../../src/terminal/terminal-live-accessory-raw-send'
 import {
   clearTerminalLiveInputFocusTimer,
-  focusTerminalLiveInputTarget,
   isTerminalLiveInputWithinByteLimit,
   scheduleTerminalLiveInputFocus
 } from '../../../../src/terminal/terminal-live-input'
+import { useTerminalLiveInputFocus } from '../../../../src/terminal/use-terminal-live-input-focus'
 import { dismissTerminalKeyboard } from '../../../../src/terminal/terminal-keyboard-dismiss'
 import type { TerminalLiveInputSender } from '../../../../src/terminal/terminal-live-input-sender'
 import { isTerminalSendRpcAccepted } from '../../../../src/terminal/terminal-send-rpc-response'
@@ -1082,6 +1082,14 @@ export default function SessionScreen() {
     activeSessionTabType: activeSessionTab?.type
   })
   const liveInputEnabled = activeHandle ? liveInputTerminalHandles.has(activeHandle) : false
+  const { focusLiveInput, handleTerminalTap } = useTerminalLiveInputFocus({
+    activeHandleRef,
+    canSend,
+    inputRef: liveInputRef,
+    keyboardHeight,
+    liveInputEnabled,
+    timerRef: liveInputFocusTimerRef
+  })
   const [browserScreencastSupported, setBrowserScreencastSupported] = useState<boolean | null>(null)
   // Why: hosts without aiVault.v1 reject listSessions, so hide the header entry instead of a dead-end "update this host" panel.
   const [agentSessionHistorySupported, setAgentSessionHistorySupported] = useState<boolean | null>(
@@ -3092,17 +3100,6 @@ export default function SessionScreen() {
   )
   sendLiveTerminalInputRef.current = sendLiveTerminalInput
 
-  const focusLiveInput = useCallback(() => {
-    if (!canSend || !liveInputEnabled) {
-      return
-    }
-    focusTerminalLiveInputTarget(liveInputRef.current, {
-      keyboardHeight,
-      refocus: () =>
-        scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => liveInputRef.current?.focus())
-    })
-  }, [canSend, keyboardHeight, liveInputEnabled])
-
   const clearSessionTabActionSheetKeyboardListener = useCallback(() => {
     sessionTabActionSheetKeyboardHideSubRef.current?.remove()
     sessionTabActionSheetKeyboardHideSubRef.current = null
@@ -3176,16 +3173,6 @@ export default function SessionScreen() {
       liveInput: liveInputRef.current
     })
   }, [])
-
-  const handleTerminalTap = useCallback(
-    (handle: string) => {
-      if (handle !== activeHandleRef.current) {
-        return
-      }
-      focusLiveInput()
-    },
-    [focusLiveInput]
-  )
 
   // Tap a terminal file path → resolve on host, open as file tab (mirrors desktop Cmd/Ctrl-click); silent on a miss.
   const handleFileTapActivationSeqRef = useRef(0)

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1082,14 +1082,22 @@ export default function SessionScreen() {
     activeSessionTabType: activeSessionTab?.type
   })
   const liveInputEnabled = activeHandle ? liveInputTerminalHandles.has(activeHandle) : false
-  const { focusLiveInput, handleTerminalTap } = useTerminalLiveInputFocus({
+  const { focusLiveInput, handleTerminalTap, resetLiveInputFocus } = useTerminalLiveInputFocus({
     activeHandleRef,
     canSend,
     inputRef: liveInputRef,
     keyboardHeight,
+    lifecycleIdentity: client,
+    lifecycleKey: JSON.stringify([hostId, worktreeId, connState]),
     liveInputEnabled,
     timerRef: liveInputFocusTimerRef
   })
+  useFocusEffect(
+    useCallback(() => {
+      // Expo retains this route while pushed screens are visible.
+      return resetLiveInputFocus
+    }, [resetLiveInputFocus])
+  )
   const [browserScreencastSupported, setBrowserScreencastSupported] = useState<boolean | null>(null)
   // Why: hosts without aiVault.v1 reject listSessions, so hide the header entry instead of a dead-end "update this host" panel.
   const [agentSessionHistorySupported, setAgentSessionHistorySupported] = useState<boolean | null>(

--- a/mobile/src/terminal/terminal-live-input-affordance.test.ts
+++ b/mobile/src/terminal/terminal-live-input-affordance.test.ts
@@ -40,7 +40,10 @@ describe('terminal live input affordance', () => {
     expect(block).toContain('!canSend && styles.liveInputFocusTargetDisabled')
     expect(block).toContain('showSoftInputOnFocus')
     expect(sessionRouteSource).toContain('useTerminalLiveInputFocus({')
+    expect(sessionRouteSource).toContain('return resetLiveInputFocus')
     expect(liveInputFocusSource).toContain('focusTerminalLiveInputTarget(inputRef.current')
+    expect(liveInputFocusSource).toContain('lifecycleIdentity,')
+    expect(liveInputFocusSource).toContain('resetLiveInputFocus')
     expect(liveInputFocusSource).toContain('keyboardHeight: context.keyboardHeight')
     expect(liveInputFocusSource).toContain(
       'scheduleTerminalLiveInputFocus(timerRef, focusLiveInput)'

--- a/mobile/src/terminal/terminal-live-input-affordance.test.ts
+++ b/mobile/src/terminal/terminal-live-input-affordance.test.ts
@@ -13,6 +13,10 @@ const commandInputStylesSource = readFileSync(
   new URL('../../app/h/[hostId]/session/mobile-session-command-input-styles.ts', import.meta.url),
   'utf8'
 )
+const liveInputFocusSource = readFileSync(
+  new URL('./use-terminal-live-input-focus.ts', import.meta.url),
+  'utf8'
+)
 
 function liveInputBarBlock(): string {
   const start = sessionRouteSource.indexOf('{liveInputEnabled ? (')
@@ -35,9 +39,12 @@ describe('terminal live input affordance', () => {
     expect(block).toContain('pressed && styles.liveInputFocusTargetPressed')
     expect(block).toContain('!canSend && styles.liveInputFocusTargetDisabled')
     expect(block).toContain('showSoftInputOnFocus')
-    expect(sessionRouteSource).toContain('focusTerminalLiveInputTarget(liveInputRef.current')
-    expect(sessionRouteSource).toContain('keyboardHeight')
-    expect(sessionRouteSource).toContain('scheduleTerminalLiveInputFocus(liveInputFocusTimerRef')
+    expect(sessionRouteSource).toContain('useTerminalLiveInputFocus({')
+    expect(liveInputFocusSource).toContain('focusTerminalLiveInputTarget(inputRef.current')
+    expect(liveInputFocusSource).toContain('keyboardHeight: context.keyboardHeight')
+    expect(liveInputFocusSource).toContain(
+      'scheduleTerminalLiveInputFocus(timerRef, focusLiveInput)'
+    )
   })
 
   it('makes the live keyboard target visible instead of status-only chrome', () => {

--- a/mobile/src/terminal/terminal-webview-mouse-click-drag-injected.ts
+++ b/mobile/src/terminal/terminal-webview-mouse-click-drag-injected.ts
@@ -179,9 +179,8 @@ export const TERMINAL_MOUSE_CLICK_DRAG_JS = `
       // Why: a dismissing tap only clears the selection (touch parity); it must
       // not also open a link or focus the keyboard underneath.
       if (gesture.dismissedSelection) return;
-      // Plain click == touch tap: links and file paths win, then tracking-mode
-      // click reports, then keyboard focus.
-      notifyTerminalSurfaceTap(e.clientX, e.clientY);
+      // Pointer clicks keep their current link, file, TUI mouse, and focus priority.
+      notifyTerminalSurfaceTap(e.clientX, e.clientY, false);
     }, true);
 
     targetSurface.addEventListener('pointercancel', function(e) {

--- a/mobile/src/terminal/terminal-webview-mouse-click.test.ts
+++ b/mobile/src/terminal/terminal-webview-mouse-click.test.ts
@@ -18,6 +18,7 @@ describe('terminal WebView external mouse click', () => {
     expect(bytes.slice(0, 4)).toBe(`${ESC}[M `)
     expect(bytes.slice(6, 10)).toBe(`${ESC}[M#`)
     expect(bytes.slice(4, 6)).toBe(bytes.slice(10, 12))
+    expect(mouse.postedMessages().filter((message) => message.type === 'terminal-tap')).toEqual([])
   })
 
   it('dismisses an existing selection with a click without focusing the keyboard', () => {

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -212,10 +212,12 @@ describe('TerminalWebView scroll routing', () => {
       "document.addEventListener('touchend'",
       '}, { capture: true, passive: true });'
     )
-    expect(touchEndBlock).toContain('notifyTerminalSurfaceTap(tapCandidate.x, tapCandidate.y)')
+    expect(touchEndBlock).toContain(
+      'notifyTerminalSurfaceTap(tapCandidate.x, tapCandidate.y, true)'
+    )
 
     const tapHandlerBlock = sliceBetween(
-      'function notifyTerminalSurfaceTap(originX, originY)',
+      'function notifyTerminalSurfaceTap(originX, originY, focusKeyboard)',
       "document.addEventListener('touchstart'"
     )
     expect(tapHandlerBlock.indexOf('oscLinkAtViewportPoint')).toBeLessThan(
@@ -229,6 +231,9 @@ describe('TerminalWebView scroll routing', () => {
     )
     expect(tapHandlerBlock).toContain("notify({ type: 'open-url', url: tappedUrl });")
     expect(tapHandlerBlock).toContain("notify({ type: 'terminal-input', bytes: clickInput });")
+    expect(tapHandlerBlock).toContain(
+      'if (focusKeyboard || !isClickMouseTrackingMode(getMouseTrackingMode()))'
+    )
     expect(tapHandlerBlock).toContain("notify({ type: 'terminal-tap' });")
   })
 

--- a/mobile/src/terminal/terminal-webview-tap-dispatch-injected.ts
+++ b/mobile/src/terminal/terminal-webview-tap-dispatch-injected.ts
@@ -163,7 +163,7 @@ export const TERMINAL_TAP_DISPATCH_JS = `
         selMode !== 'select' &&
         Date.now() - tapCandidate.t <= TAP_MAX_MS
       ) {
-        notifyTerminalSurfaceTap(tapCandidate.x, tapCandidate.y);
+        notifyTerminalSurfaceTap(tapCandidate.x, tapCandidate.y, true);
       }
       clearLongPress();
       tapCandidate = null;

--- a/mobile/src/terminal/terminal-webview-tap-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-tap-routing.test.ts
@@ -19,12 +19,12 @@ function bodyMarkup(): string {
 }
 
 // Minimal xterm stub: one scrollback line containing a URL, fixed 8x15 cells.
-function makeTerminal(lineRef: { current: string }) {
+function makeTerminal(lineRef: { current: string }, mouseTrackingMode = 'none') {
   return {
     cols: 80,
     rows: 24,
     options: { fontSize: 13 },
-    modes: {},
+    modes: { mouseTrackingMode },
     element: { scrollWidth: 800, scrollHeight: 360 },
     _core: { _renderService: { dimensions: { css: { cell: { width: 8, height: 15 } } } } },
     buffer: {
@@ -76,13 +76,14 @@ type OscLinkRange = { row: number; startCol: number; endCol: number; uri: string
 
 function boot(
   line: string,
-  oscLinks?: OscLinkRange[]
+  oscLinks?: OscLinkRange[],
+  mouseTrackingMode = 'none'
 ): { posted: Posted; setLine: (line: string) => void } {
   const posted: Posted = []
   const lineRef = { current: line }
   const w = window as unknown as { Terminal: unknown; ReactNativeWebView: unknown }
   w.Terminal = function () {
-    return makeTerminal(lineRef)
+    return makeTerminal(lineRef, mouseTrackingMode)
   }
   w.ReactNativeWebView = {
     postMessage(s: string) {
@@ -148,6 +149,17 @@ describe('terminal WebView tap routing', () => {
     fireTouch('touchmove', [{ x: tapX + 11, y: tapY + 4 }])
     fireTouch('touchend', [])
     expect(posted.find((m) => m.type === 'open-url')?.url).toBe('https://example.com/foo')
+  })
+
+  it('focuses native input after reporting a touch tap to a mouse-tracking TUI', async () => {
+    const { posted } = boot('interactive prompt', undefined, 'drag')
+    await settle()
+
+    fireTouch('touchstart', [{ x: 20, y: tapY }])
+    fireTouch('touchend', [])
+
+    expect(posted.find((message) => message.type === 'terminal-input')).toBeDefined()
+    expect(posted.filter((message) => message.type === 'terminal-tap')).toHaveLength(1)
   })
 
   it('opens the URL even right after a width-change reflow', async () => {

--- a/mobile/src/terminal/terminal-webview-tap-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-tap-routing.test.ts
@@ -158,7 +158,21 @@ describe('terminal WebView tap routing', () => {
     fireTouch('touchstart', [{ x: 20, y: tapY }])
     fireTouch('touchend', [])
 
-    expect(posted.find((message) => message.type === 'terminal-input')).toBeDefined()
+    expect(
+      posted
+        .filter((message) => message.type === 'terminal-input' || message.type === 'terminal-tap')
+        .map((message) => message.type)
+    ).toEqual(['terminal-input', 'terminal-tap'])
+  })
+
+  it('reports a non-mouse touch tap without terminal mouse bytes', async () => {
+    const { posted } = boot('plain prompt')
+    await settle()
+
+    fireTouch('touchstart', [{ x: 20, y: tapY }])
+    fireTouch('touchend', [])
+
+    expect(posted.find((message) => message.type === 'terminal-input')).toBeUndefined()
     expect(posted.filter((message) => message.type === 'terminal-tap')).toHaveLength(1)
   })
 

--- a/mobile/src/terminal/terminal-webview-url-tap.ts
+++ b/mobile/src/terminal/terminal-webview-url-tap.ts
@@ -205,7 +205,7 @@ export const URL_TAP_WEBVIEW_JS = `
     } catch (e) { return 0; }
   }
 
-  function notifyTerminalSurfaceTap(originX, originY) {
+  function notifyTerminalSurfaceTap(originX, originY, focusKeyboard) {
     var tappedOscLink = oscLinkAtViewportPoint(originX, originY);
     if (tappedOscLink && tappedOscLink.kind === 'file') {
       notify({
@@ -245,7 +245,9 @@ export const URL_TAP_WEBVIEW_JS = `
     var clickInput = buildMouseClickInput(originX, originY);
     if (clickInput) {
       notify({ type: 'terminal-input', bytes: clickInput });
-    } else if (!isClickMouseTrackingMode(getMouseTrackingMode())) {
+    }
+    // Touch still needs native input focus after the TUI consumes its mouse click.
+    if (focusKeyboard || !isClickMouseTrackingMode(getMouseTrackingMode())) {
       notify({ type: 'terminal-tap' });
     }
   }

--- a/mobile/src/terminal/use-terminal-live-input-focus.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-focus.test.ts
@@ -1,0 +1,218 @@
+import { createElement, type RefObject } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  TerminalLiveInputFocusTarget,
+  TerminalLiveInputFocusTimerRef
+} from './terminal-live-input'
+import { useTerminalLiveInputFocus } from './use-terminal-live-input-focus'
+
+type HarnessProps = {
+  readonly activeHandleRef: RefObject<string | null>
+  readonly canSend: boolean
+  readonly inputRef: RefObject<TerminalLiveInputFocusTarget | null>
+  readonly keyboardHeight?: number
+  readonly liveInputEnabled: boolean
+  readonly timerRef: TerminalLiveInputFocusTimerRef
+}
+
+type FocusHandlers = ReturnType<typeof useTerminalLiveInputFocus>
+
+function suppressReactTestRendererWarning(): () => void {
+  const originalConsoleError = console.error
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+      return
+    }
+    originalConsoleError(...args)
+  })
+  return () => spy.mockRestore()
+}
+
+function createFocusTarget(initiallyFocused = false): TerminalLiveInputFocusTarget & {
+  readonly blur: ReturnType<typeof vi.fn>
+  readonly focus: ReturnType<typeof vi.fn>
+} {
+  let focused = initiallyFocused
+  return {
+    blur: vi.fn(() => {
+      focused = false
+    }),
+    focus: vi.fn(() => {
+      focused = true
+    }),
+    isFocused: () => focused
+  }
+}
+
+function createTimerRef(): TerminalLiveInputFocusTimerRef {
+  return { current: null }
+}
+
+function createHarness(initialProps: HarnessProps): {
+  readonly handlers: () => FocusHandlers
+  readonly render: (props: HarnessProps) => void
+  readonly unmount: () => void
+} {
+  let handlers: FocusHandlers | null = null
+  let renderer: ReactTestRenderer | null = null
+
+  function Harness(props: HarnessProps): null {
+    handlers = useTerminalLiveInputFocus({
+      ...props,
+      keyboardHeight: props.keyboardHeight ?? 0
+    })
+    return null
+  }
+
+  const restoreWarning = suppressReactTestRendererWarning()
+  try {
+    act(() => {
+      renderer = create(createElement(Harness, initialProps))
+    })
+  } finally {
+    restoreWarning()
+  }
+  if (!handlers || !renderer) {
+    throw new Error('terminal live input focus harness did not render')
+  }
+
+  return {
+    handlers: () => {
+      if (!handlers) {
+        throw new Error('terminal live input focus harness is not mounted')
+      }
+      return handlers
+    },
+    render: (props) => {
+      act(() => renderer?.update(createElement(Harness, props)))
+    },
+    unmount: () => {
+      act(() => renderer?.unmount())
+      handlers = null
+    }
+  }
+}
+
+function connectedProps(
+  inputRef: RefObject<TerminalLiveInputFocusTarget | null>,
+  timerRef = createTimerRef(),
+  activeHandleRef: RefObject<string | null> = { current: 'terminal-a' }
+): HarnessProps {
+  return {
+    activeHandleRef,
+    canSend: true,
+    inputRef,
+    liveInputEnabled: true,
+    timerRef
+  }
+}
+
+describe('terminal live input focus hook', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('defers initial terminal surface focus until the WebView touch has completed', () => {
+    vi.useFakeTimers()
+    const input = createFocusTarget()
+    const harness = createHarness(connectedProps({ current: input }))
+
+    harness.handlers().handleTerminalTap('terminal-a')
+    expect(input.focus).not.toHaveBeenCalled()
+
+    vi.runOnlyPendingTimers()
+    expect(input.focus).toHaveBeenCalledTimes(1)
+    harness.unmount()
+  })
+
+  it('reacquires focus for mouse-aware and non-mouse terminal tap notifications', () => {
+    vi.useFakeTimers()
+    const input = createFocusTarget()
+    const harness = createHarness(connectedProps({ current: input }))
+
+    harness.handlers().handleTerminalTap('terminal-a')
+    vi.runOnlyPendingTimers()
+    harness.handlers().handleTerminalTap('terminal-a')
+    vi.runAllTimers()
+
+    expect(input.blur).toHaveBeenCalledTimes(1)
+    expect(input.focus).toHaveBeenCalledTimes(2)
+    harness.unmount()
+  })
+
+  it('cancels the old route focus and focuses the navigation remount', () => {
+    vi.useFakeTimers()
+    const oldInput = createFocusTarget()
+    const oldHarness = createHarness(connectedProps({ current: oldInput }))
+    oldHarness.handlers().handleTerminalTap('terminal-a')
+    oldHarness.unmount()
+
+    const newInput = createFocusTarget()
+    const newHarness = createHarness(connectedProps({ current: newInput }))
+    newHarness.handlers().handleTerminalTap('terminal-a')
+    vi.runOnlyPendingTimers()
+
+    expect(oldInput.focus).not.toHaveBeenCalled()
+    expect(newInput.focus).toHaveBeenCalledTimes(1)
+    newHarness.unmount()
+  })
+
+  it('drops a pending focus across a full reconnect and focuses the replacement mount', () => {
+    vi.useFakeTimers()
+    const oldInput = createFocusTarget()
+    const oldInputRef = { current: oldInput }
+    const oldTimerRef = createTimerRef()
+    const oldHarness = createHarness(connectedProps(oldInputRef, oldTimerRef))
+    oldHarness.handlers().handleTerminalTap('terminal-a')
+
+    oldHarness.render({ ...connectedProps(oldInputRef, oldTimerRef), canSend: false })
+    oldHarness.unmount()
+    vi.runOnlyPendingTimers()
+    expect(oldInput.focus).not.toHaveBeenCalled()
+
+    const replacementInput = createFocusTarget()
+    const replacementHarness = createHarness(connectedProps({ current: replacementInput }))
+    replacementHarness.handlers().handleTerminalTap('terminal-a')
+    vi.runOnlyPendingTimers()
+    expect(replacementInput.focus).toHaveBeenCalledTimes(1)
+    replacementHarness.unmount()
+  })
+
+  it('does not let stale handle state focus a replacement terminal', () => {
+    vi.useFakeTimers()
+    const firstInput = createFocusTarget()
+    const inputRef: RefObject<TerminalLiveInputFocusTarget | null> = { current: firstInput }
+    const timerRef = createTimerRef()
+    const activeHandleRef = { current: 'terminal-a' as string | null }
+    const harness = createHarness(connectedProps(inputRef, timerRef, activeHandleRef))
+    harness.handlers().handleTerminalTap('terminal-a')
+
+    const replacementInput = createFocusTarget()
+    inputRef.current = replacementInput
+    activeHandleRef.current = 'terminal-b'
+    harness.render(connectedProps(inputRef, timerRef, activeHandleRef))
+    vi.runOnlyPendingTimers()
+
+    expect(firstInput.focus).not.toHaveBeenCalled()
+    expect(replacementInput.focus).not.toHaveBeenCalled()
+    harness.handlers().handleTerminalTap('terminal-b')
+    vi.runOnlyPendingTimers()
+    expect(replacementInput.focus).toHaveBeenCalledTimes(1)
+    harness.unmount()
+  })
+
+  it('keeps the native focus target immediate outside the WebView tap path', () => {
+    const input = createFocusTarget()
+    const harness = createHarness(connectedProps({ current: input }))
+
+    harness.handlers().focusLiveInput()
+
+    expect(input.focus).toHaveBeenCalledTimes(1)
+    harness.unmount()
+  })
+})

--- a/mobile/src/terminal/use-terminal-live-input-focus.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-focus.test.ts
@@ -12,6 +12,8 @@ type HarnessProps = {
   readonly canSend: boolean
   readonly inputRef: RefObject<TerminalLiveInputFocusTarget | null>
   readonly keyboardHeight?: number
+  readonly lifecycleIdentity: object | null
+  readonly lifecycleKey: string
   readonly liveInputEnabled: boolean
   readonly timerRef: TerminalLiveInputFocusTimerRef
 }
@@ -103,6 +105,8 @@ function connectedProps(
     activeHandleRef,
     canSend: true,
     inputRef,
+    lifecycleIdentity: null,
+    lifecycleKey: 'host-a:worktree-a:connected',
     liveInputEnabled: true,
     timerRef
   }
@@ -145,42 +149,72 @@ describe('terminal live input focus hook', () => {
     harness.unmount()
   })
 
-  it('cancels the old route focus and focuses the navigation remount', () => {
+  it('cancels focus when navigation reuses the mounted route', () => {
     vi.useFakeTimers()
     const oldInput = createFocusTarget()
-    const oldHarness = createHarness(connectedProps({ current: oldInput }))
-    oldHarness.handlers().handleTerminalTap('terminal-a')
-    oldHarness.unmount()
-
+    const inputRef: RefObject<TerminalLiveInputFocusTarget | null> = { current: oldInput }
+    const timerRef = createTimerRef()
+    const harness = createHarness(connectedProps(inputRef, timerRef))
+    harness.handlers().handleTerminalTap('terminal-a')
     const newInput = createFocusTarget()
-    const newHarness = createHarness(connectedProps({ current: newInput }))
-    newHarness.handlers().handleTerminalTap('terminal-a')
+    inputRef.current = newInput
+    harness.render({
+      ...connectedProps(inputRef, timerRef),
+      lifecycleKey: 'host-a:worktree-b:connected'
+    })
     vi.runOnlyPendingTimers()
-
     expect(oldInput.focus).not.toHaveBeenCalled()
+    expect(newInput.focus).not.toHaveBeenCalled()
+
+    harness.handlers().handleTerminalTap('terminal-a')
+    vi.runOnlyPendingTimers()
     expect(newInput.focus).toHaveBeenCalledTimes(1)
-    newHarness.unmount()
+    harness.unmount()
   })
 
-  it('drops a pending focus across a full reconnect and focuses the replacement mount', () => {
+  it('drops pending focus when reconnect reuses the mounted route', () => {
     vi.useFakeTimers()
     const oldInput = createFocusTarget()
     const oldInputRef = { current: oldInput }
-    const oldTimerRef = createTimerRef()
-    const oldHarness = createHarness(connectedProps(oldInputRef, oldTimerRef))
-    oldHarness.handlers().handleTerminalTap('terminal-a')
-
-    oldHarness.render({ ...connectedProps(oldInputRef, oldTimerRef), canSend: false })
-    oldHarness.unmount()
+    const timerRef = createTimerRef()
+    const harness = createHarness(connectedProps(oldInputRef, timerRef))
+    harness.handlers().handleTerminalTap('terminal-a')
+    harness.render({
+      ...connectedProps(oldInputRef, timerRef),
+      canSend: false,
+      lifecycleIdentity: {},
+      lifecycleKey: 'host-a:worktree-a:disconnected'
+    })
     vi.runOnlyPendingTimers()
     expect(oldInput.focus).not.toHaveBeenCalled()
 
     const replacementInput = createFocusTarget()
-    const replacementHarness = createHarness(connectedProps({ current: replacementInput }))
-    replacementHarness.handlers().handleTerminalTap('terminal-a')
+    oldInputRef.current = replacementInput
+    harness.render({
+      ...connectedProps(oldInputRef, timerRef),
+      lifecycleIdentity: {},
+      lifecycleKey: 'host-a:worktree-a:connected'
+    })
+    harness.handlers().handleTerminalTap('terminal-a')
     vi.runOnlyPendingTimers()
     expect(replacementInput.focus).toHaveBeenCalledTimes(1)
-    replacementHarness.unmount()
+    harness.unmount()
+  })
+
+  it('cancels focus when a retained screen blurs', () => {
+    vi.useFakeTimers()
+    const input = createFocusTarget()
+    const timerRef = createTimerRef()
+    const harness = createHarness(connectedProps({ current: input }, timerRef))
+
+    harness.handlers().handleTerminalTap('terminal-a')
+    harness.handlers().resetLiveInputFocus()
+    vi.runOnlyPendingTimers()
+
+    expect(timerRef.current).toBeNull()
+    expect(input.blur).toHaveBeenCalledTimes(1)
+    expect(input.focus).not.toHaveBeenCalled()
+    harness.unmount()
   })
 
   it('does not let stale handle state focus a replacement terminal', () => {

--- a/mobile/src/terminal/use-terminal-live-input-focus.ts
+++ b/mobile/src/terminal/use-terminal-live-input-focus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from 'react'
+import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
 import {
   clearTerminalLiveInputFocusTimer,
   focusTerminalLiveInputTarget,
@@ -17,12 +17,15 @@ type UseTerminalLiveInputFocusOptions<T extends TerminalLiveInputFocusTarget> =
   TerminalLiveInputFocusContext & {
     readonly activeHandleRef: RefObject<string | null>
     readonly inputRef: RefObject<T | null>
+    readonly lifecycleIdentity: object | null
+    readonly lifecycleKey: string
     readonly timerRef: TerminalLiveInputFocusTimerRef
   }
 
 type TerminalLiveInputFocusHandlers = {
   readonly focusLiveInput: () => void
   readonly handleTerminalTap: (handle: string) => void
+  readonly resetLiveInputFocus: () => void
 }
 
 export function useTerminalLiveInputFocus<T extends TerminalLiveInputFocusTarget>({
@@ -30,6 +33,8 @@ export function useTerminalLiveInputFocus<T extends TerminalLiveInputFocusTarget
   canSend,
   inputRef,
   keyboardHeight,
+  lifecycleIdentity,
+  lifecycleKey,
   liveInputEnabled,
   timerRef
 }: UseTerminalLiveInputFocusOptions<T>): TerminalLiveInputFocusHandlers {
@@ -41,6 +46,14 @@ export function useTerminalLiveInputFocus<T extends TerminalLiveInputFocusTarget
   useLayoutEffect(() => {
     contextRef.current = { canSend, keyboardHeight, liveInputEnabled }
   }, [canSend, keyboardHeight, liveInputEnabled])
+
+  const resetLiveInputFocus = useCallback(() => {
+    clearTerminalLiveInputFocusTimer(timerRef)
+    inputRef.current?.blur()
+  }, [inputRef, timerRef])
+
+  // Retained Expo routes must not carry focus work across navigation or reconnect scopes.
+  useLayoutEffect(() => resetLiveInputFocus, [lifecycleIdentity, lifecycleKey, resetLiveInputFocus])
 
   const focusLiveInput = useCallback(() => {
     const context = contextRef.current
@@ -69,12 +82,5 @@ export function useTerminalLiveInputFocus<T extends TerminalLiveInputFocusTarget
     [activeHandleRef, focusLiveInput, timerRef]
   )
 
-  useEffect(
-    () => () => {
-      clearTerminalLiveInputFocusTimer(timerRef)
-    },
-    [timerRef]
-  )
-
-  return { focusLiveInput, handleTerminalTap }
+  return { focusLiveInput, handleTerminalTap, resetLiveInputFocus }
 }

--- a/mobile/src/terminal/use-terminal-live-input-focus.ts
+++ b/mobile/src/terminal/use-terminal-live-input-focus.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from 'react'
+import {
+  clearTerminalLiveInputFocusTimer,
+  focusTerminalLiveInputTarget,
+  scheduleTerminalLiveInputFocus,
+  type TerminalLiveInputFocusTarget,
+  type TerminalLiveInputFocusTimerRef
+} from './terminal-live-input'
+
+type TerminalLiveInputFocusContext = {
+  readonly canSend: boolean
+  readonly keyboardHeight: number
+  readonly liveInputEnabled: boolean
+}
+
+type UseTerminalLiveInputFocusOptions<T extends TerminalLiveInputFocusTarget> =
+  TerminalLiveInputFocusContext & {
+    readonly activeHandleRef: RefObject<string | null>
+    readonly inputRef: RefObject<T | null>
+    readonly timerRef: TerminalLiveInputFocusTimerRef
+  }
+
+type TerminalLiveInputFocusHandlers = {
+  readonly focusLiveInput: () => void
+  readonly handleTerminalTap: (handle: string) => void
+}
+
+export function useTerminalLiveInputFocus<T extends TerminalLiveInputFocusTarget>({
+  activeHandleRef,
+  canSend,
+  inputRef,
+  keyboardHeight,
+  liveInputEnabled,
+  timerRef
+}: UseTerminalLiveInputFocusOptions<T>): TerminalLiveInputFocusHandlers {
+  const contextRef = useRef<TerminalLiveInputFocusContext>({
+    canSend,
+    keyboardHeight,
+    liveInputEnabled
+  })
+  useLayoutEffect(() => {
+    contextRef.current = { canSend, keyboardHeight, liveInputEnabled }
+  }, [canSend, keyboardHeight, liveInputEnabled])
+
+  const focusLiveInput = useCallback(() => {
+    const context = contextRef.current
+    if (!context.canSend || !context.liveInputEnabled) {
+      return
+    }
+    focusTerminalLiveInputTarget(inputRef.current, {
+      keyboardHeight: context.keyboardHeight,
+      refocus: () => scheduleTerminalLiveInputFocus(timerRef, focusLiveInput)
+    })
+  }, [inputRef, timerRef])
+
+  const handleTerminalTap = useCallback(
+    (handle: string) => {
+      const context = contextRef.current
+      if (handle !== activeHandleRef.current || !context.canSend || !context.liveInputEnabled) {
+        return
+      }
+      // WKWebView still owns first responder during its touchend notification.
+      scheduleTerminalLiveInputFocus(timerRef, () => {
+        if (activeHandleRef.current === handle) {
+          focusLiveInput()
+        }
+      })
+    },
+    [activeHandleRef, focusLiveInput, timerRef]
+  )
+
+  useEffect(
+    () => () => {
+      clearTerminalLiveInputFocusTimer(timerRef)
+    },
+    [timerRef]
+  )
+
+  return { focusLiveInput, handleTerminalTap }
+}


### PR DESCRIPTION
## What changed

Kimi and other mouse-aware terminal TUIs consume a touch as terminal mouse input. Mobile now preserves those PTY mouse bytes and requests native live-input focus after the WebView finishes the touch gesture.

The focus request lives in a bounded lifecycle hook. It revalidates the active terminal, connection, client identity, and live-input mode before focusing; replaces earlier pending work; and clears on route blur, client replacement, disconnect, or unmount. The visible native keyboard control keeps its immediate focus behavior.

Links/files, selection dismissal, TUI mouse bytes, native chat, buffered input, reconnect gating, SSH/folder-workspace routing, and terminal hot paths are otherwise unchanged. The fix adds no polling or persistent listeners and keeps at most one replaceable timer per accepted terminal tap.

## Root cause and user impact

The first implementation posted `terminal-tap` after the SGR click but called the hidden native `TextInput.focus()` synchronously from the WebView message callback. On a fresh route or host reconnect remount, WKWebView could still be completing the mouse-aware `touchend`/first-responder handoff, so the native focus request was lost even though SGR press/release bytes reached the PTY.

At the prior regressing head `fe16936c2b8be9dd0aa7d7bfffee629a0946ab97`, initial input could work after focus was already established, but navigation/remount and full host reconnect/remount reproduced mouse bytes with dropped typed text. The continuously re-armed SGR fixture exposed that cold-remount failure.

At final head `eb963fc419b4ad7086769f62fa55da592624c1ef`, touch still reaches the TUI first, then native focus occurs after the gesture. A review-discovered P2 follow-up also clears deferred focus on retained-route blur and ties cleanup to the current client lifecycle identity, preventing stale delayed focus after navigation or client replacement.

Mouse-aware external-pointer clicks keep sending only terminal mouse input. Plain external-pointer clicks retain their prior keyboard-focus behavior.

## Review verdict

- A fresh `gpt-5.6-sol` / `xhigh` reviewer found the retained-route blur cleanup gap described above; it was fixed and covered by tests.
- A genuinely fresh same-model, same-thinking reviewer returned literal **`CLEAN`** for exact final head `eb963fc419b4ad7086769f62fa55da592624c1ef` (task `task_78b4fdeb5a43`, dispatch `ctx_bdf09fba89ae`).
- Scope review found no correctness, accessibility, lifecycle, SSH/folder-workspace, external-pointer, or performance regression requiring another change.

## Automated validation

- 40 focused mobile tests passed across native-focus lifecycle, WebView tap routing, retained-route/client-replacement cleanup, external-pointer mouse semantics, scroll routing, and the live-input affordance.
- Full mobile suite: 380 files, 2,840 passed, 3 skipped.
- Mobile TypeScript passed.
- Changed-file oxlint and oxfmt passed.
- Commit hooks and diff hygiene passed.
- Exact-head `pnpm build:cli` passed.
- Exact-head `pnpm build:electron-vite` passed.
- The initially flaky `activity-portal-readiness-loop.react185.test.tsx` passed locally 4/4; failed CI jobs were rerun and the final PR check rollup is green.

## Native validation at the exact final head

Validated only through Orca's documented emulator surface on approved iPhone `50FD514C-96F6-446E-AC90-D07A24CAB3A0`, using its stream at port 3100. The exact final-head runtime served on port 53901, and the dev client loaded the final-head Expo bundle from port 8128.

- Initial mouse-aware input: the continuously re-armed `MOCK_TUI` SGR `1002/1006` fixture visibly received mouse press/release bytes and submitted `livekimipass`.
- Full reconnect/remount: Terminal 1 visibly received SGR press/release bytes and submitted `mouse-terminal1-final` after exact-runtime reconnection and client remount.
- Background/foreground: Home/background and foreground through the Orca app preserved the connected session and completed submission.
- Navigation away/back: after leaving and reopening the session, Terminal 1 visibly submitted `nav-final` with fresh SGR press/release bytes.
- Non-mouse comparison: Terminal 2 independently retained successful `nonmouse-final` and `direct-input-final` submissions without SGR mouse bytes.
- Full client reload/remount: an exact-bundle reload returned through hosts, reconnected Host 41, and restored all three terminal sessions and output.
- Stale-listener cleanup produced no native delayed-focus/navigation side effect; retained-route and client-replacement behavior is directly covered by the automated lifecycle tests.

### Final-head evidence

Initial mouse-aware submission:

![initial mouse-aware final-head submission](https://github.com/user-attachments/assets/46b05f3f-f0d8-4989-a508-e3c136238feb)

Mouse-aware submission preserved after background/foreground:

![mouse-aware submission after background and foreground](https://github.com/user-attachments/assets/210c1ffc-a4e1-4731-8730-7cd98e3ccd0a)

Navigation-away/back submission after exact-bundle remount:

![mouse-aware navigation and remount submission](https://github.com/user-attachments/assets/39f26d32-97e0-42e1-94ab-5fa411c1e035)

Non-mouse comparison after remount:

![non-mouse final-head comparison](https://github.com/user-attachments/assets/c4bb2f74-4603-4641-8aed-01c7d5540280)

## Validation limitations

- Actual Kimi remains unavailable because no `kimi` binary is installed. The closest shipped fixture is the continuously re-armed `MOCK_TUI` SGR `1002/1006` lane.
- The terminal lane used hardware-keyboard input. The terminal software keyboard never visibly rendered, so visible summon/dismiss/reopen could not be assessed; native typing/submission is reported only where supported.
- External-pointer injection is unsupported by the approved Orca emulator surface. Automated coverage verifies mouse-aware external pointers remain PTY-only and plain external-pointer clicks keep their prior focus behavior.
- The required `$electron` skill is unavailable. Per repository instructions, no Computer Use, AppleScript, OS automation, or input injection was substituted.
- No iPad, protected device, other simulator, third stream, raw `simctl`, raw `serve-sim`, or emulator kill command was used.
- Screenshots and reports remain outside the repository and are not part of the diff.

Residual native risk is limited to actual Kimi-specific behavior, a visibly rendered software-keyboard lifecycle, and injectable external-pointer behavior that the approved surface could not exercise. This PR remains open and was not merged.
