### PR TITLE
fix(editor): make lazy-chunk recovery actually reload instead of being silently vetoed

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -279,8 +279,7 @@ import {
 } from '../shared/renderer-restart-preparation'
 import {
   prepareAndInvokeUpdaterInstall,
-  relayRendererUnloadPrevented,
-  relayUpdaterStatus
+  registerRendererRestartIpcRelays
 } from './renderer-restart-wiring'
 
 type NativeFileDropCallback = (data: NativeFileDropPayload) => void
@@ -292,12 +291,7 @@ const updaterQuitAbortRelay = createUpdaterQuitAbortRelay(
   ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
 )
 
-ipcRenderer.on('updater:status', (_event, status: UpdateStatus) => {
-  relayUpdaterStatus(updaterQuitAbortRelay, status)
-})
-ipcRenderer.on('window:unload-prevented', () => {
-  relayRendererUnloadPrevented(window)
-})
+registerRendererRestartIpcRelays(ipcRenderer, window, updaterQuitAbortRelay)
 
 function getLinuxDisplayServer(): 'wayland' | 'x11' | null {
   if (process.platform !== 'linux') {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -278,7 +278,7 @@ import { readRendererHeapStatistics } from './renderer-heap-statistics-reader'
 import {
   createUpdaterQuitAbortRelay,
   prepareRendererForAppRestart
-} from './renderer-restart-preparation'
+} from '../shared/renderer-restart-preparation'
 
 type NativeFileDropCallback = (data: NativeFileDropPayload) => void
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -236,10 +236,8 @@ import type { AgentType } from '../shared/native-chat-types'
 import {
   ORCA_APP_RESTART_ABORTED_EVENT,
   ORCA_APP_RESTART_STARTED_EVENT,
-  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
-  ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
+  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
 } from '../shared/updater-renderer-events'
-import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../shared/renderer-shutdown-events'
 import {
   ORCA_INTERNAL_FILE_DRAG_TYPE,
   createNativeFileDropPayload,
@@ -279,6 +277,11 @@ import {
   createUpdaterQuitAbortRelay,
   prepareRendererForAppRestart
 } from '../shared/renderer-restart-preparation'
+import {
+  prepareAndInvokeUpdaterInstall,
+  relayRendererUnloadPrevented,
+  relayUpdaterStatus
+} from './renderer-restart-wiring'
 
 type NativeFileDropCallback = (data: NativeFileDropPayload) => void
 
@@ -290,10 +293,10 @@ const updaterQuitAbortRelay = createUpdaterQuitAbortRelay(
 )
 
 ipcRenderer.on('updater:status', (_event, status: UpdateStatus) => {
-  updaterQuitAbortRelay.handleStatus(status)
+  relayUpdaterStatus(updaterQuitAbortRelay, status)
 })
 ipcRenderer.on('window:unload-prevented', () => {
-  window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+  relayRendererUnloadPrevented(window)
 })
 
 function getLinuxDisplayServer(): 'wayland' | 'x11' | null {
@@ -2958,19 +2961,10 @@ const api = {
     dismissNudge: () => ipcRenderer.invoke('updater:dismissNudge'),
     dismissAvailableUpdate: () => ipcRenderer.invoke('updater:dismissAvailableUpdate'),
     listBuilds: (channel) => ipcRenderer.invoke('updater:listBuilds', channel),
-    quitAndInstall: async (): Promise<void> => {
-      await prepareRendererForAppRestart(window, {
-        startedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT,
-        abortedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
-      })
-      updaterQuitAbortRelay.markPrepared()
-      try {
-        return await ipcRenderer.invoke('updater:quitAndInstall')
-      } catch (error) {
-        updaterQuitAbortRelay.abort()
-        throw error
-      }
-    },
+    quitAndInstall: (): Promise<void> =>
+      prepareAndInvokeUpdaterInstall(window, updaterQuitAbortRelay, () =>
+        ipcRenderer.invoke('updater:quitAndInstall')
+      ),
     onStatus: (callback) => {
       const listener = (_event: Electron.IpcRendererEvent, status: UpdateStatus) => callback(status)
       ipcRenderer.on('updater:status', listener)

--- a/src/preload/renderer-restart-wiring.test.ts
+++ b/src/preload/renderer-restart-wiring.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('preload restart wiring', () => {
+  const source = readFileSync(join(process.cwd(), 'src/preload/index.ts'), 'utf8')
+
+  it('relays prevented unload and async updater failure IPC into renderer lifecycle events', () => {
+    expect(source).toContain("ipcRenderer.on('updater:status'")
+    expect(source).toContain('updaterQuitAbortRelay.handleStatus(status)')
+    expect(source).toContain("ipcRenderer.on('window:unload-prevented'")
+    expect(source).toContain(
+      'window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))'
+    )
+  })
+
+  it('marks updater preparation before invoking main and aborts it on immediate IPC failure', () => {
+    const start = source.indexOf('quitAndInstall: async (): Promise<void> => {')
+    const end = source.indexOf('onStatus: (callback) => {', start)
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    const block = source.slice(start, end)
+    const prepare = block.indexOf('await prepareRendererForAppRestart(window, {')
+    const markPrepared = block.indexOf('updaterQuitAbortRelay.markPrepared()')
+    const invoke = block.indexOf("ipcRenderer.invoke('updater:quitAndInstall')")
+    const abort = block.indexOf('updaterQuitAbortRelay.abort()')
+
+    expect(prepare).toBeGreaterThanOrEqual(0)
+    expect(markPrepared).toBeGreaterThan(prepare)
+    expect(invoke).toBeGreaterThan(markPrepared)
+    expect(abort).toBeGreaterThan(invoke)
+    expect(block).toMatch(
+      /try \{\s*return await ipcRenderer\.invoke\('updater:quitAndInstall'\)\s*\} catch \(error\) \{\s*updaterQuitAbortRelay\.abort\(\)\s*throw error\s*\}/
+    )
+  })
+})

--- a/src/preload/renderer-restart-wiring.test.ts
+++ b/src/preload/renderer-restart-wiring.test.ts
@@ -3,8 +3,7 @@ import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../shared/renderer-shutdow
 import { ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT } from '../shared/updater-renderer-events'
 import {
   prepareAndInvokeUpdaterInstall,
-  relayRendererUnloadPrevented,
-  relayUpdaterStatus
+  registerRendererRestartIpcRelays
 } from './renderer-restart-wiring'
 
 describe('renderer restart wiring', () => {
@@ -12,11 +11,20 @@ describe('renderer restart wiring', () => {
     const eventTarget = new EventTarget()
     const unloadPrevented = vi.fn()
     const handleStatus = vi.fn()
+    const listeners = new Map<string, (...args: unknown[]) => void>()
+    const ipcRenderer = {
+      on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+        listeners.set(channel, listener)
+        return ipcRenderer
+      })
+    } as unknown as Parameters<typeof registerRendererRestartIpcRelays>[0]
     eventTarget.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, unloadPrevented)
 
-    relayUpdaterStatus({ handleStatus }, { state: 'error', message: 'install failed' })
-    relayRendererUnloadPrevented(eventTarget)
+    registerRendererRestartIpcRelays(ipcRenderer, eventTarget, { handleStatus })
+    listeners.get('updater:status')?.({}, { state: 'error', message: 'install failed' })
+    listeners.get('window:unload-prevented')?.({})
 
+    expect(ipcRenderer.on).toHaveBeenCalledTimes(2)
     expect(handleStatus).toHaveBeenCalledWith({ state: 'error', message: 'install failed' })
     expect(unloadPrevented).toHaveBeenCalledTimes(1)
   })

--- a/src/preload/renderer-restart-wiring.test.ts
+++ b/src/preload/renderer-restart-wiring.test.ts
@@ -1,36 +1,45 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../shared/renderer-shutdown-events'
+import { ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT } from '../shared/updater-renderer-events'
+import {
+  prepareAndInvokeUpdaterInstall,
+  relayRendererUnloadPrevented,
+  relayUpdaterStatus
+} from './renderer-restart-wiring'
 
-describe('preload restart wiring', () => {
-  const source = readFileSync(join(process.cwd(), 'src/preload/index.ts'), 'utf8')
+describe('renderer restart wiring', () => {
+  it('relays updater status and prevented unload events', () => {
+    const eventTarget = new EventTarget()
+    const unloadPrevented = vi.fn()
+    const handleStatus = vi.fn()
+    eventTarget.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, unloadPrevented)
 
-  it('relays prevented unload and async updater failure IPC into renderer lifecycle events', () => {
-    expect(source).toContain("ipcRenderer.on('updater:status'")
-    expect(source).toContain('updaterQuitAbortRelay.handleStatus(status)')
-    expect(source).toContain("ipcRenderer.on('window:unload-prevented'")
-    expect(source).toContain(
-      'window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))'
-    )
+    relayUpdaterStatus({ handleStatus }, { state: 'error', message: 'install failed' })
+    relayRendererUnloadPrevented(eventTarget)
+
+    expect(handleStatus).toHaveBeenCalledWith({ state: 'error', message: 'install failed' })
+    expect(unloadPrevented).toHaveBeenCalledTimes(1)
   })
 
-  it('marks updater preparation before invoking main and aborts it on immediate IPC failure', () => {
-    const start = source.indexOf('quitAndInstall: async (): Promise<void> => {')
-    const end = source.indexOf('onStatus: (callback) => {', start)
-    expect(start).toBeGreaterThanOrEqual(0)
-    expect(end).toBeGreaterThan(start)
-    const block = source.slice(start, end)
-    const prepare = block.indexOf('await prepareRendererForAppRestart(window, {')
-    const markPrepared = block.indexOf('updaterQuitAbortRelay.markPrepared()')
-    const invoke = block.indexOf("ipcRenderer.invoke('updater:quitAndInstall')")
-    const abort = block.indexOf('updaterQuitAbortRelay.abort()')
+  it('marks preparation before invoking main and aborts on IPC failure', async () => {
+    const eventTarget = new EventTarget()
+    const calls: string[] = []
+    eventTarget.addEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT, () => {
+      calls.push('prepared')
+    })
+    const relay = {
+      markPrepared: () => calls.push('marked'),
+      abort: () => calls.push('aborted')
+    }
+    const invoke = vi.fn(async () => {
+      calls.push('invoked')
+      throw new Error('IPC failed')
+    })
 
-    expect(prepare).toBeGreaterThanOrEqual(0)
-    expect(markPrepared).toBeGreaterThan(prepare)
-    expect(invoke).toBeGreaterThan(markPrepared)
-    expect(abort).toBeGreaterThan(invoke)
-    expect(block).toMatch(
-      /try \{\s*return await ipcRenderer\.invoke\('updater:quitAndInstall'\)\s*\} catch \(error\) \{\s*updaterQuitAbortRelay\.abort\(\)\s*throw error\s*\}/
+    await expect(prepareAndInvokeUpdaterInstall(eventTarget, relay, invoke)).rejects.toThrow(
+      'IPC failed'
     )
+
+    expect(calls).toEqual(['prepared', 'marked', 'invoked', 'aborted'])
   })
 })

--- a/src/preload/renderer-restart-wiring.ts
+++ b/src/preload/renderer-restart-wiring.ts
@@ -1,3 +1,4 @@
+import type { IpcRenderer } from 'electron'
 import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../shared/renderer-shutdown-events'
 import {
   prepareRendererForAppRestart,
@@ -9,15 +10,17 @@ import {
   ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
 } from '../shared/updater-renderer-events'
 
-export function relayUpdaterStatus(
-  relay: Pick<UpdaterQuitAbortRelay, 'handleStatus'>,
-  status: UpdateStatus
+export function registerRendererRestartIpcRelays(
+  ipcRenderer: Pick<IpcRenderer, 'on'>,
+  eventTarget: EventTarget,
+  relay: Pick<UpdaterQuitAbortRelay, 'handleStatus'>
 ): void {
-  relay.handleStatus(status)
-}
-
-export function relayRendererUnloadPrevented(eventTarget: EventTarget): void {
-  eventTarget.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+  ipcRenderer.on('updater:status', (_event, status: UpdateStatus) => {
+    relay.handleStatus(status)
+  })
+  ipcRenderer.on('window:unload-prevented', () => {
+    eventTarget.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+  })
 }
 
 export async function prepareAndInvokeUpdaterInstall(

--- a/src/preload/renderer-restart-wiring.ts
+++ b/src/preload/renderer-restart-wiring.ts
@@ -1,0 +1,39 @@
+import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../shared/renderer-shutdown-events'
+import {
+  prepareRendererForAppRestart,
+  type UpdaterQuitAbortRelay
+} from '../shared/renderer-restart-preparation'
+import type { UpdateStatus } from '../shared/types'
+import {
+  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
+  ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
+} from '../shared/updater-renderer-events'
+
+export function relayUpdaterStatus(
+  relay: Pick<UpdaterQuitAbortRelay, 'handleStatus'>,
+  status: UpdateStatus
+): void {
+  relay.handleStatus(status)
+}
+
+export function relayRendererUnloadPrevented(eventTarget: EventTarget): void {
+  eventTarget.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+}
+
+export async function prepareAndInvokeUpdaterInstall(
+  eventTarget: EventTarget,
+  relay: Pick<UpdaterQuitAbortRelay, 'markPrepared' | 'abort'>,
+  invoke: () => Promise<void>
+): Promise<void> {
+  await prepareRendererForAppRestart(eventTarget, {
+    startedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT,
+    abortedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
+  })
+  relay.markPrepared()
+  try {
+    await invoke()
+  } catch (error) {
+    relay.abort()
+    throw error
+  }
+}

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -33,7 +33,11 @@ import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
 const CombinedDiffViewer = lazy(() => import('./CombinedDiffViewer'))
-const RichMarkdownEditor = lazy(() => import('./RichMarkdownEditor'))
+// Why keyed: the reload breadcrumb is the only pre-crash evidence, and an unkeyed
+// site logs `reloadKey: "unknown"` (see crash b860def2).
+const RichMarkdownEditor = lazy(() => import('./RichMarkdownEditor'), {
+  reloadKey: 'rich-markdown-editor'
+})
 const MarkdownPreview = lazy(() => import('./MarkdownPreview'))
 const ImageViewer = lazy(() => import('./ImageViewer'))
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -33,8 +33,9 @@ import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
 const CombinedDiffViewer = lazy(() => import('./CombinedDiffViewer'))
-// Why keyed: the reload breadcrumb is the only pre-crash evidence, and an unkeyed
-// site logs `reloadKey: "unknown"` (see crash b860def2).
+// Why keyed: `reloadKey` rides on LazyChunkLoadError and on the vetoed-reload
+// breadcrumb, so the report names this chunk instead of one of the eight lazy sites
+// below. b860def2's own pre-reload crumb had already been evicted from the ring.
 const RichMarkdownEditor = lazy(() => import('./RichMarkdownEditor'), {
   reloadKey: 'rich-markdown-editor'
 })

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -33,9 +33,6 @@ import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 const DiffViewer = lazy(() => import('./DiffViewer'))
 const CombinedDiffViewer = lazy(() => import('./CombinedDiffViewer'))
-// Why keyed: `reloadKey` rides on LazyChunkLoadError and on the vetoed-reload
-// breadcrumb, so the report names this chunk instead of one of the eight lazy sites
-// below. b860def2's own pre-reload crumb had already been evicted from the ring.
 const RichMarkdownEditor = lazy(() => import('./RichMarkdownEditor'), {
   reloadKey: 'rich-markdown-editor'
 })

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment happy-dom
 
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { Suspense, act, type ReactElement, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,12 +10,20 @@ import { lazyWithRetry } from '@/lib/lazy-with-retry'
 import { RichMarkdownErrorBoundary } from './RichMarkdownErrorBoundary'
 
 const reportCrashMock = vi.hoisted(() => vi.fn())
+const recordBreadcrumbMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/lib/react-error-boundary-reporting', () => ({
   reportReactErrorBoundaryCrash: reportCrashMock
 }))
 
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: recordBreadcrumbMock
+}))
+
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+// A guard left by a *different* document is what proves the reload landed; only then
+// does lazy-with-retry produce the sentinel this boundary suppresses.
+const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
@@ -23,11 +33,20 @@ function createContainer(): { container: HTMLDivElement; root: Root } {
   return { container, root: createRoot(container) }
 }
 
-// Mirrors EditorContent: the Suspense sits above the boundary, which wraps the lazy editor.
-function BoundaryHarness({ children }: { children: ReactNode }): ReactElement {
+// Mirrors EditorContent: the Suspense sits above the boundary, which EditorContent
+// re-keys per open file (`key={viewStateScopeId}`), and which wraps the lazy editor.
+function BoundaryHarness({
+  children,
+  boundaryKey = 'pane-a'
+}: {
+  children: ReactNode
+  boundaryKey?: string
+}): ReactElement {
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <RichMarkdownErrorBoundary fileId="file-1">{children}</RichMarkdownErrorBoundary>
+      <RichMarkdownErrorBoundary key={boundaryKey} fileId="file-1">
+        {children}
+      </RichMarkdownErrorBoundary>
     </Suspense>
   )
 }
@@ -38,6 +57,8 @@ async function flushReactWork(): Promise<void> {
   })
 }
 
+// The breadcrumb dedupe is module-scoped (it has to outlive boundary remounts), so
+// every test below must use a distinct parse-error message to start from a clean slate.
 describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
   let root: Root | null = null
   let container: HTMLDivElement | null = null
@@ -45,6 +66,7 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
 
   beforeEach(() => {
     reportCrashMock.mockReset()
+    recordBreadcrumbMock.mockReset()
     window.sessionStorage.clear()
     consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
@@ -60,10 +82,11 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
     consoleError.mockRestore()
   })
 
-  // Repro for crash b860def2: an app update swapped chunk hashes, lazy-with-retry
-  // burned its one guarded reload, then surfaced LazyChunkLoadError here.
+  // The only honest sentinel case: a landed reload already refetched the chunk and it
+  // still fails to parse, so the report is not actionable. (b860def2 itself is NOT this
+  // case — its reload was vetoed, so lazy-with-retry now re-throws the real error.)
   it('renders the fallback without reporting after guarded dynamic import exhaustion', async () => {
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
       () => Promise.reject(new SyntaxError("Unexpected token ':'")),
       { retries: 0 }
@@ -82,6 +105,70 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
 
     expect(container?.textContent).toContain('rich markdown editor')
     expect(reportCrashMock).not.toHaveBeenCalled()
+    // The suppressed report was the only artifact naming this surface; keep evidence.
+    expect(recordBreadcrumbMock).toHaveBeenCalledWith('lazy_chunk_boundary_degraded', {
+      boundaryId: 'editor.rich-markdown',
+      cause: "SyntaxError: Unexpected token ':'"
+    })
+  })
+
+  // The breadcrumb ring holds 30 entries and does not coalesce this name, so an
+  // impatient Retry streak on a permanently rejected chunk would erase the trail.
+  it('records the degraded breadcrumb once across repeated Retry clicks', async () => {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
+    const LazyRejectingImport = lazyWithRetry(
+      () => Promise.reject(new SyntaxError("Unexpected token '}'")),
+      { retries: 0 }
+    )
+    ;({ container, root } = createContainer())
+
+    await act(async () => {
+      root?.render(
+        <BoundaryHarness>
+          <LazyRejectingImport />
+        </BoundaryHarness>
+      )
+    })
+    await flushReactWork()
+    await flushReactWork()
+
+    for (let click = 0; click < 3; click += 1) {
+      const retry = container?.querySelector('button')
+      expect(retry).not.toBeNull()
+      await act(async () => {
+        retry?.click()
+      })
+      await flushReactWork()
+    }
+
+    expect(container?.textContent).toContain('rich markdown editor')
+    expect(recordBreadcrumbMock).toHaveBeenCalledTimes(1)
+  })
+
+  // EditorContent re-keys the boundary per open file, so instance-scoped dedupe would
+  // re-record on every markdown tab switch — the same ring flush the Retry streak causes.
+  it('records the degraded breadcrumb once across boundary remounts', async () => {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
+    const LazyRejectingImport = lazyWithRetry(
+      () => Promise.reject(new SyntaxError("Unexpected token '<'")),
+      { retries: 0 }
+    )
+    ;({ container, root } = createContainer())
+
+    for (const boundaryKey of ['pane-a', 'pane-b', 'pane-c']) {
+      await act(async () => {
+        root?.render(
+          <BoundaryHarness boundaryKey={boundaryKey}>
+            <LazyRejectingImport />
+          </BoundaryHarness>
+        )
+      })
+      await flushReactWork()
+      await flushReactWork()
+    }
+
+    expect(container?.textContent).toContain('rich markdown editor')
+    expect(recordBreadcrumbMock).toHaveBeenCalledTimes(1)
   })
 
   it('still reports ordinary render errors', async () => {
@@ -100,6 +187,7 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
     })
 
     expect(container?.textContent).toContain('rich markdown editor')
+    expect(recordBreadcrumbMock).not.toHaveBeenCalled()
     expect(reportCrashMock).toHaveBeenCalledTimes(1)
     expect(reportCrashMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -108,5 +196,15 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
         error
       })
     )
+  })
+
+  // b860def2's pre-crash breadcrumb read `reloadKey: "unknown"`, which cannot tell
+  // the rich editor chunk apart from the seven other lazy chunks in EditorContent.
+  it('names the rich editor chunk at the EditorContent lazy call site', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/renderer/src/components/editor/EditorContent.tsx'),
+      'utf8'
+    )
+    expect(source).toContain("reloadKey: 'rich-markdown-editor'")
   })
 })

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
@@ -7,7 +7,10 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
-import { RichMarkdownErrorBoundary } from './RichMarkdownErrorBoundary'
+import {
+  clearLazyChunkBreadcrumbDedupeForTest,
+  RichMarkdownErrorBoundary
+} from './RichMarkdownErrorBoundary'
 
 const reportCrashMock = vi.hoisted(() => vi.fn())
 const recordBreadcrumbMock = vi.hoisted(() => vi.fn())
