### PR TITLE
fix(persistence): stop blocking the main thread on backup rotation

### DIFF
--- a/src/main/persistence-async-write-syscalls.test.ts
+++ b/src/main/persistence-async-write-syscalls.test.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const testState = { dir: '' }
+
+const fsCalls = vi.hoisted(() => {
+  const blocker = new Int32Array(new SharedArrayBuffer(4))
+  const calls = {
+    recording: false,
+    dirPrefix: '',
+    /** When > 0, every recorded sync call parks the main thread this long — a stalled mount in miniature. */
+    stallMs: 0,
+    syncCalls: [] as string[],
+    asyncCalls: [] as string[],
+    failAsync: null as ((fn: string, target: string) => NodeJS.ErrnoException | null) | null,
+    beforeAsync: null as ((fn: string, target: string) => void) | null,
+    waitAsync: null as ((fn: string, target: string) => Promise<void> | null) | null,
+    reset(): void {
+      calls.syncCalls.length = 0
+      calls.asyncCalls.length = 0
+      calls.stallMs = 0
+      calls.failAsync = null
+      calls.beforeAsync = null
+      calls.waitAsync = null
+    },
+    inScope(target: unknown): target is string {
+      return (
+        calls.recording &&
+        typeof target === 'string' &&
+        calls.dirPrefix !== '' &&
+        target.startsWith(calls.dirPrefix)
+      )
+    },
+    recordSync(fn: string, target: unknown): void {
+      if (!calls.inScope(target)) {
+        return
+      }
+      calls.syncCalls.push(`${fn}:${target}`)
+      if (calls.stallMs > 0) {
+        // Atomics.wait blocks the thread the way an uninterruptible syscall does.
+        Atomics.wait(blocker, 0, 0, calls.stallMs)
+      }
+    },
+    recordAsync(fn: string, target: unknown): NodeJS.ErrnoException | null {
+      if (!calls.inScope(target)) {
+        return null
+      }
+      calls.asyncCalls.push(`${fn}:${target}`)
+      calls.beforeAsync?.(fn, target)
+      return calls.failAsync?.(fn, target) ?? null
+    }
+  }
+  return calls
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const patched: Record<string, unknown> = { ...actual }
+  for (const name of Object.keys(actual)) {
+    const original = (actual as unknown as Record<string, unknown>)[name]
+    if (!name.endsWith('Sync') || typeof original !== 'function') {
+      continue
+    }
+    const fn = original as (...args: unknown[]) => unknown
+    const wrapper = (...args: unknown[]): unknown => {
+      fsCalls.recordSync(name, args[0])
+      return fn(...args)
+    }
+    patched[name] = Object.assign(wrapper, fn)
+  }
+  return { ...patched, default: patched }
+})
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  const patched: Record<string, unknown> = { ...actual }
+  for (const name of ['stat', 'access', 'rename', 'copyFile', 'rm', 'mkdir', 'open']) {
+    const fn = (actual as unknown as Record<string, (...args: unknown[]) => unknown>)[name]
+    patched[name] = async (...args: unknown[]): Promise<unknown> => {
+      const failure = fsCalls.recordAsync(name, args[0])
+      if (failure) {
+        throw failure
+      }
+      if (typeof args[0] === 'string') {
+        await fsCalls.waitAsync?.(name, args[0])
+      }
+      return fn(...args)
+    }
+  }
+  return { ...patched, default: patched }
+})
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(),
+  sshConfigHostsToTargets: vi.fn()
+}))
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: vi.fn().mockReturnValue({ nth_repo_added: 2 })
+}))
+
+// Deterministic cipher so two stores driven through identical mutations produce identical bytes.
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`enc:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8').slice('enc:'.length)
+  }
+}))
+
+const BACKUP_COUNT = 5
+const BACKUP_MIN_INTERVAL_MS = 60 * 60 * 1000
+const PAST_ROTATION_INTERVAL_MS = BACKUP_MIN_INTERVAL_MS * 2
+const SAVE_DEBOUNCE_MS = 1_000
+
+const ROTATION_INTERLEAVE_CASES = [
+  ['initial access', 'access', ''],
+  ['oldest removal', 'rm', '.bak.4'],
+  ['slot access', 'access', '.bak.0'],
+  ['slot rename', 'rename', '.bak.0'],
+  ['final copy', 'copyFile', '']
+] as const
+
+type TestStore = {
+  updateUI(updates: { sidebarWidth: number }): void
+  waitForPendingWrite(): Promise<void>
+  flushOrThrow(): void
+}
+
+async function createStore(dir: string): Promise<TestStore> {
+  testState.dir = dir
+  vi.resetModules()
+  const { Store, initDataPath } = await import('./persistence')
+  initDataPath()
+  return new Store() as unknown as TestStore
+}
+
+function dataFile(dir: string): string {
+  return join(dir, 'orca-data.json')
+}
+
+function seedStaleBackup(dir: string): void {
+  const path = `${dataFile(dir)}.bak.0`
+  writeFileSync(path, '{"stale":true}', 'utf-8')
+  const staleSeconds = (Date.now() - PAST_ROTATION_INTERVAL_MS) / 1000
+  utimesSync(path, staleSeconds, staleSeconds)
+}
+
+function ringSnapshot(dir: string): Record<string, string> {
+  const snapshot: Record<string, string> = {}
+  for (const name of readdirSync(dir).sort()) {
+    if (name === 'orca-data.json' || name.startsWith('orca-data.json.bak.')) {
+      snapshot[name] = readFileSync(join(dir, name), 'utf-8')
+    }
+  }
+  return snapshot
+}
+
+describe('async persistence write path avoids synchronous fs syscalls', () => {
+  const dirs: string[] = []
+
+  function makeDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-async-write-'))
+    dirs.push(dir)
+    return dir
+  }
+
+  beforeEach(() => {
+    fsCalls.recording = false
+    fsCalls.dirPrefix = ''
+    fsCalls.reset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    fsCalls.recording = false
+    vi.useRealTimers()
+    while (dirs.length > 0) {
+      rmSync(dirs.pop() as string, { recursive: true, force: true })
+    }
+  })
+
+  async function recordAsyncSave(
+    store: TestStore,
+    dir: string,
+    sidebarWidth: number
+  ): Promise<void> {
+    store.updateUI({ sidebarWidth })
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      vi.advanceTimersByTime(PAST_ROTATION_INTERVAL_MS)
+      await store.waitForPendingWrite()
+    } finally {
+      fsCalls.recording = false
+    }
+  }
+
+  it('issues no sync fs syscall under the profile dir when rotation runs with an empty ring', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+
+    await recordAsyncSave(store, dir, 301)
+
+    expect(fsCalls.syncCalls).toEqual([])
+    // Rotation must actually have happened, else the assertion above is vacuous.
+    expect(ringSnapshot(dir)['orca-data.json.bak.0']).toBe(readFileSync(dataFile(dir), 'utf-8'))
+  })
+
+  it('uses an awaited stat, not statSync, for the backup rotation interval check', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    seedStaleBackup(dir)
+
+    await recordAsyncSave(store, dir, 302)
+
+    expect(fsCalls.syncCalls).toEqual([])
+    expect(fsCalls.asyncCalls).toContain(`stat:${dataFile(dir)}.bak.0`)
+  })
+
+  it('issues no sync fs syscall while rotating a saturated ring', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+
+    // One more save than the ring holds, so the oldest slot is evicted and every slot renames.
+    for (let i = 0; i <= BACKUP_COUNT; i++) {
+      await recordAsyncSave(store, dir, 310 + i)
+    }
+
+    expect(fsCalls.syncCalls).toEqual([])
+    const ring = ringSnapshot(dir)
+    expect(Object.keys(ring)).toContain(`orca-data.json.bak.${BACKUP_COUNT - 1}`)
+    expect(Object.keys(ring)).not.toContain(`orca-data.json.bak.${BACKUP_COUNT}`)
+  })
+
+  it('lets a main-thread timer keep firing while a rotating save is in flight', async () => {
+    // A recorded sync call stalls long enough for the heartbeat to catch it.
+    vi.useRealTimers()
+    const dir = makeDir()
+    const store = await createStore(dir)
+    seedStaleBackup(dir)
+    // Generous stall so ordinary scheduler/GC jitter can't reach the threshold on a loaded CI box.
+    const stallMs = 500
+
+    let lastTick = Date.now()
+    let worstGapMs = 0
+    const heartbeat = setInterval(() => {
+      const now = Date.now()
+      worstGapMs = Math.max(worstGapMs, now - lastTick)
+      lastTick = now
+    }, 10)
+
+    try {
+      store.updateUI({ sidebarWidth: 341 })
+      fsCalls.dirPrefix = dir
+      fsCalls.stallMs = stallMs
+      fsCalls.recording = true
+      lastTick = Date.now()
+      await new Promise((resolve) => setTimeout(resolve, SAVE_DEBOUNCE_MS + 200))
+      await store.waitForPendingWrite()
+    } finally {
+      fsCalls.recording = false
+      clearInterval(heartbeat)
+    }
+
+    expect(worstGapMs).toBeLessThan(stallMs)
+    // The save really happened, so a small gap isn't just an absent write.
+    expect(ringSnapshot(dir)['orca-data.json.bak.0']).toBe(readFileSync(dataFile(dir), 'utf-8'))
+  }, 20_000)
+
+  it('skips rotation when a sync flush rotated during the rotation-interval await', async () => {
+    // The acquired owner keeps rotation when the flush skips the ring.
+    const dir = makeDir()
+    const store = await createStore(dir)
+    seedStaleBackup(dir)
+    const staleBackup = readFileSync(`${dataFile(dir)}.bak.0`, 'utf-8')
+
+    store.updateUI({ sidebarWidth: 361 })
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    let flushed = false
+    fsCalls.beforeAsync = (fn, target) => {
+      if (flushed || fn !== 'stat' || !target.endsWith('.bak.0')) {
+        return
+      }
+      flushed = true
+      store.updateUI({ sidebarWidth: 362 })
+      store.flushOrThrow()
+    }
+    try {
+      vi.advanceTimersByTime(PAST_ROTATION_INTERVAL_MS)
+      await store.waitForPendingWrite()
+    } finally {
+      fsCalls.recording = false
+      fsCalls.beforeAsync = null
+    }
+
+    expect(flushed).toBe(true)
+    const ring = ringSnapshot(dir)
+    expect(ring['orca-data.json.bak.0']).toBe(ring['orca-data.json'])
+    expect(ring['orca-data.json.bak.1']).toBe(staleBackup)
+    expect(ring['orca-data.json.bak.2']).toBeUndefined()
+  })
+
+  it('keeps the due check inside ownership when a second writer starts', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    seedStaleBackup(dir)
+    const almostDueSeconds = (Date.now() - (BACKUP_MIN_INTERVAL_MS - SAVE_DEBOUNCE_MS - 100)) / 1000
+    utimesSync(`${dataFile(dir)}.bak.0`, almostDueSeconds, almostDueSeconds)
+    const staleBackup = readFileSync(`${dataFile(dir)}.bak.0`, 'utf-8')
+    const statCall = `stat:${dataFile(dir)}.bak.0`
+    let releaseRotation!: () => void
+    const rotationRelease = new Promise<void>((resolve) => {
+      releaseRotation = resolve
+    })
+    let signalRotation!: () => void
+    const rotationStarted = new Promise<void>((resolve) => {
+      signalRotation = resolve
+    })
+    let held = false
+    fsCalls.waitAsync = (fn, target) => {
+      if (held || fn !== 'stat' || target !== `${dataFile(dir)}.bak.0`) {
+        return null
+      }
+      held = true
+      signalRotation()
+      return rotationRelease
+    }
+
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    store.updateUI({ sidebarWidth: 371 })
+    vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)
+    const firstWrite = store.waitForPendingWrite()
+    try {
+      await rotationStarted
+      store.updateUI({ sidebarWidth: 372 })
+      store.flushOrThrow()
+      store.updateUI({ sidebarWidth: 373 })
+      vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)
+      await store.waitForPendingWrite()
+      expect(fsCalls.asyncCalls.filter((call) => call === statCall)).toHaveLength(1)
+    } finally {
+      releaseRotation()
+      await firstWrite
+      fsCalls.recording = false
+      fsCalls.waitAsync = null
+    }
+    const ring = ringSnapshot(dir)
+    expect(ring['orca-data.json.bak.0']).toBe(ring['orca-data.json'])
+    expect(ring['orca-data.json.bak.1']).toBe(staleBackup)
+    expect(ring['orca-data.json.bak.2']).toBeUndefined()
+  })
+
+  it.each(ROTATION_INTERLEAVE_CASES)(
+    'keeps one rotation owner when a sync flush lands during %s',
+    async (_phase, expectedFn, targetSuffix) => {
+      const dir = makeDir()
+      const store = await createStore(dir)
+      seedStaleBackup(dir)
+      const staleBackup = readFileSync(`${dataFile(dir)}.bak.0`, 'utf-8')
+      const expectedTarget = `${dataFile(dir)}${targetSuffix}`
+
+      store.updateUI({ sidebarWidth: 363 })
+      fsCalls.dirPrefix = dir
+      fsCalls.recording = true
+      let flushed = false
+      fsCalls.beforeAsync = (fn, target) => {
+        if (flushed || fn !== expectedFn || target !== expectedTarget) {
+          return
+        }
+        flushed = true
+        store.updateUI({ sidebarWidth: 364 })
+        store.flushOrThrow()
+      }
+      try {
+        vi.advanceTimersByTime(PAST_ROTATION_INTERVAL_MS)
+        await store.waitForPendingWrite()
+      } finally {
+        fsCalls.recording = false
+        fsCalls.beforeAsync = null
+      }
+
+      expect(flushed).toBe(true)
+      const ring = ringSnapshot(dir)
+      expect(ring['orca-data.json.bak.0']).toBe(ring['orca-data.json'])
+      expect(ring['orca-data.json.bak.1']).toBe(staleBackup)
+      expect(ring['orca-data.json.bak.2']).toBeUndefined()
+    }
+  )
+
+  it('does not log for absent ring slots even when the mount rejects renames non-ENOENT', async () => {
+    // Probing keeps degraded mounts from logging one error per absent slot.
+    const dir = makeDir()
+    const store = await createStore(dir)
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fsCalls.failAsync = (fn, target) =>
+      fn === 'rename' && target.includes('.bak.')
+        ? Object.assign(new Error('stale NFS file handle'), { code: 'ESTALE' })
+        : null
+
+    try {
+      await recordAsyncSave(store, dir, 351)
+      expect(errors).not.toHaveBeenCalled()
+    } finally {
+      errors.mockRestore()
+    }
+  })
+
+  it('logs when a ring slot that exists fails to rotate', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    seedStaleBackup(dir)
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fsCalls.failAsync = (fn, target) =>
+      fn === 'rename' && target.endsWith('.bak.0')
+        ? Object.assign(new Error('permission denied'), { code: 'EPERM' })
+        : null
+
+    try {
+      await recordAsyncSave(store, dir, 352)
+      expect(errors).toHaveBeenCalledWith(
+        '[persistence] Failed to rotate backup',
+        `${dataFile(dir)}.bak.0`,
+        '->',
+        `${dataFile(dir)}.bak.1`,
+        expect.objectContaining({ code: 'EPERM' })
+      )
+    } finally {
+      errors.mockRestore()
+    }
+  })
+
+  it('produces a .bak ring byte-identical to the sync path, at capacity and with ring holes', async () => {
+    const asyncDir = makeDir()
+    const syncDir = makeDir()
+    // Match generated IDs so only rotation behavior can differ.
+    const seedDir = makeDir()
+    const seedStore = await createStore(seedDir)
+    seedStore.updateUI({ sidebarWidth: 320 })
+    seedStore.flushOrThrow()
+    const seed = readFileSync(dataFile(seedDir), 'utf-8')
+    for (const dir of [asyncDir, syncDir]) {
+      writeFileSync(dataFile(dir), seed, 'utf-8')
+      // Holes: slots 1 and 3 occupied, 0 and 2 missing — exercises the per-slot existence branch.
+      writeFileSync(`${dataFile(dir)}.bak.1`, '{"old":1}', 'utf-8')
+      writeFileSync(`${dataFile(dir)}.bak.3`, '{"old":3}', 'utf-8')
+    }
+
+    const widths = [321, 322, 323, 324, 325, 326]
+    const asyncStore = await createStore(asyncDir)
+    for (const width of widths) {
+      asyncStore.updateUI({ sidebarWidth: width })
+      vi.advanceTimersByTime(PAST_ROTATION_INTERVAL_MS)
+      await asyncStore.waitForPendingWrite()
+    }
+
+    const syncStore = await createStore(syncDir)
+    for (const width of widths) {
+      syncStore.updateUI({ sidebarWidth: width })
+      syncStore.flushOrThrow()
+      vi.advanceTimersByTime(PAST_ROTATION_INTERVAL_MS)
+    }
+
+    const ring = ringSnapshot(asyncDir)
+    expect(ring).toEqual(ringSnapshot(syncDir))
+    expect(Object.keys(ring)).toContain(`orca-data.json.bak.${BACKUP_COUNT - 1}`)
+  })
+
+  it('keeps the sync quit/crash fallback on synchronous syscalls', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    seedStaleBackup(dir)
+
+    store.updateUI({ sidebarWidth: 331 })
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      store.flushOrThrow()
+    } finally {
+      fsCalls.recording = false
+    }
+
+    expect(fsCalls.syncCalls).toContain(`statSync:${dataFile(dir)}.bak.0`)
+    expect(fsCalls.syncCalls).toContain(`existsSync:${dataFile(dir)}`)
+    expect(fsCalls.asyncCalls).toEqual([])
+  })
+})

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -11,7 +11,7 @@ import {
   statSync,
   realpathSync
 } from 'node:fs'
-import { rename, mkdir, rm, copyFile, open } from 'node:fs/promises'
+import { rename, mkdir, rm, copyFile, open, stat, access } from 'node:fs/promises'
 import { renameDurable, writeFileDurableSync } from './durable-file-write'
 import { join, dirname, isAbsolute, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
@@ -587,6 +587,14 @@ function parseWorkspaceSessionsByHostId(
 
 function backupPath(dataFile: string, index: number): string {
   return `${dataFile}.bak.${index}`
+}
+
+/** existsSync's non-blocking twin: existsSync is an access(F_OK) probe, so access() is the exact analogue. */
+async function exists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false
+  )
 }
 
 function buildWorkspaceDirHistoryForUpdate(
@@ -2742,6 +2750,8 @@ export class Store {
   private writeTimer: ReturnType<typeof setTimeout> | null = null
   private pendingWrite: Promise<void> | null = null
   private writeGeneration = 0
+  // Prevent a sync flush from interleaving a second rotation with awaited ring mutations.
+  private backupRotationInFlight = false
   // Why: after a profile transfer rewrites this file on disk, a late flush of stale in-memory state would resurrect the moved project.
   private writesFrozen = false
   // Content hash at last write, to skip no-op writes; derived from the payload with encrypted blobs normalized back to plaintext (see buildStateToSave), since encrypt() uses a random IV per call.
@@ -2884,28 +2894,52 @@ export class Store {
     }
   }
 
+  // Why separate from the sync twin: a statSync here parks the Electron main thread in uninterruptible
+  // sleep on a stalled SMB/NFS profile mount. Error semantics are deliberately identical: rotate.
+  private async shouldRotateBackupsAsync(dataFile: string): Promise<boolean> {
+    try {
+      const mtime = (await stat(backupPath(dataFile, 0))).mtimeMs
+      return Date.now() - mtime >= BACKUP_MIN_INTERVAL_MS
+    } catch {
+      return true
+    }
+  }
+
   // Why: rotate current file into the .bak ring so load() can recover if a later primary write is truncated or corrupt.
   private async rotateBackupsAsync(dataFile: string): Promise<void> {
-    if (!existsSync(dataFile)) {
+    if (this.backupRotationInFlight) {
       return
     }
-    await rm(backupPath(dataFile, BACKUP_COUNT - 1)).catch((err: unknown) => {
-      if (err && (err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        console.error('[persistence] Failed to remove oldest backup:', err)
+    this.backupRotationInFlight = true
+    try {
+      if (!(await this.shouldRotateBackupsAsync(dataFile))) {
+        return
       }
-    })
-    for (let i = BACKUP_COUNT - 2; i >= 0; i--) {
-      const src = backupPath(dataFile, i)
-      const dst = backupPath(dataFile, i + 1)
-      if (existsSync(src)) {
-        await rename(src, dst).catch((err) => {
-          console.error('[persistence] Failed to rotate backup', src, '->', dst, err)
-        })
+      if (!(await exists(dataFile))) {
+        return
       }
+      await rm(backupPath(dataFile, BACKUP_COUNT - 1)).catch((err: unknown) => {
+        if (err && (err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          console.error('[persistence] Failed to remove oldest backup:', err)
+        }
+      })
+      for (let i = BACKUP_COUNT - 2; i >= 0; i--) {
+        const src = backupPath(dataFile, i)
+        const dst = backupPath(dataFile, i + 1)
+        // Why probe instead of rename-then-swallow-ENOENT: a degraded mount rejects a rename of an
+        // absent slot with ESTALE/EIO, which would log once per empty slot on every debounced save.
+        if (await exists(src)) {
+          await rename(src, dst).catch((err) => {
+            console.error('[persistence] Failed to rotate backup', src, '->', dst, err)
+          })
+        }
+      }
+      await copyFile(dataFile, backupPath(dataFile, 0)).catch((err) => {
+        console.error('[persistence] Failed to snapshot current file to .bak.0:', err)
+      })
+    } finally {
+      this.backupRotationInFlight = false
     }
-    await copyFile(dataFile, backupPath(dataFile, 0)).catch((err) => {
-      console.error('[persistence] Failed to snapshot current file to .bak.0:', err)
-    })
   }
 
   private rotateBackupsSync(dataFile: string): void {
@@ -3886,18 +3920,15 @@ export class Store {
         await rm(tmpFile).catch(() => {})
       }
     }
-    // Why (issue #1158): rotate backups only after rename succeeded, and let a concurrent flush own rotation.
+    // Why (#1158): rotate only after the primary rename while this write still owns its generation.
     if (this.writeGeneration !== gen) {
       return
     }
-    const now = Date.now()
-    if (this.shouldRotateBackups(now, dataFile)) {
-      await this.rotateBackupsAsync(dataFile)
-    }
+    await this.rotateBackupsAsync(dataFile)
   }
 
   // Why: sync variant only for flush() at shutdown, where the process may exit before an async write completes.
-  private writeToDiskSync(opts: { force?: boolean } = {}): void {
+  private writeToDiskSync(opts: { force?: boolean; skipBackupRotation?: boolean } = {}): void {
     if (this.writesFrozen) {
       return
     }
@@ -3931,7 +3962,7 @@ export class Store {
       }
     }
     const now = Date.now()
-    if (this.shouldRotateBackups(now, dataFile)) {
+    if (!opts.skipBackupRotation && this.shouldRotateBackups(now, dataFile)) {
       this.rotateBackupsSync(dataFile)
     }
   }
@@ -3946,7 +3977,10 @@ export class Store {
     // Why: bump writeGeneration so an in-flight async write skips its rename and can't overwrite this sync write.
     this.writeGeneration++
     this.pendingWrite = null
-    this.writeToDiskSync({ force: asyncWriteWasInFlight })
+    this.writeToDiskSync({
+      force: asyncWriteWasInFlight,
+      skipBackupRotation: this.backupRotationInFlight
+    })
   }
 
   flushActiveViewPreferenceOrThrow(): void {


### PR DESCRIPTION
## Problem

`Store.writeToDiskAsync` — the debounced steady-state save, and the path that is *supposed* to be non-blocking — still reached `statSync` and `existsSync` on the profile directory to decide and perform `.bak` ring rotation:

- `shouldRotateBackups` → `statSync(backupPath(dataFile, 0))`, with `catch { return true }`, so a mount that **errors or stalls** is guaranteed to proceed to rotation
- `rotateBackupsAsync` → `existsSync(dataFile)`, plus one `existsSync` per ring slot

That is one `statSync` plus up to five `existsSync` calls run synchronously on the Electron main thread, on every debounced save and on the quit path.

Measured against a stalled SMB mount during this investigation: `existsSync()` blocked **45,055 ms**; a cold `statSync` took **119 s**; the process sat in macOS uninterruptible (`U`) state ignoring SIGTERM and SIGKILL.

This also silently defeats the quit deadline. `settleTeardownWithinDeadline` arms an ordinary `setTimeout` on the main thread, so while main is parked in a sync syscall the 20 s deadline **cannot fire** and `app.quit()` is never reached. A main-thread deadline cannot bound a main-thread block.

## Fix

Sync → async syscall substitution on the async path only. No change to write ordering, durability, or the `force`/generation logic.

- `shouldRotateBackupsAsync` — awaited `stat`; error semantics deliberately identical (any failure still rotates)
- `rotateBackupsAsync` — `existsSync` → awaited `access(F_OK)`, which is what `existsSync` is under the hood, so a present-but-unstattable slot (Windows share-lock, EOVERFLOW) is still seen as present rather than silently skipping the rotation
- Kept probe-then-rename rather than rename-and-swallow-ENOENT, so log behavior is unchanged in both directions: absent slots stay silent (a degraded mount answering ESTALE/EIO would otherwise log once per empty slot per save), and a present slot that fails to rename is still logged
- **New generation re-check across the added `await`** — a quit-path `flushOrThrow` can now complete a full sync write plus `rotateBackupsSync` inside that window, and rotating again would shift the ring twice for one logical save and drop the two oldest real snapshots. Caught in review, not by the original design.

The sync quit/crash path (`writeToDiskSync` / `rotateBackupsSync`) deliberately stays synchronous — the process can exit before an awaited write resolves — and that is now pinned by a test.

## ELI5

Orca keeps a few numbered backup copies of your settings, like a shelf of five snapshots. Every save slides each snapshot down a slot and puts the new one in front.

To do that sliding it used to ask the disk questions in *stop-everything* mode: "does this file exist? how old is it?" On a normal disk the answer is instant, so nobody noticed. But if your settings live on a network drive that has gone bad, the answer never comes — and *stop-everything* means exactly that. The app's clock stops too. Not the UI, not even the 20-second "give up and quit already" timer meant to rescue you. The app is frozen, and the thing meant to unfreeze it is frozen with it.

Now it asks the same questions in *get-back-to-me* mode. The disk can take as long as it likes; the app keeps running its clock, its UI, and its quit deadline while it waits.

Waiting adds one wrinkle: while we wait, a shutdown save can run and slide the shelf itself. So we re-check a counter before sliding, or the shelf slides twice for one save and the two oldest snapshots fall off the end.

## Tests

New `src/main/persistence-async-write-syscalls.test.ts`, 9 tests. **5 fail against the pre-change code** (independently verified by reverting `persistence.ts` and re-running: `Tests 5 failed | 4 passed (9)`): empty-ring syscall guard, awaited-stat guard, saturated-ring syscall guard, main-thread-timer liveness, and the sync-flush-during-await rotation race.

The other 4 are behavior-preservation guards (byte-identical `.bak` ring vs. the sync path; sync fallback stays synchronous) and pass both before and after **by design** — flagging that explicitly rather than implying all 9 are discriminating.

## Validation

- `src/main/` — 1331 files, **17,912 passed** | 57 skipped, exit 0
- `npx oxlint src/main` — exit 0
- `npx oxfmt --check` — clean
- `npx tsc --noEmit -p config/tsconfig.node.json` — exit 0, 0 TS errors

## What this does not fix

- **`ActiveViewPreference.writeAsync`** still does `renameSync` on `active-view.json` in the same profile directory from a debounced async path. On a stalled mount it parks main exactly like the syscalls removed here. Left alone on purpose: its generation guard and the swap must have no `await` between them or a concurrent `flushOrThrow`'s newer view gets clobbered, so it needs a commit-veto design (à la `writeFileDurableIfCurrent`), not a syscall swap. The invariant "no synchronous fs syscall on the main thread from the async save path" therefore holds for `writeToDiskAsync`, not profile-wide. Follow-up PR.
- Does **not** make the sync quit/shutdown path non-blocking — it must stay sync because the process can exit before an awaited write resolves.
- Does **not** add a timeout for a hung async fs call. Main stays responsive, but a save against a dead mount still never completes.
- Deliberately **not** included: moving `store?.flush()` / `stats?.flush()` into the teardown barrier. Design review found that making the quit flush async introduces a pointer-before-pointee durability inversion — `setWorkspaceSession` callers pair with the sync `flushOrThrow`, which never drains the deferred scrollback-snapshot writes, so `orca-data.json` would become durable naming snapshot refs whose bytes are still in flight while the inline fallback has already been deleted. That needs its own design.