### PR TITLE
fix(runtime-rpc): keep slow worktree creates alive after the socket idle window

### DIFF
--- a/src/cli/format-recovery.test.ts
+++ b/src/cli/format-recovery.test.ts
@@ -50,6 +50,22 @@ describe('CLI error recovery', () => {
     expect(output).not.toContain('Orca is not running')
   })
 
+  it('does not add the not-running hint to a completion warning without next steps', () => {
+    const output = formatCliError(
+      new RuntimeClientError(
+        'runtime_unavailable',
+        'The browser.tabCreate operation may have completed.',
+        {
+          requestPhase: 'awaiting_response',
+          mutationMayHaveCompleted: true
+        }
+      )
+    )
+
+    expect(output).toContain('may have completed')
+    expect(output).not.toContain('Orca is not running')
+  })
+
   it('prints did-you-mean next steps for an unknown-command error carrying data', () => {
     const error = new RuntimeClientError('invalid_argument', 'Unknown command: worktree remov', {
       suggestions: ['worktree rm'],

--- a/src/cli/format-recovery.test.ts
+++ b/src/cli/format-recovery.test.ts
@@ -1,9 +1,55 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { formatCliError } from './format'
+import { formatCliError, reportCliError } from './format'
 import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
 
 describe('CLI error recovery', () => {
+  it('preserves response-loss recovery data in JSON output', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    reportCliError(
+      new RuntimeClientError(
+        'runtime_unavailable',
+        'The operation may have completed; verify before retrying.',
+        {
+          requestPhase: 'awaiting_response',
+          mutationMayHaveCompleted: true,
+          nextSteps: ['Run: orca worktree list --json.']
+        }
+      ),
+      true
+    )
+
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      error: {
+        code: 'runtime_unavailable',
+        data: {
+          requestPhase: 'awaiting_response',
+          mutationMayHaveCompleted: true,
+          nextSteps: ['Run: orca worktree list --json.']
+        }
+      },
+      _meta: { runtimeId: null }
+    })
+  })
+
+  it('reports that a sent worktree create may have completed', () => {
+    const error = new RuntimeClientError(
+      'runtime_unavailable',
+      'The worktree.create operation may have completed after the runtime connection closed.',
+      {
+        requestPhase: 'awaiting_response',
+        mutationMayHaveCompleted: true,
+        nextSteps: ['Run: orca worktree list --json before retrying.']
+      }
+    )
+
+    const output = formatCliError(error)
+
+    expect(output).toContain('may have completed')
+    expect(output).toContain('Next step: Run: orca worktree list --json before retrying.')
+    expect(output).not.toContain('Orca is not running')
+  })
+
   it('prints did-you-mean next steps for an unknown-command error carrying data', () => {
     const error = new RuntimeClientError('invalid_argument', 'Unknown command: worktree remov', {
       suggestions: ['worktree rm'],

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -86,6 +86,10 @@ export function formatCliError(error: unknown, context: CliErrorContext = {}): s
     }
   }
   if (error instanceof RuntimeClientError && error.code === 'runtime_unavailable') {
+    const data = error.data && typeof error.data === 'object' ? error.data : undefined
+    if ((data as { mutationMayHaveCompleted?: unknown } | undefined)?.mutationMayHaveCompleted) {
+      return message
+    }
     return `${message}\nOrca is not running. Run 'orca open' first.`
   }
   // Why: error-specific recovery must win over the generic computer fallback.

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -77,15 +77,19 @@ export function printResult<TResult>(
 
 export function formatCliError(error: unknown, context: CliErrorContext = {}): string {
   const message = error instanceof Error ? error.message : String(error)
-  if (error instanceof RuntimeClientError && error.code === 'runtime_unavailable') {
-    return `${message}\nOrca is not running. Run 'orca open' first.`
-  }
-  // Why: error-specific recovery must win over the generic computer fallback.
+  // Why: explicit recovery steps describe a sent request more accurately than
+  // the generic runtime-unavailable hint. See #7410.
   if (error instanceof RuntimeClientError) {
     const nextSteps = nextStepsFromData(error.data)
     if (nextSteps.length > 0) {
       return formatMessageWithNextSteps(message, nextSteps)
     }
+  }
+  if (error instanceof RuntimeClientError && error.code === 'runtime_unavailable') {
+    return `${message}\nOrca is not running. Run 'orca open' first.`
+  }
+  // Why: error-specific recovery must win over the generic computer fallback.
+  if (error instanceof RuntimeClientError) {
     if (error.code === 'invalid_argument' && context.commandPath?.[0] === 'computer') {
       return formatMessageWithNextSteps(
         message,

--- a/src/cli/handlers/worktree-mutation-id.test.ts
+++ b/src/cli/handlers/worktree-mutation-id.test.ts
@@ -101,6 +101,36 @@ describe('worktree create mutation identity', () => {
     })
   })
 
+  it('uses the generated id in response-loss retry guidance', async () => {
+    callMock.mockRejectedValue(
+      new RuntimeClientError('runtime_unavailable', 'The runtime closed before responding.', {
+        requestPhase: 'awaiting_response',
+        mutationMayHaveCompleted: true
+      })
+    )
+
+    let thrown: unknown
+    try {
+      await invoke(
+        new Map<string, string | boolean>([
+          ['repo', 'id:repo'],
+          ['name', 'slow-create'],
+          ['no-parent', true]
+        ])
+      )
+    } catch (error) {
+      thrown = error
+    }
+
+    const sentId = (callMock.mock.calls[0]?.[1] as { clientMutationId?: string })?.clientMutationId
+    expect(sentId).toEqual(expect.any(String))
+    expect(thrown).toMatchObject({
+      data: {
+        nextSteps: expect.arrayContaining([expect.stringContaining(`--mutation-id ${sentId}`)])
+      }
+    })
+  })
+
   it('rejects mutation ids longer than the runtime schema limit', async () => {
     await expect(
       invoke(

--- a/src/cli/handlers/worktree-mutation-id.test.ts
+++ b/src/cli/handlers/worktree-mutation-id.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RuntimeClientError } from '../runtime-client'
 
 const callMock = vi.hoisted(() => vi.fn())
 
@@ -74,5 +75,43 @@ describe('worktree create mutation identity', () => {
       'worktree.create',
       expect.objectContaining({ clientMutationId: 'retry-7410' })
     )
+  })
+
+  it('includes the sent id in response-loss retry guidance', async () => {
+    callMock.mockRejectedValue(
+      new RuntimeClientError('runtime_unavailable', 'The runtime closed before responding.', {
+        requestPhase: 'awaiting_response',
+        mutationMayHaveCompleted: true
+      })
+    )
+
+    await expect(
+      invoke(
+        new Map<string, string | boolean>([
+          ['repo', 'id:repo'],
+          ['name', 'slow-create'],
+          ['no-parent', true],
+          ['mutation-id', 'retry-7410']
+        ])
+      )
+    ).rejects.toMatchObject({
+      data: {
+        nextSteps: expect.arrayContaining([expect.stringContaining('--mutation-id retry-7410')])
+      }
+    })
+  })
+
+  it('rejects mutation ids longer than the runtime schema limit', async () => {
+    await expect(
+      invoke(
+        new Map<string, string | boolean>([
+          ['repo', 'id:repo'],
+          ['name', 'slow-create'],
+          ['no-parent', true],
+          ['mutation-id', 'x'.repeat(129)]
+        ])
+      )
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+    expect(callMock).not.toHaveBeenCalled()
   })
 })

--- a/src/cli/handlers/worktree-mutation-id.test.ts
+++ b/src/cli/handlers/worktree-mutation-id.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../format', () => ({
+  formatWorktreeList: vi.fn(),
+  formatWorktreePs: vi.fn(),
+  formatWorktreeShow: vi.fn(),
+  printResult: vi.fn()
+}))
+vi.mock('../selectors', () => ({
+  getOptionalWorktreeSelector: vi.fn(),
+  getRequiredWorktreeSelector: vi.fn(),
+  resolveCurrentWorktreeSelector: vi.fn()
+}))
+vi.mock('../worktree-project-target', () => ({
+  assertWorkspaceTargetFlagsCompatible: vi.fn(),
+  hasWorkspaceProjectTarget: vi.fn(() => false),
+  resolveProjectCreateRepoSelector: vi.fn(async () => undefined)
+}))
+vi.mock('./worktree-create-parent-selector', () => ({
+  assertCreateParentFlagsCompatible: vi.fn(),
+  resolveCreateParentSelector: vi.fn(async () => ({
+    parentWorktree: undefined,
+    parentWorkspace: undefined
+  }))
+}))
+vi.mock('./worktree-linear-issue-link', () => ({
+  getOptionalLinearIssueLinkFlag: vi.fn(() => ({}))
+}))
+vi.mock('./worktree-lineage-summary', () => ({ printLineageSummary: vi.fn() }))
+
+import { WORKTREE_HANDLERS } from './worktree'
+
+describe('worktree create mutation identity', () => {
+  beforeEach(() => {
+    callMock.mockReset().mockResolvedValue({ result: {} })
+  })
+
+  const invoke = (flags: Map<string, string | boolean>) =>
+    WORKTREE_HANDLERS['worktree create']({
+      flags,
+      client: { call: callMock },
+      cwd: 'D:\\Repos\\repo',
+      json: true
+    } as never)
+
+  it('sends a fresh client mutation id for each create invocation', async () => {
+    await invoke(
+      new Map<string, string | boolean>([
+        ['repo', 'id:repo'],
+        ['name', 'slow-create'],
+        ['no-parent', true]
+      ])
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.create',
+      expect.objectContaining({ clientMutationId: expect.any(String) })
+    )
+  })
+
+  it('passes an explicit mutation id through unchanged', async () => {
+    await invoke(
+      new Map<string, string | boolean>([
+        ['repo', 'id:repo'],
+        ['name', 'slow-create'],
+        ['no-parent', true],
+        ['mutation-id', 'retry-7410']
+      ])
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.create',
+      expect.objectContaining({ clientMutationId: 'retry-7410' })
+    )
+  })
+})

--- a/src/cli/handlers/worktree-response-recovery.ts
+++ b/src/cli/handlers/worktree-response-recovery.ts
@@ -1,0 +1,24 @@
+import { RuntimeClientError } from '../runtime-client'
+
+export function addWorktreeCreateRecovery(error: unknown, clientMutationId: string): unknown {
+  if (!(error instanceof RuntimeClientError) || !isMutationCompletionWarning(error.data)) {
+    return error
+  }
+  const data = error.data as Record<string, unknown>
+  return new RuntimeClientError(error.code, error.message, {
+    ...data,
+    nextSteps: [
+      'Run: orca worktree list --json and verify whether the worktree was created.',
+      `If it is missing, retry the same command with --mutation-id ${clientMutationId}.`,
+      'If it exists, do not retry blindly; a fresh create can create a second worktree and branch.'
+    ]
+  })
+}
+
+function isMutationCompletionWarning(data: unknown): boolean {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    (data as { mutationMayHaveCompleted?: unknown }).mutationMayHaveCompleted === true
+  )
+}

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type {
   RuntimeWorktreeListResult,
   RuntimeWorktreePsResult,
@@ -33,6 +34,7 @@ import {
   resolveCreateParentSelector
 } from './worktree-create-parent-selector'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
+import { addWorktreeCreateRecovery } from './worktree-response-recovery'
 
 type HookWarningResult = {
   warning?: string
@@ -208,6 +210,9 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     const explicitParentWorkspace = explicitParent.parentWorkspace
     const startupAgent = getOptionalStartupAgent(flags)
     const setupDecision = getOptionalSetupDecision(flags)
+    const worktreeName = getRequiredStringFlag(flags, 'name')
+    // Why: route retries into the runtime's existing dedupe window; fresh commands get fresh ids.
+    const clientMutationId = getOptionalStringFlag(flags, 'mutation-id') ?? randomUUID()
     const noParent = flags.get('no-parent') === true
     const envParentWorkspace =
       !noParent && !explicitParentWorkspace && !explicitParentWorktree
@@ -229,32 +234,38 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       }
     }
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
-    const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
-      repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
-      name: getRequiredStringFlag(flags, 'name'),
-      baseBranch: getOptionalStringFlag(flags, 'base-branch'),
-      linkedIssue: getOptionalNumberFlag(flags, 'issue'),
-      ...linearIssueLink,
-      comment: getOptionalStringFlag(flags, 'comment'),
-      runHooks: flags.get('run-hooks') === true,
-      activate: flags.get('activate') === true || flags.get('run-hooks') === true,
-      ...(setupDecision ? { setupDecision } : {}),
-      parentWorktree: explicitParentWorktree,
-      ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
-      ...(envParentWorkspace ? { envParentWorkspace } : {}),
-      ...(cwdParentWorktree ? { cwdParentWorktree } : {}),
-      noParent,
-      callerTerminalHandle,
-      // Why: marks the workspace as CLI-created so the sidebar can badge and
-      // filter it. Sent on every `worktree create` — hand-typed or agent-run.
-      cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
-      ...(startupAgent
-        ? {
-            startupAgent,
-            startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
-          }
-        : {})
-    })
+    let result: Awaited<ReturnType<typeof client.call<RuntimeWorktreeCreateResult>>>
+    try {
+      result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
+        repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
+        name: worktreeName,
+        clientMutationId,
+        baseBranch: getOptionalStringFlag(flags, 'base-branch'),
+        linkedIssue: getOptionalNumberFlag(flags, 'issue'),
+        ...linearIssueLink,
+        comment: getOptionalStringFlag(flags, 'comment'),
+        runHooks: flags.get('run-hooks') === true,
+        activate: flags.get('activate') === true || flags.get('run-hooks') === true,
+        ...(setupDecision ? { setupDecision } : {}),
+        parentWorktree: explicitParentWorktree,
+        ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
+        ...(envParentWorkspace ? { envParentWorkspace } : {}),
+        ...(cwdParentWorktree ? { cwdParentWorktree } : {}),
+        noParent,
+        callerTerminalHandle,
+        // Why: marks the workspace as CLI-created so the sidebar can badge and
+        // filter it. Sent on every `worktree create` — hand-typed or agent-run.
+        cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
+        ...(startupAgent
+          ? {
+              startupAgent,
+              startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
+            }
+          : {})
+      })
+    } catch (error) {
+      throw addWorktreeCreateRecovery(error, clientMutationId)
+    }
     printHookWarning(result.result, json)
     printLineageSummary(result.result, json)
     printResult(result, json, formatWorktreeShow)

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -212,7 +212,14 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     const setupDecision = getOptionalSetupDecision(flags)
     const worktreeName = getRequiredStringFlag(flags, 'name')
     // Why: route retries into the runtime's existing dedupe window; fresh commands get fresh ids.
-    const clientMutationId = getOptionalStringFlag(flags, 'mutation-id') ?? randomUUID()
+    const explicitMutationId = getOptionalStringFlag(flags, 'mutation-id')
+    if (explicitMutationId && explicitMutationId.length > 128) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        '--mutation-id must be 128 characters or fewer'
+      )
+    }
+    const clientMutationId = explicitMutationId ?? randomUUID()
     const noParent = flags.get('no-parent') === true
     const envParentWorkspace =
       !noParent && !explicitParentWorkspace && !explicitParentWorktree

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -225,7 +225,7 @@ Common Commands:
   orca environment show --environment <selector> [--json]
   orca environment rm --environment <selector> [--json]
   orca worktree list [--repo <selector>] [--limit <n>] [--json]
