### PR TITLE
fix(mobile): exclude link-local IPv4 from pairing addresses

### DIFF
--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -95,6 +95,44 @@ describe('registerMobileHandlers', () => {
     )
   })
 
+  it('excludes link-local IPv4 so idle adapters cannot become the pairing default', async () => {
+    // Why: Windows self-assigns 169.254.0.0/16 to every adapter without DHCP —
+    // Bluetooth, VPN tunnels, unplugged Ethernet — and they rank alongside the real
+    // LAN address, so pairing can advertise a dead host.
+    networkInterfacesMock.mockReturnValue({
+      Bluetooth: [{ family: 'IPv4', internal: false, address: '169.254.246.150' }],
+      Ethernet: [{ family: 'IPv4', internal: false, address: '169.254.26.112' }],
+      'Wi-Fi': [
+        { family: 'IPv4', internal: false, address: '192.168.100.198' },
+        // neighbouring /16s stay pickable — only 169.254 is link-local
+        { family: 'IPv4', internal: false, address: '169.253.0.1' },
+        { family: 'IPv4', internal: false, address: '169.255.0.1' }
+      ]
+    })
+    const createMobilePairingOffer = vi.fn().mockResolvedValue({
+      available: true,
+      pairingUrl: 'orca://pair#lan',
+      endpoint: 'ws://192.168.100.198:6768',
+      deviceId: 'mobile-lan',
+      connectionMode: 'automatic'
+    })
+
+    registerMobileHandlers({ createMobilePairingOffer } as never)
+
+    expect(handlers.get('mobile:listNetworkInterfaces')?.()).toEqual({
+      interfaces: [
+        { name: 'Wi-Fi', address: '192.168.100.198' },
+        { name: 'Wi-Fi', address: '169.253.0.1' },
+        { name: 'Wi-Fi', address: '169.255.0.1' }
+      ]
+    })
+
+    await handlers.get('mobile:getPairingQR')?.(null, {})
+    expect(createMobilePairingOffer).toHaveBeenCalledWith(
+      expect.objectContaining({ address: '192.168.100.198' })
+    )
+  })
+
   it('includes IPv6 addresses (ranked after IPv4) and excludes link-local IPv6', () => {
     networkInterfacesMock.mockReturnValue({
       en0: [

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -31,9 +31,17 @@ function isProxyFakeIpIPv4Address(address: string): boolean {
   return /^198\.(?:18|19)\./.test(address)
 }
 
+// Why: 169.254.0.0/16 is IPv4 link-local (APIPA), self-assigned when DHCP fails.
+// Like fe80::/10 it never reaches a phone, and Windows hands them out freely to
+// idle adapters — Bluetooth, VPN tunnels, disconnected Ethernet — so without this
+// a host can offer several dead addresses ranked alongside its real LAN one.
+function isLinkLocalIPv4Address(address: string): boolean {
+  return address.startsWith('169.254.')
+}
+
 // Why: the WebSocket transport advertises 0.0.0.0 as its endpoint, which isn't
-// connectable from a mobile device. We enumerate all non-internal IPv4 and
-// (non-link-local) IPv6 addresses so the user can choose which one to advertise
+// connectable from a mobile device. We enumerate all non-internal, non-link-local
+// IPv4 and IPv6 addresses so the user can choose which one to advertise
 // in the QR code (e.g. LAN vs Tailscale). IPv6 must be included so pairing works
 // on IPv6-only hosts (e.g. a headless `orca serve` reachable only over IPv6),
 // where an IPv4-only scan returns nothing and the UI reports "no interfaces".
@@ -51,6 +59,9 @@ function getNetworkInterfaces(): NetworkInterface[] {
       if (addr.family === 'IPv4') {
         // 198.18.0.0/15 proxy fake IPs are only routable inside the desktop proxy.
         if (isProxyFakeIpIPv4Address(addr.address)) {
+          continue
+        }
+        if (isLinkLocalIPv4Address(addr.address)) {
           continue
         }
         result.push({ name, address: addr.address })


### PR DESCRIPTION
## What this fixes

`getNetworkInterfaces` in `src/main/ipc/mobile.ts` builds the list of addresses the user can advertise in the pairing QR code. It already excludes link-local IPv6, with an explicit rationale:

> link-local IPv6 addresses (fe80::/10) require a scope/zone id to be connectable and never work as a QR-advertised pairing host, so they are excluded from the pickable list

The IPv4 equivalent — `169.254.0.0/16`, APIPA — was not filtered, even though the same reasoning applies exactly.

## Why it matters

Windows self-assigns an APIPA address to every adapter that fails DHCP, which in practice means every idle one: Bluetooth, dormant VPN tunnels, unplugged Ethernet ports, inactive virtual adapters. This is not an edge case — a normal Windows laptop can carry half a dozen. The machine I hit this on reported six, against a single real LAN address.

`rankAddress` gives them rank `1`, the same rank as the real LAN address:

```ts
function rankAddress(address: string): number {
  if (isTailnetIPv4Address(address)) return 0
  return address.includes(':') ? 2 : 1
}
```

So they are interleaved with the LAN address in the picker rather than sorted below it, and `getDefaultPairingAddress` returns `ifaces[0]`. With no tailnet address present, whichever rank-1 address the OS happens to enumerate first wins — and that can be a `169.254` one. The QR code then advertises a host that does not exist, and the phone's connection attempt dies on a network timeout with nothing to indicate why.

## The change

Filter `169.254.0.0/16` alongside the existing `198.18.0.0/15` proxy fake-ip guard, and update the enumeration comment, which claimed only IPv6 link-local was excluded.

## Tests

New case in `mobile.test.ts`, modelled on the existing proxy fake-ip test (#10404):

- A Windows-shaped interface set — Bluetooth and Ethernet holding only APIPA addresses, Wi-Fi holding the real LAN address — leaves exactly the LAN address pickable.
- The neighbouring `/16`s (`169.253.0.1`, `169.255.0.1`) stay pickable, pinning the boundary so the filter can't widen silently.
- The pairing offer still resolves to the real LAN address.

Verified the test fails without the production change (returns 5 interfaces instead of 3), so it genuinely covers the regression.

## Verification

Windows 11, Node 24.18.0:

- `src/main/ipc/mobile.test.ts` — 18/18 pass
- `pnpm typecheck:node` — clean
- `oxlint` on both changed files — clean

## Visual changes

None. The pairing UI is unchanged; it simply stops being offered addresses that cannot work.

## Review notes

- **Cross-platform:** the filter is platform-neutral. `169.254.0.0/16` is link-local by RFC 3927 everywhere, and macOS and Linux self-assign from it too, so no platform guard is wanted. Windows is just where it shows up most.
- **Local / remote / SSH:** unaffected. This only narrows the address list offered for mobile pairing; it does not touch the relay, SSH worktrees, or any remote transport.
- **Agents / integrations / git providers:** untouched.
- **Security:** strictly narrowing. No address becomes pickable that wasn't before.
- **Performance:** one `startsWith` per address during enumeration.
- **UI quality:** no styling or layout changes. The picker gets shorter and every entry in it is now actually reachable.

One judgement call worth flagging: I kept this as a hard filter rather than a demotion in `rankAddress`. An APIPA address is never reachable from a phone, so leaving it selectable would only preserve a way to misconfigure pairing. If you'd rather keep them listed and just rank them last, that's a small change and I'm happy to switch.

X: @vicmandarin
