### PR TITLE
fix(opencode): preserve PermissionRequest metadata

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -372,6 +372,28 @@ describe('shared agent-hook-listener', () => {
     expect(event?.payload.interactivePrompt).toBe(JSON.stringify(properties))
   })
 
+  it('captures tool metadata for the OpenCode PermissionRequest route', () => {
+    const event = normalizeHookPayload(
+      state,
+      'opencode',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'touch /tmp/zeddeck-test' }
+        }
+      },
+      'production'
+    )
+    expect(event?.payload.state).toBe('waiting')
+    expect(event?.payload.toolName).toBe('Bash')
+    expect(event?.payload.toolInput).toBe('touch /tmp/zeddeck-test')
+    expect(event?.payload.interactivePrompt).toBe(
+      JSON.stringify({ approval: { tool: 'Bash', summary: 'touch /tmp/zeddeck-test' } })
+    )
+  })
+
   it('maps Pi tool_call ask_user_question to blocked with interactivePrompt', () => {
     const questions = {
       questions: [

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1650,6 +1650,21 @@ function extractOpenCodeToolFields(
       interactivePrompt: deriveInteractivePrompt('AskUserQuestion', toolInputSource)
     }
   }
+  if (eventName === 'PermissionRequest') {
+    const toolName = readFirstString(hookPayload, ['tool_name', 'name']) ?? 'OpenCode'
+    const rawInput =
+      hookPayload.tool_input ?? hookPayload.input ?? hookPayload.tool ?? stripHookEnvelopeKeys(hookPayload)
+    const toolInput =
+      deriveToolInputPreview(toolName, rawInput) ?? deriveFallbackToolInputPreview(rawInput)
+    return toolUpdate(
+      {
+        toolName,
+        toolInput,
+        interactivePrompt: deriveInteractivePrompt(toolName, rawInput, eventName)
+      },
+      { hasToolInputField: true }
+    )
+  }
   return {}
 }
 


### PR DESCRIPTION
Fixes #11971

## Summary

- preserve `toolName` and `toolInput` when the OpenCode hook emits `PermissionRequest`
- publish the existing structured `{ approval: { tool, summary } }` envelope through `interactivePrompt`
- retain `waiting` as the state so existing Orca attention semantics remain unchanged

## Why

OpenCode already forwards `permission.asked` as `PermissionRequest`, but `extractOpenCodeToolFields()` only handled assistant messages and `AskUserQuestion`. The Runtime therefore exposed a bare `waiting` state, forcing paired clients to parse terminal output or lose the permission distinction.

## Validation

- `corepack pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-hook-listener.test.ts`
- 118 tests passed