### PR TITLE
fix(window): stop Windows main window crashing on driveless sentinel URL

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -70,12 +70,12 @@ vi.mock('../browser/browser-manager', () => ({
 import {
   createMainWindow,
   loadMainWindow,
+  resolveBrowserWindowCloseAllowedPreloadPath,
   WINDOW_QUIT_RENDERER_ACK_TIMEOUT_MS
 } from './createMainWindow'
 import { ipcMain } from 'electron'
 import { shouldRecoverRendererAfterProcessGone } from '../crash-reporting/process-gone-classification'
 import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../shared/browser-window-close-policy'
-import { fileURLToPath } from 'node:url'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = process.platform
@@ -105,6 +105,19 @@ describe('createMainWindow', () => {
     vi.mocked(ipcMain.handle).mockReset()
     vi.mocked(ipcMain.removeHandler).mockReset()
     vi.useRealTimers()
+  })
+
+  it('resolves the window-close sentinel without throwing on driveless file URLs', () => {
+    // Why: Windows file URLs need a drive letter, so fileURLToPath on the sentinel throws
+    // ERR_INVALID_FILE_URL_PATH there and used to abort window setup before it was shown.
+    expect(() => resolveBrowserWindowCloseAllowedPreloadPath()).not.toThrow()
+
+    const resolved = resolveBrowserWindowCloseAllowedPreloadPath()
+    if (process.platform === 'win32') {
+      expect(resolved).toBeNull()
+    } else {
+      expect(resolved).toBe('/__orca_window_close_allowed__')
+    }
   })
 
   it('can defer renderer loading until startup IPC handlers are registered', () => {
@@ -281,16 +294,20 @@ describe('createMainWindow', () => {
     expect(allowWindowCloseParams.preload).toBeUndefined()
     expect(allowWindowClosePrefs).not.toHaveProperty('preload')
 
-    const allowWindowClosePathPrefs = {
-      partition: 'persist:orca-browser',
-      preload: fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+    // Why: the sentinel only has a filesystem form on POSIX, so this leg is Windows-exempt.
+    const sentinelPath = resolveBrowserWindowCloseAllowedPreloadPath()
+    if (sentinelPath !== null) {
+      const allowWindowClosePathPrefs = {
+        partition: 'persist:orca-browser',
+        preload: sentinelPath
+      }
+      windowHandlers['will-attach-webview'](
+        { preventDefault: vi.fn() } as never,
+        allowWindowClosePathPrefs as never,
+        { src: 'data:text/html,', preload: '' } as never
+      )
+      expect(allowWindowClosePathPrefs).not.toHaveProperty('preload')
     }
-    windowHandlers['will-attach-webview'](
-      { preventDefault: vi.fn() } as never,
-      allowWindowClosePathPrefs as never,
-      { src: 'data:text/html,', preload: '' } as never
-    )
-    expect(allowWindowClosePathPrefs).not.toHaveProperty('preload')
 
     const cliGuest = { marker: 'cli-guest' }
     windowHandlers['did-attach-webview']({} as never, cliGuest as never)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -206,6 +206,21 @@ type CreateMainWindowOptions = {
   onBeforeRecoveryReload?: (webContentsId: number) => void
 }
 
+/**
+ * Resolves the filesystem form of the window-close sentinel, or null where it has none.
+ *
+ * Why: the sentinel is a driveless `file:///` URL. On POSIX that maps to a real path, but
+ * Windows file URLs require a drive letter, so `fileURLToPath` throws ERR_INVALID_FILE_URL_PATH
+ * there. Returning null keeps the caller on URL-only matching instead of crashing window setup.
+ */
+export function resolveBrowserWindowCloseAllowedPreloadPath(): string | null {
+  try {
+    return fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+  } catch {
+    return null
+  }
+}
+
 export function loadMainWindow(mainWindow: BrowserWindow): void {
   if (is.dev && process.env.ELECTRON_RENDERER_URL) {
     void mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL)
@@ -444,7 +459,9 @@ export function createMainWindow(
   registerPluginPanelNavigationGuard(mainWindow.webContents)
 
   const browserWindowClosePreload = join(__dirname, 'browser-window-close-preload.js')
-  const browserWindowCloseAllowedPreloadPath = fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+  // Why: the sentinel is a driveless file URL, which only has a filesystem form on
+  // POSIX; on Windows fileURLToPath throws, so fall back to URL-only matching.
+  const browserWindowCloseAllowedPreloadPath = resolveBrowserWindowCloseAllowedPreloadPath()
   mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
     const src = typeof params.src === 'string' ? params.src : ''
     const normalizedSrc = normalizeBrowserNavigationUrl(src)
@@ -459,7 +476,8 @@ export function createMainWindow(
     const allowWindowClose = [params.preload, webPreferences.preload].some(
       (preload) =>
         preload === BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD ||
-        preload === browserWindowCloseAllowedPreloadPath
+        (browserWindowCloseAllowedPreloadPath !== null &&
+          preload === browserWindowCloseAllowedPreloadPath)
     )
     delete params.preload
     if (allowWindowClose) {


### PR DESCRIPTION
## What this fixes

On Windows, Orca currently starts with **no main window at all**. The app process launches, the dev/prod bundle loads, and then nothing is shown — the only trace is a `main_unhandled_rejection` in the log:

```
[main_unhandled_rejection] TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must be absolute
    at getPathFromURLWin32 (node:internal/url:1505:11)
    at fileURLToPath (node:internal/url:1632:35)
    at createMainWindow (out/main/index.js:203958:74)
    at openMainWindow (out/main/index.js:221190:19)
```

## Root cause

`BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD` is the driveless file URL `file:///__orca_window_close_allowed__` (`src/shared/browser-window-close-policy.ts`). `createMainWindow` passed it straight to `fileURLToPath` to precompute the filesystem form used for preload matching.

On POSIX that resolves to `/__orca_window_close_allowed__`. On Windows a file URL must carry a drive letter, so `fileURLToPath` throws `ERR_INVALID_FILE_URL_PATH`:

```
node -e "require('node:url').fileURLToPath('file:///__orca_window_close_allowed__')"
→ TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must be absolute
```

The call sits in `createMainWindow` **before the window is shown**, so the throw aborts window setup entirely.

Introduced in c79b85975 (`fix(browser): prevent window.close guest crashes`, #11910).

## Why CI didn't catch it

The existing assertion in `createMainWindow.test.ts` called `fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)` in the test body, so it throws on Windows too — the suite fails there for the same reason. The workflows run this suite on Linux/macOS, where both the product code and the test resolve fine.

## The change

- `resolveBrowserWindowCloseAllowedPreloadPath()` wraps the conversion and returns `null` on platforms where the sentinel has no filesystem form.
- The `will-attach-webview` preload check falls back to URL-only matching when the path form is unavailable, so the security behaviour is unchanged: the sentinel URL is still recognised, and every other preload is still replaced with `browser-window-close-preload.js`.
- The helper lives in `src/main/window/createMainWindow.ts` rather than next to the constant in `src/shared/`, because `src/shared/` is also bundled for the renderer and importing `node:url` there would break the web build.

## Tests

- New regression test pins the platform contract: `null` on `win32`, `/__orca_window_close_allowed__` elsewhere, and asserts the resolver never throws.
- The existing path-form leg of `enables renderer sandboxing and opens external links safely` is now skipped where the sentinel has no path form, so the suite passes on Windows.

## Verification

Run on Windows 11, Node 24.18.0, Electron 43:

- `pnpm typecheck` — clean (all three projects)
- `pnpm dev` — main window now opens; no `main_unhandled_rejection` in the log
- `createMainWindow.test.ts` — 82/82 pass
- `src/main/window/` — 228 pass, 4 fail. All four are in `clipboard-file-copy.test.ts`, which this PR does not touch; they assert driveless URLs like `file:///repo/a.png` and get `file:///C:/repo/a.png` on Windows. Same family of bug as the one fixed here, and worth a follow-up.
- `pnpm test` — full suite on Windows: 42057 pass, 301 fail. The failures are the pre-existing Windows-portability set — POSIX path separators (`expected ['\ctor\codex\home\sessions'] to include '/ctor/codex/home/sessions'`), `spawn /bin/sh ENOENT`, and PTY exit timeouts. None are in the files this PR changes. I have not tried to fix those here; happy to open issues if that's useful.
- `pnpm lint` — `oxlint`, both code-quality audits, the reliability gates and the max-lines ratchet all pass. The run then stops in `verify:skill-bundle-manifest`, which is unrelated to this change and reproduces on a clean checkout of `main`: with git's default `core.autocrlf=true` on Windows, `resources/skills/*.json` is checked out CRLF while the generator emits LF, so the byte comparison fails. `git diff --ignore-cr-at-eol` is empty. `.gitattributes` already pins `eol=lf` for `/resources/plugins/**` with the comment "Bundled plugin trees are byte-hashed; CRLF checkout would break the pinned hash" — `/resources/skills/**` looks like it needs the same line. Happy to send that as a separate PR if you agree.

Also confirmed the `will-attach-webview` allow/deny behaviour is unchanged on macOS and Linux, where `resolveBrowserWindowCloseAllowedPreloadPath()` returns exactly what `fileURLToPath` returned before.

## Visual changes

None — this restores a window that previously failed to appear on Windows. No UI was modified, so there are no screenshots to attach.

## Review notes

- **Cross-platform:** this is the whole point of the change. POSIX behaviour is byte-identical to before; Windows stops throwing. The platform difference is now explicit in code and pinned by a test rather than implied.
- **Local / remote / SSH:** untouched. `createMainWindow` runs in the desktop main process and the sentinel is local to `<webview>` attach policy; nothing here reaches a remote host, SSH worktree, or the relay.
- **Agents / integrations / git providers:** untouched — no agent, provider, or integration-specific code paths involved.
- **Security:** the allowlist is not widened. Where the path form is unavailable it simply cannot be matched, so the check is strictly no more permissive than before; `delete params.preload`, the `preloadURL` deletion, and the `nodeIntegration` flags are all unchanged.
- **Performance:** one `try`/`catch` evaluated once per window creation. No hot-path impact.
- **UI quality:** no styling, layout, or token changes.

X: @vicmandarin
