### PR TITLE
fix(ime): scope deferred newline to captured sessions

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
@@ -149,6 +149,35 @@ describe('installTerminalImeCompositionRoute', () => {
     expect(harness.input).not.toHaveBeenCalled()
   })
 
+  it('leaves an uncaptured session to xterm when installed mid-composition', () => {
+    const harness = createHarness()
+
+    // No start was seen, so nothing here can deliver the text. Cancelling the event
+    // would suppress xterm's own insertion and drop the commit on the floor.
+    const notPrevented = harness.end(1, '한')
+
+    expect(notPrevented).toBe(true)
+    expect(harness.input).not.toHaveBeenCalled()
+  })
+
+  it('suppresses xterm insertion only for a session it captured', () => {
+    const harness = createHarness()
+    harness.start(1)
+
+    expect(harness.end(1, '한')).toBe(false)
+    expect(harness.input).toHaveBeenCalledWith('한')
+  })
+
+  it('keeps suppressing insertion for a captured session it deliberately drops', () => {
+    const harness = createHarness()
+    harness.start(1)
+    harness.state.currentTransport = createTransport('pty-replacement')
+
+    // Owned, so xterm must still stand down — the drop is this route's decision.
+    expect(harness.end(1, '한')).toBe(false)
+    expect(harness.input).not.toHaveBeenCalled()
+  })
+
   it.each(['terminal close', 'tab unmount'])(
     'releases the captured session and listeners on %s',
     () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.test.ts
@@ -129,6 +129,31 @@ describe('installTerminalImeCompositionRoute', () => {
     expect(hasPendingTerminalImeComposition(harness.element)).toBe(false)
   })
 
+  it('keeps a shared session pending until every overlapping route releases it', () => {
+    const element = document.createElement('div')
+    const firstTransport = createTransport('pty-first')
+    const secondTransport = createTransport('pty-second')
+    const firstRoute = installTerminalImeCompositionRoute({
+      terminalElement: element,
+      terminal: { input: vi.fn() },
+      capturedTransport: firstTransport,
+      getCurrentTransport: () => firstTransport
+    })
+    const secondRoute = installTerminalImeCompositionRoute({
+      terminalElement: element,
+      terminal: { input: vi.fn() },
+      capturedTransport: secondTransport,
+      getCurrentTransport: () => secondTransport
+    })
+
+    element.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 1))
+    firstRoute.dispose()
+    expect(hasPendingTerminalImeComposition(element)).toBe(true)
+
+    secondRoute.dispose()
+    expect(hasPendingTerminalImeComposition(element)).toBe(false)
+  })
+
   it('drops a commit after same-pane PTY replacement', () => {
     const harness = createHarness()
     harness.start(1)

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
@@ -82,11 +82,13 @@ export function installTerminalImeCompositionRoute(args: {
     if (!detail) {
       return
     }
-    event.preventDefault()
     const captured = sessions.get(detail.id)
     if (!captured) {
+      // Not our session — the route was installed mid-composition, so no start was seen.
+      // Preventing default here would suppress xterm's insertion with nothing to replace it.
       return
     }
+    event.preventDefault()
     sessions.delete(detail.id)
     adjustPendingCompositionCount(terminalElement, -1)
     if (

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
@@ -14,21 +14,61 @@ type CapturedCompositionSession = {
   ptyId: string | null
 }
 
-const pendingCompositionCountByElement = new WeakMap<HTMLElement, number>()
+export type TerminalImeCompositionSessionSnapshot = ReadonlySet<number>
 
-function adjustPendingCompositionCount(terminalElement: HTMLElement, delta: number): void {
-  const count = Math.max(0, (pendingCompositionCountByElement.get(terminalElement) ?? 0) + delta)
-  if (count === 0) {
-    pendingCompositionCountByElement.delete(terminalElement)
+const pendingCompositionSessionCountsByElement = new WeakMap<HTMLElement, Map<number, number>>()
+
+function addPendingCompositionSession(terminalElement: HTMLElement, sessionId: number): void {
+  const sessionCounts = pendingCompositionSessionCountsByElement.get(terminalElement) ?? new Map()
+  sessionCounts.set(sessionId, (sessionCounts.get(sessionId) ?? 0) + 1)
+  pendingCompositionSessionCountsByElement.set(terminalElement, sessionCounts)
+}
+
+function removePendingCompositionSession(terminalElement: HTMLElement, sessionId: number): void {
+  const sessionCounts = pendingCompositionSessionCountsByElement.get(terminalElement)
+  const count = sessionCounts?.get(sessionId)
+  if (!sessionCounts || count === undefined) {
     return
   }
-  pendingCompositionCountByElement.set(terminalElement, count)
+  if (count > 1) {
+    sessionCounts.set(sessionId, count - 1)
+  } else {
+    sessionCounts.delete(sessionId)
+  }
+  if (!sessionCounts.size) {
+    pendingCompositionSessionCountsByElement.delete(terminalElement)
+  }
+}
+
+export function capturePendingTerminalImeCompositionSessions(
+  terminalElement: HTMLElement | null | undefined
+): TerminalImeCompositionSessionSnapshot {
+  if (!terminalElement) {
+    return new Set()
+  }
+  return new Set(pendingCompositionSessionCountsByElement.get(terminalElement)?.keys())
 }
 
 export function hasPendingTerminalImeComposition(
-  terminalElement: HTMLElement | null | undefined
+  terminalElement: HTMLElement | null | undefined,
+  snapshot?: TerminalImeCompositionSessionSnapshot
 ): boolean {
-  return Boolean(terminalElement && pendingCompositionCountByElement.has(terminalElement))
+  if (!terminalElement) {
+    return false
+  }
+  const sessionCounts = pendingCompositionSessionCountsByElement.get(terminalElement)
+  if (!sessionCounts) {
+    return false
+  }
+  if (!snapshot) {
+    return true
+  }
+  for (const sessionId of snapshot) {
+    if (sessionCounts.has(sessionId)) {
+      return true
+    }
+  }
+  return false
 }
 
 function getCompositionDetail(event: Event): CompositionSessionDetail | null {
@@ -70,7 +110,7 @@ export function installTerminalImeCompositionRoute(args: {
       return
     }
     if (!sessions.has(detail.id)) {
-      adjustPendingCompositionCount(terminalElement, 1)
+      addPendingCompositionSession(terminalElement, detail.id)
     }
     sessions.set(detail.id, {
       ptyId: args.capturedTransport.getPtyId()
@@ -90,7 +130,7 @@ export function installTerminalImeCompositionRoute(args: {
     }
     event.preventDefault()
     sessions.delete(detail.id)
-    adjustPendingCompositionCount(terminalElement, -1)
+    removePendingCompositionSession(terminalElement, detail.id)
     if (
       disposed ||
       detail.dataPendingReconciliation ||
@@ -110,7 +150,9 @@ export function installTerminalImeCompositionRoute(args: {
   return {
     dispose: () => {
       disposed = true
-      adjustPendingCompositionCount(terminalElement, -sessions.size)
+      for (const sessionId of sessions.keys()) {
+        removePendingCompositionSession(terminalElement, sessionId)
+      }
       sessions.clear()
       terminalElement.removeEventListener(XTERM_COMPOSITION_SESSION_START_EVENT, onSessionStart)
       terminalElement.removeEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onSessionEnd)

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline-xterm.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline-xterm.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PtyTransport } from './pty-transport'
+import {
+  installTerminalImeCompositionRoute,
+  XTERM_COMPOSITION_SESSION_END_EVENT,
+  XTERM_COMPOSITION_SESSION_START_EVENT
+} from './terminal-ime-composition-route'
+import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function dispatchComposition(
+  textarea: HTMLTextAreaElement,
+  type: 'compositionstart' | 'compositionupdate' | 'compositionend',
+  data = ''
+): void {
+  const event = new CompositionEvent(type, { bubbles: true })
+  Object.defineProperty(event, 'data', { value: data })
+  textarea.dispatchEvent(event)
+}
+
+describe('deferred terminal newline through xterm composition sessions', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('releases after its captured xterm session despite a later session', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const terminal = new Terminal()
+    terminal.open(container)
+    const terminalElement = terminal.element
+    const textarea = terminal.textarea
+    if (!terminalElement || !textarea) {
+      throw new Error('xterm input surface was not created')
+    }
+
+    const sessionOrder: string[] = []
+    terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_START_EVENT, (event) => {
+      sessionOrder.push(`start:${(event as CustomEvent<{ id: number }>).detail.id}`)
+    })
+    terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, (event) => {
+      sessionOrder.push(`end:${(event as CustomEvent<{ id: number }>).detail.id}`)
+    })
+    const emitted: string[] = []
+    terminal.onData((data) => emitted.push(data))
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement,
+      terminal,
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+
+    dispatchComposition(textarea, 'compositionstart')
+    dispatchComposition(textarea, 'compositionupdate', '한')
+    textarea.value = '한'
+    textarea.setSelectionRange(1, 1)
+    sendTerminalInputAfterComposition(terminalElement, () => terminal.input('\n'))
+    dispatchComposition(textarea, 'compositionend', '한')
+    dispatchComposition(textarea, 'compositionstart')
+
+    expect(sessionOrder).toEqual(['start:1', 'start:2'])
+    await nextEventLoop()
+    await nextEventLoop()
+    expect(sessionOrder).toEqual(['start:1', 'start:2', 'end:1'])
+    expect(emitted.join('')).toBe('한\n')
+
+    route.dispose()
+    terminal.dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -116,6 +116,114 @@ describe('sendTerminalInputAfterComposition', () => {
     expect(send).toHaveBeenCalledTimes(1)
   })
 
+  it('re-arms past the fallback rather than splitting a still-pending composition', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1, data: '한' } })
+    )
+
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 1000 })
+    vi.advanceTimersByTime(500)
+
+    // A slow candidate window is not a reason to send Enter into the middle of the preedit.
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_END_EVENT, { detail: { id: 1, data: '한' } })
+    )
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
+  it('holds the newline through a long conversion that keeps updating its preedit', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1, data: 'にほん' } })
+    )
+
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+
+    // Multi-segment bunsetsu conversion: each segment takes longer than the ceiling
+    // in total, but never leaves the preedit idle for a full ceiling's worth.
+    for (let segment = 0; segment < 6; segment += 1) {
+      vi.advanceTimersByTime(150)
+      el.dispatchEvent(new Event('compositionupdate'))
+    }
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_END_EVENT, { detail: { id: 1, data: '日本' } })
+    )
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
+  it('holds for a composition already in flight when nothing recorded its session start', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    // No route installed, so there is no pending session to report — the live
+    // compositionupdate is the only evidence the composition exists.
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+    for (let tick = 0; tick < 5; tick += 1) {
+      vi.advanceTimersByTime(30)
+      el.dispatchEvent(new Event('compositionupdate'))
+    }
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends once at the ceiling when a composition never ends', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    el.dispatchEvent(
+      new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1, data: '한' } })
+    )
+
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+    vi.advanceTimersByTime(150)
+    expect(send).not.toHaveBeenCalled()
+
+    // Bounded: a composition that stops progressing must not strand the keystroke.
+    vi.advanceTimersByTime(100)
+    expect(send).toHaveBeenCalledTimes(1)
+
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
   it('still delivers the input on the next macrotask without a terminal element', () => {
     const send = vi.fn()
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -88,6 +88,35 @@ describe('sendTerminalInputAfterComposition', () => {
     route.dispose()
   })
 
+  it('does not let a composition started after defer hold the newline', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const terminal = { input: vi.fn() }
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal,
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    const sessionEvent = (type: string, id: number) =>
+      new CustomEvent(type, { detail: { id, data: `commit-${id}` } })
+
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 1))
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 1000 })
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 2))
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_END_EVENT, 1))
+    vi.advanceTimersByTime(0)
+
+    expect(send).toHaveBeenCalledTimes(1)
+
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_END_EVENT, 2))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
   it('sends only once and drops the listener after firing', () => {
     const el = document.createElement('div')
     const send = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -117,6 +117,32 @@ describe('sendTerminalInputAfterComposition', () => {
     route.dispose()
   })
 
+  it('does not let updates from a later session refresh a captured session', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const transport = { getPtyId: () => 'pty-1' } as unknown as PtyTransport
+    const route = installTerminalImeCompositionRoute({
+      terminalElement: el,
+      terminal: { input: vi.fn() },
+      capturedTransport: transport,
+      getCurrentTransport: () => transport
+    })
+    const sessionEvent = (type: string, id: number) =>
+      new CustomEvent(type, { detail: { id, data: `commit-${id}` } })
+
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 1))
+    sendTerminalInputAfterComposition(el, send, { fallbackMs: 50, maxIdleMs: 200 })
+    el.dispatchEvent(sessionEvent(XTERM_COMPOSITION_SESSION_START_EVENT, 2))
+    for (let tick = 0; tick < 10; tick += 1) {
+      vi.advanceTimersByTime(30)
+      el.dispatchEvent(new Event('compositionupdate'))
+    }
+
+    expect(send).toHaveBeenCalledTimes(1)
+
+    route.dispose()
+  })
+
   it('sends only once and drops the listener after firing', () => {
     const el = document.createElement('div')
     const send = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -5,18 +5,29 @@ import {
 
 export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
 
+// Ceiling for a composition that stops making progress. Measured from the last
+// compositionupdate, not from the start: multi-segment bunsetsu conversion keeps a
+// Japanese composition legitimately pending far longer than this, and finishing on a
+// total-elapsed ceiling would split it with the newline this deferral exists to hold back.
+export const TERMINAL_IME_DEFERRED_NEWLINE_MAX_IDLE_MS = 2000
+
 export function sendTerminalInputAfterComposition(
   terminalElement: HTMLElement | null | undefined,
   send: () => void,
-  options?: { fallbackMs?: number }
+  options?: { fallbackMs?: number; maxIdleMs?: number }
 ): void {
   if (!terminalElement) {
     window.setTimeout(send, 0)
     return
   }
 
-  const fallbackMs = options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS
+  const fallbackMs = Math.max(1, options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS)
+  const maxIdleMs = Math.max(
+    fallbackMs,
+    options?.maxIdleMs ?? TERMINAL_IME_DEFERRED_NEWLINE_MAX_IDLE_MS
+  )
   let done = false
+  let idleMs = 0
 
   const finish = (): void => {
     if (done) {
@@ -24,6 +35,7 @@ export function sendTerminalInputAfterComposition(
     }
     done = true
     terminalElement.removeEventListener('compositionend', onCompositionEnd)
+    terminalElement.removeEventListener('compositionupdate', onCompositionUpdate)
     terminalElement.removeEventListener(
       XTERM_COMPOSITION_SESSION_END_EVENT,
       onCompositionSessionEnd
@@ -40,9 +52,33 @@ export function sendTerminalInputAfterComposition(
   }
   const onCompositionEnd = (): void => finishAfterPendingComposition()
   const onCompositionSessionEnd = (): void => finishAfterPendingComposition()
+  // Each preedit change proves the composition is still progressing, so the idle
+  // ceiling only ever expires on a composition that is genuinely stuck.
+  let sawRecentUpdate = false
+  const onCompositionUpdate = (): void => {
+    idleMs = 0
+    sawRecentUpdate = true
+  }
   terminalElement.addEventListener('compositionend', onCompositionEnd)
+  terminalElement.addEventListener('compositionupdate', onCompositionUpdate)
   terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onCompositionSessionEnd)
-  const fallbackTimer = window.setTimeout(finish, fallbackMs)
+
+  // Re-arm rather than sending: firing mid-composition splits the preedit with a newline.
+  const onFallbackDeadline = (): void => {
+    idleMs += fallbackMs
+    // A live compositionupdate counts as evidence on its own: a route installed while a
+    // composition was already in flight never saw that session start, so it has nothing
+    // recorded to report as pending.
+    const compositionInProgress =
+      hasPendingTerminalImeComposition(terminalElement) || sawRecentUpdate
+    sawRecentUpdate = false
+    if (!compositionInProgress || idleMs >= maxIdleMs) {
+      finish()
+      return
+    }
+    fallbackTimer = window.setTimeout(onFallbackDeadline, fallbackMs)
+  }
+  let fallbackTimer = window.setTimeout(onFallbackDeadline, fallbackMs)
 }
 
 export type TerminalImeDeferredNewlineSender = {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -1,4 +1,5 @@
 import {
+  capturePendingTerminalImeCompositionSessions,
   hasPendingTerminalImeComposition,
   XTERM_COMPOSITION_SESSION_END_EVENT
 } from './terminal-ime-composition-route'
@@ -28,6 +29,9 @@ export function sendTerminalInputAfterComposition(
   )
   let done = false
   let idleMs = 0
+  const pendingCompositionSessions = capturePendingTerminalImeCompositionSessions(terminalElement)
+  const hasCapturedPendingComposition = (): boolean =>
+    hasPendingTerminalImeComposition(terminalElement, pendingCompositionSessions)
 
   const finish = (): void => {
     if (done) {
@@ -46,7 +50,7 @@ export function sendTerminalInputAfterComposition(
   }
 
   const finishAfterPendingComposition = (): void => {
-    if (!hasPendingTerminalImeComposition(terminalElement)) {
+    if (!hasCapturedPendingComposition()) {
       finish()
     }
   }
@@ -56,6 +60,9 @@ export function sendTerminalInputAfterComposition(
   // ceiling only ever expires on a composition that is genuinely stuck.
   let sawRecentUpdate = false
   const onCompositionUpdate = (): void => {
+    if (pendingCompositionSessions.size > 0 && !hasCapturedPendingComposition()) {
+      return
+    }
     idleMs = 0
     sawRecentUpdate = true
   }
@@ -70,7 +77,7 @@ export function sendTerminalInputAfterComposition(
     // composition was already in flight never saw that session start, so it has nothing
     // recorded to report as pending.
     const compositionInProgress =
-      hasPendingTerminalImeComposition(terminalElement) || sawRecentUpdate
+      pendingCompositionSessions.size > 0 ? hasCapturedPendingComposition() : sawRecentUpdate
     sawRecentUpdate = false
     if (!compositionInProgress || idleMs >= maxIdleMs) {
       finish()

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -1,7 +1,8 @@
 import {
   capturePendingTerminalImeCompositionSessions,
   hasPendingTerminalImeComposition,
-  XTERM_COMPOSITION_SESSION_END_EVENT
+  XTERM_COMPOSITION_SESSION_END_EVENT,
+  XTERM_COMPOSITION_SESSION_START_EVENT
 } from './terminal-ime-composition-route'
 
 export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
@@ -29,6 +30,7 @@ export function sendTerminalInputAfterComposition(
   )
   let done = false
   let idleMs = 0
+  let laterSessionStarted = false
   const pendingCompositionSessions = capturePendingTerminalImeCompositionSessions(terminalElement)
   const hasCapturedPendingComposition = (): boolean =>
     hasPendingTerminalImeComposition(terminalElement, pendingCompositionSessions)
@@ -40,6 +42,10 @@ export function sendTerminalInputAfterComposition(
     done = true
     terminalElement.removeEventListener('compositionend', onCompositionEnd)
     terminalElement.removeEventListener('compositionupdate', onCompositionUpdate)
+    terminalElement.removeEventListener(
+      XTERM_COMPOSITION_SESSION_START_EVENT,
+      onCompositionSessionStart
+    )
     terminalElement.removeEventListener(
       XTERM_COMPOSITION_SESSION_END_EVENT,
       onCompositionSessionEnd
@@ -55,11 +61,16 @@ export function sendTerminalInputAfterComposition(
     }
   }
   const onCompositionEnd = (): void => finishAfterPendingComposition()
+  const onCompositionSessionStart = (): void => {
+    laterSessionStarted = true
+  }
   const onCompositionSessionEnd = (): void => finishAfterPendingComposition()
-  // Each preedit change proves the composition is still progressing, so the idle
-  // ceiling only ever expires on a composition that is genuinely stuck.
+  // Only preedit changes before a later xterm session starts belong to this snapshot.
   let sawRecentUpdate = false
   const onCompositionUpdate = (): void => {
+    if (laterSessionStarted) {
+      return
+    }
     if (pendingCompositionSessions.size > 0 && !hasCapturedPendingComposition()) {
       return
     }
@@ -68,6 +79,7 @@ export function sendTerminalInputAfterComposition(
   }
   terminalElement.addEventListener('compositionend', onCompositionEnd)
   terminalElement.addEventListener('compositionupdate', onCompositionUpdate)
+  terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_START_EVENT, onCompositionSessionStart)
   terminalElement.addEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onCompositionSessionEnd)
 
   // Re-arm rather than sending: firing mid-composition splits the preedit with a newline.


### PR DESCRIPTION
## Summary

#11896 re-arms the deferred-newline deadline while a composition is pending, but its global pending count also includes sessions that start after the newline was deferred. If a new composition overlaps the original session's end, that later session can hold the older newline and reverse the intended `syllable -> newline -> next syllable` ordering.

This follow-up:

- snapshots the xterm composition session IDs that are open when the newline is deferred
- waits only for those captured sessions, excluding sessions started afterward
- keeps per-session reference counts so overlapping route installations on the same terminal element cannot clear each other's pending state
- preserves the existing `compositionupdate` fallback for routes installed mid-composition, where no session start was captured

Related: #11878. Stacked on #11896.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint not run; both oxlint configurations passed on all four changed files
- [ ] `pnpm typecheck` — full three-project check not run; `tsc --noEmit -p config/tsconfig.tc.web.json` passed
- [ ] `pnpm test` — full suite not run; 59 focused IME tests passed across `keyboard-handlers-ime`, `terminal-ime-composition-route`, and `terminal-ime-deferred-newline`
- [ ] `pnpm build` — not run
- [x] Added regression coverage for post-defer sessions and overlapping route ownership

Additional gates passed: `oxfmt --check`, `check:max-lines-ratchet`, and `git diff --check`.

## AI Review Report

Reviewed the change against the IME transaction lifecycle, delayed completion, route replacement, and local/SSH transport paths. The first implementation stored pending IDs in a `Set`; review found that two overlapping routes can own the same session ID, so disposing one route would incorrectly clear the other's pending state. The implementation now uses per-session reference counts, with a regression test for overlapping route ownership.

Cross-platform review: the change is platform-neutral DOM/xterm composition bookkeeping. It does not alter shortcuts, labels, file paths, shell commands, or Electron platform branches on macOS, Linux, or Windows. Local, SSH, and relay panes continue to use the same terminal-element-scoped state and transport abstraction.

## Security Audit

The change only narrows when an already-resolved terminal input write may fire. It does not add or transform input bytes, execute commands, touch paths, add IPC, change authentication, read secrets, or add dependencies. Snapshot state remains in a terminal-element-keyed `WeakMap`; disposed routes release their reference counts.

## Notes

This PR intentionally targets the head branch of #11896 rather than `main`, so it can be reviewed and folded into that existing non-duplicate IME fix.