### PR TITLE
fix(terminal): add replacement policies for repeated same-handle stream

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -63,6 +63,44 @@ describe('createRemoteRuntimePtyTransport', () => {
     return payload
   }
 
+  function subscribedTerminalHandles(): string[] {
+    return subscriptionSendBinary.mock.calls
+      .map((call) => decodeTerminalStreamFrame(call[0]))
+      .flatMap((frame) => {
+        if (frame?.opcode !== TerminalStreamOpcode.Subscribe) {
+          return []
+        }
+        const payload = decodeTerminalStreamJson<{ terminal: string }>(frame.payload)
+        return payload ? [payload.terminal] : []
+      })
+  }
+
+  function readyHostSessionInventoryResponse(terminal: string, hostTabId = 'host-tab-1'): unknown {
+    return {
+      ok: true,
+      result: {
+        worktree: 'wt-1',
+        publicationEpoch: 'epoch-ready',
+        snapshotVersion: 2,
+        activeGroupId: null,
+        activeTabId: `${hostTabId}::pane:1`,
+        activeTabType: 'terminal',
+        tabs: [
+          {
+            type: 'terminal',
+            id: `${hostTabId}::pane:1`,
+            parentTabId: hostTabId,
+            leafId: 'pane:1',
+            title: 'Terminal',
+            isActive: true,
+            status: 'ready',
+            terminal
+          }
+        ]
+      }
+    }
+  }
+
   function emitOutput(streamId: number, data: string): void {
     subscriptionCallbacks?.onBinary?.(
       encodeTerminalStreamFrame({
@@ -1952,6 +1990,770 @@ describe('createRemoteRuntimePtyTransport', () => {
       cols: 100,
       rows: 30
     })
+  })
+
+  it('retries inventory and reattaches the same HUB handle after a stream ends', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onPtyExit = vi.fn()
+      const onPtyRebind = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('hub-env', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1',
+        onPtyExit,
+        onPtyRebind
+      })
+
+      resolvedPaneHandle = 'terminal-stable'
+      transport.attach({
+        existingPtyId: 'remote:hub-env@@terminal-stable',
+        cols: 100,
+        rows: 30,
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const oldStreamId = latestSubscribePayload().streamId
+      emitSnapshot(oldStreamId, 'before stream end')
+      expect(transport.isConnected()).toBe(true)
+
+      let inventoryAvailable = false
+      let hostListCalls = 0
+      runtimeCall.mockImplementation(async (args: { method: string }) => {
+        if (args.method !== 'session.tabs.list') {
+          return { ok: true, result: {} }
+        }
+        hostListCalls += 1
+        if (!inventoryAvailable) {
+          throw new Error('runtime reconnect in progress')
+        }
+        return readyHostSessionInventoryResponse('terminal-stable')
+      })
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: oldStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(16_000)
+
+      const subscribeCount = (): number =>
+        subscriptionSendBinary.mock.calls
+          .map((call) => decodeTerminalStreamFrame(call[0]))
+          .filter((frame) => frame?.opcode === TerminalStreamOpcode.Subscribe).length
+      expect(subscribeCount()).toBe(1)
+      expect(hostListCalls).toBeGreaterThan(1)
+      expect(hostListCalls).toBeLessThan(25)
+      inventoryAvailable = true
+      await vi.advanceTimersByTimeAsync(16_000)
+
+      expect(hostListCalls).toBeLessThan(40)
+      expect(subscribedTerminalHandles()).toEqual(['terminal-stable', 'terminal-stable'])
+      expect(onPtyRebind).not.toHaveBeenCalled()
+      expect(onPtyExit).not.toHaveBeenCalled()
+      expect(transport.getPtyId()).toBe('remote:hub-env@@terminal-stable')
+      expect(transport.isConnected()).toBe(false)
+
+      emitSnapshot(latestSubscribePayload().streamId, 'same handle reattached')
+      expect(transport.isConnected()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps unavailable host inventory at two recovery windows', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvedPaneHandle = 'terminal-stable'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('hub-env', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1'
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:hub-env@@terminal-stable',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const oldStreamId = latestSubscribePayload().streamId
+      emitSnapshot(oldStreamId, 'before inventory outage')
+
+      let hostListCalls = 0
+      runtimeCall.mockImplementation(async (args: { method: string }) => {
+        if (args.method === 'session.tabs.list') {
+          hostListCalls += 1
+          throw new Error('runtime reconnect in progress')
+        }
+        return { ok: true, result: {} }
+      })
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: oldStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(32_000)
+
+      const callsAfterTwoWindows = hostListCalls
+      expect(callsAfterTwoWindows).toBeGreaterThan(25)
+      expect(callsAfterTwoWindows).toBeLessThan(40)
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(hostListCalls).toBe(callsAfterTwoWindows)
+      expect(transport.getRecoveryState?.().phase).toBe('recovering')
+
+      await vi.advanceTimersByTimeAsync(9_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      expect(subscribedTerminalHandles()).toEqual(['terminal-stable'])
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reattaches from prior ready evidence when the trailing inventory poll fails', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvedPaneHandle = 'terminal-stable'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onPtyExit = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('hub-env', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1',
+        onPtyExit
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:hub-env@@terminal-stable',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const oldStreamId = latestSubscribePayload().streamId
+      emitSnapshot(oldStreamId, 'before trailing inventory failure')
+
+      let hostListCalls = 0
+      runtimeCall.mockImplementation(async (args: { method: string }) => {
+        if (args.method !== 'session.tabs.list') {
+          return { ok: true, result: {} }
+        }
+        hostListCalls += 1
+        if (hostListCalls === 1) {
+          return readyHostSessionInventoryResponse('terminal-stable')
+        }
+        throw new Error('final inventory poll failed')
+      })
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: oldStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(16_000)
+
+      expect(hostListCalls).toBeGreaterThan(1)
+      expect(hostListCalls).toBeLessThan(25)
+      expect(subscribedTerminalHandles()).toEqual(['terminal-stable', 'terminal-stable'])
+      expect(onPtyExit).not.toHaveBeenCalled()
+      expect(transport.isConnected()).toBe(false)
+      emitSnapshot(latestSubscribePayload().streamId, 'reattached from ready evidence')
+      expect(transport.isConnected()).toBe(true)
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('strengthens repeated same-handle end recovery until it disconnects', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvedPaneHandle = 'terminal-flapping'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('hub-env', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1'
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:hub-env@@terminal-flapping',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      runtimeCall.mockImplementation(async (args: { method: string }) =>
+        args.method === 'session.tabs.list'
+          ? readyHostSessionInventoryResponse('terminal-flapping')
+          : { ok: true, result: {} }
+      )
+      emitSnapshot(latestSubscribePayload().streamId, 'initial stream')
+
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        const endingStreamId = latestSubscribePayload().streamId
+        subscriptionCallbacks?.onResponse({
+          ok: true,
+          result: { type: 'end', streamId: endingStreamId, code: 0 }
+        })
+        await vi.advanceTimersByTimeAsync(16_000)
+        expect(subscribedTerminalHandles()).toHaveLength(cycle + 2)
+        emitSnapshot(latestSubscribePayload().streamId, `same handle cycle ${cycle}`)
+        expect(transport.isConnected()).toBe(true)
+      }
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: latestSubscribePayload().streamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(16_000)
+
+      expect(subscribedTerminalHandles()).toEqual([
+        'terminal-flapping',
+        'terminal-flapping',
+        'terminal-flapping'
+      ])
+      expect(transport.isConnected()).toBe(false)
+      await vi.advanceTimersByTimeAsync(45_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a delayed stale send after the pane has rebound to a healthy handle', async () => {
+    resolvedPaneHandle = 'terminal-old'
+    let resolveOldSend: (response: unknown) => void = () => {}
+    const oldSendResponse = new Promise((resolve) => {
+      resolveOldSend = resolve
+    })
+    let hostListCalls = 0
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onPtyExit = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'pane:1',
+      onPtyExit
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-old',
+      callbacks: {}
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const oldStreamId = latestSubscribePayload().streamId
+    emitSnapshot(oldStreamId, 'old handle')
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'terminal.send') {
+        return oldSendResponse
+      }
+      if (args.method === 'session.tabs.list') {
+        hostListCalls += 1
+        return Promise.resolve(readyHostSessionInventoryResponse('terminal-new'))
+      }
+      return Promise.resolve({ ok: true, result: {} })
+    })
+    const sendInputAccepted = transport.sendInputAccepted
+    if (!sendInputAccepted) {
+      throw new Error('Expected acknowledged remote terminal input')
+    }
+    const pendingSend = sendInputAccepted('sent-before-rebind')
+    await vi.waitFor(() =>
+      expect(runtimeCall).toHaveBeenCalledWith(expect.objectContaining({ method: 'terminal.send' }))
+    )
+
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'error', streamId: oldStreamId, message: 'terminal_handle_stale' }
+    })
+    await vi.waitFor(() =>
+      expect(latestSubscribePayload()).toMatchObject({ terminal: 'terminal-new' })
+    )
+    emitSnapshot(latestSubscribePayload().streamId, 'new handle')
+    expect(transport.isConnected()).toBe(true)
+
+    resolveOldSend({
+      ok: false,
+      error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
+    })
+    await expect(pendingSend).resolves.toBe(false)
+
+    expect(subscribedTerminalHandles()).toEqual(['terminal-old', 'terminal-new'])
+    expect(hostListCalls).toBe(1)
+    expect(onPtyExit).not.toHaveBeenCalled()
+    expect(transport.getPtyId()).toBe('remote:env-1@@terminal-new')
+    expect(transport.isConnected()).toBe(true)
+  })
+
+  it('honors a sticky replacement requirement during non-web pane resolution', async () => {
+    resolvedPaneHandle = 'terminal-old'
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onPtyExit = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1',
+      onPtyExit
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-old',
+      callbacks: {}
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    emitSnapshot(latestSubscribePayload().streamId, 'old handle')
+
+    let resolveOldSend: (response: unknown) => void = () => {}
+    const oldSendResponse = new Promise((resolve) => {
+      resolveOldSend = resolve
+    })
+    let resolvePane: (response: unknown) => void = () => {}
+    const paneResponse = new Promise((resolve) => {
+      resolvePane = resolve
+    })
+    runtimeCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'terminal.send') {
+        return oldSendResponse
+      }
+      if (args.method === 'terminal.resolvePane') {
+        return paneResponse
+      }
+      return Promise.resolve({ ok: true, result: {} })
+    })
+    const sendInputAccepted = transport.sendInputAccepted
+    if (!sendInputAccepted) {
+      throw new Error('Expected acknowledged remote terminal input')
+    }
+    const pendingSend = sendInputAccepted('sent-before-close')
+    await vi.waitFor(() =>
+      expect(runtimeCall).toHaveBeenCalledWith(expect.objectContaining({ method: 'terminal.send' }))
+    )
+
+    subscriptionCallbacks?.onClose?.()
+    await vi.waitFor(() =>
+      expect(runtimeCall).toHaveBeenCalledWith(
+        expect.objectContaining({ method: 'terminal.resolvePane' })
+      )
+    )
+    resolveOldSend({
+      ok: false,
+      error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
+    })
+    await expect(pendingSend).resolves.toBe(false)
+    resolvePane({
+      ok: true,
+      result: {
+        terminal: {
+          handle: 'terminal-old',
+          tabId: 'tab-1',
+          leafId: 'pane:1',
+          worktreeId: 'wt-1'
+        }
+      }
+    })
+
+    await vi.waitFor(() => expect(onPtyExit).toHaveBeenCalledOnce())
+    expect(subscribedTerminalHandles()).toEqual(['terminal-old'])
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-old')
+    expect(transport.getPtyId()).toBeNull()
+    expect(transport.isConnected()).toBe(false)
+  })
+
+  it('does not subscribe a same handle condemned after its inventory wait returns', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvedPaneHandle = 'terminal-old'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onPtyRebind = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1',
+        onPtyRebind
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-old',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const oldStreamId = latestSubscribePayload().streamId
+      emitSnapshot(oldStreamId, 'old handle')
+
+      let resolveOldSend: (response: unknown) => void = () => {}
+      const oldSendResponse = new Promise((resolve) => {
+        resolveOldSend = resolve
+      })
+      let hostListCalls = 0
+      runtimeCall.mockImplementation(
+        (args: { method: string; timeoutMs?: number }): Promise<unknown> => {
+          if (args.method === 'terminal.send') {
+            return oldSendResponse
+          }
+          if (args.method !== 'session.tabs.list') {
+            return Promise.resolve({ ok: true, result: {} })
+          }
+          hostListCalls += 1
+          const response = readyHostSessionInventoryResponse('terminal-old')
+          if ((args.timeoutMs ?? 15_000) > 1_000) {
+            return Promise.resolve(response)
+          }
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              // Why: settle the stale send between the inner wait and its caller's continuation.
+              queueMicrotask(() =>
+                queueMicrotask(() =>
+                  resolveOldSend({
+                    ok: false,
+                    error: {
+                      code: 'terminal_handle_stale',
+                      message: 'terminal_handle_stale'
+                    }
+                  })
+                )
+              )
+              resolve(response)
+            }, args.timeoutMs)
+          })
+        }
+      )
+      const sendInputAccepted = transport.sendInputAccepted
+      if (!sendInputAccepted) {
+        throw new Error('Expected acknowledged remote terminal input')
+      }
+      const pendingSend = sendInputAccepted('sent-before-stream-end')
+      await vi.waitFor(() =>
+        expect(runtimeCall).toHaveBeenCalledWith(
+          expect.objectContaining({ method: 'terminal.send' })
+        )
+      )
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: oldStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(16_000)
+      await expect(pendingSend).resolves.toBe(false)
+
+      expect(hostListCalls).toBeGreaterThan(1)
+      expect(subscribedTerminalHandles()).toEqual(['terminal-old'])
+      expect(transport.getPtyId()).toBe('remote:env-1@@terminal-old')
+      expect(transport.isConnected()).toBe(false)
+
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        {
+          worktree: 'wt-1',
+          publicationEpoch: 'epoch-replacement',
+          snapshotVersion: 3,
+          activeGroupId: null,
+          activeTabId: 'host-tab-1::pane:1',
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'host-tab-1::pane:1',
+              parentTabId: 'host-tab-1',
+              leafId: 'pane:1',
+              title: 'Terminal',
+              isActive: true,
+              status: 'ready',
+              terminal: 'terminal-new'
+            }
+          ]
+        },
+        'env-1'
+      )
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.waitFor(() =>
+        expect(latestSubscribePayload()).toMatchObject({ terminal: 'terminal-new' })
+      )
+      expect(onPtyRebind).toHaveBeenCalledWith(
+        'remote:env-1@@terminal-new',
+        'remote:env-1@@terminal-old'
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('uses a strengthened sticky policy when an inventory retry starts', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvedPaneHandle = 'terminal-old'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1'
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-old',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const oldStreamId = latestSubscribePayload().streamId
+      emitSnapshot(oldStreamId, 'old handle')
+
+      let resolveOldSend: (response: unknown) => void = () => {}
+      const oldSendResponse = new Promise((resolve) => {
+        resolveOldSend = resolve
+      })
+      let hostListCalls = 0
+      runtimeCall.mockImplementation((args: { method: string }) => {
+        if (args.method === 'terminal.send') {
+          return oldSendResponse
+        }
+        if (args.method === 'session.tabs.list') {
+          hostListCalls += 1
+          return Promise.reject(new Error('runtime reconnect in progress'))
+        }
+        return Promise.resolve({ ok: true, result: {} })
+      })
+      const sendInputAccepted = transport.sendInputAccepted
+      if (!sendInputAccepted) {
+        throw new Error('Expected acknowledged remote terminal input')
+      }
+      const pendingSend = sendInputAccepted('sent-before-stream-end')
+      await vi.waitFor(() =>
+        expect(runtimeCall).toHaveBeenCalledWith(
+          expect.objectContaining({ method: 'terminal.send' })
+        )
+      )
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: oldStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(15_000)
+      expect(transport.getRecoveryState?.().phase).toBe('backoff')
+
+      resolveOldSend({
+        ok: false,
+        error: { code: 'terminal_handle_stale', message: 'terminal_handle_stale' }
+      })
+      await expect(pendingSend).resolves.toBe(false)
+      const callsBeforeRetry = hostListCalls
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      expect(hostListCalls).toBe(callsBeforeRetry)
+      expect(subscribedTerminalHandles()).toEqual(['terminal-old'])
+      expect(transport.getPtyId()).toBe('remote:env-1@@terminal-old')
+      expect(transport.isConnected()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('requires replacement after repeated same-handle stream-end flaps', async () => {
+    vi.useFakeTimers()
+    try {
+      resolvedPaneHandle = 'terminal-flapping'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onPtyExit = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1',
+        onPtyExit
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-flapping',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      emitSnapshot(latestSubscribePayload().streamId, 'initial handle')
+      runtimeCall.mockImplementation((args: { method: string }) =>
+        args.method === 'session.tabs.list'
+          ? Promise.resolve(readyHostSessionInventoryResponse('terminal-flapping'))
+          : Promise.resolve({ ok: true, result: {} })
+      )
+
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        const endedStreamId = latestSubscribePayload().streamId
+        subscriptionCallbacks?.onResponse({
+          ok: true,
+          result: { type: 'end', streamId: endedStreamId, code: 0 }
+        })
+        await vi.advanceTimersByTimeAsync(16_000)
+        expect(subscribedTerminalHandles()).toHaveLength(cycle + 2)
+        expect(latestSubscribePayload().terminal).toBe('terminal-flapping')
+        emitSnapshot(latestSubscribePayload().streamId, `same handle ${cycle + 1}`)
+        expect(transport.isConnected()).toBe(true)
+      }
+
+      const condemnedStreamId = latestSubscribePayload().streamId
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: condemnedStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(16_000)
+
+      expect(subscribedTerminalHandles()).toEqual([
+        'terminal-flapping',
+        'terminal-flapping',
+        'terminal-flapping'
+      ])
+      expect(transport.getPtyId()).toBe('remote:env-1@@terminal-flapping')
+      expect(transport.isConnected()).toBe(false)
+      expect(onPtyExit).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(44_001)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      expect(subscribedTerminalHandles()).toHaveLength(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reuses prior ready evidence when the trailing inventory poll fails', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      resolvedPaneHandle = 'terminal-stable'
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1'
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-stable',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const oldStreamId = latestSubscribePayload().streamId
+      emitSnapshot(oldStreamId, 'before trailing failure')
+      let hostListCalls = 0
+      runtimeCall.mockImplementation(
+        async (args: { method: string; timeoutMs?: number }): Promise<unknown> => {
+          if (args.method !== 'session.tabs.list') {
+            return { ok: true, result: {} }
+          }
+          hostListCalls += 1
+          if ((args.timeoutMs ?? 15_000) <= 1_000) {
+            throw new Error('final inventory poll failed')
+          }
+          return readyHostSessionInventoryResponse('terminal-stable')
+        }
+      )
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: { type: 'end', streamId: oldStreamId, code: 0 }
+      })
+      await vi.advanceTimersByTimeAsync(16_000)
+
+      expect(hostListCalls).toBeGreaterThan(1)
+      expect(subscribedTerminalHandles()).toEqual(['terminal-stable', 'terminal-stable'])
+      expect(warn).not.toHaveBeenCalled()
+      expect(transport.isConnected()).toBe(false)
+      emitSnapshot(latestSubscribePayload().streamId, 'ready evidence reused')
+      expect(transport.isConnected()).toBe(true)
+    } finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not carry a stale-handle requirement onto the replacement stream', async () => {
+    vi.useFakeTimers()
+    try {
+      let rejectedReplacement = false
+      subscriptionSendBinary.mockImplementation((bytes: Uint8Array<ArrayBufferLike>) => {
+        const frame = decodeTerminalStreamFrame(bytes)
+        if (frame?.opcode !== TerminalStreamOpcode.Subscribe) {
+          return
+        }
+        const payload = decodeTerminalStreamJson<{ terminal: string }>(frame.payload)
+        if (payload?.terminal === 'terminal-replacement' && !rejectedReplacement) {
+          rejectedReplacement = true
+          throw new Error('Remote runtime connection closed.')
+        }
+      })
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onPtyRebind = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('hub-env', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-tab-1',
+        leafId: 'pane:1',
+        onPtyRebind
+      })
+
+      resolvedPaneHandle = 'terminal-stale'
+      transport.attach({
+        existingPtyId: 'remote:hub-env@@terminal-stale',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const staleStreamId = latestSubscribePayload().streamId
+      emitSnapshot(staleStreamId, 'before stale handle')
+
+      runtimeCall.mockImplementation(async (args: { method: string }) => {
+        if (args.method !== 'session.tabs.list') {
+          return { ok: true, result: {} }
+        }
+        return {
+          ok: true,
+          result: {
+            worktree: 'wt-1',
+            publicationEpoch: 'epoch-replacement',
+            snapshotVersion: 2,
+            activeGroupId: null,
+            activeTabId: 'host-tab-1::pane:1',
+            activeTabType: 'terminal',
+            tabs: [
+              {
+                type: 'terminal',
+                id: 'host-tab-1::pane:1',
+                parentTabId: 'host-tab-1',
+                leafId: 'pane:1',
+                title: 'Terminal',
+                isActive: true,
+                status: 'ready',
+                terminal: 'terminal-replacement'
+              }
+            ]
+          }
+        }
+      })
+
+      subscriptionCallbacks?.onResponse({
+        ok: true,
+        result: {
+          type: 'error',
+          streamId: staleStreamId,
+          message: 'terminal_handle_stale'
+        }
+      })
+      await vi.waitFor(() => expect(rejectedReplacement).toBe(true))
+      await vi.advanceTimersByTimeAsync(250)
+      await vi.waitFor(() => expect(runtimeSubscribe.mock.calls.length).toBeGreaterThanOrEqual(2))
+
+      const subscribedTerminals = subscriptionSendBinary.mock.calls
+        .map((call) => decodeTerminalStreamFrame(call[0]))
+        .flatMap((frame) => {
+          if (frame?.opcode !== TerminalStreamOpcode.Subscribe) {
+            return []
+          }
+          const payload = decodeTerminalStreamJson<{ terminal: string }>(frame.payload)
+          return payload ? [payload.terminal] : []
+        })
+      expect(subscribedTerminals).toEqual([
+        'terminal-stale',
+        'terminal-replacement',
+        'terminal-replacement'
+      ])
+      expect(onPtyRebind).toHaveBeenCalledOnce()
+      await vi.waitFor(() =>
+        expect(latestSubscribePayload()).toMatchObject({ terminal: 'terminal-replacement' })
+      )
+      emitSnapshot(latestSubscribePayload().streamId, 'replacement reattached')
+      expect(transport.isConnected()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('coalesces concurrent stale errors for the handle that was replaced', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -86,7 +86,28 @@ const REMOTE_TERMINAL_VIEWPORT_FLUSH_MS = 33
 const HOST_SESSION_ATTACH_POLL_MS = 150
 const HOST_SESSION_REPLACEMENT_POLL_MAX_MS = 1_000
 const HOST_SESSION_ATTACH_TIMEOUT_MS = 15_000
+const HOST_SESSION_INVENTORY_MAX_WINDOWS_PER_RECOVERY = 2
+const HOST_SESSION_SAME_HANDLE_END_REUSE_LIMIT = 2
 const TERMINAL_CREATE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000] as const
+
+type HostHandleReplacementPolicy = 'reuse' | 'prefer-replacement' | 'require-replacement'
+
+type HostSessionHandleWaitResult = {
+  handle: string | null | undefined
+  inventoryFailed: boolean
+}
+
+function stricterReplacementPolicy(
+  left: HostHandleReplacementPolicy,
+  right: HostHandleReplacementPolicy
+): HostHandleReplacementPolicy {
+  const rank: Record<HostHandleReplacementPolicy, number> = {
+    reuse: 0,
+    'prefer-replacement': 1,
+    'require-replacement': 2
+  }
+  return rank[left] >= rank[right] ? left : right
+}
 
 type RemoteAgentSessionLaunchResult =
   | RuntimeEnsureAgentSessionResult
@@ -162,10 +183,16 @@ export function createRemoteRuntimePtyTransport(
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
   let resubscribeEpoch: number | null = null
   let resubscribeRequestedHandle: string | null = null
-  let resubscribeRequestedRequiresReplacement = false
-  let recoveryRequiresReplacement = false
+  let resubscribeRequestedReplacementPolicy: HostHandleReplacementPolicy = 'reuse'
+  let recoveryReplacementPolicy: HostHandleReplacementPolicy = 'reuse'
+  let recoveryReplacementPolicyHandle: string | null = null
   let stopWaitingForPublishedHandle: (() => void) | null = null
   let settleHostSessionAttachRetry: ((retry: boolean) => void) | null = null
+  let resubscribeInventoryEpoch: number | null = null
+  let resubscribeInventoryWindows = 0
+  let sameHandleEndReuseHandle: string | null = null
+  let sameHandleEndReuseCount = 0
+  let sameHandleEndReuseAttachedAt: number | null = null
   let attachGeneration = 0
   let subscriptionGeneration = 0
 
@@ -240,6 +267,62 @@ export function createRemoteRuntimePtyTransport(
   let lastAttachOptions: Parameters<PtyTransport['attach']>[0] | null = null
   let resolvePaneUnavailable = false
   let recoveringPaneHandle: string | null = null
+  const getRecoveryReplacementPolicy = (targetHandle: string): HostHandleReplacementPolicy =>
+    recoveryReplacementPolicyHandle === targetHandle ? recoveryReplacementPolicy : 'reuse'
+  const resetRecoveryReplacementPolicy = (): void => {
+    recoveryReplacementPolicy = 'reuse'
+    recoveryReplacementPolicyHandle = null
+  }
+  const strengthenRecoveryReplacementPolicy = (
+    targetHandle: string,
+    replacementPolicy: HostHandleReplacementPolicy
+  ): void => {
+    if (recoveryReplacementPolicyHandle !== targetHandle) {
+      recoveryReplacementPolicyHandle = targetHandle
+      recoveryReplacementPolicy = replacementPolicy
+      return
+    }
+    recoveryReplacementPolicy = stricterReplacementPolicy(
+      recoveryReplacementPolicy,
+      replacementPolicy
+    )
+  }
+  const beginResubscribeInventoryWindow = (recoveryEpoch: number): number => {
+    if (resubscribeInventoryEpoch !== recoveryEpoch) {
+      resubscribeInventoryEpoch = recoveryEpoch
+      resubscribeInventoryWindows = 0
+    }
+    resubscribeInventoryWindows += 1
+    return resubscribeInventoryWindows
+  }
+  const resetSameHandleEndReuse = (): void => {
+    sameHandleEndReuseHandle = null
+    sameHandleEndReuseCount = 0
+    sameHandleEndReuseAttachedAt = null
+  }
+  const recordSameHandleEndReuse = (targetHandle: string): void => {
+    if (sameHandleEndReuseHandle !== targetHandle) {
+      sameHandleEndReuseHandle = targetHandle
+      sameHandleEndReuseCount = 0
+    }
+    sameHandleEndReuseCount += 1
+    sameHandleEndReuseAttachedAt = Date.now()
+  }
+  const replacementPolicyAfterWebStreamEnd = (
+    targetHandle: string
+  ): HostHandleReplacementPolicy => {
+    if (
+      sameHandleEndReuseHandle !== targetHandle ||
+      sameHandleEndReuseAttachedAt === null ||
+      Date.now() - sameHandleEndReuseAttachedAt >= REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS
+    ) {
+      resetSameHandleEndReuse()
+      return 'prefer-replacement'
+    }
+    return sameHandleEndReuseCount >= HOST_SESSION_SAME_HANDLE_END_REUSE_LIMIT
+      ? 'require-replacement'
+      : 'prefer-replacement'
+  }
   const adoptExecutionMetadata = (terminal: {
     executionHostId?: ExecutionHostId
     hostPlatform?: NodeJS.Platform
@@ -528,29 +611,46 @@ export function createRemoteRuntimePtyTransport(
   async function waitForResubscribeHostSessionHandle(
     hostTabId: string,
     previousHandle: string,
-    requireReplacement: boolean
-  ): Promise<string | null | undefined> {
+    replacementPolicy: HostHandleReplacementPolicy,
+    recoveryEpoch: number
+  ): Promise<HostSessionHandleWaitResult> {
     if (!worktreeId) {
-      return null
+      return { handle: null, inventoryFailed: false }
     }
     const worktree = toRuntimeWorktreeSelector(worktreeId)
     const startedAt = Date.now()
     let pollMs = HOST_SESSION_ATTACH_POLL_MS
     let lastListError: unknown = null
-    const finishWithUnknownLiveness = (): undefined => {
+    let lastReadyHandle: string | null = null
+    let sawSuccessfulInventory = false
+    const finishBoundedWait = (): HostSessionHandleWaitResult => {
+      const effectivePolicy = stricterReplacementPolicy(
+        replacementPolicy,
+        getRecoveryReplacementPolicy(previousHandle)
+      )
+      if (effectivePolicy === 'prefer-replacement' && lastReadyHandle) {
+        return { handle: lastReadyHandle, inventoryFailed: false }
+      }
       if (lastListError) {
         console.warn(
-          '[remote-runtime-pty] host session inventory unavailable during reconnect:',
+          sawSuccessfulInventory
+            ? '[remote-runtime-pty] final host session inventory poll failed during reconnect:'
+            : '[remote-runtime-pty] host session inventory unavailable during reconnect:',
           runtimeTerminalErrorMessage(lastListError)
         )
       }
       // Why: a bounded wait without removal evidence is unknown liveness; keep the pane for a later snapshot to reattach.
-      return undefined
+      return { handle: undefined, inventoryFailed: lastListError !== null }
     }
-    while (!destroyed && connected && handle === previousHandle) {
+    while (
+      !destroyed &&
+      connected &&
+      handle === previousHandle &&
+      recovery.isCurrent(recoveryEpoch)
+    ) {
       const requestRemainingMs = HOST_SESSION_ATTACH_TIMEOUT_MS - (Date.now() - startedAt)
       if (requestRemainingMs <= 0) {
-        return finishWithUnknownLiveness()
+        return finishBoundedWait()
       }
       try {
         const listed = await listRemoteRuntimeSessionTabsDeduped({
@@ -566,12 +666,20 @@ export function createRemoteRuntimePtyTransport(
             )
         })
         lastListError = null
+        sawSuccessfulInventory = true
         const nextHandle = findReadyHostSessionHandle(listed, hostTabId)
-        if (nextHandle && (!requireReplacement || nextHandle !== previousHandle)) {
-          return nextHandle
+        if (nextHandle) {
+          lastReadyHandle = nextHandle
+        }
+        const effectivePolicy = stricterReplacementPolicy(
+          replacementPolicy,
+          getRecoveryReplacementPolicy(previousHandle)
+        )
+        if (nextHandle && (effectivePolicy === 'reuse' || nextHandle !== previousHandle)) {
+          return { handle: nextHandle, inventoryFailed: false }
         }
         if (!hasHostSessionTerminalSurface(listed, hostTabId)) {
-          return null
+          return { handle: null, inventoryFailed: false }
         }
       } catch (error) {
         // Why: the inventory can race the reconnect that invalidated the handle; unknown liveness must not retire the pane.
@@ -579,13 +687,13 @@ export function createRemoteRuntimePtyTransport(
       }
       const remainingMs = HOST_SESSION_ATTACH_TIMEOUT_MS - (Date.now() - startedAt)
       if (remainingMs <= 0) {
-        return finishWithUnknownLiveness()
+        return finishBoundedWait()
       }
       // Why: a stale response can precede its replacement; bounded backoff avoids retrying the stale handle in a hot loop.
       await new Promise((resolve) => setTimeout(resolve, Math.min(pollMs, remainingMs)))
       pollMs = Math.min(pollMs * 2, HOST_SESSION_REPLACEMENT_POLL_MAX_MS)
     }
-    return undefined
+    return { handle: undefined, inventoryFailed: false }
   }
 
   async function attachHostSessionMirror(
@@ -1068,7 +1176,9 @@ export function createRemoteRuntimePtyTransport(
       return true
     } catch (error) {
       // Why: stale-handle errors must retire the mirror (recoverable via next snapshot), not dead-end in a red xterm banner (#7718).
-      handleRemoteTerminalError(error)
+      if (handle === targetHandle) {
+        handleRemoteTerminalError(error)
+      }
       return false
     }
   }
@@ -1093,7 +1203,9 @@ export function createRemoteRuntimePtyTransport(
       client: { id: clientId, type: 'desktop' },
       ...(desiredViewport ? { viewport: desiredViewport, claimViewport: true as const } : {})
     }).catch((error) => {
-      handleRemoteTerminalError(error)
+      if (handle === targetHandle) {
+        handleRemoteTerminalError(error)
+      }
     })
   })
 
@@ -1159,7 +1271,8 @@ export function createRemoteRuntimePtyTransport(
 
   function retireRemoteTerminalId(): void {
     recovery.cancel()
-    recoveryRequiresReplacement = false
+    resetRecoveryReplacementPolicy()
+    resetSameHandleEndReuse()
     connected = false
     connecting = false
     terminalEnded = true
@@ -1183,6 +1296,8 @@ export function createRemoteRuntimePtyTransport(
     unregisterShutdownHandlers(replacedPtyId)
     handle = nextHandle
     remotePtyId = toRemoteRuntimePtyId(nextHandle, currentRuntimeEnvironmentId)
+    resetRecoveryReplacementPolicy()
+    resetSameHandleEndReuse()
     registerShutdownHandlers(remotePtyId)
     setAttachmentReady(false)
     // Why: host handle rotation preserves the pane generation; only the store identity changes, not spawn/exit semantics.
@@ -1239,7 +1354,7 @@ export function createRemoteRuntimePtyTransport(
       if (tabId && leafId && worktreeId) {
         // Why: reconnect can re-mint a pane handle while its host coordinates live; keep xterm state mounted while re-resolving.
         closeMultiplexedStream()
-        scheduleResubscribeAfterTransportClose(true)
+        scheduleResubscribeAfterTransportClose('require-replacement')
       } else {
         retireRemoteTerminalId()
       }
@@ -1290,16 +1405,19 @@ export function createRemoteRuntimePtyTransport(
   // Why: after a transport drop the host may have re-minted this handle; re-derive from the snapshot so we don't mirror/type into whatever PTY now sits behind the stale one (#7718).
   async function resubscribeAfterTransportClose(
     previousHandle: string,
-    requireReplacement: boolean,
+    replacementPolicy: HostHandleReplacementPolicy,
     recoveryEpoch: number
   ): Promise<void> {
     if (tabId && isWebTerminalSurfaceTabId(tabId)) {
       const hostTabId = toHostSessionTabId(tabId)
-      const nextHandle = await waitForResubscribeHostSessionHandle(
+      const inventoryWindow = beginResubscribeInventoryWindow(recoveryEpoch)
+      const waitResult = await waitForResubscribeHostSessionHandle(
         hostTabId,
         previousHandle,
-        requireReplacement
+        replacementPolicy,
+        recoveryEpoch
       )
+      const nextHandle = waitResult.handle
       if (
         destroyed ||
         !connected ||
@@ -1309,6 +1427,19 @@ export function createRemoteRuntimePtyTransport(
         return
       }
       if (nextHandle === undefined) {
+        const effectivePolicy = stricterReplacementPolicy(
+          replacementPolicy,
+          getRecoveryReplacementPolicy(previousHandle)
+        )
+        if (
+          effectivePolicy !== 'require-replacement' &&
+          waitResult.inventoryFailed &&
+          inventoryWindow < HOST_SESSION_INVENTORY_MAX_WINDOWS_PER_RECOVERY
+        ) {
+          throw Object.assign(new Error('Remote runtime session inventory polling failed.'), {
+            code: 'remote_runtime_unavailable'
+          })
+        }
         return
       }
       if (!nextHandle) {
@@ -1316,15 +1447,36 @@ export function createRemoteRuntimePtyTransport(
         retireRemoteTerminalId()
         return
       }
+      const effectivePolicy = stricterReplacementPolicy(
+        replacementPolicy,
+        getRecoveryReplacementPolicy(previousHandle)
+      )
+      // Why: a stale error can strengthen policy after inventory returns but before this continuation runs.
+      if (effectivePolicy === 'require-replacement' && nextHandle === previousHandle) {
+        return
+      }
       if (nextHandle !== previousHandle) {
         rebindRemoteTerminalHandle(nextHandle)
       }
+      clearPublishedHandleWait()
+      await subscribeToHandle(
+        recoveryEpoch,
+        nextHandle === previousHandle && effectivePolicy === 'prefer-replacement'
+      )
+      return
     } else if (tabId && leafId && worktreeId) {
       const resolved = await resolvePersistedHostPane()
       if (destroyed || !connected || handle !== previousHandle) {
         return
       }
-      if (!resolved || (requireReplacement && resolved.handle === previousHandle)) {
+      const effectivePolicy = stricterReplacementPolicy(
+        replacementPolicy,
+        getRecoveryReplacementPolicy(previousHandle)
+      )
+      if (
+        !resolved ||
+        (effectivePolicy === 'require-replacement' && resolved.handle === previousHandle)
+      ) {
         retireRemoteTerminalId()
         return
       }
@@ -1337,7 +1489,7 @@ export function createRemoteRuntimePtyTransport(
   }
 
   function scheduleResubscribeAfterTransportClose(
-    requireReplacement = false,
+    replacementPolicy: HostHandleReplacementPolicy = 'reuse',
     requestedRecoveryEpoch?: number
   ): void {
     if (destroyed || !connected || !handle) {
@@ -1354,8 +1506,8 @@ export function createRemoteRuntimePtyTransport(
       viewportBatcher.clear()
       clearPendingViewportClaim()
     }
-    recoveryRequiresReplacement ||= requireReplacement
-    if (requireReplacement && stopWaitingForPublishedHandle) {
+    strengthenRecoveryReplacementPolicy(handle, replacementPolicy)
+    if (replacementPolicy === 'require-replacement' && stopWaitingForPublishedHandle) {
       // Why: once recovery is handed to accepted snapshots, repeated sends to the stale handle must not re-arm inventory RPCs.
       return
     }
@@ -1363,9 +1515,12 @@ export function createRemoteRuntimePtyTransport(
       // Why: concurrent stale errors belong to their own handle; don't carry an old handle's replacement requirement onto its successor.
       if (resubscribeRequestedHandle !== handle) {
         resubscribeRequestedHandle = handle
-        resubscribeRequestedRequiresReplacement = requireReplacement
+        resubscribeRequestedReplacementPolicy = replacementPolicy
       } else {
-        resubscribeRequestedRequiresReplacement ||= requireReplacement
+        resubscribeRequestedReplacementPolicy = stricterReplacementPolicy(
+          resubscribeRequestedReplacementPolicy,
+          replacementPolicy
+        )
       }
       return
     }
@@ -1377,16 +1532,19 @@ export function createRemoteRuntimePtyTransport(
     }
     resubscribeEpoch = recoveryEpoch
     resubscribeRequestedHandle = null
-    resubscribeRequestedRequiresReplacement = false
+    resubscribeRequestedReplacementPolicy = 'reuse'
     let retryScheduled = false
-    void resubscribeAfterTransportClose(resubscribeHandle, requireReplacement, recoveryEpoch)
+    void resubscribeAfterTransportClose(resubscribeHandle, replacementPolicy, recoveryEpoch)
       .catch((error) => {
         if (!destroyed && connected && handle && recovery.isCurrent(recoveryEpoch)) {
           clearPendingViewportClaim()
           const clientError = toRemoteRuntimeClientErrorLike(error)
           if (isRecoverableRemoteRuntimeConnectionError(clientError)) {
             retryScheduled = recovery.schedule(recoveryEpoch, (nextEpoch) => {
-              scheduleResubscribeAfterTransportClose(requireReplacement, nextEpoch)
+              const currentReplacementPolicy = handle
+                ? getRecoveryReplacementPolicy(handle)
+                : 'reuse'
+              scheduleResubscribeAfterTransportClose(currentReplacementPolicy, nextEpoch)
             })
           } else {
             recovery.cancel()
@@ -1400,9 +1558,9 @@ export function createRemoteRuntimePtyTransport(
         }
         resubscribeEpoch = null
         const pendingHandle = resubscribeRequestedHandle
-        const pendingRequiresReplacement = resubscribeRequestedRequiresReplacement
+        const pendingReplacementPolicy = resubscribeRequestedReplacementPolicy
         resubscribeRequestedHandle = null
-        resubscribeRequestedRequiresReplacement = false
+        resubscribeRequestedReplacementPolicy = 'reuse'
         if (
           !retryScheduled &&
           recovery.isCurrent(recoveryEpoch) &&
@@ -1411,7 +1569,7 @@ export function createRemoteRuntimePtyTransport(
           pendingHandle === handle &&
           !getCurrentMultiplexedStream(pendingHandle)
         ) {
-          scheduleResubscribeAfterTransportClose(pendingRequiresReplacement)
+          scheduleResubscribeAfterTransportClose(pendingReplacementPolicy)
         }
       })
   }
@@ -1428,11 +1586,14 @@ export function createRemoteRuntimePtyTransport(
       clearPendingViewportClaim()
     }
     recovery.schedule(recoveryEpoch, (nextEpoch) => {
-      scheduleResubscribeAfterTransportClose(false, nextEpoch)
+      scheduleResubscribeAfterTransportClose('reuse', nextEpoch)
     })
   }
 
-  async function subscribeToHandle(expectedRecoveryEpoch?: number): Promise<void> {
+  async function subscribeToHandle(
+    expectedRecoveryEpoch?: number,
+    sameHandleEndRecovery = false
+  ): Promise<void> {
     if (!handle) {
       return
     }
@@ -1495,10 +1656,13 @@ export function createRemoteRuntimePtyTransport(
             desiredOutputPaused,
             nextStream.setOutputPaused(desiredOutputPaused)
           )
+          if (!subscriptionAttached && sameHandleEndRecovery) {
+            recordSameHandleEndReuse(subscribedHandle)
+          }
           subscriptionAttached = true
           setAttachmentReady(true)
           connecting = false
-          recoveryRequiresReplacement = false
+          resetRecoveryReplacementPolicy()
           recovery.markHealthy()
           emitRecoveryState()
           storedCallbacks.onConnect?.()
@@ -1514,8 +1678,10 @@ export function createRemoteRuntimePtyTransport(
             multiplexedStream = null
             multiplexedStreamHandle = null
             clearPendingViewportClaim()
-            // Why: a HUB restart ends the old handle's stream before its replacement snapshot arrives; the HUB snapshot, not the paired viewer, decides whether the pane exited.
-            scheduleResubscribeAfterTransportClose(true)
+            // Why: repeated same-handle end/reuse cycles must eventually stop on a replacement boundary.
+            scheduleResubscribeAfterTransportClose(
+              replacementPolicyAfterWebStreamEnd(subscribedHandle)
+            )
             return
           }
           unregisterShutdownHandlers(subscribedPtyId)
@@ -1564,6 +1730,7 @@ export function createRemoteRuntimePtyTransport(
           multiplexedStream = null
           multiplexedStreamHandle = null
           setAttachmentReady(false)
+          resetSameHandleEndReuse()
           if (recoverable) {
             if (retryWithBackoff) {
               scheduleCapacityPressureRetry()
@@ -1596,7 +1763,7 @@ export function createRemoteRuntimePtyTransport(
     multiplexedStreamHandle = subscribedHandle
     setAttachmentReady(subscriptionAttached)
     if (subscriptionAttached) {
-      recoveryRequiresReplacement = false
+      resetRecoveryReplacementPolicy()
       recovery.markHealthy()
     }
     // Why: a viewport change during the subscribe round-trip hit the no-op one-shot fallback; replay the latest viewport so the PTY isn't stuck at subscribe-time size.
@@ -1629,7 +1796,8 @@ export function createRemoteRuntimePtyTransport(
       lastConnectOptions = options
       lastAttachOptions = null
       storedCallbacks = options.callbacks
-      recoveryRequiresReplacement = false
+      resetRecoveryReplacementPolicy()
+      resetSameHandleEndReuse()
       terminalEnded = false
       connecting = true
       emitRecoveryState(true)
@@ -1846,7 +2014,8 @@ export function createRemoteRuntimePtyTransport(
       const generation = ++attachGeneration
       cancelTerminalCreateRetryWait()
       recovery.cancel()
-      recoveryRequiresReplacement = false
+      resetRecoveryReplacementPolicy()
+      resetSameHandleEndReuse()
       clearPublishedHandleWait()
       lastAttachOptions = options
       storedCallbacks = options.callbacks
@@ -1944,7 +2113,8 @@ export function createRemoteRuntimePtyTransport(
       attachGeneration += 1
       cancelTerminalCreateRetryWait()
       recovery.cancel()
-      recoveryRequiresReplacement = false
+      resetRecoveryReplacementPolicy()
+      resetSameHandleEndReuse()
       clearPublishedHandleWait()
       inputBatcher.flush()
       inputBatcher.clear()
@@ -1975,7 +2145,8 @@ export function createRemoteRuntimePtyTransport(
       attachGeneration += 1
       cancelTerminalCreateRetryWait()
       recovery.cancel()
-      recoveryRequiresReplacement = false
+      resetRecoveryReplacementPolicy()
+      resetSameHandleEndReuse()
       clearPublishedHandleWait()
       inputBatcher.flush()
       inputBatcher.clear()
@@ -2033,7 +2204,9 @@ export function createRemoteRuntimePtyTransport(
         client: { id: clientId, type: 'desktop' },
         ...(desiredViewport ? { viewport: desiredViewport, claimViewport: true as const } : {})
       }).catch((error) => {
-        handleRemoteTerminalError(error)
+        if (handle === targetHandle) {
+          handleRemoteTerminalError(error)
+        }
       })
       return true
     },
@@ -2134,7 +2307,7 @@ export function createRemoteRuntimePtyTransport(
         return false
       }
       const recoveryEpoch = recovery.begin()
-      scheduleResubscribeAfterTransportClose(recoveryRequiresReplacement, recoveryEpoch)
+      scheduleResubscribeAfterTransportClose(getRecoveryReplacementPolicy(handle), recoveryEpoch)
       return true
     },
 


### PR DESCRIPTION
## Summary
- Strengthen remote runtime PTY recovery with replacement-policy tiers (`reuse` / `prefer-replacement` / `require-replacement`) and bounded same-handle end cycles.
- Cap reuse attempts and inventory wait windows to prevent infinite reconnect flapping.
- Track ready evidence so sessions can reattach from prior snapshots when inventory becomes unavailable.

## Test plan
- [x] Unit tests for remote-runtime PTY transport replacement policies and same-handle recovery paths
- [ ] Manually verify remote runtime terminal reconnect after host session end with same handle
- [ ] Confirm no reconnect flapping when inventory repeatedly fails