### PR TITLE
fix(ssh): stop terminal tabs disappearing after reconnect

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -153,6 +153,27 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  it('does not attribute blank split siblings to the tab launch agent', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'omp' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: '⠋ OMP',
+          2: ''
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['ssh:target@@pty-1', 'ssh:target@@pty-2'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.agentType])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_1), 'omp']
+    ])
+  })
+
   it('uses runtime orchestration metadata for title-derived worker rows', () => {
     const parentPaneKey = makePaneKey('tab-parent', LEAF_ID_1)
     const childPaneKey = makePaneKey('tab-child', LEAF_ID_2)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -125,6 +125,34 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  it('keeps launchAgent rows visible after reconnect when titles are blank (#11791)', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '', launchAgent: 'omp' })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: { 'tab-1': ['ssh:target@@pty-1'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.prompt])).toEqual([
+      ['omp', 'idle', 'OMP']
+    ])
+  })
+
+  it('does not invent agent rows for blank plain-shell titles without launchAgent', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '' })],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: { 'tab-1': ['ssh:target@@pty-1'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   it('uses runtime orchestration metadata for title-derived worker rows', () => {
     const parentPaneKey = makePaneKey('tab-parent', LEAF_ID_1)
     const childPaneKey = makePaneKey('tab-child', LEAF_ID_2)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -63,6 +63,7 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
     const layout = terminalLayoutsByTabId[tab.id]
+    const allowLaunchAgentFallback = collectLeafIds(layout?.root ?? null).length === 1
     const paneTitles = runtimePaneTitlesByTabId[tab.id]
     const paneTitleEntries =
       paneTitles && Object.keys(paneTitles).length > 0
@@ -85,6 +86,7 @@ export function buildTitleDerivedAgentRows(args: {
           leafId,
           title,
           now: args.now,
+          allowLaunchAgentFallback,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -105,6 +107,7 @@ export function buildTitleDerivedAgentRows(args: {
       leafId,
       title: tab.title,
       now: args.now,
+      allowLaunchAgentFallback,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -126,6 +129,7 @@ function buildTitleDerivedAgentRow(args: {
   leafId: string
   title: string
   now: number
+  allowLaunchAgentFallback: boolean
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
   if (!isTerminalLeafId(args.leafId)) {
@@ -140,12 +144,10 @@ function buildTitleDerivedAgentRow(args: {
   const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  // Why (#11791): after SSH reconnect, OSC titles and hooks lag while the PTY is
-  // already live — blank/shell titles would hide OMP/Codex tabs from the card.
-  // launchAgent is explicit user intent to run an agent, so surface an idle row
-  // until title/hook evidence returns. Plain shell tabs without launchAgent stay hidden.
+  // Why (#11791): launchAgent bridges blank reconnect titles only for a sole leaf;
+  // tab-level launch metadata cannot identify one pane in a split.
   if (!status || !label) {
-    if (!args.tab.launchAgent) {
+    if (!args.tab.launchAgent || !args.allowLaunchAgentFallback) {
       return null
     }
     const agentType = args.tab.launchAgent

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -128,6 +128,9 @@ function buildTitleDerivedAgentRow(args: {
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
+  if (!isTerminalLeafId(args.leafId)) {
+    return null
+  }
   const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
   const isClaudeAgentsTitle = isClaudeManagementTitle(title)
   // Why: `claude agents` is a live Claude Code Agent Teams surface, but the
@@ -135,14 +138,40 @@ function buildTitleDerivedAgentRow(args: {
   // the management/list screen as active work.
   const status = isClaudeAgentsTitle ? 'idle' : classifyTitleActivity(title)
   const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
-  if (!status || !label) {
-    return null
-  }
-  if (!isTerminalLeafId(args.leafId)) {
-    return null
-  }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
+  // Why (#11791): after SSH reconnect, OSC titles and hooks lag while the PTY is
+  // already live — blank/shell titles would hide OMP/Codex tabs from the card.
+  // launchAgent is explicit user intent to run an agent, so surface an idle row
+  // until title/hook evidence returns. Plain shell tabs without launchAgent stay hidden.
+  if (!status || !label) {
+    if (!args.tab.launchAgent) {
+      return null
+    }
+    const agentType = args.tab.launchAgent
+    const rowLabel = formatAgentTypeLabel(agentType)
+    const entry: AgentStatusEntry = {
+      paneKey,
+      state: 'working',
+      prompt: rowLabel,
+      updatedAt: args.now,
+      stateStartedAt: args.now,
+      stateHistory: [],
+      agentType,
+      terminalTitle: title,
+      lastAssistantMessage: 'Idle',
+      ...(orchestration ? { orchestration } : {})
+    }
+    return {
+      paneKey,
+      entry,
+      tab: args.tab,
+      agentType,
+      rowSource: 'live',
+      state: 'idle',
+      startedAt: 0
+    }
+  }
   const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
   // Why: a braille spinner proves activity, not identity, so the resolver drops
   // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;

--- a/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.test.ts
@@ -75,6 +75,19 @@ describe('resolveSshPaneConnectGate', () => {
     expect(gate.enterDeferredFlow).toBe(true)
   })
 
+  it('reattaches deferred tab sessions after reconnect even when already connected (#11791)', () => {
+    // Why: disconnect clears tab.ptyId and seeds deferredSshSessionIdsByTabId;
+    // remounts after reconnect see sshConnected=true, so tab-level fallback is
+    // off — deferred map must still force reattach instead of a blank spawn.
+    const gate = resolveSshPaneConnectGate({
+      ...BASE,
+      sshStatus: 'connected',
+      deferredTabSessionId: 'ssh:conn-1@@pty-7'
+    })
+    expect(gate.pendingSessionId).toBe('ssh:conn-1@@pty-7')
+    expect(gate.enterDeferredFlow).toBe(true)
+  })
+
   it('does not force a connect for runtime-owned targets', () => {
     // Why: their relay health is owned by the runtime layer; users cannot
     // connect to them directly, so a reconnect flow would strand the pane.

--- a/src/renderer/src/store/slices/direct-ssh-terminal-recovery-types.ts
+++ b/src/renderer/src/store/slices/direct-ssh-terminal-recovery-types.ts
@@ -56,6 +56,13 @@ export type DirectSshTerminalBindingState = {
 export type DirectSshTerminalBindingClearResult = {
   clearedCount: number
   patch: Partial<DirectSshTerminalBindingState> | null
+  /**
+   * Tab → relay session id to reattach after the next connect.
+   * Why: clear nulls tab.ptyId / ptyIdsByTabId so remounted panes would
+   * otherwise spawn a blank shell; lastKnown alone is not read by
+   * pty-connection — seed deferredSshSessionIdsByTabId with these ids.
+   */
+  deferredSessionIdsByTabId: Record<string, string>
 }
 
 export type DirectSshTerminalRetryResult = {

--- a/src/renderer/src/store/slices/direct-ssh-terminal-recovery.test.ts
+++ b/src/renderer/src/store/slices/direct-ssh-terminal-recovery.test.ts
@@ -127,6 +127,17 @@ describe('clearDirectSshTerminalBindings', () => {
     })
   })
 
+  it('prefers a tracked PTY over a different lastKnown session id', () => {
+    const state = makeState()
+    state.tabsByWorktree['repo::/ssh-work'][1] = makeTab('ssh-unbound', null)
+    state.ptyIdsByTabId['ssh-unbound'] = ['ssh-target@@pty-tracked']
+    state.lastKnownRelayPtyIdByTabId['ssh-unbound'] = 'ssh-target@@pty-last-known'
+
+    const result = clearDirectSshTerminalBindings(state, new Set(['repo::/ssh-work']))
+
+    expect(result.deferredSessionIdsByTabId['ssh-unbound']).toBe('ssh-target@@pty-tracked')
+  })
+
   it('re-arms reconnectable disconnects without erasing retry history', () => {
     const state = makeState()
     const authority = {

--- a/src/renderer/src/store/slices/direct-ssh-terminal-recovery.test.ts
+++ b/src/renderer/src/store/slices/direct-ssh-terminal-recovery.test.ts
@@ -109,6 +109,24 @@ describe('clearDirectSshTerminalBindings', () => {
     })
   })
 
+  it('seeds deferred reattach ids from live and lastKnown session ids (#11791)', () => {
+    const state = makeState()
+    // Why: already-cleared wake-hint still has lastKnown — disconnect must still seed deferred.
+    state.tabsByWorktree['repo::/ssh-work'][1] = makeTab('ssh-unbound', null)
+    state.lastKnownRelayPtyIdByTabId['ssh-unbound'] = 'ssh-target@@pty-unbound'
+
+    const result = clearDirectSshTerminalBindings(
+      state,
+      new Set(['repo::/ssh-work', 'folder::ssh-work'])
+    )
+
+    expect(result.deferredSessionIdsByTabId).toEqual({
+      'ssh-live': 'ssh-target@@pty-1',
+      'ssh-unbound': 'ssh-target@@pty-unbound',
+      'folder-live': 'ssh-target@@pty-2'
+    })
+  })
+
   it('re-arms reconnectable disconnects without erasing retry history', () => {
     const state = makeState()
     const authority = {
@@ -198,6 +216,13 @@ describe('clearDirectSshTerminalBindings', () => {
     expect(first.patch?.tabsByWorktree?.['repo::/ssh-work'][1]).toBe(
       state.tabsByWorktree['repo::/ssh-work'][1]
     )
-    expect(second).toEqual({ clearedCount: 0, patch: null })
+    // Why: second clear is a no-op for bindings, but still re-seeds deferred from lastKnown.
+    expect(second).toEqual({
+      clearedCount: 0,
+      patch: null,
+      deferredSessionIdsByTabId: {
+        'ssh-live': 'ssh-target@@pty-1'
+      }
+    })
   })
 })

--- a/src/renderer/src/store/slices/direct-ssh-terminal-recovery.ts
+++ b/src/renderer/src/store/slices/direct-ssh-terminal-recovery.ts
@@ -40,6 +40,19 @@ function clearPtyBinding(
   }
 }
 
+/** Prefer the live tab/leaf id; fall back to lastKnown so sleep→wake still reattaches. */
+export function resolveDirectSshReconnectSessionId(
+  state: Pick<DirectSshTerminalBindingState, 'ptyIdsByTabId' | 'lastKnownRelayPtyIdByTabId'>,
+  tab: TerminalTab
+): string | null {
+  return (
+    tab.ptyId ??
+    state.ptyIdsByTabId[tab.id]?.[0] ??
+    state.lastKnownRelayPtyIdByTabId[tab.id] ??
+    null
+  )
+}
+
 export function clearDirectSshTerminalBindings(
   state: DirectSshTerminalBindingState,
   terminalWorkspaceKeys: ReadonlySet<string>,
@@ -50,6 +63,7 @@ export function clearDirectSshTerminalBindings(
   const pendingCodexPaneRestartIds = { ...state.pendingCodexPaneRestartIds }
   const codexRestartNoticeByPtyId = { ...state.codexRestartNoticeByPtyId }
   const scopedTabIds = new Set<string>()
+  const deferredSessionIdsByTabId: Record<string, string> = {}
   let clearedCount = 0
 
   for (const workspaceKey of terminalWorkspaceKeys) {
@@ -63,6 +77,12 @@ export function clearDirectSshTerminalBindings(
         continue
       }
       scopedTabIds.add(tab.id)
+      // Why (#11791): seed deferred reattach even when ptyId was already null — lastKnown
+      // still names the relay session, and pty-connection only reads deferred/leaf maps.
+      const reconnectSessionId = resolveDirectSshReconnectSessionId(state, tab)
+      if (reconnectSessionId) {
+        deferredSessionIdsByTabId[tab.id] = reconnectSessionId
+      }
       if (tab.ptyId == null) {
         continue
       }
@@ -96,10 +116,11 @@ export function clearDirectSshTerminalBindings(
     directSshPaneRetryByTabId !== state.directSshPaneRetryByTabId ||
     directSshLivePtyBindingByTabId !== state.directSshLivePtyBindingByTabId
   if (clearedCount === 0 && !recoveryChanged) {
-    return { clearedCount, patch: null }
+    return { clearedCount, patch: null, deferredSessionIdsByTabId }
   }
   return {
     clearedCount,
+    deferredSessionIdsByTabId,
     patch: {
       tabsByWorktree,
       ptyIdsByTabId,
@@ -168,6 +189,7 @@ export function invalidateStaleDirectSshTerminalBindings(
       : {}
   return {
     clearedCount: cleared.clearedCount,
+    deferredSessionIdsByTabId: cleared.deferredSessionIdsByTabId,
     patch: { ...authorityState, ...cleared.patch, ...preservedPending }
   }
 }

--- a/src/renderer/src/store/slices/direct-ssh-terminal-retry.test.ts
+++ b/src/renderer/src/store/slices/direct-ssh-terminal-retry.test.ts
@@ -93,6 +93,24 @@ describe('direct SSH terminal retry ledger', () => {
     expect(store.getState().deferredSshSessionIdsByTabId[TAB_ID]).toBe(ptyId)
   })
 
+  it('does not publish when disconnect cleanup only finds a foreign session id', () => {
+    const store = seedStore()
+    store.setState({
+      lastKnownRelayPtyIdByTabId: { [TAB_ID]: 'ssh:other@@pty-foreign' }
+    })
+    const before = store.getState()
+    let publications = 0
+    const unsubscribe = store.subscribe(() => {
+      publications += 1
+    })
+
+    expect(store.getState().clearDirectSshTargetPtyBindings('target')).toBe(0)
+    unsubscribe()
+
+    expect(publications).toBe(0)
+    expect(store.getState()).toBe(before)
+  })
+
   it('preserves a healthy current-authority sibling in the same workspace', () => {
     const store = seedStore('ssh:target@@pty-stale')
     const sibling = makeTab({

--- a/src/renderer/src/store/slices/direct-ssh-terminal-retry.test.ts
+++ b/src/renderer/src/store/slices/direct-ssh-terminal-retry.test.ts
@@ -77,6 +77,20 @@ describe('direct SSH terminal retry ledger', () => {
     expect(store.getState().tabsByWorktree[WORKTREE_ID][0].ptyId).toBeNull()
     expect(store.getState().ptyIdsByTabId[TAB_ID]).toEqual([])
     expect(store.getState().lastKnownRelayPtyIdByTabId[TAB_ID]).toBe(ptyId)
+    // Why (#11791): remount after reconnect must reattach, not spawn a blank shell.
+    expect(store.getState().deferredSshSessionIdsByTabId[TAB_ID]).toBe(ptyId)
+  })
+
+  it('seeds deferred reattach ids when a target disconnect clears bindings (#11791)', () => {
+    const ptyId = 'ssh:target@@pty-live'
+    const store = seedStore(ptyId)
+
+    expect(store.getState().clearDirectSshTargetPtyBindings('target')).toBe(1)
+
+    expect(store.getState().tabsByWorktree[WORKTREE_ID][0].ptyId).toBeNull()
+    expect(store.getState().ptyIdsByTabId[TAB_ID]).toEqual([])
+    expect(store.getState().lastKnownRelayPtyIdByTabId[TAB_ID]).toBe(ptyId)
+    expect(store.getState().deferredSshSessionIdsByTabId[TAB_ID]).toBe(ptyId)
   })
 
   it('preserves a healthy current-authority sibling in the same workspace', () => {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2917,6 +2917,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         result.deferredSessionIdsByTabId,
         targetId
       )
+      if (!result.patch && deferredSshSessionIdsByTabId === s.deferredSshSessionIdsByTabId) {
+        return s
+      }
       return {
         ...result.patch,
         ...(deferredSshSessionIdsByTabId !== s.deferredSshSessionIdsByTabId
@@ -2947,6 +2950,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         result.deferredSessionIdsByTabId,
         authority.targetId
       )
+      if (!result.patch && deferredSshSessionIdsByTabId === s.deferredSshSessionIdsByTabId) {
+        return s
+      }
       return {
         ...result.patch,
         ...(deferredSshSessionIdsByTabId !== s.deferredSshSessionIdsByTabId

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -197,6 +197,26 @@ function resolveDirectSshTerminalKeys(state: AppState, targetId: string): Set<st
   )
 }
 
+/** Merge disconnect-seeded reattach ids for one SSH target; drop foreign-connection seeds. */
+function mergeDeferredSshSessionIdsForTarget(
+  current: Record<string, string>,
+  seeds: Record<string, string>,
+  targetId: string
+): Record<string, string> {
+  let next: Record<string, string> | null = null
+  for (const [tabId, sessionId] of Object.entries(seeds)) {
+    if (parseAppSshPtyId(sessionId)?.connectionId !== targetId) {
+      continue
+    }
+    if (current[tabId] === sessionId) {
+      continue
+    }
+    next ??= { ...current }
+    next[tabId] = sessionId
+  }
+  return next ?? current
+}
+
 function getPendingActivationSpawnCount(value: boolean | number | undefined): number {
   if (value === true) {
     return 1
@@ -2887,7 +2907,22 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     set((s) => {
       const result = clearDirectSshTerminalBindings(s, resolveDirectSshTerminalKeys(s, targetId))
       clearedCount = result.clearedCount
-      return result.patch ?? s
+      if (!result.patch && Object.keys(result.deferredSessionIdsByTabId).length === 0) {
+        return s
+      }
+      // Why (#11791): after disconnect, remounted panes only reattach via deferred/leaf
+      // session ids — tab.ptyId is null and lastKnown is not read by pty-connection.
+      const deferredSshSessionIdsByTabId = mergeDeferredSshSessionIdsForTarget(
+        s.deferredSshSessionIdsByTabId,
+        result.deferredSessionIdsByTabId,
+        targetId
+      )
+      return {
+        ...result.patch,
+        ...(deferredSshSessionIdsByTabId !== s.deferredSshSessionIdsByTabId
+          ? { deferredSshSessionIdsByTabId }
+          : {})
+      }
     })
     return clearedCount
   },
@@ -2904,7 +2939,20 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         authority
       )
       clearedCount = result.clearedCount
-      return result.patch ?? s
+      if (!result.patch && Object.keys(result.deferredSessionIdsByTabId).length === 0) {
+        return s
+      }
+      const deferredSshSessionIdsByTabId = mergeDeferredSshSessionIdsForTarget(
+        s.deferredSshSessionIdsByTabId,
+        result.deferredSessionIdsByTabId,
+        authority.targetId
+      )
+      return {
+        ...result.patch,
+        ...(deferredSshSessionIdsByTabId !== s.deferredSshSessionIdsByTabId
+          ? { deferredSshSessionIdsByTabId }
+          : {})
+      }
     })
     return clearedCount
   },

--- a/tests/e2e/ssh-docker-relay-perf.spec.ts
+++ b/tests/e2e/ssh-docker-relay-perf.spec.ts
@@ -19,6 +19,7 @@ import {
   connectDockerSshRelayTarget,
   reconnectDockerSshRelayTarget
 } from './helpers/docker-ssh-relay-connection'
+import { worktreeRow } from './worktree-row-locators'
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 const KEY_LATENCY_SAMPLES = 'abcdefghij'
@@ -354,7 +355,7 @@ test.describe('Docker SSH relay perf', () => {
     }
   })
 
-  test('keeps an SSH workspace terminal usable after disconnect and reconnect', async ({
+  test('keeps every SSH agent terminal and sidebar row after disconnect and reconnect', async ({
     orcaPage
   }, testInfo) => {
     test.slow()
@@ -365,46 +366,92 @@ test.describe('Docker SSH relay perf', () => {
       await waitForActiveWorktree(orcaPage)
       const remote = await connectDockerSshRelayTarget(orcaPage, target)
       await ensureTerminalVisible(orcaPage, 45_000)
-      await waitForActiveTerminalManager(orcaPage, 60_000)
-      const beforePtyId = await waitForActivePanePtyId(orcaPage, 60_000)
-      const beforeMarker = `SSH_RECONNECT_BEFORE_${Date.now()}`
-      await execInTerminal(orcaPage, beforePtyId, `printf ${shellQuote(beforeMarker)}`)
-      await waitForTerminalOutput(orcaPage, beforeMarker, 20_000, 60_000)
-      const recoveryStartedMarker = `SSH_RECONNECT_RECOVERY_STARTED_${Date.now()}`
-      const recoveryMarker = `SSH_RECONNECT_RECOVERY_${Date.now()}`
-      const recoveryScript = [
-        'let frame = 0',
-        "const chunk = 'Q'.repeat(4096)",
-        `process.stdout.write('${recoveryStartedMarker}\\n')`,
-        'const timer = setInterval(() => {',
-        'frame += 1',
-        "process.stdout.write('RECOVERY_FRAME_' + frame + '_' + chunk + '\\n')",
-        `if (frame === 256) { clearInterval(timer); process.stdout.write('${recoveryMarker}\\n') }`,
-        '}, 10)'
-      ].join(';')
-      await execInTerminal(orcaPage, beforePtyId, `node -e ${shellQuote(recoveryScript)}`)
-      await waitForTerminalOutput(orcaPage, recoveryStartedMarker, 30_000, 80_000)
+      await orcaPage.evaluate(() => {
+        const state = window.__store?.getState()
+        if (!state) {
+          throw new Error('Store unavailable')
+        }
+        state.setSidebarOpen(true)
+        state.setAgentActivityDisplayMode('compact')
+        if (!state.worktreeCardProperties.includes('inline-agents')) {
+          state.toggleWorktreeCardProperty('inline-agents')
+        }
+      })
+
+      const agentTabs: { tabId: string; beforePtyId: string; recoveryMarker: string }[] = []
+      for (const index of [1, 2]) {
+        const tabId = await orcaPage.evaluate((worktreeId) => {
+          const state = window.__store?.getState()
+          if (!state) {
+            throw new Error('Store unavailable')
+          }
+          const tab = state.createTab(worktreeId, undefined, undefined, {
+            activate: true,
+            launchAgent: 'omp',
+            recordInteraction: false
+          })
+          state.setActiveTab(tab.id)
+          state.setActiveTabType('terminal')
+          return tab.id
+        }, remote.worktreeId)
+        const tab = orcaPage.locator(`[data-testid="sortable-tab"][data-tab-id="${tabId}"]`)
+        await expect(tab).toBeVisible({ timeout: 30_000 })
+        await expect(tab).toHaveAttribute('data-active', 'true')
+        await waitForActiveTerminalManager(orcaPage, 60_000)
+        const beforePtyId = await waitForActivePanePtyId(orcaPage, 60_000)
+        const beforeMarker = `SSH_RECONNECT_BEFORE_${index}_${Date.now()}`
+        await execInTerminal(
+          orcaPage,
+          beforePtyId,
+          `printf '\\033]0;\\007%s\\n' ${shellQuote(beforeMarker)}`
+        )
+        await waitForTerminalOutput(orcaPage, beforeMarker, 20_000, 60_000)
+        const recoveryStartedMarker = `SSH_RECONNECT_RECOVERY_STARTED_${index}_${Date.now()}`
+        const recoveryMarker = `SSH_RECONNECT_RECOVERY_${index}_${Date.now()}`
+        const recoveryScript = [
+          `process.stdout.write('${recoveryStartedMarker}\\n')`,
+          `setTimeout(() => process.stdout.write('${recoveryMarker}\\n'), 2500)`
+        ].join(';')
+        await execInTerminal(orcaPage, beforePtyId, `node -e ${shellQuote(recoveryScript)}`)
+        await waitForTerminalOutput(orcaPage, recoveryStartedMarker, 30_000, 80_000)
+        agentTabs.push({ tabId, beforePtyId, recoveryMarker })
+      }
+
+      const agentSummary = worktreeRow(orcaPage, remote.worktreeId)
+        .locator('button.compact-agent-summary-button')
+        .first()
+      await expect(agentSummary).toHaveAttribute('aria-label', /2 agents/, { timeout: 30_000 })
 
       await reconnectDockerSshRelayTarget(orcaPage, remote.targetId)
       await ensureTerminalVisible(orcaPage, 45_000)
-      await waitForActiveTerminalManager(orcaPage, 60_000)
-      const afterPtyId = await waitForActivePanePtyId(orcaPage, 60_000)
-      await waitForTerminalOutput(orcaPage, recoveryMarker, 30_000, 80_000)
-      const afterMarker = `SSH_RECONNECT_AFTER_${Date.now()}`
-      const remoteProofPath = `/tmp/${afterMarker}`
-      await execInTerminal(
-        orcaPage,
-        afterPtyId,
-        `printf ${shellQuote(afterMarker)} | tee ${shellQuote(remoteProofPath)}`
-      )
-      await waitForTerminalOutput(orcaPage, afterMarker, 20_000, 60_000)
-      expect(execDockerSshRelayTargetCommand(target, `cat ${shellQuote(remoteProofPath)}`)).toBe(
-        afterMarker
-      )
+      const afterPtyIds: string[] = []
+      for (const [index, agentTab] of agentTabs.entries()) {
+        const tab = orcaPage.locator(
+          `[data-testid="sortable-tab"][data-tab-id="${agentTab.tabId}"]`
+        )
+        await tab.click()
+        await expect(tab).toHaveAttribute('data-active', 'true')
+        await waitForActiveTerminalManager(orcaPage, 60_000)
+        const afterPtyId = await waitForActivePanePtyId(orcaPage, 60_000)
+        afterPtyIds.push(afterPtyId)
+        await waitForTerminalOutput(orcaPage, agentTab.recoveryMarker, 30_000, 80_000)
+        const afterMarker = `SSH_RECONNECT_AFTER_${index + 1}_${Date.now()}`
+        const remoteProofPath = `/tmp/${afterMarker}`
+        await execInTerminal(
+          orcaPage,
+          afterPtyId,
+          `printf '%s' ${shellQuote(afterMarker)} | tee ${shellQuote(remoteProofPath)}`
+        )
+        await waitForTerminalOutput(orcaPage, afterMarker, 20_000, 60_000)
+        expect(execDockerSshRelayTargetCommand(target, `cat ${shellQuote(remoteProofPath)}`)).toBe(
+          afterMarker
+        )
+      }
+      await expect(agentSummary).toHaveAttribute('aria-label', /2 agents/, { timeout: 30_000 })
 
       testInfo.annotations.push({
         type: 'docker-ssh-reconnect',
-        description: `terminal survived reconnect: beforePty=${beforePtyId}, afterPty=${afterPtyId}`
+        description: `terminals survived reconnect: beforePtys=${agentTabs.map((tab) => tab.beforePtyId).join(',')} afterPtys=${afterPtyIds.join(',')}`
       })
     } finally {
       cleanupDockerSshRelayTarget(target)


### PR DESCRIPTION
## Summary

Fixes #11791.

- Preserve every tracked SSH terminal session when a target disconnects, allowing all tabs to reattach after reconnect.
- Keep launched agent rows visible while terminal titles and hooks are still rehydrating.
- Restrict the `launchAgent` fallback to single-pane tabs so blank split panes are not misclassified as duplicate agents.
- Avoid unnecessary Zustand publications when disconnect cleanup produces no state changes.
- Extend the Docker SSH reconnect test to cover multiple agent tabs, restored terminal execution, and sidebar agent-count parity.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed.

### Focused checks completed

- Focused Vitest suites: **4 files** and **51 tests** passed.
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- Focused `oxlint --deny-warnings`
- Focused `oxfmt --check`
- `pnpm run check:max-lines-ratchet`
- `pnpm exec electron-vite build --mode e2e`
- The targeted Playwright spec compiles and registers successfully.

The Docker-backed test body could not execute locally because this host is Windows and the Docker Desktop daemon was unavailable.

## AI Review Report

Reviewed the implementation against #11791 and the automated PR feedback.

The review checked:

- Whether disconnect cleanup preserves live and last-known relay PTY IDs for every affected SSH tab.
- Whether tracked PTY IDs correctly take precedence over stale `lastKnown` IDs.
- Whether filtered reconnect state can cause unnecessary Zustand publications.
- Whether blank reconnect titles can hide explicitly launched OMP or Codex agents.
- Whether tab-level `launchAgent` metadata can incorrectly attribute blank split panes.
- Multi-tab reconnect behavior, folder workspaces, SSH routing, and Electron renderer state boundaries.

The no-op publication feedback was valid and has been fixed with focused regression coverage.

`idle`: The derived row state remains `idle` for sidebar presentation.

Cross-platform behavior was reviewed for macOS, Linux, and Windows. This change does not introduce platform-specific shortcuts, labels, paths, shell commands, or Electron execution-world changes. The production changes remain platform-neutral; only the Docker SSH E2E fixture is POSIX-gated.

## Security Audit

- No new dependencies, IPC channels, authentication flows, or secret handling were introduced.
- No production shell commands or user-controlled command construction were added.
- Reconnect session IDs remain scoped to the affected SSH target and existing provider authority.
- No local-only filesystem assumptions were introduced.
- The E2E commands use the existing shell-quoting helper for generated markers and temporary remote proof paths.

No security follow-up is currently required.

## Notes

The PR now contains three commits:

1. Seed deferred reattach IDs when an SSH target disconnects.
2. Preserve launched agent rows while reconnect titles are blank.
3. Harden no-op handling, split-pane attribution, and multi-tab reconnect coverage.