### PR TITLE
fix(windows): count GPU crashes across launches so safe graphics can engage

### DIFF
--- a/src/main/app-relaunch.ts
+++ b/src/main/app-relaunch.ts
@@ -5,6 +5,8 @@ import { recordDurableCrashBreadcrumb } from './crash-reporting/durable-crash-br
 export type AppRelaunchReason =
   | 'admin-restart'
   | 'gpu-fallback'
+  /** User turned safe graphics back off from the Help menu. */
+  | 'gpu-fallback-opt-out'
   | 'profile-switch'
   | 'profile-transfer'
   | 'renderer-request'

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   GpuCrashFallbackTracker,
+  countsTowardDurableGpuCrashHistory,
   isGpuChildProcessType,
   isGpuFallbackCrashCandidate
 } from './gpu-crash-fallback-decision'
@@ -170,5 +171,28 @@ describe('isGpuFallbackCrashCandidate', () => {
         reason: 'crashed'
       })
     ).toBe(false)
+  })
+})
+
+describe('countsTowardDurableGpuCrashHistory', () => {
+  it('counts the reasons the crash loop actually produces', () => {
+    // All 57 distinct GPU child deaths across the 39 cluster-E bundles are
+    // `crashed` (53 STATUS_BREAKPOINT) or `killed` — none are `launch-failed`.
+    expect(countsTowardDurableGpuCrashHistory('crashed')).toBe(true)
+    expect(countsTowardDurableGpuCrashHistory('abnormal-exit')).toBe(true)
+  })
+
+  it('refuses launch-failed, which clusters across launches for recoverable reasons', () => {
+    // A driver update, an RDP session transition, or a monitor hotplug can fail the
+    // GPU launch on several consecutive launches. Counting those durably would latch
+    // build-sticky safe graphics on a condition that clears itself; the in-process
+    // tracker still catches 3 inside one 30s session.
+    expect(countsTowardDurableGpuCrashHistory('launch-failed')).toBe(false)
+  })
+
+  it('ignores reasons that are not fallback candidates at all', () => {
+    for (const reason of ['killed', 'clean-exit', 'oom', 'integrity-failure', '']) {
+      expect([reason, countsTowardDurableGpuCrashHistory(reason)]).toEqual([reason, false])
+    }
   })
 })

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -7,6 +7,26 @@ export type GpuCrashFallbackOptions = {
 
 const GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed', 'launch-failed'])
 
+/**
+ * Reasons that may accumulate in the *cross-launch* history.
+ *
+ * Why `launch-failed` is excluded here but kept in-process: a GPU that fails to
+ * launch clusters across launches for recoverable reasons — a driver update in
+ * flight, an RDP session transition, a monitor hotplug — and durable counting
+ * would latch build-sticky safe graphics on a condition that clears itself. Three
+ * launch failures inside one 30s session is still a broken GPU, so the in-process
+ * tracker keeps counting them.
+ *
+ * Costs nothing on the observed data: the 39 cluster-E bundles hold 57 distinct
+ * GPU child deaths (deduped by pid and timestamp) — 56 `crashed`, 53 of those
+ * STATUS_BREAKPOINT, one `killed`, and zero `launch-failed`.
+ */
+const DURABLE_GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed'])
+
+export function countsTowardDurableGpuCrashHistory(reason: string): boolean {
+  return DURABLE_GPU_FALLBACK_CRASH_REASONS.has(reason)
+}
+
 // Why: on old/flaky GPU drivers the GPU child process crashes (STATUS_BREAKPOINT
 // / ANGLE-D3D init failure) repeatedly - Windows clusters F0BDNADU79Q and
 // F0BDNRZ5MDG. GPU child deaths are intentionally suppressed as recoverable

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -17,9 +17,10 @@ const GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed', 'launch-
  * launch failures inside one 30s session is still a broken GPU, so the in-process
  * tracker keeps counting them.
  *
- * Costs nothing on the observed data: the 39 cluster-E bundles hold 57 distinct
- * GPU child deaths (deduped by pid and timestamp) — 56 `crashed`, 53 of those
- * STATUS_BREAKPOINT, one `killed`, and zero `launch-failed`.
+ * Costs nothing on the observed data: the 39 cluster-E bundles hold 111 distinct
+ * GPU child deaths — 97 `crashed` (87 STATUS_BREAKPOINT, 9 exit-34, 1 exit-`-1`),
+ * 14 `killed` (13 exit-1), and zero `launch-failed`. `killed` reaches neither
+ * counter, here or in `GPU_FALLBACK_CRASH_REASONS`; that predates this file.
  */
 const DURABLE_GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed'])
 

--- a/src/main/crash-reporting/gpu-fallback-engagement-resolution.test.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement-resolution.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import type { GpuFallbackEngagementOutcome } from './gpu-fallback-engagement'
+import { resolveGpuFallbackEngagement } from './gpu-fallback-engagement-resolution'
+
+const USER_DATA = '/tmp/orca-userdata'
+
+describe('resolveGpuFallbackEngagement', () => {
+  // Why exhaustive: every field here is a one-token change away from defeating the
+  // feature silently, and this table is the only thing that can see it.
+  const expected: Record<
+    GpuFallbackEngagementOutcome,
+    {
+      provisionalMarkerPath: string | null
+      rePersistConsentedMarker: boolean
+      clearDurableHistory: boolean
+      relaunch: boolean
+    }
+  > = {
+    restart: {
+      provisionalMarkerPath: null,
+      rePersistConsentedMarker: true,
+      clearDurableHistory: true,
+      relaunch: true
+    },
+    'confirmed-quitting': {
+      provisionalMarkerPath: null,
+      rePersistConsentedMarker: true,
+      clearDurableHistory: true,
+      relaunch: false
+    },
+    deferred: {
+      provisionalMarkerPath: null,
+      rePersistConsentedMarker: false,
+      clearDurableHistory: true,
+      relaunch: false
+    },
+    'deferred-uncleared': {
+      provisionalMarkerPath: USER_DATA,
+      rePersistConsentedMarker: false,
+      clearDurableHistory: true,
+      relaunch: false
+    },
+    latched: {
+      provisionalMarkerPath: USER_DATA,
+      rePersistConsentedMarker: false,
+      clearDurableHistory: true,
+      relaunch: false
+    },
+    'marker-failed': {
+      provisionalMarkerPath: null,
+      rePersistConsentedMarker: false,
+      clearDurableHistory: false,
+      relaunch: false
+    }
+  }
+
+  for (const [outcome, resolution] of Object.entries(expected)) {
+    it(`resolves ${outcome}`, () => {
+      expect(
+        resolveGpuFallbackEngagement(outcome as GpuFallbackEngagementOutcome, USER_DATA)
+      ).toEqual(resolution)
+    })
+  }
+
+  it('stands the shutdown drop down for every settled outcome', () => {
+    // Why its own assertion: keeping the provisional path on a settled outcome
+    // deletes the consented marker on the way out, so the relaunch comes back on
+    // the same broken GPU — the exact mutation the source-text tests could not see.
+    for (const outcome of ['restart', 'confirmed-quitting', 'deferred', 'marker-failed'] as const) {
+      expect([
+        outcome,
+        resolveGpuFallbackEngagement(outcome, USER_DATA).provisionalMarkerPath
+      ]).toEqual([outcome, null])
+    }
+  })
+
+  it('keeps the shutdown drop armed only while the marker is unconfirmed', () => {
+    for (const outcome of ['latched', 'deferred-uncleared'] as const) {
+      expect([
+        outcome,
+        resolveGpuFallbackEngagement(outcome, USER_DATA).provisionalMarkerPath
+      ]).toEqual([outcome, USER_DATA])
+    }
+  })
+
+  it('records consent on both paths where the user actually answered "restart"', () => {
+    // 'restart' latched pre-prompt with consented:false, so without the re-persist
+    // the primary consent path would land on disk indistinguishable from a latch.
+    expect(resolveGpuFallbackEngagement('restart', USER_DATA).rePersistConsentedMarker).toBe(true)
+    expect(
+      resolveGpuFallbackEngagement('confirmed-quitting', USER_DATA).rePersistConsentedMarker
+    ).toBe(true)
+    expect(resolveGpuFallbackEngagement('latched', USER_DATA).rePersistConsentedMarker).toBe(false)
+    expect(resolveGpuFallbackEngagement('deferred', USER_DATA).rePersistConsentedMarker).toBe(false)
+  })
+
+  it('relaunches only on an answered restart that no quit already claimed', () => {
+    expect(resolveGpuFallbackEngagement('restart', USER_DATA).relaunch).toBe(true)
+    for (const outcome of [
+      'confirmed-quitting',
+      'deferred',
+      'deferred-uncleared',
+      'latched',
+      'marker-failed'
+    ] as const) {
+      expect([outcome, resolveGpuFallbackEngagement(outcome, USER_DATA).relaunch]).toEqual([
+        outcome,
+        false
+      ])
+    }
+  })
+
+  it('drops the cross-launch count once the prompt has been answered', () => {
+    // Why: after 'deferred' the app keeps running with gpuFallbackActiveThisLaunch
+    // false, so handleGpuChildCrash still runs — but the stored 2 entries would make
+    // the next GPU crash inside the 5-minute window the "third" and re-latch on a
+    // prompt the user just declined.
+    for (const outcome of [
+      'restart',
+      'confirmed-quitting',
+      'deferred',
+      'deferred-uncleared',
+      'latched'
+    ] as const) {
+      expect([
+        outcome,
+        resolveGpuFallbackEngagement(outcome, USER_DATA).clearDurableHistory
+      ]).toEqual([outcome, true])
+    }
+  })
+
+  it('keeps the count armed when the marker write is what failed', () => {
+    // 'marker-failed' never prompted, so the crashes are still unaddressed. Clearing
+    // would demand three fresh crashes before retrying a transient EPERM.
+    expect(resolveGpuFallbackEngagement('marker-failed', USER_DATA).clearDurableHistory).toBe(false)
+  })
+
+  it('echoes back the caller path so a split userData cannot go unnoticed', () => {
+    expect(resolveGpuFallbackEngagement('latched', '/other/path').provisionalMarkerPath).toBe(
+      '/other/path'
+    )
+  })
+})

--- a/src/main/crash-reporting/gpu-fallback-engagement-resolution.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement-resolution.ts
@@ -1,0 +1,41 @@
+import {
+  shouldKeepProvisionalGpuFallbackMarker,
+  type GpuFallbackEngagementOutcome
+} from './gpu-fallback-engagement'
+
+/**
+ * Bookkeeping that must follow an `engageGpuFallback` outcome.
+ *
+ * Why its own module: this lived inline in index.ts, where the only coverage was
+ * source-text matching. A mutation that kept the provisional path on *every*
+ * outcome — which deletes the consented marker on the way out and brings the app
+ * back on the same broken GPU — passed the entire suite.
+ */
+export type GpuFallbackEngagementResolution = {
+  /** userData path the shutdown drop must keep retrying, or null to stand down. */
+  provisionalMarkerPath: string | null
+  /** Rewrite the marker with consent recorded, because the user answered "restart". */
+  rePersistConsentedMarker: boolean
+  /** Drop the cross-launch crash count, because this engagement settled it. */
+  clearDurableHistory: boolean
+  /** Relaunch into safe graphics now. */
+  relaunch: boolean
+}
+
+export function resolveGpuFallbackEngagement(
+  outcome: GpuFallbackEngagementOutcome,
+  userDataPath: string
+): GpuFallbackEngagementResolution {
+  return {
+    provisionalMarkerPath: shouldKeepProvisionalGpuFallbackMarker(outcome) ? userDataPath : null,
+    // Why both outcomes: the pre-prompt persist recorded consented:false, and a
+    // session-end drop can take the marker while the prompt is still open.
+    rePersistConsentedMarker: outcome === 'restart' || outcome === 'confirmed-quitting',
+    // Why every outcome but 'marker-failed': a declined prompt must not re-fire on
+    // the very next GPU crash, and a consented one is about to relaunch. Only
+    // 'marker-failed' never prompted at all, so its count stays armed to retry a
+    // write that failed transiently rather than demanding three fresh crashes.
+    clearDurableHistory: outcome !== 'marker-failed',
+    relaunch: outcome === 'restart'
+  }
+}

--- a/src/main/crash-reporting/gpu-fallback-engagement.test.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  engageGpuFallback,
+  shouldKeepProvisionalGpuFallbackMarker,
+  type GpuFallbackEngagementDeps,
+  type GpuFallbackEngagementOutcome
+} from './gpu-fallback-engagement'
+
+/** Fake disk so tests assert the marker's real state, not just call counts. */
+function createDeps(
+  overrides: Partial<GpuFallbackEngagementDeps> & { clearSucceeds?: boolean } = {}
+) {
+  const { clearSucceeds = true, ...depOverrides } = overrides
+  const order: string[] = []
+  const state = { markerOnDisk: false }
+  const deps: GpuFallbackEngagementDeps = {
+    persistMarker: vi.fn(() => {
+      order.push('persist')
+      state.markerOnDisk = true
+    }),
+    clearMarker: vi.fn(() => {
+      order.push('clear')
+      if (!clearSucceeds) {
+        return false
+      }
+      state.markerOnDisk = false
+      return true
+    }),
+    prompt: vi.fn(async () => {
+      order.push('prompt')
+      return 'restart' as const
+    }),
+    isQuitting: () => false,
+    onMarkerPersistFailed: vi.fn(),
+    onMarkerClearFailed: vi.fn(),
+    onPromptFailed: vi.fn(),
+    onRestartDeferred: vi.fn(),
+    ...depOverrides
+  }
+  return { deps, order, state }
+}
+
+describe('engageGpuFallback', () => {
+  it('persists the marker before showing the prompt', async () => {
+    const { deps, order } = createDeps()
+
+    await expect(engageGpuFallback(deps)).resolves.toBe('restart')
+
+    // The whole point: Chromium can hard-kill the process while the modal is up.
+    expect(order).toEqual(['persist', 'prompt'])
+  })
+
+  it('persists the marker synchronously, before the first await yields', async () => {
+    const { deps, state } = createDeps()
+
+    // Deliberately not awaited: any await added ahead of the write would defer it
+    // past Chromium's GPU CHECK, which is the exact bug this module exists to fix.
+    const pending = engageGpuFallback(deps)
+    expect(deps.persistMarker).toHaveBeenCalledOnce()
+    expect(state.markerOnDisk).toBe(true)
+
+    await pending
+  })
+
+  it('has the marker on disk while the prompt is still unanswered', async () => {
+    const { deps, state } = createDeps({ prompt: vi.fn(() => new Promise<never>(() => {})) })
+
+    const outcome = await Promise.race([
+      engageGpuFallback(deps),
+      new Promise((resolve) => setTimeout(() => resolve('still-pending'), 10))
+    ])
+
+    expect(outcome).toBe('still-pending')
+    // A kill landing here must find a marker the next launch can read.
+    expect(state.markerOnDisk).toBe(true)
+  })
+
+  it('clears the marker after the user chooses to keep running', async () => {
+    const { deps, order, state } = createDeps({
+      prompt: vi.fn(async () => {
+        order.push('prompt')
+        return 'continue' as const
+      })
+    })
+
+    await expect(engageGpuFallback(deps)).resolves.toBe('deferred')
+
+    expect(order).toEqual(['persist', 'prompt', 'clear'])
+    expect(state.markerOnDisk).toBe(false)
+    expect(deps.onRestartDeferred).toHaveBeenCalledOnce()
+    expect(deps.onMarkerClearFailed).not.toHaveBeenCalled()
+  })
+
+  it('honors "keep running" even when a quit races the answer', async () => {
+    // Why: a tray/OS quit resolves the parented dialog; discarding the opt-out
+    // there would strand the user in safe-graphics mode they declined.
+    const { deps, state } = createDeps({
+      prompt: vi.fn(async () => 'continue' as const),
+      isQuitting: () => true
+    })
+
+    await expect(engageGpuFallback(deps)).resolves.toBe('deferred')
+
+    expect(state.markerOnDisk).toBe(false)
+  })
+
+  it('keeps the caller armed when the decline could not be written through', async () => {
+    const { deps, state } = createDeps({
+      prompt: vi.fn(async () => 'continue' as const),
+      clearSucceeds: false
+    })
+
+    // Why a distinct outcome: a plain 'deferred' lets the caller stand down and
+    // the declined marker then latches the user in on the next launch.
+    await expect(engageGpuFallback(deps)).resolves.toBe('deferred-uncleared')
+
+    expect(state.markerOnDisk).toBe(true)
+    expect(deps.onMarkerClearFailed).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an async persistMarker instead of prompting behind it', async () => {
+    // Why: `() => void` structurally accepts an async function, whose write
+    // would land after the kill window and whose rejection would escape.
+    const { deps } = createDeps({ persistMarker: vi.fn(async () => {}) })
+
+    await expect(engageGpuFallback(deps)).resolves.toBe('marker-failed')
+
+    expect(deps.prompt).not.toHaveBeenCalled()
+    expect(deps.onMarkerPersistFailed).toHaveBeenCalledWith(expect.any(TypeError))
+  })
+
+  it('keeps the marker when the prompt itself fails', async () => {
+    const error = new Error('no display')
+    const { deps, state } = createDeps({
+      prompt: vi.fn(async () => {
+        throw error
+      })
+    })
+
+    await expect(engageGpuFallback(deps)).resolves.toBe('latched')
+
+    expect(deps.onPromptFailed).toHaveBeenCalledWith(error)
+    expect(state.markerOnDisk).toBe(true)
+    expect(deps.clearMarker).not.toHaveBeenCalled()
+  })
+
+  it('keeps a consented restart when a quit is already in flight', async () => {
+    const { deps, state } = createDeps({ isQuitting: () => true })
+
+    // Why not 'latched': the caller must not treat consented state as provisional
+    // and delete the marker on the way out.
+    await expect(engageGpuFallback(deps)).resolves.toBe('confirmed-quitting')
+
+    expect(state.markerOnDisk).toBe(true)
+    expect(deps.clearMarker).not.toHaveBeenCalled()
+  })
+
+  it('keeps the shutdown retry armed only for unsettled outcomes', () => {
+    // Why exhaustive: the caller drops its retry on a false, so a wrong entry here
+    // either strands the user in declined safe graphics or deletes consented state.
+    const expected: Record<GpuFallbackEngagementOutcome, boolean> = {
+      restart: false,
+      'confirmed-quitting': false,
+      deferred: false,
+      'deferred-uncleared': true,
+      latched: true,
+      'marker-failed': false
+    }
+    for (const [outcome, keep] of Object.entries(expected)) {
+      expect([outcome, shouldKeepProvisionalGpuFallbackMarker(outcome as never)]).toEqual([
+        outcome,
+        keep
+      ])
+    }
+  })
+
+  it('does not prompt when the marker cannot be persisted', async () => {
+    const error = new Error('EACCES')
+    const { deps } = createDeps({
+      persistMarker: vi.fn(() => {
+        throw error
+      })
+    })
+
+    await expect(engageGpuFallback(deps)).resolves.toBe('marker-failed')
+
+    // Why: a relaunch would come back on the same broken GPU, so offering one lies.
+    expect(deps.prompt).not.toHaveBeenCalled()
+    expect(deps.onMarkerPersistFailed).toHaveBeenCalledWith(error)
+  })
+})

