### PR TITLE
fix(crash-reporting): stop prompting for renderer crashes auto-recovery already healed

### DIFF
--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -110,6 +110,21 @@ describe('CrashReportStore', () => {
     await expect(store.getLatestPending()).resolves.toBeNull()
   })
 
+  it('never sweeps a React error-boundary report, even when it matches the crash event', async () => {
+    const { store } = await createStore()
+    // Same reason/exitCode as the process crash: the guard must not depend on
+    // the boundary reason literal staying distinct from Electron's exit reasons.
+    const boundary = await store.record({ ...input(), processType: 'react-render' })
+    await store.record(input())
+
+    await store.markRendererCrashesAutoRecovered(Date.parse(boundary.createdAt) - 1_000)
+
+    await expect(store.getLatestPending()).resolves.toMatchObject({
+      id: boundary.id,
+      status: 'pending'
+    })
+  })
+
   it('dismisses sibling pending records after one crash report is sent', async () => {
     const { store } = await createStore()
     await store.record(input())

--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -48,6 +48,7 @@ function input(reason = 'crashed'): CrashReportCreateInput {
 }
 
 afterEach(async () => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   grantDirAclAsyncMock.mockReset()
   grantDirAclAsyncMock.mockResolvedValue(undefined)
@@ -123,6 +124,29 @@ describe('CrashReportStore', () => {
       id: boundary.id,
       status: 'pending'
     })
+  })
+
+  it('never sweeps a renderer crash the auto-recovery cutoff excluded', async () => {
+    const { store } = await createStore()
+    // Why fake Date: the sweep matches within 5s of an anchor, so the two
+    // records must sit on either side of the cutoff by construction.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    const startedAtMs = Date.parse('2026-08-01T00:00:00.000Z')
+    vi.setSystemTime(startedAtMs)
+    const stale = await store.record(input())
+    vi.setSystemTime(startedAtMs + 4_000)
+    const anchor = await store.record(input())
+
+    // The reload was armed 6s after the stale crash, so only the anchor is in scope.
+    await store.markRendererCrashesAutoRecovered(startedAtMs + 1_000)
+
+    const reports = await store.listRecent()
+    expect(reports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: anchor.id, status: 'dismissed' }),
+        expect.objectContaining({ id: stale.id, status: 'pending' })
+      ])
+    )
   })
 
   it('dismisses sibling pending records after one crash report is sent', async () => {

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -158,7 +158,25 @@ export class CrashReportStore {
         resolved.push(recovered)
         return recovered
       })
-      return { reports: nextReports, result: resolved }
+      if (resolved.length === 0) {
+        return { reports: nextReports, result: resolved }
+      }
+      // Why: one kill burst can emit a Utility/GPU exit alongside the renderer's.
+      // dismiss() already sweeps those siblings; without the same sweep here the
+      // healed crash still reaches the user, just wearing the sibling's report.
+      const anchors = [...resolved]
+      const sweptReports = nextReports.map((report) => {
+        if (report.status !== 'pending') {
+          return report
+        }
+        if (!anchors.some((anchor) => isRelatedCrashEvent(anchor, report))) {
+          return report
+        }
+        const swept: CrashReportRecord = { ...report, status: 'dismissed' }
+        resolved.push(swept)
+        return swept
+      })
+      return { reports: sweptReports, result: resolved }
     })
   }
 

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -166,7 +166,13 @@ export class CrashReportStore {
       // healed crash still reaches the user, just wearing the sibling's report.
       const anchors = [...resolved]
       const sweptReports = nextReports.map((report) => {
-        if (report.status !== 'pending') {
+        // Why: relation matching ignores processType, so re-state the anchor
+        // pass's exclusion — a renderer-sourced report that is not the renderer
+        // process is the error boundary reporting itself, not a burst sibling.
+        if (
+          report.status !== 'pending' ||
+          (report.source === 'renderer' && report.processType !== 'renderer')
+        ) {
           return report
         }
         if (!anchors.some((anchor) => isRelatedCrashEvent(anchor, report))) {

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -126,6 +126,35 @@ export class CrashReportStore {
     return this.transitionPending(id, 'dismissed')
   }
 
+  /**
+   * Resolve pending renderer crashes that an auto-recovery reload healed.
+   *
+   * Why: `dismissed` keeps the record sendable from Help > Report Crash while
+   * taking it out of the startup prompt; the detail flag preserves the reason.
+   */
+  async markRendererCrashesAutoRecovered(notBeforeMs: number): Promise<CrashReportRecord[]> {
+    return this.withWrite(async (reports) => {
+      const resolved: CrashReportRecord[] = []
+      const nextReports = reports.map((report) => {
+        if (report.status !== 'pending' || report.source !== 'renderer') {
+          return report
+        }
+        const createdAtMs = Date.parse(report.createdAt)
+        if (!Number.isFinite(createdAtMs) || createdAtMs < notBeforeMs) {
+          return report
+        }
+        const recovered: CrashReportRecord = {
+          ...report,
+          status: 'dismissed',
+          details: { ...report.details, rendererAutoRecovered: true }
+        }
+        resolved.push(recovered)
+        return recovered
+      })
+      return { reports: nextReports, result: resolved }
+    })
+  }
+
   async formatDiagnosticText(id: string, notes?: string): Promise<string | null> {
     const reports = await this.readReports()
     const report = reports.find((candidate) => candidate.id === id)

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -166,13 +166,12 @@ export class CrashReportStore {
       // healed crash still reaches the user, just wearing the sibling's report.
       const anchors = [...resolved]
       const sweptReports = nextReports.map((report) => {
-        // Why: relation matching ignores processType, so re-state the anchor
-        // pass's exclusion — a renderer-sourced report that is not the renderer
-        // process is the error boundary reporting itself, not a burst sibling.
-        if (
-          report.status !== 'pending' ||
-          (report.source === 'renderer' && report.processType !== 'renderer')
-        ) {
+        // Why: no renderer-sourced report is a burst sibling. The anchor pass
+        // already ruled on the renderer process, and relation matching (which
+        // ignores processType and reaches 5s either side of an anchor) would
+        // otherwise re-admit the older crashes `notBeforeMs` just excluded, or
+        // an error-boundary report that no reload caused.
+        if (report.status !== 'pending' || report.source === 'renderer') {
           return report
         }
         if (!anchors.some((anchor) => isRelatedCrashEvent(anchor, report))) {

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -136,7 +136,14 @@ export class CrashReportStore {
     return this.withWrite(async (reports) => {
       const resolved: CrashReportRecord[] = []
       const nextReports = reports.map((report) => {
-        if (report.status !== 'pending' || report.source !== 'renderer') {
+        // Why: `source: 'renderer'` also covers React error-boundary reports
+        // (processType 'react-render'), which the recovery reload did not cause
+        // and must keep prompting on their own evidence.
+        if (
+          report.status !== 'pending' ||
+          report.source !== 'renderer' ||
+          report.processType !== 'renderer'
+        ) {
           return report
         }
         const createdAtMs = Date.parse(report.createdAt)

--- a/src/main/crash-reporting/renderer-recovery-crash-outcome.ts
+++ b/src/main/crash-reporting/renderer-recovery-crash-outcome.ts
@@ -13,6 +13,16 @@ export function noteRendererRecoveryReloadIssued(nowMs = Date.now()): void {
   recoveryReloadIssuedAtMs = nowMs
 }
 
+/**
+ * Disarm the outcome check because auto-recovery gave up.
+ *
+ * Why: the next bootstrap then comes from the user's own retry, and a crash the
+ * breaker refused to keep reloading is the one they most need prompted about.
+ */
+export function clearRendererRecoveryReloadIssued(): void {
+  recoveryReloadIssuedAtMs = null
+}
+
 function takeRendererRecoveryReloadIssuedAt(nowMs: number): number | null {
   const issuedAtMs = recoveryReloadIssuedAtMs
   recoveryReloadIssuedAtMs = null
@@ -55,5 +65,5 @@ export function resolveRecoveredRendererCrashReports(
 }
 
 export function _resetRendererRecoveryOutcomeForTests(): void {
-  recoveryReloadIssuedAtMs = null
+  clearRendererRecoveryReloadIssued()
 }

--- a/src/main/crash-reporting/renderer-recovery-crash-outcome.ts
+++ b/src/main/crash-reporting/renderer-recovery-crash-outcome.ts
@@ -7,6 +7,12 @@ export const RENDERER_BOOTSTRAP_RENDERED_BREADCRUMB = 'renderer_bootstrap_render
 // has to survive a loaded machine, and must expire before an unrelated boot.
 const RENDERER_RECOVERY_OUTCOME_WINDOW_MS = 30_000
 
+// Why not the window above: that bounds how long an arm stays valid, this bounds
+// how far back the arm may credit crashes — different jobs. The reload is armed
+// 250ms after its crash, so only that crash's own kill burst is ever in scope;
+// reusing the 30s window dismissed older, unhealed crashes as auto-recovered.
+const RENDERER_RECOVERY_CRASH_LOOKBACK_MS = 5_000
+
 let recoveryReloadIssuedAtMs: number | null = null
 
 export function noteRendererRecoveryReloadIssued(nowMs = Date.now()): void {
@@ -49,7 +55,7 @@ export function resolveRecoveredRendererCrashReports(
     return
   }
   void store
-    .markRendererCrashesAutoRecovered(issuedAtMs - RENDERER_RECOVERY_OUTCOME_WINDOW_MS)
+    .markRendererCrashesAutoRecovered(issuedAtMs - RENDERER_RECOVERY_CRASH_LOOKBACK_MS)
     .then((resolved) => {
       if (resolved.length === 0) {
         return

--- a/src/main/crash-reporting/renderer-recovery-crash-outcome.ts
+++ b/src/main/crash-reporting/renderer-recovery-crash-outcome.ts
@@ -1,0 +1,59 @@
+import type { CrashReportStore } from './crash-report-store'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+
+export const RENDERER_BOOTSTRAP_RENDERED_BREADCRUMB = 'renderer_bootstrap_rendered'
+
+// Why: field traces show crash -> reload -> React bootstrap under 1.5s; this only
+// has to survive a loaded machine, and must expire before an unrelated boot.
+const RENDERER_RECOVERY_OUTCOME_WINDOW_MS = 30_000
+
+let recoveryReloadIssuedAtMs: number | null = null
+
+export function noteRendererRecoveryReloadIssued(nowMs = Date.now()): void {
+  recoveryReloadIssuedAtMs = nowMs
+}
+
+function takeRendererRecoveryReloadIssuedAt(nowMs: number): number | null {
+  const issuedAtMs = recoveryReloadIssuedAtMs
+  recoveryReloadIssuedAtMs = null
+  if (issuedAtMs === null || nowMs - issuedAtMs > RENDERER_RECOVERY_OUTCOME_WINDOW_MS) {
+    return null
+  }
+  return issuedAtMs
+}
+
+type RecoveredCrashReportStore = Pick<CrashReportStore, 'markRendererCrashesAutoRecovered'>
+
+/**
+ * Resolve renderer crash reports that an auto-recovery reload actually healed.
+ *
+ * Why: this must stay synchronous up to the store call so the write is queued
+ * before the recovered renderer's getLatestPending read drains the same chain.
+ */
+export function resolveRecoveredRendererCrashReports(
+  store: RecoveredCrashReportStore,
+  nowMs = Date.now()
+): void {
+  const issuedAtMs = takeRendererRecoveryReloadIssuedAt(nowMs)
+  if (issuedAtMs === null) {
+    return
+  }
+  void store
+    .markRendererCrashesAutoRecovered(issuedAtMs - RENDERER_RECOVERY_OUTCOME_WINDOW_MS)
+    .then((resolved) => {
+      if (resolved.length === 0) {
+        return
+      }
+      recordDurableCrashBreadcrumb('renderer_crash_auto_recovered', {
+        resolvedReportCount: resolved.length,
+        recoveryLatencyMs: nowMs - issuedAtMs
+      })
+    })
+    .catch((error) => {
+      console.error('[crash-reporting] Failed to resolve auto-recovered crash reports:', error)
+    })
+}
+
+export function _resetRendererRecoveryOutcomeForTests(): void {
+  recoveryReloadIssuedAtMs = null
+}

--- a/src/main/crash-reporting/renderer-recovery-outcome-wiring.test.ts
+++ b/src/main/crash-reporting/renderer-recovery-outcome-wiring.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why a source-text test: the arm/disarm calls live in closures built inside
+// openMainWindow(), and nothing can import src/main/index.ts (app-level side
+// effects at module scope). Unit tests pin the module's behaviour; only this
+// pins that index.ts still calls it, which a revert experiment showed no other
+// test in src/main does.
+describe('renderer recovery outcome wiring in index.ts', () => {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+
+  function sliceBlock(startAnchor: string, endAnchor: string, from = 0): string {
+    const start = source.indexOf(startAnchor, from)
+    expect(start).toBeGreaterThanOrEqual(0)
+    const end = source.indexOf(endAnchor, start)
+    // Why: an unresolved end anchor slices to EOF and passes against unrelated code.
+    expect(end).toBeGreaterThan(start)
+    return source.slice(start, end)
+  }
+
+  it('arms the outcome check on the auto-recovery reload', () => {
+    const block = sliceBlock(
+      'onBeforeRecoveryReload: (webContentsId) => {',
+      "recordDurableCrashBreadcrumb('renderer_recovery_reload')"
+    )
+
+    expect(block).toContain('noteRendererRecoveryReloadIssued()')
+  })
+
+  it('disarms before prompting when the recovery breaker gives up', () => {
+    const block = sliceBlock(
+      'onRendererRecoveryExhausted: ({ details, recentRecoveryCount }) => {',
+      'void presentRendererRecoveryPrompt(recentRecoveryCount)'
+    )
+
+    expect(block).toContain('clearRendererRecoveryReloadIssued()')
+  })
+
+  it('disarms on every user-initiated reload of the main window', () => {
+    const reloadAnchor = 'onBeforeReload: ({ ignoreCache, webContentsId }) => {'
+    // Why: createMainWindow's force-reload shortcut and the app menu wire this
+    // separately, so a disarm on only one of them still mis-stamps the other.
+    const firstStart = source.indexOf(reloadAnchor)
+    const secondStart = source.indexOf(reloadAnchor, firstStart + reloadAnchor.length)
+    expect(secondStart).toBeGreaterThan(firstStart)
+    expect(source.indexOf(reloadAnchor, secondStart + reloadAnchor.length)).toBe(-1)
+
+    for (const from of [firstStart, secondStart]) {
+      const block = sliceBlock(
+        reloadAnchor,
+        "recordCrashBreadcrumb('manual_reload_requested', { ignoreCache })",
+        from
+      )
+      // Why slice the guard rather than the whole block: the app menu reloads
+      // whichever window has focus, so a disarm outside this check would let a
+      // dashboard pop-out reload throw away the main renderer's pending arm.
+      const guardStart = block.indexOf('if (mainWindow?.webContents.id === webContentsId) {')
+      expect(guardStart).toBeGreaterThanOrEqual(0)
+      const guard = block.slice(guardStart, block.lastIndexOf('}'))
+
+      expect(guard).toContain('markExpectedRendererReload(webContentsId)')
+      expect(guard).toContain('clearRendererRecoveryReloadIssued()')
+    }
+  })
+})

--- a/src/main/crash-reporting/renderer-recovery-outcome-wiring.test.ts
+++ b/src/main/crash-reporting/renderer-recovery-outcome-wiring.test.ts
@@ -37,6 +37,18 @@ describe('renderer recovery outcome wiring in index.ts', () => {
     expect(block).toContain('clearRendererRecoveryReloadIssued()')
   })
 
+  // Why this carries the invariant: every manual main-window reload marks an
+  // expected reload, so disarming in the marker covers all of them at once —
+  // including a future site that would otherwise repeat the round-5 miss.
+  it('disarms inside markExpectedRendererReload itself', () => {
+    const block = sliceBlock(
+      'function markExpectedRendererReload(webContentsId: number, durationMs = 10_000): void {',
+      '\nfunction clearExpectedRendererReload'
+    )
+
+    expect(block).toContain('clearRendererRecoveryReloadIssued()')
+  })
+
   it('disarms on every user-initiated reload of the main window', () => {
     const reloadAnchor = 'onBeforeReload: ({ ignoreCache, webContentsId }) => {'
     // Why: createMainWindow's force-reload shortcut and the app menu wire this
@@ -59,8 +71,31 @@ describe('renderer recovery outcome wiring in index.ts', () => {
       expect(guardStart).toBeGreaterThanOrEqual(0)
       const guard = block.slice(guardStart, block.lastIndexOf('}'))
 
+      // The disarm rides on this call — see the markExpectedRendererReload test.
       expect(guard).toContain('markExpectedRendererReload(webContentsId)')
-      expect(guard).toContain('clearRendererRecoveryReloadIssued()')
     }
+  })
+
+  // Why: `app:reload` is a third manual-reload path with a different callback
+  // name, so the two `onBeforeReload` sites above do not cover it.
+  it('disarms on the renderer-initiated app:reload of the main window', () => {
+    const block = sliceBlock(
+      'onBeforeRendererReload: ({ ignoreCache, webContentsId }) => {',
+      "recordCrashBreadcrumb('renderer_reload_requested', { ignoreCache })"
+    )
+    const guardStart = block.indexOf('if (window.webContents.id === webContentsId) {')
+    expect(guardStart).toBeGreaterThanOrEqual(0)
+    const guard = block.slice(guardStart, block.lastIndexOf('}'))
+
+    // The disarm rides on this call — see the markExpectedRendererReload test.
+    expect(guard).toContain('markExpectedRendererReload(webContentsId)')
+  })
+
+  // Why: a replacement main window bootstraps a renderer the dead window's
+  // recovery reload never produced, so it must not consume that window's arm.
+  it('disarms before the first load of a replacement main window', () => {
+    const block = sliceBlock("logStartupMilestone('load-start')", 'loadMainWindow(window)')
+
+    expect(block).toContain('clearRendererRecoveryReloadIssued()')
   })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -281,6 +281,7 @@ import {
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
+import { noteRendererRecoveryReloadIssued } from './crash-reporting/renderer-recovery-crash-outcome'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
@@ -1246,6 +1247,8 @@ function openMainWindow(): BrowserWindow {
     // Why: the recovery reload re-fires did-finish-load; flag it so the local-PTY orphan sweep skips that reload (#5787).
     onBeforeRecoveryReload: (webContentsId) => {
       markRecoveryReloadInFlight(webContentsId)
+      // Why: arm the outcome check before the reload so a crash this heals never prompts the user.
+      noteRendererRecoveryReloadIssued()
       recordDurableCrashBreadcrumb('renderer_recovery_reload')
     }
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -281,7 +281,10 @@ import {
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
-import { noteRendererRecoveryReloadIssued } from './crash-reporting/renderer-recovery-crash-outcome'
+import {
+  clearRendererRecoveryReloadIssued,
+  noteRendererRecoveryReloadIssued
+} from './crash-reporting/renderer-recovery-crash-outcome'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
@@ -1228,6 +1231,9 @@ function openMainWindow(): BrowserWindow {
         expectedTeardown: getExpectedTeardownScope(webContentsId)
       }),
     onRendererRecoveryExhausted: ({ details, recentRecoveryCount }) => {
+      // Why: the pending arm belongs to a reload that never brought the renderer
+      // back, so the user's retry below must not resolve these as auto-recovered.
+      clearRendererRecoveryReloadIssued()
       recordDurableCrashBreadcrumb('renderer_recovery_circuit_breaker_open', {
         reason: details.reason,
         exitCode: details.exitCode ?? null,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1247,6 +1247,9 @@ function openMainWindow(): BrowserWindow {
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
       if (mainWindow?.webContents.id === webContentsId) {
         markExpectedRendererReload(webContentsId)
+        // Why: the user reloading by hand makes the next bootstrap their retry, so a
+        // recovery reload that stalled short of bootstrap must not claim the credit.
+        clearRendererRecoveryReloadIssued()
       }
       recordCrashBreadcrumb('manual_reload_requested', { ignoreCache })
     },
@@ -2654,6 +2657,9 @@ void app.whenReady().then(async () => {
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
       if (mainWindow?.webContents.id === webContentsId) {
         markExpectedRendererReload(webContentsId)
+        // Why: the user reloading by hand makes the next bootstrap their retry, so a
+        // recovery reload that stalled short of bootstrap must not claim the credit.
+        clearRendererRecoveryReloadIssued()
       }
       recordCrashBreadcrumb('manual_reload_requested', { ignoreCache })
     },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -665,6 +665,11 @@ function createWebContentsTimedFlag(defaultDurationMs = 10_000): {
 
 function markExpectedRendererReload(webContentsId: number, durationMs = 10_000): void {
   expectedRendererReload.mark(webContentsId, durationMs)
+  // Why here and not at each call site: every caller is a manual main-window
+  // reload, so the next bootstrap is the user's retry and a stalled recovery
+  // reload must not claim it. Three call sites each repeated this and a fourth
+  // (app:reload) was missed; at the definition a new site cannot forget it.
+  clearRendererRecoveryReloadIssued()
 }
 
 function clearExpectedRendererReload(webContentsId?: number): void {
@@ -1247,9 +1252,6 @@ function openMainWindow(): BrowserWindow {
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
       if (mainWindow?.webContents.id === webContentsId) {
         markExpectedRendererReload(webContentsId)
-        // Why: the user reloading by hand makes the next bootstrap their retry, so a
-        // recovery reload that stalled short of bootstrap must not claim the credit.
-        clearRendererRecoveryReloadIssued()
       }
       recordCrashBreadcrumb('manual_reload_requested', { ignoreCache })
     },
@@ -1495,6 +1497,9 @@ function openMainWindow(): BrowserWindow {
     }
   })
   logStartupMilestone('load-start')
+  // Why: this window replaces a torn-down one, so any arm still pending belongs to
+  // a recovery reload that died with it — this bootstrap is a fresh window, not it.
+  clearRendererRecoveryReloadIssued()
   loadMainWindow(window)
   return window
 }
@@ -2657,9 +2662,6 @@ void app.whenReady().then(async () => {
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
       if (mainWindow?.webContents.id === webContentsId) {
         markExpectedRendererReload(webContentsId)
-        // Why: the user reloading by hand makes the next bootstrap their retry, so a
-        // recovery reload that stalled short of bootstrap must not claim the credit.
-        clearRendererRecoveryReloadIssued()
       }
       recordCrashBreadcrumb('manual_reload_requested', { ignoreCache })
     },

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -1,0 +1,190 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handlers, listeners } = vi.hoisted(() => ({
+  handlers: new Map<string, (_event: unknown, args?: unknown) => unknown>(),
+  listeners: new Map<string, (_event: unknown, args?: unknown) => void>()
+}))
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '1.4.162' },
+  clipboard: { writeText: vi.fn() },
+  ipcMain: {
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+    handle: vi.fn((channel: string, handler: (_event: unknown, args?: unknown) => unknown) => {
+      handlers.set(channel, handler)
+    }),
+    removeAllListeners: vi.fn((channel: string) => listeners.delete(channel)),
+    on: vi.fn((channel: string, listener: (_event: unknown, args?: unknown) => void) => {
+      listeners.set(channel, listener)
+    })
+  }
+}))
+
+vi.mock('./feedback', () => ({ submitFeedback: vi.fn() }))
+
+vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
+  getCrashBreadcrumbSnapshot: vi.fn(() => []),
+  recordCoalescedCrashBreadcrumb: vi.fn(() => ({ suppressedSinceLast: 0 })),
+  recordCrashBreadcrumb: vi.fn()
+}))
+
+vi.mock('../observability', () => ({
+  collectDiagnosticBundle: vi.fn(),
+  getDiagnosticsStatus: vi.fn()
+}))
+
+vi.mock('../observability/diagnostic-upload-endpoint', () => ({
+  resolveDiagnosticOrcaChannel: vi.fn()
+}))
+
+vi.mock('../observability/tracer', () => ({
+  startSpan: vi.fn(() => ({
+    traceId: 'trace-id',
+    spanId: 'span-id',
+    setAttribute: vi.fn(),
+    addEvent: vi.fn(),
+    fail: vi.fn(),
+    interrupt: vi.fn(),
+    end: vi.fn()
+  })),
+  flushActiveSink: vi.fn()
+}))
+
+import { CrashReportStore } from '../crash-reporting/crash-report-store'
+import {
+  _resetRendererRecoveryOutcomeForTests,
+  noteRendererRecoveryReloadIssued,
+  resolveRecoveredRendererCrashReports
+} from '../crash-reporting/renderer-recovery-crash-outcome'
+import type { CrashReportCreateInput, CrashReportRecord } from '../../shared/crash-reporting'
+import {
+  _resetRendererErrorReportDedupeForTests,
+  registerCrashReportingHandlers
+} from './crash-reporting'
+
+const tempDirs: string[] = []
+
+async function createStore(): Promise<CrashReportStore> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'orca-recovered-renderer-crash-'))
+  tempDirs.push(dir)
+  return new CrashReportStore(path.join(dir, 'crash-reports.json'))
+}
+
+// The cluster-F shape: macOS/Linux SIGKILL, Windows uses different codes on the same path.
+function killedRendererCrash(exitCode = 9): CrashReportCreateInput {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'killed',
+    exitCode,
+    appVersion: '1.4.162',
+    platform: process.platform,
+    osRelease: 'test',
+    arch: process.arch,
+    electronVersion: '41',
+    chromeVersion: '141',
+    details: { processType: 'renderer' }
+  }
+}
+
+function emitRendererBootstrapRendered(): void {
+  listeners.get('crashReports:recordBreadcrumb')?.(null, { name: 'renderer_bootstrap_rendered' })
+}
+
+async function getLatestPending(): Promise<CrashReportRecord | null> {
+  return (await handlers.get('crashReports:getLatestPending')?.(null)) as CrashReportRecord | null
+}
+
+async function getLatestReport(): Promise<CrashReportRecord | null> {
+  return (await handlers.get('crashReports:getLatestReport')?.(null)) as CrashReportRecord | null
+}
+
+beforeEach(() => {
+  handlers.clear()
+  listeners.clear()
+  _resetRendererRecoveryOutcomeForTests()
+  _resetRendererErrorReportDedupeForTests()
+})
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe('auto-recovered renderer crash reporting', () => {
+  it('does not prompt the recovered renderer for a crash the reload healed', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    await store.record(killedRendererCrash())
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toBeNull()
+  })
+
+  it.each([
+    ['macOS/Linux SIGKILL', 9],
+    ['Windows ACCESS_VIOLATION', -1073741819],
+    ['Windows renderer OOM', -536870904]
+  ])('suppresses the prompt for %s once recovery is observed', async (_label, exitCode) => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    await store.record(killedRendererCrash(exitCode))
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toBeNull()
+  })
+
+  it('keeps the healed report sendable from Help > Report Crash with its recovery flag', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const recorded = await store.record(killedRendererCrash())
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+    await getLatestPending()
+
+    const sendable = await getLatestReport()
+    expect(sendable?.id).toBe(recorded.id)
+    expect(sendable?.status).toBe('dismissed')
+    expect(sendable?.details.rendererAutoRecovered).toBe(true)
+    expect(sendable?.breadcrumbs).toEqual(recorded.breadcrumbs)
+  })
+
+  it('still prompts when the renderer booted without an auto-recovery reload', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const recorded = await store.record(killedRendererCrash())
+
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: recorded.id, status: 'pending' })
+  })
+
+  it('still prompts when the recovery reload never brought the renderer back', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const recorded = await store.record(killedRendererCrash())
+
+    noteRendererRecoveryReloadIssued()
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: recorded.id, status: 'pending' })
+  })
+
+  it('leaves an unresolved crash from a previous session pending', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const recorded = await store.record(killedRendererCrash())
+
+    const oneHourLater = Date.parse(recorded.createdAt) + 3_600_000
+    noteRendererRecoveryReloadIssued(oneHourLater)
+    resolveRecoveredRendererCrashReports(store, oneHourLater)
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: recorded.id, status: 'pending' })
+  })
+})

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -240,6 +240,20 @@ describe('auto-recovered renderer crash reporting', () => {
     await expect(getLatestPending()).resolves.toMatchObject({ id: unrelated.id, status: 'pending' })
   })
 
+  // Why 25s: inside the arm's own 30s validity, but long before the crash that
+  // armed it. Crediting it would dismiss an unhealed crash as auto-recovered.
+  it('leaves a crash older than the burst pending when a later reload is armed', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const stale = await store.record({ ...killedRendererCrash(), reason: 'oom', exitCode: null })
+
+    const armedMs = Date.parse(stale.createdAt) + 25_000
+    noteRendererRecoveryReloadIssued(armedMs)
+    resolveRecoveredRendererCrashReports(store, armedMs)
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: stale.id, status: 'pending' })
+  })
+
   it('still prompts when the renderer booted without an auto-recovery reload', async () => {
     const store = await createStore()
     registerCrashReportingHandlers(store)

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -254,6 +254,34 @@ describe('auto-recovered renderer crash reporting', () => {
     await expect(getLatestPending()).resolves.toMatchObject({ id: stale.id, status: 'pending' })
   })
 
+  // Why: the recovery reload is armed by a 250ms timer that a loaded machine can
+  // run seconds late, so the crash that armed it must stay in scope past that.
+  it('credits the crash that armed a recovery reload the main process ran late', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const recorded = await store.record(killedRendererCrash())
+
+    const armedMs = Date.parse(recorded.createdAt) + 4_000
+    noteRendererRecoveryReloadIssued(armedMs)
+    resolveRecoveredRendererCrashReports(store, armedMs)
+
+    await expect(getLatestPending()).resolves.toBeNull()
+  })
+
+  // Why: the arm outlives the reload by far longer than the lookback, because
+  // session restore over SSH can push the first render many seconds out.
+  it('resolves the crash when the recovered renderer takes many seconds to boot', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    await store.record(killedRendererCrash())
+
+    const armedMs = Date.now()
+    noteRendererRecoveryReloadIssued(armedMs)
+    resolveRecoveredRendererCrashReports(store, armedMs + 20_000)
+
+    await expect(getLatestPending()).resolves.toBeNull()
+  })
+
   it('still prompts when the renderer booted without an auto-recovery reload', async () => {
     const store = await createStore()
     registerCrashReportingHandlers(store)

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -56,6 +56,7 @@ vi.mock('../observability/tracer', () => ({
 import { CrashReportStore } from '../crash-reporting/crash-report-store'
 import {
   _resetRendererRecoveryOutcomeForTests,
+  clearRendererRecoveryReloadIssued,
   noteRendererRecoveryReloadIssued,
   resolveRecoveredRendererCrashReports
 } from '../crash-reporting/renderer-recovery-crash-outcome'
@@ -257,6 +258,22 @@ describe('auto-recovered renderer crash reporting', () => {
     noteRendererRecoveryReloadIssued()
 
     await expect(getLatestPending()).resolves.toMatchObject({ id: recorded.id, status: 'pending' })
+  })
+
+  it('still prompts after the recovery breaker opened and the user reloaded by hand', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    // The crash-on-load loop: every recovery reload dies before bootstrap.
+    const recorded = await store.record({ ...killedRendererCrash(), reason: 'launch-failed' })
+
+    noteRendererRecoveryReloadIssued()
+    // The breaker refuses the next attempt and Orca asks the user to retry.
+    clearRendererRecoveryReloadIssued()
+    // The user's own reload finally boots; it did not auto-recover anything.
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: recorded.id, status: 'pending' })
+    expect((await getLatestReport())?.details.rendererAutoRecovered).toBeUndefined()
   })
 
   it('leaves an unresolved crash from a previous session pending', async () => {

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -90,6 +90,18 @@ function killedRendererCrash(exitCode = 9): CrashReportCreateInput {
   }
 }
 
+// Same `source`, different producer: reported by the renderer's own error
+// boundary, not by a dead renderer process.
+function reactErrorBoundaryCrash(): CrashReportCreateInput {
+  return {
+    ...killedRendererCrash(),
+    processType: 'react-render',
+    reason: 'react-error-boundary',
+    exitCode: null,
+    details: { processType: 'react-render' }
+  }
+}
+
 function emitRendererBootstrapRendered(): void {
   listeners.get('crashReports:recordBreadcrumb')?.(null, { name: 'renderer_bootstrap_rendered' })
 }
@@ -154,6 +166,30 @@ describe('auto-recovered renderer crash reporting', () => {
     expect(sendable?.status).toBe('dismissed')
     expect(sendable?.details.rendererAutoRecovered).toBe(true)
     expect(sendable?.breadcrumbs).toEqual(recorded.breadcrumbs)
+  })
+
+  it('still prompts for a React error-boundary crash caught in the recovery window', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const recorded = await store.record(reactErrorBoundaryCrash())
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: recorded.id, status: 'pending' })
+    expect((await getLatestReport())?.details.rendererAutoRecovered).toBeUndefined()
+  })
+
+  it('resolves the process crash without sweeping a React error-boundary crash beside it', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const boundary = await store.record(reactErrorBoundaryCrash())
+    await store.record(killedRendererCrash())
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: boundary.id, status: 'pending' })
   })
 
   it('still prompts when the renderer booted without an auto-recovery reload', async () => {

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -86,7 +86,13 @@ function killedRendererCrash(exitCode = 9): CrashReportCreateInput {
     arch: process.arch,
     electronVersion: '41',
     chromeVersion: '141',
-    details: { processType: 'renderer' }
+    details: { processType: 'renderer' },
+    // Why: the pre-crash trail is the whole point of keeping the healed report
+    // sendable, so the retention assertion needs a non-empty snapshot.
+    breadcrumbs: [
+      { createdAt: '2026-08-01T00:00:00.000Z', name: 'renderer_bootstrap_rendered' },
+      { createdAt: '2026-08-01T00:00:01.000Z', name: 'terminal_focus', data: { paneKey: 'a' } }
+    ]
   }
 }
 
@@ -99,6 +105,16 @@ function reactErrorBoundaryCrash(): CrashReportCreateInput {
     reason: 'react-error-boundary',
     exitCode: null,
     details: { processType: 'react-render' }
+  }
+}
+
+// A kernel OOM-kill / jetsam burst takes a child process down with the renderer.
+function killedChildCrash(): CrashReportCreateInput {
+  return {
+    ...killedRendererCrash(),
+    source: 'child',
+    processType: 'Utility',
+    details: { processType: 'Utility', serviceName: 'storage.mojom.StorageService' }
   }
 }
 
