### PR TITLE
fix(codex): preserve SSH hook launch context

### DIFF
--- a/src/shared/tui-agent-launch-command.ts
+++ b/src/shared/tui-agent-launch-command.ts
@@ -18,6 +18,57 @@ export type ResolvedAgentLaunchCommand =
     }
   | { ok: false; error: string }
 
+const REMOTE_CODEX_HOOK_FEATURE_ARGS = '${ORCA_AGENT_HOOK_PORT:+--enable hooks}'
+
+function hasCodexHooksFeatureOverride(tokens: readonly string[]): boolean {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    const next = tokens[index + 1]
+    if (
+      ((token === '--enable' || token === '--disable') && next === 'hooks') ||
+      token === '--enable=hooks' ||
+      token === '--disable=hooks' ||
+      ((token === '-c' || token === '--config') && next?.startsWith('features.hooks=')) ||
+      token.startsWith('-cfeatures.hooks=') ||
+      token.startsWith('--config=features.hooks=')
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+function commandHasCodexHooksFeatureOverride(command: string, shell: AgentStartupShell): boolean {
+  if (command.includes(REMOTE_CODEX_HOOK_FEATURE_ARGS)) {
+    return true
+  }
+  const tokenized = tokenizeStartupCommand(command, shell)
+  return tokenized.ok && hasCodexHooksFeatureOverride(tokenized.tokens)
+}
+
+function enableRemoteCodexHooksForOrcaPty(args: {
+  agent: TuiAgent
+  command: string
+  shell: AgentStartupShell
+  isRemote?: boolean
+  trailingTokens?: readonly string[]
+}): string {
+  if (
+    args.agent !== 'codex' ||
+    args.isRemote !== true ||
+    args.shell !== 'posix' ||
+    commandHasCodexHooksFeatureOverride(args.command, args.shell) ||
+    hasCodexHooksFeatureOverride(args.trailingTokens ?? [])
+  ) {
+    return args.command
+  }
+  // Why: remote Codex can reuse a long-lived app-server that predates the PTY
+  // and therefore lacks Orca's per-pane hook env. A launch-only feature flag
+  // keeps hook execution in the PTY environment, while the POSIX expansion
+  // emits no arguments when agent status hooks are disabled for that PTY.
+  return `${args.command} ${REMOTE_CODEX_HOOK_FEATURE_ARGS}`
+}
+
 export function resolveAgentLaunchCommand(args: {
   agent: TuiAgent
   cmdOverrides: Partial<Record<TuiAgent, string>>
@@ -48,9 +99,18 @@ export function resolveAgentLaunchCommand(args: {
     args.sessionOptions,
     trailingTokens.tokens
   )
+  const hookAwareCommand = enableRemoteCodexHooksForOrcaPty({
+    agent: args.agent,
+    command,
+    shell: args.shell,
+    isRemote: args.isRemote,
+    trailingTokens: trailingTokens.tokens
+  })
   const optionSuffix = resolvedOptions.args.map((arg) => quoteStartupArg(arg, args.shell)).join(' ')
-  const commandWithOptions = optionSuffix ? `${command} ${optionSuffix}` : command
-  const commandWithoutSessionOptions = suffix.suffix ? `${command} ${suffix.suffix}` : command
+  const commandWithOptions = optionSuffix ? `${hookAwareCommand} ${optionSuffix}` : hookAwareCommand
+  const commandWithoutSessionOptions = suffix.suffix
+    ? `${hookAwareCommand} ${suffix.suffix}`
+    : hookAwareCommand
   // Why: session flags precede the free-form suffix so the user's explicit
   // repeated flag remains the final, winning occurrence.
   return {

--- a/src/shared/tui-agent-remote-codex-hooks.test.ts
+++ b/src/shared/tui-agent-remote-codex-hooks.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentResumeStartupPlan, buildAgentStartupPlan } from './tui-agent-startup'
+
+describe('remote Codex hook launch', () => {
+  it('enables hooks only when a remote Codex PTY exposes Orca hook coordinates', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+      platform: 'darwin',
+      isRemote: true
+    })
+
+    expect(plan?.launchCommand).toBe(
+      "codex ${ORCA_AGENT_HOOK_PORT:+--enable hooks} '--dangerously-bypass-approvals-and-sandbox' 'fix it'"
+    )
+    expect(plan?.launchConfig.agentCommand).toBe(
+      "codex ${ORCA_AGENT_HOOK_PORT:+--enable hooks} '--dangerously-bypass-approvals-and-sandbox'"
+    )
+  })
+
+  it('preserves an explicit remote Codex hooks disable override', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      agentArgs: '--dangerously-bypass-approvals-and-sandbox --disable hooks',
+      platform: 'linux',
+      isRemote: true
+    })
+
+    expect(plan?.launchCommand).toBe(
+      "codex '--dangerously-bypass-approvals-and-sandbox' '--disable' 'hooks' 'fix it'"
+    )
+  })
+
+  it('preserves an explicit remote Codex hooks config in a command override', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: { codex: 'codex --config features.hooks=false' },
+      platform: 'linux',
+      isRemote: true
+    })
+
+    expect(plan?.launchCommand).toBe("codex --config features.hooks=false 'fix it'")
+  })
+
+  it('does not alter local Codex launches', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform: 'darwin'
+    })
+
+    expect(plan?.launchCommand).toBe("codex 'fix it'")
+  })
+
+  it('does not add POSIX hook arguments to Windows remotes', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform: 'win32',
+      isRemote: true
+    })
+
+    expect(plan?.launchCommand).toBe("codex 'fix it'")
+  })
+
+  it('upgrades a captured remote Codex command when resuming an older session', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      agentCommand: 'codex --profile captured',
+      platform: 'linux',
+      isRemote: true
+    })
+
+    expect(plan?.launchCommand).toBe(
+      "codex --profile captured ${ORCA_AGENT_HOOK_PORT:+--enable hooks} 'resume' 's1'"
+    )
+    expect(plan?.launchConfig.agentCommand).toBe(
+      'codex --profile captured ${ORCA_AGENT_HOOK_PORT:+--enable hooks}'
+    )
+  })
+
+  it('does not duplicate the remote hook guard in a captured command', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: {},
+      agentCommand: 'codex ${ORCA_AGENT_HOOK_PORT:+--enable hooks}',
+      platform: 'linux',
+      isRemote: true
+    })
+
+    expect(plan?.launchCommand).toBe("codex ${ORCA_AGENT_HOOK_PORT:+--enable hooks} 'resume' 's1'")
+  })
+})

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -205,16 +205,16 @@ export function buildAgentResumeStartupPlan(args: {
   const shell = resolveStartupShell(args.platform, args.shell)
   const config = TUI_AGENT_CONFIG[args.agent]
   const resolvedAgentCommand = args.agentCommand?.trim()
-  const baseCommand = resolvedAgentCommand
-    ? ({ ok: true, command: resolvedAgentCommand } as const)
-    : resolveAgentLaunchCommand({
-        agent: args.agent,
-        cmdOverrides: args.cmdOverrides,
-        platform: args.platform,
-        shell,
-        agentArgs: args.agentArgs,
-        isRemote: args.isRemote
-      })
+  const baseCommand = resolveAgentLaunchCommand({
+    agent: args.agent,
+    cmdOverrides: resolvedAgentCommand
+      ? { ...args.cmdOverrides, [args.agent]: resolvedAgentCommand }
+      : args.cmdOverrides,
+    platform: args.platform,
+    shell,
+    agentArgs: resolvedAgentCommand ? null : args.agentArgs,
+    isRemote: args.isRemote
+  })
   if (!baseCommand.ok) {
     return null
   }


### PR DESCRIPTION
## Summary

Fixes #11941.

On Orca v1.4.163/current `main`, an interactive Codex TUI launched in an SSH worktree can reuse a long-lived `codex app-server` that predates the pane. The TUI process has Orca's pane-scoped hook environment, but the app-server does not, so the managed hook script silently exits and Orca receives no Codex session/status events.

This patch keeps the fix in the shared launch planner:

- remote POSIX Codex launches conditionally expand `--enable hooks` only when `ORCA_AGENT_HOOK_PORT` exists in that PTY;
- local Codex, non-Codex agents, and Windows remotes are unchanged;
- explicit user `--disable hooks` and `features.hooks=false` overrides remain authoritative;
- commands captured before this fix are upgraded when an SSH Codex session resumes;
- newly captured commands retain the guarded launch context without duplicating it.

The scope is intentionally small: no relay protocol, hook installer, trust store, settings migration, or renderer behavior changes.

## User-visible reproduction

Current latest Orca and the same project/account configuration:

| Execution path | Claude | Codex |
| --- | --- | --- |
| Local worktree | ✅ shown | ✅ shown |
| SSH worktree | ✅ shown | ❌ no authoritative session/status row |

Codex remains usable in the terminal and writes its JSONL transcript. What is missing is the hook/provider-session signal used by the left project/worktree row and by Agent Session History's forced refresh/original-pane mapping.

Environment used for the root-cause check:

- Orca v1.4.163
- upstream `main` at `16c5526dfda787ee3bac9925532abc2c39b78fc5`
- Codex CLI 0.146.0
- macOS client and SSH execution host

## Root cause evidence

The SSH PTY had the correct `ORCA_AGENT_HOOK_*`, pane, tab, worktree, and launch-token variables. The remote `hooks.json`, managed script, relay endpoint, and Codex trust state were all valid.

The long-lived `codex app-server --listen unix://` had none of the pane-scoped Orca variables.

| Real Codex invocation | Hook events received |
| --- | ---: |
| Interactive `codex` | **0** |
| `codex exec --ephemeral` | **3** |
| Interactive `codex --enable hooks` | **3**: SessionStart, UserPromptSubmit, Stop |

This matches the Codex upstream environment-contract discussion: a reused daemon retains its earlier environment, while a launcher carrying a config override follows the launch context: https://github.com/openai/codex/discussions/26901

## Why the guard is conditional

`${ORCA_AGENT_HOOK_PORT:+--enable hooks}` is expanded by the remote POSIX shell:

- status hooks enabled for the PTY → two arguments, `--enable hooks`;
- status hooks disabled/no Orca receiver → no arguments.

This avoids globally enabling user hooks when Orca's status-hook path is disabled. Explicit hook feature flags in either the command override or user CLI arguments are detected first and left untouched.

## Related work

| Item | Solved | Still outside that fix |
| --- | --- | --- |
| #1865 | SSH hook transport and synthetic Codex POST round trip. | Did not verify a real interactive Codex TUI callback; the real run stopped at sign-in. |
| #2123 | Remote install ordering and early status hydration. | Cannot restore an event the app-server never emits. |
| #7164 / #7367 | Host-aware SSH Agent Session History scanning/resume. | Does not restore the live provider-session hook signal. |
| #7253 / #7744 | Same SSH visibility matrix; fixed Droid/Copilot installer registration. | Codex was judged working from install/synthetic evidence, not the reused app-server path. |
| #7829 / #7873 | Replayed remote status received before pane hydration. | Assumes a hook event exists. |
| #6907 / #7969 | WSL Codex hook home and loopback bridge. | WSL-specific, not POSIX SSH app-server reuse. |
| #8711 / #8848 | Remote hook installation diagnosis and host-aware status reporting. | #8848 is explicitly diagnostic; current main can install/trust hooks while the TUI still emits zero events. |
| #8763 | Open SSH Codex recognition report. | Lacked an SSH root-cause reproduction; #11941 may explain it. |
| #9646 / #9647 | Working-row title fallback for hookless SSH Codex. | Masks one renderer symptom without restoring the lifecycle/provider session. |
| #10130 / #10178 | Idle-row fallback after an SSH Codex turn. | Also does not restore hook execution. |
| #9236 / #9237 | Analogous daemon-environment bug in newer Claude Code. | Claude-specific attribution mechanism; no Codex launch change. |

Follow-up to #8711; complementary to #8848, #9647, and #10178. Likely relevant to #8763.

## Validation

- `vitest`: 4 files, **90 tests passed**
  - new remote Codex launch
  - local launch unchanged
  - Windows remote unchanged
  - explicit disable/config override preserved
  - older captured resume command upgraded
  - guard not duplicated on later resume
- `pnpm run typecheck:node`
- targeted `oxlint --deny-warnings`
- targeted `oxfmt --check`
- `git diff --check`
- POSIX expansion check with `ORCA_AGENT_HOOK_PORT` both unset and set
- live authenticated Codex TUI comparison shown above

## Security

No new endpoint, credential, file write, or IPC surface. The fixed shell fragment contains only a constant environment-variable name and constant Codex arguments. Existing user hook feature overrides keep precedence.

## Screenshots

No new UI. This restores the existing hook-backed session/status behavior for SSH Codex.
