### PR TITLE
fix(agent-status): stop start-less SubagentStop from minting phantom working

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3354,6 +3354,17 @@ describe('shared agent-hook-listener', () => {
       expect(stopped?.payload.interactivePrompt).toBeUndefined()
     })
 
+    it('canonicalizes padded lifecycle ids so starts and stops target one row', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: ' a2 ',
+        agent_type: 'general-purpose'
+      })
+      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: ' a2 ' })
+      expect(stopped?.payload.state).toBe('done')
+      expect(stopped?.payload.subagents).toBeUndefined()
+    })
+
     it('tracks whitespace-padded inventory ids canonically so their stops can drain them', () => {
       const first = claudeEvent({
         hook_event_name: 'SubagentStop',

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3096,6 +3096,42 @@ describe('shared agent-hook-listener', () => {
       expect(stopped?.payload.subagents).toBeUndefined()
     })
 
+    it('does not mint working from a start-less SubagentStop on a pane with no lead record', () => {
+      // Why: the live /compact flow on claude 2.1.186–2.1.220 is PreCompact → SubagentStop
+      // (never started) → SessionStart(compact) → PostCompact. On a resumed session in a
+      // fresh process this minted a sticky empty-prompt 'working' no Stop ever clears (STA-2915).
+      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'compact-1' })
+      expect(stopped).toBeNull()
+    })
+
+    it('re-emits the lead done state on a start-less SubagentStop after a completed turn', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
+      claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
+      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'compact-1' })
+      expect(stopped?.payload.state).toBe('done')
+    })
+
+    it('still emits working for a spawn on a pane with no lead record', () => {
+      const spawned = claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      expect(spawned?.payload.state).toBe('working')
+      expect(spawned?.payload.subagents).toEqual([expect.objectContaining({ id: 'a1' })])
+    })
+
+    it('keeps child-driven working when a live child survives an unknown stop with no lead record', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'ghost' })
+      expect(stopped?.payload.state).toBe('working')
+      expect(stopped?.payload.subagents).toEqual([expect.objectContaining({ id: 'a1' })])
+    })
+
     it('keeps gating on tracked children when background_tasks is absent (older Claude)', () => {
       claudeEvent({
         hook_event_name: 'SubagentStart',

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3177,6 +3177,40 @@ describe('shared agent-hook-listener', () => {
       expect(duplicatePark).toBeNull()
     })
 
+    it('keeps working when a no-lead stop carries an inventory with another live child', () => {
+      // Why: after a restart the listener can miss a2's start; a1's stop still
+      // lists a2 running in background_tasks — the removal must not retire it.
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const stopped = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: [
+          { id: 'a2', type: 'subagent', status: 'running', agent_type: 'general-purpose' }
+        ]
+      })
+      // Why: veto only — a2's row materializes from its own events or the next
+      // lead Stop's fold; the stop must merely not retire the pane.
+      expect(stopped?.payload.state).toBe('working')
+    })
+
+    it('keeps working when a no-lead drain leaves a live shell in the inventory', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const stopped = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: [{ id: 's1', type: 'shell', status: 'running' }]
+      })
+      expect(stopped?.payload.state).toBe('working')
+    })
+
     it('never claims done from a no-lead TeammateIdle park', () => {
       claudeEvent({
         hook_event_name: 'SubagentStart',

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3372,6 +3372,26 @@ describe('shared agent-hook-listener', () => {
       expect(staleStop?.payload.subagents).toEqual([expect.objectContaining({ id: 'a-new' })])
     })
 
+    it('resolves to done when an empty inventory reaps the last inventory-derived rows', () => {
+      // Why: the authority that minted a1's row now reports empty; a silent
+      // drain would strand the previously published working until the sweeper.
+      const first = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'ghost-1',
+        background_tasks: [
+          { id: 'a1', type: 'subagent', status: 'running', agent_type: 'general-purpose' }
+        ]
+      })
+      expect(first?.payload.state).toBe('working')
+      const second = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'ghost-2',
+        background_tasks: []
+      })
+      expect(second?.payload.state).toBe('done')
+      expect(second?.payload.subagents).toBeUndefined()
+    })
+
     it('clears restored phantom rows when a no-lead stop carries a complete empty inventory', () => {
       seedClaudeSubagentRosterFromSnapshots(state, PANE_KEY, [
         { id: 'a1', state: 'working', startedAt: 1, agentType: 'general-purpose' },

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3102,6 +3102,15 @@ describe('shared agent-hook-listener', () => {
       // fresh process this minted a sticky empty-prompt 'working' no Stop ever clears (STA-2915).
       const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'compact-1' })
       expect(stopped).toBeNull()
+      // Why: stop/idle on an unknown pane must not retain an empty roster — authenticated but
+      // untrusted payloads could otherwise grow the map by one entry per invented pane key.
+      expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
+    })
+
+    it('does not retain a roster for TeammateIdle on a pane with no roster', () => {
+      const idled = claudeEvent({ hook_event_name: 'TeammateIdle', teammate_name: 'lane' })
+      expect(idled).toBeNull()
+      expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
     })
 
     it('re-emits the lead done state on a start-less SubagentStop after a completed turn', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3156,6 +3156,37 @@ describe('shared agent-hook-listener', () => {
       expect(duplicate).toBeNull()
     })
 
+    it('never claims done from a teammate park with no lead record', () => {
+      // Why: teammate ids are persistent across turns — a delayed stop from turn N
+      // parks the id even while its newer turn N+1 is live. Claiming done here is
+      // the uncorrelated-completion race that closed PR #11353.
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'alane-6d3cb5b52120b7bf',
+        agent_type: 'lane'
+      })
+      const staleStop = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'alane-6d3cb5b52120b7bf'
+      })
+      expect(staleStop).toBeNull()
+      const duplicatePark = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'alane-6d3cb5b52120b7bf'
+      })
+      expect(duplicatePark).toBeNull()
+    })
+
+    it('never claims done from a no-lead TeammateIdle park', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'alane-6d3cb5b52120b7bf',
+        agent_type: 'lane'
+      })
+      const idled = claudeEvent({ hook_event_name: 'TeammateIdle', teammate_name: 'lane' })
+      expect(idled).toBeNull()
+    })
+
     it('re-emits the lead done state on a start-less SubagentStop after a completed turn', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
       claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
@@ -3525,6 +3556,11 @@ describe('shared agent-hook-listener', () => {
     })
 
     it('scopes TeammateIdle to the exact teammate name for hyphen-prefix names', () => {
+      // Why: a lead record anchors the emissions — no-lead teammate parks are
+      // deliberately silent (uncorrelated-completion guard), which is not what
+      // this test pins; it pins the name-scoping of the park itself.
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'spawn lanes' })
+      claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
       claudeEvent({
         hook_event_name: 'SubagentStart',
         agent_id: 'alane-hooks-6d3cb5b5',

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3192,9 +3192,36 @@ describe('shared agent-hook-listener', () => {
           { id: 'a2', type: 'subagent', status: 'running', agent_type: 'general-purpose' }
         ]
       })
-      // Why: veto only — a2's row materializes from its own events or the next
-      // lead Stop's fold; the stop must merely not retire the pane.
       expect(stopped?.payload.state).toBe('working')
+      // Why: the additive fold must TRACK a2 — otherwise its own later stop is
+      // start-less-suppressed and the pane sticks on working forever.
+      expect(stopped?.payload.subagents).toEqual([expect.objectContaining({ id: 'a2' })])
+
+      const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a2' })
+      expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.subagents).toBeUndefined()
+    })
+
+    it('claims nothing from a no-lead removal whose agent inventory is truncated', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      // Why: 32 teammate rows fill the parser cap; the running subagent behind
+      // them is invisible, so the inventory can prove neither done nor working.
+      const cappedTasks = Array.from({ length: 32 }, (_, i) => ({
+        id: `t${i}`,
+        type: 'teammate',
+        status: 'running'
+      }))
+      cappedTasks.push({ id: 'hidden-live', type: 'subagent', status: 'running' })
+      const stopped = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: cappedTasks
+      })
+      expect(stopped).toBeNull()
     })
 
     it('keeps working when a no-lead drain leaves a live shell in the inventory', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3348,6 +3348,24 @@ describe('shared agent-hook-listener', () => {
       const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'w1' })
       expect(stopped?.payload.state).toBe('done')
       expect(stopped?.payload.subagents).toBeUndefined()
+      // Why: the wait's cached card died with its owner — a done payload carrying
+      // the stale tool/interactive card would remain actionable in the chat UI.
+      expect(stopped?.payload.toolName).toBeUndefined()
+      expect(stopped?.payload.interactivePrompt).toBeUndefined()
+    })
+
+    it('tracks whitespace-padded inventory ids canonically so their stops can drain them', () => {
+      const first = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'ghost-1',
+        background_tasks: [
+          { id: ' a2 ', type: 'subagent', status: 'running', agent_type: 'general-purpose' }
+        ]
+      })
+      expect(first?.payload.state).toBe('working')
+      expect(first?.payload.subagents).toEqual([expect.objectContaining({ id: 'a2' })])
+      const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a2' })
+      expect(drained?.payload.state).toBe('done')
     })
 
     it('keeps a newer live start alive through a delayed stale stop with an empty inventory', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3221,9 +3221,9 @@ describe('shared agent-hook-listener', () => {
         agent_id: 'a1',
         background_tasks: cappedTasks
       })
-      // Why: the uncapped raw scan still sees hidden-live running — the pane is
-      // truthfully working, never done.
-      expect(stopped?.payload.state).toBe('working')
+      // Why: hidden-live sits past the parser cap and could never be tracked or
+      // drained — incomplete evidence claims neither done nor an unresolvable working.
+      expect(stopped).toBeNull()
     })
 
     it('claims nothing from a no-lead removal when a truncated inventory shows no live work', () => {
@@ -3372,9 +3372,10 @@ describe('shared agent-hook-listener', () => {
       expect(staleStop?.payload.subagents).toEqual([expect.objectContaining({ id: 'a-new' })])
     })
 
-    it('resolves to done when an empty inventory reaps the last inventory-derived rows', () => {
-      // Why: the authority that minted a1's row now reports empty; a silent
-      // drain would strand the previously published working until the sweeper.
+    it('keeps a newer inventory-derived row through a delayed older empty-inventory stop', () => {
+      // Why: stop-time inventories are mutually unordered — a delayed older empty
+      // list must not retire a row a newer inventory minted. The tracked row keeps
+      // the pane truthfully working and its own stop resolves it.
       const first = claudeEvent({
         hook_event_name: 'SubagentStop',
         agent_id: 'ghost-1',
@@ -3388,8 +3389,27 @@ describe('shared agent-hook-listener', () => {
         agent_id: 'ghost-2',
         background_tasks: []
       })
-      expect(second?.payload.state).toBe('done')
-      expect(second?.payload.subagents).toBeUndefined()
+      expect(second?.payload.state).toBe('working')
+      expect(second?.payload.subagents).toEqual([expect.objectContaining({ id: 'a1' })])
+    })
+
+    it('never lets a stop inventory delete a live row via a non-running listing', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      // Why: a stale inventory claiming a live child completed is unordered
+      // evidence; the live row survives and its own stop still resolves done.
+      const staleClaim = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'ghost-1',
+        background_tasks: [{ id: 'a1', type: 'subagent', status: 'completed' }]
+      })
+      expect(staleClaim?.payload.state).toBe('working')
+      expect(staleClaim?.payload.subagents).toEqual([expect.objectContaining({ id: 'a1' })])
+      const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      expect(drained?.payload.state).toBe('done')
     })
 
     it('clears restored phantom rows when a no-lead stop carries a complete empty inventory', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3113,6 +3113,25 @@ describe('shared agent-hook-listener', () => {
       expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
     })
 
+    it('does not retain a roster when a child tool event carries an id the upsert rejects', () => {
+      // Why: upsert silently drops over-length ids; allocating first would strand
+      // an empty roster per invented pane key with zero emitted payloads.
+      const childTool = claudeEvent({
+        hook_event_name: 'PreToolUse',
+        agent_id: 'a'.repeat(65),
+        tool_name: 'Bash',
+        tool_input: { command: 'true' }
+      })
+      expect(childTool).toBeNull()
+      expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
+    })
+
+    it('does not retain a roster for a SubagentStart with an id the upsert rejects', () => {
+      const spawned = claudeEvent({ hook_event_name: 'SubagentStart', agent_id: 'a'.repeat(65) })
+      expect(spawned).toBeNull()
+      expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
+    })
+
     it('re-emits the lead done state on a start-less SubagentStop after a completed turn', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
       claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3398,15 +3398,42 @@ describe('shared agent-hook-listener', () => {
       expect(leadStop?.payload.subagents).toBeUndefined()
     })
 
-    it('ignores child events whose agent_id is whitespace-only', () => {
+    it('ignores child events whose agent_id is whitespace-only or empty', () => {
       // Why: agent_id present means child-origin; an unattributable id treated
       // as the lead would mint a waiting no lead Stop ever clears.
-      const waiting = claudeEvent({
+      const padded = claudeEvent({
         hook_event_name: 'PermissionRequest',
         agent_id: '   ',
         tool_name: 'Bash'
       })
-      expect(waiting).toBeNull()
+      expect(padded).toBeNull()
+      const empty = claudeEvent({
+        hook_event_name: 'PermissionRequest',
+        agent_id: '',
+        tool_name: 'Bash'
+      })
+      expect(empty).toBeNull()
+    })
+
+    it('does not let a stop resurrect its own id from a pre-stop inventory snapshot', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
+      claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      // Why: the stop outranks its own payload's stale snapshot for its own id —
+      // resurrecting a1 here would flip a done lead back to a sticky working.
+      const stopped = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: [
+          { id: 'a1', type: 'subagent', status: 'running', agent_type: 'general-purpose' }
+        ]
+      })
+      expect(stopped?.payload.state).toBe('done')
+      expect(stopped?.payload.subagents).toBeUndefined()
     })
 
     it('tracks whitespace-padded inventory ids canonically so their stops can drain them', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3221,7 +3221,58 @@ describe('shared agent-hook-listener', () => {
         agent_id: 'a1',
         background_tasks: cappedTasks
       })
+      // Why: the uncapped raw scan still sees hidden-live running — the pane is
+      // truthfully working, never done.
+      expect(stopped?.payload.state).toBe('working')
+    })
+
+    it('claims nothing from a no-lead removal when a truncated inventory shows no live work', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const teammateOnly = Array.from({ length: 33 }, (_, i) => ({
+        id: `t${i}`,
+        type: 'teammate',
+        status: 'running'
+      }))
+      const stopped = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: teammateOnly
+      })
       expect(stopped).toBeNull()
+    })
+
+    it('resolves a fresh-pane child permission wait whose child dies to done, not phantom working', () => {
+      // Why: the wait is this pane's FIRST lead record; the old no-stash fallback
+      // fabricated 'working' when the waiting child stopped — a stuck card.
+      claudeEvent({
+        hook_event_name: 'PermissionRequest',
+        agent_id: 'w1',
+        agent_type: 'general-purpose',
+        tool_name: 'Bash'
+      })
+      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'w1' })
+      expect(stopped?.payload.state).toBe('done')
+      expect(stopped?.payload.subagents).toBeUndefined()
+    })
+
+    it('clears restored phantom rows when a no-lead stop carries a complete empty inventory', () => {
+      seedClaudeSubagentRosterFromSnapshots(state, PANE_KEY, [
+        { id: 'a1', state: 'working', startedAt: 1, agentType: 'general-purpose' },
+        { id: 'a2', state: 'working', startedAt: 1, agentType: 'general-purpose' }
+      ])
+      // Why: a2's finish hook was lost while Orca was down; a1's stop reports an
+      // authoritative empty inventory, which must not leave a2 spinning forever.
+      const stopped = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: []
+      })
+      expect(stopped?.payload.state).toBe('done')
+      expect(stopped?.payload.subagents).toBeUndefined()
     })
 
     it('keeps working when a no-lead drain leaves a live shell in the inventory', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3245,6 +3245,46 @@ describe('shared agent-hook-listener', () => {
       expect(stopped).toBeNull()
     })
 
+    it('ignores over-length running inventory ids for allocation and liveness', () => {
+      // Why: such ids can never be tracked or drained — letting them allocate a
+      // roster or claim liveness recreates the retention/sticky holes.
+      const invented = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'ghost',
+        background_tasks: [{ id: 'x'.repeat(65), type: 'subagent', status: 'running' }]
+      })
+      expect(invented).toBeNull()
+      expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
+
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const drained = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: [{ id: 'y'.repeat(65), type: 'subagent', status: 'running' }]
+      })
+      expect(drained?.payload.state).toBe('done')
+    })
+
+    it('clears a fresh-pane teammate wait card with done when its owner parks', () => {
+      // Why: the wait is identity-owned; its owner parking must clear the amber
+      // card instead of leaving it fresh for the stale sweeper.
+      claudeEvent({
+        hook_event_name: 'PermissionRequest',
+        agent_id: 'alane-6d3cb5b52120b7bf',
+        agent_type: 'lane',
+        tool_name: 'Bash'
+      })
+      const parked = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'alane-6d3cb5b52120b7bf'
+      })
+      expect(parked?.payload.state).toBe('done')
+    })
+
     it('resolves a fresh-pane child permission wait whose child dies to done, not phantom working', () => {
       // Why: the wait is this pane's FIRST lead record; the old no-stash fallback
       // fabricated 'working' when the waiting child stopped — a stuck card.

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3269,9 +3269,11 @@ describe('shared agent-hook-listener', () => {
       expect(drained?.payload.state).toBe('done')
     })
 
-    it('clears a fresh-pane teammate wait card with done when its owner parks', () => {
-      // Why: the wait is identity-owned; its owner parking must clear the amber
-      // card instead of leaving it fresh for the stale sweeper.
+    it('stays silent when a fresh-pane teammate wait owner parks with its row still tracked', () => {
+      // Why: a parked owner is indistinguishable from a delayed prior-turn stop
+      // against a newer start of the same reused id — claiming done could retire
+      // newer real work (the #11353 race). The stale amber card is bounded by
+      // the stale sweeper instead.
       claudeEvent({
         hook_event_name: 'PermissionRequest',
         agent_id: 'alane-6d3cb5b52120b7bf',
@@ -3282,7 +3284,56 @@ describe('shared agent-hook-listener', () => {
         hook_event_name: 'SubagentStop',
         agent_id: 'alane-6d3cb5b52120b7bf'
       })
-      expect(parked?.payload.state).toBe('done')
+      expect(parked).toBeNull()
+    })
+
+    it('never retires a newer same-id start via a delayed prior-turn stop clearing its wait', () => {
+      claudeEvent({
+        hook_event_name: 'PermissionRequest',
+        agent_id: 'alane-6d3cb5b52120b7bf',
+        agent_type: 'lane',
+        tool_name: 'Bash'
+      })
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'alane-6d3cb5b52120b7bf',
+        agent_type: 'lane'
+      })
+      const staleStop = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'alane-6d3cb5b52120b7bf'
+      })
+      expect(staleStop?.payload.state ?? null).not.toBe('done')
+    })
+
+    it('resolves a drain to done when over-length ids fill the inventory', () => {
+      // Why: untrackable ids must not consume parser cap slots — 33 of them is
+      // not a truncated inventory, just noise.
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const junk = Array.from({ length: 33 }, (_, i) => ({
+        id: 'x'.repeat(65) + i,
+        type: 'subagent',
+        status: 'running'
+      }))
+      const drained = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a1',
+        background_tasks: junk
+      })
+      expect(drained?.payload.state).toBe('done')
+    })
+
+    it('does not mint a waiting card for an untrackable child id', () => {
+      const waiting = claudeEvent({
+        hook_event_name: 'PermissionRequest',
+        agent_id: 'w'.repeat(65),
+        tool_name: 'Bash'
+      })
+      expect(waiting).toBeNull()
     })
 
     it('resolves a fresh-pane child permission wait whose child dies to done, not phantom working', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3350,6 +3350,28 @@ describe('shared agent-hook-listener', () => {
       expect(stopped?.payload.subagents).toBeUndefined()
     })
 
+    it('keeps a newer live start alive through a delayed stale stop with an empty inventory', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a-old',
+        agent_type: 'general-purpose'
+      })
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a-new',
+        agent_type: 'general-purpose'
+      })
+      // Why: a-old's delayed stop reports the empty inventory captured before
+      // a-new existed; clearing a-new from it would retire newer live work.
+      const staleStop = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'a-old',
+        background_tasks: []
+      })
+      expect(staleStop?.payload.state).toBe('working')
+      expect(staleStop?.payload.subagents).toEqual([expect.objectContaining({ id: 'a-new' })])
+    })
+
     it('clears restored phantom rows when a no-lead stop carries a complete empty inventory', () => {
       seedClaudeSubagentRosterFromSnapshots(state, PANE_KEY, [
         { id: 'a1', state: 'working', startedAt: 1, agentType: 'general-purpose' },

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3383,16 +3383,30 @@ describe('shared agent-hook-listener', () => {
     it('routes a padded child tool event to the canonical roster row', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
       claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
-      const childTool = claudeEvent({
+      claudeEvent({
         hook_event_name: 'PreToolUse',
         agent_id: ' a4 ',
         agent_type: 'general-purpose',
         tool_name: 'Bash',
         tool_input: { command: 'true' }
       })
-      expect(childTool?.payload.subagents).toEqual([
-        expect.objectContaining({ id: 'a4', state: 'working' })
-      ])
+      // Why: a clean-id stop must drain the padded tool event's row — under a raw
+      // key it would survive and pin the lead's next Stop on working.
+      claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a4' })
+      const leadStop = claudeEvent({ hook_event_name: 'Stop' })
+      expect(leadStop?.payload.state).toBe('done')
+      expect(leadStop?.payload.subagents).toBeUndefined()
+    })
+
+    it('ignores child events whose agent_id is whitespace-only', () => {
+      // Why: agent_id present means child-origin; an unattributable id treated
+      // as the lead would mint a waiting no lead Stop ever clears.
+      const waiting = claudeEvent({
+        hook_event_name: 'PermissionRequest',
+        agent_id: '   ',
+        tool_name: 'Bash'
+      })
+      expect(waiting).toBeNull()
     })
 
     it('tracks whitespace-padded inventory ids canonically so their stops can drain them', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3355,14 +3355,44 @@ describe('shared agent-hook-listener', () => {
     })
 
     it('canonicalizes padded lifecycle ids so starts and stops target one row', () => {
+      // Why: mixed forms — padded start, clean stop — so the test fails if either
+      // read point stops trimming (identical padding would share a raw key).
       claudeEvent({
         hook_event_name: 'SubagentStart',
         agent_id: ' a2 ',
         agent_type: 'general-purpose'
       })
-      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: ' a2 ' })
+      const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a2' })
       expect(stopped?.payload.state).toBe('done')
       expect(stopped?.payload.subagents).toBeUndefined()
+    })
+
+    it('drains an inventory-minted row via a padded lifecycle stop', () => {
+      const first = claudeEvent({
+        hook_event_name: 'SubagentStop',
+        agent_id: 'ghost-1',
+        background_tasks: [
+          { id: 'a3', type: 'subagent', status: 'running', agent_type: 'general-purpose' }
+        ]
+      })
+      expect(first?.payload.state).toBe('working')
+      const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: ' a3 ' })
+      expect(drained?.payload.state).toBe('done')
+    })
+
+    it('routes a padded child tool event to the canonical roster row', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
+      claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
+      const childTool = claudeEvent({
+        hook_event_name: 'PreToolUse',
+        agent_id: ' a4 ',
+        agent_type: 'general-purpose',
+        tool_name: 'Bash',
+        tool_input: { command: 'true' }
+      })
+      expect(childTool?.payload.subagents).toEqual([
+        expect.objectContaining({ id: 'a4', state: 'working' })
+      ])
     })
 
     it('tracks whitespace-padded inventory ids canonically so their stops can drain them', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3132,6 +3132,30 @@ describe('shared agent-hook-listener', () => {
       expect(state.claudeSubagentRosterByPaneKey.has(PANE_KEY)).toBe(false)
     })
 
+    it('resolves a known-child drain to done instead of sticky working when no lead ever spoke', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      // Why: the child's own identity-matched stop drains the roster; the old no-lead
+      // 'working' default left this pane spinning until the stale sweeper.
+      const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.subagents).toBeUndefined()
+    })
+
+    it('suppresses a duplicate stale stop after a no-lead drain', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      const duplicate = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      expect(duplicate).toBeNull()
+    })
+
     it('re-emits the lead done state on a start-less SubagentStop after a completed turn', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
       claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2573,14 +2573,16 @@ function buildClaudeChildDrivenStatusPayload(
   // Why: no lead record, no live child, and an unchanged roster mean the event proves nothing is
   // running. Compact's start-less SubagentStop is exactly that; minting the default below left a
   // sticky 'working' no Stop ever clears on freshly resumed panes (STA-2915).
-  if (!lead && !rosterChanged && !claudeRosterHasWorkingSubagent(roster)) {
+  const rosterHasWorking = claudeRosterHasWorkingSubagent(roster)
+  if (!lead && !rosterChanged && !rosterHasWorking) {
     return null
   }
-  // Why: default 'working' — a spawn proves activity even before the lead's first state-bearing event (e.g. Orca restarted mid-session).
-  const leadState = lead?.state ?? 'working'
+  // Why: with no lead record the pane state is inferred from tracked children only — a live child
+  // shows working, while an identity-matched drain/park resolves to done. The old unconditional
+  // 'working' default stuck until the stale sweeper once the last child left (STA-2915 review).
+  const leadState = lead?.state ?? (rosterHasWorking ? 'working' : 'done')
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
-    stateName:
-      leadState === 'done' && claudeRosterHasWorkingSubagent(roster) ? 'working' : leadState,
+    stateName: leadState === 'done' && rosterHasWorking ? 'working' : leadState,
     updateToolSnapshot: false,
     interrupted: lead?.interrupted
   })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2432,12 +2432,14 @@ function normalizeClaudeSubagentLifecycleEvent(
   if (!lifecycleId) {
     return null
   }
-  const roster = getOrCreateClaudeSubagentRoster(state, paneKey)
+  // Why: only a spawn may allocate a roster — stop/idle on an unknown pane would retain an empty
+  // roster per untrusted pane key with no lifecycle bound (STA-2915 review finding).
+  const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   let rosterChanged = false
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
-    rosterChanged = idleClaudeTeammateByName(roster, teammateName)
+    rosterChanged = roster ? idleClaudeTeammateByName(roster, teammateName) : false
     clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
       claudeTeammateIdMatchesName(waitingAgentId, teammateName)
     )
@@ -2445,17 +2447,19 @@ function normalizeClaudeSubagentLifecycleEvent(
     const agentId = lifecycleId
     if (eventName === 'SubagentStart') {
       upsertWorkingClaudeSubagent(
-        roster,
+        getOrCreateClaudeSubagentRoster(state, paneKey),
         agentId,
         { agentType: readString(hookPayload, 'agent_type') },
         Date.now()
       )
       rosterChanged = true
     } else {
-      // Why: a stop of an untracked id (e.g. compact's start-less SubagentStop) is a roster no-op, not evidence.
-      rosterChanged = roster.has(agentId)
-      // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
-      stopClaudeSubagent(roster, agentId)
+      if (roster) {
+        // Why: a stop of an untracked id (e.g. compact's start-less SubagentStop) is a roster no-op, not evidence.
+        rosterChanged = roster.has(agentId)
+        // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
+        stopClaudeSubagent(roster, agentId)
+      }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
     }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2499,9 +2499,19 @@ function normalizeClaudeSubagentLifecycleEvent(
       )
     }
   }
+  // Why: a wait owner that still has a roster row was PARKED, not finished — a delayed stop from
+  // a prior turn can park a newly working reused id, so claiming done there would retire newer
+  // real work (the #11353 race). The clearing done fires only for an owner with no row left;
+  // a parked owner's stale amber card is bounded by the stale sweeper instead.
+  const waitOwnerStillTracked =
+    clearedOwnWait === 'deleted' &&
+    roster !== undefined &&
+    (eventName === 'TeammateIdle'
+      ? [...roster.keys()].some((id) => claudeTeammateIdMatchesName(id, lifecycleId))
+      : roster.has(lifecycleId))
   return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload, {
     removedRow,
-    clearedOwnWait: clearedOwnWait === 'deleted'
+    clearedOwnWait: clearedOwnWait === 'deleted' && !waitOwnerStillTracked
   })
 }
 
