### PR TITLE
perf(worktrees): avoid redundant fetch during deletion

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -589,6 +589,7 @@ branch refs/heads/main
     expect(calls).toContain('git merge-tree --write-tree base123 refs/heads/feature/test')
     expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
     expect(calls).toContain('git config --remove-section branch.feature/test')
+    expect(calls).not.toContain('git remote')
   })
 
   it('deletes a squash-merged branch with branch-only merge commits via expected head', async () => {
@@ -722,6 +723,9 @@ branch refs/heads/main
         stdout: 'base123\n'
       },
       'git merge-tree --write-tree base123 refs/heads/feature/test': {
+        stdout: 'stale-tree\n'
+      },
+      'git merge-tree --write-tree base123 refs/heads/feature/test#2': {
         stdout: 'tree123\n'
       },
       'git rev-parse --verify --quiet base123^{tree}': {
@@ -732,13 +736,14 @@ branch refs/heads/main
     await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
 
     const calls = getGitCalls()
+    const mergeTreeCall = 'git merge-tree --write-tree base123 refs/heads/feature/test'
+    const mergeTreeIndexes = calls.flatMap((call, index) => (call === mergeTreeCall ? [index] : []))
+    const fetchIndex = calls.indexOf('git fetch --prune origin')
     expect(calls).toContain('git fetch --prune origin')
     expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
-    expectGitCallOrder(
-      calls,
-      'git fetch --prune origin',
-      'git merge-tree --write-tree base123 refs/heads/feature/test'
-    )
+    expect(mergeTreeIndexes).toHaveLength(2)
+    expect(fetchIndex).toBeGreaterThan(mergeTreeIndexes[0])
+    expect(fetchIndex).toBeLessThan(mergeTreeIndexes[1])
     expectGitCallOrder(
       calls,
       'git fetch --prune origin',

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -574,6 +574,9 @@ branch refs/heads/main
       'git rev-parse --verify --quiet refs/remotes/origin/main^{commit}': {
         stdout: 'base123\n'
       },
+      'git rev-parse --verify --quiet HEAD^{commit}': {
+        stdout: 'base123\n'
+      },
       'git merge-tree --write-tree base123 refs/heads/feature/test': {
         stdout: 'tree123\n'
       },
@@ -723,9 +726,6 @@ branch refs/heads/main
         stdout: 'base123\n'
       },
       'git merge-tree --write-tree base123 refs/heads/feature/test': {
-        stdout: 'stale-tree\n'
-      },
-      'git merge-tree --write-tree base123 refs/heads/feature/test#2': {
         stdout: 'tree123\n'
       },
       'git rev-parse --verify --quiet base123^{tree}': {
@@ -739,11 +739,12 @@ branch refs/heads/main
     const mergeTreeCall = 'git merge-tree --write-tree base123 refs/heads/feature/test'
     const mergeTreeIndexes = calls.flatMap((call, index) => (call === mergeTreeCall ? [index] : []))
     const fetchIndex = calls.indexOf('git fetch --prune origin')
+    const updateRefIndex = calls.indexOf('git update-ref -d refs/heads/feature/test def456')
     expect(calls).toContain('git fetch --prune origin')
     expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
-    expect(mergeTreeIndexes).toHaveLength(2)
-    expect(fetchIndex).toBeGreaterThan(mergeTreeIndexes[0])
-    expect(fetchIndex).toBeLessThan(mergeTreeIndexes[1])
+    expect(mergeTreeIndexes).toHaveLength(1)
+    expect(fetchIndex).toBeLessThan(mergeTreeIndexes[0])
+    expect(mergeTreeIndexes[0]).toBeLessThan(updateRefIndex)
     expectGitCallOrder(
       calls,
       'git fetch --prune origin',

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -2,9 +2,8 @@
 import { readFile, stat } from 'node:fs/promises'
 import { isAbsolute, join, posix, resolve, win32 } from 'node:path'
 import {
-  branchHasNoUnmergedChangesOnAnyTarget,
-  getBranchCleanupTargetRefs,
-  refreshBranchCleanupTargetRefs
+  branchHasNoUnmergedChangesWithLazyTargetRefresh,
+  getBranchCleanupTargetRefs
 } from '../../shared/git-branch-cleanup'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { withSpan } from '../observability/tracer'
@@ -1267,10 +1266,9 @@ async function deleteAlreadyMergedBranchAfterSafeDeleteFailure(
       ...(execOptions?.stdin !== undefined ? { stdin: execOptions.stdin } : {})
     })
   const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
-  await refreshBranchCleanupTargetRefs(runGit, targetRefs)
   // Why: squash merges rewrite commit IDs, so `branch -d` rejects already-merged branches; delete only when Git proves no unmerged tree changes.
   if (
-    !(await branchHasNoUnmergedChangesOnAnyTarget(
+    !(await branchHasNoUnmergedChangesWithLazyTargetRefresh(
       runGit,
       branchName,
       targetRefs,

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -217,6 +217,7 @@ describe('removeWorktreeOp branch cleanup', () => {
       ['config', '--remove-section', 'branch.feature/test'],
       expect.any(String)
     )
+    expect(git).not.toHaveBeenCalledWith(['remote'], expect.any(String))
   })
 
   it('deletes a squash-merged SSH branch with branch-only merge commits via expected head', async () => {
@@ -308,6 +309,7 @@ describe('removeWorktreeOp branch cleanup', () => {
   it('refreshes the saved remote base before deleting a safe-delete-rejected SSH branch', async () => {
     const calls: { args: string[]; cwd: string }[] = []
     let zListCount = 0
+    let mergeTreeCount = 0
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push({ args, cwd })
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
@@ -345,7 +347,8 @@ describe('removeWorktreeOp branch cleanup', () => {
         return { stdout: 'base123\n', stderr: '' }
       }
       if (args[0] === 'merge-tree') {
-        return { stdout: 'tree123\n', stderr: '' }
+        mergeTreeCount += 1
+        return { stdout: mergeTreeCount === 1 ? 'stale-tree\n' : 'tree123\n', stderr: '' }
       }
       if (args[0] === 'rev-parse' && args.includes('base123^{tree}')) {
         return { stdout: 'tree123\n', stderr: '' }
@@ -360,17 +363,17 @@ describe('removeWorktreeOp branch cleanup', () => {
     const commandIndex = (expectedArgs: string[]) =>
       calls.findIndex(({ args }) => JSON.stringify(args) === JSON.stringify(expectedArgs))
     const fetchIndex = commandIndex(['fetch', '--prune', 'origin'])
-    const mergeTreeIndex = commandIndex([
-      'merge-tree',
-      '--write-tree',
-      'base123',
-      'refs/heads/feature/test'
-    ])
+    const mergeTreeArgs = ['merge-tree', '--write-tree', 'base123', 'refs/heads/feature/test']
+    const mergeTreeIndexes = calls.flatMap(({ args }, index) =>
+      JSON.stringify(args) === JSON.stringify(mergeTreeArgs) ? [index] : []
+    )
     const updateRefIndex = commandIndex(['update-ref', '-d', 'refs/heads/feature/test', '1'])
 
     expect(fetchIndex).toBeGreaterThanOrEqual(0)
     expect(calls[fetchIndex]?.cwd).toBe(resolvedRepoPath())
-    expect(fetchIndex).toBeLessThan(mergeTreeIndex)
+    expect(mergeTreeIndexes).toHaveLength(2)
+    expect(fetchIndex).toBeGreaterThan(mergeTreeIndexes[0])
+    expect(fetchIndex).toBeLessThan(mergeTreeIndexes[1])
     expect(fetchIndex).toBeLessThan(updateRefIndex)
   })
 

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -191,6 +191,9 @@ describe('removeWorktreeOp branch cleanup', () => {
       if (args[0] === 'rev-parse' && args.includes('refs/remotes/origin/main^{commit}')) {
         return { stdout: 'base123\n', stderr: '' }
       }
+      if (args[0] === 'rev-parse' && args.includes('HEAD^{commit}')) {
+        return { stdout: 'base123\n', stderr: '' }
+      }
       if (args[0] === 'merge-tree') {
         return { stdout: 'tree123\n', stderr: '' }
       }
@@ -309,7 +312,6 @@ describe('removeWorktreeOp branch cleanup', () => {
   it('refreshes the saved remote base before deleting a safe-delete-rejected SSH branch', async () => {
     const calls: { args: string[]; cwd: string }[] = []
     let zListCount = 0
-    let mergeTreeCount = 0
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push({ args, cwd })
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
@@ -347,8 +349,7 @@ describe('removeWorktreeOp branch cleanup', () => {
         return { stdout: 'base123\n', stderr: '' }
       }
       if (args[0] === 'merge-tree') {
-        mergeTreeCount += 1
-        return { stdout: mergeTreeCount === 1 ? 'stale-tree\n' : 'tree123\n', stderr: '' }
+        return { stdout: 'tree123\n', stderr: '' }
       }
       if (args[0] === 'rev-parse' && args.includes('base123^{tree}')) {
         return { stdout: 'tree123\n', stderr: '' }
@@ -371,9 +372,9 @@ describe('removeWorktreeOp branch cleanup', () => {
 
     expect(fetchIndex).toBeGreaterThanOrEqual(0)
     expect(calls[fetchIndex]?.cwd).toBe(resolvedRepoPath())
-    expect(mergeTreeIndexes).toHaveLength(2)
-    expect(fetchIndex).toBeGreaterThan(mergeTreeIndexes[0])
-    expect(fetchIndex).toBeLessThan(mergeTreeIndexes[1])
+    expect(mergeTreeIndexes).toHaveLength(1)
+    expect(fetchIndex).toBeLessThan(mergeTreeIndexes[0])
+    expect(mergeTreeIndexes[0]).toBeLessThan(updateRefIndex)
     expect(fetchIndex).toBeLessThan(updateRefIndex)
   })
 

--- a/src/relay/git-handler-branch-cleanup.ts
+++ b/src/relay/git-handler-branch-cleanup.ts
@@ -1,7 +1,6 @@
 import {
-  branchHasNoUnmergedChangesOnAnyTarget,
-  getBranchCleanupTargetRefs,
-  refreshBranchCleanupTargetRefs
+  branchHasNoUnmergedChangesWithLazyTargetRefresh,
+  getBranchCleanupTargetRefs
 } from '../shared/git-branch-cleanup'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { GitExec } from './git-handler-ops'
@@ -17,12 +16,16 @@ export async function deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
   const runGit = (args: string[], options?: { stdin?: string }) =>
     options ? git(args, repoPath, options) : git(args, repoPath)
   const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
-  await refreshBranchCleanupTargetRefs(runGit, targetRefs)
   // Why: SSH worktrees hit the same squash-merge shape as local worktrees.
   // Git's no-op merge proof lets us clean up only branches whose changes
   // already exist on the saved base ref.
   if (
-    !(await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs, capabilities))
+    !(await branchHasNoUnmergedChangesWithLazyTargetRefresh(
+      runGit,
+      branchName,
+      targetRefs,
+      capabilities
+    ))
   ) {
     return false
   }

--- a/src/shared/git-branch-cleanup.test.ts
+++ b/src/shared/git-branch-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   branchHasNoUnmergedChangesOnAnyTarget,
+  branchHasNoUnmergedChangesWithLazyTargetRefresh,
   refreshBranchCleanupTargetRefs,
   type GitBranchCleanupExec
 } from './git-branch-cleanup'
@@ -193,5 +194,78 @@ describe('branchHasNoUnmergedChangesOnAnyTarget', () => {
 
     const mergeTreeCalls = vi.mocked(runGit).mock.calls.filter(([args]) => args[0] === 'merge-tree')
     expect(mergeTreeCalls).toHaveLength(1)
+  })
+})
+
+describe('branchHasNoUnmergedChangesWithLazyTargetRefresh', () => {
+  it('skips refresh when local HEAD proves the branch changes are retained', async () => {
+    const runGit = vi.fn<GitBranchCleanupExec>(async (args) => {
+      const command = args.join(' ')
+      const stdout =
+        {
+          'rev-parse --verify --quiet HEAD^{commit}': 'local-target\n',
+          'merge-tree --write-tree local-target refs/heads/feature/test': 'local-tree\n',
+          'rev-parse --verify --quiet local-target^{tree}': 'local-tree\n'
+        }[command] ?? ''
+      return { stdout }
+    })
+
+    await expect(
+      branchHasNoUnmergedChangesWithLazyTargetRefresh(
+        runGit,
+        'feature/test',
+        ['refs/remotes/origin/main', 'HEAD'],
+        new GitCapabilityCache()
+      )
+    ).resolves.toBe(true)
+
+    expect(runGit.mock.calls.map(([args]) => args)).not.toContainEqual(['remote'])
+  })
+
+  it('refreshes before trusting a stale remote-tracking proof', async () => {
+    let refreshed = false
+    const runGit = vi.fn<GitBranchCleanupExec>(async (args) => {
+      const command = args.join(' ')
+      if (command === 'remote') {
+        return { stdout: 'origin\n' }
+      }
+      if (command === 'fetch --prune origin') {
+        refreshed = true
+        return { stdout: '' }
+      }
+      if (command === 'rev-parse --verify --quiet refs/remotes/origin/main^{commit}') {
+        return { stdout: 'remote-target\n' }
+      }
+      if (command === 'rev-parse --verify --quiet origin/main^{commit}') {
+        return { stdout: 'short-remote-target\n' }
+      }
+      if (command === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'local-target\n' }
+      }
+      if (command === 'merge-tree --write-tree remote-target refs/heads/feature/test') {
+        return { stdout: refreshed ? 'changed-tree\n' : 'remote-tree\n' }
+      }
+      if (command === 'merge-tree --write-tree short-remote-target refs/heads/feature/test') {
+        return { stdout: refreshed ? 'changed-tree\n' : 'short-remote-tree\n' }
+      }
+      if (command === 'rev-parse --verify --quiet remote-target^{tree}') {
+        return { stdout: 'remote-tree\n' }
+      }
+      if (command === 'rev-parse --verify --quiet short-remote-target^{tree}') {
+        return { stdout: 'short-remote-tree\n' }
+      }
+      return { stdout: '' }
+    })
+
+    await expect(
+      branchHasNoUnmergedChangesWithLazyTargetRefresh(
+        runGit,
+        'feature/test',
+        ['refs/remotes/origin/main', 'origin/main', 'HEAD'],
+        new GitCapabilityCache()
+      )
+    ).resolves.toBe(false)
+
+    expect(runGit.mock.calls.map(([args]) => args)).toContainEqual(['fetch', '--prune', 'origin'])
   })
 })

--- a/src/shared/git-branch-cleanup.ts
+++ b/src/shared/git-branch-cleanup.ts
@@ -253,3 +253,16 @@ export async function branchHasNoUnmergedChangesOnAnyTarget(
 
   return false
 }
+
+export async function branchHasNoUnmergedChangesWithLazyTargetRefresh(
+  runGit: GitBranchCleanupExec,
+  branchName: string,
+  targetRefs: string[],
+  capabilities: GitCapabilityCache
+): Promise<boolean> {
+  if (await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs, capabilities)) {
+    return true
+  }
+  await refreshBranchCleanupTargetRefs(runGit, targetRefs)
+  return branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs, capabilities)
+}

--- a/src/shared/git-branch-cleanup.ts
+++ b/src/shared/git-branch-cleanup.ts
@@ -8,6 +8,10 @@ export type GitBranchCleanupExec = (
 
 const SQUASH_PATCH_SCAN_LIMIT = 200
 
+function isLocalTargetRef(ref: string): boolean {
+  return ref === 'HEAD' || ref.startsWith('refs/heads/') || ref.startsWith('refs/tags/')
+}
+
 async function readOptionalGitStdout(
   runGit: GitBranchCleanupExec,
   argv: string[],
@@ -260,9 +264,19 @@ export async function branchHasNoUnmergedChangesWithLazyTargetRefresh(
   targetRefs: string[],
   capabilities: GitCapabilityCache
 ): Promise<boolean> {
-  if (await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs, capabilities)) {
+  // Why: an unrefreshed remote-tracking ref may no longer represent the remote's branch contents.
+  const localTargetRefs = targetRefs.filter(isLocalTargetRef)
+  const refreshDependentTargetRefs = targetRefs.filter((targetRef) => !isLocalTargetRef(targetRef))
+  if (
+    await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, localTargetRefs, capabilities)
+  ) {
     return true
   }
   await refreshBranchCleanupTargetRefs(runGit, targetRefs)
-  return branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, targetRefs, capabilities)
+  return branchHasNoUnmergedChangesOnAnyTarget(
+    runGit,
+    branchName,
+    refreshDependentTargetRefs,
+    capabilities
+  )
 }

--- a/tests/tools/benchmarks/worktree-deletion-branch-fixture.mjs
+++ b/tests/tools/benchmarks/worktree-deletion-branch-fixture.mjs
@@ -29,13 +29,20 @@ export function seedBranchCleanupRepro(repoPath, worktreePath) {
 
 export async function startDelayedFetchServer(delayMs) {
   const sockets = new Set()
+  const timers = new Set()
   const server = net.createServer((socket) => {
     sockets.add(socket)
-    socket.on('close', () => sockets.delete(socket))
-    socket.on('error', () => undefined)
-    setTimeout(() => {
+    const timer = setTimeout(() => {
+      timers.delete(timer)
       socket.end('HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n')
     }, delayMs)
+    timers.add(timer)
+    socket.on('close', () => {
+      clearTimeout(timer)
+      timers.delete(timer)
+      sockets.delete(socket)
+    })
+    socket.on('error', () => undefined)
   })
   await new Promise((resolve, reject) => {
     server.once('error', reject)
@@ -49,6 +56,10 @@ export async function startDelayedFetchServer(delayMs) {
     url: `http://127.0.0.1:${address.port}/remote.git`,
     close: () =>
       new Promise((resolve) => {
+        for (const timer of timers) {
+          clearTimeout(timer)
+        }
+        timers.clear()
         for (const socket of sockets) {
           socket.destroy()
         }

--- a/tests/tools/benchmarks/worktree-deletion-branch-fixture.mjs
+++ b/tests/tools/benchmarks/worktree-deletion-branch-fixture.mjs
@@ -1,0 +1,58 @@
+import { spawnSync } from 'node:child_process'
+import net from 'node:net'
+import path from 'node:path'
+
+function runGit(args, cwd) {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed (${result.status})\n${result.stderr}`)
+  }
+  return result.stdout.trim()
+}
+
+export function initializeBranchCleanupRemote(fixtureRoot, repoPath) {
+  const remotePath = path.join(fixtureRoot, 'remote.git')
+  runGit(['init', '--bare', remotePath], fixtureRoot)
+  runGit(['symbolic-ref', 'HEAD', 'refs/heads/main'], remotePath)
+  runGit(['remote', 'add', 'origin', remotePath], repoPath)
+  runGit(['push', 'origin', 'main'], repoPath)
+}
+
+export function seedBranchCleanupRepro(repoPath, worktreePath) {
+  runGit(
+    ['commit', '--allow-empty', '-m', 'Trigger safe branch cleanup', '--no-gpg-sign'],
+    worktreePath
+  )
+  const branch = runGit(['symbolic-ref', '--short', 'HEAD'], worktreePath)
+  runGit(['config', `branch.${branch}.base`, 'refs/remotes/origin/main'], repoPath)
+}
+
+export async function startDelayedFetchServer(delayMs) {
+  const sockets = new Set()
+  const server = net.createServer((socket) => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+    socket.on('error', () => undefined)
+    setTimeout(() => {
+      socket.end('HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n')
+    }, delayMs)
+  })
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Delayed fetch server did not expose a TCP port')
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/remote.git`,
+    close: () =>
+      new Promise((resolve) => {
+        for (const socket of sockets) {
+          socket.destroy()
+        }
+        server.close(resolve)
+      })
+  }
+}

--- a/tests/tools/benchmarks/worktree-deletion-dev-bench.mjs
+++ b/tests/tools/benchmarks/worktree-deletion-dev-bench.mjs
@@ -16,9 +16,11 @@ import path from 'node:path'
 // Why @playwright/test, not playwright: only the former is a declared devDependency; it re-exports
 // the same browser types, so the benchmark resolves without relying on a hoisted transitive install.
 import { chromium } from '@playwright/test'
+import * as branchFixture from './worktree-deletion-branch-fixture.mjs'
 
 const DEFAULT_ITERATIONS = 3
 const DEFAULT_HISTORY_FILES = 10_000
+const DEFAULT_FETCH_DELAY_MS = 1_500
 const CDP_START_PORT = 9_700
 const START_TIMEOUT_MS = 180_000
 const IPC_TIMEOUT_MS = 90_000
@@ -29,6 +31,7 @@ function parseArgs(argv) {
     instances: [],
     iterations: DEFAULT_ITERATIONS,
     historyFiles: DEFAULT_HISTORY_FILES,
+    fetchDelayMs: DEFAULT_FETCH_DELAY_MS,
     keepFixture: false
   }
   for (let index = 2; index < argv.length; index += 1) {
@@ -65,6 +68,8 @@ function parseArgs(argv) {
       options.iterations = readPositiveInteger(value, next())
     } else if (value === '--history-files') {
       options.historyFiles = readPositiveInteger(value, next())
+    } else if (value === '--fetch-delay-ms') {
+      options.fetchDelayMs = readPositiveInteger(value, next())
     } else {
       throw new Error(`Unknown argument: ${value}`)
     }
@@ -91,6 +96,7 @@ Options:
   --instance <label=path>  Dev checkout to launch; repeat for A/B comparison
   --iterations <count>     Deletions per instance (default: ${DEFAULT_ITERATIONS})
   --history-files <count>  Files seeded in each worktree history (default: ${DEFAULT_HISTORY_FILES})
+  --fetch-delay-ms <ms>    Slow-remote delay for branch cleanup (default: ${DEFAULT_FETCH_DELAY_MS})
   --keep-fixture           Keep disposable profiles and repos for inspection`)
 }
 
@@ -117,6 +123,7 @@ function createFixture(instanceLabel) {
   run('git', ['add', 'README.md'], repoPath)
   run('git', ['commit', '-m', 'Initialize benchmark fixture', '--no-gpg-sign'], repoPath)
   run('git', ['branch', '-m', 'main'], repoPath)
+  branchFixture.initializeBranchCleanupRemote(root, repoPath)
   return { root, repoPath, userDataPath }
 }
 
@@ -406,6 +413,7 @@ async function verifyDeletion(page, worktree, historyPath, measurement) {
 async function runIteration(page, fixture, repoState, iteration, historyFiles) {
   const worktree = await createMeasuredWorktree(page, repoState.repoId, iteration)
   await assertWorktreeRowVisible(page, worktree.id)
+  branchFixture.seedBranchCleanupRepro(fixture.repoPath, worktree.path)
   const historyPath = seedTerminalHistory(fixture.userDataPath, worktree.id, historyFiles)
   const measurement = await measureDeletion(page, worktree.id, repoState.rootWorktreeId)
   await verifyDeletion(page, worktree, historyPath, measurement)
@@ -467,6 +475,8 @@ async function benchmarkInstance(instanceConfig, index, options) {
     instanceConfig.repoRoot
   )
   const fixture = createFixture(instanceConfig.label)
+  const delayedFetchServer = await branchFixture.startDelayedFetchServer(options.fetchDelayMs)
+  run('git', ['remote', 'set-url', 'origin', delayedFetchServer.url], fixture.repoPath)
   const port = await findAvailablePort(CDP_START_PORT + index)
   const instance = launchDevInstance(instanceConfig, fixture, port)
   let browser = null
@@ -500,6 +510,7 @@ async function benchmarkInstance(instanceConfig, index, options) {
       label: instanceConfig.label,
       repoRoot: instanceConfig.repoRoot,
       historyFiles: options.historyFiles,
+      fetchDelayMs: options.fetchDelayMs,
       iterations,
       summary: summarize(iterations.map((entry) => entry.totalMs)),
       ipcSummary: summarize(iterations.flatMap((entry) => entry.ipcLatencyMs.samples)),
@@ -509,6 +520,7 @@ async function benchmarkInstance(instanceConfig, index, options) {
   } finally {
     await browser?.close().catch(() => undefined)
     await stopDevInstance(instance)
+    await delayedFetchServer.close()
     if (!options.keepFixture) {
       await rm(fixture.root, {
         recursive: true,

--- a/tests/tools/benchmarks/worktree-deletion-dev-bench.mjs
+++ b/tests/tools/benchmarks/worktree-deletion-dev-bench.mjs
@@ -475,16 +475,14 @@ async function benchmarkInstance(instanceConfig, index, options) {
     instanceConfig.repoRoot
   )
   const fixture = createFixture(instanceConfig.label)
-  const delayedFetchServer = await branchFixture.startDelayedFetchServer(options.fetchDelayMs)
-  run('git', ['remote', 'set-url', 'origin', delayedFetchServer.url], fixture.repoPath)
-  const port = await findAvailablePort(CDP_START_PORT + index)
-  const instance = launchDevInstance(instanceConfig, fixture, port)
-  let browser = null
-  console.log(`[${instanceConfig.label}] launching ${instanceConfig.repoRoot}`)
+  let delayedFetchServer, instance, browser
   try {
-    const connection = await connectToOrca(instance)
-    browser = connection.browser
-    const { page } = connection
+    delayedFetchServer = await branchFixture.startDelayedFetchServer(options.fetchDelayMs)
+    run('git', ['remote', 'set-url', 'origin', delayedFetchServer.url], fixture.repoPath)
+    const port = await findAvailablePort(CDP_START_PORT + index)
+    instance = launchDevInstance(instanceConfig, fixture, port)
+    const { browser: connectedBrowser, page } = await connectToOrca(instance)
+    browser = connectedBrowser
     const repoState = await addFixtureRepo(page, fixture.repoPath)
     const iterations = []
     for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
@@ -519,8 +517,10 @@ async function benchmarkInstance(instanceConfig, index, options) {
     }
   } finally {
     await browser?.close().catch(() => undefined)
-    await stopDevInstance(instance)
-    await delayedFetchServer.close()
+    if (instance) {
+      await stopDevInstance(instance)
+    }
+    await delayedFetchServer?.close()
     if (!options.keepFixture) {
       await rm(fixture.root, {
         recursive: true,


### PR DESCRIPTION
## Summary

Workspace deletion no longer waits for a redundant network fetch when a durable local ref already proves a safe-to-delete branch was merged (including squash merges).

The delete path now:

1. proves branch cleanup safety from local refs such as `HEAD` and `refs/heads/*`;
2. skips the network only when that local proof succeeds;
3. refreshes remote-tracking refs before using them as deletion evidence;
4. preserves the branch when the refreshed proof remains inconclusive.

The same policy is shared by local, WSL, and SSH/relay deletion. Expected-head `update-ref` protection remains unchanged.

## Screenshots

No visual change.

## Reproduction and measurements

Live macOS reproduction used a uniquely named local workspace created for this test, with an empty commit to exercise the safe-delete-rejected/tree-equivalent branch path. Deletion took **2.56 s**; the `worktree.remove.branch_delete` trace accounted for **1.635 s**. The test workspace was the only live workspace deleted.

Controlled A/B benchmark (isolated Orca dev instances, three deletions each, 10,000 history files, tree-equivalent branch commit, 1,500 ms slow remote):

| | Before | Initial fix |
|---|---:|---:|
| Median deletion | 1,973.6 ms | 279.5 ms |
| p95 deletion | 2,050.6 ms | 337.2 ms |
| Samples | 1,867.0 / 1,973.6 / 2,050.6 ms | 237.3 / 279.5 / 337.2 ms |
| Restart recovery | Pass | Pass |

**Initial median improvement: 85.84%.**

After the production safety scan narrowed the no-fetch path to durable local refs, the same 10,000-file/1,500 ms-delay candidate scenario measured **277.1 ms median / 290.3 ms p95** (266.9 / 277.1 / 290.3 ms), with restart recovery passing. This confirms the safety hardening preserves the performance win.

The benchmark creates its own disposable bare remote, branch commit, delayed loopback endpoint, Orca profile, repo, and worktrees. It verifies the workspace directory, terminal history, sidebar row, and renderer-owned tabs/files are removed, then verifies restart recovery. Its timers, sockets, dev process, and fixtures are cleaned up on success and setup/runtime failure.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:

- focused native/shared/relay Vitest suite — **61 passed**
- `pnpm typecheck:node` — passed
- `pnpm check:code-quality:changed` — passed, 0 findings across 8 changed files
- `pnpm check:max-lines-ratchet` — passed, no new bypasses
- `git diff --check` — passed
- `node --check` for both benchmark modules — passed
- post-hardening 3-run benchmark — 277.1 ms median, restart recovery passed
- teardown refactor smoke benchmark — deletion and restart recovery passed

## Production release scan

Pinned span: `3a70078ab9972f61a364c064f21e2301b53f360d..21876282e86abb7de8883faf497d9113e1ed7364`.

The scan found a release-blocking edge case in the initial commit: a stale `refs/remotes/*` ref could satisfy the first proof before an available fetch observed a non-fast-forward remote rewrite. The final commit fixes it by allowing only durable local refs to use the no-fetch proof; remote and ambiguous refs are evaluated only after the refresh attempt. Pure unit tests cover both the local short-circuit and stale remote-positive case, while native and relay tests assert `fetch -> proof -> expected-head delete` ordering.

Independent strongest-Codex and two Grok audits reviewed correctness, data-loss risk, performance, Git 2.25 compatibility, Windows/Linux/WSL, SSH/relay, folder workspaces, mobile backcompat, and benchmark methodology. Follow-up reviews found no P0/P1/P2 issue in the amendment.

## Security audit

No dependency, lockfile, package-script, workflow, production IPC/auth, credential, persisted-state, or protocol change. The only security-grep hit is benchmark `spawnSync('git', args)`: arguments are passed as argv without shell interpolation. The benchmark server binds only to `127.0.0.1` and operates exclusively on generated temporary paths.

## Compatibility notes

- Native, WSL, and SSH/relay callers use the same shared cleanup policy.
- Existing Git capability caching and the Git 2.25-compatible fallback remain unchanged.
- Folder workspaces do not enter Git branch cleanup and are unaffected.
- No mobile RPC/schema, route, pairing, persisted-state, or protocol surface changed; older clients retain the existing remove-worktree contract.