-  orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]
+  orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--mutation-id <id>] [--json]
   orca worktree show --worktree <selector> [--json]
   orca worktree current [--json]
   orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1180,6 +1180,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -1230,6 +1231,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -1352,6 +1354,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -1424,6 +1427,7 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).toHaveBeenNthCalledWith(1, 'projectHostSetup.list')
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-gpu',
       name: 'feature',
       baseBranch: undefined,
@@ -1564,6 +1568,7 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).toHaveBeenCalledTimes(1)
     expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1610,6 +1615,7 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).toHaveBeenCalledTimes(1)
     expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1677,6 +1683,7 @@ describe('orca cli worktree awareness', () => {
 
       expect(callMock).toHaveBeenCalledTimes(1)
       expect(callMock).toHaveBeenCalledWith('worktree.create', {
+        clientMutationId: expect.any(String),
         repo: 'id:repo-1',
         name: 'child',
         baseBranch: undefined,
@@ -1721,6 +1728,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1766,6 +1774,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1827,6 +1836,7 @@ describe('orca cli worktree awareness', () => {
       )
 
       expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+        clientMutationId: expect.any(String),
         repo: 'id:repo-1',
         name: 'child',
         baseBranch: undefined,
@@ -1975,6 +1985,7 @@ describe('orca cli worktree awareness', () => {
 
     const output = String(logSpy.mock.calls[0][0])
     expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -2017,6 +2028,7 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).toHaveBeenCalledTimes(1)
     expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -2052,6 +2064,7 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).toHaveBeenCalledTimes(2)
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -2825,6 +2838,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -2872,6 +2886,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'agent-task',
       baseBranch: undefined,
@@ -2919,6 +2934,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      clientMutationId: expect.any(String),
       repo: 'id:repo-1',
       name: 'agent-task',
       baseBranch: undefined,

--- a/src/cli/runtime/client-response-loss.test.ts
+++ b/src/cli/runtime/client-response-loss.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { createServer, type Server } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
 import { RuntimeClient } from './client'
+import { attachSlowMutationCompletionWarning } from './client-response-loss'
 import { RuntimeClientError } from './types'
 
 const servers = new Set<Server>()
@@ -64,5 +65,24 @@ describe('RuntimeClient response-loss recovery', () => {
         error.message.includes('may have completed')
       )
     })
+  })
+
+  it('describes a timeout as an incomplete response instead of a closed connection', () => {
+    const error = attachSlowMutationCompletionWarning(
+      new RuntimeClientError(
+        'runtime_timeout',
+        'Timed out waiting for the Orca runtime to respond.',
+        {
+          requestPhase: 'awaiting_response'
+        }
+      ),
+      'worktree.create'
+    )
+
+    expect(error).toMatchObject({
+      code: 'runtime_timeout',
+      message: expect.stringContaining('before the runtime responded')
+    })
+    expect((error as RuntimeClientError).message).not.toContain('connection closed')
   })
 })

