### PR TITLE
fix(runtime): stabilize remote session-tab sync across server and client

### DIFF
--- a/src/main/runtime/mobile-session-tabs-publication.test.ts
+++ b/src/main/runtime/mobile-session-tabs-publication.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileSessionTabsPublicationClock } from './mobile-session-tabs-publication'
+
+const WORKTREE = 'repo::/worktree'
+
+describe('MobileSessionTabsPublicationClock', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps one epoch across mutations and strictly increases the version', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    const first = clock.next(WORKTREE)
+    const second = clock.next(WORKTREE, first)
+    const third = clock.next(WORKTREE, second)
+    expect(first.publicationEpoch.startsWith('headless:')).toBe(true)
+    expect(second.publicationEpoch).toBe(first.publicationEpoch)
+    expect(third.publicationEpoch).toBe(first.publicationEpoch)
+    expect(second.snapshotVersion).toBeGreaterThan(first.snapshotVersion)
+    expect(third.snapshotVersion).toBeGreaterThan(second.snapshotVersion)
+  })
+
+  it('reuses the stored snapshot epoch over minting, whatever its source', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    const stamp = clock.next(WORKTREE, {
+      publicationEpoch: 'renderer:abc',
+      snapshotVersion: 7
+    })
+    expect(stamp.publicationEpoch).toBe('renderer:abc')
+    expect(stamp.snapshotVersion).toBe(8)
+  })
+
+  it('survives snapshot-map deletion: boot epoch is reused and the floor holds', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    const first = clock.next(WORKTREE)
+    const second = clock.next(WORKTREE, first)
+    // Entry deleted: no `existing` — the boot epoch and version floor persist.
+    const revived = clock.next(WORKTREE)
+    expect(revived.publicationEpoch).toBe(first.publicationEpoch)
+    expect(revived.snapshotVersion).toBeGreaterThan(second.snapshotVersion)
+  })
+
+  it('applies the mint prefix only to the boot-first mint', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    const hydrated = clock.next(WORKTREE, undefined, { mintPrefix: 'headless-hydrated' })
+    expect(hydrated.publicationEpoch.startsWith('headless-hydrated:')).toBe(true)
+    const later = clock.next(WORKTREE, undefined, { mintPrefix: 'headless:pty-backed' })
+    expect(later.publicationEpoch).toBe(hydrated.publicationEpoch)
+  })
+
+  it('keeps versions strictly increasing across interleaved publish sources', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    const versions: number[] = []
+    versions.push(clock.next(WORKTREE).snapshotVersion) // mutation on empty
+    versions.push(clock.nextVersion(WORKTREE, versions.at(-1))) // hydrate rebuild
+    clock.observe(WORKTREE, 50) // renderer-accepted stored version
+    versions.push(clock.nextVersion(WORKTREE, 2)) // touch over a stale entry
+    versions.push(
+      clock.next(WORKTREE, { publicationEpoch: 'e', snapshotVersion: 10 }).snapshotVersion
+    )
+    for (let i = 1; i < versions.length; i++) {
+      expect(versions[i]!).toBeGreaterThan(versions[i - 1]!)
+    }
+    expect(versions.at(-1)!).toBeGreaterThan(50)
+  })
+
+  it('observe never lowers the floor', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    clock.observe(WORKTREE, 20)
+    clock.observe(WORKTREE, 5)
+    expect(clock.nextVersion(WORKTREE)).toBe(21)
+  })
+
+  it('scopes version floors per worktree', () => {
+    const clock = new MobileSessionTabsPublicationClock()
+    clock.next('repo::/a')
+    clock.observe('repo::/a', 40)
+    // Worktree b's floor is untouched by a's publications.
+    expect(clock.next('repo::/b').snapshotVersion).toBe(1)
+    expect(clock.nextVersion('repo::/a')).toBe(41)
+  })
+
+  it('mints a fresh epoch per boot', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const boot1 = new MobileSessionTabsPublicationClock().next(WORKTREE)
+    vi.setSystemTime(new Date('2026-01-01T00:00:01Z'))
+    const boot2 = new MobileSessionTabsPublicationClock().next(WORKTREE)
+    expect(boot2.publicationEpoch).not.toBe(boot1.publicationEpoch)
+    // A rebooted host starts a new same-epoch ordering domain from version 1.
+    expect(boot2.snapshotVersion).toBe(1)
+  })
+})