@@ -2731,6 +2741,11 @@ function normalizeClaudeEvent(
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
   // Two exceptions take the full path below: waiting-inducing events (a child needs human attention on this pane) and the blocked child's own next tool event (approval granted — clear the wait as for the lead).
   const isWaitingInducing = stateName === 'waiting'
+  // Why: an untrackable child id can neither appear in the roster nor reliably clear its wait —
+  // recording it would mint an unresolvable amber card (STA-2915 review).
+  if (isWaitingInducing && eventAgentId && !isValidClaudeSubagentId(eventAgentId)) {
+    return null
+  }
   const subagentOriginId =
     !isWaitingInducing &&
     (eventName === 'PreToolUse' ||

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2471,7 +2471,16 @@ function normalizeClaudeSubagentLifecycleEvent(
       // Additive only — a complete-inventory reap here would kill a just-parked teammate row
       // before its TeammateIdle confirmation arrives.
       const inventory = readClaudeBackgroundAgentTasks(hookPayload)
-      if (
+      if (inventory.present && inventory.tasks.length === 0 && roster) {
+        // Why: an empty complete inventory reaps only claims not backed by live lifecycle events
+        // (restored/inventory-derived phantoms). A delayed stale stop's empty list must not clear
+        // a newer live start's row — that is the uncorrelated-retirement race again.
+        for (const [id, tracked] of roster) {
+          if (tracked.restoredFromSnapshot || tracked.backgroundTasksAuthoritative) {
+            roster.delete(id)
+          }
+        }
+      } else if (
         inventory.present &&
         (roster ||
           inventory.tasks.some(
@@ -2484,11 +2493,9 @@ function normalizeClaudeSubagentLifecycleEvent(
           getOrCreateClaudeSubagentRoster(state, paneKey),
           inventory.tasks,
           Date.now(),
-          // Why: an empty inventory is complete by construction and proves nothing is left
-          // alive (lead-path rule), clearing restored phantoms; a non-empty one folds
-          // additively — its reap would kill a just-parked teammate row before its
-          // TeammateIdle confirmation arrives.
-          { inventoryComplete: inventory.tasks.length === 0 }
+          // Why: additive only — a complete-inventory reap here would kill a just-parked
+          // teammate row before its TeammateIdle confirmation arrives.
+          { inventoryComplete: false }
         )
       }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2594,8 +2594,16 @@ function buildClaudeChildDrivenStatusPayload(
     })
   }
   if (evidence.removedRow) {
+    // Why: the stop's own inventory can list work this listener never saw start (post-restart);
+    // a running non-teammate task or live shell/cron vetoes done. Teammate-typed entries prove
+    // nothing ("running" even while idle), and full folding here would reap a just-parked
+    // teammate row before its TeammateIdle confirmation arrives — veto only, no reconcile.
+    const inventory = readClaudeBackgroundAgentTasks(hookPayload)
+    const inventoryShowsLiveWork =
+      inventory.tasks.some((task) => task.running && !task.teammate) ||
+      hasActiveClaudeNonAgentBackgroundWork(hookPayload)
     return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
-      stateName: 'done',
+      stateName: inventoryShowsLiveWork ? 'working' : 'done',
       updateToolSnapshot: false
     })
   }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2433,10 +2433,11 @@ function normalizeClaudeSubagentLifecycleEvent(
     return null
   }
   const roster = getOrCreateClaudeSubagentRoster(state, paneKey)
+  let rosterChanged = false
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
-    idleClaudeTeammateByName(roster, teammateName)
+    rosterChanged = idleClaudeTeammateByName(roster, teammateName)
     clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
       claudeTeammateIdMatchesName(waitingAgentId, teammateName)
     )
@@ -2449,14 +2450,17 @@ function normalizeClaudeSubagentLifecycleEvent(
         { agentType: readString(hookPayload, 'agent_type') },
         Date.now()
       )
+      rosterChanged = true
     } else {
+      // Why: a stop of an untracked id (e.g. compact's start-less SubagentStop) is a roster no-op, not evidence.
+      rosterChanged = roster.has(agentId)
       // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
       stopClaudeSubagent(roster, agentId)
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
     }
   }
