### PR TITLE
docs(ime): record the IME composition rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,16 @@ When adding or changing a Git command:
 - Keep the real-binary compatibility contract in PR CI current. When adopting a newer Git feature, add its version boundary so the preferred command and fallback both run against representative Git releases.
 - Preserve commands that begin with global Git options such as `-c` before the subcommand, including auto-maintenance suppression used by worktree-create fetches.
 
+## IME Composition
+
+These rules bind any change to keyboard handling, the chat composer, the terminal pane's input path, or the mobile composer.
+
+- Derive committed text from ranges and event data — never by diffing two observations of a mutable buffer. When the evidence is ambiguous, emit nothing.
+- Guard above the key dispatch, not inside each key branch, and guard `keyup` and global `document` listeners too.
+- `attachCustomKeyEventHandler` returning `false` does **not** call `preventDefault()`, and it bypasses xterm's `CompositionHelper` entirely. Pair the two deliberately.
+- Never normalize IME output at commit. Normalize only at path handling and equality/search comparison.
+- Add a recorded event-trace fixture for the trace that motivated the change, plus a paired negative test proving non-IME behavior is unchanged.
+
 ## Git Provider Compatibility
 
 Source-control and review changes must consider GitLab and other supported git providers, not only GitHub. Keep provider-specific behavior behind explicit checks, and avoid GitHub-only naming for generic review concepts.


### PR DESCRIPTION
## Summary

Adds an **IME Composition** section to `AGENTS.md`: five invariants that every fix in this stack depends on, each of which was violated somewhere in the codebase before it.

The one that keeps recurring is the first. Committed text was being derived by diffing two observations of a mutable buffer — read the textarea, let the engine write, read it again, subtract. That races the engine, so it silently drops or doubles characters depending on when the reads land. The rule is to derive it from ranges and event `data` instead, and to emit nothing when the evidence is ambiguous.

The other four:

- Guard **above** the key dispatch, not inside each key branch — and guard `keyup` and global `document` listeners too, which is where the misses were.
- `attachCustomKeyEventHandler` returning `false` does **not** call `preventDefault()`, and it bypasses xterm's `CompositionHelper` entirely. Two separate effects that have to be paired deliberately.
- Never normalize IME output at commit. Normalize only at path handling and equality/search comparison.
- Add an event-trace fixture plus a paired negative test proving non-IME behavior is unchanged.

## Screenshots

No code change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — not run
- [ ] Added or updated high-quality tests — not applicable, documentation only

## AI Review Report

Each rule traces to a specific defect this stack found and fixed, not to a general principle applied on faith: composition state that outlived its element, a suppression set that was implicit rather than enumerated, a guard placed inside a key branch instead of above the dispatch, and an ownership check that tested `isComposing` alone.

## Security Audit

Documentation only. No code, dependency, IPC, or path changes.

## Notes

Bottom of stack #11899. The longer-form design document that accompanied this work is deliberately **not** committed — `docs/**` is gitignored here, and the durable, enforceable part is the rule list above. The rest was analysis scaffolding.

