### PR TITLE
fix(accounts): open WSL Claude sign-in in Windows browser

### DIFF
--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -21,7 +21,8 @@ const CLAUDE_SERVICE_TEST_ROOT = join(tmpdir(), 'orca-claude-service-test')
 vi.mock('electron', () => ({
   app: {
     getPath: () => CLAUDE_SERVICE_TEST_ROOT
-  }
+  },
+  shell: { openExternal: vi.fn() }
 }))
 
 const commandMocks = vi.hoisted(() => ({
@@ -1462,7 +1463,7 @@ describe('ClaudeAccountService credential capture', () => {
           '--',
           'bash',
           '-lc',
-          "export CLAUDE_CONFIG_DIR='/home/user/.config/orca auth'; exec claude 'auth' 'status' '--json'"
+          "export PATH=\"$PATH:'/home/user/.config/orca auth/orca-opener'\"; export CLAUDE_CONFIG_DIR='/home/user/.config/orca auth'; exec claude 'auth' 'status' '--json'"
         ],
         expect.objectContaining({ shell: false, windowsVerbatimArguments: false })
       )

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -17,12 +17,13 @@ import {
 } from './keychain'
 
 const CLAUDE_SERVICE_TEST_ROOT = join(tmpdir(), 'orca-claude-service-test')
+const openExternal = vi.hoisted(() => vi.fn(async (_url: string) => undefined))
 
 vi.mock('electron', () => ({
   app: {
     getPath: () => CLAUDE_SERVICE_TEST_ROOT
   },
-  shell: { openExternal: vi.fn() }
+  shell: { openExternal }
 }))
 
 const commandMocks = vi.hoisted(() => ({
@@ -1463,12 +1464,188 @@ describe('ClaudeAccountService credential capture', () => {
           '--',
           'bash',
           '-lc',
-          "export PATH=\"$PATH:'/home/user/.config/orca auth/orca-opener'\"; export CLAUDE_CONFIG_DIR='/home/user/.config/orca auth'; exec claude 'auth' 'status' '--json'"
+          "export CLAUDE_CONFIG_DIR='/home/user/.config/orca auth'; exec claude 'auth' 'status' '--json'"
         ],
         expect.objectContaining({ shell: false, windowsVerbatimArguments: false })
       )
     } finally {
       vi.doUnmock('node:child_process')
+    }
+  })
+
+  it('composes the WSL bridge through public add and reauthenticate flows', async () => {
+    setPlatform('win32')
+    vi.resetModules()
+    openExternal.mockClear()
+    vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(null)
+    const linuxRoot = '/mnt/c/Users/Rod/AppData/Local/Temp/orca-t11823'
+    const windowsRoot = 'C:\\Users\\Rod\\AppData\\Local\\Temp\\orca-t11823'
+    const authRoot = `${linuxRoot}/.local/share/orca/claude-accounts`
+    let tempNumber = 0
+    let loginNumber = 0
+    const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
+      const rawCommand = args.at(-1) ?? ''
+      const encoded = rawCommand.match(/printf %s '([^']+)' \| base64 -d/)
+      const command = encoded ? Buffer.from(encoded[1], 'base64').toString('utf8') : rawCommand
+      if (command.includes('printf "%s\\n%s')) {
+        return 'Ubuntu\n/mnt/c/Users/Rod\n'
+      }
+      if (command.includes('mktemp -d')) {
+        tempNumber += 1
+        const tempLinuxPath = `${linuxRoot}/login-${tempNumber}`
+        mkdirSync(`${windowsRoot}\\login-${tempNumber}`, { recursive: true })
+        return `ORCA_CLAUDE_LOGIN_DIR=${tempLinuxPath}\n`
+      }
+      if (command.includes('candidate=')) {
+        const match = command.match(/candidate='([^']+)'/)
+        return `${match?.[1] ?? `${authRoot}/unknown/auth`}\n`
+      }
+      if (command.includes('mkdir -p')) {
+        const match = command.match(/mkdir -p '([^']+)'/)
+        if (match) {
+          const authPath = match[1].replace(/^\/mnt\/c\//, 'C:\\')
+          mkdirSync(authPath, { recursive: true })
+          const marker = command.match(/printf '%s\\n' '([^']+)' > '([^']+)'/)
+          if (marker) {
+            const markerPath = marker[2].replace(/^\/mnt\/c\//, 'C:\\')
+            const accountMatch = marker[2].match(/claude-accounts\/([^/]+)\/auth\//)
+            const localMarkerPath = accountMatch
+              ? join(
+                  CLAUDE_SERVICE_TEST_ROOT,
+                  'claude-accounts',
+                  accountMatch[1],
+                  'auth',
+                  '.orca-managed-claude-auth'
+                )
+              : markerPath
+            mkdirSync(join(localMarkerPath, '..'), { recursive: true })
+            writeFileSync(localMarkerPath, `${marker[1]}\n`, 'utf-8')
+          }
+        }
+      }
+      return ''
+    })
+    const makeChild = () => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdin: PassThrough
+        stdout: PassThrough
+        stderr: PassThrough
+        kill: ReturnType<typeof vi.fn>
+      }
+      child.stdin = new PassThrough()
+      child.stdout = new PassThrough()
+      child.stderr = new PassThrough()
+      child.kill = vi.fn()
+      return child
+    }
+    const spawnMock = vi.fn((_command: string, args: string[]) => {
+      const child = makeChild()
+      const shellCommand = args.at(-1) ?? ''
+      if (shellCommand.includes("'auth' 'login'")) {
+        loginNumber += 1
+        const configMatch = shellCommand.match(/CLAUDE_CONFIG_DIR='([^']+)'/)
+        const configDir = configMatch?.[1].replace(/^\/mnt\/c\//, 'C:\\')
+        if (!configDir) {
+          throw new Error('missing WSL config directory')
+        }
+        mkdirSync(configDir, { recursive: true })
+        writeFileSync(
+          join(configDir, '.credentials.json'),
+          `{"claudeAiOauth":{"accessToken":"token-${loginNumber}"}}\n`,
+          'utf-8'
+        )
+        writeFileSync(
+          join(configDir, '.claude.json'),
+          JSON.stringify({ oauthAccount: { emailAddress: `user-${loginNumber}@example.com` } }),
+          'utf-8'
+        )
+        writeFileSync(
+          join(configDir, 'open-url.request'),
+          'https://platform.claude.com/oauth/code/callback?code=redacted',
+          'utf-8'
+        )
+        setTimeout(() => child.emit('close', 0), 250)
+        return child
+      }
+      child.stdout.write('{"email":"user@example.com"}\n')
+      queueMicrotask(() => child.emit('close', 0))
+      return child
+    })
+    vi.doMock('node:child_process', () => ({
+      spawn: spawnMock,
+      execFileSync: execFileSyncMock
+    }))
+    vi.doMock('../wsl', () => ({
+      toWindowsWslPath: (linuxPath: string) => {
+        const accountMatch = linuxPath.match(/claude-accounts\/([^/]+)\/auth$/)
+        return accountMatch
+          ? join(CLAUDE_SERVICE_TEST_ROOT, 'claude-accounts', accountMatch[1], 'auth')
+          : `${windowsRoot}\\${linuxPath.split('/').at(-1)}`
+      }
+    }))
+
+    try {
+      const { ClaudeAccountService } = await import('./service')
+      let settings = {
+        claudeManagedAccounts: [] as ClaudeManagedAccount[],
+        activeClaudeManagedAccountId: null,
+        activeClaudeManagedAccountIdsByRuntime: { host: null, wsl: {} }
+      }
+      const store = {
+        getSettings: vi.fn(() => settings),
+        updateSettings: vi.fn((updates: Partial<typeof settings>) => {
+          settings = { ...settings, ...updates }
+          return settings
+        })
+      }
+      const runtimeAuth = {
+        clearLastWrittenCredentialsJson: vi.fn(),
+        forceMaterializeCurrentSelectionForRollback: vi.fn(async () => {}),
+        syncForCurrentSelection: vi.fn(async () => {})
+      }
+      const rateLimits = {
+        evictInactiveClaudeCache: vi.fn(),
+        refreshForClaudeAccountChange: vi.fn()
+      }
+      const service = new ClaudeAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeAuth as never
+      )
+
+      await service.addAccount({ runtime: 'wsl' })
+      await service.addAccount({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+      await service.reauthenticateAccount(settings.claudeManagedAccounts[0]!.id)
+
+      expect(settings.claudeManagedAccounts).toHaveLength(2)
+      expect(openExternal).toHaveBeenCalledTimes(3)
+      expect(
+        openExternal.mock.calls.every(([url]) => url.startsWith('https://platform.claude.com/'))
+      ).toBe(true)
+      expect(
+        spawnMock.mock.calls.some(([, args]) =>
+          args
+            .at(-1)
+            ?.includes(
+              `export PATH="$PATH":'/mnt/c/Users/Rod/AppData/Local/Temp/orca-t11823/login-1/orca-opener'`
+            )
+        )
+      ).toBe(true)
+      expect(
+        spawnMock.mock.calls.some(
+          ([, args]) =>
+            args.at(-1)?.includes("exec claude 'auth' 'status' '--json'") &&
+            !args.at(-1)?.includes('orca-opener')
+        )
+      ).toBe(true)
+      expect(
+        execFileSyncMock.mock.calls.some(
+          ([, args]) => args.includes('-d') && args.includes('Ubuntu')
+        )
+      ).toBe(true)
+    } finally {
+      vi.doUnmock('node:child_process')
+      rmSync(windowsRoot, { recursive: true, force: true })
     }
   })
 

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -1612,6 +1612,24 @@ describe('ClaudeAccountService credential capture', () => {
         rateLimits as never,
         runtimeAuth as never
       )
+      execFileSyncMock.mockImplementationOnce(() => {
+        throw new Error('mktemp failed')
+      })
+      expect(() =>
+        (
+          service as unknown as {
+            createTemporaryClaudeConfigDir(location: {
+              managedAuthRuntime: 'wsl'
+              wslDistro: string
+            }): unknown
+          }
+        ).createTemporaryClaudeConfigDir({
+          managedAuthRuntime: 'wsl',
+          wslDistro: 'Ubuntu'
+        })
+      ).toThrow(
+        'Orca could not prepare a temporary Claude sign-in folder with a browser opener in Ubuntu. Sign-in cannot open a browser from that distribution.'
+      )
 
       await service.addAccount({ runtime: 'wsl' })
       await service.addAccount({ runtime: 'wsl', wslDistro: 'Ubuntu' })

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -593,8 +593,10 @@ export class ClaudeAccountService {
           onUrl: async (url) => {
             try {
               await openWslLoginAuthorizationUrl(url)
-            } catch (error) {
-              openerError = error instanceof Error ? error : new Error(String(error))
+            } catch {
+              openerError = new Error(
+                'Claude sign-in could not open the authorization page. Sign-in was stopped.'
+              )
               loginAbortController.abort()
             }
           },
@@ -1087,7 +1089,7 @@ export class ClaudeAccountService {
                 '--',
                 'bash',
                 '-lc',
-                `${buildWslLoginPathExport(configDir.linuxPath)}export CLAUDE_CONFIG_DIR=${shellQuote(configDir.linuxPath)}; exec claude ${args.map(shellQuote).join(' ')}`
+                `${options?.keepStdinOpen ? buildWslLoginPathExport(configDir.linuxPath) : ''}export CLAUDE_CONFIG_DIR=${shellQuote(configDir.linuxPath)}; exec claude ${args.map(shellQuote).join(' ')}`
               ],
               env: process.env,
               shell: false,

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -590,6 +590,7 @@ export class ClaudeAccountService {
     const handoff = tempConfig.linuxPath
       ? createWslLoginOpenerHandoff({
           windowsConfigDir: tempConfig.windowsPath,
+          pollMs: 25,
           onUrl: async (url) => {
             try {
               await openWslLoginAuthorizationUrl(url)
@@ -603,6 +604,12 @@ export class ClaudeAccountService {
           onInvalid: () => {
             openerError = new Error(
               'Claude sign-in requested an unsupported browser address. Sign-in was stopped.'
+            )
+            loginAbortController.abort()
+          },
+          onReadError: () => {
+            openerError = new Error(
+              'Claude sign-in could not read the browser handoff. Sign-in was stopped.'
             )
             loginAbortController.abort()
           }
@@ -688,20 +695,25 @@ export class ClaudeAccountService {
     if (!location.wslDistro) {
       throw new Error('Could not resolve the active WSL distribution for Claude login.')
     }
-    const linuxPath = parseWslLoginConfigDirOutput(
-      execFileSync(
-        'wsl.exe',
-        [
-          '-d',
-          location.wslDistro,
-          '--',
-          'bash',
-          '-lc',
-          buildEncodedWslBashCommand(buildWslLoginConfigDirScript())
-        ],
-        { encoding: 'utf-8', timeout: 5000 }
+    let linuxPath: string | null = null
+    try {
+      linuxPath = parseWslLoginConfigDirOutput(
+        execFileSync(
+          'wsl.exe',
+          [
+            '-d',
+            location.wslDistro,
+            '--',
+            'bash',
+            '-lc',
+            buildEncodedWslBashCommand(buildWslLoginConfigDirScript())
+          ],
+          { encoding: 'utf-8', timeout: 5000 }
+        )
       )
-    )
+    } catch {
+      console.warn('[claude-accounts] WSL login opener preparation failed')
+    }
     if (!linuxPath) {
       throw new Error(
         `Orca could not prepare a temporary Claude sign-in folder with a browser opener in ${location.wslDistro}. Sign-in cannot open a browser from that distribution.`

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -33,6 +33,13 @@ import { beginClaudeAuthSwitch, endClaudeAuthSwitch } from './live-pty-gate'
 import { findDuplicateClaudeAccount } from './claude-duplicate-account'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
+import {
+  buildWslLoginConfigDirScript,
+  buildWslLoginPathExport,
+  createWslLoginOpenerHandoff,
+  openWslLoginAuthorizationUrl,
+  parseWslLoginConfigDirOutput
+} from './wsl-login-browser-opener'
 import { buildEncodedWslBashCommand } from '../wsl-bash-command'
 import { buildWindowsCommandInvocation } from './windows-command-invocation'
 import {
@@ -579,6 +586,26 @@ export class ClaudeAccountService {
   ): Promise<CapturedClaudeAuth> {
     const tempConfig = this.createTemporaryClaudeConfigDir(location)
     const loginAbortController = new AbortController()
+    let openerError: Error | null = null
+    const handoff = tempConfig.linuxPath
+      ? createWslLoginOpenerHandoff({
+          windowsConfigDir: tempConfig.windowsPath,
+          onUrl: async (url) => {
+            try {
+              await openWslLoginAuthorizationUrl(url)
+            } catch (error) {
+              openerError = error instanceof Error ? error : new Error(String(error))
+              loginAbortController.abort()
+            }
+          },
+          onInvalid: () => {
+            openerError = new Error(
+              'Claude sign-in requested an unsupported browser address. Sign-in was stopped.'
+            )
+            loginAbortController.abort()
+          }
+        })
+      : null
     this.cancelPendingClaudeLogin = () => {
       if (loginAbortController.signal.aborted) {
         return false
@@ -611,7 +638,7 @@ export class ClaudeAccountService {
         previousLegacyKeychain
       )
     } catch (error) {
-      captureError = error
+      captureError = openerError ?? error
     } finally {
       if (process.platform === 'darwin') {
         try {
@@ -631,6 +658,7 @@ export class ClaudeAccountService {
           cleanupError = error
         }
       }
+      handoff?.stop()
       this.removeTemporaryClaudeConfigDir(tempConfig)
       this.cancelPendingClaudeLogin = null
     }
@@ -658,22 +686,24 @@ export class ClaudeAccountService {
     if (!location.wslDistro) {
       throw new Error('Could not resolve the active WSL distribution for Claude login.')
     }
-    const linuxPath = execFileSync(
-      'wsl.exe',
-      [
-        '-d',
-        location.wslDistro,
-        '--',
-        'bash',
-        '-lc',
-        'mktemp -d "${TMPDIR:-/tmp}/orca-claude-login.XXXXXX"'
-      ],
-      { encoding: 'utf-8', timeout: 5000 }
+    const linuxPath = parseWslLoginConfigDirOutput(
+      execFileSync(
+        'wsl.exe',
+        [
+          '-d',
+          location.wslDistro,
+          '--',
+          'bash',
+          '-lc',
+          buildEncodedWslBashCommand(buildWslLoginConfigDirScript())
+        ],
+        { encoding: 'utf-8', timeout: 5000 }
+      )
     )
-      .replaceAll(String.fromCharCode(0), '')
-      .trim()
-    if (!linuxPath.startsWith('/')) {
-      throw new Error('Could not create a temporary WSL Claude login directory.')
+    if (!linuxPath) {
+      throw new Error(
+        `Orca could not prepare a temporary Claude sign-in folder with a browser opener in ${location.wslDistro}. Sign-in cannot open a browser from that distribution.`
+      )
     }
     return {
       windowsPath: toWindowsWslPath(linuxPath, location.wslDistro),
@@ -1057,7 +1087,7 @@ export class ClaudeAccountService {
                 '--',
                 'bash',
                 '-lc',
-                `export CLAUDE_CONFIG_DIR=${shellQuote(configDir.linuxPath)}; exec claude ${args.map(shellQuote).join(' ')}`
+                `${buildWslLoginPathExport(configDir.linuxPath)}export CLAUDE_CONFIG_DIR=${shellQuote(configDir.linuxPath)}; exec claude ${args.map(shellQuote).join(' ')}`
               ],
               env: process.env,
               shell: false,

--- a/src/main/claude-accounts/wsl-login-browser-opener.test.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.test.ts
@@ -36,7 +36,7 @@ describe('WSL Claude login browser opener', () => {
     ).toBe('/tmp/new')
     expect(parseWslLoginConfigDirOutput('ORCA_CLAUDE_LOGIN_DIR=relative')).toBeNull()
     expect(buildWslLoginPathExport('/tmp/with space')).toBe(
-      `export PATH="$PATH:'/tmp/with space/orca-opener'"; `
+      `export PATH="$PATH":'/tmp/with space/orca-opener'; `
     )
   })
 
@@ -45,15 +45,48 @@ describe('WSL Claude login browser opener', () => {
     'file:///tmp/x',
     'javascript:alert(1)',
     'not a url',
-    'https://example.com/a\nhttps://evil.example/'
+    'https://example.com/a\nhttps://evil.example/',
+    'https://platform.claude.com.evil.example/callback',
+    'https://platform.claude.com:443/callback',
+    'https://user:pass@platform.claude.com/callback',
+    'https://platform.claude.com/callback#state=b',
+    'https://localhost/callback',
+    'https://evil.example/callback'
   ])('rejects unsafe handoff %s', (value) => {
     expect(parseWslLoginOpenerHandoff(value)).toBeNull()
   })
 
   it('preserves a valid HTTPS authorization URL', () => {
     expect(
-      parseWslLoginOpenerHandoff(' https://platform.claude.com/oauth/code/callback?code=a#state=b ')
-    ).toBe('https://platform.claude.com/oauth/code/callback?code=a#state=b')
+      parseWslLoginOpenerHandoff(' https://platform.claude.com/oauth/code/callback?code=a%2Fb ')
+    ).toBe('https://platform.claude.com/oauth/code/callback?code=a%2Fb')
+    expect(parseWslLoginOpenerHandoff('https://claude.com/callback?x=1')).toBe(
+      'https://claude.com/callback?x=1'
+    )
+    expect(parseWslLoginOpenerHandoff('https://console.anthropic.com/callback')).toBe(
+      'https://console.anthropic.com/callback'
+    )
+    expect(parseWslLoginOpenerHandoff('https://anthropic.com/callback')).toBe(
+      'https://anthropic.com/callback'
+    )
+  })
+
+  it('bounds the handoff read before validation', () => {
+    vi.useFakeTimers()
+    const root = mkdtempSync(join(tmpdir(), 'orca-wsl-opener-limit-'))
+    mkdirSync(join(root, 'orca-opener'))
+    const onUrl = vi.fn()
+    const onInvalid = vi.fn()
+    const watcher = createWslLoginOpenerHandoff({ windowsConfigDir: root, onUrl, onInvalid })
+    writeFileSync(
+      join(root, 'open-url.request'),
+      `https://platform.claude.com/callback?value=${'a'.repeat(9000)}`
+    )
+    vi.advanceTimersByTime(200)
+    expect(onUrl).not.toHaveBeenCalled()
+    expect(onInvalid).toHaveBeenCalledTimes(1)
+    watcher.stop()
+    rmSync(root, { recursive: true, force: true })
   })
 
   it('deletes the handoff before validation and accepts only the first write', () => {

--- a/src/main/claude-accounts/wsl-login-browser-opener.test.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.test.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildWslLoginConfigDirScript,
+  buildWslLoginOpenerShellScript,
+  buildWslLoginPathExport,
+  createWslLoginOpenerHandoff,
+  parseWslLoginConfigDirOutput,
+  parseWslLoginOpenerHandoff
+} from './wsl-login-browser-opener'
+
+describe('WSL Claude login browser opener', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('builds a self-testing atomic opener and encoded-safe provisioning script', () => {
+    const opener = buildWslLoginOpenerShellScript()
+    const script = buildWslLoginConfigDirScript()
+    expect(opener).toContain('ORCA_CLAUDE_OPENER_SELFTEST')
+    expect(opener).toContain('mv -f')
+    expect(opener).toContain('$1')
+    expect(script).toContain("<<'ORCA_CLAUDE_OPENER'")
+    expect(script).toContain('mktemp -d "${TMPDIR:-/tmp}/orca-claude-login.XXXXXX"')
+    expect(script).toContain('chmod 700')
+    expect(script).toContain('trap cleanup EXIT')
+  })
+
+  it('parses the last valid WSL directory marker and appends the opener to PATH', () => {
+    expect(
+      parseWslLoginConfigDirOutput(
+        'noise\u0000\nORCA_CLAUDE_LOGIN_DIR=/tmp/old\nORCA_CLAUDE_LOGIN_DIR=/tmp/new\n'
+      )
+    ).toBe('/tmp/new')
+    expect(parseWslLoginConfigDirOutput('ORCA_CLAUDE_LOGIN_DIR=relative')).toBeNull()
+    expect(buildWslLoginPathExport('/tmp/with space')).toBe(
+      `export PATH="$PATH:'/tmp/with space/orca-opener'"; `
+    )
+  })
+
+  it.each([
+    'http://localhost/callback',
+    'file:///tmp/x',
+    'javascript:alert(1)',
+    'not a url',
+    'https://example.com/a\nhttps://evil.example/'
+  ])('rejects unsafe handoff %s', (value) => {
+    expect(parseWslLoginOpenerHandoff(value)).toBeNull()
+  })
+
+  it('preserves a valid HTTPS authorization URL', () => {
+    expect(
+      parseWslLoginOpenerHandoff(' https://platform.claude.com/oauth/code/callback?code=a#state=b ')
+    ).toBe('https://platform.claude.com/oauth/code/callback?code=a#state=b')
+  })
+
+  it('deletes the handoff before validation and accepts only the first write', () => {
+    vi.useFakeTimers()
+    const root = mkdtempSync(join(tmpdir(), 'orca-wsl-opener-test-'))
+    const openerDir = join(root, 'orca-opener')
+    mkdirSync(openerDir)
+    const onUrl = vi.fn()
+    const onInvalid = vi.fn()
+    const watcher = createWslLoginOpenerHandoff({ windowsConfigDir: root, onUrl, onInvalid })
+    const handoff = join(root, 'open-url.request')
+    writeFileSync(handoff, 'https://platform.claude.com/oauth/code/callback?code=one')
+    vi.advanceTimersByTime(200)
+    expect(onUrl).toHaveBeenCalledWith('https://platform.claude.com/oauth/code/callback?code=one')
+    expect(onInvalid).not.toHaveBeenCalled()
+    expect(() => readFileSync(handoff, 'utf8')).toThrow()
+    writeFileSync(handoff, 'https://platform.claude.com/oauth/code/callback?code=two')
+    vi.advanceTimersByTime(400)
+    expect(onUrl).toHaveBeenCalledTimes(1)
+    watcher.stop()
+    rmSync(root, { recursive: true, force: true })
+  })
+})

--- a/src/main/claude-accounts/wsl-login-browser-opener.test.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.test.ts
@@ -23,6 +23,7 @@ describe('WSL Claude login browser opener', () => {
     expect(opener).toContain('mv -f')
     expect(opener).toContain('$1')
     expect(script).toContain("<<'ORCA_CLAUDE_OPENER'")
+    expect(script).toContain(`${opener}\nORCA_CLAUDE_OPENER`)
     expect(script).toContain('mktemp -d "${TMPDIR:-/tmp}/orca-claude-login.XXXXXX"')
     expect(script).toContain('chmod 700')
     expect(script).toContain('trap cleanup EXIT')
@@ -77,7 +78,13 @@ describe('WSL Claude login browser opener', () => {
     mkdirSync(join(root, 'orca-opener'))
     const onUrl = vi.fn()
     const onInvalid = vi.fn()
-    const watcher = createWslLoginOpenerHandoff({ windowsConfigDir: root, onUrl, onInvalid })
+    const onReadError = vi.fn()
+    const watcher = createWslLoginOpenerHandoff({
+      windowsConfigDir: root,
+      onUrl,
+      onInvalid,
+      onReadError
+    })
     writeFileSync(
       join(root, 'open-url.request'),
       `https://platform.claude.com/callback?value=${'a'.repeat(9000)}`
@@ -85,6 +92,7 @@ describe('WSL Claude login browser opener', () => {
     vi.advanceTimersByTime(200)
     expect(onUrl).not.toHaveBeenCalled()
     expect(onInvalid).toHaveBeenCalledTimes(1)
+    expect(onReadError).not.toHaveBeenCalled()
     watcher.stop()
     rmSync(root, { recursive: true, force: true })
   })
@@ -96,7 +104,13 @@ describe('WSL Claude login browser opener', () => {
     mkdirSync(openerDir)
     const onUrl = vi.fn()
     const onInvalid = vi.fn()
-    const watcher = createWslLoginOpenerHandoff({ windowsConfigDir: root, onUrl, onInvalid })
+    const onReadError = vi.fn()
+    const watcher = createWslLoginOpenerHandoff({
+      windowsConfigDir: root,
+      onUrl,
+      onInvalid,
+      onReadError
+    })
     const handoff = join(root, 'open-url.request')
     writeFileSync(handoff, 'https://platform.claude.com/oauth/code/callback?code=one')
     vi.advanceTimersByTime(200)

--- a/src/main/claude-accounts/wsl-login-browser-opener.test.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type * as fsTypes from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -10,6 +11,11 @@ import {
   parseWslLoginConfigDirOutput,
   parseWslLoginOpenerHandoff
 } from './wsl-login-browser-opener'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fsTypes>()
+  return { ...actual, rmSync: vi.fn(actual.rmSync) }
+})
 
 describe('WSL Claude login browser opener', () => {
   afterEach(() => {
@@ -122,5 +128,40 @@ describe('WSL Claude login browser opener', () => {
     expect(onUrl).toHaveBeenCalledTimes(1)
     watcher.stop()
     rmSync(root, { recursive: true, force: true })
+  })
+
+  it('reports cleanup failures instead of dispatching a read URL', async () => {
+    vi.useFakeTimers()
+    const root = mkdtempSync(join(tmpdir(), 'orca-wsl-opener-cleanup-'))
+    mkdirSync(join(root, 'orca-opener'))
+    const onUrl = vi.fn()
+    const onInvalid = vi.fn()
+    const onReadError = vi.fn()
+    const actual = await vi.importActual<typeof fsTypes>('node:fs')
+    const remove = vi.mocked(rmSync)
+    remove.mockImplementation((path, options) => {
+      if (String(path).endsWith('.consumed')) {
+        throw new Error('cleanup failed')
+      }
+      return actual.rmSync(path, options)
+    })
+    const watcher = createWslLoginOpenerHandoff({
+      windowsConfigDir: root,
+      onUrl,
+      onInvalid,
+      onReadError
+    })
+    writeFileSync(
+      join(root, 'open-url.request'),
+      'https://platform.claude.com/callback?code=cleanup'
+    )
+    vi.advanceTimersByTime(200)
+    expect(onUrl).not.toHaveBeenCalled()
+    expect(onInvalid).not.toHaveBeenCalled()
+    expect(onReadError).toHaveBeenCalledTimes(1)
+    expect(() => readFileSync(join(root, 'open-url.request.consumed'), 'utf8')).not.toThrow()
+    watcher.stop()
+    remove.mockImplementation(actual.rmSync)
+    actual.rmSync(root, { recursive: true, force: true })
   })
 })

--- a/src/main/claude-accounts/wsl-login-browser-opener.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.ts
@@ -1,0 +1,124 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { shell } from 'electron'
+import { normalizeExternalBrowserUrl } from '../../shared/browser-url'
+import { quoteBashString } from '../wsl-bash-command'
+
+export const WSL_LOGIN_OPENER_DIR = 'orca-opener'
+export const WSL_LOGIN_OPENER_HANDOFF = 'open-url.request'
+export const WSL_LOGIN_OPENER_POLL_MS = 200
+export const WSL_LOGIN_OPENER_MAX_URL_CHARS = 2048
+
+export function buildWslLoginOpenerShellScript(): string {
+  return `#!/bin/sh
+[ -n "\${ORCA_CLAUDE_OPENER_SELFTEST:-}" ] && exit 0
+[ $# -ge 1 ] || exit 1
+dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp="$dir/${WSL_LOGIN_OPENER_HANDOFF}.$$"
+printf '%s' "$1" > "$tmp" || exit 1
+mv -f "$tmp" "$dir/${WSL_LOGIN_OPENER_HANDOFF}" || exit 1
+exit 0
+`
+}
+
+export function buildWslLoginConfigDirScript(): string {
+  return `set -eu
+dir="$(mktemp -d "\${TMPDIR:-/tmp}/orca-claude-login.XXXXXX")"
+cleanup() { rm -rf -- "$dir"; }
+trap cleanup EXIT
+mkdir -p "$dir/${WSL_LOGIN_OPENER_DIR}"
+cat > "$dir/${WSL_LOGIN_OPENER_DIR}/xdg-open" <<'ORCA_CLAUDE_OPENER'
+${buildWslLoginOpenerShellScript()}ORCA_CLAUDE_OPENER
+chmod 700 "$dir/${WSL_LOGIN_OPENER_DIR}/xdg-open"
+ln -s xdg-open "$dir/${WSL_LOGIN_OPENER_DIR}/wslview" 2>/dev/null || true
+ORCA_CLAUDE_OPENER_SELFTEST=1 "$dir/${WSL_LOGIN_OPENER_DIR}/xdg-open" selftest
+trap - EXIT
+printf 'ORCA_CLAUDE_LOGIN_DIR=%s\\n' "$dir"
+`
+}
+
+export function buildWslLoginPathExport(linuxTempDir: string): string {
+  return `export PATH="$PATH:${quoteBashString(`${linuxTempDir}/${WSL_LOGIN_OPENER_DIR}`)}"; `
+}
+
+export function parseWslLoginConfigDirOutput(raw: string): string | null {
+  const lines = raw.replaceAll(String.fromCharCode(0), '').split(/\r?\n/)
+  const marker = 'ORCA_CLAUDE_LOGIN_DIR='
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (lines[index].startsWith(marker)) {
+      const path = lines[index].slice(marker.length).trim()
+      return path.startsWith('/') ? path : null
+    }
+  }
+  return null
+}
+
+export function parseWslLoginOpenerHandoff(raw: string): string | null {
+  const trimmed = raw.trim()
+  const hasControlCharacter = [...trimmed].some((character) => {
+    const code = character.charCodeAt(0)
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f)
+  })
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > WSL_LOGIN_OPENER_MAX_URL_CHARS ||
+    hasControlCharacter
+  ) {
+    return null
+  }
+  const normalized = normalizeExternalBrowserUrl(trimmed)
+  if (!normalized) {
+    return null
+  }
+  try {
+    return new URL(normalized).protocol === 'https:' ? normalized : null
+  } catch {
+    return null
+  }
+}
+
+export function createWslLoginOpenerHandoff(args: {
+  windowsConfigDir: string
+  onUrl: (url: string) => void | Promise<void>
+  onInvalid: () => void
+  pollMs?: number
+}): { stop: () => void } {
+  const handoffPath = join(args.windowsConfigDir, WSL_LOGIN_OPENER_HANDOFF)
+  let stopped = false
+  const timer = setInterval(() => {
+    if (stopped || !existsSync(handoffPath)) {
+      return
+    }
+    let raw: string
+    try {
+      raw = readFileSync(handoffPath, 'utf8')
+    } catch {
+      return
+    }
+    stopped = true
+    clearInterval(timer)
+    try {
+      rmSync(handoffPath, { force: true })
+    } catch {
+      // Temporary-directory cleanup remains authoritative.
+    }
+    const url = parseWslLoginOpenerHandoff(raw)
+    if (url) {
+      void args.onUrl(url)
+    } else {
+      args.onInvalid()
+    }
+  }, args.pollMs ?? WSL_LOGIN_OPENER_POLL_MS)
+  return {
+    stop: () => {
+      if (!stopped) {
+        stopped = true
+        clearInterval(timer)
+      }
+    }
+  }
+}
+
+export function openWslLoginAuthorizationUrl(url: string): Promise<void> {
+  return shell.openExternal(url)
+}

--- a/src/main/claude-accounts/wsl-login-browser-opener.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.ts
@@ -131,8 +131,18 @@ export function createWslLoginOpenerHandoff(args: {
       raw = readWslLoginOpenerHandoff(claimedPath)
     } catch {
       args.onReadError()
-    } finally {
+    }
+    let cleanupFailed = false
+    try {
       rmSync(claimedPath, { force: true })
+    } catch {
+      cleanupFailed = true
+    }
+    if (cleanupFailed) {
+      if (raw !== null) {
+        args.onReadError()
+      }
+      return
     }
     if (raw === null) {
       return

--- a/src/main/claude-accounts/wsl-login-browser-opener.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.ts
@@ -1,13 +1,19 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { closeSync, existsSync, openSync, readSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { shell } from 'electron'
-import { normalizeExternalBrowserUrl } from '../../shared/browser-url'
 import { quoteBashString } from '../wsl-bash-command'
 
 export const WSL_LOGIN_OPENER_DIR = 'orca-opener'
 export const WSL_LOGIN_OPENER_HANDOFF = 'open-url.request'
 export const WSL_LOGIN_OPENER_POLL_MS = 200
 export const WSL_LOGIN_OPENER_MAX_URL_CHARS = 2048
+const WSL_LOGIN_OPENER_MAX_URL_BYTES = WSL_LOGIN_OPENER_MAX_URL_CHARS * 4
+const WSL_LOGIN_AUTHORIZATION_HOSTS = new Set([
+  'claude.com',
+  'platform.claude.com',
+  'console.anthropic.com',
+  'anthropic.com'
+])
 
 export function buildWslLoginOpenerShellScript(): string {
   return `#!/bin/sh
@@ -38,7 +44,7 @@ printf 'ORCA_CLAUDE_LOGIN_DIR=%s\\n' "$dir"
 }
 
 export function buildWslLoginPathExport(linuxTempDir: string): string {
-  return `export PATH="$PATH:${quoteBashString(`${linuxTempDir}/${WSL_LOGIN_OPENER_DIR}`)}"; `
+  return `export PATH="$PATH":${quoteBashString(`${linuxTempDir}/${WSL_LOGIN_OPENER_DIR}`)}; `
 }
 
 export function parseWslLoginConfigDirOutput(raw: string): string | null {
@@ -62,18 +68,39 @@ export function parseWslLoginOpenerHandoff(raw: string): string | null {
   if (
     trimmed.length === 0 ||
     trimmed.length > WSL_LOGIN_OPENER_MAX_URL_CHARS ||
+    Buffer.byteLength(trimmed, 'utf8') > WSL_LOGIN_OPENER_MAX_URL_BYTES ||
     hasControlCharacter
   ) {
     return null
   }
-  const normalized = normalizeExternalBrowserUrl(trimmed)
-  if (!normalized) {
-    return null
-  }
   try {
-    return new URL(normalized).protocol === 'https:' ? normalized : null
+    const parsed = new URL(trimmed)
+    const authority = trimmed.slice('https://'.length).split(/[/?#]/, 1)[0]
+    if (
+      parsed.protocol !== 'https:' ||
+      !WSL_LOGIN_AUTHORIZATION_HOSTS.has(parsed.hostname.toLowerCase()) ||
+      parsed.username !== '' ||
+      parsed.password !== '' ||
+      parsed.port !== '' ||
+      authority.toLowerCase() !== parsed.hostname.toLowerCase() ||
+      parsed.hash !== ''
+    ) {
+      return null
+    }
+    return trimmed
   } catch {
     return null
+  }
+}
+
+function readWslLoginOpenerHandoff(path: string): string {
+  const fd = openSync(path, 'r')
+  const buffer = Buffer.allocUnsafe(WSL_LOGIN_OPENER_MAX_URL_BYTES + 1)
+  try {
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0)
+    return buffer.subarray(0, bytesRead).toString('utf8')
+  } finally {
+    closeSync(fd)
   }
 }
 
@@ -89,18 +116,21 @@ export function createWslLoginOpenerHandoff(args: {
     if (stopped || !existsSync(handoffPath)) {
       return
     }
-    let raw: string
+    const claimedPath = `${handoffPath}.consumed`
     try {
-      raw = readFileSync(handoffPath, 'utf8')
+      renameSync(handoffPath, claimedPath)
     } catch {
       return
     }
     stopped = true
     clearInterval(timer)
+    let raw: string
     try {
-      rmSync(handoffPath, { force: true })
+      raw = readWslLoginOpenerHandoff(claimedPath)
     } catch {
-      // Temporary-directory cleanup remains authoritative.
+      raw = ''
+    } finally {
+      rmSync(claimedPath, { force: true })
     }
     const url = parseWslLoginOpenerHandoff(raw)
     if (url) {

--- a/src/main/claude-accounts/wsl-login-browser-opener.ts
+++ b/src/main/claude-accounts/wsl-login-browser-opener.ts
@@ -34,7 +34,8 @@ cleanup() { rm -rf -- "$dir"; }
 trap cleanup EXIT
 mkdir -p "$dir/${WSL_LOGIN_OPENER_DIR}"
 cat > "$dir/${WSL_LOGIN_OPENER_DIR}/xdg-open" <<'ORCA_CLAUDE_OPENER'
-${buildWslLoginOpenerShellScript()}ORCA_CLAUDE_OPENER
+${buildWslLoginOpenerShellScript()}
+ORCA_CLAUDE_OPENER
 chmod 700 "$dir/${WSL_LOGIN_OPENER_DIR}/xdg-open"
 ln -s xdg-open "$dir/${WSL_LOGIN_OPENER_DIR}/wslview" 2>/dev/null || true
 ORCA_CLAUDE_OPENER_SELFTEST=1 "$dir/${WSL_LOGIN_OPENER_DIR}/xdg-open" selftest
@@ -108,6 +109,7 @@ export function createWslLoginOpenerHandoff(args: {
   windowsConfigDir: string
   onUrl: (url: string) => void | Promise<void>
   onInvalid: () => void
+  onReadError: () => void
   pollMs?: number
 }): { stop: () => void } {
   const handoffPath = join(args.windowsConfigDir, WSL_LOGIN_OPENER_HANDOFF)
@@ -124,13 +126,16 @@ export function createWslLoginOpenerHandoff(args: {
     }
     stopped = true
     clearInterval(timer)
-    let raw: string
+    let raw: string | null = null
     try {
       raw = readWslLoginOpenerHandoff(claimedPath)
     } catch {
-      raw = ''
+      args.onReadError()
     } finally {
       rmSync(claimedPath, { force: true })
+    }
+    if (raw === null) {
+      return
     }
     const url = parseWslLoginOpenerHandoff(raw)
     if (url) {

--- a/src/main/claude-accounts/wsl-login-opener-flow.test.ts
+++ b/src/main/claude-accounts/wsl-login-opener-flow.test.ts
@@ -1,0 +1,45 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createWslLoginOpenerHandoff,
+  openWslLoginAuthorizationUrl
+} from './wsl-login-browser-opener'
+
+const openExternal = vi.hoisted(() => vi.fn(async (_url: string) => undefined))
+
+vi.mock('electron', () => ({ shell: { openExternal } }))
+
+describe('WSL Claude login opener flow', () => {
+  it('delivers one URL to the Windows-side browser owner and consumes the request', () => {
+    vi.useFakeTimers()
+    const root = mkdtempSync(join(tmpdir(), 'orca-wsl-login-flow-'))
+    mkdirSync(join(root, 'orca-opener'))
+    const onUrl = vi.fn((url: string) => openWslLoginAuthorizationUrl(url))
+    const onInvalid = vi.fn()
+    const watcher = createWslLoginOpenerHandoff({
+      windowsConfigDir: root,
+      onUrl,
+      onInvalid
+    })
+    writeFileSync(
+      join(root, 'open-url.request'),
+      'https://platform.claude.com/oauth/code/callback?code=secret'
+    )
+    vi.advanceTimersByTime(200)
+    expect(openExternal).toHaveBeenCalledWith(
+      'https://platform.claude.com/oauth/code/callback?code=secret'
+    )
+    expect(onInvalid).not.toHaveBeenCalled()
+    writeFileSync(
+      join(root, 'open-url.request'),
+      'https://platform.claude.com/oauth/code/callback?code=second'
+    )
+    vi.advanceTimersByTime(400)
+    expect(openExternal).toHaveBeenCalledTimes(1)
+    watcher.stop()
+    rmSync(root, { recursive: true, force: true })
+    vi.useRealTimers()
+  })
+})

--- a/src/main/claude-accounts/wsl-login-opener-flow.test.ts
+++ b/src/main/claude-accounts/wsl-login-opener-flow.test.ts
@@ -18,10 +18,12 @@ describe('WSL Claude login opener flow', () => {
     mkdirSync(join(root, 'orca-opener'))
     const onUrl = vi.fn((url: string) => openWslLoginAuthorizationUrl(url))
     const onInvalid = vi.fn()
+    const onReadError = vi.fn()
     const watcher = createWslLoginOpenerHandoff({
       windowsConfigDir: root,
       onUrl,
-      onInvalid
+      onInvalid,
+      onReadError
     })
     writeFileSync(
       join(root, 'open-url.request'),


### PR DESCRIPTION
## Summary

Give WSL Claude sign-in a private, temporary browser opener when the selected distro has no opener on PATH. The shim writes one atomic URL handoff into the existing temporary config directory; the main process validates and opens it through Electron. Existing distro openers keep precedence, and no renderer, IPC, preload, or mobile surface changes.

Closes #11823.

## Screenshots

No visual change. The only user-visible change is a more specific existing failure-toast message when opener preparation fails.

## Testing

Focused Vitest validation passed: the three touched bridge/service test files passed 52 tests. `pnpm run typecheck:node`, `pnpm run typecheck:web`, changed-file `oxlint`, and changed-file `oxfmt --check` passed.

Post-fix WSL opener validation passed: the focused bridge suite passed 17 tests, including cleanup-failure handling.

Real Windows + WSL2 and browser-owner checks remain unrun in this environment.

## AI Review Report

Native host login, existing WSL openers, credential capture, persistence, rollback, IPC, preload, renderer, web, RPC, mobile, SSH, remote, macOS, Linux, and performance surfaces remain unchanged. The fallback is scoped to interactive WSL Claude account login and reauthentication.

## Security Audit

The handoff uses one bounded read, atomically claims and deletes the request before validation, accepts only exact HTTPS hosts `claude.com`, `platform.claude.com`, `console.anthropic.com`, and `anthropic.com`, and rejects userinfo, fragments, ports, localhost, suffix lookalikes, and arbitrary hosts. The shim uses a quoted heredoc, an atomic same-filesystem rename, mode 0700, and no stdin or output. PATH injection is limited to the interactive WSL login command.

## Notes

The live base is `origin/main` at `8fc892dd023850df379c07cc4e7a46cff9a3ea84`. The committed head is `6c91419531233f6d93a406fe7417c8b909c56323`.

