### PR TITLE
Gate the mobile native chat approval card on a paused agent

### DIFF
--- a/mobile/src/session/use-mobile-native-chat-prompts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.test.ts
@@ -1,0 +1,87 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
+import { useMobileNativeChatPrompts } from './use-mobile-native-chat-prompts'
+
+const APPROVAL = JSON.stringify({
+  approval: { tool: 'Bash', summary: 'chmod 644 alpha.txt' }
+})
+
+describe('useMobileNativeChatPrompts', () => {
+  let renderer: ReactTestRenderer | null = null
+  let prompts: ReturnType<typeof useMobileNativeChatPrompts> | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    prompts = null
+  })
+
+  function Harness({ status }: { status: AgentStatusEntry | null }): null {
+    prompts = useMobileNativeChatPrompts({ enabled: true, status, messages: [] })
+    return null
+  }
+
+  function render(status: Partial<AgentStatusEntry> | null): void {
+    act(() => {
+      renderer = create(createElement(Harness, { status: status as AgentStatusEntry | null }))
+    })
+  }
+
+  function renderWithState(state: AgentStatusEntry['state']): void {
+    render({ state, interactivePrompt: APPROVAL })
+  }
+
+  it('offers the approval card while the agent is waiting on it', () => {
+    renderWithState('waiting')
+
+    expect(prompts?.permission).toMatchObject({ title: 'Allow Bash?' })
+  })
+
+  it('offers the approval card while the agent is blocked', () => {
+    renderWithState('blocked')
+
+    expect(prompts?.permission).toMatchObject({ title: 'Allow Bash?' })
+  })
+
+  it('drops the approval card once the agent is working again', () => {
+    renderWithState('working')
+
+    expect(prompts?.permission).toBeNull()
+  })
+
+  it('drops the approval card once the turn is done', () => {
+    renderWithState('done')
+
+    expect(prompts?.permission).toBeNull()
+  })
+
+  it('drops the approval card when there is no status at all', () => {
+    render(null)
+
+    expect(prompts?.permission).toBeNull()
+  })
+
+  // Both producers can fire on one paused status; the parsed prompt text carries
+  // the agent's real options, so it has to win over the envelope's guessed ones.
+  it('prefers the parsed numbered options over the envelope defaults', () => {
+    render({
+      state: 'waiting',
+      interactivePrompt: APPROVAL,
+      lastAssistantMessage: 'Do you want to proceed?\n1. Yes\n2. No, and tell Claude what to do'
+    })
+
+    expect(prompts?.permission).toMatchObject({
+      title: 'Permission requested',
+      options: [
+        { label: 'Yes', send: '1' },
+        { label: 'No, and tell Claude what to do', send: '2' }
+      ]
+    })
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-prompts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.test.ts
@@ -37,6 +37,16 @@ describe('useMobileNativeChatPrompts', () => {
     render({ state, interactivePrompt: APPROVAL })
   }
 
+  function updateState(state: AgentStatusEntry['state']): void {
+    act(() => {
+      renderer?.update(
+        createElement(Harness, {
+          status: { state, interactivePrompt: APPROVAL } as unknown as AgentStatusEntry
+        })
+      )
+    })
+  }
+
   it('offers the approval card while the agent is waiting on it', () => {
     renderWithState('waiting')
 
@@ -57,6 +67,17 @@ describe('useMobileNativeChatPrompts', () => {
 
   it('drops the approval card once the turn is done', () => {
     renderWithState('done')
+
+    expect(prompts?.permission).toBeNull()
+  })
+
+  // The envelope survives the wait it belongs to, so the card has to go on the
+  // transition itself, not only when the pane is mounted fresh in a later state.
+  it('drops the approval card when a waiting agent resumes on the same pane', () => {
+    renderWithState('waiting')
+    expect(prompts?.permission).toMatchObject({ title: 'Allow Bash?' })
+
+    updateState('working')
 
     expect(prompts?.permission).toBeNull()
   })

--- a/mobile/src/session/use-mobile-native-chat-prompts.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.ts
@@ -19,15 +19,17 @@ export function useMobileNativeChatPrompts(args: {
 }): MobileNativeChatPrompts {
   const { enabled, status, messages } = args
   const blocked = status?.state === 'waiting' || status?.state === 'blocked'
+  // Why: the approval envelope outlives the wait it was emitted for, so it only
+  // means "approve this" while the agent is still paused on it.
   const permission =
-    (blocked && status
-      ? detectAgentPermission({
+    blocked && status
+      ? (detectAgentPermission({
           state: status.state,
           lastAssistantMessage: status.lastAssistantMessage,
           toolName: status.toolName,
           toolInput: status.toolInput
-        })
-      : null) ?? parseApprovalFromStatus(status?.interactivePrompt)
+        }) ?? parseApprovalFromStatus(status.interactivePrompt))
+      : null
   const question =
     blocked && status && !permission ? parseAgentQuestion(status.lastAssistantMessage ?? '') : null
   const askFromStatus = useMemo(


### PR DESCRIPTION
## Summary

On Orca Mobile's native chat, the tool approval card (`Allow Bash?` with Allow/Deny) was derived from the presence of an approval envelope in `agentStatus.interactivePrompt`, with no check that the agent was actually paused on it. `detectAgentPermission` is gated on `waiting`/`blocked`, but `parseApprovalFromStatus` sat outside that gate as a `??` fallback, so the card was a pure function of the envelope being present.

This moves both producers inside the gate. The card now exists exactly while the agent is `waiting` or `blocked` — the contract `mobile-native-chat-permission.ts` already documents ("only fire when the agent is actually paused") and which only the heuristic path honoured.

Beyond the stale-card case in the issue, this removes a concrete phantom: `clearClaudePendingWaitForAgent` restores the lead to `working` on `SubagentStop`/`TeammateIdle` without clearing `lastToolByPaneKey`, so the following child-driven payload re-emits a dead child's approval envelope with `state: 'working'`. Before this change the phone rendered an Allow/Deny card for that dead approval on a working agent, and tapping Allow typed a stray `1` into it.

Fixes #11928

## Screenshots

No layout or styling change. The behavioural difference is which statuses render the card: previously any status carrying an approval envelope, now only `waiting`/`blocked`. It is covered by unit tests that fail on `main` (see Testing).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added `mobile/src/session/use-mobile-native-chat-prompts.test.ts` (6 tests). Two of them fail on `main` (`drops the approval card once the agent is working again`, `… once the turn is done`) — verified before writing the fix.

Mutation-checked the new tests rather than trusting them: removing the gate, inverting it, adding/removing each paused state, and swapping the `??` operand order are all caught.

- `mobile` workspace: 384 files / 2,866 tests pass, `tsc --noEmit` and `oxlint` clean.
- Repo root: `pnpm lint`, `pnpm typecheck` and `pnpm build` pass. `pnpm test` reports 42,774 passing with two pre-existing failures unrelated to this change, both reproduced on a clean tree:
  - `config/scripts/check-root-directory-entries.test.mjs` (3 tests) — `.github/scripts/check-root-directory-entries.sh` uses `declare -A`, which needs bash 4+; macOS ships bash 3.2, so the guard script exits 2 before any assertion. Reproduced by running the script directly against a scratch repository.
  - `project-view-wrapper-source-context-boundary.test.ts` — 30s timeout; passes when the file is run on its own.
- The root suite does not include `mobile/**`, and this change is entirely within it.

## AI Review Report

Ran three independent review passes over the branch before pushing — functional correctness, an adversarial pass, and a mutation-based test-quality pass.

The branch originally also gave the permission card the dismiss-on-answer that the Ask card has. **Both the functional and adversarial passes rejected it, and I dropped it.** A content-keyed dismissal hides the card whenever the live status still carries the same envelope, and nothing observable on the device separates "stale because I answered it" from "the same command is being asked again": the host deliberately keeps real permission waits sticky, Claude can batch two identical `Bash` calls with no `PostToolUse` between them, `serializeRuntimeMobileAgentStatusEntry` buckets `updatedAt` to 30s while `mobile-session-tabs-notify-coalescer` batches at 50ms/250ms so the intermediate frame need never reach the device, `accepted` only proves the desktop wrote bytes to the PTY (the allow token `'1'` is a documented guess), and `summarizeApprovalInput` clips to 200 chars so two different commands can collide on one key. Each ends with the agent blocked and the phone showing no card, no working indicator, and no route back short of toggling the overlay — strictly worse than a stale card that lingers. Retiring an answered card needs a per-request identity from the host; reasoning posted on #11928.

On the gate itself the adversarial pass traced every producer of an approval envelope: it is emitted only for a literal `PermissionRequest` event, from the Claude and Codex extractors (claude / kimi / devin / codex), and all of those normalizers map `PermissionRequest → waiting`; `codexRosterEffectiveState` never downgrades `waiting`. Providers that report a pause as `working` (Copilot `PermissionRequest`, Cursor `beforeShellExecution`) never set `interactivePrompt` at all, so the gate cannot hide them. `resolveToolState` does not inherit `interactivePrompt`, so an envelope cannot ride a later event's state. The one residual hole is recorded under Notes.

The test-quality pass mutated the source 16 ways. Survivors in the dismissal wiring were part of why it was dropped; the two survivors that applied to the gate — untested `??` precedence and an unexercised absent `status` — are now covered, and the state parameter is typed as `AgentStatusEntry['state']` instead of `string` so a typo'd literal cannot make a test pass vacuously.

Cross-platform: reviewed explicitly for macOS, Linux and Windows. The change is pure TypeScript state logic in the React Native app with no platform branch, no keyboard shortcut, no accelerator or shortcut label, no path handling, and no shell invocation, so behaviour is identical on iOS and Android and on every desktop host that serves them. Nothing Electron-specific is touched. The only platform-specific observation is the pre-existing bash 3.2 test failure noted above, which is not introduced here.

## Security Audit

- **Input handling** — the change does not add parsing. `parseApprovalFromStatus` still `JSON.parse`s `interactivePrompt` inside a `try`/`catch` and validates that `approval.tool` is a non-empty string before use; the diff only narrows when it is called.
- **Command execution / path handling / secrets / dependencies** — none touched. No new imports, no filesystem or process access, no dependency change.
- **IPC / transport** — unchanged. The hook consumes an already-delivered `AgentStatusEntry` and sends nothing.
- **Net effect on risk** — narrowing. The card's options are written verbatim into the agent's PTY, so rendering it for a non-paused agent means a tap can inject a keystroke (`1`) into a running session. Gating on the paused state removes that path, including the `SubagentStop` phantom described in the Summary.
- **Follow-up** — none required for this change. The related host-side gap (no per-request identity on a `PermissionRequest`) is a correctness limitation rather than a security one.

## Notes

- **Residual hole in the gate.** `TeammateIdle` clears a wait by name match, and `claudeTeammateIdMatchesName` matches any id shaped `a<name>-<hex>`. If one teammate's name is a prefix of another still-blocked teammate's id, the wait is falsely cleared to `working` while a genuine approval envelope is still cached, and the gate then hides a real prompt that `main` would have shown. It needs a name/id prefix collision to trigger, and the underlying false clear is pre-existing; flagging it rather than widening this PR to the roster matcher.
- **Desktop/web is not covered here.** `src/renderer/src/components/native-chat/NativeChatInteractiveCard.tsx` renders the same envelope with no paused-state gate. It is less exposed — the pane's terminal shows whether a prompt is really open, and the card dismisses on answer — so I kept this PR to the mobile surface the issue reports. Happy to extend it if you would rather have both in one change.
- **Dismiss-on-answer is deliberately absent**, for the reasons in the AI Review Report. It becomes safe once a `PermissionRequest` carries a request id, or once the host clears the envelope when an answer is written.
