### PR TITLE
fix(mobile): anchor /h group so Home Screen deep links open the target

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -124,8 +124,9 @@ export default function RootLayout() {
         return
       }
       if (path) {
-        // withAnchor: from-root push must anchor on Host (see app/h/_layout.tsx).
-        router.push(path, { withAnchor: true })
+        // Anchor only below the host index: a bare /h/<host> tap already targets it, so anchoring would stack Host twice (see app/h/_layout.tsx).
+        const belowHostIndex = path.split('/').length > 3
+        router.push(path, belowHostIndex ? { withAnchor: true } : undefined)
       }
     }
 

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -124,7 +124,8 @@ export default function RootLayout() {
         return
       }
       if (path) {
-        router.push(path)
+        // withAnchor: from-root push must anchor on Host (see app/h/_layout.tsx).
+        router.push(path, { withAnchor: true })
       }
     }
 

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -13,6 +13,15 @@ import {
 import { HostProtocolGate } from '../../src/components/HostProtocolGate'
 import { HostScreen } from './[hostId]/index'
 
+// Why: anchor the /h group to the Host screen so deep pushes from outside the
+// group (Home Screen resume/accounts, notification taps) land on the target
+// route with the Host screen underneath. Without an anchor a from-root push
+// falls back to this group's default [hostId]/index screen. Callers pass
+// { withAnchor: true } so the anchor is loaded during in-app navigation too.
+export const unstable_settings = {
+  initialRouteName: '[hostId]/index'
+}
+
 // Keep at least this much room for the detail pane when resizing the sidebar.
 const MIN_DETAIL_WIDTH = 320
 const RESIZE_EDGE_WIDTH = 24

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -13,11 +13,7 @@ import {
 import { HostProtocolGate } from '../../src/components/HostProtocolGate'
 import { HostScreen } from './[hostId]/index'
 
-// Why: anchor the /h group to the Host screen so deep pushes from outside the
-// group (Home Screen resume/accounts, notification taps) land on the target
-// route with the Host screen underneath. Without an anchor a from-root push
-// falls back to this group's default [hostId]/index screen. Callers pass
-// { withAnchor: true } so the anchor is loaded during in-app navigation too.
+// Anchor the /h group to Host so from-root deep pushes (Home cards, notification taps) land on the target, not the group's default index.
 export const unstable_settings = {
   initialRouteName: '[hostId]/index'
 }

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -808,12 +808,14 @@ export default function HomeScreen() {
                   <Pressable
                     style={({ pressed }) => [styles.resumeCard, pressed && styles.hostCardPressed]}
                     onPress={() =>
+                      // withAnchor: from-root push must anchor on Host (see app/h/_layout.tsx).
                       router.push(
                         createMobileSessionHref({
                           hostId: resumeWorktree.hostId,
                           worktreeId: resumeWorktree.worktree.worktreeId,
                           name: resumeWorktree.worktree.displayName || resumeWorktree.worktree.repo
-                        })
+                        }),
+                        { withAnchor: true }
                       )
                     }
                   >
@@ -903,7 +905,7 @@ export default function HomeScreen() {
                           styles.accountsCard,
                           pressed && styles.hostCardPressed
                         ]}
