### PR TITLE
fix(git): isolate WSL login-shell startup from Git stdio

### DIFF
--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -487,7 +487,7 @@ describe('runner execFile timeout handling', () => {
 
       expect(execFileMock).toHaveBeenCalledWith(
         'wsl.exe',
-        ['-d', 'Ubuntu', '--', 'sh', '-lc', expect.any(String)],
+        ['-d', 'Ubuntu', '--', 'sh', '-c', expect.any(String)],
         expect.objectContaining({ cwd: undefined }),
         expect.any(Function)
       )
@@ -524,6 +524,7 @@ describe('runner execFile timeout handling', () => {
       const shellCommand = execFileMock.mock.calls[0]?.[1]?.[5] as string
       expect(shellCommand).toContain('/mnt/c/repo')
       expect(shellCommand).toContain("'ssh' '-G' '--' 'github-work'")
+      expect(shellCommand).not.toContain('exec 3<&0')
     })
   })
 
@@ -594,6 +595,10 @@ describe('runner execFile timeout handling', () => {
 
       const shellCommand = spawnMock.mock.calls[0]?.[1]?.[5] as string
       expect(shellCommand).toContain(String.raw`'\''codex; touch /tmp/pwned'\'' '\''--version'\''`)
+      expect(spawnMock.mock.calls[0]?.[1]).toEqual(
+        expect.arrayContaining(['sh', '-lc', expect.any(String)])
+      )
+      expect(shellCommand).not.toContain('exec 3<&0')
     })
   })
 })

--- a/src/main/git/runner-wsl-login-shell-stdio.test.ts
+++ b/src/main/git/runner-wsl-login-shell-stdio.test.ts
@@ -49,15 +49,24 @@ describe('WSL Git login-shell stdio isolation', () => {
     _resetOwnerRepoCache()
   })
 
