### PR TITLE
fix(runtime): expose OpenCode permission interaction

### DIFF
--- a/mobile/src/worktree/worktree-list-snapshot.test.ts
+++ b/mobile/src/worktree/worktree-list-snapshot.test.ts
@@ -160,6 +160,13 @@ describe('areWorktreeListsEqual', () => {
     expect(areWorktreeListsEqual(first, second)).toBe(false)
   })
 
+  it('detects permission interaction changes', () => {
+    const first = [worktree({ agents: [agent()] })]
+    const second = [worktree({ agents: [agent({ interaction: { kind: 'permission' } })] })]
+
+    expect(areWorktreeListsEqual(first, second)).toBe(false)
+  })
+
   it('treats missing and empty agent arrays as equivalent for rendering', () => {
     const first = [worktree({ agents: undefined })]
     const second = [worktree({ agents: [] })]

--- a/mobile/src/worktree/worktree-list-snapshot.ts
+++ b/mobile/src/worktree/worktree-list-snapshot.ts
@@ -107,6 +107,7 @@ function areAgentRowsEqual(
       a.lastAssistantMessage !== b.lastAssistantMessage ||
       a.toolName !== b.toolName ||
       a.toolInput !== b.toolInput ||
+      a.interaction?.kind !== b.interaction?.kind ||
       a.interrupted !== b.interrupted ||
       a.stateStartedAt !== b.stateStartedAt ||
       a.updatedAt !== b.updatedAt

--- a/src/main/agent-hooks/hook-status-session-tabs-invalidation.test.ts
+++ b/src/main/agent-hooks/hook-status-session-tabs-invalidation.test.ts
@@ -24,9 +24,10 @@ describe('createHookStatusSessionTabsInvalidator', () => {
 
   it('stays quiet while the same status keeps being pinged', () => {
     const changed = createHookStatusSessionTabsInvalidator()
-    changed(working())
+    const permission = working({}, { interaction: { kind: 'permission' } })
+    changed(permission)
 
-    expect(changed(working())).toBe(false)
+    expect(changed(permission)).toBe(false)
   })
 
   it.each([
@@ -35,6 +36,7 @@ describe('createHookStatusSessionTabsInvalidator', () => {
     ['agentType', { agentType: 'codex' }],
     ['toolName', { toolName: 'Bash' }],
     ['interactivePrompt', { interactivePrompt: '{"questions":[]}' }],
+    ['interaction', { interaction: { kind: 'permission' as const } }],
     ['interrupted', { interrupted: true }]
   ])('invalidates when %s changes', (_field, payload) => {
     const changed = createHookStatusSessionTabsInvalidator()

--- a/src/main/agent-hooks/hook-status-session-tabs-invalidation.ts
+++ b/src/main/agent-hooks/hook-status-session-tabs-invalidation.ts
@@ -28,6 +28,7 @@ export function createHookStatusSessionTabsInvalidator(): {
       (previous.agentType ?? null) !== (next.agentType ?? null) ||
       (previous.toolName ?? null) !== (next.toolName ?? null) ||
       (previous.interactivePrompt ?? null) !== (next.interactivePrompt ?? null) ||
+      previous.interaction?.kind !== next.interaction?.kind ||
       (previous.interrupted ?? false) !== (next.interrupted ?? false)
     )
   }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -385,7 +385,6 @@ function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentSta
   }
 }
 
-/** Compares status fields that determine whether an incoming update changes the hook cache. */
 // Why: OSC never carries model/children; omit both so an equivalent OSC ping preserves the hook-cached identity graph.
 function equivalentParsedAgentStatusPayload(
   a: ParsedAgentStatusPayload,

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -397,6 +397,7 @@ function equivalentParsedAgentStatusPayload(
     a.toolName === b.toolName &&
     a.toolInput === b.toolInput &&
     a.interactivePrompt === b.interactivePrompt &&
+    a.interaction?.kind === b.interaction?.kind &&
     a.lastAssistantMessage === b.lastAssistantMessage &&
     a.interrupted === b.interrupted
   )

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -385,6 +385,7 @@ function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentSta
   }
 }
 
+/** Compares status fields that determine whether an incoming update changes the hook cache. */
 // Why: OSC never carries model/children; omit both so an equivalent OSC ping preserves the hook-cached identity graph.
 function equivalentParsedAgentStatusPayload(
   a: ParsedAgentStatusPayload,

--- a/src/main/runtime/orca-runtime-hook-agent-status-projection.test.ts
+++ b/src/main/runtime/orca-runtime-hook-agent-status-projection.test.ts
@@ -230,6 +230,31 @@ describe('headless hook agent-status projection (#11761)', () => {
     )
   })
 
+  it('keeps an OpenCode permission visible even under a non-agent title', async () => {
+    const agentStatus = await projectAgentStatus(
+      [
+        hookRow({
+          prompt: '',
+          agentType: 'opencode',
+          toolName: undefined,
+          interactivePrompt: undefined,
+          interaction: { kind: 'permission' }
+        })
+      ],
+      (runtime) => {
+        observePaneTitle(runtime, 'bash')
+      }
+    )
+
+    expect(agentStatus).toEqual(
+      expect.objectContaining({
+        agentType: 'opencode',
+        state: 'waiting',
+        interaction: { kind: 'permission' }
+      })
+    )
+  })
+
   // The title path is refreshed live; an older hook `done` must not erase it.
   it('keeps the title-derived working state when the hook row predates the title', async () => {
     const now = Date.now()

--- a/src/main/runtime/orca-runtime-opencode-permission.integration.test.ts
+++ b/src/main/runtime/orca-runtime-opencode-permission.integration.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer } from '../agent-hooks/server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { OrcaRuntimeService } from './orca-runtime'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+const TAB_ID = 'permission-tab'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = makePaneKey(TAB_ID, LEAF_ID)
+const WORKTREE_ID = 'permission-worktree'
+const PTY_ID = 'permission-pty'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('OpenCode permission hook Runtime projection', () => {
+  it('carries a safe interaction through the live hook server to session.tabs', async () => {
+    const hookServer = new AgentHookServer()
+    await hookServer.start({ env: 'production' })
+    try {
+      const env = hookServer.buildPtyEnv()
+      const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/opencode`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify({
+          paneKey: PANE_KEY,
+          tabId: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          env: 'production',
+          payload: {
+            hook_event_name: 'PermissionRequest',
+            id: 'opaque-request-id',
+            sessionID: 'canonical-session-id'
+          }
+        })
+      })
+      expect(response.status).toBe(204)
+
+      const runtime = new OrcaRuntimeService(null, undefined, {
+        getAgentStatusSnapshot: () => hookServer.getStatusSnapshot()
+      })
+      const internals = runtime as unknown as {
+        resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
+      }
+      vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
+        id: WORKTREE_ID,
+        path: '/repo/app',
+        connectionId: null,
+        repo: null,
+        folderWorkspace: null
+      })
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: PTY_ID }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      await runtime.createTerminal(`id:${WORKTREE_ID}`, {
+        tabId: TAB_ID,
+        leafId: LEAF_ID,
+        launchAgent: 'opencode',
+        title: 'Terminal'
+      })
+      runtime.onPtyData(PTY_ID, '\u001b]0;bash\u0007', Date.now())
+
+      const result = await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+      const tab = result.tabs[0]
+      const serialized = JSON.stringify(tab)
+
+      expect(tab?.type === 'terminal' && tab.agentStatus).toEqual(
+        expect.objectContaining({
+          state: 'waiting',
+          agentType: 'opencode',
+          interaction: { kind: 'permission' },
+          providerSession: { key: 'session_id', id: 'canonical-session-id' }
+        })
+      )
+      expect(serialized).not.toContain('opaque-request-id')
+      expect(
+        tab?.type === 'terminal' ? Object.keys(tab.agentStatus?.interaction ?? {}) : []
+      ).toEqual(['kind'])
+    } finally {
+      hookServer.stop()
+    }
+  })
+})

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -33170,7 +33170,7 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
-  it('attaches inline agent rows from hook-reported status (not just OSC)', async () => {
+  it('attaches inline permission rows from hook-reported status (not just OSC)', async () => {
     // Why: agent status arrives via hooks, not OSC; worktree.ps reads the hook snapshot so mobile surfaces those agents.
     const leafId = '33333333-3333-4333-8333-333333333333'
     const paneKey = `tab-1:${leafId}`
@@ -33181,9 +33181,10 @@ describe('OrcaRuntimeService', () => {
           paneKey,
           worktreeId: TEST_WORKTREE_ID,
           tabId: 'tab-1',
-          state: 'working',
-          prompt: 'ship it',
-          agentType: 'claude',
+          state: 'waiting',
+          prompt: '',
+          agentType: 'opencode',
+          interaction: { kind: 'permission' },
           lastAssistantMessage: 'on it',
           connectionId: null,
           receivedAt: now,
@@ -33239,9 +33240,10 @@ describe('OrcaRuntimeService', () => {
     expect(summary?.agents).toEqual([
       expect.objectContaining({
         paneKey,
-        state: 'working',
-        agentType: 'claude',
-        prompt: 'ship it',
+        state: 'waiting',
+        agentType: 'opencode',
+        prompt: '',
+        interaction: { kind: 'permission' },
         taskTitle: 'Dispatch prompt work',
         displayName: 'Review dispatch prompts and make worker labels distinct',
         lastAssistantMessage: 'on it',
@@ -33249,7 +33251,7 @@ describe('OrcaRuntimeService', () => {
         updatedAt: now
       })
     ])
-    expect(summary).toMatchObject({ hasHostSidebarActivity: true, status: 'working' })
+    expect(summary).toMatchObject({ hasHostSidebarActivity: true, status: 'permission' })
   })
 
   it('uses mirrored tab ownership after a workspace rename instead of stale hook attribution', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10372,6 +10372,7 @@ export class OrcaRuntimeService {
       (previous.payload.agentType ?? null) !== (payload.agentType ?? null) ||
       (previous.payload.toolName ?? null) !== (payload.toolName ?? null) ||
       (previous.payload.interactivePrompt ?? null) !== (payload.interactivePrompt ?? null) ||
+      previous.payload.interaction?.kind !== payload.interaction?.kind ||
       (previous.payload.interrupted ?? false) !== (payload.interrupted ?? false)
     )
   }
@@ -17293,6 +17294,7 @@ export class OrcaRuntimeService {
         lastAssistantMessage: string | null
         toolName: string | null
         toolInput: string | null
+        interaction: ParsedAgentStatusPayload['interaction'] | null
         interrupted: boolean
         stateStartedAt: number
         updatedAt: number
@@ -17313,6 +17315,7 @@ export class OrcaRuntimeService {
         lastAssistantMessage: payload.lastAssistantMessage ?? null,
         toolName: payload.toolName ?? null,
         toolInput: payload.toolInput ?? null,
+        interaction: payload.interaction ?? null,
         interrupted: payload.interrupted ?? false,
         stateStartedAt: snapshot.stateStartedAt,
         updatedAt: snapshot.updatedAt
@@ -17339,6 +17342,7 @@ export class OrcaRuntimeService {
         lastAssistantMessage: entry.lastAssistantMessage ?? null,
         toolName: entry.toolName ?? null,
         toolInput: entry.toolInput ?? null,
+        interaction: entry.interaction ?? null,
         interrupted: entry.interrupted ?? false,
         stateStartedAt: entry.stateStartedAt,
         updatedAt: entry.receivedAt,
@@ -17404,6 +17408,7 @@ export class OrcaRuntimeService {
         lastAssistantMessage: src.lastAssistantMessage,
         toolName: src.toolName,
         toolInput: src.toolInput,
+        interaction: src.interaction,
         interrupted: src.interrupted,
         stateStartedAt: src.stateStartedAt,
         updatedAt: src.updatedAt,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10338,7 +10338,6 @@ export class OrcaRuntimeService {
     return retainedChanged
   }
 
-  /** Updates the latest hook snapshot and reports whether Runtime clients need a refresh. */
   private retainAgentRowSnapshot(
     ptyId: string,
     paneKey: string,
@@ -29713,9 +29712,10 @@ export class OrcaRuntimeService {
             ownerAgent
           )
         : null
-      // Why: keep rich hook status on a live prompt/tool (authoritative even under a non-agent title), else interactivePrompt is lost.
+      // Why: keep live human blockers authoritative even under a non-agent title.
       const hasLiveAgentSignal =
         normalizedTabAgentStatus?.interactivePrompt != null ||
+        normalizedTabAgentStatus?.interaction != null ||
         normalizedTabAgentStatus?.toolName != null
       const keepFullAgentStatus =
         normalizedTabAgentStatus &&
@@ -29866,10 +29866,12 @@ export class OrcaRuntimeService {
       // Why: non-agent title = shell reclaimed the pane; suppress to clear stuck spinners (#1437), though a live hook signal survives.
       const hasLiveHookSignal =
         retained?.payload.interactivePrompt != null ||
+        retained?.payload.interaction != null ||
         retained?.payload.toolName != null ||
         // Why: a pending question is never inherited across hook events (unlike
         // `toolName`), so it proves the agent is parked on a selector right now.
         hookRow.live?.payload.interactivePrompt != null ||
+        hookRow.live?.payload.interaction != null ||
         // Why: headless serve has no renderer to retain an OSC row, so a fresh hook
         // agentType is the only live signal a hook-only pane can offer — and an agent
         // that reports over HTTP need never set a title this gate would recognize.
@@ -29948,9 +29950,8 @@ export class OrcaRuntimeService {
    *
    *  Why the freshness rule: `pty.lastAgentStatus` is title-derived and refreshed live,
    *  so an unconditional hook precedence would let a 29-minute-old `done` erase a pane
-   *  that is visibly working. A pending `interactivePrompt` outranks title evidence at
-   *  any age — the agent is parked on a selector until it answers — and it is also the
-   *  only signal allowed to survive the #1437 non-agent-title suppression. */
+   *  that is visibly working. A pending interaction outranks title evidence because
+   *  the agent is parked on a selector until it is answered. */
   private resolveHookLiveAgentRow(
     live: HookLiveAgentRow | null,
     pty: RuntimePtyWorktreeRecord | null,
@@ -29959,7 +29960,7 @@ export class OrcaRuntimeService {
     if (!live) {
       return null
     }
-    if (live.payload.interactivePrompt != null) {
+    if (live.payload.interactivePrompt != null || live.payload.interaction != null) {
       return live
     }
     // Why only this stamp: it is the sole wall-clock date on the pane's live title,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10338,6 +10338,7 @@ export class OrcaRuntimeService {
     return retainedChanged
   }
 
+  /** Updates the latest hook snapshot and reports whether Runtime clients need a refresh. */
   private retainAgentRowSnapshot(
     ptyId: string,
     paneKey: string,

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -51,6 +51,7 @@ type CapturedStatus = {
     prompt: string
     agentType?: string
     toolName?: string
+    interaction?: { kind: string }
   }
 }
 
@@ -183,7 +184,8 @@ function captureAgentStatuses(events: CapturedStatus[]): void {
         state: event.payload.state,
         prompt: event.payload.prompt,
         agentType: event.payload.agentType,
-        toolName: event.payload.toolName
+        toolName: event.payload.toolName,
+        ...(event.payload.interaction ? { interaction: event.payload.interaction } : {})
       }
     })
   })
@@ -293,6 +295,34 @@ describe('SshRelaySession agent hooks over a fake relay transport', () => {
         toolName: undefined
       }
     })
+  })
+
+  it('rebuilds a remote permission interaction at the main-process trust boundary', async () => {
+    relay = createFakeRelay()
+    vi.mocked(deployAndLaunchRelay).mockResolvedValue({
+      transport: relay.transport,
+      serverBuildId: 'test-relay-build',
+      platform: 'linux-x64'
+    })
+    const events: CapturedStatus[] = []
+    captureAgentStatuses(events)
+
+    session = createSession('conn-permission')
+    await session.establish({} as SshConnection)
+    relay.notifyAgentHook(
+      makeEnvelope({
+        source: 'opencode',
+        payload: {
+          state: 'waiting',
+          prompt: '',
+          agentType: 'opencode',
+          interaction: { kind: 'permission', requestID: 'secret' } as never
+        }
+      })
+    )
+
+    await waitForStatusCount(events, 1)
+    expect(events[0]?.payload.interaction).toEqual({ kind: 'permission' })
   })
 
   it('clears stamped status on reconnect loss but not final shutdown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4947,6 +4947,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     agentType?: string
     toolName?: string
     toolInput?: string
+    interaction?: { kind: 'permission' }
     lastAssistantMessage?: string
     interrupted?: boolean
     terminalHandle?: string
@@ -6070,9 +6071,10 @@ describe('useIpcEvents agent status snapshot integration', () => {
       Promise.resolve([
         {
           paneKey: FUTURE_PANE_KEY,
-          state: 'working' as const,
-          prompt: 'p',
-          agentType: 'claude',
+          state: 'waiting' as const,
+          prompt: '',
+          agentType: 'opencode',
+          interaction: { kind: 'permission' as const },
           receivedAt: 1_700_000_000_000,
           stateStartedAt: 1_699_999_999_000
         }
@@ -6155,7 +6157,12 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(setAgentStatus).toHaveBeenCalledTimes(1)
     expect(setAgentStatus).toHaveBeenCalledWith(
       FUTURE_PANE_KEY,
-      expect.objectContaining({ state: 'working', prompt: 'p', agentType: 'claude' }),
+      expect.objectContaining({
+        state: 'waiting',
+        prompt: '',
+        agentType: 'opencode',
+        interaction: { kind: 'permission' }
+      }),
       'Future Tab',
       { updatedAt: 1_700_000_000_000, stateStartedAt: 1_699_999_999_000 },
       expectWorktreeRouting('wt-1'),

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3097,6 +3097,7 @@ export function useIpcEvents(): void {
         toolInput: data.toolInput,
         // Why: the live AskUserQuestion prompt rides this field; omitting it drops the native question card on web/mobile.
         interactivePrompt: data.interactivePrompt,
+        interaction: data.interaction,
         lastAssistantMessage: data.lastAssistantMessage,
         interrupted: data.interrupted,
         // Why: same trap as interactivePrompt — this rebuild is a field whitelist, so subagent child rows vanish if omitted.

--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts
@@ -32,6 +32,7 @@ function referenceProjection(map: AppState['agentStatusByPaneKey']): string {
         toolName: entry.toolName ?? null,
         toolInput: entry.toolInput ?? null,
         interactivePrompt: entry.interactivePrompt ?? null,
+        interaction: entry.interaction ?? null,
         lastAssistantMessage: entry.lastAssistantMessage ?? null,
         interrupted: entry.interrupted ?? null
       }))
@@ -78,6 +79,7 @@ describe('mobile agent-status projection equivalence', () => {
         toolName: undefined,
         toolInput: undefined,
         interactivePrompt: undefined,
+        interaction: undefined,
         lastAssistantMessage: undefined,
         interrupted: undefined
       })
@@ -108,6 +110,7 @@ describe('mobile agent-status projection equivalence', () => {
           updatedAt: 1740000000000 + BUCKET_MS * 3 * (round + 1),
           state: round % 2 === 0 ? 'done' : 'working',
           prompt: `changed prompt round ${round}`,
+          interaction: round % 2 === 0 ? { kind: 'permission' } : undefined,
           lastAssistantMessage: `answer round ${round}`
         })
       }

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -599,6 +599,7 @@ function buildRuntimeMobileEditorDraftsProjection(editorDrafts: AppState['editor
   )
 }
 
+/** Serializes a stable mobile projection used to detect agent-status graph changes. */
 function serializeRuntimeMobileAgentStatusEntry(
   paneKey: string,
   entry: AppState['agentStatusByPaneKey'][string]

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -622,6 +622,7 @@ function serializeRuntimeMobileAgentStatusEntry(
     toolInput: entry.toolInput ?? null,
     // Why: include so a newly-captured AskUserQuestion prompt re-fires the mobile republish even when no other field changed.
     interactivePrompt: entry.interactivePrompt ?? null,
+    interaction: entry.interaction ?? null,
     lastAssistantMessage: entry.lastAssistantMessage ?? null,
     interrupted: entry.interrupted ?? null
   })

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -599,7 +599,6 @@ function buildRuntimeMobileEditorDraftsProjection(editorDrafts: AppState['editor
   )
 }
 
-/** Serializes a stable mobile projection used to detect agent-status graph changes. */
 function serializeRuntimeMobileAgentStatusEntry(
   paneKey: string,
   entry: AppState['agentStatusByPaneKey'][string]

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1378,7 +1378,6 @@ function sameAgentStateHistory(
   )
 }
 
-/** Compares mirrored agent entries to avoid publishing unchanged session-tab snapshots. */
 function agentStatusEntryEqual(a: AgentStatusEntry | undefined, b: AgentStatusEntry): boolean {
   if (!a) {
     return false

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1378,6 +1378,7 @@ function sameAgentStateHistory(
   )
 }
 
+/** Compares mirrored agent entries to avoid publishing unchanged session-tab snapshots. */
 function agentStatusEntryEqual(a: AgentStatusEntry | undefined, b: AgentStatusEntry): boolean {
   if (!a) {
     return false

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1395,6 +1395,7 @@ function agentStatusEntryEqual(a: AgentStatusEntry | undefined, b: AgentStatusEn
     a.toolName === b.toolName &&
     a.toolInput === b.toolInput &&
     a.interactivePrompt === b.interactivePrompt &&
+    a.interaction?.kind === b.interaction?.kind &&
     a.lastAssistantMessage === b.lastAssistantMessage &&
     a.interrupted === b.interrupted &&
     a.promptInteractionKey === b.promptInteractionKey &&

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1918,6 +1918,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           // Why: full untruncated AskUserQuestion JSON so mobile/web can render the live prompt
           // card; parseAgentStatusPayload clears it on tool/state change.
           interactivePrompt: payload.interactivePrompt,
+          interaction: payload.interaction,
           lastAssistantMessage: payload.lastAssistantMessage,
           // Why: reused panes can start non-orchestrated work; only final done rows keep the
           // previous lineage fallback so completed children stay grouped.

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -372,6 +372,32 @@ describe('shared agent-hook-listener', () => {
     expect(event?.payload.interactivePrompt).toBe(JSON.stringify(properties))
   })
 
+  it('exposes an OpenCode PermissionRequest as a generic interaction', () => {
+    const event = normalizeHookPayload(
+      state,
+      'opencode',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PermissionRequest',
+          id: 'opaque-request-id',
+          sessionID: 'opaque-session-id'
+        }
+      },
+      'production'
+    )
+
+    expect(event?.payload).toMatchObject({
+      state: 'waiting',
+      agentType: 'opencode',
+      interaction: { kind: 'permission' }
+    })
+    expect(event?.payload.toolName).toBeUndefined()
+    expect(event?.payload.toolInput).toBeUndefined()
+    expect(event?.payload.interactivePrompt).toBeUndefined()
+    expect(JSON.stringify(event?.payload)).not.toContain('opaque-')
+  })
+
   it('maps Pi tool_call ask_user_question to blocked with interactivePrompt', () => {
     const questions = {
       questions: [

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -537,6 +537,7 @@ export type ToolSnapshot = {
   clearLastAssistantMessage?: boolean
 }
 
+/** Merges event-local tool metadata with the pane cache and clears ephemeral interactions. */
 function resolveToolState(
   state: HookListenerState,
   paneKey: string,
@@ -734,6 +735,7 @@ function hasAnyOwnField(record: Record<string, unknown>, keys: readonly string[]
   return keys.some((key) => hasOwnField(record, key))
 }
 
+/** Marks extracted metadata as an explicit tool update for cache-merging semantics. */
 function toolUpdate(
   fields: Pick<ToolSnapshot, 'toolName' | 'toolInput' | 'interactivePrompt' | 'interaction'>,
   options?: { hasToolInputField?: boolean }
@@ -1648,6 +1650,7 @@ function extractAmpToolFields(
   return {}
 }
 
+/** Extracts OpenCode activity, questions, and permission state without leaking opaque IDs. */
 function extractOpenCodeToolFields(
   eventName: unknown,
   hookPayload: Record<string, unknown>
@@ -3484,6 +3487,7 @@ function normalizeCodexEvent(
   })
 }
 
+/** Normalizes OpenCode-family hook events into their public agent-status payload. */
 function normalizeOpenCodeFamilyEvent(
   source: 'opencode' | 'mimo-code',
   state: HookListenerState,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -529,6 +529,8 @@ export type ToolSnapshot = {
   toolInput?: string
   /** Full JSON of an AskUserQuestion tool input; set only on its own event and NOT inherited (resolveToolState) so no stale prompt lingers. */
   interactivePrompt?: string
+  /** Structured human interaction; event-scoped like interactivePrompt. */
+  interaction?: ParsedAgentStatusPayload['interaction']
   hasToolUpdate?: boolean
   hasToolInputField?: boolean
   lastAssistantMessage?: string
@@ -565,6 +567,8 @@ function resolveToolState(
     toolInput,
     // Why: don't inherit previous.interactivePrompt — valid only for its one AskUserQuestion event; carrying it forward leaves a stale live card.
     interactivePrompt: update.interactivePrompt,
+    // Why: an interaction is live only for the event that reported it; later activity clears it.
+    interaction: update.interaction,
     lastAssistantMessage: update.clearLastAssistantMessage
       ? undefined
       : (update.lastAssistantMessage ?? previous.lastAssistantMessage)
@@ -731,7 +735,7 @@ function hasAnyOwnField(record: Record<string, unknown>, keys: readonly string[]
 }
 
 function toolUpdate(
-  fields: Pick<ToolSnapshot, 'toolName' | 'toolInput' | 'interactivePrompt'>,
+  fields: Pick<ToolSnapshot, 'toolName' | 'toolInput' | 'interactivePrompt' | 'interaction'>,
   options?: { hasToolInputField?: boolean }
 ): ToolSnapshot {
   return {
@@ -1663,6 +1667,11 @@ function extractOpenCodeToolFields(
       hasToolUpdate: true,
       interactivePrompt: deriveInteractivePrompt('AskUserQuestion', toolInputSource)
     }
+  }
+  if (eventName === 'PermissionRequest') {
+    // Why: OpenCode exposes only opaque request/session identifiers here. Publish
+    // the permission kind without fabricating tool details or leaking identifiers.
+    return { ...clearActiveToolFieldsUpdate(), interaction: { kind: 'permission' } }
   }
   return {}
 }
@@ -3512,6 +3521,7 @@ function normalizeOpenCodeFamilyEvent(
     toolName: snapshot.toolName,
     toolInput: snapshot.toolInput,
     interactivePrompt: snapshot.interactivePrompt,
+    interaction: snapshot.interaction,
     lastAssistantMessage: snapshot.lastAssistantMessage
   })
 }

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -537,7 +537,6 @@ export type ToolSnapshot = {
   clearLastAssistantMessage?: boolean
 }
 
-/** Merges event-local tool metadata with the pane cache and clears ephemeral interactions. */
 function resolveToolState(
   state: HookListenerState,
   paneKey: string,
@@ -735,7 +734,6 @@ function hasAnyOwnField(record: Record<string, unknown>, keys: readonly string[]
   return keys.some((key) => hasOwnField(record, key))
 }
 
-/** Marks extracted metadata as an explicit tool update for cache-merging semantics. */
 function toolUpdate(
   fields: Pick<ToolSnapshot, 'toolName' | 'toolInput' | 'interactivePrompt' | 'interaction'>,
   options?: { hasToolInputField?: boolean }
@@ -1650,7 +1648,6 @@ function extractAmpToolFields(
   return {}
 }
 
-/** Extracts OpenCode activity, questions, and permission state without leaking opaque IDs. */
 function extractOpenCodeToolFields(
   eventName: unknown,
   hookPayload: Record<string, unknown>
@@ -3487,7 +3484,6 @@ function normalizeCodexEvent(
   })
 }
 
-/** Normalizes OpenCode-family hook events into their public agent-status payload. */
 function normalizeOpenCodeFamilyEvent(
   source: 'opencode' | 'mimo-code',
   state: HookListenerState,

--- a/src/shared/agent-status-interaction.ts
+++ b/src/shared/agent-status-interaction.ts
@@ -1,0 +1,13 @@
+export type AgentStatusInteraction = {
+  kind: 'permission'
+}
+
+export function normalizeAgentStatusInteraction(
+  value: unknown
+): AgentStatusInteraction | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  const interaction = value as Record<string, unknown>
+  return interaction.kind === 'permission' ? { kind: 'permission' } : undefined
+}

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -4,6 +4,7 @@ import {
   isFreshNonDoneAgentStatus,
   parseAgentStatusPayload,
   normalizeAgentStatusPayload,
+  pickParsedAgentStatusPayload,
   AGENT_STATUS_JSON_STRUCTURE_LIMITS,
   AGENT_STATUS_MAX_FIELD_LENGTH,
   AGENT_STATUS_MAX_SUBAGENTS,
@@ -66,6 +67,20 @@ describe('parseAgentStatusPayload', () => {
     expect(
       normalizeAgentStatusPayload({ state: 'waiting', interaction: { kind: 'question' } })
     ).toMatchObject({ interaction: undefined })
+    expect(
+      normalizeAgentStatusPayload({ state: 'working', interaction: { kind: 'permission' } })
+    ).toMatchObject({ interaction: undefined })
+  })
+
+  it('keeps interactions while stripping IPC-only fields from Runtime projections', () => {
+    expect(
+      pickParsedAgentStatusPayload({
+        state: 'waiting',
+        prompt: '',
+        interaction: { kind: 'permission' },
+        launchToken: 'secret'
+      } as never)
+    ).toEqual({ state: 'waiting', prompt: '', interaction: { kind: 'permission' } })
   })
 
   it('returns null for invalid state', () => {

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -59,6 +59,15 @@ describe('parseAgentStatusPayload', () => {
     }
   })
 
+  it('accepts only known structured interaction kinds', () => {
+    expect(
+      normalizeAgentStatusPayload({ state: 'waiting', interaction: { kind: 'permission' } })
+    ).toMatchObject({ interaction: { kind: 'permission' } })
+    expect(
+      normalizeAgentStatusPayload({ state: 'waiting', interaction: { kind: 'question' } })
+    ).toMatchObject({ interaction: undefined })
+  })
+
   it('returns null for invalid state', () => {
     expect(parseAgentStatusPayload('{"state":"running"}')).toBeNull()
     expect(parseAgentStatusPayload('{"state":"idle"}')).toBeNull()

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -344,6 +344,7 @@ function normalizeSubagentsField(value: unknown): AgentSubagentSnapshot[] | unde
   return normalized.length > 0 ? normalized : undefined
 }
 
+/** Returns the canonical supported interaction, omitting malformed or unknown kinds. */
 function normalizeInteractionField(value: unknown): AgentStatusInteraction | undefined {
   if (typeof value !== 'object' || value === null) {
     return undefined

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -10,16 +10,17 @@ import {
   normalizePromptField
 } from './agent-status-field-normalization'
 import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
+import {
+  normalizeAgentStatusInteraction,
+  type AgentStatusInteraction
+} from './agent-status-interaction'
 
 export { AGENT_STATUS_MAX_FIELD_LENGTH } from './agent-status-field-normalization'
+export type { AgentStatusInteraction } from './agent-status-interaction'
 
 export const AGENT_STATUS_STATES = ['working', 'blocked', 'waiting', 'done'] as const
 export type AgentStatusState = (typeof AGENT_STATUS_STATES)[number]
 
-/** A structured human interaction the agent is awaiting. */
-export type AgentStatusInteraction = {
-  kind: 'permission'
-}
 // Why: agent types aren't a fixed set (custom agents exist); any non-empty string is
 // accepted — these well-known names are just a convenience union for pattern-matching.
 export type WellKnownAgentType =
@@ -207,6 +208,7 @@ export function pickParsedAgentStatusPayload(
     ...(row.toolName !== undefined ? { toolName: row.toolName } : {}),
     ...(row.toolInput !== undefined ? { toolInput: row.toolInput } : {}),
     ...(row.interactivePrompt !== undefined ? { interactivePrompt: row.interactivePrompt } : {}),
+    ...(row.interaction !== undefined ? { interaction: row.interaction } : {}),
     ...(row.lastAssistantMessage !== undefined
       ? { lastAssistantMessage: row.lastAssistantMessage }
       : {}),
@@ -344,15 +346,6 @@ function normalizeSubagentsField(value: unknown): AgentSubagentSnapshot[] | unde
   return normalized.length > 0 ? normalized : undefined
 }
 
-/** Returns the canonical supported interaction, omitting malformed or unknown kinds. */
-function normalizeInteractionField(value: unknown): AgentStatusInteraction | undefined {
-  if (typeof value !== 'object' || value === null) {
-    return undefined
-  }
-  const interaction = value as Record<string, unknown>
-  return interaction.kind === 'permission' ? { kind: 'permission' } : undefined
-}
-
 /** Structural equality for subagent lists so stores can reuse the previous
  *  array reference (and skip fanout) when nothing actually changed. */
 export function agentSubagentsEqual(
@@ -413,7 +406,7 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
       obj.interactivePrompt,
       AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH
     ),
-    interaction: normalizeInteractionField(obj.interaction),
+    interaction: state === 'waiting' ? normalizeAgentStatusInteraction(obj.interaction) : undefined,
     lastAssistantMessage: normalizeOptionalMultilineField(
       obj.lastAssistantMessage,
       AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -15,6 +15,11 @@ export { AGENT_STATUS_MAX_FIELD_LENGTH } from './agent-status-field-normalizatio
 
 export const AGENT_STATUS_STATES = ['working', 'blocked', 'waiting', 'done'] as const
 export type AgentStatusState = (typeof AGENT_STATUS_STATES)[number]
+
+/** A structured human interaction the agent is awaiting. */
+export type AgentStatusInteraction = {
+  kind: 'permission'
+}
 // Why: agent types aren't a fixed set (custom agents exist); any non-empty string is
 // accepted — these well-known names are just a convenience union for pattern-matching.
 export type WellKnownAgentType =
@@ -121,6 +126,8 @@ export type AgentStatusEntry = {
   /** JSON of the AskUserQuestion tool input, captured live; unlike toolInput it's not
    *  truncated (clients render the full card). Cleared once the agent moves on so a stale prompt can't linger. */
   interactivePrompt?: string
+  /** Typed interaction state for clients that cannot inspect terminal output. */
+  interaction?: AgentStatusInteraction
   /** Most recent assistant message preview, when the hook carried one. */
   lastAssistantMessage?: string
   /** True when this `done` was reached via interrupt, not normal completion
@@ -168,6 +175,8 @@ export type AgentStatusPayload = {
   /** JSON string of the AskUserQuestion tool input, captured live. See the
    *  AgentStatusEntry field for semantics. Not truncated like toolInput. */
   interactivePrompt?: string
+  /** Typed interaction state for clients that cannot inspect terminal output. */
+  interaction?: AgentStatusInteraction
   lastAssistantMessage?: string
   interrupted?: boolean
   /** Live in-process children of the reporting session. See AgentStatusEntry. */
@@ -335,6 +344,14 @@ function normalizeSubagentsField(value: unknown): AgentSubagentSnapshot[] | unde
   return normalized.length > 0 ? normalized : undefined
 }
 
+function normalizeInteractionField(value: unknown): AgentStatusInteraction | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  const interaction = value as Record<string, unknown>
+  return interaction.kind === 'permission' ? { kind: 'permission' } : undefined
+}
+
 /** Structural equality for subagent lists so stores can reuse the previous
  *  array reference (and skip fanout) when nothing actually changed. */
 export function agentSubagentsEqual(
@@ -395,6 +412,7 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
       obj.interactivePrompt,
       AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH
     ),
+    interaction: normalizeInteractionField(obj.interaction),
     lastAssistantMessage: normalizeOptionalMultilineField(
       obj.lastAssistantMessage,
       AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -743,7 +743,8 @@ export type RuntimeWorktreeAgentRow = {
   lastAssistantMessage: string | null
   toolName: string | null
   toolInput: string | null
-  interaction: AgentStatusEntry['interaction'] | null
+  /** Optional for compatibility with older Runtime hosts. */
+  interaction?: AgentStatusEntry['interaction'] | null
   interrupted: boolean
   /** When the current `state` was first reported (ms). Drives "Xm ago". */
   stateStartedAt: number

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -743,6 +743,7 @@ export type RuntimeWorktreeAgentRow = {
   lastAssistantMessage: string | null
   toolName: string | null
   toolInput: string | null
+  interaction: AgentStatusEntry['interaction'] | null
   interrupted: boolean
   /** When the current `state` was first reported (ms). Drives "Xm ago". */
   stateStartedAt: number


### PR DESCRIPTION
## Summary

- Exposes OpenCode `PermissionRequest` as the typed Runtime interaction `{ kind: "permission" }`.
- Preserves `waiting` while omitting the opaque permission-request ID from the interaction payload.
- Retains the canonical OpenCode provider-session ID in the existing `providerSession: { key: "session_id", id }` field for provider-session routing and resume behavior.
- Carries the interaction through IPC, synced sessions, `session.tabs`, and `worktree.ps`.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (not run; full repository lint is outside this focused change)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (not run; focused suites below)
- [ ] `pnpm build` (not run; no build-affecting change)
- [x] Added regression coverage for hook normalization, trust-boundary reconstruction, deduplication, desktop/SSH/mobile projection, live permission retention, and provider-session identity.

Executed on the final head:

- `corepack pnpm exec vitest run --config config/vitest.config.ts` on the nine changed focused test files (1,330 passed, 1 skipped)
- `corepack pnpm run typecheck`
- `corepack pnpm exec oxfmt --check` on all 22 modified files

## AI Review Report

Reviewed the hook-to-Runtime data path for stale interaction state, status deduplication, session synchronization, `session.tabs`, and `worktree.ps` projection. Verified that the new permission interaction is cleared by subsequent events, remains live under a non-agent pane title, and never contains the opaque permission-request ID. The canonical provider-session ID remains intentionally available only through the existing provider-session field.

Cross-platform review: this change adds no shortcuts, labels, paths, shell commands, or Electron-specific behavior. The structured in-memory payload is platform-neutral for macOS, Linux, and Windows, including SSH relay reconstruction.

## Security Audit

The hook payload is treated as untrusted. The interaction normalizer accepts only the allowlisted `permission` kind and reconstructs the canonical object, discarding unknown fields. The opaque permission-request ID, tool details, and commands are not copied to Runtime clients. The event's canonical provider-session ID continues through the existing `providerSession: { key: "session_id", id }` channel for established provider-session routing and resume semantics; it is intentionally separate from the interaction payload.

No auth, secrets, dependency, command-execution, path-handling, workflow, executable-mode, or download changes are introduced.

## Notes

Questions continue to use the existing `interactivePrompt` payload. This PR adds the missing typed signal only for OpenCode permission requests.

Fixes #11971
