### PR TITLE
fix(runtime): cap runtime file listings before SSH transport

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -98,8 +98,14 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
     'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
 }))
 
+vi.mock('../ipc/filesystem-list-files', () => ({
+  listQuickOpenFiles: vi.fn()
+}))
+
 import { awaitRuntimeFileWatcherUnsubscribes, RuntimeFileCommands } from './orca-runtime-files'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import { listQuickOpenFiles } from '../ipc/filesystem-list-files'
+import { buildExcludePathPrefixes, buildRgArgsForQuickOpen } from '../../shared/quick-open-filter'
 import {
   resetSshConnectionGenerations,
   setSshConnectionGeneration
@@ -212,6 +218,7 @@ describe('RuntimeFileCommands', () => {
     watchMock.mockReset()
     checkRgAvailableMock.mockReset()
     vi.mocked(getSshFilesystemProvider).mockReset()
+    vi.mocked(listQuickOpenFiles).mockReset()
     resetSshConnectionGenerations()
     getLocalGitOptionsForRegisteredWorktreeMock.mockReset()
     wslAwareSpawnMock.mockReset()
@@ -232,6 +239,234 @@ describe('RuntimeFileCommands', () => {
       value: originalPlatform
     })
     vi.useRealTimers()
+  })
+
+  it('caps a constructed remote runtime listing before serialization', async () => {
+    // Constructed from issue #11884's n=159027 relay log and 2 MiB lane because
+    // the issue artifact is workflow metadata, not a repository test fixture.
+    const inventory = Array.from(
+      { length: 159027 },
+      (_, index) => `src/pkg-${index}/module-${index}/file-${index}.ts`
+    )
+    const listFiles = vi.fn(
+      async (_rootPath: string, options?: { excludePaths?: string[]; maxResults?: number }) =>
+        options?.maxResults === undefined ? inventory : inventory.slice(0, options.maxResults)
+    )
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles } as never)
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+
+    const result = await commands.listRuntimeFiles('id:wt-1')
+    const options = listFiles.mock.calls[0]?.[1]
+    const serializedBytes = Buffer.byteLength(JSON.stringify(result), 'utf8')
+    process.stdout.write(
+      `reproduction maxResults=${String(options?.maxResults)} excludePaths=${String(options?.excludePaths)} resultLength=${result.length} serializedBytes=${serializedBytes} laneLimit=2097152\n`
+    )
+
+    expect({
+      excludePaths: options?.excludePaths,
+      maxResults: options?.maxResults,
+      resultLength: result.length
+    }).toEqual({ excludePaths: undefined, maxResults: 20001, resultLength: 20001 })
+    expect(serializedBytes).toBeLessThanOrEqual(2097152)
+  })
+
+  it('preserves the mobile listing sentinel on the remote route', async () => {
+    let inventory = Array.from({ length: 5000 }, (_, index) => `src/file-${index}.ts`)
+    const listFiles = vi.fn(async (_rootPath: string, options?: { maxResults?: number }) =>
+      inventory.slice(0, options?.maxResults ?? inventory.length)
+    )
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles } as never)
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+
+    const atLimit = await commands.listMobileFiles('id:wt-1')
+    inventory = Array.from({ length: 5001 }, (_, index) => `src/file-${index}.ts`)
+    const aboveLimit = await commands.listMobileFiles('id:wt-1')
+
+    expect(listFiles.mock.calls).toEqual([
+      ['/remote/repo', { maxResults: 5001 }],
+      ['/remote/repo', { maxResults: 5001 }]
+    ])
+    expect(atLimit.files).toHaveLength(5000)
+    expect(atLimit.totalCount).toBe(5000)
+    expect(atLimit.truncated).toBe(false)
+    expect(aboveLimit.files).toHaveLength(5000)
+    expect(aboveLimit.totalCount).toBe(5001)
+    expect(aboveLimit.truncated).toBe(true)
+    process.stdout.write('remote mobile boundary 5000/5001 passed\n')
+  })
+
+  it('preserves the mobile listing sentinel on the local route', async () => {
+    let inventory = Array.from({ length: 5000 }, (_, index) => `src/file-${index}.ts`)
+    vi.mocked(listQuickOpenFiles).mockImplementation(
+      async (_rootPath, _store, _excludePaths, _signal, maxResults) =>
+        inventory.slice(0, maxResults ?? inventory.length)
+    )
+    const { commands, store } = createRuntimeFileCommands()
+
+    const atLimit = await commands.listMobileFiles('id:wt-1')
+    inventory = Array.from({ length: 5002 }, (_, index) => `src/file-${index}.ts`)
+    const aboveLimit = await commands.listMobileFiles('id:wt-1')
+
+    expect(vi.mocked(listQuickOpenFiles).mock.calls).toEqual([
+      ['/repo', store, undefined, undefined, 5001],
+      ['/repo', store, undefined, undefined, 5001]
+    ])
+    expect(atLimit).toMatchObject({ totalCount: 5000, truncated: false })
+    expect(atLimit.files).toHaveLength(5000)
+    expect(aboveLimit).toMatchObject({ totalCount: 5001, truncated: true })
+    expect(aboveLimit.files).toHaveLength(5000)
+    process.stdout.write('local mobile boundary 5001/5002 passed\n')
+  })
+
+  it('preserves the existing mobile search bounds on both routes', async () => {
+    const remoteListFiles = vi.fn().mockResolvedValue(['src/remote.ts'])
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles: remoteListFiles } as never)
+    const remoteTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const remote = createRuntimeFileCommands({ resolveRuntimeFileTarget: remoteTarget })
+    await remote.commands.searchMobileFilePaths('id:wt-1', 'remote', 10)
+
+    vi.mocked(getSshFilesystemProvider).mockReset()
+    vi.mocked(listQuickOpenFiles).mockResolvedValue(['src/local.ts'])
+    const local = createRuntimeFileCommands()
+    await local.commands.searchMobileFilePaths('id:wt-1', 'local', 10)
+
+    expect(remoteListFiles).toHaveBeenCalledWith('/remote/repo', { maxResults: 20001 })
+    expect(listQuickOpenFiles).toHaveBeenCalledWith(
+      '/repo',
+      local.store,
+      undefined,
+      undefined,
+      20001
+    )
+  })
+
+  it('preserves remote markdown projection in one bounded request', async () => {
+    const inventory = ['README.md', 'notes.txt', 'guide.mdx']
+    const listFiles = vi.fn(async (_rootPath: string, options?: { maxResults?: number }) =>
+      inventory.slice(0, options?.maxResults ?? inventory.length)
+    )
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles } as never)
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+
+    const result = await commands.listRuntimeMarkdownDocuments('id:wt-1')
+
+    expect(listFiles).toHaveBeenCalledWith('/remote/repo', { maxResults: 20001 })
+    expect(listFiles).toHaveBeenCalledTimes(1)
+    expect(listFiles).not.toHaveBeenCalledWith(
+      '/remote/repo',
+      expect.objectContaining({ excludePaths: expect.anything() })
+    )
+    expect(result.map(({ relativePath, name }) => ({ relativePath, name }))).toEqual([
+      { relativePath: 'guide.mdx', name: 'guide' },
+      { relativePath: 'README.md', name: 'README' }
+    ])
+  })
+
+  it('keeps relay list argument construction independent of inventory size', async () => {
+    let inventory = ['/remote/repo/README.md']
+    const capturedOptions: { maxResults?: number; excludePaths?: string[] }[] = []
+    const listFiles = vi.fn(async (_rootPath: string, options?: { maxResults?: number }) => {
+      capturedOptions.push(options ?? {})
+      return inventory.slice(0, options?.maxResults ?? inventory.length)
+    })
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles } as never)
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+
+    await commands.listRuntimeMarkdownDocuments('id:wt-1')
+    inventory = Array.from({ length: 20001 }, (_, index) => `/remote/repo/src/file-${index}.txt`)
+    await commands.listRuntimeMarkdownDocuments('id:wt-1')
+
+    const argsForOptions = (options: (typeof capturedOptions)[number]) =>
+      buildRgArgsForQuickOpen({
+        searchRoot: '.',
+        excludePathPrefixes: buildExcludePathPrefixes('/remote/repo', options.excludePaths),
+        forceSlashSeparator: true
+      })
+    const smallArgs = argsForOptions(capturedOptions[0] ?? {})
+    const largeArgs = argsForOptions(capturedOptions[1] ?? {})
+
+    expect(capturedOptions).toEqual([{ maxResults: 20001 }, { maxResults: 20001 }])
+    expect(buildExcludePathPrefixes('/remote/repo', capturedOptions[0]?.excludePaths)).toEqual([])
+    expect(buildExcludePathPrefixes('/remote/repo', capturedOptions[1]?.excludePaths)).toEqual([])
+    expect(smallArgs).toEqual(largeArgs)
+    expect(smallArgs.primary).toHaveLength(largeArgs.primary.length)
+    expect(smallArgs.ignoredPass).toHaveLength(largeArgs.ignoredPass.length)
+    expect(smallArgs.primary).not.toContain(expect.stringContaining('file-'))
+  })
+
+  it('preserves local runtime listing results and exclusions below the cap', async () => {
+    const expected = ['src/index.ts', 'README.md']
+    vi.mocked(listQuickOpenFiles).mockResolvedValue(expected)
+    const { commands, store } = createRuntimeFileCommands()
+    const excludePaths = ['packages/app']
+
+    const result = await commands.listRuntimeFiles('id:wt-1', { excludePaths })
+
+    expect(result).toEqual(expected)
+    expect(listQuickOpenFiles).toHaveBeenCalledWith('/repo', store, excludePaths, undefined, 20001)
+  })
+
+  it('preserves remote runtime listing results and exclusions below the cap', async () => {
+    const expected = ['src/index.ts', 'README.md']
+    const listFiles = vi.fn().mockResolvedValue(expected)
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ listFiles } as never)
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+    const excludePaths = ['packages/app']
+
+    const result = await commands.listRuntimeFiles('id:wt-1', { excludePaths })
+
+    expect(result).toEqual(expected)
+    expect(listFiles).toHaveBeenCalledWith('/remote/repo', {
+      excludePaths,
+      maxResults: 20001
+    })
+  })
+
+  it('preserves provider-unavailable results and local markdown traversal', async () => {
+    const remoteTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'conn-1'
+    }))
+    const remote = createRuntimeFileCommands({ resolveRuntimeFileTarget: remoteTarget })
+
+    await expect(remote.commands.listRuntimeFiles('id:wt-1')).resolves.toEqual([])
+    await expect(remote.commands.listMobileFiles('id:wt-1')).resolves.toMatchObject({
+      files: [],
+      totalCount: 0,
+      truncated: false
+    })
+    await expect(remote.commands.listRuntimeMarkdownDocuments('id:wt-1')).rejects.toThrow(
+      'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+    )
+    expect(getSshFilesystemProvider).toHaveBeenCalledTimes(3)
+
+    vi.mocked(getSshFilesystemProvider).mockReset()
+    const local = createRuntimeFileCommands()
+    await expect(local.commands.listRuntimeMarkdownDocuments('id:wt-1')).resolves.toEqual([])
+    expect(getSshFilesystemProvider).not.toHaveBeenCalled()
   })
 
   it('opens source control diffs through the renderer host (inheriting active runtime env)', async () => {

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -262,10 +262,6 @@ describe('RuntimeFileCommands', () => {
     const result = await commands.listRuntimeFiles('id:wt-1')
     const options = listFiles.mock.calls[0]?.[1]
     const serializedBytes = Buffer.byteLength(JSON.stringify(result), 'utf8')
-    process.stdout.write(
-      `reproduction maxResults=${String(options?.maxResults)} excludePaths=${String(options?.excludePaths)} resultLength=${result.length} serializedBytes=${serializedBytes} laneLimit=2097152\n`
-    )
-
     expect({
       excludePaths: options?.excludePaths,
       maxResults: options?.maxResults,
@@ -300,7 +296,6 @@ describe('RuntimeFileCommands', () => {
     expect(aboveLimit.files).toHaveLength(5000)
     expect(aboveLimit.totalCount).toBe(5001)
     expect(aboveLimit.truncated).toBe(true)
-    process.stdout.write('remote mobile boundary 5000/5001 passed\n')
   })
 
   it('preserves the mobile listing sentinel on the local route', async () => {
@@ -323,7 +318,6 @@ describe('RuntimeFileCommands', () => {
     expect(atLimit.files).toHaveLength(5000)
     expect(aboveLimit).toMatchObject({ totalCount: 5001, truncated: true })
     expect(aboveLimit.files).toHaveLength(5000)
-    process.stdout.write('local mobile boundary 5001/5002 passed\n')
   })
 
   it('preserves the existing mobile search bounds on both routes', async () => {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -89,6 +89,7 @@ import { beginWatcherInstall } from '../ipc/watcher-removal-gate'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
 import { toSshExecutionHostId } from '../../shared/execution-host'
 import { renameLocalPathSerializedByDestination } from '../destination-serialized-local-rename'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../../shared/quick-open-listing-limits'
 
 const MOBILE_FILE_LIST_LIMIT = 5000
 const MOBILE_FILE_PATH_SEARCH_CACHE_LIMIT = 20_000
@@ -538,8 +539,14 @@ export class RuntimeFileCommands {
     const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     const { worktree, connectionId } = target
     const files = connectionId
-      ? await this.listRemoteMobileFiles(worktree.path, connectionId)
-      : await listQuickOpenFiles(worktree.path, store)
+      ? await this.listRemoteMobileFiles(worktree.path, connectionId, MOBILE_FILE_LIST_LIMIT + 1)
+      : await listQuickOpenFiles(
+          worktree.path,
+          store,
+          undefined,
+          undefined,
+          MOBILE_FILE_LIST_LIMIT + 1
+        )
     const entries = files
       .filter((relativePath) => isSafeMobileRelativePath(relativePath))
       .sort((a, b) => a.localeCompare(b))
@@ -1833,9 +1840,18 @@ export class RuntimeFileCommands {
       if (!provider) {
         return []
       }
-      return provider.listFiles(target.worktree.path, { excludePaths: options.excludePaths })
+      return provider.listFiles(target.worktree.path, {
+        excludePaths: options.excludePaths,
+        maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
+      })
     }
-    return listQuickOpenFiles(target.worktree.path, this.host.requireStore(), options.excludePaths)
+    return listQuickOpenFiles(
+      target.worktree.path,
+      this.host.requireStore(),
+      options.excludePaths,
+      undefined,
+      QUICK_OPEN_LISTING_MAX_RESULTS
+    )
   }
 
   async listRuntimeMarkdownDocuments(worktreeSelector: string): Promise<MarkdownDocument[]> {
@@ -1845,7 +1861,9 @@ export class RuntimeFileCommands {
       if (!provider) {
         throw new Error(SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      const relativePaths = await provider.listFiles(target.worktree.path)
+      const relativePaths = await provider.listFiles(target.worktree.path, {
+        maxResults: QUICK_OPEN_LISTING_MAX_RESULTS
+      })
       return markdownDocumentsFromRelativePaths(target.worktree.path, relativePaths)
     }
     return listMarkdownDocuments(target.worktree.path)


### PR DESCRIPTION
## Summary

Refs #11884.

An oversized remote `fs.listFiles` response can exceed the relay's 2,097,152-byte legacy lane and close the shared SSH connection. The diagnostic report from @bakabaka0613 at https://github.com/stablyai/orca/issues/11884 records `METHOD=fs.listFiles`, `n=159027`, the lane error, socket closure, and reconnect.

The result-bound contract already exists from `RuntimeFileCommands` through the SSH provider and relay scanner. This change supplies each caller's existing budget before enumeration and serialization:

- Local and SSH mobile listing request exactly 5,001 paths, preserving 5,000 visible entries plus one truncation sentinel.
- Mobile path search remains unchanged at 20,001.
- Local and SSH runtime listing request the existing 20,001 Quick Open ceiling.
- Remote Markdown discovery makes one 20,001-path request and projects documents from that bounded prefix.
- Local Markdown traversal remains unchanged.

The change does not use returned paths as continuation exclusions. Relay command arguments therefore stay fixed instead of growing with every prior result.

## No visual change

No renderer, mobile UI, layout, styling, copy, or interaction code changes.

Mobile listing still returns at most 5,000 entries. Its `totalCount` is bounded at 5,001, and `truncated` remains false through 5,000 and true when the bounded inventory contains 5,001 paths.

Remote Markdown completion now considers one bounded 20,001-path prefix. Documents that occur only after that prefix are outside this caller-cap slice.

## Testing

- [ ] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime-files.test.ts src/relay/fs-handler-list-files-ignored.test.ts`
- [ ] `pnpm run typecheck:node`
- [ ] `pnpm exec oxlint src/main/runtime/orca-runtime-files.ts src/main/runtime/orca-runtime-files.test.ts`
- [ ] `pnpm exec oxfmt --check src/main/runtime/orca-runtime-files.ts src/main/runtime/orca-runtime-files.test.ts`
- [ ] `pnpm run check:max-lines-ratchet`
- [ ] `git diff --check`
- [ ] `git diff --cached --name-only` lists only `src/main/runtime/orca-runtime-files.ts` and `src/main/runtime/orca-runtime-files.test.ts`
- [ ] The 159,027-path reproduction records an undefined base bound and a 20,001-path head result
- [ ] Local and SSH mobile fixtures honor `maxResults: 5001` at the 5,000, 5,001, and 5,002 boundaries
- [ ] Remote Markdown uses one bounded request with no result-derived `excludePaths`
- [ ] Production-captured Markdown provider options produce fixed ripgrep argument arrays as returned inventory grows
- [ ] Below-limit runtime results, caller exclusions, mobile path search, provider absence, and local Markdown traversal remain unchanged

No live relay, dispatcher lane, SSH transport, or Windows/WSL2 deployment is exercised by these tests.

## AI Review Report

The caller layer owns the consumer budgets. The mobile list uses its 5,000-entry output limit plus one sentinel, while Quick Open, mobile path search, and remote Markdown discovery use the existing 20,001 ceiling.

Review rejected result-derived `excludePaths` as continuation state. The relay turns each excluded path into multiple ripgrep arguments, so that mechanism grows without bound and changes the meaning of a nested-worktree exclusion field.

The rebuilt tests require bound-honoring fakes. A 5,002-path local mobile fixture catches both an incorrect 20,001 request and a mock that ignores `maxResults`. The remote Markdown regression captures the options emitted by the production command and passes them through relay exclusion normalization and ripgrep argument construction, so a future result-derived exclusion changes the asserted arguments.

The behavior is provider-neutral at the command boundary and preserves macOS, Linux, Windows, local, and SSH routing. Live Windows-to-WSL2 continuity remains unverified.

## Security Audit

The change adds no input type, parser, IPC or RPC method, transport message, process spawn, path authorization rule, credential access, dependency, or logging.

Caller-supplied nested-worktree exclusions remain unchanged. Returned path content is never promoted into exclusion or command state. Each affected request can retain no more paths than its fixed consumer budget.

The relay's 2,097,152-byte ceiling and `closeClient` backstop remain unchanged. T11884-1 owns dispatcher isolation and legacy preload-IPC callers.

## Notes

Refs #11884.

Proof provenance uses live `origin/main` `8fc892dd023850df379c07cc4e7a46cff9a3ea84`; the implementation was rebased onto that head before publication.

The legacy preload-IPC handlers at `src/main/ipc/filesystem.ts:806` and `src/main/ipc/filesystem.ts:1074` remain outside this change. Replacing `closeClient` with a per-request error also remains outside this caller-side slice.

The 20,001 runtime bound limits entry count, not serialized bytes for every possible path-length distribution. The tests measure the issue-shaped fixture and do not claim universal byte containment or live field confirmation.