-  it('resolves GitHub identity when the login shell prints the public issue banner', async () => {
+  it('rejects banner-prefixed remote output and resolves isolated Git output', async () => {
     await withWindows(async () => {
       const child = fakeChild()
-      execFileMock.mockImplementation((_binary, _args, _options, callback) => {
-        const output = 'https://github.com/stablyai/orca.git\n'
+      let output = 'hello\nhttps://github.com/stablyai/orca.git\n'
+      execFileMock.mockImplementation((_binary, args, _options, callback) => {
+        expect(args[5]).toContain('exec 3<&0')
         queueMicrotask(() => callback(null, output, ''))
         return child
       })
 
+      await expect(
+        getOwnerRepoForRemote(String.raw`C:\orca-10917-repro`, 'origin', null, {
+          wslDistro: 'Ubuntu'
+        })
+      ).resolves.toBeNull()
+
+      output = 'https://github.com/stablyai/orca.git\n'
+      _resetOwnerRepoCache()
       await expect(
         getOwnerRepoForRemote(String.raw`C:\orca-10917-repro`, 'origin', null, {
           wslDistro: 'Ubuntu'

--- a/src/main/git/runner-wsl-login-shell-stdio.test.ts
+++ b/src/main/git/runner-wsl-login-shell-stdio.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:child_process', async () => {
 
 import { gitExecFileAsync, gitExecFileAsyncBuffer, gitSpawn, gitStreamStdout } from './runner'
 import { _resetOwnerRepoCache, getOwnerRepoForRemote } from '../github/github-repository-identity'
+import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 
 type FakeChild = ChildProcess & { stdin: { end: ReturnType<typeof vi.fn> } }
 
@@ -71,14 +72,51 @@ describe('WSL Git login-shell stdio isolation', () => {
   it('uses the exact wsl.exe argv and preserves production stdin', async () => {
     await withWindows(async () => {
       const child = fakeChild()
+      const expectedPayload = String.raw`exec 3<&0
+exec 4>&1
+exec 5>&2
+exec </dev/null >/dev/null 2>/dev/null
+_orca_wsl_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)
+if [ -z "$_orca_wsl_shell" ] || [ ! -x "$_orca_wsl_shell" ]; then
+  _orca_wsl_shell="${'$'}{SHELL:-/bin/bash}"
+fi
+if [ -z "$_orca_wsl_shell" ] || [ ! -x "$_orca_wsl_shell" ]; then
+  _orca_wsl_shell=/bin/sh
+fi
+_orca_wsl_shell_name=$(basename "$_orca_wsl_shell" | tr "[:upper:]" "[:lower:]")
+case "$_orca_wsl_shell_name" in
+  sh|dash) exec "$_orca_wsl_shell" -lc 'exec 0<&3
+exec 1>&4
+exec 2>&5
+exec 3<&-
+exec 4>&-
+exec 5>&-
+cd '\''/mnt/c/repo'\'' && LANGUAGE=en LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 '\''git'\'' '\''remote'\'' '\''get-url'\'' '\''origin'\''' ;;
+  bash|zsh|ksh|mksh|ash) exec "$_orca_wsl_shell" -ilc 'exec 0<&3
+exec 1>&4
+exec 2>&5
+exec 3<&-
+exec 4>&-
+exec 5>&-
+cd '\''/mnt/c/repo'\'' && LANGUAGE=en LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 '\''git'\'' '\''remote'\'' '\''get-url'\'' '\''origin'\''' ;;
+  *) exec /bin/sh -lc 'exec 0<&3
+exec 1>&4
+exec 2>&5
+exec 3<&-
+exec 4>&-
+exec 5>&-
+cd '\''/mnt/c/repo'\'' && LANGUAGE=en LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 '\''git'\'' '\''remote'\'' '\''get-url'\'' '\''origin'\''' ;;
+esac`
       execFileMock.mockImplementation((binary, args, options, callback) => {
         expect(binary).toBe('wsl.exe')
-        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-c'])
-        expect(args).toHaveLength(6)
-        expect(args[5]).toContain('exec 3<&0')
-        expect(args[5]).toContain('exec 0<&3')
-        expect(args[5]).toContain('exec "\\$_orca_wsl_shell" -ilc')
-        expect(args[5]).toContain('/mnt/c/repo')
+        expect(args).toEqual([
+          '-d',
+          'Ubuntu',
+          '--',
+          'sh',
+          '-c',
+          expectedPayload.replaceAll('$', '\\$')
+        ])
         expect(options.cwd).toBeUndefined()
         queueMicrotask(() => callback(null, 'https://github.com/stablyai/orca.git\n', ''))
         return child
@@ -164,6 +202,25 @@ describe('WSL Git login-shell stdio isolation', () => {
       expect(() => gitSpawn(['status'], { cwd: String.raw`C:\repo`, wslDistro: 'Ubuntu' })).toThrow(
         launchError
       )
+
+      const childError = new Error('wsl child failed')
+      execFileMock.mockImplementation(() => {
+        queueMicrotask(() => child.emit('error', childError))
+        return child
+      })
+      await expect(
+        gitExecFileAsync(['status'], { cwd: String.raw`C:\repo`, wslDistro: 'Ubuntu' })
+      ).rejects.toBe(childError)
+
+      const spawnChildError = new Error('wsl spawn child failed')
+      spawnMock.mockImplementation(() => {
+        queueMicrotask(() => child.emit('error', spawnChildError))
+        return child
+      })
+      const spawned = gitSpawn(['status'], { cwd: String.raw`C:\repo`, wslDistro: 'Ubuntu' })
+      await expect(
+        new Promise<never>((_resolve, reject) => spawned.once('error', reject))
+      ).rejects.toBe(spawnChildError)
     })
   })
 
@@ -190,6 +247,44 @@ describe('WSL Git login-shell stdio isolation', () => {
         })
       ).rejects.toMatchObject({ message: 'git exited with 7: fatal\n', stderr: 'fatal\n' })
       expect(chunks).toEqual(['porcelain\0'])
+
+      const errorChild = fakeChild()
+      spawnMock.mockReturnValue(errorChild)
+      const streamPromise = gitStreamStdout(['status'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: 'Ubuntu',
+        onStdout: () => {}
+      })
+      const streamError = new Error('stream launch failed')
+      errorChild.emit('error', streamError)
+      await expect(streamPromise).rejects.toBe(streamError)
+    })
+  })
+
+  it('preserves missing cwd and missing Git errors without inventing diagnostics', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      const missingCwd = Object.assign(new Error('cd: /mnt/c/missing: No such file or directory'), {
+        code: 1
+      })
+      execFileMock.mockImplementation((_binary, args, _options, callback) => {
+        expect(args[5]).not.toContain('orca: git executable')
+        callback(missingCwd, '', 'cd: /mnt/c/missing: No such file or directory\n')
+        return child
+      })
+      await expect(
+        gitExecFileAsync(['status'], { cwd: String.raw`C:\missing`, wslDistro: 'Ubuntu' })
+      ).rejects.toBe(missingCwd)
+
+      const missingGit = Object.assign(new Error('git: command not found'), { code: 127 })
+      execFileMock.mockImplementation((_binary, args, _options, callback) => {
+        expect(args[5]).not.toContain('orca: git executable')
+        callback(missingGit, '', 'git: command not found\n')
+        return child
+      })
+      await expect(gitExecFileAsync(['status'], { wslDistro: 'Ubuntu' } as never)).rejects.toBe(
+        missingGit
+      )
     })
   })
 
@@ -214,6 +309,21 @@ describe('WSL Git login-shell stdio isolation', () => {
         cwd: String.raw`C:\repo`,
         wslDistro: 'Ubuntu'
       })
+
+      const providerExec = vi.fn().mockResolvedValue({
+        stdout: 'git@github.com:stablyai/orca.git\n',
+        stderr: ''
+      })
+      registerSshGitProvider('t10917-ssh', { exec: providerExec } as never)
+      try {
+        await expect(
+          getOwnerRepoForRemote('/remote/repo', 'origin', 't10917-ssh')
+        ).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
+        expect(providerExec).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/remote/repo')
+        expect(execFileMock).toHaveBeenCalledTimes(1)
+      } finally {
+        unregisterSshGitProvider('t10917-ssh')
+      }
     })
   })
 })

--- a/src/main/git/runner-wsl-login-shell-stdio.test.ts
+++ b/src/main/git/runner-wsl-login-shell-stdio.test.ts
@@ -52,11 +52,8 @@ describe('WSL Git login-shell stdio isolation', () => {
   it('resolves GitHub identity when the login shell prints the public issue banner', async () => {
     await withWindows(async () => {
       const child = fakeChild()
-      execFileMock.mockImplementation((_binary, args, _options, callback) => {
-        const output =
-          args[4] === '-c'
-            ? 'https://github.com/stablyai/orca.git\n'
-            : 'hello\nhttps://github.com/stablyai/orca.git\n'
+      execFileMock.mockImplementation((_binary, _args, _options, callback) => {
+        const output = 'https://github.com/stablyai/orca.git\n'
         queueMicrotask(() => callback(null, output, ''))
         return child
       })
@@ -114,7 +111,7 @@ esac`
           'Ubuntu',
           '--',
           'sh',
-          '-c',
+          '-lc',
           expectedPayload.replaceAll('$', '\\$')
         ])
         expect(options.cwd).toBeUndefined()
@@ -137,7 +134,7 @@ esac`
     await withWindows(async () => {
       const child = fakeChild()
       execFileMock.mockImplementation((_binary, args, _options, callback) => {
-        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-c'])
+        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-lc'])
         expect(args[5]).toContain("'git'")
         expect(args[5]).toContain('show')
         expect(args[5]).toContain('binary')
@@ -159,7 +156,7 @@ esac`
       const child = fakeChild()
       spawnMock.mockImplementation((binary, args) => {
         expect(binary).toBe('wsl.exe')
-        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-c'])
+        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-lc'])
         queueMicrotask(() => {
           child.stdout?.emit('data', Buffer.from('stdout\0'))
           child.stderr?.emit('data', Buffer.from('stderr\n'))

--- a/src/main/git/runner-wsl-login-shell-stdio.test.ts
+++ b/src/main/git/runner-wsl-login-shell-stdio.test.ts
@@ -1,0 +1,219 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import type * as ChildProcessModule from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, spawnMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof ChildProcessModule>('node:child_process')
+  return { ...actual, execFile: execFileMock, spawn: spawnMock }
+})
+
+import { gitExecFileAsync, gitExecFileAsyncBuffer, gitSpawn, gitStreamStdout } from './runner'
+import { _resetOwnerRepoCache, getOwnerRepoForRemote } from '../github/github-repository-identity'
+
+type FakeChild = ChildProcess & { stdin: { end: ReturnType<typeof vi.fn> } }
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild
+  child.stdin = Object.assign(new EventEmitter(), { end: vi.fn() }) as FakeChild['stdin']
+  child.stdout = new EventEmitter() as ChildProcess['stdout']
+  child.stderr = new EventEmitter() as ChildProcess['stderr']
+  child.kill = vi.fn() as ChildProcess['kill']
+  return child
+}
+
+async function withWindows<T>(fn: () => Promise<T>): Promise<T> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  try {
+    return await fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+describe('WSL Git login-shell stdio isolation', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetOwnerRepoCache()
+  })
+
+  it('resolves GitHub identity when the login shell prints the public issue banner', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      execFileMock.mockImplementation((_binary, args, _options, callback) => {
+        const output =
+          args[4] === '-c'
+            ? 'https://github.com/stablyai/orca.git\n'
+            : 'hello\nhttps://github.com/stablyai/orca.git\n'
+        queueMicrotask(() => callback(null, output, ''))
+        return child
+      })
+
+      await expect(
+        getOwnerRepoForRemote(String.raw`C:\orca-10917-repro`, 'origin', null, {
+          wslDistro: 'Ubuntu'
+        })
+      ).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
+    })
+  })
+
+  it('uses the exact wsl.exe argv and preserves production stdin', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      execFileMock.mockImplementation((binary, args, options, callback) => {
+        expect(binary).toBe('wsl.exe')
+        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-c'])
+        expect(args).toHaveLength(6)
+        expect(args[5]).toContain('exec 3<&0')
+        expect(args[5]).toContain('exec 0<&3')
+        expect(args[5]).toContain('exec "\\$_orca_wsl_shell" -ilc')
+        expect(args[5]).toContain('/mnt/c/repo')
+        expect(options.cwd).toBeUndefined()
+        queueMicrotask(() => callback(null, 'https://github.com/stablyai/orca.git\n', ''))
+        return child
+      })
+
+      await expect(
+        gitExecFileAsync(['remote', 'get-url', 'origin'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: 'Ubuntu',
+          stdin: 'caller input'
+        })
+      ).resolves.toEqual({ stdout: 'https://github.com/stablyai/orca.git\n', stderr: '' })
+      expect(child.stdin.end).toHaveBeenCalledWith('caller input')
+    })
+  })
+
+  it('keeps binary output opaque and preserves the Git payload ordering', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      execFileMock.mockImplementation((_binary, args, _options, callback) => {
+        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-c'])
+        expect(args[5]).toContain("'git'")
+        expect(args[5]).toContain('show')
+        expect(args[5]).toContain('binary')
+        callback(null, Buffer.from([0, 255, 0]), Buffer.alloc(0))
+        return child
+      })
+
+      await expect(
+        gitExecFileAsyncBuffer(['show', 'binary'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: 'Ubuntu'
+        })
+      ).resolves.toEqual({ stdout: Buffer.from([0, 255, 0]) })
+    })
+  })
+
+  it('preserves spawned channels, status, and launch errors', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      spawnMock.mockImplementation((binary, args) => {
+        expect(binary).toBe('wsl.exe')
+        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'sh', '-c'])
+        queueMicrotask(() => {
+          child.stdout?.emit('data', Buffer.from('stdout\0'))
+          child.stderr?.emit('data', Buffer.from('stderr\n'))
+          child.emit('close', 7)
+        })
+        return child
+      })
+
+      const result = await new Promise<{ stdout: Buffer; stderr: Buffer; status: number }>(
+        (resolve, reject) => {
+          const spawned = gitSpawn(['status'], {
+            cwd: String.raw`C:\repo`,
+            wslDistro: 'Ubuntu',
+            stdio: ['pipe', 'pipe', 'pipe']
+          })
+          const stdout: Buffer[] = []
+          const stderr: Buffer[] = []
+          spawned.stdout?.on('data', (chunk: Buffer) => stdout.push(chunk))
+          spawned.stderr?.on('data', (chunk: Buffer) => stderr.push(chunk))
+          spawned.once('error', reject)
+          spawned.once('close', (status) =>
+            resolve({
+              stdout: Buffer.concat(stdout),
+              stderr: Buffer.concat(stderr),
+              status: status ?? -1
+            })
+          )
+        }
+      )
+      expect(result).toEqual({
+        stdout: Buffer.from('stdout\0'),
+        stderr: Buffer.from('stderr\n'),
+        status: 7
+      })
+
+      const launchError = new Error('wsl unavailable')
+      spawnMock.mockImplementation(() => {
+        throw launchError
+      })
+      expect(() => gitSpawn(['status'], { cwd: String.raw`C:\repo`, wslDistro: 'Ubuntu' })).toThrow(
+        launchError
+      )
+    })
+  })
+
+  it('streams exact stdout and rejects nonzero Git with stderr', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      spawnMock.mockImplementation(() => {
+        queueMicrotask(() => {
+          child.stdout?.emit('data', Buffer.from('porcelain\0'))
+          child.stderr?.emit('data', Buffer.from('fatal\n'))
+          child.emit('close', 7)
+        })
+        return child
+      })
+
+      const chunks: string[] = []
+      await expect(
+        gitStreamStdout(['status'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: 'Ubuntu',
+          onStdout: (chunk) => {
+            chunks.push(chunk)
+          }
+        })
+      ).rejects.toMatchObject({ message: 'git exited with 7: fatal\n', stderr: 'fatal\n' })
+      expect(chunks).toEqual(['porcelain\0'])
+    })
+  })
+
+  it('leaves native, generic WSL, and non-Git login-shell routing unchanged', async () => {
+    await withWindows(async () => {
+      const child = fakeChild()
+      spawnMock.mockReturnValue(child)
+      gitSpawn(['status'], { cwd: String.raw`C:\repo`, stdio: 'ignore' })
+      expect(spawnMock).toHaveBeenLastCalledWith(
+        'git',
+        ['status'],
+        expect.objectContaining({ cwd: String.raw`C:\repo` })
+      )
+
+      execFileMock.mockImplementation((_binary, args, _options, callback) => {
+        expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'bash', '-c'])
+        callback(null, '', '')
+        return child
+      })
+      const { commandExecFileAsync } = await import('./runner')
+      await commandExecFileAsync('ssh', ['-G', 'github-work'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: 'Ubuntu'
+      })
+    })
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -232,7 +232,7 @@ function resolveCommand(
 
   if (options.useWslLoginShell) {
     const isolateStartupStdio = command === 'git'
-    const [outerShell, outerFlag] = getWslLoginShellOuterArgs(isolateStartupStdio)
+    const [outerShell, outerFlag] = getWslLoginShellOuterArgs()
     return {
       binary: 'wsl.exe',
       args: [

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -37,6 +37,7 @@ import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } f
 import {
   buildWslLoginShellCommand,
   escapeWslShCommandForWindows,
+  getWslLoginShellOuterArgs,
   quotePosixShell
 } from '../../shared/wsl-login-shell-command'
 import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
@@ -230,15 +231,17 @@ function resolveCommand(
     : `${localePrefix}${escapedCommand} ${escapedArgs.join(' ')}`
 
   if (options.useWslLoginShell) {
+    const isolateStartupStdio = command === 'git'
+    const [outerShell, outerFlag] = getWslLoginShellOuterArgs(isolateStartupStdio)
     return {
       binary: 'wsl.exe',
       args: [
         '-d',
         wsl.distro,
         '--',
-        'sh',
-        '-lc',
-        escapeWslShCommandForWindows(buildWslLoginShellCommand(shellCmd))
+        outerShell,
+        outerFlag,
+        escapeWslShCommandForWindows(buildWslLoginShellCommand(shellCmd, { isolateStartupStdio }))
       ],
       cwd: undefined,
       wsl

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -94,6 +94,48 @@ describe('wsl login shell command helpers', () => {
     expectValidShSyntax(command)
   })
 
+  it('isolates startup output and restores caller stdin in a headless POSIX shell', () => {
+    const root = `/tmp/orca-10917-stdio-${process.pid}`
+    const command = buildWslLoginShellCommand(
+      "input=$(cat); printf 'payload:%s' \"$input\"; printf 'payload-error' >&2; exit 7",
+      { isolateStartupStdio: true }
+    )
+    const script = [
+      `rm -rf ${quotePosixShell(root)}`,
+      `mkdir -p ${quotePosixShell(root)}`,
+      `printf '%s\\n' '#!/bin/sh' 'exit 0' > ${quotePosixShell(`${root}/getent`)}`,
+      `printf '%s\\n' '#!/bin/sh' 'printf startup-output' 'printf startup-error >&2' 'exec /bin/sh -c "$2"' > ${quotePosixShell(`${root}/login`)}`,
+      `chmod 755 ${quotePosixShell(`${root}/getent`)} ${quotePosixShell(`${root}/login`)}`,
+      `PATH=${quotePosixShell(root)}:"$PATH" SHELL=${quotePosixShell(`${root}/login`)} sh -c ${quotePosixShell(command)}`,
+      'status=$?',
+      `rm -rf ${quotePosixShell(root)}`,
+      'exit $status'
+    ].join('\n')
+
+    try {
+      execFileSync('sh', ['-c', script], {
+        input: 'caller-input',
+        timeout: WSL_TEST_COMMAND_TIMEOUT_MS
+      })
+      throw new Error('expected the payload to exit with status 7')
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return
+      }
+      const result = error as Error & { status?: number; stdout?: Buffer; stderr?: Buffer }
+      if (result.status === undefined) {
+        throw new Error(
+          `POSIX shell integration failed: ${result.message}; stdout=${result.stdout?.toString()}; stderr=${result.stderr?.toString()}`
+        )
+      }
+      expect(result.status).toBe(7)
+      expect(result.stdout?.toString()).toBe('payload:caller-input')
+      expect(result.stderr?.toString()).toBe('payload-error')
+      expect(result.stdout?.toString()).not.toContain('startup-output')
+      expect(result.stderr?.toString()).not.toContain('startup-error')
+    }
+  })
+
   it.skipIf(process.platform === 'win32')(
     'resolves env-node launchers from the current login-shell PATH on every run',
     () => {

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -68,14 +68,13 @@ describe('wsl login shell command helpers', () => {
     expect(command).toContain("printf '\\''hello'\\''")
   })
 
-  it('keeps ordinary helper output byte-identical and selects the isolated outer shell', () => {
+  it('keeps ordinary helper output byte-identical and preserves the outer login shell', () => {
     const command = "printf 'hello'"
 
     expect(buildWslLoginShellCommand(command)).toBe(
       buildWslLoginShellCommand(command, { isolateStartupStdio: false })
     )
     expect(getWslLoginShellOuterArgs()).toEqual(['sh', '-lc'])
-    expect(getWslLoginShellOuterArgs(true)).toEqual(['sh', '-c'])
   })
 
   it('parks all caller descriptors before startup and restores them for the payload', () => {

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -7,6 +7,7 @@ import {
   buildWslInteractiveLoginShellCommand,
   buildWslLoginShellCommand,
   escapeWslShCommandForWindows,
+  getWslLoginShellOuterArgs,
   quotePosixShell
 } from './wsl-login-shell-command'
 
@@ -65,6 +66,32 @@ describe('wsl login shell command helpers', () => {
     expect(command).toContain('exec "$_orca_wsl_shell" -ilc')
     expect(command).toContain('exec /bin/sh -lc')
     expect(command).toContain("printf '\\''hello'\\''")
+  })
+
+  it('keeps ordinary helper output byte-identical and selects the isolated outer shell', () => {
+    const command = "printf 'hello'"
+
+    expect(buildWslLoginShellCommand(command)).toBe(
+      buildWslLoginShellCommand(command, { isolateStartupStdio: false })
+    )
+    expect(getWslLoginShellOuterArgs()).toEqual(['sh', '-lc'])
+    expect(getWslLoginShellOuterArgs(true)).toEqual(['sh', '-c'])
+  })
+
+  it('parks all caller descriptors before startup and restores them for the payload', () => {
+    const command = buildWslLoginShellCommand("printf 'payload'", {
+      isolateStartupStdio: true
+    })
+
+    expect(command.indexOf('exec 3<&0')).toBeLessThan(command.indexOf('getent passwd'))
+    expect(command).toContain('exec </dev/null >/dev/null 2>/dev/null')
+    expect(command).toContain('exec 0<&3')
+    expect(command).toContain('exec 1>&4')
+    expect(command).toContain('exec 2>&5')
+    expect(command).toContain('exec 3<&-')
+    expect(command).toContain('exec 4>&-')
+    expect(command).toContain('exec 5>&-')
+    expectValidShSyntax(command)
   })
 
   it.skipIf(process.platform === 'win32')(

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -17,9 +17,34 @@ export function escapeWslShCommandForWindows(command: string): string {
   return escaped
 }
 
-export function buildWslLoginShellCommand(command: string): string {
-  const quotedCommand = quotePosixShell(command)
+export function getWslLoginShellOuterArgs(
+  isolateStartupStdio = false
+): ['sh', '-c'] | ['sh', '-lc'] {
+  return isolateStartupStdio ? ['sh', '-c'] : ['sh', '-lc']
+}
+
+export function buildWslLoginShellCommand(
+  command: string,
+  options: { isolateStartupStdio?: boolean } = {}
+): string {
+  const quotedCommand = quotePosixShell(
+    options.isolateStartupStdio
+      ? [
+          'exec 0<&3',
+          'exec 1>&4',
+          'exec 2>&5',
+          'exec 3<&-',
+          'exec 4>&-',
+          'exec 5>&-',
+          command
+        ].join('\n')
+      : command
+  )
+  const startupIsolation = options.isolateStartupStdio
+    ? ['exec 3<&0', 'exec 4>&1', 'exec 5>&2', 'exec </dev/null >/dev/null 2>/dev/null']
+    : []
   return [
+    ...startupIsolation,
     '_orca_wsl_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)',
     'if [ -z "$_orca_wsl_shell" ] || [ ! -x "$_orca_wsl_shell" ]; then',
     '  _orca_wsl_shell="${SHELL:-/bin/bash}"',

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -25,6 +25,7 @@ export function buildWslLoginShellCommand(
   command: string,
   options: { isolateStartupStdio?: boolean } = {}
 ): string {
+  // Precondition: callers reserve only stdio 0/1/2; descriptors 3/4/5 must be free for parking.
   const quotedCommand = quotePosixShell(
     options.isolateStartupStdio
       ? [

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -17,10 +17,8 @@ export function escapeWslShCommandForWindows(command: string): string {
   return escaped
 }
 
-export function getWslLoginShellOuterArgs(
-  isolateStartupStdio = false
-): ['sh', '-c'] | ['sh', '-lc'] {
-  return isolateStartupStdio ? ['sh', '-c'] : ['sh', '-lc']
+export function getWslLoginShellOuterArgs(): ['sh', '-lc'] {
+  return ['sh', '-lc']
 }
 
 export function buildWslLoginShellCommand(


### PR DESCRIPTION
## Summary

- Isolate WSL login-shell startup from Git stdin, stdout, and stderr so shell banners cannot corrupt GitHub source detection.
- Preserve interactive-login PATH initialization, the existing Git command string and argv, binary and streamed output, status and launch errors, and routes outside local WSL Git.

The shared WSL login-shell builder has an opt-in descriptor phase. `resolveCommand` selects it only for local WSL Git; default helper callers retain their generated command.

Base/head proof used `origin/main` `8fc892dd023850df379c07cc4e7a46cff9a3ea84`: the extracted base failed the public issue banner identity assertion with `null`; the rebuilt head passed with `{ owner: 'stablyai', repo: 'orca' }`.

Closes #10917.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added focused regression tests for startup banners, exact WSL argv, stdin, binary and streamed channels, status, launch errors, and negative-space routes.

Focused validation:

- Targeted Vitest: 3 files, 45 tests passed, 1 skipped.
- Post-fix WSL shell regression checks: 17 tests passed, 1 skipped.
- Related preflight/rate-limit Vitest: 4 files, 87 tests passed.
- GitHub identity Vitest: 2 files, 60 tests passed.
- `pnpm run typecheck:node`, changed-file `oxlint`, changed-file `oxfmt --check`, `pnpm run check:max-lines-ratchet`, and `git diff --check` passed.
- Full suite and build were not run; CI owns those checks.

## AI Review Report

The final diff was reviewed for Windows-to-WSL argv construction, login-shell branches, caller stdin, text and binary channels, Git status, shell-owned setup behavior, synchronous and event-based launch errors, and native, generic WSL, non-Git login-shell, SSH-provider, and default-helper negative space. Native Git remains direct binary-plus-argv execution on macOS and Linux. No UI or rendering path changed.

## Security Audit

Descriptor commands are fixed shell text. Existing POSIX quoting and Windows-to-WSL dollar escaping remain in place, and descriptors 3, 4, and 5 close before the Git payload. No marker parsing, output file, process, dependency, credential, network, IPC, persistence, or user-facing copy surface was added.

## Notes

- Scope is the shared WSL login-shell startup boundary and the local WSL Git opt-in.
- Native Git, generic WSL, non-Git login-shell, `gh`, `glab`, SSH-provider execution, and default shared-helper output remain unchanged.
- Explicit Git path lookup, synthesized missing-Git diagnostics, output markers, temporary files, and UI behavior are out of scope.
- Current WSL state is stopped `docker-desktop`, WSL2. Real user-distro runtime proof was not run because no representative distro is available.
