### PR TITLE
fix(agent-hooks): handle Claude SessionEnd

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -4727,6 +4727,38 @@ describe('Claude hook normalization', () => {
     expect(result?.payload.lastAssistantMessage).toBeUndefined()
   })
 
+  it('SessionEnd clears a stale Claude permission wait', () => {
+    _internals.normalizeHookPayload(
+      'claude',
+      buildBody({
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'deploy production'
+      }),
+      'production'
+    )
+    const waiting = _internals.normalizeHookPayload(
+      'claude',
+      buildBody({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash'
+      }),
+      'production'
+    )
+    expect(waiting?.payload.state).toBe('waiting')
+
+    const ended = _internals.normalizeHookPayload(
+      'claude',
+      buildBody({
+        hook_event_name: 'SessionEnd',
+        reason: 'prompt_input_exit'
+      }),
+      'production'
+    )
+
+    expect(ended?.payload.state).toBe('done')
+    expect(ended?.payload.prompt).toBe('deploy production')
+  })
+
   describe('Stop transcript scan', () => {
     let tmpDir: string
     let transcriptPath: string

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -324,7 +324,7 @@ describe('ClaudeHookService.install', () => {
           readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
         ) as { hooks: Record<string, { hooks: { command: string }[] }[]> }
 
-        for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
+        for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure', 'SessionEnd']) {
           const command = settings.hooks[eventName]?.[0]?.hooks?.[0]?.command
           expect(command).toMatch(WINDOWS_POWERSHELL_LAUNCHER)
         }
@@ -381,6 +381,7 @@ describe('ClaudeHookService.installRemote', () => {
       'UserPromptSubmit',
       'Stop',
       'StopFailure',
+      'SessionEnd',
       'SubagentStart',
       'SubagentStop',
       'TeammateIdle',
@@ -481,7 +482,7 @@ describe('OpenClaudeHookService-compatible install', () => {
         configPath: openClaudeSettings
       })
       const parsed = JSON.parse(readFileSync(openClaudeSettings, 'utf-8'))
-      for (const event of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
+      for (const event of ['UserPromptSubmit', 'Stop', 'StopFailure', 'SessionEnd']) {
         const command = parsed.hooks[event][0].hooks[0].command as string
         expect(isOpenClaudeManagedCommand(command)).toBe(true)
         if (process.platform !== 'win32') {

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -33,6 +33,8 @@ export const CLAUDE_EVENTS = [
   // Why: OpenClaude skips normal Stop hooks after API/model errors and emits
   // StopFailure instead; without this hook Orca leaves the turn spinning.
   { eventName: 'StopFailure', definition: { hooks: [{ type: 'command', command: '' }] } },
+  // Why: a session can exit without a final Stop, leaving Orca stuck as working or waiting.
+  { eventName: 'SessionEnd', definition: { hooks: [{ type: 'command', command: '' }] } },
   // Why: subagent/teammate lifecycle feeds the sidebar's child rows and keeps
   // a pane 'working' while background children outlive the lead's turn.
   // TeammateIdle parks turn-based teammates without trusting their permanently

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1393,6 +1393,76 @@ describe('shared agent-hook-listener', () => {
     })
   })
 
+  it('normalizes Claude SessionEnd to done from a working turn', () => {
+    normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'UserPromptSubmit', prompt: 'finish the task' }
+      },
+      'production'
+    )
+
+    const ended = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'SessionEnd', reason: 'prompt_input_exit' }
+      },
+      'production'
+    )
+
+    expect(ended?.payload).toMatchObject({
+      state: 'done',
+      prompt: 'finish the task',
+      agentType: 'claude'
+    })
+  })
+
+  it('clears working Claude subagents when SessionEnd terminates the session', () => {
+    normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'UserPromptSubmit', prompt: 'delegate the task' }
+      },
+      'production'
+    )
+    normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'SubagentStart',
+          agent_id: 'worker-1',
+          agent_type: 'general-purpose'
+        }
+      },
+      'production'
+    )
+
+    const ended = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'SessionEnd', reason: 'prompt_input_exit' }
+      },
+      'production'
+    )
+
+    expect(ended?.payload).toMatchObject({
+      state: 'done',
+      prompt: 'delegate the task',
+      agentType: 'claude'
+    })
+    expect(ended?.payload.subagents).toBeUndefined()
+  })
+
   it('normalizes Devin documented lifecycle events', () => {
     const started = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1355,6 +1355,44 @@ describe('shared agent-hook-listener', () => {
     expect(event?.payload.lastAssistantMessage).toBeUndefined()
   })
 
+  it('normalizes Claude SessionEnd to done after a permission wait', () => {
+    normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'UserPromptSubmit', prompt: 'deploy production' }
+      },
+      'production'
+    )
+    const waiting = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'PermissionRequest', tool_name: 'Bash' }
+      },
+      'production'
+    )
+    expect(waiting?.payload.state).toBe('waiting')
+
+    const ended = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'SessionEnd', reason: 'prompt_input_exit' }
+      },
+      'production'
+    )
+
+    expect(ended?.payload).toMatchObject({
+      state: 'done',
+      prompt: 'deploy production',
+      agentType: 'claude'
+    })
+  })
+
   it('normalizes Devin documented lifecycle events', () => {
     const started = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2628,7 +2628,8 @@ function normalizeClaudeEvent(
   }
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
   // Why: only a turn boundary may declare an interrupt or carry a prior one forward; any other event starts a fresh turn and drops it.
-  const isTurnBoundary = eventName === 'Stop' || eventName === 'StopFailure'
+  const isTurnBoundary =
+    eventName === 'Stop' || eventName === 'StopFailure' || eventName === 'SessionEnd'
   const interrupted =
     isTurnBoundary &&
     ((eventAgentId === undefined && hookPayload['is_interrupt'] === true) ||

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2718,7 +2718,12 @@ function normalizeClaudeEvent(
     return buildClaudeChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
-  if (isTurnBoundary && eventAgentId === undefined) {
+  if (eventName === 'SessionEnd' && eventAgentId === undefined) {
+    // Why: no later child/task event is guaranteed after session teardown, so stale session-scoped work must not gate the terminal done state.
+    state.claudeSubagentRosterByPaneKey.delete(paneKey)
+    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
+    state.claudeActiveSessionCronPaneKeys.delete(paneKey)
+  } else if (isTurnBoundary && eventAgentId === undefined) {
     // Why: background_tasks is trusted only where unambiguous (see foldClaudeBackgroundTasksIntoRoster) — teammates report "running" here even while idle.
     // Older Claude builds without the field keep the incrementally tracked roster.
     if (backgroundTasks.present) {


### PR DESCRIPTION
## Summary

- register Claude/OpenClaude-compatible `SessionEnd` in Orca's managed hooks
- normalize clean session teardown to `done` so stale working/waiting status clears
- cover local/remote hook installation and the permission-wait regression

Fixes #11944

## Testing

- [x] Targeted Vitest suite: 383 passed, 2 skipped
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] Full `pnpm test`: 42,832 passed, 81 skipped, 6 unrelated local-environment failures

The full suite's failures are outside the changed Claude hook paths: two relay tests caused by injected Git config environment variables (and passed when rerun with those variables removed), three macOS runs of the Bash-based root-directory guard, and one existing non-ASCII Zsh wrapper-path test.

## AI Review Summary

- Cross-platform: the shared hook JSON and event normalizer contain no OS-specific paths or shortcuts.
- Local/SSH/folder workspaces: the same `CLAUDE_EVENTS` list drives local and remote installers; remote registration has regression coverage.
- Agents/integrations: behavior is limited to the Claude-compatible hook service; other providers are unchanged.
- Performance: reuses the existing lightweight hook transport with no polling, timer, or hot-loop work.
- UI quality: no visual change; session exit now clears stale sidebar status.
- Security: reuses the existing managed hook and status transport; no new command, secret, file, network, or IPC surface.

## Manual verification

- Not run: packaged Claude Code exit flow on Windows or SSH.

X (Twitter): not provided
