### PR TITLE
fix(mobile): open resume workspace route reliably

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -50,6 +50,7 @@ import {
   type TaskProvider
 } from '../src/tasks/mobile-task-providers'
 import { useResponsiveLayout } from '../src/layout/responsive-layout'
+import { createMobileSessionHref } from '../src/session/mobile-session-route'
 
 function endpointLabel(endpoint: string): string {
   try {
@@ -807,7 +808,11 @@ export default function HomeScreen() {
                     style={({ pressed }) => [styles.resumeCard, pressed && styles.hostCardPressed]}
                     onPress={() =>
                       router.push(
-                        `/h/${resumeWorktree.hostId}/session/${encodeURIComponent(resumeWorktree.worktree.worktreeId)}`
+                        createMobileSessionHref({
+                          hostId: resumeWorktree.hostId,
+                          worktreeId: resumeWorktree.worktree.worktreeId,
+                          name: resumeWorktree.worktree.displayName || resumeWorktree.worktree.repo
+                        })
                       )
                     }
                   >

--- a/mobile/src/session/mobile-session-route.test.ts
+++ b/mobile/src/session/mobile-session-route.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { createMobileSessionHref } from './mobile-session-route'
+
+const homeSource = readFileSync(new URL('../../app/index.tsx', import.meta.url), 'utf8')
+
+describe('mobile session route', () => {
+  it('keeps dynamic route identities raw for Expo Router to encode', () => {
+    expect(
+      createMobileSessionHref({
+        hostId: 'host/one',
+        worktreeId: 'repo::/Users/ada/orca/workspaces/fix #1',
+        name: 'Fix #1'
+      })
+    ).toEqual({
+      pathname: '/h/[hostId]/session/[worktreeId]',
+      params: {
+        hostId: 'host/one',
+        worktreeId: 'repo::/Users/ada/orca/workspaces/fix #1',
+        name: 'Fix #1'
+      }
+    })
+  })
+
+  it('routes the home Resume card through the typed dynamic href', () => {
+    const start = homeSource.indexOf('{/* ─── Resume card ─── */}')
+    const end = homeSource.indexOf('{/* ─── Quick actions ─── */}', start)
+    const resumeCard = homeSource.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    expect(resumeCard).toContain('createMobileSessionHref({')
+    expect(resumeCard).not.toContain('encodeURIComponent(resumeWorktree.worktree.worktreeId)')
+  })
+})

--- a/mobile/src/session/mobile-session-route.ts
+++ b/mobile/src/session/mobile-session-route.ts
@@ -1,0 +1,17 @@
+export type MobileSessionRouteParams = {
+  hostId: string
+  worktreeId: string
+  name?: string
+}
+
+export type MobileSessionHref = {
+  pathname: '/h/[hostId]/session/[worktreeId]'
+  params: MobileSessionRouteParams
+}
+
+export function createMobileSessionHref(params: MobileSessionRouteParams): MobileSessionHref {
+  return {
+    pathname: '/h/[hostId]/session/[worktreeId]',
+    params
+  }
+}


### PR DESCRIPTION
## Summary

- route the home Resume card through a typed Expo dynamic href
- pass raw host and workspace identities so Expo encodes them exactly once
- add regression coverage for encoded-sensitive IDs and the Resume card wiring

## Reproduction

On the attached iOS simulator, opening the Host card loaded Host 1 and its workspace. Returning home and tapping Resume instead landed on an empty Host screen and never opened the session.

The Resume card constructed a nested route string manually. Workspace IDs contain path characters such as `/`, so Expo Router could interpret part of the ID as route structure during the direct cross-stack navigation.

## Validation

- `pnpm --dir mobile test` — 380 files passed; 2,833 tests passed and 3 skipped
- `pnpm --dir mobile typecheck`
- scoped mobile lint and formatting checks
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:code-quality:changed`

Live baseline reproduction was completed. The attached simulator served another checkout, and the worktree-local candidate launcher stopped before Metro with `selector_ambiguous`, so candidate validation is deterministic plus the full mobile suite.