--- a/src/cli/runtime/client-response-loss.test.ts
+++ b/src/cli/runtime/client-response-loss.test.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createServer, type Server } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RuntimeClient } from './client'
+import { RuntimeClientError } from './types'
+
+const servers = new Set<Server>()
+
+afterEach(async () => {
+  await Promise.all(
+    [...servers].map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve())
+        })
+    )
+  )
+  servers.clear()
+})
+
+function endpoint(): string {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\orca-t7410-client-${process.pid}-${randomUUID()}`
+    : join(mkdtempSync(join(tmpdir(), 'orca-runtime-client-response-loss-')), 'runtime.sock')
+}
+
+describe('RuntimeClient response-loss recovery', () => {
+  it('marks a sent slow mutation as possibly completed', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-client-response-loss-'))
+    const server = createServer((socket) => {
+      socket.once('data', () => socket.end())
+    })
+    const socketEndpoint = endpoint()
+    servers.add(server)
+    await new Promise<void>((resolve) => server.listen(socketEndpoint, resolve))
+    writeFileSync(
+      join(userDataPath, 'orca-runtime.json'),
+      JSON.stringify({
+        runtimeId: 'runtime-1',
+        pid: process.pid,
+        transports: [
+          { kind: process.platform === 'win32' ? 'named-pipe' : 'unix', endpoint: socketEndpoint }
+        ],
+        authToken: 'token',
+        startedAt: Date.now()
+      }),
+      'utf8'
+    )
+
+    const client = new RuntimeClient(userDataPath, 2_000)
+    await expect(
+      client.call('worktree.create', { repo: 'id:repo', name: 'slow-create' })
+    ).rejects.toSatisfy((error: unknown) => {
+      return (
+        error instanceof RuntimeClientError &&
+        error.code === 'runtime_unavailable' &&
+        error.data !== null &&
+        typeof error.data === 'object' &&
+        (error.data as Record<string, unknown>).requestPhase === 'awaiting_response' &&
+        (error.data as Record<string, unknown>).mutationMayHaveCompleted === true &&
+        error.message.includes('may have completed')
+      )
+    })
+  })
+})

--- a/src/cli/runtime/client-response-loss.ts
+++ b/src/cli/runtime/client-response-loss.ts
@@ -26,9 +26,12 @@ export function attachSlowMutationCompletionWarning(error: unknown, method: stri
   if (data?.requestPhase !== 'awaiting_response') {
     return error
   }
-  return new RuntimeClientError(
-    error.code,
-    `The ${method} operation may have completed after the runtime connection closed before responding. Verify state before retrying.`,
-    { ...data, mutationMayHaveCompleted: true }
-  )
+  const completionMessage =
+    error.code === 'runtime_unavailable'
+      ? `The ${method} operation may have completed after the runtime connection closed before responding. Verify state before retrying.`
+      : `${error.message} The ${method} operation may have completed before the runtime responded. Verify state before retrying.`
+  return new RuntimeClientError(error.code, completionMessage, {
+    ...data,
+    mutationMayHaveCompleted: true
+  })
 }

--- a/src/cli/runtime/client-response-loss.ts
+++ b/src/cli/runtime/client-response-loss.ts
@@ -1,0 +1,34 @@
+import { isSlowDispatchMutationMethod } from '../../shared/runtime-slow-dispatch'
+import { RuntimeClientError } from './types'
+
+export function attachMutationRecovery(error: unknown, requestId: string | undefined): unknown {
+  if (!requestId || !(error instanceof RuntimeClientError)) {
+    return error
+  }
+  return new RuntimeClientError(
+    error.code,
+    `${error.message} Orchestration mutation request ID: ${requestId}.`,
+    {
+      ...(error.data && typeof error.data === 'object' ? error.data : {}),
+      orchestrationRequestId: requestId
+    }
+  )
+}
+
+export function attachSlowMutationCompletionWarning(error: unknown, method: string): unknown {
+  if (!(error instanceof RuntimeClientError) || !isSlowDispatchMutationMethod(method)) {
+    return error
+  }
+  const data =
+    error.data && typeof error.data === 'object'
+      ? (error.data as Record<string, unknown>)
+      : undefined
+  if (data?.requestPhase !== 'awaiting_response') {
+    return error
+  }
+  return new RuntimeClientError(
+    error.code,
+    `The ${method} operation may have completed after the runtime connection closed before responding. Verify state before retrying.`,
+    { ...data, mutationMayHaveCompleted: true }
+  )
+}

--- a/src/cli/runtime/client.ts
+++ b/src/cli/runtime/client.ts
@@ -5,6 +5,7 @@ import {
   isOrchestrationMutation,
   orchestrationMigrationData
 } from '../../shared/orchestration-rpc-contract'
+import { attachMutationRecovery, attachSlowMutationCompletionWarning } from './client-response-loss'
 import { parsePairingCode, type PairingOffer } from '../../shared/pairing'
 import { launchOrcaApp } from './launch'
 import { getDefaultUserDataPath, readMetadata } from './metadata'
@@ -111,7 +112,10 @@ export class RuntimeClient {
           envelope
         )
       } catch (error) {
-        throw attachMutationRecovery(error, orchestrationRequestId)
+        throw attachSlowMutationCompletionWarning(
+          attachMutationRecovery(error, orchestrationRequestId),
+          method
+        )
       }
       if (response.ok === false) {
         throw new RuntimeRpcFailureError(response)
@@ -128,7 +132,10 @@ export class RuntimeClient {
     try {
       response = await sendRequest<TResult>(metadata, method, params, effectiveTimeoutMs, envelope)
     } catch (error) {
-      throw attachMutationRecovery(error, orchestrationRequestId)
+      throw attachSlowMutationCompletionWarning(
+        attachMutationRecovery(error, orchestrationRequestId),
+        method
+      )
     }
     if (response.ok === false) {
       throw new RuntimeRpcFailureError(response)
@@ -287,20 +294,6 @@ export class RuntimeClient {
       'Timed out waiting for an Orca desktop window. The runtime may still be running headlessly.'
     )
   }
-}
-
-function attachMutationRecovery(error: unknown, requestId: string | undefined): unknown {
-  if (!requestId || !(error instanceof RuntimeClientError)) {
-    return error
-  }
-  return new RuntimeClientError(
-    error.code,
-    `${error.message} Orchestration mutation request ID: ${requestId}.`,
-    {
-      ...(error.data && typeof error.data === 'object' ? error.data : {}),
-      orchestrationRequestId: requestId
-    }
-  )
 }
 
 function throwDesktopActivationBlocked(): never {

--- a/src/cli/runtime/client.ts
+++ b/src/cli/runtime/client.ts
@@ -118,7 +118,7 @@ export class RuntimeClient {
         )
       }
       if (response.ok === false) {
-        throw new RuntimeRpcFailureError(response)
+        throw attachSlowMutationCompletionWarning(new RuntimeRpcFailureError(response), method)
       }
       if (this.environmentSelector) {
         markEnvironmentUsed(this.userDataPath, this.environmentSelector, {
@@ -138,7 +138,7 @@ export class RuntimeClient {
       )
     }
     if (response.ok === false) {
-      throw new RuntimeRpcFailureError(response)
+      throw attachSlowMutationCompletionWarning(new RuntimeRpcFailureError(response), method)
     }
     return response
   }

--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createServer, type Socket } from 'node:net'
+import { randomUUID } from 'node:crypto'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import { MAX_TIMER_DELAY_MS } from '../../shared/timer-delay'
@@ -9,6 +10,13 @@ import { sendRequest } from './transport'
 
 const servers = new Set<ReturnType<typeof createServer>>()
 const sockets = new Set<Socket>()
+
+function testEndpoint(label: string): string {
+  if (process.platform === 'win32') {
+    return `\\\\.\\pipe\\orca-t7410-${process.pid}-${label}-${randomUUID()}`
+  }
+  return join(mkdtempSync(join(tmpdir(), `orca-runtime-transport-${label}-`)), 'runtime.sock')
+}
 
 afterEach(async () => {
   for (const socket of sockets) {
@@ -135,5 +143,51 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
       code: 'runtime_unavailable'
     })
     expect(Date.now() - start).toBeLessThan(5000)
+  })
+})
+
+describe('runtime transport response phase', () => {
+  it('marks a clean close after request write as awaiting_response', async () => {
+    const endpoint = testEndpoint('close')
+    const server = createServer((socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+      socket.once('data', () => socket.end())
+    })
+    servers.add(server)
+    await new Promise<void>((resolve) => server.listen(endpoint, resolve))
+
+    const metadata: RuntimeMetadata = {
+      runtimeId: 'runtime-1',
+      pid: 123,
+      transports: [{ kind: process.platform === 'win32' ? 'named-pipe' : 'unix', endpoint }],
+      authToken: 'token',
+      startedAt: 1
+    }
+
+    await expect(sendRequest(metadata, 'worktree.create', {}, 2_000)).rejects.toMatchObject({
+      code: 'runtime_unavailable',
+      data: { requestPhase: 'awaiting_response', method: 'worktree.create' }
+    })
+  })
+
+  it('marks a refused connection as not_sent', async () => {
+    const metadata: RuntimeMetadata = {
+      runtimeId: 'runtime-1',
+      pid: 123,
+      transports: [
+        {
+          kind: process.platform === 'win32' ? 'named-pipe' : 'unix',
+          endpoint: testEndpoint('refused')
+        }
+      ],
+      authToken: 'token',
+      startedAt: 1
+    }
+
+    await expect(sendRequest(metadata, 'worktree.create', {}, 2_000)).rejects.toMatchObject({
+      code: 'runtime_unavailable',
+      data: { requestPhase: 'not_sent', method: 'worktree.create' }
+    })
   })
 })

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -33,6 +33,7 @@ export async function sendRequest<TResult>(
     const socket = createConnection(transport.endpoint)
     let buffer = ''
     let settled = false
+    let requestSent = false
     const requestId = randomUUID()
 
     const timeout = setTimeout(() => {
@@ -44,7 +45,8 @@ export async function sendRequest<TResult>(
       reject(
         new RuntimeClientError(
           'runtime_timeout',
-          'Timed out waiting for the Orca runtime to respond.'
+          'Timed out waiting for the Orca runtime to respond.',
+          { requestPhase: requestSent ? 'awaiting_response' : 'not_sent', method }
         )
       )
     }, timeoutMs)
@@ -71,7 +73,8 @@ export async function sendRequest<TResult>(
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'Could not connect to the running Orca app. Restart Orca and try again.'
+          'Could not connect to the running Orca app. Restart Orca and try again.',
+          { requestPhase: requestSent ? 'awaiting_response' : 'not_sent', method }
         )
       })
     })
@@ -84,7 +87,8 @@ export async function sendRequest<TResult>(
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+          'The Orca runtime closed the connection before responding. The operation may have completed; verify state before retrying.',
+          { requestPhase: requestSent ? 'awaiting_response' : 'not_sent', method }
         )
       })
     })
@@ -193,6 +197,7 @@ export async function sendRequest<TResult>(
           orchestrationCompatibilityEvidence: envelope?.orchestrationCompatibilityEvidence
         })}\n`
       )
