### PR TITLE
fix(mobile): switch to the opened diff tab from the Source Control pane

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -260,7 +260,7 @@ import {
 } from '../../../../src/session/mobile-session-route-helpers'
 import { resolveMarkdownFloatingActionsBottom } from '../../../../src/session/markdown-floating-actions-layout'
 import { resolveTabStripScrollOffset } from '../../../../src/session/tab-strip-scroll'
-import { activateOpenedSourceControlDiffTab } from '../../../../src/session/opened-mobile-session-tab'
+import { useOpenedSourceControlDiffActivation } from '../../../../src/session/use-opened-source-control-diff-activation'
 import {
   createMobileSessionCreateWarningState,
   dismissMobileSessionCreateWarningState,
@@ -3226,44 +3226,14 @@ export default function SessionScreen() {
     [client, fetchSessionTabs, hostId, routeWorktreeName, router, scheduleDelayedAction, worktreeId]
   )
 
-  const handleOpenedFileDiffActivationSeqRef = useRef(0)
-  // Capture active tab at tap time; reading it after openDiff would misread a mid-RPC switch and let the retry steal focus.
-  const fileOpenStartActiveTabIdRef = useRef<string | null>(null)
-  const handleFileOpenStart = useCallback(() => {
-    fileOpenStartActiveTabIdRef.current = activeSessionTabIdRef.current
-  }, [])
-  const handleOpenedFileDiff = useCallback(
-    (relativePath: string) => {
-      const activationSeq = ++handleOpenedFileDiffActivationSeqRef.current
-      const activeTabIdAtTap = fileOpenStartActiveTabIdRef.current
-
-      let activated = false
-      const activateOpenedTab = async (): Promise<void> => {
-        // Route matching through the shared helper so the repro test exercises the same logic production runs.
-        const settled = await activateOpenedSourceControlDiffTab<MobileSessionTab>({
-          relativePath,
-          activeTabIdAtTap,
-          fetchSessionTabs,
-          getTabs: () => sessionTabsRef.current,
-          getActiveTabId: () => activeSessionTabIdRef.current,
-          getActivationState: () => ({
-            activated,
-            activationSeq,
-            latestActivationSeq: handleOpenedFileDiffActivationSeqRef.current
-          }),
-          switchSessionTab: (tab) => switchSessionTabRef.current?.(tab)
-        })
-        if (settled) {
-          activated = true
-        }
-      }
-
-      scheduleDelayedAction(() => void activateOpenedTab(), 300)
-      scheduleDelayedAction(() => void activateOpenedTab(), 900)
-      scheduleDelayedAction(() => void activateOpenedTab(), 1800)
-    },
-    [fetchSessionTabs, scheduleDelayedAction]
-  )
+  const { handleFileOpenStart, handleOpenedFileDiff } = useOpenedSourceControlDiffActivation({
+    worktreeId,
+    activeSessionTabIdRef,
+    sessionTabsRef,
+    switchSessionTabRef,
+    fetchSessionTabs,
+    scheduleDelayedAction
+  })
 
   const handleTerminalOpenUrl = useCallback(
     (handle: string, url: string) => {

--- a/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
@@ -22,7 +22,9 @@ export default function MobileSourceControlScreen() {
       initialTab={parseSourceControlHubTab(params.tab)}
       embedded={false}
       // Full-screen route can't reach the session's tab activation; hand the opened
-      // diff to the session (origin:'session' only) so it switches on focus after pop.
+      // diff to the session so it switches on focus after pop. Safe to wire
+      // unconditionally: the opener only calls onOpenedFileDiff for origin:'session'
+      // (non-session origins early-return before the openDiff RPC).
       onOpenedFileDiff={(relativePath) =>
         recordPendingSourceControlDiffOpen({ worktreeId, relativePath })
       }

--- a/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/source-control/[worktreeId].tsx
@@ -2,6 +2,7 @@ import { useLocalSearchParams } from 'expo-router'
 import { MobileSourceControlPanel } from '../../../../src/source-control/MobileSourceControlPanel'
 import { firstParam } from '../../../../src/source-control/mobile-source-control-screen-state'
 import { parseSourceControlHubTab } from '../../../../src/source-control/mobile-source-control-hub-tab'
+import { recordPendingSourceControlDiffOpen } from '../../../../src/session/pending-source-control-diff-open'
 
 export default function MobileSourceControlScreen() {
   const params = useLocalSearchParams<{
@@ -11,14 +12,20 @@ export default function MobileSourceControlScreen() {
     origin?: string | string[]
     tab?: string | string[]
   }>()
+  const worktreeId = firstParam(params.worktreeId)
   return (
     <MobileSourceControlPanel
       hostId={firstParam(params.hostId)}
-      worktreeId={firstParam(params.worktreeId)}
+      worktreeId={worktreeId}
       name={firstParam(params.name)}
       origin={firstParam(params.origin)}
       initialTab={parseSourceControlHubTab(params.tab)}
       embedded={false}
+      // Full-screen route can't reach the session's tab activation; hand the opened
+      // diff to the session (origin:'session' only) so it switches on focus after pop.
+      onOpenedFileDiff={(relativePath) =>
+        recordPendingSourceControlDiffOpen({ worktreeId, relativePath })
+      }
     />
   )
 }

--- a/mobile/src/session/pending-source-control-diff-open.test.ts
+++ b/mobile/src/session/pending-source-control-diff-open.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  recordPendingSourceControlDiffOpen,
+  takePendingSourceControlDiffOpen
+} from './pending-source-control-diff-open'
+
+// The bridge is a module singleton; clear it between cases so state can't leak.
+afterEach(() => {
+  takePendingSourceControlDiffOpen('wt-1')
+  takePendingSourceControlDiffOpen('wt-2')
+})
+
+describe('pending-source-control-diff-open', () => {
+  it('hands the recorded path to the matching worktree and clears it', () => {
+    recordPendingSourceControlDiffOpen({ worktreeId: 'wt-1', relativePath: 'src/app.ts' })
+
+    expect(takePendingSourceControlDiffOpen('wt-1')).toBe('src/app.ts')
+    // Single-consume: a second read finds nothing so a focus re-fire can't re-activate.
+    expect(takePendingSourceControlDiffOpen('wt-1')).toBeNull()
+  })
+
+  it('does not hand a record to a different worktree and preserves it', () => {
+    recordPendingSourceControlDiffOpen({ worktreeId: 'wt-1', relativePath: 'src/app.ts' })
+
+    expect(takePendingSourceControlDiffOpen('wt-2')).toBeNull()
+    // The intended worktree can still consume it later.
+    expect(takePendingSourceControlDiffOpen('wt-1')).toBe('src/app.ts')
+  })
+
+  it('returns null when nothing is pending', () => {
+    expect(takePendingSourceControlDiffOpen('wt-1')).toBeNull()
+  })
+
+  it('keeps only the most recent open when the route records twice', () => {
+    recordPendingSourceControlDiffOpen({ worktreeId: 'wt-1', relativePath: 'src/first.ts' })
+    recordPendingSourceControlDiffOpen({ worktreeId: 'wt-1', relativePath: 'src/second.ts' })
+
+    expect(takePendingSourceControlDiffOpen('wt-1')).toBe('src/second.ts')
+  })
+})

--- a/mobile/src/session/pending-source-control-diff-open.ts
+++ b/mobile/src/session/pending-source-control-diff-open.ts
@@ -1,0 +1,28 @@
+// Bridges the full-screen mobile Source Control route back to the session screen.
+//
+// On narrow layouts, tapping Source Control pushes a full-screen route (with
+// origin: 'session') instead of docking a pane. Tapping a changed file there opens
+// a diff tab on the desktop via files.openDiff, but the route lives on a separate
+// navigation-stack entry and cannot reach the session screen's tab-activation logic.
+// It records the opened path here; the session consumes it on focus (after the route
+// pops) and switches its active session tab to the matching diff. Without this the
+// diff tab appears in the strip but the session never switches to it.
+//
+// Scoped by worktreeId so a stale record from one worktree can't activate a tab in
+// another; single-consume so a focus re-fire can't re-activate an already-shown diff.
+type PendingSourceControlDiffOpen = { worktreeId: string; relativePath: string }
+
+let pending: PendingSourceControlDiffOpen | null = null
+
+export function recordPendingSourceControlDiffOpen(open: PendingSourceControlDiffOpen): void {
+  pending = open
+}
+
+export function takePendingSourceControlDiffOpen(worktreeId: string): string | null {
+  if (pending?.worktreeId === worktreeId) {
+    const { relativePath } = pending
+    pending = null
+    return relativePath
+  }
+  return null
+}

--- a/mobile/src/session/use-opened-source-control-diff-activation.test.ts
+++ b/mobile/src/session/use-opened-source-control-diff-activation.test.ts
@@ -1,0 +1,146 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useOpenedSourceControlDiffActivation } from './use-opened-source-control-diff-activation'
+import {
+  recordPendingSourceControlDiffOpen,
+  takePendingSourceControlDiffOpen
+} from './pending-source-control-diff-open'
+
+// Run the focus callback once on mount, mirroring a screen refocus.
+vi.mock('expo-router', async () => {
+  const react = await import('react')
+  return {
+    useFocusEffect: (cb: () => undefined | (() => void)) => {
+      react.useEffect(() => cb(), [cb])
+    }
+  }
+})
+
+type TestTab = { type: string; id: string; mode?: string; relativePath?: string }
+
+const TABS: TestTab[] = [
+  { type: 'terminal', id: 'terminal-1' },
+  { type: 'file', id: 'diff-1', mode: 'diff', relativePath: 'src/app.ts' }
+]
+
+// Let the void-wrapped async activation settle (fetchSessionTabs + sync work).
+async function flushActivation(run: () => void): Promise<void> {
+  await act(async () => {
+    run()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function createHarness(tabs: TestTab[], activeTabId: string) {
+  const scheduled: Array<() => void> = []
+  const switched: string[] = []
+  const activeRef = { current: activeTabId as string | null }
+  const tabsRef = { current: tabs }
+  const switchRef = {
+    current: ((tab: TestTab) => {
+      activeRef.current = tab.id
+      switched.push(tab.id)
+    }) as ((tab: TestTab) => void) | null
+  }
+  let handlers: {
+    handleFileOpenStart: () => void
+    handleOpenedFileDiff: (relativePath: string) => void
+  } | null = null
+  function Harness(): null {
+    handlers = useOpenedSourceControlDiffActivation<TestTab>({
+      worktreeId: 'wt-1',
+      activeSessionTabIdRef: activeRef,
+      sessionTabsRef: tabsRef,
+      switchSessionTabRef: switchRef,
+      fetchSessionTabs: async () => {},
+      scheduleDelayedAction: (fn) => scheduled.push(fn)
+    })
+    return null
+  }
+  return { Harness, scheduled, switched, activeRef, getHandlers: () => handlers }
+}
+
+describe('useOpenedSourceControlDiffActivation', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    // Drain any leftover bridge state so a singleton record can't leak across cases.
+    takePendingSourceControlDiffOpen('wt-1')
+    takePendingSourceControlDiffOpen('other')
+  })
+
+  async function mount(harness: ReturnType<typeof createHarness>): Promise<void> {
+    await act(async () => {
+      renderer = create(createElement(harness.Harness))
+      await Promise.resolve()
+    })
+  }
+
+  it('activates a diff the full-screen route recorded once the session refocuses', async () => {
+    // Route side: opening a changed file records the pending diff before it pops back.
+    recordPendingSourceControlDiffOpen({ worktreeId: 'wt-1', relativePath: 'src/app.ts' })
+    const harness = createHarness(TABS, 'terminal-1')
+
+    await mount(harness)
+    // Focus claimed the pending open and scheduled the activation retries.
+    expect(harness.scheduled.length).toBeGreaterThan(0)
+
+    await flushActivation(() => harness.scheduled[0]?.())
+
+    expect(harness.switched).toEqual(['diff-1'])
+    expect(harness.activeRef.current).toBe('diff-1')
+  })
+
+  it('consumes the pending open once, so a later refocus does not re-activate', async () => {
+    recordPendingSourceControlDiffOpen({ worktreeId: 'wt-1', relativePath: 'src/app.ts' })
+
+    await mount(createHarness(TABS, 'terminal-1'))
+    // The record is claimed on first focus; a fresh mount finds nothing to do.
+    const second = createHarness(TABS, 'terminal-1')
+    await mount(second)
+
+    expect(second.scheduled).toEqual([])
+    expect(second.switched).toEqual([])
+  })
+
+  it('ignores a pending open recorded for a different worktree', async () => {
+    recordPendingSourceControlDiffOpen({ worktreeId: 'other', relativePath: 'src/app.ts' })
+    const harness = createHarness(TABS, 'terminal-1')
+
+    await mount(harness)
+
+    expect(harness.scheduled).toEqual([])
+    expect(harness.switched).toEqual([])
+  })
+
+  it('does nothing on focus when no file open is pending', async () => {
+    const harness = createHarness(TABS, 'terminal-1')
+
+    await mount(harness)
+
+    expect(harness.scheduled).toEqual([])
+    expect(harness.switched).toEqual([])
+  })
+
+  it('still activates via the docked handlers (snapshot at tap, switch after open)', async () => {
+    const harness = createHarness(TABS, 'terminal-1')
+    await mount(harness)
+    expect(harness.scheduled).toEqual([])
+
+    act(() => harness.getHandlers()?.handleFileOpenStart())
+    act(() => harness.getHandlers()?.handleOpenedFileDiff('src/app.ts'))
+    expect(harness.scheduled.length).toBeGreaterThan(0)
+
+    await flushActivation(() => harness.scheduled[0]?.())
+
+    expect(harness.switched).toEqual(['diff-1'])
+  })
+})

--- a/mobile/src/session/use-opened-source-control-diff-activation.ts
+++ b/mobile/src/session/use-opened-source-control-diff-activation.ts
@@ -1,0 +1,94 @@
+import { useCallback, useRef, type MutableRefObject } from 'react'
+import { useFocusEffect } from 'expo-router'
+import {
+  activateOpenedSourceControlDiffTab,
+  type OpenedMobileSessionTabCandidate
+} from './opened-mobile-session-tab'
+import { takePendingSourceControlDiffOpen } from './pending-source-control-diff-open'
+
+type Options<T extends OpenedMobileSessionTabCandidate> = {
+  worktreeId: string
+  activeSessionTabIdRef: MutableRefObject<string | null>
+  sessionTabsRef: MutableRefObject<T[]>
+  switchSessionTabRef: MutableRefObject<((tab: T) => void) | null>
+  fetchSessionTabs: () => Promise<void>
+  scheduleDelayedAction: (fn: () => void, ms: number) => void
+}
+
+// Owns activating the diff tab opened by tapping a changed file in mobile Source Control.
+// Docked panels call handleFileOpenStart at tap (snapshotting the active tab so a mid-RPC
+// switch isn't stolen back) then handleOpenedFileDiff once the desktop opens it. The
+// full-screen route can't reach these across the nav stack, so it records the path and this
+// hook claims it on refocus — treating the current tab as the tap-time tab since the route
+// covered the session.
+export function useOpenedSourceControlDiffActivation<T extends OpenedMobileSessionTabCandidate>(
+  options: Options<T>
+): { handleFileOpenStart: () => void; handleOpenedFileDiff: (relativePath: string) => void } {
+  const {
+    worktreeId,
+    activeSessionTabIdRef,
+    sessionTabsRef,
+    switchSessionTabRef,
+    fetchSessionTabs,
+    scheduleDelayedAction
+  } = options
+
+  const activationSeqRef = useRef(0)
+  const fileOpenStartActiveTabIdRef = useRef<string | null>(null)
+
+  const handleFileOpenStart = useCallback(() => {
+    fileOpenStartActiveTabIdRef.current = activeSessionTabIdRef.current
+  }, [activeSessionTabIdRef])
+
+  const handleOpenedFileDiff = useCallback(
+    (relativePath: string) => {
+      const activationSeq = ++activationSeqRef.current
+      const activeTabIdAtTap = fileOpenStartActiveTabIdRef.current
+
+      let activated = false
+      const activateOpenedTab = async (): Promise<void> => {
+        // Route matching through the shared helper so the repro test exercises the same logic production runs.
+        const settled = await activateOpenedSourceControlDiffTab<T>({
+          relativePath,
+          activeTabIdAtTap,
+          fetchSessionTabs,
+          getTabs: () => sessionTabsRef.current,
+          getActiveTabId: () => activeSessionTabIdRef.current,
+          getActivationState: () => ({
+            activated,
+            activationSeq,
+            latestActivationSeq: activationSeqRef.current
+          }),
+          switchSessionTab: (tab) => switchSessionTabRef.current?.(tab)
+        })
+        if (settled) {
+          activated = true
+        }
+      }
+
+      scheduleDelayedAction(() => void activateOpenedTab(), 300)
+      scheduleDelayedAction(() => void activateOpenedTab(), 900)
+      scheduleDelayedAction(() => void activateOpenedTab(), 1800)
+    },
+    [
+      activeSessionTabIdRef,
+      fetchSessionTabs,
+      scheduleDelayedAction,
+      sessionTabsRef,
+      switchSessionTabRef
+    ]
+  )
+
+  useFocusEffect(
+    useCallback(() => {
+      const relativePath = takePendingSourceControlDiffOpen(worktreeId)
+      if (!relativePath) {
+        return
+      }
+      fileOpenStartActiveTabIdRef.current = activeSessionTabIdRef.current
+      handleOpenedFileDiff(relativePath)
+    }, [activeSessionTabIdRef, handleOpenedFileDiff, worktreeId])
+  )
+
+  return { handleFileOpenStart, handleOpenedFileDiff }
+}


### PR DESCRIPTION
## Summary

On phones (narrow layout), tapping a changed file in the **Source Control** pane opened the file's diff tab but the session never switched to it — the tab appeared in the strip while the terminal stayed in the foreground.

The full-screen Source Control route is pushed with `origin: 'session'`, so tapping a file opens the diff on the desktop via `files.openDiff` and then relies on `onOpenedFileDiff` to activate the new tab on the phone. That callback was only wired on the **docked** (tablet) layout through `SessionDockColumn`; the separate full-screen route never passed it and can't reach the session screen's activation logic across the navigation stack. After `router.back()`, the mobile client's per-client tab selection still pointed at the terminal.

**Fix:** bridge the opened path across the navigation stack.

- New worktree-scoped store (`pending-source-control-diff-open.ts`): the route records the opened path; the session claims it on refocus and runs the existing `activateOpenedSourceControlDiffTab` activation to switch tabs.
- Consolidated the activation cluster (`handleFileOpenStart` / `handleOpenedFileDiff` + refs) into one hook (`use-opened-source-control-diff-activation.ts`) that owns both the docked handlers and the new route-focus consumption. This also removed the inline block from the ~5k-line session screen (net −30 lines there), clearing a `max-lines` breach without disabling the rule.

The docked/tablet path is behavior-unchanged (same handlers, now returned from the hook). Only `origin:'session'` opens record, so non-session entry points (which navigate to the in-app review viewer) are unaffected.

## Screenshots

No screen recording captured — the RN simulator was not available in this environment. Behavior change is tab activation only:

- **Before:** tap a file in Source Control (phone) → diff tab is added but the session stays on the previous tab.
- **After:** tap a file → session switches to the opened diff tab (matching the docked/tablet behavior).

Worth a quick manual smoke test on a phone-width device before merge.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Run in the `mobile/` workspace: `oxlint` (clean), `tsc --noEmit` (clean), `vitest run` (**2803 passed / 3 pre-existing skips, 378 files**), `oxfmt --check` (clean). `pnpm build` (RN/Electron packaging) was not exercised here. New regression tests: `useOpenedSourceControlDiffActivation` proves a route-recorded diff activates on refocus (fails without this fix), plus worktree-scoped bridge unit tests; existing `activateOpenedSourceControlDiffTab` tests still pass.

## AI Review Report

Self-reviewed the diff with focus on the fix's blast radius:

- **Handler identity stability** — the extracted hook takes refs as deps, so `handleFileOpenStart` / `handleOpenedFileDiff` keep stable identities and `SessionDockColumn`'s memoization is preserved.
- **No double-activation** — docked and route layouts are mutually exclusive (`canDockPanel`), so only one activation path runs.
- **Scope** — `onOpenedFileDiff` only fires for `origin:'session'`; non-session entry points still route to the in-app review viewer. The bridge is worktree-scoped and single-consume, preventing cross-worktree bleed or re-activation on an unrelated refocus.
- **Cross-platform** — pure React Native navigation/hook logic; no `metaKey`/`ctrlKey`, path separators, shell, or Electron platform-specific code was touched, so macOS/Linux/Windows behavior is unaffected.

## Security Audit

No new trust boundary. The bridge carries a `relativePath` string that already flows into the existing `files.openDiff` RPC, which the desktop validates (`isSafeMobileRelativePath`) before touching the filesystem. No input parsing, command execution, auth, secrets, dependency, or IPC changes. The pending store is an in-memory module singleton with no persistence.

## Notes

- Mobile-only change; docked/tablet path behavior is unchanged.
- The activation-cluster extraction was needed to keep the session screen under its `max-lines` limit without a lint disable (per repo policy).
- Follow-up: on-device smoke test on a phone-width layout.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
