### PR TITLE
fix(terminal): preserve follow output through streaming refocus

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2971,6 +2971,105 @@
       "demotionRule": "Demote or quarantine if the unit gate flakes without a product bug or harness bug filed to the owner."
     },
     {
+      "id": "terminal-scroll.streaming-refocus-intent",
+      "title": "Streaming refocus preserves follow-output viewport intent",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-rendering",
+      "layer": "renderer-unit-and-electron-e2e",
+      "surfaces": [
+        "terminal lifecycle",
+        "window focus recovery",
+        "hidden-to-visible resume",
+        "xterm write backlog",
+        "scrollback"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon"],
+      "coverageNotes": "Unit coverage proves provider-independent ordering for any PaneManager. Live Electron coverage exercises a local PTY through the daemon on macOS; SSH, WSL, remote-runtime, Linux, and Windows remain unproved for this exact race.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/11753",
+        "https://github.com/stablyai/orca/pull/11915"
+      ],
+      "invariant": "When output is queued during a focus or visibility transition, Orca records the pre-flush viewport intent before xterm parses backlog writes, so a follow-output terminal stays at the bottom and a pinned terminal keeps its prior position.",
+      "oracle": "Unit tests require exactly one intent sync before each queued-output flush. The Electron test injects a transient top-of-buffer xterm wobble during refocus and requires every presented scrollbar frame, including the final rendered output, to remain at the bottom.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts",
+        "pnpm exec electron-vite build --mode e2e",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-streaming-refocus-viewport.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=5"
+      ],
+      "testFiles": [
+        "src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts",
+        "tests/e2e/terminal-streaming-refocus-viewport.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts",
+          "assertions": [
+            "window-wake recovery synchronizes viewport intent exactly once before flushing queued output",
+            "heavy visibility resume synchronizes intent exactly once before flushing queued output"
+          ]
+        },
+        {
+          "file": "tests/e2e/terminal-streaming-refocus-viewport.spec.ts",
+          "assertions": [
+            "phase-one scrollback is visibly ready at the bottom without a fixed sleep",
+            "no presented animation frame moves the scrollbar thumb away from the bottom during refocus",
+            "the final streamed marker renders with the visible scrollbar still at the bottom"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.096,
+          "summary": "14 tests passed, including exact sync count and pre-flush ordering for wake and heavy visibility resume."
+        },
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-streaming-refocus-viewport.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --repeat-each=5",
+          "result": "passed",
+          "durationSeconds": 35.2,
+          "summary": "Five consecutive Electron iterations passed after replacing fixed-time readiness and stale tab capture with deterministic viewport and pane-identity oracles."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "focused renderer unit test or one Electron E2E iteration"
+      },
+      "flakeHistory": {
+        "status": "soaking",
+        "evidence": "Five consecutive local Electron iterations passed; CI soak history is still required before promotion."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The controlled xterm viewport wobble reproduces the pinned-top failure with post-flush intent sampling and passes when intent is latched before the queued write flush."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Wake recovery keeps one O(panes) intent pass before the existing bounded 64 KiB-per-pane flush. Heavy resume removes its second intent pass and keeps the existing bounded 256 KiB-per-pane flush; no polling, timers, subprocesses, IPC, output parsing, fit, or repaint work is added."
+      },
+      "promotionCriteria": [
+        "Collect stable CI soak history for the Electron race gate.",
+        "Run the live oracle on Linux and Windows terminal backends.",
+        "Add live SSH or remote-runtime coverage for queued output during refocus."
+      ],
+      "knownGaps": [
+        "The deterministic wobble uses xterm private buffer state and must be updated if that internal contract changes.",
+        "Live Linux, Windows, SSH, WSL, and remote-runtime execution is not covered for this exact race.",
+        "The Electron gate proves follow-output behavior; adjacent scroll-intent coverage protects pinned viewport behavior."
+      ],
+      "demotionRule": "Demote or quarantine if the Electron oracle flakes without a product bug or harness bug filed to terminal-rendering."
+    },
+    {
       "id": "startup-upgrade.persisted-session-corpus",
       "title": "Current Orca preserves or recovers old production persisted sessions",
       "maturity": "experimental",

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -169,6 +169,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     })
 
     expect(flushTerminalOutput).toHaveBeenCalledOnce()