--- a/src/main/crash-reporting/gpu-fallback-engagement.ts
+++ b/src/main/crash-reporting/gpu-fallback-engagement.ts
@@ -1,0 +1,99 @@
+import type { GpuFallbackRestartDecision } from './gpu-fallback-restart-prompt'
+
+/**
+ * Orders the steps that engage Windows safe-graphics mode.
+ *
+ * Why the marker is persisted BEFORE the prompt: Chromium terminates the whole
+ * browser process with a fatal CHECK ("GPU process isn't usable. Goodbye." ->
+ * STATUS_BREAKPOINT / 0x80000003) on the 6th GPU-process failure. Orca engages
+ * on the 3rd, so the modal restart prompt is racing a hard kill that lands ~2.5s
+ * later when the GPU crashes, and ~7ms later when it cannot launch at all.
+ * Persisting after the click meant an unattended machine never latched the
+ * fallback and crash-looped on every subsequent launch.
+ *
+ * The marker is therefore written without consent, so callers must drop it again
+ * on an orderly shutdown — see `shouldKeepProvisionalGpuFallbackMarker`.
+ */
+export type GpuFallbackEngagementDeps = {
+  /** Must be synchronous — an async write would miss the kill window entirely. */
+  persistMarker: () => void
+  /** Returns false when the marker could not be removed. */
+  clearMarker: () => boolean
+  prompt: () => Promise<GpuFallbackRestartDecision>
+  isQuitting: () => boolean
+  onMarkerPersistFailed: (error: unknown) => void
+  onMarkerClearFailed: () => void
+  onPromptFailed: (error: unknown) => void
+  onRestartDeferred: () => void
+}
+
+export type GpuFallbackEngagementOutcome =
+  /** Marker is on disk and the user asked to restart now. */
+  | 'restart'
+  /** User confirmed, but a quit is already running it down; keep the marker, skip the relaunch. */
+  | 'confirmed-quitting'
+  /** User chose to keep running; marker cleared, next launch keeps hardware GPU. */
+  | 'deferred'
+  /** User declined but the marker is still on disk; the caller must keep retrying. */
+  | 'deferred-uncleared'
+  /** Marker is on disk but unconfirmed; only an abnormal death should keep it. */
+  | 'latched'
+  /** Marker could not be persisted, so neither answer could be honored. */
+  | 'marker-failed'
+
+/**
+ * Whether the caller must keep retrying the marker delete on shutdown.
+ *
+ * Pure so the mapping is testable: `latched` never got an answer, and
+ * `deferred-uncleared` got a decline the delete could not honor.
+ */
+export function shouldKeepProvisionalGpuFallbackMarker(
+  outcome: GpuFallbackEngagementOutcome
+): boolean {
+  return outcome === 'latched' || outcome === 'deferred-uncleared'
+}
+
+export async function engageGpuFallback(
+  deps: GpuFallbackEngagementDeps
+): Promise<GpuFallbackEngagementOutcome> {
+  try {
+    // `() => void` structurally accepts an async function, whose write would land
+    // after the kill window and whose rejection would escape this catch.
+    const persisted = deps.persistMarker() as unknown
+    if (isThenable(persisted)) {
+      void (persisted as PromiseLike<void>).then?.(
+        () => undefined,
+        () => undefined
+      )
+      throw new TypeError('persistMarker must be synchronous')
+    }
+  } catch (error) {
+    // Without a durable marker a relaunch returns to the same broken GPU.
+    deps.onMarkerPersistFailed(error)
+    return 'marker-failed'
+  }
+
+  let decision: GpuFallbackRestartDecision
+  try {
+    decision = await deps.prompt()
+  } catch (error) {
+    deps.onPromptFailed(error)
+    return 'latched'
+  }
+
+  // The decision is honored before `isQuitting`: a tray/OS quit resolves the
+  // parented dialog, and dropping the answer there would ignore explicit consent.
+  if (decision !== 'restart') {
+    const cleared = deps.clearMarker()
+    if (!cleared) {
+      deps.onMarkerClearFailed()
+    }
+    deps.onRestartDeferred()
+    return cleared ? 'deferred' : 'deferred-uncleared'
+  }
+  return deps.isQuitting() ? 'confirmed-quitting' : 'restart'
+}
+
+function isThenable(value: unknown): boolean {
+  return typeof (value as PromiseLike<unknown> | undefined)?.then === 'function'
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -140,6 +140,7 @@ import {
 import {
   DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS,
   clearGpuCrashHistory,
+  discardExpiredGpuCrashHistory,
   evaluateGpuCrashHistory,
   gpuCrashHistoryFileExists,
   inertGpuCrashHistoryDecision,
@@ -1581,14 +1582,23 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   // Why gated: the sweep readdirs all of userData — Cache, Code Cache, GPUCache,
   // Local Storage — on a path that runs before whenReady on every Windows launch,
   // and a temp can only be orphaned next to a file the fallback already wrote.
-  const sweepForOrphans =
-    gpuFallbackMarkerFileExists(userDataPath) || gpuCrashHistoryFileExists(userDataPath)
-  const marker = readActiveGpuFallbackMarker(userDataPath, getGpuFallbackEnvironment())
+  const environment = getGpuFallbackEnvironment()
+  const historyExists = gpuCrashHistoryFileExists(userDataPath)
+  const sweepForOrphans = gpuFallbackMarkerFileExists(userDataPath) || historyExists
+  const marker = readActiveGpuFallbackMarker(userDataPath, environment)
   if (sweepForOrphans) {
     void sweepStaleGpuFallbackMarkerTempFiles(userDataPath).catch(() => undefined)
     void sweepStaleGpuCrashHistoryTempFiles(userDataPath).catch(() => undefined)
   }
   if (!marker) {
+    // Why here: one or two GPU deaths is the common launch, and nothing else ever
+    // deletes that file — it would keep the gate above armed on every later launch.
+    if (historyExists) {
+      void discardExpiredGpuCrashHistory(userDataPath, environment, {
+        now: Date.now(),
+        windowMs: DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS
+      }).catch(() => undefined)
+    }
     return
   }
   app.disableHardwareAcceleration()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1634,8 +1634,9 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
   // would otherwise move the write out from under it.
   const userDataPath = getCanonicalUserDataPath()
   const inProcess = gpuCrashFallbackTracker.recordGpuCrash(performance.now())
-  // Why durable too: this failure kills the launch ~0.8s in, so the in-memory count
-  // resets at 1 and the same-session threshold is structurally unreachable.
+  // Why durable too: the in-memory count resets on every launch, and 66 of the 73
+  // observed launches recorded only one or two GPU deaths. Per machine that takes the
+  // bundles reaching the threshold from 2 of 21 to 6 — wider reach, not a new one.
   // Why reason-gated: `launch-failed` clusters across launches for recoverable
   // reasons (driver update, RDP transition, monitor hotplug) — see the reason set.
   const countsDurably = countsTowardDurableGpuCrashHistory(reason)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,6 +130,7 @@ import { enableRendererHeapHeadroom } from './startup/renderer-heap-headroom'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
 import {
   clearGpuFallbackMarker,
+  gpuFallbackMarkerFileExists,
   readActiveGpuFallbackMarker,
   sweepStaleGpuFallbackMarkerTempFiles,
   writeGpuFallbackMarker,
@@ -137,14 +138,22 @@ import {
   type WindowsGpuFallbackEnvironment
 } from './startup/gpu-fallback-marker'
 import {
-  engageGpuFallback,
-  shouldKeepProvisionalGpuFallbackMarker
-} from './crash-reporting/gpu-fallback-engagement'
+  DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS,
+  clearGpuCrashHistory,
+  evaluateGpuCrashHistory,
+  gpuCrashHistoryFileExists,
+  inertGpuCrashHistoryDecision,
+  persistGpuCrashTimes,
+  sweepStaleGpuCrashHistoryTempFiles
+} from './startup/gpu-crash-history'
+import { engageGpuFallback } from './crash-reporting/gpu-fallback-engagement'
+import { resolveGpuFallbackEngagement } from './crash-reporting/gpu-fallback-engagement-resolution'
 import { applyGpuFallbackCommandLineSwitches } from './startup/gpu-fallback-switches'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   GpuCrashFallbackTracker,
+  countsTowardDurableGpuCrashHistory,
   isGpuFallbackCrashCandidate
 } from './crash-reporting/gpu-crash-fallback-decision'
 import { promptForGpuFallbackRestart } from './crash-reporting/gpu-fallback-restart-prompt'
@@ -369,6 +378,9 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
 let gpuFallbackActiveThisLaunch = false
+// Why a separate latch: the durable history and the in-process tracker can each
+// fire, so without this a later same-session crash opens a second restart prompt.
+let gpuFallbackEngagementStarted = false
 // Why: the safe-graphics marker is written before the user answers, so it must be
 // dropped again if the app reaches an orderly shutdown instead of a GPU kill.
 let provisionalGpuFallbackUserDataPath: string | null = null
@@ -1565,51 +1577,100 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   // Why canonical: handleGpuChildCrash writes through the same helper, and a late
   // app.setName/setPath would silently split the read and write paths.
   const userDataPath = getCanonicalUserDataPath()
-  // A kill between the marker's write and rename orphans a temp file next to it.
-  void sweepStaleGpuFallbackMarkerTempFiles(userDataPath).catch(() => undefined)
+  // A kill between a write and its rename orphans a temp file next to the target.
+  // Why gated: the sweep readdirs all of userData — Cache, Code Cache, GPUCache,
+  // Local Storage — on a path that runs before whenReady on every Windows launch,
+  // and a temp can only be orphaned next to a file the fallback already wrote.
+  const sweepForOrphans =
+    gpuFallbackMarkerFileExists(userDataPath) || gpuCrashHistoryFileExists(userDataPath)
   const marker = readActiveGpuFallbackMarker(userDataPath, getGpuFallbackEnvironment())
+  if (sweepForOrphans) {
+    void sweepStaleGpuFallbackMarkerTempFiles(userDataPath).catch(() => undefined)
+    void sweepStaleGpuCrashHistoryTempFiles(userDataPath).catch(() => undefined)
+  }
   if (!marker) {
     return
   }
   app.disableHardwareAcceleration()
   const appliedSwitches = applyGpuFallbackCommandLineSwitches(app.commandLine, process.platform)
   gpuFallbackActiveThisLaunch = true
+  // Why: the user is already in safe graphics, so pre-fallback crash times must not
+  // re-fire the prompt on the first unrelated GPU hiccup of this launch.
+  clearGpuCrashHistory(userDataPath)
   // Why: with no GPU child left, child-process-gone can't report a GPU fault, so
   // name the applied switches in the trail any later crash report carries.
   recordCrashBreadcrumb('gpu_fallback_applied', {
     crashesInWindow: marker.crashesInWindow,
+    consented: marker.consented,
     switches: appliedSwitches.join(',')
   })
 }
 
+// Why swallow: the marker is already on disk, so a tracer failure here must not
+// surface as 'marker-failed' and cancel the restart the write just earned.
+function recordGpuFallbackMarkerPersisted(
+  consented: boolean,
+  data: Record<string, string | number | boolean | null>
+): void {
+  try {
+    recordDurableCrashBreadcrumb('gpu_fallback_marker_persisted', { ...data, consented })
+  } catch {
+    // Diagnostics only; the marker is what the next launch reads.
+  }
+}
+
 // Why: a burst of GPU child crashes means HW acceleration is unusable — persist a build-scoped marker and offer software rendering.
 async function handleGpuChildCrash(reason: string, exitCode: number | null): Promise<void> {
-  // Software rendering already active or shutting down: nothing more to do.
-  if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
+  // Software rendering already active, engagement under way, or shutting down.
+  if (gpuFallbackActiveThisLaunch || gpuFallbackEngagementStarted || isQuitting || isServeMode) {
     return
   }
-  const result = gpuCrashFallbackTracker.recordGpuCrash(performance.now())
-  if (!result.shouldEngageFallback) {
-    return
-  }
-  recordCrashBreadcrumb('gpu_fallback_engaged', {
-    reason,
-    exitCode,
-    crashesInWindow: result.crashesInWindow
-  })
-  const engagedAt = Date.now()
+  // Why first: everything below this point must stay inert off Windows.
   const environment = getWindowsGpuFallbackEnvironment()
   if (!environment) {
     return
   }
-  const fallbackData = {
-    processReason: reason,
-    exitCode,
-    crashesInWindow: result.crashesInWindow
-  }
   // Why canonical: the reader above resolves the same way, and a late app.setName
   // would otherwise move the write out from under it.
   const userDataPath = getCanonicalUserDataPath()
+  const inProcess = gpuCrashFallbackTracker.recordGpuCrash(performance.now())
+  // Why durable too: this failure kills the launch ~0.8s in, so the in-memory count
+  // resets at 1 and the same-session threshold is structurally unreachable.
+  // Why reason-gated: `launch-failed` clusters across launches for recoverable
+  // reasons (driver update, RDP transition, monitor hotplug) — see the reason set.
+  const countsDurably = countsTowardDurableGpuCrashHistory(reason)
+  const durable = countsDurably
+    ? evaluateGpuCrashHistory(userDataPath, environment, {
+        now: Date.now(),
+        windowMs: DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS,
+        threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
+      })
+    : inertGpuCrashHistoryDecision()
+  if (!inProcess.shouldEngageFallback && !durable.crossesThreshold) {
+    // Why only here: on the crash that fires, this fsync would land in front of the
+    // marker write, which is racing a kill that can arrive ~7ms after the failure.
+    // Why gated: an inert decision carries no times, so writing it would erase the
+    // real ones an excluded reason is only supposed to be ignored by.
+    if (countsDurably) {
+      persistGpuCrashTimes(userDataPath, environment, durable.crashTimes)
+    }
+    return
+  }
+  gpuFallbackEngagementStarted = true
+  const crashesInWindow = Math.max(inProcess.crashesInWindow, durable.crashesInWindow)
+  recordCrashBreadcrumb('gpu_fallback_engaged', {
+    reason,
+    exitCode,
+    crashesInWindow,
+    crashesAcrossLaunches: durable.crashesInWindow,
+    trigger: inProcess.shouldEngageFallback ? 'in-process' : 'durable'
+  })
+  const engagedAt = Date.now()
+  const fallbackData = {
+    processReason: reason,
+    exitCode,
+    crashesInWindow
+  }
   const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
   // Why: Chromium fatally CHECKs the browser process on the 6th GPU failure, so
   // the marker must land before the prompt or an unattended crash never latches.
@@ -1617,10 +1678,13 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
     persistMarker: () => {
       writeGpuFallbackMarker(
         userDataPath,
-        { engagedAt, crashesInWindow: result.crashesInWindow },
+        { engagedAt, crashesInWindow, consented: false },
         environment
       )
       provisionalGpuFallbackUserDataPath = userDataPath
+      // Why after the write: a kill lands here more often than anywhere else, and
+      // this is the only record separating a provisional latch from a consented one.
+      recordGpuFallbackMarkerPersisted(false, fallbackData)
     },
     clearMarker: () => clearGpuFallbackMarker(userDataPath),
     prompt: () => promptForGpuFallbackRestart(window),
@@ -1639,28 +1703,52 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
     onRestartDeferred: () =>
       recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData)
   })