-  return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
+  return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload, rosterChanged)
 }
 
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
@@ -2553,12 +2557,19 @@ function buildClaudeChildDrivenStatusPayload(
   state: HookListenerState,
   eventName: unknown,
   paneKey: string,
-  hookPayload: Record<string, unknown>
+  hookPayload: Record<string, unknown>,
+  rosterChanged = false
 ): ParsedAgentStatusPayload | null {
-  // Why: default 'working' — a spawn proves activity even before the lead's first state-bearing event (e.g. Orca restarted mid-session).
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
-  const leadState = lead?.state ?? 'working'
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  // Why: no lead record, no live child, and an unchanged roster mean the event proves nothing is
+  // running. Compact's start-less SubagentStop is exactly that; minting the default below left a
+  // sticky 'working' no Stop ever clears on freshly resumed panes (STA-2915).
+  if (!lead && !rosterChanged && !claudeRosterHasWorkingSubagent(roster)) {
+    return null
+  }
+  // Why: default 'working' — a spawn proves activity even before the lead's first state-bearing event (e.g. Orca restarted mid-session).
+  const leadState = lead?.state ?? 'working'
   return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
     stateName:
       leadState === 'done' && claudeRosterHasWorkingSubagent(roster) ? 'working' : leadState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -33,6 +33,7 @@ import {
   foldClaudeBackgroundTasksIntoRoster,
   hasActiveClaudeNonAgentBackgroundWork,
   idleClaudeTeammateByName,
+  isValidClaudeSubagentId,
   readClaudeBackgroundAgentTasks,
   reapRestoredClaudeSubagentsWithoutLiveAgent,
   stopClaudeSubagent,
@@ -2446,13 +2447,16 @@ function normalizeClaudeSubagentLifecycleEvent(
   } else {
     const agentId = lifecycleId
     if (eventName === 'SubagentStart') {
-      upsertWorkingClaudeSubagent(
-        getOrCreateClaudeSubagentRoster(state, paneKey),
-        agentId,
-        { agentType: readString(hookPayload, 'agent_type') },
-        Date.now()
-      )
-      rosterChanged = true
+      // Why: upsert rejects invalid ids silently — allocate only for an id it will accept.
+      if (isValidClaudeSubagentId(agentId)) {
+        upsertWorkingClaudeSubagent(
+          getOrCreateClaudeSubagentRoster(state, paneKey),
+          agentId,
+          { agentType: readString(hookPayload, 'agent_type') },
+          Date.now()
+        )
+        rosterChanged = true
+      }
     } else {
       if (roster) {
         // Why: a stop of an untracked id (e.g. compact's start-less SubagentStop) is a roster no-op, not evidence.
@@ -2631,7 +2635,12 @@ function normalizeClaudeEvent(
       eventName === 'PostToolUseFailure')
       ? eventAgentId
       : undefined
-  if (eventAgentId && (subagentOriginId || isWaitingInducing)) {
+  if (
+    eventAgentId &&
+    (subagentOriginId || isWaitingInducing) &&
+    isValidClaudeSubagentId(eventAgentId)
+  ) {
+    // Why: upsert rejects invalid ids silently — allocate only for an id it will accept.
     upsertWorkingClaudeSubagent(
       getOrCreateClaudeSubagentRoster(state, paneKey),
       eventAgentId,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2479,7 +2479,10 @@ function normalizeClaudeSubagentLifecycleEvent(
       const runningTasks = inventory.tasks.filter(
         // Why: an id the upsert would reject can neither be tracked nor drained — letting it
         // allocate or claim liveness recreates the retention/sticky holes through inventory ids.
-        (task) => task.running && !task.teammate && isValidClaudeSubagentId(task.id)
+        // The stop is authoritative for its own id: a pre-stop snapshot still listing it as
+        // running must not resurrect the row this very event just removed.
+        (task) =>
+          task.running && !task.teammate && task.id !== agentId && isValidClaudeSubagentId(task.id)
       )
       if (inventory.present && inventory.tasks.length === 0 && roster) {
         // Why: restored rows are pre-restart claims, so ANY live inventory postdates them —
@@ -2733,12 +2736,13 @@ function normalizeClaudeEvent(
     hasActiveClaudeNonAgentBackgroundWork(hookPayload)
 
   // Why: canonicalize like the inventory parser and lifecycle handler — a padded id must hit
-  // the same roster key and wait ownership as its trimmed twin.
-  const rawAgentId = readString(hookPayload, 'agent_id')
-  const eventAgentId = rawAgentId?.trim() || undefined
-  // Why: agent_id present means child-origin by contract; a whitespace-only id cannot be
-  // attributed, and treating the event as the LEAD's would mint lead waiting/working that no
-  // lead Stop ever clears.
+  // the same roster key and wait ownership as its trimmed twin. Read the raw field, not
+  // readString: it swallows empty strings, which would erase the child-origin marker.
+  const rawAgentId = hookPayload['agent_id']
+  const eventAgentId = typeof rawAgentId === 'string' ? rawAgentId.trim() || undefined : undefined
+  // Why: an agent_id field present means child-origin by contract; an unattributable value
+  // (empty, whitespace, non-string junk) treated as the LEAD's would mint lead waiting/working
+  // that no lead Stop ever clears.
   if (rawAgentId !== undefined && eventAgentId === undefined) {
     return null
   }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2470,34 +2470,31 @@ function normalizeClaudeSubagentLifecycleEvent(
       // tracking them keeps their own later drains resolvable instead of start-less-suppressed.
       // Additive only — a complete-inventory reap here would kill a just-parked teammate row
       // before its TeammateIdle confirmation arrives.
+      // Why: stop-time inventories are mutually UNORDERED — any deletion they drive can be a
+      // stale claim against newer live state, so stop-time processing is strictly additive.
+      // Listed-non-running cleanup belongs to turn-serialized lead-Stop folds only.
       const inventory = readClaudeBackgroundAgentTasks(hookPayload)
+      const runningTasks = inventory.tasks.filter(
+        // Why: an id the upsert would reject can neither be tracked nor drained — letting it
+        // allocate or claim liveness recreates the retention/sticky holes through inventory ids.
+        (task) => task.running && !task.teammate && isValidClaudeSubagentId(task.id)
+      )
       if (inventory.present && inventory.tasks.length === 0 && roster) {
-        // Why: an empty complete inventory reaps only claims not backed by live lifecycle events
-        // (restored/inventory-derived phantoms). A delayed stale stop's empty list must not clear
-        // a newer live start's row — that is the uncorrelated-retirement race again. The reap is
-        // same-source-correlated removal evidence: the authority that minted those rows now
-        // reports empty, so a silent drain must not strand the published working.
+        // Why: restored rows are pre-restart claims, so ANY live inventory postdates them —
+        // reaping them on an empty inventory is temporally safe, and counts as removal
+        // evidence (same authority class that persisted the claim now reports empty). Rows
+        // minted by other stop-time inventories stay: those sources are unordered.
         for (const [id, tracked] of roster) {
-          if (tracked.restoredFromSnapshot || tracked.backgroundTasksAuthoritative) {
+          if (tracked.restoredFromSnapshot) {
             roster.delete(id)
             removedRow = true
           }
         }
-      } else if (
-        inventory.present &&
-        (roster ||
-          inventory.tasks.some(
-            // Why: an id the upsert would reject can neither be tracked nor drained — letting it
-            // allocate or claim liveness recreates the retention/sticky holes through inventory ids.
-            (task) => task.running && !task.teammate && isValidClaudeSubagentId(task.id)
-          ))
-      ) {
+      } else if (inventory.present && runningTasks.length > 0) {
         foldClaudeBackgroundTasksIntoRoster(
           getOrCreateClaudeSubagentRoster(state, paneKey),
-          inventory.tasks,
+          runningTasks,
           Date.now(),
-          // Why: additive only — a complete-inventory reap here would kill a just-parked
-          // teammate row before its TeammateIdle confirmation arrives.
           { inventoryComplete: false }
         )
       }
@@ -2624,29 +2621,6 @@ export function clearClaudeAnsweredQuestionWait(
 }
 
 /** Re-emit the lead's cached state on child activity — gated up to 'working' while a child works — without touching the lead's tool/prompt caches, so a live card or permission wait survives child churn. */
-// Why: the roster parser bounds TRACKED rows at the wire cap; this boolean liveness scan of the
-// raw array must still see a running subagent-typed entry hidden past it.
-function rawInventoryHasRunningSubagentTask(hookPayload: Record<string, unknown>): boolean {
-  const raw = hookPayload['background_tasks']
-  return (
-    Array.isArray(raw) &&
-    raw.some((item) => {
-      if (typeof item !== 'object' || item === null) {
-        return false
-      }
-      const task = item as Record<string, unknown>
-      return (
-        task.type === 'subagent' &&
-        task.status === 'running' &&
-        // Why: an id the upsert would reject can never be tracked or drained; letting it claim
-        // liveness would pin an unresolvable working on the pane.
-        typeof task.id === 'string' &&
-        isValidClaudeSubagentId(task.id)
-      )
-    })
-  )
-}
-
 function buildClaudeChildDrivenStatusPayload(
   state: HookListenerState,
   eventName: unknown,
@@ -2677,18 +2651,15 @@ function buildClaudeChildDrivenStatusPayload(
     })
   }
   if (evidence.removedRow) {
-    // Why: live shells/crons veto done, and the uncapped raw scan sees a running subagent hidden
-    // past the parser cap (tracked folding surfaces the listed ones through the working branch).
-    if (
-      hasActiveClaudeNonAgentBackgroundWork(hookPayload) ||
-      rawInventoryHasRunningSubagentTask(hookPayload)
-    ) {
+    // Why: live shells/crons in the payload's own inventory veto done — the pane still works.
+    if (hasActiveClaudeNonAgentBackgroundWork(hookPayload)) {
       return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
         stateName: 'working',
         updateToolSnapshot: false
       })
     }
-    // Why: a truncated inventory with no visible live work is incomplete evidence — claim nothing.
+    // Why: a truncated inventory may hide running children past the parser cap — incomplete
+    // evidence claims nothing (no done, and no working the roster could never resolve).
     const inventory = readClaudeBackgroundAgentTasks(hookPayload)
     if (inventory.present && inventory.truncated) {
       return null

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2436,11 +2436,13 @@ function normalizeClaudeSubagentLifecycleEvent(
   // Why: only a spawn may allocate a roster — stop/idle on an unknown pane would retain an empty
   // roster per untrusted pane key with no lifecycle bound (STA-2915 review finding).
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
-  let rosterChanged = false
+  let removedRow = false
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
-    rosterChanged = roster ? idleClaudeTeammateByName(roster, teammateName) : false
+    if (roster) {
+      idleClaudeTeammateByName(roster, teammateName)
+    }
     clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
       claudeTeammateIdMatchesName(waitingAgentId, teammateName)
     )
@@ -2455,20 +2457,21 @@ function normalizeClaudeSubagentLifecycleEvent(
           { agentType: readString(hookPayload, 'agent_type') },
           Date.now()
         )
-        rosterChanged = true
       }
     } else {
       if (roster) {
-        // Why: a stop of an untracked id (e.g. compact's start-less SubagentStop) is a roster no-op, not evidence.
-        rosterChanged = roster.has(agentId)
+        const hadRow = roster.has(agentId)
         // Why: one-shot stops are true finishes (row removed); teammate-shaped stops are turn ends on 2.1.21x — the row parks idle and a later SubagentStart revives it.
         stopClaudeSubagent(roster, agentId)
+        removedRow = hadRow && !roster.has(agentId)
       }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
     }
   }
-  return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload, rosterChanged)
+  return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload, {
+    removedRow
+  })
 }
 
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
@@ -2566,26 +2569,37 @@ function buildClaudeChildDrivenStatusPayload(
   eventName: unknown,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  rosterChanged = false
+  evidence: { removedRow?: boolean } = {}
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
-  // Why: no lead record, no live child, and an unchanged roster mean the event proves nothing is
-  // running. Compact's start-less SubagentStop is exactly that; minting the default below left a
-  // sticky 'working' no Stop ever clears on freshly resumed panes (STA-2915).
   const rosterHasWorking = claudeRosterHasWorkingSubagent(roster)
-  if (!lead && !rosterChanged && !rosterHasWorking) {
-    return null
+  if (lead) {
+    return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
+      stateName: lead.state === 'done' && rosterHasWorking ? 'working' : lead.state,
+      updateToolSnapshot: false,
+      interrupted: lead.interrupted
+    })
   }
-  // Why: with no lead record the pane state is inferred from tracked children only — a live child
-  // shows working, while an identity-matched drain/park resolves to done. The old unconditional
-  // 'working' default stuck until the stale sweeper once the last child left (STA-2915 review).
-  const leadState = lead?.state ?? (rosterHasWorking ? 'working' : 'done')
-  return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
-    stateName: leadState === 'done' && rosterHasWorking ? 'working' : leadState,
-    updateToolSnapshot: false,
-    interrupted: lead?.interrupted
-  })
+  // Why: with no lead record only positive evidence may speak. A live child shows working; a
+  // one-shot removal resolves to done — the row is gone, so a delayed duplicate stop finds
+  // nothing and cannot re-claim. Teammate parks and idle-only refreshes claim nothing: a stale
+  // stop from a previous turn parks a persistent id even while its newer turn is live, so
+  // inferring done there is PR #11353's uncorrelated-completion race. Everything else (e.g.
+  // compact's start-less SubagentStop) proves nothing and stays silent (STA-2915).
+  if (rosterHasWorking) {
+    return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
+      stateName: 'working',
+      updateToolSnapshot: false
+    })
+  }
+  if (evidence.removedRow) {
+    return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
+      stateName: 'done',
+      updateToolSnapshot: false
+    })
+  }
+  return null
 }
 
 function normalizeClaudeEvent(

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2516,6 +2516,18 @@ function normalizeClaudeSubagentLifecycleEvent(
     (eventName === 'TeammateIdle'
       ? [...roster.keys()].some((id) => claudeTeammateIdMatchesName(id, lifecycleId))
       : roster.has(lifecycleId))
+  if (clearedOwnWait === 'deleted') {
+    // Why: the wait's cached card (interactivePrompt/tool preview) died with its owner; carrying
+    // it into the clearing emission would leave an actionable card on a resolved pane. Mirrors
+    // clearClaudeAnsweredQuestionWait's cache reset.
+    const previousTool = state.lastToolByPaneKey.get(paneKey)
+    state.lastToolByPaneKey.set(
+      paneKey,
+      previousTool?.lastAssistantMessage
+        ? { lastAssistantMessage: previousTool.lastAssistantMessage }
+        : {}
+    )
+  }
   return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload, {
     removedRow,
     clearedOwnWait: clearedOwnWait === 'deleted' && !waitOwnerStillTracked

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2734,7 +2734,14 @@ function normalizeClaudeEvent(
 
   // Why: canonicalize like the inventory parser and lifecycle handler — a padded id must hit
   // the same roster key and wait ownership as its trimmed twin.
-  const eventAgentId = readString(hookPayload, 'agent_id')?.trim() || undefined
+  const rawAgentId = readString(hookPayload, 'agent_id')
+  const eventAgentId = rawAgentId?.trim() || undefined
+  // Why: agent_id present means child-origin by contract; a whitespace-only id cannot be
+  // attributed, and treating the event as the LEAD's would mint lead waiting/working that no
+  // lead Stop ever clears.
+  if (rawAgentId !== undefined && eventAgentId === undefined) {
+    return null
+  }
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
   // Two exceptions take the full path below: waiting-inducing events (a child needs human attention on this pane) and the blocked child's own next tool event (approval granted — clear the wait as for the lead).
   const isWaitingInducing = stateName === 'waiting'

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2437,13 +2437,14 @@ function normalizeClaudeSubagentLifecycleEvent(
   // roster per untrusted pane key with no lifecycle bound (STA-2915 review finding).
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
   let removedRow = false
+  let clearedOwnWait: 'none' | 'restored' | 'deleted' = 'none'
   if (eventName === 'TeammateIdle') {
     const teammateName = lifecycleId
     // Why: on claude 2.1.21x teammates are turn-based — TeammateIdle means "turn over, awaiting mail", not finished. The row parks as idle (confirmed teammate) instead of leaving, so the sidebar keeps showing resumable children.
     if (roster) {
       idleClaudeTeammateByName(roster, teammateName)
     }
-    clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
+    clearedOwnWait = clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) =>
       claudeTeammateIdMatchesName(waitingAgentId, teammateName)
     )
   } else {
@@ -2472,7 +2473,12 @@ function normalizeClaudeSubagentLifecycleEvent(
       const inventory = readClaudeBackgroundAgentTasks(hookPayload)
       if (
         inventory.present &&
-        (roster || inventory.tasks.some((task) => task.running && !task.teammate))
+        (roster ||
+          inventory.tasks.some(
+            // Why: an id the upsert would reject can neither be tracked nor drained — letting it
+            // allocate or claim liveness recreates the retention/sticky holes through inventory ids.
+            (task) => task.running && !task.teammate && isValidClaudeSubagentId(task.id)
+          ))
       ) {
         foldClaudeBackgroundTasksIntoRoster(
           getOrCreateClaudeSubagentRoster(state, paneKey),
@@ -2486,11 +2492,16 @@ function normalizeClaudeSubagentLifecycleEvent(
         )
       }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
-      clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
+      clearedOwnWait = clearClaudePendingWaitForAgent(
+        state,
+        paneKey,
+        (waitingAgentId) => waitingAgentId === agentId
+      )
     }
   }
   return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload, {
-    removedRow
+    removedRow,
+    clearedOwnWait: clearedOwnWait === 'deleted'
   })
 }
 
@@ -2551,19 +2562,21 @@ function clearClaudePendingWaitForAgent(
   state: HookListenerState,
   paneKey: string,
   ownsWait: (waitingAgentId: string) => boolean
-): void {
+): 'none' | 'restored' | 'deleted' {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
   if (lead?.state !== 'waiting' || !lead.waitingAgentId || !ownsWait(lead.waitingAgentId)) {
-    return
+    return 'none'
   }
   if (lead.stateBeforeWait) {
     state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait)
-    return
+    return 'restored'
   }
   // Why: no stash means the wait was this pane's FIRST lead record (child wait on a fresh
   // process); fabricating 'working' here becomes a stuck card when the waiting child dies —
-  // drop the record and let the evidence rules decide downstream (STA-2915 review).
+  // drop the record. The caller emits an identity-correlated clearing transition so the
+  // stale waiting card does not linger (STA-2915 review).
   state.claudeLeadStateByPaneKey.delete(paneKey)
+  return 'deleted'
 }
 
 /** Clear an AskUserQuestion wait after the answer is typed (answering emits no hook event; the caller infers it from the submit keystroke). Restores the stashed pre-wait lead state or 'working', drops the cached card, and returns the pane state to emit (gated up to 'working' while children run). */
@@ -2602,7 +2615,14 @@ function rawInventoryHasRunningSubagentTask(hookPayload: Record<string, unknown>
         return false
       }
       const task = item as Record<string, unknown>
-      return task.type === 'subagent' && task.status === 'running'
+      return (
+        task.type === 'subagent' &&
+        task.status === 'running' &&
+        // Why: an id the upsert would reject can never be tracked or drained; letting it claim
+        // liveness would pin an unresolvable working on the pane.
+        typeof task.id === 'string' &&
+        isValidClaudeSubagentId(task.id)
+      )
     })
   )
 }