@@ -190,6 +206,30 @@ describe('auto-recovered renderer crash reporting', () => {
     emitRendererBootstrapRendered()
 
     await expect(getLatestPending()).resolves.toMatchObject({ id: boundary.id, status: 'pending' })
+  })
+
+  it('sweeps a sibling child crash from the same kill burst', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    await store.record(killedChildCrash())
+    await store.record(killedRendererCrash())
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toBeNull()
+  })
+
+  it('leaves an unrelated pending crash alone while sweeping the burst', async () => {
+    const store = await createStore()
+    registerCrashReportingHandlers(store)
+    const unrelated = await store.record({ ...killedChildCrash(), reason: 'oom', exitCode: 5 })
+    await store.record(killedRendererCrash())
+
+    noteRendererRecoveryReloadIssued()
+    emitRendererBootstrapRendered()
+
+    await expect(getLatestPending()).resolves.toMatchObject({ id: unrelated.id, status: 'pending' })
   })
 
   it('still prompts when the renderer booted without an auto-recovery reload', async () => {

--- a/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
+++ b/src/main/ipc/crash-reporting-recovered-renderer-prompt.test.ts
@@ -199,7 +199,14 @@ describe('auto-recovered renderer crash reporting', () => {
   it('resolves the process crash without sweeping a React error-boundary crash beside it', async () => {
     const store = await createStore()
     registerCrashReportingHandlers(store)
-    const boundary = await store.record(reactErrorBoundaryCrash())
+    // Why the crash-shaped reason/exitCode: relation matching ignores
+    // processType, so a boundary report only survives the sweep on its own
+    // guard — not on the reason literal happening not to collide.
+    const boundary = await store.record({
+      ...reactErrorBoundaryCrash(),
+      reason: 'killed',
+      exitCode: 9
+    })
     await store.record(killedRendererCrash())
 
     noteRendererRecoveryReloadIssued()

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -33,6 +33,10 @@ import {
   isClipboardTextWriteTooLargeError
 } from '../../shared/clipboard-text'
 import { formatCrashReportCopyText } from '../crash-reporting/crash-report-copy-text'
+import {
+  RENDERER_BOOTSTRAP_RENDERED_BREADCRUMB,
+  resolveRecoveredRendererCrashReports
+} from '../crash-reporting/renderer-recovery-crash-outcome'
 import { TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB } from '../../shared/terminal-webgl-diagnostics'
 
 const inFlightSubmissions = new Set<string>()
@@ -419,6 +423,11 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
     (_event, args?: { name?: unknown; data?: unknown }) => {
       if (!args || typeof args.name !== 'string') {
         return
+      }
+      if (args.name === RENDERER_BOOTSTRAP_RENDERED_BREADCRUMB) {
+        // Why: the recovered renderer asks for the startup prompt right after
+        // this breadcrumb, so the healed crash must be resolved first.
+        resolveRecoveredRendererCrashReports(store)
       }
       const data = sanitizeRendererBreadcrumbData(args.data)
       if (COALESCED_RENDERER_BREADCRUMB_NAMES.has(args.name)) {


### PR DESCRIPTION
## Description

Cluster `F_linux_mac_killed_oom` — **10 crash reports** from #orca-crashes between 2026-07-30 and 2026-08-01 where the renderer process was killed and **the app recovered by itself**, but the user was still shown a crash prompt on the next launch for a crash that no longer affected them.

The reports are `killed` with `exitCode 9` (SIGKILL) on macOS and Linux, one `61696`, and two where the bundle carried no captured crash report at all. What they share is not a cause — it is an *outcome*: Orca's own renderer auto-recovery reload (`onBeforeRecoveryReload` → `markRecoveryReloadInFlight`) brought the window back within ~1.5s, the user kept working, and the pending crash record sat on disk until the next cold start told them something had gone wrong.

**This PR does not stop the renderer from being killed.** It is a reporting-correctness fix: it stops Orca from prompting about a crash it already healed, while keeping every byte of that crash's evidence.

Three changes:

1. **`src/main/crash-reporting/renderer-recovery-crash-outcome.ts` (new).** Arms a 30s window when a recovery reload is issued, and — when the reloaded renderer reports it actually came back — resolves the pending renderer crash reports that fall inside it. The 30s bound is deliberately generous against a loaded machine but short enough that it cannot span an unrelated boot. `resolveRecoveredRendererCrashReports` stays synchronous up to the store call so the write is queued on the store's chain **before** the recovered renderer's `getLatestPending` read drains it — the ordering is the whole fix, and it is what round 1 spent its effort trying to break.

2. **`src/main/crash-reporting/crash-report-store.ts` — `markRendererCrashesAutoRecovered`.** Transitions matching records to `dismissed` and stamps `details.rendererAutoRecovered = true`. `dismissed` is chosen over deletion precisely because it keeps the record sendable from **Help → Report Crash**: the user stops being nagged, we do not lose the report.

3. **`src/main/index.ts` + `src/main/ipc/crash-reporting.ts`.** Arm the window at the existing `onBeforeRecoveryReload` hook; resolve on the existing `renderer_bootstrap_rendered` breadcrumb. No new IPC channel, no new renderer code.

**Deliberately untouched:** `shouldRecoverRendererAfterProcessGone` (`process-gone-classification.ts:88`) and `process-gone-recorder.ts`. Which crashes get auto-recovered, and the `electron.process_gone` span that is emitted and force-flushed *before* `store.record()`, are unchanged. This PR only decides what to do with a report **after** recovery is proven.

## Fix evidence

### The 10 reports

| report_id | reason | exit | platform | version |
| --- | --- | --- | --- | --- |
| `2b92f8dd` | killed | 9 | macOS 25.2.0 arm64 | 1.4.161 |
| `8132524b` | killed | 9 | Linux 7.0.0-28-generic | 1.4.162 |
| `2727bad8` | killed | 9 | macOS 25.5.0 arm64 | 1.4.162 |
| *(no captured report)* | — | — | macOS 24.5.0 arm64 | 1.4.162 |
| `482062c0` | killed | 61696 | Linux 7.1.3-2-cachyos | 1.4.162 |
| *(no captured report)* | — | — | macOS 25.5.0 arm64 | 1.4.162 |
| `95917814` | killed | 9 | macOS 27.0.0 arm64 | 1.4.162 |
| `fbf655cd` | killed | 9 | Linux 7.0.12+kali | 1.4.162 |
| `f2fc9fb1` | killed | 9 | Linux 7.0.12+kali | 1.4.162 |
| `5a47a6a2` | killed | 9 | Linux 7.0.12+kali | 1.4.162 |

### Red–green, verbatim

The whole point of a reporting fix is that the test must fail without the source change. Both experiments were run by reverting **only** the source hunk and leaving the tests in place.

**Experiment 1 — the core fix.** Reverting `renderer-recovery-crash-outcome.ts` + the two wiring hunks:

```
 Tests  5 failed | 3 passed (8)
```

The 3 that pass are negative pins by design — "still prompts when the renderer booted without an auto-recovery reload", "still prompts when the recovery reload never brought the renderer back", "leaves an unresolved crash from a previous session pending". They assert the fix does **not** fire, so they must pass before and after. That is stated here rather than quietly counted as coverage.

**Experiment 2 — the round-1 defect fix.** Reverting only `report.processType !== 'renderer'` from the skip predicate:

```
     × still prompts for a React error-boundary crash caught in the recovery window
     × resolves the process crash without sweeping a React error-boundary crash beside it
 Tests  2 failed | 8 passed (10)
```

### Gates

```
$ npx vitest run src/main/ipc/ src/main/crash-reporting/
 Test Files  178 passed | 1 skipped (179)
      Tests  2714 passed | 10 skipped (2724)

$ npx oxlint <changed files>                       exit 0
$ npx oxfmt --check <changed files>                All matched files use the correct format.
$ npx tsc --noEmit -p config/tsconfig.node.json    exit 0
```

**Experiment 3 — the round-3 defect fix.** Reverting only the sweep's producer guard:

```
     × resolves the process crash without sweeping a React error-boundary crash beside it
     × never sweeps a React error-boundary report, even when it matches the crash event
      Tests  2 failed | 26 passed (28)
```

## ELI5

Sometimes the part of Orca that draws your screen gets killed — the operating system runs low on memory, or something inside goes wrong. When that happens Orca quietly reloads that part and puts your window back, usually in about a second and a half. Most people never notice.

But Orca had already written "a crash happened" into a notebook on disk, and nothing ever crossed it out. So the next time you started Orca — maybe the next morning — it told you about a crash that it had already fixed for you while you were working. Ten people got that message in two days.

Now, when Orca reloads your window *and the window actually comes back*, it crosses that entry out. It doesn't erase it: the report is still there under **Help → Report Crash** if you want to send it to us, and it still says *why* it was crossed out. You just stop being told about a problem that is already over.

The important part is the "*and the window actually comes back*". If the reload fails and you are staring at a blank window, Orca still tells you — because then it isn't fixed.

## Trade-offs

1. **THIS PR ALSO MAKES ORCA PROMPT *MORE*, IN ONE SPECIFIC SHAPE.** Round 7's cutoff fix means that in a stalled-recovery chain — two renderer crashes ~4s apart with the recovery arm landing ~6s after the first — the older crash now stays pending where it was previously swept silently. Executed: `T5 firstCrash: pending | secondCrash: dismissed`, user still prompted. This is the intended direction: the cutoff is saying "that one wasn't part of this burst", and swallowing an unhealed crash is the worse error. But it is a real increase in prompting in a case that previously produced none, and it belongs here rather than buried in a review round.

2. **REDUCED PROMPT VOLUME IS THE POINT, AND IT IS ALSO THE RISK.** If the renderer is being killed *repeatedly* — say once an hour on a memory-starved machine — the user now sees no prompt at all, because each kill is individually healed. Previously the pile-up of prompts was itself the signal that something was wrong. Mitigation: every resolved report is still on disk, still sendable, and a `renderer_crash_auto_recovered` durable breadcrumb records `resolvedReportCount` and `recoveryLatencyMs` — but a breadcrumb is not a page. **A user with a chronically dying renderer is now quieter than before, and that is a real loss of signal.** This is the trade the PR makes on purpose; it is worth naming plainly.

3. **THE 30s WINDOW IS A HEURISTIC AND IS NOT IDENTITY-SCOPED.** It is armed globally, not per-`webContents`. If two windows crashed and recovered inside the same 30s, one recovery could resolve the other's report. Round 1 raised this as LOW; I did not fix it, because the arm is *consumed* on the first `renderer_bootstrap_rendered` (`takeRendererRecoveryReloadIssuedAt` nulls it), so the exposure is one report in a genuinely simultaneous double-crash — and getting identity scoping wrong would fail *closed*, resurrecting exactly the prompts this PR removes. Named, not fixed.

4. **`renderer_bootstrap_rendered` IS EMITTED AT RENDER-SCHEDULE TIME, NOT COMMIT TIME** (`src/renderer/src/main.tsx:65`). A renderer that loads its bundle and calls `root.render()` but never commits — a blank window with a running JS context — would be counted as recovered and its report resolved. The common blank-window failures (bundle never loads, renderer dies again) do not reach that line and still prompt correctly, which is why this is a LOW and not a blocker. But the narrow "loads, renders, never commits" case is a hole, and it is not covered by a test.

5. **THE DISCRIMINATOR IS AN EXACT STRING MATCH.** After round 1, resolution requires `processType === 'renderer'` exactly. `src/main/index.ts:1220` is the only site that records native renderer process-gone crashes and it writes that literal, so this is correct today — but it is a string coupling with no shared constant. If a future call site writes `'Renderer'` or passes `details.type` through, cluster-F reports silently start prompting again. That is a fail-*closed* direction (nagging, not silence), which is why it was accepted.

6. **HELP > REPORT CRASH CAN NOW SURFACE THE WRONG REPORT OF THE PAIR.** `getLatestSendableReport` returns the first pending-or-dismissed record, and `record()` prepends — so when Electron emits child-process-gone *after* render-process-gone (Electron does not specify that order), the swept sibling sits at index 0. The user is then offered the Utility crash — `dismissed`, empty `details`, no recorded reason for the dismissal — while the healed renderer report carrying the full breadcrumb trail sits at index 1 and is never offered. **This is not a regression:** before the sweep that sibling was `pending`, which `getLatestSendableReport` also accepts, so it was returned then too. But it does undercut this PR's stated "keeps the record sendable" goal in the burst case, and the deliberate decision *not* to stamp `rendererAutoRecovered` on the sibling — correct, because the reload did not heal the Utility process — means nothing records why it was dismissed at all. `dismiss()` has the identical gap. Left for a follow-up rather than widened here.

7. **A FOURTH MAIN-WINDOW RELOAD PATH IS STILL UNCOVERED, KNOWINGLY.** With a browser `<webview>` guest focused, the app-level `forceReload` shortcut calls `renderer.reloadIgnoringCache()` directly on the host main-window `webContents` (`browser-guest-ui.ts:445`), bypassing this mechanism entirely. That site is *also* missing the pre-existing `markExpectedRendererReload` marking — so it is half-broken on `main` already, not only against this PR's invariant — and `browserManager` is a no-arg module singleton with no options bag, so wiring it means threading a callback through `browser-manager.ts` into browser code this PR does not otherwise touch. Fixing one half without the other would leave the site incoherently guarded. **Deferred deliberately to a browser-scoped follow-up that fixes both halves together.** Reachability is narrow — it needs a recovery reload stalled short of bootstrap *and* a rendered, focused browser guest — but it is not zero, and it is named here rather than left for a reviewer to find.

8. **NO PLATFORM DIVERGENCE, BUT ALSO NO WINDOWS PROOF.** The change is platform-agnostic main-process code and the tests cover the Windows exit codes (`-1073741819` ACCESS_VIOLATION, `-536870904` renderer OOM) as well as SIGKILL. It has not been run on a real Windows box; Windows crash work is tracked separately in cluster E. SSH and folder-workspace behavior are untouched — nothing here is worktree- or host-aware.

## Adversarial review

**6 rounds. Rounds 1–5 each found a real defect; each was fixed. Round 6 result recorded at the end.**

**Round 1 — could not refute the core; found one MEDIUM defect, FIXED.**
The reviewer was asked to break the ordering claim and reported: *"Could not refute it; the ordering holds end to end."* It also confirmed the blank-window case still prompts and that crash telemetry survives resolution. Gates at that point: 36 files / 396 tests passed, `oxlint` exit 0, `tsc` exit 0, and a revert experiment showing 5 failed / 3 passed.

> **MEDIUM — `crash-report-store.ts:139`.** `markRendererCrashesAutoRecovered` filtered on `source === 'renderer'` only, so it also swept **React error-boundary** crash reports (`processType: 'react-render'`, recorded at `crash-reporting.ts:191`) that the recovery reload did not cause. They were marked `dismissed` *and* stamped `details.rendererAutoRecovered = true`, which is factually wrong.

This mattered well beyond a tidiness complaint, and the reviewer said so: several other clusters in this same triage batch **are** React #185 boundary errors. A #185 update loop burns memory, and a renderer kill within 30s of it would have destroyed the only durable evidence for that cluster. Fixed in `b8e597bc20` by requiring `processType === 'renderer'`, with the two regression tests shown in Experiment 2 above.

Round 1 also corrected the original author's count of negative pins — there are **3**, not 2 — and judged all three legitimate. That correction is reflected in the Fix-evidence section rather than buried here.

**Round 1 LOW findings, both accepted and NOT fixed:** the render-schedule-vs-commit hole (trade-off 3) and the un-scoped 30s arm (trade-off 2).

**Round 2 — could not refute the core; found one LOW gap, FIXED.**
Round 2 proved the `processType === 'renderer'` discriminator is **complete**, not just correct-today: exactly two `store.record` call sites exist in all of `src/main` — `process-gone-recorder.ts:156` (fed by `index.ts:1634`) and `ipc/crash-reporting.ts:189` — and the `details.type` passthrough is unreachable because that path hard-codes `source: 'child'`. Legacy records are safe: `git log -S 'processType: string'` returns only `77264240c8` (#2012), which already wrote the literal. That closes trade-off 4 below more tightly than it was originally written.

> **LOW — `crash-report-store.ts`.** `markRendererCrashesAutoRecovered` did not apply the sibling/related-crash sweep that `dismiss()` applies via `transitionStatus` + `isRelatedCrashEvent`. When one kill burst produces BOTH a renderer crash and a non-suppressed child crash — kernel OOM-killer or macOS jetsam taking a Utility process down alongside the renderer — the renderer report was auto-dismissed but the sibling stayed pending and became the startup prompt.

Verified empirically by the reviewer, not argued: recording `child`/`Utility`/`killed`/`9` (serviceName `storage.mojom.StorageService`) and then `renderer`/`renderer`/`killed`/`9` resolved 1 report, and `getLatestPending` then returned the **child** report. Since this cluster is specifically about OOM/SIGKILL bursts, that sub-case is materially likely, not theoretical. Fixed in `77705fba8c` by running a second pass with the exact predicate `dismiss()` already uses, anchored on a **snapshot** of the resolved set so a swept sibling cannot itself become an anchor for a further sweep.

**Round 3 — could not break the sweep; found one LOW, FIXED, and caught a fake test.**

Round 3 attacked the sweep by construction and could not break it. Proven by probe, not reasoning: no transitive expansion (R@0s, C1@+4s related to R, C2@+8s related to C1 but not R → C2 stays pending); the N-anchor sweep is exactly the **union** of N single-anchor dismisses, so there is no order dependence and no reach `dismiss()` lacks; no duplicate entries in the returned set; anchor eligibility correctly respects `notBefore`.

> **LOW — the sweep pass had no producer guard.** It checked only `status !== 'pending'`. The anchor pass deliberately excludes `react-render` reports with a comment saying they "must keep prompting on their own evidence" — the sweep silently dropped that invariant. Any pending boundary report matching `isRelatedCrashEvent` was dismissed with no user-visible trace.

Unreachable in production **today** only because `ipc/crash-reporting.ts:192` hard-codes `reason: 'react-error-boundary'` and `exitCode: null`, which no Electron process-gone reason can equal. That is an invariant held by a string literal in a different file, 200 lines away, with nothing pinning it — and round 1's MEDIUM established exactly why that matters: several other clusters in this same triage batch **are** React #185 boundary errors, and swallowing their reports destroys the only durable evidence for them. Fixed in `d85576e50b` by restating the anchor pass's own `source`/`processType` exclusion. The reviewer deliberately did **not** reuse the shared `isReactErrorBoundaryReport()` helper, because that helper itself tests the reason literal and so would reintroduce the exact fragility being removed.

**Round 3 also invalidated one of this PR's own tests.** `resolves the process crash without sweeping a React error-boundary crash beside it` was passing *incidentally* — purely because the boundary fixture's `reason`/`exitCode` did not match the anchor's. It still passed with the guard removed entirely, so it pinned nothing about the sweep. Both regression tests now use a crash-shaped `killed`/`9` boundary fixture and fail without the guard (Experiment 3 above). This is worth stating plainly: a green test that cannot fail is worse than no test, because it is read as coverage.

**Round 3 LOW accepted and NOT fixed — see trade-off 5.**

**Round 4 — NOT clean. Found the defect three rounds of review had walked past.**

Rounds 1–3 all reviewed the *resolution* side: which reports get dismissed. Nobody audited the *arming* side — when the flag is set, and when it should be cancelled. It was set in exactly one place and cancelled in none.

> **MEDIUM — the arm survives auto-recovery giving up.** When the renderer-recovery circuit breaker opens, the arm from the last *allowed* attempt stays live for its full 30s. Orca then shows the "Orca keeps failing to load" dialog, and the user's own Reload consumes that arm. The entire crash-on-load loop is written `dismissed` with `rendererAutoRecovered: true` — a flag that is a direct lie, because the same code path had just recorded `renderer_recovery_circuit_breaker_open`.

The reachability is concrete, not theoretical: `createMainWindow.ts:600-613` calls the arm only when `recovery.allowed`, then calls `onRendererRecoveryExhausted` on refusal; `index.ts:1512` shows the modal and on Reload calls `loadMainWindow` with no disarm. The breaker allows 3 recoveries per 60s, so the stale arm is seconds old when the dialog appears — comfortably inside the window.

This silences precisely the **highest-signal crash class we have**: repeated `launch-failed` before bootstrap. That is the cluster E shape. A reporting-side fix that suppressed crash-loop reports would have been a straightforward regression, and it took four rounds to find because every earlier round was looking at the other half of the mechanism.

Fixed in `50e1b50b09` with three lines of production code — `clearRendererRecoveryReloadIssued()`, called first thing in `onRendererRecoveryExhausted`. Verified load-bearing: neutering the function to a no-op fails exactly the one new test (1 failed / 12 passed) and nothing else.

**Round 4 also confirmed, by probe, three things earlier rounds had only argued.** The two-pass write is concurrency-clean (a crash recorded mid-sweep survives as pending; `getLatestPending` queued right after sees fully-swept state; overlapping resolutions do not double-resolve; repeated resolution is idempotent). The child sweep is defensible — Orca uses **no** `utilityProcess.fork()` anywhere in `src/main`, so every `source: 'child'` report is a Chromium child, none independently actionable. And the round-3 guard is complete across all three `store.record` call sites, though currently unreachable, which round 3's own test comment already said.

### A coverage gap in the round-4 fix, disclosed rather than papered over

The new regression test calls `clearRendererRecoveryReloadIssued()` **directly**. It pins the function, not the call site — `createMainWindow.test.ts` passes `onRendererRecoveryExhausted` as a `vi.fn()`, so the callback body in `index.ts` is exercised by nothing. Deleting the call from `index.ts` would leave the suite green. Round 5 was tasked with either closing that seam or stating specifically why it could not be closed. Flagging it here because this PR has already been bitten once by a test that could not fail (see round 3), and the same mistake twice in one branch should be visible to a reviewer rather than discovered by one.

**Round 5 confirmed it and found it was worse.** Deleting the call and running the full 1,343-file `src/main` suite left everything green apart from the known-flaky SSH SFTP file. And the same held for the *arming* call from round 1 — so **the branch's entire arm/disarm mechanism was silently revertible without a single red test**.

Behavioural coverage turned out to be genuinely impossible, with evidence rather than a shrug: no test in the repo imports `src/main/index.ts` (it runs `app.whenReady()`, the single-instance lock and top-level `app.on` handlers at module scope), and the callbacks are closures built inside `openMainWindow()`, which throws on ~14 uninitialised module-global services before it ever reaches `createMainWindow()`. The repo already has an established answer for exactly this — two bounded source-text wiring tests under `src/main/startup/`, one carrying a comment recording the lesson that an unresolved end anchor slices to EOF and passes against code that never runs. Round 5 followed both rules. I mutation-verified the result independently: **dropping any one of the four call sites turns exactly one test red**, including the one-of-two-reload-sites case.

### Round 5's second finding — a real false-dismiss round 4 had declined

Round 4 declined to disarm on manual reload as "not diff-minimal". Round 5 argued that was the wrong call and demonstrated a user-reachable path:

1. The renderer crashes; auto-recovery issues a reload and sets the arm.
2. That reload stalls short of `renderer_bootstrap_rendered` **without** tripping the circuit breaker — a blank window, a `did-fail-load`, a renderer still starved on a memory-pressured machine, or on macOS the user closing the blank window and re-opening from the dock.
3. The user hits ⌘R (or View ▸ Reload) within 30s. It boots, and **consumes the stale arm**.

The crash is then dismissed and stamped `details.rendererAutoRecovered: true` — factually false, since the *user* healed it, and a user who had to reload by hand is precisely the one who wants the prompt. Every same-burst sibling is silently dismissed too, without even the flag. Round 4's own commit message — "the next bootstrap then comes from the user's own retry" — applies verbatim; the breaker simply has not opened yet.

Fixed in both `onBeforeReload` bodies (`createMainWindow`'s force-reload shortcut and the app menu wire them separately, so one is not enough) and **inside** the existing main-window guard, because the menu path reloads whichever window has focus — an unguarded disarm would let a dashboard pop-out reload throw away the main renderer's arm.

I verified the load-bearing safety claim myself rather than accepting it: `onBeforeReload` fires only from `createMainWindow.ts:668` and `register-app-menu.ts:80`, both user-initiated, while recovery goes through `onBeforeRecoveryReload` → `loadMainWindow`. The two paths are disjoint, so the recovery reload can never disarm its own arm.

**Targets that survived round 5's attack.** The module-global arm is correct rather than needing per-`webContents` scoping: the arm is *consumed* at bootstrap, so by the time any breaker opens it is already null; `createMainWindow(` has exactly one non-test call site and every `openMainWindow()` path is guarded against a live window, so two simultaneously-recovering main windows do not exist; and the dashboard pop-out registers no `render-process-gone` handler and cannot emit `renderer_bootstrap_rendered` (one emitter, `main.tsx:65`). The 30s constant survived attack in both directions — it only has to cover re-eval of an already page-cached bundle, and backward it cannot reach an unrelated renderer crash because the renderer is dead for the whole arm→bootstrap gap.

**Round 5 declined round 4's suggested refactor, and I agree.** Factoring out a shared `isRendererProcessCrash()` helper would leave the sweep still restating `report.source === 'renderer' &&` itself — it dedups roughly one term in exchange for a function hop. The drift risk is better covered by the two existing tests that fail if either guard is dropped.

**Round 4 LOWs accepted and NOT fixed.** (i) The anchor predicate and the sweep exclusion encode the same concept in two inverted forms with no shared symbol; nothing breaks today — weakening only the sweep guard still fails round 3's two tests — but a third call site would not be protected. (ii) The sweep is one-sided in time: resolution lands ~1.75s after the crash while the relation window is 5s, so a burst sibling recorded in the remaining ~3s tail is never swept and prompts at next launch. Not a regression — `dismiss()` has the identical shape on `main` — and a deferred re-sweep is not worth the complexity.

**Round 6 — NOT clean. Round 5 had covered two of *four* manual reload paths.**

Round 5 stated the invariant "disarm on every manual main-window reload" and fixed the two `onBeforeReload` sites. Round 6 found two more, and the reason the first was missed is the interesting part:

> **MEDIUM — `index.ts:1364`, the `app:reload` IPC path.** The renderer's own "Reload Orca" button (`preload/index.ts:486` → `ipcMain.handle('app:reload')` → `onBeforeRendererReload`) called `markExpectedRendererReload()` but never disarmed. **Round 5's wiring test could not see it**: the test anchors on the literal `onBeforeReload: ({ ignoreCache, webContentsId }) => {` and even asserts there are exactly *two* such occurrences — this site is spelled `onBeforeRendererReload`, so that `-1` assertion still passed while the site sat unguarded.

> **MEDIUM — `index.ts:1500`, a replacement main window consumes a live arm.** The arm is module-global rather than keyed to a `webContents`. `openMainWindow()` uses `deferLoad: true` and ends in `loadMainWindow(window)`, so a window opened after the old one died — macOS dock re-activation, tray reopen, second-instance focus — bootstraps a renderer that consumes the *dead* window's arm and dismisses every pending renderer crash in the lookback. Round 6 verified clearing is always safe here: `focus-existing-window.ts:135` only opens when the previous window is absent or destroyed, so the arm can only ever be stale, and `deferLoad: true` means the new window's renderer cannot have armed anything yet.

> **LOW — `renderer-recovery-crash-outcome.ts:60`, one constant doing two jobs.** `RENDERER_RECOVERY_OUTCOME_WINDOW_MS` bounds how long an arm stays *valid*; it was also being used to bound how far *back* an arm may credit crashes. The reload is armed 250ms after its crash, so only that crash's own kill burst is ever in scope. At 30s, an unrelated crash **25 seconds older, with a different reason the reload never healed**, was dismissed and stamped `rendererAutoRecovered: true`. Round 6 proved this by execution rather than argument, and it chains with `process-gone-classification.ts:98`: `integrity-failure` *is* recorded but is explicitly non-recoverable, so it never gets a reload of its own — if it lands in the lookback of another crash whose recovery reload stalled, it was silently swallowed.

The first two were fixed by **consolidation rather than a third and fourth call-site disarm**. The disarm now lives inside `markExpectedRendererReload()` itself. Every caller is a manual main-window reload — verified by enumerating all three call sites — and the recovery path uses a different marker (`markRecoveryReloadInFlight`), so it cannot disarm its own arm. A future reload site now cannot forget the disarm, and the wiring test pins the invariant **at the definition** instead of at three call-site spellings, which is what let `app:reload` slip through in the first place. The third was fixed with a separate `RENDERER_RECOVERY_CRASH_LOOKBACK_MS = 5_000`, matching `RELATED_CRASH_WINDOW_MS`.

I re-verified all three by mutation myself rather than accepting the reviewer's word: deleting any one turns **exactly one** test red, and the suite is green with all three in place (3152 passed | 11 skipped). Round 6 also independently re-ran round 5's mutation and my pre-existing-failure claim, and confirmed both.

**Round 6's attacks that found nothing** — worth listing, because it tells a reviewer what is genuinely covered: write ordering (`process-gone-recorder.ts` contains zero `await` tokens, so the record is queued synchronously ahead of the arm), IPC ordering (`recordBreadcrumb` is a plain `ipcRenderer.send` with no buffering or coalescing), clock steps in **both** directions plus sleep/resume — with the backward step shown to fail in the *safe* direction — the sibling sweep, the react-render exclusion, popout/webview isolation (only `createMainWindow.ts:617` produces `source:'renderer'`+`processType:'renderer'`), and the Windows retry ladder.

**Round 7 — NOT clean. Round 6's own fix was partly undone inside the same function.**

Round 6 added `RENDERER_RECOVERY_CRASH_LOOKBACK_MS` so an arm can only credit crashes from its own kill burst. The *anchor* pass honours that cutoff. The **sweep** pass did not:

> **MEDIUM-LOW — `crash-report-store.ts:168`, the sibling sweep overrides the cutoff the anchor pass just applied.** `isRelatedCrashEvent` ignores `processType` and reaches 5s either side of *any* anchor, and the sweep guard only excluded react-render. So a renderer-process crash the cutoff had just excluded was dismissed anyway as a "burst sibling" of a crash from the same process — pushing effective reach to cutoff + 5s, and dropping the `rendererAutoRecovered` flag that records *why* it was resolved. Demonstrated by execution: a stale crash at `arm-6000ms` and an anchor at `arm-1500ms` both came back `dismissed`, the stale one with bare `{"processType":"renderer"}`.

Fixed by collapsing the guard to `status !== 'pending' || source === 'renderer'`. Every renderer-sourced report is either an anchor the first pass already ruled on, or a react-render boundary report the reload did not cause; **neither is ever a burst sibling**, which is the only thing the sweep exists to catch. This *subsumes* the previous react-render exclusion rather than replacing it — deleting the whole guard reds **three** tests (round 3's and round 5's two boundary tests, plus round 7's new cutoff test), so both protections still ride on it.

**The honest bound, so nobody overrates this.** With normal timing the newest anchor sits 250ms before the arm — the recovery-timer delay — so the naturally exploitable band is about **250ms wide**, not 5s. It only widens toward the full 5s when the arm lands late relative to its crash, or through a chain of anchors. The fix is worth making on structural grounds regardless: the sweep should not be able to override a decision the anchor pass just made.

> **LOW — both of round 6's new constants were unpinned in the direction that regresses.** Round 6 split one constant into two. Cutting the arm window 30s → 3s, or the lookback 5s → 500ms, each left the **entire** main-process suite green (2727 passed, zero failures). Raising the lookback back to 30s *is* caught by round 6's 25s test — so the split was protected against reversion but not against erosion, and erosion is the direction that loses the triggering crash.

Fixed with two tests pinning each constant from the side that matters: the lookback has to survive a 250ms recovery timer that a loaded machine runs seconds late, and the arm window has to outlive a slow first render (session restore over SSH). Each fails on exactly its own constant and no other.

**Round 7's attacks that found nothing** — the closed enumerations are the useful part. All three `markExpectedRendererReload` callers enumerated independently (`index.ts:1254` force-reload shortcut, `:1368` `app:reload`, `:2664` app menu): all user-initiated, all behind a main-window `webContents`-id guard, so round 6's consolidation is correct at every one and there is no caller where the arm should survive. Every way the main renderer can bootstrap was enumerated and ruled out, including **two sites round 6 had not listed** — `lazy-with-retry.ts:152` and `GhAuthErrorHelp.tsx:46/50`, both `window.location.reload()` — neither of which can fire while an arm is live, because `main.tsx:65` emits the breadcrumb at module scope before any lazy chunk or component runs. The 10s expected-reload TTL and the 30s arm validity were traced in both orderings and do not interact. Round 6's four wiring sites were re-verified by deleting each one: each reds exactly one named test, so that suite is not vacuous. The branch's headline claim was verified end-to-end against a real store — after auto-recovery the report is still returned by `getLatestReport` and `submit` succeeds, `{"ok":true,...,"rendererAutoRecovered":true,"status":"sent"}` — which depends on `canSubmitDismissedReport` requiring `args.reportId` and `CrashReportDialogSurface.tsx:174` passing it; it does.

### Known trade-off, carried forward deliberately

Two things are knowingly left in place, stated here rather than buried so that a reviewer who spots either finds we already knew:

1. **`browser-guest-ui.ts:445`'s `forceReload` bypasses this path entirely.** It is also missing the pre-existing `markExpectedRendererReload` marking, and `browserManager` is a no-arg singleton, so both halves belong in one browser-scoped change rather than being half-fixed here.

2. **The lookback is anchored to the reload, not to the crash that caused it** — a 5s proxy for a 250ms relationship. The one residual way the triggering crash falls outside it is a main-process event-loop stall of >4.75s between `render-process-gone` (which assigns `createdAt` on the next microtask) and the 250ms timer firing — not implausible for this cluster specifically, since renderer SIGKILL usually means system-wide memory pressure. **This is a hypothesis, not a demonstrated defect:** round 7 could not construct a deterministic in-code trigger, and two structural bounds argue it stays rare — the arm is set at crash+250ms with nothing else in the path, and the circuit breaker caps the chain at 3 recoveries then disarms. Worst case is a **re-appearing prompt for a healed crash — i.e. exactly the pre-branch behaviour, never a wrong dismissal.** Closing the class properly means passing the crash timestamp through `onBeforeRecoveryReload`; changing a callback signature to close an undemonstrated hole was judged out of proportion, and round 7's new test now pins the lookback at ≥4s so the realistic erosion path is covered.

## Performance review

**Clean — no HIGH or MEDIUM, nothing needed fixing.** Numbers are measured, not argued.

The whole added path is gated behind a module-global that is `null` on every launch that did not just auto-recover a renderer crash. The disarmed no-op — one string compare, one null check — measured **~38ns/call over 100,000 calls** (3.85ms total, p50 and p95 both 0.0000ms). That is the cost on a normal launch.

**Off the critical path to first paint, on three independent grounds.** The renderer sends the breadcrumb with `ipcRenderer.send` and never awaits it; the main handler is `ipcMain.on` (not `handle`) and returns after merely queueing a microtask onto `writeChain` — measured p50 **0.0015ms**, max 0.0566ms *while armed*; and the only consumer of the resulting write is a `useEffect` in `CrashReportDialog`, which returns `null` until it has a report. So the entire cost lands on "how soon the crash prompt appears" — on the recovery path only, where the correct outcome is that it never appears.

**The nested sweep is hard-bounded and cannot grow.** `readReportsFromDisk` slices to `MAX_REPORTS` *before* `mutate` sees the array, so worst case is 5×5. Confirmed empirically by seeding `crash-reports.json` with **10,000 entries** — 5 came back. Its CPU cost of 0.61µs is 0.02% of the 3.19ms of disk I/O around it.

**The Windows retry ladder is the one place with a real number.** One `withWrite` wraps two separately-laddered operations (read and write), so 2 × 750ms = **1500ms of sleeps**, with a ~21.5s ceiling if both `icacls` repairs also time out. But the sleeps are async `setTimeout` — the event loop stays free — and the only thing downstream is the crash prompt this diff exists to suppress. The ladder is also pre-existing and already runs on the `record()` path that precedes this.

**One genuine (if tiny) waste, traced and deliberately not fixed.** `withWrite` rewrites the file even when zero reports matched (~3ms, once per crash recovery). The review proposed the fix and then rejected its own proposal: the unconditional rewrite is what truncates an oversized `crash-reports.json` back to 5 — proven by the 10,000-entry probe — so skipping it would silently drop that self-heal. Proposed and rejected rather than silently applied.

## Related

PR #11925 (test-only, honestly labelled as such) remains valid and complementary — it pins existing behavior this PR does not change.

**Round 8 — clean. Loop terminated.**

Round 8 attacked round 7's central claim: that the class of "genuine burst sibling that is renderer-sourced" is empty, so restricting the sibling sweep costs nothing real. Round 7 *derived* that. Round 8 executed it and came back with something stronger.

The decisive fact is in `getProcessGoneDedupeKey`: for `source: 'renderer'` the key is `renderer:${processType}`, which **discards reason and exitCode entirely**.

```
T1b renderer killed: renderer:renderer | renderer crashed: renderer:renderer | child: child:GPU:killed:9
T1  first: true   sameBurst(+50ms): false
T1  at+1.9s: false   at+2.1s: true
```

A differently-reasoned renderer death in the same burst collapses onto the same key, and the 2s window swallows anything burst-shaped. Combined with `recordProcessGoneCrash('renderer', 'renderer', …)` at `index.ts:1222` being the only renderer-sourced process-gone producer — with a hardcoded `processType` literal — **one kill burst can yield at most one `source:'renderer'` process report, and that one is the anchor.** The class is empty by construction, not by argument.

The sweep's actual job is intact: a four-process burst (GPU + two Utility + renderer) still fully resolves after the change — `T2 resolved count: 4`, `getLatestPending()` null.

**Two observations recorded rather than fixed.**

1. **The react-render guard is defensive-only, and this PR should not be read as fixing a live bug there.** `recordRendererErrorReport` hardcodes `reason: 'react-error-boundary'` with `exitCode: null`, while `isRelatedCrashEvent` requires **both** reason and exitCode to match. A boundary report therefore can never be crash-shaped, and could not have matched a process crash in production anyway. Rounds 3 and 5 deliberately used a crash-shaped boundary report in their tests so the guard is load-bearing independently of the reason literal — the right call, but it means the protection is against a future change, not against a shape that occurs today.

2. **An asymmetry with `dismiss()` was created and deliberately left.** `transitionStatus`'s sweep has no source or processType guard, so `dismiss()` *does* sweep an older renderer report that `markRendererCrashesAutoRecovered` now refuses to (`T4 dismiss() leaves the older renderer report: dismissed`). Judged correct rather than a defect: the two sweeps rest on different evidence — `dismiss()` anchors on a report the user has **seen and acknowledged**, so suppressing a second prompt for the same event is right, while the auto-recovery sweep anchors on something nobody saw, which is exactly why round 6's cutoff exists. No explanatory comment was added on purpose: a future "let's unify the two sweeps" refactor reds the new test, and a failing test is stronger protection than a comment someone can read past.

Gates on the pushed tree: 224 files passed / 1 skipped, 3155 passed / 11 skipped; `tsc` exit 0; `oxlint` exit 0; `oxfmt` clean. The crash-reporting suites were additionally run three times under `--sequence.shuffle` (125 passed each) to confirm the new store test's `vi.useFakeTimers({toFake:['Date']})` cannot leak into siblings.


Made with [Orca](https://github.com/stablyai/orca) 🐋



