### PR TITLE
fix(sidebar): keep the toolbar labels in the selected UI language

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarToolbar.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.test.tsx
@@ -4,6 +4,8 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AppState } from '@/store'
+import { i18n } from '@/i18n/i18n'
+import ko from '@/i18n/locales/ko.json'
 import SidebarToolbar from './SidebarToolbar'
 
 const mocks = vi.hoisted(() => ({
@@ -82,12 +84,15 @@ describe('SidebarToolbar moved workspace board hint', () => {
     }
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     roots.splice(0).forEach((root) => {
       act(() => root.unmount())
     })
     document.body.replaceChildren()
     vi.clearAllMocks()
+    // Why: the language-change case mutates the shared i18n instance; restore
+    // here so a failing assertion cannot leave later tests running in Korean.
+    await i18n.changeLanguage('en')
   })
 
   it('does not show the moved hint to brand-new users after their first board click', async () => {
@@ -129,6 +134,26 @@ describe('SidebarToolbar moved workspace board hint', () => {
 
     expect(container.textContent).toContain('Workspace board moved to the bottom bar')
     expect(window.localStorage.getItem('orca.workspaceBoardMovedHintSeen.v1')).toBe('true')
+  })
+
+  // Why: the toolbar is a React.memo boundary whose props never change on a
+  // language switch, so without its own useTranslation() subscription it keeps
+  // the English copy it rendered at boot (the persisted locale is applied
+  // asynchronously, after the lazy catalog loads).
+  it('relabels itself when the UI language changes after mount', async () => {
+    const { container } = await renderToolbar()
+    expect(container.querySelector('button[aria-label="Workspace board"]')).not.toBeNull()
+
+    await act(async () => {
+      await i18n.changeLanguage('ko')
+    })
+
+    // Why: read the expected copy from the catalog instead of hardcoding it, so
+    // editing the Korean wording cannot fail this test as a bogus stale-render
+    // report.
+    const localized = ko.auto.components.sidebar.SidebarToolbar['49f62c5665']
+    expect(localized).not.toBe('Workspace board')
+    expect(container.querySelector(`button[aria-label="${localized}"]`)).not.toBeNull()
   })
 
   it('renders the profile switcher before settings in the footer controls', async () => {

--- a/src/renderer/src/components/sidebar/SidebarToolbar.tsx
+++ b/src/renderer/src/components/sidebar/SidebarToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Kanban } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { ScrollToCurrentWorkspaceToolbarButton } from './ScrollToCurrentWorkspaceToolbarButton'
@@ -23,6 +24,12 @@ const SidebarToolbar = React.memo(function SidebarToolbar({
   workspaceBoardDragPreviewOpen = false,
   onWorkspaceBoardToggle
 }: SidebarToolbarProps) {
+  // Why: this memo boundary needs its own language subscription, while
+  // translate() preserves Orca's pseudo-localization behavior. Without it the
+  // toolbar (and the ScrollToCurrentWorkspaceToolbarButton it renders) keeps
+  // whatever language was active at boot — English, since the persisted locale
+  // is applied asynchronously after the lazy catalog loads.
+  useTranslation()
   const [workspaceBoardMovedHintOpen, setWorkspaceBoardMovedHintOpen] = React.useState(false)
   const movedHintEligibleRef = React.useRef<boolean | null>(null)
   const persistedUIReady = useAppStore((state) => state.persistedUIReady)


### PR DESCRIPTION
## Summary

With a non-English UI language, the two sidebar bottom-bar tooltips stay in English — "Workspace board" and "Reveal active workspace" — while everything around them, including the sidebar nav directly above, is translated. The catalogs are fine; both keys are present in all five locales.

`SidebarToolbar` is a `React.memo` boundary. Its props do not change when the UI language does, so React skips it, and `translate()` — a plain function, not a hook — keeps returning whatever language was resolved when the component last rendered. The app boots with `lng: 'en'` and applies the persisted locale asynchronously once the lazy catalog chunk loads, so the toolbar and the `ScrollToCurrentWorkspaceToolbarButton` it renders freeze on the English fallback. `RendererRoot` already re-renders the tree via `useTranslation()`, but the memo boundary swallows it. Whether the toolbar's last render lands before or after `changeLanguage()` resolves is a race, which is why this reproduces on Windows but not macOS for the same build and locale.

Fix: subscribe the memo boundary with `useTranslation()` — the one-line pattern `SidebarNav` and `AgentKanbanCard` already carry. `translate()` is kept so pseudo-localization still applies.

Reported against 1.4.162 on Windows 11, UI language Korean.

**It no longer reproduces on 1.4.163 — and that is the argument for merging this, not against it.** Neither `SidebarToolbar.tsx`, `ScrollToCurrentWorkspaceToolbarButton.tsx`, nor the i18n boot path changed between those releases; current `main` still has no `useTranslation()` on the memo boundary and still boots `lng: 'en'` with lazily loaded catalogs. Bundling shifted and the toolbar's last render now happens to land after `changeLanguage()` resolves — the same luck macOS has always had. The defect is intact; only the timing moved, and it can move back on any chunking change, cold start, or slow disk.

## Screenshots

Before — both tooltips render the English fallback:

<img width="664" height="216" alt="before-reveal-active-workspace" src="https://github.com/user-attachments/assets/b32da5ed-9937-49b9-aa7e-1b1144656352" />

<img width="664" height="216" alt="before-workspace-board" src="https://github.com/user-attachments/assets/34a7a0ff-ae85-4e6c-b3d7-3d1481b82883" />

After, same build and locale: `활성 워크스페이스로 이동` and `워크스페이스 보드`. No macOS-visible change — it already won the race.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Verified on Windows with Node 22 while the repo wants Node 24, so two scripts could not complete locally:

- `pnpm lint` aborts at `verify:skill-bundle-manifest`. This reproduces unchanged on the base commit, so it is environmental. Ran individually and passing: `oxlint` (including the react-doctor config on the changed files), `check:reliability-gates`, `check:max-lines-ratchet`, and all three `verify:localization-*` gates. `oxfmt --check` clean.
- `pnpm test` cannot run its `ensure-native-runtime` preflight, so `vitest` was invoked directly. Full suite run on both this branch and the base commit: failures are identical (53 files / 158 tests, all main-process/CLI/native/Windows-path), passing goes 42102 → 42103, the one test added here. `components/sidebar/` and `i18n/` are fully green (218 files / 1860 tests).
- `pnpm build` not run; two-file renderer change with no build-graph impact.

New test in `SidebarToolbar.test.tsx`: mounts the toolbar, calls `i18n.changeLanguage('ko')` without touching props, asserts the `aria-label` becomes the Korean copy. It fails on current `main` and passes with the fix. Expected copy is read from `ko.json` rather than hardcoded, with a companion assertion that it differs from the English source, so a reworded translation cannot fail this as a bogus stale-render report while a deleted one still fails as a missing translation. `afterEach` resets the shared `i18n` to `en`.

## AI Review Report

Reviewed with Claude Opus 5 (Claude Code).

- **Root cause vs. symptom.** The catalogs were checked before the code, which ruled out a missing translation and redirected to render staleness. Blast radius was enumerated, not assumed: 37 renderer files pair `React.memo` with `translate()`, 34 of which still lack a `useTranslation()` subscription after this change. Those are called out under Notes rather than silently bundled in.
- **Cross-platform (macOS, Linux, Windows).** Explicitly checked, since the symptom is Windows-only. No platform-specific code, paths, shells, shortcuts, labels, or Electron APIs are involved — the platform only shifts render timing. The fix is platform-neutral and cannot regress macOS or Linux, which already happened to win the race.
- **Correctness.** `useTranslation()` in a memoized component subscribes it to i18next language events, the same mechanism `SidebarNav` and `AgentKanbanCard` rely on. No new pattern.
- **Test quality.** Run against the unpatched component to confirm it actually fails. Hardened during review: hardcoded copy replaced with a catalog lookup, and the language reset moved into `afterEach` so a failing assertion cannot leak Korean into later tests.
- **Lint noise.** The `pnpm lint` failure was reproduced on the base commit before being attributed to the environment.

## Security Audit

No security-relevant surface. The diff adds a hook call and a test — no input handling, command execution, path handling, filesystem, auth, secrets, network, or IPC. No new dependencies; `react-i18next` is already used across the renderer. Strings still flow through the existing catalog, so no new user-controlled data reaches the DOM. No follow-up needed.

## Notes

34 other files pair `React.memo` with `translate()` and no `useTranslation()` — `StatusBar`, `TabBar`, `Terminal`, `WorktreeCard`, `SidebarFilter`, several `right-sidebar` components, and others. They are unreported only because they happen to re-render for other reasons, but they are exposed to the same boot race. Two ways to close it: sweep them with the same one-line subscription, or add an AST gate next to `no-top-level-translate.test.ts` requiring `useTranslation()` in any renderer file that combines `memo(` with `translate(`. Happy to follow up with either.
