### PR TITLE
feat(linear): remember Linear project per Orca project in the New Issue modal

### DIFF
--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -690,7 +690,9 @@ const LocalWindowsRuntimePreferenceIpcArgs = z.discriminatedUnion('kind', [
 const ProjectUpdateIpcArgs = z.object({
   projectId: z.string().min(1),
   updates: z.object({
-    localWindowsRuntimePreference: LocalWindowsRuntimePreferenceIpcArgs.optional()
+    localWindowsRuntimePreference: LocalWindowsRuntimePreferenceIpcArgs.optional(),
+    defaultLinearProjectId: z.string().min(1).nullable().optional(),
+    defaultLinearProjectWorkspaceId: z.string().min(1).nullable().optional()
   })
 })
 

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -525,6 +525,63 @@ describe('Store', () => {
     })
   })
 
+  it('preserves a project Linear default across the repo-backed projection on load', async () => {
+    // Why: repo-backed projects are re-derived from repos on every load; persisted-only fields must be carried back or they vanish.
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      repos: [makeRepo({ id: 'r1', path: '/repo', displayName: 'Repo' })],
+      projects: [
+        makeProject({
+          id: 'repo:r1',
+          displayName: 'Repo',
+          sourceRepoIds: ['r1'],
+          defaultLinearProjectId: 'lin-proj-1',
+          defaultLinearProjectWorkspaceId: 'ws-1'
+        })
+      ],
+      projectHostSetups: []
+    })
+
+    const store = await createStore()
+
+    const projected = store.getProjects().find((project) => project.id === 'repo:r1')
+    expect(projected?.defaultLinearProjectId).toBe('lin-proj-1')
+    expect(projected?.defaultLinearProjectWorkspaceId).toBe('ws-1')
+  })
+
+  it('updates, persists, and clears a project Linear issue default', async () => {
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      repos: [makeRepo({ id: 'r1', path: '/repo', displayName: 'Repo' })],
+      projects: [makeProject({ id: 'repo:r1', displayName: 'Repo', sourceRepoIds: ['r1'] })],
+      projectHostSetups: []
+    })
+    const store = await createStore()
+
+    const updated = store.updateProject('repo:r1', {
+      defaultLinearProjectId: 'lin-proj-2',
+      defaultLinearProjectWorkspaceId: 'ws-2'
+    })
+
+    expect(updated?.defaultLinearProjectId).toBe('lin-proj-2')
+    expect(updated?.defaultLinearProjectWorkspaceId).toBe('ws-2')
+    store.flush()
+    const reloaded = await createStore()
+    const reloadedProject = reloaded.getProjects().find((project) => project.id === 'repo:r1')
+    expect(reloadedProject?.defaultLinearProjectId).toBe('lin-proj-2')
+    expect(reloadedProject?.defaultLinearProjectWorkspaceId).toBe('ws-2')
+
+    reloaded.updateProject('repo:r1', {
+      defaultLinearProjectId: null,
+      defaultLinearProjectWorkspaceId: null
+    })
+    reloaded.flush()
+    const cleared = await createStore()
+    const clearedProject = cleared.getProjects().find((project) => project.id === 'repo:r1')
+    expect(clearedProject?.defaultLinearProjectId).toBeUndefined()
+    expect(clearedProject?.defaultLinearProjectWorkspaceId).toBeUndefined()
+  })
+
   it('migrates legacy WSL agent settings into the global Windows runtime default', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2287,13 +2287,29 @@ function mergeProjectHostSetupCompatibilityState(
     }))
   const projectedProjects = projection.projects.map((project) => {
     const existingProject = existingProjectsById.get(project.id)
-    return existingProject?.localWindowsRuntimePreference
-      ? {
-          ...project,
-          localWindowsRuntimePreference: existingProject.localWindowsRuntimePreference,
-          updatedAt: Math.max(project.updatedAt, existingProject.updatedAt)
-        }
-      : project
+    // Why: repo-backed projects are re-derived from repos on every load, so persisted-only fields must be copied back onto the fresh projection or they vanish from in-memory state.
+    if (!existingProject) {
+      return project
+    }
+    const hasRuntimePref = Boolean(existingProject.localWindowsRuntimePreference)
+    const hasLinearDefault = Boolean(existingProject.defaultLinearProjectId)
+    if (!hasRuntimePref && !hasLinearDefault) {
+      return project
+    }
+    const merged: Project = {
+      ...project,
+      updatedAt: Math.max(project.updatedAt, existingProject.updatedAt)
+    }
+    if (hasRuntimePref) {
+      merged.localWindowsRuntimePreference = existingProject.localWindowsRuntimePreference
+    }
+    if (hasLinearDefault) {
+      merged.defaultLinearProjectId = existingProject.defaultLinearProjectId
+      if (existingProject.defaultLinearProjectWorkspaceId != null) {
+        merged.defaultLinearProjectWorkspaceId = existingProject.defaultLinearProjectWorkspaceId
+      }
+    }
+    return merged
   })
   return {
     projects: [...projectedProjects, ...independentProjects],
@@ -3717,6 +3733,28 @@ export class Store {
         project.localWindowsRuntimePreference = normalizeProjectRuntimePreference(
           updates.localWindowsRuntimePreference
         )
+      }
+    }
+    if ('defaultLinearProjectId' in updates) {
+      const value = updates.defaultLinearProjectId
+      if (value == null) {
+        delete project.defaultLinearProjectId
+        delete project.defaultLinearProjectWorkspaceId
+      } else {
+        project.defaultLinearProjectId = value
+        const workspaceId = updates.defaultLinearProjectWorkspaceId ?? null
+        if (workspaceId) {
+          project.defaultLinearProjectWorkspaceId = workspaceId
+        } else {
+          delete project.defaultLinearProjectWorkspaceId
+        }
+      }
+    } else if ('defaultLinearProjectWorkspaceId' in updates) {
+      const workspaceId = updates.defaultLinearProjectWorkspaceId
+      if (workspaceId == null) {
+        delete project.defaultLinearProjectWorkspaceId
+      } else {
+        project.defaultLinearProjectWorkspaceId = workspaceId
       }
     }
     project.updatedAt = Date.now()

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -43,7 +43,9 @@ const LocalWindowsRuntimePreference = z.discriminatedUnion('kind', [
 const ProjectUpdate = z.object({
   projectId: requiredString('Missing project ID'),
   updates: z.object({
-    localWindowsRuntimePreference: LocalWindowsRuntimePreference.optional()
+    localWindowsRuntimePreference: LocalWindowsRuntimePreference.optional(),
+    defaultLinearProjectId: z.string().min(1).nullable().optional(),
+    defaultLinearProjectWorkspaceId: z.string().min(1).nullable().optional()
   })
 })
 

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -43,6 +43,45 @@ describe('repo RPC methods', () => {
     })
   })
 
