### PR TITLE
feat(shortcuts): iTerm-style Ctrl/Cmd modifier remap on macOS

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -167,6 +167,7 @@ function createSettings(overrides: TestSettingsOverrides = {}): GlobalSettings {
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,
     terminalJISYenToBackslash: false,
+    modifierRemap: 'none',
     experimentalMobile: false,
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -173,6 +173,7 @@ function createSettings(overrides: TestSettingsOverrides = {}): GlobalSettings {
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,
     terminalJISYenToBackslash: false,
+    modifierRemap: 'none',
     experimentalMobile: false,
     mobileAutoRestoreFitMs: null,
     experimentalPet: false,

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -43,6 +43,7 @@ import {
   type KeybindingMatchOptions,
   type KeybindingOverrides
 } from '../../shared/keybindings'
+import { applyCtrlCmdSwapToInput, isCtrlCmdSwapActive } from '../../shared/modifier-remap'
 import { getMainE2EConfig } from '../e2e-config'
 import { buildEditableContextMenuTemplate } from './editable-context-menu'
 import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId } from '../ipc/ui'
@@ -789,10 +790,16 @@ export function createMainWindow(
     return true
   }
 
-  mainWindow.webContents.on('before-input-event', (event, input) => {
+  mainWindow.webContents.on('before-input-event', (event, rawInput) => {
     if (shortcutRecorderFocused) {
       return
     }
+
+    // Why: main resolves shortcuts ahead of the renderer, so the remap has to land here too.
+    const input = applyCtrlCmdSwapToInput(
+      rawInput,
+      isCtrlCmdSwapActive(store?.getSettings().modifierRemap, process.platform)
+    )
 
     if (input.type === 'keyDown' && is.dev && input.code === 'F12') {
       event.preventDefault()

--- a/src/main/window/dashboard-popout-window.ts
+++ b/src/main/window/dashboard-popout-window.ts
@@ -13,6 +13,7 @@ import {
   type KeybindingInput,
   type KeybindingOverrides
 } from '../../shared/keybindings'
+import { applyCtrlCmdSwapToInput, isCtrlCmdSwapActive } from '../../shared/modifier-remap'
 
 const MIN_WIDTH = 480
 const MIN_HEIGHT = 360
@@ -210,10 +211,15 @@ export function createOrFocusDashboardPopout(
 
   // Why: the pop-out has no renderer-side shortcut plumbing; resolve only the
   // zoom chords here and let every other key fall through untouched.
-  window.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown') {
+  window.webContents.on('before-input-event', (event, rawInput) => {
+    if (rawInput.type !== 'keyDown') {
       return
     }
+    // Why: the pop-out resolves zoom in main only, so it needs the main window's remap too.
+    const input = applyCtrlCmdSwapToInput(
+      rawInput,
+      isCtrlCmdSwapActive(store?.getSettings().modifierRemap, process.platform)
+    )
     const direction = resolveZoomShortcut(input, options.getKeybindings?.())
     if (direction) {
       event.preventDefault()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { resolveLeftTitlebarChromeLayout } from '@/lib/titlebar-left-chrome'
 import { shouldShowWorktreeCreationSurface } from '@/lib/worktree-creation-surface'
 import { buildAppFontFamily } from '@/lib/app-font-family'
+import { syncCtrlCmdSwapFromSettings } from '@/lib/install-modifier-remap'
 import { toast } from 'sonner'
 import { Toaster } from '@/components/ui/sonner'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -1461,6 +1462,10 @@ function App(): React.JSX.Element {
       buildAppFontFamily(settings?.appFontFamily)
     )
   }, [settings?.appFontFamily])
+
+  useEffect(() => {
+    syncCtrlCmdSwapFromSettings(settings?.modifierRemap)
+  }, [settings?.modifierRemap])
 
   // Refresh GitHub data (PR/issue status) when window regains focus
   useEffect(() => {

--- a/src/renderer/src/components/settings/ModifierRemapControl.tsx
+++ b/src/renderer/src/components/settings/ModifierRemapControl.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import type { ModifierRemap } from '../../../../shared/modifier-remap'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsRow } from './SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+
+export function ModifierRemapControl({
+  modifierRemap,
+  keywords,
+  updateSettings
+}: {
+  modifierRemap: ModifierRemap
+  keywords?: string[]
+  updateSettings: (updates: { modifierRemap?: ModifierRemap }) => Promise<void> | void
+}): React.JSX.Element {
+  return (
+    <SearchableSetting
+      id="modifier-remap"
+      title={translate('settings.modifierRemap.title', 'Modifier Keys')}
+      description={translate(
+        'settings.modifierRemap.description',
+        'Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal as a control character. Native menu shortcuts such as ⌘Q stay on Command.'
+      )}
+      keywords={keywords}
+      className="max-w-none"
+    >
+      <SettingsRow
+        label={translate('settings.modifierRemap.rowLabel', 'Ctrl / Command')}
+        description={translate(
+          'settings.modifierRemap.rowDescription',
+          'Applies to every key event, including terminal panes'
+        )}
+        control={
+          <Select
+            value={modifierRemap}
+            onValueChange={(value) =>
+              void updateSettings({ modifierRemap: value as ModifierRemap })
+            }
+          >
+            <SelectTrigger className="w-[180px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">
+                {translate('settings.modifierRemap.option.none', 'Default')}
+              </SelectItem>
+              <SelectItem value="swap-ctrl-cmd">
+                {translate('settings.modifierRemap.option.swap', 'Swap Ctrl and Command')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/ShortcutFilterRail.tsx
+++ b/src/renderer/src/components/settings/ShortcutFilterRail.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Search, X } from 'lucide-react'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
 import { formatKeybindingList, type KeybindingDefinition } from '../../../../shared/keybindings'
+import { isCtrlCmdSwapEnabled } from '../../lib/install-modifier-remap'
 import { cn } from '../../lib/utils'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -100,7 +101,7 @@ export function matchesShortcutLocalSearch(
     row.item.id,
     row.groupTitle,
     ...row.item.searchKeywords,
-    formatKeybindingList(row.effective, platform)
+    formatKeybindingList(row.effective, platform, { swapCtrlCmd: isCtrlCmdSwapEnabled() })
   ]
   return searchableText.some((value) => value.toLowerCase().includes(query))
 }

--- a/src/renderer/src/components/settings/ShortcutRecorderButton.tsx
+++ b/src/renderer/src/components/settings/ShortcutRecorderButton.tsx
@@ -5,6 +5,7 @@ import {
   type KeybindingActionId,
   type KeybindingInput
 } from '../../../../shared/keybindings'
+import { isCtrlCmdSwapEnabled } from '../../lib/install-modifier-remap'
 import {
   ModifierDoubleTapDetector,
   modifierFromKeyEvent,
@@ -182,7 +183,10 @@ export function ShortcutRecorderButton({
       ? translate('auto.components.settings.ShortcutRecorderButton.152e0bcd64', 'Add shortcut')
       : translate('auto.components.settings.ShortcutRecorderButton.5bd56445da', 'Change shortcut')
 
-  const keys = binding === null ? [] : formatKeybinding(binding, platform)
+  const keys =
+    binding === null
+      ? []
+      : formatKeybinding(binding, platform, { swapCtrlCmd: isCtrlCmdSwapEnabled() })
 
   return (
     <Tooltip>

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -32,7 +32,12 @@ import {
 } from './ShortcutFilterRail'
 import { ShortcutRowsList } from './ShortcutRowsList'
 import { ShortcutTerminalPolicyControl } from './ShortcutTerminalPolicyControl'
-import { getTerminalShortcutPolicySearchEntry } from './shortcuts-search'
+import {
+  getModifierRemapSearchEntry,
+  getTerminalShortcutPolicySearchEntry
+} from './shortcuts-search'
+import { ModifierRemapControl } from './ModifierRemapControl'
+import { getShortcutPlatform } from '../../lib/shortcut-platform'
 import { matchesSettingsSearch } from './settings-search'
 import { clearRecordingActionForShortcutMutation } from './shortcut-recording-state'
 import {
@@ -58,6 +63,7 @@ export function ShortcutsPane(): React.JSX.Element {
   const terminalShortcutPolicy = useAppStore(
     (state) => state.settings?.terminalShortcutPolicy ?? 'orca-first'
   )
+  const modifierRemap = useAppStore((state) => state.settings?.modifierRemap ?? 'none')
   const updateSettings = useAppStore((state) => state.updateSettings)
   const keybindings = useAppStore((state) => state.keybindings)
   const keybindingSnapshot = useAppStore((state) => state.keybindingSnapshot)
@@ -299,6 +305,10 @@ export function ShortcutsPane(): React.JSX.Element {
   }
 
   const showPolicy = matchesSettingsSearch(searchQuery, getTerminalShortcutPolicySearchEntry())
+  // Why: Linux/Windows already run app chords on Ctrl, so the swap has nothing to offer there.
+  const showModifierRemap =
+    getShortcutPlatform() === 'darwin' &&
+    matchesSettingsSearch(searchQuery, getModifierRemapSearchEntry())
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-6 overflow-hidden">
@@ -307,6 +317,14 @@ export function ShortcutsPane(): React.JSX.Element {
           <ShortcutTerminalPolicyControl
             terminalShortcutPolicy={terminalShortcutPolicy}
             keywords={getTerminalShortcutPolicySearchEntry().keywords}
+            updateSettings={updateSettings}
+          />
+        ) : null}
+
+        {showModifierRemap ? (
+          <ModifierRemapControl
+            modifierRemap={modifierRemap}
+            keywords={getModifierRemapSearchEntry().keywords}
             updateSettings={updateSettings}
           />
         ) : null}

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -11,6 +11,7 @@ import {
   type KeybindingInput
 } from '../../../../shared/keybindings'
 import { EMPTY_DISABLED_TUI_AGENTS } from './shortcut-groups'
+import { isCtrlCmdSwapEnabled } from '../../lib/install-modifier-remap'
 import { useAppStore } from '../../store'
 import { KeybindingsFileActions } from './KeybindingsFileActions'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
@@ -207,7 +208,9 @@ export function ShortcutsPane(): React.JSX.Element {
         .join(', ')
       setErrors((prev) => ({
         ...prev,
-        [actionId]: `${formatKeybindingList([blockingConflict.binding], platform)} conflicts with ${labels}.`
+        [actionId]: `${formatKeybindingList([blockingConflict.binding], platform, {
+          swapCtrlCmd: isCtrlCmdSwapEnabled()
+        })} conflicts with ${labels}.`
       }))
       return false
     }

--- a/src/renderer/src/components/settings/shortcut-definition-catalog.ts
+++ b/src/renderer/src/components/settings/shortcut-definition-catalog.ts
@@ -5,6 +5,7 @@ import {
   type KeybindingDefinition,
   type KeybindingOverrides
 } from '../../../../shared/keybindings'
+import { isCtrlCmdSwapEnabled } from '../../lib/install-modifier-remap'
 import type { TuiAgent } from '../../../../shared/types'
 import type { ActivePluginCommand } from '@/store/plugin-panels'
 import { buildPluginCommandKeybindingDefinitions } from '@/lib/plugin-command-keybindings'
@@ -48,7 +49,9 @@ export function buildShortcutDefinitionCatalog(options: {
     for (const actionId of conflict.actionIds) {
       conflictByAction.set(actionId, [
         ...(conflictByAction.get(actionId) ?? []),
-        `${formatKeybindingList([conflict.binding], options.platform)} conflicts with ${labels}.`
+        `${formatKeybindingList([conflict.binding], options.platform, {
+          swapCtrlCmd: isCtrlCmdSwapEnabled()
+        })} conflicts with ${labels}.`
       ])
     }
   }

--- a/src/renderer/src/components/settings/shortcuts-search.ts
+++ b/src/renderer/src/components/settings/shortcuts-search.ts
@@ -34,6 +34,25 @@ export const getTerminalShortcutPolicySearchEntry = createLocalizedCatalog(
   })
 )
 
+export const getModifierRemapSearchEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate('settings.modifierRemap.searchTitle', 'Modifier Keys'),
+    description: translate(
+      'settings.modifierRemap.searchDescription',
+      'Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('settings.modifierRemap.keyword.ctrl', 'ctrl'),
+      ...translateSearchKeyword('settings.modifierRemap.keyword.control', 'control'),
+      ...translateSearchKeyword('settings.modifierRemap.keyword.cmd', 'cmd'),
+      ...translateSearchKeyword('settings.modifierRemap.keyword.command', 'command'),
+      ...translateSearchKeyword('settings.modifierRemap.keyword.modifier', 'modifier'),
+      ...translateSearchKeyword('settings.modifierRemap.keyword.remap', 'remap'),
+      ...translateSearchKeyword('settings.modifierRemap.keyword.swap', 'swap')
+    ]
+  })
+)
+
 export const getShortcutsPaneSearchEntries = createLocalizedCatalog(() => [
   ...KEYBINDING_DEFINITIONS.map((item) => ({
     title: item.title,
@@ -44,5 +63,6 @@ export const getShortcutsPaneSearchEntries = createLocalizedCatalog(() => [
     ),
     keywords: [...item.searchKeywords]
   })),
-  getTerminalShortcutPolicySearchEntry()
+  getTerminalShortcutPolicySearchEntry(),
+  getModifierRemapSearchEntry()
 ])

--- a/src/renderer/src/hooks/useShortcutLabel.ts
+++ b/src/renderer/src/hooks/useShortcutLabel.ts
@@ -6,8 +6,10 @@ import {
   type KeybindingActionId,
   type KeybindingOverrides
 } from '../../../shared/keybindings'
+import { isCtrlCmdSwapActive } from '../../../shared/modifier-remap'
 import { useAppStore } from '../store'
 import { getShortcutPlatform } from '../lib/shortcut-platform'
+import { isCtrlCmdSwapEnabled } from '../lib/install-modifier-remap'
 
 export { getShortcutPlatform }
 
@@ -16,29 +18,39 @@ export type ShortcutKeyComboDetails = {
   doubleTap: boolean
 }
 
+// Why: hooks read the setting from the store so labels re-render the moment the remap flips;
+// the plain formatters fall back to the listener's state for non-React callers.
+function useSwapCtrlCmd(): boolean {
+  const modifierRemap = useAppStore((state) => state.settings?.modifierRemap)
+  return isCtrlCmdSwapActive(modifierRemap, getShortcutPlatform())
+}
+
 export function formatShortcutLabel(
   actionId: KeybindingActionId,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  swapCtrlCmd: boolean = isCtrlCmdSwapEnabled()
 ): string {
   const platform = getShortcutPlatform()
   return formatKeybindingList(
     getEffectiveKeybindingsForAction(actionId, platform, overrides),
-    platform
+    platform,
+    { swapCtrlCmd }
   )
 }
 
 export function formatPrimaryShortcutLabel(
   actionId: KeybindingActionId,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  swapCtrlCmd: boolean = isCtrlCmdSwapEnabled()
 ): string {
   const platform = getShortcutPlatform()
   const [binding] = getEffectiveKeybindingsForAction(actionId, platform, overrides)
-  return binding ? formatKeybindingList([binding], platform) : 'Unassigned'
+  return binding ? formatKeybindingList([binding], platform, { swapCtrlCmd }) : 'Unassigned'
 }
 
 export function useShortcutLabel(actionId: KeybindingActionId): string {
   const keybindings = useAppStore((state) => state.keybindings)
-  return formatShortcutLabel(actionId, keybindings)
+  return formatShortcutLabel(actionId, keybindings, useSwapCtrlCmd())
 }
 
 // Why: returns null for unbound actions instead of the display sentinel
@@ -46,40 +58,43 @@ export function useShortcutLabel(actionId: KeybindingActionId): string {
 // UI logic to formatter copy (which may change or become localized).
 export function formatOptionalShortcutLabel(
   actionId: KeybindingActionId,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  swapCtrlCmd: boolean = isCtrlCmdSwapEnabled()
 ): string | null {
   const platform = getShortcutPlatform()
   const bindings = getEffectiveKeybindingsForAction(actionId, platform, overrides)
   if (bindings.length === 0) {
     return null
   }
-  return formatKeybindingList(bindings, platform)
+  return formatKeybindingList(bindings, platform, { swapCtrlCmd })
 }
 
 export function useOptionalShortcutLabel(actionId: KeybindingActionId): string | null {
   const keybindings = useAppStore((state) => state.keybindings)
-  return formatOptionalShortcutLabel(actionId, keybindings)
+  return formatOptionalShortcutLabel(actionId, keybindings, useSwapCtrlCmd())
 }
 
 export function formatShortcutKeys(
   actionId: KeybindingActionId,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  swapCtrlCmd: boolean = isCtrlCmdSwapEnabled()
 ): string[] {
-  return formatShortcutKeyComboDetails(actionId, overrides)[0]?.keys ?? []
+  return formatShortcutKeyComboDetails(actionId, overrides, swapCtrlCmd)[0]?.keys ?? []
 }
 
 export function useShortcutKeys(actionId: KeybindingActionId): string[] {
   const keybindings = useAppStore((state) => state.keybindings)
-  return formatShortcutKeys(actionId, keybindings)
+  return formatShortcutKeys(actionId, keybindings, useSwapCtrlCmd())
 }
 
 export function formatShortcutKeyComboDetails(
   actionId: KeybindingActionId,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  swapCtrlCmd: boolean = isCtrlCmdSwapEnabled()
 ): ShortcutKeyComboDetails[] {
   const platform = getShortcutPlatform()
   return getEffectiveKeybindingsForAction(actionId, platform, overrides).map((binding) => ({
-    keys: formatKeybinding(binding, platform),
+    keys: formatKeybinding(binding, platform, { swapCtrlCmd }),
     doubleTap: isDoubleTapBinding(binding)
   }))
 }
@@ -88,7 +103,7 @@ export function useShortcutKeyComboDetails(
   actionId: KeybindingActionId
 ): ShortcutKeyComboDetails[] {
   const keybindings = useAppStore((state) => state.keybindings)
-  return formatShortcutKeyComboDetails(actionId, keybindings)
+  return formatShortcutKeyComboDetails(actionId, keybindings, useSwapCtrlCmd())
 }
 
 export function useShortcutKeyDetails(actionId: KeybindingActionId): ShortcutKeyComboDetails {
@@ -97,9 +112,10 @@ export function useShortcutKeyDetails(actionId: KeybindingActionId): ShortcutKey
 
 export function formatShortcutKeyCombos(
   actionId: KeybindingActionId,
-  overrides?: KeybindingOverrides
+  overrides?: KeybindingOverrides,
+  swapCtrlCmd: boolean = isCtrlCmdSwapEnabled()
 ): string[][] {
-  return formatShortcutKeyComboDetails(actionId, overrides).map((combo) => combo.keys)
+  return formatShortcutKeyComboDetails(actionId, overrides, swapCtrlCmd).map((combo) => combo.keys)
 }
 
 export function useShortcutKeyCombos(actionId: KeybindingActionId): string[][] {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -59,6 +59,27 @@
         "title": "Show Menu Bar Icon",
         "description": "Keep an Orca shortcut and activity indicator in the macOS menu bar."
       }
+    },
+    "modifierRemap": {
+      "searchTitle": "Modifier Keys",
+      "searchDescription": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal.",
+      "keyword": {
+        "ctrl": "ctrl",
+        "control": "control",
+        "cmd": "cmd",
+        "command": "command",
+        "modifier": "modifier",
+        "remap": "remap",
+        "swap": "swap"
+      },
+      "title": "Modifier Keys",
+      "description": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal as a control character. Native menu shortcuts such as ⌘Q stay on Command.",
+      "rowLabel": "Ctrl / Command",
+      "rowDescription": "Applies to every key event, including terminal panes",
+      "option": {
+        "none": "Default",
+        "swap": "Swap Ctrl and Command"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -36,6 +36,27 @@
         "title": "Mostrar icono en la barra de menús",
         "description": "Mantén un acceso directo de Orca e indicador de actividad en la barra de menús de macOS."
       }
+    },
+    "modifierRemap": {
+      "searchTitle": "Modifier Keys",
+      "searchDescription": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal.",
+      "keyword": {
+        "ctrl": "ctrl",
+        "control": "control",
+        "cmd": "cmd",
+        "command": "command",
+        "modifier": "modifier",
+        "remap": "remap",
+        "swap": "swap"
+      },
+      "title": "Modifier Keys",
+      "description": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal as a control character. Native menu shortcuts such as ⌘Q stay on Command.",
+      "rowLabel": "Ctrl / Command",
+      "rowDescription": "Applies to every key event, including terminal panes",
+      "option": {
+        "none": "Default",
+        "swap": "Swap Ctrl and Command"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -36,6 +36,27 @@
         "title": "メニューバーアイコンを表示",
         "description": "macOS メニューバーに Orca のショートカットとアクティビティインジケーターを表示します。"
       }
+    },
+    "modifierRemap": {
+      "searchTitle": "Modifier Keys",
+      "searchDescription": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal.",
+      "keyword": {
+        "ctrl": "ctrl",
+        "control": "control",
+        "cmd": "cmd",
+        "command": "command",
+        "modifier": "modifier",
+        "remap": "remap",
+        "swap": "swap"
+      },
+      "title": "Modifier Keys",
+      "description": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal as a control character. Native menu shortcuts such as ⌘Q stay on Command.",
+      "rowLabel": "Ctrl / Command",
+      "rowDescription": "Applies to every key event, including terminal panes",
+      "option": {
+        "none": "Default",
+        "swap": "Swap Ctrl and Command"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -36,6 +36,27 @@
         "title": "메뉴 바 아이콘 표시",
         "description": "macOS 메뉴 바에 Orca 바로가기 및 활동 표시기를 유지합니다."
       }
+    },
+    "modifierRemap": {
+      "searchTitle": "Modifier Keys",
+      "searchDescription": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal.",
+      "keyword": {
+        "ctrl": "ctrl",
+        "control": "control",
+        "cmd": "cmd",
+        "command": "command",
+        "modifier": "modifier",
+        "remap": "remap",
+        "swap": "swap"
+      },
+      "title": "Modifier Keys",
+      "description": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal as a control character. Native menu shortcuts such as ⌘Q stay on Command.",
+      "rowLabel": "Ctrl / Command",
+      "rowDescription": "Applies to every key event, including terminal panes",
+      "option": {
+        "none": "Default",
+        "swap": "Swap Ctrl and Command"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -36,6 +36,27 @@
         "title": "显示菜单栏图标",
         "description": "在 macOS 菜单栏中保留 Orca 快捷方式和活动指示器。"
       }
+    },
+    "modifierRemap": {
+      "searchTitle": "Modifier Keys",
+      "searchDescription": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal.",
+      "keyword": {
+        "ctrl": "ctrl",
+        "control": "control",
+        "cmd": "cmd",
+        "command": "command",
+        "modifier": "modifier",
+        "remap": "remap",
+        "swap": "swap"
+      },
+      "title": "Modifier Keys",
+      "description": "Swap Ctrl and Command so app shortcuts fire from Ctrl and Command reaches the terminal as a control character. Native menu shortcuts such as ⌘Q stay on Command.",
+      "rowLabel": "Ctrl / Command",
+      "rowDescription": "Applies to every key event, including terminal panes",
+      "option": {
+        "none": "Default",
+        "swap": "Swap Ctrl and Command"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/lib/install-modifier-remap.test.ts
+++ b/src/renderer/src/lib/install-modifier-remap.test.ts
@@ -71,4 +71,20 @@ describe('installCtrlCmdSwap', () => {
     expect(event.metaKey).toBe(true)
     expect(event.ctrlKey).toBe(false)
   })
+
+  it('ignores a second install so the swap is not applied twice', () => {
+    dispose = installCtrlCmdSwap()
+    const second = installCtrlCmdSwap()
+    setCtrlCmdSwapEnabled(true)
+
+    // Two listeners would swap back to the original and silently disable the remap.
+    const event = dispatch({ key: 'c', code: 'KeyC', metaKey: true })
+    expect(event.ctrlKey).toBe(true)
+    expect(event.metaKey).toBe(false)
+
+    // The redundant install owns nothing, so disposing it must not detach the real listener.
+    second()
+    const still = dispatch({ key: 'p', code: 'KeyP', ctrlKey: true })
+    expect(still.metaKey).toBe(true)
+  })
 })

--- a/src/renderer/src/lib/install-modifier-remap.test.ts
+++ b/src/renderer/src/lib/install-modifier-remap.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import { installCtrlCmdSwap, setCtrlCmdSwapEnabled } from './install-modifier-remap'
+
+let dispose: (() => void) | null = null
+
+afterEach(() => {
+  dispose?.()
+  dispose = null
+  setCtrlCmdSwapEnabled(false)
+})
+
+/** Dispatches through window so the capture listener sees the object a consumer would. */
+function dispatch(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { ...init, bubbles: true, cancelable: true })
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('installCtrlCmdSwap', () => {
+  it('rewrites cmd to ctrl so downstream consumers encode a control chord', () => {
+    dispose = installCtrlCmdSwap()
+    setCtrlCmdSwapEnabled(true)
+
+    const event = dispatch({ key: 'c', code: 'KeyC', metaKey: true })
+
+    expect(event.ctrlKey).toBe(true)
+    expect(event.metaKey).toBe(false)
+  })
+
+  it('rewrites ctrl to cmd so app chords fire from the ctrl key', () => {
+    dispose = installCtrlCmdSwap()
+    setCtrlCmdSwapEnabled(true)
+
+    const event = dispatch({ key: 'p', code: 'KeyP', ctrlKey: true })
+
+    expect(event.metaKey).toBe(true)
+    expect(event.ctrlKey).toBe(false)
+  })
+
+  it('leaves events untouched while disabled', () => {
+    dispose = installCtrlCmdSwap()
+
+    const event = dispatch({ key: 'c', code: 'KeyC', metaKey: true })
+
+    expect(event.metaKey).toBe(true)
+    expect(event.ctrlKey).toBe(false)
+  })
+
+  it('preserves chords that hold both modifiers, and unmodified keys', () => {
+    dispose = installCtrlCmdSwap()
+    setCtrlCmdSwapEnabled(true)
+
+    const both = dispatch({ key: 'k', code: 'KeyK', ctrlKey: true, metaKey: true })
+    expect(both.ctrlKey).toBe(true)
+    expect(both.metaKey).toBe(true)
+
+    const bare = dispatch({ key: 'a', code: 'KeyA', shiftKey: true })
+    expect(bare.ctrlKey).toBe(false)
+    expect(bare.metaKey).toBe(false)
+    expect(bare.shiftKey).toBe(true)
+  })
+
+  it('stops rewriting after dispose', () => {
+    const stop = installCtrlCmdSwap()
+    setCtrlCmdSwapEnabled(true)
+    stop()
+
+    const event = dispatch({ key: 'c', code: 'KeyC', metaKey: true })
+
+    expect(event.metaKey).toBe(true)
+    expect(event.ctrlKey).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/install-modifier-remap.ts
+++ b/src/renderer/src/lib/install-modifier-remap.ts
@@ -1,0 +1,59 @@
+import { isCtrlCmdSwapActive, modifiersNeedSwap } from '../../../shared/modifier-remap'
+import { getShortcutPlatform } from './shortcut-platform'
+
+/**
+ * Renderer half of the Ctrl/Cmd remap: rewrites the modifier flags on every key event
+ * during the window capture phase, before any consumer sees it.
+ *
+ * Window capture runs ahead of xterm's own capture listeners on the terminal textarea,
+ * so the same mutated event drives both Orca's keybinding matcher and xterm's encoder —
+ * a swapped Cmd+C reaches the PTY as a real ^C.
+ *
+ * Everything downstream — matching, recording, conflict detection — therefore lives in
+ * post-swap coordinates. Only the glyph layer inverts back (see formatKeybinding).
+ */
+
+const REMAPPED_EVENTS = ['keydown', 'keyup', 'keypress'] as const
+
+let enabled = false
+
+/** Toggled from settings; the listener installs once at bootstrap, before settings load. */
+export function setCtrlCmdSwapEnabled(value: boolean): void {
+  enabled = value
+}
+
+export function syncCtrlCmdSwapFromSettings(modifierRemap: unknown): void {
+  setCtrlCmdSwapEnabled(isCtrlCmdSwapActive(modifierRemap, getShortcutPlatform()))
+}
+
+export function isCtrlCmdSwapEnabled(): boolean {
+  return enabled
+}
+
+function overrideModifier(event: KeyboardEvent, property: string, value: boolean): void {
+  // defineProperty shadows the prototype getter; plain assignment is a silent no-op on DOM events.
+  Object.defineProperty(event, property, { value, configurable: true, enumerable: true })
+}
+
+function swapEventModifiers(event: KeyboardEvent): void {
+  if (!enabled) {
+    return
+  }
+  const modifiers = { control: event.ctrlKey, meta: event.metaKey }
+  if (!modifiersNeedSwap(modifiers)) {
+    return
+  }
+  overrideModifier(event, 'ctrlKey', modifiers.meta)
+  overrideModifier(event, 'metaKey', modifiers.control)
+}
+
+export function installCtrlCmdSwap(target: Window = window): () => void {
+  for (const type of REMAPPED_EVENTS) {
+    target.addEventListener(type, swapEventModifiers as EventListener, { capture: true })
+  }
+  return () => {
+    for (const type of REMAPPED_EVENTS) {
+      target.removeEventListener(type, swapEventModifiers as EventListener, { capture: true })
+    }
+  }
+}

--- a/src/renderer/src/lib/install-modifier-remap.ts
+++ b/src/renderer/src/lib/install-modifier-remap.ts
@@ -47,11 +47,22 @@ function swapEventModifiers(event: KeyboardEvent): void {
   overrideModifier(event, 'metaKey', modifiers.control)
 }
 
+// Why: two listeners would swap the same event twice — an identity, silently disabling the remap.
+let installedTarget: Window | null = null
+
 export function installCtrlCmdSwap(target: Window = window): () => void {
+  if (installedTarget) {
+    return () => undefined
+  }
+  installedTarget = target
   for (const type of REMAPPED_EVENTS) {
     target.addEventListener(type, swapEventModifiers as EventListener, { capture: true })
   }
   return () => {
+    if (installedTarget !== target) {
+      return
+    }
+    installedTarget = null
     for (const type of REMAPPED_EVENTS) {
       target.removeEventListener(type, swapEventModifiers as EventListener, { capture: true })
     }

--- a/src/renderer/src/lib/terminal-shortcut-capture-notification.tsx
+++ b/src/renderer/src/lib/terminal-shortcut-capture-notification.tsx
@@ -8,6 +8,7 @@ import {
   type KeybindingActionId,
   type KeybindingOverrides
 } from '../../../shared/keybindings'
+import { isCtrlCmdSwapEnabled } from './install-modifier-remap'
 import { useAppStore } from '../store'
 import { translate } from '@/i18n/i18n'
 
@@ -60,7 +61,8 @@ export function showTerminalShortcutCaptureNotification({
 
   const bindingLabel = formatKeybindingList(
     getEffectiveKeybindingsForAction(actionId, platform, keybindings),
-    platform
+    platform,
+    { swapCtrlCmd: isCtrlCmdSwapEnabled() }
   )
   // Why: this toast stays up longer than normal, so keep it compact while still
   // exposing the captured shortcut and the edit path.

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -9,6 +9,7 @@ import {
   recordRendererCrashBreadcrumb
 } from './lib/crash-diagnostics'
 import { applyDocumentTheme } from './lib/document-theme'
+import { installCtrlCmdSwap } from './lib/install-modifier-remap'
 import { installTypingLatencyDiagnostic } from './lib/typing-latency-diagnostic'
 import { shouldEnableReactGrab } from './lib/react-grab-dev-gate'
 import { I18nProvider } from './i18n/I18nProvider'
@@ -18,6 +19,8 @@ import { getOrCreateRendererRoot } from './lib/react-renderer-root'
 recordRendererCrashBreadcrumb('renderer_bootstrap_started', { dev: import.meta.env.DEV })
 installRendererCrashDiagnostics()
 installTypingLatencyDiagnostic()
+// Why: must capture before App's keydown listener and xterm's textarea listeners; inert until enabled.
+installCtrlCmdSwap()
 
 if (
   import.meta.env.DEV &&

--- a/src/renderer/src/popout.tsx
+++ b/src/renderer/src/popout.tsx
@@ -9,6 +9,7 @@ import {
   recordRendererCrashBreadcrumb
 } from './lib/crash-diagnostics'
 import { applyDocumentTheme } from './lib/document-theme'
+import { installCtrlCmdSwap, syncCtrlCmdSwapFromSettings } from './lib/install-modifier-remap'
 import { buildAppFontFamily } from './lib/app-font-family'
 import { I18nProvider } from './i18n/I18nProvider'
 import { translate } from './i18n/i18n'
@@ -22,6 +23,7 @@ import { getOrCreateRendererRoot } from './lib/react-renderer-root'
 // window. It shares the preload/window.api but not the DOM or JS context.
 recordRendererCrashBreadcrumb('popout_bootstrap_started', { dev: import.meta.env.DEV })
 installRendererCrashDiagnostics('dashboard-popout')
+installCtrlCmdSwap()
 
 function applyPopoutAppearance(settings: GlobalSettings | null): void {
   applyDocumentTheme(settings?.theme ?? 'system', { disableTransitions: false })
@@ -43,6 +45,7 @@ if (startupSettings) {
   useAppStore.setState({ settings: startupSettings })
 }
 applyPopoutAppearance(startupSettings)
+syncCtrlCmdSwapFromSettings(startupSettings?.modifierRemap)
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {
@@ -85,6 +88,7 @@ function PopoutSettingsSync(): null {
 
   useEffect(() => {
     applyPopoutAppearance(settings)
+    syncCtrlCmdSwapFromSettings(settings?.modifierRemap)
     if (settings?.theme !== 'system') {
       return
     }

--- a/src/renderer/src/web/main.tsx
+++ b/src/renderer/src/web/main.tsx
@@ -17,10 +17,15 @@ import {
   saveStoredWebRuntimeEnvironment
 } from './web-runtime-environment'
 import { installWebPreloadApi } from './web-preload-api'
+import { installCtrlCmdSwap } from '../lib/install-modifier-remap'
 import { I18nProvider } from '../i18n/I18nProvider'
 import { translate } from '../i18n/i18n'
 
 const App = lazy(() => import('../App'))
+
+// Why: App syncs the remap setting on every surface, so without the listener here the web build
+// would invert shortcut glyphs while the keys themselves kept their unswapped behavior.
+installCtrlCmdSwap()
 
 function WebRoot(): React.JSX.Element {
   const initialPairingInput = useMemo(() => readPairingInputFromLocation(window.location), [])

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -343,6 +343,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalMacOptionAsAlt: 'auto',
     terminalMacOptionAsAltMigrated: false,
     terminalJISYenToBackslash: false,
+    modifierRemap: 'none',
     experimentalMobile: false,
     mobileEmulatorEnabled: true,
     mobileEmulatorDefaultDeviceUdid: null,

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -1795,3 +1795,42 @@ describe('digit-index shortcuts', () => {
     ).toEqual([])
   })
 })
+
+describe('formatKeybinding with the Ctrl/Cmd remap', () => {
+  it('shows the physical key, inverting the glyphs bindings are stored against', () => {
+    // Mod resolves to Cmd on darwin, but with the swap the user physically presses Ctrl.
+    expect(formatKeybinding('Mod+P', 'darwin', { swapCtrlCmd: true })).toEqual(['⌃', 'P'])
+    expect(formatKeybinding('Cmd+P', 'darwin', { swapCtrlCmd: true })).toEqual(['⌃', 'P'])
+    expect(formatKeybinding('Ctrl+Tab', 'darwin', { swapCtrlCmd: true })).toEqual(['⌘', 'Tab'])
+  })
+
+  it('leaves labels alone when the remap is off', () => {
+    expect(formatKeybinding('Mod+P', 'darwin')).toEqual(['⌘', 'P'])
+    expect(formatKeybinding('Mod+P', 'darwin', { swapCtrlCmd: false })).toEqual(['⌘', 'P'])
+    expect(formatKeybinding('Ctrl+Tab', 'darwin')).toEqual(['⌃', 'Tab'])
+  })
+
+  it('ignores the remap off darwin, where the swap never applies', () => {
+    expect(formatKeybinding('Mod+P', 'linux', { swapCtrlCmd: true })).toEqual(['Ctrl', 'P'])
+    expect(formatKeybinding('Cmd+P', 'win32', { swapCtrlCmd: true })).toEqual(['Cmd', 'P'])
+  })
+
+  it('does not disturb Alt and Shift', () => {
+    expect(formatKeybinding('Mod+Alt+Shift+A', 'darwin', { swapCtrlCmd: true })).toEqual([
+      '⌃',
+      '⌥',
+      '⇧',
+      'A'
+    ])
+  })
+
+  it('inverts double-tap glyphs too', () => {
+    expect(formatKeybinding('DoubleTap+Mod', 'darwin', { swapCtrlCmd: true })).toEqual(['⌃', '⌃'])
+    expect(formatKeybinding('DoubleTap+Ctrl', 'darwin', { swapCtrlCmd: true })).toEqual(['⌘', '⌘'])
+  })
+
+  it('threads the option through formatKeybindingList', () => {
+    expect(formatKeybindingList(['Mod+P'], 'darwin', { swapCtrlCmd: true })).toBe('⌃P')
+    expect(formatKeybindingList(['Mod+P'], 'darwin')).toBe('⌘P')
+  })
+})

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -2190,14 +2190,29 @@ export function matchKeybindingDigitIndex(
   return null
 }
 
-function formatModifierGlyph(modifier: ModifierToken, isMac: boolean): string {
+/** Bindings are stored in post-remap coordinates, so labels invert the swap to show the physical key. */
+export type KeybindingFormatOptions = { swapCtrlCmd?: boolean }
+
+function macMetaGlyph(swapCtrlCmd: boolean): string {
+  return swapCtrlCmd ? '⌃' : '⌘'
+}
+
+function macControlGlyph(swapCtrlCmd: boolean): string {
+  return swapCtrlCmd ? '⌘' : '⌃'
+}
+
+function formatModifierGlyph(
+  modifier: ModifierToken,
+  isMac: boolean,
+  swapCtrlCmd: boolean
+): string {
   switch (modifier) {
     case 'Mod':
-      return isMac ? '⌘' : 'Ctrl'
+      return isMac ? macMetaGlyph(swapCtrlCmd) : 'Ctrl'
     case 'Cmd':
-      return isMac ? '⌘' : 'Cmd'
+      return isMac ? macMetaGlyph(swapCtrlCmd) : 'Cmd'
     case 'Ctrl':
-      return isMac ? '⌃' : 'Ctrl'
+      return isMac ? macControlGlyph(swapCtrlCmd) : 'Ctrl'
     case 'Alt':
       return isMac ? '⌥' : 'Alt'
     case 'Shift':
@@ -2205,25 +2220,30 @@ function formatModifierGlyph(modifier: ModifierToken, isMac: boolean): string {
   }
 }
 
-export function formatKeybinding(binding: string, platform: NodeJS.Platform): string[] {
+export function formatKeybinding(
+  binding: string,
+  platform: NodeJS.Platform,
+  options: KeybindingFormatOptions = {}
+): string[] {
   const parsed = parseKeybinding(binding)
   if (!parsed) {
     return [binding]
   }
   const isMac = platform === 'darwin'
+  const swapCtrlCmd = isMac && options.swapCtrlCmd === true
   if (parsed.doubleTapModifier) {
-    const glyph = formatModifierGlyph(parsed.doubleTapModifier, isMac)
+    const glyph = formatModifierGlyph(parsed.doubleTapModifier, isMac, swapCtrlCmd)
     return [glyph, glyph]
   }
   const parts: string[] = []
   if (parsed.mod) {
-    parts.push(isMac ? '⌘' : 'Ctrl')
+    parts.push(isMac ? macMetaGlyph(swapCtrlCmd) : 'Ctrl')
   }
   if (parsed.meta) {
-    parts.push(isMac ? '⌘' : 'Cmd')
+    parts.push(isMac ? macMetaGlyph(swapCtrlCmd) : 'Cmd')
   }
   if (parsed.control) {
-    parts.push(isMac ? '⌃' : 'Ctrl')
+    parts.push(isMac ? macControlGlyph(swapCtrlCmd) : 'Ctrl')
   }
   if (parsed.alt) {
     parts.push(isMac ? '⌥' : 'Alt')
@@ -2237,7 +2257,8 @@ export function formatKeybinding(binding: string, platform: NodeJS.Platform): st
 
 export function formatKeybindingList(
   bindings: readonly string[],
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  options: KeybindingFormatOptions = {}
 ): string {
   if (bindings.length === 0) {
     return 'Unassigned'
@@ -2245,7 +2266,7 @@ export function formatKeybindingList(
   return bindings
     .map((binding) => {
       const separator = isDoubleTapBinding(binding) ? ' ' : platform === 'darwin' ? '' : '+'
-      return formatKeybinding(binding, platform).join(separator)
+      return formatKeybinding(binding, platform, options).join(separator)
     })
     .join(', ')
 }

--- a/src/shared/modifier-remap.test.ts
+++ b/src/shared/modifier-remap.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCtrlCmdSwapActive,
+  modifiersNeedSwap,
+  normalizeModifierRemap,
+  swapCtrlCmd
+} from './modifier-remap'
+
+describe('normalizeModifierRemap', () => {
+  it('defaults anything unrecognized to none', () => {
+    expect(normalizeModifierRemap(undefined)).toBe('none')
+    expect(normalizeModifierRemap(null)).toBe('none')
+    expect(normalizeModifierRemap('nonsense')).toBe('none')
+    expect(normalizeModifierRemap(true)).toBe('none')
+    expect(normalizeModifierRemap('swap-ctrl-cmd')).toBe('swap-ctrl-cmd')
+  })
+})
+
+describe('isCtrlCmdSwapActive', () => {
+  it('only activates on darwin', () => {
+    expect(isCtrlCmdSwapActive('swap-ctrl-cmd', 'darwin')).toBe(true)
+    expect(isCtrlCmdSwapActive('swap-ctrl-cmd', 'linux')).toBe(false)
+    expect(isCtrlCmdSwapActive('swap-ctrl-cmd', 'win32')).toBe(false)
+  })
+
+  it('stays off for the default setting', () => {
+    expect(isCtrlCmdSwapActive('none', 'darwin')).toBe(false)
+    expect(isCtrlCmdSwapActive(undefined, 'darwin')).toBe(false)
+  })
+})
+
+describe('swapCtrlCmd', () => {
+  it('exchanges the two modifiers in both directions', () => {
+    expect(swapCtrlCmd({ control: true, meta: false })).toEqual({ control: false, meta: true })
+    expect(swapCtrlCmd({ control: false, meta: true })).toEqual({ control: true, meta: false })
+  })
+
+  it('leaves both-set and neither-set states alone', () => {
+    expect(swapCtrlCmd({ control: true, meta: true })).toEqual({ control: true, meta: true })
+    expect(swapCtrlCmd({ control: false, meta: false })).toEqual({ control: false, meta: false })
+  })
+
+  it('is its own inverse', () => {
+    for (const control of [true, false]) {
+      for (const meta of [true, false]) {
+        expect(swapCtrlCmd(swapCtrlCmd({ control, meta }))).toEqual({ control, meta })
+      }
+    }
+  })
+})
+
+describe('modifiersNeedSwap', () => {
+  it('is false when swapping would be a no-op', () => {
+    expect(modifiersNeedSwap({ control: false, meta: false })).toBe(false)
+    expect(modifiersNeedSwap({ control: true, meta: true })).toBe(false)
+    expect(modifiersNeedSwap({ control: true, meta: false })).toBe(true)
+    expect(modifiersNeedSwap({ control: false, meta: true })).toBe(true)
+  })
+})

--- a/src/shared/modifier-remap.ts
+++ b/src/shared/modifier-remap.ts
@@ -1,0 +1,42 @@
+/**
+ * iTerm-style global Ctrl/Cmd remap.
+ *
+ * The swap is applied once, to the key event itself, at each boundary where input
+ * enters Orca (main's before-input-event, and each renderer's window capture phase).
+ * Everything downstream — the keybinding matcher, xterm's encoder, Monaco — reads the
+ * already-swapped flags and needs no knowledge of this setting.
+ */
+
+export type ModifierRemap = 'none' | 'swap-ctrl-cmd'
+
+/** Modifier pair shared by Electron's `before-input-event` input and our DOM adapter. */
+export type SwappableModifiers = {
+  control: boolean
+  meta: boolean
+}
+
+export function normalizeModifierRemap(value: unknown): ModifierRemap {
+  return value === 'swap-ctrl-cmd' ? 'swap-ctrl-cmd' : 'none'
+}
+
+// Why: Linux/Windows already put app chords on Ctrl; swapping there inverts a working layout.
+export function isCtrlCmdSwapActive(value: unknown, platform: NodeJS.Platform): boolean {
+  return normalizeModifierRemap(value) === 'swap-ctrl-cmd' && platform === 'darwin'
+}
+
+export function swapCtrlCmd(modifiers: SwappableModifiers): SwappableModifiers {
+  return { control: modifiers.meta, meta: modifiers.control }
+}
+
+/** True when the swap would change this event; lets callers skip untouched events. */
+export function modifiersNeedSwap(modifiers: SwappableModifiers): boolean {
+  return modifiers.control !== modifiers.meta
+}
+
+/** Swapped copy of an Electron `before-input-event` input; returns the original when inactive. */
+export function applyCtrlCmdSwapToInput<T extends SwappableModifiers>(
+  input: T,
+  active: boolean
+): T {
+  return active && modifiersNeedSwap(input) ? { ...input, ...swapCtrlCmd(input) } : input
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { Automation, AutomationExecutionTargetType, AutomationRun } from './automations-types'
 import type { WorkspaceSource } from './workspace-source'
 import type { ReleaseBuild, ReleaseChannel } from './release-channel'
+import type { ModifierRemap } from './modifier-remap'
 import type { GitHubProjectSettings } from './github-project-types'
 import type {
   AgentStatusState,
@@ -2995,6 +2996,10 @@ export type GlobalSettings = {
   terminalMacOptionAsAltMigrated: boolean
   /** Whether macOS terminal input maps the physical JIS Yen (¥) key to backslash, per common terminal expectation. */
   terminalJISYenToBackslash: boolean
+  /** macOS-only iTerm-style modifier remap. 'swap-ctrl-cmd' exchanges Ctrl and Cmd on every key
+   *  event as it enters Orca, so app chords fire from Ctrl and Cmd reaches the PTY as a control
+   *  character. Native menu-role accelerators (Cmd+Q/C/V/X/Z/A) are OS-owned and stay on Cmd. */
+  modifierRemap: ModifierRemap
   experimentalMobile: boolean
   /** Why: iOS Simulator is default-on for capable macOS hosts; this is the durable off switch (hides UI, blocks CLI attach). */
   mobileEmulatorEnabled?: boolean


### PR DESCRIPTION
Closes #12009.

Adds a macOS-only `modifierRemap` setting (`'none' | 'swap-ctrl-cmd'`, default `'none'`) that exchanges Ctrl and Cmd, the way iTerm2's **Preferences → Keys → Remap Modifiers** does. Deliberately not the full per-modifier matrix — just the swap the issue asks for.

## Approach

The swap happens **once, on the key event, at each boundary where input enters Orca**. Nothing changes in the keybinding registry, the matcher, or the 79 `Mod+` defaults.

Rewriting `hasModifier` would have fixed app shortcuts and nothing else, since xterm reads the DOM event directly — Cmd+C still wouldn't send SIGINT. Mutating the event covers both and inherits xterm's encoder (kitty, win32, modifyOtherKeys) rather than re-deriving control bytes. This works because `_keyDown` calls `_customKeyEventHandler(event)` first and then passes the *same live event* to `evaluateKeyDown`, and because xterm binds its listeners on the terminal textarea — so a window capture listener runs first and covers app shortcuts and terminal encoding together.

Four boundaries:

1. `before-input-event` in `createMainWindow.ts` — authoritative, resolves ahead of the renderer.
2. Renderer window capture, installed in `main.tsx` before App's own listener.
3. `popout.tsx` and `dashboard-popout-window.ts` — the pop-out has its own React root and resolves zoom in main only.
4. `web/main.tsx` — renders the same `App`, which already syncs the setting.

## Display layer

Bindings stay stored in post-swap coordinates, so `formatKeybinding` inverts its glyph branches when the remap is on. Without that, Settings would list ⌘P for a chord you press with Ctrl.

This also settles the shortcut recorder: it records the **post-swap** chord. Suspending the remap while recording feels right and is wrong — it would store `Ctrl+P`, which the matcher, seeing `Cmd+P`, would never match again.

## Limits

Native menu-role accelerators (Cmd+Q/C/V/X/Z/A) intercept in the main process and stay on Cmd. iTerm has the same limitation, so the setting's description says so rather than leaving it to be discovered. Pairs best with `terminalShortcutPolicy: terminal-first`, since Ctrl+W would otherwise close a tab instead of deleting a word.

## Testing

Unit tests cover the swap logic, the capture listener (including the double-install case, where two listeners would cancel each other out), and the inverted glyph output. Verified manually on macOS: Ctrl+P opens the palette, Cmd+C sends SIGINT in a terminal pane, and Settings renders ⌃ instead of ⌘.

Non-English catalogs carry the English strings for the new keys, matching what `sync:localization-catalog` produces for a newly introduced key — happy to swap in real translations if you'd prefer them in this PR.