@@ -2612,7 +2632,7 @@ function buildClaudeChildDrivenStatusPayload(
   eventName: unknown,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  evidence: { removedRow?: boolean } = {}
+  evidence: { removedRow?: boolean; clearedOwnWait?: boolean } = {}
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
@@ -2653,6 +2673,14 @@ function buildClaudeChildDrivenStatusPayload(
     if (inventory.present && inventory.truncated) {
       return null
     }
+    return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
+      stateName: 'done',
+      updateToolSnapshot: false
+    })
+  }
+  if (evidence.clearedOwnWait) {
+    // Why: the waiting card's own agent id parked/stopped — an identity-correlated resolution.
+    // Staying silent would leave the stale amber wait visible until the stale sweeper.
     return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
       stateName: 'done',
       updateToolSnapshot: false

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2474,10 +2474,13 @@ function normalizeClaudeSubagentLifecycleEvent(
       if (inventory.present && inventory.tasks.length === 0 && roster) {
         // Why: an empty complete inventory reaps only claims not backed by live lifecycle events
         // (restored/inventory-derived phantoms). A delayed stale stop's empty list must not clear
-        // a newer live start's row — that is the uncorrelated-retirement race again.
+        // a newer live start's row — that is the uncorrelated-retirement race again. The reap is
+        // same-source-correlated removal evidence: the authority that minted those rows now
+        // reports empty, so a silent drain must not strand the published working.
         for (const [id, tracked] of roster) {
           if (tracked.restoredFromSnapshot || tracked.backgroundTasksAuthoritative) {
             roster.delete(id)
+            removedRow = true
           }
         }
       } else if (

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2465,6 +2465,22 @@ function normalizeClaudeSubagentLifecycleEvent(
         stopClaudeSubagent(roster, agentId)
         removedRow = hadRow && !roster.has(agentId)
       }
+      // Why: the stop's inventory can list children this listener never saw start (post-restart);
+      // tracking them keeps their own later drains resolvable instead of start-less-suppressed.
+      // Additive only — a complete-inventory reap here would kill a just-parked teammate row
+      // before its TeammateIdle confirmation arrives.
+      const inventory = readClaudeBackgroundAgentTasks(hookPayload)
+      if (
+        inventory.present &&
+        (roster || inventory.tasks.some((task) => task.running && !task.teammate))
+      ) {
+        foldClaudeBackgroundTasksIntoRoster(
+          getOrCreateClaudeSubagentRoster(state, paneKey),
+          inventory.tasks,
+          Date.now(),
+          { inventoryComplete: false }
+        )
+      }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
       clearClaudePendingWaitForAgent(state, paneKey, (waitingAgentId) => waitingAgentId === agentId)
     }
@@ -2594,16 +2610,22 @@ function buildClaudeChildDrivenStatusPayload(
     })
   }
   if (evidence.removedRow) {
-    // Why: the stop's own inventory can list work this listener never saw start (post-restart);
-    // a running non-teammate task or live shell/cron vetoes done. Teammate-typed entries prove
-    // nothing ("running" even while idle), and full folding here would reap a just-parked
-    // teammate row before its TeammateIdle confirmation arrives — veto only, no reconcile.
+    // Why: live shells/crons veto done (the raw-array check is uncapped). A truncated agent-task
+    // inventory is incomplete evidence — a running child past the parser cap would be invisible —
+    // so it claims neither done nor working. Running non-teammate tasks were already folded into
+    // the roster above and surface through the working branch.
+    if (hasActiveClaudeNonAgentBackgroundWork(hookPayload)) {
+      return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
+        stateName: 'working',
+        updateToolSnapshot: false
+      })
+    }
     const inventory = readClaudeBackgroundAgentTasks(hookPayload)
