### PR TITLE
fix(status-bar): show and refresh the remote server's usage when it owns accounts

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -46,6 +46,7 @@ import { WORKTREE_REFRESH_CONCURRENCY } from './store/slices/worktrees'
 import { useShallow } from 'zustand/react/shallow'
 import { isRemoteWorkspaceSnapshotApplyInProgress, useIpcEvents } from './hooks/useIpcEvents'
 import { useAutomationDispatchEvents } from './hooks/useAutomationDispatchEvents'
+import { useRemoteAccountUsageSync } from './hooks/remote-account-usage-sync'
 import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGate'
 import { AgentHibernationGate } from './components/AgentHibernationGate'
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
@@ -746,6 +747,8 @@ function App(): React.JSX.Element {
   useIpcEvents()
   useRemoteRuntimeRecoveryTriggers()
   useAutomationDispatchEvents()
+  // Why: usage surfaces read the account owner's rate limits; with a Remote Orca Server active those live server-side and only arrive via accounts.subscribe (#7973).
+  useRemoteAccountUsageSync()
   // Why: retention runs at App level (in <RetainedAgentsSyncGate />, a null leaf) so "done" agents survive card collapse and its high-churn subscriptions don't re-render App.
   // Why: git polling lives at App level (RightSidebar unmounts when closed, stranding stale Rebasing/Merging badges); gate on workspaceSessionReady so it doesn't compete with first paint.
   useGitStatusPolling({ enabled: workspaceSessionReady })

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -37,6 +37,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useAppStore } from '../../store'
+import { selectAccountOwnerRateLimits } from '../../store/slices/rate-limits'
 import { selectFloatingWorkspaceHasUnread } from '../../store/selectors'
 import type {
   ClaudeRateLimitAccountsState,
@@ -703,8 +704,10 @@ export function ClaudeSwitcherMenu({
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const refreshClaudeRateLimitsForTarget = useAppStore((s) => s.refreshClaudeRateLimitsForTarget)
   const fetchInactiveClaudeAccountUsage = useAppStore((s) => s.fetchInactiveClaudeAccountUsage)
-  const inactiveClaudeAccounts = useAppStore((s) => s.rateLimits.inactiveClaudeAccounts)
-  const claudeTarget = useAppStore((s) => s.rateLimits.claudeTarget)
+  const inactiveClaudeAccounts = useAppStore(
+    (s) => selectAccountOwnerRateLimits(s).inactiveClaudeAccounts
+  )
+  const claudeTarget = useAppStore((s) => selectAccountOwnerRateLimits(s).claudeTarget)
   const settings = useAppStore((s) => s.settings)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
@@ -1369,8 +1372,10 @@ export function CodexSwitcherMenu({
   const refreshCodexRateLimitsForTarget = useAppStore((s) => s.refreshCodexRateLimitsForTarget)
   const consumeCodexRateLimitResetCredit = useAppStore((s) => s.consumeCodexRateLimitResetCredit)
   const fetchInactiveCodexAccountUsage = useAppStore((s) => s.fetchInactiveCodexAccountUsage)
-  const inactiveCodexAccounts = useAppStore((s) => s.rateLimits.inactiveCodexAccounts)
-  const codexTarget = useAppStore((s) => s.rateLimits.codexTarget)
+  const inactiveCodexAccounts = useAppStore(
+    (s) => selectAccountOwnerRateLimits(s).inactiveCodexAccounts
+  )
+  const codexTarget = useAppStore((s) => selectAccountOwnerRateLimits(s).codexTarget)
   const settings = useAppStore((s) => s.settings)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
@@ -1973,9 +1978,10 @@ function useStatusBarMenuFocusHandoff(): {
 
 function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Element | null {
   const floatingTerminalShortcut = useShortcutLabel('floatingTerminal.toggle')
-  const rateLimits = useAppStore((s) => s.rateLimits)
+  const rateLimits = useAppStore(selectAccountOwnerRateLimits)
   const settings = useAppStore((s) => s.settings)
   const refreshRateLimits = useAppStore((s) => s.refreshRateLimits)
+  const refreshRemoteAccountUsage = useAppStore((s) => s.refreshRemoteAccountUsage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const usagePercentageDisplay = normalizeUsagePercentageDisplay(
@@ -2046,6 +2052,9 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   }, [])
 
   const refreshDetectedAgents = useAppStore((s) => s.refreshDetectedAgents)
+  // Why: with a Remote Orca Server the server owns the accounts doing the work;
+  // refreshing this desktop's usage cannot move their bars (#7973).
+  const refreshUsageEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() || null
   const handleRefresh = useCallback(async () => {
     if (isRefreshing) {
       return
@@ -2053,13 +2062,24 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     setIsRefreshing(true)
     try {
       // Why: re-run PATH detection so a freshly-installed/removed CLI's bar appears/hides without restarting Orca.
-      await Promise.all([refreshRateLimits(), refreshDetectedAgents()])
+      await Promise.all([
+        refreshUsageEnvironmentId
+          ? refreshRemoteAccountUsage(refreshUsageEnvironmentId)
+          : refreshRateLimits(),
+        refreshDetectedAgents()
+      ])
     } finally {
       if (mountedRef.current) {
         setIsRefreshing(false)
       }
     }
-  }, [isRefreshing, refreshRateLimits, refreshDetectedAgents])
+  }, [
+    isRefreshing,
+    refreshUsageEnvironmentId,
+    refreshRemoteAccountUsage,
+    refreshRateLimits,
+    refreshDetectedAgents
+  ])
 
   if (!statusBarVisible) {
     return null

--- a/src/renderer/src/hooks/remote-account-usage-sync.test.tsx
+++ b/src/renderer/src/hooks/remote-account-usage-sync.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+import { act } from 'react'
+import { getDefaultSettings } from '../../../shared/constants'
+import { useAppStore } from '@/store'
+import type { ProviderAccountsSnapshot } from '@/runtime/runtime-provider-accounts-client'
+import { useRemoteAccountUsageSync } from './remote-account-usage-sync'
+
+type WatchHandlers = {
+  onSnapshot: (snapshot: ProviderAccountsSnapshot) => void
+  onError: (error: unknown) => void
+  onClosed?: () => void
+}
+
+const watchProviderAccounts = vi.hoisted(() => vi.fn())
+vi.mock('@/runtime/runtime-provider-accounts-client', () => ({ watchProviderAccounts }))
+
+const closeWatcher = vi.fn()
+let watchHandlers: WatchHandlers | null = null
+
+function setActiveEnvironment(environmentId: string | null): void {
+  act(() => {
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: environmentId }
+    })
+  })
+}
+
+function snapshotFixture(
+  rateLimits: ProviderAccountsSnapshot['rateLimits']
+): ProviderAccountsSnapshot {
+  const emptyAccounts = {
+    accounts: [],
+    activeAccountId: null,
+    activeAccountIdsByRuntime: { host: null, wsl: {} }
+  }
+  return { claude: emptyAccounts, codex: emptyAccounts, rateLimits }
+}
+
+function remoteRateLimitsFixture(
+  marker: string
+): NonNullable<ProviderAccountsSnapshot['rateLimits']> {
+  return {
+    ...useAppStore.getState().rateLimits,
+    claude: {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: 1,
+      error: marker,
+      status: 'ok'
+    }
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  watchProviderAccounts.mockReset()
+  closeWatcher.mockReset()
+  watchHandlers = null
+  watchProviderAccounts.mockImplementation((_settings: unknown, handlers: WatchHandlers) => {
+    watchHandlers = handlers
+    return { close: closeWatcher }
+  })
+  useAppStore.setState({ remoteRateLimits: null })
+  setActiveEnvironment(null)
+})
+
+afterEach(() => {
+  // Why: this config has no vitest globals, so testing-library's auto-cleanup
+  // never registers; without this, hooks from prior tests keep resubscribing.
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useRemoteAccountUsageSync', () => {
+  it('does not subscribe while local accounts own usage', () => {
+    renderHook(() => useRemoteAccountUsageSync())
+
+    expect(watchProviderAccounts).not.toHaveBeenCalled()
+    expect(useAppStore.getState().remoteRateLimits).toBeNull()
+  })
+
+  it('mirrors remote snapshots into the store and ignores rate-limit-less frames', () => {
+    setActiveEnvironment('env-1')
+    renderHook(() => useRemoteAccountUsageSync())
+
+    expect(watchProviderAccounts).toHaveBeenCalledWith(
+      { activeRuntimeEnvironmentId: 'env-1' },
+      expect.any(Object)
+    )
+
+    act(() => {
+      watchHandlers?.onSnapshot(snapshotFixture(remoteRateLimitsFixture('pushed')))
+    })
+    expect(useAppStore.getState().remoteRateLimits?.state.claude?.error).toBe('pushed')
+
+    act(() => {
+      watchHandlers?.onSnapshot(snapshotFixture(null))
+    })
+    expect(useAppStore.getState().remoteRateLimits?.state.claude?.error).toBe('pushed')
+  })
+
+  it('clears the mirror and resubscribes when the account owner changes', () => {
+    setActiveEnvironment('env-1')
+    const { rerender } = renderHook(() => useRemoteAccountUsageSync())
+    act(() => {
+      watchHandlers?.onSnapshot(snapshotFixture(remoteRateLimitsFixture('old-owner')))
+    })
+
+    setActiveEnvironment('env-2')
+    rerender()
+
+    expect(closeWatcher).toHaveBeenCalled()
+    expect(useAppStore.getState().remoteRateLimits).toBeNull()
+    expect(watchProviderAccounts).toHaveBeenLastCalledWith(
+      { activeRuntimeEnvironmentId: 'env-2' },
+      expect.any(Object)
+    )
+  })
+
+  it('resubscribes with a delay after the stream closes or errors', () => {
+    setActiveEnvironment('env-1')
+    renderHook(() => useRemoteAccountUsageSync())
+    expect(watchProviderAccounts).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      watchHandlers?.onClosed?.()
+    })
+    expect(watchProviderAccounts).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(watchProviderAccounts).toHaveBeenCalledTimes(2)
+
+    // Why: consecutive failures back off; the second retry needs 10s, not 5s.
+    act(() => {
+      watchHandlers?.onError(new Error('unreachable'))
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(watchProviderAccounts).toHaveBeenCalledTimes(2)
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+    expect(watchProviderAccounts).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops retrying after unmount', () => {
+    setActiveEnvironment('env-1')
+    const { unmount } = renderHook(() => useRemoteAccountUsageSync())
+
+    act(() => {
+      watchHandlers?.onClosed?.()
+    })
+    unmount()
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(watchProviderAccounts).toHaveBeenCalledTimes(1)
+    expect(closeWatcher).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/remote-account-usage-sync.ts
+++ b/src/renderer/src/hooks/remote-account-usage-sync.ts
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+import { useAppStore } from '@/store'
+import {
+  watchProviderAccounts,
+  type ProviderAccountsWatcher
+} from '@/runtime/runtime-provider-accounts-client'
+
+const RESUBSCRIBE_MIN_DELAY_MS = 5_000
+const RESUBSCRIBE_MAX_DELAY_MS = 60_000
+
+/**
+ * Mirrors the active Remote Orca Server's RateLimitState into the store so
+ * usage surfaces show the account owner's usage, not this desktop's (#7973).
+ *
+ * accounts.subscribe pushes a fresh AccountsSnapshot whenever the server's
+ * RateLimitService state changes — its poll, forced refreshes, account
+ * switches, and live statusline posts from running sessions — so the bars
+ * track remote work in near-real-time. Mount once at App level.
+ */
+export function useRemoteAccountUsageSync(): void {
+  const environmentId = useAppStore((s) => s.settings?.activeRuntimeEnvironmentId?.trim() || null)
+  const setRemoteRateLimits = useAppStore((s) => s.setRemoteRateLimits)
+  const clearRemoteRateLimits = useAppStore((s) => s.clearRemoteRateLimits)
+
+  useEffect(() => {
+    clearRemoteRateLimits()
+    if (!environmentId) {
+      return
+    }
+
+    let disposed = false
+    let watcher: ProviderAccountsWatcher | null = null
+    let retryTimer: number | null = null
+    let retryDelayMs = RESUBSCRIBE_MIN_DELAY_MS
+
+    // Why: transport cutovers replay the subscription without a close, so this
+    // only fires for real stream ends (serve shutdown, auth loss). Backoff keeps
+    // an unreachable host at one dial per minute instead of a tight loop.
+    const scheduleResubscribe = (): void => {
+      if (disposed || retryTimer !== null) {
+        return
+      }
+      retryTimer = window.setTimeout(() => {
+        retryTimer = null
+        connect()
+      }, retryDelayMs)
+      retryDelayMs = Math.min(retryDelayMs * 2, RESUBSCRIBE_MAX_DELAY_MS)
+    }
+
+    const connect = (): void => {
+      if (disposed) {
+        return
+      }
+      watcher?.close()
+      watcher = watchProviderAccounts(
+        { activeRuntimeEnvironmentId: environmentId },
+        {
+          onSnapshot: (snapshot) => {
+            if (disposed) {
+              return
+            }
+            retryDelayMs = RESUBSCRIBE_MIN_DELAY_MS
+            if (snapshot.rateLimits) {
+              setRemoteRateLimits(environmentId, snapshot.rateLimits)
+            }
+          },
+          onError: scheduleResubscribe,
+          onClosed: scheduleResubscribe
+        }
+      )
+    }
+
+    connect()
+    return () => {
+      disposed = true
+      if (retryTimer !== null) {
+        window.clearTimeout(retryTimer)
+      }
+      watcher?.close()
+    }
+  }, [clearRemoteRateLimits, environmentId, setRemoteRateLimits])
+}

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
@@ -262,6 +262,42 @@ describe('watchProviderAccounts', () => {
     expect(snapshots).toHaveLength(2)
   })
 
+  it('notifies onClosed when the remote stream ends after delivering a snapshot', async () => {
+    const errors: unknown[] = []
+    const closes: number[] = []
+    watchProviderAccounts(REMOTE, {
+      onSnapshot: () => {},
+      onError: (error) => errors.push(error),
+      onClosed: () => closes.push(1)
+    })
+    await flushMicrotasks()
+
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'ready', snapshot: snapshotFixture('ready') }
+    })
+    subscriptionCallbacks?.onClose?.()
+
+    expect(closes).toHaveLength(1)
+    expect(errors).toHaveLength(0)
+  })
+
+  it('reports a close before any snapshot as an error, not onClosed', async () => {
+    const errors: unknown[] = []
+    const closes: number[] = []
+    watchProviderAccounts(REMOTE, {
+      onSnapshot: () => {},
+      onError: (error) => errors.push(error),
+      onClosed: () => closes.push(1)
+    })
+    await flushMicrotasks()
+
+    subscriptionCallbacks?.onClose?.()
+
+    expect(closes).toHaveLength(0)
+    expect(errors).toHaveLength(1)
+  })
+
   it('surfaces remote subscription failures as errors', async () => {
     const errors: unknown[] = []
     watchProviderAccounts(REMOTE, {

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.ts
@@ -79,6 +79,10 @@ export function watchProviderAccounts(
   handlers: {
     onSnapshot: (snapshot: ProviderAccountsSnapshot) => void
     onError: (error: unknown) => void
+    // Remote only: the stream ended after delivering snapshots (a close before
+    // the first snapshot surfaces through onError). Long-lived watchers use
+    // this to resubscribe; the local one-shot path never fires it.
+    onClosed?: () => void
   }
 ): ProviderAccountsWatcher {
   const target = getActiveRuntimeTarget(settings)
@@ -175,9 +179,14 @@ export function watchProviderAccounts(
           }
         },
         onClose: () => {
-          if (!closed && !receivedSnapshot) {
-            handlers.onError(new Error('Remote provider account subscription closed.'))
+          if (closed) {
+            return
           }
+          if (!receivedSnapshot) {
+            handlers.onError(new Error('Remote provider account subscription closed.'))
+            return
+          }
+          handlers.onClosed?.()
         }
       }
     )

--- a/src/renderer/src/store/slices/rate-limits.test.ts
+++ b/src/renderer/src/store/slices/rate-limits.test.ts
@@ -1,7 +1,11 @@
 import { createStore, type StoreApi } from 'zustand/vanilla'
-import { describe, expect, it } from 'vitest'
-import { createRateLimitSlice } from './rate-limits'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRateLimitSlice, selectAccountOwnerRateLimits } from './rate-limits'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
 import type { AppState } from '../types'
+
+const callRuntimeRpc = vi.hoisted(() => vi.fn())
+vi.mock('../../runtime/runtime-rpc-client', () => ({ callRuntimeRpc }))
 
 function createRateLimitStore(): StoreApi<AppState> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -10,10 +14,97 @@ function createRateLimitStore(): StoreApi<AppState> {
   ) as unknown as StoreApi<AppState>
 }
 
+function remoteStateFixture(marker: string): RateLimitState {
+  return {
+    ...createRateLimitStore().getState().rateLimits,
+    claude: {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: 1,
+      error: marker,
+      status: 'ok'
+    }
+  }
+}
+
+function setActiveEnvironment(store: StoreApi<AppState>, environmentId: string | null): void {
+  store.setState({
+    settings: { activeRuntimeEnvironmentId: environmentId } as AppState['settings']
+  })
+}
+
+beforeEach(() => {
+  callRuntimeRpc.mockReset()
+})
+
 describe('createRateLimitSlice', () => {
   it('initializes Antigravity usage with a stable pending key', () => {
     const store = createRateLimitStore()
 
     expect(store.getState().rateLimits.antigravity).toBeNull()
+  })
+
+  it('applies a remote snapshot only while its environment owns accounts', () => {
+    const store = createRateLimitStore()
+    setActiveEnvironment(store, 'env-1')
+
+    store.getState().setRemoteRateLimits('env-1', remoteStateFixture('current-owner'))
+    expect(store.getState().remoteRateLimits?.environmentId).toBe('env-1')
+
+    // Why: a slow frame from the previous owner must not label the new owner's usage.
+    store.getState().setRemoteRateLimits('env-0', remoteStateFixture('stale-owner'))
+    expect(store.getState().remoteRateLimits?.state.claude?.error).toBe('current-owner')
+  })
+
+  it('selects the remote snapshot for the active environment and falls back to local', () => {
+    const store = createRateLimitStore()
+    setActiveEnvironment(store, 'env-1')
+
+    // No remote snapshot yet: local state keeps the surface populated.
+    expect(selectAccountOwnerRateLimits(store.getState())).toBe(store.getState().rateLimits)
+
+    const remote = remoteStateFixture('remote')
+    store.getState().setRemoteRateLimits('env-1', remote)
+    expect(selectAccountOwnerRateLimits(store.getState())).toBe(remote)
+
+    // Back to local accounts: the lingering remote snapshot must not win.
+    setActiveEnvironment(store, null)
+    expect(selectAccountOwnerRateLimits(store.getState())).toBe(store.getState().rateLimits)
+
+    store.getState().clearRemoteRateLimits()
+    expect(store.getState().remoteRateLimits).toBeNull()
+  })
+
+  it('refreshRemoteAccountUsage forces a server usage refresh and stores the snapshot', async () => {
+    const store = createRateLimitStore()
+    setActiveEnvironment(store, 'env-1')
+    const remote = remoteStateFixture('forced')
+    callRuntimeRpc.mockResolvedValue({ rateLimits: remote })
+
+    await store.getState().refreshRemoteAccountUsage('env-1')
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'accounts.list',
+      { refreshUsage: true },
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    )
+    expect(store.getState().remoteRateLimits?.state).toBe(remote)
+  })
+
+  it('refreshRemoteAccountUsage keeps prior state on RPC failure and null snapshots', async () => {
+    const store = createRateLimitStore()
+    setActiveEnvironment(store, 'env-1')
+    const remote = remoteStateFixture('kept')
+    store.getState().setRemoteRateLimits('env-1', remote)
+
+    callRuntimeRpc.mockRejectedValueOnce(new Error('offline'))
+    await store.getState().refreshRemoteAccountUsage('env-1')
+    expect(store.getState().remoteRateLimits?.state).toBe(remote)
+
+    callRuntimeRpc.mockResolvedValueOnce({ rateLimits: null })
+    await store.getState().refreshRemoteAccountUsage('env-1')
+    expect(store.getState().remoteRateLimits?.state).toBe(remote)
   })
 })

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -1,9 +1,21 @@
 import type { StateCreator } from 'zustand'
 import type { RateLimitRuntimeTarget, RateLimitState } from '../../../../shared/rate-limit-types'
 import type { AppState } from '../types'
+import { callRuntimeRpc } from '../../runtime/runtime-rpc-client'
+
+// Why: forcing a server-side usage refresh serially re-fetches every provider
+// and the inactive-account caches; give it the same headroom as mobile.
+const REMOTE_USAGE_REFRESH_TIMEOUT_MS = 60_000
+
+export type RemoteAccountRateLimits = {
+  environmentId: string
+  state: RateLimitState
+}
 
 export type RateLimitSlice = {
   rateLimits: RateLimitState
+  // The active Remote Orca Server's usage snapshot (see #7973); null while local accounts own usage.
+  remoteRateLimits: RemoteAccountRateLimits | null
   fetchRateLimits: () => Promise<void>
   refreshRateLimits: () => Promise<void>
   refreshGrokRateLimits: () => Promise<void>
@@ -13,6 +25,20 @@ export type RateLimitSlice = {
   fetchInactiveClaudeAccountUsage: () => Promise<void>
   fetchInactiveCodexAccountUsage: () => Promise<void>
   setRateLimitsFromPush: (state: RateLimitState) => void
+  setRemoteRateLimits: (environmentId: string, state: RateLimitState) => void
+  clearRemoteRateLimits: () => void
+  refreshRemoteAccountUsage: (environmentId: string) => Promise<void>
+}
+
+// Why: with a Remote Orca Server active the server owns provider accounts
+// (#7973), so usage surfaces must read its snapshot — the local state describes
+// this desktop's credentials, which are not the ones doing the remote work.
+export function selectAccountOwnerRateLimits(s: AppState): RateLimitState {
+  const environmentId = s.settings?.activeRuntimeEnvironmentId?.trim() || null
+  if (environmentId && s.remoteRateLimits?.environmentId === environmentId) {
+    return s.remoteRateLimits.state
+  }
+  return s.rateLimits
 }
 
 export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice> = (set, get) => ({
@@ -32,6 +58,7 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     inactiveClaudeAccounts: [],
     inactiveCodexAccounts: []
   },
+  remoteRateLimits: null,
 
   fetchRateLimits: async () => {
     try {
@@ -148,5 +175,39 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
 
   setRateLimitsFromPush: (state) => {
     set({ rateLimits: state })
+  },
+
+  setRemoteRateLimits: (environmentId, state) => {
+    // Why: a slow subscription frame or refresh can resolve after the user
+    // switches account owners; a stale owner's snapshot must not be presented
+    // as the new owner's usage.
+    const active = get().settings?.activeRuntimeEnvironmentId?.trim() || null
+    if (active !== environmentId) {
+      return
+    }
+    set({ remoteRateLimits: { environmentId, state } })
+  },
+
+  clearRemoteRateLimits: () => {
+    set({ remoteRateLimits: null })
+  },
+
+  refreshRemoteAccountUsage: async (environmentId) => {
+    try {
+      // Why: refreshUsage forces the server's OAuth fetch lane (bypassing its
+      // poll throttle), which is the only way the Fable/weekly windows move on
+      // a headless host between statusline posts.
+      const snapshot = await callRuntimeRpc<{ rateLimits: RateLimitState | null }>(
+        { kind: 'environment', environmentId },
+        'accounts.list',
+        { refreshUsage: true },
+        { timeoutMs: REMOTE_USAGE_REFRESH_TIMEOUT_MS }
+      )
+      if (snapshot.rateLimits) {
+        get().setRemoteRateLimits(environmentId, snapshot.rateLimits)
+      }
+    } catch (error) {
+      console.error('Failed to refresh remote account usage:', error)
+    }
   }
 })


### PR DESCRIPTION
## Problem

When a client is attached to a Remote Orca Server, the server owns the provider accounts (#7973): the status-bar account switcher lists the server's accounts and account switches apply server-side. But the usage surfaces never made that move — the usage roster, the per-provider drill-in bars, and the bottom-bar segments all kept rendering the desktop's own `RateLimitState`, and the refresh button only re-fetched the desktop's local credentials.

The result is a panel that looks coherent but mixes two hosts: it names the server's active account while charting some other account's usage. The account actually doing the remote work never moves, no matter how often the user hits refresh — reported as "usage barely updates against a remote server, and even the refresh button doesn't refresh my current account's progress."

## Fix

- **Mirror the server's usage into the client.** A new `useRemoteAccountUsageSync` hook (mounted once at App level) keeps a persistent `accounts.subscribe` watcher on the active runtime environment and mirrors each snapshot's `rateLimits` into a new `remoteRateLimits` store field. The server pushes a fresh snapshot whenever its `RateLimitService` state changes — forced refreshes, account switches, and live statusline posts from running sessions — so the bars track remote work in near-real-time, the same lane the mobile app already uses.
- **Select the account owner's state.** `selectAccountOwnerRateLimits` returns the active environment's snapshot when one is mirrored and falls back to local state otherwise. The status-bar roster, Claude/Codex switcher menus, and inactive-account usage rows now read through it. Applying a snapshot is guarded by owner: a slow frame from a previous environment can't be presented as the new owner's usage.
- **Route refresh to the owner.** With a remote environment active, the refresh button calls `accounts.list { refreshUsage: true }` on the server — the forced lane that bypasses its poll throttle and is the only way the Fable/weekly OAuth windows move on a headless host between statusline posts — and applies the returned snapshot. Local refresh behavior is unchanged when no environment is active.
- **Survive stream ends.** `watchProviderAccounts` gains an optional `onClosed` handler (remote only; a close before the first snapshot still surfaces through `onError`). The long-lived watcher resubscribes with exponential backoff; transport cutovers already replay the subscription without a close, so backoff only engages for real stream ends.

## Compatibility

No server or protocol changes: `accounts.subscribe` and `accounts.list { refreshUsage }` are existing methods already allowlisted for paired clients. Local-only desktops, direct-SSH hosts, and WSL account targets keep the exact current behavior — the remote lane only engages while `activeRuntimeEnvironmentId` is set. The web client, whose `window.api.rateLimits` is a stub, gains working usage display through the same subscription.

## Tests

Slice coverage for the owner-scoped selector (remote wins only while its environment is active, local fallback before the first snapshot and after switching back), the stale-owner apply guard, and the forced remote refresh (parameters, null-snapshot and RPC-failure keep prior state). Hook coverage for subscribe/mirror, ignoring rate-limit-less frames, owner-change cleanup and resubscription, backoff after close/error, and unmount teardown. `watchProviderAccounts` coverage for `onClosed` after a delivered snapshot vs. error on close before one. All touched suites (status bar, settings/AccountsPane, renderer store + runtime, 3,000+ tests) and `pnpm run typecheck` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
