### PR TITLE
fix(ime): let Escape reach the shell when the composition flag has drifted

### DIFF
--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -229,6 +229,24 @@ describe('shouldSuppressTerminalImeKeyboardEvent — macOS', () => {
     ).toBe(true)
   })
 
+  it('lets an unmarked Escape through so a drifted flag cannot strand vim in insert mode', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(event({ key: 'Escape', code: 'Escape' }), composing)
+    ).toBe(false)
+  })
+
+  it.each([
+    ['isComposing', { isComposing: true }],
+    ['the Process marker', { key: 'Process', keyCode: 229 }]
+  ])('still suppresses an Escape the IME marks with %s', (_label, marker) => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Escape', code: 'Escape', ...marker }),
+        composing
+      )
+    ).toBe(true)
+  })
+
   it('does not suppress ordinary text keys solely because composition is active', () => {
     expect(
       shouldSuppressTerminalImeKeyboardEvent(event({ key: 'a', code: 'KeyA' }), composing)

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -59,6 +59,23 @@ export type XtermImeKeyboardOptions = {
 
 export const TERMINAL_INTERRUPT_INPUT = '\x03'
 const TERMINAL_MODIFIER_KEYS = new Set(['Alt', 'AltGraph', 'Control', 'Meta', 'Shift'])
+// Keys an open candidate window consumes: navigation, commit, and preedit editing.
+//
+// Escape is deliberately absent. An Escape the IME really owns arrives marked
+// (isComposing, or keyCode 229 / key 'Process') and is already suppressed by the
+// clauses below. An unmarked one means this derived flag has drifted — compositionend
+// is not guaranteed, so the flag can stand until the tracker's stale expiry. Swallowing
+// Escape that long strands vim in insert mode with no recovery.
+//
+// Letting it through bounds recovery by keystrokes instead. Escape skips the finalize
+// path the other keys take: our xterm patch cancels on Escape
+// (CompositionHelper.keydown:278) whenever xterm still has a composition in flight,
+// discarding the preedit and swallowing the key. That cancel clears xterm's own flag
+// but not this tracker, so the next Escape gets through — worst case one extra
+// keypress, and none at all when only this tracker drifted.
+//
+// The general rule this follows: suppress on the per-event markers the IME actually
+// sets, and let a key with no marker through rather than trusting derived state.
 const TERMINAL_IME_OWNED_KEYS = new Set([
   'ArrowDown',
   'ArrowLeft',
@@ -68,7 +85,6 @@ const TERMINAL_IME_OWNED_KEYS = new Set([
   'Delete',
   'End',
   'Enter',
-  'Escape',
   'Home',
   'PageDown',
   'PageUp'


### PR DESCRIPTION
## Summary

Escape was suppressed in the terminal whenever the derived composition flag was set. That flag is not the per-event `isComposing` bit — it is tracked from composition events, and `compositionend` is not guaranteed, so it can stand until the tracker's 10 s stale expiry. For up to that long Escape never reached the pty, vim could not leave insert mode, and there was no way to recover.

Escape is now removed from `TERMINAL_IME_OWNED_KEYS`. An Escape the IME really owns still arrives *marked* — by `isComposing`, or `keyCode 229` / `key 'Process'` — and the existing clauses still suppress it. An unmarked Escape only ever means the flag has drifted.

## What letting it through actually costs

Escape does **not** take the finalize-then-encode path the other IME-owned keys take. Our vendored xterm build gives it its own branch in `CompositionHelper.keydown` ([`:278-282`](https://github.com/stablyai/orca/pull/11894)), ahead of the `_finalizeComposition` fall-through. While xterm still believes a composition is in flight, that branch cancels — discarding the preedit and returning `false` — and `CoreBrowserTerminal._keyDown:875-879` then returns before `evaluateKeyDown`, so no `\x1b` is written.

The cancel clears xterm's `_isComposing` but not the terminal's tracker, so **the next Escape passes through**. Worst case is one extra keypress; when only the tracker drifted and xterm has already settled, the first Escape reaches the shell. Either way recovery is bounded by keystrokes instead of by a 10 s timer.

The rest of the IME-owned set — arrows, Backspace, Delete, Enter, Home/End, PageUp/PageDown — is unchanged. Those are candidate-window keys, and forwarding them mid-composition is exactly what the set exists to prevent.

## Screenshots

No visual change. Behavioral: Escape reaches the shell instead of being swallowed.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 28 passing in `xterm-bypass-policy.test.ts`, 2905 across the terminal-pane and IME suites
- [ ] `pnpm build` — not run
- [x] Added or updated high-quality tests that would catch regressions — a positive test (unmarked Escape passes) paired with negative tests (Escape marked by `isComposing`, `229`, and `'Process'` is still suppressed)

## AI Review Report

This PR's stated rationale was **wrong in its first version and a review subagent caught it**, which is worth flagging explicitly for reviewers.

The original claim was that `CompositionHelper.keydown` finalizes an in-flight composition before returning true, so the preedit would be committed and the Escape encoded after it. That is true of upstream xterm and true of the other keys — but false for Escape in *our patched build*, because our patch adds the cancel branch at `:278` three lines above the block that was traced. I re-verified this directly against `node_modules/@xterm/xterm/src/browser/input/CompositionHelper.ts` rather than taking the reviewer's word for it, and confirmed the full chain including the early return at `CoreBrowserTerminal._keyDown:875-879`. The commit message, the code comment, and the architecture doc in #11893 were all corrected.

The change itself was correct throughout; only the reasoning was wrong. Swallowing Escape for a 10 s window with no recovery is strictly worse than costing at most one extra keypress.

The general rule this follows: guard every key at the top of keydown on evidence the event itself carries, and keep the suppression set enumerated rather than implicit. Under that rule Escape does not belong in the set — an Escape the IME really owns arrives marked and is suppressed by the marker clauses; an unmarked one only ever means our derived flag has drifted. Orca's terminal guard is unusual in consulting a derived flag that can outlive the composition at all, which is exactly why Escape must not be suppressed on that flag alone.

Cross-platform: the marked-Escape clauses cover the Windows (`229`) and Android (`'Process'`) markers as well as `isComposing`, so IME-owned Escape stays suppressed on all three platforms. No `metaKey` or path handling in this diff.

## Security Audit

- **Input handling**: sends `\x1b` to the pty in a case where it was previously swallowed. Escape is not a privileged or destructive byte, and the user pressed the key — this restores intended input rather than synthesizing it.
- No command execution, path handling, auth, secrets, dependency, or IPC changes.

## Notes

Base: #11896. Reviewers wanting to check the xterm trace should read the `src` patch from #11894.


