### PR TITLE
fix(ui): ignore IME composition Enter in the comment composer and replace field

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.ime-enter.test.tsx
@@ -29,6 +29,52 @@ afterEach(() => {
   container.remove()
 })
 
+type BarSpies = {
+  onReplaceCurrent?: () => void
+  onClose?: () => void
+  onMoveToMatch?: (direction: 1 | -1) => void
+}
+
+function renderFields(spies: BarSpies): {
+  searchInput: HTMLInputElement
+  replaceInput: HTMLInputElement
+} {
+  act(() => {
+    root.render(
+      <RichMarkdownSearchBar
+        activeMatchIndex={0}
+        isOpen
+        isReplaceMode
+        matchCase={false}
+        matchCount={2}
+        query="배포"
+        replaceQuery="릴리스"
+        replaceDisabled={false}
+        searchInputRef={createRef<HTMLInputElement>()}
+        wholeWord={false}
+        onClose={spies.onClose ?? vi.fn()}
+        onMoveToMatch={spies.onMoveToMatch ?? vi.fn()}
+        onQueryChange={vi.fn()}
+        onReplaceAll={vi.fn()}
+        onReplaceCurrent={spies.onReplaceCurrent ?? vi.fn()}
+        onReplaceQueryChange={vi.fn()}
+        onToggleMatchCase={vi.fn()}
+        onToggleReplaceMode={vi.fn()}
+        onToggleWholeWord={vi.fn()}
+      />
+    )
+  })
+  const inputs = [...container.querySelectorAll('input')]
+  // Why: the two rows are distinguished by their values, not by order-dependent
+  // selectors that would silently pick the wrong field if the layout changes.
+  const searchInput = inputs.find((candidate) => candidate.value === '배포')
+  const replaceInput = inputs.find((candidate) => candidate.value === '릴리스')
+  if (!searchInput || !replaceInput) {
+    throw new Error('search bar fields not rendered')
+  }
+  return { searchInput, replaceInput }
+}
+
 function renderBar(spies: { onReplaceCurrent: () => void; onClose: () => void }): HTMLInputElement {
   act(() => {
     root.render(
@@ -126,6 +172,71 @@ describe('RichMarkdownSearchBar replace-field IME guard', () => {
     const input = renderBar({ onReplaceCurrent: vi.fn(), onClose })
 
     pressKey(input, 'Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('RichMarkdownSearchBar search-field IME guard', () => {
+  it('does not move to the next match on the Enter that commits a composition', () => {
+    const onMoveToMatch = vi.fn()
+    const { searchInput } = renderFields({ onMoveToMatch })
+
+    pressKey(searchInput, 'Enter', { isComposing: true })
+
+    expect(onMoveToMatch).not.toHaveBeenCalled()
+  })
+
+  it('does not move to the previous match on a composing Shift+Enter', () => {
+    const onMoveToMatch = vi.fn()
+    const { searchInput } = renderFields({ onMoveToMatch })
+
+    pressKey(searchInput, 'Enter', { isComposing: true, shiftKey: true })
+
+    expect(onMoveToMatch).not.toHaveBeenCalled()
+  })
+
+  it('does not move on an Enter reported as keyCode 229', () => {
+    const onMoveToMatch = vi.fn()
+    const { searchInput } = renderFields({ onMoveToMatch })
+
+    pressKey(searchInput, 'Enter', { keyCode: 229 })
+
+    expect(onMoveToMatch).not.toHaveBeenCalled()
+  })
+
+  it('does not close the bar on the Escape that cancels a composition', () => {
+    const onClose = vi.fn()
+    const { searchInput } = renderFields({ onClose })
+
+    pressKey(searchInput, 'Escape', { isComposing: true })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still moves to the next match on a plain Enter', () => {
+    const onMoveToMatch = vi.fn()
+    const { searchInput } = renderFields({ onMoveToMatch })
+
+    pressKey(searchInput, 'Enter')
+
+    expect(onMoveToMatch).toHaveBeenCalledWith(1)
+  })
+
+  it('still moves to the previous match on a plain Shift+Enter', () => {
+    const onMoveToMatch = vi.fn()
+    const { searchInput } = renderFields({ onMoveToMatch })
+
+    pressKey(searchInput, 'Enter', { shiftKey: true })
+
+    expect(onMoveToMatch).toHaveBeenCalledWith(-1)
+  })
+
+  it('still closes the bar on a plain Escape', () => {
+    const onClose = vi.fn()
+    const { searchInput } = renderFields({ onClose })
+
+    pressKey(searchInput, 'Escape')
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.ime-enter.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+
+import { act, createRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RichMarkdownSearchBar } from './RichMarkdownSearchBar'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useOptionalShortcutLabel: () => null
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderBar(spies: { onReplaceCurrent: () => void; onClose: () => void }): HTMLInputElement {
+  act(() => {
+    root.render(
+      <RichMarkdownSearchBar
+        activeMatchIndex={0}
+        isOpen
+        isReplaceMode
+        matchCase={false}
+        matchCount={2}
+        query="배포"
+        replaceQuery="릴리스"
+        replaceDisabled={false}
+        searchInputRef={createRef<HTMLInputElement>()}
+        wholeWord={false}
+        onClose={spies.onClose}
+        onMoveToMatch={vi.fn()}
+        onQueryChange={vi.fn()}
+        onReplaceAll={vi.fn()}
+        onReplaceCurrent={spies.onReplaceCurrent}
+        onReplaceQueryChange={vi.fn()}
+        onToggleMatchCase={vi.fn()}
+        onToggleReplaceMode={vi.fn()}
+        onToggleWholeWord={vi.fn()}
+      />
+    )
+  })
+  // Why: the replace row is the second field; its input carries the replace value.
+  const input = [...container.querySelectorAll('input')].find(
+    (candidate) => candidate.value === '릴리스'
+  )
+  if (!input) {
+    throw new Error('replace input not rendered')
+  }
+  return input
+}
+
+function pressKey(
+  input: HTMLInputElement,
+  key: string,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('RichMarkdownSearchBar replace-field IME guard', () => {
+  it('does not replace on the Enter that commits a CJK composition', () => {
+    const onReplaceCurrent = vi.fn()
+    const input = renderBar({ onReplaceCurrent, onClose: vi.fn() })
+
+    pressKey(input, 'Enter', { isComposing: true })
+
+    expect(onReplaceCurrent).not.toHaveBeenCalled()
+  })
+
+  it('does not replace on an Enter reported as keyCode 229', () => {
+    const onReplaceCurrent = vi.fn()
+    const input = renderBar({ onReplaceCurrent, onClose: vi.fn() })
+
+    pressKey(input, 'Enter', { keyCode: 229 })
+
+    expect(onReplaceCurrent).not.toHaveBeenCalled()
+  })
+
+  it('does not close the bar on the Escape that cancels a composition', () => {
+    const onClose = vi.fn()
+    const input = renderBar({ onReplaceCurrent: vi.fn(), onClose })
+
+    pressKey(input, 'Escape', { isComposing: true })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('still replaces on a plain Enter', () => {
+    const onReplaceCurrent = vi.fn()
+    const input = renderBar({ onReplaceCurrent, onClose: vi.fn() })
+
+    pressKey(input, 'Enter')
+
+    expect(onReplaceCurrent).toHaveBeenCalledTimes(1)
+  })
+
+  it('still closes the bar on a plain Escape', () => {
+    const onClose = vi.fn()
+    const input = renderBar({ onReplaceCurrent: vi.fn(), onClose })
+
+    pressKey(input, 'Escape')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
@@ -112,6 +112,12 @@ export function RichMarkdownSearchBar({
               value={query}
               onChange={(event) => onQueryChange(event.target.value)}
               onKeyDown={(event) => {
+                // Why: while a CJK candidate is composing, Enter only confirms it
+                // and Escape only cancels it — moving to the next match or closing
+                // the bar here would act on a keystroke aimed at the IME.
+                if (isImeCompositionKeyDown(event)) {
+                  return
+                }
                 if (event.key === 'Enter' && event.shiftKey) {
                   event.preventDefault()
                   onMoveToMatch(-1)

--- a/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSearchBar.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { translate } from '@/i18n/i18n'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 
 type RichMarkdownSearchBarProps = {
@@ -247,6 +248,12 @@ export function RichMarkdownSearchBar({
                 value={replaceQuery}
                 onChange={(event) => onReplaceQueryChange(event.target.value)}
                 onKeyDown={(event) => {
+                  // Why: while a CJK candidate is composing, Enter only confirms it
+                  // and Escape only cancels it — replacing the match or closing the
+                  // bar here would act on a keystroke aimed at the IME.
+                  if (isImeCompositionKeyDown(event)) {
+                    return
+                  }
                   if (event.key === 'Enter') {
                     event.preventDefault()
                     onReplaceCurrent()

--- a/src/renderer/src/components/right-sidebar/right-panel-comment-composer.ime-enter.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-composer.ime-enter.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RightPanelCommentComposer } from './right-panel-comment-composer'
+
+vi.mock('@/components/ShortcutKeyCombo', () => ({
+  ShortcutKeyCombo: () => <span />
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  // Why: the composer picks its submit modifier from the user agent; pin it to
+  // the non-Mac branch so the test always drives Ctrl+Enter.
+  vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Windows')
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+function renderComposer(onSubmit: () => Promise<{ ok: true }>): HTMLTextAreaElement {
+  act(() => {
+    root.render(
+      <RightPanelCommentComposer
+        placeholder="댓글을 입력하세요"
+        submitLabel="등록"
+        onSubmit={onSubmit}
+      />
+    )
+  })
+  const textarea = container.querySelector('textarea')
+  if (!textarea) {
+    throw new Error('comment textarea not rendered')
+  }
+  return textarea
+}
+
+function typeBody(textarea: HTMLTextAreaElement, value: string): void {
+  act(() => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set?.call(
+      textarea,
+      value
+    )
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function pressEnter(
+  textarea: HTMLTextAreaElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ctrlKey: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    textarea.dispatchEvent(event)
+  })
+}
+
+describe('RightPanelCommentComposer IME Enter guard', () => {
+  it('does not submit on the Ctrl+Enter that commits a CJK composition', () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }) as const)
+    const textarea = renderComposer(onSubmit)
+    typeBody(textarea, '확인했습니다')
+
+    pressEnter(textarea, { isComposing: true })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on a Ctrl+Enter reported as keyCode 229', () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }) as const)
+    const textarea = renderComposer(onSubmit)
+    typeBody(textarea, '확인했습니다')
+
+    pressEnter(textarea, { keyCode: 229 })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('still submits on a plain Ctrl+Enter', () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }) as const)
+    const textarea = renderComposer(onSubmit)
+    typeBody(textarea, '확인했습니다')
+
+    pressEnter(textarea)
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('확인했습니다')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx
+++ b/src/renderer/src/components/right-sidebar/right-panel-comment-composer.tsx
@@ -3,6 +3,7 @@ import { Bold, Code2, Italic, List, Quote } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { cn } from '@/lib/utils'
 import {
   getCommentBodySubmitState,
@@ -171,6 +172,11 @@ export function RightPanelCommentComposer({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Why: an Enter that only confirms a CJK IME candidate must not post the
+      // comment; it would submit without the syllable still being composed.
+      if (isImeCompositionKeyDown(event)) {
+        return
+      }
       const modifierPressed = isMac ? event.metaKey : event.ctrlKey
       if (event.key === 'Enter' && modifierPressed) {
         event.preventDefault()


### PR DESCRIPTION
## Summary

Follow-up to #11879, same class of bug in two more surfaces.

On the 2-set Korean layout, seven jamo require Shift — ㅃ ㅉ ㄸ ㄲ ㅆ ㅒ ㅖ — so Korean users are composing for a large share of ordinary typing (`있다`, `했다`, `예를 들어`, `얘기`). The Enter that only confirms a CJK candidate was reaching two handlers that act on it:

- **`right-panel-comment-composer.tsx`** — `Cmd/Ctrl+Enter` posted the comment mid-composition, so the comment goes out missing its final syllable. Long-form prose, so this is the highest-loss case.
- **`RichMarkdownSearchBar.tsx`** (replace field) — Enter ran `onReplaceCurrent()`, **mutating the document** on a keystroke aimed at the candidate list. Escape had the mirror problem: it closed the search bar instead of letting the IME cancel the composition.

Both are guarded with the existing `isImeCompositionKeyDown` helper, the same one the rename and title inputs already use (`SortableTab.tsx:291`, `EditorFileTab.tsx:308`, `WorktreeTitleInlineRename.tsx:231`, `WorkspaceDirectorySetting.tsx:203`). These two fields were simply missed in that migration.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — see Notes for two wrapper scripts that cannot run on Windows; their underlying `oxlint` invocations were run directly and are clean
- [x] `pnpm typecheck` — all three projects (`node`, `cli`, `web`) clean
- [x] `pnpm test` — ran the affected scope: `src/renderer/src/components/right-sidebar/` + `src/renderer/src/components/editor/`, 2559 passed. Two pre-existing failures, see Notes.
- [ ] `pnpm build` — not run locally; see Notes
- [x] Added or updated high-quality tests that would catch regressions

Two new colocated tests, modeled on the merged `SmartWorkspaceNameField.ime-enter.test.tsx`:

- `right-panel-comment-composer.ime-enter.test.tsx`
- `RichMarkdownSearchBar.ime-enter.test.tsx`

**Verified both fail without the fix.** Stashing only the production file leaves the controls green and turns exactly the guard cases red:

```
right-panel-comment-composer
× does not submit on the Ctrl+Enter that commits a CJK composition
× does not submit on a Ctrl+Enter reported as keyCode 229
  Tests  2 failed | 1 passed (3)

RichMarkdownSearchBar
× does not replace on the Enter that commits a CJK composition
× does not replace on an Enter reported as keyCode 229
× does not close the bar on the Escape that cancels a composition
  Tests  3 failed | 2 passed (5)
```

With the fixes restored: 3/3 and 5/5.

The passing controls are the point — a plain `Ctrl+Enter` still submits, a plain Enter still replaces, and a plain Escape still closes the bar. The guards suppress only composition keystrokes rather than disabling the handlers.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Escape semantics.** Initially only the Enter branch was guarded. Review flagged that Escape during composition belongs to the IME too — it cancels the candidate, and swallowing it to close the search bar loses the user's composition. Both handlers only branch on Enter/Escape, so an early return is the correct shape here (matching `SortableTab.tsx:289-300`) rather than per-branch conditions.
- **Narrower shape rejected for the search bar's other input.** Only the replace field is changed. The find field's next/prev handlers are navigational and out of scope for this PR.
- **Cross-platform.** `right-panel-comment-composer` already derives its submit modifier via `navigator.userAgent.includes('Mac')` at line 89 — untouched, and no `metaKey` is newly hardcoded. The test pins the user agent to the non-Mac branch so it asserts `Ctrl+Enter` deterministically rather than depending on the runner's platform. `isImeCompositionKeyDown` reads only `isComposing` and `keyCode === 229` and already ships on all three platforms. No paths, shell behavior, or Electron APIs touched.
- **SSH / remote and folder workspaces.** Pure renderer keyboard logic with no host, transport, or workspace-type dependency; identical behavior for SSH hosts, WSL, and folder workspaces.
- **No `max-lines` suppression** added or bumped; `check:max-lines-ratchet` passes. `oxlint`, `react-doctor`, `check:reliability-gates`, and all three localization verifiers pass.

## Security Audit

Basic audit from the same review. Both changes only *narrow* the conditions under which an action fires, so they reduce rather than expand the surface:

- **Unintended mutation.** The `RichMarkdownSearchBar` case is the security-relevant one — an IME keystroke could rewrite document content without a deliberate user action. The guard removes that path. No new mutation path is added.
- **Input handling.** Reads three fields off the keyboard event (`isComposing`, `keyCode`, `key`). No parsing, no interpolation, no `dangerouslySetInnerHTML`.
- **Command execution / path handling / secrets / auth / IPC / dependencies.** Untouched. No new dependency; `isImeCompositionKeyDown` is an existing in-repo module.
- **Test doubles.** Both tests mock only UI primitives and i18n; no process, filesystem, or network access.

No follow-up required.

## Notes

**Two pre-existing test failures in the affected folders, unrelated to this PR.** Both are Windows CRLF issues and were confirmed by stashing every local change and re-running against a clean `upstream/main` — they fail identically there:

- `monaco-content-sync.undo-history.test.ts` — `expected 'first line\r\nappended' to be 'first line\nappended'`
- `SourceControl.host-context-boundary.test.ts` — a source-text assertion that does not match under CRLF

**Two `pnpm lint` sub-steps cannot execute on Windows.** `check-changed-code-quality.mjs` and `lint-react-doctor-changed.mjs` both die with `Error: spawnSync pnpm.cmd EINVAL` before reaching any analysis — the known Node-on-Windows restriction on spawning `.cmd` without `shell: true`. Environmental and unrelated to this change; both run normally on the Linux CI runners. Their underlying commands were run directly and are clean.

**`pnpm build` not run locally.** This machine is on Node v22.13.1 while `engines` requires Node 24. This PR touches only renderer TypeScript with no native, packaging, or build-config surface, so CI's `package` jobs are the meaningful signal.

**Related.** #11067 migrates the rename/notes dialogs onto the same helper and does not touch either file here, so there is no overlap. #11879 covers the quick-commands menu.

Other unguarded Enter-submit handlers remain — the Linear and GitHub Projects title fields, the native-chat free-text answer, and several pickers. Happy to continue in separate PRs if this shape looks right.