+    expect(syncTerminalScrollIntentFromViewport).toHaveBeenCalledOnce()
     expect(syncTerminalScrollIntentFromViewport.mock.invocationCallOrder[0]).toBeLessThan(
       flushTerminalOutput.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
     )

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -151,6 +151,49 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
   })
 
+  it('latches viewport intent before refocus recovery flushes streaming output', async () => {
+    const terminal = { name: 'streaming-terminal' }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([{ terminal }])
+    const { syncTerminalScrollIntentFromViewport } = vi.mocked(
+      await import('@/lib/pane-manager/terminal-scroll-intent')
+    )
+    const { flushTerminalOutput } = vi.mocked(
+      await import('@/lib/pane-manager/pane-terminal-output-scheduler')
+    )
+
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: true,
+      clearGlyphAtlases: false
+    })
+
+    expect(flushTerminalOutput).toHaveBeenCalledOnce()
+    expect(syncTerminalScrollIntentFromViewport.mock.invocationCallOrder[0]).toBeLessThan(
+      flushTerminalOutput.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    )
+  })
+
+  it('does not overwrite pre-reveal intent after queuing hidden output', async () => {
+    const terminal = { name: 'hidden-streaming-terminal' }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([{ terminal }])
+    const { syncTerminalScrollIntentFromViewport } = vi.mocked(
+      await import('@/lib/pane-manager/terminal-scroll-intent')
+    )
+    const { flushTerminalOutput } = vi.mocked(
+      await import('@/lib/pane-manager/pane-terminal-output-scheduler')
+    )
+
+    resumeTerminalVisibility(resumeArgs(manager, false))
+
+    expect(flushTerminalOutput).toHaveBeenCalledOnce()
+    expect(syncTerminalScrollIntentFromViewport).toHaveBeenCalledOnce()
+    expect(syncTerminalScrollIntentFromViewport.mock.invocationCallOrder[0]).toBeLessThan(
+      flushTerminalOutput.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    )
+  })
+
   it('resets each pane linkifier hover cache on window wake recovery so links recover without a scroll', () => {
     const first = { name: 'pane-a' }
     const second = { name: 'pane-b' }

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -143,6 +143,8 @@ export function recoverVisibleTerminalWindowWake({
 }: RecoverVisibleTerminalWindowWakeArgs): void {
   // Why: macOS screensaver/display wake can leave xterm visible but with a
   // stale renderer/input surface; Orca's own hidden-state resume never runs.
+  // Why: backlog writes can expose transient viewport geometry while parsing.
+  syncTerminalViewportIntents(manager)
   for (const pane of manager.getPanes()) {
     requestTerminalBacklogRecovery(pane.terminal)
     flushTerminalOutput(pane.terminal, { maxChars: WINDOW_WAKE_FLUSH_CHARS })
@@ -154,7 +156,6 @@ export function recoverVisibleTerminalWindowWake({
       resetTerminalLinkifierHoverState(pane.terminal)
     }
   }
-  syncTerminalViewportIntents(manager)
   manager.resumeRendering()
   // Why: wake re-attaches WebGL — same transient cell-metric wobble guard as the heavy resume.
   manager.fitAllRevealedPanes()
@@ -192,7 +193,7 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
     requestTerminalBacklogRecovery(pane.terminal)
     flushTerminalOutput(pane.terminal, { maxChars: VISIBLE_RESUME_FLUSH_CHARS })
   }
-  syncTerminalViewportIntents(manager)
+  // Intent was latched by the caller before queued writes can expose transient geometry.
   // Resume WebGL immediately so the terminal shows its last-known state
   // on the first painted frame. macOS context creation is ~5 ms; on
   // Windows (ANGLE -> D3D11) it can be 100-500 ms but a deferred resume

--- a/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
+++ b/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
@@ -184,19 +184,19 @@ test.describe('terminal streaming refocus viewport', () => {
     await injectQueuedWriteAndRefocus(orcaPage, tabId, paneKey)
     const frames = await framesPromise
 
-    expect(frames.every((frame) => frame.targetPresented)).toBe(true)
+    expect(frames.filter((frame) => !frame.targetPresented)).toEqual([])
     expect(
-      frames.every(
+      frames.filter(
         (frame) =>
-          frame.thumbTop !== null &&
-          frame.maxThumbTop !== null &&
-          Math.abs(frame.maxThumbTop - frame.thumbTop) <= 2
+          frame.thumbTop === null ||
+          frame.maxThumbTop === null ||
+          Math.abs(frame.maxThumbTop - frame.thumbTop) > 2
       )
-    ).toBe(true)
+    ).toEqual([])
     expect(frames.some((frame) => (frame.maxThumbTop ?? 0) > 1)).toBe(true)
     expect(
-      frames.every((frame) => (frame.maxThumbTop ?? 0) <= 1 || (frame.thumbTop ?? 0) > 1)
-    ).toBe(true)
+      frames.filter((frame) => (frame.maxThumbTop ?? 0) > 1 && (frame.thumbTop ?? 0) <= 1)
+    ).toEqual([])
     await expect
       .poll(() => getTerminalContent(orcaPage, 30_000), { timeout: 15_000 })
       .toContain('REFOCUS_STREAM_DONE')

--- a/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
+++ b/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
@@ -1,0 +1,214 @@
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  execInTerminal,
+  getTerminalContent,
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { waitForTerminalPtyDataInjector } from './helpers/terminal-pty-injection'
+
+const STREAMING_FIXTURE_PATH = path.join(
+  process.cwd(),
+  'tests/e2e/fixtures/streaming-scrollback-fixture.cjs'
+)
+
+type RevealFrame = {
+  targetPresented: boolean
+  thumbTop: number | null
+  maxThumbTop: number | null
+}
+
+async function closeFeatureTips(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    store?.getState().markFeatureTipsSeen(['orca-cli', 'cmd-j-palette', 'voice-dictation'])
+    if (store?.getState().activeModal === 'feature-tips') {
+      store.getState().closeModal()
+    }
+  })
+}
+
+async function activeTerminalTabId(page: Page): Promise<string> {
+  const tabId = await page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    return state?.activeTabType === 'terminal'
+      ? (state.activeTabId ?? null)
+      : worktreeId
+        ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+        : null
+  })
+  if (!tabId) {
+    throw new Error('Active terminal tab unavailable')
+  }
+  return tabId
+}
+
+async function injectQueuedWriteAndRefocus(
+  page: Page,
+  tabId: string,
+  paneKey: string
+): Promise<void> {
+  await page.evaluate(
+    ({ targetTabId, paneKey }) => {
+      const pane = window.__paneManagers?.get(targetTabId)?.getPanes?.()[0]
+      if (!pane) {
+        throw new Error('Hidden terminal pane unavailable')
+      }
+      const terminal = pane.terminal
+      const bufferService = (
+        terminal as typeof terminal & {
+          _core?: {
+            _bufferService?: { buffer?: { ydisp: number }; isUserScrolling: boolean }
+          }
+        }
+      )._core?._bufferService
+      const internalBuffer = bufferService?.buffer
+      if (!internalBuffer || !bufferService) {
+        throw new Error('xterm internal buffer unavailable')
+      }
+      const originalWrite = terminal.write
+      let wobbleApplied = false
+      terminal.write = ((data: string, callback?: () => void) => {
+        terminal.write = originalWrite
+        wobbleApplied = true
+        internalBuffer.ydisp = 0
+        bufferService.isUserScrolling = true
+        if (terminal.buffer.active.viewportY !== 0) {
+          throw new Error('xterm viewport wobble was not observable')
+        }
+        originalWrite.call(terminal, data, callback)
+      }) as typeof terminal.write
+      const injector = (
+        window as Window & {
+          __terminalPtyDataInjection?: {
+            inject: (paneKey: string, data: string) => boolean
+          }
+        }
+      ).__terminalPtyDataInjection
+      const rows = Array.from(
+        { length: 400 },
+        (_, index) => `REFOCUS_STREAM_ROW_${String(index).padStart(4, '0')}_${'x'.repeat(80)}\n`
+      ).join('')
+      if (!injector?.inject(paneKey, `${rows}REFOCUS_STREAM_DONE\n`)) {
+        throw new Error('PTY data injector unavailable')
+      }
+      window.dispatchEvent(new Event('focus'))
+      if (!wobbleApplied) {
+        throw new Error('refocus did not flush the queued xterm write')
+      }
+    },
+    { targetTabId: tabId, paneKey }
+  )
+}
+
+async function sampleRevealFrames(page: Page, targetTabId: string): Promise<RevealFrame[]> {
+  return page.evaluate(
+    (targetTabId) =>
+      new Promise<RevealFrame[]>((resolve) => {
+        const frames: RevealFrame[] = []
+        const startedAt = performance.now()
+        const isPresented = (element: Element | null): boolean => {
+          if (!(element instanceof HTMLElement)) {
+            return false
+          }
+          for (
+            let current: HTMLElement | null = element;
+            current;
+            current = current.parentElement
+          ) {
+            const style = getComputedStyle(current)
+            if (
+              style.display === 'none' ||
+              style.visibility === 'hidden' ||
+              style.opacity === '0'
+            ) {
+              return false
+            }
+          }
+          const rect = element.getBoundingClientRect()
+          return (
+            rect.width > 0 &&
+            rect.height > 0 &&
+            rect.right > 0 &&
+            rect.bottom > 0 &&
+            rect.left < window.innerWidth &&
+            rect.top < window.innerHeight
+          )
+        }
+        const sample = (): void => {
+          const pane = window.__paneManagers?.get(targetTabId)?.getPanes?.()[0]
+          const targetXterm = pane?.container.querySelector('.xterm') ?? null
+          const scrollbar =
+            targetXterm?.querySelector<HTMLElement>('.xterm-scrollbar.xterm-vertical') ?? null
+          const thumb = scrollbar?.querySelector<HTMLElement>('.xterm-slider') ?? null
+          frames.push({
+            targetPresented: isPresented(targetXterm),
+            thumbTop: thumb?.offsetTop ?? null,
+            maxThumbTop: scrollbar && thumb ? scrollbar.clientHeight - thumb.offsetHeight : null
+          })
+          if (performance.now() - startedAt >= 700) {
+            resolve(frames)
+            return
+          }
+          requestAnimationFrame(sample)
+        }
+        sample()
+      }),
+    targetTabId
+  )
+}
+
+test.describe('terminal streaming refocus viewport', () => {
+  test('keeps follow-output at the bottom through a queued-write refocus wobble', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await closeFeatureTips(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const tabId = await activeTerminalTabId(orcaPage)
+    const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
+    await waitForTerminalPtyDataInjector(orcaPage, paneKey)
+    await execInTerminal(orcaPage, ptyId, `node "${STREAMING_FIXTURE_PATH}"`)
+    await expect.poll(() => getTerminalContent(orcaPage, 30_000)).toContain('STREAM_PHASE1_DONE')
+    await orcaPage.waitForTimeout(400)
+
+    const framesPromise = sampleRevealFrames(orcaPage, tabId)
+    await injectQueuedWriteAndRefocus(orcaPage, tabId, paneKey)
+    const frames = await framesPromise
+
+    expect(frames.every((frame) => frame.targetPresented)).toBe(true)
+    expect(
+      frames.every(
+        (frame) =>
+          frame.thumbTop !== null &&
+          frame.maxThumbTop !== null &&
+          Math.abs(frame.maxThumbTop - frame.thumbTop) <= 2
+      )
+    ).toBe(true)
+    expect(frames.some((frame) => (frame.maxThumbTop ?? 0) > 1)).toBe(true)
+    expect(
+      frames.every((frame) => (frame.maxThumbTop ?? 0) <= 1 || (frame.thumbTop ?? 0) > 1)
+    ).toBe(true)
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 30_000), { timeout: 15_000 })
+      .toContain('REFOCUS_STREAM_DONE')
+    const visibleScrollbar = orcaPage.locator('.xterm-scrollbar.xterm-vertical:visible').first()
+    await expect(visibleScrollbar).toBeVisible()
+    expect(
+      await visibleScrollbar.evaluate((scrollbar) => {
+        const thumb = scrollbar.querySelector<HTMLElement>('.xterm-slider')
+        return Boolean(
+          thumb && Math.abs(scrollbar.clientHeight - thumb.offsetHeight - thumb.offsetTop) <= 2
+        )
+      })
+    ).toBe(true)
+  })
+})

