### PR TITLE
feat(sidebar): add a project straight into a project group from its header

### DIFF
--- a/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddProjectFromFolderDialog.tsx
@@ -55,6 +55,8 @@ const AddProjectFromFolderDialog = React.memo(function AddProjectFromFolderDialo
 
   const openNonGitConfirmation = useCallback(() => {
     closeModal()
+    // Why: this dialog is opened from the file explorer, never from a group header, so it
+    // deliberately carries no Add Project target into the confirm step.
     openModal('confirm-non-git-folder', {
       folderPath,
       ...(connectionId ? { connectionId } : {}),

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -32,6 +32,7 @@ export default React.memo(function AddRepoDialog({
     !hosted && typeof s.modalData.droppedLocalPath === 'string' ? s.modalData.droppedLocalPath : ''
   )
   const addRepoPath = useAppStore((s) => s.addRepoPath)
+  const addProjectTarget = useAppStore((s) => s.addProjectTarget)
   const scanNestedRepos = useAppStore((s) => s.scanNestedRepos)
   const cancelNestedRepoScan = useAppStore((s) => s.cancelNestedRepoScan)
   const importNestedRepos = useAppStore((s) => s.importNestedRepos)
@@ -171,6 +172,7 @@ export default React.memo(function AddRepoDialog({
   const isRuntimeEnvironmentActive = Boolean(selectedRuntimeEnvironmentId)
   const selectedHostKind = hostSelection.selectedParsedHost?.kind
   const { handleBrowse, resetLocalFolderFlow } = useAddRepoLocalFolderFlow({
+    addProjectTarget,
     isOpen,
     droppedLocalPath,
     activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,

--- a/src/renderer/src/components/sidebar/AddRepoSteps.default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.default-checkout.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactModule from 'react'
 import type { Repo } from '../../../../shared/repo-types'
+import type { AddProjectTarget } from '@/lib/added-project-group-assignment'
 
 const mocks = vi.hoisted(() => ({
   stateValues: [] as unknown[],
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     repos: [] as Repo[],
     projects: [],
     projectHostSetups: [],
+    addProjectTarget: null as AddProjectTarget | null,
     clearOrcaHookTrustForRepo: vi.fn(),
     openModal: vi.fn(),
     cancelNestedRepoScan: vi.fn()
@@ -96,6 +98,7 @@ describe('useRemoteRepo default-checkout handoff', () => {
     mocks.storeState.repos = []
     mocks.storeState.projects = []
     mocks.storeState.projectHostSetups = []
+    mocks.storeState.addProjectTarget = null
     mocks.listTargets.mockResolvedValue([
       { id: 'ssh-1', label: 'Builder 1' },
       { id: 'ssh-2', label: 'Builder 2' }
@@ -225,5 +228,24 @@ describe('useRemoteRepo default-checkout handoff', () => {
     expect(mocks.storeState.cancelNestedRepoScan).toHaveBeenCalledWith('scan-ssh', {
       runtimeEnvironmentId: null
     })
+  })
+
+  // Why: closing add-repo drops the Add Project target, so the confirm step re-declares it.
+  it('carries the Add Project target into the non-git folder confirmation', async () => {
+    const addProjectTarget: AddProjectTarget = { groupId: 'group-1', hostId: 'ssh:ssh-1' }
+    mocks.storeState.addProjectTarget = addProjectTarget
+    mocks.addRemote.mockRejectedValue(new Error('Not a valid git repository: /srv/repo'))
+    const closeModal = vi.fn()
+    const { useRemoteRepo } = await import('./AddRepoSteps')
+
+    const result = useRemoteRepo(mocks.fetchWorktrees, vi.fn(), closeModal, mocks.onGitRepoReady)
+    await result.handleAddRemoteRepo()
+
+    expect(closeModal).toHaveBeenCalledTimes(1)
+    expect(mocks.storeState.openModal).toHaveBeenCalledWith(
+      'confirm-non-git-folder',
+      expect.objectContaining({ folderPath: '/srv/repo', connectionId: 'ssh-1', addProjectTarget })
+    )
+    expect(mocks.onGitRepoReady).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -218,10 +218,13 @@ export function useRemoteRepo(
         // Why: match the local add-project flow — show confirmation dialog so
         // users understand git features will be unavailable, rather than
         // silently adding as a folder.
+        // Why: closeModal drops the Add Project target, so re-declare it for the confirm step.
+        const { addProjectTarget } = useAppStore.getState()
         closeModal()
         useAppStore.getState().openModal('confirm-non-git-folder', {
           folderPath: trimmedRemotePath,
-          connectionId: selectedTargetId
+          connectionId: selectedTargetId,
+          ...(addProjectTarget ? { addProjectTarget } : {})
         })
         return
       }

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
@@ -3,6 +3,8 @@ import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { AddProjectTarget } from '@/lib/added-project-group-assignment'
 
 type ButtonCapture = {
   label: string
@@ -17,8 +19,15 @@ const mocks = vi.hoisted(() => ({
       folderPath: '/srv/non-git',
       runtimeEnvironmentId: 'env-1'
     } as Record<string, unknown>,
-    closeModal: vi.fn(),
+    // Why: mirrors the real slice — closing drops the target, which is exactly what confirm races.
+    closeModal: vi.fn(() => {
+      mocks.state.addProjectTarget = null
+    }),
     addNonGitFolder: vi.fn(),
+    addProjectTarget: null as AddProjectTarget | null,
+    clearAddProjectTarget: vi.fn(),
+    moveProjectToGroup: vi.fn(),
+    projectGroups: [] as ProjectGroup[],
     runtimeEnvironments: [{ id: 'env-1', name: 'Remote Mac' }],
     repos: [] as Repo[],
     projects: [],
@@ -126,6 +135,9 @@ describe('NonGitFolderDialog', () => {
     mocks.state.repos = []
     mocks.state.projects = []
     mocks.state.projectHostSetups = []
+    mocks.state.addProjectTarget = null
+    mocks.state.projectGroups = []
+    mocks.state.moveProjectToGroup.mockResolvedValue(true)
     mocks.state.worktreesByRepo = {}
     mocks.state.fetchWorktrees.mockResolvedValue(true)
     mocks.onboardingGet.mockResolvedValue(null)
@@ -252,6 +264,65 @@ describe('NonGitFolderDialog', () => {
     expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalledWith(
       localWorktree.id,
       expect.anything()
+    )
+  })
+
+  // Why: confirm closes the dialog at once, which drops the store target before the add can read
+  // it — so the target has to ride along with the add itself.
+  it('hands the Add Project target to the local folder add before closing', () => {
+    const addProjectTarget: AddProjectTarget = { groupId: 'group-1', hostId: 'local' }
+    mocks.state.modalData = { folderPath: '/srv/non-git', addProjectTarget }
+    mocks.state.addProjectTarget = addProjectTarget
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    const button = mocks.buttons.find((entry) => entry.label.includes('Open as Folder'))
+    button?.onClick?.()
+
+    expect(mocks.state.addNonGitFolder).toHaveBeenCalledWith(
+      '/srv/non-git',
+      expect.objectContaining({ addProjectTarget })
+    )
+    expect(mocks.state.closeModal).toHaveBeenCalled()
+  })
+
+  it('groups an SSH folder even though confirm closes the dialog first', async () => {
+    const addProjectTarget: AddProjectTarget = { groupId: 'group-1', hostId: 'ssh:ssh-1' }
+    mocks.state.modalData = { folderPath: '/srv/non-git', connectionId: 'ssh-1', addProjectTarget }
+    mocks.state.addProjectTarget = addProjectTarget
+    mocks.state.projectGroups = [
+      {
+        id: 'group-1',
+        name: 'OSS',
+        parentPath: null,
+        connectionId: 'ssh-1',
+        parentGroupId: null,
+        createdFrom: 'manual',
+        tabOrder: 0,
+        isCollapsed: false,
+        color: null,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    mocks.addRemote.mockResolvedValue({
+      repo: {
+        id: 'ssh-repo',
+        path: '/srv/non-git',
+        displayName: 'non-git',
+        badgeColor: '#111',
+        addedAt: 1,
+        kind: 'folder',
+        connectionId: 'ssh-1'
+      } satisfies Repo
+    })
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    const button = mocks.buttons.find((entry) => entry.label.includes('Open as Folder'))
+    button?.onClick?.()
+
+    expect(mocks.state.closeModal).toHaveBeenCalled()
+    await vi.waitFor(() =>
+      expect(mocks.state.moveProjectToGroup).toHaveBeenCalledWith('ssh-repo', 'group-1')
     )
   })
 })

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -55,6 +55,9 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
         )
 
   const handleConfirm = useCallback(() => {
+    // Why: closeModal below drops the Add Project target before either add resolves, so hand it
+    // down the call instead of letting the add read the store.
+    const { addProjectTarget } = useAppStore.getState()
     if (connectionId && folderPath) {
       void (async () => {
         try {
@@ -68,9 +71,11 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
           if ('error' in result) {
             throw new Error(result.error)
           }
-          const { repo } = upsertAddedRepoWithProjectHostSetup(result.repo, {
-            sshConnectionId: connectionId
-          })
+          const { repo } = upsertAddedRepoWithProjectHostSetup(
+            result.repo,
+            { sshConnectionId: connectionId },
+            addProjectTarget
+          )
           const state = useAppStore.getState()
           const hadProjectBeforeAdd = stateBeforeAdd.repos.length > 0
           await markOnboardingProjectAdded('addedFolder')
@@ -139,7 +144,8 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
     } else if (folderPath) {
       void addNonGitFolder(folderPath, {
         runtimeEnvironmentId: runtimeEnvironmentId || null,
-        ...(displayName ? { displayName } : {})
+        ...(displayName ? { displayName } : {}),
+        ...(addProjectTarget ? { addProjectTarget } : {})
       })
     }
     closeModal()

--- a/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
@@ -39,7 +39,8 @@ vi.mock('@/components/ui/dropdown-menu', () => createDropdownMenuModuleMock())
 
 function setProjectGroupWithoutWorktreeRowsState(
   filterRepoIds: string[] = [],
-  collapsedGroups = new Set<string>()
+  collapsedGroups = new Set<string>(),
+  options: { group?: Partial<ProjectGroup>; withUngroupedRepo?: boolean } = {}
 ): void {
   const group: ProjectGroup = {
     id: 'group-1',
@@ -51,12 +52,15 @@ function setProjectGroupWithoutWorktreeRowsState(
     isCollapsed: false,
     color: null,
     createdAt: 1,
-    updatedAt: 1
+    updatedAt: 1,
+    ...options.group
   }
   const repo: Repo = {
     ...makeRepo(),
     projectGroupId: group.id
   }
+  const ungroupedRepo: Repo = { ...makeRepo(), id: 'ungrouped-repo', displayName: 'Loose' }
+  const repos = options.withUngroupedRepo ? [repo, ungroupedRepo] : [repo]
 
   mockStore.state = {
     ...makeFolderWorkspacePathStatusMockState(),
@@ -84,7 +88,7 @@ function setProjectGroupWithoutWorktreeRowsState(
     reorderRepos: vi.fn(),
     reportVisibleGitHubPRRefreshCandidates: vi.fn(),
     retainedAgentsByPaneKey: {},
-    repos: [repo],
+    repos,
     runtimePaneTitlesByTabId: {},
     setFilterRepoIds: vi.fn(),
     setHideDefaultBranchWorkspace: vi.fn(),
@@ -108,9 +112,7 @@ function setProjectGroupWithoutWorktreeRowsState(
     workspaceStatuses: [],
     worktreeCardProperties: ['status', 'inline-agents'],
     worktreeLineageById: {},
-    worktreesByRepo: {
-      [repo.id]: []
-    }
+    worktreesByRepo: Object.fromEntries(repos.map((entry) => [entry.id, []]))
   }
 }
 
@@ -143,6 +145,35 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(markup).toContain('data-repo-header-collapse-affordance=""')
     expect(markup).toContain('aria-expanded="false"')
     expect(markup).toContain('-rotate-90')
+  })
+
+  it('offers Add project on a plain project group header', async () => {
+    setProjectGroupWithoutWorktreeRowsState([], new Set(), {
+      group: { parentPath: null, createdFrom: 'manual' }
+    })
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('aria-label="Add project to Imported Services"')
+  })
+
+  // Why: folder-backed groups already spend the Plus slot on "create workspace".
+  it('leaves the Plus slot to folder-backed project groups', async () => {
+    setProjectGroupWithoutWorktreeRowsState()
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('aria-label="Create workspace for Imported Services"')
+    expect(markup).not.toContain('aria-label="Add project to')
+  })
+
+  it('does not offer Add project on the synthetic Ungrouped header', async () => {
+    setProjectGroupWithoutWorktreeRowsState([], new Set(), {
+      group: { parentPath: null, createdFrom: 'manual' },
+      withUngroupedRepo: true
+    })
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('aria-label="Add project to Imported Services"')
+    expect(markup).not.toContain('aria-label="Add project to Ungrouped"')
   })
 
   it('does not render the project collapse affordance on flat section headers', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -312,6 +312,7 @@ const WorktreeList = React.memo(function WorktreeList({
         handleRenameProjectGroup={projectGroupDialogs.handleRenameProjectGroup}
         handleDeleteProjectGroup={projectGroupDialogs.handleDeleteProjectGroup}
         handleCreateFolderWorkspace={handleCreateFolderWorkspace}
+        handleAddProjectToGroup={projectGroupDialogs.handleAddProjectToGroup}
         activeModal={activeModal}
         pendingRevealWorktree={pendingRevealWorktree}
         pendingRevealSidebarRow={pendingRevealSidebarRow}

--- a/src/renderer/src/components/sidebar/add-repo-store-upsert.ts
+++ b/src/renderer/src/components/sidebar/add-repo-store-upsert.ts
@@ -7,6 +7,10 @@ import {
 import type { Repo } from '../../../../shared/repo-types'
 import { useAppStore } from '@/store'
 import { getRepoHostIdentity } from '@/store/slices/repo-host-identity'
+import {
+  assignAddedProjectToTargetGroup,
+  type AddProjectTarget
+} from '@/lib/added-project-group-assignment'
 
 type AddedRepoOwner = {
   runtimeEnvironmentId?: string | null
@@ -32,7 +36,8 @@ function repoWithCapturedOwner(repo: Repo, owner: AddedRepoOwner): Repo {
 
 export function upsertAddedRepoWithProjectHostSetup(
   repo: Repo,
-  owner: AddedRepoOwner = {}
+  owner: AddedRepoOwner = {},
+  addProjectTarget?: AddProjectTarget | null
 ): { alreadyPresent: boolean; repo: Repo } {
   const state = useAppStore.getState()
   const ownedRepo = repoWithCapturedOwner(repo, owner)
@@ -50,5 +55,8 @@ export function upsertAddedRepoWithProjectHostSetup(
     projects: projection.projects,
     projectHostSetups: projection.setups
   })
+
+  // Why: fire-and-forget keeps this helper synchronous for its callers; the assignment never rejects.
+  void assignAddedProjectToTargetGroup(useAppStore.getState(), ownedRepo, addProjectTarget)
   return { alreadyPresent, repo: ownedRepo }
 }

--- a/src/renderer/src/components/sidebar/complete-nested-folder-open.ts
+++ b/src/renderer/src/components/sidebar/complete-nested-folder-open.ts
@@ -24,11 +24,14 @@ export async function completeNestedFolderOpen(args: {
   try {
     const state = useAppStore.getState()
     if (args.connectionId) {
+      // Why: closeModal drops the Add Project target, so re-declare it for the confirm step.
+      const { addProjectTarget } = state
       args.closeModal()
       state.openModal('confirm-non-git-folder', {
         folderPath: args.scan.selectedPath,
         connectionId: args.connectionId,
         runtimeEnvironmentId: args.owner,
+        ...(addProjectTarget ? { addProjectTarget } : {}),
         ...(args.displayName ? { displayName: args.displayName } : {})
       })
       return

--- a/src/renderer/src/components/sidebar/use-add-repo-host-selection.test.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-host-selection.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactModule from 'react'
 import type { SidebarHostOption } from './sidebar-host-options'
+import type { AddProjectTarget } from '@/lib/added-project-group-assignment'
 
 const mocks = vi.hoisted(() => ({
   stateValues: [] as unknown[],
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   refIndex: 0,
   hostOptions: [] as SidebarHostOption[],
   storeState: {
+    addProjectTarget: null as AddProjectTarget | null,
     settings: { activeRuntimeEnvironmentId: null as string | null },
     setActiveRuntimeEnvironmentPreference: vi.fn(),
     setSshConnectionState: vi.fn(),
@@ -102,6 +104,7 @@ describe('useAddRepoHostSelection', () => {
         presence: 'active'
       }
     ]
+    mocks.storeState.addProjectTarget = null
     mocks.storeState.settings = { activeRuntimeEnvironmentId: null }
     mocks.storeState.setActiveRuntimeEnvironmentPreference.mockResolvedValue(true)
     mocks.storeState.sshConnectionStates = new Map()
@@ -117,6 +120,28 @@ describe('useAddRepoHostSelection', () => {
         }
       }
     })
+  })
+
+  // Why: a group header's Add Project names the group's host; seeding from the focused host would
+  // route the add elsewhere and only fail after the project is already added.
+  it('seeds the host from the Add Project target when the dialog opens', async () => {
+    mocks.storeState.addProjectTarget = { groupId: 'group-1', hostId: 'ssh:ssh-1' }
+    mocks.stateValues = ['local', false]
+    const { useAddRepoHostSelection } = await import('./use-add-repo-host-selection')
+
+    useAddRepoHostSelection({ isOpen: true, setStep: vi.fn() })
+
+    expect(mocks.stateSetters[0]).toHaveBeenCalledWith('ssh:ssh-1')
+  })
+
+  it('falls back to the focused host when the target host is not selectable', async () => {
+    mocks.storeState.addProjectTarget = { groupId: 'group-1', hostId: 'ssh:missing' }
+    mocks.stateValues = ['local', false]
+    const { useAddRepoHostSelection } = await import('./use-add-repo-host-selection')
+
+    useAddRepoHostSelection({ isOpen: true, setStep: vi.fn() })
+
+    expect(mocks.stateSetters[0]).toHaveBeenCalledWith('local')
   })
 
   it('exposes the selected SSH target id', async () => {

--- a/src/renderer/src/components/sidebar/use-add-repo-host-selection.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-host-selection.ts
@@ -32,6 +32,7 @@ export function useAddRepoHostSelection({
   handleConnectAddProjectHost: (hostId: ExecutionHostId) => Promise<void>
 } {
   const settings = useAppStore((s) => s.settings)
+  const addProjectTargetHostId = useAppStore((s) => s.addProjectTarget?.hostId ?? null)
   const setSshConnectionState = useAppStore((s) => s.setSshConnectionState)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
@@ -82,11 +83,15 @@ export function useAddRepoHostSelection({
   useEffect(() => {
     if (isOpen && !previousOpenRef.current) {
       const focusedHostId = getSettingsFocusedExecutionHostId(settings)
-      const nextHostId = selectableHostOptions.some(
-        (host) => host.id === focusedHostId && canSelectAddRepoHost(host)
-      )
-        ? focusedHostId
-        : (pairedWebRuntimeHost?.id ?? (isWebClient ? null : LOCAL_EXECUTION_HOST_ID))
+      const isSelectable = (hostId: ExecutionHostId | null): hostId is ExecutionHostId =>
+        selectableHostOptions.some((host) => host.id === hostId && canSelectAddRepoHost(host))
+      // Why: a group header's Add Project names the group's host; seeding from the focused host
+      // would route the add elsewhere and only fail after the project is already added.
+      const nextHostId = isSelectable(addProjectTargetHostId)
+        ? addProjectTargetHostId
+        : isSelectable(focusedHostId)
+          ? focusedHostId
+          : (pairedWebRuntimeHost?.id ?? (isWebClient ? null : LOCAL_EXECUTION_HOST_ID))
       if (nextHostId) {
         setSelectedAddProjectHostId(nextHostId)
       }
@@ -95,7 +100,14 @@ export function useAddRepoHostSelection({
       setHostSelectorOpen(false)
     }
     previousOpenRef.current = isOpen
-  }, [isOpen, isWebClient, pairedWebRuntimeHost?.id, selectableHostOptions, settings])
+  }, [
+    addProjectTargetHostId,
+    isOpen,
+    isWebClient,
+    pairedWebRuntimeHost?.id,
+    selectableHostOptions,
+    settings
+  ])
 
   const handleSelectAddProjectHost = useCallback(
     async (hostId: ExecutionHostId): Promise<void> => {

--- a/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactModule from 'react'
 import type { NestedRepoScanResult } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
+import type { AddProjectTarget } from '@/lib/added-project-group-assignment'
 
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactModule>()
@@ -238,5 +239,46 @@ describe('useAddRepoLocalFolderFlow', () => {
 
     expect(addRepoPath).not.toHaveBeenCalled()
     expect(onGitRepoReady).not.toHaveBeenCalled()
+  })
+
+  // Why: the first add consumes the store target, so a multi-select pick would otherwise group
+  // only its first folder — the target rides along with every add in the batch instead.
+  it('carries the Add Project target to every folder picked in one batch', async () => {
+    const addProjectTarget: AddProjectTarget = { groupId: 'group-1', hostId: 'local' }
+    pickFolders.mockResolvedValue(['/projects/alpha', '/projects/beta'])
+    const { useAddRepoLocalFolderFlow } = await import('./useAddRepoLocalFolderFlow')
+
+    const { handleBrowse } = useAddRepoLocalFolderFlow({
+      isOpen: true,
+      droppedLocalPath: '',
+      activeRuntimeEnvironmentId: null,
+      addProjectTarget,
+      addRepoPath,
+      closeModal,
+      fetchWorktrees,
+      scanNestedRepos,
+      setActiveNestedScanId,
+      setNestedScanInProgress,
+      showNestedRepoReview,
+      onGitRepoReady,
+      setIsAdding,
+      setAddProjectBusyLabel
+    })
+
+    await handleBrowse()
+
+    expect(addRepoPath).toHaveBeenCalledTimes(2)
+    expect(addRepoPath).toHaveBeenNthCalledWith(
+      1,
+      '/projects/alpha',
+      undefined,
+      expect.objectContaining({ addProjectTarget })
+    )
+    expect(addRepoPath).toHaveBeenNthCalledWith(
+      2,
+      '/projects/beta',
+      undefined,
+      expect.objectContaining({ addProjectTarget })
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.ts
@@ -4,11 +4,9 @@ import { track } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import {
   buildNestedRepoScanTelemetry,
-  createNestedRepoTelemetryAttemptId,
-  type NestedRepoTelemetryRuntimeKind
+  createNestedRepoTelemetryAttemptId
 } from '../../../../shared/nested-repo-telemetry'
 import type { AddRepoExistingWorkspaceSource } from '../../../../shared/telemetry-events'
-import type { NestedRepoScanResult } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorktreeFetchOptions } from '@/store/slices/worktree-helpers'
 import type { RepoSlice } from '@/store/repos/repo-state'
@@ -16,17 +14,8 @@ import { createNestedRepoScanId } from './add-repo-dialog-types'
 import { translate } from '@/i18n/i18n'
 import { worktreeRefreshOptions } from './add-repo-runtime-owner'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
-
-type ShowNestedRepoReview = (args: {
-  scan: NestedRepoScanResult
-  selectedPath: string
-  connectionId: string | null
-  attemptId: string
-  runtimeKind: NestedRepoTelemetryRuntimeKind
-  inProgress: boolean
-  scanId: string | null
-  runtimeEnvironmentId?: string | null
-}) => void
+import type { AddProjectTarget } from '@/lib/added-project-group-assignment'
+import type { ShowNestedRepoReviewArgs } from './useAddRepoNestedReviewState'
 
 type LocalPathAddResult =
   | { status: 'completed'; repo: Repo }
@@ -38,6 +27,7 @@ export function useAddRepoLocalFolderFlow({
   isOpen,
   droppedLocalPath,
   activeRuntimeEnvironmentId,
+  addProjectTarget,
   addRepoPath,
   closeModal,
   fetchWorktrees,
@@ -52,13 +42,15 @@ export function useAddRepoLocalFolderFlow({
   isOpen: boolean
   droppedLocalPath: string
   activeRuntimeEnvironmentId: string | null | undefined
+  /** Why: the first add consumes the store target; passing it keeps a multi-folder pick grouped. */
+  addProjectTarget?: AddProjectTarget | null
   addRepoPath: RepoSlice['addRepoPath']
   closeModal: () => void
   fetchWorktrees: (repoId: string, options?: WorktreeFetchOptions) => Promise<unknown>
   scanNestedRepos: RepoSlice['scanNestedRepos']
   setActiveNestedScanId: (scanId: string | null, runtimeEnvironmentId?: string | null) => void
   setNestedScanInProgress: (inProgress: boolean) => void
-  showNestedRepoReview: ShowNestedRepoReview
+  showNestedRepoReview: (args: ShowNestedRepoReviewArgs) => void
   onGitRepoReady: (
     repoId: string,
     source: AddRepoExistingWorkspaceSource,
@@ -162,7 +154,8 @@ export function useAddRepoLocalFolderFlow({
         }
         setAddProjectBusyLabel('Opening project...')
         const repo = await addRepoPath(path, undefined, {
-          runtimeEnvironmentId: activeRuntimeEnvironmentId ?? null
+          runtimeEnvironmentId: activeRuntimeEnvironmentId ?? null,
+          ...(addProjectTarget ? { addProjectTarget } : {})
         })
         if (gen !== localAddGenRef.current) {
           return { status: 'cancelled' }
@@ -195,6 +188,7 @@ export function useAddRepoLocalFolderFlow({
     },
     [
       activeRuntimeEnvironmentId,
+      addProjectTarget,
       addRepoPath,
       clearNestedScanState,
       closeModal,

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
@@ -27,6 +27,7 @@ const folderRepo: Repo = {
 const mocks = vi.hoisted(() => ({
   state: {
     repos: [] as Repo[],
+    addProjectTarget: null as AddProjectTarget | null,
     addNonGitFolder: vi.fn(),
     closeModal: vi.fn(),
     openModal: vi.fn()
@@ -56,6 +57,7 @@ vi.mock('@/lib/telemetry', () => ({
 
 import { track } from '@/lib/telemetry'
 import { useAddRepoNestedImportFlow } from './useAddRepoNestedImportFlow'
+import type { AddProjectTarget } from '@/lib/added-project-group-assignment'
 
 const scan: NestedRepoScanResult = {
   selectedPath: '/workspace/platform',
@@ -96,6 +98,7 @@ describe('useAddRepoNestedImportFlow open folder fallback', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.state.repos = []
+    mocks.state.addProjectTarget = null
     mocks.state.addNonGitFolder.mockResolvedValue(folderRepo)
   })
 
@@ -197,6 +200,23 @@ describe('useAddRepoNestedImportFlow open folder fallback', () => {
       folderPath: '/workspace/platform',
       connectionId: 'ssh-builder'
     })
+  })
+
+  // Why: closing add-repo drops the Add Project target, so the confirm step re-declares it.
+  it('carries the Add Project target into the SSH non-git folder confirmation', async () => {
+    const addProjectTarget: AddProjectTarget = { groupId: 'group-1', hostId: 'ssh:ssh-builder' }
+    mocks.state.addProjectTarget = addProjectTarget
+    const { handleOpenNestedRootFolder } = useTestAddRepoNestedImportFlow({
+      nestedConnectionId: 'ssh-builder',
+      nestedRuntimeKind: 'ssh'
+    })
+
+    await handleOpenNestedRootFolder()
+
+    expect(mocks.state.openModal).toHaveBeenCalledWith(
+      'confirm-non-git-folder',
+      expect.objectContaining({ folderPath: '/workspace/platform', addProjectTarget })
+    )
   })
 
   it('keeps SSH import and completion pinned when repo hydration is missing', async () => {

--- a/src/renderer/src/components/sidebar/useAddRepoNestedReviewState.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedReviewState.ts
@@ -3,7 +3,7 @@ import type { NestedRepoTelemetryRuntimeKind } from '../../../../shared/nested-r
 import type { NestedRepoScanResult } from '../../../../shared/project-group-types'
 import { defaultProjectGroupNameForPath, type AddRepoDialogStep } from './add-repo-dialog-types'
 
-type ShowNestedRepoReviewArgs = {
+export type ShowNestedRepoReviewArgs = {
   scan: NestedRepoScanResult
   selectedPath: string
   connectionId: string | null

--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -28,6 +28,7 @@ import {
 import { FolderPathStatusIndicator } from './FolderPathStatusIndicator'
 import { RepoScanUnavailableIndicator } from './RepoScanUnavailableIndicator'
 import {
+  ProjectGroupAddProjectButton,
   ProjectGroupCreateWorkspaceButton,
   ProjectGroupHeaderMenu
 } from './project-group-header-actions'
@@ -62,6 +63,7 @@ export type SectionHeaderRowContext = {
   onRenameProjectGroup: (groupId: string, currentName: string, hostId?: ExecutionHostId) => void
   onDeleteProjectGroup: (groupId: string, groupName: string, hostId?: ExecutionHostId) => void
   onCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
+  onAddProjectToGroup: (projectGroup: ProjectGroup) => void
   onWorkspaceStatusDragOver: (event: React.DragEvent, status: WorkspaceStatus) => void
   onWorkspaceStatusDragLeave: (event: React.DragEvent) => void
   onWorkspacePinDragOver: (event: React.DragEvent) => void
@@ -171,6 +173,16 @@ export function renderWorktreeSectionHeaderRow(args: {
         projectGroupId: folderBackedProjectGroup.id
       })
     : null
+  // Why: folder-backed groups already spend the Plus slot on "create workspace", and `createdFrom`
+  // narrows out the synthetic "Ungrouped" bucket, which has nothing to add a project to.
+  const projectGroupForAddProject =
+    isProjectGroupHeader &&
+    !row.repo &&
+    !folderBackedProjectGroup &&
+    row.projectGroup &&
+    'createdFrom' in row.projectGroup
+      ? row.projectGroup
+      : null
   const isHeaderCollapsed = ctx.collapsedGroups.has(row.key)
   // Why: repo/project/status/pinned share compact section chrome; flat "All" stays a simple label.
   const showHeaderCollapseAffordance =
@@ -376,6 +388,14 @@ export function renderWorktreeSectionHeaderRow(args: {
               pathStatus={projectGroupPathStatus}
               disabled={isFolderWorkspaceCreateDisabled(projectGroupPathStatus)}
               onCreate={ctx.onCreateFolderWorkspace}
+            />
+          ) : null}
+
+          {projectGroupForAddProject ? (
+            <ProjectGroupAddProjectButton
+              projectGroup={projectGroupForAddProject}
+              label={row.label}
+              onAddProject={ctx.onAddProjectToGroup}
             />
           ) : null}
 

--- a/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import { ProjectGroupAddProjectButton } from './project-group-header-actions'
+
+const group: ProjectGroup = {
+  id: 'group-1',
+  name: 'OSS',
+  parentPath: null,
+  connectionId: null,
+  executionHostId: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+let root: Root | null = null
+let container: HTMLDivElement
+
+function renderButton(
+  onAddProject: (projectGroup: ProjectGroup) => void,
+  rowHandlers: {
+    onClick?: () => void
+    onPointerDown?: () => void
+    onKeyDown?: () => void
+  } = {}
+): HTMLButtonElement {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(
+      <TooltipProvider>
+        {/* Why: the real header row arms drag/collapse on these events; the button must swallow them. */}
+        <div
+          onClick={rowHandlers.onClick}
+          onPointerDown={rowHandlers.onPointerDown}
+          onKeyDown={rowHandlers.onKeyDown}
+        >
+          <ProjectGroupAddProjectButton
+            projectGroup={group}
+            label="OSS"
+            onAddProject={onAddProject}
+          />
+        </div>
+      </TooltipProvider>
+    )
+  })
+  const button = container.querySelector('button')
+  if (!button) {
+    throw new Error('button did not render')
+  }
+  return button
+}
+
+describe('ProjectGroupAddProjectButton', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+      root = null
+    }
+    document.body.replaceChildren()
+  })
+
+  it('renders as a hover header action named after the group', () => {
+    const button = renderButton(vi.fn())
+
+    expect(button.getAttribute('aria-label')).toBe('Add project to OSS')
+    expect(button.hasAttribute('data-repo-header-action')).toBe(true)
+  })
+
+  it('hands the clicked group to the add-project callback', () => {
+    const onAddProject = vi.fn()
+    const button = renderButton(onAddProject)
+
+    act(() => {
+      button.click()
+    })
+
+    expect(onAddProject).toHaveBeenCalledTimes(1)
+    expect(onAddProject).toHaveBeenCalledWith(group)
+  })
+
+  it('does not let the click toggle the header row', () => {
+    const onClick = vi.fn()
+    const button = renderButton(vi.fn(), { onClick })
+
+    act(() => {
+      button.click()
+    })
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('does not arm the header drag on pointer down', () => {
+    const onPointerDown = vi.fn()
+    const button = renderButton(vi.fn(), { onPointerDown })
+
+    act(() => {
+      button.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
+    })
+
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+
+  it('keeps Enter on the button from collapsing the header', () => {
+    const onKeyDown = vi.fn()
+    const button = renderButton(vi.fn(), { onKeyDown })
+
+    act(() => {
+      button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    expect(onKeyDown).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.tsx
@@ -134,3 +134,45 @@ export function ProjectGroupCreateWorkspaceButton({
     </Tooltip>
   )
 }
+
+export function ProjectGroupAddProjectButton({
+  projectGroup,
+  label,
+  onAddProject
+}: {
+  projectGroup: ProjectGroup
+  label: string
+  onAddProject: (projectGroup: ProjectGroup) => void
+}): React.JSX.Element {
+  const addLabel = translate(
+    'auto.components.sidebar.WorktreeList.addProjectToGroup',
+    'Add project to {{value0}}',
+    { value0: label }
+  )
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          data-repo-header-action=""
+          className={REPO_HEADER_ACTION_BUTTON_CLASS}
+          aria-label={addLabel}
+          onKeyDown={stopRepoHeaderKeyboardToggle}
+          onPointerDown={handleRepoHeaderActionPointerDown}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onAddProject(projectGroup)
+          }}
+        >
+          <Plus className="size-3" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {addLabel}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
@@ -7,6 +7,7 @@ import { useProjectGroupDialogs, type ProjectGroupDialogs } from './use-project-
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 
 const mocks = vi.hoisted(() => ({
+  openModal: vi.fn(),
   moveProjectToGroup: vi.fn(),
   createProjectGroup: vi.fn(),
   updateProjectGroup: vi.fn(),
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
+      openModal: mocks.openModal,
       moveProjectToGroup: mocks.moveProjectToGroup,
       createProjectGroup: mocks.createProjectGroup,
       updateProjectGroup: mocks.updateProjectGroup,
@@ -131,6 +133,17 @@ describe('project group dialogs carry the owner host', () => {
     expect(mocks.deleteProjectGroupWithContainedProjects).toHaveBeenCalledWith(remoteGroup.id, {
       removeContainedProjects: false,
       hostId: 'runtime:env-1'
+    })
+  })
+
+  it('opens Add Project targeted at the group and the host that owns it', async () => {
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleAddProjectToGroup(remoteGroup)
+    })
+
+    expect(mocks.openModal).toHaveBeenCalledWith('add-repo', {
+      addProjectTarget: { groupId: 'group-1', hostId: 'runtime:env-1' }
     })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
+import { addProjectTargetForGroup } from '@/lib/added-project-group-assignment'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
@@ -68,6 +69,7 @@ export function useProjectGroupDialogs(args: {
   projectGroups: readonly ProjectGroup[]
 }) {
   const { repos, repoMap, projectGroups } = args
+  const openModal = useAppStore((s) => s.openModal)
   const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
   const createProjectGroup = useAppStore((s) => s.createProjectGroup)
   const updateProjectGroup = useAppStore((s) => s.updateProjectGroup)
@@ -103,6 +105,13 @@ export function useProjectGroupDialogs(args: {
       setNameDialog({ type: 'rename', groupId, currentName, hostId })
     },
     []
+  )
+
+  const handleAddProjectToGroup = useCallback(
+    (projectGroup: ProjectGroup) => {
+      openModal('add-repo', { addProjectTarget: addProjectTargetForGroup(projectGroup) })
+    },
+    [openModal]
   )
 
   const handleSubmitProjectGroupName = useCallback(
@@ -199,6 +208,7 @@ export function useProjectGroupDialogs(args: {
     handleMoveProjectToGroup,
     handleRemoveProjectFromGroup,
     handleRenameProjectGroup,
+    handleAddProjectToGroup,
     handleSubmitProjectGroupName,
     handleDeleteProjectGroup,
     handleConfirmDeleteProjectGroup

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
@@ -50,6 +50,7 @@ export type VirtualizedWorktreeViewportProps = {
   handleRenameProjectGroup: (groupId: string, currentName: string, hostId?: ExecutionHostId) => void
   handleDeleteProjectGroup: (groupId: string, groupName: string, hostId?: ExecutionHostId) => void
   handleCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
+  handleAddProjectToGroup: (projectGroup: ProjectGroup) => void
   activeModal: string
   pendingRevealWorktree: PendingSidebarWorktreeReveal | null
   pendingRevealSidebarRow: PendingSidebarRowReveal | null

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -103,6 +103,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       onRenameProjectGroup: props.handleRenameProjectGroup,
       onDeleteProjectGroup: props.handleDeleteProjectGroup,
       onCreateFolderWorkspace: props.handleCreateFolderWorkspace,
+      onAddProjectToGroup: props.handleAddProjectToGroup,
       onWorkspaceStatusDragOver: statusDrag.handleWorkspaceStatusDragOver,
       onWorkspaceStatusDragLeave: statusDrag.handleWorkspaceStatusDragLeave,
       onWorkspacePinDragOver: statusDrag.handleWorkspacePinDragOver,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -547,6 +547,13 @@
       }
     },
     "lib": {
+      "added-project-group-assignment": {
+        "groupGone": "The group is no longer available",
+        "hostMismatch": "{{group}} is on a different host",
+        "moveFailed": "Could not add the project to {{group}}",
+        "stayedUngrouped": "{{project}} was added but stays outside the group.",
+        "unexpected": "Could not add the project to the group"
+      },
       "agent": {
         "catalog": {
           "5dff448636": "OpenClaw",
@@ -5635,6 +5642,7 @@
           "e97297cb75": "Hide {{value0}} child workspace",
           "0cd15956d4": "Hide {{value0}} child workspaces",
           "bd37a57ac8": "Create workspace for {{value0}}",
+          "addProjectToGroup": "Add project to {{value0}}",
           "b667b59632": "Some projects could not be removed from Orca",
           "f94466bc39": "{{value0}} of {{value1}} contained project{{value2}} remained after deleting the group.",
           "groupDeleteFailed": "Failed to delete group",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -318,6 +318,13 @@
       }
     },
     "lib": {
+      "added-project-group-assignment": {
+        "groupGone": "El grupo ya no está disponible",
+        "hostMismatch": "{{group}} está en otro host",
+        "moveFailed": "No se pudo añadir el proyecto a {{group}}",
+        "stayedUngrouped": "{{project}} se añadió, pero permanece fuera del grupo.",
+        "unexpected": "No se pudo añadir el proyecto al grupo"
+      },
       "agent": {
         "catalog": {
           "5dff448636": "OpenClaw",
@@ -4735,6 +4742,7 @@
           "e97297cb75": "Ocultar {{value0}} espacio de trabajo secundario",
           "0cd15956d4": "Ocultar {{value0}} espacios de trabajo secundarios",
           "bd37a57ac8": "Crear espacio de trabajo para {{value0}}",
+          "addProjectToGroup": "Añadir proyecto a {{value0}}",
           "b667b59632": "Algunos proyectos no se pudieron eliminar de Orca",
           "f94466bc39": "{{value0}} de {{value1}} proyecto{{value2}} contenido(s) permanecieron tras eliminar el grupo.",
           "groupDeleteFailed": "No se pudo eliminar el grupo",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -420,6 +420,13 @@
       }
     },
     "lib": {
+      "added-project-group-assignment": {
+        "groupGone": "Le groupe n'est plus disponible",
+        "hostMismatch": "{{group}} se trouve sur un autre hôte",
+        "moveFailed": "Impossible d'ajouter le projet à {{group}}",
+        "stayedUngrouped": "{{project}} a été ajouté mais reste en dehors du groupe.",
+        "unexpected": "Impossible d'ajouter le projet au groupe"
+      },
       "agent": {
         "catalog": {
           "5dff448636": "OpenClaw",
@@ -5385,6 +5392,7 @@
           "e97297cb75": "Masquer {{value0}} espace de travail enfant",
           "0cd15956d4": "Masquer {{value0}} espaces de travail enfants",
           "bd37a57ac8": "Créer un espace de travail pour {{value0}}",
+          "addProjectToGroup": "Ajouter un projet à {{value0}}",
           "b667b59632": "Certains projets n'ont pas pu être retirés d'Orca",
           "f94466bc39": "{{value0}} projet{{value2}} sur {{value1}} est resté après la suppression du groupe.",
           "groupDeleteFailed": "Échec de la suppression du groupe",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -318,6 +318,13 @@
       }
     },
     "lib": {
+      "added-project-group-assignment": {
+        "groupGone": "このグループは利用できなくなりました",
+        "hostMismatch": "{{group}} は別のホストにあります",
+        "moveFailed": "プロジェクトを {{group}} に追加できませんでした",
+        "stayedUngrouped": "{{project}} は追加されましたが、グループの外に残っています。",
+        "unexpected": "プロジェクトをグループに追加できませんでした"
+      },
       "agent": {
         "catalog": {
           "5dff448636": "OpenClaw",
@@ -4716,6 +4723,7 @@
           "e97297cb75": "{{value0}} 個の子ワークスペースを非表示",
           "0cd15956d4": "{{value0}} 個の子ワークスペースを非表示",
           "bd37a57ac8": "{{value0}} のワークスペースを作成",
+          "addProjectToGroup": "{{value0}} にプロジェクトを追加",
           "b667b59632": "一部のプロジェクトを Orca から削除できませんでした",
           "f94466bc39": "グループ削除後も、含まれていたプロジェクト{{value2}} {{value1}} 件中 {{value0}} 件が残りました。",
           "groupDeleteFailed": "グループの削除に失敗しました",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -321,6 +321,13 @@
       }
     },
     "lib": {
+      "added-project-group-assignment": {
+        "groupGone": "그룹을 더 이상 사용할 수 없습니다",
+        "hostMismatch": "{{group}}은(는) 다른 호스트에 있습니다",
+        "moveFailed": "프로젝트를 {{group}}에 추가하지 못했습니다",
+        "stayedUngrouped": "{{project}}이(가) 추가되었지만 그룹 밖에 남아 있습니다.",
+        "unexpected": "프로젝트를 그룹에 추가하지 못했습니다"
+      },
       "agent": {
         "catalog": {
           "5dff448636": "OpenClaw",
@@ -4721,6 +4728,7 @@
           "e97297cb75": "{{value0}}개 하위 워크스페이스 숨기기",
           "0cd15956d4": "{{value0}}개 하위 워크스페이스 숨기기",
           "bd37a57ac8": "{{value0}}에 대한 워크스페이스 만들기",
+          "addProjectToGroup": "{{value0}}에 프로젝트 추가",
           "b667b59632": "일부 프로젝트를 Orca에서 제거하지 못했습니다.",
           "f94466bc39": "그룹 삭제 후에도 {{value0}}/{{value1}} 프로젝트{{value2}}가 남아 있습니다.",
           "groupDeleteFailed": "그룹을 삭제하지 못했습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -321,6 +321,13 @@
       }
     },
     "lib": {
+      "added-project-group-assignment": {
+        "groupGone": "该分组已不可用",
+        "hostMismatch": "{{group}} 位于其他主机",
+        "moveFailed": "无法将项目添加到 {{group}}",
+        "stayedUngrouped": "{{project}} 已添加，但仍在分组之外。",
+        "unexpected": "无法将项目添加到分组"
+      },
       "agent": {
         "catalog": {
           "5dff448636": "OpenClaw",
@@ -4764,6 +4771,7 @@
           "e97297cb75": "隐藏 {{value0}} 个子工作区",
           "0cd15956d4": "隐藏 {{value0}} 个子工作区",
           "bd37a57ac8": "为 {{value0}} 创建工作区",
+          "addProjectToGroup": "向 {{value0}} 添加项目",
           "b667b59632": "部分项目无法从 Orca 中移除",
           "f94466bc39": "删除分组后，{{value1}} 个包含项目{{value2}}中仍剩 {{value0}} 个。",
           "groupDeleteFailed": "删除分组失败",

--- a/src/renderer/src/lib/added-project-group-assignment.test.ts
+++ b/src/renderer/src/lib/added-project-group-assignment.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProjectGroup } from '../../../shared/project-group-types'
+import type { Repo } from '../../../shared/repo-types'
+import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../../shared/execution-host'
+import {
+  addProjectTargetForGroup,
+  assignAddedProjectToTargetGroup,
+  readAddProjectTarget,
+  type AddedProjectGroupAssignmentState
+} from './added-project-group-assignment'
+
+const mocks = vi.hoisted(() => ({ toastError: vi.fn() }))
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
+
+function makeRepo(overrides: Partial<Repo> & { id: string }): Repo {
+  return {
+    path: `/tmp/${overrides.id}`,
+    displayName: overrides.id,
+    projectGroupId: null,
+    connectionId: null,
+    executionHostId: null,
+    ...overrides
+  } as Repo
+}
+
+function makeGroup(overrides: Partial<ProjectGroup> & { id: string; name: string }): ProjectGroup {
+  return {
+    parentPath: null,
+    connectionId: null,
+    executionHostId: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  }
+}
+
+const LOCAL_GROUP = makeGroup({ id: 'group-1', name: 'OSS' })
+
+function makeState(
+  overrides: Partial<AddedProjectGroupAssignmentState> = {}
+): AddedProjectGroupAssignmentState {
+  return {
+    addProjectTarget: { groupId: 'group-1', hostId: LOCAL_EXECUTION_HOST_ID },
+    projectGroups: [LOCAL_GROUP],
+    moveProjectToGroup: vi.fn().mockResolvedValue(true),
+    clearAddProjectTarget: vi.fn(),
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  mocks.toastError.mockReset()
+})
+
+describe('addProjectTargetForGroup', () => {
+  it('names the local host for a group without a host stamp', () => {
+    expect(addProjectTargetForGroup(LOCAL_GROUP)).toEqual({
+      groupId: 'group-1',
+      hostId: LOCAL_EXECUTION_HOST_ID
+    })
+  })
+
+  // Why: the store keys groups on [host, id], so the target must carry the owner host too.
+  it('derives the SSH host from the connection id', () => {
+    const group = makeGroup({ id: 'group-1', name: 'OSS', connectionId: 'ssh-1' })
+
+    expect(addProjectTargetForGroup(group)).toEqual({
+      groupId: 'group-1',
+      hostId: toSshExecutionHostId('ssh-1')
+    })
+  })
+
+  it('prefers the stamped execution host over the connection id', () => {
+    const group = makeGroup({
+      id: 'group-1',
+      name: 'OSS',
+      connectionId: 'ssh-1',
+      executionHostId: 'runtime:env-1'
+    })
+
+    expect(addProjectTargetForGroup(group)).toEqual({ groupId: 'group-1', hostId: 'runtime:env-1' })
+  })
+})
+
+describe('readAddProjectTarget', () => {
+  it('reads a well-formed target out of modal data', () => {
+    expect(
+      readAddProjectTarget({ addProjectTarget: { groupId: 'group-1', hostId: 'local' } })
+    ).toEqual({ groupId: 'group-1', hostId: 'local' })
+  })
+
+  it.each([
+    ['no target', {}],
+    ['a non-object target', { addProjectTarget: 'group-1' }],
+    ['a missing host', { addProjectTarget: { groupId: 'group-1' } }],
+    ['a missing group', { addProjectTarget: { hostId: 'local' } }],
+    ['an empty group id', { addProjectTarget: { groupId: '', hostId: 'local' } }]
+  ])('returns null for %s', (_label, data) => {
+    expect(readAddProjectTarget(data)).toBeNull()
+  })
+
+  // Why: both sides of the later host comparison normalize, so the target must too or a padded
+  // id would misreport the group as gone.
+  it('normalizes a padded host id', () => {
+    expect(
+      readAddProjectTarget({ addProjectTarget: { groupId: 'group-1', hostId: ' local ' } })
+    ).toEqual({ groupId: 'group-1', hostId: LOCAL_EXECUTION_HOST_ID })
+  })
+
+  it('rejects a host id that is not an execution host', () => {
+    expect(
+      readAddProjectTarget({ addProjectTarget: { groupId: 'group-1', hostId: 'nope' } })
+    ).toBeNull()
+  })
+})
+
+describe('assignAddedProjectToTargetGroup', () => {
+  it('moves the added project into the target group', async () => {
+    const state = makeState()
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+
+    expect(state.moveProjectToGroup).toHaveBeenCalledWith('repo-1', 'group-1')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the add flow has no target', async () => {
+    const state = makeState({ addProjectTarget: null })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+
+    expect(state.moveProjectToGroup).not.toHaveBeenCalled()
+    expect(state.clearAddProjectTarget).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  // Why: re-adding an existing project must keep the group it already has.
+  it('leaves an already grouped project where it is', async () => {
+    const state = makeState()
+
+    await assignAddedProjectToTargetGroup(
+      state,
+      makeRepo({ id: 'repo-1', projectGroupId: 'group-other' })
+    )
+
+    expect(state.moveProjectToGroup).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  // Why: skipping the move must still burn the target, or it stays armed for the next add.
+  it.each([
+    ['the project is already grouped', { id: 'repo-1', projectGroupId: 'group-other' }],
+    ['the target group is gone', { id: 'repo-1' }],
+    ['the hosts do not match', { id: 'repo-1', connectionId: 'ssh-1' }]
+  ])('consumes the target even when %s', async (label, repoOverrides) => {
+    const state = makeState(label === 'the target group is gone' ? { projectGroups: [] } : {})
+
+    await assignAddedProjectToTargetGroup(state, makeRepo(repoOverrides))
+
+    expect(state.clearAddProjectTarget).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: without this, a later unrelated add would inherit the group.
+  it('consumes the target so it applies to one project only', async () => {
+    const state = makeState()
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+
+    expect(state.clearAddProjectTarget).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a target group that disappeared mid-flow', async () => {
+    const state = makeState({ projectGroups: [] })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+
+    expect(state.moveProjectToGroup).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: the store keys groups on [host, id], so a same-id group on another host is not the target.
+  it('does not match a same-id group belonging to another host', async () => {
+    const state = makeState({
+      projectGroups: [makeGroup({ id: 'group-1', name: 'OSS', connectionId: 'ssh-1' })]
+    })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+
+    expect(state.moveProjectToGroup).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: the backend normalizes an unknown group to null and still reports success, so a
+  // cross-host move would silently leave the project ungrouped.
+  it('refuses to move a project onto a group from a different host', async () => {
+    const state = makeState()
+
+    await assignAddedProjectToTargetGroup(
+      state,
+      makeRepo({ id: 'repo-1', connectionId: 'ssh-1', displayName: 'orca' })
+    )
+
+    expect(state.moveProjectToGroup).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    const [message, options] = mocks.toastError.mock.calls[0]
+    expect(String(message)).toContain('OSS')
+    expect(String(options?.description)).toContain('orca')
+  })
+
+  it('reports a rejected move instead of leaving the project silently ungrouped', async () => {
+    const state = makeState({ moveProjectToGroup: vi.fn().mockResolvedValue(false) })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1', displayName: 'orca' }))
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    const [message, options] = mocks.toastError.mock.calls[0]
+    expect(String(message)).toContain('OSS')
+    expect(String(options?.description)).toContain('orca')
+  })
+
+  // Why: callers discard the promise, so a throw here would land in an unhandled rejection.
+  it('never rejects when the move throws', async () => {
+    const state = makeState({
+      moveProjectToGroup: vi.fn().mockRejectedValue(new Error('host offline'))
+    })
+
+    await expect(
+      assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+    ).resolves.toBeUndefined()
+  })
+
+  it('never rejects when the store shape is unexpected', async () => {
+    const state = makeState({
+      projectGroups: undefined as unknown as readonly ProjectGroup[]
+    })
+
+    await expect(
+      assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }))
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('assignAddedProjectToTargetGroup with an explicit target', () => {
+  // Why: the non-git confirm dialog closes (dropping the store target) before its add resolves,
+  // so it hands the target down the call instead.
+  it('honors an explicit target after the store target is gone', async () => {
+    const state = makeState({ addProjectTarget: null })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }), {
+      groupId: 'group-1',
+      hostId: LOCAL_EXECUTION_HOST_ID
+    })
+
+    expect(state.moveProjectToGroup).toHaveBeenCalledWith('repo-1', 'group-1')
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('prefers the explicit target over a store target', async () => {
+    const state = makeState({
+      projectGroups: [LOCAL_GROUP, makeGroup({ id: 'group-2', name: 'Other' })]
+    })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1' }), {
+      groupId: 'group-2',
+      hostId: LOCAL_EXECUTION_HOST_ID
+    })
+
+    expect(state.moveProjectToGroup).toHaveBeenCalledWith('repo-1', 'group-2')
+  })
+})
+
+describe('assignAddedProjectToTargetGroup unexpected failures', () => {
+  // Why: never rejecting must not mean never telling the user.
+  it('reports an unexpected failure instead of only logging it', async () => {
+    const state = makeState({
+      projectGroups: undefined as unknown as readonly ProjectGroup[]
+    })
+
+    await assignAddedProjectToTargetGroup(state, makeRepo({ id: 'repo-1', displayName: 'orca' }))
+
+    expect(mocks.toastError).toHaveBeenCalledTimes(1)
+    const [, options] = mocks.toastError.mock.calls[0]
+    expect(String(options?.description)).toContain('orca')
+  })
+})

--- a/src/renderer/src/lib/added-project-group-assignment.ts
+++ b/src/renderer/src/lib/added-project-group-assignment.ts
@@ -1,0 +1,144 @@
+import { toast } from 'sonner'
+import type { ProjectGroup } from '../../../shared/project-group-types'
+import type { Repo } from '../../../shared/repo-types'
+import {
+  getRepoExecutionHostId,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
+import { getProjectGroupHostId } from '@/store/slices/project-group-owner-routing'
+import { ERROR_TOAST_DURATION } from '@/store/repos/repo-state'
+import { translate } from '@/i18n/i18n'
+
+/** Group an Add Project flow was launched from. Carries the owner host: one store list holds every host's groups, keyed on [host, id]. */
+export type AddProjectTarget = {
+  groupId: string
+  hostId: ExecutionHostId
+}
+
+export type AddedProjectGroupAssignmentState = {
+  addProjectTarget: AddProjectTarget | null
+  projectGroups: readonly ProjectGroup[]
+  moveProjectToGroup: (projectId: string, groupId: string | null) => Promise<boolean>
+  clearAddProjectTarget: () => void
+}
+
+export function addProjectTargetForGroup(
+  group: Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>
+): AddProjectTarget {
+  return { groupId: group.id, hostId: getProjectGroupHostId(group) }
+}
+
+export function readAddProjectTarget(data: Record<string, unknown>): AddProjectTarget | null {
+  const target = data.addProjectTarget
+  if (!target || typeof target !== 'object') {
+    return null
+  }
+  const { groupId, hostId: rawHostId } = target as Partial<AddProjectTarget>
+  // Why: the host comparison downstream normalizes both sides, so the target must match.
+  const hostId = typeof rawHostId === 'string' ? normalizeExecutionHostId(rawHostId) : null
+  if (typeof groupId !== 'string' || !groupId || !hostId) {
+    return null
+  }
+  return { groupId, hostId }
+}
+
+/**
+ * Moves a project into the group its Add Project flow targeted. The target is consumed on the
+ * first attempt so a later, unrelated add cannot inherit it. Callers whose modal closes before
+ * the add resolves pass the target explicitly, since closing drops it from the store.
+ */
+export async function assignAddedProjectToTargetGroup(
+  state: AddedProjectGroupAssignmentState,
+  repo: Repo,
+  explicitTarget?: AddProjectTarget | null
+): Promise<void> {
+  // Why: fire-and-forget callers discard the promise, so nothing here may reject —
+  // not even the failure-reporting path.
+  try {
+    const target = explicitTarget ?? state.addProjectTarget
+    if (!target) {
+      return
+    }
+    // Why: consume before any other exit, or a skipped assignment leaves the target armed
+    // for the next unrelated add.
+    state.clearAddProjectTarget()
+    // Why: re-adding an existing project must keep the group it already has.
+    if (repo.projectGroupId) {
+      return
+    }
+
+    const group = state.projectGroups.find(
+      (candidate) =>
+        candidate.id === target.groupId && getProjectGroupHostId(candidate) === target.hostId
+    )
+    if (!group) {
+      console.error('[project-group] target group is gone', { target, repoId: repo.id })
+      reportAssignmentFailure(
+        translate(
+          'auto.lib.added-project-group-assignment.groupGone',
+          'The group is no longer available'
+        ),
+        repo
+      )
+      return
+    }
+
+    // Why: moveProjectToGroup routes by the project's host, and a backend that does not know
+    // the group silently normalizes it to null while still reporting success.
+    const repoHostId = getRepoExecutionHostId(repo)
+    if (repoHostId !== target.hostId) {
+      console.error('[project-group] cross-host assignment refused', {
+        target,
+        repoId: repo.id,
+        repoHostId
+      })
+      reportAssignmentFailure(
+        translate(
+          'auto.lib.added-project-group-assignment.hostMismatch',
+          '{{group}} is on a different host',
+          { group: group.name }
+        ),
+        repo
+      )
+      return
+    }
+
+    if (await state.moveProjectToGroup(repo.id, target.groupId)) {
+      return
+    }
+    console.error('[project-group] move rejected', { target, repoId: repo.id })
+    reportAssignmentFailure(
+      translate(
+        'auto.lib.added-project-group-assignment.moveFailed',
+        'Could not add the project to {{group}}',
+        { group: group.name }
+      ),
+      repo
+    )
+  } catch (err) {
+    console.error('[project-group] assignment threw', { repoId: repo.id, err })
+    try {
+      reportAssignmentFailure(
+        translate(
+          'auto.lib.added-project-group-assignment.unexpected',
+          'Could not add the project to the group'
+        ),
+        repo
+      )
+    } catch {
+      // Why: reporting itself failed; the console.error above is the last resort.
+    }
+  }
+}
+
+function reportAssignmentFailure(message: string, repo: Repo): void {
+  toast.error(message, {
+    description: translate(
+      'auto.lib.added-project-group-assignment.stayedUngrouped',
+      '{{project}} was added but stays outside the group.',
+      { project: repo.displayName }
+    ),
+    duration: ERROR_TOAST_DURATION
+  })
+}

--- a/src/renderer/src/store/project-groups/project-group-mutations.ts
+++ b/src/renderer/src/store/project-groups/project-group-mutations.ts
@@ -246,6 +246,15 @@ export function createProjectGroupMutationActions(
             folderWorkspacePathStatuses: {}
           }
         })
+        // Why: the host normalizes an unknown group to null and still returns the repo, so the
+        // store reflects what it persisted but the move itself did not happen.
+        if ((ownedMoved.projectGroupId ?? null) !== groupId) {
+          console.error('Project group move was normalized away by the host:', {
+            projectId,
+            groupId
+          })
+          return false
+        }
         return true
       } catch (err) {
         console.error('Failed to move repo to group:', err)

--- a/src/renderer/src/store/repos/repo-add-actions.ts
+++ b/src/renderer/src/store/repos/repo-add-actions.ts
@@ -26,6 +26,7 @@ import {
 import { mergeProjectCompatibilityForHostRepoChange } from './repo-catalog-identity'
 import { warnIfProjectKnownInAnotherProfile } from '../projects/project-profile-presence'
 import { warnIfProjectCrossesWslFilesystemBoundary } from '../projects/project-wsl-filesystem-boundary-advisory'
+import { assignAddedProjectToTargetGroup } from '@/lib/added-project-group-assignment'
 
 export function createRepoAddActions(
   set: Parameters<StateCreator<AppState>>[0],
@@ -86,8 +87,11 @@ export function createRepoAddActions(
           }
           // Why: folder mode is a capability downgrade (no worktrees/SCM/PRs/checks), so confirm via dialog rather than silently falling back.
           const { openModal } = get()
+          const addProjectTarget = options?.addProjectTarget ?? get().addProjectTarget
           openModal('confirm-non-git-folder', {
             folderPath: path,
+            // Why: openModal only keeps a target the opener re-declares, so carry it across the handoff.
+            ...(addProjectTarget ? { addProjectTarget } : {}),
             ...(displayName ? { displayName } : {}),
             ...(target.kind === 'environment' ? { runtimeEnvironmentId: target.environmentId } : {})
           })
@@ -133,6 +137,9 @@ export function createRepoAddActions(
           // Why after the set(): the project row carrying the runtime override only exists once the repo is in state.
           warnIfProjectCrossesWslFilesystemBoundary(repo, get().projects, get().settings)
         }
+        // Why: the project is already added; blocking this return on the group move would make
+        // every caller wait out moveProjectToGroup's remote timeout on a slow host.
+        void assignAddedProjectToTargetGroup(get(), repo, options?.addProjectTarget)
         return repo
       } catch (err) {
         console.error('Failed to add project:', err)

--- a/src/renderer/src/store/repos/repo-state.ts
+++ b/src/renderer/src/store/repos/repo-state.ts
@@ -25,6 +25,7 @@ import type {
   FolderWorkspacePathStatusRequest
 } from '../../../../shared/folder-workspace-path-status'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { AddProjectTarget } from '../../lib/added-project-group-assignment'
 
 export const ERROR_TOAST_DURATION = 60_000
 
@@ -134,6 +135,8 @@ export type AddRepoPathOptions = {
   runtimeEnvironmentId?: string | null
   /** Overrides the host's basename naming for the new project. */
   displayName?: string
+  /** Group to place the project in; wins over the UI slice's in-flight target. */
+  addProjectTarget?: AddProjectTarget | null
 }
 
 export type RuntimeCatalogFetchOptions = { runtimeEnvironmentId?: string | null }

--- a/src/renderer/src/store/slices/repos-add-project-target-group.test.ts
+++ b/src/renderer/src/store/slices/repos-add-project-target-group.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import { upsertAddedRepoWithProjectHostSetup } from '../../components/sidebar/add-repo-store-upsert'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../../../shared/execution-host'
+import {
+  addProjectTargetForGroup,
+  type AddProjectTarget
+} from '../../lib/added-project-group-assignment'
+import {
+  installReposRuntimeRoutingHarness,
+  projectGroupsMoveProject,
+  reposAdd
+} from './repos-runtime-routing-fixture'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() }
+}))
+
+installReposRuntimeRoutingHarness()
+
+const LOCAL_TARGET: AddProjectTarget = { groupId: 'group-1', hostId: LOCAL_EXECUTION_HOST_ID }
+
+const projectGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'OSS',
+  parentPath: null,
+  connectionId: null,
+  executionHostId: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const addedRepo: Repo = {
+  id: 'repo-1',
+  path: '/tmp/orca',
+  displayName: 'orca',
+  badgeColor: '#111',
+  addedAt: 2
+}
+
+beforeEach(() => {
+  reposAdd.mockResolvedValue({ repo: addedRepo })
+  projectGroupsMoveProject.mockImplementation(({ groupId }: { groupId: string | null }) => ({
+    ...addedRepo,
+    projectGroupId: groupId
+  }))
+})
+
+// Why: the assignment is fire-and-forget; advance a few ticks so a move that would fire has
+// fired before asserting it did not.
+async function flushAssignment(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+// Why: the add-project entry points split across two funnels — the repo slice's addRepoPath
+// and the dialog-side upsert helper. A target group has to survive both.
+describe('add project into a target group', () => {
+  it('assigns a project added through addRepoPath', async () => {
+    const store = createTestStore()
+    store.setState({ projectGroups: [projectGroup], addProjectTarget: LOCAL_TARGET })
+
+    await store.getState().addRepoPath('/tmp/orca')
+    // Why: the move lands after addRepoPath resolves, so poll rather than assert straight through.
+    await vi.waitFor(() => expect(projectGroupsMoveProject).toHaveBeenCalled())
+
+    expect(projectGroupsMoveProject).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'repo-1', groupId: 'group-1' })
+    )
+  })
+
+  // Why: the project is already persisted when addRepoPath returns; waiting on the group move
+  // would expose moveProjectToGroup's remote timeout to every caller.
+  it('returns from addRepoPath without waiting for the group move', async () => {
+    const store = createTestStore()
+    let releaseMove = (): void => {}
+    projectGroupsMoveProject.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseMove = () => resolve({ ...addedRepo, projectGroupId: 'group-1' })
+        })
+    )
+    store.setState({ projectGroups: [projectGroup], addProjectTarget: LOCAL_TARGET })
+
+    await expect(store.getState().addRepoPath('/tmp/orca')).resolves.toBeTruthy()
+
+    releaseMove()
+  })
+
+  it('assigns a project added through the dialog upsert helper', async () => {
+    // Why: the helper reads the app store singleton rather than an injected store.
+    const { useAppStore } = await import('../index')
+    useAppStore.setState({
+      repos: [],
+      projectGroups: [projectGroup],
+      addProjectTarget: LOCAL_TARGET
+    })
+
+    upsertAddedRepoWithProjectHostSetup(addedRepo)
+    await vi.waitFor(() => expect(projectGroupsMoveProject).toHaveBeenCalled())
+
+    expect(projectGroupsMoveProject).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'repo-1', groupId: 'group-1' })
+    )
+  })
+
+  it('leaves an add with no target ungrouped', async () => {
+    const store = createTestStore()
+    store.setState({ projectGroups: [projectGroup], addProjectTarget: null })
+
+    await store.getState().addRepoPath('/tmp/orca')
+    await flushAssignment()
+
+    expect(projectGroupsMoveProject).not.toHaveBeenCalled()
+  })
+
+  // Why: picking a folder that is already a project is still an explicit request to put it in
+  // this group, so it gets grouped rather than being a no-op the user cannot explain.
+  it('groups a re-added project that had no group', async () => {
+    const store = createTestStore()
+    store.setState({
+      repos: [addedRepo],
+      projectGroups: [projectGroup],
+      addProjectTarget: LOCAL_TARGET
+    })
+
+    await store.getState().addRepoPath('/tmp/orca')
+    await vi.waitFor(() => expect(projectGroupsMoveProject).toHaveBeenCalled())
+
+    expect(projectGroupsMoveProject).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'repo-1', groupId: 'group-1' })
+    )
+  })
+
+  // Why: the counterpart — an existing group is the user's earlier decision and outranks this one.
+  it('leaves a re-added project in the group it already had', async () => {
+    const store = createTestStore()
+    const groupedRepo = { ...addedRepo, projectGroupId: 'group-other' }
+    reposAdd.mockResolvedValue({ repo: groupedRepo })
+    store.setState({
+      repos: [groupedRepo],
+      projectGroups: [projectGroup],
+      addProjectTarget: LOCAL_TARGET
+    })
+
+    await store.getState().addRepoPath('/tmp/orca')
+    await flushAssignment()
+
+    expect(projectGroupsMoveProject).not.toHaveBeenCalled()
+    expect(store.getState().repos.find((repo) => repo.id === 'repo-1')?.projectGroupId).toBe(
+      'group-other'
+    )
+  })
+
+  // Why: one Add Project flow places one project; a later unrelated add must not inherit it.
+  it('does not reuse the target for a second add', async () => {
+    const store = createTestStore()
+    store.setState({ projectGroups: [projectGroup], addProjectTarget: LOCAL_TARGET })
+
+    await store.getState().addRepoPath('/tmp/orca')
+    await vi.waitFor(() => expect(projectGroupsMoveProject).toHaveBeenCalled())
+    projectGroupsMoveProject.mockClear()
+    reposAdd.mockResolvedValue({ repo: { ...addedRepo, id: 'repo-2', path: '/tmp/other' } })
+    await store.getState().addRepoPath('/tmp/other')
+    await flushAssignment()
+
+    expect(projectGroupsMoveProject).not.toHaveBeenCalled()
+  })
+
+  // Why: a non-git path swaps add-repo for the confirm dialog; openModal only keeps a target the
+  // opener re-declares, so the handoff has to carry it or the folder lands ungrouped.
+  it('carries the target across the non-git folder confirmation handoff', async () => {
+    const store = createTestStore()
+    reposAdd.mockResolvedValue({ error: 'Not a valid git repository: /tmp/orca' })
+    store.getState().openModal('add-repo', { addProjectTarget: LOCAL_TARGET })
+    store.setState({ projectGroups: [projectGroup] })
+
+    await expect(store.getState().addRepoPath('/tmp/orca')).resolves.toBeNull()
+
+    expect(store.getState().activeModal).toBe('confirm-non-git-folder')
+    expect(store.getState().addProjectTarget).toEqual(LOCAL_TARGET)
+  })
+})
+
+describe('add project into a target group around the dialog boundary', () => {
+  it('arms the target the group header hands to openModal', () => {
+    const store = createTestStore()
+
+    store
+      .getState()
+      .openModal('add-repo', { addProjectTarget: addProjectTargetForGroup(projectGroup) })
+
+    expect(store.getState().activeModal).toBe('add-repo')
+    expect(store.getState().addProjectTarget).toEqual(LOCAL_TARGET)
+  })
+
+  // Why: NonGitFolderDialog starts the add and closes at once, which nulls the store target
+  // before the add can read it — so the dialog hands the target down the call instead.
+  it('groups a folder confirmed after the dialog closed', async () => {
+    const store = createTestStore()
+    reposAdd.mockResolvedValue({ repo: { ...addedRepo, kind: 'folder' } })
+    store.setState({ projectGroups: [projectGroup] })
+    store.getState().openModal('confirm-non-git-folder', {
+      folderPath: '/tmp/orca',
+      addProjectTarget: LOCAL_TARGET
+    })
+    const addProjectTarget = store.getState().addProjectTarget
+
+    const pending = store.getState().addRepoPath('/tmp/orca', 'folder', { addProjectTarget })
+    store.getState().closeModal()
+    await pending
+
+    await vi.waitFor(() =>
+      expect(projectGroupsMoveProject).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: 'repo-1', groupId: 'group-1' })
+      )
+    )
+  })
+
+  it('leaves a re-added project the upsert helper receives already grouped where it is', async () => {
+    const { useAppStore } = await import('../index')
+    const groupedRepo = { ...addedRepo, projectGroupId: 'group-other' }
+    useAppStore.setState({
+      repos: [groupedRepo],
+      projectGroups: [projectGroup],
+      addProjectTarget: LOCAL_TARGET
+    })
+
+    upsertAddedRepoWithProjectHostSetup(groupedRepo)
+    await flushAssignment()
+
+    expect(projectGroupsMoveProject).not.toHaveBeenCalled()
+    expect(useAppStore.getState().repos.find((repo) => repo.id === 'repo-1')?.projectGroupId).toBe(
+      'group-other'
+    )
+  })
+
+  it('assigns an SSH-hosted project added through the upsert helper to its SSH group', async () => {
+    const { useAppStore } = await import('../index')
+    const sshGroup: ProjectGroup = { ...projectGroup, connectionId: 'ssh-1' }
+    const sshRepo: Repo = { ...addedRepo, connectionId: 'ssh-1' }
+    projectGroupsMoveProject.mockImplementation(({ groupId }: { groupId: string | null }) => ({
+      ...sshRepo,
+      projectGroupId: groupId
+    }))
+    useAppStore.setState({
+      repos: [],
+      projectGroups: [sshGroup],
+      addProjectTarget: { groupId: 'group-1', hostId: toSshExecutionHostId('ssh-1') }
+    })
+
+    upsertAddedRepoWithProjectHostSetup(sshRepo, { sshConnectionId: 'ssh-1' })
+    await vi.waitFor(() => expect(projectGroupsMoveProject).toHaveBeenCalled())
+
+    expect(projectGroupsMoveProject).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'repo-1', groupId: 'group-1' })
+    )
+  })
+})

--- a/src/renderer/src/store/slices/repos-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups.test.ts
@@ -849,6 +849,18 @@ describe('project group store routing', () => {
     expect(store.getState().repos).toEqual([{ ...movedRepo, executionHostId: 'local' }])
   })
 
+  // Why: the host normalizes an unknown group to null and still returns the repo, so a
+  // returned row outside the requested group is a failed move, not a success.
+  it('reports a move the host normalized away instead of claiming success', async () => {
+    projectGroupsMoveProject.mockResolvedValue({ ...remoteRepo, projectGroupId: null })
+    const store = createTestStore()
+    store.setState({ repos: [remoteRepo], projectGroups: [projectGroup] })
+
+    await expect(store.getState().moveProjectToGroup(remoteRepo.id, projectGroup.id)).resolves.toBe(
+      false
+    )
+  })
+
   it('propagates specific folder workspace create failures to callers', async () => {
     folderWorkspacesCreate.mockRejectedValue(new Error('folder_workspace_path_missing:/srv/app'))
     const store = createTestStore()

--- a/src/renderer/src/store/slices/ui-add-project-target.test.ts
+++ b/src/renderer/src/store/slices/ui-add-project-target.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { createUIStore } from './ui-slice-test-harness'
+
+const TARGET = { groupId: 'group-1', hostId: 'local' }
+
+describe('createUISlice addProjectTarget', () => {
+  it('starts with no target', () => {
+    expect(createUIStore().getState().addProjectTarget).toBeNull()
+  })
+
+  it('stores the group and host when add-repo opens with a target', () => {
+    const store = createUIStore()
+
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    expect(store.getState().addProjectTarget).toEqual(TARGET)
+  })
+
+  it('clears the target when the flow ends', () => {
+    const store = createUIStore()
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    store.getState().closeModal()
+
+    expect(store.getState().addProjectTarget).toBeNull()
+  })
+
+  it('clears a stale target when add-repo opens without one', () => {
+    const store = createUIStore()
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    store.getState().openModal('add-repo')
+
+    expect(store.getState().addProjectTarget).toBeNull()
+  })
+
+  // Why: a non-git path closes add-repo and opens the confirm dialog, so that step
+  // re-declares the target rather than inheriting it.
+  it('accepts the target re-declared by a handoff step', () => {
+    const store = createUIStore()
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    store.getState().closeModal()
+    store
+      .getState()
+      .openModal('confirm-non-git-folder', { folderPath: '/tmp/x', addProjectTarget: TARGET })
+
+    expect(store.getState().addProjectTarget).toEqual(TARGET)
+  })
+
+  // Why: the file explorer opens this dialog on its own; it must not inherit a group
+  // the user picked for an earlier, unrelated add.
+  it('does not let an unrelated add inherit a target', () => {
+    const store = createUIStore()
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    store.getState().openModal('confirm-add-project-from-folder', { folderPath: '/tmp/y' })
+
+    expect(store.getState().addProjectTarget).toBeNull()
+  })
+
+  // Why: switching to an unrelated modal without closing first ends the add flow just the same,
+  // and the composer hosts its own Add Project dialog that would otherwise consume the target.
+  it('drops the target when a modal outside the add flow opens', () => {
+    const store = createUIStore()
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    store.getState().openModal('new-workspace-composer', { addProjectTarget: TARGET })
+
+    expect(store.getState().addProjectTarget).toBeNull()
+  })
+
+  it.each([
+    ['a missing host', { groupId: 'group-1' }],
+    ['a missing group', { hostId: 'local' }],
+    ['an empty group id', { groupId: '', hostId: 'local' }],
+    ['a non-object', 'group-1']
+  ])('rejects %s', (_label, addProjectTarget) => {
+    const store = createUIStore()
+
+    store.getState().openModal('add-repo', { addProjectTarget })
+
+    expect(store.getState().addProjectTarget).toBeNull()
+  })
+
+  it('is cleared by clearAddProjectTarget so one flow assigns one project', () => {
+    const store = createUIStore()
+    store.getState().openModal('add-repo', { addProjectTarget: TARGET })
+
+    store.getState().clearAddProjectTarget()
+
+    expect(store.getState().addProjectTarget).toBeNull()
+  })
+})

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-contextual.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-contextual.ts
@@ -8,6 +8,7 @@ import type { ContextualTourId } from '../../../../../shared/contextual-tours'
 import type { OrcaHookScriptKind } from '../../../lib/orca-hook-trust'
 import type { SettingsNavigationTarget } from '../../../lib/settings-navigation-types'
 import type { ExecutionHostId } from '../../../../../shared/execution-host'
+import type { AddProjectTarget } from '../../../lib/added-project-group-assignment'
 
 export type UISliceContextual = {
   openSettingsPage: () => void
@@ -51,6 +52,13 @@ export type UISliceContextual = {
     | 'new-workspace-composer'
     | 'confirm-orca-yaml-hooks'
   modalData: Record<string, unknown>
+  /**
+   * Group the in-flight Add Project flow targets. Re-read from modal data on every openModal, so
+   * it survives only the add-flow steps that re-declare it; also cleared on close and once an add
+   * consumes it.
+   */
+  addProjectTarget: AddProjectTarget | null
+  clearAddProjectTarget: () => void
   openModal: (modal: UISliceContextual['activeModal'], data?: Record<string, unknown>) => void
   closeModal: () => void
   featureTipsSeenIds: FeatureTipId[]

--- a/src/renderer/src/store/slices/ui/ui-slice-modal-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-modal-actions.ts
@@ -1,10 +1,20 @@
 import type { UISlice, UISliceGet, UISliceSet } from './ui-slice-contract'
 import { settleEvictedModalData } from '../modal-slot-dismissal'
+import { readAddProjectTarget } from '../../../lib/added-project-group-assignment'
+
+// Why: the steps an Add Project flow can pass through. Every openModal reassigns the target, so
+// any other modal ends the flow and drops it rather than arming it for an unrelated add.
+const ADD_PROJECT_TARGET_MODALS = new Set<UISlice['activeModal']>([
+  'add-repo',
+  'confirm-non-git-folder'
+])
 
 export function createUiModalActions(set: UISliceSet, get: UISliceGet): Partial<UISlice> {
   return {
     activeModal: 'none',
     modalData: {},
+    addProjectTarget: null,
+    clearAddProjectTarget: () => set({ addProjectTarget: null }),
     openModal: (modal, data = {}) => {
       if (modal === 'add-repo' || modal === 'create-worktree') {
         get().recordFeatureInteraction?.('workspace-creation')
@@ -12,13 +22,14 @@ export function createUiModalActions(set: UISliceSet, get: UISliceGet): Partial<
       const evicted = get().modalData
       set({
         activeModal: modal,
-        modalData: data
+        modalData: data,
+        addProjectTarget: ADD_PROJECT_TARGET_MODALS.has(modal) ? readAddProjectTarget(data) : null
       })
       settleEvictedModalData(evicted)
     },
     closeModal: () => {
       const evicted = get().modalData
-      set({ activeModal: 'none', modalData: {} })
+      set({ activeModal: 'none', modalData: {}, addProjectTarget: null })
       settleEvictedModalData(evicted)
     }
   }


### PR DESCRIPTION
## ELI5

Hover a project group in the sidebar and there is now a **+** next to the group's **…** menu. Click it, add a project the usual way, and the project lands inside that group instead of appearing at the top level and needing a separate "Move to group".

## What Changed

- **Group header action** — `ProjectGroupAddProjectButton` renders on plain project-group headers (not folder-backed ones, whose Plus already means "create workspace"; never on the synthetic *Ungrouped* bucket). It opens the existing Add Project dialog with `openModal('add-repo', { addProjectTarget: { groupId, hostId } })`.
- **`addProjectTarget` in the UI slice** — host-scoped target for the in-flight add flow. Every `openModal` reassigns it, so only the add-flow steps that re-declare it (`add-repo`, `confirm-non-git-folder`) keep it; `closeModal` and any other modal drop it, so an unrelated later add can never inherit a group.
- **Assignment** (`lib/added-project-group-assignment.ts`) runs fire-and-forget from both add funnels — `addRepoPath` and `upsertAddedRepoWithProjectHostSetup` — so clone, create, local folder, SSH path and non-git folder all land in the group. It consumes the target before any other exit, keeps an already-grouped re-added project where it is, refuses cross-host moves, never rejects, and toasts on every failure (the project stays added, just ungrouped).
- **Explicit target** via `AddRepoPathOptions.addProjectTarget` for flows that close the dialog before the add resolves (`NonGitFolderDialog` confirm) and for multi-folder picks, so every folder selected in one Browse lands in the group.
- **Host selector** seeds from the target's host, so adding to a remote group routes the add to the host that owns it instead of failing after the fact.
- **`moveProjectToGroup`** now returns `false` when the host normalized the requested group away (it persists `null` and still returns the repo), which also hardens the existing drag/menu move.

## Why

Setting up a group meant three steps per project: add it from the sidebar (it lands ungrouped), open the *project's* menu, **Move to group**. The group header is where the intent is, so that is where the action belongs.

## Linked Issue

Fixes #11963

## Visual Proof

**Before:** a project group's hover actions were only collapse and **…** (Rename / Delete group) — nothing on the group could receive a project.

**After:**

| Group header hover | Add Project dialog opened from the group | Result |
| --- | --- | --- |
| ![group header hover](https://raw.githubusercontent.com/jeongph/orca/assets/add-project-from-group-header/group-header-hover.png) | ![add project dialog](https://raw.githubusercontent.com/jeongph/orca/assets/add-project-from-group-header/add-project-dialog.png) | ![result](https://raw.githubusercontent.com/jeongph/orca/assets/add-project-from-group-header/result.png) |

1. The **+** on the `OSS` header, right of the **…** menu.
2. The unchanged Add Project dialog it opens (host preselected from the group).
3. `second-project` landed inside `OSS`; `loose-repo`, added without a target, stays outside. Captured on a windowless dev build driven over CDP — the add went through `addRepoPath`, the funnel behind **Browse folder**.

## Testing

Platform: macOS (local host). SSH/remote paths are covered by unit tests (host-scoped target, SSH non-git handoff, remote host seeding), not by a live SSH session.

- [x] I manually tested these changes locally — windowless dev build over CDP: clicked **+** on `OSS`, saw `addProjectTarget` armed, added a repo through the dialog's funnel, and verified it landed in `OSS` while an untargeted add stayed ungrouped (screenshots above).
- [x] Automated tests added/updated:
  - `lib/added-project-group-assignment.test.ts` — every branch of the assignment (consume-first, re-add keeps group, gone group, cross-host refusal, rejected move, never rejects, explicit target, host-id normalization).
  - `store/slices/ui-add-project-target.test.ts` — target lifetime across `openModal` / `closeModal` / handoff / unrelated modals.
  - `store/slices/repos-add-project-target-group.test.ts` — both funnels through the real store, target survives the confirm-dialog close, SSH-hosted upsert, non-reuse across adds.
  - `store/slices/repos-project-groups.test.ts` — normalized-away move reports `false`.
  - `NonGitFolderDialog.test.tsx` — confirm hands the target down even though it closes the dialog first (local and SSH branches).
  - `useAddRepoLocalFolderFlow.test.ts` — every folder in a multi-select batch carries the target.
  - `AddRepoSteps.default-checkout.test.ts`, `useAddRepoNestedImportFlow.test.ts` — SSH / nested handoffs re-declare the target.
  - `use-add-repo-host-selection.test.ts` — host seeded from the target, focused-host fallback.
  - `WorktreeList.group-headers.test.ts` — real render: button on plain groups, absent on folder-backed groups and on *Ungrouped*.
  - `project-group-header-actions.test.tsx` — click hands the group over; click / pointerdown / Enter do not reach the header row.
  - `use-project-group-dialogs-owner-host.test.tsx` — the header handler opens `add-repo` targeted at the group's owner host.
- `pnpm typecheck`, changed-file lint, localization verifiers, and the sidebar / store / lib / i18n suites (654 files, 5922 tests) pass locally.

## Not in this PR

Nested-repo import (a parent folder containing several repos, imported "separately" or "as group") goes through `importNestedRepos`, which bypasses both funnels, so those projects still land outside the target group. Worth a follow-up; noting it here so it is not read as covered.

## AI Disclosure

Written with Claude Code (Claude Fable 5.1); reviewed with opus-model review agents whose findings — the confirm-dialog target drop, the normalized-away move, multi-folder picks, host seeding — are fixed and covered by the tests above. All code was read and verified by me.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- SSH / remote: groups and projects are matched on `[host, id]`; a cross-host move is refused with a toast rather than silently landing ungrouped. The dialog opens on the group's host.
- Folder workspaces: folder-backed groups deliberately do not get the button (their Plus is "create workspace"); assignment is skipped for them because nothing arms a target.
- Cross-platform: no path or shortcut handling added.
- i18n: new keys in all six locales (`auto.components.sidebar.WorktreeList.addProjectToGroup`, `auto.lib.added-project-group-assignment.*`).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

---

**History:** this PR originally added an *Add project* item to the group's **…** menu. It has been rewritten as a header **+** button on top of current `main` (the previous branch was ~2.5k commits behind and `WorktreeList.tsx` has since been split into `worktree-list/*`), keeping the store-level design the earlier reviews validated.
