### PR TITLE
fix(terminal): expand environment variables in Windows PATH

### DIFF
--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -17,6 +17,7 @@ import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import type { CliInstallMethod, CliInstallStatus } from '../../shared/cli-install-types'
+import { expandWindowsEnvironmentVariables } from '../../shared/windows-environment-expansion'
 import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
 import {
   invalidateWindowsUserPathRegistryCache,
@@ -1085,13 +1086,6 @@ function normalizeWindowsPath(
     .replaceAll('/', '\\')
     .replace(/\\+$/, '')
     .toLowerCase()
-}
-
-function expandWindowsEnvironmentVariables(value: string, env: NodeJS.ProcessEnv): string {
-  return value.replace(/%([^%]+)%/g, (match, rawName: string) => {
-    const envKey = Object.keys(env).find((key) => key.toLowerCase() === rawName.toLowerCase())
-    return envKey && env[envKey] ? env[envKey] : match
-  })
 }
 
 function escapeWindowsBatchValue(value: string): string {

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -208,6 +208,7 @@ describe('createPtySubprocess', () => {
         rows: 24,
         cwd: 'C:\\repo',
         env: {
+          ORCA_AGENT_TEAMS_TEAM_ID: 'team-test',
           ORCA_PATH_ROOT: 'C:\\Users\\orca\\AppData\\Local',
           PATH: '%orca_path_root%\\agy\\bin;C:\\Windows'
         }

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -196,6 +196,33 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('expands variables in PATH before spawning a Windows shell', () => {
+    spawnMock.mockReturnValue(mockPtyProcess())
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: {
+          ORCA_PATH_ROOT: 'C:\\Users\\orca\\AppData\\Local',
+          PATH: '%orca_path_root%\\agy\\bin;C:\\Windows'
+        }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock.mock.calls.at(-1)?.[2].env.PATH).toBe(
+      'C:\\Users\\orca\\AppData\\Local\\agy\\bin;C:\\Windows'
+    )
+  })
+
   it('appends Git prompt guards after the detached daemon inherited config', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
@@ -2057,8 +2084,10 @@ describe('createPtySubprocess', () => {
   it('preserves a daemon-owned custom Codex home while deleting a stale private marker', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     const previousCodexHome = process.env.CODEX_HOME
     const previousOrcaCodexHome = process.env.ORCA_CODEX_HOME
+    Object.defineProperty(process, 'platform', { value: 'linux' })
     process.env.CODEX_HOME = '/daemon/user/codex-home'
     process.env.ORCA_CODEX_HOME = '/daemon/stale/managed-home'
 
@@ -2071,6 +2100,9 @@ describe('createPtySubprocess', () => {
         envToDelete: ['ORCA_CODEX_HOME']
       })
     } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
       if (previousCodexHome === undefined) {
         delete process.env.CODEX_HOME
       } else {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -65,6 +65,7 @@ import { getAgentForegroundContextPaths } from '../providers/agent-foreground-co
 import { assertSafeAgentStartupCwd, resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../shared/hermes-startup-query'
 import type { TuiAgent } from '../../shared/types'
+import { expandWindowsPathEnvironmentVariables } from '../../shared/windows-environment-expansion'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
 
 const PANE_IDENTITY_ENV_KEYS = [
@@ -582,6 +583,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   removeInheritedNoColor(env)
 
   env.LANG ??= 'en_US.UTF-8'
+  expandWindowsPathEnvironmentVariables(env)
 
   // Why: shellOverride must win over env.COMSPEC, or Windows always resolves to cmd.exe/PowerShell regardless of the user's pick.
   const resolvedWslContext = resolveWslSessionContext(opts)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -65,7 +65,10 @@ import { getAgentForegroundContextPaths } from '../providers/agent-foreground-co
 import { assertSafeAgentStartupCwd, resolveSafePtyDefaultCwd } from '../providers/pty-default-cwd'
 import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../shared/hermes-startup-query'
 import type { TuiAgent } from '../../shared/types'
-import { expandWindowsPathEnvironmentVariables } from '../../shared/windows-environment-expansion'
+import {
+  expandWindowsEnvironmentVariables,
+  expandWindowsPathEnvironmentVariables
+} from '../../shared/windows-environment-expansion'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
 
 const PANE_IDENTITY_ENV_KEYS = [
@@ -172,12 +175,17 @@ function promoteAgentTeamsShimPath(
   if (!env.ORCA_AGENT_TEAMS_TEAM_ID || !requestedPath) {
     return
   }
-  const shimDir = requestedPath.split(delimiter)[0]
+  const normalizedRequestedPath =
+    process.platform === 'win32'
+      ? expandWindowsEnvironmentVariables(requestedPath, env)
+      : requestedPath
+  const pathDelimiter = process.platform === 'win32' ? ';' : delimiter
+  const shimDir = normalizedRequestedPath.split(pathDelimiter)[0]
   if (!shimDir) {
     return
   }
-  const currentParts = env.PATH?.split(delimiter).filter(Boolean) ?? []
-  env.PATH = [shimDir, ...currentParts.filter((part) => part !== shimDir)].join(delimiter)
+  const currentParts = env.PATH?.split(pathDelimiter).filter(Boolean) ?? []
+  env.PATH = [shimDir, ...currentParts.filter((part) => part !== shimDir)].join(pathDelimiter)
 }
 
 /**
@@ -583,8 +591,6 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   removeInheritedNoColor(env)
 
   env.LANG ??= 'en_US.UTF-8'
-  expandWindowsPathEnvironmentVariables(env)
-
   // Why: shellOverride must win over env.COMSPEC, or Windows always resolves to cmd.exe/PowerShell regardless of the user's pick.
   const resolvedWslContext = resolveWslSessionContext(opts)
   // Why: older persisted tabs can carry a PowerShell/cmd shellOverride; ignore it so WSL reconnects still enter the distro.
@@ -770,6 +776,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   ) {
     addWslEnvKeys(env, [POWERLEVEL10K_WIZARD_DISABLE_ENV])
   }
+  expandWindowsPathEnvironmentVariables(env)
   promoteAgentTeamsShimPath(env, opts.env?.PATH)
 
   // Why: asar packaging can strip +x from node-pty's spawn-helper; the daemon is a separate forked process from the main-process fix.

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -224,6 +224,24 @@ describe('LocalPtyProvider', () => {
       expect(typeof result.id).toBe('string')
     })
 
+    it('expands variables in PATH before spawning a Windows shell', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: {
+          ORCA_PATH_ROOT: 'C:\\Users\\orca\\AppData\\Local',
+          PATH: '%orca_path_root%\\agy\\bin;C:\\Windows'
+        }
+      })
+
+      expect(spawnMock.mock.calls.at(-1)?.[2].env.PATH).toBe(
+        'C:\\Users\\orca\\AppData\\Local\\agy\\bin;C:\\Windows'
+      )
+    })
+
     it('reattaches to an existing caller-supplied session id without spawning', async () => {
       const first = await provider.spawn({ cols: 80, rows: 24, sessionId: 'serve-session-1' })
       spawnMock.mockClear()

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -232,6 +232,7 @@ describe('LocalPtyProvider', () => {
         rows: 24,
         cwd: 'C:\\repo',
         env: {
+          ORCA_AGENT_TEAMS_TEAM_ID: 'team-test',
           ORCA_PATH_ROOT: 'C:\\Users\\orca\\AppData\\Local',
           PATH: '%orca_path_root%\\agy\\bin;C:\\Windows'
         }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -65,7 +65,10 @@ import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
-import { expandWindowsPathEnvironmentVariables } from '../../shared/windows-environment-expansion'
+import {
+  expandWindowsEnvironmentVariables,
+  expandWindowsPathEnvironmentVariables
+} from '../../shared/windows-environment-expansion'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -159,12 +162,17 @@ function promoteAgentTeamsShimPath(
   if (!env.ORCA_AGENT_TEAMS_TEAM_ID || !requestedPath) {
     return
   }
-  const shimDir = requestedPath.split(delimiter)[0]
+  const normalizedRequestedPath =
+    process.platform === 'win32'
+      ? expandWindowsEnvironmentVariables(requestedPath, env)
+      : requestedPath
+  const pathDelimiter = process.platform === 'win32' ? ';' : delimiter
+  const shimDir = normalizedRequestedPath.split(pathDelimiter)[0]
   if (!shimDir) {
     return
   }
-  const currentParts = env.PATH?.split(delimiter).filter(Boolean) ?? []
-  env.PATH = [shimDir, ...currentParts.filter((part) => part !== shimDir)].join(delimiter)
+  const currentParts = env.PATH?.split(pathDelimiter).filter(Boolean) ?? []
+  env.PATH = [shimDir, ...currentParts.filter((part) => part !== shimDir)].join(pathDelimiter)
 }
 
 /**
@@ -699,7 +707,6 @@ export class LocalPtyProvider implements IPtyProvider {
     if (args.env?.TERM) {
       finalEnv.TERM = args.env.TERM
     }
-    expandWindowsPathEnvironmentVariables(finalEnv)
     if (process.platform === 'win32') {
       const codexHomeWslInfo = finalEnv.CODEX_HOME ? parseWslPath(finalEnv.CODEX_HOME) : null
       if (pathWin32.basename(shellPath).toLowerCase() === 'wsl.exe') {
@@ -791,6 +798,7 @@ export class LocalPtyProvider implements IPtyProvider {
         shellReadyLaunch = args.command ? shellLaunch : null
       }
     }
+    expandWindowsPathEnvironmentVariables(finalEnv)
     promoteAgentTeamsShimPath(finalEnv, args.env?.PATH)
 
     // Why: worktree-scoped HISTFILE — without it worktrees share one global history (terminal-history-scope-design §7–§10).

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -65,6 +65,7 @@ import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
+import { expandWindowsPathEnvironmentVariables } from '../../shared/windows-environment-expansion'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -698,6 +699,7 @@ export class LocalPtyProvider implements IPtyProvider {
     if (args.env?.TERM) {
       finalEnv.TERM = args.env.TERM
     }
+    expandWindowsPathEnvironmentVariables(finalEnv)
     if (process.platform === 'win32') {
       const codexHomeWslInfo = finalEnv.CODEX_HOME ? parseWslPath(finalEnv.CODEX_HOME) : null
       if (pathWin32.basename(shellPath).toLowerCase() === 'wsl.exe') {

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -242,6 +242,18 @@ describe('readPersistedWindowsPathSegments', () => {
 })
 
 describe('mergePersistedWindowsPath', () => {
+  it('expands variables already present in the inherited PATH', () => {
+    const execFileSync = vi.fn().mockReturnValue('    Path    REG_SZ    \r\n')
+    const env = {
+      ORCA_PATH_ROOT: 'C:\\Users\\orca\\AppData\\Local',
+      Path: '%orca_path_root%\\agy\\bin;C:\\Windows'
+    }
+
+    mergePersistedWindowsPath(env, { platform: 'win32', execFileSync, env })
+
+    expect(env.Path).toBe('C:\\Users\\orca\\AppData\\Local\\agy\\bin;C:\\Windows')
+  })
+
   it('appends missing persisted segments without reordering the inherited PATH', () => {
     const execFileSync = vi
       .fn()

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -1,4 +1,8 @@
 import { execFile, execFileSync } from 'node:child_process'
+import {
+  expandWindowsEnvironmentVariables,
+  expandWindowsPathEnvironmentVariables
+} from '../../shared/windows-environment-expansion'
 import { getRegExePath } from '../win32-utils'
 
 type ExecFile = typeof execFile
@@ -42,14 +46,6 @@ function parseRegistryPathValue(output: string, valueName: string): string | nul
     }
   }
   return null
-}
-
-function expandWindowsEnvironmentVariables(value: string, env: NodeJS.ProcessEnv): string {
-  return value.replace(/%([^%]+)%/g, (match, rawName: string) => {
-    const name = rawName.toLowerCase()
-    const envKey = Object.keys(env).find((key) => key.toLowerCase() === name)
-    return envKey && env[envKey] ? env[envKey] : match
-  })
 }
 
 function getPathDelimiter(platform: NodeJS.Platform): string {
@@ -246,6 +242,7 @@ function mergeWindowsPathSegments(
   platform: NodeJS.Platform,
   sourceEnv: NodeJS.ProcessEnv
 ): void {
+  expandWindowsPathEnvironmentVariables(env, platform)
   const pathKey = env.Path !== undefined ? 'Path' : env.PATH !== undefined ? 'PATH' : 'Path'
   const pathDelimiter = getPathDelimiter(platform)
   const currentPath = env[pathKey] ?? sourceEnv.PATH ?? sourceEnv.Path ?? ''

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -34,6 +34,10 @@ vi.mock('node-pty', () => ({
   spawn: mockPtySpawn
 }))
 
+vi.mock('../main/pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: vi.fn((_pid: number, fallback: () => void) => fallback())
+}))
+
 import {
   IMMEDIATE_PTY_EXIT_TIMEOUT_MS,
   MAX_RELAY_PTY_SESSIONS,
@@ -102,6 +106,7 @@ function createMockDispatcher() {
 describe('PtyHandler', () => {
   let dispatcher: ReturnType<typeof createMockDispatcher>
   let handler: PtyHandler
+  let originalPlatform: PropertyDescriptor | undefined
 
   async function spawnPty(
     params: Record<string, unknown> = {}
@@ -122,6 +127,8 @@ describe('PtyHandler', () => {
   }
 
   beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
     vi.useFakeTimers()
     mockPtySpawn.mockReset()
     mockPtyInstance.onData.mockReset()
@@ -132,6 +139,7 @@ describe('PtyHandler', () => {
     mockPtyInstance.clear.mockReset()
     mockPtyInstance.pause.mockReset()
     mockPtyInstance.resume.mockReset()
+    vi.spyOn(ptyShellUtils, 'processHasChildren').mockResolvedValue(false)
 
     mockPtySpawn.mockReturnValue({ ...mockPtyInstance })
 
@@ -144,6 +152,10 @@ describe('PtyHandler', () => {
     await vi.runAllTimersAsync()
     await cleanup.catch(() => {})
     vi.useRealTimers()
+    vi.restoreAllMocks()
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
   })
 
   it('registers all expected handlers', () => {
@@ -2555,6 +2567,27 @@ describe('PtyHandler', () => {
     expect(spawnEnv.name).toBe('xterm-256color')
     expect(spawnEnv.env.TERM).toBe('xterm-256color')
     expect(spawnEnv.env.TERM_PROGRAM).toBe('Orca')
+  })
+
+  it('expands variables in PATH before spawning a Windows relay shell', async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      await dispatcher.callRequest('pty.spawn', {
+        env: {
+          ORCA_PATH_ROOT: 'C:\\Users\\orca\\AppData\\Local',
+          PATH: '%orca_path_root%\\agy\\bin;C:\\Windows'
+        }
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    const spawnEnv = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
+    expect(spawnEnv.env.PATH).toBe('C:\\Users\\orca\\AppData\\Local\\agy\\bin;C:\\Windows')
   })
 
   it('uses the safe terminal default when TERM is deleted without a custom value', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -50,6 +50,7 @@ import {
 } from '../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend, type PtyOwnerBackend } from '../shared/pty-owner-backend'
 import { RecentPtyOutputBuffer } from '../main/runtime/recent-pty-output-buffer'
+import { expandWindowsPathEnvironmentVariables } from '../shared/windows-environment-expansion'
 import {
   agentSessionOwnerBindingsEqual,
   ClaimedAgentPtyOwnerRegistry
@@ -613,6 +614,7 @@ export class PtyHandler {
     if (!result.TERM) {
       result.TERM = 'xterm-256color'
     }
+    expandWindowsPathEnvironmentVariables(result)
     return result
   }
 

--- a/src/shared/windows-environment-expansion.test.ts
+++ b/src/shared/windows-environment-expansion.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  expandWindowsEnvironmentVariables,
+  expandWindowsPathEnvironmentVariables
+} from './windows-environment-expansion'
+
+describe('expandWindowsEnvironmentVariables', () => {
+  it('expands names case-insensitively and preserves unknown variables', () => {
+    expect(
+      expandWindowsEnvironmentVariables('%localappdata%\\agy\\bin;%MISSING%\\bin', {
+        LOCALAPPDATA: 'C:\\Users\\orca\\AppData\\Local'
+      })
+    ).toBe('C:\\Users\\orca\\AppData\\Local\\agy\\bin;%MISSING%\\bin')
+  })
+
+  it('expands variables with empty values', () => {
+    expect(expandWindowsEnvironmentVariables('before%EMPTY%after', { EMPTY: '' })).toBe(
+      'beforeafter'
+    )
+  })
+})
+
+describe('expandWindowsPathEnvironmentVariables', () => {
+  it('expands every Windows PATH casing without changing other variables', () => {
+    const env = {
+      ORCA_PATH_ROOT: 'C:\\Users\\orca',
+      Path: '%ORCA_PATH_ROOT%\\bin',
+      PATH: '%orca_path_root%\\tools',
+      TEMPLATE: '%ORCA_PATH_ROOT%\\template'
+    }
+
+    expandWindowsPathEnvironmentVariables(env, 'win32')
+
+    expect(env.Path).toBe('C:\\Users\\orca\\bin')
+    expect(env.PATH).toBe('C:\\Users\\orca\\tools')
+    expect(env.TEMPLATE).toBe('%ORCA_PATH_ROOT%\\template')
+  })
+
+  it('leaves non-Windows PATH values unchanged', () => {
+    const env = { ROOT: '/opt/orca', PATH: '%ROOT%/bin:/usr/bin' }
+
+    expandWindowsPathEnvironmentVariables(env, 'linux')
+
+    expect(env.PATH).toBe('%ROOT%/bin:/usr/bin')
+  })
+})

--- a/src/shared/windows-environment-expansion.ts
+++ b/src/shared/windows-environment-expansion.ts
@@ -1,0 +1,38 @@
+function getEnvironmentVariable(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string
+): string | undefined {
+  const exactValue = env[name]
+  if (typeof exactValue === 'string') {
+    return exactValue
+  }
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase())
+  const value = key ? env[key] : undefined
+  return typeof value === 'string' ? value : undefined
+}
+
+export function expandWindowsEnvironmentVariables(
+  value: string,
+  env: Readonly<Record<string, string | undefined>>
+): string {
+  return value.replace(/%([^%]+)%/g, (match, name: string) => {
+    return getEnvironmentVariable(env, name) ?? match
+  })
+}
+
+export function expandWindowsPathEnvironmentVariables(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (platform !== 'win32') {
+    return
+  }
+  const sourceEnv = { ...env }
+  for (const key of Object.keys(env)) {
+    const value = env[key]
+    if (key.toLowerCase() !== 'path' || typeof value !== 'string') {
+      continue
+    }
+    env[key] = expandWindowsEnvironmentVariables(value, sourceEnv)
+  }
+}

--- a/tests/e2e/terminal-windows-path-expansion.spec.ts
+++ b/tests/e2e/terminal-windows-path-expansion.spec.ts
@@ -1,0 +1,38 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test as base } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForSessionReady } from './helpers/store'
+import { execInTerminal, waitForActivePanePtyId, waitForTerminalOutput } from './helpers/terminal'
+
+const probeRoot = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-path-expansion-'))
+const probeBin = path.join(probeRoot, 'bin')
+mkdirSync(probeBin)
+writeFileSync(
+  path.join(probeBin, 'orca-path-expansion-probe.cmd'),
+  '@echo off\r\necho ORCA_PATH_EXPANSION_OK\r\n'
+)
+
+const test = base
+test.use({
+  launchEnv: {
+    ORCA_E2E_PATH_ROOT: probeRoot,
+    PATH: `%ORCA_E2E_PATH_ROOT%\\bin${path.delimiter}${process.env.PATH ?? ''}`
+  }
+})
+
+test.afterAll(() => {
+  rmSync(probeRoot, { recursive: true, force: true })
+})
+
+test.skip(process.platform !== 'win32', 'Windows PATH expansion requires a native Windows shell')
+
+test('expands variables in PATH before spawning a Windows shell', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  const ptyId = await waitForActivePanePtyId(orcaPage)
+
+  await execInTerminal(orcaPage, ptyId, 'orca-path-expansion-probe')
+
+  await waitForTerminalOutput(orcaPage, 'ORCA_PATH_EXPANSION_OK')
+})


### PR DESCRIPTION
## Summary

Fixes Windows terminal command lookup when `PATH` contains variables such as `%LOCALAPPDATA%`, `%USERPROFILE%`, or `%NVM_HOME%`.

Expansion now applies at the final environment assembly boundary for local, daemon, and Windows SSH relay PTYs. Agent Teams PATH promotion also normalizes its requested shim path so it cannot reintroduce an unexpanded segment after expansion.

Closes #11788.

## Screenshots

No visual change.

## Testing

- [x] Focused Vitest suite: 359 passed, 38 skipped
- [x] Native Windows Electron E2E: `terminal-windows-path-expansion.spec.ts` (1 passed)
- [x] Full TypeScript typecheck (node, CLI, web)
- [x] Oxlint on all changed files
- [x] Added regressions for local, daemon, relay, persisted PATH merging, case-insensitive/unknown/empty variables, and post-expansion Agent Teams PATH promotion

`pnpm lint` passed code-quality, type-aware, reliability, max-lines, and bundled-guide checks, then stopped on pre-existing stale generated skill manifests unrelated to this diff.

## Adversarial Review

Reviewed all PATH mutation points after environment assembly. The original implementation expanded too early in local and daemon PTYs, allowing Agent Teams shim promotion to prepend the raw `%VAR%` segment again. The takeover moves expansion to the last PATH mutation boundary and expands the promoted requested segment before deduplication.

The relay fresh-spawn and revive paths have no later Windows PATH mutation. Non-Windows paths remain unchanged. Windows SSH relays expand on the remote Windows host; Linux/macOS relays do not apply Windows syntax.

## Security Audit

The implementation only substitutes `%NAME%` references from the existing environment before PTY spawning. Unknown variables remain unchanged. It adds no command execution, IPC, authentication, secret handling, or dependencies.