@@ -57,8 +60,10 @@ async function flushReactWork(): Promise<void> {
   })
 }
 
-// The breadcrumb dedupe is module-scoped (it has to outlive boundary remounts), so
-// every test below must use a distinct parse-error message to start from a clean slate.
+// The parse error a corrupt rich-editor chunk rejects with; reused across tests to
+// prove the module-scoped dedupe is reset rather than dodged by unique messages.
+const CORRUPT_CHUNK_PARSE_ERROR = "Unexpected token ':'"
+
 describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
   let root: Root | null = null
   let container: HTMLDivElement | null = null
@@ -67,6 +72,8 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
   beforeEach(() => {
     reportCrashMock.mockReset()
     recordBreadcrumbMock.mockReset()
+    // Dedupe is module-scoped so it can outlive boundary remounts; reset it per test.
+    clearLazyChunkBreadcrumbDedupeForTest()
     window.sessionStorage.clear()
     consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
   })
@@ -88,8 +95,8 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
   it('renders the fallback without reporting after guarded dynamic import exhaustion', async () => {
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
-      () => Promise.reject(new SyntaxError("Unexpected token ':'")),
-      { retries: 0 }
+      () => Promise.reject(new SyntaxError(CORRUPT_CHUNK_PARSE_ERROR)),
+      { retries: 0, reloadKey: 'rich-markdown-editor' }
     )
     ;({ container, root } = createContainer())
 
@@ -108,16 +115,18 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
     // The suppressed report was the only artifact naming this surface; keep evidence.
     expect(recordBreadcrumbMock).toHaveBeenCalledWith('lazy_chunk_boundary_degraded', {
       boundaryId: 'editor.rich-markdown',
-      cause: "SyntaxError: Unexpected token ':'"
+      reloadKey: 'rich-markdown-editor',
+      cause: `SyntaxError: ${CORRUPT_CHUNK_PARSE_ERROR}`
     })
   })
 
   // The breadcrumb ring holds 30 entries and does not coalesce this name, so an
   // impatient Retry streak on a permanently rejected chunk would erase the trail.
