### PR TITLE
fix(mobile): open the Resume workspace through a mounted host stack

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -54,7 +54,7 @@ import {
 } from '../src/tasks/mobile-task-providers'
 import { useOpenMobileTasks } from '../src/tasks/use-open-mobile-tasks'
 import { useResponsiveLayout } from '../src/layout/responsive-layout'
-import { createMobileSessionHref } from '../src/session/mobile-session-route'
+import { useOpenMobileSession } from '../src/session/use-open-mobile-session'
 
 function endpointLabel(endpoint: string): string {
   try {
@@ -207,6 +207,7 @@ function repoColor(name: string): string {
 export default function HomeScreen() {
   const router = useRouter()
   const openMobileTasks = useOpenMobileTasks()
+  const openMobileSession = useOpenMobileSession()
   const insets = useSafeAreaInsets()
   // Why: cap/center content on wide/tablet canvases so cards don't stretch edge-to-edge on iPad.
   const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
@@ -736,13 +737,11 @@ export default function HomeScreen() {
                   <Pressable
                     style={({ pressed }) => [styles.resumeCard, pressed && styles.hostCardPressed]}
                     onPress={() =>
-                      router.push(
-                        createMobileSessionHref({
-                          hostId: resumeWorktree.hostId,
-                          worktreeId: resumeWorktree.worktree.worktreeId,
-                          name: resumeWorktree.worktree.displayName || resumeWorktree.worktree.repo
-                        })
-                      )
+                      openMobileSession({
+                        hostId: resumeWorktree.hostId,
+                        worktreeId: resumeWorktree.worktree.worktreeId,
+                        name: resumeWorktree.worktree.displayName || resumeWorktree.worktree.repo
+                      })
                     }
                   >
                     <View style={styles.resumeIcon}>

--- a/mobile/src/navigation/host-stack-navigation.test.ts
+++ b/mobile/src/navigation/host-stack-navigation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  hostStackHostRoute,
+  navigateToHostStackRoute,
+  type HostStackNavigationState
+} from './host-stack-navigation'
+
+const TARGET = { name: '[hostId]/tasks', params: { hostId: 'host/one' } } as const
+
+function navigationHarness(initialState: HostStackNavigationState) {
+  let stateListener = () => {}
+  let state = initialState
+  const navigation = {
+    addListener: vi.fn((_event: 'state', listener: () => void) => {
+      stateListener = listener
+      return vi.fn()
+    }),
+    dispatch: vi.fn(),
+    getState: () => state
+  }
+  return {
+    navigation,
+    setState(nextState: HostStackNavigationState) {
+      state = nextState
+      stateListener()
+    }
+  }
+}
+
+function committedHostState(hostIdParam: string): HostStackNavigationState {
+  return {
+    index: 0,
+    routes: [
+      {
+        name: 'h',
+        state: {
+          key: '/h',
+          index: 0,
+          routes: [{ key: 'host-index', name: '[hostId]/index', params: { hostId: hostIdParam } }]
+        }
+      }
+    ]
+  }
+}
+
+describe('host stack navigation', () => {
+  it('matches a host committed as the encoded segment it was pushed as', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const push = vi.fn()
+
+    navigateToHostStackRoute(harness.navigation, { push }, 'host/one', TARGET)
+    expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
+
+    harness.setState(committedHostState(encodeURIComponent('host/one')))
+
+    expect(harness.navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'host-index', payload: TARGET })
+    )
+  })
+
+  it('ignores a different host whose id merely decodes badly', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+
+    navigateToHostStackRoute(harness.navigation, { push: vi.fn() }, 'host/one', TARGET)
+    harness.setState(committedHostState('100%'))
+
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/navigation/host-stack-navigation.test.ts
+++ b/mobile/src/navigation/host-stack-navigation.test.ts
@@ -1,25 +1,32 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  coordinateHostStackNavigation,
   hostStackHostRoute,
   navigateToHostStackRoute,
   type HostStackNavigationState
 } from './host-stack-navigation'
 
 const TARGET = { name: '[hostId]/tasks', params: { hostId: 'host/one' } } as const
+const OTHER_TARGET = {
+  name: '[hostId]/session/[worktreeId]',
+  params: { hostId: 'host/one', worktreeId: 'repo::/tmp/wt' }
+} as const
 
 function navigationHarness(initialState: HostStackNavigationState) {
   let stateListener = () => {}
   let state = initialState
+  const unsubscribe = vi.fn()
   const navigation = {
     addListener: vi.fn((_event: 'state', listener: () => void) => {
       stateListener = listener
-      return vi.fn()
+      return unsubscribe
     }),
     dispatch: vi.fn(),
     getState: () => state
   }
   return {
     navigation,
+    unsubscribe,
     setState(nextState: HostStackNavigationState) {
       state = nextState
       stateListener()
@@ -50,12 +57,17 @@ describe('host stack navigation', () => {
 
     navigateToHostStackRoute(harness.navigation, { push }, 'host/one', TARGET)
     expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
 
     harness.setState(committedHostState(encodeURIComponent('host/one')))
 
-    expect(harness.navigation.dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'host-index', payload: TARGET })
-    )
+    expect(harness.navigation.dispatch).toHaveBeenCalledTimes(1)
+    expect(harness.navigation.dispatch).toHaveBeenCalledWith({
+      type: 'REPLACE',
+      target: '/h',
+      source: 'host-index',
+      payload: TARGET
+    })
   })
 
   it('ignores a different host whose id merely decodes badly', () => {
@@ -65,5 +77,54 @@ describe('host stack navigation', () => {
     harness.setState(committedHostState('100%'))
 
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('stops listening and never replaces once canceled', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+
+    const controller = navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn() },
+      'host/one',
+      TARGET
+    )
+    controller.cancel()
+
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1)
+    expect(controller.isActive()).toBe(false)
+
+    harness.setState(committedHostState('host/one'))
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('retargets a still-pending transition to the same host instead of pushing twice', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const push = vi.fn()
+    const router = { push }
+
+    const pending = coordinateHostStackNavigation(
+      null,
+      harness.navigation,
+      router,
+      'host/one',
+      TARGET
+    )
+    const retargeted = coordinateHostStackNavigation(
+      pending,
+      harness.navigation,
+      router,
+      'host/one',
+      OTHER_TARGET
+    )
+
+    expect(retargeted).toBe(pending)
+    expect(push).toHaveBeenCalledTimes(1)
+
+    harness.setState(committedHostState('host/one'))
+
+    expect(harness.navigation.dispatch).toHaveBeenCalledTimes(1)
+    expect(harness.navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: OTHER_TARGET })
+    )
   })
 })

--- a/mobile/src/navigation/host-stack-navigation.test.ts
+++ b/mobile/src/navigation/host-stack-navigation.test.ts
@@ -12,14 +12,19 @@ const OTHER_TARGET = {
   params: { hostId: 'host/one', worktreeId: 'repo::/tmp/wt' }
 } as const
 
+// Removal is modeled for real: a no-op unsubscribe would let `setState` keep
+// calling a canceled listener, testing the `active` guard instead of teardown.
 function navigationHarness(initialState: HostStackNavigationState) {
-  let stateListener = () => {}
+  const stateListeners = new Set<() => void>()
   let state = initialState
   const unsubscribe = vi.fn()
   const navigation = {
     addListener: vi.fn((_event: 'state', listener: () => void) => {
-      stateListener = listener
-      return unsubscribe
+      stateListeners.add(listener)
+      return () => {
+        unsubscribe()
+        stateListeners.delete(listener)
+      }
     }),
     dispatch: vi.fn(),
     getState: () => state
@@ -27,9 +32,12 @@ function navigationHarness(initialState: HostStackNavigationState) {
   return {
     navigation,
     unsubscribe,
+    listenerCount: () => stateListeners.size,
     setState(nextState: HostStackNavigationState) {
       state = nextState
-      stateListener()
+      for (const listener of stateListeners) {
+        listener()
+      }
     }
   }
 }
@@ -88,9 +96,11 @@ describe('host stack navigation', () => {
       'host/one',
       TARGET
     )
+    expect(harness.listenerCount()).toBe(1)
     controller.cancel()
 
     expect(harness.unsubscribe).toHaveBeenCalledTimes(1)
+    expect(harness.listenerCount()).toBe(0)
     expect(controller.isActive()).toBe(false)
 
     harness.setState(committedHostState('host/one'))
@@ -119,6 +129,7 @@ describe('host stack navigation', () => {
 
     expect(retargeted).toBe(pending)
     expect(push).toHaveBeenCalledTimes(1)
+    expect(harness.listenerCount()).toBe(1)
 
     harness.setState(committedHostState('host/one'))
 

--- a/mobile/src/navigation/host-stack-navigation.ts
+++ b/mobile/src/navigation/host-stack-navigation.ts
@@ -1,0 +1,155 @@
+export type HostStackNavigationState = Readonly<{
+  key?: string
+  index: number
+  routes: readonly HostStackNavigationRoute[]
+}>
+
+export type HostStackNavigationRoute = Readonly<{
+  key?: string
+  name: string
+  params?: Readonly<{ hostId?: unknown }>
+  state?: HostStackNavigationState
+}>
+
+/** A screen inside app/h/_layout.tsx plus the params it needs, e.g.
+ *  `{ name: '[hostId]/session/[worktreeId]', params: { hostId, worktreeId } }`. */
+export type HostStackRouteTarget = Readonly<{
+  name: string
+  params: Readonly<Record<string, string>>
+}>
+
+export type HostStackReplaceAction = Readonly<{
+  type: 'REPLACE'
+  target: string
+  source: string
+  payload: HostStackRouteTarget
+}>
+
+export type HostStackRootNavigation = {
+  addListener: (event: 'state', listener: () => void) => () => void
+  dispatch: (action: HostStackReplaceAction) => void
+  getState: () => HostStackNavigationState
+}
+
+export type HostStackHostRoute = `/h/${string}`
+
+export type HostStackRouter = {
+  push: (route: HostStackHostRoute) => void
+}
+
+export type HostStackNavigationController = Readonly<{
+  cancel: () => void
+  isActive: () => boolean
+  retarget: (target: HostStackRouteTarget) => void
+}>
+
+export type PendingHostStackNavigation = Readonly<{
+  hostId: string
+  controller: HostStackNavigationController
+}>
+
+export function hostStackHostRoute(hostId: string): HostStackHostRoute {
+  return `/h/${encodeURIComponent(hostId)}`
+}
+
+function mountedHostStack(
+  state: HostStackNavigationState,
+  expectedHostId: string
+): { key: string; routeKey: string } | null {
+  const hostContainer = state.routes[state.index]
+  const hostState = hostContainer?.state
+  const hostRoute = hostState?.routes[hostState.index]
+  if (
+    hostContainer?.name !== 'h' ||
+    !hostState?.key ||
+    hostRoute?.name !== '[hostId]/index' ||
+    !hostRoute.key ||
+    hostRoute.params?.hostId !== expectedHostId
+  ) {
+    return null
+  }
+  return { key: hostState.key, routeKey: hostRoute.key }
+}
+
+/** Opens a deep host route by mounting `/h/[hostId]` first and replacing it once
+ *  its stack is committed. A cold push straight to a nested route resolves to the
+ *  host index without the dynamic id, which lands on a blank host screen. */
+export function navigateToHostStackRoute(
+  navigation: HostStackRootNavigation,
+  router: HostStackRouter,
+  hostId: string,
+  target: HostStackRouteTarget
+): HostStackNavigationController {
+  let active = true
+  let hostRouteSeen = false
+  let selectedTarget = target
+  let unsubscribeState = () => {}
+  const dispose = () => {
+    if (!active) {
+      return
+    }
+    active = false
+    unsubscribeState()
+  }
+
+  // Why: cold Expo deep links resolve to index; target the route only after its HostStack exists.
+  const onState = () => {
+    if (!active) {
+      return
+    }
+    const state = navigation.getState()
+    const currentRoute = state.routes[state.index]
+    if (currentRoute?.name === 'h') {
+      hostRouteSeen = true
+    } else if (hostRouteSeen) {
+      dispose()
+      return
+    }
+    const hostStack = mountedHostStack(state, hostId)
+    if (!hostStack) {
+      return
+    }
+    dispose()
+    navigation.dispatch({
+      type: 'REPLACE',
+      target: hostStack.key,
+      source: hostStack.routeKey,
+      payload: selectedTarget
+    })
+  }
+
+  try {
+    unsubscribeState = navigation.addListener('state', onState)
+    router.push(hostStackHostRoute(hostId))
+  } catch (error) {
+    dispose()
+    throw error
+  }
+  return {
+    cancel: dispose,
+    isActive: () => active,
+    retarget: (nextTarget) => {
+      if (active) {
+        selectedTarget = nextTarget
+      }
+    }
+  }
+}
+
+export function coordinateHostStackNavigation(
+  current: PendingHostStackNavigation | null,
+  navigation: HostStackRootNavigation,
+  router: HostStackRouter,
+  hostId: string,
+  target: HostStackRouteTarget
+): PendingHostStackNavigation {
+  if (current?.hostId === hostId && current.controller.isActive()) {
+    current.controller.retarget(target)
+    return current
+  }
+  current?.controller.cancel()
+  return {
+    hostId,
+    controller: navigateToHostStackRoute(navigation, router, hostId, target)
+  }
+}

--- a/mobile/src/navigation/host-stack-navigation.ts
+++ b/mobile/src/navigation/host-stack-navigation.ts
@@ -52,6 +52,22 @@ export function hostStackHostRoute(hostId: string): HostStackHostRoute {
   return `/h/${encodeURIComponent(hostId)}`
 }
 
+// Why: the host is pushed as an encoded segment, so the committed route may hold
+// either form — an id with `/`, `#`, or `%` must still match its own push.
+function hostParamMatches(param: unknown, expectedHostId: string): boolean {
+  if (typeof param !== 'string') {
+    return false
+  }
+  if (param === expectedHostId) {
+    return true
+  }
+  try {
+    return decodeURIComponent(param) === expectedHostId
+  } catch {
+    return false // Lone `%` — not our encoding.
+  }
+}
+
 function mountedHostStack(
   state: HostStackNavigationState,
   expectedHostId: string
@@ -64,7 +80,7 @@ function mountedHostStack(
     !hostState?.key ||
     hostRoute?.name !== '[hostId]/index' ||
     !hostRoute.key ||
-    hostRoute.params?.hostId !== expectedHostId
+    !hostParamMatches(hostRoute.params?.hostId, expectedHostId)
   ) {
     return null
   }

--- a/mobile/src/navigation/use-open-host-stack-route.ts
+++ b/mobile/src/navigation/use-open-host-stack-route.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useNavigation, useRouter } from 'expo-router'
+import {
+  coordinateHostStackNavigation,
+  type HostStackRootNavigation,
+  type HostStackRouteTarget,
+  type PendingHostStackNavigation
+} from './host-stack-navigation'
+
+export function useOpenHostStackRoute(): (hostId: string, target: HostStackRouteTarget) => void {
+  const navigation = useNavigation<HostStackRootNavigation>()
+  const router = useRouter()
+  const pendingRef = useRef<PendingHostStackNavigation | null>(null)
+
+  useEffect(
+    () => () => {
+      pendingRef.current?.controller.cancel()
+      pendingRef.current = null
+    },
+    []
+  )
+
+  return useCallback(
+    (hostId, target) => {
+      pendingRef.current = coordinateHostStackNavigation(
+        pendingRef.current,
+        navigation,
+        router,
+        hostId,
+        target
+      )
+    },
+    [navigation, router]
+  )
+}

--- a/mobile/src/navigation/use-open-host-stack-route.ts
+++ b/mobile/src/navigation/use-open-host-stack-route.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useNavigation, useRouter } from 'expo-router'
 import {
   coordinateHostStackNavigation,
@@ -7,23 +7,26 @@ import {
   type PendingHostStackNavigation
 } from './host-stack-navigation'
 
+// Why: one root navigator means one pending transition. A per-hook ref would let a
+// Resume tap and a Tasks tap arm two independent pushes that cannot cancel each other.
+let pendingNavigation: PendingHostStackNavigation | null = null
+
 export function useOpenHostStackRoute(): (hostId: string, target: HostStackRouteTarget) => void {
   const navigation = useNavigation<HostStackRootNavigation>()
   const router = useRouter()
-  const pendingRef = useRef<PendingHostStackNavigation | null>(null)
 
   useEffect(
     () => () => {
-      pendingRef.current?.controller.cancel()
-      pendingRef.current = null
+      pendingNavigation?.controller.cancel()
+      pendingNavigation = null
     },
     []
   )
 
   return useCallback(
     (hostId, target) => {
-      pendingRef.current = coordinateHostStackNavigation(
-        pendingRef.current,
+      pendingNavigation = coordinateHostStackNavigation(
+        pendingNavigation,
         navigation,
         router,
         hostId,

--- a/mobile/src/session/mobile-session-route.test.ts
+++ b/mobile/src/session/mobile-session-route.test.ts
@@ -97,10 +97,13 @@ describe('mobile session route', () => {
   it('routes the home Resume card through the cold-navigator-safe transition', () => {
     const start = homeSource.indexOf('{/* ─── Resume card ─── */}')
     const end = homeSource.indexOf('{/* ─── Quick actions ─── */}', start)
-    const resumeCard = homeSource.slice(start, end)
 
+    // Assert the markers first: a renamed banner would otherwise slice garbage and
+    // report a missing call instead of the real cause.
     expect(start).toBeGreaterThanOrEqual(0)
     expect(end).toBeGreaterThan(start)
+
+    const resumeCard = homeSource.slice(start, end)
     expect(resumeCard).toContain('openMobileSession({')
     expect(resumeCard).not.toContain('router.push(')
   })

--- a/mobile/src/session/mobile-session-route.test.ts
+++ b/mobile/src/session/mobile-session-route.test.ts
@@ -10,12 +10,12 @@ import {
 const homeSource = readFileSync(new URL('../../app/index.tsx', import.meta.url), 'utf8')
 
 function navigationHarness(initialState: HostStackNavigationState) {
-  let stateListener = () => {}
+  const stateListeners = new Set<() => void>()
   let state = initialState
   const navigation = {
     addListener: vi.fn((_event: 'state', listener: () => void) => {
-      stateListener = listener
-      return vi.fn()
+      stateListeners.add(listener)
+      return () => stateListeners.delete(listener)
     }),
     dispatch: vi.fn(),
     getState: () => state
@@ -24,7 +24,9 @@ function navigationHarness(initialState: HostStackNavigationState) {
     navigation,
     setState(nextState: HostStackNavigationState) {
       state = nextState
-      stateListener()
+      for (const listener of stateListeners) {
+        listener()
+      }
     }
   }
 }

--- a/mobile/src/session/mobile-session-route.test.ts
+++ b/mobile/src/session/mobile-session-route.test.ts
@@ -1,19 +1,61 @@
 import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
-import { createMobileSessionHref } from './mobile-session-route'
+import { describe, expect, it, vi } from 'vitest'
+import { mobileSessionRouteTarget } from './mobile-session-route'
+import {
+  hostStackHostRoute,
+  navigateToHostStackRoute,
+  type HostStackNavigationState
+} from '../navigation/host-stack-navigation'
 
 const homeSource = readFileSync(new URL('../../app/index.tsx', import.meta.url), 'utf8')
 
+function navigationHarness(initialState: HostStackNavigationState) {
+  let stateListener = () => {}
+  let state = initialState
+  const navigation = {
+    addListener: vi.fn((_event: 'state', listener: () => void) => {
+      stateListener = listener
+      return vi.fn()
+    }),
+    dispatch: vi.fn(),
+    getState: () => state
+  }
+  return {
+    navigation,
+    setState(nextState: HostStackNavigationState) {
+      state = nextState
+      stateListener()
+    }
+  }
+}
+
+function mountedHostState(hostId: string): HostStackNavigationState {
+  return {
+    index: 1,
+    routes: [
+      { name: 'index' },
+      {
+        name: 'h',
+        state: {
+          key: '/h',
+          index: 0,
+          routes: [{ key: 'host-index', name: '[hostId]/index', params: { hostId } }]
+        }
+      }
+    ]
+  }
+}
+
 describe('mobile session route', () => {
-  it('keeps dynamic route identities raw for Expo Router to encode', () => {
+  it('keeps dynamic route identities raw for the navigator to encode', () => {
     expect(
-      createMobileSessionHref({
+      mobileSessionRouteTarget({
         hostId: 'host/one',
         worktreeId: 'repo::/Users/ada/orca/workspaces/fix #1',
         name: 'Fix #1'
       })
     ).toEqual({
-      pathname: '/h/[hostId]/session/[worktreeId]',
+      name: '[hostId]/session/[worktreeId]',
       params: {
         hostId: 'host/one',
         worktreeId: 'repo::/Users/ada/orca/workspaces/fix #1',
@@ -22,14 +64,44 @@ describe('mobile session route', () => {
     })
   })
 
-  it('routes the home Resume card through the typed dynamic href', () => {
+  it('omits an absent workspace name instead of sending an empty param', () => {
+    expect(
+      mobileSessionRouteTarget({ hostId: 'host-1', worktreeId: 'repo::/tmp/wt' }).params
+    ).toEqual({ hostId: 'host-1', worktreeId: 'repo::/tmp/wt' })
+  })
+
+  it('mounts the host before replacing it with the session route', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const push = vi.fn()
+    const target = mobileSessionRouteTarget({
+      hostId: 'host/one',
+      worktreeId: 'repo::/Users/ada/orca/workspaces/fix #1',
+      name: 'Fix #1'
+    })
+
+    navigateToHostStackRoute(harness.navigation, { push }, 'host/one', target)
+
+    expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+
+    harness.setState(mountedHostState('host/one'))
+
+    expect(harness.navigation.dispatch).toHaveBeenCalledWith({
+      type: 'REPLACE',
+      target: '/h',
+      source: 'host-index',
+      payload: target
+    })
+  })
+
+  it('routes the home Resume card through the cold-navigator-safe transition', () => {
     const start = homeSource.indexOf('{/* ─── Resume card ─── */}')
     const end = homeSource.indexOf('{/* ─── Quick actions ─── */}', start)
     const resumeCard = homeSource.slice(start, end)
 
     expect(start).toBeGreaterThanOrEqual(0)
     expect(end).toBeGreaterThan(start)
-    expect(resumeCard).toContain('createMobileSessionHref({')
-    expect(resumeCard).not.toContain('encodeURIComponent(resumeWorktree.worktree.worktreeId)')
+    expect(resumeCard).toContain('openMobileSession({')
+    expect(resumeCard).not.toContain('router.push(')
   })
 })

--- a/mobile/src/session/mobile-session-route.ts
+++ b/mobile/src/session/mobile-session-route.ts
@@ -1,17 +1,20 @@
+import type { HostStackRouteTarget } from '../navigation/host-stack-navigation'
+
 export type MobileSessionRouteParams = {
   hostId: string
   worktreeId: string
   name?: string
 }
 
-export type MobileSessionHref = {
-  pathname: '/h/[hostId]/session/[worktreeId]'
-  params: MobileSessionRouteParams
-}
-
-export function createMobileSessionHref(params: MobileSessionRouteParams): MobileSessionHref {
+/** Identities stay raw — the navigator owns the params, so pre-encoding a
+ *  workspace id would reach the session screen still escaped. */
+export function mobileSessionRouteTarget({
+  hostId,
+  worktreeId,
+  name
+}: MobileSessionRouteParams): HostStackRouteTarget {
   return {
-    pathname: '/h/[hostId]/session/[worktreeId]',
-    params
+    name: '[hostId]/session/[worktreeId]',
+    params: name ? { hostId, worktreeId, name } : { hostId, worktreeId }
   }
 }

--- a/mobile/src/session/use-open-mobile-session.ts
+++ b/mobile/src/session/use-open-mobile-session.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react'
+import { useOpenHostStackRoute } from '../navigation/use-open-host-stack-route'
+import { mobileSessionRouteTarget, type MobileSessionRouteParams } from './mobile-session-route'
+
+export function useOpenMobileSession(): (params: MobileSessionRouteParams) => void {
+  const openHostStackRoute = useOpenHostStackRoute()
+
+  return useCallback(
+    (params) => {
+      openHostStackRoute(params.hostId, mobileSessionRouteTarget(params))
+    },
+    [openHostStackRoute]
+  )
+}

--- a/mobile/src/tasks/mobile-task-navigation.ts
+++ b/mobile/src/tasks/mobile-task-navigation.ts
@@ -1,72 +1,36 @@
+import {
+  coordinateHostStackNavigation,
+  hostStackHostRoute,
+  navigateToHostStackRoute,
+  type HostStackHostRoute,
+  type HostStackNavigationController,
+  type HostStackNavigationState,
+  type HostStackRootNavigation,
+  type HostStackRouteTarget,
+  type HostStackRouter,
+  type PendingHostStackNavigation
+} from '../navigation/host-stack-navigation'
 import type { TaskProvider } from './mobile-task-providers'
 
-export type MobileTasksHostRoute = `/h/${string}`
-
-export type MobileTasksNavigationState = Readonly<{
-  key?: string
-  index: number
-  routes: readonly MobileTasksNavigationRoute[]
-}>
-
-export type MobileTasksNavigationRoute = Readonly<{
-  key?: string
-  name: string
-  params?: Readonly<{ hostId?: unknown }>
-  state?: MobileTasksNavigationState
-}>
-
-export type MobileTasksRootNavigation = {
-  addListener: (event: 'state', listener: () => void) => () => void
-  dispatch: (action: MobileTasksHostReplaceAction) => void
-  getState: () => MobileTasksNavigationState
-}
-
-export type MobileTasksHostReplaceAction = Readonly<{
-  type: 'REPLACE'
-  target: string
-  source: string
-  payload: Readonly<{
-    name: '[hostId]/tasks'
-    params: Readonly<{ hostId: string; taskSource?: TaskProvider }>
-  }>
-}>
-
-export type MobileTasksRouter = {
-  push: (route: MobileTasksHostRoute) => void
-}
-
-export type MobileTasksNavigationController = Readonly<{
-  cancel: () => void
-  isActive: () => boolean
-  selectProvider: (provider?: TaskProvider) => void
-}>
-
-export type PendingMobileTasksNavigation = Readonly<{
-  hostId: string
-  controller: MobileTasksNavigationController
-}>
+export type MobileTasksHostRoute = HostStackHostRoute
+export type MobileTasksNavigationState = HostStackNavigationState
+export type MobileTasksRootNavigation = HostStackRootNavigation
+export type MobileTasksRouter = HostStackRouter
+export type MobileTasksNavigationController = HostStackNavigationController
+export type PendingMobileTasksNavigation = PendingHostStackNavigation
 
 export function mobileTasksHostRoute(hostId: string): MobileTasksHostRoute {
-  return `/h/${encodeURIComponent(hostId)}`
+  return hostStackHostRoute(hostId)
 }
 
-function mountedHostStack(
-  state: MobileTasksNavigationState,
-  expectedHostId: string
-): { key: string; routeKey: string } | null {
-  const hostContainer = state.routes[state.index]
-  const hostState = hostContainer?.state
-  const hostRoute = hostState?.routes[hostState.index]
-  if (
-    hostContainer?.name !== 'h' ||
-    !hostState?.key ||
-    hostRoute?.name !== '[hostId]/index' ||
-    !hostRoute.key ||
-    hostRoute.params?.hostId !== expectedHostId
-  ) {
-    return null
+export function mobileTasksRouteTarget(
+  hostId: string,
+  provider?: TaskProvider
+): HostStackRouteTarget {
+  return {
+    name: '[hostId]/tasks',
+    params: provider ? { hostId, taskSource: provider } : { hostId }
   }
-  return { key: hostState.key, routeKey: hostRoute.key }
 }
 
 export function navigateToMobileTasks(
@@ -75,64 +39,12 @@ export function navigateToMobileTasks(
   hostId: string,
   provider?: TaskProvider
 ): MobileTasksNavigationController {
-  let active = true
-  let hostRouteSeen = false
-  let selectedProvider = provider
-  let unsubscribeState = () => {}
-  const dispose = () => {
-    if (!active) {
-      return
-    }
-    active = false
-    unsubscribeState()
-  }
-
-  // Why: cold Expo deep links resolve to index; target Tasks only after its HostStack exists.
-  const onState = () => {
-    if (!active) {
-      return
-    }
-    const state = navigation.getState()
-    const currentRoute = state.routes[state.index]
-    if (currentRoute?.name === 'h') {
-      hostRouteSeen = true
-    } else if (hostRouteSeen) {
-      dispose()
-      return
-    }
-    const hostStack = mountedHostStack(state, hostId)
-    if (!hostStack) {
-      return
-    }
-    dispose()
-    const action: MobileTasksHostReplaceAction = {
-      type: 'REPLACE',
-      target: hostStack.key,
-      source: hostStack.routeKey,
-      payload: {
-        name: '[hostId]/tasks',
-        params: selectedProvider ? { hostId, taskSource: selectedProvider } : { hostId }
-      }
-    }
-    navigation.dispatch(action)
-  }
-
-  try {
-    unsubscribeState = navigation.addListener('state', onState)
-    router.push(mobileTasksHostRoute(hostId))
-  } catch (error) {
-    dispose()
-    throw error
-  }
-  return {
-    cancel: dispose,
-    isActive: () => active,
-    selectProvider: (nextProvider) => {
-      if (active) {
-        selectedProvider = nextProvider
-      }
-    }
-  }
+  return navigateToHostStackRoute(
+    navigation,
+    router,
+    hostId,
+    mobileTasksRouteTarget(hostId, provider)
+  )
 }
 
 export function coordinateMobileTasksNavigation(
@@ -142,13 +54,11 @@ export function coordinateMobileTasksNavigation(
   hostId: string,
   provider?: TaskProvider
 ): PendingMobileTasksNavigation {
-  if (current?.hostId === hostId && current.controller.isActive()) {
-    current.controller.selectProvider(provider)
-    return current
-  }
-  current?.controller.cancel()
-  return {
+  return coordinateHostStackNavigation(
+    current,
+    navigation,
+    router,
     hostId,
-    controller: navigateToMobileTasks(navigation, router, hostId, provider)
-  }
+    mobileTasksRouteTarget(hostId, provider)
+  )
 }

--- a/mobile/src/tasks/use-open-mobile-tasks.ts
+++ b/mobile/src/tasks/use-open-mobile-tasks.ts
@@ -1,35 +1,15 @@
-import { useCallback, useEffect, useRef } from 'react'
-import { useNavigation, useRouter } from 'expo-router'
-import {
-  coordinateMobileTasksNavigation,
-  type MobileTasksRootNavigation,
-  type PendingMobileTasksNavigation
-} from './mobile-task-navigation'
+import { useCallback } from 'react'
+import { useOpenHostStackRoute } from '../navigation/use-open-host-stack-route'
+import { mobileTasksRouteTarget } from './mobile-task-navigation'
 import type { TaskProvider } from './mobile-task-providers'
 
 export function useOpenMobileTasks(): (hostId: string, provider?: TaskProvider) => void {
-  const navigation = useNavigation<MobileTasksRootNavigation>()
-  const router = useRouter()
-  const pendingRef = useRef<PendingMobileTasksNavigation | null>(null)
-
-  useEffect(
-    () => () => {
-      pendingRef.current?.controller.cancel()
-      pendingRef.current = null
-    },
-    []
-  )
+  const openHostStackRoute = useOpenHostStackRoute()
 
   return useCallback(
     (hostId, provider) => {
-      pendingRef.current = coordinateMobileTasksNavigation(
-        pendingRef.current,
-        navigation,
-        router,
-        hostId,
-        provider
-      )
+      openHostStackRoute(hostId, mobileTasksRouteTarget(hostId, provider))
     },
-    [navigation, router]
+    [openHostStackRoute]
   )
 }


### PR DESCRIPTION
## Summary

Tapping **Resume** on Home landed on a blank host screen instead of opening the workspace session. Resume now uses the same mount-then-replace transition Home already uses for the host editor (#11635) and Tasks (#11853).

### Root cause

A cold push straight into the nested `/h/[hostId]` navigator resolves to the host index route without the dynamic id — the same failure #11853 documented for Tasks. `app/h/_layout.tsx` then mounts `HostProtocolGate` with `hostId: undefined`, so `useHostClient(undefined)` never connects and the detail stack renders an empty host screen.

#11876 addressed this by swapping the manual href for a typed dynamic href, but that did not change the resolved route. `expo-router`'s `resolveHref` → `encodeParam` already applies `encodeURIComponent` to dynamic segments, so `{ pathname: '/h/[hostId]/session/[worktreeId]', params }` resolves to the same URL the manual string produced (`/h/<host>/session/<encoded workspace id>`; the workspace id was already passed through `encodeURIComponent`). The direct cross-stack push — the actual cause — stayed in place.

### Change

- extract the mount-then-replace mechanism out of `mobile-task-navigation` into `src/navigation/host-stack-navigation`: mount `/h/[hostId]`, wait for that stack to commit, then `REPLACE` its index route with the concrete target.
- Tasks keeps its public API and behavior, now as a thin wrapper over the shared mechanism, so the two Home entry points cannot drift apart again.
- Resume opens `[hostId]/session/[worktreeId]` through the same transition via `useOpenMobileSession`.
- host and workspace identities stay raw in the `REPLACE` payload — the navigator owns encoding, so an id containing `/`, `::`, or `#` reaches the session screen unescaped.

## Screenshots

![Home Resume before and after the fix](https://raw.githubusercontent.com/kaynansc/orca/pr-assets-mobile-resume/resume-fix.png)

Tapping **Resume** on a cold app start, on an iOS simulator paired to a headless desktop runtime. Before, the tap lands on a host screen with no host id and a disconnected dot; after, it opens the workspace session with the host connected. The "before" capture was taken by restoring `mobile/app/index.tsx` and `mobile/src/session/mobile-session-route.ts` to their `b04c695` state and letting fast refresh apply it, so it is the real prior behavior rather than a mock-up.

No styling change — the Resume card and the session screen are unchanged; only the transition between them is.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 4,042 files and 42,934 tests passed. 5 failures in 2 files are pre-existing on this machine and unrelated: `src/relay/agent-exec-handler.test.ts` asserts on the spawned `codex` environment and picks up local shell variables, and `config/scripts/check-root-directory-entries.test.mjs` runs a shell guard against a throwaway git fixture that exits `2` here. Both fail identically at the `b04c695` merge-base, and the whole diff is confined to `mobile/`.
- [ ] `pnpm build` — not run locally; the change is confined to `mobile/`, which is a separate pnpm workspace and is not part of the desktop bundle.
- [x] `pnpm --dir mobile test` — 383 files, 2,862 passed and 3 skipped
- [x] `pnpm --dir mobile typecheck`, `pnpm --dir mobile lint`, `pnpm --dir mobile format:check`
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm run check:code-quality:changed` — 0 new findings across the changed files
- [x] Added or updated high-quality tests that would catch regressions

Regression coverage in `mobile/src/session/mobile-session-route.test.ts`:

- the session target keeps `/`, `::`, and `#` raw in its params, and omits `name` when the workspace has none
- driving `navigateToHostStackRoute` with the session target pushes `/h/[hostId]` first, dispatches nothing until the host stack commits, and only then replaces it with `[hostId]/session/[worktreeId]`
- a source guard asserts the Resume card goes through `openMobileSession` and no longer calls `router.push` directly — the shape that regressed

The existing `mobile-task-navigation` suite still passes unchanged against the extracted mechanism, which is the intended proof that Tasks behavior is untouched.

End-to-end on an iOS simulator paired to a headless desktop runtime (`node mobile/scripts/start-emulator.mjs`): reproduced the blank host screen on the `b04c695` implementation, then applied the fix through fast refresh and confirmed the same tap opens the workspace session — the two captures above. Android was not exercised; the code path is platform-neutral React Navigation state, with no platform branches.

## AI Review Report

Reviewed with Claude Code. Risks checked and outcomes:

- **Cross-platform (macOS / Linux / Windows):** the change is React Navigation state handling inside the Expo app — no platform branches, no keyboard shortcuts or accelerators, no shortcut labels, no filesystem paths, no shell invocation, no Electron main/renderer code. It behaves identically on iOS and Android, and the desktop app is untouched.
- **SSH / remote / local:** navigation only; the session screen resolves its host client exactly as before, so LAN, Tailscale, relay, and SSH-backed hosts all follow the same path. No assumption that the workspace is local.
- **Worktrees and folder workspaces:** the workspace id is forwarded verbatim, so git worktrees, folder workspaces (`folder:` ids), and the floating-workspace sentinel keep the branching that already exists in the session screen.
- **Agents and git providers:** nothing agent- or provider-specific is touched.
- **Performance:** the state listener is armed for one transition and disposed on the first match, when navigation leaves the host stack, if `push` throws, or when the Home screen unmounts — the same lifecycle the Tasks flow already shipped. No polling, no work added to a hot path.
- **UI quality:** no styling, layout, token, or copy change; `docs/STYLEGUIDE.md` is not engaged.
- **Behavior on failure:** if the host stack never commits, the user is left on the host screen with its workspace list — the same graceful degradation as Tasks, and strictly better than the blank screen this replaces.

Flagged and resolved during review: the extraction had to keep `mobile-task-navigation`'s exported surface intact so the Tasks tests remain a real check rather than a rewritten one; the wrapper now re-exports its types and delegates, and its suite passes untouched.

## Security Audit

- **Input handling:** host and workspace ids come from the host's own catalog over the existing authenticated RPC channel — no new external input, no parsing of untrusted strings.
- **Command execution / path handling:** none. Ids are navigation params only; nothing is resolved against the filesystem or passed to a shell.
- **Auth / secrets / IPC:** unchanged. No credential, token, keychain, or pairing code is touched, and no new IPC surface is introduced.
- **Encoding:** ids are handed to the navigator raw and encoded once by it, removing the double-encoding hazard of hand-built route strings. Nothing is interpolated into HTML, a URL opened externally, or a log line.
- **Dependencies:** none added or changed.

No follow-up needed.

## Notes

- iOS and Android only; no desktop impact.
- Follow-up worth considering (out of scope here): `navigateToMobileHostEdit` still uses the older `requestAnimationFrame` variant of this transition rather than waiting for the host stack to commit. It could move onto `host-stack-navigation` too, but that is a separate behavior change and belongs in its own PR.

X handle: [@KaynanSampaio1](https://x.com/KaynanSampaio1)