--- a/src/main/runtime/mobile-session-tabs-publication.ts
+++ b/src/main/runtime/mobile-session-tabs-publication.ts
@@ -1,0 +1,80 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+export type MobileSessionPublicationStamp = {
+  publicationEpoch: string
+  snapshotVersion: number
+}
+
+const CLIENT_NAVIGATION_EPOCH_SUFFIX = ':client-navigation'
+
+// Why: per-client projection rewrites the epoch to `${raw}:client-navigation`
+// and clients echo that projected epoch back in closeLifecycle. Comparing it
+// verbatim against the raw stored epoch made every projected close read as
+// 'stale-publication'.
+export function normalizeClientEchoedPublicationEpoch(publicationEpoch: string): string {
+  return publicationEpoch.endsWith(CLIENT_NAVIGATION_EPOCH_SUFFIX)
+    ? publicationEpoch.slice(0, -CLIENT_NAVIGATION_EPOCH_SUFFIX.length)
+    : publicationEpoch
+}
+
+/**
+ * Why: remote clients gate session-tab frames with a same-epoch version check,
+ * so cross-epoch frames apply unconditionally. The desktop renderer publishes
+ * ONE stable epoch per boot; minting a fresh headless epoch per mutation made
+ * that gate vacuous and let delayed frames clobber newer snapshots. This clock
+ * gives the headless host the same contract: one epoch per worktree per boot
+ * and a strictly-increasing version across every publish site.
+ */
+export class MobileSessionTabsPublicationClock {
+  // Why: `:headless-merge:` suffixes must not flip per preserved-set change —
+  // that re-opens the cross-epoch bypass. Boot-stable, so merged epochs stay
+  // comparable within a boot and versions carry the ordering.
+  readonly mergeSignature = createHash('sha1').update(randomUUID()).digest('hex').slice(0, 12)
+  private readonly mintedEpochByWorktree = new Map<string, string>()
+  private readonly versionFloorByWorktree = new Map<string, number>()
+
+  next(
+    worktreeId: string,
+    existing?: { publicationEpoch: string; snapshotVersion: number },
+    options: { mintPrefix?: string } = {}
+  ): MobileSessionPublicationStamp {
+    return {
+      publicationEpoch: this.epoch(worktreeId, existing?.publicationEpoch, options.mintPrefix),
+      snapshotVersion: this.nextVersion(worktreeId, existing?.snapshotVersion)
+    }
+  }
+
+  // Reuse the stored snapshot's epoch, else the epoch already minted for this
+  // worktree this boot, else mint once. The prefix (`headless`,
+  // `headless-hydrated`, `headless:pty-backed`) only shapes the boot-first mint
+  // so logs stay greppable by publish source.
+  epoch(worktreeId: string, existingEpoch?: string, mintPrefix = 'headless'): string {
+    if (existingEpoch !== undefined) {
+      return existingEpoch
+    }
+    const minted = this.mintedEpochByWorktree.get(worktreeId)
+    if (minted !== undefined) {
+      return minted
+    }
+    const fresh = `${mintPrefix}:${Date.now().toString(36)}`
+    this.mintedEpochByWorktree.set(worktreeId, fresh)
+    return fresh
+  }
+
+  // Strictly increasing per worktree regardless of publish source; the floor
+  // survives snapshot-map deletion/replacement within the boot.
+  nextVersion(worktreeId: string, existingVersion?: number): number {
+    const floor = this.versionFloorByWorktree.get(worktreeId) ?? 0
+    const version = Math.max(floor, existingVersion ?? 0) + 1
+    this.versionFloorByWorktree.set(worktreeId, version)
+    return version
+  }
+
+  // Raise the floor to a version stored outside the clock (an accepted renderer
+  // revision) so later clock versions never fall below what clients saw.
+  observe(worktreeId: string, version: number): void {
+    if (version > (this.versionFloorByWorktree.get(worktreeId) ?? 0)) {
+      this.versionFloorByWorktree.set(worktreeId, version)
+    }
+  }
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8928,15 +8928,44 @@ describe('OrcaRuntimeService', () => {
       expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-restored', {
         scrollbackRows: 5000
       })
+      // Why no seq: without a provider sequence sync this boot, the provider's
+      // cumulative seq is a foreign domain and must not reach clients.
       expect(snapshot).toEqual({
         data: 'restored screen\r\n',
         scrollbackAnsi: 'restored history\r\n',
         cols: 120,
         rows: 40,
         cwd: '/projects/restored',
+        source: 'headless'
+      })
+    })
+
+    it('anchors the provider snapshot seq once a provider sequence sync has run', async () => {
+      const { runtime } = createSideEffectRuntime()
+      const serializeProviderBuffer = vi.fn().mockResolvedValue({
+        data: 'restored screen\r\n',
+        cols: 120,
+        rows: 40,
         seq: 900,
         source: 'headless'
       })
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null,
+        serializeProviderBuffer,
+        hasRendererSerializer: () => false
+      })
+      runtime.synchronizePtyOutputSequenceFromProvider('pty-restored', {
+        value: 900,
+        generation: 'continued'
+      })
+
+      const snapshot = await runtime.serializeTerminalBuffer('pty-restored', {
+        scrollbackRows: 5000
+      })
+
+      expect(snapshot?.seq).toBe(900)
     })
 
     it('prefers provider history over a partial headless mirror for requested snapshots', async () => {
@@ -8959,13 +8988,14 @@ describe('OrcaRuntimeService', () => {
       syncSinglePty(runtime)
       runtime.onPtyData('pty-1', 'partial current screen\r\n', 100)
 
-      await expect(
-        runtime.serializeAuthoritativeTerminalBuffer('pty-1', { scrollbackRows: 5000 })
-      ).resolves.toMatchObject({
-        data: 'authoritative screen\r\n',
-        scrollbackAnsi: 'deep provider history\r\n',
-        seq: 900
+      const authoritative = await runtime.serializeAuthoritativeTerminalBuffer('pty-1', {
+        scrollbackRows: 5000
       })
+      expect(authoritative).toMatchObject({
+        data: 'authoritative screen\r\n',
+        scrollbackAnsi: 'deep provider history\r\n'
+      })
+      expect(authoritative?.seq).toBeUndefined()
       expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-1', {
         scrollbackRows: 5000
       })
@@ -28256,6 +28286,88 @@ describe('OrcaRuntimeService', () => {
       leafId: HEADLESS_LEAF_ID,
       status: 'ready'
     })
+  })
+
+  function makeRestartRestoredReadyTabRuntime(hasPty: boolean): {
+    runtime: OrcaRuntimeService
+    spawn: ReturnType<typeof vi.fn>
+    persistedPtyId: string
+  } {
+    const persistedPtyId = `${TEST_WORKTREE_ID}@@serve-restored-pty`
+    const spawn = vi.fn().mockResolvedValue({ id: persistedPtyId, isReattach: true })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: persistedPtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Restored Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: persistedPtyId })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      // Why: the provider inventory reports the session live across a host restart
+      // regardless of whether this process has attached its output stream.
+      listProcesses: async () => [
+        { id: persistedPtyId, cwd: TEST_WORKTREE_PATH, title: 'restored' }
+      ],
+      hasPty: () => hasPty
+    })
+    runtime.registerPty(persistedPtyId, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    return { runtime, spawn, persistedPtyId }
+  }
+
+  it('re-materializes a ready session tab whose PTY has no provider attachment this boot', async () => {
+    const { runtime, spawn, persistedPtyId } = makeRestartRestoredReadyTabRuntime(false)
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.tabs[0]).toMatchObject({ type: 'terminal', status: 'ready' })
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab', HEADLESS_LEAF_ID, {
+      notifyClients: false
+    })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: TEST_WORKTREE_ID,
+        tabId: 'host-tab',
+        leafId: HEADLESS_LEAF_ID,
+        sessionId: persistedPtyId,
+        persistHostSessionBinding: true
+      })
+    )
+  })
+
+  it('keeps ready session tab activation spawn-free while the PTY is provider-attached', async () => {
+    const { runtime, spawn } = makeRestartRestoredReadyTabRuntime(true)
+
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.tabs[0]).toMatchObject({ type: 'terminal', status: 'ready' })
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab', HEADLESS_LEAF_ID, {
+      notifyClients: false
+    })
+
+    expect(spawn).not.toHaveBeenCalled()
   })
 
   function makePendingAgentTabActivationRuntime(opts: { disabledTuiAgents?: string[] } = {}): {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -27024,6 +27024,667 @@ describe('OrcaRuntimeService', () => {
     expect(runtime.getStatus().graphStatus).toBe('ready')
   })
 
+  it('publishes one stable epoch with strictly increasing versions across headless mutations', async () => {
+    // Regression: every headless mutation minted a fresh publicationEpoch, so the
+    // client's same-epoch version gate never ordered frames and delayed pushes
+    // could clobber newer state.
+    let ptyCounter = 0
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn(async () => ({ id: `stable-epoch-pty-${++ptyCounter}` })),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    const first = await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { activate: true })
+    const second = await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, { activate: true })
+    const base = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(base.publicationEpoch.startsWith('headless')).toBe(true)
+    const leftGroupId = base.tabGroups![0]!.id
+
+    await runtime.moveMobileSessionTab(`id:${TEST_WORKTREE_ID}`, {
+      kind: 'split',
+      tabId: second.tabId!,
+      targetGroupId: leftGroupId,
+      splitDirection: 'right'
+    })
+    const afterSplit = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(afterSplit.publicationEpoch).toBe(base.publicationEpoch)
+    expect(afterSplit.snapshotVersion).toBeGreaterThan(base.snapshotVersion)
+
+    await runtime.moveMobileSessionTab(`id:${TEST_WORKTREE_ID}`, {
+      kind: 'move-to-group',
+      tabId: second.tabId!,
+      targetGroupId: leftGroupId
+    })
+    const afterMove = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(afterMove.publicationEpoch).toBe(base.publicationEpoch)
+    expect(afterMove.snapshotVersion).toBeGreaterThan(afterSplit.snapshotVersion)
+
+    // Sweep the remaining clock-routed mutation entry points: reverting any of
+    // them to per-mutation epoch minting must fail here, not only split/move.
+    const group = afterMove.tabGroups![0]!
+    const mutations: [string, () => Promise<unknown>][] = [
+      [
+        'reorder',
+        () =>
+          runtime.moveMobileSessionTab(`id:${TEST_WORKTREE_ID}`, {
+            kind: 'reorder',
+            tabId: group.tabOrder.at(-1)!,
+            targetGroupId: group.id,
+            tabOrder: group.tabOrder.toReversed()
+          })
+      ],
+      [
+        'pin',
+        () =>
+          runtime.setMobileSessionTabProps(`id:${TEST_WORKTREE_ID}`, {
+            tabId: first.tabId!,
+            isPinned: true
+          })
+      ],
+      [
+        'color',
+        () =>
+          runtime.setMobileSessionTabProps(`id:${TEST_WORKTREE_ID}`, {
+            tabId: first.tabId!,
+            color: '#ff8800'
+          })
+      ]
+    ]
+    let previous = afterMove
+    for (const [label, mutate] of mutations) {
+      await mutate()
+      const current = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+      expect(current.publicationEpoch, label).toBe(base.publicationEpoch)
+      expect(current.snapshotVersion, label).toBeGreaterThan(previous.snapshotVersion)
+      previous = current
+    }
+  })
+
+  it('keeps the epoch and never regresses the version when hydration follows mutations', async () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal()
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const base = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(base.publicationEpoch.startsWith('headless-hydrated:')).toBe(true)
+
+    await runtime.setMobileSessionTabProps(`id:${TEST_WORKTREE_ID}`, {
+      tabId: 'host-tab',
+      color: '#ff8800'
+    })
+    const mutated = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(mutated.publicationEpoch).toBe(base.publicationEpoch)
+    expect(mutated.snapshotVersion).toBeGreaterThan(base.snapshotVersion)
+
+    runtime['hydrateHeadlessMobileSessionTabsFromWorkspaceSession'](TEST_WORKTREE_ID, {
+      force: true
+    })
+    const rehydrated = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(rehydrated.publicationEpoch).toBe(base.publicationEpoch)
+    expect(rehydrated.snapshotVersion).toBeGreaterThanOrEqual(mutated.snapshotVersion)
+  })
+
+  it('flags a not-yet-hydrated worktree list as hydrationPending without advancing the floor', async () => {
+    // Plain store has no workspace session: the hydrate gate short-circuits and
+    // the fabricated empty list must not read as authoritative.
+    const runtime = new OrcaRuntimeService(store)
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(result.hydrationPending).toBe(true)
+    expect(result.publicationEpoch).toBe('none')
+    expect(result.snapshotVersion).toBe(0)
+    expect(result.tabs).toEqual([])
+    // The fabricated frame never touches the publication clock.
+    expect(
+      runtime['mobileSessionPublicationClock']['versionFloorByWorktree'].get(TEST_WORKTREE_ID)
+    ).toBeUndefined()
+  })
+
+  it('does not flag a hydrated worktree that genuinely has zero tabs', async () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] }
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(result.hydrationPending).toBeUndefined()
+    expect(result.tabs).toEqual([])
+  })
+
+  it('serves authoritative empty, not hydrationPending, after the renderer deletes a worktree entry', async () => {
+    // Regression: on a headed hub the full hydrate never runs, so a worktree
+    // whose tabs were all closed (renderer omits it) fabricated
+    // hydrationPending forever and remote clients kept ghost tabs.
+    const runtime = new OrcaRuntimeService(store)
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: 'md-1',
+          activeTabType: 'markdown',
+          tabs: [
+            {
+              type: 'markdown',
+              id: 'md-1',
+              title: 'Notes',
+              filePath: `${TEST_WORKTREE_PATH}/notes.md`,
+              relativePath: 'notes.md',
+              language: 'markdown',
+              mode: 'edit',
+              isDirty: false,
+              isActive: true,
+              documentVersion: 'v1',
+              sourceFileId: 'file-1',
+              sourceFilePath: `${TEST_WORKTREE_PATH}/notes.md`,
+              sourceRelativePath: 'notes.md'
+            }
+          ]
+        }
+      ]
+    })
+
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [], mobileSessionTabs: [] })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(result.tabs).toEqual([])
+    expect(result.hydrationPending).toBeUndefined()
+  })
+
+  it('marks workspace worktrees hydrated when a headed renderer batch omits them', async () => {
+    // Regression: with an attached authoritative window the full hydrate is
+    // gated off, so an empty worktree never turned authoritative and remote
+    // clients never bootstrapped its initial terminal (frame never fresh).
+    electronMocks.BrowserWindow.fromId.mockReturnValue({ isDestroyed: () => false } as never)
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] }
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    // Renderer sync IS hydration: the batch covers the workspace, so absence
+    // of this worktree authoritatively means zero tabs.
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [], mobileSessionTabs: [] })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(result.hydrationPending).toBeUndefined()
+    expect(result.tabs).toEqual([])
+  })
+
+  it('rebuilds a runtime-owned-seeded subset entry on full hydrate, keeping the seeded tab', async () => {
+    // Regression: the serve/SSH-only hydrate seeded an entry first and the full
+    // hydrate skipped it as populated, so only the runtime-owned subset of
+    // persisted tabs ever surfaced.
+    const sshPtyId = 'ssh:ssh-1@@seeded-pty'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: 'ssh-tab',
+            ptyId: sshPtyId,
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'SSH Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          },
+          {
+            id: 'plain-tab',
+            ptyId: 'plain-pty',
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Plain Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 2
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'ssh-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: sshPtyId }),
+        'plain-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: 'plain-pty' })
+      }
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    runtime['hydrateHeadlessMobileSessionTabsFromWorkspaceSession'](TEST_WORKTREE_ID, {
+      allowAttachedWindow: true,
+      onlyRuntimeOwnedTerminals: true
+    })
+    const seeded = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+    const seededParentIds = seeded.tabs.map((tab) =>
+      tab.type === 'terminal' ? tab.parentTabId : tab.id
+    )
+    expect(seededParentIds).toEqual(['ssh-tab'])
+    const seededSshTab = seeded.tabs[0]!
+
+    const full = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const fullParentIds = full.tabs.map((tab) =>
+      tab.type === 'terminal' ? tab.parentTabId : tab.id
+    )
+    expect(fullParentIds).toEqual(expect.arrayContaining(['ssh-tab', 'plain-tab']))
+    // The seeded runtime-owned tab object survives the rebuild (live bindings kept).
+    const stored = runtime['mobileSessionTabsByWorktree'].get(TEST_WORKTREE_ID)!
+    expect(stored.tabs).toContain(seededSshTab)
+    expect(full.publicationEpoch).toBe(seeded.publicationEpoch)
+    expect(full.snapshotVersion).toBeGreaterThan(seeded.snapshotVersion)
+
+    // The rebuild clears the seed mark: a later full hydrate skips again and
+    // the snapshot stays stable.
+    const again = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(again.tabs.map((tab) => (tab.type === 'terminal' ? tab.parentTabId : tab.id))).toEqual(
+      fullParentIds
+    )
+  })
+
+  it('kills an unbound live daemon PTY on headless close and tombstones the tab', async () => {
+    // Regression: a PTY left unbound after a failed restart restore (tabId null)
+    // was neither matched nor killed on close, so another device re-adopted it
+    // and the closed session resurrected fleet-wide.
+    const ptyId = 'local-pty-1'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        }
+      })
+    )
+    const kill = vi.fn(() => true)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: ptyId,
+          incarnationId: 'inc-local',
+          terminalHandle: 'term_local',
+          title: 'Live',
+          cwd: TEST_WORKTREE_PATH,
+          worktreeId: TEST_WORKTREE_ID,
+          wslDistro: null
+        }
+      ]
+    })
+    const before = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(before.terminals.map((terminal) => terminal.ptyId)).toEqual([ptyId])
+    const events: RuntimeMobileSessionTabsResult[] = []
+    const unsubscribe = runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+
+    const result = await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab', {
+      reason: 'user'
+    })
+    unsubscribe()
+
+    expect(result).toEqual({ closed: true })
+    expect(kill).toHaveBeenCalledWith(ptyId)
+    // The removal frame itself carries the tombstone.
+    const removal = events.findLast((event) => event.worktree === TEST_WORKTREE_ID)!
+    expect(removal.tabs).toEqual([])
+    expect(removal.recentlyClosedTabIds).toContain('host-tab')
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.recentlyClosedTabIds).toContain('host-tab')
+    const all = await runtime.listAllMobileSessionTabs()
+    expect(
+      all.find((snapshot) => snapshot.worktree === TEST_WORKTREE_ID)?.recentlyClosedTabIds
+    ).toContain('host-tab')
+    // The dying PTY is hidden from the terminal inventory even though the
+    // controller still reports it, so no device sees an adoptable orphan.
+    const after = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(after.terminals).toEqual([])
+  })
+
+  it('does not kill a reused daemon PTY id whose incarnation contradicts the closed tab', async () => {
+    // Regression guard: local provider ids are reused after a daemon restart,
+    // so a stale persisted binding alone must not be kill authority over an
+    // unbound live record that provably belongs to another session.
+    const ptyId = 'local-pty-1'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: ptyId })
+        },
+        // The pane's process before the daemon restart had a different incarnation.
+        terminalPtyIncarnationsByPaneKey: {
+          [`host-tab:${HEADLESS_LEAF_ID}`]: 'inc-before-restart'
+        }
+      })
+    )
+    const kill = vi.fn(() => true)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: ptyId,
+          incarnationId: 'inc-after-restart',
+          terminalHandle: 'term_local',
+          title: 'Live',
+          cwd: TEST_WORKTREE_PATH,
+          worktreeId: TEST_WORKTREE_ID,
+          wslDistro: null
+        }
+      ]
+    })
+    const before = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(before.terminals.map((terminal) => terminal.ptyId)).toEqual([ptyId])
+
+    const result = await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab', {
+      reason: 'user'
+    })
+
+    expect(result).toEqual({ closed: true })
+    expect(kill).not.toHaveBeenCalled()
+    // The tab is still tombstoned so every device treats it as closed…
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.recentlyClosedTabIds).toContain('host-tab')
+    // …but the innocent live PTY keeps its inventory entry.
+    const after = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(after.terminals.map((terminal) => terminal.ptyId)).toEqual([ptyId])
+  })
+
+  it('tombstones a split leaf close so the dying pane is hidden and never re-adopted', async () => {
+    // Regression guard: leaf close kills its PTY asynchronously; without the
+    // pty tombstone another device's terminal.list still saw it live and its
+    // orphan recovery dropped every session-tabs frame for the worktree.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: TEST_REPO_ID,
+      activeWorktreeId: TEST_WORKTREE_ID,
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] }
+    })
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    const leafPtyA = 'pane-pty-a'
+    const leafPtyB = 'pane-pty-b'
+    runtime['mobileSessionTabsByWorktree'].set(TEST_WORKTREE_ID, {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer-epoch',
+      snapshotVersion: 1,
+      activeGroupId: null,
+      activeTabId: `host-tab::${HEADLESS_LEAF_ID}`,
+      activeTabType: 'terminal',
+      tabs: [
+        {
+          type: 'terminal',
+          id: `host-tab::${HEADLESS_LEAF_ID}`,
+          parentTabId: 'host-tab',
+          leafId: HEADLESS_LEAF_ID,
+          ptyId: leafPtyA,
+          title: 'Terminal',
+          isActive: true
+        },
+        {
+          type: 'terminal',
+          id: `host-tab::${HEADLESS_SECOND_LEAF_ID}`,
+          parentTabId: 'host-tab',
+          leafId: HEADLESS_SECOND_LEAF_ID,
+          ptyId: leafPtyB,
+          title: 'Terminal',
+          isActive: false
+        }
+      ]
+    })
+    runtime.registerPty(leafPtyA, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.registerPty(leafPtyB, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_SECOND_LEAF_ID
+    })
+    const kill = vi.fn(() => true)
+    runtime.setNotifier({ closeTerminal: vi.fn() } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: leafPtyA,
+          incarnationId: 'inc-a',
+          terminalHandle: 'term_a',
+          title: 'A',
+          cwd: TEST_WORKTREE_PATH,
+          worktreeId: TEST_WORKTREE_ID,
+          wslDistro: null
+        },
+        {
+          id: leafPtyB,
+          incarnationId: 'inc-b',
+          terminalHandle: 'term_b',
+          title: 'B',
+          cwd: TEST_WORKTREE_PATH,
+          worktreeId: TEST_WORKTREE_ID,
+          wslDistro: null
+        }
+      ]
+    })
+    const before = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(before.terminals.map((terminal) => terminal.ptyId)).toEqual(
+      expect.arrayContaining([leafPtyA, leafPtyB])
+    )
+
+    const result = await runtime.closeMobileSessionTab(
+      `id:${TEST_WORKTREE_ID}`,
+      `host-tab::${HEADLESS_SECOND_LEAF_ID}`,
+      { reason: 'user' }
+    )
+
+    expect(result).toEqual({ closed: true })
+    expect(kill).toHaveBeenCalledWith(leafPtyB)
+    // The dying pane is hidden from inventory even though the controller still
+    // reports it, and no device may re-adopt it.
+    const after = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(after.terminals.map((terminal) => terminal.ptyId)).toEqual([leafPtyA])
+    await expect(
+      runtime.adoptTerminalOrphans({
+        worktree: `id:${TEST_WORKTREE_ID}`,
+        expectedTopologyRevision: 0,
+        claims: [
+          {
+            terminal: 'term_b',
+            ptyId: leafPtyB,
+            incarnationId: 'inc-b',
+            tabId: 'tab-b',
+            leafId: HEADLESS_SECOND_LEAF_ID
+          }
+        ]
+      })
+    ).rejects.toThrow('terminal_orphan_tombstoned')
+  })
+
+  it('publishes recentlyClosedTabIds when a headless browser tab is closed', async () => {
+    // Spec S2.2: every successful server-side close records a tombstone —
+    // browser closes included.
+    const browserTab: Tab = {
+      id: 'browser-page-1',
+      entityId: 'browser-page-1',
+      groupId: 'group-1',
+      worktreeId: TEST_WORKTREE_ID,
+      contentType: 'browser',
+      label: 'Live Browser',
+      customLabel: null,
+      color: null,
+      sortOrder: 1,
+      createdAt: 2,
+      isPreview: false,
+      isPinned: false
+    }
+    const session = makeWorkspaceSessionWithHeadlessTerminal({
+      unifiedTabs: { [TEST_WORKTREE_ID]: [browserTab] },
+      tabGroups: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: 'group-1',
+            worktreeId: TEST_WORKTREE_ID,
+            activeTabId: 'browser-page-1',
+            tabOrder: ['browser-page-1']
+          }
+        ]
+      }
+    })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(session)
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    const closeTab = vi.fn().mockResolvedValue(undefined)
+    runtime.setOffscreenBrowserBackend({ createTab: vi.fn(), closeTab })
+    let bridgeTabs = [
+      {
+        browserPageId: 'browser-page-1',
+        index: 0,
+        url: 'https://example.com/',
+        title: 'Live Browser',
+        active: true
+      }
+    ]
+    runtime.setAgentBrowserBridge({ tabList: vi.fn(() => ({ tabs: bridgeTabs })) } as never)
+
+    const before = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(before.tabs.some((tab) => tab.type === 'browser' && tab.id === 'browser-page-1')).toBe(
+      true
+    )
+
+    const result = await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'browser-page-1', {
+      reason: 'user'
+    })
+    // The offscreen page is gone after the close, so later reconciles drop it.
+    bridgeTabs = []
+
+    expect(result).toEqual({ closed: true })
+    expect(closeTab).toHaveBeenCalledWith('browser-page-1')
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.recentlyClosedTabIds).toContain('browser-page-1')
+    expect(listed.tabs.some((tab) => tab.type === 'browser' && tab.id === 'browser-page-1')).toBe(
+      false
+    )
+  })
+
+  it('refuses to adopt a tombstoned PTY and hides it from orphan reporting', async () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: TEST_REPO_ID,
+      activeWorktreeId: TEST_WORKTREE_ID,
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] }
+    })
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow: vi.fn() } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: 'pty-agent',
+          incarnationId: 'inc-agent',
+          terminalHandle: 'term_agent',
+          title: 'Agent',
+          cwd: TEST_WORKTREE_PATH,
+          worktreeId: TEST_WORKTREE_ID,
+          wslDistro: null
+        }
+      ]
+    })
+    const before = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(before.terminals.map((terminal) => terminal.ptyId)).toEqual(['pty-agent'])
+
+    runtime['sessionTabCloseTombstones'].recordPty(TEST_WORKTREE_ID, 'pty-agent')
+
+    const listed = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.terminals).toEqual([])
+    await expect(
+      runtime.adoptTerminalOrphans({
+        worktree: `id:${TEST_WORKTREE_ID}`,
+        expectedTopologyRevision: 0,
+        claims: [
+          {
+            terminal: 'term_agent',
+            ptyId: 'pty-agent',
+            incarnationId: 'inc-agent',
+            tabId: 'tab-agent',
+            leafId: HEADLESS_LEAF_ID
+          }
+        ]
+      })
+    ).rejects.toThrow('terminal_orphan_tombstoned')
+  })
+
+  it('fails a session tab close honestly when no renderer route exists', async () => {
+    // Regression: with the window closed the notifier is gone, and the close
+    // ack'd `{closed:true}` while the tab lived on — hidden, not closed.
+    const runtime = new OrcaRuntimeService(store)
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer-epoch',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: 'md-1',
+          activeTabType: 'markdown',
+          tabs: [
+            {
+              type: 'markdown',
+              id: 'md-1',
+              title: 'Notes',
+              filePath: `${TEST_WORKTREE_PATH}/notes.md`,
+              relativePath: 'notes.md',
+              language: 'markdown',
+              mode: 'edit',
+              isDirty: false,
+              isActive: true,
+              documentVersion: 'v1',
+              sourceFileId: 'file-1',
+              sourceFilePath: `${TEST_WORKTREE_PATH}/notes.md`,
+              sourceRelativePath: 'notes.md'
+            }
+          ]
+        }
+      ]
+    })
+
+    await expect(runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'md-1')).rejects.toThrow(
+      'renderer_unavailable'
+    )
+  })
+
   it('briefly preserves abnormal SSH exits for paired pane recovery', async () => {
     vi.useFakeTimers()
     try {
@@ -29344,6 +30005,45 @@ describe('OrcaRuntimeService', () => {
       expect(kill).not.toHaveBeenCalled()
       expect(closeTerminalTab).not.toHaveBeenCalled()
       expect(closeTerminal).not.toHaveBeenCalled()
+    })
+
+    it('accepts a lifecycle close that echoes a client-navigation projected epoch', async () => {
+      // Regression: per-client projection appends ':client-navigation' to the
+      // epoch and clients echo the projected value; comparing it verbatim
+      // refused every projected close as 'stale-publication'.
+      const { runtime } = makeAdoptedLiveTabRuntime()
+      const projected = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`, 'device-1')
+      expect(projected.publicationEpoch.endsWith(':client-navigation')).toBe(true)
+      const terminal = projected.tabs.find((tab) => tab.type === 'terminal')
+      if (!terminal || terminal.status !== 'ready') {
+        throw new Error('expected a ready terminal fixture')
+      }
+
+      const result = await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab', {
+        reason: 'pty-exit',
+        expectedPublicationEpoch: projected.publicationEpoch,
+        expectedTerminalHandle: terminal.terminal
+      })
+
+      // Passing the epoch gate lands on liveness adjudication, not staleness.
+      expect(result.refusalReason).toBe('live-host-pty')
+    })
+
+    it('tombstones a renderer-acked whole-tab close so its PTY leaves the inventory', async () => {
+      const { runtime, closeTerminalTab } = makeAdoptedLiveTabRuntime()
+      const before = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+      expect(before.terminals.map((terminal) => terminal.ptyId)).toEqual(['serve-live-1'])
+
+      await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab', {
+        reason: 'user'
+      })
+
+      expect(closeTerminalTab).toHaveBeenCalledWith('host-tab')
+      const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+      expect(listed.recentlyClosedTabIds).toContain('host-tab')
+      // The still-dying PTY is no longer presented as live or adoptable.
+      const after = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
+      expect(after.terminals).toEqual([])
     })
 
     it('refuses a reused tab id that names a different terminal incarnation', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -516,6 +516,11 @@ import {
   deriveClientSessionTabSelection,
   projectClientSessionTabSelection
 } from './client-session-tab-selection'
+import {
+  MobileSessionTabsPublicationClock,
+  normalizeClientEchoedPublicationEpoch
+} from './mobile-session-tabs-publication'
+import { SessionTabCloseTombstoneStore } from './session-tab-close-tombstones'
 import type {
   PtyProviderBufferSnapshot,
   IFilesystemProvider,
@@ -2645,6 +2650,19 @@ export class OrcaRuntimeService {
   private readonly rendererPublicationThrottle = new RendererPublicationThrottle()
   private tabs = new Map<string, RuntimeSyncedTab>()
   private mobileSessionTabsByWorktree = new Map<string, RuntimeMobileSessionTabsSnapshot>()
+  // Why: headless publications must reuse one epoch per worktree per boot with
+  // strictly-increasing versions, or the client's same-epoch gate is vacuous.
+  private readonly mobileSessionPublicationClock = new MobileSessionTabsPublicationClock()
+  // Why: closes kill PTYs asynchronously; tombstones stop other devices from
+  // treating a dying PTY as a live orphan or re-adopting the closed session.
+  private readonly sessionTabCloseTombstones = new SessionTabCloseTombstoneStore()
+  // Why: distinguishes "hydrated with zero tabs" (authoritative empty list)
+  // from a missing snapshot entry the host has not hydrated yet
+  // (hydrationPending, must not wipe a client mirror).
+  private readonly fullyHydratedMobileSessionWorktrees = new Set<string>()
+  // Why: a serve/SSH-only hydrate seeds a subset entry; track that provenance
+  // so the full hydrate still rebuilds instead of skipping it as populated.
+  private readonly runtimeOwnedSeededMobileSessionWorktrees = new Set<string>()
   // Why: renderer publication ordering must be judged against the renderer's
   // own last-accepted (epoch, version) — never against the stored snapshot's
   // version, which main-local touches bump independently and can push
@@ -4617,9 +4635,10 @@ export class OrcaRuntimeService {
     return worktreeIds
   }
 
-  private getWorkspaceSessionHydrationTargets(
-    includeAllPersistedWorktrees: boolean
-  ): Map<string, WorkspaceSessionState> {
+  private getWorkspaceSessionHydrationTargets(includeAllPersistedWorktrees: boolean): {
+    targets: Map<string, WorkspaceSessionState>
+    coveredWorktreeIds: Set<string>
+  } {
     const repos = this.store?.getRepos?.() ?? []
     const repoHostIdByRepoId = new Map(
       repos.map((repo) => [repo.id, getRepoExecutionHostId(repo)] as const)
@@ -4642,6 +4661,7 @@ export class OrcaRuntimeService {
     }
 
     const targets = new Map<string, WorkspaceSessionState>()
+    const coveredWorktreeIds = new Set<string>()
     for (const hostId of hostIds) {
       const session = this.store?.getWorkspaceSession?.(hostId)
       if (!session) {
@@ -4655,16 +4675,19 @@ export class OrcaRuntimeService {
             : (repoHostIdByRepoId.get(
                 getRepoIdFromWorktreeId(scope?.type === 'worktree' ? scope.worktreeId : worktreeId)
               ) ?? LOCAL_EXECUTION_HOST_ID)
+        if (ownerHostId !== hostId) {
+          continue
+        }
+        coveredWorktreeIds.add(worktreeId)
         if (
-          ownerHostId === hostId &&
-          (includeAllPersistedWorktrees ||
-            this.workspaceSessionWorktreeHasRuntimeOwnedPtyCandidate(session, worktreeId, tabs))
+          includeAllPersistedWorktrees ||
+          this.workspaceSessionWorktreeHasRuntimeOwnedPtyCandidate(session, worktreeId, tabs)
         ) {
           targets.set(worktreeId, session)
         }
       }
     }
-    return targets
+    return { targets, coveredWorktreeIds }
   }
 
   getStatus(): RuntimeStatus {
@@ -4910,7 +4933,10 @@ export class OrcaRuntimeService {
       }
       this.mobileSessionTabsByWorktree.set(worktreeId, {
         ...next,
-        snapshotVersion: snapshot.snapshotVersion + 1
+        snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+          worktreeId,
+          snapshot.snapshotVersion
+        )
       })
       this.mobileSessionTabsNotifyCoalescer.schedule(worktreeId)
       return
@@ -5406,7 +5432,10 @@ export class OrcaRuntimeService {
       // The accepted-renderer tracking is untouched: this is a main-local bump.
       this.mobileSessionTabsByWorktree.set(worktreeId, {
         ...stored,
-        snapshotVersion: stored.snapshotVersion + 1
+        snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+          worktreeId,
+          stored.snapshotVersion
+        )
       })
       changedMobileWorktrees.add(worktreeId)
     }
@@ -5592,12 +5621,20 @@ export class OrcaRuntimeService {
           continue
         }
       }
+      if (options.onlyRuntimeOwnedTerminals !== true) {
+        // Why: after a full hydrate a missing snapshot entry means "zero tabs",
+        // not "not hydrated yet" — see getMobileSessionTabsForWorktree.
+        this.fullyHydratedMobileSessionWorktrees.add(entryWorktreeId)
+      }
       const existing = this.mobileSessionTabsByWorktree.get(entryWorktreeId)
       if (
         existing &&
         existing.tabs.length > 0 &&
         options.force !== true &&
-        options.onlyRuntimeOwnedTerminals !== true
+        options.onlyRuntimeOwnedTerminals !== true &&
+        // Why: a serve/SSH-only seed is a subset — the full hydrate must still
+        // rebuild it or persisted non-runtime tabs never surface.
+        !this.runtimeOwnedSeededMobileSessionWorktrees.has(entryWorktreeId)
       ) {
         // Why: terminals are stable/persisted so we normally skip a rebuild, but
         // offscreen browser tabs are live and may have been created/closed since.
@@ -5631,8 +5668,15 @@ export class OrcaRuntimeService {
         ...browserTabs.map((tab) => tab.id)
       ]
       const groupId = this.getHeadlessMobileSessionGroupId(entryWorktreeId)
+      // Why: the full rebuild over a runtime-owned seed must keep the seeded
+      // tabs (live serve/SSH/daemon bindings) — existing-first, like the
+      // runtime-owned merge — while adding the persisted rest (#11448).
+      const mergeExistingRuntimeOwnedTabs =
+        existing !== undefined &&
+        (options.onlyRuntimeOwnedTerminals === true ||
+          this.runtimeOwnedSeededMobileSessionWorktrees.has(entryWorktreeId))
       const mergedTabs =
-        options.onlyRuntimeOwnedTerminals === true && existing
+        mergeExistingRuntimeOwnedTabs && existing
           ? this.mergeMobileSessionSnapshotTabs(existing.tabs, tabs)
           : tabs
       const mergedActiveTab =
@@ -5678,7 +5722,7 @@ export class OrcaRuntimeService {
             // browser's persisted group forward instead of coalescing left.
             this.collectBrowserGroupAssignment(persistedGroups, mergedBrowserOrder)
           )
-        : options.onlyRuntimeOwnedTerminals === true && existing?.tabGroups
+        : mergeExistingRuntimeOwnedTabs && existing?.tabGroups
           ? this.appendBrowserTabOrder(
               this.mergeMobileSessionTabGroups(
                 entryWorktreeId,
@@ -5709,9 +5753,16 @@ export class OrcaRuntimeService {
       const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
         worktree: existing?.worktree ?? entryWorktreeId,
         publicationEpoch: mergedIntoRendererPublication
-          ? this.getMergedMobileSessionPublicationEpoch(existing, tabs)
-          : `headless-hydrated:${Date.now().toString(36)}`,
-        snapshotVersion: (existing?.snapshotVersion ?? 0) + 1,
+          ? this.getMergedMobileSessionPublicationEpoch(existing)
+          : this.mobileSessionPublicationClock.epoch(
+              entryWorktreeId,
+              existing?.publicationEpoch,
+              'headless-hydrated'
+            ),
+        snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+          entryWorktreeId,
+          existing?.snapshotVersion
+        ),
         activeGroupId: existing?.activeGroupId ?? groupId,
         activeTabId: mergedActiveTab?.id ?? null,
         activeTabType: mergedActiveTab?.type ?? null,
@@ -5720,10 +5771,20 @@ export class OrcaRuntimeService {
         // existing split layout forward or each sync drops it and fans out.
         ...(hasPersistedSplit && persistedLayout
           ? { tabGroupLayout: persistedLayout }
-          : options.onlyRuntimeOwnedTerminals === true && existing?.tabGroupLayout
+          : mergeExistingRuntimeOwnedTabs && existing?.tabGroupLayout
             ? { tabGroupLayout: existing.tabGroupLayout }
             : {}),
         tabs: mergedTabs
+      }
+      // Why: seed provenance — a runtime-owned hydrate only marks entries it
+      // created (or re-marks its own seed); the full hydrate's rebuild clears
+      // the mark so later full hydrates can skip again.
+      if (options.onlyRuntimeOwnedTerminals === true) {
+        if (existing === undefined) {
+          this.runtimeOwnedSeededMobileSessionWorktrees.add(entryWorktreeId)
+        }
+      } else {
+        this.runtimeOwnedSeededMobileSessionWorktrees.delete(entryWorktreeId)
       }
       // Why: the runtime-owned hydrate runs on EVERY graph sync; when the rebuilt
       // projection matches the existing snapshot, keep the existing object and
@@ -5738,8 +5799,8 @@ export class OrcaRuntimeService {
   }
 
   // Why: content equality for the hydrate's idempotence check — compares every
-  // client-visible field EXCEPT publicationEpoch/snapshotVersion (both are
-  // freshly minted on each rebuild and would defeat the comparison). Tab and
+  // client-visible field EXCEPT publicationEpoch/snapshotVersion (the version
+  // is freshly minted on each rebuild and would defeat the comparison). Tab and
   // group objects are rebuilt each hydrate, so compare by value, not identity.
   private headlessMobileSnapshotContentUnchanged(
     existing: RuntimeMobileSessionTabsSnapshot,
@@ -5838,8 +5899,12 @@ export class OrcaRuntimeService {
       : (nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null)
     this.mobileSessionTabsByWorktree.set(worktreeId, {
       ...existing,
-      publicationEpoch: `headless-hydrated:${Date.now().toString(36)}`,
-      snapshotVersion: existing.snapshotVersion + 1,
+      // Why: keep the existing epoch — reconcile is a same-boot content update
+      // and clients order same-epoch frames by version.
+      snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+        worktreeId,
+        existing.snapshotVersion
+      ),
       ...(activeStillPresent
         ? {}
         : { activeTabId: active?.id ?? null, activeTabType: active?.type ?? null }),
@@ -6327,9 +6392,9 @@ export class OrcaRuntimeService {
     )
     const next: RuntimeMobileSessionTabsSnapshot = {
       worktree: worktreeId,
-      publicationEpoch:
-        existing?.publicationEpoch ?? `headless:pty-backed:${Date.now().toString(36)}`,
-      snapshotVersion: (existing?.snapshotVersion ?? 0) + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, existing, {
+        mintPrefix: 'headless:pty-backed'
+      }),
       activeGroupId: existing?.activeGroupId ?? this.getHeadlessMobileSessionGroupId(worktreeId),
       activeTabId: activeTab?.id ?? null,
       activeTabType: activeTab?.type ?? null,
@@ -6363,7 +6428,10 @@ export class OrcaRuntimeService {
       }
       this.mobileSessionTabsByWorktree.set(worktreeId, {
         ...snapshot,
-        snapshotVersion: snapshot.snapshotVersion + 1
+        snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+          worktreeId,
+          snapshot.snapshotVersion
+        )
       })
       if (options.immediate) {
         // Why: readiness/lifecycle changes are structural and must not wait
@@ -7301,8 +7369,7 @@ export class OrcaRuntimeService {
     }))
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       activeTabId: activeTab.id,
       activeTabType: 'terminal',
       tabGroups: this.buildHeadlessMobileSessionTabGroups(
@@ -7436,7 +7503,8 @@ export class OrcaRuntimeService {
     }
     if (
       options.expectedPublicationEpoch !== undefined &&
-      snapshot?.publicationEpoch !== options.expectedPublicationEpoch
+      snapshot?.publicationEpoch !==
+        normalizeClientEchoedPublicationEpoch(options.expectedPublicationEpoch)
     ) {
       this.republishMobileSessionTabsSnapshot(worktreeId)
       return {
@@ -7552,6 +7620,17 @@ export class OrcaRuntimeService {
         return { closed: true }
       }
       if (closingWholeParent && this.notifier?.closeTerminalTab) {
+        // Why: the renderer kills the PTYs during retirement; capture their ids
+        // before the relay so the tombstone can cover them.
+        const relayedPtyIds = snapshot!.tabs.flatMap((candidate) =>
+          candidate.type === 'terminal' && candidate.parentTabId === tab.parentTabId
+            ? [
+                candidate.ptyId,
+                candidate.parentLayout?.ptyIdsByLeafId?.[candidate.leafId],
+                this.findPtyForMobileTerminalTab(worktreeId, candidate)?.ptyId
+              ].filter((ptyId): ptyId is string => Boolean(ptyId))
+            : []
+        )
         // Why: whole-tab close is a lifecycle transaction. The renderer reply
         // arrives only after canonical retirement and a forced session flush.
         const win = this.getAvailableAuthoritativeWindow()
@@ -7585,6 +7664,7 @@ export class OrcaRuntimeService {
           this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
           this.store?.flushOrThrow?.()
         }
+        this.recordSessionTabCloseTombstone(worktreeId, tab.parentTabId, relayedPtyIds)
         this.clearRuntimeSessionOwnershipForMobileTab(worktreeId, snapshot!, tab.parentTabId)
         return { closed: true }
       }
@@ -7604,6 +7684,9 @@ export class OrcaRuntimeService {
       if (tab.id === tabId) {
         const pty = this.findPtyForMobileTerminalTab(worktreeId, tab)
         if (pty) {
+          // Why: leaf close kills just this pane; tombstone the PTY so no device
+          // adopts it while it dies (the parent tab may live on).
+          this.sessionTabCloseTombstones.recordPty(worktreeId, pty.ptyId)
           this.ptyController?.kill(pty.ptyId)
         } else {
           this.notifier?.closeTerminal(tab.parentTabId)
@@ -7621,9 +7704,25 @@ export class OrcaRuntimeService {
       // snapshot so paired clients stop showing it.
       await this.closeHeadlessMobileBrowserTab(worktreeId, snapshot!, tab)
     } else {
-      this.notifier?.closeSessionTab?.(tab.id, worktreeId)
+      if (!this.notifier?.closeSessionTab) {
+        // Why: acking with no renderer route hides the tab without closing it —
+        // silent client/host divergence. Fail honestly so clients restore it.
+        throw new Error('renderer_unavailable')
+      }
+      this.notifier.closeSessionTab(tab.id, worktreeId)
     }
     return { closed: true }
+  }
+
+  private recordSessionTabCloseTombstone(
+    worktreeId: string,
+    hostTabId: string,
+    ptyIds: Iterable<string>
+  ): void {
+    this.sessionTabCloseTombstones.record(worktreeId, hostTabId)
+    for (const ptyId of ptyIds) {
+      this.sessionTabCloseTombstones.recordPty(worktreeId, ptyId)
+    }
   }
 
   // Why: a refused echoed close means the echoing client already pruned its
@@ -7634,7 +7733,10 @@ export class OrcaRuntimeService {
     if (snapshot) {
       this.mobileSessionTabsByWorktree.set(worktreeId, {
         ...snapshot,
-        snapshotVersion: snapshot.snapshotVersion + 1
+        snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+          worktreeId,
+          snapshot.snapshotVersion
+        )
       })
     }
     this.notifyMobileSessionTabsChanged(worktreeId)
@@ -7672,12 +7774,12 @@ export class OrcaRuntimeService {
     if (tab.browserPageId) {
       await this.offscreenBrowserBackend?.closeTab(tab.browserPageId).catch(() => {})
     }
+    this.recordSessionTabCloseTombstone(worktreeId, tab.id, [])
     const nextTabs = snapshot.tabs.filter((candidate) => candidate.id !== tab.id)
     const active = nextTabs.find((candidate) => candidate.isActive) ?? nextTabs[0] ?? null
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       activeTabId: active?.id ?? null,
       activeTabType: active?.type ?? null,
       tabGroups: (snapshot.tabGroups ?? []).map((group) => ({
@@ -7731,8 +7833,7 @@ export class OrcaRuntimeService {
         )
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       ...(hasTargetGroup ? { activeGroupId: targetGroupId } : {}),
       activeTabId: tab.id,
       activeTabType: 'browser',
@@ -7762,10 +7863,43 @@ export class OrcaRuntimeService {
     const projectedPtyIds = this.removePersistedHeadlessTerminalTab(worktreeId, closedParentTabId, {
       allowMissing: options.allowMissingPersistedTab
     })
+    // Why: a live daemon PTY left unbound (tabId null after a failed restart
+    // surface restore) is still this tab's process per its persisted binding;
+    // leaving it alive would let another device re-adopt the closed session.
+    // But local provider ids ARE reused after a daemon restart, so when the
+    // closed tab's persisted pane incarnations are known and the unbound live
+    // record carries a DIFFERENT incarnation, the id now belongs to another
+    // session — never kill it.
+    const persistedIncarnationsForClosedTab = new Set(
+      Object.entries(
+        this.getWorkspaceSessionForWorktree(worktreeId)?.terminalPtyIncarnationsByPaneKey ?? {}
+      )
+        .filter(([paneKey]) => paneKey.startsWith(`${closedParentTabId}:`))
+        .map(([, incarnationId]) => incarnationId)
+    )
+    const isLiveDaemonPtyForClosedTab = (ptyId: string): boolean => {
+      const record = this.ptysById.get(ptyId)
+      if (record?.connected !== true || record.worktreeId !== worktreeId) {
+        return false
+      }
+      if (record.tabId !== null) {
+        return record.tabId === closedParentTabId
+      }
+      return (
+        persistedIncarnationsForClosedTab.size === 0 ||
+        record.incarnationId === null ||
+        persistedIncarnationsForClosedTab.has(record.incarnationId)
+      )
+    }
     // Why: local provider ids can be reused after restart, so a dormant
-    // persisted id is not kill authority. SSH relay ids remain durable exact
-    // identities even before pane metadata reconnects.
-    const ptyIdsToKill = new Set(projectedPtyIds.filter((ptyId) => parseAppSshPtyId(ptyId)))
+    // persisted id is not kill authority — only a live daemon match for this
+    // tab/worktree is. SSH relay ids remain durable exact identities even
+    // before pane metadata reconnects.
+    const ptyIdsToKill = new Set(
+      projectedPtyIds.filter(
+        (ptyId) => parseAppSshPtyId(ptyId) || isLiveDaemonPtyForClosedTab(ptyId)
+      )
+    )
     for (const candidate of snapshot.tabs) {
       if (candidate.type !== 'terminal' || candidate.parentTabId !== closedParentTabId) {
         continue
@@ -7778,13 +7912,20 @@ export class OrcaRuntimeService {
           other.parentTabId !== closedParentTabId &&
           other.ptyId === ptyId
       )
-      if (ptyId && !hasOtherOwner && (livePty || parseAppSshPtyId(ptyId))) {
+      if (
+        ptyId &&
+        !hasOtherOwner &&
+        (livePty || parseAppSshPtyId(ptyId) || isLiveDaemonPtyForClosedTab(ptyId))
+      ) {
         // Why: a live serve leaf can exist before its debounced binding reaches
         // persistence. Include it from the authoritative snapshot so split
         // close cannot leave a provider process behind.
         ptyIdsToKill.add(ptyId)
       }
     }
+    // Why: tombstone before emitting (kill success or not) so the removal frame
+    // itself carries recentlyClosedTabIds and no device re-adopts a dying PTY.
+    this.recordSessionTabCloseTombstone(worktreeId, closedParentTabId, ptyIdsToKill)
     if (options.killPtys !== false) {
       for (const ptyId of ptyIdsToKill) {
         this.ptyController?.kill(ptyId)
@@ -7799,8 +7940,7 @@ export class OrcaRuntimeService {
     const active = nextTabs.find((candidate) => candidate.isActive) ?? nextTabs[0] ?? null
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       activeTabId: active?.id ?? null,
       activeTabType: active?.type ?? null,
       tabGroups: this.buildHeadlessMobileSessionTabGroups(
@@ -8011,8 +8151,7 @@ export class OrcaRuntimeService {
     }
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       tabs
     }
     this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
@@ -8097,8 +8236,7 @@ export class OrcaRuntimeService {
     }
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       tabs
     }
     this.mobileSessionTabsByWorktree.set(worktreeId, nextSnapshot)
@@ -8152,8 +8290,7 @@ export class OrcaRuntimeService {
       : [{ ...targetGroup, tabOrder, activeTabId: reorderedTargetActiveTabId }]
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       activeTabId: active?.id ?? null,
       activeTabType: active?.type ?? null,
       tabGroups: nextGroups,
@@ -8195,8 +8332,7 @@ export class OrcaRuntimeService {
     }
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       activeGroupId: split.newGroupId,
       tabGroups: split.groups,
       tabGroupLayout: split.layout
@@ -8231,8 +8367,7 @@ export class OrcaRuntimeService {
     const layout = moved.layout ?? { type: 'leaf' as const, groupId: move.targetGroupId }
     const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
       ...snapshot,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: snapshot.snapshotVersion + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, snapshot),
       activeGroupId: move.targetGroupId,
       tabGroups: moved.groups,
       tabGroupLayout: layout
@@ -14718,6 +14853,14 @@ export class OrcaRuntimeService {
         if (targetWorktreeId && leaf.worktreeId !== targetWorktreeId) {
           continue
         }
+        // Why: a tombstoned PTY is dying from a recent close; presenting it as
+        // live would stall remote frame recovery or invite re-adoption.
+        if (
+          leaf.ptyId &&
+          this.sessionTabCloseTombstones.isPtyTombstoned(leaf.worktreeId, leaf.ptyId)
+        ) {
+          continue
+        }
         if (
           opts.requireFreshPtyLiveness &&
           (!leaf.ptyId || !refreshedPtyLiveness?.has(leaf.ptyId))
@@ -14739,6 +14882,11 @@ export class OrcaRuntimeService {
     // so mobile does not show a false "No terminals" create flow.
     for (const pty of this.ptysById.values()) {
       if (!pty.connected || ptyIdsFromLeaves.has(pty.ptyId)) {
+        continue
+      }
+      // Why: keep dying just-closed PTYs out of the inventory — reporting one
+      // as an adoptable orphan resurrects the closed session on other devices.
+      if (this.sessionTabCloseTombstones.isPtyTombstoned(pty.worktreeId, pty.ptyId)) {
         continue
       }
       if (opts.requireFreshPtyLiveness && !refreshedPtyLiveness?.has(pty.ptyId)) {
@@ -14842,6 +14990,14 @@ export class OrcaRuntimeService {
       }
       seenPtyIds.add(claim.ptyId)
       seenPaneKeys.add(paneKey)
+      // Why: a tombstoned PTY/tab is a recent close still dying — adopting it
+      // would resurrect the closed session on every paired device.
+      if (
+        this.sessionTabCloseTombstones.isPtyTombstoned(workspace.id, claim.ptyId) ||
+        this.sessionTabCloseTombstones.isTabTombstoned(workspace.id, claim.tabId)
+      ) {
+        throw new Error('terminal_orphan_tombstoned')
+      }
       const live = this.getLivePtyForHandle(claim.terminal)
       const pty = live?.pty
       const controllerIdentity = terminalIdentityByPtyId.get(claim.ptyId)
@@ -25144,8 +25300,7 @@ export class OrcaRuntimeService {
     }
     const next: RuntimeMobileSessionTabsSnapshot = {
       worktree: worktreeId,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
-      snapshotVersion: (existing?.snapshotVersion ?? 0) + 1,
+      ...this.mobileSessionPublicationClock.next(worktreeId, existing),
       // Why: activating the new tab also focuses its group, so a "+" targeting a specific split group makes that group active too.
       activeGroupId:
         activate && opts.targetGroupId
@@ -28324,8 +28479,11 @@ export class OrcaRuntimeService {
       notify: false
     })
     // Why: graph sync must scan each persisted host session once, not once per workspace.
+    const hydrationCoverage = this.getWorkspaceSessionHydrationTargets(
+      Boolean(this.offscreenBrowserBackend)
+    )
     const worktreeSessionsToHydrate = new Map<string, WorkspaceSessionState | null>(
-      this.getWorkspaceSessionHydrationTargets(Boolean(this.offscreenBrowserBackend))
+      hydrationCoverage.targets
     )
     if (this.offscreenBrowserBackend) {
       for (const snapshot of snapshots) {
@@ -28341,6 +28499,17 @@ export class OrcaRuntimeService {
         onlyRuntimeOwnedTerminals: true,
         ...(workspaceSession ? { runtimeOwnedTerminalCandidateKnown: true, workspaceSession } : {})
       })
+    }
+    // Why: renderer sync IS hydration on a headed hub (the full hydrate is
+    // gated off by the attached window). Absence from the batch means zero
+    // tabs, so every persisted worktree the scan covered — not only the
+    // runtime-owned hydrate targets — must serve authoritative-empty for
+    // remote bootstrap instead of hydrationPending forever.
+    for (const worktreeId of hydrationCoverage.coveredWorktreeIds) {
+      this.fullyHydratedMobileSessionWorktrees.add(worktreeId)
+    }
+    for (const worktreeId of worktreeSessionsToHydrate.keys()) {
+      this.fullyHydratedMobileSessionWorktrees.add(worktreeId)
     }
     const nextWorktrees = new Set<string>()
     for (const snapshot of snapshots) {
@@ -28389,6 +28558,12 @@ export class OrcaRuntimeService {
           ? nextSnapshot
           : { ...nextSnapshot, snapshotVersion: storedVersion }
       )
+      // Why: keep the headless clock's floor above every stored version so a
+      // later clock-published frame can never regress below what clients saw.
+      this.mobileSessionPublicationClock.observe(snapshot.worktree, storedVersion)
+      // Why: the entry now carries a full renderer publication, not a
+      // runtime-owned-only seed.
+      this.runtimeOwnedSeededMobileSessionWorktrees.delete(snapshot.worktree)
       this.acceptedRendererMobileSnapshotByWorktree.set(snapshot.worktree, {
         publicationEpoch: snapshot.publicationEpoch,
         rendererVersion: snapshot.snapshotVersion
@@ -28416,6 +28591,10 @@ export class OrcaRuntimeService {
         } else {
           this.mobileSessionTabsByWorktree.delete(worktreeId)
           this.acceptedRendererMobileSnapshotByWorktree.delete(worktreeId)
+          this.runtimeOwnedSeededMobileSessionWorktrees.delete(worktreeId)
+          // Why: the renderer authoritatively stopped publishing this worktree,
+          // so a later fabricated empty list must not read as hydrationPending.
+          this.fullyHydratedMobileSessionWorktrees.add(worktreeId)
           // Why: drop any pending coalesced notify so a stale snapshot can't land after the removed frame.
           this.mobileSessionTabsNotifyCoalescer.cancel(worktreeId)
           this.notifyMobileSessionTabsRemoved(worktreeId)
@@ -28460,10 +28639,7 @@ export class OrcaRuntimeService {
     )
     return {
       ...snapshot,
-      publicationEpoch: this.getMergedMobileSessionPublicationEpoch(
-        snapshot,
-        normalizedPreservedTabs
-      ),
+      publicationEpoch: this.getMergedMobileSessionPublicationEpoch(snapshot),
       snapshotVersion: Math.max(snapshot.snapshotVersion, existing.snapshotVersion),
       activeGroupId: snapshot.activeGroupId ?? existing.activeGroupId,
       activeTabId: activeTab?.id ?? null,
@@ -28495,9 +28671,12 @@ export class OrcaRuntimeService {
     )
     return {
       ...existing,
-      publicationEpoch: this.getMergedMobileSessionPublicationEpoch(existing, tabs),
+      publicationEpoch: this.getMergedMobileSessionPublicationEpoch(existing),
       // Why: mint a fresh version or clients' same-epoch gate drops the prune frame.
-      snapshotVersion: existing.snapshotVersion + 1,
+      snapshotVersion: this.mobileSessionPublicationClock.nextVersion(
+        existing.worktree,
+        existing.snapshotVersion
+      ),
       activeGroupId:
         existing.activeGroupId ?? this.getHeadlessMobileSessionGroupId(existing.worktree),
       activeTabId: activeTab?.id ?? null,
@@ -28600,24 +28779,15 @@ export class OrcaRuntimeService {
   }
 
   private getMergedMobileSessionPublicationEpoch(
-    snapshot: RuntimeMobileSessionTabsSnapshot,
-    preservedTabs: readonly RuntimeMobileSessionSnapshotTab[]
+    snapshot: RuntimeMobileSessionTabsSnapshot
   ): string {
-    // Why: preserved snapshots can merge repeatedly; strip the prior merge suffix first so the publication epoch stays idempotent.
+    // Why: preserved snapshots can merge repeatedly; strip the prior merge
+    // suffix first so the publication epoch stays idempotent. The signature is
+    // boot-stable — hashing the preserved set flipped the epoch per change and
+    // bypassed the client's same-epoch version gate; strictly-increasing
+    // versions carry preserved-set changes instead.
     const normalizedPublicationEpoch = snapshot.publicationEpoch.split(':headless-merge:')[0]
-    const signature = createHash('sha1')
-      .update(
-        preservedTabs
-          .map((tab) =>
-            tab.type === 'terminal'
-              ? `${tab.id}:${tab.parentTabId}:${tab.ptyId ?? ''}:${tab.leafId}`
-              : tab.id
-          )
-          .join('|')
-      )
-      .digest('hex')
-      .slice(0, 12)
-    return `${normalizedPublicationEpoch}:headless-merge:${signature}`
+    return `${normalizedPublicationEpoch}:headless-merge:${this.mobileSessionPublicationClock.mergeSignature}`
   }
 
   private notifyMobileSessionTabsRemoved(worktreeId: string): void {
@@ -28696,11 +28866,20 @@ export class OrcaRuntimeService {
   ): RuntimeMobileSessionTabsResult {
     const snapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
     if (!snapshot) {
+      // Why: an entry deleted mid-boot can still have live tombstones; carry
+      // them so clients keep treating just-closed tabs as closed.
+      const recentlyClosedTabIds = this.sessionTabCloseTombstones.activeIds(worktreeId)
       return this.clientSessionTabSelections.project(
         {
           worktree: worktreeId,
           publicationEpoch: 'none',
           snapshotVersion: 0,
+          // Why: a fabricated empty list is only authoritative once a full
+          // hydrate ran; before that, clients must not wipe their mirror on it.
+          ...(this.fullyHydratedMobileSessionWorktrees.has(worktreeId)
+            ? {}
+            : { hydrationPending: true as const }),
+          ...(recentlyClosedTabIds.length > 0 ? { recentlyClosedTabIds } : {}),
           activeGroupId: null,
           activeTabId: null,
           activeTabType: null,
@@ -29056,10 +29235,14 @@ export class OrcaRuntimeService {
           )?.id ??
           tabGroups?.[0]?.id ??
           null)
+    // Why: every emission (list, listAll, subscribe frames, coalesced notifies)
+    // flows through here, so tombstones reach clients on whichever frame ships.
+    const recentlyClosedTabIds = this.sessionTabCloseTombstones.activeIds(snapshot.worktree)
     return {
       worktree: snapshot.worktree,
       publicationEpoch: snapshot.publicationEpoch,
       snapshotVersion: snapshot.snapshotVersion,
+      ...(recentlyClosedTabIds.length > 0 ? { recentlyClosedTabIds } : {}),
       activeGroupId,
       activeTabId: active?.id ?? null,
       activeTabType: active?.type ?? null,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1491,9 +1491,12 @@ type RuntimeVisibleTerminalState = {
 type ProviderBufferAcquisition = {
   generation: number
   scrollbackRows: number
-  promise: Promise<PtyProviderBufferSnapshot | null>
+  promise: Promise<SequenceAnchoredProviderSnapshot | null>
   timedOut: boolean
 }
+
+/** Provider snapshot for clients; seq is omitted until a provider sequence sync anchors it to this boot's output domain. */
+type SequenceAnchoredProviderSnapshot = Omit<PtyProviderBufferSnapshot, 'seq'> & { seq?: number }
 
 type RuntimeTerminalBufferSnapshot = {
   data: string
@@ -2842,7 +2845,7 @@ export class OrcaRuntimeService {
   private providerBufferAcquisitionsByPtyId = new Map<string, ProviderBufferAcquisition>()
   private providerVisibleStateByPtyId = new Map<string, RuntimeVisibleTerminalState>()
   private providerVisibleRetryAtByPtyId = new Map<string, number>()
-  private providerSnapshotsWithLiveModeTransition = new WeakSet<PtyProviderBufferSnapshot>()
+  private providerSnapshotsWithLiveModeTransition = new WeakSet<SequenceAnchoredProviderSnapshot>()
   private ptyLifecycleGenerationById = new Map<string, number>()
   private nextPtyLifecycleGeneration = 1
   private recentPtyPathCandidatesById = new Map<string, string[]>()
@@ -7179,14 +7182,19 @@ export class OrcaRuntimeService {
       // their tab id, so focusing the renderer would silently no-op.
       // Phone-local activation also needs this path for inactive restored tabs:
       // desktop focus is intentionally suppressed, but the PTY still must exist.
+      const sessionId = tab.ptyId ?? tab.parentLayout?.ptyIdsByLeafId?.[tab.leafId] ?? undefined
+      // Why: a host restart restores 'ready' records from the provider inventory, but the
+      // daemon streams output only to the process that last ran createOrAttach; a ready tab
+      // whose PTY is detached must re-materialize or subscribers never see live bytes.
+      const ptyStreamDetached =
+        sessionId !== undefined && this.ptyController?.hasPty?.(sessionId) === false
       const shouldMaterializePendingTerminal =
         publicTab?.type === 'terminal' &&
-        publicTab.status !== 'ready' &&
+        (publicTab.status !== 'ready' || ptyStreamDetached) &&
         (!targetsHost ||
           !this.notifier?.focusTerminal ||
           this.shouldMaterializeHeadlessMobileSessionTab(snapshot!, tab))
       if (shouldMaterializePendingTerminal) {
-        const sessionId = tab.ptyId ?? tab.parentLayout?.ptyIdsByLeafId?.[tab.leafId] ?? undefined
         const targetGroupId = snapshot?.tabGroups?.find((group) =>
           group.tabOrder.includes(tab.parentTabId)
         )?.id
@@ -11003,7 +11011,9 @@ export class OrcaRuntimeService {
         if (snapshot.oscLinks !== undefined) {
           state.emulator.setRestoredOscLinks(snapshot.oscLinks)
         }
-        state.outputSequence = snapshot.seq
+        if (snapshot.seq !== undefined) {
+          state.outputSequence = snapshot.seq
+        }
       })
       .catch(() => {
         // Best-effort: live bytes already chain behind this replacement state.
@@ -11146,7 +11156,7 @@ export class OrcaRuntimeService {
     ptyId: string,
     opts: { scrollbackRows?: number } = {},
     wait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
-  ): Promise<PtyProviderBufferSnapshot | null> {
+  ): Promise<SequenceAnchoredProviderSnapshot | null> {
     const generation = this.getPtyLifecycleGeneration(ptyId)
     const scrollbackRows = Math.max(0, Math.floor(opts.scrollbackRows ?? 0))
     let acquisition = this.providerBufferAcquisitionsByPtyId.get(ptyId)
@@ -11171,7 +11181,7 @@ export class OrcaRuntimeService {
       return acquisition.promise
     }
     const result = await withTimeout<
-      { settled: true; value: PtyProviderBufferSnapshot | null } | { settled: false }
+      { settled: true; value: SequenceAnchoredProviderSnapshot | null } | { settled: false }
     >(
       acquisition.promise.then((value) => ({ settled: true as const, value })),
       wait.timeoutMs,
@@ -11190,7 +11200,7 @@ export class OrcaRuntimeService {
     ptyId: string,
     opts: { scrollbackRows?: number },
     generation: number
-  ): Promise<PtyProviderBufferSnapshot | null> {
+  ): Promise<SequenceAnchoredProviderSnapshot | null> {
     const liveModeTracker = new TerminalKittyKeyboardModeTracker()
     let liveModeTrackers = this.providerModeSnapshotScansByPtyId.get(ptyId)
     if (!liveModeTrackers) {
@@ -11228,14 +11238,21 @@ export class OrcaRuntimeService {
         this.providerModeTrackersByPtyId.set(ptyId, modeTracker)
         effectiveAlternateScreen = modeTracker.isAlternateScreen
       }
-      const providerOffset = this.providerSequenceOffsetByPtyId.get(ptyId) ?? 0
-      const reconciledSnapshot = this.preferTrackedLastTitle(ptyId, {
-        ...snapshot,
-        seq: providerOffset + snapshot.seq,
-        ...(effectiveAlternateScreen !== undefined
-          ? { alternateScreen: effectiveAlternateScreen }
-          : {})
-      })
+      // Why: until a provider sequence sync runs this boot, snapshot.seq lives in the
+      // provider's cumulative domain while live frames use the boot-local counter; a
+      // foreign seq poisons client dedupe baselines into dropping all live output.
+      const providerOffset = this.providerSequenceOffsetByPtyId.get(ptyId)
+      const { seq: providerDomainSeq, ...snapshotWithoutSeq } = snapshot
+      const reconciledSnapshot = this.preferTrackedLastTitle<SequenceAnchoredProviderSnapshot>(
+        ptyId,
+        {
+          ...snapshotWithoutSeq,
+          ...(providerOffset !== undefined ? { seq: providerOffset + providerDomainSeq } : {}),
+          ...(effectiveAlternateScreen !== undefined
+            ? { alternateScreen: effectiveAlternateScreen }
+            : {})
+        }
+      )
       if (liveModeTracker.hasObservedAlternateScreenSwitch) {
         this.providerSnapshotsWithLiveModeTransition.add(reconciledSnapshot)
       }
@@ -11396,13 +11413,16 @@ export class OrcaRuntimeService {
     if (this.getPtyLifecycleGeneration(ptyId) !== generation) {
       return null
     }
+    // Why: an unsynced provider seq is a foreign domain; watermark with the counter read
+    // before the capture so any byte that raced the snapshot invalidates this cache entry.
+    const visibleSequence = snapshot.seq ?? outputSequence
     const visibleState: RuntimeVisibleTerminalState = {
       lines,
       isAlternateScreen: snapshot.alternateScreen ?? false,
-      sequence: snapshot.seq,
+      sequence: visibleSequence,
       generation
     }
-    if (this.getPtyOutputSequence(ptyId) <= snapshot.seq) {
+    if (this.getPtyOutputSequence(ptyId) <= visibleSequence) {
       this.providerVisibleStateByPtyId.set(ptyId, visibleState)
     }
     return visibleState

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -703,6 +703,38 @@ describe('session tab RPC methods', () => {
     )
   })
 
+  it('carries hydrationPending on the subscribe initial frame', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listMobileSessionTabs: vi.fn().mockResolvedValue({
+        worktree: 'wt-1',
+        publicationEpoch: 'none',
+        snapshotVersion: 0,
+        hydrationPending: true,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null,
+        tabs: []
+      }),
+      onMobileSessionTabsChanged: vi.fn(() => vi.fn()),
+      registerSubscriptionCleanup: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+    const messages: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      makeRequest('session.tabs.subscribe', { worktree: 'id:wt-1' }),
+      (message) => messages.push(message),
+      { connectionId: 'conn-1' }
+    )
+
+    expect(JSON.parse(messages[0]!).result).toMatchObject({
+      type: 'snapshot',
+      worktree: 'wt-1',
+      hydrationPending: true
+    })
+  })
+
   it('keeps duplicate session tab subscribers for one worktree independent', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/session-tab-close-tombstones.test.ts
+++ b/src/main/runtime/session-tab-close-tombstones.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS,
+  SessionTabCloseTombstoneStore
+} from './session-tab-close-tombstones'
+
+describe('SessionTabCloseTombstoneStore', () => {
+  it('reports recorded tab ids until the TTL expires', () => {
+    const store = new SessionTabCloseTombstoneStore()
+    store.record('wt-1', 'tab-a', 1_000)
+    store.record('wt-1', 'tab-b', 2_000)
+
+    expect(store.activeIds('wt-1', 2_000)).toEqual(['tab-a', 'tab-b'])
+    expect(store.isTabTombstoned('wt-1', 'tab-a', 2_000)).toBe(true)
+
+    // tab-a expires first; tab-b outlives it by its own record time.
+    const justPastFirst = 1_000 + SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS
+    expect(store.activeIds('wt-1', justPastFirst)).toEqual(['tab-b'])
+    expect(store.isTabTombstoned('wt-1', 'tab-a', justPastFirst)).toBe(false)
+    expect(store.activeIds('wt-1', 2_000 + SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS)).toEqual([])
+  })
+
+  it('re-recording refreshes the TTL', () => {
+    const store = new SessionTabCloseTombstoneStore()
+    store.record('wt-1', 'tab-a', 1_000)
+    store.record('wt-1', 'tab-a', 20_000)
+
+    expect(store.isTabTombstoned('wt-1', 'tab-a', 1_000 + SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS)).toBe(
+      true
+    )
+    expect(
+      store.isTabTombstoned('wt-1', 'tab-a', 20_000 + SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS)
+    ).toBe(false)
+  })
+
+  it('isolates tombstones per worktree', () => {
+    const store = new SessionTabCloseTombstoneStore()
+    store.record('wt-1', 'tab-a', 1_000)
+    store.recordPty('wt-1', 'pty-1', 1_000)
+
+    expect(store.activeIds('wt-2', 1_000)).toEqual([])
+    expect(store.isTabTombstoned('wt-2', 'tab-a', 1_000)).toBe(false)
+    expect(store.isPtyTombstoned('wt-2', 'pty-1', 1_000)).toBe(false)
+    expect(store.isPtyTombstoned('wt-1', 'pty-1', 1_000)).toBe(true)
+  })
+
+  it('tracks pty tombstones independently of tab tombstones', () => {
+    const store = new SessionTabCloseTombstoneStore()
+    store.recordPty('wt-1', 'pty-1', 1_000)
+
+    // A pty tombstone never leaks into recentlyClosedTabIds.
+    expect(store.activeIds('wt-1', 1_000)).toEqual([])
+    expect(store.isPtyTombstoned('wt-1', 'pty-1', 1_000)).toBe(true)
+    expect(store.isPtyTombstoned('wt-1', 'pty-1', 1_000 + SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS)).toBe(
+      false
+    )
+  })
+})

--- a/src/main/runtime/session-tab-close-tombstones.ts
+++ b/src/main/runtime/session-tab-close-tombstones.ts
@@ -1,0 +1,69 @@
+export const SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS = 30_000
+
+/**
+ * Why: a close kills its PTY asynchronously, so for a short window other
+ * devices can still see the PTY alive but absent from the snapshot and either
+ * stall their frame pipeline on a "live-unresolved orphan" or re-adopt the
+ * dying process, resurrecting the closed session fleet-wide. Tombstones mark
+ * recently closed host tabs (and their killed/kill-pending PTYs) so inventory
+ * and adoption treat them as closed until the kill has settled.
+ */
+export class SessionTabCloseTombstoneStore {
+  private readonly closedTabExpiryByWorktree = new Map<string, Map<string, number>>()
+  private readonly closedPtyExpiryByWorktree = new Map<string, Map<string, number>>()
+
+  record(worktreeId: string, hostTabId: string, now = Date.now()): void {
+    this.recordEntry(this.closedTabExpiryByWorktree, worktreeId, hostTabId, now)
+  }
+
+  recordPty(worktreeId: string, ptyId: string, now = Date.now()): void {
+    this.recordEntry(this.closedPtyExpiryByWorktree, worktreeId, ptyId, now)
+  }
+
+  /** Host tab ids closed within the TTL, for the snapshot's recentlyClosedTabIds. */
+  activeIds(worktreeId: string, now = Date.now()): string[] {
+    const entries = this.sweep(this.closedTabExpiryByWorktree, worktreeId, now)
+    return entries ? [...entries.keys()] : []
+  }
+
+  isTabTombstoned(worktreeId: string, hostTabId: string, now = Date.now()): boolean {
+    return this.sweep(this.closedTabExpiryByWorktree, worktreeId, now)?.has(hostTabId) === true
+  }
+
+  isPtyTombstoned(worktreeId: string, ptyId: string, now = Date.now()): boolean {
+    return this.sweep(this.closedPtyExpiryByWorktree, worktreeId, now)?.has(ptyId) === true
+  }
+
+  private recordEntry(
+    expiryByWorktree: Map<string, Map<string, number>>,
+    worktreeId: string,
+    id: string,
+    now: number
+  ): void {
+    const entries = this.sweep(expiryByWorktree, worktreeId, now) ?? new Map<string, number>()
+    entries.set(id, now + SESSION_TAB_CLOSE_TOMBSTONE_TTL_MS)
+    expiryByWorktree.set(worktreeId, entries)
+  }
+
+  // Lazy sweep: expired entries are dropped whenever their worktree is touched.
+  private sweep(
+    expiryByWorktree: Map<string, Map<string, number>>,
+    worktreeId: string,
+    now: number
+  ): Map<string, number> | null {
+    const entries = expiryByWorktree.get(worktreeId)
+    if (!entries) {
+      return null
+    }
+    for (const [id, expiresAt] of entries) {
+      if (expiresAt <= now) {
+        entries.delete(id)
+      }
+    }
+    if (entries.size === 0) {
+      expiryByWorktree.delete(worktreeId)
+      return null
+    }
+    return entries
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14421,7 +14421,10 @@
         "reconnectTimeout": "The server did not reconnect on the updated version."
       },
       "webRuntimeSession": {
-        "remoteHostDisconnected": "The workspace is not connected to a remote Orca host."
+        "remoteHostDisconnected": "The workspace is not connected to a remote Orca host.",
+        "closePinnedRefused": "The host declined to close a pinned tab",
+        "closePinnedRefusedDescription": "Unpin the tab, then close it again.",
+        "closeFailedRestored": "Couldn't close the session on the host — it has been restored"
       }
     }
   },

--- a/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
@@ -30,6 +30,8 @@ const store = {
     ]
   },
   tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] as { id: string; launchAgent?: string }[] },
+  pendingStartupByTabId: {} as Record<string, { command: string }>,
+  automaticAgentResumeClaimsByTabId: {} as Record<string, unknown>,
   openFiles: [] as { id: string; worktreeId: string }[],
   browserTabsByWorktree: {} as Record<string, { id: string }[]>,
   tabBarOrderByWorktree: {} as Record<string, string[]>,
@@ -98,7 +100,11 @@ describe('launchAgentInNewTab paired web runtime', () => {
     expect(mocks.createTab).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
-    expect(mocks.closeTab).toHaveBeenCalledWith('stale-agent-tab', { reason: 'cleanup' })
+    // Why: the prune is local-only — a stale row must never fire terminal.close at the host.
+    expect(mocks.closeTab).toHaveBeenCalledWith('stale-agent-tab', {
+      reason: 'cleanup',
+      remoteCloseOwnedByHost: true
+    })
   })
 
   it('forwards prompt launch env and captured config to the host runtime', async () => {

--- a/src/renderer/src/lib/launch-agent-web-host-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  closeTab: vi.fn(),
+  createWebRuntimeSessionTerminal: vi.fn(),
+  setActiveTabType: vi.fn()
+}))
+
+const store = {
+  tabsByWorktree: {} as Record<string, { id: string; launchAgent?: string }[]>,
+  pendingStartupByTabId: {} as Record<string, { command: string }>,
+  automaticAgentResumeClaimsByTabId: {} as Record<string, unknown>,
+  closeTab: mocks.closeTab,
+  setActiveTabType: mocks.setActiveTabType
+}
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => store } }))
+vi.mock('sonner', () => ({ toast: { message: vi.fn(), error: vi.fn() } }))
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: mocks.createWebRuntimeSessionTerminal,
+  createWebRuntimeAgentSessionTerminal: vi.fn(),
+  createWebRuntimeAgentSessionTerminalWithLaunchDraft: vi.fn(),
+  isWebTerminalSurfaceTabId: (id: string) => id.startsWith('web-surface:')
+}))
+
+import { launchAgentInWebHostTab } from './launch-agent-web-host-tab'
+import {
+  recordWebAgentSessionHandoff,
+  resetWebAgentSessionHandoffsForTests
+} from '@/runtime/web-agent-session-handoff'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+
+const startupPlan: AgentStartupPlan = {
+  agent: 'claude',
+  launchCommand: 'claude',
+  expectedProcess: 'claude',
+  followupPrompt: null,
+  launchConfig: { agentArgs: '', agentEnv: {} }
+}
+
+function launch(): Promise<{ delivered: boolean; failureNotified: boolean }> {
+  return launchAgentInWebHostTab({
+    agent: 'claude',
+    worktreeId: 'wt-1',
+    environmentId: 'env-1',
+    startupPlan,
+    prompt: '',
+    promptDelivery: 'auto-submit',
+    pastePromptAfterReady: null,
+    submitPastedPrompt: false
+  })
+}
+
+describe('launchAgentInWebHostTab stale-tab prune', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetWebAgentSessionHandoffsForTests()
+    store.tabsByWorktree = { 'wt-1': [] }
+    store.pendingStartupByTabId = {}
+    store.automaticAgentResumeClaimsByTabId = {}
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue({ status: 'created' })
+    // Why: mirror the real store — a closed tab leaves tabsByWorktree, so the
+    // post-create pass sees the pruned state, not the pre-create one.
+    mocks.closeTab.mockImplementation((tabId: string) => {
+      for (const [worktreeId, tabs] of Object.entries(store.tabsByWorktree)) {
+        store.tabsByWorktree[worktreeId] = tabs.filter((tab) => tab.id !== tabId)
+      }
+    })
+  })
+
+  it('keeps a provisional tab with a recorded handoff through pre- and post-create prunes', async () => {
+    store.tabsByWorktree['wt-1'] = [{ id: 'prov-1', launchAgent: 'claude' }]
+    recordWebAgentSessionHandoff({
+      environmentId: 'env-1',
+      worktreeId: 'wt-1',
+      provisionalTabId: 'prov-1',
+      hostTabId: 'host-1',
+      hostTerminalHandle: 'term-1'
+    })
+
+    await launch()
+
+    expect(mocks.closeTab).not.toHaveBeenCalled()
+    expect(store.tabsByWorktree['wt-1']).toEqual([{ id: 'prov-1', launchAgent: 'claude' }])
+  })
+
+  it('keeps tabs with a queued startup command or an automatic resume claim', async () => {
+    store.tabsByWorktree['wt-1'] = [
+      { id: 'pending-1', launchAgent: 'claude' },
+      { id: 'claimed-1', launchAgent: 'claude' }
+    ]
+    store.pendingStartupByTabId['pending-1'] = { command: 'claude' }
+    store.automaticAgentResumeClaimsByTabId['claimed-1'] = { worktreeId: 'wt-1' }
+
+    await launch()
+
+    expect(mocks.closeTab).not.toHaveBeenCalled()
+  })
+
+  it('prunes a genuinely stale tab without firing a host terminal.close', async () => {
+    store.tabsByWorktree['wt-1'] = [
+      { id: 'stale-1', launchAgent: 'claude' },
+      { id: 'plain-terminal' },
+      { id: 'web-surface:1', launchAgent: 'claude' }
+    ]
+
+    await launch()
+
+    expect(mocks.closeTab).toHaveBeenCalledTimes(1)
+    expect(mocks.closeTab).toHaveBeenCalledWith('stale-1', {
+      reason: 'cleanup',
+      remoteCloseOwnedByHost: true
+    })
+    expect(store.tabsByWorktree['wt-1'].map((tab) => tab.id)).toEqual([
+      'plain-terminal',
+      'web-surface:1'
+    ])
+  })
+
+  it('post-create prune ignores tabs created mid-operation', async () => {
+    store.tabsByWorktree['wt-1'] = [{ id: 'stale-1', launchAgent: 'claude' }]
+    mocks.createWebRuntimeSessionTerminal.mockImplementation(async () => {
+      store.tabsByWorktree['wt-1'] = [
+        ...store.tabsByWorktree['wt-1'],
+        { id: 'mid-op-tab', launchAgent: 'claude' }
+      ]
+      return { status: 'created' }
+    })
+
+    await launch()
+
+    expect(mocks.closeTab).toHaveBeenCalledTimes(1)
+    expect(mocks.closeTab).toHaveBeenCalledWith('stale-1', {
+      reason: 'cleanup',
+      remoteCloseOwnedByHost: true
+    })
+    expect(store.tabsByWorktree['wt-1'].map((tab) => tab.id)).toEqual(['mid-op-tab'])
+  })
+})

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -11,16 +11,41 @@ import type { Tab, TuiAgent } from '../../../shared/types'
 import type { AgentPromptDelivery } from '../../../shared/agent-session-host-authority'
 import { translate } from '@/i18n/i18n'
 import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operation'
+import { hasWebAgentSessionHandoffForProvisionalTab } from '@/runtime/web-agent-session-handoff'
 
-function removeStaleLocalAgentTabsForWebHostLaunch(worktreeId: string): void {
+function removeStaleLocalAgentTabsForWebHostLaunch(
+  worktreeId: string,
+  pruneableTabIds?: ReadonlySet<string>
+): ReadonlySet<string> {
   const state = useAppStore.getState()
+  const survivingTabIds = new Set<string>()
   for (const tab of state.tabsByWorktree[worktreeId] ?? []) {
-    if (tab.launchAgent && !isWebTerminalSurfaceTabId(tab.id)) {
-      // Why: pruning a stale local agent tab is a system close — keep it out of
-      // the Cmd+Shift+T reopen stack.
-      state.closeTab(tab.id, { reason: 'cleanup' })
+    if (!tab.launchAgent || isWebTerminalSurfaceTabId(tab.id)) {
+      survivingTabIds.add(tab.id)
+      continue
     }
+    // Why: a provisional tab mid-launch (recorded handoff, queued startup, or
+    // resume claim) is not stale — pruning it kills the create it belongs to.
+    if (
+      hasWebAgentSessionHandoffForProvisionalTab(worktreeId, tab.id) ||
+      state.pendingStartupByTabId[tab.id] ||
+      state.automaticAgentResumeClaimsByTabId[tab.id]
+    ) {
+      survivingTabIds.add(tab.id)
+      continue
+    }
+    // Why: the post-create pass may only prune tabs it saw pre-create; anything
+    // newer was born mid-operation and is not stale.
+    if (pruneableTabIds && !pruneableTabIds.has(tab.id)) {
+      survivingTabIds.add(tab.id)
+      continue
+    }
+    // Why: pruning a stale local agent tab is a system close — keep it out of
+    // the Cmd+Shift+T reopen stack. remoteCloseOwnedByHost keeps the prune
+    // local so it can never fire terminal.close at a live host session.
+    state.closeTab(tab.id, { reason: 'cleanup', remoteCloseOwnedByHost: true })
   }
+  return survivingTabIds
 }
 
 /**
@@ -65,7 +90,7 @@ export function launchAgentInWebHostTab(args: {
   const launchPreferences = toAgentLaunchPreferences(startupPlan.sessionOptions)
   const structuredPromptDelivery: AgentPromptDelivery =
     promptDelivery === 'draft' ? 'draft' : 'auto-submit'
-  removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
+  const preCreateSurvivingTabIds = removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
   const launch = {
     worktreeId,
     environmentId,
@@ -102,7 +127,7 @@ export function launchAgentInWebHostTab(args: {
   }): { delivered: boolean; failureNotified: boolean } => {
     // Why: created means the host accepted the launch, not that a local tab
     // exists; keep pruning stale local rows until the snapshot mirrors.
-    removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
+    removeStaleLocalAgentTabsForWebHostLaunch(worktreeId, preCreateSurvivingTabIds)
     if (outcome.status === 'failed') {
       toast.error(
         outcome.message ||

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -396,7 +396,7 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
     return
   }
 
-  if (!beginWebRuntimeWakeTerminalRespawn(worktreeId)) {
+  if (!beginWebRuntimeWakeTerminalRespawn(runtimeEnvironmentId, worktreeId)) {
     return
   }
 
@@ -407,7 +407,7 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
     activate: true,
     selectWorktree: false
   }).finally(() => {
-    endWebRuntimeWakeTerminalRespawn(worktreeId)
+    endWebRuntimeWakeTerminalRespawn(runtimeEnvironmentId, worktreeId)
   })
 }
 

--- a/src/renderer/src/runtime/web-agent-session-handoff.ts
+++ b/src/renderer/src/runtime/web-agent-session-handoff.ts
@@ -44,6 +44,21 @@ export function resolveWebAgentSessionHandoff(args: WebAgentSessionHandoffKey): 
   return handoffByProvisionalTab.get(handoffKey(args))?.hostTabId ?? null
 }
 
+/** Environment-agnostic lookup: callers that only know the worktree (e.g. the
+ * QuickLaunch prune) must still treat a handed-off provisional tab as live. */
+export function hasWebAgentSessionHandoffForProvisionalTab(
+  worktreeId: string,
+  provisionalTabId: string
+): boolean {
+  const suffix = `\0${worktreeId}\0${provisionalTabId}`
+  for (const key of handoffByProvisionalTab.keys()) {
+    if (key.endsWith(suffix)) {
+      return true
+    }
+  }
+  return false
+}
+
 export function isWebAgentSessionHandoffPostCreateSnapshotConfirmed(
   args: WebAgentSessionHandoffKey
 ): boolean {

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -33,6 +33,12 @@ import {
   recordWebAgentSessionHandoff,
   resetWebAgentSessionHandoffsForTests
 } from './web-agent-session-handoff'
+import {
+  clearWebSessionTerminalOrphanRecoveryForTests,
+  recoverWebSessionTerminalOrphansBeforeApply
+} from './web-session-terminal-orphan-recovery'
+import { listRemoteRuntimeSessionTabsDeduped } from './remote-runtime-session-tabs-inflight'
+import { toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { toRuntimeExecutionHostId } from '../../../shared/execution-host'
 
 const mocks = vi.hoisted(() => ({
@@ -48,7 +54,8 @@ const mocks = vi.hoisted(() => ({
   trackTerminalPaneSplit: vi.fn(),
   deliverLaunchPromptToAgentTab: vi.fn(),
   seedNativeChatLaunchDraftForAgentTab: vi.fn(),
-  getRuntimeEnvironmentIdForWorktree: vi.fn()
+  getRuntimeEnvironmentIdForWorktree: vi.fn(),
+  toastError: vi.fn()
 }))
 
 vi.mock('../store', () => ({
@@ -79,12 +86,20 @@ vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
   seedNativeChatLaunchDraftForAgentTab: mocks.seedNativeChatLaunchDraftForAgentTab
 }))
 
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError }
+}))
+
 const ENVIRONMENT_ID = 'web-env-1'
 const RUNTIME_EXECUTION_HOST_ID = toRuntimeExecutionHostId(ENVIRONMENT_ID)
 const WORKTREE_ID = 'repo::/worktree'
 const FOCUS_LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
-afterEach(() => resetWebSessionCloseIntentForTests())
+afterEach(() => {
+  resetWebSessionCloseIntentForTests()
+  // Why: refreshes now join the per-worktree recovery chain; drop it so a test's pending entry cannot gate the next test's applies.
+  clearWebSessionTerminalOrphanRecoveryForTests()
+})
 
 function makeSnapshot(): RuntimeMobileSessionTabsResult {
   return {
@@ -99,22 +114,21 @@ function makeSnapshot(): RuntimeMobileSessionTabsResult {
 }
 
 describe('refreshWebRuntimeSessionTabsSnapshot', () => {
+  beforeEach(() => {
+    // Why: the refresh now funnels through orphan recovery, which reads the local mirror.
+    mocks.getState.mockReturnValue({ tabsByWorktree: {} })
+    mocks.setState.mockImplementation((updater: (state: unknown) => unknown) =>
+      updater({ state: 'before' })
+    )
+  })
+
   afterEach(() => {
     resetWebAgentSessionHandoffsForTests()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
 
-  it('confirms only the exact handoff after its post-create list completes', async () => {
-    const runtimeCall = vi.fn().mockResolvedValue({
-      id: 'list',
-      ok: true,
-      result: makeSnapshot()
-    })
-    vi.stubGlobal('window', {
-      api: { runtimeEnvironments: { call: runtimeCall } }
-    })
-    mocks.applyFreshWebSessionTabsSnapshot.mockImplementation((state) => state)
+  const recordHandoffPair = (): void => {
     recordWebAgentSessionHandoff({
       environmentId: ENVIRONMENT_ID,
       worktreeId: WORKTREE_ID,
@@ -129,6 +143,39 @@ describe('refreshWebRuntimeSessionTabsSnapshot', () => {
       hostTabId: 'host-b',
       hostTerminalHandle: 'term_host-b'
     })
+  }
+  const confirmed = (provisionalTabId: string): boolean =>
+    isWebAgentSessionHandoffPostCreateSnapshotConfirmed({
+      environmentId: ENVIRONMENT_ID,
+      worktreeId: WORKTREE_ID,
+      provisionalTabId
+    })
+
+  it('confirms only the exact handoff after its post-create list contains the host tab', async () => {
+    const runtimeCall = vi.fn().mockResolvedValue({
+      id: 'list',
+      ok: true,
+      result: {
+        ...makeSnapshot(),
+        tabs: [
+          {
+            type: 'terminal' as const,
+            id: 'host-a::leaf-1',
+            parentTabId: 'host-a',
+            leafId: 'leaf-1',
+            title: 'Codex',
+            terminal: 'term_host-a',
+            status: 'ready' as const,
+            isActive: true
+          }
+        ]
+      }
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+    mocks.applyFreshWebSessionTabsSnapshot.mockImplementation((state) => state)
+    recordHandoffPair()
 
     await refreshWebRuntimeSessionTabsSnapshot(ENVIRONMENT_ID, WORKTREE_ID, {
       acceptCurrentSnapshot: true,
@@ -139,12 +186,6 @@ describe('refreshWebRuntimeSessionTabsSnapshot', () => {
       }
     })
 
-    const confirmed = (provisionalTabId: string): boolean =>
-      isWebAgentSessionHandoffPostCreateSnapshotConfirmed({
-        environmentId: ENVIRONMENT_ID,
-        worktreeId: WORKTREE_ID,
-        provisionalTabId
-      })
     expect(confirmed('provisional-a')).toBe(true)
     expect(confirmed('provisional-b')).toBe(false)
     expect(mocks.acceptReplayedWebSessionTabsSnapshot).toHaveBeenCalledWith(
@@ -168,6 +209,97 @@ describe('refreshWebRuntimeSessionTabsSnapshot', () => {
     })
     expect(confirmed('provisional-a')).toBe(false)
   })
+
+  it('does not confirm the handoff when the post-create list lacks the host tab', async () => {
+    const runtimeCall = vi.fn().mockResolvedValue({
+      id: 'list',
+      ok: true,
+      result: makeSnapshot()
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+    mocks.applyFreshWebSessionTabsSnapshot.mockImplementation((state) => state)
+    recordHandoffPair()
+
+    await refreshWebRuntimeSessionTabsSnapshot(ENVIRONMENT_ID, WORKTREE_ID, {
+      acceptCurrentSnapshot: true,
+      confirmAgentSessionHandoff: {
+        provisionalTabId: 'provisional-a',
+        hostTabId: 'host-a',
+        hostTerminalHandle: 'term_host-a'
+      }
+    })
+
+    // Why: a stale list without the host tab must not arm absence-based retirement of the provisional tab.
+    expect(confirmed('provisional-a')).toBe(false)
+    expect(confirmed('provisional-b')).toBe(false)
+    expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues the list-result apply behind a delayed in-flight subscription frame', async () => {
+    const candidateState = {
+      tabsByWorktree: {
+        [WORKTREE_ID]: [{ id: 'web-terminal-host-tab', worktreeId: WORKTREE_ID } as never]
+      },
+      terminalLayoutsByTabId: {
+        'web-terminal-host-tab': {
+          root: { type: 'leaf' as const, leafId: 'leaf-1' },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-1': toRemoteRuntimePtyId('term_live', ENVIRONMENT_ID) }
+        }
+      },
+      activeTabIdByWorktree: {},
+      activeGroupIdByWorktree: {}
+    }
+    let releaseDelayedFrame: ((value: unknown) => void) | null = null
+    const delayedFrameCall = vi.fn(
+      async () =>
+        await new Promise((resolve) => {
+          releaseDelayedFrame = resolve
+        })
+    )
+    const delayedFrame = { ...makeSnapshot(), publicationEpoch: 'stale-epoch' }
+    const delayedApply = vi.fn()
+    const delayed = recoverWebSessionTerminalOrphansBeforeApply(
+      candidateState,
+      delayedFrame,
+      ENVIRONMENT_ID,
+      delayedFrameCall as never
+    ).then((recovered) => {
+      if (recovered) {
+        delayedApply(recovered)
+      }
+    })
+    const listSnapshot = { ...makeSnapshot(), snapshotVersion: 5 }
+    const runtimeCall = vi.fn().mockResolvedValue({ id: 'list', ok: true, result: listSnapshot })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+    mocks.applyFreshWebSessionTabsSnapshot.mockImplementation((state) => state)
+
+    const refresh = refreshWebRuntimeSessionTabsSnapshot(ENVIRONMENT_ID, WORKTREE_ID)
+    await vi.waitFor(() => expect(releaseDelayedFrame).not.toBeNull())
+    await vi.waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    // Why: the list result already resolved, but its apply must wait behind the delayed frame.
+    expect(mocks.applyFreshWebSessionTabsSnapshot).not.toHaveBeenCalled()
+
+    releaseDelayedFrame!({
+      ok: true,
+      result: { terminals: [], totalCount: 0, truncated: false }
+    })
+    await Promise.all([delayed, refresh])
+
+    expect(delayedApply).toHaveBeenCalledWith(delayedFrame)
+    expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalledWith(
+      expect.anything(),
+      listSnapshot,
+      ENVIRONMENT_ID
+    )
+    expect(delayedApply.mock.invocationCallOrder[0]!).toBeLessThan(
+      mocks.applyFreshWebSessionTabsSnapshot.mock.invocationCallOrder[0]!
+    )
+  })
 })
 
 describe('activateWebRuntimeSessionWorktree', () => {
@@ -176,7 +308,9 @@ describe('activateWebRuntimeSessionWorktree', () => {
     mocks.getState.mockReturnValue({
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
-      }
+      },
+      // Why: non-empty so the bounded recovery re-list loop bails instead of outliving the test.
+      tabsByWorktree: { [WORKTREE_ID]: [{ id: 'local-terminal-1' }] }
     })
     mocks.setState.mockImplementation((updater: (state: unknown) => unknown) =>
       updater({ state: 'before' })
@@ -250,6 +384,7 @@ describe('createWebRuntimeSessionBrowserTab', () => {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
       activeWorktreeId: WORKTREE_ID,
+      tabsByWorktree: {},
       browserPagesByWorkspace: {},
       remoteBrowserPageHandlesByPageId: {},
       createBrowserTab: mocks.createBrowserTab,
@@ -452,6 +587,7 @@ describe('createWebRuntimeSessionBrowserTab', () => {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
       activeWorktreeId,
+      tabsByWorktree: {},
       browserPagesByWorkspace: {},
       remoteBrowserPageHandlesByPageId: {},
       createBrowserTab: mocks.createBrowserTab,
@@ -540,6 +676,7 @@ describe('createWebRuntimeSessionTerminal', () => {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
       activeWorktreeId: WORKTREE_ID,
+      tabsByWorktree: {},
       browserPagesByWorkspace: {},
       remoteBrowserPageHandlesByPageId: {},
       createBrowserTab: mocks.createBrowserTab,
@@ -590,6 +727,57 @@ describe('createWebRuntimeSessionTerminal', () => {
     ).resolves.toEqual({ status: 'created' })
 
     expect(selectedHosts).toEqual([RUNTIME_EXECUTION_HOST_ID])
+  })
+
+  it('waits out a pre-create in-flight list instead of using it as the post-create proof', async () => {
+    let resolvePreOpList: ((snapshot: RuntimeMobileSessionTabsResult) => void) | null = null
+    void listRemoteRuntimeSessionTabsDeduped({
+      environmentId: ENVIRONMENT_ID,
+      worktreeId: WORKTREE_ID,
+      load: () =>
+        new Promise<RuntimeMobileSessionTabsResult>((resolve) => {
+          resolvePreOpList = resolve
+        })
+    })
+    const postCreateSnapshot = { ...makeSnapshot(), snapshotVersion: 3 }
+    const runtimeCall = vi.fn(async (request: { method: string }) => {
+      if (request.method === 'session.tabs.createTerminal') {
+        return {
+          id: 'create',
+          ok: true,
+          result: { tab: { id: 'host-tab-2', leafId: 'leaf-1' } }
+        }
+      }
+      return { id: 'list', ok: true, result: postCreateSnapshot }
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const create = createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      environmentId: ENVIRONMENT_ID
+    })
+    await vi.waitFor(() =>
+      expect(runtimeCall).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'session.tabs.createTerminal' })
+      )
+    )
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    // Why: a list that began before the create committed cannot serve as the post-create proof.
+    expect(runtimeCall.mock.calls.some(([request]) => request.method === 'session.tabs.list')).toBe(
+      false
+    )
+
+    resolvePreOpList!({ ...makeSnapshot(), publicationEpoch: 'pre-op' })
+    await expect(create).resolves.toEqual({ status: 'created' })
+
+    expect(runtimeCall.mock.calls.some(([request]) => request.method === 'session.tabs.list')).toBe(
+      true
+    )
+    expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalledWith(
+      expect.anything(),
+      postCreateSnapshot,
+      ENVIRONMENT_ID
+    )
   })
 
   it.each([
@@ -1547,6 +1735,7 @@ describe('web runtime session tab actions', () => {
       settings: {
         activeRuntimeEnvironmentId: ENVIRONMENT_ID
       },
+      tabsByWorktree: {},
       setActiveWorktree: mocks.setActiveWorktree
     })
     mocks.resolveHostSessionTabIdForWebSessionTab.mockImplementation(
@@ -1762,6 +1951,8 @@ describe('web runtime session tab actions', () => {
         Date.now()
       )
     ).toBe(false)
+    // Why: lifecycle echoes are not user actions; no toast for their failures.
+    expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
   it('restores reconciliation authority when the host refuses a lifecycle close', async () => {
@@ -1862,6 +2053,103 @@ describe('web runtime session tab actions', () => {
       )
     ).toBe(true)
     expect(mocks.acceptReplayedWebSessionTabsSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('restores the tab and refreshes when a user close fails on the host', async () => {
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'close',
+        ok: false,
+        error: { code: 'internal', message: 'close_failed' }
+      })
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: makeSnapshot() })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      closeWebRuntimeSessionTab({
+        worktreeId: WORKTREE_ID,
+        tabId: 'local-browser-unified',
+        reason: 'user'
+      })
+    ).resolves.toBe(false)
+
+    // Why: the failed close must drop suppression and honestly restore the host's tab.
+    expect(
+      isWebSessionCloseIntentPending(
+        { environmentId: ENVIRONMENT_ID },
+        WORKTREE_ID,
+        'host-browser-unified',
+        Date.now()
+      )
+    ).toBe(false)
+    expect(mocks.acceptReplayedWebSessionTabsSnapshot).toHaveBeenCalledWith(
+      ENVIRONMENT_ID,
+      WORKTREE_ID
+    )
+    expect(runtimeCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: 'session.tabs.list' })
+    )
+    expect(mocks.applyFreshWebSessionTabsSnapshot).toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      expect.stringContaining('restored'),
+      expect.objectContaining({ description: expect.stringContaining('close_failed') })
+    )
+  })
+
+  it('shows pinned-specific guidance when the host rejects closing a pinned tab', async () => {
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'close',
+        ok: false,
+        error: { code: 'invalid_request', message: 'terminal_tab_pinned' }
+      })
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: makeSnapshot() })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      closeWebRuntimeSessionTab({
+        worktreeId: WORKTREE_ID,
+        tabId: 'local-browser-unified',
+        reason: 'user'
+      })
+    ).resolves.toBe(false)
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      expect.stringContaining('pinned'),
+      expect.objectContaining({ description: expect.stringContaining('Unpin') })
+    )
+  })
+
+  it('suppresses the restored toast when the tab was already closed elsewhere (tab_not_found)', async () => {
+    // Why: a double-close race leaves the tab gone; claiming it "has been
+    // restored" would be false. The refresh still reconciles the absence.
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'close',
+        ok: false,
+        error: { code: 'invalid_request', message: 'tab_not_found' }
+      })
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: makeSnapshot() })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await expect(
+      closeWebRuntimeSessionTab({
+        worktreeId: WORKTREE_ID,
+        tabId: 'local-browser-unified',
+        reason: 'user'
+      })
+    ).resolves.toBe(false)
+
+    expect(runtimeCall).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: 'session.tabs.list' })
+    )
+    expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
   it('clears an optimistic close intent when pairing CAS rejects the host call', async () => {

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -25,6 +25,7 @@ import type {
   RuntimeCreateAgentSessionResult,
   RuntimeEnsureAgentSessionResult
 } from '../../../shared/agent-session-host-authority'
+import { toast } from 'sonner'
 import type { TerminalPaneLayoutNode, TuiAgent } from '../../../shared/types'
 import type { AppState } from '../store/types'
 import { getRuntimeEnvironmentIdForWorktree } from '../lib/worktree-runtime-owner'
@@ -56,6 +57,7 @@ import {
   listRemoteRuntimeSessionTabsAfterCurrentInFlight,
   listRemoteRuntimeSessionTabsDeduped
 } from './remote-runtime-session-tabs-inflight'
+import { recoverWebSessionTerminalOrphansBeforeApply } from './web-session-terminal-orphan-recovery'
 import { runRemoteAgentSessionLaunch } from './remote-agent-session-launch'
 import { translate } from '../i18n/i18n'
 import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
@@ -394,7 +396,9 @@ async function createWebRuntimeSessionTerminalResult(
     await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId, {
       expectedEnvironmentPairingRevision: intentOwner.pairingRevision,
       // Why: the publication can beat the RPC response; replay it once after caller focus intent exists.
-      acceptCurrentSnapshot: args.activate !== false && Boolean(createdTabId)
+      acceptCurrentSnapshot: args.activate !== false && Boolean(createdTabId),
+      // Why: a list that began before creation committed cannot prove the created tab's state.
+      listAfterCurrentInFlight: true
     })
     return {
       outcome: { status: 'created' },
@@ -560,6 +564,7 @@ export async function refreshWebRuntimeSessionTabsSnapshot(
   options: {
     expectedEnvironmentPairingRevision?: number
     acceptCurrentSnapshot?: boolean
+    listAfterCurrentInFlight?: boolean
     confirmAgentSessionHandoff?: {
       provisionalTabId: string
       hostTabId: string
@@ -580,9 +585,10 @@ export async function refreshWebRuntimeSessionTabsSnapshot(
       // re-accept its current version after the exact provisional handoff is known.
       acceptReplayedWebSessionTabsSnapshot(environmentId, worktreeId)
     }
-    const listSessionTabs = options.confirmAgentSessionHandoff
-      ? listRemoteRuntimeSessionTabsAfterCurrentInFlight
-      : listRemoteRuntimeSessionTabsDeduped
+    const listSessionTabs =
+      options.confirmAgentSessionHandoff || options.listAfterCurrentInFlight
+        ? listRemoteRuntimeSessionTabsAfterCurrentInFlight
+        : listRemoteRuntimeSessionTabsDeduped
     const snapshot = await listSessionTabs({
       environmentId,
       worktreeId,
@@ -599,15 +605,35 @@ export async function refreshWebRuntimeSessionTabsSnapshot(
         )
       }
     })
+    // Why: subscription frames apply through this per-worktree chain; joining it keeps
+    // a delayed push frame from applying after this newer list result, and gives list
+    // results the same live-orphan drop protection.
+    const recovered = await recoverWebSessionTerminalOrphansBeforeApply(
+      useAppStore.getState(),
+      snapshot,
+      environmentId
+    )
+    if (!recovered) {
+      return
+    }
     if (options.confirmAgentSessionHandoff) {
-      const { confirmWebAgentSessionHandoffAfterCreate } =
-        await import('./web-agent-session-handoff')
-      // Why: this list completed after structured creation, so absence now proves the exact host tab already retired.
-      confirmWebAgentSessionHandoffAfterCreate({
-        environmentId,
-        worktreeId,
-        ...options.confirmAgentSessionHandoff
-      })
+      const confirm = options.confirmAgentSessionHandoff
+      // Why: only a list that actually contained the host tab proves the create was
+      // published; confirming on a stale absence lets retirement kill the provisional tab.
+      const hostTabListed = recovered.tabs.some(
+        (tab) =>
+          tab.id === confirm.hostTabId ||
+          (tab.type === 'terminal' && tab.parentTabId === confirm.hostTabId)
+      )
+      if (hostTabListed) {
+        const { confirmWebAgentSessionHandoffAfterCreate } =
+          await import('./web-agent-session-handoff')
+        confirmWebAgentSessionHandoffAfterCreate({
+          environmentId,
+          worktreeId,
+          ...confirm
+        })
+      }
     }
     const { applyFreshWebSessionTabsSnapshot, applyWebSessionTabsStorePatch } =
       await import('./web-session-tabs-sync')
@@ -616,7 +642,7 @@ export async function refreshWebRuntimeSessionTabsSnapshot(
     }
     applyWebSessionTabsStorePatch((state) => {
       // Why: eager refreshes can resolve after the user switched worktrees; update tabs without stealing focus.
-      const patch = applyFreshWebSessionTabsSnapshot(state, snapshot, environmentId)
+      const patch = applyFreshWebSessionTabsSnapshot(state, recovered, environmentId)
       return patch === state ? state : patch
     })
   } catch (error) {
@@ -945,12 +971,16 @@ async function callWebRuntimeSessionTabMethod(
     for (const hostTabId of closeIntentTabIds) {
       clearWebSessionCloseIntent(intentOwner, args.worktreeId, hostTabId)
     }
-    if (isLifecycleClose) {
+    if (isClose) {
+      // Why: the host kept the tab; re-list so the mirror honestly restores it instead of diverging silently.
       const { acceptReplayedWebSessionTabsSnapshot } = await import('./web-session-tabs-sync')
       acceptReplayedWebSessionTabsSnapshot(environmentId, args.worktreeId)
       await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId, {
         expectedEnvironmentPairingRevision: intentOwner.pairingRevision
       })
+      if (!isLifecycleClose) {
+        showWebRuntimeSessionUserCloseFailureToast(error)
+      }
     }
     console.warn(
       `[web-runtime-session] failed to ${isClose ? 'close' : 'activate'} tab:`,
@@ -958,6 +988,38 @@ async function callWebRuntimeSessionTabMethod(
     )
     return false
   }
+}
+
+// Why: user closes were fire-and-forget; the tab honestly reappearing needs an explanation, and pinned refusals need an action.
+function showWebRuntimeSessionUserCloseFailureToast(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.includes('tab_not_found')) {
+    // Why: a double-close race — the tab is already gone and the refresh
+    // reconciles its absence; "restored" copy would be false.
+    return
+  }
+  if (message.includes('terminal_tab_pinned')) {
+    toast.error(
+      translate(
+        'auto.runtime.webRuntimeSession.closePinnedRefused',
+        'The host declined to close a pinned tab'
+      ),
+      {
+        description: translate(
+          'auto.runtime.webRuntimeSession.closePinnedRefusedDescription',
+          'Unpin the tab, then close it again.'
+        )
+      }
+    )
+    return
+  }
+  toast.error(
+    translate(
+      'auto.runtime.webRuntimeSession.closeFailedRestored',
+      "Couldn't close the session on the host — it has been restored"
+    ),
+    { description: message }
+  )
 }
 
 export function splitWebRuntimeTerminal(

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.test.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   beginWebRuntimeWakeTerminalRespawn,
+  clearWebRuntimeWakeTerminalRespawnForEnvironment,
   clearWebRuntimeWakeTerminalRespawnForWorktree,
   endWebRuntimeWakeTerminalRespawn,
   resetWebRuntimeWakeTerminalRespawnForTests,
@@ -13,18 +14,29 @@ describe('web-runtime-wake-terminal-respawn', () => {
   })
 
   it('dedupes concurrent wake respawn requests for the same worktree', () => {
-    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
-    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
-    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
-    endWebRuntimeWakeTerminalRespawn('wt-1')
-    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
-    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(true)
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(false)
+    endWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(false)
+    expect(beginWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(true)
   })
 
   it('clears wake respawn tracking for a removed worktree', () => {
-    beginWebRuntimeWakeTerminalRespawn('wt-1')
-    clearWebRuntimeWakeTerminalRespawnForWorktree('wt-1')
-    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
-    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    beginWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')
+    clearWebRuntimeWakeTerminalRespawnForWorktree('env-1', 'wt-1')
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(false)
+    expect(beginWebRuntimeWakeTerminalRespawn('env-1', 'wt-1')).toBe(true)
+  })
+
+  it("scopes an environment clear to that environment's in-flight guards", () => {
+    // Regression: env A's recycle wiped every environment's guards, letting a
+    // concurrent env B respawn duplicate its terminal.
+    beginWebRuntimeWakeTerminalRespawn('env-a', 'wt-1')
+    beginWebRuntimeWakeTerminalRespawn('env-b', 'wt-1')
+    clearWebRuntimeWakeTerminalRespawnForEnvironment('env-a')
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('env-a', 'wt-1')).toBe(false)
+    expect(shouldSkipWebRuntimeWakeTerminalRespawn('env-b', 'wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('env-b', 'wt-1')).toBe(false)
   })
 })

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
@@ -1,29 +1,50 @@
 const wakeTerminalRespawnInFlightByWorktree = new Set<string>()
 
-export function shouldSkipWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
-  return wakeTerminalRespawnInFlightByWorktree.has(worktreeId)
+// Why: env-scoped keys let one environment's teardown clear only its own
+// in-flight guards instead of releasing every environment's.
+function wakeRespawnKey(environmentId: string, worktreeId: string): string {
+  return `${environmentId}\0${worktreeId}`
 }
 
-export function beginWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
-  if (wakeTerminalRespawnInFlightByWorktree.has(worktreeId)) {
+export function shouldSkipWebRuntimeWakeTerminalRespawn(
+  environmentId: string,
+  worktreeId: string
+): boolean {
+  return wakeTerminalRespawnInFlightByWorktree.has(wakeRespawnKey(environmentId, worktreeId))
+}
+
+export function beginWebRuntimeWakeTerminalRespawn(
+  environmentId: string,
+  worktreeId: string
+): boolean {
+  const key = wakeRespawnKey(environmentId, worktreeId)
+  if (wakeTerminalRespawnInFlightByWorktree.has(key)) {
     return false
   }
-  wakeTerminalRespawnInFlightByWorktree.add(worktreeId)
+  wakeTerminalRespawnInFlightByWorktree.add(key)
   return true
 }
 
-export function endWebRuntimeWakeTerminalRespawn(worktreeId: string): void {
-  wakeTerminalRespawnInFlightByWorktree.delete(worktreeId)
+export function endWebRuntimeWakeTerminalRespawn(environmentId: string, worktreeId: string): void {
+  wakeTerminalRespawnInFlightByWorktree.delete(wakeRespawnKey(environmentId, worktreeId))
 }
 
-export function clearWebRuntimeWakeTerminalRespawnForWorktree(worktreeId: string): void {
-  wakeTerminalRespawnInFlightByWorktree.delete(worktreeId)
+export function clearWebRuntimeWakeTerminalRespawnForWorktree(
+  environmentId: string,
+  worktreeId: string
+): void {
+  wakeTerminalRespawnInFlightByWorktree.delete(wakeRespawnKey(environmentId, worktreeId))
 }
 
-export function clearAllWebRuntimeWakeTerminalRespawn(): void {
-  wakeTerminalRespawnInFlightByWorktree.clear()
+export function clearWebRuntimeWakeTerminalRespawnForEnvironment(environmentId: string): void {
+  const keyPrefix = `${environmentId}\0`
+  for (const key of wakeTerminalRespawnInFlightByWorktree) {
+    if (key.startsWith(keyPrefix)) {
+      wakeTerminalRespawnInFlightByWorktree.delete(key)
+    }
+  }
 }
 
 export function resetWebRuntimeWakeTerminalRespawnForTests(): void {
-  clearAllWebRuntimeWakeTerminalRespawn()
+  wakeTerminalRespawnInFlightByWorktree.clear()
 }

--- a/src/renderer/src/runtime/web-session-close-intent.test.ts
+++ b/src/renderer/src/runtime/web-session-close-intent.test.ts
@@ -4,9 +4,9 @@ import {
   clearWebSessionCloseIntentsForOwner,
   clearWebSessionCloseIntentsForWorktree,
   isWebSessionCloseIntentPending,
-  reconcileWebSessionCloseIntents,
   recordWebSessionCloseIntent,
-  resetWebSessionCloseIntentForTests
+  resetWebSessionCloseIntentForTests,
+  sweepExpiredWebSessionCloseIntents
 } from './web-session-close-intent'
 
 const WT = 'repo::/wt'
@@ -15,13 +15,30 @@ const OWNER = { environmentId: 'runtime-a', pairingRevision: 1 }
 afterEach(() => resetWebSessionCloseIntentForTests())
 
 describe('web session close intent', () => {
-  it('keeps an intent until the host confirms removal', () => {
+  it('keeps suppressing after a tab-absent frame until the TTL expires', () => {
+    // Why: absence in one frame is not proof of completion; a delayed pre-close
+    // frame can still follow, so the intent must outlive the confirming frame.
     recordWebSessionCloseIntent(OWNER, WT, 'host-tab-1', 1000)
-    reconcileWebSessionCloseIntents(OWNER, WT, new Set(['host-tab-1', 'host-tab-2']))
-    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-1', 1000)).toBe(true)
+    sweepExpiredWebSessionCloseIntents(OWNER, WT, 2000)
+    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-1', 2000)).toBe(true)
 
-    reconcileWebSessionCloseIntents(OWNER, WT, new Set(['host-tab-2']))
-    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-1', 1000)).toBe(false)
+    sweepExpiredWebSessionCloseIntents(OWNER, WT, 9000)
+    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-1', 9000)).toBe(true)
+
+    sweepExpiredWebSessionCloseIntents(OWNER, WT, 12_000)
+    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-1', 12_000)).toBe(false)
+  })
+
+  it('sweeps only expired intents within the owner and worktree partition', () => {
+    const otherOwner = { environmentId: 'runtime-b', pairingRevision: 1 }
+    recordWebSessionCloseIntent(OWNER, WT, 'host-tab-old', 1000)
+    recordWebSessionCloseIntent(OWNER, WT, 'host-tab-new', 9000)
+    recordWebSessionCloseIntent(otherOwner, WT, 'host-tab-other', 1000)
+
+    sweepExpiredWebSessionCloseIntents(OWNER, WT, 12_000)
+    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-old', 12_000)).toBe(false)
+    expect(isWebSessionCloseIntentPending(OWNER, WT, 'host-tab-new', 12_000)).toBe(true)
+    expect(isWebSessionCloseIntentPending(otherOwner, WT, 'host-tab-other', 9000)).toBe(true)
   })
 
   it('expires a never-confirmed close', () => {

--- a/src/renderer/src/runtime/web-session-close-intent.ts
+++ b/src/renderer/src/runtime/web-session-close-intent.ts
@@ -53,18 +53,20 @@ export function isWebSessionCloseIntentPending(
   return true
 }
 
-export function reconcileWebSessionCloseIntents(
+// Why: one tab-absent frame is not proof the close completed — a delayed pre-close
+// frame can still follow and resurrect the tab; suppress until the TTL expires.
+export function sweepExpiredWebSessionCloseIntents(
   owner: WebSessionIntentOwner,
   worktreeId: string,
-  presentHostTabIds: ReadonlySet<string>
+  now: number
 ): void {
   const partitionKey = closeIntentPartitionKey(owner, worktreeId)
   const byTab = pendingCloseByOwnerAndWorktree.get(partitionKey)
   if (!byTab) {
     return
   }
-  for (const hostTabId of byTab.keys()) {
-    if (!presentHostTabIds.has(hostTabId)) {
+  for (const [hostTabId, intent] of byTab) {
+    if (now - intent.recordedAt > CLOSE_INTENT_TTL_MS) {
       byTab.delete(hostTabId)
     }
   }

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: these tests cover one reconciliation boundary
  * across ready, pending, split, and batched session snapshots. */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { posix as pathPosix } from 'node:path'
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
 import { makePaneKey } from '../../../shared/stable-pane-id'
@@ -34,6 +34,8 @@ import {
   applyWebSessionTabsSnapshot,
   applyWebSessionTabsSnapshots,
   clearWebSessionTabsTrackingForEnvironment,
+  getLastKnownHostTerminalTabCount,
+  reconcileWebSessionMirrorEnvironmentSync,
   resolveHostSessionTabIdForWebSessionTab,
   resetWebSessionTabsSnapshotFreshnessForTests,
   shouldSyncAllRuntimeSessionTabs,
@@ -279,14 +281,24 @@ describe('applyWebSessionTabsSnapshot', () => {
       toWebTerminalSurfaceTabId('host-tab-1')
     )
 
-    // The host's post-close snapshot omits the tab -> intent clears; a later
-    // snapshot that re-adds the SAME id (a genuinely new tab) is no longer hidden.
+    // A tab-absent frame no longer clears the intent (a delayed pre-close frame
+    // can still follow); a same-id tab stays hidden until the TTL expires, after
+    // which a snapshot that re-adds the SAME id (a genuinely new tab) shows again.
     applyWebSessionTabsSnapshot(makeState(), makeSnapshot([]), ENV, NOW + 1)
+    const stillHidden = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot([surface], { snapshotVersion: 4 }),
+      ENV,
+      NOW + 2
+    )
+    expect((stillHidden.tabsByWorktree?.[WT] ?? []).map((tab) => tab.id)).not.toContain(
+      toWebTerminalSurfaceTabId('host-tab-1')
+    )
     const reopened = applyWebSessionTabsSnapshot(
       makeState(),
       makeSnapshot([surface], { snapshotVersion: 5 }),
       ENV,
-      NOW + 2
+      NOW + 10_001
     )
     expect((reopened.tabsByWorktree?.[WT] ?? []).map((tab) => tab.id)).toContain(
       toWebTerminalSurfaceTabId('host-tab-1')
@@ -3866,5 +3878,285 @@ describe('applyWebSessionTabsSnapshot', () => {
     })
     expect(patch.activeTabId).toBe(mirroredId)
     expect(patch.activeTabIdByWorktree?.[WT]).toBe(mirroredId)
+  })
+})
+
+describe('hydrationPending and fabricated-empty snapshot guards', () => {
+  const readySurface = {
+    type: 'terminal' as const,
+    id: HOST_SURFACE_ID,
+    parentTabId: 'host-tab-1',
+    leafId: LEAF_ID,
+    title: 'Terminal',
+    status: 'ready' as const,
+    terminal: 'term_host',
+    isActive: true
+  }
+
+  beforeEach(() => {
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    resetWebSessionCloseIntentForTests()
+    resetWebSessionFocusIntentForTests()
+    resetWebSessionReorderIntentForTests()
+  })
+
+  it('skips a hydrationPending frame without touching the mirror or the freshness floor', () => {
+    const ready = makeSnapshot([readySurface], { snapshotVersion: 3 })
+    expect(shouldApplyWebSessionTabsSnapshot(ready, ENV)).toBe(true)
+    expect(getLastKnownHostTerminalTabCount(ENV, WT)).toBe(1)
+
+    const pending = makeSnapshot([], {
+      publicationEpoch: 'none',
+      snapshotVersion: 0,
+      hydrationPending: true,
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+    expect(shouldApplyWebSessionTabsSnapshot(pending, ENV)).toBe(false)
+    // Why: the pending frame must not poison the floor or the terminal count.
+    expect(getLastKnownHostTerminalTabCount(ENV, WT)).toBe(1)
+    const state = makeState()
+    expect(applyFreshWebSessionTabsSnapshot(state, pending, ENV, NOW)).toBe(state)
+    // The floor still reflects the last real frame: same-epoch newer frames apply.
+    expect(
+      shouldApplyWebSessionTabsSnapshot(makeSnapshot([readySurface], { snapshotVersion: 4 }), ENV)
+    ).toBe(true)
+  })
+
+  it('skips a hydrationPending frame on any epoch, not only the fabricated one', () => {
+    const pending = makeSnapshot([], {
+      publicationEpoch: 'headless:abc',
+      snapshotVersion: 7,
+      hydrationPending: true,
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+    expect(shouldApplyWebSessionTabsSnapshot(pending, ENV)).toBe(false)
+  })
+
+  it("skips an epoch-'none' empty frame only while the mirror still has terminal tabs", () => {
+    const fabricated = (): RuntimeMobileSessionTabsResult =>
+      makeSnapshot([], {
+        publicationEpoch: 'none',
+        snapshotVersion: 0,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null
+      })
+    // Empty mirror: degrade to current behavior and apply (old-server compatibility).
+    expect(shouldApplyWebSessionTabsSnapshot(fabricated(), ENV)).toBe(true)
+
+    // Non-empty mirror: the fabricated frame must not wipe it, even cross-epoch.
+    expect(shouldApplyWebSessionTabsSnapshot(makeSnapshot([readySurface]), ENV)).toBe(true)
+    expect(shouldApplyWebSessionTabsSnapshot(fabricated(), ENV)).toBe(false)
+    expect(getLastKnownHostTerminalTabCount(ENV, WT)).toBe(1)
+  })
+
+  it('still applies a hydrated genuinely-empty snapshot', () => {
+    expect(shouldApplyWebSessionTabsSnapshot(makeSnapshot([readySurface]), ENV)).toBe(true)
+    const hydratedEmpty = makeSnapshot([], {
+      publicationEpoch: 'epoch-2',
+      snapshotVersion: 1,
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+    expect(shouldApplyWebSessionTabsSnapshot(hydratedEmpty, ENV)).toBe(true)
+  })
+
+  it("skips the projected 'none:client-navigation' empty frame paired clients actually receive", () => {
+    // Regression: per-client projection rewrites the fabricated epoch to
+    // 'none:client-navigation' (version 0 + revision), so a strict 'none'
+    // match never fired for a paired device.
+    const projected = (): RuntimeMobileSessionTabsResult =>
+      makeSnapshot([], {
+        publicationEpoch: 'none:client-navigation',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null
+      })
+    // Empty mirror: degrade to current behavior and apply (old-server compatibility).
+    expect(shouldApplyWebSessionTabsSnapshot(projected(), ENV)).toBe(true)
+
+    // Non-empty mirror: the projected fabricated frame must not wipe it.
+    expect(shouldApplyWebSessionTabsSnapshot(makeSnapshot([readySurface]), ENV)).toBe(true)
+    expect(shouldApplyWebSessionTabsSnapshot(projected(), ENV)).toBe(false)
+    expect(getLastKnownHostTerminalTabCount(ENV, WT)).toBe(1)
+  })
+
+  it('skips a fabricated empty frame when the store still mirrors terminal tabs after a tracking wipe', () => {
+    // Reconnect recycles the terminal counter; the surviving store mirror must
+    // still veto the wipe.
+    const mirroredTab: TerminalTab = {
+      id: toWebTerminalSurfaceTabId('host-tab-1'),
+      ptyId: 'remote-pty-1',
+      worktreeId: WT,
+      title: 'Terminal',
+      defaultTitle: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW
+    }
+    const mirrorState = makeState({
+      tabsByWorktree: { [WT]: [mirroredTab] }
+    })
+    const fabricated = makeSnapshot([], {
+      publicationEpoch: 'none',
+      snapshotVersion: 0,
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null
+    })
+    expect(getLastKnownHostTerminalTabCount(ENV, WT)).toBe(0)
+    expect(shouldApplyWebSessionTabsSnapshot(fabricated, ENV, mirrorState)).toBe(false)
+    expect(applyFreshWebSessionTabsSnapshot(mirrorState, fabricated, ENV, NOW)).toBe(mirrorState)
+  })
+
+  it('skips a fabricated empty frame when the mirror holds only a browser tab', () => {
+    // The remembered count is terminal-only; non-terminal mirrors need the
+    // store-based emptiness check.
+    const workspace: BrowserWorkspace = {
+      id: 'mirror-browser-workspace',
+      worktreeId: WT,
+      activePageId: 'mirror-browser-page',
+      pageIds: ['mirror-browser-page'],
+      url: 'https://example.com/',
+      title: 'Example',
+      loading: false,
+      faviconUrl: null,
+      canGoBack: false,
+      canGoForward: false,
+      loadError: null,
+      createdAt: NOW
+    }
+    const page: BrowserPage = {
+      id: 'mirror-browser-page',
+      workspaceId: workspace.id,
+      worktreeId: WT,
+      url: 'https://example.com/',
+      title: 'Example',
+      loading: false,
+      faviconUrl: null,
+      canGoBack: false,
+      canGoForward: false,
+      loadError: null,
+      createdAt: NOW
+    }
+    const mirrorState = makeState({
+      browserTabsByWorktree: { [WT]: [workspace] },
+      browserPagesByWorkspace: { [workspace.id]: [page] },
+      remoteBrowserPageHandlesByPageId: {
+        [page.id]: { environmentId: ENV, remotePageId: 'host-browser-page' }
+      }
+    })
+    const fabricated = (): RuntimeMobileSessionTabsResult =>
+      makeSnapshot([], {
+        publicationEpoch: 'none:client-navigation',
+        snapshotVersion: 0,
+        activeGroupId: null,
+        activeTabId: null,
+        activeTabType: null
+      })
+    expect(getLastKnownHostTerminalTabCount(ENV, WT)).toBe(0)
+    expect(shouldApplyWebSessionTabsSnapshot(fabricated(), ENV, mirrorState)).toBe(false)
+    // An empty mirror still degrades to current behavior and applies.
+    expect(shouldApplyWebSessionTabsSnapshot(fabricated(), ENV, makeState())).toBe(true)
+  })
+})
+
+describe('reconcileWebSessionMirrorEnvironmentSync', () => {
+  const entryKey = (environmentId: string, connectionGeneration: number): string =>
+    `${environmentId}\u0001runtime-1\u0001${connectionGeneration}\u00015`
+
+  beforeEach(() => {
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    resetWebSessionCloseIntentForTests()
+    resetWebSessionFocusIntentForTests()
+    resetWebSessionReorderIntentForTests()
+    vi.stubGlobal('window', {
+      api: {
+        runtimeEnvironments: {
+          // Why: the sync starter fires listAll/subscribeAll; parking them keeps the test on the reconcile logic.
+          call: vi.fn(() => new Promise(() => {})),
+          subscribe: vi.fn(() => new Promise(() => {}))
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("recycles only the reconnected environment's floors and intents", () => {
+    const disposersByEntryKey = new Map<string, () => void>()
+    reconcileWebSessionMirrorEnvironmentSync({
+      disposersByEntryKey,
+      runtimeSessionMirrorEnvironmentKey: [entryKey('env-a', 1), entryKey('env-b', 1)].join(
+        '\u0000'
+      ),
+      workspaceSessionReady: true
+    })
+    expect([...disposersByEntryKey.keys()]).toEqual([entryKey('env-a', 1), entryKey('env-b', 1)])
+
+    const frame = makeSnapshot([], { activeTabType: null })
+    expect(shouldApplyWebSessionTabsSnapshot(frame, 'env-a')).toBe(true)
+    expect(shouldApplyWebSessionTabsSnapshot(frame, 'env-b')).toBe(true)
+    recordWebSessionCloseIntent({ environmentId: 'env-a', pairingRevision: 5 }, WT, 'tab-a', NOW)
+    recordWebSessionCloseIntent({ environmentId: 'env-b', pairingRevision: 5 }, WT, 'tab-b', NOW)
+
+    // env-a reconnects (connection-generation bump); env-b is unchanged.
+    reconcileWebSessionMirrorEnvironmentSync({
+      disposersByEntryKey,
+      runtimeSessionMirrorEnvironmentKey: [entryKey('env-a', 2), entryKey('env-b', 1)].join(
+        '\u0000'
+      ),
+      workspaceSessionReady: true
+    })
+    expect(new Set(disposersByEntryKey.keys())).toEqual(
+      new Set([entryKey('env-a', 2), entryKey('env-b', 1)])
+    )
+
+    // env-a: floor cleared (the same frame applies again) and its intent dropped.
+    expect(shouldApplyWebSessionTabsSnapshot(frame, 'env-a')).toBe(true)
+    expect(
+      isWebSessionCloseIntentPending(
+        { environmentId: 'env-a', pairingRevision: 5 },
+        WT,
+        'tab-a',
+        NOW + 1
+      )
+    ).toBe(false)
+    // env-b: floor and intent intact.
+    expect(shouldApplyWebSessionTabsSnapshot(frame, 'env-b')).toBe(false)
+    expect(
+      isWebSessionCloseIntentPending(
+        { environmentId: 'env-b', pairingRevision: 5 },
+        WT,
+        'tab-b',
+        NOW + 1
+      )
+    ).toBe(true)
+  })
+
+  it('disposes every environment when the workspace session is no longer ready', () => {
+    const disposersByEntryKey = new Map<string, () => void>()
+    reconcileWebSessionMirrorEnvironmentSync({
+      disposersByEntryKey,
+      runtimeSessionMirrorEnvironmentKey: entryKey('env-a', 1),
+      workspaceSessionReady: true
+    })
+    expect(disposersByEntryKey.size).toBe(1)
+
+    reconcileWebSessionMirrorEnvironmentSync({
+      disposersByEntryKey,
+      runtimeSessionMirrorEnvironmentKey: entryKey('env-a', 1),
+      workspaceSessionReady: false
+    })
+    expect(disposersByEntryKey.size).toBe(0)
   })
 })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- web session-tab sync reconciles terminal, unified-tab, group, and PTY maps atomically to avoid split-brain tab state */
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { AppState } from '../store'
 import { useAppStore } from '../store'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
@@ -58,7 +58,7 @@ import {
   clearWebSessionCloseIntentsForOwner,
   clearWebSessionCloseIntentsForWorktree,
   isWebSessionCloseIntentPending,
-  reconcileWebSessionCloseIntents
+  sweepExpiredWebSessionCloseIntents
 } from './web-session-close-intent'
 import {
   clearWebSessionReorderIntentsForOwner,
@@ -67,7 +67,7 @@ import {
 } from './web-session-reorder-intent'
 import {
   beginWebRuntimeWakeTerminalRespawn,
-  clearAllWebRuntimeWakeTerminalRespawn,
+  clearWebRuntimeWakeTerminalRespawnForEnvironment,
   clearWebRuntimeWakeTerminalRespawnForWorktree,
   endWebRuntimeWakeTerminalRespawn,
   shouldSkipWebRuntimeWakeTerminalRespawn
@@ -217,9 +217,37 @@ export function acceptReplayedWebSessionTabsSnapshot(
   }
 }
 
+// Why: mirrored host-owned tabs surviving in the store are reconnect-proof
+// evidence the host published content for this env+worktree — the terminal
+// counter alone is wiped on environment recycle and blind to browser/editor
+// mirrors.
+function webSessionMirrorHasHostTabs(
+  state: WebSessionTabsSyncState,
+  environmentId: string,
+  worktreeId: string
+): boolean {
+  if ((state.tabsByWorktree[worktreeId] ?? []).some((tab) => isWebTerminalSurfaceTabId(tab.id))) {
+    return true
+  }
+  if (
+    state.openFiles.some(
+      (file) =>
+        file.worktreeId === worktreeId &&
+        file.mirroredFromRuntimeSession === true &&
+        file.runtimeEnvironmentId === environmentId
+    )
+  ) {
+    return true
+  }
+  return (state.browserTabsByWorktree[worktreeId] ?? []).some((workspace) =>
+    browserWorkspaceHasRemoteEnvironmentPage(state, workspace, environmentId)
+  )
+}
+
 export function shouldApplyWebSessionTabsSnapshot(
   snapshot: RuntimeMobileSessionTabsResult,
-  environmentId: string
+  environmentId: string,
+  mirrorState?: WebSessionTabsSyncState
 ): boolean {
   const key = sessionTabsFreshnessKey(environmentId, snapshot.worktree)
   if ((snapshot as { removed?: unknown }).removed === true) {
@@ -230,6 +258,22 @@ export function shouldApplyWebSessionTabsSnapshot(
   }
   if (snapshot.worktree === FLOATING_TERMINAL_WORKTREE_ID) {
     // Why: the floating workspace is a local synthetic terminal; a remote empty same-id snapshot would delete the user's local floating tabs.
+    return false
+  }
+  if (snapshot.hydrationPending === true) {
+    // Why: a not-yet-hydrated host list proves nothing; applying it would wipe the mirror and recording it would poison the freshness floor.
+    return false
+  }
+  if (
+    // Why: per-client projection rewrites the fabricated epoch to
+    // 'none:client-navigation', and every remote client is projected.
+    (snapshot.publicationEpoch === 'none' || snapshot.publicationEpoch.startsWith('none:')) &&
+    snapshot.tabs.length === 0 &&
+    (getLastKnownHostTerminalTabCount(environmentId, snapshot.worktree) > 0 ||
+      (mirrorState !== undefined &&
+        webSessionMirrorHasHostTabs(mirrorState, environmentId, snapshot.worktree)))
+  ) {
+    // Why: old servers fabricate {epoch:'none', tabs:[]} for a missing worktree entry; that must not wipe a non-empty mirror.
     return false
   }
   rememberHostTerminalTabCount(environmentId, snapshot)
@@ -347,7 +391,7 @@ function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeI
   latestSessionTabsSnapshotByWorktree.delete(key)
   replayableSessionTabsSnapshotByWorktree.delete(key)
   lastHostTerminalTabCountByWorktree.delete(key)
-  clearWebRuntimeWakeTerminalRespawnForWorktree(worktreeId)
+  clearWebRuntimeWakeTerminalRespawnForWorktree(environmentId, worktreeId)
   clearWebSessionReorderIntentsForWorktree({ environmentId }, worktreeId)
   clearWebSessionCloseIntentsForWorktree({ environmentId }, worktreeId)
   clearWebAgentSessionHandoffsForWorktree(environmentId, worktreeId)
@@ -386,7 +430,9 @@ export function clearWebSessionTabsTrackingForEnvironment(environmentId: string)
     }
   }
   clearWebAgentSessionHandoffsForEnvironment(trimmedEnvironmentId)
-  clearAllWebRuntimeWakeTerminalRespawn()
+  // Why: another environment's wake respawn may be mid-flight; wiping its guard
+  // would let a duplicate terminal spawn there.
+  clearWebRuntimeWakeTerminalRespawnForEnvironment(trimmedEnvironmentId)
 }
 
 function hostSessionTabMappingKey(args: {
@@ -1760,15 +1806,11 @@ export function applyWebSessionTabsSnapshot(
   if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
     return state
   }
-  // Why: an in-flight pre-close snapshot can flash a closing tab back, so drop tabs the client is closing until the host confirms removal.
+  // Why: an in-flight pre-close snapshot can flash a closing tab back, so drop tabs the client is closing until the intent's TTL expires.
   // Why: key close intents by host session tab id (terminal parentTabId else tab.id), not browserPageId, or browser closes never get suppressed.
   const snapshotHostTabId = (tab: RuntimeMobileSessionTabsResult['tabs'][number]): string =>
     tab.type === 'terminal' ? tab.parentTabId : tab.id
-  reconcileWebSessionCloseIntents(
-    { environmentId },
-    worktreeId,
-    new Set(rawSnapshot.tabs.map((tab) => snapshotHostTabId(tab)))
-  )
+  sweepExpiredWebSessionCloseIntents({ environmentId }, worktreeId, now)
   const snapshot: RuntimeMobileSessionTabsResult = rawSnapshot.tabs.some((tab) =>
     isWebSessionCloseIntentPending({ environmentId }, worktreeId, snapshotHostTabId(tab), now)
   )
@@ -2653,7 +2695,7 @@ export function applyFreshWebSessionTabsSnapshot(
   environmentId: string,
   now = Date.now()
 ): WebSessionTabsSyncState | Partial<WebSessionTabsSyncState> {
-  if (!shouldApplyWebSessionTabsSnapshot(snapshot, environmentId)) {
+  if (!shouldApplyWebSessionTabsSnapshot(snapshot, environmentId, state)) {
     return state
   }
   return applyWebSessionTabsSnapshot(state, snapshot, environmentId, now)
@@ -2666,7 +2708,7 @@ export function applyFreshWebSessionTabsSnapshots(
   now = Date.now()
 ): WebSessionTabsSyncState | Partial<WebSessionTabsSyncState> {
   const freshSnapshots = snapshots.filter((snapshot) =>
-    shouldApplyWebSessionTabsSnapshot(snapshot, environmentId)
+    shouldApplyWebSessionTabsSnapshot(snapshot, environmentId, state)
   )
   return freshSnapshots.length === 0
     ? state
@@ -2686,6 +2728,229 @@ export function applyWebSessionTabsStorePatch(
   // Why: paired-web snapshots bypass setAgentStatus, so arm the stale-boundary timer explicitly like local hook events do.
   if (mirroredAgentStatusChanged) {
     useAppStore.getState().scheduleAgentStatusFreshness()
+  }
+}
+
+type WebSessionMirrorEnvironmentEntry = {
+  environmentId: string
+  expectedEnvironmentPairingRevision: number | undefined
+}
+
+function startWebSessionMirrorEnvironmentSync(entry: WebSessionMirrorEnvironmentEntry): () => void {
+  const { environmentId, expectedEnvironmentPairingRevision } = entry
+  let disposed = false
+  const unsubscribes: (() => void)[] = []
+
+  // Why: the stream's initial snapshot can land after first render, so a one-shot fetch makes initial parity deterministic.
+  void window.api.runtimeEnvironments
+    .call({
+      selector: environmentId,
+      method: 'session.tabs.listAll',
+      params: {},
+      timeoutMs: 15_000,
+      expectedEnvironmentPairingRevision
+    })
+    .then(async (response: RuntimeRpcResponse<unknown>) => {
+      if (
+        disposed ||
+        getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
+      ) {
+        return
+      }
+      if (response.ok === false) {
+        console.warn('[web-session-tabs-sync] initial listAll failed:', response.error.message)
+        return
+      }
+      const result = response.result
+      if (!isSessionTabsListAllResult(result)) {
+        console.warn('[web-session-tabs-sync] initial listAll returned an invalid payload')
+        return
+      }
+      const recovered = await Promise.all(
+        result.snapshots.map((snapshot) =>
+          recoverWebSessionTerminalOrphansBeforeApply(
+            useAppStore.getState(),
+            snapshot,
+            environmentId
+          )
+        )
+      )
+      if (disposed) {
+        return
+      }
+      const applicable = recovered.filter(
+        (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
+      )
+      applyWebSessionTabsStorePatch((state) =>
+        applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
+      )
+    })
+    .catch((error) => {
+      if (!disposed) {
+        console.warn(
+          '[web-session-tabs-sync] failed to load initial session tabs:',
+          error instanceof Error ? error.message : String(error)
+        )
+      }
+    })
+
+  void window.api.runtimeEnvironments
+    .subscribe(
+      {
+        selector: environmentId,
+        method: 'session.tabs.subscribeAll',
+        params: {},
+        timeoutMs: 15_000,
+        expectedEnvironmentPairingRevision
+      },
+      {
+        onResponse: (response: RuntimeRpcResponse<unknown>) => {
+          if (
+            disposed ||
+            getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
+          ) {
+            return
+          }
+          if (response.ok === false) {
+            console.warn(
+              '[web-session-tabs-sync] global subscription failed:',
+              response.error.message
+            )
+            return
+          }
+          const event = response.result as SessionTabsStreamEvent
+          const replayed = isRuntimeSubscriptionReplayResponse(response)
+          if (event.type === 'snapshots') {
+            void Promise.all(
+              event.snapshots.map((snapshot) =>
+                recoverWebSessionTerminalOrphansBeforeApply(
+                  useAppStore.getState(),
+                  snapshot,
+                  environmentId
+                )
+              )
+            )
+              .then((recovered) => {
+                if (!disposed) {
+                  const applicable = recovered.filter(
+                    (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
+                  )
+                  if (replayed) {
+                    for (const snapshot of applicable) {
+                      acceptReplayedWebSessionTabsSnapshot(environmentId, snapshot.worktree)
+                    }
+                  }
+                  applyWebSessionTabsStorePatch((state) =>
+                    applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
+                  )
+                }
+              })
+              .catch((error) => {
+                if (!disposed) {
+                  console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
+                }
+              })
+            return
+          }
+          if (event.type !== 'snapshot' && event.type !== 'updated') {
+            return
+          }
+          void recoverWebSessionTerminalOrphansBeforeApply(
+            useAppStore.getState(),
+            event,
+            environmentId
+          )
+            .then((recovered) => {
+              if (!disposed && recovered) {
+                if (replayed) {
+                  acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
+                }
+                applyWebSessionTabsStorePatch((state) =>
+                  applyFreshWebSessionTabsSnapshot(state, recovered, environmentId)
+                )
+              }
+            })
+            .catch((error) => {
+              if (!disposed) {
+                console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
+              }
+            })
+        },
+        onError: (error) => {
+          console.warn('[web-session-tabs-sync] global subscription error:', error.message)
+        }
+      }
+    )
+    .then((handle) => {
+      if (disposed) {
+        handle.unsubscribe()
+        return
+      }
+      unsubscribes.push(handle.unsubscribe)
+    })
+    .catch((error) => {
+      if (!disposed) {
+        console.warn(
+          '[web-session-tabs-sync] failed to subscribe globally:',
+          error instanceof Error ? error.message : String(error)
+        )
+      }
+    })
+
+  return () => {
+    disposed = true
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe()
+    }
+    // Why: reconnect/pairing churn invalidates only THIS environment's mirror bookkeeping; other environments keep their floors and intents.
+    clearWebSessionTabsTrackingForEnvironment(environmentId)
+    const owner = {
+      environmentId,
+      pairingRevision: expectedEnvironmentPairingRevision
+    }
+    clearWebSessionCloseIntentsForOwner(owner)
+    clearWebSessionFocusIntentsForOwner(owner)
+    clearWebSessionReorderIntentsForOwner(owner)
+  }
+}
+
+export function reconcileWebSessionMirrorEnvironmentSync(args: {
+  disposersByEntryKey: Map<string, () => void>
+  runtimeSessionMirrorEnvironmentKey: string
+  workspaceSessionReady: boolean
+}): void {
+  const { disposersByEntryKey, runtimeSessionMirrorEnvironmentKey, workspaceSessionReady } = args
+  // Why: applying the host snapshot before startup hydration writes browser-local session state clobbers it and leaves the sidebar stale.
+  const nextEntriesByKey = new Map<string, WebSessionMirrorEnvironmentEntry>()
+  if (workspaceSessionReady && runtimeSessionMirrorEnvironmentKey) {
+    for (const entryKey of runtimeSessionMirrorEnvironmentKey.split('\u0000')) {
+      const [environmentId = '', , , rawRevision = ''] = entryKey.split('\u0001')
+      if (
+        !environmentId.trim() ||
+        !shouldSyncAllRuntimeSessionTabs({
+          activeRuntimeEnvironmentId: environmentId,
+          workspaceSessionReady
+        })
+      ) {
+        continue
+      }
+      nextEntriesByKey.set(entryKey, {
+        environmentId,
+        expectedEnvironmentPairingRevision: rawRevision === '' ? undefined : Number(rawRevision)
+      })
+    }
+  }
+  // Why: recycle only the environment whose runtime identity changed — one reconnect must not clear every environment's floors and intents.
+  for (const [entryKey, dispose] of disposersByEntryKey) {
+    if (!nextEntriesByKey.has(entryKey)) {
+      disposersByEntryKey.delete(entryKey)
+      dispose()
+    }
+  }
+  for (const [entryKey, entry] of nextEntriesByKey) {
+    if (!disposersByEntryKey.has(entryKey)) {
+      disposersByEntryKey.set(entryKey, startWebSessionMirrorEnvironmentSync(entry))
+    }
   }
 }
 
@@ -2723,212 +2988,27 @@ export function useWebSessionTabsSync(): void {
   })
   const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
 
+  const mirrorSyncDisposersByEntryKey = useRef(new Map<string, () => void>())
+
   useEffect(() => {
-    const environments = runtimeSessionMirrorEnvironmentKey
-      ? runtimeSessionMirrorEnvironmentKey
-          .split('\u0000')
-          .map((entry) => {
-            const [environmentId = '', , , rawRevision = ''] = entry.split('\u0001')
-            return {
-              environmentId,
-              expectedEnvironmentPairingRevision:
-                rawRevision === '' ? undefined : Number(rawRevision)
-            }
-          })
-          .filter(({ environmentId }) => environmentId.trim())
-      : []
     // Why: mirror all paired runtimes' sessions, not just the selected worktree, so background worktrees don't look asleep (selectedness isn't liveness).
-    // Why: applying the host snapshot before startup hydration writes browser-local session state clobbers it and leaves the sidebar stale.
-    if (!workspaceSessionReady || environments.length === 0) {
-      return
-    }
-
-    let disposed = false
-    const unsubscribes: (() => void)[] = []
-    // Why: the stream's initial snapshot can land after first render, so a one-shot fetch makes initial parity deterministic.
-    for (const { environmentId, expectedEnvironmentPairingRevision } of environments) {
-      if (
-        !shouldSyncAllRuntimeSessionTabs({
-          activeRuntimeEnvironmentId: environmentId,
-          workspaceSessionReady
-        })
-      ) {
-        continue
-      }
-      void window.api.runtimeEnvironments
-        .call({
-          selector: environmentId,
-          method: 'session.tabs.listAll',
-          params: {},
-          timeoutMs: 15_000,
-          expectedEnvironmentPairingRevision
-        })
-        .then(async (response: RuntimeRpcResponse<unknown>) => {
-          if (
-            disposed ||
-            getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
-          ) {
-            return
-          }
-          if (response.ok === false) {
-            console.warn('[web-session-tabs-sync] initial listAll failed:', response.error.message)
-            return
-          }
-          const result = response.result
-          if (!isSessionTabsListAllResult(result)) {
-            console.warn('[web-session-tabs-sync] initial listAll returned an invalid payload')
-            return
-          }
-          const recovered = await Promise.all(
-            result.snapshots.map((snapshot) =>
-              recoverWebSessionTerminalOrphansBeforeApply(
-                useAppStore.getState(),
-                snapshot,
-                environmentId
-              )
-            )
-          )
-          if (disposed) {
-            return
-          }
-          const applicable = recovered.filter(
-            (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
-          )
-          applyWebSessionTabsStorePatch((state) =>
-            applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
-          )
-        })
-        .catch((error) => {
-          if (!disposed) {
-            console.warn(
-              '[web-session-tabs-sync] failed to load initial session tabs:',
-              error instanceof Error ? error.message : String(error)
-            )
-          }
-        })
-
-      void window.api.runtimeEnvironments
-        .subscribe(
-          {
-            selector: environmentId,
-            method: 'session.tabs.subscribeAll',
-            params: {},
-            timeoutMs: 15_000,
-            expectedEnvironmentPairingRevision
-          },
-          {
-            onResponse: (response: RuntimeRpcResponse<unknown>) => {
-              if (
-                disposed ||
-                getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
-              ) {
-                return
-              }
-              if (response.ok === false) {
-                console.warn(
-                  '[web-session-tabs-sync] global subscription failed:',
-                  response.error.message
-                )
-                return
-              }
-              const event = response.result as SessionTabsStreamEvent
-              const replayed = isRuntimeSubscriptionReplayResponse(response)
-              if (event.type === 'snapshots') {
-                void Promise.all(
-                  event.snapshots.map((snapshot) =>
-                    recoverWebSessionTerminalOrphansBeforeApply(
-                      useAppStore.getState(),
-                      snapshot,
-                      environmentId
-                    )
-                  )
-                )
-                  .then((recovered) => {
-                    if (!disposed) {
-                      const applicable = recovered.filter(
-                        (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
-                      )
-                      if (replayed) {
-                        for (const snapshot of applicable) {
-                          acceptReplayedWebSessionTabsSnapshot(environmentId, snapshot.worktree)
-                        }
-                      }
-                      applyWebSessionTabsStorePatch((state) =>
-                        applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
-                      )
-                    }
-                  })
-                  .catch((error) => {
-                    if (!disposed) {
-                      console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
-                    }
-                  })
-                return
-              }
-              if (event.type !== 'snapshot' && event.type !== 'updated') {
-                return
-              }
-              void recoverWebSessionTerminalOrphansBeforeApply(
-                useAppStore.getState(),
-                event,
-                environmentId
-              )
-                .then((recovered) => {
-                  if (!disposed && recovered) {
-                    if (replayed) {
-                      acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
-                    }
-                    applyWebSessionTabsStorePatch((state) =>
-                      applyFreshWebSessionTabsSnapshot(state, recovered, environmentId)
-                    )
-                  }
-                })
-                .catch((error) => {
-                  if (!disposed) {
-                    console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
-                  }
-                })
-            },
-            onError: (error) => {
-              console.warn('[web-session-tabs-sync] global subscription error:', error.message)
-            }
-          }
-        )
-        .then((handle) => {
-          if (disposed) {
-            handle.unsubscribe()
-            return
-          }
-          unsubscribes.push(handle.unsubscribe)
-        })
-        .catch((error) => {
-          if (!disposed) {
-            console.warn(
-              '[web-session-tabs-sync] failed to subscribe globally:',
-              error instanceof Error ? error.message : String(error)
-            )
-          }
-        })
-    }
-
-    return () => {
-      disposed = true
-      for (const unsubscribe of unsubscribes) {
-        unsubscribe()
-      }
-      // Why: environment ids churn as paired runtimes reconnect; don't leak stale tracking for the renderer lifetime.
-      for (const { environmentId, expectedEnvironmentPairingRevision } of environments) {
-        clearWebSessionTabsTrackingForEnvironment(environmentId)
-        const owner = {
-          environmentId,
-          pairingRevision: expectedEnvironmentPairingRevision
-        }
-        clearWebSessionCloseIntentsForOwner(owner)
-        clearWebSessionFocusIntentsForOwner(owner)
-        clearWebSessionReorderIntentsForOwner(owner)
-      }
-    }
+    reconcileWebSessionMirrorEnvironmentSync({
+      disposersByEntryKey: mirrorSyncDisposersByEntryKey.current,
+      runtimeSessionMirrorEnvironmentKey,
+      workspaceSessionReady
+    })
   }, [runtimeSessionMirrorEnvironmentKey, workspaceSessionReady])
+
+  useEffect(() => {
+    const disposersByEntryKey = mirrorSyncDisposersByEntryKey.current
+    return () => {
+      // Why: environment ids churn as paired runtimes reconnect; don't leak stale tracking for the renderer lifetime.
+      for (const dispose of disposersByEntryKey.values()) {
+        dispose()
+      }
+      disposersByEntryKey.clear()
+    }
+  }, [])
 
   useEffect(() => {
     const environmentId = activeWorktreeRuntimeEnvironmentId?.trim()
@@ -2967,8 +3047,8 @@ export function useWebSessionTabsSync(): void {
         acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
       }
       const recoveredEvent: SessionTabsStreamEvent = { ...recovered, type: event.type }
-      const fresh = shouldApplyWebSessionTabsSnapshot(recovered, environmentId)
       const syncState = useAppStore.getState()
+      const fresh = shouldApplyWebSessionTabsSnapshot(recovered, environmentId, syncState)
       const localWorktreeTabs = syncState.tabsByWorktree[activeWorktreeId] ?? []
       const localTerminalCount = localWorktreeTabs.length
       const hasLiveLocalPty = localWorktreeTabs.some(
@@ -2988,7 +3068,7 @@ export function useWebSessionTabsSync(): void {
         snapshotIsFresh: fresh,
         localTerminalCount,
         hasLiveLocalPty,
-        skipWakeRespawn: shouldSkipWebRuntimeWakeTerminalRespawn(activeWorktreeId)
+        skipWakeRespawn: shouldSkipWebRuntimeWakeTerminalRespawn(environmentId, activeWorktreeId)
       })
       if (fresh) {
         applyWebSessionTabsStorePatch((state) =>
@@ -3005,7 +3085,7 @@ export function useWebSessionTabsSync(): void {
       } else if (
         !disposed &&
         shouldRespawnAfterWake &&
-        beginWebRuntimeWakeTerminalRespawn(activeWorktreeId)
+        beginWebRuntimeWakeTerminalRespawn(environmentId, activeWorktreeId)
       ) {
         requestedRespawnAfterWake = true
         await createWebRuntimeSessionTerminal({
@@ -3013,7 +3093,7 @@ export function useWebSessionTabsSync(): void {
           environmentId,
           activate: true,
           selectWorktree: false
-        }).finally(() => endWebRuntimeWakeTerminalRespawn(activeWorktreeId))
+        }).finally(() => endWebRuntimeWakeTerminalRespawn(environmentId, activeWorktreeId))
       }
     }
     void window.api.runtimeEnvironments

--- a/src/renderer/src/runtime/web-session-terminal-orphan-recovery.test.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-recovery.test.ts
@@ -142,6 +142,45 @@ describe('web session terminal orphan recovery', () => {
     )
   })
 
+  it('treats tombstoned host tabs as closed so the frame applies without adoption', async () => {
+    const worktree = 'repo::/worktree'
+    const call = vi.fn()
+    const state = {
+      tabsByWorktree: {
+        [worktree]: [{ id: 'web-terminal-host-tab', worktreeId: worktree } as never]
+      },
+      terminalLayoutsByTabId: {
+        'web-terminal-host-tab': {
+          root: { type: 'leaf' as const, leafId: 'leaf-1' },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: {
+            'leaf-1': toRemoteRuntimePtyId('term_live', 'windows-2')
+          }
+        }
+      },
+      activeTabIdByWorktree: {},
+      activeGroupIdByWorktree: {}
+    }
+    // Why: another device just closed host-tab; its still-dying PTY must not be
+    // treated as a live-unresolved orphan that drops (or re-adopts) this frame.
+    const tombstoned = {
+      worktree,
+      publicationEpoch: 'post-close',
+      snapshotVersion: 3,
+      recentlyClosedTabIds: ['host-tab'],
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null,
+      tabs: []
+    }
+
+    await expect(
+      recoverWebSessionTerminalOrphansBeforeApply(state, tombstoned, 'windows-2', call as never)
+    ).resolves.toEqual(tombstoned)
+    expect(call).not.toHaveBeenCalled()
+  })
+
   it('does not apply absence when an exact recoverable orphan cannot be adopted yet', async () => {
     const worktree = 'repo::/worktree'
     const call = vi.fn(async ({ method }) =>

--- a/src/renderer/src/runtime/web-session-terminal-orphan-recovery.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-recovery.ts
@@ -58,9 +58,12 @@ async function recoverTerminalOrphans(
       .filter((tab) => tab.type === 'terminal')
       .map((tab) => `${tab.parentTabId}\0${tab.leafId}`)
   )
+  // Why: a tombstoned host tab was just closed on another device; its dying PTYs are closed, not adoptable live orphans, so they must not gate the frame.
+  const tombstonedHostTabIds = new Set(snapshot.recentlyClosedTabIds ?? [])
   const candidates = (state.tabsByWorktree[snapshot.worktree] ?? []).filter(
     (tab) =>
       isWebTerminalSurfaceTabId(tab.id) &&
+      !tombstonedHostTabIds.has(toHostSessionTabId(tab.id)) &&
       Object.keys(state.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId ?? {}).some(
         (leafId) => !hostSurfaceKeys.has(`${toHostSessionTabId(tab.id)}\0${leafId}`)
       )

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -332,6 +332,10 @@ export type RuntimeMobileSessionTabsResult = {
   snapshotVersion: number
   /** Live-only targeted command; omitted from durable/list snapshots so reconnect cannot replay navigation. */
   navigationIntent?: 'follow'
+  /** Host has not hydrated this worktree yet; the (possibly empty) list is not authoritative and must not clear a client mirror. */
+  hydrationPending?: true
+  /** Host tabs closed within the tombstone TTL; clients treat their still-dying PTYs as closed, not live orphans. */
+  recentlyClosedTabIds?: readonly string[]
   activeGroupId: string | null
   activeTabId: string | null
   activeTabType: 'terminal' | 'markdown' | 'file' | 'browser' | null


### PR DESCRIPTION
## Problem

When a client is attached to a remote orca server (`orca serve` over the pairing relay), session-tab management is unreliable in ways local desktop use never shows. All of the symptoms below are timing-dependent, so they reproduce intermittently rather than on demand, and they get markedly worse the busier the server is (more session activity means more snapshot publications in flight, which widens every race window) and the more devices are paired. Reproduced on a macOS headless serve host with one and with two paired desktop clients.

- **Creating a session can bump an existing tab off the strip.** Launching a new session sometimes removes the last tab in the worktree. The removed tab is not closed: its agent/PTY keeps running server-side and keeps consuming resources — it has just vanished from the client's mirror, invisibly, with no UI path to bring it back until some unrelated mutation forces a fresh snapshot of that worktree.
- **Switching worktrees flickers or wipes the session list.** Activating a worktree sometimes shows its sessions for a moment and then removes all of them; other times only a subset (in practice the serve/SSH-owned terminals) ever appears, and the remaining sessions never materialize even though they are alive on the host.
- **Closed sessions come back.** Closing a tab looks successful, but after restarting the local client (server untouched) — or sometimes merely re-activating the worktree — the closed tab is back, its session still running on the host. In the worst variants the close never happened server-side at all, and the client showed no indication of the failure.
- **Multiple devices amplify everything.** With two clients attached, closing a tab on one device can freeze the other device's view of that worktree — it silently drops every subsequent snapshot until an unrelated publication lands — and in one deterministic case (a PTY left unbound by a failed post-restart surface restore) a close performed on one device is later resurrected for every device.

The common thread: the client mirrors host session-tab snapshots, and each mechanism meant to keep that mirror consistent — publication-epoch freshness gating, close intents, terminal orphan recovery — assumes conditions the remote/headless path does not actually provide.

## Root causes (each traced end-to-end in code)

1. **The client freshness gate is vacuous against headless servers.** The gate rejects only same-epoch, non-increasing `snapshotVersion` frames — a different `publicationEpoch` always applies (`web-session-tabs-sync.ts`), by design assuming one epoch per host boot (as desktop mode does). The headless server minted a fresh `headless:${Date.now()}` epoch on nearly every mutation (10 sites) plus `headless-hydrated:` and `:headless-merge:` variants, so every in-flight frame was "a new generation" and whichever applied last won. Subscription frames serialize through the orphan-recovery chain, but `session.tabs.list` results apply outside it, so a delayed push frame regularly landed after a newer list result and authoritatively culled fresh tabs.
2. **Not-yet-hydrated worktrees are served as authoritative-empty.** A missing `mobileSessionTabsByWorktree` entry fabricates `{publicationEpoch:'none', tabs:[]}`, which the worktree-activation list path applied with no guard — full wipe until the next real publication. Separately, the runtime-owned (serve/SSH-only) hydrate seeds a subset entry that permanently blocks the full rebuild via an `existing.tabs.length>0` skip — subset lock-in.
3. **User closes are fire-and-forget with volatile guards.** Close intents are in-memory with a 10s TTL; a failed close RPC only `console.warn`s, and restart re-lists the host-authoritative snapshot, deterministically re-materializing the tab. One environment's reconnect also wiped every environment's freshness floors and intents.
4. **No cross-device close tombstone.** After device A closes a tab, device B's orphan recovery sees a still-dying PTY absent from the snapshot and drops every frame for that worktree; a PTY already unbound at close time (failed post-restart restore) escapes the kill entirely and gets re-adopted, resurrecting the closed session fleet-wide.
5. **Per-client navigation projection corrupts the epoch echo.** Projected snapshots carry `${epoch}:client-navigation`, but `session.tabs.closeLifecycle` compared the client's echo against the raw epoch with `!==`, so any projected echo was refused 'stale-publication' and triggered a cluster republish (latent at HEAD; live with older clients).
6. **QuickLaunch's stale-tab prune closes live provisional tabs.** It force-closed every local-UUID `launchAgent` tab pre- and post-create with no liveness/handoff check — hibernation-resumed provisional tabs (appended last in the strip) matched, and with a bound handle the close killed the host session: the one path where creating a session literally destroys a neighbor.
7. **Some server close paths ack without closing.** A headed hub with its window closed no-ops markdown/file closes but returns `{closed:true}`; unbound daemon PTYs escaped the kill scope ("hidden, not closed").
8. **After a host restart, restored tabs never reattach the daemon output stream, and provider snapshots leak a foreign sequence domain.** The boot inventory restores session-tab records as `ready`, but the daemon only streams a session's output to the process that last ran `createOrAttach` — and nothing in the new serve process ever does (headless serve has no renderer, so the renderer spawn/reattach paths that normally do this are unreachable). Subscribers get correct snapshots and zero live bytes: typing executes, but output only appears when a tab switch refetches a snapshot. Compounding it, provider buffer snapshots translated their seq with a defaulted-to-0 offset, publishing the daemon's cumulative counter while live frames carry the boot-local counter reset at startup — so even once a spawn path did attach, the client dedupe baseline armed from the snapshot's foreign seq silently dropped every live frame as already-covered, re-poisoning itself on each snapshot refetch.

## Fixes

**Server** — new `MobileSessionTabsPublicationClock` (`mobile-session-tabs-publication.ts`): one stable epoch per worktree per boot, strictly monotonic `snapshotVersion` across all publish sites (mutations, hydration, merge, recovery); the `:headless-merge:` epoch flip becomes a boot-stable merge signature riding version bumps. Missing-entry results now carry `hydrationPending: true` until a full hydrate (or renderer batch, which is hydration on a headed hub) covers the worktree; the full hydrate rebuilds over runtime-owned-seeded subset entries, preserving live runtime-owned bindings. New `SessionTabCloseTombstoneStore` (30s TTL) records every successful close; `recentlyClosedTabIds` rides every published snapshot, `terminal.list` hides tombstoned PTYs, adoption refuses them, and the unbound-PTY kill scope widens to persisted bindings corroborated by pane incarnations (positive incarnation mismatch is never killed). `closeLifecycle` normalizes a trailing `:client-navigation` before the stale-publication comparison. The notifier-less close branch throws `renderer_unavailable` instead of faking success.

**Client** — `session.tabs.list` results now apply through the same per-worktree serialized chain as subscription frames (gaining its orphan-recovery protection); the post-create refresh uses the after-current-in-flight variant; the agent-handoff confirm only arms when the confirm list actually contains the host tab. Failed user closes recover visibly (accept-replay + refresh + toast) instead of silently diverging; sync tracking, intents, and wake-respawn guards are scoped per environment; `hydrationPending` frames (and `'none'`-epoch empties from older servers, including their `:client-navigation` projections) never clear a non-empty mirror; tombstone-covered candidates let post-close frames apply instead of freezing the worktree. QuickLaunch's prune skips tabs with a recorded handoff or pending create, only prunes tabs that existed before the operation, and never fires host `terminal.close` for pruned local tabs.

**Server, host restart** — `session.tabs.activate` now re-materializes a `ready` tab whose PTY has no provider attachment this boot (`ptyController.hasPty(...) === false`), which reattaches the daemon output stream and runs the provider sequence sync as one operation through the existing spawn pipeline. Provider buffer snapshots omit `seq` until a sequence sync has anchored the provider offset for this boot — clients already treat a seq-less snapshot as baseline-clearing, so live frames flow instead of being dropped against a foreign-domain watermark — and the provider visible-state cache watermarks with the pre-capture boot-local counter so a raced byte invalidates it instead of the foreign seq pinning it fresh forever.

## Compatibility

Both new protocol fields (`hydrationPending`, `recentlyClosedTabIds`) are optional: old clients ignore them (no worse than today), new clients degrade to current behavior against old servers. The stable-epoch change makes old clients' existing gate work correctly rather than requiring anything of them.

## Tests

Each mechanism has regression coverage: publication-clock unit tests (stable epoch, monotonic versions across interleaved sources, reboot behavior), runtime-level epoch-stability sweeps across mutation entry points, hydrationPending/subset-rebuild/authoritative-empty cases, tombstone store + publish + list-hiding + adoption-refusal + unbound-PTY kill, projected-epoch closeLifecycle acceptance, client apply-ordering/serialization, close-failure recovery, per-environment isolation, QuickLaunch prune scenarios, and the host-restart cases (re-materialize on a detached `ready` tab vs spawn-free activation while attached; seq omitted while unanchored vs translated once synced). All touched suites plus `pnpm run typecheck` are green after each commit.

## Real-world verification

Deployed on the original repro environment: `orca serve` running on a Mac mini (M4), with a MacBook attached to it remotely over the pairing relay. With this branch on both ends, the session-loss symptoms no longer reproduce — creating sessions does not bump existing tabs, worktree switching shows the full session list without flicker or wipes, and closed sessions stay closed across local client restarts. Continued use surfaced the host-restart defect (root cause 8): with sessions now surviving a restart of both ends, the restored terminals executed input but rendered no live output until a tab switch. That fix is included in this branch and was verified in the same environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