+  it('updates a project Linear issue default on the runtime server', async () => {
+    const project = {
+      id: 'project-1',
+      displayName: 'Project',
+      badgeColor: '#737373',
+      sourceRepoIds: [],
+      createdAt: 1,
+      updatedAt: 2,
+      defaultLinearProjectId: 'lin-proj-1',
+      defaultLinearProjectWorkspaceId: 'ws-1'
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateProject: vi.fn().mockReturnValue(project)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('project.update', {
+        projectId: 'project-1',
+        updates: {
+          defaultLinearProjectId: 'lin-proj-1',
+          defaultLinearProjectWorkspaceId: 'ws-1'
+        }
+      })
+    )
+
+    expect(runtime.updateProject).toHaveBeenCalledWith('project-1', {
+      defaultLinearProjectId: 'lin-proj-1',
+      defaultLinearProjectWorkspaceId: 'ws-1'
+    })
+    expect(response).toMatchObject({
+      ok: true,
+      result: {
+        project: { id: 'project-1', defaultLinearProjectId: 'lin-proj-1' }
+      }
+    })
+  })
+
   it('creates a repo on the runtime server', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3088,6 +3088,8 @@ export default function TaskPage(): React.JSX.Element {
   const allWorktrees = useAllWorktrees()
   const openModal = useAppStore((s) => s.openModal)
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const projects = useAppStore((s) => s.projects)
+  const updateProject = useAppStore((s) => s.updateProject)
   const fetchWorkItemsAcrossRepos = useAppStore((s) => s.fetchWorkItemsAcrossRepos)
   const fetchPRChecks = useAppStore((s) => s.fetchPRChecks)
   const getCachedWorkItems = useAppStore((s) => s.getCachedWorkItems)
@@ -3458,6 +3460,24 @@ export default function TaskPage(): React.JSX.Element {
       .find((context): context is TaskSourceContext => context !== null)
     return firstRepoContext?.projectId ?? 'account-backed-task-source'
   }, [selectedRepos])
+  // Why: the Linear-project default is only meaningful when a real Orca project is in scope; the sentinel marks account-backed mode with no project.
+  const activeOrcaProjectId =
+    fallbackTaskSourceProjectId === 'account-backed-task-source'
+      ? null
+      : fallbackTaskSourceProjectId
+  const activeOrcaLinearDefault = useMemo(() => {
+    if (!activeOrcaProjectId) {
+      return null
+    }
+    const project = projects.find((entry) => entry.id === activeOrcaProjectId)
+    if (!project?.defaultLinearProjectId) {
+      return null
+    }
+    return {
+      projectId: project.defaultLinearProjectId,
+      workspaceId: project.defaultLinearProjectWorkspaceId ?? null
+    }
+  }, [activeOrcaProjectId, projects])
   const linearTaskSourceContext = useMemo(
     () =>
       normalizeTaskSourceContext({
@@ -5651,6 +5671,7 @@ export default function TaskPage(): React.JSX.Element {
   const [newLinearIssuePriority, setNewLinearIssuePriority] = useState<number>(0)
   const [newLinearIssueProjectId, setNewLinearIssueProjectId] = useState<string | null>(null)
   const [newLinearIssueLabelIds, setNewLinearIssueLabelIds] = useState<string[]>([])
+  const [newLinearIssueRememberProject, setNewLinearIssueRememberProject] = useState(false)
 
   const newLinearIssueTargetTeam = useMemo(
     () => availableTeams.find((t) => t.id === newLinearIssueTeamId) ?? availableTeams[0] ?? null,
@@ -5706,11 +5727,22 @@ export default function TaskPage(): React.JSX.Element {
       selectedLinearProject.workspaceId === newLinearIssueTargetTeam?.workspaceId
     ) {
       setNewLinearIssueProjectId(selectedLinearProject.id)
+    } else if (
+      activeOrcaLinearDefault &&
+      newLinearIssueTargetTeam?.workspaceId != null &&
+      newLinearIssueTargetTeam?.workspaceId === activeOrcaLinearDefault.workspaceId
+    ) {
+      setNewLinearIssueProjectId(activeOrcaLinearDefault.projectId)
     } else {
       setNewLinearIssueProjectId(null)
     }
     setNewLinearIssueLabelIds([])
-  }, [newLinearIssueTargetTeam?.id, newLinearIssueTargetTeam?.workspaceId, selectedLinearProject])
+  }, [
+    newLinearIssueTargetTeam?.id,
+    newLinearIssueTargetTeam?.workspaceId,
+    selectedLinearProject,
+    activeOrcaLinearDefault
+  ])
 
   const newLinearStates = useTeamStates(
     linearConnected ? newLinearIssueTargetTeam?.id || null : null,
@@ -5807,6 +5839,7 @@ export default function TaskPage(): React.JSX.Element {
       setNewLinearIssuePriority(0)
       setNewLinearIssueProjectId(null)
       setNewLinearIssueLabelIds([])
+      setNewLinearIssueRememberProject(false)
       setNewLinearIssueProjects([])
       setNewLinearIssueProjectsLoading(false)
       setNewLinearIssueSubmitting(false)
@@ -6968,6 +7001,14 @@ export default function TaskPage(): React.JSX.Element {
             : undefined
         }
       )
+      if (newLinearIssueRememberProject && activeOrcaProjectId) {
+        // Why: fire-and-forget; the toggle only shows when an Orca project is in scope, so persisting links that project to the chosen Linear project for next time.
+        void updateProject(activeOrcaProjectId, {
+          defaultLinearProjectId: newLinearIssueProjectId ?? null,
+          defaultLinearProjectWorkspaceId:
+            (newLinearIssueProjectId && newLinearIssueTargetTeam?.workspaceId) || null
+        })
+      }
       setNewLinearIssueOpen(false)
       setNewLinearIssueTitle('')
       setNewLinearIssueBody('')
@@ -6976,6 +7017,7 @@ export default function TaskPage(): React.JSX.Element {
       setNewLinearIssuePriority(0)
       setNewLinearIssueProjectId(null)
       setNewLinearIssueLabelIds([])
+      setNewLinearIssueRememberProject(false)
       setLinearRefreshNonce((n) => n + 1)
       useAppStore.getState().recordFeatureInteraction('linear-tasks')
 
@@ -7009,6 +7051,9 @@ export default function TaskPage(): React.JSX.Element {
     newLinearIssueAssigneeId,
     newLinearIssueProjectId,
     newLinearIssueLabelIds,
+    newLinearIssueRememberProject,
+    activeOrcaProjectId,
+    updateProject,
     providerRuntimeContextKey,
     selectedLinearProject,
     setSelectedLinearIssue,
@@ -8529,16 +8574,27 @@ export default function TaskPage(): React.JSX.Element {
                                 }
                                 setNewLinearIssueTitle('')
                                 setNewLinearIssueBody('')
+                                const defaultLinearWorkspaceId =
+                                  activeOrcaLinearDefault?.workspaceId ?? null
                                 const projectTeamId =
                                   selectedLinearProject?.teams?.[0]?.id ??
                                   availableTeams.find(
                                     (team) =>
-                                      team.workspaceId === selectedLinearProject?.workspaceId
+                                      team.workspaceId === selectedLinearProject?.workspaceId ||
+                                      (defaultLinearWorkspaceId != null &&
+                                        team.workspaceId === defaultLinearWorkspaceId)
                                   )?.id
                                 setNewLinearIssueTeamId(
                                   projectTeamId ?? availableTeams[0]?.id ?? null
                                 )
-                                setNewLinearIssueProjectId(selectedLinearProject?.id ?? null)
+                                setNewLinearIssueProjectId(
+                                  selectedLinearProject?.id ??
+                                    activeOrcaLinearDefault?.projectId ??
+                                    null
+                                )
+                                setNewLinearIssueRememberProject(
+                                  activeOrcaProjectId != null && activeOrcaLinearDefault != null
+                                )
                                 setNewLinearIssueOpen(true)
                               }}
                               disabled={availableTeams.length === 0}
@@ -11984,6 +12040,35 @@ export default function TaskPage(): React.JSX.Element {
                       ))}
                     </div>
                   )}
