### PR TITLE
fix(terminal): keep pane font zoom uniform

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -303,7 +303,6 @@ function TerminalPane(
 ): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const managerRef = useRef<PaneManager | null>(null)
-  const paneFontSizesRef = useRef<Map<number, number>>(new Map())
   const expandedPaneIdRef = useRef<number | null>(null)
   const expandedStyleSnapshotRef = useRef<Map<HTMLElement, { display: string; flex: string }>>(
     new Map()
@@ -1438,7 +1437,6 @@ function TerminalPane(
     managerRef,
     containerRef,
     expandedStyleSnapshotRef,
-    paneFontSizesRef,
     paneTransportsRef,
     paneCwdRef,
     paneMode2031Ref,
@@ -1733,7 +1731,7 @@ function TerminalPane(
     pendingCodexPaneRestartIds
   ])
 
-  useTerminalFontZoom({ isActive, containerRef, managerRef, paneFontSizesRef, settingsRef })
+  useTerminalFontZoom({ isActive, containerRef, managerRef, settingsRef, updateSettings })
 
   useTerminalKeyboardShortcuts({
     tabId,

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -155,7 +155,6 @@ describe('applyTerminalAppearance theme assignment', () => {
       settings,
       true,
       new Map(),
-      new Map(),
       'false',
       new Map(),
       new Map()
@@ -175,6 +174,25 @@ describe('applyTerminalAppearance theme assignment', () => {
     // Identity-stable theme means xterm never re-runs _setTheme, so a TUI's modifyColors mutation survives the font tweak.
     expect(pane.terminal.options.theme).toBe(firstTheme)
     expect(pane.terminal.options.fontSize).toBe(settings.terminalFontSize + 2)
+  })
+
+  it('reapplies the global font size uniformly to every pane', () => {
+    const panes = [makePane(1), makePane(2)]
+    panes[0].terminal.options.fontSize = 11
+    panes[1].terminal.options.fontSize = 19
+    const settings = { ...getDefaultSettings('/tmp'), terminalFontSize: 16 }
+
+    applyTerminalAppearance(
+      makeManager(panes),
+      settings,
+      true,
+      new Map(),
+      'false',
+      new Map(),
+      new Map()
+    )
+
+    expect(panes.map((pane) => pane.terminal.options.fontSize)).toEqual([16, 16])
   })
 
   it('still assigns a fresh theme when composed values actually change', () => {
@@ -304,16 +322,7 @@ describe('publishTerminalViewAttributesAtAppStart', () => {
         setPaneLigaturesEnabled: vi.fn(),
         setPaneStyleOptions: vi.fn()
       } as unknown as PaneManager
-      applyTerminalAppearance(
-        manager,
-        settings,
-        true,
-        new Map(),
-        new Map(),
-        'false',
-        new Map(),
-        new Map()
-      )
+      applyTerminalAppearance(manager, settings, true, new Map(), 'false', new Map(), new Map())
       expect(publishMock).toHaveBeenCalledTimes(1)
     } finally {
       delete (globalThis as { window?: unknown }).window

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -131,7 +131,6 @@ export function applyTerminalAppearance(
   manager: PaneManager,
   settings: GlobalSettings,
   systemPrefersDark: boolean,
-  paneFontSizes: Map<number, number>,
   paneTransports: Map<number, PtyTransport>,
   effectiveMacOptionAsAlt: EffectiveMacOptionAsAlt,
   paneMode2031: Map<number, boolean>,
@@ -173,8 +172,7 @@ export function applyTerminalAppearance(
     pane.terminal.options.cursorStyle = cursorStyle
     pane.terminal.options.cursorInactiveStyle = resolveTerminalCursorInactiveStyle(cursorStyle)
     pane.terminal.options.cursorBlink = settings.terminalCursorBlink
-    const paneSize = paneFontSizes.get(pane.id)
-    pane.terminal.options.fontSize = paneSize ?? settings.terminalFontSize
+    pane.terminal.options.fontSize = settings.terminalFontSize
     pane.terminal.options.fontFamily = buildFontFamily(settings.terminalFontFamily)
     pane.terminal.options.fontWeight = terminalFontWeights.fontWeight
     pane.terminal.options.fontWeightBold = terminalFontWeights.fontWeightBold

--- a/src/renderer/src/components/terminal-pane/terminal-cursor-inactive-style.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cursor-inactive-style.test.ts
@@ -25,16 +25,7 @@ describe('terminal inactive cursor style', () => {
       terminalCursorStyle: 'bar' as const
     }
 
-    applyTerminalAppearance(
-      manager,
-      settings,
-      false,
-      new Map(),
-      new Map(),
-      'false',
-      new Map(),
-      new Map()
-    )
+    applyTerminalAppearance(manager, settings, false, new Map(), 'false', new Map(), new Map())
 
     expect(options.cursorStyle).toBe('bar')
     expect(options.cursorInactiveStyle).toBe('bar')

--- a/src/renderer/src/components/terminal-pane/terminal-view-attributes-publisher.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-view-attributes-publisher.test.ts
@@ -169,7 +169,6 @@ describe('applyTerminalAppearance publication', () => {
       settings,
       true,
       new Map(),
-      new Map(),
       'false',
       new Map(),
       new Map()
@@ -178,7 +177,6 @@ describe('applyTerminalAppearance publication', () => {
       makeManager([makePane(3)]),
       settings,
       true,
-      new Map(),
       new Map(),
       'false',
       new Map(),
@@ -195,7 +193,6 @@ describe('applyTerminalAppearance publication', () => {
       { ...settings, terminalFontSize: settings.terminalFontSize + 2 },
       true,
       new Map(),
-      new Map(),
       'false',
       new Map(),
       new Map()
@@ -207,7 +204,6 @@ describe('applyTerminalAppearance publication', () => {
       makeManager([makePane(1)]),
       { ...settings, terminalCursorStyle: 'underline' },
       true,
-      new Map(),
       new Map(),
       'false',
       new Map(),
@@ -225,7 +221,6 @@ describe('applyTerminalAppearance publication', () => {
       settings,
       true,
       new Map(),
-      new Map(),
       'false',
       new Map(),
       new Map()
@@ -234,7 +229,6 @@ describe('applyTerminalAppearance publication', () => {
       makeManager([makePane(1)]),
       settings,
       false,
-      new Map(),
       new Map(),
       'false',
       new Map(),

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -260,7 +260,6 @@ type UseTerminalPaneLifecycleDeps = {
   expandedStyleSnapshotRef: React.MutableRefObject<
     Map<HTMLElement, { display: string; flex: string }>
   >
-  paneFontSizesRef: React.RefObject<Map<number, number>>
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   /** Per-pane live cwd (from the OSC 7 handler); read synchronously by split handlers for cache hits. */
   paneCwdRef: React.RefObject<PaneCwdMap>
@@ -596,7 +595,6 @@ export function useTerminalPaneLifecycle({
   managerRef,
   containerRef,
   expandedStyleSnapshotRef,
-  paneFontSizesRef,
   paneTransportsRef,
   paneCwdRef,
   paneMode2031Ref,
@@ -674,7 +672,6 @@ export function useTerminalPaneLifecycle({
       manager,
       currentSettings,
       systemPrefersDarkRef.current,
-      paneFontSizesRef.current,
       paneTransportsRef.current,
       effectiveMacOptionAsAltRef.current,
       paneMode2031Ref.current,
@@ -1303,7 +1300,6 @@ export function useTerminalPaneLifecycle({
           paneTransportsRef.current.delete(paneId)
         }
         clearRuntimePaneTitle(tabId, paneId)
-        paneFontSizesRef.current.delete(paneId)
         replayingPanesRef.current.delete(paneId)
         restoredViewportBlankingPanesRef.current.delete(paneId)
         // Clean up pane title state so closed panes don't leave stale entries.

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
@@ -14,7 +14,8 @@ vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactModule>()
   return {
     ...actual,
-    useEffect: (effect: () => void | (() => void)) => effect()
+    useEffect: (effect: () => void | (() => void)) => effect(),
+    useRef: <T>(initialValue: T) => ({ current: initialValue })
   }
 })
 
@@ -120,6 +121,71 @@ describe('useTerminalFontZoom', () => {
     expect(updateSettings).toHaveBeenCalledOnce()
     expect(updateSettings).toHaveBeenCalledWith({ terminalFontSize: 15 })
     expect(mocks.dispatchZoomLevelChanged).toHaveBeenCalledWith('terminal', 107)
+  })
+
+  it('resets to the configured base size and reports zoom relative to that base', () => {
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    const { listener, terminals, updateSettings } = useMountedTerminalFontZoom(helper, 20)
+
+    listener('in')
+
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([21, 21])
+    expect(updateSettings).toHaveBeenLastCalledWith({ terminalFontSize: 21 })
+    expect(mocks.dispatchZoomLevelChanged).toHaveBeenLastCalledWith('terminal', 105)
+
+    listener('reset')
+
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([20, 20])
+    expect(updateSettings).toHaveBeenLastCalledWith({ terminalFontSize: 20 })
+    expect(mocks.dispatchZoomLevelChanged).toHaveBeenLastCalledWith('terminal', 100)
+    expect(mocks.safeFit).toHaveBeenCalledTimes(4)
+  })
+
+  it('preserves the configured base independently across hooks sharing settings', () => {
+    const firstContainer = document.createElement('div')
+    const secondContainer = document.createElement('div')
+    const firstHelper = document.createElement('textarea')
+    const secondHelper = document.createElement('textarea')
+    firstHelper.className = 'xterm-helper-textarea'
+    secondHelper.className = 'xterm-helper-textarea'
+    firstContainer.appendChild(firstHelper)
+    secondContainer.appendChild(secondHelper)
+    document.body.append(firstContainer, secondContainer)
+
+    const sharedSettingsRef = { current: { terminalFontSize: 20 } }
+    const firstTerminal = { options: { fontSize: 20 } }
+    const secondTerminal = { options: { fontSize: 20 } }
+    const updateSettings = vi.fn()
+    useTerminalFontZoom({
+      isActive: true,
+      containerRef: { current: firstContainer },
+      managerRef: {
+        current: { getPanes: () => [{ id: 1, terminal: firstTerminal }] }
+      } as never,
+      settingsRef: sharedSettingsRef,
+      updateSettings
+    })
+    useTerminalFontZoom({
+      isActive: true,
+      containerRef: { current: secondContainer },
+      managerRef: {
+        current: { getPanes: () => [{ id: 2, terminal: secondTerminal }] }
+      } as never,
+      settingsRef: sharedSettingsRef,
+      updateSettings
+    })
+
+    firstHelper.focus()
+    terminalZoomListeners[0]('in')
+    expect(sharedSettingsRef.current.terminalFontSize).toBe(21)
+
+    secondHelper.focus()
+    terminalZoomListeners[1]('reset')
+
+    expect(secondTerminal.options.fontSize).toBe(20)
+    expect(updateSettings).toHaveBeenLastCalledWith({ terminalFontSize: 20 })
+    expect(mocks.dispatchZoomLevelChanged).toHaveBeenLastCalledWith('terminal', 100)
   })
 
   it('clamps zoom out and resets the persisted size to the global default', () => {

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
@@ -49,7 +49,7 @@ describe('useTerminalFontZoom', () => {
 
   function useMountedTerminalFontZoom(
     activeElement: HTMLElement,
-    terminalFontSize = 14
+    terminalFontSize: number | null = 14
   ): {
     terminals: { options: { fontSize?: number } }[]
     listener: (direction: 'in' | 'out' | 'reset') => void
@@ -70,7 +70,9 @@ describe('useTerminalFontZoom', () => {
           getPanes: () => panes
         }
       } as never,
-      settingsRef: { current: { terminalFontSize } },
+      settingsRef: {
+        current: terminalFontSize === null ? null : { terminalFontSize }
+      },
       updateSettings
     })
     const listener = terminalZoomListeners.at(-1)
@@ -92,6 +94,18 @@ describe('useTerminalFontZoom', () => {
     expect(mocks.safeFit).not.toHaveBeenCalled()
     expect(updateSettings).not.toHaveBeenCalled()
     expect(mocks.dispatchZoomLevelChanged).not.toHaveBeenCalled()
+  })
+
+  it('does not apply or persist zoom before settings load', () => {
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    const { listener, terminals, updateSettings } = useMountedTerminalFontZoom(helper, null)
+
+    listener('in')
+
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([12, 18])
+    expect(mocks.safeFit).not.toHaveBeenCalled()
+    expect(updateSettings).not.toHaveBeenCalled()
   })
 
   it('applies and persists the global font size to every pane while terminal owns focus', () => {

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.test.ts
@@ -47,52 +47,82 @@ describe('useTerminalFontZoom', () => {
     })
   })
 
-  function useMountedTerminalFontZoom(activeElement: HTMLElement): {
-    terminal: { options: { fontSize?: number } }
+  function useMountedTerminalFontZoom(
+    activeElement: HTMLElement,
+    terminalFontSize = 14
+  ): {
+    terminals: { options: { fontSize?: number } }[]
     listener: (direction: 'in' | 'out' | 'reset') => void
+    updateSettings: ReturnType<typeof vi.fn>
   } {
     const container = document.createElement('div')
     document.body.appendChild(container)
     container.appendChild(activeElement)
     activeElement.focus()
-    const terminal = { options: { fontSize: 14 } }
+    const terminals = [{ options: { fontSize: 12 } }, { options: { fontSize: 18 } }]
+    const panes = terminals.map((terminal, index) => ({ id: index + 1, terminal }))
+    const updateSettings = vi.fn()
     useTerminalFontZoom({
       isActive: true,
       containerRef: { current: container },
       managerRef: {
         current: {
-          getActivePane: () => ({ id: 1, terminal })
+          getPanes: () => panes
         }
       } as never,
-      paneFontSizesRef: { current: new Map() },
-      settingsRef: { current: { terminalFontSize: 14 } }
+      settingsRef: { current: { terminalFontSize } },
+      updateSettings
     })
     const listener = terminalZoomListeners.at(-1)
     expect(listener).toBeTypeOf('function')
-    return { terminal, listener: listener as (direction: 'in' | 'out' | 'reset') => void }
+    return {
+      terminals,
+      listener: listener as (direction: 'in' | 'out' | 'reset') => void,
+      updateSettings
+    }
   }
 
   it('ignores zoom events when terminal input no longer owns focus', () => {
     const button = document.createElement('button')
-    const { listener, terminal } = useMountedTerminalFontZoom(button)
+    const { listener, terminals, updateSettings } = useMountedTerminalFontZoom(button)
 
     listener('in')
 
-    expect(terminal.options.fontSize).toBe(14)
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([12, 18])
     expect(mocks.safeFit).not.toHaveBeenCalled()
+    expect(updateSettings).not.toHaveBeenCalled()
     expect(mocks.dispatchZoomLevelChanged).not.toHaveBeenCalled()
   })
 
-  it('applies terminal font zoom while the xterm helper textarea owns focus', () => {
+  it('applies and persists the global font size to every pane while terminal owns focus', () => {
     const helper = document.createElement('textarea')
     helper.className = 'xterm-helper-textarea'
-    const { listener, terminal } = useMountedTerminalFontZoom(helper)
+    const { listener, terminals, updateSettings } = useMountedTerminalFontZoom(helper)
 
     listener('in')
 
-    expect(terminal.options.fontSize).toBe(15)
-    expect(mocks.safeFit).toHaveBeenCalledTimes(1)
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([15, 15])
+    expect(mocks.safeFit).toHaveBeenCalledTimes(2)
+    expect(updateSettings).toHaveBeenCalledOnce()
+    expect(updateSettings).toHaveBeenCalledWith({ terminalFontSize: 15 })
     expect(mocks.dispatchZoomLevelChanged).toHaveBeenCalledWith('terminal', 107)
+  })
+
+  it('clamps zoom out and resets the persisted size to the global default', () => {
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    const { listener, terminals, updateSettings } = useMountedTerminalFontZoom(helper)
+
+    for (let step = 0; step < 10; step += 1) {
+      listener('out')
+    }
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([8, 8])
+    expect(updateSettings).toHaveBeenLastCalledWith({ terminalFontSize: 8 })
+
+    listener('reset')
+    expect(terminals.map((terminal) => terminal.options.fontSize)).toEqual([14, 14])
+    expect(updateSettings).toHaveBeenLastCalledWith({ terminalFontSize: 14 })
+    expect(mocks.dispatchZoomLevelChanged).toHaveBeenLastCalledWith('terminal', 100)
   })
 
   it('only lets the pane owning the focused helper apply terminal font zoom', () => {
@@ -105,28 +135,28 @@ describe('useTerminalFontZoom', () => {
     focusedHelper.focus()
 
     const inactiveTerminal = { options: { fontSize: 14 } }
-    const activeTerminal = { options: { fontSize: 14 } }
+    const activeTerminals = [{ options: { fontSize: 12 } }, { options: { fontSize: 18 } }]
     useTerminalFontZoom({
       isActive: true,
       containerRef: { current: inactiveContainer },
       managerRef: {
         current: {
-          getActivePane: () => ({ id: 1, terminal: inactiveTerminal })
+          getPanes: () => [{ id: 1, terminal: inactiveTerminal }]
         }
       } as never,
-      paneFontSizesRef: { current: new Map() },
-      settingsRef: { current: { terminalFontSize: 14 } }
+      settingsRef: { current: { terminalFontSize: 14 } },
+      updateSettings: vi.fn()
     })
     useTerminalFontZoom({
       isActive: true,
       containerRef: { current: activeContainer },
       managerRef: {
         current: {
-          getActivePane: () => ({ id: 2, terminal: activeTerminal })
+          getPanes: () => activeTerminals.map((terminal, index) => ({ id: index + 2, terminal }))
         }
       } as never,
-      paneFontSizesRef: { current: new Map() },
-      settingsRef: { current: { terminalFontSize: 14 } }
+      settingsRef: { current: { terminalFontSize: 14 } },
+      updateSettings: vi.fn()
     })
 
     for (const listener of terminalZoomListeners) {
@@ -134,7 +164,7 @@ describe('useTerminalFontZoom', () => {
     }
 
     expect(inactiveTerminal.options.fontSize).toBe(14)
-    expect(activeTerminal.options.fontSize).toBe(15)
-    expect(mocks.safeFit).toHaveBeenCalledTimes(1)
+    expect(activeTerminals.map((terminal) => terminal.options.fontSize)).toEqual([15, 15])
+    expect(mocks.safeFit).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -41,7 +41,11 @@ export function useTerminalFontZoom({
         return
       }
 
-      const currentSize = settingsRef.current?.terminalFontSize ?? DEFAULT_FONT_SIZE
+      const settings = settingsRef.current
+      if (!settings) {
+        return
+      }
+      const currentSize = settings.terminalFontSize ?? DEFAULT_FONT_SIZE
 
       let nextSize: number
       if (direction === 'reset') {
@@ -52,9 +56,7 @@ export function useTerminalFontZoom({
         nextSize = Math.max(MIN_FONT_SIZE, currentSize - 1)
       }
 
-      if (settingsRef.current) {
-        settingsRef.current = { ...settingsRef.current, terminalFontSize: nextSize }
-      }
+      settingsRef.current = { ...settings, terminalFontSize: nextSize }
       for (const pane of panes) {
         pane.terminal.options.fontSize = nextSize
         safeFit(pane)

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -4,29 +4,29 @@ import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { getPaneOwnedActiveHelperTextarea } from './regular-terminal-focus-ownership'
 
+const DEFAULT_FONT_SIZE = 14
+const MIN_FONT_SIZE = 8
+const MAX_FONT_SIZE = 32
+
 type FontZoomDeps = {
   isActive: boolean
   containerRef: React.RefObject<HTMLElement | null>
   managerRef: React.RefObject<PaneManager | null>
-  paneFontSizesRef: React.RefObject<Map<number, number>>
   settingsRef: React.RefObject<{ terminalFontSize?: number } | null>
+  updateSettings: (updates: { terminalFontSize: number }) => void | Promise<void>
 }
 
 export function useTerminalFontZoom({
   isActive,
   containerRef,
   managerRef,
-  paneFontSizesRef,
-  settingsRef
+  settingsRef,
+  updateSettings
 }: FontZoomDeps): void {
   useEffect(() => {
     if (!isActive) {
       return
     }
-    const MIN_FONT_SIZE = 8
-    const MAX_FONT_SIZE = 32
-    const FONT_SIZE_STEP = 1
-
     return window.api.ui.onTerminalZoom((direction) => {
       const container = containerRef.current
       if (!container || !getPaneOwnedActiveHelperTextarea(container, document.activeElement)) {
@@ -36,31 +36,33 @@ export function useTerminalFontZoom({
       if (!manager) {
         return
       }
-      const pane = manager.getActivePane()
-      if (!pane) {
+      const panes = manager.getPanes()
+      if (panes.length === 0) {
         return
       }
 
-      const globalSize = settingsRef.current?.terminalFontSize ?? 14
-      const currentSize = paneFontSizesRef.current.get(pane.id) ?? globalSize
+      const currentSize = settingsRef.current?.terminalFontSize ?? DEFAULT_FONT_SIZE
 
       let nextSize: number
       if (direction === 'reset') {
-        nextSize = globalSize
-        paneFontSizesRef.current.delete(pane.id)
+        nextSize = DEFAULT_FONT_SIZE
       } else if (direction === 'in') {
-        nextSize = Math.min(MAX_FONT_SIZE, currentSize + FONT_SIZE_STEP)
-        paneFontSizesRef.current.set(pane.id, nextSize)
+        nextSize = Math.min(MAX_FONT_SIZE, currentSize + 1)
       } else {
-        nextSize = Math.max(MIN_FONT_SIZE, currentSize - FONT_SIZE_STEP)
-        paneFontSizesRef.current.set(pane.id, nextSize)
+        nextSize = Math.max(MIN_FONT_SIZE, currentSize - 1)
       }
 
-      pane.terminal.options.fontSize = nextSize
-      safeFit(pane)
+      if (settingsRef.current) {
+        settingsRef.current = { ...settingsRef.current, terminalFontSize: nextSize }
+      }
+      for (const pane of panes) {
+        pane.terminal.options.fontSize = nextSize
+        safeFit(pane)
+      }
+      void updateSettings({ terminalFontSize: nextSize })
 
-      const percent = Math.round((nextSize / globalSize) * 100)
+      const percent = Math.round((nextSize / DEFAULT_FONT_SIZE) * 100)
       dispatchZoomLevelChanged('terminal', percent)
     })
-  }, [containerRef, isActive, managerRef, paneFontSizesRef, settingsRef])
+  }, [containerRef, isActive, managerRef, settingsRef, updateSettings])
 }

--- a/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
+++ b/src/renderer/src/components/terminal-pane/useTerminalFontZoom.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
@@ -23,6 +23,8 @@ export function useTerminalFontZoom({
   settingsRef,
   updateSettings
 }: FontZoomDeps): void {
+  const baseFontSizeRef = useRef<number | null>(settingsRef.current?.terminalFontSize ?? null)
+
   useEffect(() => {
     if (!isActive) {
       return
@@ -45,11 +47,13 @@ export function useTerminalFontZoom({
       if (!settings) {
         return
       }
+      const baseSize = baseFontSizeRef.current ?? settings.terminalFontSize ?? DEFAULT_FONT_SIZE
+      baseFontSizeRef.current = baseSize
       const currentSize = settings.terminalFontSize ?? DEFAULT_FONT_SIZE
 
       let nextSize: number
       if (direction === 'reset') {
-        nextSize = DEFAULT_FONT_SIZE
+        nextSize = baseSize
       } else if (direction === 'in') {
         nextSize = Math.min(MAX_FONT_SIZE, currentSize + 1)
       } else {
@@ -63,7 +67,7 @@ export function useTerminalFontZoom({
       }
       void updateSettings({ terminalFontSize: nextSize })
 
-      const percent = Math.round((nextSize / DEFAULT_FONT_SIZE) * 100)
+      const percent = Math.round((nextSize / baseSize) * 100)
       dispatchZoomLevelChanged('terminal', percent)
     })
   }, [containerRef, isActive, managerRef, settingsRef, updateSettings])


### PR DESCRIPTION
## Summary

- Keep Cmd +/- terminal zoom global across every pane in the active terminal tab.
- Persist the selected `terminalFontSize` instead of storing per-pane temporary overrides.
- Preserve each mounted terminal hook's configured base size so Cmd+0 restores the user preference and the overlay percentage is relative to that preference.
- Reapply one global font size whenever terminal appearance is refreshed.

한국어 폰트 적용 뒤 분할 창마다 글자 크기가 달라져 해상도와 가독성이 들쭉날쭉해 보이던 문제를 막습니다.

## Screenshots

- Not attached because the live terminal screenshot contains private workspace content.
- The change affects font-size consistency across split panes, not the static layout.

## Testing

- [x] 7 focused zoom regression tests passed.
- [x] 2,880 terminal-pane tests passed.
- [x] Web TypeScript check passed.
- [x] Oxlint passed on all changed files.

## AI Review Report

- CodeRabbit found a settings-hydration race that could persist the default size before settings load. Fixed by ignoring zoom until settings exist.
- Greptile found that Cmd+0 overwrote a configured size such as 20 with 14 and that the overlay used 14 as the denominator. Fixed in `97e055326`: each mounted hook preserves the configured base, including a regression where two hooks share the same settings ref.
- Cross-platform: existing `CmdOrCtrl` routing is unchanged; renderer logic is platform-neutral.
- SSH/remote/local: pane management and settings propagation paths are unchanged; the fix only changes shared font-size state.
- Agents/integrations/git providers: no integration or source-control behavior changed.
- Performance: one scalar ref per mounted hook; no new subscriptions or loops.
- UI: no layout change; all panes receive the same size and `safeFit` call.
- Security: no authentication, network, filesystem, or permission boundary changed.

## Notes

- Based directly on the latest `main` commit at PR creation; the current PR head still contains `origin/main` as an ancestor.
- Packaged macOS verification requires the repository's official signed release pipeline.
- X handle: not provided.
