### PR TITLE
fix(updater): notarize hourly macOS builds so TCC grants survive updates

### DIFF
--- a/.github/workflows/hourly-mac-build.yml
+++ b/.github/workflows/hourly-mac-build.yml
@@ -7,9 +7,11 @@ name: Hourly macOS Dev Build
 #   - macOS only. Other platforms keep using RC/stable.
 #   - No tests, no lint, no e2e. This channel trades safety for latency; PR CI
 #     and release-cut remain the gates that matter.
-#   - Signed but NOT notarized. Squirrel.Mac validates the replacement bundle's
-#     signature, not its notarization, so in-place updates still work while the
-#     ~10min notary round trip is skipped 24x a day.
+#   - Signed AND notarized, exactly like a release. The notary round trip is the
+#     one slow step kept: macOS anchors a notarized app's TCC grants on identifier
+#     + team rather than on its cdhash, so those grants survive an update. Without
+#     a ticket every hourly reads as a new client and silently loses file access
+#     under Documents/Desktop/Downloads — 24 times a day.
 #
 # Artifacts publish to stablyai/orca-hourly, never to stablyai/orca: the main
 # repo's releases atom feed exposes only its 10 newest entries, so 24 hourly
@@ -24,10 +26,14 @@ name: Hourly macOS Dev Build
 #   HOURLY_RELEASE_APP_ID           the App's numeric id
 #   HOURLY_RELEASE_APP_PRIVATE_KEY  the App's .pem private key
 #
-# Installation tokens live one hour, which is ample here: this job skips tests,
-# notarization, and Windows signing entirely, so a run is pack + upload and lands
-# well inside that. If one ever did overrun, the release is still an unpublished
-# draft at that point, so nothing user-visible breaks.
+# Installation tokens live one hour, which is why this mints twice. Install and
+# build need no token at all, and notarization can hold the publish step for tens
+# of minutes; minting again once the build is done starts the clock at the first
+# call that actually uses it rather than burning a third of it on `pnpm install`.
+# A pathological retry can still outrun the second token, but the release is an
+# unpublished draft until the manifest check passes, so the damage is a stranded
+# invisible draft — and the build-number query counts drafts, so it holds its
+# number and the next run does not reuse it.
 
 on:
   schedule:
@@ -57,11 +63,11 @@ jobs:
   build-hourly-mac:
     if: github.repository == 'stablyai/orca'
     runs-on: blacksmith-6vcpu-macos-15
-    # Why 120: it must exceed the worst case the retry budgets below can produce
-    # (install 3x10 + publish 2x25 = 80, plus ~30 for checkout/build/verify), or
+    # Why 150: it must exceed the worst case the retry budgets below can produce
+    # (install 3x10 + publish 2x45 = 120, plus ~25 for checkout/build/verify), or
     # the job is killed mid-retry and no cleanup step runs at all. A typical run
-    # is far shorter — there is no notarization, Windows signing, or test phase.
-    timeout-minutes: 120
+    # is far shorter — this is the notary queue's tail, not its median.
+    timeout-minutes: 150
     env:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
@@ -212,12 +218,27 @@ jobs:
           # silent, which is correct for unvetted dev artifacts.
           ORCA_DIAGNOSTICS_TOKEN_URL: https://www.onorca.dev/diagnostics/token
 
+      # Why a second mint: everything from here on writes to the hourly repo, and
+      # the notary round trip inside the publish step can be tens of minutes. The
+      # token minted at the top has already spent install + build of its one hour
+      # on steps that never touched it; restarting the clock here gives the slow
+      # part the full budget.
+      - name: Re-mint hourly repo token for publish
+        id: app_token_publish
+        if: steps.freshness.outputs.should_build == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HOURLY_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HOURLY_RELEASE_APP_PRIVATE_KEY }}
+          owner: stablyai
+          repositories: orca-hourly
+
       - name: Create hourly release
         id: release
         if: steps.freshness.outputs.should_build == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
           TAG: v${{ steps.hourly.outputs.version }}
           NAME: ${{ steps.hourly.outputs.name }}
           SHA: ${{ steps.freshness.outputs.head_sha }}