+                  {activeOrcaProjectId ? (
+                    <>
+                      <div className="my-1 h-px bg-border/60" />
+                      <button
+                        type="button"
+                        role="checkbox"
+                        aria-checked={newLinearIssueRememberProject}
+                        disabled={newLinearIssueSubmitting}
+                        onClick={() => setNewLinearIssueRememberProject((v) => !v)}
+                        className="w-full flex items-center gap-2 text-left px-2 py-1.5 text-xs rounded-sm hover:bg-muted transition-colors text-foreground/80 disabled:opacity-50"
+                      >
+                        <span
+                          className={`flex size-3.5 flex-shrink-0 items-center justify-center rounded-[3px] border transition-colors ${
+                            newLinearIssueRememberProject
+                              ? 'border-foreground bg-foreground text-background'
+                              : 'border-border/80'
+                          }`}
+                        >
+                          {newLinearIssueRememberProject ? <Check className="size-3" /> : null}
+                        </span>
+                        <span>
+                          {translate(
+                            'auto.components.TaskPage.linearRememberProject',
+                            'Remember for this Orca project'
+                          )}
+                        </span>
+                      </button>
+                    </>
+                  ) : null}
                 </PopoverContent>
               </Popover>
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1825,7 +1825,8 @@
         "jiraToggleSortDirection": "Sort {{value0}}",
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
-        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved."
+        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
+        "linearRememberProject": "Remember for this Orca project"
       },
       "Terminal": {
         "73768427cf": "Close",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1802,7 +1802,8 @@
         "jiraToggleSortDirection": "Ordenar de forma {{value0}}",
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
-        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved."
+        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
+        "linearRememberProject": "Remember for this Orca project"
       },
       "Terminal": {
         "73768427cf": "Cerrar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1802,7 +1802,8 @@
         "jiraToggleSortDirection": "{{value0}}に並べ替え",
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
-        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved."
+        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
+        "linearRememberProject": "Remember for this Orca project"
       },
       "Terminal": {
         "73768427cf": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1802,7 +1802,8 @@
         "jiraToggleSortDirection": "{{value0}}으로 정렬",
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
-        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved."
+        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
+        "linearRememberProject": "Remember for this Orca project"
       },
       "Terminal": {
         "73768427cf": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1802,7 +1802,8 @@
         "jiraToggleSortDirection": "按{{value0}}排序",
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
-        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved."
+        "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
+        "linearRememberProject": "Remember for this Orca project"
       },
       "Terminal": {
         "73768427cf": "关闭",

--- a/src/renderer/src/store/slices/repos-project-runtime.test.ts
+++ b/src/renderer/src/store/slices/repos-project-runtime.test.ts
@@ -322,4 +322,66 @@ describe('repo slice project runtime updates', () => {
     expect(store.getState().projects[0]?.sourceRepoIds).toEqual(['local-repo', 'remote-repo'])
     expect(store.getState().projects[0]?.localWindowsRuntimePreference).toBeUndefined()
   })
+
+  it('updates a project Linear issue default through the projects API', async () => {
+    const project: Project = {
+      id: 'project-1',
+      displayName: 'Project',
+      badgeColor: '#000',
+      sourceRepoIds: ['local-repo'],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    projectsUpdate.mockResolvedValue({
+      ...project,
+      defaultLinearProjectId: 'lin-proj-1',
+      defaultLinearProjectWorkspaceId: 'ws-1'
+    })
+    const store = createTestStore()
+    store.setState({ projects: [project] })
+
+    await store.getState().updateProject(project.id, {
+      defaultLinearProjectId: 'lin-proj-1',
+      defaultLinearProjectWorkspaceId: 'ws-1'
+    })
+
+    expect(store.getState().projects[0]?.defaultLinearProjectId).toBe('lin-proj-1')
+    expect(store.getState().projects[0]?.defaultLinearProjectWorkspaceId).toBe('ws-1')
+    expect(projectsUpdate).toHaveBeenCalledWith({
+      projectId: project.id,
+      updates: { defaultLinearProjectId: 'lin-proj-1', defaultLinearProjectWorkspaceId: 'ws-1' }
+    })
+  })
+
+  it('clears a project Linear issue default without dropping shared source repos', async () => {
+    const project: Project = {
+      id: 'github:stablyai/orca',
+      displayName: 'Orca',
+      badgeColor: '#000',
+      sourceRepoIds: ['local-repo', 'remote-repo'],
+      defaultLinearProjectId: 'lin-proj-1',
+      defaultLinearProjectWorkspaceId: 'ws-1',
+      createdAt: 1,
+      updatedAt: 2
+    }
+    projectsUpdate.mockResolvedValue({
+      id: project.id,
+      displayName: project.displayName,
+      badgeColor: project.badgeColor,
+      sourceRepoIds: ['local-repo'],
+      createdAt: project.createdAt,
+      updatedAt: 3
+    })
+    const store = createTestStore()
+    store.setState({ projects: [project] })
+
+    await store.getState().updateProject(project.id, {
+      defaultLinearProjectId: null,
+      defaultLinearProjectWorkspaceId: null
+    })
+
+    expect(store.getState().projects[0]?.sourceRepoIds).toEqual(['local-repo', 'remote-repo'])
+    expect(store.getState().projects[0]?.defaultLinearProjectId).toBeUndefined()
+    expect(store.getState().projects[0]?.defaultLinearProjectWorkspaceId).toBeUndefined()
+  })
 })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -533,6 +533,30 @@ function mergeUpdatedProjectCompatibilityProject(
       project.localWindowsRuntimePreference = localWindowsRuntimePreference
     }
   }