-    const inventoryShowsLiveWork =
-      inventory.tasks.some((task) => task.running && !task.teammate) ||
-      hasActiveClaudeNonAgentBackgroundWork(hookPayload)
+    if (inventory.present && inventory.truncated) {
+      return null
+    }
     return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
-      stateName: inventoryShowsLiveWork ? 'working' : 'done',
+      stateName: 'done',
       updateToolSnapshot: false
     })
   }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2478,7 +2478,11 @@ function normalizeClaudeSubagentLifecycleEvent(
           getOrCreateClaudeSubagentRoster(state, paneKey),
           inventory.tasks,
           Date.now(),
-          { inventoryComplete: false }
+          // Why: an empty inventory is complete by construction and proves nothing is left
+          // alive (lead-path rule), clearing restored phantoms; a non-empty one folds
+          // additively — its reap would kill a just-parked teammate row before its
+          // TeammateIdle confirmation arrives.
+          { inventoryComplete: inventory.tasks.length === 0 }
         )
       }
       // Why: a blocked child that dies without another tool event would pin its permission/question wait on the pane forever — nothing else references that agent again.
@@ -2552,7 +2556,14 @@ function clearClaudePendingWaitForAgent(
   if (lead?.state !== 'waiting' || !lead.waitingAgentId || !ownsWait(lead.waitingAgentId)) {
     return
   }
-  state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait ?? { state: 'working' })
+  if (lead.stateBeforeWait) {
+    state.claudeLeadStateByPaneKey.set(paneKey, lead.stateBeforeWait)
+    return
+  }
+  // Why: no stash means the wait was this pane's FIRST lead record (child wait on a fresh
+  // process); fabricating 'working' here becomes a stuck card when the waiting child dies —
+  // drop the record and let the evidence rules decide downstream (STA-2915 review).
+  state.claudeLeadStateByPaneKey.delete(paneKey)
 }
 
 /** Clear an AskUserQuestion wait after the answer is typed (answering emits no hook event; the caller infers it from the submit keystroke). Restores the stashed pre-wait lead state or 'working', drops the cached card, and returns the pane state to emit (gated up to 'working' while children run). */