+  // Reuses the previous test's error to pin that the dedupe set is actually cleared.
   it('records the degraded breadcrumb once across repeated Retry clicks', async () => {
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
-      () => Promise.reject(new SyntaxError("Unexpected token '}'")),
+      () => Promise.reject(new SyntaxError(CORRUPT_CHUNK_PARSE_ERROR)),
       { retries: 0 }
     )
     ;({ container, root } = createContainer())

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import { Suspense, act, type ReactElement, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { lazyWithRetry } from '@/lib/lazy-with-retry'
+import { RichMarkdownErrorBoundary } from './RichMarkdownErrorBoundary'
+
+const reportCrashMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/react-error-boundary-reporting', () => ({
+  reportReactErrorBoundaryCrash: reportCrashMock
+}))
+
+const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function createContainer(): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  return { container, root: createRoot(container) }
+}
+
+// Mirrors EditorContent: the Suspense sits above the boundary, which wraps the lazy editor.
+function BoundaryHarness({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <RichMarkdownErrorBoundary fileId="file-1">{children}</RichMarkdownErrorBoundary>
+    </Suspense>
+  )
+}
+
+async function flushReactWork(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    reportCrashMock.mockReset()
+    window.sessionStorage.clear()
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+    window.sessionStorage.clear()
+    consoleError.mockRestore()
+  })
+
+  // Repro for crash b860def2: an app update swapped chunk hashes, lazy-with-retry
+  // burned its one guarded reload, then surfaced LazyChunkLoadError here.
+  it('renders the fallback without reporting after guarded dynamic import exhaustion', async () => {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    const LazyRejectingImport = lazyWithRetry(
+      () => Promise.reject(new SyntaxError("Unexpected token ':'")),
+      { retries: 0 }
+    )
+    ;({ container, root } = createContainer())
+
+    await act(async () => {
+      root?.render(
+        <BoundaryHarness>
+          <LazyRejectingImport />
+        </BoundaryHarness>
+      )
+    })
+    await flushReactWork()
+    await flushReactWork()
+
+    expect(container?.textContent).toContain('rich markdown editor')
+    expect(reportCrashMock).not.toHaveBeenCalled()
+  })
+
+  it('still reports ordinary render errors', async () => {
+    const error = new Error('ordinary render failure')
+    function BrokenEditor(): ReactElement {
+      throw error
+    }
+    ;({ container, root } = createContainer())
+
+    await act(async () => {
+      root?.render(
+        <BoundaryHarness>
+          <BrokenEditor />
+        </BoundaryHarness>
+      )
+    })
+
+    expect(container?.textContent).toContain('rich markdown editor')
+    expect(reportCrashMock).toHaveBeenCalledTimes(1)
+    expect(reportCrashMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundaryId: 'editor.rich-markdown',
+        surface: 'rich-markdown-editor',
+        error
+      })
+    )
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.lazy-chunk.test.tsx
@@ -1,7 +1,5 @@
 // @vitest-environment happy-dom
 
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { Suspense, act, type ReactElement, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -24,8 +22,6 @@ vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
 }))
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
-// A guard left by a *different* document is what proves the reload landed; only then
-// does lazy-with-retry produce the sentinel this boundary suppresses.
 const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -36,8 +32,6 @@ function createContainer(): { container: HTMLDivElement; root: Root } {
   return { container, root: createRoot(container) }
 }
 
-// Mirrors EditorContent: the Suspense sits above the boundary, which EditorContent
-// re-keys per open file (`key={viewStateScopeId}`), and which wraps the lazy editor.
 function BoundaryHarness({
   children,
   boundaryKey = 'pane-a'
@@ -60,8 +54,6 @@ async function flushReactWork(): Promise<void> {
   })
 }
 
-// The parse error a corrupt rich-editor chunk rejects with; reused across tests to
-// prove the module-scoped dedupe is reset rather than dodged by unique messages.
 const CORRUPT_CHUNK_PARSE_ERROR = "Unexpected token ':'"
 
 describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
@@ -72,7 +64,6 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
   beforeEach(() => {
     reportCrashMock.mockReset()
     recordBreadcrumbMock.mockReset()
-    // Dedupe is module-scoped so it can outlive boundary remounts; reset it per test.
     clearLazyChunkBreadcrumbDedupeForTest()
     window.sessionStorage.clear()
     consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
@@ -89,9 +80,6 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
     consoleError.mockRestore()
   })
 
-  // The only honest sentinel case: a landed reload already refetched the chunk and it
-  // still fails to parse, so the report is not actionable. (b860def2 itself is NOT this
-  // case — its reload was vetoed, so lazy-with-retry now re-throws the real error.)
   it('renders the fallback without reporting after guarded dynamic import exhaustion', async () => {
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
@@ -112,7 +100,6 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
 
     expect(container?.textContent).toContain('rich markdown editor')
     expect(reportCrashMock).not.toHaveBeenCalled()
-    // The suppressed report was the only artifact naming this surface; keep evidence.
     expect(recordBreadcrumbMock).toHaveBeenCalledWith('lazy_chunk_boundary_degraded', {
       boundaryId: 'editor.rich-markdown',
       reloadKey: 'rich-markdown-editor',
@@ -120,9 +107,6 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
     })
   })
 
-  // The breadcrumb ring holds 30 entries and does not coalesce this name, so an
-  // impatient Retry streak on a permanently rejected chunk would erase the trail.
-  // Reuses the previous test's error to pin that the dedupe set is actually cleared.
   it('records the degraded breadcrumb once across repeated Retry clicks', async () => {
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
@@ -154,8 +138,6 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
     expect(recordBreadcrumbMock).toHaveBeenCalledTimes(1)
   })
 
-  // EditorContent re-keys the boundary per open file, so instance-scoped dedupe would
-  // re-record on every markdown tab switch — the same ring flush the Retry streak causes.
   it('records the degraded breadcrumb once across boundary remounts', async () => {
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
@@ -205,15 +187,5 @@ describe('RichMarkdownErrorBoundary lazy chunk containment', () => {
         error
       })
     )
-  })
-
-  // b860def2's pre-crash breadcrumb read `reloadKey: "unknown"`, which cannot tell
-  // the rich editor chunk apart from the seven other lazy chunks in EditorContent.
-  it('names the rich editor chunk at the EditorContent lazy call site', () => {
-    const source = readFileSync(
-      join(process.cwd(), 'src/renderer/src/components/editor/EditorContent.tsx'),
-      'utf8'
-    )
-    expect(source).toContain("reloadKey: 'rich-markdown-editor'")
   })
 })

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
@@ -14,12 +14,7 @@ type State = {
   fileId: string
 }
 