+  if ('defaultLinearProjectId' in updates) {
+    const value =
+      'defaultLinearProjectId' in updated
+        ? updated.defaultLinearProjectId
+        : updates.defaultLinearProjectId
+    // Why: a clear (null) must win over a stale default preserved from another host by the compatibility merge.
+    if (value == null) {
+      delete project.defaultLinearProjectId
+      delete project.defaultLinearProjectWorkspaceId
+    } else {
+      project.defaultLinearProjectId = value
+    }
+  }
+  if ('defaultLinearProjectWorkspaceId' in updates) {
+    const value =
+      'defaultLinearProjectWorkspaceId' in updated
+        ? updated.defaultLinearProjectWorkspaceId
+        : updates.defaultLinearProjectWorkspaceId
+    if (value == null) {
+      delete project.defaultLinearProjectWorkspaceId
+    } else {
+      project.defaultLinearProjectWorkspaceId = value
+    }
+  }
   return project
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -117,6 +117,12 @@ export type Project = {
   gitRemoteIdentity?: GitRemoteIdentity
   /** Local Windows projects inherit the global runtime default unless this override is set. */
   localWindowsRuntimePreference?: LocalWindowsRuntimePreference
+  /**
+   * Linear project pre-selected by default when filing a new Linear issue from this Orca project.
+   * `null` clears an existing default; absence leaves it untouched.
+   */
+  defaultLinearProjectId?: string | null
+  defaultLinearProjectWorkspaceId?: string | null
   sourceRepoIds: string[]
   createdAt: number
   updatedAt: number
@@ -124,7 +130,12 @@ export type Project = {
 
 export type ProjectUpdateArgs = {
   projectId: string
-  updates: Partial<Pick<Project, 'localWindowsRuntimePreference'>>
+  updates: Partial<
+    Pick<
+      Project,
+      'localWindowsRuntimePreference' | 'defaultLinearProjectId' | 'defaultLinearProjectWorkspaceId'
+    >
+  >
 }
 
 export type ProjectHostSetupState = 'ready' | 'not-set-up' | 'setting-up' | 'error' | 'unsupported'


### PR DESCRIPTION
## Problem

In the **New Linear issue** modal (`src/renderer/src/components/TaskPage.tsx`), the **Project** picker (`newLinearIssueProjectId`) selects a *Linear* project and is submitted as `projectId` to `linearCreateIssue`. Its default is seeded **only** from Tasks-page navigation state (`selectedLinearProject`):

```ts
setNewLinearIssueProjectId(selectedLinearProject?.id ?? null)
```

So whenever a user is not already viewing a specific Linear project, the field starts empty and must be **re-picked on every ticket**. There is no persisted association between an Orca project and a Linear project — the only Linear ↔ Orca link today is issue-level (`Worktree.linkedLinearIssue`, set via *Start workspace from issue*), which is the opposite direction.

Users who always file issues for the same Orca project into the same Linear project repeat the same selection every time.

## Proposal / Solution

Link an Orca project to a Linear project **once**, so the Project field pre-fills automatically for that Orca project. The user can still change it (or clear the link) at any time.

This mirrors the existing `localWindowsRuntimePreference` precedent: an optional, persisted field on the Orca `Project` type that survives the repo-backed projection merge.

### Changes
- **Types** (`src/shared/types.ts`): `Project.defaultLinearProjectId` + `defaultLinearProjectWorkspaceId`; `ProjectUpdateArgs` extended.
- **Persistence** (`src/main/persistence.ts`): carry the fields through `mergeProjectHostSetupCompatibilityState` (the silent drop point where repo-backed projects are re-derived from repos on load) and handle set/clear in `updateProject`.
- **IPC + RPC** (`src/main/ipc/repos.ts`, `src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts`): allow-list the new fields in the zod schemas so SSH/remote hosts can update them via `project.update`.
- **Store** (`src/renderer/src/store/slices/repos.ts`): a clear (`null`) wins over a stale default preserved from another host by the cross-host compatibility merge.
- **Modal UX** (`TaskPage.tsx`):
  - The active Orca project is derived from the existing `fallbackTaskSourceProjectId`. When it is the `account-backed-task-source` sentinel (no repo selected), no Orca project is in scope and the feature stays hidden.
  - On open: if the user isn't viewing a Linear project and the active Orca project has a stored default, seed the picker from it and pick a team in the stored workspace so the project resolves.
  - The team-sync effect re-applies the stored default instead of clobbering it to `null`.
  - A **"Remember for this Orca project"** checkbox is added inside the Project picker (only when an Orca project is in scope), pre-checked when a default already exists.
  - On successful creation with the box checked, `updateProject` persists the current Linear project as the default. Choosing "No Project" with the box checked clears the link.

### Edge cases
- **No Orca project in scope** (account-backed mode): checkbox hidden, no default applied.
- **Stored default in another workspace / deleted project**: existing team/workspace sync degrades gracefully; re-saving updates the link.
- **Cross-host (SSH/remote)**: goes through the same `project.update` path as `localWindowsRuntimePreference`.
- **Clear semantics**: `null`/`undefined` remove the default; "Remember No Project" ≡ clearing.

## Verification
- `pnpm run typecheck` ✅
- `pnpm exec oxlint` on changed files ✅ (no new warnings)
- `pnpm run verify:localization-catalog` / `verify:localization-coverage` ✅ (new key synced across en/es/ja/ko/zh)
- `pnpm run check:max-lines-ratchet` ✅ (no new bypasses)
- Unit tests added and passing (persistence round-trip + projection survival, store update/clear, RPC dispatch): 428 passed ✅

> Note: `pnpm run verify:skill-bundle-manifest` fails in this environment on a clean checkout too — it needs upstream release tags fetched (`Fetch all release tags before regenerating skill artifacts`); unrelated to this change.

## Non-goals
- No change to Linear auth/workspace/team filtering or issue mutation behavior.
- No change to GitHub/Jira create flows.
- No reverse-direction change to "Start workspace from issue".

## Open questions
- Should the link also be surfaced in project settings (e.g. Repository pane) for editing outside the create modal? Left to a follow-up.
- Should the link influence the "Start workspace from issue" default repo? Out of scope.