--- a/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
+++ b/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
@@ -10,6 +10,7 @@ import {
   waitForActiveTerminalManager
 } from './helpers/terminal'
 import { waitForTerminalPtyDataInjector } from './helpers/terminal-pty-injection'
+import { nodeTerminalCommand } from './terminal-node-command'
 
 const STREAMING_FIXTURE_PATH = path.join(
   process.cwd(),
@@ -32,20 +33,44 @@ async function closeFeatureTips(page: Page): Promise<void> {
   })
 }
 
-async function activeTerminalTabId(page: Page): Promise<string> {
-  const tabId = await page.evaluate(() => {
-    const state = window.__store?.getState()
-    const worktreeId = state?.activeWorktreeId
-    return state?.activeTabType === 'terminal'
-      ? (state.activeTabId ?? null)
-      : worktreeId
-        ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
-        : null
-  })
-  if (!tabId) {
-    throw new Error('Active terminal tab unavailable')
-  }
-  return tabId
+async function waitForPhaseOneAtBottom(page: Page, tabId: string): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate((targetTabId) => {
+          const pane = window.__paneManagers?.get(targetTabId)?.getPanes?.()[0]
+          const terminal = pane?.terminal
+          if (!terminal) {
+            return false
+          }
+          const buffer = terminal.buffer.active
+          let containsMarker = false
+          for (let line = buffer.baseY; line < buffer.baseY + terminal.rows; line += 1) {
+            if (buffer.getLine(line)?.translateToString(true).includes('STREAM_PHASE1_DONE')) {
+              containsMarker = true
+              break
+            }
+          }
+          const scrollbar = pane.container.querySelector<HTMLElement>(
+            '.xterm-scrollbar.xterm-vertical'
+          )
+          const thumb = scrollbar?.querySelector<HTMLElement>('.xterm-slider') ?? null
+          return Boolean(
+            buffer.baseY > 0 &&
+            buffer.viewportY === buffer.baseY &&
+            containsMarker &&
+            scrollbar &&
+            thumb &&
+            scrollbar.clientHeight - thumb.offsetHeight > 1 &&
+            Math.abs(scrollbar.clientHeight - thumb.offsetHeight - thumb.offsetTop) <= 2
+          )
+        }, tabId),
+      {
+        timeout: 30_000,
+        message: 'phase-one output did not render with the visible viewport at the bottom'
+      }
+    )
+    .toBe(true)
 }
 
 async function injectQueuedWriteAndRefocus(
@@ -175,14 +200,11 @@ test.describe('terminal streaming refocus viewport', () => {
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage, 30_000)
     const ptyId = await waitForActivePanePtyId(orcaPage)
-    const tabId = await activeTerminalTabId(orcaPage)
     const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
+    const tabId = paneKey.slice(0, paneKey.indexOf(':'))
     await waitForTerminalPtyDataInjector(orcaPage, paneKey)
-    await execInTerminal(orcaPage, ptyId, `node ${JSON.stringify(STREAMING_FIXTURE_PATH)}`)
-    await expect
-      .poll(() => getTerminalContent(orcaPage), { timeout: 30_000 })
-      .toContain('STREAM_PHASE1_DONE')
-    await orcaPage.waitForTimeout(400)
+    await execInTerminal(orcaPage, ptyId, nodeTerminalCommand([STREAMING_FIXTURE_PATH]))
+    await waitForPhaseOneAtBottom(orcaPage, tabId)
 
     const framesPromise = sampleRevealFrames(orcaPage, tabId)
     await injectQueuedWriteAndRefocus(orcaPage, tabId, paneKey)

--- a/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
+++ b/tests/e2e/terminal-streaming-refocus-viewport.spec.ts
@@ -60,6 +60,7 @@ async function injectQueuedWriteAndRefocus(
         throw new Error('Hidden terminal pane unavailable')
       }
       const terminal = pane.terminal
+      // Why: fail loudly if xterm moves the private buffer path that models this wobble.
       const bufferService = (
         terminal as typeof terminal & {
           _core?: {
@@ -97,6 +98,7 @@ async function injectQueuedWriteAndRefocus(
       if (!injector?.inject(paneKey, `${rows}REFOCUS_STREAM_DONE\n`)) {
         throw new Error('PTY data injector unavailable')
       }
+      // Why: focus recovery must flush through terminal.write in this synchronous dispatch.
       window.dispatchEvent(new Event('focus'))
       if (!wobbleApplied) {
         throw new Error('refocus did not flush the queued xterm write')
@@ -176,8 +178,10 @@ test.describe('terminal streaming refocus viewport', () => {
     const tabId = await activeTerminalTabId(orcaPage)
     const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
     await waitForTerminalPtyDataInjector(orcaPage, paneKey)
-    await execInTerminal(orcaPage, ptyId, `node "${STREAMING_FIXTURE_PATH}"`)
-    await expect.poll(() => getTerminalContent(orcaPage, 30_000)).toContain('STREAM_PHASE1_DONE')
+    await execInTerminal(orcaPage, ptyId, `node ${JSON.stringify(STREAMING_FIXTURE_PATH)}`)
+    await expect
+      .poll(() => getTerminalContent(orcaPage), { timeout: 30_000 })
+      .toContain('STREAM_PHASE1_DONE')
     await orcaPage.waitForTimeout(400)
 
     const framesPromise = sampleRevealFrames(orcaPage, tabId)
@@ -198,7 +202,7 @@ test.describe('terminal streaming refocus viewport', () => {
       frames.filter((frame) => (frame.maxThumbTop ?? 0) > 1 && (frame.thumbTop ?? 0) <= 1)
     ).toEqual([])
     await expect
-      .poll(() => getTerminalContent(orcaPage, 30_000), { timeout: 15_000 })
+      .poll(() => getTerminalContent(orcaPage), { timeout: 15_000 })
       .toContain('REFOCUS_STREAM_DONE')
     const visibleScrollbar = orcaPage.locator('.xterm-scrollbar.xterm-vertical:visible').first()
     await expect(visibleScrollbar).toBeVisible()


### PR DESCRIPTION
## Summary

Keep a terminal that was following live output at the bottom when Orca refocuses or reveals it while queued agent output is streaming. A user-pinned historical viewport remains pinned.

Fixes #11753

## Description

Refocus and heavy visibility recovery could sample xterm's viewport after queued output began parsing. During that write, xterm can transiently expose `viewportY = 0` while its native scrolling flag is set, so Orca records the top as the user's pinned position and enforces it after recovery.

This change:

- latches each pane's scroll intent before requesting or flushing backlog output;
- removes the second heavy-resume sample that could overwrite the pre-recovery intent;
- adds ordering unit coverage and a frame-by-frame Electron regression test.

The production behavior is renderer-local and uses the existing terminal abstractions, so it applies equally to native, folder-workspace, and SSH-backed terminals.

## ELI5

When Orca refocused a busy terminal, it sometimes looked at the scroll position during the split second that xterm was rearranging new output. That temporary position looked like “the user scrolled to the top,” so Orca faithfully kept it there. Orca now remembers whether you were following output before it pours in the backlog, then preserves that intent through recovery.

## Screenshots

https://github.com/user-attachments/assets/2b83da2e-59fd-4a84-8b60-87b69315ed76

Original WebM: VP8, 1920×1080. The streaming terminal stays on the newest rows through refocus and finishes with `REFOCUS_STREAM_DONE` visible at the bottom.

## Proof

The new Electron test starts a real terminal with scrollback, queues a 400-row streaming burst, reproduces xterm's transient top-of-buffer geometry inside the queued write, and dispatches the same refocus recovery event. It samples the visible scrollbar thumb on every animation frame and verifies the final output marker is rendered.

Controlled red/green result:

- Restoring the previous production ordering makes the test fail because the visible scrollbar remains away from the bottom.
- With this fix, the recorded proof passes 3/3 and the hardened deterministic oracle passes 5/5; every sampled frame and the final visible scrollbar remain at the bottom.

```bash
SKIP_BUILD=1 ORCA_E2E_RECORD_VIDEO=1 pnpm exec playwright test \
  tests/e2e/terminal-streaming-refocus-viewport.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --workers=1 \
  --repeat-each=5
```

## Testing

- [ ] `pnpm lint` — the repository-wide command stops on existing unrelated warning gates detailed below; every changed file passes targeted `oxlint`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run as one local monolithic command; the complete CI unit matrix passes on Node 24 and Node 26.
- [ ] `pnpm build` — not run as one local command; CI packaging passes on macOS and Windows.
- [x] Added high-quality unit and Electron coverage that red/greens against the old ordering.

## Proof of no regressions

- Current-head CI: 44 checks passed, including static analysis, typecheck, all 32 Node 24/26 test shards, Git compatibility, shell contracts, macOS/Windows packaging, and the changed-spec Electron run. Two non-applicable conditional E2E jobs were skipped.
- `pnpm typecheck` — passed locally.
- Focused viewport intent/output scheduler unit suite — 5 files, 143 tests passed.
- Hardened Electron regression — 5/5 repeated runs passed after removing the fixed sleep and stale active-tab capture.
- Adjacent Electron coverage — 12 scenarios passed across follow-output, pinned viewport, streaming worktree switch, and inline-TUI reveal behavior. Eleven passed in the combined serial run; the remaining case initially could not create its fixture because the shared temporary repo was missing (`ENOENT`), then passed in isolation (1/1).
- Targeted `oxlint` for all changed files — passed.
- `pnpm run check:reliability-gates` — passed (59 gates).
- `pnpm run check:max-lines-ratchet` — passed with no new bypasses.
- `git diff --check` — passed.

Repository-wide `pnpm lint` reaches unrelated existing warning gates and stops on duplicate imports in two `tests/tools/benchmarks/terminal-cold-park-*.mjs` files. The type-aware repository audit likewise stops on unrelated `restrict-template-expressions` warnings in `tests/tools/win-update-e2e/`.

## AI Review Report

The review checked the recovery ordering, follow-output and pinned-viewport state transitions, test observability, SSH/folder-workspace behavior, and cross-platform compatibility for macOS, Linux, and Windows. No shortcuts, labels, or Electron platform branches change.

Automated review flagged missing sync call-count coverage, opaque frame failures, Windows/POSIX shell quoting for the E2E fixture path, mistaken `getTerminalContent` timeout arguments, and undocumented test coupling to xterm internals/synchronous focus dispatch. All were corrected and the unit, typecheck, lint, and Electron regression checks were rerun. The latest Greptile review rates the change 5/5 and reports no files needing attention.

## Terminal reliability contract

- Invariant: queued output during refocus or reveal cannot turn a follow-output viewport into pinned-top intent; adjacent scroll-intent coverage continues to protect genuinely pinned viewports.
- Oracle: unit tests require one pre-flush intent sync, while Electron samples the visible scrollbar on every animation frame and requires the final streamed marker at the bottom.
- Determinism: readiness is based on rendered scrollback, viewport state, and scrollbar geometry; there is no fixed sleep.
- Red/green: the controlled xterm wobble fails with post-flush sampling and passes with pre-flush intent latching.
- Maturity: registered as experimental `terminal-scroll.streaming-refocus-intent`; 5/5 local Electron iterations passed.
- Coverage gap: the shared renderer path applies to local, folder, SSH, WSL, and remote terminals, but this exact live race has only been exercised on macOS with a local PTY through the daemon.

## Performance audit

PASS with no P0/P1/P2 findings. Wake recovery still performs one O(panes) intent pass before the existing bounded 64 KiB-per-pane flush. Heavy resume drops from two intent passes to one and retains its bounded 256 KiB-per-pane flush. No polling, timers, subprocesses, IPC, output parsing, global session scans, fit, or repaint work was added.

## Production release scan

PASS with no P0/P1/P2 security, malware, supply-chain, dependency, or packaging findings across `v1.4.163..593dd82efa` (33 commits, 29 matched PRs). There are no lockfile, dependency, install-hook, native-module, binary, signing, packaged-resource, or release-workflow changes attributable to this PR. `pnpm audit --prod` reports zero vulnerabilities across 144 production dependencies.

## Security Audit

No production input handling, authentication, secrets, dependencies, IPC contracts, filesystem access, or command execution are added. The E2E-only command uses the shared `nodeTerminalCommand` quoting path so macOS, Linux, and Windows invoke the runner Node executable safely even when PATH or fixture paths differ. PTY data injection remains confined to the existing E2E hook and uses static generated test data. The proof video is hosted as a GitHub attachment and is not committed.

## Notes

- The E2E wobble harness deliberately accesses xterm's private `_core._bufferService` fields to reproduce the transient geometry; it fails loudly if that version-coupled path changes.
- The focus dispatch assertion deliberately verifies that the current recovery chain flushes synchronously through `terminal.write`.
