### PR TITLE
fix(window): stop the window-close sentinel from blanking the app on Windows

### DIFF
--- a/src/main/window/browser-window-close-preload-path.test.ts
+++ b/src/main/window/browser-window-close-preload-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../shared/browser-window-close-policy'
+import {
+  fileUrlToPathOrNull,
+  resolveBrowserWindowCloseAllowedPreloadPath
+} from './browser-window-close-preload-path'
+
+describe('fileUrlToPathOrNull', () => {
+  it('converts a real file URL', () => {
+    const converted = fileUrlToPathOrNull(
+      process.platform === 'win32' ? 'file:///C:/tmp/x.js' : 'file:///tmp/x.js'
+    )
+    expect(converted).toBeTruthy()
+    expect(converted).toContain('x.js')
+  })
+
+  // Why: this is the guard the window-close marker depends on. A non-file scheme is rejected on
+  // every platform, so it exercises the catch without depending on the host being Windows.
+  it('returns null instead of throwing for a URL that cannot be a path', () => {
+    expect(() => fileUrlToPathOrNull('https://example.com/x.js')).not.toThrow()
+    expect(fileUrlToPathOrNull('https://example.com/x.js')).toBeNull()
+  })
+})
+
+describe('resolveBrowserWindowCloseAllowedPreloadPath', () => {
+  // Why: regression guard for the blank-window bug. Converting the sentinel throws on win32
+  // (a win32 file URL needs a drive letter), and an unguarded call in createMainWindow aborted
+  // window creation, so the app rendered blank on Windows.
+  it('never throws, whatever the platform makes of the sentinel', () => {
+    expect(() => resolveBrowserWindowCloseAllowedPreloadPath()).not.toThrow()
+  })
+
+  it('returns either a path or null, and never the raw marker', () => {
+    const resolved = resolveBrowserWindowCloseAllowedPreloadPath()
+    expect(resolved === null || typeof resolved === 'string').toBe(true)
+    expect(resolved).not.toBe(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+  })
+})

--- a/src/main/window/browser-window-close-preload-path.ts
+++ b/src/main/window/browser-window-close-preload-path.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from 'node:url'
+import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../shared/browser-window-close-policy'
+
+/**
+ * `fileURLToPath` for URLs that may not name a real file. Returns null instead of
+ * throwing so a caller can treat "no path form on this platform" as a normal case.
+ */
+export function fileUrlToPathOrNull(fileUrl: string): string | null {
+  try {
+    return fileURLToPath(fileUrl)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Path form of the window-close allow marker, or null where the platform has none.
+ *
+ * The marker is a sentinel (`file:///__orca_window_close_allowed__`), not a real file.
+ * Electron may hand it back already normalized to a path, so the attach guard compares
+ * against both forms — but win32 file URLs require a drive letter, so converting the
+ * sentinel throws there. Lives in main only: the shared policy module that owns the
+ * marker is also bundled into the renderer, which must not pull in `node:url`.
+ */
+export function resolveBrowserWindowCloseAllowedPreloadPath(): string | null {
+  return fileUrlToPathOrNull(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+}

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -75,7 +75,7 @@ import {
 import { ipcMain } from 'electron'
 import { shouldRecoverRendererAfterProcessGone } from '../crash-reporting/process-gone-classification'
 import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../shared/browser-window-close-policy'
-import { fileURLToPath } from 'node:url'
+import { resolveBrowserWindowCloseAllowedPreloadPath } from './browser-window-close-preload-path'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = process.platform
@@ -281,16 +281,21 @@ describe('createMainWindow', () => {
     expect(allowWindowCloseParams.preload).toBeUndefined()
     expect(allowWindowClosePrefs).not.toHaveProperty('preload')
 
-    const allowWindowClosePathPrefs = {
-      partition: 'persist:orca-browser',
-      preload: fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+    // Why: the sentinel has no path form on win32, where converting it throws. Exercise the
+    // path-form branch only where a path exists; the marker branch above covers every platform.
+    const allowedPreloadPath = resolveBrowserWindowCloseAllowedPreloadPath()
+    if (allowedPreloadPath !== null) {
+      const allowWindowClosePathPrefs = {
+        partition: 'persist:orca-browser',
+        preload: allowedPreloadPath
+      }
+      windowHandlers['will-attach-webview'](
+        { preventDefault: vi.fn() } as never,
+        allowWindowClosePathPrefs as never,
+        { src: 'data:text/html,', preload: '' } as never
+      )
+      expect(allowWindowClosePathPrefs).not.toHaveProperty('preload')
     }
-    windowHandlers['will-attach-webview'](
-      { preventDefault: vi.fn() } as never,
-      allowWindowClosePathPrefs as never,
-      { src: 'data:text/html,', preload: '' } as never
-    )
-    expect(allowWindowClosePathPrefs).not.toHaveProperty('preload')
 
     const cliGuest = { marker: 'cli-guest' }
     windowHandlers['did-attach-webview']({} as never, cliGuest as never)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -10,7 +10,7 @@ import {
   screen
 } from 'electron'
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { resolveBrowserWindowCloseAllowedPreloadPath } from './browser-window-close-preload-path'
 import { is } from '@electron-toolkit/utils'
 import type { Store } from '../persistence'
 import { getAppIconPath } from '../app-icon'
@@ -444,7 +444,9 @@ export function createMainWindow(
   registerPluginPanelNavigationGuard(mainWindow.webContents)
 
   const browserWindowClosePreload = join(__dirname, 'browser-window-close-preload.js')
-  const browserWindowCloseAllowedPreloadPath = fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+  // Why: null on platforms where the sentinel has no path form (win32 file URLs need a drive
+  // letter). Converting it unguarded here threw and aborted window creation, blanking the app.
+  const browserWindowCloseAllowedPreloadPath = resolveBrowserWindowCloseAllowedPreloadPath()
   mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
     const src = typeof params.src === 'string' ? params.src : ''
     const normalizedSrc = normalizeBrowserNavigationUrl(src)


### PR DESCRIPTION
Fixes #11957.

## Summary

On Windows, `main` at `16c5526df` opens a window that never renders — the app is blank with nothing surfaced in the UI, only a stack trace in the main-process log.

`c79b85975` (PR #11910) added this near the top of `createMainWindow`:

```ts
const browserWindowCloseAllowedPreloadPath = fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
```

`BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD` is a sentinel — `file:///__orca_window_close_allowed__` — not a real file. On POSIX it resolves harmlessly to `/__orca_window_close_allowed__`. On Windows `fileURLToPath` throws `ERR_INVALID_FILE_URL_PATH`, because a win32 file URL requires a drive letter. Unguarded, during window construction, so window creation aborts.

```
> node -e "require('node:url').fileURLToPath('file:///__orca_window_close_allowed__')"
TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must be absolute
```

This treats "no path form on this platform" as a normal case: convert through a helper returning `null` on failure, and compare against it only when non-null. The marker-form comparison in the same predicate already covers every platform, so the attach guard loses nothing on Windows — a guest can still be allow-listed by the marker exactly as before.

The helper lives in `src/main/window/` rather than beside the marker in `src/shared/browser-window-close-policy.ts`, because that shared module is also imported by the renderer (`browser-pane/browser-page-webview.ts`) and must not pull in `node:url`.

## Screenshots

No visual change on any platform where the app currently starts. On Windows the change is between a blank window and a working one.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — `src/main/window/` suites; see Notes
- [ ] `pnpm build` — not run locally; relies on CI
- [x] Added or updated high-quality tests that would catch regressions

**`createMainWindow.test.ts` went from 5+ failures to 81/81 passing on Windows.**

That file could not run on Windows either, because it built the path form with the same unguarded call:

```ts
// createMainWindow.test.ts:286
preload: fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
```

It now uses the helper and exercises the path-form branch only where a path exists; the marker-form assertion above it still runs everywhere, so POSIX coverage is unchanged.

New `browser-window-close-preload-path.test.ts` covers the helper. Its guard test uses a non-`file:` scheme, which is rejected on *every* platform — so it exercises the catch on Linux CI rather than passing vacuously there and only failing on a Windows host.

## AI Review Report

Reviewed with Claude Code. Risks checked: whether narrowing the comparison weakens the `will-attach-webview` security guard, renderer bundling of `node:url`, and whether the fix masks a real misconfiguration.

- **Security guard unchanged.** The predicate is `preload === MARKER || preload === markerPath`. On Windows `markerPath` is now `null`, and no string preload equals `null`, so the branch simply never matches there — which is correct, since Electron cannot produce a win32 path form of a URL that has none. The fail-closed `src`/partition allowlist above it is untouched. There is no path where this makes a guest *more* privileged.
- **Renderer bundling.** Verified `src/shared/browser-window-close-policy.ts` is imported by the renderer, so the helper deliberately does not live there.
- **Not masking a misconfiguration.** The sentinel is intentionally not a real file — it is a marker compared by identity. Swallowing its conversion failure is the correct semantic, not a papered-over error. The helper is scoped to this one use rather than a general "ignore all URL errors" utility.

Cross-platform: this *is* the cross-platform fix. Behavior on macOS and Linux is byte-identical (the conversion still succeeds and the path comparison still runs); Windows goes from broken to working. Verified `fileURLToPath` throws for this input on Windows and succeeds on POSIX.

## Security Audit

Touches a security-relevant code path — the `will-attach-webview` guard that decides whether a guest keeps a preload — so worth being explicit: the change only removes a comparison that could never match on the affected platform. No IPC, command execution, path handling, auth, secrets, or dependency changes. No new input reaches any sink; the helper's only caller passes a compile-time constant.

## Notes

Worth checking whether CI runs `src/main/window/` on Windows. These tests fail there at `16c5526df`, so if the matrix covered Windows this would have been caught before merge — and this class of bug (a POSIX-only path assumption) will recur otherwise.

`clipboard-file-copy.test.ts` also fails 4 tests on Windows in this worktree, identically on pristine `main`. Unrelated to this change and left alone, but it looks like the same family of platform assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
