### PR TITLE
feat(editor): add opt-in collapsed unchanged regions for file diffs

### DIFF
--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -25,6 +25,7 @@ import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-
 import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
+import { buildDiffEditorHideUnchangedOptions } from './diff-editor-hide-unchanged-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
 import { monacoFindOptions } from './monaco-find-options'
@@ -428,6 +429,7 @@ export default function DiffViewer({
               lineNumbers: 'on',
               ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
               ...buildDiffEditorWhitespaceOptions(settings?.diffShowWhitespace),
+              ...buildDiffEditorHideUnchangedOptions(settings?.diffCollapseUnchangedRegions),
               automaticLayout: true,
               renderOverviewRuler: true,
               scrollbar: diffEditorScrollbarOptions,

--- a/src/renderer/src/components/editor/diff-editor-hide-unchanged-options.test.ts
+++ b/src/renderer/src/components/editor/diff-editor-hide-unchanged-options.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiffEditorHideUnchangedOptions } from './diff-editor-hide-unchanged-options'
+
+describe('buildDiffEditorHideUnchangedOptions', () => {
+  it('enables collapsing only when the setting is explicitly on', () => {
+    expect(buildDiffEditorHideUnchangedOptions(true)).toEqual({
+      hideUnchangedRegions: { enabled: true }
+    })
+  })
+
+  // Why: the option must always be present, not omitted when off. Monaco keeps the last applied
+  // value across an options update, so dropping the key would strand a diff editor in collapsed
+  // mode after the user turns the setting back off.
+  it('emits an explicit disabled state for off, undefined, and legacy settings', () => {
+    for (const value of [false, undefined]) {
+      expect(buildDiffEditorHideUnchangedOptions(value)).toEqual({
+        hideUnchangedRegions: { enabled: false }
+      })
+    }
+  })
+})

--- a/src/renderer/src/components/editor/diff-editor-hide-unchanged-options.ts
+++ b/src/renderer/src/components/editor/diff-editor-hide-unchanged-options.ts
@@ -1,0 +1,15 @@
+import type { editor } from 'monaco-editor'
+
+/**
+ * Collapses runs of unchanged lines in a diff into expandable bands, leaving a few
+ * lines of context around each change. The combined diff view enables this
+ * unconditionally; single-file diffs gate it behind a setting so full-file review
+ * stays the default.
+ */
+export function buildDiffEditorHideUnchangedOptions(
+  collapseUnchangedRegions: boolean | undefined
+): Pick<editor.IStandaloneDiffEditorConstructionOptions, 'hideUnchangedRegions'> {
+  return {
+    hideUnchangedRegions: { enabled: collapseUnchangedRegions === true }
+  }
+}

--- a/src/renderer/src/components/settings/CollapseUnchangedRegionsSetting.tsx
+++ b/src/renderer/src/components/settings/CollapseUnchangedRegionsSetting.tsx
@@ -1,0 +1,77 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { translate } from '@/i18n/i18n'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+
+const KEYWORDS = [
+  'diff',
+  'collapse',
+  'hide unchanged',
+  'unchanged lines',
+  'fold',
+  'context lines',
+  'hunk'
+]
+
+function getTitle(): string {
+  return translate(
+    'auto.components.settings.GeneralEditorSettingsSection.collapseUnchangedTitle',
+    'Collapse Unchanged Regions'
+  )
+}
+
+function getDescription(): string {
+  return translate(
+    'auto.components.settings.GeneralEditorSettingsSection.collapseUnchangedDescription',
+    'Show only changed lines and a little surrounding context in a file diff, hiding the rest behind expandable bands. The View All Changes diff always collapses this way.'
+  )
+}
+
+export function CollapseUnchangedRegionsSetting({
+  settings,
+  updateSettings
+}: {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}): React.JSX.Element {
+  const title = getTitle()
+  const description = getDescription()
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={description}
+      keywords={KEYWORDS}
+      className="flex items-center justify-between gap-4 py-2"
+    >
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <Label>{title}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <SettingsSegmentedControl
+        ariaLabel={title}
+        value={settings.diffCollapseUnchangedRegions ? 'on' : 'off'}
+        onChange={(option) => {
+          void updateSettings({ diffCollapseUnchangedRegions: option === 'on' })
+        }}
+        options={[
+          {
+            value: 'off',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.bf16ef0af2',
+              'Off'
+            )
+          },
+          {
+            value: 'on',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.3f6892f307',
+              'On'
+            )
+          }
+        ]}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -10,6 +10,7 @@ import { clampNumber } from '@/lib/terminal-theme'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { SearchableSetting } from './SearchableSetting'
+import { CollapseUnchangedRegionsSetting } from './CollapseUnchangedRegionsSetting'
 import {
   SettingsSegmentedControl,
   SettingsSubsectionHeader,
@@ -234,6 +235,8 @@ export function GeneralEditorSettingsSection({
       <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
 
       <DiffShowWhitespaceSetting settings={settings} updateSettings={updateSettings} />
+
+      <CollapseUnchangedRegionsSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7102,7 +7102,9 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
           "7ddd66fede": "Editor Word Wrap",
-          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling.",
+          "collapseUnchangedTitle": "Collapse Unchanged Regions",
+          "collapseUnchangedDescription": "Show only changed lines and a little surrounding context in a file diff, hiding the rest behind expandable bands. The View All Changes diff always collapses this way."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -173,6 +173,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalInactivePaneOpacity: DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY,
     terminalRightClickToPaste: getDefaultTerminalRightClickToPaste(),
     notifications: getDefaultNotificationSettings(),
+
     voice: getDefaultVoiceSettings()
   })
 }

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -158,6 +158,7 @@ export function buildDefaultSettings(args: {
     diffDefaultView: 'inline',
     diffWordWrap: false,
     diffShowWhitespace: false,
+    diffCollapseUnchangedRegions: false,
     combinedDiffFileTreeVisibleByDefault: false,
     prBotAuthorOverrides: [],
     promptCacheTimerEnabled: false,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -280,6 +280,8 @@ export type GlobalSettings = {
   diffDefaultView: 'inline' | 'side-by-side'
   diffWordWrap: boolean
   diffShowWhitespace: boolean
+  /** Opt-in: single-file diffs collapse unchanged regions, as the combined diff view already does; optional for legacy settings. */
+  diffCollapseUnchangedRegions?: boolean
   combinedDiffFileTreeVisibleByDefault: boolean
   /** Bot-marked comment-author logins (stored lowercased); escape hatch for review bots on regular accounts that defeat provider metadata/heuristics. */
   prBotAuthorOverrides: string[]


### PR DESCRIPTION
**What:** Opt-in collapse of unchanged regions in single-file diffs, matching what "View All Changes" already does.
**Risk:** One boolean setting, default off — no behavior change without explicit user action. Greptile: **5/5 "Safe to merge"**.
**State:** Rebased on `main` today (0 behind, 0 conflicts); all review-bot threads resolved.

## ELI5

Today, opening a single file's diff shows every line of the file even if only one line changed, so reviewing a small edit in a long file means a lot of scrolling. This adds an optional Settings > General > Editor switch, "Collapse Unchanged Regions" (off by default), that hides untouched stretches behind expandable "hidden lines" bands — the same way the existing View All Changes view already behaves. Nothing changes unless you turn it on.

---

## Summary

The combined "View All Changes" diff already collapses runs of unchanged lines into expandable bands — `DiffSectionBody.tsx` sets Monaco's `hideUnchangedRegions: { enabled: true }`. A single-file diff opened by clicking one file in Source Control does not, so it renders the whole file. Reviewing a one-line change in a long file means scrolling past everything that did not change.

This adds a **General → Editor** setting, **default off**, that applies the same Monaco option to the single-file diff viewer. Off preserves today's full-file rendering for everyone who has not opted in.

One detail worth noting: the option is always emitted rather than omitted when the setting is off. Monaco retains the last applied value across an options update, so dropping the key would strand an already-open diff in collapsed mode after the user turns the setting back off. `buildDiffEditorHideUnchangedOptions` therefore returns an explicit `{ enabled: false }`, and a test pins that.

## Screenshots

No new chrome. The setting is one segmented Off/On control in General → Editor, sitting directly above the existing "Diff Word Wrap" control and matching its shape. When enabled, single-file diffs render exactly as the existing View All Changes diff already does — unchanged runs become clickable "N hidden lines" bands.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (939 settings/editor/shared tests pass)
- [ ] `pnpm build` — not run locally; relies on CI
- [x] Added or updated high-quality tests that would catch regressions

`diff-editor-hide-unchanged-options.test.ts` covers on, off, and the legacy-`undefined` case, including the always-emit-the-key behavior described above.

## AI Review Report

Reviewed with Claude Code. Risks checked: Monaco option lifecycle across settings changes and model swaps, settings persistence and defaulting for existing profiles, and consistency with the combined diff surface.

- **Stale option on toggle-off** — found and handled; see the Summary note. This is the one behavior here that is not obvious from the diff.
- **Legacy settings** — the field is optional (`diffCollapseUnchangedRegions?: boolean`) and every read goes through `=== true`, so profiles written before this change behave exactly as they do today without a migration.
- **Surface consistency** — the combined viewer keeps its unconditional `hideUnchangedRegions`. This PR deliberately does not put that surface behind the setting: it is a summary view where collapsing is the point, and changing it would be a behavior regression for existing users.
- **Max-lines** — the setting was initially written inline in `GeneralEditorSettingsSection.tsx`, which pushed it to 437 lines against the repo's 400 ceiling. Rather than add a `max-lines` disable (which `AGENTS.md` forbids outright), it is extracted into its own `CollapseUnchangedRegionsSetting.tsx`, matching the one-setting-per-file pattern already used by `CompareAgainstUpstreamSetting` and others.

Cross-platform: no platform-dependent code. This is a single Monaco editor option plus a settings boolean — no shortcuts, labels, paths, shell behavior, or Electron platform APIs are touched.

## Security Audit

Minimal surface. No IPC, command execution, path handling, auth, secrets, or dependency changes. The only new persisted value is a boolean flowing through the existing settings store, consumed as a Monaco rendering option. No user input reaches any new sink. No follow-up needed.

## Notes

Independent of #11866 and #11867 — no shared files, applies cleanly on its own.

Worth flagging for maintainers: the discoverability gap here is real. A user looking for "show me only the changed lines" would reasonably expect that from the per-file diff and may not find that View All Changes already does it. If you would rather this default **on** for parity with the combined view, that is a one-line change to `constants.ts` — I defaulted it off to avoid changing behavior for existing users without opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