+      requestSent = true
     })
   })
 }

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -87,7 +87,7 @@ export async function sendRequest<TResult>(
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'The Orca runtime closed the connection before responding. The operation may have completed; verify state before retrying.',
+          'The Orca runtime closed the connection before responding. Restart Orca and try again.',
           { requestPhase: requestSent ? 'awaiting_response' : 'not_sent', method }
         )
       })
@@ -184,6 +184,7 @@ export async function sendRequest<TResult>(
       }
     })
     socket.on('connect', () => {
+      // Why: this marks bytes accepted by the client socket, not server acknowledgement.
       socket.write(
         `${JSON.stringify({
           id: requestId,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -86,7 +86,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--mutation-id <id>] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -104,7 +104,8 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'parent-worktree',
       'no-parent',
       'run-hooks',
-      'activate'
+      'activate',
+      'mutation-id'
     ],
     notes: [
       'This creates a new checkout. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
@@ -119,7 +120,8 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'With --agent --json, read the new agent handle from result.agentTerminalHandle; older runtimes return only result.startupTerminal.handle, and may return neither for folder-based repos.',
       'Repo-defined setup hooks follow the repository setup policy; pass --setup run to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',
-      'Passing --run-hooks is kept as a legacy alias for --setup run and reveals the worktree.'
+      'Passing --run-hooks is kept as a legacy alias for --setup run and reveals the worktree.',
+      'Pass --mutation-id from a prior response-loss warning when retrying the same create.'
     ],
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -121,7 +121,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'Repo-defined setup hooks follow the repository setup policy; pass --setup run to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',
       'Passing --run-hooks is kept as a legacy alias for --setup run and reveals the worktree.',
-      'Pass --mutation-id from a prior response-loss warning when retrying the same create.'
+      'Pass --mutation-id from a prior response-loss warning only when retrying the same create inputs; changing inputs with the same id reuses the original result.'
     ],
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',

--- a/src/main/runtime/rpc/transport.ts
+++ b/src/main/runtime/rpc/transport.ts
@@ -9,11 +9,11 @@
 
 // Why: per-message hook bag owned by the Unix transport. `signal` aborts
 // when the underlying connection terminates so long-poll handlers can bail
-// out. `startKeepalive` is opt-in per request — only long-poll dispatches
-// call it, so short RPCs pay no timer overhead. See design doc §3.1.
+// out. `startKeepalive` is opt-in per request; an optional duration bounds
+// slow non-abortable dispatches. See design doc §3.1.
 export type RpcMessageContext = {
   signal: AbortSignal
-  startKeepalive: () => void
+  startKeepalive: (maxDurationMs?: number) => void
 }
 
 export type RpcTransport = {

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -108,13 +108,14 @@ describe('UnixSocketTransport', () => {
     })
     const socket = new FakeSocket()
     let dispatchCount = 0
+    let siblingReply: ((response: string) => void) | undefined
 
     transport.onMessage((_msg, reply, context) => {
       dispatchCount += 1
       if (dispatchCount === 1) {
         context?.startKeepalive(250)
       } else {
-        void reply
+        siblingReply = reply
       }
     })
 
@@ -128,7 +129,11 @@ describe('UnixSocketTransport', () => {
 
     vi.advanceTimersByTime(300)
     expect(socket.destroyed).toBe(false)
+    expect(dispatchCount).toBe(2)
     expect(socket.writes.at(-1)).toContain('"id":"slow"')
     expect(socket.writes.at(-1)).toContain('"requestPhase":"awaiting_response"')
+    expect(siblingReply).toBeTypeOf('function')
+    siblingReply?.('{"id":"sibling","ok":true}')
+    expect(socket.writes.at(-1)).toContain('"id":"sibling"')
   })
 })

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -99,4 +99,36 @@ describe('UnixSocketTransport', () => {
     vi.advanceTimersByTime(300)
     expect(socket.writes).toHaveLength(2)
   })
+
+  it('returns a bounded failure without destroying sibling dispatches', () => {
+    const transport = new UnixSocketTransport({
+      endpoint: '/tmp/orca-runtime-rpc-test.sock',
+      kind: 'unix',
+      keepaliveIntervalMs: 100
+    })
+    const socket = new FakeSocket()
+    let dispatchCount = 0
+
+    transport.onMessage((_msg, reply, context) => {
+      dispatchCount += 1
+      if (dispatchCount === 1) {
+        context?.startKeepalive(250)
+      } else {
+        void reply
+      }
+    })
+
+    ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
+      socket as unknown as Socket
+    )
+    socket.emit(
+      'data',
+      '{"id":"slow","method":"worktree.create"}\n{"id":"sibling","method":"status.get"}\n'
+    )
+
+    vi.advanceTimersByTime(300)
+    expect(socket.destroyed).toBe(false)
+    expect(socket.writes.at(-1)).toContain('"id":"slow"')
+    expect(socket.writes.at(-1)).toContain('"requestPhase":"awaiting_response"')
+  })
 })

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -74,4 +74,28 @@ describe('UnixSocketTransport', () => {
     vi.advanceTimersByTime(500)
     expect(socket.writes).toHaveLength(1)
   })
+
+  it('stops a bounded keepalive without affecting the socket idle policy', () => {
+    const transport = new UnixSocketTransport({
+      endpoint: '/tmp/orca-runtime-rpc-test.sock',
+      kind: 'unix',
+      keepaliveIntervalMs: 100
+    })
+    const socket = new FakeSocket()
+
+    transport.onMessage((_msg, _reply, context) => {
+      context?.startKeepalive(250)
+    })
+
+    ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
+      socket as unknown as Socket
+    )
+    socket.emit('data', '{"id":"bounded","method":"worktree.create"}\n')
+
+    vi.advanceTimersByTime(300)
+    expect(socket.writes).toHaveLength(2)
+
+    vi.advanceTimersByTime(300)
+    expect(socket.writes).toHaveLength(2)
+  })
 })

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -75,7 +75,7 @@ describe('UnixSocketTransport', () => {
     expect(socket.writes).toHaveLength(1)
   })
 
-  it('stops a bounded keepalive without affecting the socket idle policy', () => {
+  it('stops and destroys a bounded keepalive connection at expiry', () => {
     const transport = new UnixSocketTransport({
       endpoint: '/tmp/orca-runtime-rpc-test.sock',
       kind: 'unix',
@@ -94,6 +94,7 @@ describe('UnixSocketTransport', () => {
 
     vi.advanceTimersByTime(300)
     expect(socket.writes).toHaveLength(2)
+    expect(socket.destroyed).toBe(true)
 
     vi.advanceTimersByTime(300)
     expect(socket.writes).toHaveLength(2)

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -163,11 +163,12 @@ export class UnixSocketTransport implements RpcTransport {
   }
 
   // Why: the keepalive timer is opt-in per request via `startKeepalive()`.
-  // Short RPCs never call it and pay no timer overhead; only long-poll
-  // handlers (e.g. orchestration.check --wait) arm it. See §3.1.
+  // Short RPCs never call it and pay no timer overhead; slow dispatches can
+  // also arm it with a bounded duration. See §3.1.
   private dispatchMessage(socket: Socket, rawMessage: string, inflight: Set<() => void>): void {
     let replied = false
     let keepaliveTimer: NodeJS.Timeout | null = null
+    let keepaliveExpiryTimer: NodeJS.Timeout | null = null
     // Why: each dispatch needs its own abort signal and keepalive timer
     // cleanup. Socket close runs every cleanup without touching sibling
     // dispatches that already replied on the same connection.
@@ -181,6 +182,10 @@ export class UnixSocketTransport implements RpcTransport {
       if (keepaliveTimer) {
         clearInterval(keepaliveTimer)
         keepaliveTimer = null
+      }
+      if (keepaliveExpiryTimer) {
+        clearTimeout(keepaliveExpiryTimer)
+        keepaliveExpiryTimer = null
       }
       if (abort) {
         abortController.abort()
@@ -201,7 +206,7 @@ export class UnixSocketTransport implements RpcTransport {
       }
     }
 
-    const startKeepalive = (): void => {
+    const startKeepalive = (maxDurationMs?: number): void => {
       if (keepaliveTimer || replied) {
         return
       }
@@ -215,6 +220,18 @@ export class UnixSocketTransport implements RpcTransport {
       // Why: don't hold the process open solely on the keepalive interval.
       if (typeof keepaliveTimer.unref === 'function') {
         keepaliveTimer.unref()
+      }
+      if (maxDurationMs !== undefined) {
+        keepaliveExpiryTimer = setTimeout(() => {
+          if (keepaliveTimer) {
+            clearInterval(keepaliveTimer)
+            keepaliveTimer = null
+          }
+          keepaliveExpiryTimer = null
+        }, maxDurationMs)
+        if (typeof keepaliveExpiryTimer.unref === 'function') {
+          keepaliveExpiryTimer.unref()
+        }
       }
     }
 

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -169,6 +169,19 @@ export class UnixSocketTransport implements RpcTransport {
     let replied = false
     let keepaliveTimer: NodeJS.Timeout | null = null
     let keepaliveExpiryTimer: NodeJS.Timeout | null = null
+    let requestId = 'unknown'
+    let requestMethod = 'unknown'
+    try {
+      const request = JSON.parse(rawMessage) as { id?: unknown; method?: unknown }
+      if (typeof request.id === 'string' && request.id.length > 0) {
+        requestId = request.id
+      }
+      if (typeof request.method === 'string' && request.method.length > 0) {
+        requestMethod = request.method
+      }
+    } catch {
+      // Why: handleMessage owns request validation; transport expiry only needs best-effort frame metadata.
+    }
     // Why: each dispatch needs its own abort signal and keepalive timer
     // cleanup. Socket close runs every cleanup without touching sibling
     // dispatches that already replied on the same connection.
@@ -228,9 +241,23 @@ export class UnixSocketTransport implements RpcTransport {
             keepaliveTimer = null
           }
           keepaliveExpiryTimer = null
-          // Why: reclaim the connection at the bound even when socket activity
-          // from another dispatch would otherwise keep the shared idle timer alive.
-          socket.destroy()
+          // Why: a shared socket can carry a sibling request; return a terminal
+          // failure for this dispatch instead of destroying that sibling's channel.
+          if (inflight.size > 1) {
+            reply(
+              JSON.stringify({
+                id: requestId,
+                ok: false,
+                error: {
+                  code: 'runtime_unavailable',
+                  message: 'The runtime stopped sending keepalive frames before responding.',
+                  data: { requestPhase: 'awaiting_response', method: requestMethod }
+                }
+              })
+            )
+          } else {
+            socket.destroy()
+          }
         }, maxDurationMs)
         if (typeof keepaliveExpiryTimer.unref === 'function') {
           keepaliveExpiryTimer.unref()

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -228,6 +228,9 @@ export class UnixSocketTransport implements RpcTransport {
             keepaliveTimer = null
           }
           keepaliveExpiryTimer = null
+          // Why: reclaim the connection at the bound even when socket activity
+          // from another dispatch would otherwise keep the shared idle timer alive.
+          socket.destroy()
         }, maxDurationMs)
         if (typeof keepaliveExpiryTimer.unref === 'function') {
           keepaliveExpiryTimer.unref()

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -9,9 +9,9 @@ import { chmodSync, existsSync, rmSync } from 'node:fs'
 import type { RpcMessageContext, RpcTransport } from './transport'
 
 const MAX_RUNTIME_RPC_MESSAGE_BYTES = 1024 * 1024
-const RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS = 30_000
+export const RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS = 30_000
 const MAX_RUNTIME_RPC_CONNECTIONS = 32
-const DEFAULT_KEEPALIVE_INTERVAL_MS = 10_000
+export const DEFAULT_KEEPALIVE_INTERVAL_MS = 10_000
 
 export type UnixSocketTransportOptions = {
   endpoint: string
@@ -21,6 +21,9 @@ export type UnixSocketTransportOptions = {
   // the client honours them, the client-side idle timer. Tests override this
   // to avoid waiting 10 s for a frame.
   keepaliveIntervalMs?: number
+  // Why: tests use a short real idle window to exercise socket teardown without
+  // waiting 30 s; production leaves this at RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS.
+  idleTimeoutMs?: number
 }
 
 type MessageHandler = (
@@ -33,14 +36,16 @@ export class UnixSocketTransport implements RpcTransport {
   private readonly endpoint: string
   private readonly kind: 'unix' | 'named-pipe'
   private readonly keepaliveIntervalMs: number
+  private readonly idleTimeoutMs: number
   private server: Server | null = null
   private messageHandler: MessageHandler | null = null
   private readonly activeSockets = new Set<Socket>()
 
-  constructor({ endpoint, kind, keepaliveIntervalMs }: UnixSocketTransportOptions) {
+  constructor({ endpoint, kind, keepaliveIntervalMs, idleTimeoutMs }: UnixSocketTransportOptions) {
     this.endpoint = endpoint
     this.kind = kind
     this.keepaliveIntervalMs = keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS
+    this.idleTimeoutMs = idleTimeoutMs ?? RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS
   }
 
   onMessage(handler: MessageHandler): void {
@@ -116,7 +121,7 @@ export class UnixSocketTransport implements RpcTransport {
 
     socket.setEncoding('utf8')
     socket.setNoDelay(true)
-    socket.setTimeout(RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS, () => {
+    socket.setTimeout(this.idleTimeoutMs, () => {
       socket.destroy()
     })
     socket.on('error', () => {

--- a/src/main/runtime/runtime-rpc-slow-dispatch.test.ts
+++ b/src/main/runtime/runtime-rpc-slow-dispatch.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
 import { readRuntimeMetadata } from './runtime-metadata'
 import type { RpcResponse } from './rpc/core'
-import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import { OrcaRuntimeRpcServer, SLOW_DISPATCH_KEEPALIVE_MAX_MS } from './runtime-rpc'
 import {
   DEFAULT_KEEPALIVE_INTERVAL_MS,
   RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS
@@ -141,8 +141,8 @@ describe('slow local RPC dispatches', () => {
 
     expect(createResult).toMatchObject({ ok: true })
     expect(waitResult).toMatchObject({ ok: true })
-    expect(createKeepalive).toHaveBeenCalledTimes(1)
-    expect(waitKeepalive).toHaveBeenCalledTimes(1)
+    expect(createKeepalive).toHaveBeenCalledWith(SLOW_DISPATCH_KEEPALIVE_MAX_MS)
+    expect(waitKeepalive).toHaveBeenCalledWith()
     expect(signals.get('worktree.create')).toBeUndefined()
     expect(signals.get('terminal.wait')).toBe(waitAbort.signal)
     expect(RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS).toBe(30_000)

--- a/src/main/runtime/runtime-rpc-slow-dispatch.test.ts
+++ b/src/main/runtime/runtime-rpc-slow-dispatch.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createConnection } from 'node:net'
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { readRuntimeMetadata } from './runtime-metadata'
+import type { RpcResponse } from './rpc/core'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import {
+  DEFAULT_KEEPALIVE_INTERVAL_MS,
+  RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS
+} from './rpc/unix-socket-transport'
+
+function request(server: OrcaRuntimeRpcServer, method: string): string {
+  return JSON.stringify({
+    id: `${method}-request`,
+    authToken: server['authToken'],
+    method,
+    params: {}
+  })
+}
+
+function response(server: OrcaRuntimeRpcServer, id: string): Record<string, unknown> {
+  return {
+    id,
+    ok: true,
+    result: { accepted: true },
+    _meta: { runtimeId: server['runtime'].getRuntimeId() }
+  }
+}
+
+function sendLocalRequest(
+  endpoint: string,
+  authToken: string,
+  method: string,
+  params: unknown
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(endpoint)
+    const id = `${method}-client-request`
+    let buffer = ''
+    socket.setEncoding('utf8')
+    socket.once('error', reject)
+    socket.on('data', (chunk: string) => {
+      buffer += chunk
+      let newline = buffer.indexOf('\n')
+      while (newline !== -1) {
+        const frame = JSON.parse(buffer.slice(0, newline)) as Record<string, unknown>
+        buffer = buffer.slice(newline + 1)
+        newline = buffer.indexOf('\n')
+        if (frame._keepalive === true) {
+          continue
+        }
+        socket.end()
+        resolve(frame)
+        return
+      }
+    })
+    socket.on('connect', () => {
+      socket.write(`${JSON.stringify({ id, authToken, method, params })}\n`)
+    })
+  })
+}
+
+describe('slow local RPC dispatches', () => {
+  it('response is not lost when a slow create outlives the socket idle window', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-slow-dispatch-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      socketIdleTimeoutMs: 100,
+      keepaliveIntervalMs: 20
+    })
+    const handlerCompleted = { value: false }
+    const dispatch = vi.spyOn(server['dispatcher'], 'dispatch').mockImplementation(async (req) => {
+      await new Promise((resolve) => setTimeout(resolve, 260))
+      handlerCompleted.value = true
+      return {
+        id: req.id,
+        ok: true,
+        result: { worktree: { id: 'worktree-test' } },
+        _meta: { runtimeId: runtime.getRuntimeId() }
+      }
+    })
+
+    await server.start()
+    try {
+      const metadata = readRuntimeMetadata(userDataPath)
+      if (!metadata || !metadata.authToken || !metadata.transports[0]) {
+        throw new Error('runtime metadata was not written')
+      }
+      const result = await sendLocalRequest(
+        metadata.transports[0].endpoint,
+        metadata.authToken,
+        'worktree.create',
+        { repo: 'id:repo', name: 'slow-create' }
+      )
+
+      expect(result).toMatchObject({ ok: true })
+      expect(handlerCompleted.value).toBe(true)
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'worktree.create' }),
+        { signal: undefined }
+      )
+    } finally {
+      await server.stop()
+      dispatch.mockRestore()
+    }
+  })
+
+  it('arms keepalive without long-poll admission or abort wiring', async () => {
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath: mkdtempSync(join(tmpdir(), 'orca-runtime-slow-dispatch-')),
+      longPollCap: 1
+    })
+    const createKeepalive = vi.fn()
+    const waitKeepalive = vi.fn()
+    const createAbort = new AbortController()
+    const waitAbort = new AbortController()
+    const signals = new Map<string, AbortSignal | undefined>()
+    const dispatch = vi
+      .spyOn(server['dispatcher'], 'dispatch')
+      .mockImplementation(async (req, options) => {
+        signals.set(req.method, options?.signal)
+        return response(server, req.id) as RpcResponse
+      })
+
+    const [createResult, waitResult] = await Promise.all([
+      server['handleMessage'](request(server, 'worktree.create'), {
+        signal: createAbort.signal,
+        startKeepalive: createKeepalive
+      }),
+      server['handleMessage'](request(server, 'terminal.wait'), {
+        signal: waitAbort.signal,
+        startKeepalive: waitKeepalive
+      })
+    ])
+
+    expect(createResult).toMatchObject({ ok: true })
+    expect(waitResult).toMatchObject({ ok: true })
+    expect(createKeepalive).toHaveBeenCalledTimes(1)
+    expect(waitKeepalive).toHaveBeenCalledTimes(1)
+    expect(signals.get('worktree.create')).toBeUndefined()
+    expect(signals.get('terminal.wait')).toBe(waitAbort.signal)
+    expect(RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS).toBe(30_000)
+    expect(DEFAULT_KEEPALIVE_INTERVAL_MS).toBe(10_000)
+    dispatch.mockRestore()
+  })
+
+  it('emits keepalive frames before a slow create terminal frame', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-slow-dispatch-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      socketIdleTimeoutMs: 100,
+      keepaliveIntervalMs: 20
+    })
+    vi.spyOn(server['dispatcher'], 'dispatch').mockImplementation(async (req) => {
+      await new Promise((resolve) => setTimeout(resolve, 130))
+      return {
+        id: req.id,
+        ok: true,
+        result: { accepted: true },
+        _meta: { runtimeId: runtime.getRuntimeId() }
+      }
+    })
+
+    await server.start()
+    try {
+      const metadata = readRuntimeMetadata(userDataPath)
+      if (!metadata || !metadata.transports[0]) {
+        throw new Error('runtime transport metadata was not written')
+      }
+      const frames: Record<string, unknown>[] = []
+      await new Promise<void>((resolve, reject) => {
+        const socket = createConnection(metadata.transports[0].endpoint)
+        let buffer = ''
+        socket.setEncoding('utf8')
+        socket.once('error', reject)
+        socket.on('data', (chunk: string) => {
+          buffer += chunk
+          let newline = buffer.indexOf('\n')
+          while (newline !== -1) {
+            frames.push(JSON.parse(buffer.slice(0, newline)) as Record<string, unknown>)
+            buffer = buffer.slice(newline + 1)
+            newline = buffer.indexOf('\n')
+          }
+          if (frames.some((frame) => frame._keepalive !== true)) {
+            socket.end()
+            resolve()
+          }
+        })
+        socket.on('connect', () => {
+          socket.write(
+            `${JSON.stringify({
+              id: 'frame-request',
+              authToken: server['authToken'],
+              method: 'worktree.create',
+              params: {}
+            })}\n`
+          )
+        })
+      })
+      expect(frames.some((frame) => frame._keepalive === true)).toBe(true)
+      expect(frames.at(-1)).toMatchObject({ ok: true })
+    } finally {
+      await server.stop()
+    }
+  })
+})

--- a/src/main/runtime/runtime-rpc-slow-dispatch.test.ts
+++ b/src/main/runtime/runtime-rpc-slow-dispatch.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { createConnection } from 'node:net'
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
+import { ALL_RPC_METHODS } from './rpc/methods'
 import { readRuntimeMetadata } from './runtime-metadata'
 import type { RpcResponse } from './rpc/core'
 import { OrcaRuntimeRpcServer, SLOW_DISPATCH_KEEPALIVE_MAX_MS } from './runtime-rpc'
@@ -210,5 +211,14 @@ describe('slow local RPC dispatches', () => {
     } finally {
       await server.stop()
     }
+  })
+
+  it('keeps the classifier aligned with the registered RPC methods', () => {
+    const registered = new Set(ALL_RPC_METHODS.map((method) => method.name))
+    expect(
+      ['worktree.create', 'browser.tabCreate', 'browser.snapshot'].every((name) =>
+        registered.has(name)
+      )
+    ).toBe(true)
   })
 })

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -16,6 +16,7 @@ import type { RpcRequest, RpcResponse } from './rpc/core'
 import { errorResponse } from './rpc/errors'
 import type { RpcMessageContext, RpcTransport } from './rpc/transport'
 import { UnixSocketTransport } from './rpc/unix-socket-transport'
+import { isSlowDispatchMethod } from '../../shared/runtime-slow-dispatch'
 import { WebSocketTransport } from './rpc/ws-transport'
 import { readWsFallbackPort, writeWsFallbackPort } from './rpc/ws-fallback-port-store'
 import type { WebSocket } from 'ws'
@@ -63,8 +64,9 @@ type OrcaRuntimeRpcServerOptions = {
   // Why: true when the caller pinned a port (`orca serve --port`) so bind order prefers it over a stale STA-1511 fallback (#8535).
   preferPinnedWsPort?: boolean
   webClientRoot?: string
-  // Why: test-only overrides for the two constants below; production must not pass these (defaults set by §3.1).
+  // Why: test-only overrides for the transport and long-poll constants below; production must not pass these.
   keepaliveIntervalMs?: number
+  socketIdleTimeoutMs?: number
   longPollCap?: number
   // Why: test-only override for the ownership reclaim cadence.
   metadataOwnershipPollMs?: number
@@ -475,6 +477,7 @@ export class OrcaRuntimeRpcServer {
   private readonly webClientRoot: string | undefined
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
+  private readonly socketIdleTimeoutMs: number | undefined
   private readonly longPollCap: number
   private readonly metadataOwnershipPollMs: number
   private readonly askLongPollCap: number
@@ -521,6 +524,7 @@ export class OrcaRuntimeRpcServer {
     preferPinnedWsPort = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
+    socketIdleTimeoutMs,
     longPollCap = LONG_POLL_CAP,
     metadataOwnershipPollMs = RUNTIME_METADATA_OWNERSHIP_POLL_MS
   }: OrcaRuntimeRpcServerOptions) {
@@ -534,6 +538,7 @@ export class OrcaRuntimeRpcServer {
     this.preferPinnedWsPort = preferPinnedWsPort
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
+    this.socketIdleTimeoutMs = socketIdleTimeoutMs
     this.longPollCap = longPollCap
     this.metadataOwnershipPollMs = metadataOwnershipPollMs
     // Why: derived, not configurable — the reservation must hold for whatever cap a caller picks.
@@ -1094,7 +1099,8 @@ export class OrcaRuntimeRpcServer {
     const socketTransport = new UnixSocketTransport({
       endpoint: transportMeta.endpoint,
       kind: transportMeta.kind as 'unix' | 'named-pipe',
-      keepaliveIntervalMs: this.keepaliveIntervalMs
+      keepaliveIntervalMs: this.keepaliveIntervalMs,
+      idleTimeoutMs: this.socketIdleTimeoutMs
     })
 
     // Why: the `.catch` guarantees reply() always fires so a throw can't strand the client or leak the AbortController.
@@ -1287,8 +1293,9 @@ export class OrcaRuntimeRpcServer {
     if (rejection) {
       return this.buildError(request.id, 'runtime_busy', rejection)
     }
-    if (longPoll) {
-      // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
+    if (longPoll || isSlowDispatchMethod(request.method)) {
+      // Why: slow I/O-bound methods need liveness frames but are not long polls.
+      // Keep them outside capacity admission and abort-signal wiring.
       context?.startKeepalive()
     }
 

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -67,6 +67,7 @@ type OrcaRuntimeRpcServerOptions = {
   // Why: test-only overrides for the transport and long-poll constants below; production must not pass these.
   keepaliveIntervalMs?: number
   socketIdleTimeoutMs?: number
+  slowDispatchKeepaliveMaxMs?: number
   longPollCap?: number
   // Why: test-only override for the ownership reclaim cadence.
   metadataOwnershipPollMs?: number
@@ -482,6 +483,7 @@ export class OrcaRuntimeRpcServer {
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
   private readonly socketIdleTimeoutMs: number | undefined
+  private readonly slowDispatchKeepaliveMaxMs: number
   private readonly longPollCap: number
   private readonly metadataOwnershipPollMs: number
   private readonly askLongPollCap: number
@@ -529,6 +531,7 @@ export class OrcaRuntimeRpcServer {
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
     socketIdleTimeoutMs,
+    slowDispatchKeepaliveMaxMs = SLOW_DISPATCH_KEEPALIVE_MAX_MS,
     longPollCap = LONG_POLL_CAP,
     metadataOwnershipPollMs = RUNTIME_METADATA_OWNERSHIP_POLL_MS
   }: OrcaRuntimeRpcServerOptions) {
@@ -543,6 +546,7 @@ export class OrcaRuntimeRpcServer {
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.socketIdleTimeoutMs = socketIdleTimeoutMs
+    this.slowDispatchKeepaliveMaxMs = slowDispatchKeepaliveMaxMs
     this.longPollCap = longPollCap
     this.metadataOwnershipPollMs = metadataOwnershipPollMs
     // Why: derived, not configurable — the reservation must hold for whatever cap a caller picks.
@@ -1302,7 +1306,7 @@ export class OrcaRuntimeRpcServer {
     } else if (isSlowDispatchMethod(request.method)) {
       // Why: slow I/O-bound methods need liveness frames but are not long polls.
       // Keep them outside capacity admission and abort-signal wiring.
-      context?.startKeepalive(SLOW_DISPATCH_KEEPALIVE_MAX_MS)
+      context?.startKeepalive(this.slowDispatchKeepaliveMaxMs)
     }
 
     try {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -140,6 +140,10 @@ export type MobilePairingConnectionContext = Readonly<{
 // Why: keepalive frames count as socket activity, resetting both idle timers so long-polls outlive the 30s/60s idle caps. See §3.1.
 const KEEPALIVE_INTERVAL_MS = 10_000
 
+// Why: slow non-abortable dispatches may outlive the idle window, but liveness
+// must not hold a client connection forever when the underlying operation hangs.
+export const SLOW_DISPATCH_KEEPALIVE_MAX_MS = 5 * 60_000
+
 // Why: cap long-polls at half the 32-slot connection budget so they can't starve short RPCs; overflow → runtime_busy. See §7 risk #2.
 const LONG_POLL_CAP = 16
 
@@ -1293,10 +1297,12 @@ export class OrcaRuntimeRpcServer {
     if (rejection) {
       return this.buildError(request.id, 'runtime_busy', rejection)
     }
-    if (longPoll || isSlowDispatchMethod(request.method)) {
+    if (longPoll) {
+      context?.startKeepalive()
+    } else if (isSlowDispatchMethod(request.method)) {
       // Why: slow I/O-bound methods need liveness frames but are not long polls.
       // Keep them outside capacity admission and abort-signal wiring.
-      context?.startKeepalive()
+      context?.startKeepalive(SLOW_DISPATCH_KEEPALIVE_MAX_MS)
     }
 
     try {

--- a/src/shared/runtime-slow-dispatch.test.ts
+++ b/src/shared/runtime-slow-dispatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isSlowDispatchMethod, isSlowDispatchMutationMethod } from './runtime-slow-dispatch'
+
+describe('runtime slow dispatch classification', () => {
+  it.each(['worktree.create', 'browser.tabCreate', 'browser.snapshot'])(
+    'keeps %s alive',
+    (method) => {
+      expect(isSlowDispatchMethod(method)).toBe(true)
+    }
+  )
+
+  it('classifies only state-changing slow methods as mutations', () => {
+    expect(isSlowDispatchMutationMethod('worktree.create')).toBe(true)
+    expect(isSlowDispatchMutationMethod('browser.tabCreate')).toBe(true)
+    expect(isSlowDispatchMutationMethod('browser.snapshot')).toBe(false)
+    expect(isSlowDispatchMutationMethod('status.get')).toBe(false)
+  })
+})

--- a/src/shared/runtime-slow-dispatch.test.ts
+++ b/src/shared/runtime-slow-dispatch.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { isSlowDispatchMethod, isSlowDispatchMutationMethod } from './runtime-slow-dispatch'
+import {
+  isSlowDispatchMethod,
+  isSlowDispatchMutationMethod,
+  SLOW_DISPATCH_METHODS,
+  SLOW_DISPATCH_MUTATION_METHODS
+} from './runtime-slow-dispatch'
 
 describe('runtime slow dispatch classification', () => {
   it.each(['worktree.create', 'browser.tabCreate', 'browser.snapshot'])(
@@ -14,5 +19,11 @@ describe('runtime slow dispatch classification', () => {
     expect(isSlowDispatchMutationMethod('browser.tabCreate')).toBe(true)
     expect(isSlowDispatchMutationMethod('browser.snapshot')).toBe(false)
     expect(isSlowDispatchMutationMethod('status.get')).toBe(false)
+  })
+
+  it('keeps the mutation subset inside the slow-dispatch set', () => {
+    expect(
+      [...SLOW_DISPATCH_MUTATION_METHODS].every((method) => SLOW_DISPATCH_METHODS.has(method))
+    ).toBe(true)
   })
 })

--- a/src/shared/runtime-slow-dispatch.ts
+++ b/src/shared/runtime-slow-dispatch.ts
@@ -1,12 +1,12 @@
 // Why: these local RPC methods can spend longer than the transport idle window
 // in I/O-bound work, so the connection needs liveness frames while they run.
-const SLOW_DISPATCH_METHODS: ReadonlySet<string> = new Set([
+export const SLOW_DISPATCH_METHODS: ReadonlySet<string> = new Set([
   'worktree.create',
   'browser.tabCreate',
   'browser.snapshot'
 ])
 
-const SLOW_DISPATCH_MUTATION_METHODS: ReadonlySet<string> = new Set([
+export const SLOW_DISPATCH_MUTATION_METHODS: ReadonlySet<string> = new Set([
   'worktree.create',
   'browser.tabCreate'
 ])

--- a/src/shared/runtime-slow-dispatch.ts
+++ b/src/shared/runtime-slow-dispatch.ts
@@ -1,0 +1,20 @@
+// Why: these local RPC methods can spend longer than the transport idle window
+// in I/O-bound work, so the connection needs liveness frames while they run.
+const SLOW_DISPATCH_METHODS: ReadonlySet<string> = new Set([
+  'worktree.create',
+  'browser.tabCreate',
+  'browser.snapshot'
+])
+
+const SLOW_DISPATCH_MUTATION_METHODS: ReadonlySet<string> = new Set([
+  'worktree.create',
+  'browser.tabCreate'
+])
+
+export function isSlowDispatchMethod(method: string): boolean {
+  return SLOW_DISPATCH_METHODS.has(method)
+}
+
+export function isSlowDispatchMutationMethod(method: string): boolean {
+  return SLOW_DISPATCH_MUTATION_METHODS.has(method)
+}


### PR DESCRIPTION
## Summary

- Keep slow local `worktree.create` RPCs alive past the 30-second socket idle window so the CLI receives the result when the runtime continues working.
- Send the existing worktree mutation identity from the CLI and provide a deliberate `--mutation-id` retry path when a response is lost.
- Tell users that a sent request may have completed and to verify state before retrying; preserve the existing error codes and remote transport behavior.

Closes #7410.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation planned:

- Real scaled-idle RPC test through the CLI transport, including Windows named-pipe coverage.
- Long-poll capacity and abort-signal regression coverage.
- CLI transport phase, client recovery, human recovery, JSON recovery, mutation-id routing, and flag-parity tests.

Validation completed: the focused response-loss pack passed with 5 files, 19 tests passed, and 0 skipped; the broader focused pack passed with 14 files, 350 tests passed, and 5 skipped. `pnpm run lint` reached the code-quality, reliability, and max-lines gates, then stopped because the generated skill-bundle manifests are stale; those generated files remain outside this PR.

## AI Review Report

Two adversarial review passes covered the keepalive split from long-poll admission, local Unix and Windows named-pipe behavior, CLI retry identity, error-code compatibility, remote/WebSocket and Electron boundaries, resource limits, filesystem and command handling, and the absence of rollback or atomicity claims. The second pass found no P1 or P2 findings; remaining P3 capacity and runtime-skew caveats are documented in the implementation decisions.

## Security Audit

The change reuses the authenticated keepalive frame and the existing bounded `clientMutationId` schema. It adds no endpoint, credential, shell, path, IPC, or dependency surface. The retry id is rendered as guidance only and is never executed by the CLI.

## Notes

The runtime already owns `dedupeWorktreeCreate`; this change routes the CLI into that authority and does not add rollback, compensation, orphan cleanup, automatic state re-query, or guaranteed duplicate prevention. Slow-dispatch keepalive is capped at five minutes, after which the connection is reclaimed and the existing response-loss recovery applies. Remote WebSocket and Electron IPC create paths are unchanged. The exact macOS reporter environment remains a maintainer or reporter verification item.
