### PR TITLE
fix(runtime): bind mobile WS listener to loopback until pairing (STA-2370)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2740,6 +2740,9 @@ void app.whenReady().then(async () => {
     // Why: mobile pairing needs the stable pre-setName() path (getCanonicalUserDataPath), not a late app.getPath('userData') that drops paired devices across restarts.
     userDataPath: getCanonicalUserDataPath(),
     enableWebSocket: true,
+    // Why: STA-2370 — the desktop app binds the WS listener to loopback until the user pairs a device;
+    // `orca serve` is an explicit remote opt-in, and E2E keeps the wide bind its harness connects over.
+    exposeNetworkByDefault: Boolean(serveOptions) || isE2E,
     ...(isE2E ? { wsPort: e2eWsPort } : {}),
     ...(devWsPort !== undefined ? { wsPort: devWsPort } : {}),
     ...(serveOptions?.wsPort !== undefined

--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -22,6 +22,7 @@ vi.mock('os', () => ({
 }))
 
 import { registerMobileHandlers } from './mobile'
+import { NETWORK_EXPOSURE_FAILED_GUIDANCE } from '../runtime/network-exposure-guidance'
 
 describe('registerMobileHandlers', () => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -285,7 +286,8 @@ describe('registerMobileHandlers', () => {
       endpoint: 'ws://100.64.1.20:6768',
       deviceId: 'runtime-1'
     })
-    const rpcServer = { createPairingOffer }
+    const ensureNetworkExposure = vi.fn().mockResolvedValue(undefined)
+    const rpcServer = { createPairingOffer, ensureNetworkExposure }
 
     registerMobileHandlers(rpcServer as never)
 
@@ -308,6 +310,35 @@ describe('registerMobileHandlers', () => {
       name: expect.stringMatching(/^Runtime /),
       scope: 'runtime'
     })
+    // Why: STA-2370 — generating a runtime offer must widen the listener BEFORE advertising its endpoint,
+    // or a client could read the URL and connect before the LAN bind exists. Assert call ORDER, not just
+    // that the widen ran, so a regression that widens after minting the offer is caught.
+    expect(ensureNetworkExposure).toHaveBeenCalled()
+    expect(ensureNetworkExposure.mock.invocationCallOrder[0]).toBeLessThan(
+      createPairingOffer.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('reports the runtime pairing url unavailable and mints no offer when the widen fails', async () => {
+    const createPairingOffer = vi.fn()
+    // Why: STA-2370 — a failed widen leaves the listener on loopback, so the handler must NOT advertise a
+    // LAN endpoint. A regression that swallows the rejection and mints an offer against a loopback-only
+    // listener is caught here: createPairingOffer must never run.
+    const ensureNetworkExposure = vi.fn().mockRejectedValue(new Error('bind refused'))
+    const rpcServer = { createPairingOffer, ensureNetworkExposure }
+
+    registerMobileHandlers(rpcServer as never)
+
+    await expect(
+      handlers.get('mobile:getRuntimePairingUrl')?.(null, { address: '100.64.1.20' })
+    ).resolves.toEqual({
+      available: false,
+      reason: 'network_exposure_failed',
+      guidance: NETWORK_EXPOSURE_FAILED_GUIDANCE
+    })
+
+    expect(ensureNetworkExposure).toHaveBeenCalled()
+    expect(createPairingOffer).not.toHaveBeenCalled()
   })
 
   it('lists runtime access grants including unused generated links', () => {

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -4,6 +4,7 @@ import type { RuntimeAccessGrant } from '../../shared/runtime-access-grants'
 import type { MobilePairingConnectionMode } from '../../shared/mobile-pairing-connection-mode'
 import { isTailnetIPv4Address } from '../../shared/tailnet-address'
 import type { DeviceEntry } from '../runtime/device-registry'
+import { NETWORK_EXPOSURE_FAILED_GUIDANCE } from '../runtime/network-exposure-guidance'
 import type { OrcaRuntimeRpcServer } from '../runtime/runtime-rpc'
 import type { RelayBrokerStatus } from '../runtime/relay/relay-session-broker'
 import { encodeMobilePairingQr, type MobilePairingQrResult } from '../runtime/mobile-pairing-qr'
@@ -178,6 +179,25 @@ export function registerMobileHandlers(
       const ip = args?.address ?? getDefaultPairingAddress()
       if (!ip) {
         return { available: false as const }
+      }
+
+      // Why: STA-2370 — generating a runtime pairing offer is the user's explicit opt-in to remote
+      // reach, so widen the loopback listener before advertising its LAN endpoint. If the widen fails the
+      // listener stays on loopback, so report unavailable rather than advertise a dead LAN endpoint.
+      try {
+        await rpcServer.ensureNetworkExposure()
+      } catch (error) {
+        console.error(
+          '[mobile] Network exposure failed while creating a runtime pairing offer:',
+          error
+        )
+        // Why: STA-2370 — carry the specific reason/guidance to the renderer (mirrors the mobile-QR path) so
+        // a widen failure is distinguishable from a missing address, not collapsed into a bare unavailable.
+        return {
+          available: false as const,
+          reason: 'network_exposure_failed' as const,
+          guidance: NETWORK_EXPOSURE_FAILED_GUIDANCE
+        }
       }
 
       // Why: web/desktop runtime clients need full runtime access, not the

--- a/src/main/runtime/network-exposure-guidance.ts
+++ b/src/main/runtime/network-exposure-guidance.ts
@@ -1,0 +1,5 @@
+// Why: shared between the runtime RPC server (createMobilePairingOffer) and the mobile IPC layer
+// (getRuntimePairingUrl) so a failed pairing widen surfaces one consistent message. Kept in its own light
+// module so the mobile IPC unit test can import the string without loading the full RPC/SSH module graph.
+export const NETWORK_EXPOSURE_FAILED_GUIDANCE =
+  'Could not expose the runtime to the network for pairing. The listener kept serving locally; retry, or choose an unused --port if the LAN bind was refused.'

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -127,6 +127,12 @@ export class WebSocketTransport implements RpcTransport {
     return this.port
   }
 
+  // Why: the actual OS-reported bind interface, so callers can verify loopback vs all-interfaces (STA-2370).
+  get resolvedHost(): string | null {
+    const addr = this.httpServer?.address()
+    return addr && typeof addr === 'object' ? addr.address : null
+  }
+
   async start(): Promise<void> {
     if (this.wss) {
       return

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -24,6 +24,7 @@ import {
   encodeTerminalStreamText
 } from '../../shared/terminal-stream-protocol'
 import { decrypt, deriveSharedKey, encrypt, generateKeyPair } from './rpc/e2ee-crypto'
+import { WebSocketTransport } from './rpc/ws-transport'
 import { DeviceRegistry } from './device-registry'
 import { DEVICE_REGISTRY_FILENAME, E2EE_KEYPAIR_FILENAME } from './mobile-pairing-files'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../shared/protocol-version'
@@ -5479,5 +5480,379 @@ describe('OrcaRuntimeRpcServer', () => {
         realPrototype.exec = originalExec
       }
     })
+  })
+})
+
+describe('OrcaRuntimeRpcServer WebSocket bind host (STA-2370)', () => {
+  const wsTransportOf = (server: OrcaRuntimeRpcServer): WebSocketTransport | undefined =>
+    (server['activeTransports'] as unknown[]).find(
+      (transport): transport is WebSocketTransport => transport instanceof WebSocketTransport
+    )
+
+  it('binds the listener to loopback on a fresh desktop with no paired device', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      expect(server.getDeviceRegistry()?.listDevices()).toHaveLength(0)
+      // Why: the exposure regression — before STA-2370 this bound 0.0.0.0 with zero devices paired.
+      expect(wsTransportOf(server)?.resolvedHost).toBe('127.0.0.1')
+      expect(new URL(server.getWebSocketEndpoint()!).hostname).toBe('127.0.0.1')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('widens the listener to all interfaces when a mobile pairing offer is created', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      const loopbackPort = wsTransportOf(server)?.resolvedPort
+      expect(wsTransportOf(server)?.resolvedHost).toBe('127.0.0.1')
+
+      const offer = await server.createMobilePairingOffer({
+        address: '100.64.1.20',
+        connectionMode: 'local-only'
+      })
+      expect(offer.available).toBe(true)
+
+      expect(wsTransportOf(server)?.resolvedHost).toBe('0.0.0.0')
+      expect(new URL(server.getWebSocketEndpoint()!).hostname).toBe('0.0.0.0')
+      // Why: the widen reuses the same port so the QR's already-advertised endpoint stays valid.
+      expect(wsTransportOf(server)?.resolvedPort).toBe(loopbackPort)
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('binds all interfaces at startup when exposeNetworkByDefault is set (orca serve)', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0,
+      exposeNetworkByDefault: true
+    })
+
+    await server.start()
+    try {
+      expect(wsTransportOf(server)?.resolvedHost).toBe('0.0.0.0')
+      expect(new URL(server.getWebSocketEndpoint()!).hostname).toBe('0.0.0.0')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('binds all interfaces at startup when a previously-connected device can reconnect', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    // Why: a device that has actually connected (lastSeenAt > 0) may reconnect, so the listener must be
+    // reachable at startup without waiting for a new pairing action.
+    const registry = new DeviceRegistry(userDataPath)
+    const device = registry.getOrCreatePendingDevice('Paired phone', 'mobile')
+    registry.updateLastSeen(device.deviceId)
+
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      expect(
+        server
+          .getDeviceRegistry()
+          ?.listDevices()
+          .some((d) => d.lastSeenAt > 0)
+      ).toBe(true)
+      expect(wsTransportOf(server)?.resolvedHost).toBe('0.0.0.0')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('stays on loopback at startup for a pending device that has never connected', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    // Why: a pending device (offer created but never connected: lastSeenAt === 0) is not a reconnect, so
+    // the listener must stay loopback — this distinguishes the reconnect widen from a blanket any-device
+    // widen (a revert to listDevices().length > 0 would wrongly expose the LAN here).
+    const registry = new DeviceRegistry(userDataPath)
+    registry.getOrCreatePendingDevice('Pending phone', 'mobile')
+
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      expect(server.getDeviceRegistry()?.listDevices()).toHaveLength(1)
+      expect(
+        server
+          .getDeviceRegistry()
+          ?.listDevices()
+          .every((d) => d.lastSeenAt === 0)
+      ).toBe(true)
+      expect(wsTransportOf(server)?.resolvedHost).toBe('127.0.0.1')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('keeps the same MobileSocketWiring instance across a pairing widen (relay capture stays valid)', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      const wiringBeforeWiden = server.getMobileSocketWiring()
+      expect(wiringBeforeWiden).not.toBeNull()
+      expect(wsTransportOf(server)?.resolvedHost).toBe('127.0.0.1')
+
+      const offer = await server.createMobilePairingOffer({
+        address: '100.64.1.20',
+        connectionMode: 'local-only'
+      })
+      expect(offer.available).toBe(true)
+      expect(wsTransportOf(server)?.resolvedHost).toBe('0.0.0.0')
+
+      // Why: DesktopRelayService captures the wiring once at construction and hands it to every relay
+      // broker, so the widen must swap the transport under the SAME wiring — replacing the wiring would
+      // strand relay sockets on a dead object (lost connection IDs, binary handling, revocation targeting).
+      expect(server.getMobileSocketWiring()).toBe(wiringBeforeWiden)
+
+      // Why: object identity alone would pass even if the post-widen transport were never re-attached to the
+      // captured wiring. Prove the swap functionally — route a revocation through the pre-widen wiring and
+      // assert it reaches the NEW (0.0.0.0) transport, confirming attachTransport ran on the same wiring
+      // after the rebind. A revert that leaves the wiring pointed at the stopped loopback transport fails here.
+      const widenedTransport = wsTransportOf(server)
+      expect(widenedTransport).toBeDefined()
+      const terminateSpy = vi.spyOn(widenedTransport!, 'terminateClientConnections')
+      wiringBeforeWiden!.terminateDeviceConnections('device-token-xyz')
+      expect(terminateSpy).toHaveBeenCalledWith('device-token-xyz')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('coalesces concurrent pairing widens into a single rebind', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      expect(wsTransportOf(server)?.resolvedHost).toBe('127.0.0.1')
+      const widenSpy = vi.spyOn(
+        server as unknown as { widenWebSocketBind: () => Promise<void> },
+        'widenWebSocketBind'
+      )
+
+      await Promise.all([server.ensureNetworkExposure(), server.ensureNetworkExposure()])
+
+      // Why: two racing pairing offers must share one rebind via networkExposurePromise — two competing
+      // stop/start races would fight for the port and could strand the listener on a random one.
+      expect(widenSpy).toHaveBeenCalledTimes(1)
+      expect(wsTransportOf(server)?.resolvedHost).toBe('0.0.0.0')
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('reports pairing unavailable but keeps a serving loopback listener when the widen bind fails', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      const loopbackPort = wsTransportOf(server)?.resolvedPort
+      // Why: force the wide bind to throw AFTER the loopback listener is stopped, then let the loopback
+      // recovery bind through — proving no stranded/closed socket and a retry-able state.
+      const target = server as unknown as {
+        startWebSocketTransport: (opts: { host: string }) => Promise<unknown>
+        wsBoundHost: string | null
+      }
+      const original = target.startWebSocketTransport.bind(server)
+      vi.spyOn(target, 'startWebSocketTransport').mockImplementation(async (opts) => {
+        if (opts.host === '0.0.0.0') {
+          throw new Error('injected wide bind failure')
+        }
+        return original(opts)
+      })
+
+      const offer = await server.createMobilePairingOffer({
+        address: '100.64.1.20',
+        connectionMode: 'local-only'
+      })
+      // Why: a failed widen must NOT advertise a LAN endpoint with no LAN listener behind it — the offer is
+      // reported unavailable (STA-2370). A revert that swallows the widen failure would return available:true.
+      expect(offer.available).toBe(false)
+      if (!offer.available) {
+        expect(offer.reason).toBe('network_exposure_failed')
+      }
+      // Why: the listener must keep serving on loopback (same port) rather than being left stranded/closed.
+      expect(wsTransportOf(server)?.resolvedHost).toBe('127.0.0.1')
+      expect(wsTransportOf(server)?.resolvedPort).toBe(loopbackPort)
+      // Why: wsBoundHost stays loopback so a later pairing offer retries the widen.
+      expect(target.wsBoundHost).toBe('127.0.0.1')
+    } finally {
+      await server.stop()
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('keeps the widened listener tracked when persisting pairing metadata fails', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    try {
+      // Why: fail metadata publication AFTER the wide bind already succeeded. The live 0.0.0.0 listener must
+      // stay tracked in activeTransports — a revert that runs loopback recovery here orphans a running wide
+      // listener (an untracked 0.0.0.0 socket outside stop(): the exact STA-2370 exposure).
+      const target = server as unknown as {
+        writeMetadata: () => void
+        wsBoundHost: string | null
+        activeTransports: unknown[]
+      }
+      let injected = false
+      const originalWrite = target.writeMetadata.bind(server)
+      vi.spyOn(target, 'writeMetadata').mockImplementation(() => {
+        if (!injected && target.wsBoundHost === '0.0.0.0') {
+          injected = true
+          throw new Error('injected metadata write failure')
+        }
+        return originalWrite()
+      })
+
+      const offer = await server.createMobilePairingOffer({
+        address: '100.64.1.20',
+        connectionMode: 'local-only'
+      })
+      expect(injected).toBe(true)
+      // Why: only metadata persistence failed; the wide bind succeeded, so pairing is available and the wide
+      // listener is tracked (not orphaned) — bound to all interfaces, exactly one WebSocket transport.
+      expect(offer.available).toBe(true)
+      expect(wsTransportOf(server)?.resolvedHost).toBe('0.0.0.0')
+      expect(target.activeTransports.filter((t) => t instanceof WebSocketTransport)).toHaveLength(1)
+    } finally {
+      await server.stop()
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('does not strand a wide listener when stop() races an in-flight widen', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+
+    const target = server as unknown as {
+      startWebSocketTransport: (opts: {
+        host: string
+      }) => Promise<{ transport: WebSocketTransport; endpoint: string }>
+      activeTransports: unknown[]
+    }
+    const original = target.startWebSocketTransport.bind(server)
+    let releaseWideStart: () => void = () => {}
+    const wideStartGate = new Promise<void>((resolve) => {
+      releaseWideStart = resolve
+    })
+    let wideStopSpy: ReturnType<typeof vi.spyOn> | null = null
+    vi.spyOn(target, 'startWebSocketTransport').mockImplementation(async (opts) => {
+      if (opts.host === '0.0.0.0') {
+        // Why: hold the widen mid-flight (loopback already stopped) so stop() must race the rebind.
+        await wideStartGate
+        const result = await original(opts)
+        wideStopSpy = vi.spyOn(result.transport, 'stop')
+        return result
+      }
+      return original(opts)
+    })
+
+    // Why: begin a pairing widen but do not await it, then start shutdown while it is still in-flight.
+    const widen = server.ensureNetworkExposure()
+    const stopping = server.stop()
+    releaseWideStart()
+    await Promise.all([widen.catch(() => {}), stopping])
+
+    try {
+      // Why: STA-2370 — stop() must fence and await the in-flight widen so the freshly-bound wide listener is
+      // snapshotted and stopped, never written back into the cleared arrays as a live 0.0.0.0 leak. A revert
+      // (no fence) leaves the wide transport in activeTransports after stop() and never calls its stop().
+      expect(target.activeTransports).toHaveLength(0)
+      expect(wideStopSpy).not.toBeNull()
+      expect(wideStopSpy).toHaveBeenCalled()
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('refuses to widen a pairing offer that arrives after the server has stopped', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const server = new OrcaRuntimeRpcServer({
+      runtime: new OrcaRuntimeService(),
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+
+    await server.start()
+    const widenSpy = vi.spyOn(
+      server as unknown as { widenWebSocketBind: () => Promise<void> },
+      'widenWebSocketBind'
+    )
+    await server.stop()
+
+    // Why: STA-2370 — the `stopping` fence must reject a widen that arrives on its own AFTER shutdown, not
+    // only one already in-flight during stop() (covered above via the pending-exposure await). Reverting the
+    // `stopping` guard alone still passes the race test, but here ensureNetworkExposure would re-enter
+    // widenWebSocketBind and re-open a 0.0.0.0 listener on a server that is supposed to be down.
+    await server.ensureNetworkExposure()
+    expect(widenSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -5,6 +5,7 @@ import { readdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import type { RuntimeMetadata, RuntimeTransportMetadata } from '../../shared/runtime-bootstrap'
 import type { OrcaRuntimeService } from './orca-runtime'
+import { NETWORK_EXPOSURE_FAILED_GUIDANCE } from './network-exposure-guidance'
 import { writeRuntimeMetadata } from './runtime-metadata'
 import {
   RUNTIME_METADATA_OWNERSHIP_POLL_MS,
@@ -53,6 +54,11 @@ import {
 
 const DEFAULT_WS_PORT = 6768
 
+// Why: STA-2370 — the WS listener defaults to loopback so a desktop with no paired device is not
+// reachable from the LAN; it widens to all interfaces only on explicit pairing (or `orca serve`).
+const WS_BIND_HOST_LOOPBACK = '127.0.0.1'
+const WS_BIND_HOST_ALL_INTERFACES = '0.0.0.0'
+
 type OrcaRuntimeRpcServerOptions = {
   runtime: OrcaRuntimeService
   userDataPath: string
@@ -62,6 +68,9 @@ type OrcaRuntimeRpcServerOptions = {
   wsPort?: number
   // Why: true when the caller pinned a port (`orca serve --port`) so bind order prefers it over a stale STA-1511 fallback (#8535).
   preferPinnedWsPort?: boolean
+  // Why: STA-2370 — bind the WS listener to all interfaces at startup instead of loopback-until-paired.
+  // Only `orca serve` (explicit remote opt-in) and E2E set this; the desktop app widens lazily on pairing.
+  exposeNetworkByDefault?: boolean
   webClientRoot?: string
   // Why: test-only overrides for the two constants below; production must not pass these (defaults set by §3.1).
   keepaliveIntervalMs?: number
@@ -76,6 +85,7 @@ export type PairingOfferUnavailableReason =
   | 'e2ee_key_unavailable'
   | 'invalid_advertised_endpoint'
   | 'relay_mint_failed'
+  | 'network_exposure_failed'
 
 export type PairingOfferUnavailable = {
   available: false
@@ -472,7 +482,15 @@ export class OrcaRuntimeRpcServer {
   private readonly enableWebSocket: boolean
   private readonly wsPort: number
   private readonly preferPinnedWsPort: boolean
+  private readonly exposeNetworkByDefault: boolean
   private readonly webClientRoot: string | undefined
+  // Why: STA-2370 — the host the WS listener is currently bound to, so pairing can widen loopback→all-interfaces once.
+  private wsBoundHost: string | null = null
+  // Why: STA-2370 — in-flight widen so concurrent pairing requests share a single rebind.
+  private networkExposurePromise: Promise<void> | null = null
+  // Why: STA-2370 — set by stop() so a racing pairing widen can't recreate a live wide listener into the
+  // cleared transport arrays after shutdown; stop() also awaits any in-flight widen before snapshotting.
+  private stopping = false
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
   private readonly longPollCap: number
@@ -487,6 +505,9 @@ export class OrcaRuntimeRpcServer {
   private transports: RuntimeTransportMetadata[] = []
   private metadataOwnershipWatch: RuntimeMetadataOwnershipWatch | null = null
   private mobileSocketWiring: MobileSocketWiring | null = null
+  // Why: detaches the current WebSocketTransport from the session wiring so a pairing rebind can swap
+  // transports under the SAME wiring (see ensureMobileSocketWiring) instead of orphaning relay sockets.
+  private detachWebSocketWiring: (() => void) | null = null
   private mobileRelayPairingProvider: MobileRelayPairingProvider | null = null
   private mobileRelayPairingOfferQueue: Promise<void> = Promise.resolve()
   private mobileRelayPairingOfferInFlight: {
@@ -519,6 +540,7 @@ export class OrcaRuntimeRpcServer {
     enableWebSocket = false,
     wsPort = DEFAULT_WS_PORT,
     preferPinnedWsPort = false,
+    exposeNetworkByDefault = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
     longPollCap = LONG_POLL_CAP,
@@ -532,6 +554,7 @@ export class OrcaRuntimeRpcServer {
     this.enableWebSocket = enableWebSocket
     this.wsPort = wsPort
     this.preferPinnedWsPort = preferPinnedWsPort
+    this.exposeNetworkByDefault = exposeNetworkByDefault
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.longPollCap = longPollCap
@@ -704,6 +727,18 @@ export class OrcaRuntimeRpcServer {
     name?: string
     rotate?: boolean
   }): Promise<MobilePairingOffer> {
+    // Why: STA-2370 — creating a mobile pairing offer is the user's explicit opt-in to LAN reach, so
+    // widen the loopback listener before advertising its LAN endpoint in the QR. If the widen fails the
+    // listener stays on loopback, so report unavailable rather than advertise a dead LAN endpoint.
+    try {
+      await this.ensureNetworkExposure()
+    } catch (error) {
+      console.error(
+        '[runtime] Network exposure failed while creating a mobile pairing offer:',
+        error
+      )
+      return pairingUnavailable('network_exposure_failed', NETWORK_EXPOSURE_FAILED_GUIDANCE)
+    }
     if (args.connectionMode === 'local-only') {
       this.mobilePairingOfferGeneration += 1
       return this.createMobilePairingOfferSerial(args, this.mobilePairingOfferGeneration)
@@ -1136,74 +1171,19 @@ export class OrcaRuntimeRpcServer {
         this.e2eeKeypair = pairingIdentity.e2eeKeypair
         this.pairingInitializationFailure = null
         try {
-          const wsTransport = new WebSocketTransport({
-            host: '0.0.0.0',
+          const host = this.resolveInitialWebSocketBindHost()
+          const { transport, endpoint } = await this.startWebSocketTransport({
+            host,
             port: this.wsPort,
-            staticRoot: this.webClientRoot,
+            preferPinnedPort: this.preferPinnedWsPort,
             // Why: stable fallback port across restarts keeps paired devices' endpoints valid (STA-1511); wsPort 0 = random (E2E).
-            ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {}),
-            ...(this.preferPinnedWsPort ? { preferPinnedPort: true } : {})
+            ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
           })
-          // Why: session-scoped (recreated per start) so each desktop launch may notify once.
-          this.unpairedDeviceAuthThrottle = new UnpairedDeviceAuthThrottle({
-            onTrigger: () => this.onUnpairedDeviceAuthFailure?.()
-          })
-          const mobileSocketWiring = new MobileSocketWiring({
-            deviceRegistry: pairingIdentity.deviceRegistry,
-            e2eeKeypair: pairingIdentity.e2eeKeypair,
-            onText: (socket, plaintext, reply, sendBinary) => {
-              void this.handleWebSocketMessage(
-                plaintext,
-                reply,
-                sendBinary,
-                undefined,
-                socket.ws,
-                socket.device.deviceToken,
-                socket
-              )
-            },
-            onBinary: (socket, bytes) => this.handleWebSocketBinaryMessage(bytes, socket.ws),
-            onReady: () => {
-              // Why: first authenticated mobile/remote client (direct WS and
-              // cloud relay both attach here) starts path-candidate tracking.
-              // Activation is a local-host concern: candidate buffers live on the
-              // buffer-owning host's runtime, so a remote runtime proxy may
-              // legitimately lack this method (its own server activates it).
-              this.runtime.activateRecentPtyPathCandidateTracking?.()
-              this.mobileRelayPairingProvider?.onDemandStateChanged?.()
-            },
-            onClose: (socket, hasOtherConnections) => {
-              if (!socket) {
-                return
-              }
-              this.abortWebSocketDispatches(socket.ws)
-              // Why: subscriptions and binary streams are socket-scoped, but disconnect state is device-scoped across transports.
-              this.runtime.cleanupSubscriptionsForConnection(socket.connectionId)
-              this.runtime.cancelMobileDictationForConnection(socket.connectionId)
-              this.binaryStreamHandlers.delete(socket.connectionId)
-              if (!hasOtherConnections) {
-                this.runtime.onClientDisconnected(socket.device.deviceToken)
-              }
-            },
-            // Why: relay attempts are authorized upstream; only direct failures should prompt local re-pairing.
-            onUnpairedDeviceAuthFailure: (metadata) => {
-              if (metadata.transport === 'direct') {
-                this.unpairedDeviceAuthThrottle?.recordFailure()
-              }
-            }
-          })
-          mobileSocketWiring.attachTransport(wsTransport)
-          this.mobileSocketWiring = mobileSocketWiring
-
-          await wsTransport.start()
-          if (this.wsPort !== 0 && wsTransport.resolvedPort !== this.wsPort) {
-            writeWsFallbackPort(this.userDataPath, wsTransport.resolvedPort)
+          if (this.wsPort !== 0 && transport.resolvedPort !== this.wsPort) {
+            writeWsFallbackPort(this.userDataPath, transport.resolvedPort)
           }
-          activeTransports.push(wsTransport)
-          transportsMeta.push({
-            kind: 'websocket',
-            endpoint: `ws://0.0.0.0:${wsTransport.resolvedPort}`
-          })
+          activeTransports.push(transport)
+          transportsMeta.push({ kind: 'websocket', endpoint })
         } catch (error) {
           // Why: WebSocket transport is supplementary; on failure (e.g. port in use) continue with Unix socket only.
           console.error('[runtime] Failed to start WebSocket transport:', error)
@@ -1246,18 +1226,267 @@ export class OrcaRuntimeRpcServer {
     })
   }
 
+  // Why: STA-2370 — a desktop with no previously-connected device stays on loopback until the user
+  // explicitly pairs; `orca serve`/E2E (exposeNetworkByDefault) and a reconnecting paired device bind wide.
+  private resolveInitialWebSocketBindHost(): string {
+    if (this.exposeNetworkByDefault) {
+      return WS_BIND_HOST_ALL_INTERFACES
+    }
+    const hasConnectedDevice =
+      this.deviceRegistry?.listDevices().some((device) => device.lastSeenAt > 0) ?? false
+    return hasConnectedDevice ? WS_BIND_HOST_ALL_INTERFACES : WS_BIND_HOST_LOOPBACK
+  }
+
+  // Why: builds and starts a WS transport bound to `host`, wiring the session-scoped mobile socket
+  // handlers. Shared by initial start() and the pairing-time widen so both paths stay identical.
+  private async startWebSocketTransport(options: {
+    host: string
+    port: number
+    preferPinnedPort: boolean
+    fallbackPort?: number
+  }): Promise<{ transport: WebSocketTransport; endpoint: string }> {
+    const deviceRegistry = this.deviceRegistry
+    const e2eeKeypair = this.e2eeKeypair
+    if (!deviceRegistry || !e2eeKeypair) {
+      throw new Error('WebSocket transport requires an initialized pairing identity')
+    }
+    const wsTransport = new WebSocketTransport({
+      host: options.host,
+      port: options.port,
+      staticRoot: this.webClientRoot,
+      ...(options.fallbackPort !== undefined ? { fallbackPort: options.fallbackPort } : {}),
+      ...(options.preferPinnedPort ? { preferPinnedPort: true } : {})
+    })
+    const mobileSocketWiring = this.ensureMobileSocketWiring(deviceRegistry, e2eeKeypair)
+    this.detachWebSocketWiring = mobileSocketWiring.attachTransport(wsTransport)
+
+    try {
+      await wsTransport.start()
+    } catch (error) {
+      // Why: a listener that never bound must not stay attached to the session wiring (it would leak into
+      // terminateDeviceConnections); detach before propagating so the wiring only tracks live transports.
+      this.detachWebSocketWiring?.()
+      this.detachWebSocketWiring = null
+      throw error
+    }
+    this.wsBoundHost = options.host
+    return {
+      transport: wsTransport,
+      endpoint: `ws://${options.host}:${wsTransport.resolvedPort}`
+    }
+  }
+
+  // Why: one MobileSocketWiring per server session. Direct WS and cloud relay both attach to it, and
+  // DesktopRelayService captures it once at construction, so a loopback→wide pairing rebind must swap the
+  // transport under the SAME wiring — replacing the wiring would strand relay sockets (lost connection IDs,
+  // binary handling, and revocation targeting) on a dead object.
+  private ensureMobileSocketWiring(
+    deviceRegistry: DeviceRegistry,
+    e2eeKeypair: E2EEKeypair
+  ): MobileSocketWiring {
+    if (this.mobileSocketWiring) {
+      return this.mobileSocketWiring
+    }
+    // Why: session-scoped so each desktop launch may notify once (a mid-session rebind must not reset it).
+    this.unpairedDeviceAuthThrottle = new UnpairedDeviceAuthThrottle({
+      onTrigger: () => this.onUnpairedDeviceAuthFailure?.()
+    })
+    const mobileSocketWiring = new MobileSocketWiring({
+      deviceRegistry,
+      e2eeKeypair,
+      onText: (socket, plaintext, reply, sendBinary) => {
+        void this.handleWebSocketMessage(
+          plaintext,
+          reply,
+          sendBinary,
+          undefined,
+          socket.ws,
+          socket.device.deviceToken,
+          socket
+        )
+      },
+      onBinary: (socket, bytes) => this.handleWebSocketBinaryMessage(bytes, socket.ws),
+      onReady: () => {
+        // Why: first authenticated mobile/remote client (direct WS and
+        // cloud relay both attach here) starts path-candidate tracking.
+        // Activation is a local-host concern: candidate buffers live on the
+        // buffer-owning host's runtime, so a remote runtime proxy may
+        // legitimately lack this method (its own server activates it).
+        this.runtime.activateRecentPtyPathCandidateTracking?.()
+        this.mobileRelayPairingProvider?.onDemandStateChanged?.()
+      },
+      onClose: (socket, hasOtherConnections) => {
+        if (!socket) {
+          return
+        }
+        this.abortWebSocketDispatches(socket.ws)
+        // Why: subscriptions and binary streams are socket-scoped, but disconnect state is device-scoped across transports.
+        this.runtime.cleanupSubscriptionsForConnection(socket.connectionId)
+        this.runtime.cancelMobileDictationForConnection(socket.connectionId)
+        this.binaryStreamHandlers.delete(socket.connectionId)
+        if (!hasOtherConnections) {
+          this.runtime.onClientDisconnected(socket.device.deviceToken)
+        }
+      },
+      // Why: relay attempts are authorized upstream; only direct failures should prompt local re-pairing.
+      onUnpairedDeviceAuthFailure: (metadata) => {
+        if (metadata.transport === 'direct') {
+          this.unpairedDeviceAuthThrottle?.recordFailure()
+        }
+      }
+    })
+    this.mobileSocketWiring = mobileSocketWiring
+    return mobileSocketWiring
+  }
+
+  // Why: STA-2370 — widen the loopback listener to all interfaces so a freshly generated pairing
+  // offer's advertised LAN endpoint is reachable. Idempotent and only ever runs on the first opt-in
+  // (before any device has connected), so no live socket is disrupted; the resolved port is reused so
+  // an already-issued endpoint stays valid.
+  async ensureNetworkExposure(): Promise<void> {
+    if (
+      !this.enableWebSocket ||
+      this.stopping ||
+      this.wsBoundHost === WS_BIND_HOST_ALL_INTERFACES
+    ) {
+      return
+    }
+    // Why: concurrent pairing requests must share one rebind — two simultaneous stop/start races would
+    // fight for the port and strand the listener on a random one.
+    if (!this.networkExposurePromise) {
+      this.networkExposurePromise = this.widenWebSocketBind().finally(() => {
+        this.networkExposurePromise = null
+      })
+    }
+    return this.networkExposurePromise
+  }
+
+  private async widenWebSocketBind(): Promise<void> {
+    const current = this.activeTransports.find(
+      (transport): transport is WebSocketTransport => transport instanceof WebSocketTransport
+    )
+    if (!current) {
+      return
+    }
+    const index = this.activeTransports.indexOf(current)
+    const previousPort = current.resolvedPort
+    let widened: { transport: WebSocketTransport; endpoint: string }
+    try {
+      // Why: detach the loopback listener from the session wiring before stopping it so terminateDevice-
+      // Connections never iterates a dead transport; the new listener re-attaches to the SAME wiring.
+      this.detachWebSocketWiring?.()
+      await current.stop()
+      widened = await this.startWebSocketTransport({
+        host: WS_BIND_HOST_ALL_INTERFACES,
+        port: previousPort,
+        preferPinnedPort: true
+      })
+    } catch (error) {
+      // Why: the wide bind failed after the loopback listener was already stopped. Restore a serving
+      // loopback listener on the same port (wsBoundHost stays loopback so a later offer retries), then
+      // propagate — the caller must not advertise a LAN endpoint with no LAN listener behind it (STA-2370).
+      console.error('[runtime] Failed to widen WebSocket transport for pairing:', error)
+      await this.recoverWebSocketBindAfterFailedWiden(index, previousPort)
+      throw error
+    }
+    // Why: register the live wide transport BEFORE persisting metadata so a metadata-write failure can
+    // never orphan a running 0.0.0.0 listener outside activeTransports (and thus outside stop()).
+    this.activeTransports[index] = widened.transport
+    const metaIndex = this.transports.findIndex((meta) => meta.kind === 'websocket')
+    if (metaIndex >= 0) {
+      this.transports[metaIndex] = { kind: 'websocket', endpoint: widened.endpoint }
+    }
+    try {
+      // Why: a rebind that lands on a different port (same-port bind refused) must be persisted so a
+      // later reconnect from a device paired to this port matches on the next launch (STA-1511).
+      if (this.wsPort !== 0 && widened.transport.resolvedPort !== this.wsPort) {
+        writeWsFallbackPort(this.userDataPath, widened.transport.resolvedPort)
+      }
+      this.writeMetadata()
+    } catch (persistError) {
+      // Why: the wide listener is live and tracked; a persistence failure must not tear it down. Keep
+      // serving — the in-memory endpoint is already correct.
+      console.error(
+        '[runtime] Widened WebSocket listener but failed to persist pairing metadata:',
+        persistError
+      )
+    }
+  }
+
+  // Why: a failed widen already tore down the loopback listener; bring one back on the same host/port so the
+  // runtime keeps serving locally (wsBoundHost stays loopback, so the next pairing offer retries the widen).
+  private async recoverWebSocketBindAfterFailedWiden(
+    index: number,
+    previousPort: number
+  ): Promise<void> {
+    let restored: { transport: WebSocketTransport; endpoint: string }
+    try {
+      restored = await this.startWebSocketTransport({
+        host: WS_BIND_HOST_LOOPBACK,
+        port: previousPort,
+        preferPinnedPort: true
+      })
+    } catch (recoveryError) {
+      // Why: even the loopback restore failed — drop the dead WebSocket transport so we never advertise an
+      // endpoint with no listener. The Unix socket keeps serving and a restart re-establishes the listener.
+      console.error(
+        '[runtime] Failed to restore WebSocket transport after widen failure:',
+        recoveryError
+      )
+      this.activeTransports.splice(index, 1)
+      const metaIndex = this.transports.findIndex((meta) => meta.kind === 'websocket')
+      if (metaIndex >= 0) {
+        this.transports.splice(metaIndex, 1)
+      }
+      this.wsBoundHost = null
+      try {
+        this.writeMetadata()
+      } catch {
+        // Why: metadata already reflects the torn-down listener; nothing else to recover here.
+      }
+      return
+    }
+    // Why: register the restored loopback listener BEFORE persisting metadata so a write failure can never
+    // orphan a live transport outside activeTransports (and thus outside stop()).
+    this.activeTransports[index] = restored.transport
+    const metaIndex = this.transports.findIndex((meta) => meta.kind === 'websocket')
+    if (metaIndex >= 0) {
+      this.transports[metaIndex] = { kind: 'websocket', endpoint: restored.endpoint }
+    }
+    try {
+      this.writeMetadata()
+    } catch (persistError) {
+      // Why: the loopback listener is live and tracked; a persistence failure must not tear it down.
+      console.error(
+        '[runtime] Restored loopback WebSocket listener but failed to persist metadata:',
+        persistError
+      )
+    }
+  }
+
   /** Why: test-only seam — runs one ownership check instead of waiting out the poll interval. */
   checkRuntimeMetadataOwnership(): void {
     this.metadataOwnershipWatch?.check()
   }
 
   async stop(): Promise<void> {
+    // Why: STA-2370 — refuse new widens, then let any in-flight pairing widen settle into the live
+    // transport arrays before snapshotting them, so a racing rebind can't strand a wide 0.0.0.0 listener
+    // by writing it back into a cleared array after shutdown (see widenWebSocketBind).
+    this.stopping = true
+    const pendingExposure = this.networkExposurePromise
+    if (pendingExposure) {
+      await pendingExposure.catch(() => {
+        // Why: a failed widen already recovered/logged; we only need it to finish mutating the arrays.
+      })
+    }
     const transports = this.activeTransports
     this.activeTransports = []
     this.transports = []
     this.metadataOwnershipWatch?.stop()
     this.metadataOwnershipWatch = null
     this.mobileSocketWiring = null
+    this.detachWebSocketWiring = null
     if (transports.length === 0) {
       return
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3619,7 +3619,7 @@ export type PreloadApi = {
     >
     openWindowsNetworkSettings: () => Promise<boolean>
     getRuntimePairingUrl: (args?: { address?: string; rotate?: boolean }) => Promise<
-      | { available: false }
+      | { available: false; reason?: 'network_exposure_failed'; guidance?: string }
       | {
           available: true
           pairingUrl: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4623,7 +4623,7 @@ const api = {
       address?: string
       rotate?: boolean
     }): Promise<
-      | { available: false }
+      | { available: false; reason?: 'network_exposure_failed'; guidance?: string }
       | {
           available: true
           pairingUrl: string

--- a/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
@@ -192,11 +192,14 @@ export function RuntimePairingUrlGenerator({
       if (!result.available) {
         clearGeneratedUrls()
         if (mountedRef.current) {
+          // Why: STA-2370 — surface the specific network-exposure guidance when the widen failed; fall back
+          // to the generic message for other unavailable cases (e.g. no reachable address).
           toast.error(
-            translate(
-              'auto.components.settings.RuntimePairingUrlGenerator.2752126f3e',
-              'Runtime pairing is unavailable.'
-            )
+            result.guidance ??
+              translate(
+                'auto.components.settings.RuntimePairingUrlGenerator.2752126f3e',
+                'Runtime pairing is unavailable.'
+              )
           )
         }
         return


### PR DESCRIPTION
## Summary

Closes STA-2370: Orca's mobile/daemon WebSocket listener bound to wildcard `0.0.0.0` at startup, exposing it to the whole LAN with no explicit opt-in boundary.

This change makes the runtime RPC WebSocket listener **bind to loopback `127.0.0.1` by default** and widen to `0.0.0.0` (same resolved port, `preferPinnedPort`) **only on an explicit opt-in**:

- creating a mobile/runtime pairing offer (`ensureNetworkExposure` → `widenWebSocketBind`), or
- at startup when `exposeNetworkByDefault` is set (`orca serve` / E2E), or
- at startup when a previously-paired device (`lastSeenAt > 0`) exists, so reconnect keeps working.

Widen failures are propagated rather than swallowed: the listener is restored on loopback (same port) and the caller reports pairing **unavailable** (`network_exposure_failed`) instead of advertising a dead LAN endpoint. The single `MobileSocketWiring` is retained across the loopback→wide rebind (the new transport is re-attached), and `stop()` fences/awaits any in-flight widen so it cannot resurrect a listener after teardown.

Scope: `src/main/runtime/runtime-rpc.ts` (bind-host resolution, widen/rollback, stop fence), `rpc/ws-transport.ts`, `network-exposure-guidance.ts` (shared guidance string), `ipc/mobile.ts` (structured-unavailable on widen failure), `index.ts`, `preload/*` (result union), `RuntimePairingUrlGenerator.tsx` (surface guidance), plus tests. The already-merged credential-mirroring (#9501) is untouched.

## Screenshots

No user-facing UI change — this is a runtime listener-bind behavior change. The mobile UI, copy, and layout are unchanged.

Included below is **mobile QA evidence** captured on a real iOS simulator paired to an isolated `serve` running this branch build, proving pairing / session / reconnect / opt-out still work end-to-end against the loopback-default listener. The kernel-level bind property itself was verified separately with `lsof` (see AI Review Report).

**Pairing — explicit opt-in consent prompt:**
![pairing](https://github.com/user-attachments/assets/d812b514-438d-4187-b989-e681fec93a34)

**Paired — desktop connected, branch worktree catalog loaded (widen-on-offer succeeded):**
![paired](https://github.com/user-attachments/assets/0ca30a4e-00ad-46d3-b7a9-32d4c6fbbed0)

**Session — live PTY shell in the worktree over the widened socket (binary frames through the retained wiring):**
![terminal](https://github.com/user-attachments/assets/01c883b1-d23b-488e-aabd-0320ab37c1fc)

**Reconnect — after terminate + relaunch, host auto-reconnects (persisted credential), active tab restored:**
![reconnect](https://github.com/user-attachments/assets/448554f7-86b4-4f4f-9d3a-0fbb47c16f23)

**Connected endpoint `127.0.0.1:54256` + opt-out actions:**
![host-actions](https://github.com/user-attachments/assets/ec15027d-3787-4f2b-a5aa-678772555491)

**Opt-out — host removed cleanly:**
![removed](https://github.com/user-attachments/assets/176e2edd-f90f-4c85-9706-53a99a4900d0)

## Testing

- [x] `pnpm lint` — oxlint + oxfmt clean (verified across gate rounds; no new disables)
- [x] `pnpm typecheck` — node project typecheck exit 0 this run; web/preload stub union re-confirmed by the review
- [x] `pnpm test` — targeted suites green: `runtime-rpc.test.ts` + `mobile.test.ts` → **103 passed** (`vitest run --config config/vitest.config.ts`)
- [x] `pnpm build` — TypeScript compile of `out/main` + `out/cli` succeeded and ran live in a real Electron `serve` for the QA above; electron-builder packaging not exercised (no packaging-surface change)
- [x] Added/updated regression tests that fail on revert: new `runtime-rpc.test.ts` cases assert loopback-default bind, widen-on-opt-in (same port), failure propagation/rollback, single-wiring retention across rebind (functionally, via `terminateDeviceConnections`), the `stopping` guard, and `stop()` racing an in-flight widen; `mobile.test.ts` covers the `getRuntimePairingUrl` widen-failure structured-unavailable path.

## AI Review Report

Ran a fresh, independent same-model adversarial review loop (new reviewer per round, no memory of prior rounds, prompted to refute) until a clean final round. Findings across rounds and their resolutions:

- **Wiring/relay retention across rebind (R1a):** the loopback→wide rebind must not recreate `MobileSocketWiring` (the relay captured it at construction). Verified: one wiring per server session, new transport re-attached; revocation/binary handling retained — proven functionally by a test that revokes through the pre-widen wiring and asserts the post-widen transport terminates the connection.
- **Failure propagation (R1b/R2-1):** a failed widen no longer mints a LAN URL with no listener behind it — it restores a serving loopback listener on the same port and rethrows; both offer paths report unavailable.
- **Transport registration ordering (R2-2)** and **stop() fencing an in-flight widen (R2-3):** live transport registered before metadata persist (persist errors only log); `stop()` sets a stopping fence and awaits the pending widen before clearing arrays.
- **Guidance module boundary + result union (R3):** shared guidance extracted to a light module so the mobile IPC test doesn't pull the RPC/SSH graph; preload union widened; renderer surfaces `result.guidance`.

**Cross-platform (macOS / Linux / Windows) explicitly checked:** the change is network-bind logic with no OS-specific shortcuts, labels, or path handling. The Windows mobile-firewall helper path (`mobile:getWindowsFirewallStatus` / `repairWindowsFirewall`) still reads the endpoint port correctly after the bind change. SSH/remote reach and folder-workspace (non-git) cases were considered: `orca serve` keeps its always-wide startup (remote/headless reach preserved), and the loopback default only affects the local desktop app path. No local-only assumptions were introduced.

Final review round: **clean, land-ready**; targeted suites green (103 passed); node typecheck exit 0.

## Security Audit

This PR *is* the security fix. Reviewed:

- **Network exposure / listener bind:** verified at the OS socket level with `lsof` on a real build — default desktop start listens on `127.0.0.1:<port>`; after a pairing offer it widens to `*:<same port>`; `orca serve` binds `*` at startup; `stop()` releases the socket. This is the core STA-2370 property.
- **Dead-endpoint / bearer-credential handling:** a widen failure never advertises a LAN endpoint with no listener; pairing tokens remain revocable and a failed exposure surfaces structured `network_exposure_failed` guidance rather than a silent LAN QR.
- **IPC:** the mobile IPC handlers return typed `available:false` payloads with reason/guidance; no new privileged surface. Windows firewall repair stays gated to window renderers.
- **Secrets:** no secrets added or logged in the diff. Pairing payloads are disposable local credentials and are not embedded in this PR or its screenshots.
- **Credential mirroring (#9501):** unchanged — not reworked.

No outstanding security follow-up from the review.

## Notes

- **Reconnect scope:** the startup-widen-on-`lastSeenAt>0` decision is the desktop-app path (`orca serve` is always-wide), so it's covered by the `lsof` kernel proof + revert-proof unit tests; the simulator QA exercised the user-facing reconnect (terminate → relaunch → auto-reconnect with persisted credential).
- **Managed-hook consent** is intentionally **out of scope** for this listener-exposure fix.
- A separate performance/resource audit was run against the final HEAD and found no regression (no added polling, timers, or per-connection allocations on the hot path).
