### PR TITLE
fix(tab-bar): ignore IME composition Enter in the quick commands menu

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.ime-enter.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.ime-enter.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import type * as ReactNamespace from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TabBarQuickCommandsMenu } from './TabBarQuickCommandsMenu'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+
+vi.mock('@/components/ui/command', async () => {
+  const react = await vi.importActual<typeof ReactNamespace>('react')
+  return {
+    Command: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    CommandEmpty: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    CommandInput: react.forwardRef<
+      HTMLInputElement,
+      { onKeyDown?: React.KeyboardEventHandler<HTMLInputElement> }
+    >(({ onKeyDown }, ref) => (
+      <input ref={ref} data-quick-command-search="true" onKeyDown={onKeyDown} />
+    )),
+    CommandList: react.forwardRef<HTMLDivElement, { children?: React.ReactNode }>(
+      ({ children }, ref) => <div ref={ref}>{children}</div>
+    ),
+    CommandSeparator: () => <div />
+  }
+})
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({
+    children,
+    onKeyDown
+  }: {
+    children?: React.ReactNode
+    onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
+  }) => <div onKeyDown={onKeyDown}>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ShortcutKeyCombo', () => ({
+  ShortcutKeyCombo: () => <span />
+}))
+
+vi.mock('./TabBarQuickCommandItem', () => ({
+  TabBarQuickCommandItem: () => <div />
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutKeyComboDetails: () => []
+}))
+
+vi.mock('./tab-bar-quick-commands-shortcut', () => ({
+  useTabBarQuickCommandsShortcut: () => undefined
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  getAgentLabel: (agent: string) => agent
+}))
+
+vi.mock('../../../../shared/terminal-quick-commands', () => ({
+  getTerminalQuickCommandBody: (command: { command?: string }) => command.command ?? '',
+  isTerminalAgentQuickCommand: () => false
+}))
+
+// Why: the picker's real ranking is not under test — pin it so the highlighted
+// row is deterministic and Enter has an unambiguous target.
+vi.mock('@/lib/terminal-quick-command-search', () => ({
+  searchTerminalQuickCommands: (commands: readonly TerminalQuickCommand[]) => [...commands],
+  getTerminalQuickCommandPickerValue: ({
+    filteredCommands
+  }: {
+    filteredCommands: readonly TerminalQuickCommand[]
+  }) => filteredCommands[0]?.id ?? ''
+}))
+
+const DEPLOY: TerminalQuickCommand = {
+  id: 'cmd-deploy',
+  label: '배포',
+  command: 'echo 배포',
+  appendEnter: true
+}
+
+const RESET: TerminalQuickCommand = {
+  id: 'cmd-reset',
+  label: '초기화',
+  command: 'echo 초기화',
+  appendEnter: true
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderMenu(onRunCommand: (command: TerminalQuickCommand) => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <TabBarQuickCommandsMenu
+        repoCommands={[DEPLOY, RESET]}
+        globalCommands={[]}
+        mostRecent={null}
+        onAddCommand={vi.fn()}
+        onDeleteCommand={vi.fn()}
+        onEditCommand={vi.fn()}
+        onRunCommand={onRunCommand}
+      />
+    )
+  })
+  const input = container.querySelector<HTMLInputElement>('[data-quick-command-search="true"]')
+  if (!input) {
+    throw new Error('quick commands search input not rendered')
+  }
+  return input
+}
+
+function pressKey(
+  input: HTMLInputElement,
+  key: string,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('TabBarQuickCommandsMenu IME Enter guard', () => {
+  it('does not run the highlighted command on the Enter that commits a CJK composition', () => {
+    const onRunCommand = vi.fn()
+    const input = renderMenu(onRunCommand)
+
+    pressKey(input, 'Enter', { isComposing: true })
+
+    expect(onRunCommand).not.toHaveBeenCalled()
+  })
+
+  it('does not run the highlighted command on an Enter reported as keyCode 229', () => {
+    const onRunCommand = vi.fn()
+    const input = renderMenu(onRunCommand)
+
+    pressKey(input, 'Enter', { keyCode: 229 })
+
+    expect(onRunCommand).not.toHaveBeenCalled()
+  })
+
+  it('still runs the highlighted command on a plain Enter', () => {
+    const onRunCommand = vi.fn()
+    const input = renderMenu(onRunCommand)
+
+    pressKey(input, 'Enter')
+
+    expect(onRunCommand).toHaveBeenCalledTimes(1)
+    expect(onRunCommand).toHaveBeenCalledWith(DEPLOY)
+  })
+
+  it('leaves the highlighted row alone when an arrow key belongs to the IME', () => {
+    const onRunCommand = vi.fn()
+    const input = renderMenu(onRunCommand)
+
+    // The composing ArrowDown must not move the selection, so the following
+    // plain Enter still runs the first command.
+    pressKey(input, 'ArrowDown', { isComposing: true })
+    pressKey(input, 'Enter')
+
+    expect(onRunCommand).toHaveBeenCalledWith(DEPLOY)
+  })
+
+  it('still moves the highlighted row on a plain arrow key (control for the guard)', () => {
+    const onRunCommand = vi.fn()
+    const input = renderMenu(onRunCommand)
+
+    // Proves the case above was suppressed by the guard rather than inert:
+    // without composition the same ArrowDown advances to the second command.
+    pressKey(input, 'ArrowDown')
+    pressKey(input, 'Enter')
+
+    expect(onRunCommand).toHaveBeenCalledWith(RESET)
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../../shared/terminal-quick-commands'
 import type { TerminalQuickCommand } from '../../../../shared/types'
 import { getAgentLabel } from '@/lib/agent-catalog'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { TabBarQuickCommandItem } from './TabBarQuickCommandItem'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -158,7 +159,11 @@ export function TabBarQuickCommandsMenu({
   )
   const handleSearchKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === 'Enter' && selectedCommand) {
+      // Why: Enter and the arrows belong to the IME while a CJK candidate is
+      // composing — running the highlighted command here would execute one the
+      // user never picked, and moving the selection would fight the candidate list.
+      const imeComposing = isImeCompositionKeyDown(event)
+      if (event.key === 'Enter' && selectedCommand && !imeComposing) {
         // Why: cmdk does not submit the highlighted item from CommandInput
         // inside a DropdownMenu — mirror other searchable menus and run it here.
         event.preventDefault()
@@ -168,6 +173,7 @@ export function TabBarQuickCommandsMenu({
       }
       if (
         (event.key === 'ArrowDown' || event.key === 'ArrowUp') &&
+        !imeComposing &&
         filteredVisibleCommands.length > 0
       ) {
         event.preventDefault()


### PR DESCRIPTION
## Summary

On the 2-set Korean layout, seven jamo require Shift — ㅃ ㅉ ㄸ ㄲ ㅆ ㅒ ㅖ — so Korean users compose constantly inside the quick-commands search field. The Enter that only confirms a CJK composition candidate was reaching `handleSearchKeyDown` and running the highlighted quick command, **executing a terminal command the user never picked**. The last syllable is lost and the menu closes.

The arrow keys had the same problem in the same handler: `ArrowDown`/`ArrowUp` moved the command selection while the IME was still using them to walk its own candidate list (Japanese/Chinese conversion, and Korean candidate lists where present).

Both branches are now guarded with the existing `isImeCompositionKeyDown` helper — the same one `SortableTab.tsx:291` and `EditorFileTab.tsx:308` in this very folder already use. This field was simply missed when those were migrated.

The printable-key `stopPropagation()` branch is deliberately **not** guarded, so Radix typeahead suppression behaves exactly as before.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — see Notes for two wrapper scripts that cannot run on Windows; their underlying `oxlint` invocations were run directly and are clean
- [x] `pnpm typecheck` — all three projects (`node`, `cli`, `web`) clean
- [x] `pnpm test` — ran the affected scope: 38 files / 266 tests pass across `src/renderer/src/components/tab-bar/` plus `ime-composition-keyboard-event.test.ts`
- [ ] `pnpm build` — not run locally; see Notes
- [x] Added or updated high-quality tests that would catch regressions

New colocated test: `TabBarQuickCommandsMenu.ime-enter.test.tsx`, modeled on the existing `SmartWorkspaceNameField.ime-enter.test.tsx`.

**Verified the tests actually fail without the fix.** Stashing only the production change leaves the two control cases green and turns exactly the three guard cases red:

```
× does not run the highlighted command on the Enter that commits a CJK composition
    AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
× does not run the highlighted command on an Enter reported as keyCode 229
    AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
× leaves the highlighted row alone when an arrow key belongs to the IME
    AssertionError: expected "vi.fn()" to be called with arguments: [ { id: 'cmd-deploy', …(3) } ]

Tests  3 failed | 2 passed (5)
```

With the fix restored: 5 passed (5).

The two passing controls matter — a plain Enter still runs the highlighted command, and a plain `ArrowDown` still advances the selection — so the guard is proven to suppress only composition keystrokes rather than disabling the handler.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Over-broad guard.** The first draft returned early for the whole handler, matching `SortableTab`'s shape. Review flagged that this would also skip the `event.key.length === 1` → `stopPropagation()` branch; on platforms where Chromium reports the composed character rather than `key: 'Process'`, the keystroke would then bubble to Radix's `DropdownMenu` typeahead and jump the highlighted row while typing Korean. Narrowed to guard only the two branches that take action. No behavior change for printable keys.
- **Cross-platform.** No `metaKey`/`ctrlKey` hardcoding is introduced; the change touches neither shortcuts nor labels nor paths nor shell behavior. `isImeCompositionKeyDown` reads only `isComposing` and `keyCode === 229` and is already shipped on all three platforms. The bug reproduces on Windows (Microsoft 두벌식) and the same code path is platform-independent, so macOS and Linux IMEs get the identical fix. No Electron-specific API touched.
- **SSH / remote and folder workspaces.** The handler is pure renderer keyboard logic with no host, transport, or workspace-type dependency; behavior is identical for SSH hosts, WSL, and folder workspaces.
- **Neighboring handler considered and excluded.** `DropdownMenuContent`'s own `onKeyDown` also calls `runAndClose`, but only when `!showSearch` — i.e. when there is exactly one command and no `CommandInput` is rendered. With no text input on that surface no composition can occur, so a guard there would be dead code. Left unchanged intentionally.
- **Line-number-only lint warning.** `react-doctor(no-array-index-as-key)` reports on this file, but at unchanged content; `git diff -U0` confirms the hunks are limited to lines 23, 162–166 and 176. No `max-lines` suppression was added or bumped; `check:max-lines-ratchet` passes.

## Security Audit

Basic audit from the same review. This change only *narrows* the conditions under which a command is executed, so it strictly reduces the attack surface rather than expanding it:

- **Command execution.** The bug itself is the security-relevant part — an IME keystroke could trigger `onRunCommand`, running a shell command without deliberate user selection. The guard removes that path. No new execution path is added.
- **Input handling.** Reads three boolean/numeric fields off the keyboard event (`isComposing`, `keyCode`, `key`). No parsing, no interpolation, no `dangerouslySetInnerHTML`.
- **Path handling / secrets / auth / IPC / dependencies.** Untouched. No new dependency; `isImeCompositionKeyDown` is an existing in-repo module.
- **Test doubles.** The new test mocks only UI primitives and the search ranking module; it spawns no process and touches no filesystem or network.

No follow-up required.

## Notes

**Two `pnpm lint` sub-steps cannot execute on Windows.** `check-changed-code-quality.mjs` and `lint-react-doctor-changed.mjs` both die with `Error: spawnSync pnpm.cmd EINVAL` before reaching any analysis — the known Node-on-Windows restriction on spawning `.cmd` without `shell: true`. This is environmental and unrelated to this change; both run normally on the Linux CI runners. I ran their underlying commands directly instead:

- `oxlint <both files>` — clean
- `oxlint --config config/oxlint-react-doctor.json <both files>` — only the pre-existing warning noted above

The remaining `pnpm lint` steps all pass locally: `oxlint`, `check:reliability-gates`, `check:max-lines-ratchet`, `verify:localization-catalog`, `verify:localization-extraction`, `verify:localization-coverage`.

**`pnpm build` not run locally.** This machine is on Node v22.13.1 while `engines` requires Node 24, and `pnpm install` reported a `windows-native-registry` native rebuild failure unrelated to this change. Since this PR touches only renderer TypeScript with no native, packaging, or build-config surface, CI's `package (ubuntu)` / `package (windows)` jobs are the meaningful signal.

**Related.** This is the same class of bug as the merged #9526 and the open #11067, which migrated other inputs onto `isImeCompositionKeyDown`. #11067 covers the rename/notes dialogs and does not touch this file, so there is no overlap. Separately, #11878 / #11616 concern the Windows terminal IME `Process`-key path, which is unrelated to this renderer handler.

Other unguarded Enter-submit handlers remain (comment composers, markdown search-and-replace, several pickers). Happy to follow up with those in separate PRs if the approach here looks right.
