### PR TITLE
fix(terminal): close async capability review gaps

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -4632,13 +4632,12 @@
         "renderer startup",
         "cold terminal restoration",
         "hidden terminal parking",
-        "SSH terminal restoration",
-        "paired web terminal restoration"
+        "SSH terminal restoration"
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["daemon", "ssh", "remote-runtime"],
-      "coveredPlatforms": ["macos", "linux"],
-      "coveredProviders": ["daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["daemon", "ssh"],
       "coverageNotes": "A preload contract and Electron main-stall oracle prove capability lookup is asynchronous. Startup prefetch covers restored primary and split-pane PTY identities before cold activation, while unknown providers remain eager. Docker SSH journeys prove remote terminals still remount eagerly and reclaim their authenticated PTY owner after restart.",
       "motivatingLinks": ["https://stablygroup.slack.com/archives/C0BD60A5J85/p1785524559818629"],
       "invariant": "PTY snapshot capability discovery must never synchronously block renderer JavaScript. Restored daemon capability must be known before workspace readiness enables cold activation; unknown or legacy capability must remain eager. A healthy SSH provider must return definitive false without polling. One unresponsive capability batch must fail open within one second regardless of PTY count, and stale async responses must not update current bindings.",
@@ -4686,7 +4685,7 @@
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pty-snapshot-capability-main-stall.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=3",
           "result": "passed",
           "durationSeconds": 16.8,
-          "summary": "Three 1.5-second main stalls produced 32 renderer calls each; maximum interval gaps were 70.3ms, 70.1ms, and 71.6ms, and maximum call-return durations were 0.1ms, 0.1ms, and 0.2ms. The synchronous baseline produced a 1465.1ms interval gap and 1464.2ms call-return duration. Cold daemon restore and both Docker SSH restore journeys also passed."
+          "summary": "Three 1.5-second main stalls produced 32 renderer calls each; maximum interval gaps were 70.3ms, 70.1ms, and 71.6ms, and maximum call-return durations were 0.1ms, 0.1ms, and 0.2ms. The synchronous baseline produced a 1465.1ms interval gap and 1464.2ms call-return duration."
         }
       ],
       "runtimeBudget": {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6672,8 +6672,7 @@ describe('registerPtyHandlers', () => {
   })
 
   it('answers false, not null, for a resolved provider with no snapshot capability', async () => {
-    // Why: null is never cached, so a provider that merely omits the optional
-    // method would keep the renderer's retry timer armed for the whole session.
+    // Null is never cached, so missing optional methods must resolve false.
     registerPtyHandlers(mainWindow as never)
     setLocalPtyProvider({ spawn: vi.fn(), write: vi.fn() } as never)
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -6341,11 +6341,7 @@ export function registerPtyHandlers(
         }
         seen.add(value)
         const provider = tryGetProviderForPty(value)
-        // Why null is reserved for an unresolved route: the renderer never caches
-        // it and keeps re-arming, so a provider that merely omits the optional
-        // method would poll forever. Omitting it means "no authoritative
-        // snapshot" — the same mount-eagerly outcome null already produced, but
-        // cacheable. Degraded routing keeps its explicit false for the same reason.
+        // Resolved providers without the optional method are definitively non-authoritative; null remains retryable.
         capabilities.push({
           id: value,
           authoritative:

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts
@@ -122,6 +122,19 @@ describe('terminal provider snapshot capabilities', () => {
     expect(terminalProviderHasAuthoritativeSnapshot('pty-1')).toBe(false)
   })
 
+  it('retries immediately when a timeout consumes the retry delay', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const synchronization = synchronizeTerminalProviderSnapshotCapabilities(
+      ['pty-1'],
+      () => new Promise(() => {})
+    )
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expect(synchronization).resolves.toBe(0)
+  })
+
   it('ignores a stale capability response after the live PTY set changes', async () => {
     let resolveStale!: (value: { id: string; authoritative: boolean | null }[]) => void
     const stale = new Promise<{ id: string; authoritative: boolean | null }[]>((resolve) => {
@@ -140,8 +153,7 @@ describe('terminal provider snapshot capabilities', () => {
   })
 
   it('stops polling for a PTY whose route never resolves', async () => {
-    // The retry re-arms this module's own timer, so a fixed delay is a 1 Hz IPC
-    // plus a full all-PTY scan for the life of the app.
+    // Bounded retries prevent lifelong capability polling for vanished routes.
     const resolve = vi.fn(async () => [{ id: 'gone-pty', authoritative: null }])
     const backoffSchedule = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000]
 

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
@@ -54,12 +54,7 @@ function refreshEarliestUnknownCapabilityRetry(): void {
   }
 }
 
-/**
- * Why bounded: an id that stays unknown re-arms this resolver's own retry timer,
- * so a fixed delay is a 1 Hz main-process IPC plus a full all-PTY scan for the
- * life of the app. Settling on `false` is the same mount-eagerly behaviour an
- * unresolved id already gets, and it lets the loop converge.
- */
+// Unknown routes settle eager after bounded retries to avoid lifelong capability polling.
 function backOffUnknownCapability(ptyId: string, nowMs: number): void {
   const attempts = (unknownCapabilityAttemptsByPtyId.get(ptyId) ?? 0) + 1
   if (attempts >= UNKNOWN_CAPABILITY_MAX_ATTEMPTS) {
@@ -180,7 +175,7 @@ export async function synchronizeTerminalProviderSnapshotCapabilities(
     }
   }
   refreshEarliestUnknownCapabilityRetry()
-  return unknownCapabilityRetryDelayMs(nowMs)
+  return unknownCapabilityRetryDelayMs(observedAtMs === undefined ? Date.now() : nowMs)
 }
 
 export function startTerminalProviderSnapshotCapabilitySynchronization(

--- a/tests/e2e/pty-snapshot-capability-main-stall.spec.ts
+++ b/tests/e2e/pty-snapshot-capability-main-stall.spec.ts
@@ -12,6 +12,10 @@ test('PTY capability lookup keeps renderer JavaScript responsive while main is s
   orcaPage
 }) => {
   await orcaPage.evaluate(() => {
+    const getCapabilities = window.api.pty.getAuthoritativeBufferSnapshotCapabilities
+    if (!getCapabilities) {
+      throw new Error('PTY snapshot capability API is unavailable')
+    }
     const probe: CapabilityProbe = {
       calls: 0,
       gapsMs: [],
@@ -24,7 +28,7 @@ test('PTY capability lookup keeps renderer JavaScript responsive while main is s
       probe.gapsMs.push(tickAt - previousTickAt)
       previousTickAt = tickAt
       const callStartedAt = performance.now()
-      void window.api.pty.getAuthoritativeBufferSnapshotCapabilities?.(['ssh:e2e@@pty-1'])
+      void getCapabilities(['ssh:e2e@@pty-1']).catch(() => {})
       probe.returnDurationsMs.push(performance.now() - callStartedAt)
       probe.calls += 1
     }, 50)


### PR DESCRIPTION
## Summary

- fixes the stale timeout clock so capability retries do not wait an extra second
- makes the renderer-stall E2E fail when the capability API is missing
- narrows reliability metadata and evidence to directly verified coverage
- shortens new comments to match repository guidance

Follow-up to #11881, which merged while its review loop was still running.

## Screenshots

No visual change.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/preload/pty-snapshot-capability-ipc.test.ts src/main/ipc/pty.test.ts src/main/providers/ssh-pty-provider.test.ts src/renderer/src/components/terminal/terminal-provider-snapshot-capability.test.ts src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.test.tsx src/renderer/src/components/terminal/background-terminal-worktree-mount.test.ts src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts src/renderer/src/app-startup-routing.test.ts --reporter=dot` (574 passed)
- `pnpm run check:reliability-gates`
- `pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pty-snapshot-capability-main-stall.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=3` (3 passed)

## AI Review Report

Reviewed retry timing, timeout recovery, stale-generation handling, IPC validation, E2E false-pass behavior, and reliability evidence traceability. CodeRabbit reported no actionable code findings on this follow-up.

## Security Audit

No new permissions, command execution, filesystem access, network surface, or secret handling. The change only adjusts renderer retry scheduling, tests, comments, and reliability metadata.

## Notes

The local full typecheck was contaminated by unrelated untracked freeze-lab tests in the active worktree; clean-tree PR CI typecheck passed.