-                        onPress={() => router.push(`/h/${host.id}/accounts`)}
+                        onPress={() => router.push(`/h/${host.id}/accounts`, { withAnchor: true })}
                       >
                         {showHostName ? (
                           <Text style={styles.accountsHostLabel} numberOfLines={1}>

--- a/mobile/src/navigation/host-route-anchor.test.ts
+++ b/mobile/src/navigation/host-route-anchor.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// Why: pushing a deep /h/[hostId]/... route from outside the group (the Home
+// Screen resume/account cards, notification taps) lands on the group's default
+// [hostId]/index ("Host") screen instead of the target — cold Expo deep links
+// resolve to the group index (see coordinateMobileTasksNavigation, which works
+// around the same issue for Tasks). The fix pairs an initialRouteName anchor on
+// the /h group with withAnchor on each from-root push. Native-stack focus can
+// only be verified on-device, so these guards keep both halves in place.
+function readApp(relativePath: string): string {
+  return readFileSync(new URL(`../../app/${relativePath}`, import.meta.url), 'utf8')
+}
+
+function pushCall(source: string, marker: string): string {
+  const markerIndex = source.indexOf(marker)
+  expect(markerIndex).toBeGreaterThanOrEqual(0)
+  const openParen = source.indexOf('(', source.lastIndexOf('router.push', markerIndex))
+  expect(openParen).toBeGreaterThanOrEqual(0)
+  // Why: the resume push nests createMobileSessionHref({...}), so match balanced
+  // parens rather than stopping at the first ')'.
+  let depth = 0
+  for (let i = openParen; i < source.length; i++) {
+    if (source[i] === '(') {
+      depth++
+    } else if (source[i] === ')' && --depth === 0) {
+      return source.slice(openParen, i + 1)
+    }
+  }
+  throw new Error(`Unbalanced router.push() for marker: ${marker}`)
+}
+
+describe('host route group anchoring', () => {
+  it('anchors the /h group to the Host screen so from-root deep links keep it underneath', () => {
+    const layout = readApp('h/_layout.tsx')
+    expect(layout).toContain('export const unstable_settings')
+    expect(layout).toMatch(/initialRouteName:\s*'\[hostId\]\/index'/)
+  })
+
+  it('opens the resume worktree with withAnchor so it lands on the session, not Host', () => {
+    const home = readApp('index.tsx')
+    expect(pushCall(home, 'worktreeId: resumeWorktree.worktree.worktreeId')).toContain(
+      'withAnchor: true'
+    )
+  })
+
+  it('opens the Account-usage card with withAnchor', () => {
+    const home = readApp('index.tsx')
+    expect(pushCall(home, '/accounts`')).toContain('withAnchor: true')
+  })
+
+  it('opens notification taps with withAnchor so a session tap lands on the session', () => {
+    const root = readApp('_layout.tsx')
+    expect(pushCall(root, 'router.push(path')).toContain('withAnchor: true')
+  })
+})

--- a/mobile/src/navigation/host-route-anchor.test.ts
+++ b/mobile/src/navigation/host-route-anchor.test.ts
@@ -1,13 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
-// Why: pushing a deep /h/[hostId]/... route from outside the group (the Home
-// Screen resume/account cards, notification taps) lands on the group's default
-// [hostId]/index ("Host") screen instead of the target — cold Expo deep links
-// resolve to the group index (see coordinateMobileTasksNavigation, which works
-// around the same issue for Tasks). The fix pairs an initialRouteName anchor on
-// the /h group with withAnchor on each from-root push. Native-stack focus can
-// only be verified on-device, so these guards keep both halves in place.
+// Source-text guards (native-stack focus is only verifiable on-device) that keep both halves of the fix in place: the /h anchor and withAnchor on each from-root push.
 function readApp(relativePath: string): string {
   return readFileSync(new URL(`../../app/${relativePath}`, import.meta.url), 'utf8')
 }
@@ -17,8 +11,7 @@ function pushCall(source: string, marker: string): string {
   expect(markerIndex).toBeGreaterThanOrEqual(0)
   const openParen = source.indexOf('(', source.lastIndexOf('router.push', markerIndex))
   expect(openParen).toBeGreaterThanOrEqual(0)
-  // Why: the resume push nests createMobileSessionHref({...}), so match balanced
-  // parens rather than stopping at the first ')'.
+  // Match balanced parens: the resume push nests createMobileSessionHref({...}).
   let depth = 0
   for (let i = openParen; i < source.length; i++) {
     if (source[i] === '(') {


### PR DESCRIPTION
## Problem

On the mobile app, tapping the Home Screen **quick-resume line** opens an empty page with the **"Host"** header instead of the worktree's terminal session. The same failure affects the **Account-usage card** and **notification taps** that point at a worktree.

## Root cause

The `/h` route group has **no `initialRouteName` anchor**. A deep push into the group from the root — where the group navigator isn't mounted yet — resolves to the group's default first screen, `[hostId]/index` (the "Host" screen, `mobile/app/h/[hostId]/index.tsx` -> `hostName || 'Host'`), and never places the deep target on top.

This is the exact behavior already documented in `coordinateMobileTasksNavigation`:

> *"cold Expo deep links resolve to index; target Tasks only after its HostStack exists"*

The Tasks card works around it (push `/h/[hostId]`, wait for the stack, then `REPLACE` to Tasks). But `resume`, `accounts`, and notification taps push the deep route directly, so they still land on the Host screen. Navigation from *within* the already-mounted group (host-list -> session) is unaffected, which is why only the from-root entry points broke.

## Fix

- Add `unstable_settings = { initialRouteName: '[hostId]/index' }` to `mobile/app/h/_layout.tsx` (defines the anchor; also fixes cold-start notification deep links automatically).
- Pass `{ withAnchor: true }` on the from-root pushes — resume card + account-usage card (`mobile/app/index.tsx`) and notification taps (`mobile/app/_layout.tsx`) — so React Navigation loads the Host screen as the anchor and places the target on top, with back navigation returning through the host. Tasks keeps its existing coordinator workaround.

## How it was verified

- Reproduced the app's URL parsing with its real `whatwg-url-minimum` and expo-router `getStateFromPath` — encoding/parsing was **not** the cause.
- Confirmed the "Host" string only renders in `[hostId]/index.tsx`, and the session header is `worktreeName || 'Terminal'`.
- In a real `@react-navigation/core` render, verified `withAnchor` builds the correct `[[hostId]/index, *session]` stack (target focused on top) and is safe for the anchor-only target.
- Added `mobile/src/navigation/host-route-anchor.test.ts` (guards the anchor config + each `withAnchor` call site); it fails on all assertions against the pre-fix sources.
- `tsc --noEmit`, `oxlint`, and the full mobile suite (2864 tests) pass.

> Native-stack focus behavior can't run in CI/Node, so the final confirmation is on-device: tap the resume line -> it should open the worktree terminal (not the Host page); back should go Host -> Home.

🤖 Diagnosed and fixed with Pi (ce-debug).