@@ -2580,6 +2591,22 @@ export function clearClaudeAnsweredQuestionWait(
 }
 
 /** Re-emit the lead's cached state on child activity — gated up to 'working' while a child works — without touching the lead's tool/prompt caches, so a live card or permission wait survives child churn. */
+// Why: the roster parser bounds TRACKED rows at the wire cap; this boolean liveness scan of the
+// raw array must still see a running subagent-typed entry hidden past it.
+function rawInventoryHasRunningSubagentTask(hookPayload: Record<string, unknown>): boolean {
+  const raw = hookPayload['background_tasks']
+  return (
+    Array.isArray(raw) &&
+    raw.some((item) => {
+      if (typeof item !== 'object' || item === null) {
+        return false
+      }
+      const task = item as Record<string, unknown>
+      return task.type === 'subagent' && task.status === 'running'
+    })
+  )
+}
+
 function buildClaudeChildDrivenStatusPayload(
   state: HookListenerState,
   eventName: unknown,
@@ -2610,16 +2637,18 @@ function buildClaudeChildDrivenStatusPayload(
     })
   }
   if (evidence.removedRow) {
-    // Why: live shells/crons veto done (the raw-array check is uncapped). A truncated agent-task
-    // inventory is incomplete evidence — a running child past the parser cap would be invisible —
-    // so it claims neither done nor working. Running non-teammate tasks were already folded into
-    // the roster above and surface through the working branch.
-    if (hasActiveClaudeNonAgentBackgroundWork(hookPayload)) {
+    // Why: live shells/crons veto done, and the uncapped raw scan sees a running subagent hidden
+    // past the parser cap (tracked folding surfaces the listed ones through the working branch).
+    if (
+      hasActiveClaudeNonAgentBackgroundWork(hookPayload) ||
+      rawInventoryHasRunningSubagentTask(hookPayload)
+    ) {
       return buildClaudeStatusPayload(state, eventName, '', paneKey, hookPayload, {
         stateName: 'working',
         updateToolSnapshot: false
       })
     }
+    // Why: a truncated inventory with no visible live work is incomplete evidence — claim nothing.
     const inventory = readClaudeBackgroundAgentTasks(hookPayload)
     if (inventory.present && inventory.truncated) {
       return null

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2429,7 +2429,9 @@ function normalizeClaudeSubagentLifecycleEvent(
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
   const lifecycleField = eventName === 'TeammateIdle' ? 'teammate_name' : 'agent_id'
-  const lifecycleId = readString(hookPayload, lifecycleField)
+  // Why: inventory ids are trimmed at parse — lifecycle ids must canonicalize identically or a
+  // padded stop misses the trimmed roster key and the row can never drain.
+  const lifecycleId = readString(hookPayload, lifecycleField)?.trim()
   if (!lifecycleId) {
     return null
   }
@@ -2730,7 +2732,9 @@ function normalizeClaudeEvent(
     (eventName === 'Stop' || eventName === 'StopFailure') &&
     hasActiveClaudeNonAgentBackgroundWork(hookPayload)
 
-  const eventAgentId = readString(hookPayload, 'agent_id')
+  // Why: canonicalize like the inventory parser and lifecycle handler — a padded id must hit
+  // the same roster key and wait ownership as its trimmed twin.
+  const eventAgentId = readString(hookPayload, 'agent_id')?.trim() || undefined
   // Why: subagent/teammate events carry `agent_id` (lead's don't); child tool activity keeps its row live but must not become the lead's state or overwrite its tool/prompt caches (a live card would vanish).
   // Two exceptions take the full path below: waiting-inducing events (a child needs human attention on this pane) and the blocked child's own next tool event (approval granted — clear the wait as for the lead).
   const isWaitingInducing = stateName === 'waiting'

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -191,12 +191,11 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
     if (obj.type !== 'subagent' && obj.type !== 'teammate') {
       continue
     }
+    // Why: canonicalize before validating — a whitespace-padded id stored raw would publish
+    // trimmed in snapshots yet never match its own lifecycle SubagentStop, so it could not drain.
+    const id = typeof obj.id === 'string' ? obj.id.trim() : ''
     // Why: an id the upsert rejects can never be tracked — it must not consume a cap slot either.
-    if (
-      typeof obj.id !== 'string' ||
-      obj.id.trim().length === 0 ||
-      !isValidClaudeSubagentId(obj.id)
-    ) {
+    if (id.length === 0 || !isValidClaudeSubagentId(id)) {
       continue
     }
     if (tasks.length >= AGENT_STATUS_MAX_SUBAGENTS) {
@@ -206,7 +205,7 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
       break
     }
     tasks.push({
-      id: obj.id,
+      id,
       agentType: typeof obj.agent_type === 'string' ? obj.agent_type : undefined,
       description: typeof obj.description === 'string' ? obj.description : undefined,
       running: obj.status === 'running',

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -73,6 +73,12 @@ export function isClaudeTeammateLifecycleId(id: string): boolean {
   return separator > 1 && id.startsWith('a') && /^[0-9a-f]+$/i.test(id.slice(separator + 1))
 }
 
+/** Pre-check for callers that allocate a roster to upsert into — upsert rejects
+ *  invalid ids silently, which would strand the fresh roster empty forever. */
+export function isValidClaudeSubagentId(id: string): boolean {
+  return id.length > 0 && id.length <= CLAUDE_SUBAGENT_ID_MAX_LENGTH
+}
+
 export function upsertWorkingClaudeSubagent(
   roster: ClaudeSubagentRoster,
   id: string,

--- a/src/shared/claude-subagent-roster.ts
+++ b/src/shared/claude-subagent-roster.ts
@@ -191,7 +191,12 @@ export function readClaudeBackgroundAgentTasks(hookPayload: Record<string, unkno
     if (obj.type !== 'subagent' && obj.type !== 'teammate') {
       continue
     }
-    if (typeof obj.id !== 'string' || obj.id.trim().length === 0) {
+    // Why: an id the upsert rejects can never be tracked — it must not consume a cap slot either.
+    if (
+      typeof obj.id !== 'string' ||
+      obj.id.trim().length === 0 ||
+      !isValidClaudeSubagentId(obj.id)
+    ) {
       continue
     }
     if (tasks.length >= AGENT_STATUS_MAX_SUBAGENTS) {


### PR DESCRIPTION
## Summary

Fixes Linear STA-2915: after Claude `/compact` on a freshly resumed session, the worktree card/sidebar agent row could stick on **Working…** forever (empty prompt, no tool, `stateStartedAt == updatedAt`) while the TUI sat idle.

Live event capture across Claude Code 2.1.186 / 2.1.205 / 2.1.218 / 2.1.220 shows compact emits `PreCompact → SubagentStop (never started) → SessionStart(compact) → PostCompact` — and **no** `UserPromptSubmit` (the issue's original theory, and the mechanism PR #11353 targeted, no longer exists on any harness back to June 22). The real culprit is receiver-side: `buildClaudeChildDrivenStatusPayload` defaults the lead state to `working` when the pane has no cached lead record, so compact's start-less `SubagentStop` on a resumed pane in a fresh Orca process mints a `working` that no `Stop` ever clears (until the 30-minute stale window).

The fix emits child-driven status only on positive evidence: a cached lead record, a live working child in the roster, or an actual roster change from the event. Unlike #11353's `PostCompact → done` mapping (rejected for stale-completion races), this claims no completion authority, needs no correlation ID, and adds no per-pane state.

Reproduced live on the current production build (fresh pane + `claude --resume` + `/compact` → sticky `working` row minted at the exact SubagentStop timestamp) and re-run on this branch's dev build (same sequence → no row minted; real turns still track `working → done` normally).

## Screenshots

No visual change (status correctness fix). Post-fix rig screenshot of the idle sidebar after compact is attached to the Linear issue evidence.

## Testing

- [x] `pnpm lint` (oxlint + react-doctor config on changed files: clean; oxfmt clean)
- [x] `pnpm typecheck`
- [x] `pnpm test` (664 passed across src/shared + src/relay + src/main/agent-hooks suites)
- [x] Added regression tests: start-less `SubagentStop` with no lead record emits nothing (fails on parent commit); lead-present compact re-emits `done`; spawn with no lead still mints `working`; unknown stop with a surviving live child keeps `working`

## AI Review Report

Reviewed the guard's interaction with every `buildClaudeChildDrivenStatusPayload` call site: subagent lifecycle (start/stop/teammate-idle), child tool activity (upserts a working row before emitting, so unaffected), and known-child turn-boundary re-emits (now fail closed to no claim instead of minting `working` with zero evidence). TeammateIdle roster transitions still emit (rosterChanged from `idleClaudeTeammateByName`), preserving idle-row UI refreshes. Cross-platform: pure shared normalization logic consumed identically by the local hook server and the SSH relay; no shortcuts, paths, shell, or Electron platform surface touched. A same-model Codex review loop runs on this exact head via Orca orchestration; findings will be pushed before merge.

## Security Audit

No new input surface: the change only tightens which authenticated hook events may emit a status payload. Untrusted payload fields (`agent_id`) already flowed through these paths; the guard strictly reduces what an unauthenticated-content payload can cause (it can no longer mint a phantom `working` on an eventless pane). No exec, path, secret, or IPC changes.

## Notes

- Kimi is unaffected (its normalizer ignores subagent lifecycle events entirely).
- The known-stop-with-no-lead path previously emitted `working` after a restart-seeded roster drained; it now emits nothing, leaving the restored persisted status in place until real lead evidence arrives — fail-closed by design.