-// Module-scoped, not per instance: EditorContent re-keys this boundary per open file,
-// so an instance field would re-record on every markdown tab switch and flush the
-// 30-entry breadcrumb ring that this very evidence lives in. The key is the cause's
-// name+message, which embeds per-chunk URLs for fetch failures, so a session that
-// exhausts recovery across many lazy sites can accumulate dozens of entries — small
-// and bounded by distinct failures, not by one.
+// Module scope deduplicates breadcrumbs across file-keyed boundary remounts.
 const recordedLazyChunkCauses = new Set<string>()
 
 export function clearLazyChunkBreadcrumbDedupeForTest(): void {
@@ -60,17 +55,12 @@ export class RichMarkdownErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('[RichMarkdownEditor] render crash contained by boundary', error, info)
-    // Retries and the one guarded reload are already spent, so a crash report is not
-    // actionable — but it was the only artifact naming this surface, so leave a
-    // breadcrumb. Fallback still renders (matches RecoverableRenderErrorBoundary).
     if (isLazyChunkLoadError(error)) {
       const cause = describeLazyChunkCause(error)
       if (!recordedLazyChunkCauses.has(cause)) {
         recordedLazyChunkCauses.add(cause)
         recordRendererCrashBreadcrumb('lazy_chunk_boundary_degraded', {
           boundaryId: 'editor.rich-markdown',
-          // Carried on the error itself: the pre-reload crumb naming the chunk may
-          // already have been evicted from the 30-entry ring (crash b860def2).
           reloadKey: error.reloadKey,
           cause
         })

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { isLazyChunkLoadError } from '@/lib/lazy-with-retry'
 import { reportReactErrorBoundaryCrash } from '@/lib/react-error-boundary-reporting'
 import { translate } from '@/i18n/i18n'
@@ -11,6 +12,20 @@ type Props = {
 type State = {
   error: Error | null
   fileId: string
+}
+
+// Module-scoped, not per instance: EditorContent re-keys this boundary per open file,
+// so an instance field would re-record on every markdown tab switch and flush the
+// 30-entry breadcrumb ring that this very evidence lives in. Bounded by the number of
+// distinct chunk failures a document can see (effectively one).
+const recordedLazyChunkCauses = new Set<string>()
+
+function describeLazyChunkCause(error: Error): string {
+  const cause = (error as { cause?: unknown }).cause
+  if (cause instanceof Error) {
+    return `${cause.name}: ${cause.message}`
+  }
+  return cause === undefined ? 'unknown' : String(cause)
 }
 
 // Why: a thrown exception inside the TipTap/ProseMirror render or in the
@@ -39,10 +54,18 @@ export class RichMarkdownErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('[RichMarkdownEditor] render crash contained by boundary', error, info)
-    // Why: lazy-with-retry already spent its retries and its one guarded reload, so a
-    // chunk-hash swap after an app update is expected degradation, not a crash. The
-    // fallback below still renders (matches RecoverableRenderErrorBoundary).
+    // Retries and the one guarded reload are already spent, so a crash report is not
+    // actionable — but it was the only artifact naming this surface, so leave a
+    // breadcrumb. Fallback still renders (matches RecoverableRenderErrorBoundary).
     if (isLazyChunkLoadError(error)) {
+      const cause = describeLazyChunkCause(error)
+      if (!recordedLazyChunkCauses.has(cause)) {
+        recordedLazyChunkCauses.add(cause)
+        recordRendererCrashBreadcrumb('lazy_chunk_boundary_degraded', {
+          boundaryId: 'editor.rich-markdown',
+          cause
+        })
+      }
       return
     }
     void reportReactErrorBoundaryCrash({

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isLazyChunkLoadError } from '@/lib/lazy-with-retry'
 import { reportReactErrorBoundaryCrash } from '@/lib/react-error-boundary-reporting'
 import { translate } from '@/i18n/i18n'
 
@@ -38,6 +39,12 @@ export class RichMarkdownErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
     console.error('[RichMarkdownEditor] render crash contained by boundary', error, info)
+    // Why: lazy-with-retry already spent its retries and its one guarded reload, so a
+    // chunk-hash swap after an app update is expected degradation, not a crash. The
+    // fallback below still renders (matches RecoverableRenderErrorBoundary).
+    if (isLazyChunkLoadError(error)) {
+      return
+    }
     void reportReactErrorBoundaryCrash({
       boundaryId: 'editor.rich-markdown',
       surface: 'rich-markdown-editor',

--- a/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownErrorBoundary.tsx
@@ -16,9 +16,15 @@ type State = {
 
 // Module-scoped, not per instance: EditorContent re-keys this boundary per open file,
 // so an instance field would re-record on every markdown tab switch and flush the
-// 30-entry breadcrumb ring that this very evidence lives in. Bounded by the number of
-// distinct chunk failures a document can see (effectively one).
+// 30-entry breadcrumb ring that this very evidence lives in. The key is the cause's
+// name+message, which embeds per-chunk URLs for fetch failures, so a session that
+// exhausts recovery across many lazy sites can accumulate dozens of entries — small
+// and bounded by distinct failures, not by one.
 const recordedLazyChunkCauses = new Set<string>()
+
+export function clearLazyChunkBreadcrumbDedupeForTest(): void {
+  recordedLazyChunkCauses.clear()
+}
 
 function describeLazyChunkCause(error: Error): string {
   const cause = (error as { cause?: unknown }).cause
@@ -63,6 +69,9 @@ export class RichMarkdownErrorBoundary extends React.Component<Props, State> {
         recordedLazyChunkCauses.add(cause)
         recordRendererCrashBreadcrumb('lazy_chunk_boundary_degraded', {
           boundaryId: 'editor.rich-markdown',
+          // Carried on the error itself: the pre-reload crumb naming the chunk may
+          // already have been evicted from the 30-entry ring (crash b860def2).
+          reloadKey: error.reloadKey,
           cause
         })
       }

--- a/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.lazy-chunk.test.tsx
+++ b/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.lazy-chunk.test.tsx
@@ -14,8 +14,6 @@ vi.mock('@/lib/react-error-boundary-reporting', () => ({
 }))
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
-// Only a guard left by a *different* document proves the reload landed, which is
-// what makes lazy-with-retry emit the sentinel this boundary suppresses.
 const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true

--- a/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.lazy-chunk.test.tsx
+++ b/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.lazy-chunk.test.tsx
@@ -14,6 +14,9 @@ vi.mock('@/lib/react-error-boundary-reporting', () => ({
 }))
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+// Only a guard left by a *different* document proves the reload landed, which is
+// what makes lazy-with-retry emit the sentinel this boundary suppresses.
+const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
@@ -60,7 +63,7 @@ describe('RecoverableRenderErrorBoundary lazy chunk containment', () => {
   })
 
   it('renders the fallback without reporting after guarded dynamic import exhaustion', async () => {
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const LazyRejectingImport = lazyWithRetry(
       () =>
         Promise.reject(

--- a/src/renderer/src/lib/lazy-chunk-recovery-reload.ts
+++ b/src/renderer/src/lib/lazy-chunk-recovery-reload.ts
@@ -1,0 +1,77 @@
+import { prepareRendererForAppRestart } from '../../../shared/renderer-restart-preparation'
+import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
+import {
+  ORCA_APP_RESTART_ABORTED_EVENT,
+  ORCA_APP_RESTART_STARTED_EVENT
+} from '../../../shared/updater-renderer-events'
+
+/**
+ * Why: `window.location.reload()` alone cannot recover a corrupt lazy chunk in an
+ * editor app. Terminal's beforeunload handler preventDefault()s whenever any open
+ * file is dirty, and Electron's will-prevent-unload cancels the navigation with no
+ * dialog — so the recovery reload for crash b860def2 was requested and silently
+ * dropped, leaving the pane dead for 44 minutes. The updater already solved this:
+ * back up hot-exit buffers, take the one synchronous session checkpoint, and latch
+ * `isIntentionalAppRestartInProgress()` so the dirty-tab guard stands down. This
+ * runs that same sequence for chunk recovery.
+ */
+
+export type LazyChunkRecoveryReloadOutcome =
+  /** Hot-exit backup or the session checkpoint refused; unsaved work stays put. */
+  | 'checkpoint-refused'
+  /** Something still vetoed beforeunload after the restart latch was armed. */
+  | 'unload-vetoed'
+  /** No veto signal, but the document outlived the grace window. */
+  | 'never-landed'
+
+// Backstop only. The veto event is authoritative, but a headless/paired-web host may
+// cancel navigation without one, so never suspend the boundary indefinitely.
+const RELOAD_SETTLE_GRACE_MS = 10_000
+
+function waitForRefusedNavigation(
+  win: Window
+): Promise<Exclude<LazyChunkRecoveryReloadOutcome, 'checkpoint-refused'>> {
+  return new Promise((resolve) => {
+    let graceTimer: ReturnType<typeof setTimeout> | undefined
+    const settle = (
+      outcome: Exclude<LazyChunkRecoveryReloadOutcome, 'checkpoint-refused'>
+    ): void => {
+      if (graceTimer !== undefined) {
+        clearTimeout(graceTimer)
+      }
+      win.removeEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, onUnloadPrevented)
+      resolve(outcome)
+    }
+    const onUnloadPrevented = (): void => settle('unload-vetoed')
+
+    win.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, onUnloadPrevented)
+    graceTimer = setTimeout(() => settle('never-landed'), RELOAD_SETTLE_GRACE_MS)
+  })
+}
+
+/**
+ * Requests the one recovery reload. Resolves ONLY when the navigation was refused —
+ * a landed reload tears the document down instead, so the caller stays suspended.
+ */
+export async function requestLazyChunkRecoveryReload(
+  win: Window
+): Promise<LazyChunkRecoveryReloadOutcome> {
+  try {
+    await prepareRendererForAppRestart(win, {
+      startedEventName: ORCA_APP_RESTART_STARTED_EVENT,
+      abortedEventName: ORCA_APP_RESTART_ABORTED_EVENT
+    })
+  } catch {
+    // prepareRendererForAppRestart already dispatched the abort; never reload over
+    // editor buffers that could not be backed up.
+    return 'checkpoint-refused'
+  }
+
+  const refused = waitForRefusedNavigation(win)
+  win.location.reload()
+  const outcome = await refused
+  // Why: the latch suppresses the unsaved-changes prompt, so a document that stayed
+  // alive must never keep it armed.
+  win.dispatchEvent(new Event(ORCA_APP_RESTART_ABORTED_EVENT))
+  return outcome
+}

--- a/src/renderer/src/lib/lazy-chunk-recovery-reload.ts
+++ b/src/renderer/src/lib/lazy-chunk-recovery-reload.ts
@@ -5,16 +5,7 @@ import {
   ORCA_APP_RESTART_STARTED_EVENT
 } from '../../../shared/updater-renderer-events'
 
-/**
- * Why: `window.location.reload()` alone cannot recover a corrupt lazy chunk in an
- * editor app. Terminal's beforeunload handler preventDefault()s whenever any open
- * file is dirty, and Electron's will-prevent-unload cancels the navigation with no
- * dialog — so the recovery reload for crash b860def2 was requested and silently
- * dropped, leaving the pane dead for 44 minutes. The updater already solved this:
- * back up hot-exit buffers, take the one synchronous session checkpoint, and latch
- * `isIntentionalAppRestartInProgress()` so the dirty-tab guard stands down. This
- * runs that same sequence for chunk recovery.
- */
+// Bare reloads are vetoed by dirty tabs; restart preparation backs them up first.
 
 export type LazyChunkRecoveryReloadOutcome =
   /** Hot-exit backup or the session checkpoint refused; unsaved work stays put. */
@@ -23,36 +14,40 @@ export type LazyChunkRecoveryReloadOutcome =
   | 'unload-vetoed'
   /** No veto signal, but the document outlived the grace window. */
   | 'never-landed'
+  /** The host rejected the reload request before navigation could begin. */
+  | 'request-failed'
 
-// Backstop only. The veto event is authoritative, but a headless/paired-web host may
-// cancel navigation without one, so never suspend the boundary indefinitely.
+// Paired-web hosts may veto navigation without emitting the Electron signal.
 const RELOAD_SETTLE_GRACE_MS = 10_000
 
-function waitForRefusedNavigation(
-  win: Window
-): Promise<Exclude<LazyChunkRecoveryReloadOutcome, 'checkpoint-refused'>> {
-  return new Promise((resolve) => {
-    let graceTimer: ReturnType<typeof setTimeout> | undefined
-    const settle = (
-      outcome: Exclude<LazyChunkRecoveryReloadOutcome, 'checkpoint-refused'>
-    ): void => {
-      if (graceTimer !== undefined) {
-        clearTimeout(graceTimer)
-      }
-      win.removeEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, onUnloadPrevented)
-      resolve(outcome)
-    }
-    const onUnloadPrevented = (): void => settle('unload-vetoed')
+type RefusedNavigationWait = {
+  outcome: Promise<'unload-vetoed' | 'never-landed'>
+  cancel: () => void
+}
 
+function waitForRefusedNavigation(win: Window): RefusedNavigationWait {
+  let graceTimer: ReturnType<typeof setTimeout> | undefined
+  let onUnloadPrevented: () => void = () => undefined
+  const cancel = (): void => {
+    if (graceTimer !== undefined) {
+      clearTimeout(graceTimer)
+      graceTimer = undefined
+    }
+    win.removeEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, onUnloadPrevented)
+  }
+  const outcome = new Promise<'unload-vetoed' | 'never-landed'>((resolve) => {
+    const settle = (result: 'unload-vetoed' | 'never-landed'): void => {
+      cancel()
+      resolve(result)
+    }
+    onUnloadPrevented = () => settle('unload-vetoed')
     win.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, onUnloadPrevented)
     graceTimer = setTimeout(() => settle('never-landed'), RELOAD_SETTLE_GRACE_MS)
   })
+  return { outcome, cancel }
 }
 
-/**
- * Requests the one recovery reload. Resolves ONLY when the navigation was refused —
- * a landed reload tears the document down instead, so the caller stays suspended.
- */
+/** Resolves only if the navigation is refused; a landed reload destroys this document. */
 export async function requestLazyChunkRecoveryReload(
   win: Window
 ): Promise<LazyChunkRecoveryReloadOutcome> {
@@ -62,16 +57,21 @@ export async function requestLazyChunkRecoveryReload(
       abortedEventName: ORCA_APP_RESTART_ABORTED_EVENT
     })
   } catch {
-    // prepareRendererForAppRestart already dispatched the abort; never reload over
-    // editor buffers that could not be backed up.
+    // Never reload over editor buffers that could not be backed up.
     return 'checkpoint-refused'
   }
 
-  const refused = waitForRefusedNavigation(win)
-  win.location.reload()
-  const outcome = await refused
-  // Why: the latch suppresses the unsaved-changes prompt, so a document that stayed
-  // alive must never keep it armed.
-  win.dispatchEvent(new Event(ORCA_APP_RESTART_ABORTED_EVENT))
-  return outcome
+  let cancelRefusalWait = (): void => undefined
+  try {
+    const refused = waitForRefusedNavigation(win)
+    cancelRefusalWait = refused.cancel
+    win.location.reload()
+    return await refused.outcome
+  } catch {
+    return 'request-failed'
+  } finally {
+    cancelRefusalWait()
+    // A surviving document must not retain the restart latch.
+    win.dispatchEvent(new Event(ORCA_APP_RESTART_ABORTED_EVENT))
+  }
 }

--- a/src/renderer/src/lib/lazy-with-retry.right-sidebar-syntax-error.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.right-sidebar-syntax-error.test.ts
@@ -25,10 +25,7 @@ import { isLazyChunkLoadError, loadLazyWithRetry } from './lazy-with-retry'
 // corrupt-chunk failure; these tests pin that behavior.
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
-// Only a token left by a *different* document proves the reload landed; a token
-// matching this document means the reload was requested and vetoed.
 const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
-const VETOED_RELOAD_GUARD_VALUE = (): string => String(performance.timeOrigin)
 
 // The exact error the renderer received from the corrupt right-sidebar chunk.
 const reportedCrashError = (): SyntaxError => new SyntaxError("Unexpected token ')'")
@@ -112,32 +109,5 @@ describe('right-sidebar lazy chunk SyntaxError crash (regression)', () => {
     expect(isLazyChunkLoadError(fetchOutcome)).toBe(true) // recovered
     // The parse error from the very same corrupt chunk must be recovered too.
     expect(isLazyChunkLoadError(parseOutcome)).toBe(true)
-  })
-
-  // Deliberate narrowing of the recovery above: a guard this document wrote itself
-  // means its reload() was vetoed, so no refetch ever happened and the sentinel
-  // would hide a live failure from the boundary.
-  it('surfaces the raw SyntaxError when this document is the one whose reload was vetoed', async () => {
-    const reload = spyOnReload()
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, VETOED_RELOAD_GUARD_VALUE())
-    const error = reportedCrashError()
-    const factory = vi.fn(() => Promise.reject(error))
-
-    const loaded = loadLazyWithRetry(factory, { retries: 0, reloadKey: 'right-sidebar' })
-    // Track settlement rather than awaiting: a regression leaves this pending forever.
-    let caught: unknown = 'pending'
-    void loaded.then(
-      (value) => {
-        caught = value
-      },
-      (rejection: unknown) => {
-        caught = rejection
-      }
-    )
-    await vi.advanceTimersByTimeAsync(5000)
-
-    expect(caught).toBe(error)
-    expect(isLazyChunkLoadError(caught)).toBe(false)
-    expect(reload).not.toHaveBeenCalled() // re-arming would loop against the veto
   })
 })

--- a/src/renderer/src/lib/lazy-with-retry.right-sidebar-syntax-error.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.right-sidebar-syntax-error.test.ts
@@ -13,8 +13,8 @@ import { isLazyChunkLoadError, loadLazyWithRetry } from './lazy-with-retry'
 //     const SourceControl = lazy(() => import('./SourceControl'))   // lazyWithRetry
 //
 // So the corrupt-chunk recovery IS wired in. The crash was a BLIND SPOT in that
-// recovery: after the single guarded window.location.reload() has already fired
-// once this session (sessionStorage 'orca:lazy-chunk-reload-attempted' === '1'),
+// recovery: after the single guarded window.location.reload() has already landed
+// once this session (the guard holds a *previous* document's identity),
 // loadLazyWithRetry only converted the failure into a recoverable
 // LazyChunkLoadError when isKnownDynamicImportFailure(error) was true. A corrupt /
 // truncated chunk that parses as invalid JS rejects import() with a native
@@ -25,6 +25,10 @@ import { isLazyChunkLoadError, loadLazyWithRetry } from './lazy-with-retry'
 // corrupt-chunk failure; these tests pin that behavior.
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+// Only a token left by a *different* document proves the reload landed; a token
+// matching this document means the reload was requested and vetoed.
+const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
+const VETOED_RELOAD_GUARD_VALUE = (): string => String(performance.timeOrigin)
 
 // The exact error the renderer received from the corrupt right-sidebar chunk.
 const reportedCrashError = (): SyntaxError => new SyntaxError("Unexpected token ')'")
@@ -57,9 +61,9 @@ afterEach(() => {
 describe('right-sidebar lazy chunk SyntaxError crash (regression)', () => {
   it('recovers a corrupt right-sidebar chunk SyntaxError instead of surfacing it to the boundary', async () => {
     const reload = spyOnReload()
-    // The one guarded reload already happened earlier this session: the user has
-    // navigated/reloaded once after the stale chunk was first hit.
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    // The one guarded reload already landed earlier this session: the guard was
+    // written by the document that reloaded, not by this one.
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
 
     // import('./SourceControl') rejects with the native parse error from the
     // corrupt chunk — exactly what the crash report captured.
@@ -87,7 +91,7 @@ describe('right-sidebar lazy chunk SyntaxError crash (regression)', () => {
     // chunk, surfaced as a fetch failure, IS recovered; surfaced as a parse error,
     // it is not. Both are the same unrecoverable corrupt right-sidebar chunk.
     const recover = async (makeError: () => Error): Promise<unknown> => {
-      window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+      window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
       const factory = vi.fn(() => Promise.reject(makeError()))
       const loaded = loadLazyWithRetry(factory, { retries: 0, reloadKey: 'right-sidebar' })
       try {
@@ -108,5 +112,32 @@ describe('right-sidebar lazy chunk SyntaxError crash (regression)', () => {
     expect(isLazyChunkLoadError(fetchOutcome)).toBe(true) // recovered
     // The parse error from the very same corrupt chunk must be recovered too.
     expect(isLazyChunkLoadError(parseOutcome)).toBe(true)
+  })
+
+  // Deliberate narrowing of the recovery above: a guard this document wrote itself
+  // means its reload() was vetoed, so no refetch ever happened and the sentinel
+  // would hide a live failure from the boundary.
+  it('surfaces the raw SyntaxError when this document is the one whose reload was vetoed', async () => {
+    const reload = spyOnReload()
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, VETOED_RELOAD_GUARD_VALUE())
+    const error = reportedCrashError()
+    const factory = vi.fn(() => Promise.reject(error))
+
+    const loaded = loadLazyWithRetry(factory, { retries: 0, reloadKey: 'right-sidebar' })
+    // Track settlement rather than awaiting: a regression leaves this pending forever.
+    let caught: unknown = 'pending'
+    void loaded.then(
+      (value) => {
+        caught = value
+      },
+      (rejection: unknown) => {
+        caught = rejection
+      }
+    )
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(caught).toBe(error)
+    expect(isLazyChunkLoadError(caught)).toBe(false)
+    expect(reload).not.toHaveBeenCalled() // re-arming would loop against the veto
   })
 })

--- a/src/renderer/src/lib/lazy-with-retry.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.test.ts
@@ -5,6 +5,9 @@ import type { ComponentType } from 'react'
 import { isLazyChunkLoadError, loadLazyWithRetry } from './lazy-with-retry'
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+// A guard holding a *different* document's token is the only proof the reload
+// landed; a token matching this document means the reload was vetoed.
+const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
 const Comp: ComponentType = () => null
 const chunkParseError = (): SyntaxError => new SyntaxError("Unexpected token ']'")
 const chunkFetchError = (): TypeError =>
@@ -103,15 +106,45 @@ describe('loadLazyWithRetry', () => {
 
     expect(factory).toHaveBeenCalledTimes(3)
     expect(reload).toHaveBeenCalledTimes(1)
-    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe('1')
-    // The load promise must suspend (never settle) while the page reloads, so the
-    // error boundary never flashes.
+    // The guard stores the requesting document's identity, not a bare flag.
+    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe(String(performance.timeOrigin))
+    // The load promise must stay pending across the reload window, so the error
+    // boundary never flashes ahead of the navigation.
     expect(settled).toBe(false)
+  })
+
+  // Crash b860def2: reload() was called at 19:05 and the document was still alive at
+  // 19:49 (no renderer bootstrap in between), so the requesting pane suspended forever.
+  it('surfaces the original error when the guarded reload never tears the document down', async () => {
+    const reload = spyOnReload()
+    stubCrashReportsBreadcrumb()
+    const error = chunkParseError()
+    const factory = vi.fn(() => Promise.reject(error))
+
+    const loaded = loadLazyWithRetry(factory, { retries: 0 })
+    let settled: unknown = 'pending'
+    void loaded.then(
+      (value) => {
+        settled = value
+      },
+      (rejection) => {
+        settled = rejection
+      }
+    )
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(reload).toHaveBeenCalledTimes(1)
+    // Still suspended inside the grace window, so a landed reload shows no fallback.
+    expect(settled).toBe('pending')
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(settled).toBe(error)
+    expect(reload).toHaveBeenCalledTimes(1)
   })
 
   it('does NOT reload twice — wraps known chunk failures once the guard is already set', async () => {
     const reload = spyOnReload()
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const error = chunkFetchError()
     const factory = vi.fn(() => Promise.reject(error))
 
@@ -128,9 +161,29 @@ describe('loadLazyWithRetry', () => {
     expect(isLazyChunkLoadError(caught)).toBe(true)
   })
 
+  // Crash b860def2: the guarded reload() was vetoed, the document lived on for 44
+  // minutes, and the still-set guard turned the next failure into the sentinel that
+  // error boundaries suppress — hiding a recovery that never ran.
+  it('reports the original error when the guard belongs to this same document (reload vetoed)', async () => {
+    const reload = spyOnReload()
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(performance.timeOrigin))
+    const error = chunkParseError()
+    const factory = vi.fn(() => Promise.reject(error))
+
+    const loaded = loadLazyWithRetry(factory, { retries: 0 })
+    const assertion = expect(loaded).rejects.toBe(error)
+    await vi.advanceTimersByTimeAsync(5000)
+    await assertion
+
+    // Re-arming the reload here would loop against whatever vetoed the first one.
+    expect(reload).not.toHaveBeenCalled()
+    const caught = await loaded.catch((rejection) => rejection)
+    expect(isLazyChunkLoadError(caught)).toBe(false)
+  })
+
   it('preserves the original error when the guarded failure is not a dynamic import failure', async () => {
     const reload = spyOnReload()
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const error = new Error('render bug from lazy module evaluation')
     const factory = vi.fn(() => Promise.reject(error))
 
@@ -152,7 +205,7 @@ describe('loadLazyWithRetry', () => {
     // same dead import). Regression guard for crash report e08749bb (right
     // sidebar, "Unexpected token ')'").
     const reload = spyOnReload()
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const error = chunkParseError()
     const factory = vi.fn(() => Promise.reject(error))
 
@@ -172,7 +225,7 @@ describe('loadLazyWithRetry', () => {
     // An ordinary Error from a lazy module is a genuine evaluation bug, not a
     // corrupt chunk; it must still surface raw after the guard is set.
     const reload = spyOnReload()
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const error = new Error('render bug from lazy module evaluation')
     const factory = vi.fn(() => Promise.reject(error))
 
@@ -250,14 +303,14 @@ describe('loadLazyWithRetry', () => {
 
   it('keeps the reload guard set across a successful load (no second reload in one session)', async () => {
     const reload = spyOnReload()
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
     const factory = vi.fn(() => Promise.resolve({ default: Comp }))
 
     await loadLazyWithRetry(factory)
 
     // The guard must survive a healthy load — otherwise a sibling chunk's success
     // would re-arm the reload and an auto-mounted corrupt chunk would loop.
-    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe('1')
+    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe(LANDED_RELOAD_GUARD_VALUE)
     expect(reload).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/lazy-with-retry.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.test.ts
@@ -2,7 +2,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ComponentType } from 'react'
 
-import { isLazyChunkLoadError, loadLazyWithRetry } from './lazy-with-retry'
+import {
+  isLazyChunkLoadError,
+  loadLazyWithRetry,
+  resetLazyChunkReloadRequestsForTest
+} from './lazy-with-retry'
+import { preventUnloadAndScheduleShutdownCheckpointReset } from './shutdown-checkpoint-guard'
+import {
+  isIntentionalAppRestartInProgress,
+  registerUpdaterBeforeUnloadBypass
+} from './updater-beforeunload'
+import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
+import { ORCA_APP_RESTART_ABORTED_EVENT } from '../../../shared/updater-renderer-events'
+import {
+  ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT,
+  type EditorPrepareHotExitDetail
+} from '../../../shared/editor-save-events'
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
 // A guard holding a *different* document's token is the only proof the reload
@@ -44,6 +59,8 @@ function makeSessionStorageThrow(): void {
 beforeEach(() => {
   vi.useFakeTimers()
   window.sessionStorage.clear()
+  // The per-document reload cap is module state; a fresh document per test.
+  resetLazyChunkReloadRequestsForTest()
 })
 
 afterEach(() => {
@@ -181,6 +198,33 @@ describe('loadLazyWithRetry', () => {
     expect(isLazyChunkLoadError(caught)).toBe(false)
   })
 
+  // b860def2's only reload evidence was a 19:05 breadcrumb, evicted from the 30-entry
+  // ring long before the 19:49 report. This path now files the report, so it must leave
+  // its own proof in the same tick.
+  it('records a lazy_chunk_reload_vetoed breadcrumb in the tick that reports the crash', async () => {
+    spyOnReload()
+    const recordBreadcrumb = stubCrashReportsBreadcrumb()
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(performance.timeOrigin))
+    const error = chunkParseError()
+
+    const loaded = loadLazyWithRetry(() => Promise.reject(error), {
+      retries: 0,
+      reloadKey: 'rich-markdown-editor'
+    })
+    const assertion = expect(loaded).rejects.toBe(error)
+    await vi.advanceTimersByTimeAsync(1)
+    await assertion
+
+    expect(recordBreadcrumb).toHaveBeenCalledWith({
+      name: 'lazy_chunk_reload_vetoed',
+      data: {
+        reloadKey: 'rich-markdown-editor',
+        message: "Unexpected token ']'",
+        outcome: 'guard-not-landed'
+      }
+    })
+  })
+
   it('preserves the original error when the guarded failure is not a dynamic import failure', async () => {
     const reload = spyOnReload()
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
@@ -312,5 +356,233 @@ describe('loadLazyWithRetry', () => {
     // would re-arm the reload and an auto-mounted corrupt chunk would loop.
     expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe(LANDED_RELOAD_GUARD_VALUE)
     expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('carries the reloadKey on LazyChunkLoadError so the crash names the call site', async () => {
+    spyOnReload()
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, LANDED_RELOAD_GUARD_VALUE)
+    const factory = vi.fn(() => Promise.reject(chunkParseError()))
+
+    const loaded = loadLazyWithRetry(factory, { retries: 0, reloadKey: 'rich-markdown-editor' })
+    const settled = loaded.then(
+      () => null,
+      (rejection: unknown) => rejection
+    )
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(await settled).toMatchObject({ reloadKey: 'rich-markdown-editor' })
+  })
+})
+
+// Crash b860def2: `window.location.reload()` was requested at 19:05:00.984Z and never
+// landed — Terminal's beforeunload handler preventDefault()s whenever any open editor
+// file is dirty and Electron's will-prevent-unload cancels the navigation with no
+// dialog. In an editor app with one unsaved tab, chunk recovery could never run.
+describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto', () => {
+  type Harness = {
+    navigations: string[]
+    hotExitBackups: number
+    restartLatchAtNavigation: boolean
+    cleanup: () => void
+  }
+
+  // Mirrors production: Terminal.tsx's dirty-tab guard + Electron's will-prevent-unload
+  // relay (preload dispatches ORCA_RENDERER_UNLOAD_PREVENTED_EVENT on cancel).
+  function installDirtyEditorTab(options: { hotExitBackupFails?: boolean } = {}): Harness {
+    const harness: Harness = {
+      navigations: [],
+      hotExitBackups: 0,
+      restartLatchAtNavigation: false,
+      cleanup: () => {}
+    }
+    const cleanupBypass = registerUpdaterBeforeUnloadBypass()
+
+    const dirtyTabGuard = (event: Event): void => {
+      if (isIntentionalAppRestartInProgress()) {
+        return
+      }
+      preventUnloadAndScheduleShutdownCheckpointReset(event, window)
+    }
+    const hotExitBackup = (event: Event): void => {
+      const detail = (event as CustomEvent<EditorPrepareHotExitDetail>).detail
+      detail.claim()
+      harness.hotExitBackups += 1
+      if (options.hotExitBackupFails === true) {
+        detail.reject('Some unsaved editor changes cannot be backed up before restart.')
+        return
+      }
+      detail.resolve()
+    }
+
+    window.addEventListener('beforeunload', dirtyTabGuard)
+    window.addEventListener(ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT, hotExitBackup)
+    vi.spyOn(window.location, 'reload').mockImplementation(() => {
+      harness.restartLatchAtNavigation = isIntentionalAppRestartInProgress()
+      const accepted = window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+      harness.navigations.push(accepted ? 'landed' : 'cancelled')
+      if (!accepted) {
+        window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+      }
+    })
+
+    harness.cleanup = () => {
+      window.removeEventListener('beforeunload', dirtyTabGuard)
+      window.removeEventListener(ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT, hotExitBackup)
+      cleanupBypass()
+    }
+    return harness
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    window.sessionStorage.clear()
+    resetLazyChunkReloadRequestsForTest()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    delete (window as unknown as { api?: unknown }).api
+    window.sessionStorage.clear()
+  })
+
+  it('lands the recovery reload despite an unsaved editor tab', async () => {
+    const harness = installDirtyEditorTab()
+    const error = chunkParseError()
+
+    const loaded = loadLazyWithRetry(() => Promise.reject(error), { retries: 0 })
+    let settled: unknown = 'pending'
+    void loaded.then(
+      (value) => {
+        settled = value
+      },
+      (rejection: unknown) => {
+        settled = rejection
+      }
+    )
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(harness.navigations).toEqual(['landed'])
+    expect(harness.restartLatchAtNavigation).toBe(true)
+    // Unsaved buffers are backed up before the document is thrown away.
+    expect(harness.hotExitBackups).toBe(1)
+    // A landed navigation kills the document, so the boundary never sees the error.
+    expect(settled).toBe('pending')
+    harness.cleanup()
+  })
+
+  it('refuses to reload when unsaved buffers cannot be backed up', async () => {
+    const harness = installDirtyEditorTab({ hotExitBackupFails: true })
+    const recordBreadcrumb = stubCrashReportsBreadcrumb()
+    const restartAborted = vi.fn()
+    window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, restartAborted)
+    const error = chunkParseError()
+
+    const loaded = loadLazyWithRetry(() => Promise.reject(error), {
+      retries: 0,
+      reloadKey: 'rich-markdown-editor'
+    })
+    let settled: unknown = 'pending'
+    void loaded.then(
+      (value) => {
+        settled = value
+      },
+      (rejection: unknown) => {
+        settled = rejection
+      }
+    )
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(harness.navigations).toEqual([])
+    expect(settled).toBe(error)
+    // The latch suppresses the unsaved-changes prompt; never leave it armed.
+    expect(restartAborted).toHaveBeenCalled()
+    expect(isIntentionalAppRestartInProgress()).toBe(false)
+    expect(recordBreadcrumb).toHaveBeenCalledWith({
+      name: 'lazy_chunk_reload_vetoed',
+      data: {
+        reloadKey: 'rich-markdown-editor',
+        message: "Unexpected token ']'",
+        outcome: 'checkpoint-refused'
+      }
+    })
+    window.removeEventListener(ORCA_APP_RESTART_ABORTED_EVENT, restartAborted)
+    harness.cleanup()
+  })
+
+  it('settles on the unload-prevented signal instead of waiting out the blind grace window', async () => {
+    // Chromium throttles background-tab timers, so a 10s blind wait can stretch far past
+    // a real veto — and the old timer was never cleared for a navigation that did land.
+    vi.spyOn(window.location, 'reload').mockImplementation(() => {
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+    })
+    const error = chunkParseError()
+
+    const loaded = loadLazyWithRetry(() => Promise.reject(error), { retries: 0 })
+    let settled: unknown = 'pending'
+    void loaded.then(
+      (value) => {
+        settled = value
+      },
+      (rejection: unknown) => {
+        settled = rejection
+      }
+    )
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(settled).toBe(error)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('drops the stale guard after a vetoed reload but caps re-arming per document', async () => {
+    const reload = vi.fn(() => {
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+    })
+    vi.spyOn(window.location, 'reload').mockImplementation(reload)
+    const error = chunkParseError()
+    const attempt = async (): Promise<unknown> => {
+      let settled: unknown = 'pending'
+      void loadLazyWithRetry(() => Promise.reject(error), { retries: 0 }).then(
+        (value) => {
+          settled = value
+        },
+        (rejection: unknown) => {
+          settled = rejection
+        }
+      )
+      await vi.advanceTimersByTimeAsync(50)
+      return settled
+    }
+
+    expect(await attempt()).toBe(error)
+    // A guard left by a reload that never happened denies this document recovery for
+    // the rest of the session, even once the user saves the tab that blocked it.
+    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
+
+    expect(await attempt()).toBe(error)
+    expect(reload).toHaveBeenCalledTimes(2)
+
+    // ...but clearing the guard must not let a permanently vetoing window loop.
+    expect(await attempt()).toBe(error)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the guard while a reload is in flight so a sibling chunk cannot re-arm it', async () => {
+    spyOnReload() // no veto signal: the navigation stays in flight for the grace window
+    const error = chunkParseError()
+
+    void loadLazyWithRetry(() => Promise.reject(error), { retries: 0 }).then(
+      () => undefined,
+      () => undefined
+    )
+    await vi.advanceTimersByTimeAsync(50)
+    // A second lazy site fails while the document is already tearing down.
+    void loadLazyWithRetry(() => Promise.reject(error), { retries: 0 }).then(
+      () => undefined,
+      () => undefined
+    )
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe(String(performance.timeOrigin))
   })
 })

--- a/src/renderer/src/lib/lazy-with-retry.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.test.ts
@@ -20,8 +20,6 @@ import {
 } from '../../../shared/editor-save-events'
 
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
-// A guard holding a *different* document's token is the only proof the reload
-// landed; a token matching this document means the reload was vetoed.
 const LANDED_RELOAD_GUARD_VALUE = 'doc-before-the-reload'
 const Comp: ComponentType = () => null
 const chunkParseError = (): SyntaxError => new SyntaxError("Unexpected token ']'")
@@ -59,7 +57,6 @@ function makeSessionStorageThrow(): void {
 beforeEach(() => {
   vi.useFakeTimers()
   window.sessionStorage.clear()
-  // The per-document reload cap is module state; a fresh document per test.
   resetLazyChunkReloadRequestsForTest()
 })
 
@@ -123,15 +120,10 @@ describe('loadLazyWithRetry', () => {
 
     expect(factory).toHaveBeenCalledTimes(3)
     expect(reload).toHaveBeenCalledTimes(1)
-    // The guard stores the requesting document's identity, not a bare flag.
     expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBe(String(performance.timeOrigin))
-    // The load promise must stay pending across the reload window, so the error
-    // boundary never flashes ahead of the navigation.
     expect(settled).toBe(false)
   })
 
-  // Crash b860def2: reload() was called at 19:05 and the document was still alive at
-  // 19:49 (no renderer bootstrap in between), so the requesting pane suspended forever.
   it('surfaces the original error when the guarded reload never tears the document down', async () => {
     const reload = spyOnReload()
     stubCrashReportsBreadcrumb()
@@ -151,7 +143,6 @@ describe('loadLazyWithRetry', () => {
 
     await vi.advanceTimersByTimeAsync(5000)
     expect(reload).toHaveBeenCalledTimes(1)
-    // Still suspended inside the grace window, so a landed reload shows no fallback.
     expect(settled).toBe('pending')
 
     await vi.advanceTimersByTimeAsync(10_000)
@@ -178,9 +169,6 @@ describe('loadLazyWithRetry', () => {
     expect(isLazyChunkLoadError(caught)).toBe(true)
   })
 
-  // Crash b860def2: the guarded reload() was vetoed, the document lived on for 44
-  // minutes, and the still-set guard turned the next failure into the sentinel that
-  // error boundaries suppress — hiding a recovery that never ran.
   it('reports the original error when the guard belongs to this same document (reload vetoed)', async () => {
     const reload = spyOnReload()
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(performance.timeOrigin))
@@ -192,15 +180,11 @@ describe('loadLazyWithRetry', () => {
     await vi.advanceTimersByTimeAsync(5000)
     await assertion
 
-    // Re-arming the reload here would loop against whatever vetoed the first one.
     expect(reload).not.toHaveBeenCalled()
     const caught = await loaded.catch((rejection) => rejection)
     expect(isLazyChunkLoadError(caught)).toBe(false)
   })
 
-  // b860def2's only reload evidence was a 19:05 breadcrumb, evicted from the 30-entry
-  // ring long before the 19:49 report. This path now files the report, so it must leave
-  // its own proof in the same tick.
   it('records a lazy_chunk_reload_vetoed breadcrumb in the tick that reports the crash', async () => {
     spyOnReload()
     const recordBreadcrumb = stubCrashReportsBreadcrumb()
@@ -374,26 +358,20 @@ describe('loadLazyWithRetry', () => {
   })
 })
 
-// Crash b860def2: `window.location.reload()` was requested at 19:05:00.984Z and never
-// landed — Terminal's beforeunload handler preventDefault()s whenever any open editor
-// file is dirty and Electron's will-prevent-unload cancels the navigation with no
-// dialog. In an editor app with one unsaved tab, chunk recovery could never run.
 describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto', () => {
   type Harness = {
     navigations: string[]
     hotExitBackups: number
     restartLatchAtNavigation: boolean
-    cleanup: () => void
   }
 
-  // Mirrors production: Terminal.tsx's dirty-tab guard + Electron's will-prevent-unload
-  // relay (preload dispatches ORCA_RENDERER_UNLOAD_PREVENTED_EVENT on cancel).
+  let cleanupHarness: (() => void) | undefined
+
   function installDirtyEditorTab(options: { hotExitBackupFails?: boolean } = {}): Harness {
     const harness: Harness = {
       navigations: [],
       hotExitBackups: 0,
-      restartLatchAtNavigation: false,
-      cleanup: () => {}
+      restartLatchAtNavigation: false
     }
     const cleanupBypass = registerUpdaterBeforeUnloadBypass()
 
@@ -425,7 +403,7 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
       }
     })
 
-    harness.cleanup = () => {
+    cleanupHarness = () => {
       window.removeEventListener('beforeunload', dirtyTabGuard)
       window.removeEventListener(ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT, hotExitBackup)
       cleanupBypass()
@@ -440,6 +418,8 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
   })
 
   afterEach(() => {
+    cleanupHarness?.()
+    cleanupHarness = undefined
     vi.restoreAllMocks()
     vi.useRealTimers()
     delete (window as unknown as { api?: unknown }).api
@@ -464,11 +444,8 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
 
     expect(harness.navigations).toEqual(['landed'])
     expect(harness.restartLatchAtNavigation).toBe(true)
-    // Unsaved buffers are backed up before the document is thrown away.
     expect(harness.hotExitBackups).toBe(1)
-    // A landed navigation kills the document, so the boundary never sees the error.
     expect(settled).toBe('pending')
-    harness.cleanup()
   })
 
   it('refuses to reload when unsaved buffers cannot be backed up', async () => {
@@ -495,7 +472,6 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
 
     expect(harness.navigations).toEqual([])
     expect(settled).toBe(error)
-    // The latch suppresses the unsaved-changes prompt; never leave it armed.
     expect(restartAborted).toHaveBeenCalled()
     expect(isIntentionalAppRestartInProgress()).toBe(false)
     expect(recordBreadcrumb).toHaveBeenCalledWith({
@@ -507,12 +483,37 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
       }
     })
     window.removeEventListener(ORCA_APP_RESTART_ABORTED_EVENT, restartAborted)
-    harness.cleanup()
+  })
+
+  it('clears recovery state when the host rejects the reload request', async () => {
+    const harness = installDirtyEditorTab()
+    const recordBreadcrumb = stubCrashReportsBreadcrumb()
+    vi.mocked(window.location.reload).mockImplementation(() => {
+      throw new Error('reload unavailable')
+    })
+    const error = chunkParseError()
+
+    const settled = await loadLazyWithRetry(() => Promise.reject(error), {
+      retries: 0,
+      reloadKey: 'rich-markdown-editor'
+    }).catch((rejection: unknown) => rejection)
+
+    expect(settled).toBe(error)
+    expect(harness.hotExitBackups).toBe(1)
+    expect(isIntentionalAppRestartInProgress()).toBe(false)
+    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(recordBreadcrumb).toHaveBeenCalledWith({
+      name: 'lazy_chunk_reload_vetoed',
+      data: {
+        reloadKey: 'rich-markdown-editor',
+        message: "Unexpected token ']'",
+        outcome: 'request-failed'
+      }
+    })
   })
 
   it('settles on the unload-prevented signal instead of waiting out the blind grace window', async () => {
-    // Chromium throttles background-tab timers, so a 10s blind wait can stretch far past
-    // a real veto — and the old timer was never cleared for a navigation that did land.
     vi.spyOn(window.location, 'reload').mockImplementation(() => {
       window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
     })
@@ -555,14 +556,11 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
     }
 
     expect(await attempt()).toBe(error)
-    // A guard left by a reload that never happened denies this document recovery for
-    // the rest of the session, even once the user saves the tab that blocked it.
     expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
 
     expect(await attempt()).toBe(error)
     expect(reload).toHaveBeenCalledTimes(2)
 
-    // ...but clearing the guard must not let a permanently vetoing window loop.
     expect(await attempt()).toBe(error)
     expect(reload).toHaveBeenCalledTimes(2)
   })
@@ -576,7 +574,6 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
       () => undefined
     )
     await vi.advanceTimersByTimeAsync(50)
-    // A second lazy site fails while the document is already tearing down.
     void loadLazyWithRetry(() => Promise.reject(error), { retries: 0 }).then(
       () => undefined,
       () => undefined

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -13,10 +13,8 @@ import {
  * ']'"). React.lazy permanently caches that rejection, so the error boundary's
  * "Retry" — which just re-renders the same Lazy — can never recover it; the
  * surface stays dead and reports a react-error-boundary crash. This wrapper first
- * retries transient fetch failures, then performs ONE guarded full reload — routed
- * through the intentional-restart path so Orca's dirty-tab beforeunload guard cannot
- * silently veto it — to refetch fresh chunk bytes and rebuild the ES module map,
- * before finally falling through to the error boundary.
+ * retries transient failures, then requests one restart-prepared reload before
+ * falling through to the error boundary.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirror React.lazy's own ComponentType<any> constraint so every existing call site type-checks unchanged.
@@ -49,23 +47,15 @@ export function isLazyChunkLoadError(error: unknown): error is LazyChunkLoadErro
   return error instanceof LazyChunkLoadError
 }
 
-// One recovery reload per session. The guard survives the reload itself (so we
-// never loop) but resets when the window/app closes, so a later launch — e.g.
-// after an update ships fresh chunks — can earn another reload. sessionStorage
-// (not localStorage) gives exactly that lifetime; a healthy sibling load never
-// clears it, otherwise an auto-mounted corrupt chunk would loop. The one exception
-// is a reload this document proved never landed (see clearChunkReloadGuard).
+// The session guard survives a landed reload to prevent loops, but a surviving
+// document clears its own token so a later failure can retry recovery.
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
-// Stand-in document identity for hosts without a usable performance.timeOrigin; a
-// reload re-evaluates this module, so a fresh value still means the reload landed.
+// Reloading reevaluates this fallback, giving the new document a different token.
 const FALLBACK_RELOAD_TOKEN = `doc-${Math.random().toString(36).slice(2)}`
 const DEFAULT_RETRIES = 2
 const DEFAULT_BASE_DELAY_MS = 250
 
-// The guard stores the requesting document's identity, not a bare flag: reload() can be
-// vetoed (beforeunload preventDefault → Electron cancels the navigation) and a bare flag
-// would then read as "recovery ran" forever inside a document that never reloaded (crash
-// b860def2). timeOrigin changes per navigation, so a value still ours means no reload.
+// A matching token proves this document requested a reload that never landed.
 function currentDocumentReloadToken(): string {
   const timeOrigin = typeof performance === 'undefined' ? Number.NaN : performance.timeOrigin
   return Number.isFinite(timeOrigin) && timeOrigin > 0 ? String(timeOrigin) : FALLBACK_RELOAD_TOKEN
@@ -98,9 +88,6 @@ function markChunkReloadAttempted(): boolean {
   }
 }
 
-// Why: a token this document wrote itself proves no reload happened, so leaving it in
-// place would deny the surface recovery for the whole session even after whatever
-// vetoed the navigation is gone (e.g. the user saved the dirty tab).
 function clearChunkReloadGuard(): void {
   try {
     window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
@@ -109,12 +96,9 @@ function clearChunkReloadGuard(): void {
   }
 }
 
-// sessionStorage cannot bound a document that keeps re-arming its own guard, so cap
-// recovery requests in memory; the counter dies with the document a reload replaces.
+// A per-document cap prevents repeated vetoes from creating a reload loop.
 const MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2
 let reloadRequestsThisDocument = 0
-// A sibling chunk failing mid-navigation reads the same 'reload-not-landed' guard;
-// clearing it there would re-arm a document that is already tearing down.
 let reloadRequestInFlight = false
 
 export function resetLazyChunkReloadRequestsForTest(): void {
@@ -211,11 +195,15 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     reloadRequestsThisDocument += 1
     reloadRequestInFlight = true
     recordReloadBreadcrumb('lazy_chunk_reload', reloadKey, failureMessage)
-    // Resolves only if the navigation was refused; a landed reload kills this document.
-    const outcome: LazyChunkRecoveryReloadOutcome = await requestLazyChunkRecoveryReload(window)
-    reloadRequestInFlight = false
-    clearChunkReloadGuard()
-    recordReloadBreadcrumb('lazy_chunk_reload_vetoed', reloadKey, failureMessage, outcome)
+    let outcome: LazyChunkRecoveryReloadOutcome = 'request-failed'
+    try {
+      // A landed reload tears down this document before the promise settles.
+      outcome = await requestLazyChunkRecoveryReload(window)
+    } finally {
+      reloadRequestInFlight = false
+      clearChunkReloadGuard()
+      recordReloadBreadcrumb('lazy_chunk_reload_vetoed', reloadKey, failureMessage, outcome)
+    }
     throw lastError
   }
 
@@ -228,8 +216,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     !reloadRequestInFlight &&
     isKnownDynamicImportFailure(lastError)
   ) {
-    // Why here and not only at request time: this crumb lands in the same tick as the
-    // crash report, so the 30-entry ring cannot evict it the way it evicted b860def2's.
+    // Record the veto beside the resulting crash report before the ring can evict it.
     clearChunkReloadGuard()
     recordReloadBreadcrumb(
       'lazy_chunk_reload_vetoed',
@@ -239,10 +226,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     )
   }
 
-  // No proven reload (SSR / node / blocked storage / a reload this document asked
-  // for but never got) or unknown failure: re-throw the original error so normal
-  // error reporting semantics stay intact. Boundaries suppress the sentinel, so
-  // wrapping an unproven recovery here would hide the failure entirely.
+  // Without a proven reload, preserve normal error-reporting behavior.
   throw lastError
 }
 

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -1,5 +1,10 @@
 import { lazy, type ComponentType, type LazyExoticComponent } from 'react'
 
+import {
+  requestLazyChunkRecoveryReload,
+  type LazyChunkRecoveryReloadOutcome
+} from './lazy-chunk-recovery-reload'
+
 /**
  * Resilient replacement for React.lazy.
  *
@@ -8,9 +13,10 @@ import { lazy, type ComponentType, type LazyExoticComponent } from 'react'
  * ']'"). React.lazy permanently caches that rejection, so the error boundary's
  * "Retry" — which just re-renders the same Lazy — can never recover it; the
  * surface stays dead and reports a react-error-boundary crash. This wrapper first
- * retries transient fetch failures, then performs ONE guarded full reload to
- * refetch fresh chunk bytes and rebuild the ES module map, before finally falling
- * through to the error boundary.
+ * retries transient fetch failures, then performs ONE guarded full reload — routed
+ * through the intentional-restart path so Orca's dirty-tab beforeunload guard cannot
+ * silently veto it — to refetch fresh chunk bytes and rebuild the ES module map,
+ * before finally falling through to the error boundary.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirror React.lazy's own ComponentType<any> constraint so every existing call site type-checks unchanged.
@@ -23,14 +29,18 @@ type ReloadGuardState = 'not-attempted' | 'reload-landed' | 'reload-not-landed' 
 export type LazyWithRetryOptions = {
   retries?: number
   baseDelayMs?: number
-  /** Label surfaced in the reload breadcrumb for triage; not used for control flow. */
+  /** Names the call site on the reload breadcrumbs and on LazyChunkLoadError; never control flow. */
   reloadKey?: string
 }
 
 export class LazyChunkLoadError extends Error {
-  constructor(cause: unknown) {
+  /** Which lazy call site failed; carried on the error so reports name it without a breadcrumb. */
+  readonly reloadKey: string
+
+  constructor(cause: unknown, reloadKey = 'unknown') {
     super('Lazy chunk load failed after reload recovery was exhausted')
     this.name = 'LazyChunkLoadError'
+    this.reloadKey = reloadKey
     ;(this as { cause?: unknown }).cause = cause
   }
 }
@@ -42,9 +52,9 @@ export function isLazyChunkLoadError(error: unknown): error is LazyChunkLoadErro
 // One recovery reload per session. The guard survives the reload itself (so we
 // never loop) but resets when the window/app closes, so a later launch — e.g.
 // after an update ships fresh chunks — can earn another reload. sessionStorage
-// (not localStorage) gives exactly that lifetime; it is never cleared mid-session,
-// otherwise a sibling chunk's healthy load would re-arm the reload and an
-// auto-mounted corrupt chunk would loop.
+// (not localStorage) gives exactly that lifetime; a healthy sibling load never
+// clears it, otherwise an auto-mounted corrupt chunk would loop. The one exception
+// is a reload this document proved never landed (see clearChunkReloadGuard).
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
 // Stand-in document identity for hosts without a usable performance.timeOrigin; a
 // reload re-evaluates this module, so a fresh value still means the reload landed.
@@ -88,33 +98,53 @@ function markChunkReloadAttempted(): boolean {
   }
 }
 
-function recordReloadBreadcrumb(reloadKey: string, message: string): void {
+// Why: a token this document wrote itself proves no reload happened, so leaving it in
+// place would deny the surface recovery for the whole session even after whatever
+// vetoed the navigation is gone (e.g. the user saved the dirty tab).
+function clearChunkReloadGuard(): void {
+  try {
+    window.sessionStorage.removeItem(RELOAD_GUARD_KEY)
+  } catch {
+    // Best effort: a document that cannot clear the guard just forfeits its retry.
+  }
+}
+
+// sessionStorage cannot bound a document that keeps re-arming its own guard, so cap
+// recovery requests in memory; the counter dies with the document a reload replaces.
+const MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2
+let reloadRequestsThisDocument = 0
+// A sibling chunk failing mid-navigation reads the same 'reload-not-landed' guard;
+// clearing it there would re-arm a document that is already tearing down.
+let reloadRequestInFlight = false
+
+export function resetLazyChunkReloadRequestsForTest(): void {
+  reloadRequestsThisDocument = 0
+  reloadRequestInFlight = false
+}
+
+type ReloadBreadcrumbName = 'lazy_chunk_reload' | 'lazy_chunk_reload_vetoed'
+
+function recordReloadBreadcrumb(
+  name: ReloadBreadcrumbName,
+  reloadKey: string,
+  message: string,
+  outcome?: string
+): void {
   // Inlined rather than importing crash-diagnostics so this low-level recovery
   // primitive stays free of the renderer/webview module graph (keeps it SSR- and
   // unit-test-friendly). Mirrors crash-diagnostics' best-effort breadcrumb call.
   try {
     const api = (window as Window & { api?: Window['api'] }).api
-    api?.crashReports.recordBreadcrumb({ name: 'lazy_chunk_reload', data: { reloadKey, message } })
+    api?.crashReports.recordBreadcrumb({
+      name,
+      data: { reloadKey, message, ...(outcome === undefined ? {} : { outcome }) }
+    })
   } catch {
     // Crash evidence is best-effort and must never mask the original failure.
   }
 }
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
-
-// Grace window for reload() to tear the document down. Long enough that the error
-// fallback never flashes ahead of a real navigation.
-const RELOAD_SETTLE_GRACE_MS = 10_000
-
-// Suspends the boundary while reload() tears the page down. Suspending forever would
-// hang the pane on a spinner when the reload is vetoed (Orca preventDefault()s
-// beforeunload for dirty editor tabs), so surface the real failure once the grace
-// window proves the navigation never happened.
-function suspendUntilReloadLands(loadError: unknown): Promise<never> {
-  return new Promise<never>((_resolve, reject) => {
-    setTimeout(() => reject(loadError), RELOAD_SETTLE_GRACE_MS)
-  })
-}
 
 function isKnownDynamicImportFailure(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -166,21 +196,47 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     }
   }
 
+  const reloadKey = options.reloadKey ?? 'unknown'
+  const failureMessage = lastError instanceof Error ? lastError.message : String(lastError)
   const reloadGuardState = readChunkReloadGuardState()
-  if (typeof window !== 'undefined' && reloadGuardState === 'not-attempted') {
+
+  if (
+    typeof window !== 'undefined' &&
+    reloadGuardState === 'not-attempted' &&
+    reloadRequestsThisDocument < MAX_RELOAD_REQUESTS_PER_DOCUMENT
+  ) {
     if (!markChunkReloadAttempted()) {
       throw lastError
     }
-    recordReloadBreadcrumb(
-      options.reloadKey ?? 'unknown',
-      lastError instanceof Error ? lastError.message : String(lastError)
-    )
-    window.location.reload()
-    return suspendUntilReloadLands(lastError)
+    reloadRequestsThisDocument += 1
+    reloadRequestInFlight = true
+    recordReloadBreadcrumb('lazy_chunk_reload', reloadKey, failureMessage)
+    // Resolves only if the navigation was refused; a landed reload kills this document.
+    const outcome: LazyChunkRecoveryReloadOutcome = await requestLazyChunkRecoveryReload(window)
+    reloadRequestInFlight = false
+    clearChunkReloadGuard()
+    recordReloadBreadcrumb('lazy_chunk_reload_vetoed', reloadKey, failureMessage, outcome)
+    throw lastError
   }
 
   if (reloadGuardState === 'reload-landed' && isKnownDynamicImportFailure(lastError)) {
-    throw new LazyChunkLoadError(lastError)
+    throw new LazyChunkLoadError(lastError, reloadKey)
+  }
+
+  if (
+    reloadGuardState === 'reload-not-landed' &&
+    !reloadRequestInFlight &&
+    isKnownDynamicImportFailure(lastError)
+  ) {
+    // Why here and not only at request time: this crumb lands in the same tick as the
+    // crash report, so the 30-entry ring cannot evict it the way it evicted b860def2's.
+    clearChunkReloadGuard()
+    recordReloadBreadcrumb(
+      'lazy_chunk_reload_vetoed',
+      reloadKey,
+      failureMessage,
+      'guard-not-landed'
+    )
   }
 
   // No proven reload (SSR / node / blocked storage / a reload this document asked

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -18,7 +18,7 @@ type AnyComponent = ComponentType<any>
 
 type LazyFactory<T extends AnyComponent> = () => Promise<{ default: T }>
 
-type ReloadGuardState = 'not-attempted' | 'attempted' | 'unavailable'
+type ReloadGuardState = 'not-attempted' | 'reload-landed' | 'reload-not-landed' | 'unavailable'
 
 export type LazyWithRetryOptions = {
   retries?: number
@@ -46,15 +46,31 @@ export function isLazyChunkLoadError(error: unknown): error is LazyChunkLoadErro
 // otherwise a sibling chunk's healthy load would re-arm the reload and an
 // auto-mounted corrupt chunk would loop.
 const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+// Stand-in document identity for hosts without a usable performance.timeOrigin; a
+// reload re-evaluates this module, so a fresh value still means the reload landed.
+const FALLBACK_RELOAD_TOKEN = `doc-${Math.random().toString(36).slice(2)}`
 const DEFAULT_RETRIES = 2
 const DEFAULT_BASE_DELAY_MS = 250
+
+// The guard stores the requesting document's identity, not a bare flag: reload() can be
+// vetoed (beforeunload preventDefault → Electron cancels the navigation) and a bare flag
+// would then read as "recovery ran" forever inside a document that never reloaded (crash
+// b860def2). timeOrigin changes per navigation, so a value still ours means no reload.
+function currentDocumentReloadToken(): string {
+  const timeOrigin = typeof performance === 'undefined' ? Number.NaN : performance.timeOrigin
+  return Number.isFinite(timeOrigin) && timeOrigin > 0 ? String(timeOrigin) : FALLBACK_RELOAD_TOKEN
+}
 
 function readChunkReloadGuardState(): ReloadGuardState {
   if (typeof window === 'undefined') {
     return 'unavailable'
   }
   try {
-    return window.sessionStorage.getItem(RELOAD_GUARD_KEY) === '1' ? 'attempted' : 'not-attempted'
+    const stored = window.sessionStorage.getItem(RELOAD_GUARD_KEY)
+    if (stored === null) {
+      return 'not-attempted'
+    }
+    return stored === currentDocumentReloadToken() ? 'reload-not-landed' : 'reload-landed'
   } catch {
     // Why: when storage is blocked we cannot prove a reload happened, but still
     // fail closed on reloads so a broken chunk never loops.
@@ -64,7 +80,7 @@ function readChunkReloadGuardState(): ReloadGuardState {
 
 function markChunkReloadAttempted(): boolean {
   try {
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, '1')
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, currentDocumentReloadToken())
     return true
   } catch {
     // A reload without a durable guard can loop, so treat write failure as unavailable.
@@ -86,9 +102,19 @@ function recordReloadBreadcrumb(reloadKey: string, message: string): void {
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
-// Suspends the React.lazy boundary while window.location.reload() tears the page
-// down, so the error fallback never flashes in the moment before the reload lands.
-const SUSPEND_UNTIL_RELOAD = new Promise<never>(() => undefined)
+// Grace window for reload() to tear the document down. Long enough that the error
+// fallback never flashes ahead of a real navigation.
+const RELOAD_SETTLE_GRACE_MS = 10_000
+
+// Suspends the boundary while reload() tears the page down. Suspending forever would
+// hang the pane on a spinner when the reload is vetoed (Orca preventDefault()s
+// beforeunload for dirty editor tabs), so surface the real failure once the grace
+// window proves the navigation never happened.
+function suspendUntilReloadLands(loadError: unknown): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    setTimeout(() => reject(loadError), RELOAD_SETTLE_GRACE_MS)
+  })
+}
 
 function isKnownDynamicImportFailure(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -150,15 +176,17 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       lastError instanceof Error ? lastError.message : String(lastError)
     )
     window.location.reload()
-    return SUSPEND_UNTIL_RELOAD
+    return suspendUntilReloadLands(lastError)
   }
 
-  if (reloadGuardState === 'attempted' && isKnownDynamicImportFailure(lastError)) {
+  if (reloadGuardState === 'reload-landed' && isKnownDynamicImportFailure(lastError)) {
     throw new LazyChunkLoadError(lastError)
   }
 
-  // No proven reload attempt (SSR / node / blocked storage) or unknown failure:
-  // re-throw the original error so normal error reporting semantics stay intact.
+  // No proven reload (SSR / node / blocked storage / a reload this document asked
+  // for but never got) or unknown failure: re-throw the original error so normal
+  // error reporting semantics stay intact. Boundaries suppress the sentinel, so
+  // wrapping an unproven recovery here would hide the failure entirely.
   throw lastError
 }
 

--- a/src/shared/renderer-restart-preparation.test.ts
+++ b/src/shared/renderer-restart-preparation.test.ts
@@ -1,7 +1,5 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
-import type { UpdateStatus } from '../shared/types'
+import type { UpdateStatus } from './types'
 import {
   createUpdaterQuitAbortRelay,
   prepareRendererForAppRestart
@@ -53,38 +51,5 @@ describe('createUpdaterQuitAbortRelay', () => {
     relay.handleStatus({ state: 'error', message: 'check failed' } satisfies UpdateStatus)
 
     expect(aborted).not.toHaveBeenCalled()
-  })
-})
-
-describe('preload restart wiring', () => {
-  const source = readFileSync(join(process.cwd(), 'src/preload/index.ts'), 'utf8')
-
-  it('relays prevented unload and async updater failure IPC into renderer lifecycle events', () => {
-    expect(source).toContain("ipcRenderer.on('updater:status'")
-    expect(source).toContain('updaterQuitAbortRelay.handleStatus(status)')
-    expect(source).toContain("ipcRenderer.on('window:unload-prevented'")
-    expect(source).toContain(
-      'window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))'
-    )
-  })
-
-  it('marks updater preparation before invoking main and aborts it on immediate IPC failure', () => {
-    const start = source.indexOf('quitAndInstall: async (): Promise<void> => {')
-    const end = source.indexOf('onStatus: (callback) => {', start)
-    expect(start).toBeGreaterThanOrEqual(0)
-    expect(end).toBeGreaterThan(start)
-    const block = source.slice(start, end)
-    const prepare = block.indexOf('await prepareRendererForAppRestart(window, {')
-    const markPrepared = block.indexOf('updaterQuitAbortRelay.markPrepared()')
-    const invoke = block.indexOf("ipcRenderer.invoke('updater:quitAndInstall')")
-    const abort = block.indexOf('updaterQuitAbortRelay.abort()')
-
-    expect(prepare).toBeGreaterThanOrEqual(0)
-    expect(markPrepared).toBeGreaterThan(prepare)
-    expect(invoke).toBeGreaterThan(markPrepared)
-    expect(abort).toBeGreaterThan(invoke)
-    expect(block).toMatch(
-      /try \{\s*return await ipcRenderer\.invoke\('updater:quitAndInstall'\)\s*\} catch \(error\) \{\s*updaterQuitAbortRelay\.abort\(\)\s*throw error\s*\}/
-    )
   })
 })

--- a/src/shared/renderer-restart-preparation.ts
+++ b/src/shared/renderer-restart-preparation.ts
@@ -1,8 +1,8 @@
 import {
   ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT,
   type EditorPrepareHotExitDetail
-} from '../shared/editor-save-events'
-import type { UpdateStatus } from '../shared/types'
+} from './editor-save-events'
+import type { UpdateStatus } from './types'
 
 export type AppRestartPrepOptions = {
   startedEventName: string


### PR DESCRIPTION
## Summary

Fixes production crash report `b860def2-cad3-4ef9-b055-016c360f5864`, where lazy-chunk recovery requested a renderer reload but a dirty editor tab silently vetoed it. The editor could then remain stuck in the same document while treating recovery as already exhausted.

This PR:

- routes lazy-chunk reloads through Orca's existing restart-preparation sequence: back up dirty editor buffers, checkpoint the renderer session, arm the intentional-restart bypass, then reload;
- stores the requesting document's identity in the session guard, so Orca can distinguish a reload that landed from one that was vetoed;
- bounds a refused reload to 10 seconds, clears stale guards/listeners/timers, and caps retries per document to prevent loops;
- preserves the original reportable error when recovery did not actually happen;
- contains a proven post-reload lazy-chunk failure in the rich-markdown pane without filing a duplicate crash report, while retaining diagnostic breadcrumbs and a chunk-specific `reloadKey`;
- moves restart preparation into `src/shared` so preload and renderer recovery use one implementation.

Production diagnostics support the root cause: a `lazy_chunk_reload` breadcrumb was recorded, but no renderer bootstrap followed; periodic renderer activity continued in the same document until the crash report was created 44 minutes later.

## ELI5

Orca loads parts of its UI in small files. After an update, an already-open window can ask for an old file that no longer exists. Reloading the window normally fixes that.

The bug was that Orca wrote “reload attempted” on a sticky note and then asked to reload. If any editor tab had unsaved changes, Orca blocked the reload to protect the work—but the sticky note remained. Orca then believed the reload had happened even though it was still the same window, so the editor could stay broken.

Now Orca first backs up unsaved edits and saves the session, then reloads. The sticky note also identifies which copy of the window wrote it: if the same copy is still reading it, the reload did not happen. Orca clears the stale note and surfaces the real error instead of pretending recovery succeeded.

## Screenshots

No visual change. Existing fallback UI and copy are unchanged.

## Testing

- [x] `pnpm lint` — local focused lint and CI static analysis passed
- [x] `pnpm typecheck` — node, CLI, and web TypeScript projects passed locally
- [x] `pnpm test` — 33 focused tests passed locally; the full Node 24 and Node 26 CI matrices passed
- [x] `pnpm build` — Linux and Windows CI package jobs passed
- [x] Added or updated high-quality regression tests

Focused coverage includes:

- dirty editor tabs no longer veto recovery after hot-exit backup;
- failed backup/checkpoint refuses the reload without losing work;
- landed, vetoed, timed-out, and host-thrown reload requests clean up correctly;
- same-document guards stay reportable while prior-document guards remain loop-safe;
- concurrent lazy failures cannot re-arm an in-flight reload;
- rich-markdown lazy failures render the existing fallback and deduplicate breadcrumbs;
- preload updater/unload relays are tested behaviorally rather than through source-text matching.

`npm run check:max-lines-ratchet` also passes with no new bypasses.

## AI Review Report

Reviewed the full lazy-load, restart-preparation, unload-veto, persistence, and boundary-reporting paths.

The review found and fixed one cleanup bug: if the host threw while requesting `location.reload()`, the in-flight flag, session guard, restart latch, timer, and unload listener could remain armed. The request now cancels those resources in `finally`, records a `request-failed` outcome, and preserves the original chunk error. A regression test covers this path.

The review also replaced brittle source-text preload tests with behavioral tests and made dirty-tab test cleanup failure-safe.

Concurrency, stale session state, blocked storage, partial checkpoint completion, repeated vetoes, breadcrumb loss, and ordinary non-chunk errors were checked. Cross-platform review covered macOS, Linux, Windows, Electron's `will-prevent-unload`, and the paired-web fallback where that Electron signal is unavailable. No shortcut, path, shell, Git, SSH-host, or folder-workspace assumptions are introduced; the behavior is renderer-local and workspace-type agnostic.

## Security Audit

No new command execution, filesystem paths, credentials, auth, dependencies, or provider APIs are introduced. The only IPC behavior touched is the existing typed updater status/unload relay.

The intentional unload bypass remains fail-closed: it is armed only after dirty buffers are backed up and the synchronous renderer checkpoint succeeds. If either step fails, Orca aborts recovery and keeps the current document and unsaved work intact. Reload attempts remain session-guarded and per-document capped.

## Verdict

**Valid and should be merged.** The production evidence matches the vetoed-reload failure mode, the fix reuses Orca's established restart safety contract, and the failure/concurrency paths now have strong regression coverage. The main trade-off is intentional: after a reload is proven to have landed, a persistent lazy-chunk failure produces a contained pane fallback and breadcrumb rather than another crash report, matching `RecoverableRenderErrorBoundary`'s existing policy.

## Notes

This closes only `b860def2-cad3-4ef9-b055-016c360f5864`. The two unrelated `useConfirmationDialog must be used inside ConfirmationDialogProvider` development-session reports from the original crash cluster are not changed here.

