### PR TITLE
fix(ime): stop dropping and splitting composition commits in the terminal

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
@@ -149,6 +149,35 @@ describe('installTerminalImeCompositionRoute', () => {
     expect(harness.input).not.toHaveBeenCalled()
   })
 
+  it('leaves an uncaptured session to xterm when installed mid-composition', () => {
+    const harness = createHarness()
+
+    // No start was seen, so nothing here can deliver the text. Cancelling the event
+    // would suppress xterm's own insertion and drop the commit on the floor.
+    const notPrevented = harness.end(1, '한')
+
+    expect(notPrevented).toBe(true)
+    expect(harness.input).not.toHaveBeenCalled()
+  })
+
+  it('suppresses xterm insertion only for a session it captured', () => {
+    const harness = createHarness()
+    harness.start(1)
+
+    expect(harness.end(1, '한')).toBe(false)
+    expect(harness.input).toHaveBeenCalledWith('한')
+  })
+
+  it('keeps suppressing insertion for a captured session it deliberately drops', () => {
+    const harness = createHarness()
+    harness.start(1)
+    harness.state.currentTransport = createTransport('pty-replacement')
+
+    // Owned, so xterm must still stand down — the drop is this route's decision.
+    expect(harness.end(1, '한')).toBe(false)
+    expect(harness.input).not.toHaveBeenCalled()
+  })
+
   it.each(['terminal close', 'tab unmount'])(
     'releases the captured session and listeners on %s',
     () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
@@ -82,11 +82,13 @@ export function installTerminalImeCompositionRoute(args: {
     if (!detail) {
       return
     }
-    event.preventDefault()
     const captured = sessions.get(detail.id)
     if (!captured) {
+      // Not our session — the route was installed mid-composition, so no start was seen.
+      // Preventing default here would suppress xterm's insertion with nothing to replace it.
       return
     }
+    event.preventDefault()
     sessions.delete(detail.id)
     adjustPendingCompositionCount(terminalElement, -1)
     if (

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -116,6 +116,114 @@ describe('sendTerminalInputAfterComposition', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
+  it('re-arms past the fallback rather than splitting a still-pending composition', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1, data: '한' } })
+    )
+
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 1000 })
+    vi.advanceTimersByTime(500)
+
+    // A slow candidate window is not a reason to send Enter into the middle of the preedit.
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_END_EVENT, { detail: { id: 1, data: '한' } })
+    )
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
+  it('holds the newline through a long conversion that keeps updating its preedit', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1, data: 'にほん' } })
+    )
+
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+
+    // Multi-segment bunsetsu conversion: each segment takes longer than the ceiling
+    // in total, but never leaves the preedit idle for a full ceiling's worth.
+    for (let segment = 0; segment < 6; segment += 1) {
+      vi.advanceTimersByTime(150)
+      el.dispatchEvent(new Event('compositionupdate'))
+    }
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_END_EVENT, { detail: { id: 1, data: '日本' } })
+    )
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
+  it('holds for a composition already in flight when nothing recorded its session start', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    // No route installed, so there is no pending session to report — the live
+    // compositionupdate is the only evidence the composition exists.
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+    for (let tick = 0; tick < 5; tick += 1) {
+      vi.advanceTimersByTime(30)
+      el.dispatchEvent(new Event('compositionupdate'))
+    }
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends once at the ceiling when a composition never ends', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1, data: '한' } })
+    )
+
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+    vi.advanceTimersByTime(150)
+    expect(send).not.toHaveBeenCalled()
+
+    // Bounded: a composition that stops progressing must not strand the keystroke.
+    vi.advanceTimersByTime(100)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
   it('still delivers the input on the next macrotask without a terminal element', () => {
     const send = vi.fn()
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -5,18 +5,29 @@ import {
 
 export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
 
+// Ceiling for a composition that stops making progress. Measured from the last
+// compositionupdate, not from the start: multi-segment bunsetsu conversion keeps a
+// Japanese composition legitimately pending far longer than this, and finishing on a
+// total-elapsed ceiling would split it with the newline this deferral exists to hold back.
+export const TERMINAL_IME_DEFERRED_NEWLINE_MAX_IDLE_MS = 2000
+
 export function sendTerminalInputAfterComposition(
   terminalElement: HTMLElement | null | undefined,
   send: () => void,
-  options?: { fallbackMs?: number }
+  options?: { fallbackMs?: number; maxIdleMs?: number }
 ): void {
   if (!terminalElement) {
     window.setTimeout(send, 0)
     return
   }
 
-  const fallbackMs = options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS
+  const fallbackMs = Math.max(1, options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS)
+  const maxIdleMs = Math.max(
+    fallbackMs,
+    options?.maxIdleMs ?? TERMINAL_IME_DEFERRED_NEWLINE_MAX_IDLE_MS
+  )
   let done = false
+  let idleMs = 0
 
   const finish = (): void => {
     if (done) {
@@ -24,6 +35,7 @@ export function sendTerminalInputAfterComposition(
     }
     done = true
     terminalElement.removeEventListener('compositionend', onCompositionEnd)
+    terminalElement.removeEventListener('compositionupdate', onCompositionUpdate)
     terminalElement.removeEventListener(
       XTERM_COMPOSITION_SESSION_END_EVENT,
       onCompositionSessionEnd
@@ -40,9 +52,33 @@ export function sendTerminalInputAfterComposition(
   }
   const onCompositionEnd = (): void => finishAfterPendingComposition()
   const onCompositionSessionEnd = (): void => finishAfterPendingComposition()
+  // Each preedit change proves the composition is still progressing, so the idle
+  // ceiling only ever expires on a composition that is genuinely stuck.
+  let sawRecentUpdate = false
+  const onCompositionUpdate = (): void => {
+    idleMs = 0
+    sawRecentUpdate = true
+  }
   terminalElement.addEventListener('compositionend', onCompositionEnd)
+  terminalElement.addEventListener('compositionupdate', onCompositionUpdate)
   terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onCompositionSessionEnd)
-  const fallbackTimer = window.setTimeout(finish, fallbackMs)
+
+  // Re-arm rather than sending: firing mid-composition splits the preedit with a newline.
+  const onFallbackDeadline = (): void => {
+    idleMs += fallbackMs
+    // A live compositionupdate counts as evidence on its own: a route installed while a
+    // composition was already in flight never saw that session start, so it has nothing
+    // recorded to report as pending.
+    const compositionInProgress =
+      hasPendingTerminalImeComposition(terminalElement) || sawRecentUpdate
+    sawRecentUpdate = false
+    if (!compositionInProgress || idleMs >= maxIdleMs) {
+      finish()
+      return
+    }
+    fallbackTimer = window.setTimeout(onFallbackDeadline, fallbackMs)
+  }
+  let fallbackTimer = window.setTimeout(onFallbackDeadline, fallbackMs)
 }
 
 export type TerminalImeDeferredNewlineSender = {


### PR DESCRIPTION
## Summary

Three terminal IME bugs, all of which corrupt committed CJK text.

**1. Dropped commits after a transport swap.** The composition route delivered a finished commit to whatever transport was current at delivery time. If the pty was swapped mid-composition, the text landed on the wrong pty. The route now checks transport identity and ownership before delivering, and deliberately drops when the captured transport is gone — that drop is the route's decision to make, rather than silently writing to a stranger.

**2. Newlines split the preedit.** The deferred-newline fallback called `finish` directly, bypassing the pending-composition re-check the event path uses. A composition still open at 200 ms got a newline sent into the middle of its preedit — you press Enter, and your half-converted Japanese gets cut in two with a line break through it.

The deadline now re-arms while a composition is pending. Its 2 s ceiling is measured **from the last `compositionupdate`, not from the start**: multi-segment bunsetsu conversion legitimately keeps a Japanese composition pending far longer than any fixed total-elapsed budget, so a wall-clock ceiling would reintroduce exactly the split it is meant to prevent. A composition that stops progressing still cannot strand the keystroke.

**3. Compositions already in flight when the route installs.** The re-arm asked the route whether a composition was pending, but a route installed mid-composition never saw that session start, so it had nothing recorded to report — and the deadline split that composition too. A live `compositionupdate` now counts as evidence in its own right.

## Screenshots

No visual change in the UI chrome. The user-visible effect is in terminal text: committed CJK no longer lands on the wrong pty or gets bisected by a newline.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 2905 passing across the terminal-pane and IME suites
- [ ] `pnpm build` — not run
- [x] Added or updated high-quality tests that would catch regressions

On the idle ceiling specifically: the new test (`holds the newline through a long conversion that keeps updating its preedit`) was verified to **fail** without the fix and pass with it, so it is a real regression test rather than a tautology.

## AI Review Report

A review subagent found the wall-clock ceiling bug in my own first version of this PR — the original 2 s budget was absolute, which would split any conversion running longer than 2 s. A total-elapsed ceiling is the wrong shape for this: composition length is a property of what the user is typing, not of anything going wrong. The bound that is actually meaningful is idle time — a composition that has stopped progressing. Fixed here, with the regression test above.

Also verified while fixing it: xterm's own `CompositionHelper.blur():245-247` already finalizes on blur, so the original "compositionend is not guaranteed on focus loss" rationale was not the real justification for the ceiling. The comment now states the actual one — a composition that stops progressing.

Cross-platform: the deferral is driven by DOM composition events and the xterm session events, both platform-neutral. SSH and folder-workspace cases are unaffected — the route keys on transport identity, which is the same abstraction for local, SSH, and relay ptys, and the drop-on-missing-transport path is what makes an SSH reconnect safe.

## Security Audit

- **IPC / transport**: this is the security-relevant part, and it improves. Previously a commit could be written to a transport other than the one that owned the composition; the ownership + identity check closes that. Writing input to the wrong pty is a real confidentiality concern when the swapped-in pty is a different host or a different user's shell over SSH.
- **Input handling**: composed text is passed through unmodified. Per the IME rules it is deliberately **not** normalized at commit — normalization happens only at path handling and equality comparison, so no normalization-based bypass is introduced here.
- No command execution, auth, secrets, or dependency changes.

## Notes

Base: #11895. Depends on #11894 for the readable `CompositionHelper` source.