-  if (!shouldKeepProvisionalGpuFallbackMarker(outcome)) {
-    provisionalGpuFallbackUserDataPath = null
+  // Why delegated: this mapping is unit-tested; deriving it inline here left the
+  // whole feature defeatable by a one-token change no test could see.
+  const resolution = resolveGpuFallbackEngagement(outcome, userDataPath)
+  provisionalGpuFallbackUserDataPath = resolution.provisionalMarkerPath
+  // Why here and not at fire time: a kill during the prompt must leave the count
+  // armed to fire again, while a decline must not re-prompt on the very next crash.
+  if (resolution.clearDurableHistory) {
+    clearGpuCrashHistory(userDataPath)
   }
-  if (outcome === 'confirmed-quitting') {
-    // Why re-persist: a session-end drop can land while the prompt is still open.
+  if (resolution.rePersistConsentedMarker) {
     try {
       writeGpuFallbackMarker(
         userDataPath,
-        { engagedAt, crashesInWindow: result.crashesInWindow },
+        { engagedAt, crashesInWindow, consented: true },
         environment
       )
+      recordGpuFallbackMarkerPersisted(true, fallbackData)
     } catch (error) {
       console.warn('[gpu-fallback] failed to re-persist marker after consent:', error)
       recordDurableCrashBreadcrumb('gpu_fallback_marker_failed', fallbackData)
     }
   }
-  if (outcome !== 'restart') {
+  if (!resolution.relaunch) {
     return
   }
   isQuitting = true
   relaunchApp('gpu-fallback', fallbackData)
   // Why: app.exit(0) skips before-quit, so destroy the Windows tray manually to avoid a stale icon.
+  destroySystemTray()
+  app.exit(0)
+}
+
+// Why a user-visible escape hatch: the marker is build-sticky, so a false latch
+// would otherwise hold a working GPU in software rendering until the next update.
+function turnOffGpuFallback(): void {
+  const userDataPath = getCanonicalUserDataPath()
+  clearGpuCrashHistory(userDataPath)
+  if (!clearGpuFallbackMarker(userDataPath)) {
+    // Why not relaunch: the next launch would read the marker and come straight back.
+    recordDurableCrashBreadcrumb('gpu_fallback_marker_clear_failed', { phase: 'user-opt-out' })
+    return
+  }
+  provisionalGpuFallbackUserDataPath = null
+  recordDurableCrashBreadcrumb('gpu_fallback_disabled_by_user')
+  isQuitting = true
+  relaunchApp('gpu-fallback-opt-out')
   destroySystemTray()
   app.exit(0)
 }
@@ -1671,6 +1759,13 @@ function dropUnconfirmedGpuFallbackMarker(): void {
   if (provisionalGpuFallbackUserDataPath === null) {
     return
   }
+  // Why the count too: an orderly shutdown proves the burst was survivable, so
+  // leaving it armed would re-latch on the next single GPU crash inside the window.
+  // Why not hoisted above the null guard: only an engagement sets this path, and a
+  // quit that clears the count unconditionally would wipe the 1-2 crashes recorded
+  // by a loop the user quits out of by hand — the counting this file exists for.
+  // The residual is bounded: an uncleared count ages out of the 5-minute window.
+  clearGpuCrashHistory(provisionalGpuFallbackUserDataPath)
   if (!clearGpuFallbackMarker(provisionalGpuFallbackUserDataPath)) {
     // `quit` is the last JS event, so this is terminal: the next launch starts in
     // safe graphics and clears itself on the next Orca or Electron version.
@@ -2693,6 +2788,8 @@ void app.whenReady().then(async () => {
 
   registerAppMenu({
     appMenuLabel: devInstanceIdentity.name,
+    isGpuFallbackActive: () => gpuFallbackActiveThisLaunch,
+    onTurnOffGpuFallback: turnOffGpuFallback,
     onCheckForUpdates: (options) => runUserInitiatedUpdateCheck(options),
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
       if (mainWindow?.webContents.id === webContentsId) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -129,11 +129,17 @@ import {
 import { enableRendererHeapHeadroom } from './startup/renderer-heap-headroom'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
 import {
+  clearGpuFallbackMarker,
   readActiveGpuFallbackMarker,
+  sweepStaleGpuFallbackMarkerTempFiles,
   writeGpuFallbackMarker,
   type GpuFallbackEnvironment,
   type WindowsGpuFallbackEnvironment
 } from './startup/gpu-fallback-marker'
+import {
+  engageGpuFallback,
+  shouldKeepProvisionalGpuFallbackMarker
+} from './crash-reporting/gpu-fallback-engagement'
 import { applyGpuFallbackCommandLineSwitches } from './startup/gpu-fallback-switches'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
@@ -141,10 +147,7 @@ import {
   GpuCrashFallbackTracker,
   isGpuFallbackCrashCandidate
 } from './crash-reporting/gpu-crash-fallback-decision'
-import {
-  promptForGpuFallbackRestart,
-  type GpuFallbackRestartDecision
-} from './crash-reporting/gpu-fallback-restart-prompt'
+import { promptForGpuFallbackRestart } from './crash-reporting/gpu-fallback-restart-prompt'
 import {
   shouldSuppressDevEducation,
   suppressDevEducationForStore
@@ -366,6 +369,9 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
 let gpuFallbackActiveThisLaunch = false
+// Why: the safe-graphics marker is written before the user answers, so it must be
+// dropped again if the app reaches an orderly shutdown instead of a GPU kill.
+let provisionalGpuFallbackUserDataPath: string | null = null
 let gpuFeatureStatus: Electron.GPUFeatureStatus | null = null
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
@@ -1250,6 +1256,9 @@ function openMainWindow(): BrowserWindow {
     }
   })
   recordCrashBreadcrumb('main_window_created')
+  // Why: a Windows logoff/shutdown can end the session without reaching will-quit,
+  // and that reboot is exactly the driver-update case that must not latch safe graphics.
+  window.on('session-end', dropUnconfirmedGpuFallbackMarker)
   logStartupMilestone('window-created')
   // Why: Windows Tray construction can block synchronously on Shell_NotifyIcon, so both platforms defer creation to after first paint.
   let trayCreated = false
@@ -1553,7 +1562,12 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   if (isServeMode || process.platform !== 'win32') {
     return
   }
-  const marker = readActiveGpuFallbackMarker(app.getPath('userData'), getGpuFallbackEnvironment())
+  // Why canonical: handleGpuChildCrash writes through the same helper, and a late
+  // app.setName/setPath would silently split the read and write paths.
+  const userDataPath = getCanonicalUserDataPath()
+  // A kill between the marker's write and rename orphans a temp file next to it.
+  void sweepStaleGpuFallbackMarkerTempFiles(userDataPath).catch(() => undefined)
+  const marker = readActiveGpuFallbackMarker(userDataPath, getGpuFallbackEnvironment())
   if (!marker) {
     return
   }
@@ -1584,12 +1598,8 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
     crashesInWindow: result.crashesInWindow
   })
   const engagedAt = Date.now()
-  const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
-  let restartDecision: GpuFallbackRestartDecision
-  try {
-    restartDecision = await promptForGpuFallbackRestart(window)
-  } catch (error) {
-    console.warn('[gpu-fallback] failed to show restart prompt:', error)
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment) {
     return
   }
   const fallbackData = {
@@ -1597,28 +1607,55 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
     exitCode,
     crashesInWindow: result.crashesInWindow
   }
-  if (isQuitting) {
-    return
+  // Why canonical: the reader above resolves the same way, and a late app.setName
+  // would otherwise move the write out from under it.
+  const userDataPath = getCanonicalUserDataPath()
+  const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
+  // Why: Chromium fatally CHECKs the browser process on the 6th GPU failure, so
+  // the marker must land before the prompt or an unattended crash never latches.
+  const outcome = await engageGpuFallback({
+    persistMarker: () => {
+      writeGpuFallbackMarker(
+        userDataPath,
+        { engagedAt, crashesInWindow: result.crashesInWindow },
+        environment
+      )
+      provisionalGpuFallbackUserDataPath = userDataPath
+    },
+    clearMarker: () => clearGpuFallbackMarker(userDataPath),
+    prompt: () => promptForGpuFallbackRestart(window),
+    isQuitting: () => isQuitting,
+    onMarkerPersistFailed: (error) => {
+      console.warn('[gpu-fallback] failed to persist marker:', error)
+      recordDurableCrashBreadcrumb('gpu_fallback_marker_failed', fallbackData)
+    },
+    onMarkerClearFailed: () =>
+      recordDurableCrashBreadcrumb('gpu_fallback_marker_clear_failed', fallbackData),
+    onPromptFailed: (error) => {
+      console.warn('[gpu-fallback] failed to show restart prompt:', error)
+      // Why durable: this is the state the process is most likely to be killed in.
+      recordDurableCrashBreadcrumb('gpu_fallback_prompt_failed', fallbackData)
+    },
+    onRestartDeferred: () =>
+      recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData)
+  })
+  if (!shouldKeepProvisionalGpuFallbackMarker(outcome)) {
+    provisionalGpuFallbackUserDataPath = null
   }
-  if (restartDecision !== 'restart') {
-    recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData)
-    return
+  if (outcome === 'confirmed-quitting') {
+    // Why re-persist: a session-end drop can land while the prompt is still open.
+    try {
+      writeGpuFallbackMarker(
+        userDataPath,
+        { engagedAt, crashesInWindow: result.crashesInWindow },
+        environment
+      )
+    } catch (error) {
+      console.warn('[gpu-fallback] failed to re-persist marker after consent:', error)
+      recordDurableCrashBreadcrumb('gpu_fallback_marker_failed', fallbackData)
+    }
   }
-  const environment = getWindowsGpuFallbackEnvironment()
-  if (!environment) {
-    return
-  }
-  try {
-    writeGpuFallbackMarker(
-      app.getPath('userData'),
-      {
-        engagedAt,
-        crashesInWindow: result.crashesInWindow
-      },
-      environment
-    )
-  } catch (error) {
-    console.warn('[gpu-fallback] failed to persist marker:', error)
+  if (outcome !== 'restart') {
     return
   }
   isQuitting = true
@@ -1626,6 +1663,21 @@ async function handleGpuChildCrash(reason: string, exitCode: number | null): Pro
   // Why: app.exit(0) skips before-quit, so destroy the Windows tray manually to avoid a stale icon.
   destroySystemTray()
   app.exit(0)
+}
+
+// Why: an orderly shutdown proves Chromium's GPU CHECK never landed, so a marker
+// the user never confirmed must not survive into the next launch.
+function dropUnconfirmedGpuFallbackMarker(): void {
+  if (provisionalGpuFallbackUserDataPath === null) {
+    return
+  }
+  if (!clearGpuFallbackMarker(provisionalGpuFallbackUserDataPath)) {
+    // `quit` is the last JS event, so this is terminal: the next launch starts in
+    // safe graphics and clears itself on the next Orca or Electron version.
+    recordDurableCrashBreadcrumb('gpu_fallback_marker_clear_failed', { phase: 'shutdown' })
+    return
+  }
+  provisionalGpuFallbackUserDataPath = null
 }
 
 function recordProcessGoneCrash(
@@ -2933,6 +2985,11 @@ app.on('before-quit', () => {
   // Why: defer PTY cleanup to will-quit so the renderer captures scrollback before PTY-exit events unmount TerminalPane (dropping its capture callbacks).
   rateLimits?.stop()
 })
+
+// Why 'quit', not will-quit: will-quit's first pass only means a quit was requested
+// and then defers teardown for seconds, during which Chromium's GPU CHECK can still
+// fire. Only 'quit' proves the process is leaving without that kill.
+app.on('quit', dropUnconfirmedGpuFallbackMarker)
 
 // Why: will-quit fires twice — first pass runs sync cleanup + preventDefault to await checkpoint writes; second pass exits.
 let daemonDisconnectDone = false

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -417,4 +417,35 @@ describe('registerAppMenu', () => {
     expect(appearanceSubmenu.find((item) => item.label === leftLabel)?.accelerator).toBeUndefined()
     expect(appearanceSubmenu.find((item) => item.label === rightLabel)?.accelerator).toBeUndefined()
   })
+
+  it('offers the safe-graphics escape hatch only while the fallback is latched', () => {
+    const label = 'Turn Off Safe Graphics Mode'
+
+    registerAppMenu(buildMenuOptions())
+    expect(getSubmenu(getTemplate(), 'Help').map((item) => item.label)).not.toContain(label)
+
+    buildFromTemplateMock.mockReset()
+    buildFromTemplateMock.mockImplementation((template) => ({ template }))
+    const options = {
+      ...buildMenuOptions(),
+      isGpuFallbackActive: vi.fn(() => true),
+      onTurnOffGpuFallback: vi.fn()
+    }
+    registerAppMenu(options)
+
+    // Why it must exist: the marker is build-sticky, so without this a false latch
+    // holds a working GPU in software rendering until the next app update.
+    const item = getSubmenu(getTemplate(), 'Help').find((entry) => entry.label === label)
+    expect(item).toBeDefined()
+    item?.click?.({} as never, {} as never, {} as never)
+    expect(options.onTurnOffGpuFallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the escape hatch when no handler is wired, rather than a dead item', () => {
+    registerAppMenu({ ...buildMenuOptions(), isGpuFallbackActive: vi.fn(() => true) })
+
+    expect(getSubmenu(getTemplate(), 'Help').map((item) => item.label)).not.toContain(
+      'Turn Off Safe Graphics Mode'
+    )
+  })
 })

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -37,6 +37,10 @@ type RegisterAppMenuOptions = {
   onToggleAppearance: (key: AppearanceMenuKey) => void
   getAppearanceState: () => AppearanceMenuState
   getKeybindings?: () => KeybindingOverrides | undefined
+  // Why an escape hatch: the safe-graphics marker is build-sticky, so without this
+  // a false latch leaves a user in software rendering until the next app update.
+  isGpuFallbackActive?: () => boolean
+  onTurnOffGpuFallback?: () => void
   // Why: the macOS app-menu title. Passed the per-branch dev label since
   // app.name is now pinned to a stable value for Keychain-key stability.
   appMenuLabel?: string
@@ -57,7 +61,9 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     onToggleRightSidebar,
     onToggleAppearance,
     getAppearanceState,
-    getKeybindings
+    getKeybindings,
+    isGpuFallbackActive,
+    onTurnOffGpuFallback
   } = options
 
   const isMac = process.platform === 'darwin'
@@ -292,10 +298,24 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     submenu: [{ role: 'minimize' }, { role: 'zoom' }]
   }
 
+  // Why only while latched: the item is meaningless otherwise, and the marker is
+  // read before whenReady so this state cannot change during the launch.
+  const gpuFallbackItems: Electron.MenuItemConstructorOptions[] =
+    isGpuFallbackActive?.() && onTurnOffGpuFallback
+      ? [
+          { type: 'separator' },
+          {
+            label: translateMain('menu.turnOffSafeGraphics', 'Turn Off Safe Graphics Mode'),
+            click: () => onTurnOffGpuFallback()
+          }
+        ]
+      : []
+
   const helpMenu: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.help', 'Help'),
     submenu: [
       crashReportItem,
+      ...gpuFallbackItems,
       { type: 'separator' },
       featureTourItem,
       setupGuideItem,

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -137,15 +137,109 @@ describe('startup ordering', () => {
     expect(persistBody).not.toMatch(/\bawait[\s(]/)
 
     // Why exactly two writers: the pre-prompt persist, plus the re-persist that
-    // recovers a consented restart whose marker a session-end drop already took.
+    // records consent (and recovers a marker a session-end drop already took).
     expect(handler.split('writeGpuFallbackMarker(')).toHaveLength(3)
-    const confirmedQuittingIndex = handler.indexOf("outcome === 'confirmed-quitting'")
-    expect(confirmedQuittingIndex).toBeGreaterThanOrEqual(0)
-    expect(handler.lastIndexOf('writeGpuFallbackMarker(')).toBeGreaterThan(confirmedQuittingIndex)
+    const resolutionIndex = handler.indexOf('resolveGpuFallbackEngagement(outcome')
+    expect(resolutionIndex).toBeGreaterThanOrEqual(0)
+    expect(handler.lastIndexOf('writeGpuFallbackMarker(')).toBeGreaterThan(resolutionIndex)
 
-    // Why pinned: the outcome -> retry mapping is unit-tested, so the handler must
-    // defer to it rather than re-deriving the outcome list inline.
-    expect(handler).toContain('if (!shouldKeepProvisionalGpuFallbackMarker(outcome)) {')
+    // Why pinned: the outcome -> bookkeeping mapping is unit-tested in
+    // gpu-fallback-engagement-resolution, so re-deriving it inline here would
+    // restore the zero-coverage gap this extraction closed.
+    expect(handler).toContain(
+      'provisionalGpuFallbackUserDataPath = resolution.provisionalMarkerPath'
+    )
+    expect(handler).toContain('if (resolution.rePersistConsentedMarker) {')
+    expect(handler).toContain('if (!resolution.relaunch) {')
+    expect(handler).not.toContain('shouldKeepProvisionalGpuFallbackMarker(')
+
+    // Why: consent is what separates a latch the user chose from one the crash
+    // imposed, and without it on disk the fix's own efficacy is unmeasurable.
+    expect(handler).toContain('consented: false')
+    expect(handler).toContain('consented: true')
+  })
+
+  it('counts GPU crashes across launches, not just within one', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const start = source.indexOf('async function handleGpuChildCrash(')
+    const end = source.indexOf('function recordProcessGoneCrash(', start)
+    const handler = source.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+
+    // Why both: the in-process burst path is what catches a driver that fails
+    // mid-session; the durable path is the only one reachable when the crash
+    // kills the launch in 0.8s.
+    const inProcessIndex = handler.indexOf('gpuCrashFallbackTracker.recordGpuCrash(')
+    const durableIndex = handler.indexOf('evaluateGpuCrashHistory(')
+    const gateIndex = handler.indexOf(
+      'if (!inProcess.shouldEngageFallback && !durable.crossesThreshold) {'
+    )
+    const persistIndex = handler.indexOf('persistGpuCrashTimes(')
+    expect(inProcessIndex).toBeGreaterThanOrEqual(0)
+    expect(durableIndex).toBeGreaterThan(inProcessIndex)
+    expect(gateIndex).toBeGreaterThan(durableIndex)
+    // Why inside the non-firing branch: on the crash that fires, this write's fsync
+    // would land in front of the marker write that is racing Chromium's kill.
+    expect(persistIndex).toBeGreaterThan(gateIndex)
+    expect(persistIndex).toBeLessThan(handler.indexOf('gpuFallbackEngagementStarted = true'))
+    expect(handler.split('persistGpuCrashTimes(')).toHaveLength(2)
+
+    // Why inert off Windows: the environment check must precede every write.
+    const environmentIndex = handler.indexOf('getWindowsGpuFallbackEnvironment()')
+    expect(environmentIndex).toBeGreaterThanOrEqual(0)
+    expect(environmentIndex).toBeLessThan(inProcessIndex)
+    expect(handler.indexOf('getCanonicalUserDataPath()')).toBeGreaterThan(environmentIndex)
+
+    // Why cleared only after the prompt resolved: a kill while the modal is up must
+    // leave the count armed to fire again, while a decline must not re-prompt on the
+    // very next crash.
+    const clearIndex = handler.indexOf('clearGpuCrashHistory(userDataPath)')
+    expect(clearIndex).toBeGreaterThan(handler.indexOf('await engageGpuFallback({'))
+    // Why latched: either counter can fire, so a later same-session crash would
+    // otherwise stack a second modal on top of the first.
+    expect(handler).toContain('gpuFallbackEngagementStarted = true')
+    expect(handler).toContain('gpuFallbackEngagementStarted ||')
+  })
+
+  // Why one test over three call sites: they are the whole lifecycle of the durable
+  // count, each is a one-token deletion away from silently reverting the feature to
+  // the in-process tracker, and each survived the suite until this test existed.
+  it('writes and clears the cross-launch GPU crash count at exactly three places', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const slice = (from: string, to: string): string => {
+      const start = source.indexOf(from)
+      const end = source.indexOf(to, start)
+      expect(start).toBeGreaterThanOrEqual(0)
+      expect(end).toBeGreaterThan(start)
+      return source.slice(start, end)
+    }
+
+    // Why guarded: an excluded reason (`launch-failed`) evaluates to the inert
+    // decision, whose crashTimes is []. Persisting that truncates the real count to
+    // zero, so one excluded death silently erases the whole accumulated history.
+    const handler = slice('async function handleGpuChildCrash(', 'function recordProcessGoneCrash(')
+    expect(handler).toContain('const countsDurably = countsTowardDurableGpuCrashHistory(reason)')
+    expect(handler).toContain(
+      'if (countsDurably) {\n      persistGpuCrashTimes(userDataPath, environment, durable.crashTimes)\n    }'
+    )
+
+    // Why cleared on a safe-graphics launch: the marker is already applied, so the
+    // pre-fallback times must not re-fire the prompt on the first GPU hiccup here.
+    const reader = slice(
+      'function maybeApplyGpuFallbackForThisLaunch()',
+      'function recordGpuFallbackMarkerPersisted('
+    )
+    expect(reader).toContain('clearGpuCrashHistory(userDataPath)')
+
+    // Why cleared on an orderly quit: a shutdown that reached 'quit' proves the
+    // burst was survivable, so an unconfirmed marker's count must not outlive it.
+    const drop = slice(
+      'function dropUnconfirmedGpuFallbackMarker()',
+      'function recordProcessGoneCrash('
+    )
+    expect(drop).toContain('clearGpuCrashHistory(provisionalGpuFallbackUserDataPath)')
   })
 
   it('drops an unconfirmed GPU fallback marker only once the quit is committed', () => {
@@ -166,9 +260,37 @@ describe('startup ordering', () => {
       'dropUnconfirmedGpuFallbackMarker'
     )
 
-    // Why source-wide: the marker may only be dropped by the shutdown helper and
-    // by the explicit "Keep Running" answer.
-    expect(source.split('clearGpuFallbackMarker(')).toHaveLength(3)
+    // Why source-wide: the marker may only be dropped by the shutdown helper, by
+    // the explicit "Keep Running" answer, and by the Help-menu opt-out.
+    expect(source.split('clearGpuFallbackMarker(')).toHaveLength(4)
+    expect(source).toContain('function turnOffGpuFallback()')
+  })
+
+  it('gives a latched user a way out that does not come straight back', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const start = source.indexOf('function turnOffGpuFallback()')
+    const end = source.indexOf('function dropUnconfirmedGpuFallbackMarker()', start)
+    const optOut = source.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+
+    // Why both: the marker latches the next launch and the count would re-latch the
+    // one after it, so clearing only one of them leaves the user still stuck.
+    expect(optOut).toContain('clearGpuCrashHistory(userDataPath)')
+    expect(optOut).toContain('clearGpuFallbackMarker(userDataPath)')
+    // Why gated on the clear: relaunching over a marker still on disk returns the
+    // user straight to safe graphics, having promised otherwise.
+    const clearIndex = optOut.indexOf('if (!clearGpuFallbackMarker(userDataPath)) {')
+    const relaunchIndex = optOut.indexOf("relaunchApp('gpu-fallback-opt-out'")
+    expect(clearIndex).toBeGreaterThanOrEqual(0)
+    expect(relaunchIndex).toBeGreaterThan(clearIndex)
+    // Why canonical: a split path would clear a marker the next launch never reads.
+    expect(optOut).toContain('getCanonicalUserDataPath()')
+
+    // Why surfaced only while latched: the menu item is meaningless otherwise.
+    expect(source).toContain('isGpuFallbackActive: () => gpuFallbackActiveThisLaunch')
+    expect(source).toContain('onTurnOffGpuFallback: turnOffGpuFallback')
   })
 
   it('reads and writes the GPU fallback marker through the same userData path', () => {
@@ -184,11 +306,19 @@ describe('startup ordering', () => {
     // Why: a split between reader and writer paths turns the whole fallback into
     // a silent no-op — the marker lands somewhere the next launch never looks.
     expect(source.slice(readerStart, readerEnd)).toContain('getCanonicalUserDataPath()')
-    // Why here: a kill between the marker's write and rename orphans a temp file,
-    // and this is the only launch-time site that reclaims them.
-    expect(source.slice(readerStart, readerEnd)).toContain(
-      'sweepStaleGpuFallbackMarkerTempFiles(userDataPath)'
-    )
+    // Why here: a kill between a write and its rename orphans a temp file, and
+    // this is the only launch-time site that reclaims them.
+    const reader = source.slice(readerStart, readerEnd)
+    expect(reader).toContain('sweepStaleGpuFallbackMarkerTempFiles(userDataPath)')
+    expect(reader).toContain('sweepStaleGpuCrashHistoryTempFiles(userDataPath)')
+    // Why gated: the sweep readdirs all of userData (Cache / GPUCache / Local
+    // Storage) on a pre-whenReady path that runs on every Windows launch.
+    expect(reader).toContain('if (sweepForOrphans) {')
+    expect(reader).toContain('gpuFallbackMarkerFileExists(userDataPath)')
+    expect(reader).toContain('gpuCrashHistoryFileExists(userDataPath)')
+    // Why platform-gated: safe graphics is a Windows-only remedy, and
+    // enableMainProcessGpuFeatures() carries the macOS Graphite fix it skips.
+    expect(reader).toContain("process.platform !== 'win32'")
     expect(source.slice(readerEnd, writerEnd)).toContain('getCanonicalUserDataPath()')
     expect(source.slice(readerStart, writerEnd)).not.toContain("app.getPath('userData')")
   })

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -339,6 +339,12 @@ describe('startup ordering', () => {
     expect(reader).toContain('if (sweepForOrphans) {')
     expect(reader).toContain('gpuFallbackMarkerFileExists(userDataPath)')
     expect(reader).toContain('gpuCrashHistoryFileExists(userDataPath)')
+    // Why on the no-marker branch: a launch that latched clears the history outright,
+    // and without this the gate above stays armed for the life of the install.
+    expect(reader).toContain('void discardExpiredGpuCrashHistory(userDataPath, environment, {')
+    expect(reader.indexOf('discardExpiredGpuCrashHistory')).toBeGreaterThan(
+      reader.indexOf('if (!marker) {')
+    )
     // Why platform-gated: safe graphics is a Windows-only remedy, and
     // enableMainProcessGpuFeatures() carries the macOS Graphite fix it skips.
     expect(reader).toContain("process.platform !== 'win32'")

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -266,6 +266,29 @@ describe('startup ordering', () => {
     expect(source).toContain('function turnOffGpuFallback()')
   })
 
+  // Why source-level: the listener is a closure inside the async init body, so the
+  // only alternative is booting Electron behind a fake `app`.
+  it('counts a GPU death whose breadcrumb was suppressed', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const start = source.indexOf("app.on('child-process-gone'")
+    const end = source.indexOf("logStartupMilestone('services-initialized')", start)
+    const listener = source.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+
+    // Why siblings: `recordProcessGoneCrash` drops repeats on a 30s key, and that
+    // suppression is a `return` inside the recorder. Nesting the GPU handler under it
+    // — or making the recorder's result gate it — would hand the durable counter the
+    // deduped stream, and a crash loop repeats the same reason by definition.
+    expect(listener).toContain("recordProcessGoneCrash('child'")
+    expect(listener).toContain('    })\n    if (\n      isGpuFallbackCrashCandidate({')
+    const guardIndex = listener.indexOf('isGpuFallbackCrashCandidate({')
+    const handlerIndex = listener.indexOf('void handleGpuChildCrash(')
+    expect(guardIndex).toBeGreaterThan(listener.indexOf("recordProcessGoneCrash('child'"))
+    expect(handlerIndex).toBeGreaterThan(guardIndex)
+  })
+
   it('gives a latched user a way out that does not come straight back', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const start = source.indexOf('function turnOffGpuFallback()')

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -95,6 +95,104 @@ describe('startup ordering', () => {
     )
   })
 
+  it('persists the GPU fallback marker in the same turn as the GPU crash event', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const start = source.indexOf('async function handleGpuChildCrash(')
+    const end = source.indexOf('function recordProcessGoneCrash(', start)
+    const handler = source.slice(start, end)
+    const engageIndex = handler.indexOf('await engageGpuFallback({')
+    const persistIndex = handler.indexOf('persistMarker: () => {')
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    expect(engageIndex).toBeGreaterThanOrEqual(0)
+    expect(persistIndex).toBeGreaterThan(engageIndex)
+
+    // Why the dispatch site too: the turn begins at child-process-gone, so an
+    // await introduced there would push the write past the kill just as surely.
+    const listenerStart = source.indexOf("app.on('child-process-gone'")
+    const listenerEnd = source.indexOf('void handleGpuChildCrash(', listenerStart)
+    expect(listenerStart).toBeGreaterThanOrEqual(0)
+    expect(listenerEnd).toBeGreaterThan(listenerStart)
+    const listener = source.slice(listenerStart, listenerEnd)
+    expect(listener).not.toMatch(/\bawait[\s(]/)
+    expect(listener).not.toContain('async (')
+
+    // Why: Chromium fatally CHECKs the browser process on the 6th GPU failure —
+    // ~7ms after the first when it cannot launch. Any await before the marker
+    // write pushes it past that kill and restores the cross-launch crash loop.
+    expect(handler.slice(0, engageIndex)).not.toMatch(/\bawait[\s(]/)
+
+    // Why: pin the write inside persistMarker — asserting only that the source
+    // mentions writeGpuFallbackMarker lets it drift into a later callback.
+    // Why bound on the next dep key, not the next `},` — the write's own object
+    // literal closes with `},` and would truncate the body being asserted.
+    const persistEnd = handler.indexOf('clearMarker:', persistIndex)
+    expect(persistEnd).toBeGreaterThan(persistIndex)
+    const persistBody = handler.slice(persistIndex, persistEnd)
+    expect(persistBody).toContain('writeGpuFallbackMarker(')
+    expect(persistBody).toContain('provisionalGpuFallbackUserDataPath = userDataPath')
+    // Why: an await inside persistMarker defers the write past the kill just as
+    // surely as one before the call. (An `async` callback fails the anchor above.)
+    expect(persistBody).not.toMatch(/\bawait[\s(]/)
+
+    // Why exactly two writers: the pre-prompt persist, plus the re-persist that
+    // recovers a consented restart whose marker a session-end drop already took.
+    expect(handler.split('writeGpuFallbackMarker(')).toHaveLength(3)
+    const confirmedQuittingIndex = handler.indexOf("outcome === 'confirmed-quitting'")
+    expect(confirmedQuittingIndex).toBeGreaterThanOrEqual(0)
+    expect(handler.lastIndexOf('writeGpuFallbackMarker(')).toBeGreaterThan(confirmedQuittingIndex)
+
+    // Why pinned: the outcome -> retry mapping is unit-tested, so the handler must
+    // defer to it rather than re-deriving the outcome list inline.
+    expect(handler).toContain('if (!shouldKeepProvisionalGpuFallbackMarker(outcome)) {')
+  })
+
+  it('drops an unconfirmed GPU fallback marker only once the quit is committed', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    // Why not will-quit: its first pass only means a quit was requested, then defers
+    // teardown for seconds during which Chromium's GPU CHECK can still fire.
+    expect(source).toContain("app.on('quit', dropUnconfirmedGpuFallbackMarker)")
+    // Why session-end too: Windows logoff/shutdown is the driver-update reboot case.
+    expect(source).toContain("window.on('session-end', dropUnconfirmedGpuFallbackMarker)")
+
+    // Why bound on the NEXT listener: bounding on an early statement inside the
+    // handler let a drop reintroduced further down pass unnoticed.
+    const willQuitStart = source.indexOf("app.on('will-quit'")
+    const willQuitEnd = source.indexOf("app.on('window-all-closed'", willQuitStart)
+    expect(willQuitStart).toBeGreaterThanOrEqual(0)
+    expect(willQuitEnd).toBeGreaterThan(willQuitStart)
+    expect(source.slice(willQuitStart, willQuitEnd)).not.toContain(
+      'dropUnconfirmedGpuFallbackMarker'
+    )
+
+    // Why source-wide: the marker may only be dropped by the shutdown helper and
+    // by the explicit "Keep Running" answer.
+    expect(source.split('clearGpuFallbackMarker(')).toHaveLength(3)
+  })
+
+  it('reads and writes the GPU fallback marker through the same userData path', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const readerStart = source.indexOf('function maybeApplyGpuFallbackForThisLaunch()')
+    const readerEnd = source.indexOf('async function handleGpuChildCrash(', readerStart)
+    const writerEnd = source.indexOf('function recordProcessGoneCrash(', readerEnd)
+
+    expect(readerStart).toBeGreaterThanOrEqual(0)
+    expect(readerEnd).toBeGreaterThan(readerStart)
+    expect(writerEnd).toBeGreaterThan(readerEnd)
+
+    // Why: a split between reader and writer paths turns the whole fallback into
+    // a silent no-op — the marker lands somewhere the next launch never looks.
+    expect(source.slice(readerStart, readerEnd)).toContain('getCanonicalUserDataPath()')
+    // Why here: a kill between the marker's write and rename orphans a temp file,
+    // and this is the only launch-time site that reclaims them.
+    expect(source.slice(readerStart, readerEnd)).toContain(
+      'sweepStaleGpuFallbackMarkerTempFiles(userDataPath)'
+    )
+    expect(source.slice(readerEnd, writerEnd)).toContain('getCanonicalUserDataPath()')
+    expect(source.slice(readerStart, writerEnd)).not.toContain("app.getPath('userData')")
+  })
+
   it('reconciles retained Codex homes after authoritative daemon inventory', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const daemonInitIndex = source.indexOf('await initDaemonPtyProvider(signal')

--- a/src/main/startup/gpu-crash-history.test.ts
+++ b/src/main/startup/gpu-crash-history.test.ts
@@ -1,0 +1,404 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD } from '../crash-reporting/gpu-crash-fallback-decision'
+import {
+  DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS,
+  GPU_CRASH_HISTORY_FILE,
+  inertGpuCrashHistoryDecision,
+  MAX_GPU_CRASH_HISTORY_ENTRIES,
+  appendGpuCrashTime,
+  clearGpuCrashHistory,
+  gpuCrashHistoryFileExists,
+  pruneGpuCrashTimes,
+  readGpuCrashHistory,
+  evaluateGpuCrashHistory,
+  persistGpuCrashTimes,
+  sweepStaleGpuCrashHistoryTempFiles
+} from './gpu-crash-history'
+import type { GpuFallbackEnvironment } from './gpu-fallback-marker'
+
+const WINDOW = DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS
+const THRESHOLD = DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
+const NOW = 1_800_000_000_000
+
+describe('pruneGpuCrashTimes', () => {
+  it('keeps only times inside the window, oldest first', () => {
+    expect(pruneGpuCrashTimes([NOW - 100, NOW - WINDOW - 1, NOW - 50], NOW, WINDOW)).toEqual([
+      NOW - 100,
+      NOW - 50
+    ])
+  })
+
+  it('keeps a time exactly on the window edge', () => {
+    expect(pruneGpuCrashTimes([NOW - WINDOW], NOW, WINDOW)).toEqual([NOW - WINDOW])
+  })
+
+  it('drops values a clock jump or a corrupt file made nonsense', () => {
+    // Why: these come off disk, so a NaN or a year-3000 stamp would otherwise pin
+    // the count permanently over the threshold.
+    const junk = [Number.NaN, Number.POSITIVE_INFINITY, -1, NOW + 86_400_000, '5', null, {}]
+    expect(pruneGpuCrashTimes([...junk, NOW - 10], NOW, WINDOW)).toEqual([NOW - 10])
+  })
+
+  it('tolerates a small forward clock skew', () => {
+    // NTP corrections move the wall clock by seconds; discarding those would drop
+    // a crash that really did just happen.
+    expect(pruneGpuCrashTimes([NOW + 5_000], NOW, WINDOW)).toEqual([NOW + 5_000])
+  })
+
+  it('returns nothing when `now` itself is unusable', () => {
+    expect(pruneGpuCrashTimes([NOW], Number.NaN, WINDOW)).toEqual([])
+  })
+
+  it('drops entries stranded in the future by a backwards clock jump', () => {
+    // Why this matters most: a rolling window only ever prunes the OLD end, so a
+    // future-dated entry would sit in the window forever and two later crashes
+    // would latch build-sticky safe graphics with no burst and no consent.
+    const stored = [NOW - 30_000, NOW - 15_000, NOW]
+    for (const jumpMs of [
+      90_000, // NTP correction past the skew tolerance
+      3_600_000, // hibernate / VM resume
+      5 * 3_600_000 // dual-boot RTC skew: Windows local time vs Linux UTC
+    ]) {
+      const rewound = NOW - jumpMs
+      const kept = pruneGpuCrashTimes(stored, rewound, WINDOW)
+      // Nothing survives beyond the skew tolerance, so a rewind can never leave
+      // enough entries to reach the threshold on its own.
+      expect([jumpMs, kept.every((time) => time <= rewound + 60_000)]).toEqual([jumpMs, true])
+      expect([jumpMs, kept.length < THRESHOLD]).toEqual([jumpMs, true])
+    }
+
+    // A rewind past the tolerance strands everything.
+    expect(pruneGpuCrashTimes(stored, NOW - 3_600_000, WINDOW)).toEqual([])
+    // Inside the tolerance, only what is genuinely near-present survives.
+    expect(pruneGpuCrashTimes(stored, NOW - 90_000, WINDOW)).toEqual([NOW - 30_000])
+  })
+
+  it('cannot be pushed over the threshold by future-dated entries', () => {
+    const rewound = NOW - 4 * 3_600_000
+    const result = appendGpuCrashTime([NOW - 20_000, NOW - 10_000], rewound, {
+      windowMs: WINDOW,
+      threshold: THRESHOLD
+    })
+    // Only the crash that actually just happened survives.
+    expect(result).toEqual({
+      crashTimes: [rewound],
+      crashesInWindow: 1,
+      crossesThreshold: false
+    })
+  })
+
+  it('does not let future-dated entries fill the cap and crowd out real crashes', () => {
+    const rewound = NOW - 3_600_000
+    const future = Array.from({ length: MAX_GPU_CRASH_HISTORY_ENTRIES * 2 }, (_, i) => NOW + i)
+    const real = [rewound - 30_000, rewound - 15_000]
+    const result = appendGpuCrashTime([...future, ...real], rewound, {
+      windowMs: WINDOW,
+      threshold: THRESHOLD
+    })
+    expect(result.crashTimes).toEqual([rewound - 30_000, rewound - 15_000, rewound])
+    expect(result.crossesThreshold).toBe(true)
+  })
+
+  it('evicts oldest-first and still crosses the threshold at a full cap', () => {
+    // Why: a cap that evicted the newest, or that sat below the threshold, would
+    // silently suppress a machine crashing hard enough to overflow it.
+    const many = Array.from({ length: MAX_GPU_CRASH_HISTORY_ENTRIES + 40 }, (_, i) => NOW - 100 + i)
+    const result = appendGpuCrashTime(many, NOW, { windowMs: WINDOW, threshold: THRESHOLD })
+    expect(result.crashTimes).toHaveLength(MAX_GPU_CRASH_HISTORY_ENTRIES)
+    expect(result.crashTimes[0]).toBeGreaterThan(many[0])
+    expect(result.crashTimes.at(-1)).toBe(NOW)
+    expect(result.crossesThreshold).toBe(true)
+    expect(MAX_GPU_CRASH_HISTORY_ENTRIES).toBeGreaterThan(THRESHOLD)
+  })
+})
+
+describe('DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS', () => {
+  it('spans the measured crash-loop shape without reaching back hours', () => {
+    // Measured: 18-24s median gap between consecutive crashing launches; the first
+    // 8 crashes on F0BN5HZL8FJ span 96s. Three crashes need ~40-50s.
+    expect(DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS).toBeGreaterThan(2 * 24_000 * 3)
+    // Every extra minute is false-positive surface, and the marker is written
+    // before the user consents.
+    expect(DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS).toBeLessThanOrEqual(300_000)
+  })
+})
+
+describe('appendGpuCrashTime', () => {
+  it('does not cross the threshold before the third crash', () => {
+    expect(appendGpuCrashTime([], NOW, { windowMs: WINDOW, threshold: THRESHOLD })).toMatchObject({
+      crashesInWindow: 1,
+      crossesThreshold: false
+    })
+    expect(
+      appendGpuCrashTime([NOW - 20_000], NOW, { windowMs: WINDOW, threshold: THRESHOLD })
+    ).toMatchObject({ crashesInWindow: 2, crossesThreshold: false })
+  })
+
+  it('crosses on the third crash spread across launches', () => {
+    // The measured shape: one GPU death per launch, launches ~20s apart.
+    const result = appendGpuCrashTime([NOW - 44_000, NOW - 22_000], NOW, {
+      windowMs: WINDOW,
+      threshold: THRESHOLD
+    })
+    expect(result).toMatchObject({ crashesInWindow: 3, crossesThreshold: true })
+    expect(result.crashTimes).toEqual([NOW - 44_000, NOW - 22_000, NOW])
+  })
+
+  it('does not count crashes that aged out of the window', () => {
+    expect(
+      appendGpuCrashTime([NOW - WINDOW - 1, NOW - WINDOW - 2], NOW, {
+        windowMs: WINDOW,
+        threshold: THRESHOLD
+      })
+    ).toMatchObject({ crashesInWindow: 1, crossesThreshold: false })
+  })
+
+  it('bounds the array so a crash loop cannot grow the file', () => {
+    const many = Array.from({ length: 200 }, (_, index) => NOW - 200 + index)
+    const result = appendGpuCrashTime(many, NOW, { windowMs: WINDOW, threshold: THRESHOLD })
+    expect(result.crashTimes).toHaveLength(MAX_GPU_CRASH_HISTORY_ENTRIES)
+    // Why the newest: the dropped entries are the ones about to age out anyway.
+    expect(result.crashTimes.at(-1)).toBe(NOW)
+    expect(result.crashesInWindow).toBe(MAX_GPU_CRASH_HISTORY_ENTRIES)
+  })
+
+  it('never counts a crash time it refused to keep', () => {
+    const result = appendGpuCrashTime([NOW - 10, NOW - 20], Number.NaN, {
+      windowMs: WINDOW,
+      threshold: THRESHOLD
+    })
+    expect(result).toEqual({ crashTimes: [], crashesInWindow: 0, crossesThreshold: false })
+  })
+})
+
+describe('gpu-crash-history file', () => {
+  let userDataPath: string
+  const environment = {
+    appVersion: '1.4.163',
+    electronVersion: '42.3.3',
+    platform: 'win32' as const
+  }
+  /** The production sequence for a crash that does not fire: evaluate, then persist. */
+  const record = (now: number, env: GpuFallbackEnvironment = environment) => {
+    const decision = evaluateGpuCrashHistory(userDataPath, env, {
+      now,
+      windowMs: WINDOW,
+      threshold: THRESHOLD
+    })
+    persistGpuCrashTimes(userDataPath, env, decision.crashTimes)
+    return decision
+  }
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-crash-history-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('accumulates across separate calls and fires on the third', () => {
+    // The bug this exists for: three launches, one GPU death each, ~20s apart.
+    expect(record(NOW).crossesThreshold).toBe(false)
+    expect(record(NOW + 20_000).crossesThreshold).toBe(false)
+    const third = record(NOW + 41_000)
+    expect(third.crossesThreshold).toBe(true)
+    expect(third.crashesInWindow).toBe(3)
+  })
+
+  it('evaluates without writing, so the fsync never precedes the marker write', () => {
+    // Why load-bearing: the marker write races a kill that can land ~7ms after the
+    // GPU failure, so the firing crash skips this write entirely.
+    record(NOW)
+    record(NOW + 1_000)
+    const before = readFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), 'utf-8')
+
+    const decision = evaluateGpuCrashHistory(userDataPath, environment, {
+      now: NOW + 2_000,
+      windowMs: WINDOW,
+      threshold: THRESHOLD
+    })
+
+    expect(decision.crossesThreshold).toBe(true)
+    expect(readFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), 'utf-8')).toBe(before)
+  })
+
+  it('is truncated to nothing by persisting an inert decision', () => {
+    // Why asserted rather than commented: an excluded reason (`launch-failed`) makes
+    // handleGpuChildCrash evaluate to inertGpuCrashHistoryDecision(), whose crashTimes
+    // is []. Persisting that rewrites the file empty, so a single excluded GPU death
+    // erases every real crash counted so far and the fallback never reaches three.
+    // The persist must therefore stay gated on the reason counting durably.
+    record(NOW)
+    record(NOW + 1_000)
+    expect(readGpuCrashHistory(userDataPath, environment)).toHaveLength(2)
+
+    persistGpuCrashTimes(userDataPath, environment, inertGpuCrashHistoryDecision().crashTimes)
+
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([])
+  })
+
+  it('round-trips the persisted times', () => {
+    record(NOW)
+    record(NOW + 1_000)
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([NOW, NOW + 1_000])
+    expect(gpuCrashHistoryFileExists(userDataPath)).toBe(true)
+  })
+
+  it('leaves no temp file behind', () => {
+    record(NOW)
+    record(NOW + 1)
+    expect(readdirSync(userDataPath).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+
+  it('discards history from a different app build', () => {
+    record(NOW)
+    record(NOW + 1_000)
+
+    const upgraded = { ...environment, appVersion: '1.4.164' }
+    expect(readGpuCrashHistory(userDataPath, upgraded)).toEqual([])
+    // A new build gets one clean slate, the same policy the marker uses.
+    expect(record(NOW + 2_000, upgraded).crashesInWindow).toBe(1)
+  })
+
+  it('discards history from a different Electron build', () => {
+    record(NOW)
+    expect(
+      readGpuCrashHistory(userDataPath, { ...environment, electronVersion: '43.0.0' })
+    ).toEqual([])
+  })
+
+  it('discards a corrupt or wrong-version file instead of trusting it', () => {
+    writeFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), '{ not json')
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([])
+
+    writeFileSync(
+      join(userDataPath, GPU_CRASH_HISTORY_FILE),
+      JSON.stringify({ schemeVersion: 999, crashTimes: [NOW, NOW, NOW], ...environment })
+    )
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([])
+    expect(record(NOW).crossesThreshold).toBe(false)
+  })
+
+  it('ignores a crashTimes value that is not an array', () => {
+    writeFileSync(
+      join(userDataPath, GPU_CRASH_HISTORY_FILE),
+      JSON.stringify({ schemeVersion: 1, crashTimes: 'lots', ...environment })
+    )
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([])
+  })
+
+  it('does not latch after the wall clock steps backwards', () => {
+    // Two real crashes, then the clock rewinds 5 hours (dual-boot RTC skew). The
+    // stored entries are now future-dated; a rolling window never prunes that end,
+    // so without the future check they would sit there and the next crash would be
+    // the "third" — safe graphics latched with no burst and no consent.
+    record(NOW)
+    record(NOW + 20_000)
+    expect(readGpuCrashHistory(userDataPath, environment)).toHaveLength(2)
+
+    const rewound = NOW - 5 * 3_600_000
+    const afterJump = record(rewound)
+
+    expect(afterJump.crossesThreshold).toBe(false)
+    expect(afterJump.crashesInWindow).toBe(1)
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([rewound])
+  })
+
+  it('does not fire on a stale count from hours earlier', () => {
+    record(NOW)
+    record(NOW + 1_000)
+    expect(record(NOW + 4 * 3_600_000).crossesThreshold).toBe(false)
+  })
+
+  it('caps the persisted array', () => {
+    for (let index = 0; index < MAX_GPU_CRASH_HISTORY_ENTRIES + 20; index += 1) {
+      record(NOW + index)
+    }
+    expect(readGpuCrashHistory(userDataPath, environment)).toHaveLength(
+      MAX_GPU_CRASH_HISTORY_ENTRIES
+    )
+  })
+
+  it('clears the history so an engaged fallback cannot immediately re-fire', () => {
+    record(NOW)
+    record(NOW + 1_000)
+    clearGpuCrashHistory(userDataPath)
+
+    expect(gpuCrashHistoryFileExists(userDataPath)).toBe(false)
+    expect(record(NOW + 2_000).crossesThreshold).toBe(false)
+  })
+
+  it('clearing a history that is already gone is not an error', () => {
+    expect(() => clearGpuCrashHistory(userDataPath)).not.toThrow()
+  })
+
+  it('hands out a fresh inert decision rather than one shared mutable array', () => {
+    const first = inertGpuCrashHistoryDecision()
+    first.crashTimes.push(NOW)
+    expect(inertGpuCrashHistoryDecision()).toEqual({
+      crashTimes: [],
+      crashesInWindow: 0,
+      crossesThreshold: false
+    })
+  })
+
+  it('never throws when the file cannot be written', () => {
+    // A directory at the target path fails both the durable and the direct write.
+    mkdirSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))
+
+    // Why: this runs on the path racing Chromium's kill, so a throw here would
+    // take out the marker write that is the actual remedy.
+    expect(() => record(NOW)).not.toThrow()
+    expect(readdirSync(userDataPath).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+
+  it('sweeps temp files orphaned by a kill between write and rename', async () => {
+    record(NOW)
+    const orphan = join(userDataPath, `${GPU_CRASH_HISTORY_FILE}.999999.123.abc.tmp`)
+    writeFileSync(orphan, '{}')
+
+    await sweepStaleGpuCrashHistoryTempFiles(userDataPath)
+
+    expect(existsSync(orphan)).toBe(false)
+    // The history itself shares the prefix and must survive the sweep.
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([NOW])
+  })
+
+  for (const platform of ['darwin', 'linux'] as const) {
+    it(`writes nothing and never fires on ${platform}`, () => {
+      const foreign = { ...environment, platform }
+
+      for (let index = 0; index < 10; index += 1) {
+        expect(record(NOW + index * 1_000, foreign)).toEqual({
+          crashTimes: [],
+          crashesInWindow: 0,
+          crossesThreshold: false
+        })
+      }
+
+      expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+      expect(readdirSync(userDataPath)).toEqual([])
+    })
+
+    it(`discards a history file that followed a profile onto ${platform}`, () => {
+      record(NOW)
+      record(NOW + 1_000)
+      const persisted = readFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), 'utf-8')
+      expect(persisted).toContain('win32')
+
+      expect(readGpuCrashHistory(userDataPath, { ...environment, platform })).toEqual([])
+      expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+    })
+  }
+})

--- a/src/main/startup/gpu-crash-history.test.ts
+++ b/src/main/startup/gpu-crash-history.test.ts
@@ -7,9 +7,10 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs'
+import type * as FsPromises from 'node:fs/promises'
 import os from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   countsTowardDurableGpuCrashHistory
@@ -21,6 +22,7 @@ import {
   MAX_GPU_CRASH_HISTORY_ENTRIES,
   appendGpuCrashTime,
   clearGpuCrashHistory,
+  discardExpiredGpuCrashHistory,
   gpuCrashHistoryFileExists,
   pruneGpuCrashTimes,
   readGpuCrashHistory,
@@ -29,6 +31,18 @@ import {
   sweepStaleGpuCrashHistoryTempFiles
 } from './gpu-crash-history'
 import type { GpuFallbackEnvironment } from './gpu-fallback-marker'
+
+// Why mocked rather than chmod: a read-only parent directory does not stop an unlink
+// on Windows, so the EPERM case this guards against would not reproduce there.
+const removalFailure = vi.hoisted(() => ({ error: null as NodeJS.ErrnoException | null }))
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return {
+    ...actual,
+    rm: (...args: Parameters<typeof actual.rm>) =>
+      removalFailure.error ? Promise.reject(removalFailure.error) : actual.rm(...args)
+  }
+})
 
 const WINDOW = DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS
 const THRESHOLD = DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
@@ -134,6 +148,17 @@ describe('DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS', () => {
     // Every extra minute is false-positive surface, and the marker is written
     // before the user consents.
     expect(DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS).toBeLessThanOrEqual(300_000)
+  })
+
+  it('reaches back 360s of real time once forward clock skew is counted', () => {
+    // The number the doc comment has to argue against. The skew tolerance sits on the
+    // young end of the window, so a stamp from a clock running 60s fast is accepted and
+    // then gets the whole window from there: 360s of real elapsed time, not 300s.
+    const skewed = NOW + 60_000
+    expect(pruneGpuCrashTimes([skewed], NOW, WINDOW)).toEqual([skewed])
+    expect(pruneGpuCrashTimes([NOW + 61_000], NOW, WINDOW)).toEqual([])
+    expect(pruneGpuCrashTimes([skewed], NOW + 360_000, WINDOW)).toEqual([skewed])
+    expect(pruneGpuCrashTimes([skewed], NOW + 361_000, WINDOW)).toEqual([])
   })
 })
 
@@ -318,6 +343,9 @@ describe('gpu-crash-history file', () => {
   it('discards a corrupt or wrong-version file instead of trusting it', () => {
     writeFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), '{ not json')
     expect(readGpuCrashHistory(userDataPath, environment)).toEqual([])
+    // Why removed rather than left for the next write: a file nothing can read still
+    // arms the startup temp sweep on every launch it survives.
+    expect(gpuCrashHistoryFileExists(userDataPath)).toBe(false)
 
     writeFileSync(
       join(userDataPath, GPU_CRASH_HISTORY_FILE),
@@ -410,6 +438,97 @@ describe('gpu-crash-history file', () => {
     expect(existsSync(orphan)).toBe(false)
     // The history itself shares the prefix and must survive the sweep.
     expect(readGpuCrashHistory(userDataPath, environment)).toEqual([NOW])
+  })
+
+  // Why this exists at all: 66 of the 73 observed launches record one or two GPU
+  // deaths and never reach three, and no other caller deletes the file on that path —
+  // it would sit there arming the startup temp sweep for the life of the install.
+  describe('discardExpiredGpuCrashHistory', () => {
+    const discard = (now: number, env: GpuFallbackEnvironment = environment) =>
+      discardExpiredGpuCrashHistory(userDataPath, env, { now, windowMs: WINDOW })
+
+    afterEach(() => {
+      removalFailure.error = null
+    })
+
+    it('deletes a history whose entries have all aged out', async () => {
+      record(NOW)
+      record(NOW + 1_000)
+
+      await discard(NOW + WINDOW + 61_000)
+
+      expect(existsSync(join(userDataPath, GPU_CRASH_HISTORY_FILE))).toBe(false)
+    })
+
+    it('leaves the next launch with nothing to arm the temp sweep', async () => {
+      record(NOW)
+      // The exact gate maybeApplyGpuFallbackForThisLaunch reads to fire the readdirs.
+      expect(gpuCrashHistoryFileExists(userDataPath)).toBe(true)
+
+      await discard(NOW + WINDOW + 61_000)
+
+      expect(gpuCrashHistoryFileExists(userDataPath)).toBe(false)
+      expect(record(NOW + WINDOW + 62_000).crashesInWindow).toBe(1)
+    })
+
+    it('keeps a history that still holds a crash inside the window', async () => {
+      record(NOW)
+      record(NOW + WINDOW - 1_000)
+
+      // One entry has aged out and one has not. Deleting here would throw away the
+      // live count that the next crash needs to reach the threshold.
+      await discard(NOW + WINDOW + 1)
+
+      expect(readGpuCrashHistory(userDataPath, environment)).toEqual([NOW, NOW + WINDOW - 1_000])
+      expect(gpuCrashHistoryFileExists(userDataPath)).toBe(true)
+    })
+
+    it('does not throw when the unlink is refused', async () => {
+      for (const code of ['EACCES', 'EPERM', 'EBUSY']) {
+        record(NOW)
+        removalFailure.error = Object.assign(new Error(`${code}: refused`), { code })
+
+        // Why asserted: this runs on the pre-whenReady startup path, where a rejection
+        // would surface as an unhandled one before any window exists to report it.
+        await expect(discard(NOW + WINDOW + 61_000)).resolves.toBeUndefined()
+
+        // The count is untouched, so the whole cost is one more armed sweep.
+        expect([code, gpuCrashHistoryFileExists(userDataPath)]).toEqual([code, true])
+        removalFailure.error = null
+      }
+    })
+
+    it('does nothing when there is no history to discard', async () => {
+      await expect(discard(NOW)).resolves.toBeUndefined()
+      expect(readdirSync(userDataPath)).toEqual([])
+    })
+
+    it('deletes a corrupt file instead of leaving it to arm the sweep', async () => {
+      writeFileSync(join(userDataPath, GPU_CRASH_HISTORY_FILE), '{ not json')
+
+      await discard(NOW)
+
+      expect(gpuCrashHistoryFileExists(userDataPath)).toBe(false)
+    })
+
+    it('deletes another build history even while its entries are live', async () => {
+      record(NOW)
+
+      await discard(NOW, { ...environment, appVersion: '1.4.164' })
+
+      // This build can never count them, so keeping them only arms the sweep.
+      expect(gpuCrashHistoryFileExists(userDataPath)).toBe(false)
+    })
+
+    for (const platform of ['darwin', 'linux'] as const) {
+      it(`deletes a live history that followed a profile onto ${platform}`, async () => {
+        record(NOW)
+
+        await discard(NOW, { ...environment, platform })
+
+        expect(gpuCrashHistoryFileExists(userDataPath)).toBe(false)
+      })
+    }
   })
 
   for (const platform of ['darwin', 'linux'] as const) {

--- a/src/main/startup/gpu-crash-history.test.ts
+++ b/src/main/startup/gpu-crash-history.test.ts
@@ -10,7 +10,10 @@ import {
 import os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD } from '../crash-reporting/gpu-crash-fallback-decision'
+import {
+  DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
+  countsTowardDurableGpuCrashHistory
+} from '../crash-reporting/gpu-crash-fallback-decision'
 import {
   DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS,
   GPU_CRASH_HISTORY_FILE,
@@ -199,6 +202,26 @@ describe('gpu-crash-history file', () => {
     persistGpuCrashTimes(userDataPath, env, decision.crashTimes)
     return decision
   }
+  /**
+   * The same sequence with handleGpuChildCrash's reason gate in front of it, so a
+   * reason excluded from the durable history evaluates inert and writes nothing.
+   * Mirrors index.ts; `desktop-startup-ordering` is what holds index.ts to this shape.
+   */
+  const recordForReason = (reason: string, now: number) => {
+    const countsDurably = countsTowardDurableGpuCrashHistory(reason)
+    const decision = countsDurably
+      ? evaluateGpuCrashHistory(userDataPath, environment, {
+          now,
+          windowMs: WINDOW,
+          threshold: THRESHOLD
+        })
+      : inertGpuCrashHistoryDecision()
+    if (countsDurably) {
+      persistGpuCrashTimes(userDataPath, environment, decision.crashTimes)
+    }
+    return decision
+  }
+
   beforeEach(() => {
     userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-crash-history-test-'))
   })
@@ -246,6 +269,20 @@ describe('gpu-crash-history file', () => {
     persistGpuCrashTimes(userDataPath, environment, inertGpuCrashHistoryDecision().crashTimes)
 
     expect(readGpuCrashHistory(userDataPath, environment)).toEqual([])
+  })
+
+  it('keeps the accumulated count when an excluded reason lands mid-sequence', () => {
+    // Why mixed reasons: every other durable test drives one reason, so none composes
+    // the gate with the count and the erasure above stays hypothetical. This is the
+    // real sequence — two `crashed` deaths, then a `launch-failed` that must be ignored
+    // rather than persisted over them, then the third `crashed` that still fires.
+    expect(recordForReason('crashed', NOW).crossesThreshold).toBe(false)
+    expect(recordForReason('crashed', NOW + 20_000).crossesThreshold).toBe(false)
+
+    expect(recordForReason('launch-failed', NOW + 25_000).crashesInWindow).toBe(0)
+
+    expect(readGpuCrashHistory(userDataPath, environment)).toEqual([NOW, NOW + 20_000])
+    expect(recordForReason('crashed', NOW + 41_000).crossesThreshold).toBe(true)
   })
 
   it('round-trips the persisted times', () => {

--- a/src/main/startup/gpu-crash-history.ts
+++ b/src/main/startup/gpu-crash-history.ts
@@ -1,0 +1,242 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  durableWriteTempPath,
+  removeStaleDurableWriteTempFiles,
+  writeFileDurableSync
+} from '../durable-file-write'
+import type { GpuFallbackEnvironment } from './gpu-fallback-marker'
+
+/**
+ * Cross-launch record of GPU child-process deaths.
+ *
+ * Why durable: `GpuCrashFallbackTracker` counts crashes in memory, so its count
+ * resets to zero on every launch. In the 39 Windows bundles, 53 of the 55 launches
+ * that recorded a GPU death recorded exactly one (median 1.4s after `app_started`,
+ * range 0.8-510s), and none recorded three inside the tracker's 30s window.
+ *
+ * That per-launch count is a floor rather than a measurement: `process_gone_suppressed`
+ * coalesces identical repeats on a 30s key, and the same bundles carry 36
+ * `gpu_fallback_applied` breadcrumbs, so the in-process tracker does still reach three
+ * and engage. Counting across launches is what makes the threshold reachable from the
+ * deaths that are observable.
+ *
+ * Not established by that data: that engaging helps. 30 of the 56 attributable deaths
+ * landed on a launch that had already applied safe graphics, all STATUS_BREAKPOINT —
+ * but every one predates `--in-process-gpu` (#11295, v1.4.163, tagged 5h after the last
+ * of them), which is what finally removed the GPU child the old fallback left running.
+ * Efficacy of the current fallback is unmeasured in both directions.
+ *
+ * Why a standalone file (not the Store): same reason as gpu-fallback-marker.ts —
+ * this is read and written before app.whenReady(), where the Store does not exist.
+ */
+
+export const GPU_CRASH_HISTORY_FILE = 'gpu-crash-history.json'
+export const GPU_CRASH_HISTORY_SCHEME_VERSION = 1
+
+/**
+ * Why 5 minutes, derived from the measured distribution rather than rounded up:
+ * the gap between consecutive crashing launches was 18-24s (median), and the
+ * first 8 crashes on F0BN5HZL8FJ span 96s (12s/crash). Three crashes therefore
+ * need ~40-50s. Five minutes tolerates ~2.5 min on each of the two inter-crash
+ * gaps — 6-8x the observed median, enough for a user who reads the Windows crash
+ * dialog or tries a driver update before relaunching — and still covers ~12
+ * consecutive launches at the observed rate.
+ *
+ * Why not 10 minutes: false-positive surface scales linearly with the window,
+ * and the marker is written before the user consents. Too short only delays the
+ * remedy to the next tight burst; too long latches safe graphics on a machine
+ * that was never in the loop. The asymmetry says pick the shorter number.
+ */
+export const DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS = 300_000
+
+/**
+ * Why 32: an order of magnitude above the threshold of 3, so the cap can never
+ * suppress a crossing (that would need >32 crashes inside the window, which is
+ * 10x over threshold and already firing). Eviction is oldest-first — entries
+ * nearest to ageing out anyway. Future-dated entries are dropped before the cap
+ * applies, so a bad clock cannot fill it and crowd out real crashes.
+ */
+export const MAX_GPU_CRASH_HISTORY_ENTRIES = 32
+
+// Why tolerated at all: NTP corrections move the wall clock by seconds. Anything
+// further ahead is a bad clock, and trusting it would pin a stale crash in the
+// window until the clock caught up.
+const GPU_CRASH_HISTORY_FUTURE_SKEW_MS = 60_000
+
+export type GpuCrashHistoryDecision = {
+  /** Times to persist, oldest first. */
+  crashTimes: number[]
+  crashesInWindow: number
+  /** True once the durable count reaches the fallback threshold. */
+  crossesThreshold: boolean
+}
+
+/** Epoch-ms crash times still inside the window, dropping anything a clock jump made nonsense. */
+export function pruneGpuCrashTimes(
+  times: readonly unknown[],
+  now: number,
+  windowMs: number
+): number[] {
+  if (!Number.isFinite(now)) {
+    return []
+  }
+  const oldest = now - windowMs
+  const newest = now + GPU_CRASH_HISTORY_FUTURE_SKEW_MS
+  return times
+    .filter(
+      (time): time is number =>
+        typeof time === 'number' &&
+        Number.isFinite(time) &&
+        time >= 0 &&
+        time >= oldest &&
+        time <= newest
+    )
+    .sort((a, b) => a - b)
+}
+
+/** Adds `now` to `times` and reports whether the durable threshold is now met. */
+export function appendGpuCrashTime(
+  times: readonly unknown[],
+  now: number,
+  options: { windowMs: number; threshold: number; maxEntries?: number }
+): GpuCrashHistoryDecision {
+  const pruned = pruneGpuCrashTimes([...times, now], now, options.windowMs)
+  // Keep the newest: the entries dropped here are the ones about to age out anyway.
+  const crashTimes = pruned.slice(-(options.maxEntries ?? MAX_GPU_CRASH_HISTORY_ENTRIES))
+  return {
+    crashTimes,
+    crashesInWindow: crashTimes.length,
+    crossesThreshold: crashTimes.length >= options.threshold
+  }
+}
+
+/** Why a factory: a shared instance would hand every caller the same mutable array. */
+export function inertGpuCrashHistoryDecision(): GpuCrashHistoryDecision {
+  return { crashTimes: [], crashesInWindow: 0, crossesThreshold: false }
+}
+
+function historyPath(userDataPath: string): string {
+  return join(userDataPath, GPU_CRASH_HISTORY_FILE)
+}
+
+/** Why exported: the startup temp sweep is gated on a fallback file having existed. */
+export function gpuCrashHistoryFileExists(userDataPath: string): boolean {
+  return existsSync(historyPath(userDataPath))
+}
+
+/** Why no retry: a stale history costs at most one extra loop iteration. */
+function clearHistoryBestEffort(userDataPath: string): void {
+  try {
+    rmSync(historyPath(userDataPath), { force: true })
+  } catch {
+    // The next launch revalidates it anyway.
+  }
+}
+
+export function clearGpuCrashHistory(userDataPath: string): void {
+  clearHistoryBestEffort(userDataPath)
+}
+
+/**
+ * Stored crash times for this exact build. A mismatched build or platform discards
+ * them, the same policy the marker uses: a new build gets one clean slate.
+ */
+export function readGpuCrashHistory(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment
+): number[] {
+  if (environment.platform !== 'win32') {
+    clearHistoryBestEffort(userDataPath)
+    return []
+  }
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(readFileSync(historyPath(userDataPath), 'utf-8')) as Record<string, unknown>
+  } catch {
+    // Missing or corrupt means no history; a corrupt file is overwritten by the next write.
+    return []
+  }
+  if (
+    parsed.schemeVersion !== GPU_CRASH_HISTORY_SCHEME_VERSION ||
+    parsed.platform !== 'win32' ||
+    parsed.appVersion !== environment.appVersion ||
+    parsed.electronVersion !== environment.electronVersion
+  ) {
+    clearHistoryBestEffort(userDataPath)
+    return []
+  }
+  const stored: unknown[] = Array.isArray(parsed.crashTimes) ? parsed.crashTimes : []
+  // Range checks belong to pruneGpuCrashTimes, which needs `now`; this is only the
+  // shape boundary, so a hand-edited file cannot put a string into the array.
+  return stored.filter(
+    (time): time is number => typeof time === 'number' && Number.isFinite(time) && time >= 0
+  )
+}
+
+/**
+ * Persists `crashTimes`. Never throws: this runs on the crash path racing
+ * Chromium's kill, and a lost entry only costs one more iteration of the loop.
+ *
+ * Why separate from the evaluation: the caller skips this entirely on the crash
+ * that fires the fallback, so its fsync never lands in front of the marker write.
+ */
+export function persistGpuCrashTimes(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment,
+  crashTimes: readonly number[]
+): void {
+  if (environment.platform !== 'win32') {
+    return
+  }
+  const target = historyPath(userDataPath)
+  const payload = JSON.stringify({
+    schemeVersion: GPU_CRASH_HISTORY_SCHEME_VERSION,
+    crashTimes,
+    appVersion: environment.appVersion,
+    electronVersion: environment.electronVersion,
+    platform: 'win32'
+  })
+  const tmp = durableWriteTempPath(target)
+  try {
+    writeFileDurableSync(tmp, target, payload)
+    return
+  } catch {
+    // Windows AV/indexer holds make renameSync EPERM where a direct write still lands.
+  }
+  try {
+    writeFileSync(target, payload)
+  } catch {
+    // Nothing left to try; the in-process tracker is still armed for this session.
+  }
+  try {
+    rmSync(tmp, { force: true })
+  } catch {
+    // Swept next launch alongside the marker's orphans.
+  }
+}
+
+/**
+ * Reads the stored history, adds a GPU child death at `options.now` (epoch ms),
+ * and reports whether the durable count has reached the threshold. Writes nothing
+ * — the caller decides, so a fallback that fires can go straight to the marker.
+ * Inert off Windows.
+ */
+export function evaluateGpuCrashHistory(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment,
+  options: { now: number; windowMs: number; threshold: number }
+): GpuCrashHistoryDecision {
+  if (environment.platform !== 'win32') {
+    return inertGpuCrashHistoryDecision()
+  }
+  return appendGpuCrashTime(readGpuCrashHistory(userDataPath, environment), options.now, {
+    windowMs: options.windowMs,
+    threshold: options.threshold
+  })
+}
+
+/** Why: the kill this history exists to survive can land between write and rename. */
+export async function sweepStaleGpuCrashHistoryTempFiles(userDataPath: string): Promise<void> {
+  await removeStaleDurableWriteTempFiles(historyPath(userDataPath))
+}

--- a/src/main/startup/gpu-crash-history.ts
+++ b/src/main/startup/gpu-crash-history.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   durableWriteTempPath,
@@ -47,10 +48,15 @@ export const GPU_CRASH_HISTORY_SCHEME_VERSION = 1
  * dialog or tries a driver update before relaunching — and still covers ~12
  * consecutive launches at the observed rate.
  *
- * Why not 10 minutes: false-positive surface scales linearly with the window,
- * and the marker is written before the user consents. Too short only delays the
- * remedy to the next tight burst; too long latches safe graphics on a machine
- * that was never in the loop. The asymmetry says pick the shorter number.
+ * What the code actually reaches back is 360s, not 300s: GPU_CRASH_HISTORY_FUTURE_SKEW_MS
+ * lets an entry sit up to 60s ahead of now, so one written by a clock running 60s fast
+ * survives 360s of real elapsed time. That 360s is the number to argue against.
+ *
+ * Why not 10 minutes: false-positive surface scales linearly with the window, and the
+ * marker is written before the user consents — 360s of worst-case reach is already the
+ * ceiling this trade accepts. Too short only delays the remedy to the next tight burst;
+ * too long latches safe graphics on a machine that was never in the loop. The asymmetry
+ * says pick the shorter number.
  */
 export const DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS = 300_000
 
@@ -142,6 +148,30 @@ export function clearGpuCrashHistory(userDataPath: string): void {
   clearHistoryBestEffort(userDataPath)
 }
 
+/** Times this build may count, or null when the file is corrupt or another build's. */
+function parseGpuCrashHistory(raw: string, environment: GpuFallbackEnvironment): number[] | null {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return null
+  }
+  if (
+    parsed.schemeVersion !== GPU_CRASH_HISTORY_SCHEME_VERSION ||
+    parsed.platform !== 'win32' ||
+    parsed.appVersion !== environment.appVersion ||
+    parsed.electronVersion !== environment.electronVersion
+  ) {
+    return null
+  }
+  const stored: unknown[] = Array.isArray(parsed.crashTimes) ? parsed.crashTimes : []
+  // Range checks belong to pruneGpuCrashTimes, which needs `now`; this is only the
+  // shape boundary, so a hand-edited file cannot put a string into the array.
+  return stored.filter(
+    (time): time is number => typeof time === 'number' && Number.isFinite(time) && time >= 0
+  )
+}
+
 /**
  * Stored crash times for this exact build. A mismatched build or platform discards
  * them, the same policy the marker uses: a new build gets one clean slate.
@@ -154,28 +184,60 @@ export function readGpuCrashHistory(
     clearHistoryBestEffort(userDataPath)
     return []
   }
-  let parsed: Record<string, unknown>
+  let raw: string
   try {
-    parsed = JSON.parse(readFileSync(historyPath(userDataPath), 'utf-8')) as Record<string, unknown>
+    raw = readFileSync(historyPath(userDataPath), 'utf-8')
   } catch {
-    // Missing or corrupt means no history; a corrupt file is overwritten by the next write.
+    // Missing or unreadable means no history.
     return []
   }
-  if (
-    parsed.schemeVersion !== GPU_CRASH_HISTORY_SCHEME_VERSION ||
-    parsed.platform !== 'win32' ||
-    parsed.appVersion !== environment.appVersion ||
-    parsed.electronVersion !== environment.electronVersion
-  ) {
+  const times = parseGpuCrashHistory(raw, environment)
+  if (times === null) {
+    // Why removed rather than left for the next write to overwrite: an unusable file
+    // still arms the startup temp sweep for every launch it survives.
     clearHistoryBestEffort(userDataPath)
     return []
   }
-  const stored: unknown[] = Array.isArray(parsed.crashTimes) ? parsed.crashTimes : []
-  // Range checks belong to pruneGpuCrashTimes, which needs `now`; this is only the
-  // shape boundary, so a hand-edited file cannot put a string into the array.
-  return stored.filter(
-    (time): time is number => typeof time === 'number' && Number.isFinite(time) && time >= 0
-  )
+  return times
+}
+
+/**
+ * Deletes a history whose entries have all aged out, so it stops arming the startup
+ * temp sweep for the life of the install. Why not inside persistGpuCrashTimes: its
+ * caller always appends `now`, so the crash path never sees an empty result — only a
+ * later launch does.
+ *
+ * Why async: the launch that pays for this file already runs the sweep off the critical
+ * path, and startup must not take on a synchronous read to earn back an async readdir.
+ * The one race is a GPU death landing between the read and the unlink — its listener is
+ * registered inside app.whenReady(), so it needs a read slow enough to still be pending
+ * then. It costs that launch's first entry and nothing else, degrading toward not
+ * firing, which is the same direction every other edge in this feature takes.
+ */
+export async function discardExpiredGpuCrashHistory(
+  userDataPath: string,
+  environment: GpuFallbackEnvironment,
+  options: { now: number; windowMs: number }
+): Promise<void> {
+  const target = historyPath(userDataPath)
+  let raw: string
+  try {
+    raw = await readFile(target, 'utf-8')
+  } catch {
+    // Missing is the outcome this aims for; unreadable is retried next launch.
+    return
+  }
+  // Off Windows the file only followed a profile here, so nothing in it is countable.
+  const times = environment.platform === 'win32' ? parseGpuCrashHistory(raw, environment) : null
+  // A live entry is the cross-launch evidence this file exists to accumulate.
+  if (times !== null && pruneGpuCrashTimes(times, options.now, options.windowMs).length > 0) {
+    return
+  }
+  try {
+    await rm(target, { force: true })
+  } catch {
+    // An AV/indexer hold on Windows costs one more armed sweep, nothing else.
+  }
 }
 
 /**

--- a/src/main/startup/gpu-crash-history.ts
+++ b/src/main/startup/gpu-crash-history.ts
@@ -11,21 +11,25 @@ import type { GpuFallbackEnvironment } from './gpu-fallback-marker'
  * Cross-launch record of GPU child-process deaths.
  *
  * Why durable: `GpuCrashFallbackTracker` counts crashes in memory, so its count
- * resets to zero on every launch. In the 39 Windows bundles, 53 of the 55 launches
- * that recorded a GPU death recorded exactly one (median 1.4s after `app_started`,
- * range 0.8-510s), and none recorded three inside the tracker's 30s window.
+ * resets to zero on every launch. The 39 Windows bundles hold 111 distinct GPU child
+ * deaths over 73 launches that retained an `app_started` breadcrumb; 66 of those
+ * launches recorded one or two deaths, and 7 recorded four inside 90ms.
  *
- * That per-launch count is a floor rather than a measurement: `process_gone_suppressed`
- * coalesces identical repeats on a 30s key, and the same bundles carry 36
- * `gpu_fallback_applied` breadcrumbs, so the in-process tracker does still reach three
- * and engage. Counting across launches is what makes the threshold reachable from the
- * deaths that are observable.
+ * So the 3-in-30s threshold is reachable, not unreachable — it is met on those 7, and
+ * 36 launches started with safe graphics already applied. What it misses is the common
+ * shape. Measured per machine (one bundle is one ring buffer), of the 21 bundles holding
+ * a fallback-eligible death, 2 reach three inside 30s within a single launch and 6 reach
+ * three inside 5 minutes when counted across launches. Tripling the reach is the claim
+ * this file supports; making an unreachable threshold reachable is not.
  *
- * Not established by that data: that engaging helps. 30 of the 56 attributable deaths
- * landed on a launch that had already applied safe graphics, all STATUS_BREAKPOINT —
- * but every one predates `--in-process-gpu` (#11295, v1.4.163, tagged 5h after the last
- * of them), which is what finally removed the GPU child the old fallback left running.
- * Efficacy of the current fallback is unmeasured in both directions.
+ * Per-launch counts are a floor rather than a measurement either way, since
+ * `process_gone_suppressed` coalesces identical repeats on a 30s key.
+ *
+ * Not established by that data: that engaging helps. 57 of the 111 deaths landed on a
+ * launch that had already applied safe graphics, all STATUS_BREAKPOINT — but every one
+ * predates `--in-process-gpu` (#11295, v1.4.163, tagged 5h after the last of them),
+ * which is what finally removed the GPU child the old fallback left running. Efficacy
+ * of the current fallback is unmeasured in both directions.
  *
  * Why a standalone file (not the Store): same reason as gpu-fallback-marker.ts —
  * this is read and written before app.whenReady(), where the Store does not exist.

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -1,12 +1,52 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import type * as DurableFileWrite from '../durable-file-write'
+// Why vi.mock, not vi.spyOn: the named ESM import is inlined, so a spy on the
+// module namespace never intercepts and the failure cases silently pass.
+const durableWrite = vi.hoisted(() => ({ failWith: null as Error | null, calls: 0 }))
+// Why a counter, not a spy: same inlining problem, and rmSync's own maxRetries
+// applies only to recursive removals, so the hand-rolled retry needs proving.
+const rmControl = vi.hoisted(() => ({ failuresLeft: 0, calls: 0 }))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  return {
+    ...actual,
+    rmSync: (path: Parameters<typeof actual.rmSync>[0], options?: object) => {
+      rmControl.calls += 1
+      if (rmControl.failuresLeft > 0) {
+        rmControl.failuresLeft -= 1
+        throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' })
+      }
+      return actual.rmSync(path, options)
+    }
+  }
+})
+vi.mock('../durable-file-write', async (importOriginal) => {
+  const actual = await importOriginal<typeof DurableFileWrite>()
+  const fs = await import('node:fs')
+  return {
+    ...actual,
+    writeFileDurableSync: (tmpPath: string, finalPath: string, payload: string) => {
+      durableWrite.calls += 1
+      if (durableWrite.failWith) {
+        // Why write first: the real failure is renameSync, which leaves the temp
+        // behind — throwing before it would leave the orphan cleanup uncovered.
+        fs.writeFileSync(tmpPath, payload, 'utf-8')
+        throw durableWrite.failWith
+      }
+      actual.writeFileDurableSync(tmpPath, finalPath, payload)
+    }
+  }
+})
 import {
   GPU_FALLBACK_MARKER_FILE,
   clearGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
+  sweepStaleGpuFallbackMarkerTempFiles,
   writeGpuFallbackMarker
 } from './gpu-fallback-marker'
 
@@ -20,9 +60,15 @@ describe('gpu-fallback-marker', () => {
 
   beforeEach(() => {
     userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-fallback-test-'))
+    durableWrite.failWith = null
+    durableWrite.calls = 0
+    rmControl.failuresLeft = 0
+    rmControl.calls = 0
   })
 
   afterEach(() => {
+    durableWrite.failWith = null
+    rmControl.failuresLeft = 0
     rmSync(userDataPath, { recursive: true, force: true })
   })
 
@@ -36,6 +82,42 @@ describe('gpu-fallback-marker', () => {
       electronVersion: '42.3.3',
       platform: 'win32'
     })
+  })
+
+  it('overwrites an existing marker and leaves no temp file behind', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 2, crashesInWindow: 5 }, environment)
+
+    expect(readGpuFallbackMarker(userDataPath)?.engagedAt).toBe(2)
+    // Why: the durable write renames through a temp file; an orphan would accumulate
+    // on every GPU crash burst.
+    expect(readdirSync(userDataPath).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+
+  it('still writes the marker when the durable rename is refused', () => {
+    // Why: Windows AV/indexer holds make renameSync EPERM where a direct write
+    // lands. This path must never end up worse than a plain writeFileSync.
+    durableWrite.failWith = Object.assign(new Error('EPERM: rename'), { code: 'EPERM' })
+
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 7, crashesInWindow: 3 }, environment)
+
+    // Why assert the call: an ineffective mock would leave this green while
+    // covering nothing but the happy path.
+    expect(durableWrite.calls).toBe(1)
+    expect(readGpuFallbackMarker(userDataPath)?.engagedAt).toBe(7)
+    expect(readdirSync(userDataPath).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+
+  it('reports the durable-write cause when the direct fallback also fails', () => {
+    const durableError = Object.assign(new Error('EPERM: rename'), { code: 'EPERM' })
+    durableWrite.failWith = durableError
+    // A directory at the marker path makes the direct writeFileSync fail too.
+    mkdirSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))
+
+    // Why the durable error, not the fallback's: it names the real cause.
+    expect(() =>
+      writeGpuFallbackMarker(userDataPath, { engagedAt: 9, crashesInWindow: 3 }, environment)
+    ).toThrow(durableError)
   })
 
   it('returns null when no marker exists', () => {
@@ -107,6 +189,85 @@ describe('gpu-fallback-marker', () => {
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
     expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('sweeps temp files orphaned by a kill between write and rename', async () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    // A foreign pid: the sweeper deliberately skips this process's own in-flight temps.
+    const orphan = join(userDataPath, `${GPU_FALLBACK_MARKER_FILE}.999999.123.abc.tmp`)
+    writeFileSync(orphan, '{}')
+
+    await sweepStaleGpuFallbackMarkerTempFiles(userDataPath)
+
+    expect(existsSync(orphan)).toBe(false)
+    // The marker itself shares the prefix and must survive the sweep.
+    expect(readGpuFallbackMarker(userDataPath)?.engagedAt).toBe(1)
+  })
+
+  it('retries a marker delete that is briefly refused', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    rmControl.calls = 0
+    rmControl.failuresLeft = 2
+
+    expect(clearGpuFallbackMarker(userDataPath)).toBe(true)
+
+    expect(rmControl.calls).toBe(3)
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('reports a marker delete that never succeeds, after backing off', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
+
+    const startedAt = Date.now()
+    expect(clearGpuFallbackMarker(userDataPath)).toBe(false)
+    const elapsed = Date.now() - startedAt
+
+    // Why the timing: a hot spin of 4 immediate unlinks satisfies the call count
+    // identically but cannot outlast the AV hold the backoff exists for.
+    expect(elapsed).toBeGreaterThanOrEqual(100)
+    rmControl.failuresLeft = 0
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
+  })
+
+  it('never blocks startup revalidation on an undeletable marker', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
+
+    const startedAt = Date.now()
+    // Version mismatch: the revalidation path that runs pre-window on every launch.
+    expect(
+      readActiveGpuFallbackMarker(userDataPath, { ...environment, appVersion: '9.9.9' })
+    ).toBeNull()
+    const elapsed = Date.now() - startedAt
+
+    // Why: this runs before the window exists, so an AV hold must not add a
+    // multi-hundred-millisecond stall for a delete the next launch redoes anyway.
+    expect(elapsed).toBeLessThan(100)
+    expect(rmControl.calls).toBe(1)
+  })
+
+  it('treats an already-gone marker as cleared even when the unlink errors', () => {
+    // Why: a concurrent delete makes rmSync throw on a file that is already gone;
+    // reporting that as a failure would keep the caller retrying forever.
+    rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
+
+    expect(clearGpuFallbackMarker(userDataPath)).toBe(true)
+    expect(rmControl.calls).toBe(1)
+  })
+
+  it('writes the marker before spending any time on the orphan temp', () => {
+    durableWrite.failWith = Object.assign(new Error('EPERM: rename'), { code: 'EPERM' })
+    rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
+
+    const startedAt = Date.now()
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 5, crashesInWindow: 3 }, environment)
+    const elapsed = Date.now() - startedAt
+
+    expect(readGpuFallbackMarker(userDataPath)?.engagedAt).toBe(5)
+    // Why: backing off on the temp before the write would push the marker past
+    // the Chromium kill this whole path exists to survive.
+    expect(elapsed).toBeLessThan(100)
   })
 
   it('can explicitly clear the marker', () => {

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -44,6 +44,7 @@ vi.mock('../durable-file-write', async (importOriginal) => {
 import {
   GPU_FALLBACK_MARKER_FILE,
   clearGpuFallbackMarker,
+  gpuFallbackMarkerFileExists,
   readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
   sweepStaleGpuFallbackMarkerTempFiles,
@@ -73,20 +74,71 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('round-trips a written marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 123, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 123, crashesInWindow: 3, consented: false },
+      environment
+    )
     expect(readGpuFallbackMarker(userDataPath)).toEqual({
-      schemeVersion: 2,
+      schemeVersion: 3,
       engagedAt: 123,
       crashesInWindow: 3,
+      consented: false,
       appVersion: '1.2.3',
       electronVersion: '42.3.3',
       platform: 'win32'
     })
   })
 
+  it('round-trips the consent flag that separates a latch from a chosen restart', () => {
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 123, crashesInWindow: 3, consented: true },
+      environment
+    )
+    expect(readGpuFallbackMarker(userDataPath)?.consented).toBe(true)
+  })
+
+  it('rejects a scheme-2 marker that predates the consent flag', () => {
+    // Why: without `consented` there is no way to tell a user-confirmed latch from
+    // one the crash imposed, so the bump must invalidate the old shape outright.
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 2,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        ...environment
+      })
+    )
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+  })
+
+  it('rejects a marker whose consent flag is not a boolean', () => {
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 3,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        consented: 'yes',
+        ...environment
+      })
+    )
+    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+  })
+
   it('overwrites an existing marker and leaves no temp file behind', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 2, crashesInWindow: 5 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, consented: false },
+      environment
+    )
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 2, crashesInWindow: 5, consented: false },
+      environment
+    )
 
     expect(readGpuFallbackMarker(userDataPath)?.engagedAt).toBe(2)
     // Why: the durable write renames through a temp file; an orphan would accumulate
@@ -99,7 +151,11 @@ describe('gpu-fallback-marker', () => {
     // lands. This path must never end up worse than a plain writeFileSync.
     durableWrite.failWith = Object.assign(new Error('EPERM: rename'), { code: 'EPERM' })
 
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 7, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 7, crashesInWindow: 3, consented: false },
+      environment
+    )
 
     // Why assert the call: an ineffective mock would leave this green while
     // covering nothing but the happy path.
@@ -116,7 +172,11 @@ describe('gpu-fallback-marker', () => {
 
     // Why the durable error, not the fallback's: it names the real cause.
     expect(() =>
-      writeGpuFallbackMarker(userDataPath, { engagedAt: 9, crashesInWindow: 3 }, environment)
+      writeGpuFallbackMarker(
+        userDataPath,
+        { engagedAt: 9, crashesInWindow: 3, consented: false },
+        environment
+      )
     ).toThrow(durableError)
   })
 
@@ -126,7 +186,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('keeps an active marker for repeated launches on the same build', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, consented: false },
+      environment
+    )
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
     const firstRead = readActiveGpuFallbackMarker(userDataPath, environment)
@@ -138,7 +202,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('clears an active marker when the app build changes', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, consented: false },
+      environment
+    )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
@@ -150,7 +218,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('clears an active marker outside Windows', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, consented: false },
+      environment
+    )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
@@ -165,7 +237,11 @@ describe('gpu-fallback-marker', () => {
   // carries the macOS disable-skia-graphite fix. A marker that survived on darwin would silently
   // strip the fix from the Macs it targets, so pin the platform gate for darwin specifically.
   it('clears an active marker on macOS so the Graphite fix is never skipped', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, consented: false },
+      environment
+    )
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
@@ -191,8 +267,20 @@ describe('gpu-fallback-marker', () => {
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
+  it('reports a marker file that exists but does not parse, so the sweep still runs', () => {
+    // Why: the startup sweep is gated on this, and gating it on a *readable* marker
+    // would skip the reclaim in exactly the torn-write case it exists for.
+    expect(gpuFallbackMarkerFileExists(userDataPath)).toBe(false)
+    writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
+    expect(gpuFallbackMarkerFileExists(userDataPath)).toBe(true)
+  })
+
   it('sweeps temp files orphaned by a kill between write and rename', async () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, consented: false },
+      environment
+    )
     // A foreign pid: the sweeper deliberately skips this process's own in-flight temps.
     const orphan = join(userDataPath, `${GPU_FALLBACK_MARKER_FILE}.999999.123.abc.tmp`)
     writeFileSync(orphan, '{}')
@@ -205,7 +293,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('retries a marker delete that is briefly refused', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, consented: false },
+      environment
+    )
     rmControl.calls = 0
     rmControl.failuresLeft = 2
 
@@ -216,7 +308,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('reports a marker delete that never succeeds, after backing off', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, consented: false },
+      environment
+    )
     rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
 
     const startedAt = Date.now()
@@ -231,7 +327,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('never blocks startup revalidation on an undeletable marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, consented: false },
+      environment
+    )
     rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
 
     const startedAt = Date.now()
@@ -261,7 +361,11 @@ describe('gpu-fallback-marker', () => {
     rmControl.failuresLeft = Number.MAX_SAFE_INTEGER
 
     const startedAt = Date.now()
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 5, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 5, crashesInWindow: 3, consented: false },
+      environment
+    )
     const elapsed = Date.now() - startedAt
 
     expect(readGpuFallbackMarker(userDataPath)?.engagedAt).toBe(5)
@@ -271,7 +375,11 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('can explicitly clear the marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 4, consented: false },
+      environment
+    )
     clearGpuFallbackMarker(userDataPath)
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
   })

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -16,7 +16,8 @@ import {
  */
 
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
-export const GPU_FALLBACK_SCHEME_VERSION = 2
+// Bumped to 3 for `consented`, which self-invalidates markers written without it.
+export const GPU_FALLBACK_SCHEME_VERSION = 3
 
 export type GpuFallbackEnvironment = {
   appVersion: string
@@ -30,6 +31,8 @@ export type GpuFallbackMarker = {
   schemeVersion: number
   engagedAt: number
   crashesInWindow: number
+  /** False while the marker is only a pre-prompt latch; true once the user chose to restart. */
+  consented: boolean
   appVersion: string
   electronVersion: string
   platform: 'win32'
@@ -37,6 +40,11 @@ export type GpuFallbackMarker = {
 
 function markerPath(userDataPath: string): string {
   return join(userDataPath, GPU_FALLBACK_MARKER_FILE)
+}
+
+/** Why exported: the startup temp sweep is gated on a fallback file having existed. */
+export function gpuFallbackMarkerFileExists(userDataPath: string): boolean {
+  return existsSync(markerPath(userDataPath))
 }
 
 export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
@@ -52,6 +60,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
       !Number.isFinite(parsed.engagedAt) ||
       typeof parsed.crashesInWindow !== 'number' ||
       !Number.isFinite(parsed.crashesInWindow) ||
+      typeof parsed.consented !== 'boolean' ||
       typeof parsed.appVersion !== 'string' ||
       typeof parsed.electronVersion !== 'string' ||
       parsed.platform !== 'win32'
@@ -62,6 +71,7 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
       schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
       engagedAt: parsed.engagedAt,
       crashesInWindow: parsed.crashesInWindow,
+      consented: parsed.consented,
       appVersion: parsed.appVersion,
       electronVersion: parsed.electronVersion,
       platform: parsed.platform
@@ -74,13 +84,14 @@ export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker |
 
 export function writeGpuFallbackMarker(
   userDataPath: string,
-  info: { engagedAt: number; crashesInWindow: number },
+  info: { engagedAt: number; crashesInWindow: number; consented: boolean },
   environment: WindowsGpuFallbackEnvironment
 ): void {
   const marker: GpuFallbackMarker = {
     schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
     engagedAt: info.engagedAt,
     crashesInWindow: info.crashesInWindow,
+    consented: info.consented,
     appVersion: environment.appVersion,
     electronVersion: environment.electronVersion,
     platform: 'win32'

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -1,5 +1,10 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import {
+  durableWriteTempPath,
+  removeStaleDurableWriteTempFiles,
+  writeFileDurableSync
+} from '../durable-file-write'
 
 /**
  * Persisted "disable hardware acceleration for this build" marker.
@@ -80,14 +85,90 @@ export function writeGpuFallbackMarker(
     electronVersion: environment.electronVersion,
     platform: 'win32'
   }
-  writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
+  // Why: this write races Chromium's GPU kill (and often a driver TDR), so a bare
+  // writeFileSync can leave a truncated file that reads back as "no fallback".
+  const target = markerPath(userDataPath)
+  const payload = JSON.stringify(marker)
+  const tmp = durableWriteTempPath(target)
+  try {
+    writeFileDurableSync(tmp, target, payload)
+  } catch (durableError) {
+    // writeFileDurableSync cannot throw once its rename returned (the directory
+    // fsync swallows its own errors), so reaching here means nothing was written.
+    try {
+      // Why: renameSync is EPERM on Windows while an AV/indexer holds the target
+      // open, where a direct write still lands. Never end up worse than before.
+      writeFileSync(target, payload)
+    } catch {
+      // Why rethrow the durable error: it names the real cause (EPERM on rename).
+      throw durableError
+    } finally {
+      // Why after the write and without retries: the same handle that refused the
+      // rename usually refuses this unlink, and blocking here would push the
+      // marker past the kill it exists to survive. Orphans are swept next launch.
+      try {
+        rmSync(tmp, { force: true })
+      } catch {
+        // Recoverable: sweepStaleGpuFallbackMarkerTempFiles reclaims it.
+      }
+    }
+  }
 }
 
-export function clearGpuFallbackMarker(userDataPath: string): void {
+/** Why: the kill this marker guards against can land between write and rename. */
+export async function sweepStaleGpuFallbackMarkerTempFiles(userDataPath: string): Promise<void> {
+  await removeStaleDurableWriteTempFiles(markerPath(userDataPath))
+}
+
+/**
+ * Removes the marker, blocking for a short backoff if Windows refuses the unlink.
+ * Returns false when it is still on disk, so callers can report it.
+ *
+ * Only for callers with no second chance: the terminal `quit` event, and the
+ * prompt's "Keep Running" answer. Revalidation on the startup path must not
+ * block a window behind an AV hold — it uses `clearMarkerBestEffort`.
+ */
+export function clearGpuFallbackMarker(userDataPath: string): boolean {
+  return removeFileWithRetries(markerPath(userDataPath))
+}
+
+/** Why no retry: startup can just revalidate again on the next launch. */
+function clearMarkerBestEffort(userDataPath: string): void {
   try {
     rmSync(markerPath(userDataPath), { force: true })
   } catch {
-    // best effort; a stale marker is revalidated on the next launch
+    // A stale marker is revalidated on the next launch.
+  }
+}
+
+// Why hand-rolled: rmSync's maxRetries/retryDelay only apply to recursive removals,
+// so a single-file unlink gets no retry at all.
+const FILE_REMOVE_RETRY_DELAYS_MS = [20, 40, 80]
+
+function removeFileWithRetries(filePath: string): boolean {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      rmSync(filePath, { force: true })
+      return true
+    } catch {
+      if (!existsSync(filePath)) {
+        return true
+      }
+      if (attempt >= FILE_REMOVE_RETRY_DELAYS_MS.length) {
+        return false
+      }
+      sleepSync(FILE_REMOVE_RETRY_DELAYS_MS[attempt])
+    }
+  }
+}
+
+// Why Atomics.wait: `quit` and the deferred prompt path are synchronous, so a
+// timer-based backoff would never run before the process leaves.
+function sleepSync(milliseconds: number): void {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+  } catch {
+    // SharedArrayBuffer unavailable: fall through and retry immediately.
   }
 }
 
@@ -98,7 +179,7 @@ export function readActiveGpuFallbackMarker(
   const marker = readGpuFallbackMarker(userDataPath)
   if (!marker) {
     if (existsSync(markerPath(userDataPath))) {
-      clearGpuFallbackMarker(userDataPath)
+      clearMarkerBestEffort(userDataPath)
     }
     return null
   }
@@ -110,7 +191,7 @@ export function readActiveGpuFallbackMarker(
   ) {
     // Why: the marker is sticky only for the build that observed the driver
     // crash burst; updates get one fresh hardware attempt automatically.
-    clearGpuFallbackMarker(userDataPath)
+    clearMarkerBestEffort(userDataPath)
     return null
   }
   return marker

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -67,6 +67,7 @@
     "exploreOrca": "Explore Orca",
     "gettingStarted": "Getting Started with Orca",
     "reportCrash": "Report Crash...",
+    "turnOffSafeGraphics": "Turn Off Safe Graphics Mode",
     "file": "File",
     "exit": "Exit",
     "edit": "Edit",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -44,6 +44,7 @@
     "exploreOrca": "Explorar Orca",
     "gettingStarted": "Primeros pasos con Orca",
     "reportCrash": "Informar fallo...",
+    "turnOffSafeGraphics": "Desactivar el modo de gráficos seguros",
     "file": "Archivo",
     "exit": "Salir",
     "edit": "Editar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -44,6 +44,7 @@
     "exploreOrca": "Orca を探索",
     "gettingStarted": "Orca を使い始める",
     "reportCrash": "クラッシュを報告...",
+    "turnOffSafeGraphics": "セーフグラフィックスモードをオフにする",
     "file": "ファイル",
     "exit": "終了",
     "edit": "編集",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -44,6 +44,7 @@
     "exploreOrca": "Orca 둘러보기",
     "gettingStarted": "Orca 시작하기",
     "reportCrash": "크래시 신고...",
+    "turnOffSafeGraphics": "안전 그래픽 모드 끄기",
     "file": "파일",
     "exit": "종료",
     "edit": "편집",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -44,6 +44,7 @@
     "exploreOrca": "探索 Orca",
     "gettingStarted": "Orca 入门",
     "reportCrash": "发送错误报告...",
+    "turnOffSafeGraphics": "关闭安全图形模式",
     "file": "文件",
     "exit": "退出",
     "edit": "编辑",


### PR DESCRIPTION
## Description

Cluster `E_windows_gpu_crash_loop` — **39 crash reports** from #orca-crashes between 2026-07-30 and 2026-08-01, all Windows. The dominant signature is exit code `-2147483645` = `0x80000003` **STATUS_BREAKPOINT** from the GPU child process, followed 0.02s later by the renderer.

Orca already has a defence for exactly this: `GpuCrashFallbackTracker` watches for repeated GPU child deaths and offers to relaunch in safe-graphics mode. **In these bundles it engages, and the loop continues anyway.** It reaches its threshold on 7 of 73 observed launches; this PR extends it to the shape that dominates the rest — but see *What this does not fix*.

### The bug

The tracker counts crashes **in memory**, in the main process, with a 3-crash / 30-second threshold.

Across the 39 bundles there are **111 distinct GPU child deaths** over **73 launches that retained an `app_started` breadcrumb** (214 launches are visible in total; `app_started` is not durable, so it does not survive in every ring buffer). Deaths land a median **1.3s** after `app_started`, range 0.8–510s.

The threshold is **reachable, and it is reached** — but only on the minority shape. Deaths per launch are **49 launches × 1, 17 × 2, 7 × 4**; the seven four-death launches are four deaths inside ~90ms and they fire the tracker. **66 of 73 launches recorded one or two**, which the 30-second in-memory window can never accumulate because it resets with the launch.

Measured per machine — one bundle is one ring buffer — over the 21 bundles holding at least one fallback-eligible death:

| Condition | Bundles reaching it |
|---|---|
| 3 deaths inside 30s **within one launch** (today's tracker) | **2 of 21** |
| 3 deaths inside 5 min **across launches** (this PR) | **6 of 21** |

**Tripling the fallback's reach is the claim this PR supports.** Making an unreachable threshold reachable is not — an earlier draft said that and it was wrong.

Per-launch counts are a **floor, not a measurement** in either direction: `process_gone_suppressed` coalesces identical repeats on a 30s key, so repeats inside 30s are invisible in the breadcrumb trail.

> **Correction (adversarial rounds 2–3).** Two claims in earlier drafts were false and are withdrawn. (1) The fallback does **not** "never engage": the bundles carry **36 distinct `gpu_fallback_applied` breadcrumbs**, each with `crashesInWindow: 3`, across at least 4 machines. (2) The same-session threshold is **not** structurally unreachable: seven launches recorded four GPU deaths inside 90ms. The death census itself was also undercounted — 57 was a parser artefact (one of the three breadcrumb serialisations in these bundles was not being read); the correct figure is 111.

### What this does not fix

**Engaging the fallback is not established to end the loop.** Of the 111 GPU child deaths, **57 (51%) happened on a launch that had already applied safe graphics** — every one of them `crashed` / `-2147483645` STATUS_BREAKPOINT, landing a median **1.2s** after `app_started` (max 12.2s). Safe graphics did not delay the death, let alone prevent it.

So this PR makes a remedy fire *earlier and more often*, on evidence that the remedy did **not** stop this crash on the machines that already reached it. The change is still defensible — it is a strict superset of today's behaviour and the off switch bounds the cost — but it should not be merged on the belief that it resolves cluster E. Reproduction of the counts is in the review thread.

**One thing cuts the other way, and it is the strongest argument the fix has.** Every `gpu_fallback_applied` observation above predates `--in-process-gpu`, and this is provable rather than inferred:

| | |
|---|---|
| `3b7ea59c5b` (#11295) adds `--in-process-gpu` | in `v1.4.163`, **not** in `v1.4.162` (`git merge-base --is-ancestor`) |
| `v1.4.163` tagged | **2026-07-31T22:15:11Z** |
| 36 engagements span | 2026-07-27T21:57:14Z → **2026-07-31T17:14:52Z** |

The last observed engagement is **5h00m before the first build containing the switch was even tagged**, so no bundle can be reporting it. That matters because #11295's own finding was that the old fallback *did not remove the GPU child* — `disableHardwareAcceleration()` + `--disable-gpu` left `gpuProcessCount` at 1 — which is exactly why GPU children kept dying on "safe graphics" launches in the data above. The 51% is a measurement of a remedy that has since been repaired.

That does not rescue the remedy — it means **current fallback efficacy is unmeasured in both directions**. Neither "it will work" nor "it won't" is supported by the bundles, and the recommended Windows smoke test is the only thing that would settle it.

### The fix

Count GPU child deaths **across launches**, in a small durable file (`gpu-crash-history.json`), and engage the fallback when three land inside a 5-minute window regardless of which launch they came from.

Durable counting is a strict superset of the in-process tracker — it fires in every case the old one would, plus the 1-2-deaths-per-launch shape the old one resets through — so the in-process tracker is left in place and unchanged for its own (still valid, still firing) same-session scenario.

Supporting pieces:

- **`gpu-crash-history.ts`** (new) — prune / append / persist, written before `app.whenReady()`, so it is a standalone file rather than the Store (same constraint and same precedent as the existing `gpu-fallback-marker.ts`).
- **`gpu-fallback-engagement-resolution.ts`** (new) — the bookkeeping that must follow an engagement outcome, extracted from `index.ts`. See *Fix evidence*: this extraction exists because a real mutation survived the entire suite while it was inline.
- **A user-facing off switch** — Help → *Turn Off Safe Graphics Mode*. See *Trade-offs*; this is load-bearing, not a nicety.

## Fix evidence

### Mutation testing — the honest kind, where one mutation survived first

Every mutation below was applied, confirmed failing, reverted, and the revert grep-verified.

| # | Mutation | Result |
|---|---|---|
| 1 | `provisionalMarkerPath: userDataPath` unconditionally | **5 failures**, headline `stands the shutdown drop down for every settled outcome` |
| 2 | `clearDurableHistory: false` | **6 failures** |
| 3 | Re-add `'launch-failed'` to `DURABLE_GPU_FALLBACK_CRASH_REASONS` | **1 failure** |
| 4 | Delete `time <= newest` from `pruneGpuCrashTimes` | **5 failures** |
| 5 | `provisionalGpuFallbackUserDataPath = userDataPath` at the `index.ts` call site | caught by the retained source-text test |

### The bug adversarial review found — a `launch-failed` death **erased** the whole durable count

Stated up front because it defeated the entire feature and **357 tests passed with it present**.

`inertGpuCrashHistoryDecision()` returns `crashTimes: []` for excluded reasons, and that empty array was handed straight to `persistGpuCrashTimes` — so "ignore this reason" silently became "destroy the accumulated count". Executed probe against the real modules, mirroring `handleGpuChildCrash`:

```
crashed  t0      -> stored [t0]
crashed  t0+1000 -> stored [t0, t0+1000]
launch-failed    -> stored []          <-- both real crashes destroyed
crashed  t0+3000 -> stored [t0+3000], crossesThreshold=false
```

Without the interleaved `launch-failed`, the third crash fires. One excluded event reset the cross-launch counter to zero — the precise mechanism this PR exists to add. Fixed by guarding the persist on `countsTowardDurableGpuCrashHistory(reason)`, which leaves the decision shape (and every existing assertion) untouched.

**Field probability is low** — zero of the 111 observed GPU deaths are `launch-failed`, which is exactly why the reason was excluded in the first place. It is rated HIGH for silently defeating the feature with zero coverage, not for frequency.

**Mutation 1 is the reason `gpu-fallback-engagement-resolution.ts` exists as a module.** While that logic was inline in `index.ts`, its only coverage was source-text matching, and a mutation that kept the provisional marker path on *every* outcome — which deletes the consented marker on the way out and brings the app back up on the same broken GPU — **passed the entire suite**. Extracting it was what made the mutation killable.

### Clock-jump handling

A persisted array of `Date.now()` timestamps is exposed to backward clock jumps (sleep/resume, NTP). The in-process tracker defends monotonicity by clamping *forward* (`Math.max(...)`), which is correct for `performance.now()` and would **invert into a bug** if carried over here: after a backward jump the history would hold future-dated entries, every new entry would be pinned up to that future value, and the history would become permanently unprunable — latching safe graphics with no burst at all.

That clamp was **not** carried over. There is no `Math.max` in either new module. Pruning drops future-dated entries instead, with a 60s tolerance for ordinary NTP correction:

```ts
const oldest = now - windowMs
const newest = now + GPU_CRASH_HISTORY_FUTURE_SKEW_MS   // 60_000
```

Pinned by tests named for the attack: `drops entries stranded in the future by a backwards clock jump`, `cannot be pushed over the threshold by future-dated entries`, `does not let future-dated entries fill the cap and crowd out real crashes`, `does not latch after the wall clock steps backwards`, `tolerates a small forward clock skew`.

### Gates — including the ones that did not run

| Gate | Result |
|---|---|
| `npx vitest run src/main/startup/ src/main/crash-reporting/ src/main/menu/` | exit 0 — 43 files, **382 passed**, 1 skipped |
| `npx vitest run -c config/vitest.config.ts src/renderer/src/i18n/` | exit 0 — 8 files, 32 passed |
| `npx vitest run src/main/i18n/ src/shared/ui-locale.test.ts` | exit 0 — 2 files, 20 passed |
| `npx tsc --noEmit -p config/tsconfig.node.json` | exit 0, zero diagnostics |
| `npx oxlint <changed files>` | exit 0 |
| `npx oxfmt --check <changed files>` | all correctly formatted |

**Did not run, stated rather than implied:**

- The **full renderer suite**. Only the i18n subset ran, because `en.json` (one added key) is the only renderer-side change.
- `npx tsc --noEmit -p config/tsconfig.web.json` fails with **12 pre-existing TS6307 project-reference errors**, none in touched files, confirmed pre-existing by reverting and re-running. Not fixed; out of scope.
- ~~Three known-flaky files were never executed.~~ **Corrected — they have now been run, and they fail.** A full `npx vitest run src/main/` gives 7 failed files / 11 failed tests. Re-running those 7 in isolation, 5 pass alone (`automations/service`, `daemon/history-manager`, `persistence`, `skills/skill-freshness-inventory`, `terminal-history-async-delete`) — load flake under full-suite parallelism. The 2 that remain are `ssh-connection-sftp-namespace` and `node-pty-fd-leak`, and neither is attributable to this branch: `git diff 7bb5e453d7 -- src/main/daemon/ src/main/ssh/` is empty, `node-pty-fd-leak` fails deterministically 3/3 on a native binding string mismatch (`expected /posix_spawn failed: ENOENT/ but got 'posix_spawnp failed.'`), and `ssh-connection-sftp-namespace` reproduces on an unrelated branch. Stating this rather than leaving it as "unobserved", which was the weaker and less useful claim.
- **No build, no packaging, no app launch.**

## ⚠️ This change has never been run on Windows

The `awin` machine was unreachable for the entire session. Every result above was produced on **macOS (darwin 25.3.0)** by unit tests plus static gates. No Orca build was produced, no packaged app was launched, and the GPU-fallback path was never exercised against a real Chromium GPU-child death on any OS.

Per-claim provenance, so nobody has to guess which is which:

| Claim | Backed by |
|---|---|
| GPU crash counts persist across launches and engage on the 3rd | **Unit tests on macOS only**, against a temp userData dir with a synthetic `win32` environment. Real Windows filesystem semantics (AV/indexer `EPERM` on `renameSync`, which the durable-write helper has a fallback for) were **not** exercised. |
| The in-process tracker cannot reach 3 from the *observable* deaths | **Withdrawn — it can, and does.** 7 of 73 launches recorded four GPU deaths inside 90ms, and 36 `gpu_fallback_applied` breadcrumbs (each `crashesInWindow: 3`) show it engaging. Two earlier drafts overstated this; see the correction note. |
| Durable counting widens the fallback's reach | **Measured, per machine** — of the 21 bundles holding a fallback-eligible death, **2** reach 3-in-30s within one launch and **6** reach 3-in-5min across launches. This is the claim the PR now rests on. |
| Engaging safe graphics ends the crash loop | **Contradicted by the bundles** — 57 of 111 deaths (51%) occurred on launches that had already applied safe graphics, all STATUS_BREAKPOINT, median 1.2s in. See *What this does not fix*. |
| `launch-failed` is safe to exclude from durable counting | **Measured from the bundles** — **111 distinct GPU child deaths**: 97 `crashed` (87 STATUS_BREAKPOINT, 9 exit-34, 1 exit-`-1`), 14 `killed` (13 exit-1), **0 `launch-failed`**. Two earlier tallies were wrong in opposite directions — "250 deaths" double-counted the same death across bundles; "57 deaths" missed the embedded-array breadcrumb serialisation entirely. The substantive claim (zero `launch-failed`) survives both corrections. Still a judgment call about future data. |
| `killed` GPU deaths are counted | **No — 14 of the 111 are `killed`**, which is in neither `GPU_FALLBACK_CRASH_REASONS` nor the durable set, so they reach no counter. Pre-existing behaviour; unchanged by this PR and called out rather than fixed here. |
| The 5-minute window | **Reasoned from bundle timestamps** (18–24s median inter-launch gap; 8 crashes in 96s on one machine). Never validated against a live loop. |
| Windows-only; inert on macOS and Linux | **Genuinely tested on macOS** — records 10 crashes on darwin and asserts `readdirSync(userDataPath)` is empty. A real negative result on the platform that matters for the claim. Linux is simulated by platform string, not run on Linux. |
| The user-facing off switch works | **Source-text and unit assertions only.** Nobody has ever clicked it. |
| Consent flag lands `false` pre-prompt, `true` on confirmed restart | Unit-tested on macOS; the actual modal was never shown. |

**Recommended Windows smoke test, before or shortly after merge:** force 3 GPU child deaths across 3 launches; confirm `gpu-crash-history.json` appears in userData; confirm the prompt fires on the 3rd; confirm declining clears the file; confirm nothing is written on a healthy launch.

## ELI5

Orca already knew how to say "your graphics driver keeps crashing — want me to restart in a simpler mode?" The trouble is how it kept count.

It counted on its fingers: crash one, put up a finger. Three fingers and it speaks up. But the graphics crash usually happens about a second into a launch and only once per launch, so Orca mostly put up one finger and then forgot it on the next start. Now it writes the count on a piece of paper instead. Restarting doesn't erase the paper, so the third crash gets noticed and Orca can offer the fix. The paper is thrown away once the question is settled, or after five minutes with no crashes.

The honest caveat: on the machines in this cluster that already got as far as asking, switching to the simpler mode **didn't stop the crashing**. So this makes Orca better at noticing and offering — not, on the evidence we have, better at fixing.

## Trade-offs

**1. The marker is written *before* the user consents — and that is deliberate.** With the median GPU death landing 1.3s after `app_started`, there may be no time for a dialog on the next launch either, so the fallback has to be able to engage without a completed conversation. Consequence: a user killed mid-prompt leaves a `consented: false` marker that still applies safe graphics on the next launch. That is the crash-loop escape hatch working as designed, but it does mean **safe graphics can engage without anyone having said yes**.

**2. That is why the Help → Turn Off Safe Graphics Mode item exists**, and it is the mitigation for #1. It is beyond the original brief and technically droppable — but if it is dropped, trade-off 1 stops being a residual risk and becomes a real one: a user could be stuck in reduced-performance graphics with no in-app way out. **Recommend keeping it.**

**3. Safe graphics means worse graphics.** Engaging the fallback disables GPU acceleration. It is a real, user-visible performance regression — correctly traded against an app that will not start at all, but a regression.

**4. False positives are now possible across launches where they were not before.** Three GPU deaths in 5 minutes need no longer be one session. A user who force-quits during GPU-heavy work three times in five minutes could plausibly trip it. Bounded by: `launch-failed` excluded from durable counting, a 32-entry cap, and the off switch in #2.

**5. Window length is a judgment call from 39 bundles.** 5 minutes was chosen over 10 because false-positive surface scales linearly with the window and the marker precedes consent; too short only delays the remedy to the next burst, too long latches on a machine that was never looping. The asymmetry favours the shorter number, but it is calibrated on one crash cluster, not on a population.

**6. Known dev-only residual, not fixed.** `shouldSkipSingleInstanceLock` requires `isDev`, and dev is not gated off the GPU path, so two Windows dev instances sharing `orca-dev` userData could lose a history update. It fails safe — undercount, never a spurious fallback — and cannot affect shipped builds.

**7. The `index.ts` call site is still guarded by source-text tests, and that gap already let a HIGH through — this is not a stylistic preference.** Extracting `resolveGpuFallbackEngagement` closed the merge-gate hole that mutation 1 found, but the wiring that calls it is pinned by text matching. The one genuine HIGH found in this branch lived at exactly that call site: `handleGpuChildCrash` persisted `durable.crashTimes` unconditionally, so a single `launch-failed` death wrote `[]` over the accumulated history and erased it. With the fix reverted, **the entire suite passes — 44 files, 388 tests, exit 0.** So the tripwire's real coverage shape is that it fires when the text of one specific assignment changes and is blind to a semantically fatal change five statements away. An integration test driving `handleGpuChildCrash` through a fake `app`/`dialog` is a **required follow-up**, not a nice-to-have. It does not block this merge — the fix is correct and the pure modules are well covered — but a reviewer should read this as a disclosed hole, not a tidiness note.

**8. The clock-skew tolerance widens the window by 20%, which trade-off 5's reasoning does not account for.** With crashes 1 and 2 recorded by a 60s-fast clock and crash 3 by a corrected one, the maximum real-time span across which three crashes still fire is `windowMs + 60_000` = **360s, not 300s** (measured; one millisecond further apart and it stops firing). So "5 minutes" is really "5 minutes, or 6 in the worst case a bad clock allows". Bounded and acceptable, but the false-positive surface is a fifth larger than the number in trade-off 5 implies.

**9. Two smaller gaps, named rather than fixed.** `menu.turnOffSafeGraphics` exists in `en.json` only — es/ja/ko/zh each carry 26 of 27 menu keys and will render the English string for the off switch that trade-off 2 calls load-bearing. And `consented` is written and validated but **never read for behaviour**; it is a forensic field today, so the provenance table's row about it should not be read as describing something that gates the fallback.

## Adversarial review

**The loop has not returned a clean verdict. The most recent round closed `clean: false`,** with a recommendation to ship after PR-body corrections rather than after code changes — all of which are applied above. Stating that plainly because this PR is unusual in how much of what the review found landed in the *description* rather than the diff.

What the loop changed, in rough order of how badly it was needed:

1. **"The fallback never engages" was false, and it was this PR's opening sentence.** The bundles carry 36 distinct `gpu_fallback_applied` breadcrumbs at `crashesInWindow: 3`, and 7 launches recorded four GPU deaths inside 90ms — the in-process tracker reaches its threshold and latches. The entire "structurally unreachable" framing was wrong and is gone. The PR now rests on a narrower, measured claim: durable counting takes the bundles that reach the threshold from 2 of 21 to 6 of 21. This is the single largest correction in the effort.
2. **A HIGH that defeated the whole feature**: a `launch-failed` death persisted `[]` over the accumulated history. Executed probe: `crashed t0 → [t0]`, `crashed t0+1000 → [t0, t0+1000]`, `launch-failed → []`, both real crashes destroyed. **357 tests passed with the bug present, and 357/357 still passed with the fix reverted** — the fix was and is unprotected by the suite, which is what trade-off 7 now says in the language it deserves.
3. **A withdrawn inference was restated as measured fact** in the section a reviewer reads first. "The GPU child dies ~0.8s after `app_started`, one death per launch" became the measured range (0.8–510s, median 1.3s) plus an explicit note that the per-launch count is a floor, not a measurement, because `process_gone_suppressed` coalesces repeats on a 30s key.
4. **The provenance count was wrong twice, in opposite directions.** "250 GPU child deaths" was a serialization-occurrence tally counting the same death across multiple bundles; deduping gave 57. Then a later round found that dedupe had been reading only two of the three breadcrumb serialisations in these bundles, so 57 was itself an undercount. The measured figure is **111**. The conclusion the number was cited for — zero `launch-failed` — survived both corrections, which is the only reason the exclusion set was not also wrong.
5. **Clock-jump handling was attacked at the boundaries and held.** Six executed assertions: `now+60_000` kept / `now+60_001` dropped, `now-windowMs` kept / one past dropped, three launches fire on the third and never the second, five re-evaluations never double-count, a clock stepped back one hour does not latch. Every pathology degrades toward *not firing* — the right asymmetry for a feature whose marker precedes consent. This produced no defect and is reported as an executed negative.

Mutation testing killed every cell it was pointed at, including the one the body claims the source-text test catches. The honest counterpoint is item 2: mutation coverage was strong exactly where modules are pure and absent exactly where the bug was.

### A late report that complicates the cluster

Report `762a9391-8ed2-4034-8b99-ff3436d1e5aa` (Windows 10.0.26200, created on 1.4.162) arrived after this work was scoped, labelled `oom` / `-536870904`. **It is not an OOM.** Every `renderer_memory` sample is flat at 33–41 MB against a 4192 MB limit; the renderer died with a trivial JS heap. The breadcrumbs show the real mechanism — repeated `webgl-context-loss` and `webgl-atlas-reset` over ~70s, then `process_gone_suppressed (processType=GPU, reason=crashed, exitCode=34)`, then the renderer.

Two consequences worth stating. The GPU death carries **`exitCode=34`, not STATUS_BREAKPOINT**, so the population characterised in the provenance table is not the whole story — the exclusion set keys on `reason`, not exit code, so this death still counts, but the table should not be read as describing every shape.

The second was raised as a potential blocker and **is resolved in the fix's favour, by source inspection**: a death that emits `process_gone_suppressed` *does* still reach the durable history. The suppression lives inside `recordProcessGoneCrash` (`process-gone-recorder.ts:86-108`), and its early `return` exits only the recorder. `handleGpuChildCrash` is a **sibling statement in the same `child-process-gone` listener** (`index.ts:2767-2781`), not downstream of it:

```ts
app.on('child-process-gone', (_event, details) => {
  recordProcessGoneCrash(...)                    // may suppress the breadcrumb and return
  if (isGpuFallbackCrashCandidate({ platform, processType, reason })) {
    void handleGpuChildCrash(...)                // reached regardless
  }
})
```

This matters more than it looks. Breadcrumb suppression is exactly what makes the per-launch death count unobservable (see *The bug*), so had the two shared a code path, the durable counter would have been blind in precisely the high-frequency case it exists to catch — and the bundles could never have shown it. They do not share a path. **Read, not executed:** no test pins this independence, and a future refactor that moves the GPU branch inside the recorder would silently reintroduce the coupling.

Made with [Orca](https://github.com/stablyai/orca) 🐋

---

## Corrections and additions after the body above was written

Three statements above are now stale. They are corrected here rather than edited in place, so the review history stays legible.

**Correction 1 — "the entire suite passes with the fix reverted" is wrong.** Trade-off 7 and adversarial item 2 both state that reverting the `countsDurably` guard leaves the suite green ("44 files, 388 tests, exit 0" / "357/357 still passed"). It does not. Re-measured on this branch by reverting the guard in `index.ts` and running the gate bare:

```
FAIL  src/main/startup/desktop-startup-ordering.test.ts > startup ordering >
      writes and clears the cross-launch GPU crash count at exactly three places
AssertionError: expected 'async function handleGpuChildCrash(re…' to contain 'if (countsDurably) {\n      persistGp…'

Test Files  1 failed | 42 passed (43)
     Tests  1 failed | 383 passed | 1 skipped (385)
```

The source-text assertion added by this branch does catch the revert. Trade-off 7's own sentence — "it fires when the text of one specific assignment changes" — is the accurate half; the "entire suite passes" claim next to it contradicts it and was measured before that assertion existed. The HIGH was never shipping unprotected. What remains true is the *shape* of the protection: it is text matching, so it is whitespace-sensitive and blind to a semantically equivalent rewrite.

**Addition 1 — the HIGH now has behavioural coverage too.** No existing durable test composed the reason gate with the count; every one drove a single reason, which is why the erasure stayed hypothetical. Added `keeps the accumulated count when an excluded reason lands mid-sequence` (`gpu-crash-history.test.ts`): two `crashed` appends, one `launch-failed` through the same gate `handleGpuChildCrash` applies, then the third `crashed`. Dropping the gate from that sequence fails it on the erasure itself, not on a string:

```
AssertionError: expected [] to deeply equal [ 1800000000000, 1800000020000 ]
```

This is a mirror of the `index.ts` control flow, so it pins the *policy* behaviourally while `desktop-startup-ordering` remains what holds `index.ts` to that policy. The integration test through a fake `app`/`dialog` that trade-off 7 calls a required follow-up is still a follow-up; this narrows the hole rather than closing it.

**Correction 2 — the suppression independence is now executed, not only read.** The "Read, not executed" caveat under the suppression analysis no longer applies. `counts a GPU death whose breadcrumb was suppressed` (`desktop-startup-ordering.test.ts`) pins the two calls as siblings in the `child-process-gone` listener. Verified load-bearing by mutating the listener to nest the GPU branch inside the recorder, which fails it. The coverage is source-level, for the reason the caveat gave: the listener is a closure inside the async init body, so the alternative is booting Electron behind a fake `app`.

**Correction 3 — the locale gap in item 9 is fixed.** `menu.turnOffSafeGraphics` now exists in es/ja/ko/zh, so all five catalogs carry 27 of 27 menu keys and the off switch renders in the user's language. The `consented`-is-forensic-only half of item 9 stands unchanged.

**Not done — the orderly-quit hoist, deliberately.** Hoisting `clearGpuCrashHistory` above the null guard in `dropUnconfirmedGpuFallbackMarker` was considered and rejected on evidence. It was predicated on no path reaching `quit` while the GPU/renderer pair is dying, and there is one: `onRendererRecoveryExhausted` (`index.ts:1247`) calls `presentRendererRecoveryPrompt` (`index.ts:1530`), whose dialog has `buttons: ['Reload', 'Quit']` and `cancelId: 1` — so clicking Quit *or* dismissing with Esc runs `app.quit()`. The GPU and renderer trackers count separately, so the durable count can sit at 1 or 2 when the renderer breaker trips. Hoisting would wipe it there, on exactly the crash family this PR exists to accumulate. The existing comment at `index.ts:1762-1765` describes this correctly and is left in place.

---

## Performance review

Verdict: **ship.** Measured against the real modules via Node 24 type-stripping on a real filesystem — no mocks, no vitest, no fake timers, real `performance.now()`. Every figure is best-of-N with N stated.

**The healthy path is 1.8 µs on Windows and exactly zero elsewhere.** `maybeApplyGpuFallbackForThisLaunch()` returns at `index.ts:1574` on anything that is not `win32`, so macOS and Linux pay no filesystem work at all. On Windows with no fallback files present — the overwhelmingly common case — the change adds exactly two `existsSync` calls: **1.76 µs best / 1.90 µs median** on top of a pre-existing 4.82 µs marker read, against the real 33-entry Orca profile directory on APFS. Cold (forced kernel lookup, unique directory per op) it is 4.40 µs. **No write happens on a healthy launch** — `persistGpuCrashTimes` has exactly one call site and it sits behind a GPU child death.

**The durable write count is hard-capped at 2 per launch regardless of burst size,** established by replaying `index.ts:1623-1660` against the real modules and counting actual writes:

| launch shape | durable writes | fired by | file on disk | stray temps |
|---|---|---|---|---|
| 1 death (most common) | 1 | — | 117 B | 0 |
| 2 deaths (next most common) | 2 | — | 131 B | 0 |
| 4 deaths in 90 ms (the corrected-census burst shape) | 2 | in-process | 131 B | 0 |
| 40 deaths in 400 ms (crash loop) | **2** | in-process | 131 B | 0 |
| 4× `launch-failed` (durably excluded) | 0 | in-process | absent | 0 |

Crash 3 latches `gpuFallbackEngagementStarted` and skips the persist by design; crash 4+ early-returns at `index.ts:1625`. The whole read-modify-write is synchronous — the first `await` is on the crossing branch only — so a 90 ms burst cannot tear the file, and zero orphaned `.tmp` files were observed on every shape.

**Nothing is unbounded.** 32-entry cap (feeding it 5,000 in-window entries stores 32), 551 bytes at cap, clock jumps prune cleanly in both directions, and a hand-edited 100,000-entry file prunes in 0.94 ms and self-heals to 32 on the next write.

**A cost the corrected census newly surfaces, stated rather than left to be discovered.** On the 7 launches with four deaths inside 90 ms, the in-process tracker fires on death 3 anyway — so the two durable writes on deaths 1 and 2 are ~8.6 ms of synchronous main-thread fsync buying nothing the in-process counter did not already deliver, on exactly the tightest-burst shape. Acceptable: the app is dying regardless, and those writes are what make the *other* 66 launches count. But it is real and it lands on the loudest failure.

**On the crash path** `writeFileDurableSync` is ~8.5 ms on APFS, of which the fsyncs are 99.6% and the write itself is 30 µs. Windows skips the directory fsync (`durable-file-write.ts:27-43` swallows the failed `openSync` on a directory), so it pays roughly the 4.3 ms half.

### Two findings, both fixed in `07a6e62969`

1. **`gpu-crash-history.json` is never deleted once written below threshold.** All four `clearGpuCrashHistory` call sites require an active marker or a completed engagement, so a launch with one or two deaths writes the file and never clears it. Entries age out logically but the file stays forever, which keeps `gpuCrashHistoryFileExists()` true and permanently arms the gated double-`readdir` sweep on every subsequent launch. The corrected census is what raises this from trivia to worth fixing: it is **66 of 73 launches — the dominant outcome, not an edge case.**
2. **The window comment is off by 60 s.** `DEFAULT_GPU_CRASH_DURABLE_WINDOW_MS`'s comment argues for 300 s over 600 s on false-positive surface, but the code delivers **360 s** once the 60 s future-skew tolerance is added — confirmed by measurement (an entry from a clock 60 s fast survives exactly 360 s and dies at 361 s). Behaviour is right, the argument is made against the wrong number.

Both are fixed. `discardExpiredGpuCrashHistory` runs on the startup path only when a history file exists and no marker is active: it reads the file asynchronously, and deletes it when pruning leaves nothing live — also when the file is corrupt or belongs to another build, since an unusable file arms the sweep just as effectively as a valid one. A history still holding an in-window entry is never touched; that entry is the cross-launch evidence this PR exists to accumulate. Deletion failure is swallowed (an AV or indexer hold on Windows costs one more armed sweep and nothing else). It could not live in `persistGpuCrashTimes` — that function's caller always appends `now`, so the crash path never observes an empty result; only a later launch does.

**Mutation evidence, run against the committed tree.** Disabling the `rm` — the exact defect reported — fails **6 of 47** tests in `gpu-crash-history.test.ts`. Removing the live-entry guard so it always deletes fails **1**. Both directions are pinned, not just the happy path. Full main-process typecheck (`config/tsconfig.node.json`) clean.

**One of the seven mutants survived the first pass, and the fix for that is part of this commit.** M7 — making the corrupt-file branch return without deleting — **passed, 63 tests, exit 0**. The existing corrupt-file test asserted only on the returned value, and its coverage reached the corrupt path through the *async* discard rather than through `readGpuCrashHistory`, so the crash-path deletion was unpinned. Closed by adding a `gpuCrashHistoryFileExists` assertion to that test; M7 now fails. Recorded rather than folded into the kill count, because a mutant that survives until you notice it is the only evidence in a mutation table that carries information — the rest confirm what the tests were already written to check.

**On the corrupt-file deletion being a behaviour change.** `readGpuCrashHistory` previously left an unparseable or foreign-build file in place for the next write to overwrite. It now removes it. That is deliberate and is the same defect as the one this commit fixes: an unusable file arms the startup temp sweep for every launch it survives, and nothing else was ever going to remove it. The cost is one extra `rmSync` on a path that only runs when the file was already useless.

**Precision correction to the performance review's item 2.** The 360 s boundary is **inclusive**: an entry from a 60 s-fast clock survives at exactly +360,000 ms and is dropped at +360,001 ms. The review's "dies at 361 s" was 1-second measurement granularity, not a different result. The argument in item 2 stands unchanged; only the boundary figure is sharpened.

**On the EPERM path being simulated rather than provoked.** The durable-write failure fallback is driven through `vi.hoisted` mocks rather than by `chmod`, because the failure being modelled is a Windows AV/indexer hold on `renameSync` — `chmod` does not reproduce it on Windows and the harness never ran on Windows at all (see the caveat above). The mock pins the branch; it does not evidence that the branch is reached in the field.

**One claim in the first draft of this fix was too strong and was corrected before commit.** Its comment asserted that nothing could race the async delete, on the grounds that the `child-process-gone` listener is registered inside `app.whenReady()`. Being queued before `whenReady` resolves does not prevent the listener firing during the `await readFile`. The race is real but needs a read slow enough to still be pending at that point, and it costs that launch's first entry and nothing else — degrading toward *not* firing, the same direction as every other edge in this feature. The comment now says that instead.

### Not measured, stated as such rather than estimated

Windows NTFS syscall costs (no Windows host — the *shape* carries over, the milliseconds do not), network-share and roaming-profile userData, end-to-end packaged startup delta, and true cold boot. SSH and folder workspaces change nothing here: `getCanonicalUserDataPath()` is the local Electron profile regardless of where the workspace lives.

Measured at `f4269a1a7e`, re-verified at `686bb62af8`; that commit is comment-only, so every number describes the current tree.
