### PR TITLE
fix(terminal): avoid delayed atlas wipes on tab reveal

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -21,12 +21,6 @@ vi.mock('./pane-helpers', () => ({
   fitPanes: vi.fn(),
   focusActivePane: vi.fn()
 }))
-const scheduleTabRevealWebglAtlasRecovery = vi.fn()
-vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  // Why: the light-tab reveal must recover the atlas immediately, decoupled from
-  // the terminal-output debounce (which a background stream could otherwise defer).
-  scheduleTabRevealWebglAtlasRecovery: () => scheduleTabRevealWebglAtlasRecovery()
-}))
 const resetTerminalLinkifierHoverState = vi.fn()
 const isTerminalLinkifierHoverActive = vi.fn((_terminal: unknown) => false)
 vi.mock('@/lib/pane-manager/terminal-linkifier-hover-reset', () => ({
@@ -72,7 +66,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     vi.clearAllMocks()
   })
 
-  it('schedules a pane-scoped repaint on a light tab reveal', () => {
+  it('schedules one coordinated repaint on a light tab reveal', () => {
     // The light path is the "click the tab that was not open" gesture: it has
     // no rendering resume or fit, so without this repaint a hidden-while-
     // working pane keeps compositing pre-hide pixels.
@@ -81,9 +75,6 @@ describe('resumeTerminalVisibility reveal repaint', () => {
 
     expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
     expect(manager.resumeRendering).not.toHaveBeenCalled()
-    // Reveal recovery is immediate (not the terminal-output debounce), so a
-    // background stream in another pane cannot defer this tab's atlas rebuild.
-    expect(scheduleTabRevealWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
 
   it('captures native trim movement before enforcing viewport intent', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -14,7 +14,6 @@ import {
   resetTerminalLinkifierHoverState
 } from '@/lib/pane-manager/terminal-linkifier-hover-reset'
 import { focusActivePane } from './pane-helpers'
-import { scheduleTabRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 const WINDOW_WAKE_FLUSH_CHARS = 64 * 1024
@@ -77,10 +76,6 @@ export function resumeTerminalVisibility({
       // overlay's delayed geometry fit. Still request hidden-output recovery:
       // agent TUIs can suppress hidden bytes until the pane is foregrounded.
       requestLightTabBacklogRecovery(manager)
-      // Why: reveal recovery must be immediate, not the terminal-output debounce
-      // — a background agent streaming in another pane must not defer this tab's
-      // atlas rebuild.
-      scheduleTabRevealWebglAtlasRecovery()
       if (isActive) {
         focusActivePane(manager)
       }
@@ -93,9 +88,8 @@ export function resumeTerminalVisibility({
       // terminals; refresh after reset so rebuilt atlases repaint from xterm.
       resetAndRefreshAllTerminalWebglAtlases()
     }
-    // Why: the synchronous recovery above can fire before the revealed pane is
-    // attached and laid out. Follow up after layout with one shared-atlas-safe
-    // recovery covering every live terminal manager.
+    // Why: reveal work can start before the pane is attached and laid out.
+    // Recover once after layout, coordinating every shared-atlas renderer.
     manager.scheduleRevealRepaint()
   })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
@@ -5,7 +5,6 @@ import {
 } from '@/lib/pane-manager/pane-manager-registry'
 import {
   scheduleImagePasteWebglAtlasRecovery,
-  scheduleTabRevealWebglAtlasRecovery,
   scheduleTerminalWebglAtlasRecovery,
   TERMINAL_OUTPUT_RECOVERY_QUIET_MS
 } from './terminal-webgl-atlas-recovery'
@@ -151,32 +150,6 @@ describe('terminal WebGL atlas recovery', () => {
     expect(manager.refreshAllPanes).not.toHaveBeenCalled()
   })
 
-  it('recovers immediately on a tab reveal, not through the streaming debounce', () => {
-    // Regression guard (STA-1365 review): reveal recovery must stay immediate so a
-    // background agent streaming in another pane cannot defer a revealed tab's
-    // atlas rebuild. It shares the paste path's immediate burst, not the debounce.
-    vi.useFakeTimers()
-    const rafCallbacks: FrameRequestCallback[] = []
-    vi.stubGlobal(
-      'requestAnimationFrame',
-      vi.fn((callback: FrameRequestCallback) => {
-        rafCallbacks.push(callback)
-        return rafCallbacks.length
-      })
-    )
-    const manager = registerManager()
-
-    scheduleTabRevealWebglAtlasRecovery()
-    // First burst leg fires on the next frame — no 200ms debounce wait.
-    rafCallbacks[0]?.(0)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
-    vi.advanceTimersByTime(120)
-    vi.advanceTimersByTime(380)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
-  })
-
   it('does not recover mid-stream while terminal output keeps arriving', () => {
     // Regression (STA-1365): an alternate-screen TUI requests atlas recovery on
     // every redraw frame. Recovering mid-stream clears the shared glyph atlas and
@@ -277,8 +250,8 @@ describe('terminal WebGL atlas recovery', () => {
     // (foreground and hidden-output PTY writes) funnel through
     // scheduleTerminalWebglAtlasRecovery and re-arm the one module-global debounce
     // timer, so a single continuous stream (even a hidden one) keeps the recovery
-    // deferred for everyone. Image paste and tab reveal use their own immediate
-    // burst and are not coupled to the shared debounce timer.
+    // deferred for everyone. Image paste uses its own immediate burst and is not
+    // coupled to the shared debounce timer.
     vi.useFakeTimers()
     const rafCallbacks: FrameRequestCallback[] = []
     vi.stubGlobal(

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
@@ -41,12 +41,6 @@ export function scheduleImagePasteWebglAtlasRecovery(): void {
   scheduleAtlasRecoveryBurst()
 }
 
-export function scheduleTabRevealWebglAtlasRecovery(): void {
-  // Why: a tab reveal is one-shot, so recover immediately — decoupled from the
-  // streaming debounce so a background stream can't defer a revealed tab's rebuild.
-  scheduleAtlasRecoveryBurst()
-}
-
 export function scheduleTerminalWebglAtlasRecovery(): void {
   // Why: terminal-output recovery (foreground + hidden PTY writes). Trailing-edge
   // debounce so a clear only ever runs after 200ms of quiet — never mid-stream;

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -370,6 +370,7 @@ describe('useTerminalPaneGlobalEffects', () => {
 
     manager.resumeRendering.mockClear()
     manager.resetWebglTextureAtlases.mockClear()
+    manager.scheduleRevealRepaint.mockClear()
     manager.refreshAllPanes.mockClear()
     manager.suspendRendering.mockClear()
     mocks.fitAndFocusPanes.mockClear()
@@ -399,10 +400,13 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.resumeRendering).not.toHaveBeenCalled()
     expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
     expect(mocks.fitPanes).not.toHaveBeenCalled()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
     expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
     vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
   })
 
   it('keeps visible active-state updates on the light resume path', () => {
@@ -452,6 +456,7 @@ describe('useTerminalPaneGlobalEffects', () => {
 
     manager.resumeRendering.mockClear()
     manager.resetWebglTextureAtlases.mockClear()
+    manager.scheduleRevealRepaint.mockClear()
     manager.refreshAllPanes.mockClear()
     mocks.fitAndFocusPanes.mockClear()
     mocks.fitPanes.mockClear()
@@ -471,10 +476,13 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(manager.resumeRendering).not.toHaveBeenCalled()
     expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
     expect(mocks.fitPanes).not.toHaveBeenCalled()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
     expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
     vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(manager.refreshAllPanes).not.toHaveBeenCalled()
   })
 
   it('suspends rendering when a terminal tab first mounts hidden', () => {

--- a/tests/e2e/terminal-opencode-fullscreen-tui-tab-switch-repro.spec.ts
+++ b/tests/e2e/terminal-opencode-fullscreen-tui-tab-switch-repro.spec.ts
@@ -1,0 +1,493 @@
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveTabId,
+  getActiveWorktreeId,
+  waitForSessionReady
+} from './helpers/store'
+import { getTerminalContentForPtyId, waitForPtyShellEcho } from './terminal-pty-readiness'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { compareTerminalScreenshots } from './terminal-screenshot-diff'
+
+const OPENCODE_ROOT = process.env.ORCA_E2E_OPENCODE_ROOT
+const EVIDENCE_DIR = path.join(process.cwd(), '.tmp', 'issue-11757-opencode-tab-reveal-fix')
+const STREAM_TRIGGER_PATH = path.join(EVIDENCE_DIR, 'stream.trigger')
+const FRAME_MARKER = 'OPENCODE_FULLSCREEN_TUI_REPRO'
+
+type PaneClip = { x: number; y: number; width: number; height: number }
+
+type TerminalProbe = {
+  frameText: string
+  synchronizedOutput: boolean
+  paused: boolean
+  cols: number
+  rows: number
+}
+
+type AtlasResetCounts = Record<string, number>
+
+function quoteTerminalArg(value: string): string {
+  if (process.platform === 'win32') {
+    return `'${value.replaceAll("'", "''")}'`
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function opencodeFullScreenHarnessCommand(root: string, triggerPath: string): string {
+  const bun = process.env.ORCA_E2E_BUN_EXECUTABLE ?? 'bun'
+  const packageDirectory = path.join(root, 'packages', 'opencode')
+  const harness = String.raw`
+;(async () => {
+  const { existsSync, unlinkSync } = await import('node:fs')
+  const { BoxRenderable, TextRenderable, createCliRenderer } = await import('@opentui/core')
+  const triggerPath = ${JSON.stringify(triggerPath)}
+
+  const renderer = await createCliRenderer({
+    externalOutputMode: 'passthrough',
+    targetFps: 60,
+    gatherStats: false,
+    exitOnCtrlC: false,
+    useKittyKeyboard: {},
+    autoFocus: false,
+    openConsoleOnError: false,
+    useMouse: false
+  })
+  const rootRenderable = renderer.root
+  const ctx = rootRenderable.ctx
+  const panel = new BoxRenderable(ctx, {
+    width: '100%',
+    height: '100%',
+    flexDirection: 'column',
+    paddingLeft: 2,
+    paddingTop: 1,
+    gap: 1
+  })
+  rootRenderable.add(panel)
+
+  const header = new BoxRenderable(ctx, { flexDirection: 'row', gap: 1, height: 1 })
+  panel.add(header)
+  header.add(new TextRenderable(ctx, { content: '◆', fg: '#ff8a00' }))
+  header.add(new TextRenderable(ctx, { content: '${FRAME_MARKER}', fg: '#ff8a00' }))
+
+  const frameText = new TextRenderable(ctx, {
+    content: '${FRAME_MARKER} frame 00000 ready',
+    fg: '#e7edf7'
+  })
+  panel.add(frameText)
+  panel.add(new TextRenderable(ctx, {
+    content: '╭──────────────────────────────────────────────────────────────────────────────╮',
+    fg: '#6aa9ff'
+  }))
+  const rows = []
+  for (let index = 0; index < 26; index += 1) {
+    const row = new TextRenderable(ctx, {
+      content: '│ ' + String(index + 1).padStart(2, '0') + '  OpenCode streaming tool output ' + '#'.repeat(38) + ' │',
+      fg: index % 2 === 0 ? '#e7edf7' : '#a9b7c6'
+    })
+    rows.push(row)
+    panel.add(row)
+  }
+  panel.add(new TextRenderable(ctx, {
+    content: '╰──────────────────────────────────────────────────────────────────────────────╯',
+    fg: '#6aa9ff'
+  }))
+
+  let frame = 0
+  let timer = null
+  let triggerTimer = null
+  let stopping = false
+  const stop = () => {
+    if (stopping) return
+    stopping = true
+    if (timer) clearInterval(timer)
+    if (triggerTimer) clearInterval(triggerTimer)
+    renderer.destroy()
+    process.exit(0)
+  }
+  const renderCanonicalFrame = () => {
+    frame = 0
+    frameText.content = '${FRAME_MARKER} frame 00000 ready'
+    for (const [index, row] of rows.entries()) {
+      row.content = '│ ' + String(index + 1).padStart(2, '0') +
+        '  OpenCode streaming tool output ' + '#'.repeat(38) + ' │'
+    }
+    renderer.requestRender()
+  }
+  const startStreaming = () => {
+    if (timer) clearInterval(timer)
+    frame = 0
+    timer = setInterval(() => {
+      frame += 1
+      frameText.content = '${FRAME_MARKER} frame ' + String(frame).padStart(5, '0') +
+        (frame % 2 === 0 ? ' thinking' : ' streaming')
+      for (const [index, row] of rows.entries()) {
+        const phase = (frame + index) % 32
+        row.content = '│ ' + String(index + 1).padStart(2, '0') +
+          '  OpenCode streaming tool output ' + '#'.repeat(phase + 6).padEnd(38, ' ') + ' │'
+      }
+      renderer.requestRender()
+      if (frame >= 30) {
+        clearInterval(timer)
+        timer = null
+        renderCanonicalFrame()
+      }
+    }, 28)
+  }
+  process.on('SIGINT', stop)
+  process.on('SIGTERM', stop)
+  process.stdin.resume()
+  if (process.stdin.isTTY) process.stdin.setRawMode(true)
+  process.stdin.on('data', (data) => {
+    const input = Buffer.from(data)
+    if (input.includes(3)) stop()
+  })
+  triggerTimer = setInterval(() => {
+    if (!existsSync(triggerPath)) return
+    unlinkSync(triggerPath)
+    startStreaming()
+  }, 20)
+  renderCanonicalFrame()
+})().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})
+`
+  const encoded = Buffer.from(harness, 'utf8').toString('base64')
+  const expression = `eval(Buffer.from('${encoded}', 'base64').toString())`
+  return [
+    quoteTerminalArg(bun),
+    '--cwd',
+    quoteTerminalArg(packageDirectory),
+    '-e',
+    quoteTerminalArg(expression)
+  ].join(' ')
+}
+
+async function createSiblingTerminalTab(page: Page, worktreeId: string): Promise<string> {
+  return page.evaluate((worktreeId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    return store.getState().createTab(worktreeId, undefined, undefined, { activate: false }).id
+  }, worktreeId)
+}
+
+async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((tabId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setActiveTabType('terminal')
+    store.getState().setActiveTab(tabId)
+  }, tabId)
+  await expect.poll(() => getActiveTabId(page), { timeout: 5_000 }).toBe(tabId)
+  await waitForActiveTerminalManager(page, 15_000)
+}
+
+async function setWebglEnabled(page: Page, tabId: string): Promise<boolean> {
+  await page.evaluate((tabId) => {
+    const state = window.__store?.getState()
+    if (!state?.settings) {
+      throw new Error('Store unavailable')
+    }
+    window.__store?.setState({
+      settings: { ...state.settings, terminalGpuAcceleration: 'on' }
+    })
+    window.__paneManagers?.get(tabId)?.setTerminalGpuAcceleration?.('on')
+  }, tabId)
+  return page
+    .waitForFunction(
+      (tabId) =>
+        (window.__paneManagers?.get(tabId)?.getRenderingDiagnostics?.() ?? []).some(
+          (diagnostic) => diagnostic.hasWebgl
+        ),
+      tabId,
+      { timeout: 20_000 }
+    )
+    .then(() => true)
+    .catch(() => false)
+}
+
+async function readPaneClip(page: Page, tabId: string): Promise<PaneClip> {
+  return page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+    const rect = pane?.container.getBoundingClientRect()
+    if (!rect || rect.width < 10 || rect.height < 10) {
+      throw new Error(`No visible pane clip for tab ${tabId}`)
+    }
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+  }, tabId)
+}
+
+async function captureStablePane(page: Page, tabId: string): Promise<Buffer> {
+  let previous = await page.screenshot({ clip: await readPaneClip(page, tabId) })
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await page.waitForTimeout(80)
+    const current = await page.screenshot({ clip: await readPaneClip(page, tabId) })
+    if (current.equals(previous)) {
+      return current
+    }
+    previous = current
+  }
+  throw new Error('OpenCode pane did not reach a stable frame')
+}
+
+async function installAtlasResetProbe(page: Page, tabIds: string[]): Promise<void> {
+  await page.evaluate((tabIds) => {
+    const scope = window as Window & {
+      __opencodeRevealResetProbe?: { counts: AtlasResetCounts; restore: () => void }
+    }
+    const counts: AtlasResetCounts = {}
+    const restores: (() => void)[] = []
+    for (const tabId of tabIds) {
+      const manager = window.__paneManagers?.get(tabId)
+      if (!manager) {
+        throw new Error(`No pane manager for tab ${tabId}`)
+      }
+      const original = manager.resetWebglTextureAtlases
+      counts[tabId] = 0
+      manager.resetWebglTextureAtlases = function () {
+        counts[tabId] += 1
+        return original.call(manager)
+      }
+      restores.push(() => {
+        manager.resetWebglTextureAtlases = original
+      })
+    }
+    scope.__opencodeRevealResetProbe = {
+      counts,
+      restore: () => restores.forEach((restore) => restore())
+    }
+  }, tabIds)
+}
+
+async function readAtlasResetCounts(page: Page): Promise<AtlasResetCounts> {
+  return page.evaluate(() => {
+    const probe = (
+      window as Window & {
+        __opencodeRevealResetProbe?: { counts: AtlasResetCounts }
+      }
+    ).__opencodeRevealResetProbe
+    if (!probe) {
+      throw new Error('Atlas reset probe unavailable')
+    }
+    return { ...probe.counts }
+  })
+}
+
+async function uninstallAtlasResetProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const scope = window as Window & {
+      __opencodeRevealResetProbe?: { restore: () => void }
+    }
+    scope.__opencodeRevealResetProbe?.restore()
+    delete scope.__opencodeRevealResetProbe
+  })
+}
+
+async function readTerminalProbe(page: Page, tabId: string): Promise<TerminalProbe> {
+  return page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+    if (!pane) {
+      throw new Error(`No pane for tab ${tabId}`)
+    }
+    const terminal = pane.terminal
+    const buffer = terminal.buffer.active
+    const frameText = Array.from({ length: terminal.rows }, (_, row) => {
+      return buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''
+    }).join('\n')
+    const core = terminal._core as {
+      coreService?: { decPrivateModes?: { synchronizedOutput?: boolean } }
+      _renderService?: { _isPaused?: boolean }
+    }
+    return {
+      frameText,
+      synchronizedOutput: core.coreService?.decPrivateModes?.synchronizedOutput === true,
+      paused: core._renderService?._isPaused === true,
+      cols: terminal.cols,
+      rows: terminal.rows
+    }
+  }, tabId)
+}
+
+async function toggleSidebarForRepaint(page: Page): Promise<void> {
+  const wasOpen = await page.evaluate(() => window.__store?.getState().rightSidebarOpen ?? false)
+  await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setRightSidebarOpen(!store.getState().rightSidebarOpen)
+  })
+  await page.waitForTimeout(250)
+  await page.evaluate((wasOpen) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    store.getState().setRightSidebarOpen(wasOpen)
+  }, wasOpen)
+  await page.waitForTimeout(500)
+}
+
+test('keeps a streaming full-screen OpenTUI intact across a hidden tab reveal', async ({
+  orcaPage
+}, testInfo: TestInfo) => {
+  test.setTimeout(150_000)
+  test.skip(
+    !OPENCODE_ROOT || !existsSync(path.join(OPENCODE_ROOT, 'packages', 'opencode', 'package.json')),
+    'Set ORCA_E2E_OPENCODE_ROOT to a checked-out OpenCode source tree to run the full-screen OpenTUI repro'
+  )
+
+  await waitForSessionReady(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+
+  const worktreeId = await getActiveWorktreeId(orcaPage)
+  const firstTabId = await getActiveTabId(orcaPage)
+  if (!worktreeId || !firstTabId || !OPENCODE_ROOT) {
+    throw new Error('No active worktree terminal tab')
+  }
+  const ptyId = await waitForActivePanePtyId(orcaPage)
+  await waitForPtyShellEcho(orcaPage, ptyId, 20_000)
+  test.skip(
+    !(await setWebglEnabled(orcaPage, firstTabId)),
+    'WebGL is required for the full-screen paint-layer repro'
+  )
+
+  let before: Buffer | undefined
+  let afterReveal: Buffer | undefined
+  let afterResize: Buffer | undefined
+  let resetProbeInstalled = false
+  try {
+    mkdirSync(EVIDENCE_DIR, { recursive: true })
+    if (existsSync(STREAM_TRIGGER_PATH)) {
+      unlinkSync(STREAM_TRIGGER_PATH)
+    }
+    await sendToTerminal(
+      orcaPage,
+      ptyId,
+      `${opencodeFullScreenHarnessCommand(OPENCODE_ROOT, STREAM_TRIGGER_PATH)}\r`
+    )
+    await expect
+      .poll(() => getTerminalContentForPtyId(orcaPage, ptyId, 40_000), {
+        timeout: 45_000,
+        message: 'OpenCode source OpenTUI harness did not render its full-screen marker'
+      })
+      .toContain(FRAME_MARKER)
+    await orcaPage.waitForTimeout(500)
+
+    before = await captureStablePane(orcaPage, firstTabId)
+    const secondTabId = await createSiblingTerminalTab(orcaPage, worktreeId)
+    await activateTerminalTab(orcaPage, secondTabId)
+    await orcaPage.waitForTimeout(500)
+    await installAtlasResetProbe(orcaPage, [firstTabId, secondTabId])
+    resetProbeInstalled = true
+
+    writeFileSync(STREAM_TRIGGER_PATH, 'stream')
+    await orcaPage.waitForTimeout(120)
+    const triggerConsumed = !existsSync(STREAM_TRIGGER_PATH)
+    const hidden = await readTerminalProbe(orcaPage, firstTabId)
+    await activateTerminalTab(orcaPage, firstTabId)
+    await orcaPage.waitForTimeout(650)
+    const resetCounts = await readAtlasResetCounts(orcaPage)
+    await orcaPage.waitForTimeout(180)
+    const afterRevealProbe = await readTerminalProbe(orcaPage, firstTabId)
+    afterReveal = await captureStablePane(orcaPage, firstTabId)
+
+    await toggleSidebarForRepaint(orcaPage)
+    const afterResizeProbe = await readTerminalProbe(orcaPage, firstTabId)
+    afterResize = await captureStablePane(orcaPage, firstTabId)
+    const revealDiff = compareTerminalScreenshots(before, afterReveal)
+    const resizeDiff = compareTerminalScreenshots(before, afterResize)
+
+    mkdirSync(EVIDENCE_DIR, { recursive: true })
+    writeFileSync(path.join(EVIDENCE_DIR, 'before.png'), before)
+    writeFileSync(path.join(EVIDENCE_DIR, 'after-reveal.png'), afterReveal)
+    writeFileSync(path.join(EVIDENCE_DIR, 'after-resize.png'), afterResize)
+    writeFileSync(
+      path.join(EVIDENCE_DIR, 'state.json'),
+      `${JSON.stringify(
+        {
+          triggerConsumed,
+          hidden,
+          afterRevealProbe,
+          afterResizeProbe,
+          resetCounts,
+          revealDiff,
+          resizeDiff
+        },
+        null,
+        2
+      )}\n`
+    )
+
+    await testInfo.attach('fullscreen-opentui-before.png', {
+      body: before,
+      contentType: 'image/png'
+    })
+    await testInfo.attach('fullscreen-opentui-after-reveal.png', {
+      body: afterReveal,
+      contentType: 'image/png'
+    })
+    await testInfo.attach('fullscreen-opentui-after-resize.png', {
+      body: afterResize,
+      contentType: 'image/png'
+    })
+    await testInfo.attach('fullscreen-opentui-state.json', {
+      body: Buffer.from(
+        JSON.stringify(
+          {
+            triggerConsumed,
+            hidden,
+            afterRevealProbe,
+            afterResizeProbe,
+            resetCounts,
+            revealDiff,
+            resizeDiff
+          },
+          null,
+          2
+        )
+      ),
+      contentType: 'application/json'
+    })
+    console.log(
+      `[terminal-repro] fullscreen-opentui=${JSON.stringify({
+        triggerConsumed,
+        hidden,
+        afterRevealProbe,
+        afterResizeProbe,
+        resetCounts,
+        revealDiff,
+        resizeDiff
+      })}`
+    )
+
+    expect(triggerConsumed).toBe(true)
+    expect(afterRevealProbe.frameText).toContain(`${FRAME_MARKER} frame 00000 ready`)
+    expect(resetCounts[firstTabId]).toBe(1)
+    expect(resetCounts[secondTabId]).toBe(1)
+    expect(revealDiff.matches).toBe(true)
+    expect(resizeDiff.matches).toBe(true)
+  } finally {
+    if (resetProbeInstalled) {
+      await uninstallAtlasResetProbe(orcaPage).catch(() => {})
+    }
+    if (existsSync(STREAM_TRIGGER_PATH)) {
+      unlinkSync(STREAM_TRIGGER_PATH)
+    }
+    await sendToTerminal(orcaPage, ptyId, '\u0003\u0003').catch(() => {})
+  }
+})


### PR DESCRIPTION
## Re-evaluation

This PR is draft and is not ready to merge as a fix for #11757.

- The earlier stranded and recovered screenshots do not establish recovery; they are visually equivalent.
- On the pre-change build, 20 of 20 reveal captures were byte-identical to baseline. The test failed only because it observed four atlas reset calls instead of one.
- Three of 20 post-resize captures differed because the viewport jumped from the top to rows 15 through 26. That is a separate viewport issue, not garbled glyph recovery.
- The exact Orca 1.4.161 release also passed 10 of 10 runs of the existing eight-cycle tab-switch pixel oracle.

The current diff demonstrates removal of redundant reset work, but it does not yet demonstrate the reported visual corruption or prove that the removed reset burst caused it. The PR will remain draft until a natural red-green visual oracle justifies the fix; otherwise it should be withdrawn.

Stacked base: #11864.