### PR TITLE
fix(terminal): enable ConPTY backend for WSL panes to fix CJK line splitting

### DIFF
--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.test.ts
@@ -89,7 +89,9 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
     ).toEqual({})
   })
 
-  it('skips compatibility options for WSL cwd terminals', () => {
+  // WSL panes spawn wsl.exe through ConPTY; xterm.js needs the conpty backend
+  // to handle ConPTY's wrap markers or CJK text (width=2) splits per line (#11919).
+  it('includes WSL cwd terminals for ConPTY compatibility', () => {
     for (const cwd of [
       '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo',
       '\\\\wsl$\\Debian\\home\\me\\repo',
@@ -105,11 +107,13 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
           shellOverride: null,
           executionHostId: 'local'
         })
-      ).toEqual({})
+      ).toEqual({
+        windowsPty: { backend: 'conpty', buildNumber: 26100 }
+      })
     }
   })
 
-  it('skips compatibility options when the shell override launches WSL', () => {
+  it('includes WSL shell override terminals for ConPTY compatibility', () => {
     expect(
       buildWindowsPtyCompatibilityOptions({
         userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
@@ -119,7 +123,9 @@ describe('buildWindowsPtyCompatibilityOptions', () => {
         shellOverride: 'C:\\Windows\\System32\\wsl.exe',
         executionHostId: 'local'
       })
-    ).toEqual({})
+    ).toEqual({
+      windowsPty: { backend: 'conpty', buildNumber: 26100 }
+    })
   })
 
   it('returns no options outside Windows', () => {
@@ -240,6 +246,20 @@ describe('isLocalNativeWindowsConpty', () => {
     ).toBe(true)
   })
 
+  // WSL-internal Linux PTY decodes CSI-u correctly, so Kitty keyboard stays on.
+  // ConPTY wrap-marker handling is separately enabled via buildWindowsPtyCompatibilityOptions.
+  it('does NOT treat a WSL pane as a native ConPTY (Kitty keyboard stays advertised)', () => {
+    expect(
+      isLocalNativeWindowsConpty({
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+        connectionId: null,
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo',
+        shellOverride: null,
+        executionHostId: 'local'
+      })
+    ).toBe(false)
+  })
+
   it('does NOT treat a remote-runtime (serve) pane as a native ConPTY even when the raw Windows heuristic matches', () => {
     // Regression: a serve-hosted pane on a Windows client has no SSH connectionId
     // and a Linux cwd, so isLocalNativeWindowsPty returns true. Without the
@@ -275,7 +295,7 @@ describe('isLocalNativeWindowsConpty', () => {
     ).toBe(false)
   })
 
-  it('stays false on a local host when the pane is not a native Windows PTY', () => {
+  it('stays false on a local host when the pane is not a Windows PTY', () => {
     // Non-Windows client: the raw heuristic is false, so the gate result is false
     // regardless of the local execution host.
     expect(

--- a/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
+++ b/src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts
@@ -42,18 +42,22 @@ function buildXtermWindowsPtyOptions(
   return { backend: 'conpty', buildNumber }
 }
 
-/**
- * xterm options that select the native-Windows ConPTY backend, returned only for
- * a genuine local Windows pane and `{}` otherwise.
- *
- * Why it requires `executionHostId`: a serve/remote-runtime pane on a Windows
- * client looks local to the raw heuristic (no SSH `connectionId`, Linux `cwd`),
- * so gating on the execution host keeps the ConPTY backend off remote PTYs.
- */
+/** Windows client, no SSH connection. Check before gating on execution host. */
+function isWindowsPtyIgnoringWsl(context: WindowsPtyCompatibilityContext): boolean {
+  return isWindowsUserAgent(context.userAgent) && context.connectionId === null
+}
+
+/** Whether a pane spawns through a local Windows ConPTY — native-Windows and WSL (#11919). */
+export function isLocalWindowsConptyPane(
+  context: WindowsPtyCompatibilityContext & { executionHostId: ExecutionHostId }
+): boolean {
+  return context.executionHostId === LOCAL_EXECUTION_HOST_ID && isWindowsPtyIgnoringWsl(context)
+}
+
 export function buildWindowsPtyCompatibilityOptions(
   context: WindowsPtyCompatibilityContext & { executionHostId: ExecutionHostId }
 ): Partial<ITerminalOptions> {
-  if (!isLocalNativeWindowsConpty(context)) {
+  if (!isLocalWindowsConptyPane(context)) {
     return {}
   }
   const buildNumber = parseWindowsBuildNumber(context.osRelease)
@@ -79,21 +83,19 @@ export function resolveWindowsShellOverride(
  * local pane from a serve pane, so callers gate it with `isLocalNativeWindowsConpty`.
  */
 export function isLocalNativeWindowsPty(context: WindowsPtyCompatibilityContext): boolean {
-  if (!isWindowsUserAgent(context.userAgent)) {
-    return false
-  }
-  if (context.connectionId !== null) {
-    return false
-  }
-  if (isWslCwd(context.cwd) || isWslShellOverride(context.shellOverride)) {
-    return false
-  }
-  return true
+  return (
+    isWindowsPtyIgnoringWsl(context) &&
+    !isWslCwd(context.cwd) &&
+    !isWslShellOverride(context.shellOverride)
+  )
 }
 
 /**
  * Whether a pane is a genuine local native Windows ConPTY that needs the ConPTY
- * cursor/synchronized-output workarounds.
+ * cursor/synchronized-output workarounds and Kitty keyboard withhold. Excludes
+ * WSL panes (WSL-internal Linux PTY decodes CSI-u correctly), so Kitty keyboard
+ * stays advertised for WSL while `windowsPty` is separately enabled via
+ * `isLocalWindowsConptyPane`.
  *
  * Why this is gated on the execution host: a serve/remote-runtime pane on a
  * Windows client has no SSH `connectionId` and a Linux `cwd`, so


### PR DESCRIPTION
## Summary

WSL panes in the Orca desktop app on Windows spawn `wsl.exe` through ConPTY, but `isLocalNativeWindowsConpty()` excluded them from the `windowsPty` option. Without the `conpty` backend, xterm.js treats ConPTY's wrap markers as real line breaks, causing CJK text (width=2 cells) to split per character.

**Fix:** Add `isLocalWindowsConptyPane()` that includes WSL panes, and use it in `buildWindowsPtyCompatibilityOptions()` so xterm.js gets the `conpty` backend for WSL too.

`isLocalNativeWindowsConpty()` (used for Kitty keyboard withhold) stays unchanged so WSL keeps CSI-u support — WSL-internal Linux PTY decodes Kitty CSI-u correctly.

Fixes #11919.

## Root cause

`src/renderer/src/lib/pane-manager/windows-pty-compatibility.ts:88` — `isLocalNativeWindowsPty()` excluded WSL panes (checks `isWslCwd()` and `isWslShellOverride()`), so `buildWindowsPtyCompatibilityOptions()` returned `{}` for WSL. xterm.js then had no `windowsPty` option and didn't know it was talking to ConPTY.

ConPTY echoes input with its own `\r\n` wrap markers. xterm.js without the `conpty` backend flag treats each wrapped visual line as a real line break. CJK characters are width=2 cells (Unicode 11), so ConPTY wrapping triggers roughly twice as often per screen line vs ASCII — Korean text breaks per character while English works.

## Verification

- **CDP inspection** confirmed all WSL PTY sessions have `cwd: \\wsl.localhost\Ubuntu\...` → `isWslCwd()` = true → `windowsPty` was `{}`.
- **Agent-affected:** all (Hermes TUI, Claude Code, OpenCode, Crush, etc.) — the bug is in xterm.js wrapping, not in any agent.
- **External terminal works:** Windows Terminal → WSL → Hermes is fine because Windows Terminal sets the ConPTY backend correctly.

## Changes

- `windows-pty-compatibility.ts`: Add `isLocalWindowsConptyPane()` (includes WSL); `buildWindowsPtyCompatibilityOptions()` uses it. `isLocalNativeWindowsConpty()` unchanged (Kitty keyboard stays advertised for WSL).
- `windows-pty-compatibility.test.ts`: Update tests — WSL panes now get ConPTY options (`#11919`), but `isLocalNativeWindowsConpty()` still excludes WSL for Kitty keyboard.

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/` — 594 passed, 1 skipped
- [x] Manual: type Korean `안녕하세요` in an Orca WSL terminal pane — should appear on one line
- [ ] Manual: verify Kitty keyboard protocol still advertised for WSL (e.g. `claude` CLI enhanced keys work)

## Notes

This is the Orca-side fix. The xterm.js patch (`config/patches/@xterm__xterm@6.1.0-beta.287.patch`) and `keypressMayOverlapComposition` logic from #11293 may also need Windows-specific adjustments for full robustness, but enabling the ConPTY backend for WSL panes is the correct first step — xterm.js needs to know it's talking to ConPTY.

## Related

- #11919 — issue
- #11293 — IME composition lifecycle reconciliation (may have introduced the `keypressMayOverlapComposition` edge case on Windows)
- #8038 — macOS desktop terminal Hangul syllable on new line
- #9803 — Windows terminal Korean input issues