@@ -244,30 +265,37 @@ jobs:
 
           Built from [\`stablyai/orca@$short_sha\`](https://github.com/stablyai/orca/commit/$SHA).
 
-          **Unvetted.** No tests ran. Signed but not notarized — installable
-          through Orca's in-app updater, but a manual download will be
-          Gatekeeper-quarantined."
+          **Unvetted.** No tests ran. Signed and notarized like a release, so it
+          installs through Orca's in-app updater and opens from a manual download
+          without a Gatekeeper prompt — but nothing here has been reviewed."
           echo "tag=$TAG" >>"$GITHUB_OUTPUT"
 
       - name: Publish hourly macOS artifacts
         if: steps.freshness.outputs.should_build == 'true'
         uses: nick-fields/retry@v4
         with:
-          # Why lower than the release pipeline's 3x45: that budget is sized for
-          # notarization and Windows signing, neither of which runs here. An attempt
-          # is pack + upload only.
-          timeout_minutes: 25
+          # Why 45 like the release pipeline: an attempt is pack + notarize +
+          # upload, and the notary queue is the unbounded part. Why 2 attempts and
+          # not 3: a missed hourly costs an hour, and the next cron picks the same
+          # commit up, so a third attempt buys less than it costs in runner time.
+          timeout_minutes: 45
           max_attempts: 2
           retry_wait_seconds: 30
           command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_MAC_HOURLY=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
         env:
           # Why: electron-builder's github publisher targets the repo named in the
           # config; the token must therefore carry write access to orca-hourly.
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
           ORCA_HOURLY_BUILD_VERSION: ${{ steps.hourly.outputs.version }}
           ORCA_BUILD_COMMIT: ${{ steps.hourly.outputs.commit }}
           CSC_LINK: ${{ secrets.MAC_CERTS }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          # Why all three: electron-builder's notarize step authenticates to the
+          # Apple notary service with the app-specific password, not with the
+          # signing cert. Omitting them fails the build rather than skipping it,
+          # since `notarize` is now on for this path.
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       # Why: the updater resolves a tag, then fetches latest-mac.yml from it. A
@@ -277,7 +305,7 @@ jobs:
         if: steps.freshness.outputs.should_build == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
@@ -307,7 +335,7 @@ jobs:
         if: steps.freshness.outputs.should_build == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
           TAG: ${{ steps.release.outputs.tag }}
           NAME: ${{ steps.hourly.outputs.name }}
         run: |
@@ -333,7 +361,7 @@ jobs:
           steps.publish_live.outcome != 'success'
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -uo pipefail
@@ -346,7 +374,7 @@ jobs:
         if: steps.freshness.outputs.should_build == 'true'
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
         run: |
           set -euo pipefail
           # Why: --cleanup-tag so pruning does not leave orphan tags behind that

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -16,9 +16,9 @@ const { writeMacBuildCompatibility } = require('./scripts/mac-build-compatibilit
 const { verifyPackagedPluginResources } = require('./scripts/verify-packaged-plugin-resources.cjs')
 const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.cjs')
 
-// Why: hourly dev builds must carry the *release* identity — same bundle id and
-// Developer ID signature — or Squirrel.Mac refuses to swap them over an installed
-// Orca. Only notarization is skipped, which in-place updates never check.
+// Why: hourly dev builds must carry the *release* identity — same bundle id,
+// Developer ID signature, and notarization ticket — or Squirrel.Mac refuses to
+// swap them over an installed Orca and macOS treats each build as a new app.
 const isMacHourly = process.env.ORCA_MAC_HOURLY === '1'
 const isMacRelease = process.env.ORCA_MAC_RELEASE === '1' || isMacHourly
 const isLinuxArm64Release = process.env.ORCA_LINUX_ARM64_RELEASE === '1'
@@ -330,11 +330,14 @@ module.exports = {
     // explicit release path so production artifacts remain strict while dev
     // artifacts do not fail with broken ad-hoc launch behavior.
     hardenedRuntime: isMacRelease,
-    // Why: Squirrel.Mac validates the replacement bundle's signature, not its
-    // notarization, so hourly builds stay installable while skipping the ~10min
-    // notary round trip 24x a day. A manually-downloaded hourly zip will be
-    // Gatekeeper-quarantined — that is the accepted tradeoff for a dev channel.
-    notarize: isMacRelease && !isMacHourly,
+    // Why hourly builds notarize too, despite the ~10min notary round trip: TCC
+    // anchors a notarized Developer ID app's permission grants on identifier +
+    // team, which is cdhash-independent and so survives an update. Without a
+    // ticket there is no such stable identity, so every hourly reads as a
+    // different client — the grant row stays but stops matching, and file access
+    // under Documents/Desktop/Downloads fails with EPERM and no re-prompt. At 24
+    // builds a day that revokes the user's grants faster than they can re-grant.
+    notarize: isMacRelease,
     extraResources: [
       ...commonExtraResources,
       ...createPackagedRuntimeNodeModuleResources('darwin'),

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -313,15 +313,18 @@ describe('electron-builder config', () => {
     })
   })
 
-  // Why: notarization is the one release step hourly skips; in-place updates never
-  // check it, and 24 notary round trips a day is the cost being avoided.
-  it('skips notarization only for hourly builds', () => {
+  // Why hourly must notarize despite the round trip: TCC anchors a notarized
+  // Developer ID app's grants on identifier + team, not on its cdhash, so they
+  // survive an update. An unnotarized hourly reads as a new client every build
+  // and loses file access under Documents/Desktop/Downloads with no re-prompt.
+  it('notarizes hourly builds like releases, and neither locally', () => {
     withHourlyEnv((config) => {
-      expect(config.mac.notarize).toBe(false)
+      expect(config.mac.notarize).toBe(true)
     })
     withEnv({ ORCA_MAC_RELEASE: '1' }, (config) => {
       expect(config.mac.notarize).toBe(true)
     })
+    expect(electronBuilderConfig.mac.notarize).toBe(false)
   })
 
   // Why: the main repo's releases atom feed exposes only its 10 newest entries.

--- a/src/renderer/src/components/settings/ReleaseChannelSection.tsx
+++ b/src/renderer/src/components/settings/ReleaseChannelSection.tsx
@@ -27,7 +27,7 @@ const CHANNEL_LABELS: Record<ReleaseChannel, string> = {
 const CHANNEL_DESCRIPTIONS: Record<ReleaseChannel, string> = {
   stable: 'Shipped releases. What everyone else is running.',
   rc: 'Release candidates cut ahead of each stable.',
-  hourly: 'macOS only. Unvetted builds from main, built every hour. No tests, no notarization.'
+  hourly: 'macOS only. Unvetted builds from main, built every hour. No tests.'
 }
 
 function formatBuildLabel(build: ReleaseBuild): string {
@@ -226,7 +226,7 @@ export function ReleaseChannelSection(): React.JSX.Element {
           <p className="text-xs text-muted-foreground">
             {translate(
               'auto.components.settings.ReleaseChannelSection.hourlyWarning',
-              'Hourly builds are macOS-only, ship straight from main with no test gate, and are signed but not notarized. Keep a stable build handy.'
+              'Hourly builds are macOS-only and ship straight from main with no test gate. Keep a stable build handy.'
             )}
           </p>
         </div>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10089,7 +10089,7 @@
           "description": "Switch update channels or jump to any published build, including older ones. Downgrades are allowed and unvetted builds can be broken.",
           "devOnly": "Dev only",
           "channelAriaLabel": "Update channel",
-          "hourlyWarning": "Hourly builds are macOS-only, ship straight from main with no test gate, and are signed but not notarized. Keep a stable build handy.",
+          "hourlyWarning": "Hourly builds are macOS-only and ship straight from main with no test gate. Keep a stable build handy.",
           "loadingBuilds": "Loading builds…",
           "noBuilds": "No builds found",
           "refresh": "Refresh build list",


### PR DESCRIPTION
Hourly builds were signed but not notarized, to skip the ~10min notary round trip 24x a day. That was the wrong call.

macOS anchors a **notarized** Developer ID app's TCC grants on identifier + team, which is cdhash-independent and therefore survives an in-place update. Without a notarization ticket there is no such stable identity, so every hourly reads as a *different client*: the grant row is still there but stops matching, and file access under `Documents` / `Desktop` / `Downloads` fails with `EPERM` and **no re-prompt**. `tccutil reset` clears it until the next hourly lands. `orca-hourly` has shipped as many as 14 builds in a single day, so that is up to 14 grant invalidations a day for anyone whose projects live in a protected folder.

The original justification — Squirrel.Mac validates the replacement bundle's *signature*, not its notarization — is true but is the wrong requirement. The in-place bundle swap was never the culprit; notarization is the variable that actually changed.

## Changes

- `config/electron-builder.config.cjs`: `notarize: isMacRelease && !isMacHourly` → `notarize: isMacRelease`. Local dev builds are unaffected.
- Hourly workflow publish step gains `APPLE_ID` and `APPLE_APP_SPECIFIC_PASSWORD` (it already had `APPLE_TEAM_ID`); without them the build now **fails** rather than silently skipping notarization.
- Budgets absorb the notary round trip: publish retry `25x2` → `45x2` (matching the release pipeline's per-attempt budget), job `timeout-minutes` 120 → 150.
- The App installation token is re-minted after the build. Its one-hour life was previously being spent on `pnpm install` and the build, neither of which uses it; the notary wait now gets the full budget. If a pathological retry still outruns it, the release is an unpublished draft at that point, and the build-number query counts drafts, so nothing user-visible breaks and no number is reused.
- Comments and user-facing copy that asserted "signed but not notarized" are rewritten: workflow header, release body, `CHANNEL_DESCRIPTIONS.hourly`, and the picker's hourly warning (plus `en.json`).
- `electron-builder-config.test.mjs` now asserts hourly notarizes like a release, and that a plain local build still does not.

macOS-only, as requested.

Existing unnotarized hourly releases are left in place for now; they can be pruned once a notarized build has published so the channel is never empty.

Made with [Orca](https://github.com/stablyai/orca) 🐋
