### PR TITLE
fix(P1-A): async SSH consumer-recovery persistence and detach on failed connect

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -2730,6 +2730,81 @@ describe('SSH IPC handlers', () => {
       expect(order).toEqual(['leases:detached', 'leases:detached:persisted', 'recovery:upsert'])
     })
 
+    it('holds a retry that starts while the detach write is still pending', async () => {
+      const targetId = 'ssh-consumer-identity-pending-retry'
+      const order: string[] = []
+      let settleLeaseRelease!: () => void
+      mockStore.markSshRemotePtyLeasesAsync.mockImplementationOnce((_id: string, state: string) => {
+        order.push(`leases:${state}`)
+        return new Promise<void>((resolve) => {
+          settleLeaseRelease = () => {
+            order.push(`leases:${state}:persisted`)
+            resolve()
+          }
+        })
+      })
+      mockStore.upsertSshPtyConsumerRecovery.mockImplementation(async () => {
+        order.push('recovery:upsert')
+      })
+      mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
+      mockConnectionManager.connect.mockRejectedValueOnce(new Error('transport refused'))
+
+      const failedConnect = handlers.get('ssh:connect')!(null, { targetId })
+      const failure = expect(failedConnect).rejects.toThrow('transport refused')
+      await vi.waitFor(() => expect(order).toContain('leases:detached'))
+
+      // Retry mid-write: it must not mint a session or re-own leases while the release is pending.
+      mockConnectionManager.connect.mockResolvedValue({})
+      markConnected(targetId)
+      const retry = handlers.get('ssh:connect')!(null, { targetId }) as Promise<unknown>
+      const retrySettled = vi.fn()
+      void retry.then(retrySettled, retrySettled)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(retrySettled).not.toHaveBeenCalled()
+      expect(order).not.toContain('leases:detached:persisted')
+
+      settleLeaseRelease()
+      await failure
+      // Why: the retry folds onto the still-latched attempt rather than starting a second connect,
+      // so it inherits that attempt's failure instead of racing its teardown.
+      await expect(retry).rejects.toThrow('transport refused')
+      expect(mockConnectionManager.connect).toHaveBeenCalledTimes(1)
+      expect(order).toEqual(['leases:detached', 'leases:detached:persisted'])
+
+      await handlers.get('ssh:connect')!(null, { targetId })
+
+      expect(order).toEqual(['leases:detached', 'leases:detached:persisted', 'recovery:upsert'])
+    })
+
+    it('replaces a live session whose detach write keeps failing', async () => {
+      const targetId = 'ssh-consumer-identity-detach-write-failure'
+      mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
+      mockConnectionManager.connect.mockResolvedValue({})
+      markConnected(targetId)
+      await handlers.get('ssh:connect')!(null, { targetId })
+      const claimedId = getSshPtyConsumerRecovery(targetId)?.clientInstanceId
+      expect(claimedId).toEqual(expect.any(String))
+
+      // Why a permanent reject, not once: it proves the failed session is gone rather than merely
+      // retried — a second connect that still holds it would fail on the same write again.
+      mockStore.markSshRemotePtyLeasesAsync.mockImplementation((_id: string, state: string) =>
+        state === 'detached'
+          ? Promise.reject(new Error('lease write failed'))
+          : Promise.resolve(undefined)
+      )
+      await expect(handlers.get('ssh:connect')!(null, { targetId })).rejects.toThrow(
+        'lease write failed'
+      )
+
+      mockConnectionManager.connect.mockClear()
+      await handlers.get('ssh:connect')!(null, { targetId })
+
+      expect(mockConnectionManager.connect).toHaveBeenCalledTimes(1)
+      // Why: the abandoned session still released its identity synchronously, so the replacement
+      // reclaims the owner instead of minting a new one.
+      expect(getSshPtyConsumerRecovery(targetId)?.clientInstanceId).toBe(claimedId)
+    })
+
     it('resumes the remembered owner lease after a failed establish', async () => {
       const targetId = 'ssh-consumer-identity-establish-failure'
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -281,6 +281,8 @@ describe('SSH IPC handlers', () => {
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),
+    markSshRemotePtyLeasesAsync: vi.fn(),
+    markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     removeSshRemotePtyLeases: vi.fn()
   }
   const mockWindow = {
@@ -356,7 +358,10 @@ describe('SSH IPC handlers', () => {
     mockStore.getSshRemotePtyLeases.mockReset().mockReturnValue([])
     mockStore.markSshRemotePtyLease.mockReset()
     mockStore.markSshRemotePtyLeases.mockReset()
+    mockStore.markSshRemotePtyLeasesAsync.mockReset()
+    mockStore.markSshRemotePtyLeasesAttachedAsync.mockReset()
     mockStore.removeSshRemotePtyLeases.mockReset()
+    mockStore.upsertSshPtyConsumerRecovery.mockReset()
 
     mockConnectionManager.connect.mockReset()
     mockConnectionManager.disconnect.mockReset()
@@ -528,7 +533,7 @@ describe('SSH IPC handlers', () => {
 
     expect(mockPortForwardManager.removeAllForwards).toHaveBeenCalledWith('ssh-1')
     expect(mockMux.dispose).toHaveBeenCalledWith('shutdown')
-    expect(mockStore.markSshRemotePtyLeases).toHaveBeenCalledWith('ssh-1', 'terminated')
+    expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith('ssh-1', 'terminated')
     expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
     expect(mockStore.removeSshRemotePtyLeases).toHaveBeenCalledWith('ssh-1')
     expect(mockSshStore.removeTarget).toHaveBeenCalledWith('ssh-1')
@@ -2621,7 +2626,7 @@ describe('SSH IPC handlers', () => {
     })
 
     await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
-    mockStore.markSshRemotePtyLeases.mockClear()
+    mockStore.markSshRemotePtyLeasesAsync.mockClear()
     mockStore.markSshRemotePtyLease.mockClear()
     mockStore.getSshRemotePtyLeases.mockReturnValue([
       { targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' }
@@ -2629,8 +2634,8 @@ describe('SSH IPC handlers', () => {
 
     await handlers.get('ssh:resetRelay')!(null, { targetId: 'ssh-1' })
 
-    expect(mockStore.markSshRemotePtyLeases).not.toHaveBeenCalledWith('ssh-1', 'terminated')
-    expect(mockStore.markSshRemotePtyLeases).toHaveBeenCalledWith('ssh-1', 'detached')
+    expect(mockStore.markSshRemotePtyLeasesAsync).not.toHaveBeenCalledWith('ssh-1', 'terminated')
+    expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith('ssh-1', 'detached')
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'pty-1', 'expired')
     expect(mockForceStopRelayForTarget).toHaveBeenCalledWith(conn, 'ssh-1')
   })
@@ -2651,12 +2656,31 @@ describe('SSH IPC handlers', () => {
 
     it('reclaims the consumer identity after a failed transport connect', async () => {
       const targetId = 'ssh-consumer-identity-connect-failure'
+      let settleLeasePersistence!: () => void
+      mockStore.markSshRemotePtyLeasesAsync.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            settleLeasePersistence = resolve
+          })
+      )
       mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
       mockConnectionManager.connect.mockRejectedValueOnce(new Error('transport refused'))
 
-      await expect(handlers.get('ssh:connect')!(null, { targetId })).rejects.toThrow(
-        'transport refused'
+      const failedConnect = handlers.get('ssh:connect')!(null, { targetId }) as Promise<unknown>
+      const failure = expect(failedConnect).rejects.toThrow('transport refused')
+      const settled = vi.fn()
+      void failedConnect.then(settled, settled)
+
+      await vi.waitFor(() =>
+        expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith(targetId, 'detached')
       )
+      expect(mockStore.markSshRemotePtyLeases).not.toHaveBeenCalled()
+      // Why: the connect rejection is gated on the durable 'detached' write, so the retry it
+      // triggers cannot re-mark leases 'attached' ahead of the abandoned session's release.
+      expect(settled).not.toHaveBeenCalled()
+
+      settleLeasePersistence()
+      await failure
       const claimedId = getSshPtyConsumerRecovery(targetId)?.clientInstanceId
       expect(claimedId).toEqual(expect.any(String))
 
@@ -2670,8 +2694,45 @@ describe('SSH IPC handlers', () => {
       )
     })
 
+    it('releases the abandoned leases before a fast reconnect re-owns them', async () => {
+      const targetId = 'ssh-consumer-identity-fast-reconnect'
+      const order: string[] = []
+      let settleLeaseRelease!: () => void
+      mockStore.markSshRemotePtyLeasesAsync.mockImplementationOnce((_id: string, state: string) => {
+        order.push(`leases:${state}`)
+        return new Promise<void>((resolve) => {
+          settleLeaseRelease = () => {
+            order.push(`leases:${state}:persisted`)
+            resolve()
+          }
+        })
+      })
+      mockStore.upsertSshPtyConsumerRecovery.mockImplementation(async () => {
+        order.push('recovery:upsert')
+      })
+      mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
+      mockConnectionManager.connect.mockRejectedValueOnce(new Error('transport refused'))
+
+      const failedConnect = handlers.get('ssh:connect')!(null, { targetId })
+      const failure = expect(failedConnect).rejects.toThrow('transport refused')
+      await vi.waitFor(() => expect(order).toContain('leases:detached'))
+      expect(order).not.toContain('leases:detached:persisted')
+
+      settleLeaseRelease()
+      await failure
+
+      mockConnectionManager.connect.mockResolvedValue({})
+      markConnected(targetId)
+      await handlers.get('ssh:connect')!(null, { targetId })
+
+      // Why: the reclaimed owner is only re-persisted after the abandoned 'detached' write landed,
+      // so no late release can strand the reconnected leases in 'detached'.
+      expect(order).toEqual(['leases:detached', 'leases:detached:persisted', 'recovery:upsert'])
+    })
+
     it('resumes the remembered owner lease after a failed establish', async () => {
       const targetId = 'ssh-consumer-identity-establish-failure'
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
       mockConnectionManager.connect.mockResolvedValue({})
       markConnected(targetId)
@@ -2682,25 +2743,33 @@ describe('SSH IPC handlers', () => {
       mockMux.request.mockImplementationOnce(() =>
         Promise.reject(new Error('relay handshake aborted'))
       )
-
-      await expect(handlers.get('ssh:connect')!(null, { targetId })).rejects.toThrow(
-        'relay handshake aborted'
+      mockStore.markSshRemotePtyLeasesAsync.mockRejectedValueOnce(
+        new Error('lease persistence failed')
       )
-      const claimedId = getSshPtyConsumerRecovery(targetId)?.clientInstanceId
-      expect(claimedId).toEqual(expect.any(String))
 
-      mockMux.request.mockClear()
-      await handlers.get('ssh:connect')!(null, { targetId })
+      try {
+        await expect(handlers.get('ssh:connect')!(null, { targetId })).rejects.toThrow(
+          'relay handshake aborted'
+        )
+        await vi.waitFor(() => expect(warn).toHaveBeenCalled())
+        const claimedId = getSshPtyConsumerRecovery(targetId)?.clientInstanceId
+        expect(claimedId).toEqual(expect.any(String))
 
-      expect(getSshPtyConsumerRecovery(targetId)?.clientInstanceId).toBe(claimedId)
-      expect(mockMux.request).toHaveBeenCalledWith(
-        'pty.openClient',
-        expect.objectContaining({
-          clientInstanceId: claimedId,
-          resume: { ownerGeneration: 1, ownerLease: 'ipc-test-owner' }
-        }),
-        expect.anything()
-      )
+        mockMux.request.mockClear()
+        await handlers.get('ssh:connect')!(null, { targetId })
+
+        expect(getSshPtyConsumerRecovery(targetId)?.clientInstanceId).toBe(claimedId)
+        expect(mockMux.request).toHaveBeenCalledWith(
+          'pty.openClient',
+          expect.objectContaining({
+            clientInstanceId: claimedId,
+            resume: { ownerGeneration: 1, ownerLease: 'ipc-test-owner' }
+          }),
+          expect.anything()
+        )
+      } finally {
+        warn.mockRestore()
+      }
     })
   })
 

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -259,6 +259,7 @@ import {
   getPtyIdsForConnection
 } from './pty'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
+import { getSshPtyConsumerRecovery } from '../ssh/ssh-pty-consumer-recovery'
 
 describe('SSH IPC handlers', () => {
   const relayBuildId = '0.1.0+ipc-test'
@@ -2632,6 +2633,75 @@ describe('SSH IPC handlers', () => {
     expect(mockStore.markSshRemotePtyLeases).toHaveBeenCalledWith('ssh-1', 'detached')
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('ssh-1', 'pty-1', 'expired')
     expect(mockForceStopRelayForTarget).toHaveBeenCalledWith(conn, 'ssh-1')
+  })
+
+  describe('SSH PTY consumer identity across failed connects', () => {
+    function makeTarget(id: string): SshTarget {
+      return { id, label: 'Server', host: 'example.com', port: 22, username: 'deploy' }
+    }
+
+    function markConnected(targetId: string): void {
+      mockConnectionManager.getState.mockReturnValue({
+        targetId,
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      })
+    }
+
+    it('reclaims the consumer identity after a failed transport connect', async () => {
+      const targetId = 'ssh-consumer-identity-connect-failure'
+      mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
+      mockConnectionManager.connect.mockRejectedValueOnce(new Error('transport refused'))
+
+      await expect(handlers.get('ssh:connect')!(null, { targetId })).rejects.toThrow(
+        'transport refused'
+      )
+      const claimedId = getSshPtyConsumerRecovery(targetId)?.clientInstanceId
+      expect(claimedId).toEqual(expect.any(String))
+
+      mockConnectionManager.connect.mockResolvedValue({})
+      markConnected(targetId)
+      await handlers.get('ssh:connect')!(null, { targetId })
+
+      expect(getSshPtyConsumerRecovery(targetId)?.clientInstanceId).toBe(claimedId)
+      expect(mockStore.upsertSshPtyConsumerRecovery).toHaveBeenCalledWith(
+        expect.objectContaining({ targetId, clientInstanceId: claimedId })
+      )
+    })
+
+    it('resumes the remembered owner lease after a failed establish', async () => {
+      const targetId = 'ssh-consumer-identity-establish-failure'
+      mockSshStore.getTarget.mockReturnValue(makeTarget(targetId))
+      mockConnectionManager.connect.mockResolvedValue({})
+      markConnected(targetId)
+      // Why: fail the first request after the consumer session opens, so establish() rejects with an
+      // owner lease already remembered — the state a retry must be able to resume from.
+      const openClientResponse = await mockMux.request('pty.openClient')
+      mockMux.request.mockImplementationOnce(() => Promise.resolve(openClientResponse))
+      mockMux.request.mockImplementationOnce(() =>
+        Promise.reject(new Error('relay handshake aborted'))
+      )
+
+      await expect(handlers.get('ssh:connect')!(null, { targetId })).rejects.toThrow(
+        'relay handshake aborted'
+      )
+      const claimedId = getSshPtyConsumerRecovery(targetId)?.clientInstanceId
+      expect(claimedId).toEqual(expect.any(String))
+
+      mockMux.request.mockClear()
+      await handlers.get('ssh:connect')!(null, { targetId })
+
+      expect(getSshPtyConsumerRecovery(targetId)?.clientInstanceId).toBe(claimedId)
+      expect(mockMux.request).toHaveBeenCalledWith(
+        'pty.openClient',
+        expect.objectContaining({
+          clientInstanceId: claimedId,
+          resume: { ownerGeneration: 1, ownerLease: 'ipc-test-owner' }
+        }),
+        expect.anything()
+      )
+    })
   })
 
   it('ssh:getState returns connection state', async () => {

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -115,7 +115,7 @@ export function listRegisteredRemovedSshTargetLabels(): Record<string, string> {
 export async function disconnectRegisteredSshTarget(targetId: string): Promise<void> {
   invalidateConnectAttempt(targetId)
   await runTargetLifecycle(targetId, () =>
-    teardownSshTargetTransport(targetId, (session) => session.detach())
+    teardownSshTargetTransport(targetId, (session) => session.detachAndPersist())
   )
 }
 
@@ -128,7 +128,7 @@ export async function removeRegisteredSshTarget(targetId: string): Promise<void>
   await runTargetLifecycle(targetId, async () => {
     try {
       // Why: removal is destructive; dispose so remote PTYs cannot reattach to a deleted target.
-      await teardownSshTargetTransport(targetId, (session) => session.dispose())
+      await teardownSshTargetTransport(targetId, (session) => session.disposeAndPersist())
     } catch (err) {
       // Why: a failed disconnect must not block metadata removal, else the target lingers in the store with uncleaned leases.
       console.warn(
@@ -191,7 +191,7 @@ async function awaitTargetLifecycle(targetId: string): Promise<void> {
 
 async function teardownSshTargetTransport(
   targetId: string,
-  teardown: (session: SshRelaySession) => void
+  teardown: (session: SshRelaySession) => void | Promise<void>
 ): Promise<void> {
   let transportDisconnect: Promise<{ ok: true } | { ok: false; error: unknown }>
   try {
@@ -220,7 +220,7 @@ async function teardownSshTargetTransport(
 
 async function teardownActiveSshSession(
   targetId: string,
-  teardown: (session: SshRelaySession) => void
+  teardown: (session: SshRelaySession) => void | Promise<void>
 ): Promise<void> {
   const session = activeSessions.get(targetId)
   if (!session) {
@@ -234,7 +234,7 @@ async function teardownActiveSshSession(
     teardownError = { error }
   }
   try {
-    teardown(session)
+    await teardown(session)
   } catch (error) {
     teardownError ??= { error }
   }
@@ -248,11 +248,16 @@ async function teardownActiveSshSession(
   }
 }
 
-// Why: a dropped session must detach, not just leave activeSessions — detach() releases the SSH PTY
+// Why: a dropped session must detach, not just leave activeSessions — detach releases the SSH PTY
 // consumer identity so the next connect reclaims its owner lease instead of minting a new one.
-function abandonFailedSshSession(targetId: string, session: SshRelaySession): void {
+// Why awaited, and why the map entry outlives the await: a retry can start the moment this returns,
+// so it must either find the session (and await this same latched teardown at the existing-session
+// path) or find nothing because the 'detached' lease write is already durable. Deleting first lets a
+// fast reconnect mark leases 'attached' and then have this session's late 'detached' write clobber it.
+async function abandonFailedSshSession(targetId: string, session: SshRelaySession): Promise<void> {
+  // Why: detachAndPersist transitions recovery ownership synchronously; only durability is awaited.
   try {
-    session.detach()
+    await session.detachAndPersist()
   } catch (error) {
     // Why: a teardown throw must not mask the connect error the caller is about to rethrow.
     console.warn(
@@ -1062,7 +1067,7 @@ export function registerSshHandlers(
       if (!isCurrentConnectAttempt(targetId, authority)) {
         throw createCancelledConnectAttemptError()
       }
-      existingSession.detach()
+      await existingSession.detachAndPersist()
       if (activeSessions.get(targetId) === existingSession) {
         activeSessions.delete(targetId)
         clearRelayLostBackoff(targetId)
@@ -1108,7 +1113,7 @@ export function registerSshHandlers(
       }
       // Why: clear this failed connect's flag so a later non-prompting connect isn't deferred.
       credentialRequestedForTarget.delete(targetId)
-      abandonFailedSshSession(targetId, session)
+      await abandonFailedSshSession(targetId, session)
       clearRelayLostBackoff(targetId)
       clearRelayStateOverride(targetId)
       broadcastSshState(getCurrentMainWindow, targetId, {
@@ -1146,9 +1151,16 @@ export function registerSshHandlers(
       if (!ownsSession()) {
         throw createCancelledConnectAttemptError()
       }
-      abandonFailedSshSession(targetId, session)
+      await abandonFailedSshSession(targetId, session)
       clearRelayLostBackoff(targetId)
-      await connectionManager!.disconnect(targetId)
+      try {
+        await connectionManager!.disconnect(targetId)
+      } catch (disconnectError) {
+        // Why: the establish failure is the actionable error; a teardown throw must not replace it.
+        console.warn(
+          `[ssh] Failed to disconnect transport after failed establish for ${targetId}: ${disconnectError instanceof Error ? disconnectError.message : String(disconnectError)}`
+        )
+      }
       throw err
     }
 
@@ -1218,7 +1230,7 @@ export function registerSshHandlers(
         // Why: a failed relay shutdown can leave the remote process alive in the grace window; keep the lease/session so the user can retry.
         throw new Error(`Failed to terminate SSH host sessions: ${shutdownFailures.join('; ')}`)
       }
-      await teardownSshTargetTransport(args.targetId, (session) => session.dispose())
+      await teardownSshTargetTransport(args.targetId, (session) => session.disposeAndPersist())
     })
   })
 
@@ -1237,7 +1249,9 @@ export function registerSshHandlers(
     const session = activeSessions.get(targetId)
     if (session) {
       // Why: detach() not dispose() — reset has its own stale-lease semantics below that dispose()'s clean-termination recording would hide.
-      await teardownActiveSshSession(targetId, (capturedSession) => capturedSession.detach())
+      await teardownActiveSshSession(targetId, (capturedSession) =>
+        capturedSession.detachAndPersist()
+      )
     }
 
     const existingConn = connectionManager!.getConnection(targetId)
@@ -1461,9 +1475,7 @@ export async function resetSshHandlerStateForTests(): Promise<void> {
   }
   ipcMain.removeHandler('ssh:submitCredential')
 
-  for (const session of activeSessions.values()) {
-    session.dispose()
-  }
+  await Promise.all([...activeSessions.values()].map((session) => session.disposeAndPersist()))
   activeSessions.clear()
   for (const targetId of relayLostBackoff.keys()) {
     clearRelayLostBackoff(targetId)

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -248,6 +248,22 @@ async function teardownActiveSshSession(
   }
 }
 
+// Why: a dropped session must detach, not just leave activeSessions — detach() releases the SSH PTY
+// consumer identity so the next connect reclaims its owner lease instead of minting a new one.
+function abandonFailedSshSession(targetId: string, session: SshRelaySession): void {
+  try {
+    session.detach()
+  } catch (error) {
+    // Why: a teardown throw must not mask the connect error the caller is about to rethrow.
+    console.warn(
+      `[ssh] Failed to detach abandoned session for ${targetId}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  if (activeSessions.get(targetId) === session) {
+    activeSessions.delete(targetId)
+  }
+}
+
 function relayGracePeriodForTarget(target: SshTarget | null | undefined): number | undefined {
   return target?.relayGracePeriodSeconds
 }
@@ -1092,7 +1108,7 @@ export function registerSshHandlers(
       }
       // Why: clear this failed connect's flag so a later non-prompting connect isn't deferred.
       credentialRequestedForTarget.delete(targetId)
-      activeSessions.delete(targetId)
+      abandonFailedSshSession(targetId, session)
       clearRelayLostBackoff(targetId)
       clearRelayStateOverride(targetId)
       broadcastSshState(getCurrentMainWindow, targetId, {
@@ -1130,7 +1146,7 @@ export function registerSshHandlers(
       if (!ownsSession()) {
         throw createCancelledConnectAttemptError()
       }
-      activeSessions.delete(targetId)
+      abandonFailedSshSession(targetId, session)
       clearRelayLostBackoff(targetId)
       await connectionManager!.disconnect(targetId)
       throw err

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -1067,11 +1067,18 @@ export function registerSshHandlers(
       if (!isCurrentConnectAttempt(targetId, authority)) {
         throw createCancelledConnectAttemptError()
       }
-      await existingSession.detachAndPersist()
-      if (activeSessions.get(targetId) === existingSession) {
-        activeSessions.delete(targetId)
-        clearRelayLostBackoff(targetId)
-        clearRelayStateOverride(targetId)
+      try {
+        await existingSession.detachAndPersist()
+      } finally {
+        // Why finally: detachAndPersist runs its in-memory half synchronously, so the session is
+        // dead even when the lease write rejects — keeping it in activeSessions would strand every
+        // later connect on the same dead session. Why still after the await, not before it: the
+        // write has settled by now, so it can no longer clobber the replacement's 'attached' write.
+        if (activeSessions.get(targetId) === existingSession) {
+          activeSessions.delete(targetId)
+          clearRelayLostBackoff(targetId)
+          clearRelayStateOverride(targetId)
+        }
       }
     }
 
@@ -1475,7 +1482,10 @@ export async function resetSshHandlerStateForTests(): Promise<void> {
   }
   ipcMain.removeHandler('ssh:submitCredential')
 
-  await Promise.all([...activeSessions.values()].map((session) => session.disposeAndPersist()))
+  // Why: allSettled — a rejected disposal write must not abort the rest of the reset and leak state into the next test.
+  await Promise.allSettled(
+    [...activeSessions.values()].map((session) => session.disposeAndPersist())
+  )
   activeSessions.clear()
   for (const targetId of relayLostBackoff.keys()) {
     clearRelayLostBackoff(targetId)

--- a/src/main/persistence-async-write-syscalls.test.ts
+++ b/src/main/persistence-async-write-syscalls.test.ts
@@ -143,6 +143,26 @@ type TestStore = {
   flushOrThrow(): void
   flushPendingAsync(): Promise<void>
   flushPendingOrThrowAsync(): Promise<void>
+  upsertSshPtyConsumerRecovery(record: {
+    targetId: string
+    clientInstanceId: string
+    serverBuildId: string
+    clientGeneration: number
+    ownerGeneration: number
+    ownerLease: string
+  }): Promise<void>
+  removeSshPtyConsumerRecovery(targetId: string): Promise<void>
+}
+
+function consumerRecovery(clientInstanceId: string) {
+  return {
+    targetId: 'ssh-1',
+    clientInstanceId,
+    serverBuildId: 'relay-build-1',
+    clientGeneration: 3,
+    ownerGeneration: 5,
+    ownerLease: 'secret-owner-lease'
+  }
 }
 
 async function createStore(dir: string): Promise<TestStore> {
@@ -653,6 +673,84 @@ describe('async persistence write path avoids synchronous fs syscalls', () => {
     expect(ring).toEqual(ringSnapshot(syncDir))
     expect(Object.keys(ring)).toContain(`orca-data.json.bak.${BACKUP_COUNT - 1}`)
   })
+
+  it('persists SSH PTY consumer recovery without a sync syscall, durable once awaited', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      await store.upsertSshPtyConsumerRecovery(consumerRecovery('client-1'))
+    } finally {
+      fsCalls.recording = false
+    }
+
+    expect(fsCalls.syncCalls).toEqual([])
+    // Durability is awaited, not merely debounced: the record is on disk when the promise resolves.
+    const persisted = JSON.parse(readFileSync(dataFile(dir), 'utf-8')) as {
+      sshPtyConsumerRecoveries: { clientInstanceId: string }[]
+    }
+    expect(persisted.sshPtyConsumerRecoveries).toHaveLength(1)
+    expect(persisted.sshPtyConsumerRecoveries[0]?.clientInstanceId).toBe('client-1')
+  })
+
+  it('removes SSH PTY consumer recovery without a sync syscall, durable once awaited', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    await store.upsertSshPtyConsumerRecovery(consumerRecovery('client-1'))
+
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      await store.removeSshPtyConsumerRecovery('ssh-1')
+    } finally {
+      fsCalls.recording = false
+    }
+
+    expect(fsCalls.syncCalls).toEqual([])
+    const persisted = JSON.parse(readFileSync(dataFile(dir), 'utf-8')) as {
+      sshPtyConsumerRecoveries: unknown[]
+    }
+    expect(persisted.sshPtyConsumerRecoveries).toEqual([])
+  })
+
+  it('lets a main-thread timer keep firing while a consumer-recovery write is in flight', async () => {
+    // The P1-A freeze itself: a stalled profile mount must not park the main thread on establish.
+    vi.useRealTimers()
+    const dir = makeDir()
+    const store = await createStore(dir)
+    const stallMs = 1_000
+    // Why half: a sync write parks the loop for at least stallMs while the async path ticks every
+    // ~10ms, so this leaves room for scheduler jitter on a loaded runner without going vacuous.
+    const maxAcceptableGapMs = stallMs / 2
+
+    let lastTick = Date.now()
+    let worstGapMs = 0
+    const heartbeat = setInterval(() => {
+      const now = Date.now()
+      worstGapMs = Math.max(worstGapMs, now - lastTick)
+      lastTick = now
+    }, 10)
+
+    try {
+      fsCalls.dirPrefix = dir
+      fsCalls.stallMs = stallMs
+      fsCalls.recording = true
+      lastTick = Date.now()
+      const write = store.upsertSshPtyConsumerRecovery(consumerRecovery('client-1'))
+      // Why not await first: a fully synchronous write finishes before the interval can fire, so the
+      // heartbeat would never observe the stall it exists to detect.
+      await new Promise((resolve) => setTimeout(resolve, stallMs + 200))
+      await write
+    } finally {
+      fsCalls.recording = false
+      clearInterval(heartbeat)
+    }
+
+    expect(worstGapMs).toBeLessThan(maxAcceptableGapMs)
+    expect(readFileSync(dataFile(dir), 'utf-8')).toContain('client-1')
+  }, 20_000)
 
   it('keeps the sync quit/crash fallback on synchronous syscalls', async () => {
     const dir = makeDir()

--- a/src/main/persistence-async-write-syscalls.test.ts
+++ b/src/main/persistence-async-write-syscalls.test.ts
@@ -152,6 +152,13 @@ type TestStore = {
     ownerLease: string
   }): Promise<void>
   removeSshPtyConsumerRecovery(targetId: string): Promise<void>
+  upsertSshRemotePtyLease(lease: {
+    targetId: string
+    ptyId: string
+    state: 'attached' | 'detached' | 'expired'
+  }): void
+  markSshRemotePtyLeasesAsync(targetId: string, state: 'attached' | 'detached'): Promise<void>
+  markSshRemotePtyLeasesAttachedAsync(targetId: string, ptyIds: readonly string[]): Promise<void>
 }
 
 function consumerRecovery(clientInstanceId: string) {
@@ -546,6 +553,8 @@ describe('async persistence write path avoids synchronous fs syscalls', () => {
       vi.advanceTimersByTime(SAVE_DEBOUNCE_MS)
       allWrites = store.waitForPendingWrite()
       expect(fsCalls.asyncCalls.filter((call) => call === statCall)).toHaveLength(1)
+      releaseRotation()
+      await Promise.all([firstWrite, allWrites])
     } finally {
       releaseRotation()
       await allWrites
@@ -695,6 +704,26 @@ describe('async persistence write path avoids synchronous fs syscalls', () => {
     expect(persisted.sshPtyConsumerRecoveries[0]?.clientInstanceId).toBe('client-1')
   })
 
+  it('rejects the consumer-recovery durability barrier when the primary write fails', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    const writeError = Object.assign(new Error('profile mount rejected write'), { code: 'EIO' })
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    fsCalls.failAsync = (fn, target) =>
+      fn === 'open' && target.startsWith(`${dataFile(dir)}.`) ? writeError : null
+
+    try {
+      await expect(store.upsertSshPtyConsumerRecovery(consumerRecovery('client-1'))).rejects.toBe(
+        writeError
+      )
+    } finally {
+      fsCalls.recording = false
+      errors.mockRestore()
+    }
+  })
+
   it('removes SSH PTY consumer recovery without a sync syscall, durable once awaited', async () => {
     const dir = makeDir()
     const store = await createStore(dir)
@@ -713,6 +742,100 @@ describe('async persistence write path avoids synchronous fs syscalls', () => {
       sshPtyConsumerRecoveries: unknown[]
     }
     expect(persisted.sshPtyConsumerRecoveries).toEqual([])
+  })
+
+  it('persists failed-session lease detachment without a sync syscall', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })
+
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      await store.markSshRemotePtyLeasesAsync('ssh-1', 'detached')
+    } finally {
+      fsCalls.recording = false
+    }
+
+    expect(fsCalls.syncCalls).toEqual([])
+    const persisted = JSON.parse(readFileSync(dataFile(dir), 'utf-8')) as {
+      sshRemotePtyLeases: { state: string }[]
+    }
+    expect(persisted.sshRemotePtyLeases[0]?.state).toBe('detached')
+  })
+
+  it('persists selected reattach leases in one async write', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'detached' })
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-2', state: 'expired' })
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-3', state: 'detached' })
+
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      await store.markSshRemotePtyLeasesAttachedAsync('ssh-1', ['pty-1', 'pty-2'])
+    } finally {
+      fsCalls.recording = false
+    }
+
+    expect(fsCalls.syncCalls).toEqual([])
+    const persisted = JSON.parse(readFileSync(dataFile(dir), 'utf-8')) as {
+      sshRemotePtyLeases: { ptyId: string; state: string }[]
+    }
+    expect(persisted.sshRemotePtyLeases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ptyId: 'pty-1', state: 'attached' }),
+        expect.objectContaining({ ptyId: 'pty-2', state: 'expired' }),
+        expect.objectContaining({ ptyId: 'pty-3', state: 'detached' })
+      ])
+    )
+  })
+
+  it('keeps async writers serialized across a synchronous shutdown flush', async () => {
+    const dir = makeDir()
+    const store = await createStore(dir)
+    let signalFirstOpen!: () => void
+    const firstOpen = new Promise<void>((resolve) => {
+      signalFirstOpen = resolve
+    })
+    let releaseFirstOpen!: () => void
+    const firstOpenRelease = new Promise<void>((resolve) => {
+      releaseFirstOpen = resolve
+    })
+    let held = false
+    fsCalls.waitAsync = (fn, target) => {
+      if (held || fn !== 'open' || !target.endsWith('.tmp')) {
+        return null
+      }
+      held = true
+      signalFirstOpen()
+      return firstOpenRelease
+    }
+
+    fsCalls.dirPrefix = dir
+    fsCalls.recording = true
+    try {
+      const firstWrite = store.upsertSshPtyConsumerRecovery(consumerRecovery('client-1'))
+      await firstOpen
+      store.flushOrThrow()
+      const secondWrite = store.upsertSshPtyConsumerRecovery(consumerRecovery('client-2'))
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(fsCalls.asyncCalls.filter((call) => call.startsWith('open:'))).toHaveLength(1)
+      releaseFirstOpen()
+      await Promise.all([firstWrite, secondWrite])
+    } finally {
+      releaseFirstOpen()
+      fsCalls.recording = false
+      fsCalls.waitAsync = null
+    }
+
+    const persisted = JSON.parse(readFileSync(dataFile(dir), 'utf-8')) as {
+      sshPtyConsumerRecoveries: { clientInstanceId: string }[]
+    }
+    expect(persisted.sshPtyConsumerRecoveries[0]?.clientInstanceId).toBe('client-2')
   })
 
   it('lets a main-thread timer keep firing while a consumer-recovery write is in flight', async () => {

--- a/src/main/persistence-async-write-syscalls.test.ts
+++ b/src/main/persistence-async-write-syscalls.test.ts
@@ -12,6 +12,7 @@ import type * as NodeFs from 'node:fs'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import type { SshRemotePtyLeaseState } from '../shared/ssh-types'
 
 const testState = { dir: '' }
 
@@ -155,9 +156,9 @@ type TestStore = {
   upsertSshRemotePtyLease(lease: {
     targetId: string
     ptyId: string
-    state: 'attached' | 'detached' | 'expired'
+    state: SshRemotePtyLeaseState
   }): void
-  markSshRemotePtyLeasesAsync(targetId: string, state: 'attached' | 'detached'): Promise<void>
+  markSshRemotePtyLeasesAsync(targetId: string, state: SshRemotePtyLeaseState): Promise<void>
   markSshRemotePtyLeasesAttachedAsync(targetId: string, ptyIds: readonly string[]): Promise<void>
 }
 

--- a/src/main/persistence-async-write-syscalls.test.ts
+++ b/src/main/persistence-async-write-syscalls.test.ts
@@ -771,11 +771,13 @@ describe('async persistence write path avoids synchronous fs syscalls', () => {
     store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'detached' })
     store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-2', state: 'expired' })
     store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-3', state: 'detached' })
+    // Why: a PTY that exits mid-reattach is terminated before the batch write lands; it must stay dead.
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-4', state: 'terminated' })
 
     fsCalls.dirPrefix = dir
     fsCalls.recording = true
     try {
-      await store.markSshRemotePtyLeasesAttachedAsync('ssh-1', ['pty-1', 'pty-2'])
+      await store.markSshRemotePtyLeasesAttachedAsync('ssh-1', ['pty-1', 'pty-2', 'pty-4'])
     } finally {
       fsCalls.recording = false
     }
@@ -788,7 +790,8 @@ describe('async persistence write path avoids synchronous fs syscalls', () => {
       expect.arrayContaining([
         expect.objectContaining({ ptyId: 'pty-1', state: 'attached' }),
         expect.objectContaining({ ptyId: 'pty-2', state: 'expired' }),
-        expect.objectContaining({ ptyId: 'pty-3', state: 'detached' })
+        expect.objectContaining({ ptyId: 'pty-3', state: 'detached' }),
+        expect.objectContaining({ ptyId: 'pty-4', state: 'terminated' })
       ])
     )
   })

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6800,7 +6800,7 @@ describe('Store', () => {
   it('durably encrypts SSH PTY consumer ownership for process restart recovery', async () => {
     const store = await createStore()
     store.setGitHubCache({ pr: { 'o/r#1': { fetchedAt: 1 } as never }, issue: {} })
-    store.upsertSshPtyConsumerRecovery({
+    await store.upsertSshPtyConsumerRecovery({
       targetId: 'ssh-1',
       clientInstanceId: 'client-1',
       serverBuildId: 'relay-build-1',
@@ -6858,7 +6858,7 @@ describe('Store', () => {
       port: 22,
       username: 'orca'
     })
-    store.upsertSshPtyConsumerRecovery({
+    await store.upsertSshPtyConsumerRecovery({
       targetId: 'ssh-1',
       clientInstanceId: 'client-1',
       serverBuildId: 'relay-build-1',

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3846,16 +3846,6 @@ export class Store {
     return write
   }
 
-  // Why: recovery ownership must be durable before relay setup continues without blocking the main thread.
-  private async flushImmediateAsync(): Promise<void> {
-    if (this.writeTimer) {
-      clearTimeout(this.writeTimer)
-      this.writeTimer = null
-    }
-    this.firstPendingSaveAt = null
-    await this.enqueueWrite()
-  }
-
   /** Wait for any in-flight async disk write to complete. Used in tests. */
   async waitForPendingWrite(): Promise<void> {
     await Promise.all([this.pendingWrite, this.activeViewPreference.waitForPendingWrite()])
@@ -6925,8 +6915,8 @@ export class Store {
   private async flushSshPtyConsumerRecovery(): Promise<void> {
     // Why: ownership must be durable before relay setup continues, but this runs on the live
     // establish/reconnect path — a sync flush would park the main thread on a stalled profile mount.
-    // Why not caught here: the failure must reach the awaiting caller; enqueueWrite already logs it.
-    await this.flushImmediateAsync()
+    // Why not caught here: the failure must reach the awaiting caller.
+    await this.flushDurableStateOrThrowAsync()
   }
 
   // ── SSH Remote PTY Leases ──────────────────────────────────────────
@@ -6981,7 +6971,7 @@ export class Store {
     state: SshRemotePtyLease['state']
   ): Promise<void> {
     if (this.updateSshRemotePtyLeaseStates(targetId, state)) {
-      await this.flushImmediateAsync()
+      await this.flushDurableStateOrThrowAsync()
     }
   }
 
@@ -6993,7 +6983,7 @@ export class Store {
       ptyIds.map((ptyId) => this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId))
     )
     if (this.updateSshRemotePtyLeaseStates(targetId, 'attached', relayPtyIds)) {
-      await this.flushImmediateAsync()
+      await this.flushDurableStateOrThrowAsync()
     }
   }
 
@@ -7213,6 +7203,26 @@ export class Store {
       return Promise.reject(new Error('Cannot flush while persistence is finalized'))
     }
     return this.flushCurrentStateAsync(false, options.signal)
+  }
+
+  // Async twin of flushOrThrow: durable state only. Active-view and GitHub sidecars are
+  // quit/startup work and must not be snapshotted on the live SSH establish/reconnect path.
+  private async flushDurableStateOrThrowAsync(): Promise<void> {
+    if (this.writesFrozen || this.quitFlushStarted) {
+      throw new Error('Cannot flush while persistence is finalized')
+    }
+    for (;;) {
+      if (this.writeTimer) {
+        clearTimeout(this.writeTimer)
+        this.writeTimer = null
+      }
+      this.firstPendingSaveAt = null
+      const generation = this.writeGeneration
+      await this.enqueueWrite()
+      if (generation === this.writeGeneration) {
+        break
+      }
+    }
   }
 
   private async flushCurrentStateAsync(

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4054,6 +4054,7 @@ export class Store {
         }
       }
     }
+    // Why: later async flushes must remain serialized behind the invalidated writer.
     this.writeToDiskSync({
       force: asyncWriteWasInFlight,
       skipBackupRotation: this.backupRotationInFlight
@@ -6922,13 +6923,10 @@ export class Store {
   }
 
   private async flushSshPtyConsumerRecovery(): Promise<void> {
-    try {
-      // Why: ownership must be durable before relay setup continues, but this runs on the live
-      // establish/reconnect path — a sync flush would park the main thread on a stalled profile mount.
-      await this.flushImmediateAsync()
-    } catch (err) {
-      console.error('[persistence] Failed to flush SSH PTY consumer recovery:', err)
-    }
+    // Why: ownership must be durable before relay setup continues, but this runs on the live
+    // establish/reconnect path — a sync flush would park the main thread on a stalled profile mount.
+    // Why not caught here: the failure must reach the awaiting caller; enqueueWrite already logs it.
+    await this.flushImmediateAsync()
   }
 
   // ── SSH Remote PTY Leases ──────────────────────────────────────────
@@ -6973,13 +6971,47 @@ export class Store {
   }
 
   markSshRemotePtyLeases(targetId: string, state: SshRemotePtyLease['state']): void {
+    if (this.updateSshRemotePtyLeaseStates(targetId, state)) {
+      this.flush()
+    }
+  }
+
+  async markSshRemotePtyLeasesAsync(
+    targetId: string,
+    state: SshRemotePtyLease['state']
+  ): Promise<void> {
+    if (this.updateSshRemotePtyLeaseStates(targetId, state)) {
+      await this.flushImmediateAsync()
+    }
+  }
+
+  async markSshRemotePtyLeasesAttachedAsync(
+    targetId: string,
+    ptyIds: readonly string[]
+  ): Promise<void> {
+    const relayPtyIds = new Set(
+      ptyIds.map((ptyId) => this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId))
+    )
+    if (this.updateSshRemotePtyLeaseStates(targetId, 'attached', relayPtyIds)) {
+      await this.flushImmediateAsync()
+    }
+  }
+
+  private updateSshRemotePtyLeaseStates(
+    targetId: string,
+    state: SshRemotePtyLease['state'],
+    ptyIds?: ReadonlySet<string>
+  ): boolean {
     const now = Date.now()
     let changed = false
     const shouldClearBindings = state === 'terminated' || state === 'expired'
     const leasesToClear: SshRemotePtyLease[] = []
     this.state.sshRemotePtyLeases ??= []
     for (const lease of this.state.sshRemotePtyLeases) {
-      if (lease.targetId !== targetId) {
+      if (lease.targetId !== targetId || (ptyIds && !ptyIds.has(lease.ptyId))) {
+        continue
+      }
+      if (state === 'attached' && (lease.state === 'terminated' || lease.state === 'expired')) {
         continue
       }
       if (state === 'detached' && lease.state !== 'attached') {
@@ -7002,9 +7034,7 @@ export class Store {
     const bindingsChanged = shouldClearBindings
       ? this.clearSshRemotePtyBindingsForLeases(targetId, leasesToClear)
       : false
-    if (changed || bindingsChanged) {
-      this.flush()
-    }
+    return changed || bindingsChanged
   }
 
   markSshRemotePtyLease(targetId: string, ptyId: string, state: SshRemotePtyLease['state']): void {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3846,6 +3846,16 @@ export class Store {
     return write
   }
 
+  // Why: recovery ownership must be durable before relay setup continues without blocking the main thread.
+  private async flushImmediateAsync(): Promise<void> {
+    if (this.writeTimer) {
+      clearTimeout(this.writeTimer)
+      this.writeTimer = null
+    }
+    this.firstPendingSaveAt = null
+    await this.enqueueWrite()
+  }
+
   /** Wait for any in-flight async disk write to complete. Used in tests. */
   async waitForPendingWrite(): Promise<void> {
     await Promise.all([this.pendingWrite, this.activeViewPreference.waitForPendingWrite()])
@@ -6888,7 +6898,7 @@ export class Store {
     return record ? structuredClone(record) : null
   }
 
-  upsertSshPtyConsumerRecovery(record: SshPtyConsumerRecovery): void {
+  async upsertSshPtyConsumerRecovery(record: SshPtyConsumerRecovery): Promise<void> {
     const normalized = normalizeSshPtyConsumerRecovery(record)
     if (!normalized) {
       throw new Error('Invalid SSH PTY consumer recovery record')
@@ -6898,23 +6908,24 @@ export class Store {
       ...recoveries.filter((candidate) => candidate.targetId !== normalized.targetId),
       normalized
     ]
-    this.flushSshPtyConsumerRecovery()
+    await this.flushSshPtyConsumerRecovery()
   }
 
-  removeSshPtyConsumerRecovery(targetId: string): void {
+  async removeSshPtyConsumerRecovery(targetId: string): Promise<void> {
     const recoveries = this.state.sshPtyConsumerRecoveries ?? []
     const next = recoveries.filter((record) => record.targetId !== targetId)
     if (next.length === recoveries.length) {
       return
     }
     this.state.sshPtyConsumerRecoveries = next
-    this.flushSshPtyConsumerRecovery()
+    await this.flushSshPtyConsumerRecovery()
   }
 
-  private flushSshPtyConsumerRecovery(): void {
+  private async flushSshPtyConsumerRecovery(): Promise<void> {
     try {
-      // Why: ownership must be durable before relay setup continues, but active-view and GitHub sidecars are unrelated startup work.
-      this.flushOrThrow()
+      // Why: ownership must be durable before relay setup continues, but this runs on the live
+      // establish/reconnect path — a sync flush would park the main thread on a stalled profile mount.
+      await this.flushImmediateAsync()
     } catch (err) {
       console.error('[persistence] Failed to flush SSH PTY consumer recovery:', err)
     }

--- a/src/main/ssh/ssh-pty-consumer-recovery.test.ts
+++ b/src/main/ssh/ssh-pty-consumer-recovery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type { SshPtyConsumerOwnerState } from './ssh-pty-consumer-session'
+import {
+  claimSshPtyConsumerRecovery,
+  detachSshPtyConsumerRecovery,
+  rememberSshPtyConsumerRecovery
+} from './ssh-pty-consumer-recovery'
+
+describe('SSH PTY consumer recovery', () => {
+  it('keeps a detached identity when a concurrent open finishes late', async () => {
+    const targetId = 'remember-detach-race'
+    const store = {
+      getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
+      upsertSshPtyConsumerRecovery: vi.fn()
+    } as unknown as Store
+    const claimed = claimSshPtyConsumerRecovery(targetId, store)
+    let finishOpen!: (owner: SshPtyConsumerOwnerState) => void
+    const opened = new Promise<SshPtyConsumerOwnerState>((resolve) => {
+      finishOpen = resolve
+    })
+    const remembering = opened.then((owner) =>
+      rememberSshPtyConsumerRecovery({
+        targetId,
+        clientInstanceId: claimed.clientInstanceId,
+        serverBuildId: 'relay-build',
+        owner,
+        store
+      })
+    )
+
+    detachSshPtyConsumerRecovery(targetId, claimed.clientInstanceId)
+    finishOpen({
+      mode: 'negotiated',
+      clientInstanceId: claimed.clientInstanceId,
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'late-owner'
+    })
+    await remembering
+
+    expect(store.upsertSshPtyConsumerRecovery).not.toHaveBeenCalled()
+    expect(claimSshPtyConsumerRecovery(targetId, store)).toBe(claimed)
+  })
+})

--- a/src/main/ssh/ssh-pty-consumer-recovery.ts
+++ b/src/main/ssh/ssh-pty-consumer-recovery.ts
@@ -56,13 +56,15 @@ export function getSshPtyConsumerRecovery(
   return recoveryByTarget.get(targetId)
 }
 
-export function rememberSshPtyConsumerRecovery(args: {
+// Why async: the in-memory update lands synchronously (before the first await) so no caller can
+// observe a torn state; only the awaited durability barrier is deferred.
+export async function rememberSshPtyConsumerRecovery(args: {
   targetId: string
   clientInstanceId: string
   serverBuildId: string
   owner: SshPtyConsumerOwnerState
   store: Store
-}): void {
+}): Promise<void> {
   const current = recoveryByTarget.get(args.targetId)
   if (current?.clientInstanceId !== args.clientInstanceId) {
     return
@@ -70,7 +72,7 @@ export function rememberSshPtyConsumerRecovery(args: {
   current.detached = false
   current.serverBuildId = args.serverBuildId
   current.owner = args.owner
-  args.store.upsertSshPtyConsumerRecovery({
+  await args.store.upsertSshPtyConsumerRecovery({
     targetId: args.targetId,
     clientInstanceId: args.clientInstanceId,
     serverBuildId: args.serverBuildId,
@@ -81,14 +83,14 @@ export function rememberSshPtyConsumerRecovery(args: {
   })
 }
 
-export function removeSshPtyConsumerOwnerRecovery(
+export async function removeSshPtyConsumerOwnerRecovery(
   targetId: string,
   clientInstanceId: string,
   store: Store
-): void {
+): Promise<void> {
   const persisted = store.getSshPtyConsumerRecovery(targetId)
   if (persisted?.clientInstanceId === clientInstanceId) {
-    store.removeSshPtyConsumerRecovery(targetId)
+    await store.removeSshPtyConsumerRecovery(targetId)
   }
 }
 
@@ -99,14 +101,14 @@ export function detachSshPtyConsumerRecovery(targetId: string, clientInstanceId:
   }
 }
 
-export function forgetSshPtyConsumerRecovery(
+export async function forgetSshPtyConsumerRecovery(
   targetId: string,
   clientInstanceId: string,
   store: Store
-): void {
+): Promise<void> {
   const current = recoveryByTarget.get(targetId)
   if (current?.clientInstanceId === clientInstanceId) {
     recoveryByTarget.delete(targetId)
   }
-  removeSshPtyConsumerOwnerRecovery(targetId, clientInstanceId, store)
+  await removeSshPtyConsumerOwnerRecovery(targetId, clientInstanceId, store)
 }

--- a/src/main/ssh/ssh-pty-consumer-recovery.ts
+++ b/src/main/ssh/ssh-pty-consumer-recovery.ts
@@ -66,10 +66,9 @@ export async function rememberSshPtyConsumerRecovery(args: {
   store: Store
 }): Promise<void> {
   const current = recoveryByTarget.get(args.targetId)
-  if (current?.clientInstanceId !== args.clientInstanceId) {
+  if (current?.clientInstanceId !== args.clientInstanceId || current.detached) {
     return
   }
-  current.detached = false
   current.serverBuildId = args.serverBuildId
   current.owner = args.owner
   await args.store.upsertSshPtyConsumerRecovery({

--- a/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
+++ b/src/main/ssh/ssh-relay-session-agent-hooks.integration.test.ts
@@ -154,7 +154,9 @@ function createSession(targetId: string): InstanceType<typeof SshRelaySession> {
     removeSshPtyConsumerRecovery: vi.fn(),
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
-    markSshRemotePtyLeases: vi.fn()
+    markSshRemotePtyLeases: vi.fn(),
+    markSshRemotePtyLeasesAsync: vi.fn(),
+    markSshRemotePtyLeasesAttachedAsync: vi.fn()
   } as unknown as Store
   const portForwardManager = {
     removeAllForwards: vi.fn().mockResolvedValue(undefined)

--- a/src/main/ssh/ssh-relay-session-data-delivery.test.ts
+++ b/src/main/ssh/ssh-relay-session-data-delivery.test.ts
@@ -819,7 +819,7 @@ describe('SshRelaySession data delivery', () => {
     )
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(targetId, 'pty-1', 'detached')
     expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(targetId, 'pty-1', 'expired')
-    expect(mockStore.markSshRemotePtyLeases).not.toHaveBeenCalled()
+    expect(mockStore.markSshRemotePtyLeasesAsync).not.toHaveBeenCalled()
     expect(clearProviderPtyState).not.toHaveBeenCalled()
     expect(clearPtyOwnershipForConnection).not.toHaveBeenCalled()
     expect(deletePtyOwnership).not.toHaveBeenCalled()
@@ -836,10 +836,8 @@ describe('SshRelaySession data delivery', () => {
     })
 
     expect(acceptOutputDataMock.mock.calls.map(([payload]) => payload.data)).toEqual(['live'])
-    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
-      'empty-recovery',
-      'pty-1',
-      'attached'
-    )
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith('empty-recovery', [
+      'pty-1'
+    ])
   })
 })

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -220,12 +220,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       const reconnect = session.reconnect(mockConn)
       await vi.advanceTimersByTimeAsync(750)
 
-      expect(
-        vi
-          .mocked(mockStore.markSshRemotePtyLease)
-          .mock.calls.filter(([, , state]) => state === 'attached')
-          .map(([, id]) => id)
-      ).toHaveLength(48)
+      expect(setPtyOwnership).toHaveBeenCalledTimes(48)
+      expect(mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
       expect(peakActive).toBeLessThanOrEqual(8)
 
       await vi.advanceTimersByTimeAsync(20_000)
@@ -235,6 +231,11 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       expect(attempts.get('pty-0')).toBe(2)
       expect(attempts.get('pty-1')).toBe(2)
       expect(session.getState()).toBe('ready')
+      expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledOnce()
+      expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith(
+        'target-1',
+        expect.arrayContaining(ptyIds.slice(2))
+      )
       expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
         'target-1',
         expect.any(String),
@@ -420,7 +421,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId
     })
     expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(mockStore.markSshRemotePtyLease).mock.invocationCallOrder[0]!
+      vi.mocked(mockStore.markSshRemotePtyLeasesAttachedAsync).mock.invocationCallOrder[0]!
     )
   })
 
@@ -564,7 +565,9 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       leafId: INCARNATION_LEAF_ID,
       incarnationId
     })
-    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-live', 'attached')
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith('target-1', [
+      'pty-live'
+    ])
     expect(consoleError).toHaveBeenCalledWith(
       '[ssh-relay-session] Failed to persist reconnect incarnation:',
       expect.any(Error)

--- a/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
@@ -97,7 +97,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 }))
 
 const { deployAndLaunchRelay } = await import('./ssh-relay-deploy')
-const { clearPtyOwnershipForConnection } = await import('../ipc/pty')
+const { clearPtyOwnershipForConnection, unregisterSshPtyProvider } = await import('../ipc/pty')
 
 describe('SshRelaySession consumer recovery durability', () => {
   beforeEach(() => {
@@ -312,5 +312,44 @@ describe('SshRelaySession consumer recovery durability', () => {
     vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockClear()
     await session.detachAndPersist()
     expect(mockStore.markSshRemotePtyLeasesAsync).not.toHaveBeenCalled()
+  })
+
+  it('re-issues only the lease write after a rejected detach persistence', async () => {
+    const targetId = 'target-detach-write-retry'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockRejectedValueOnce(
+      new Error('lease write failed')
+    )
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+    vi.mocked(clearPtyOwnershipForConnection).mockClear()
+
+    await expect(session.detachAndPersist()).rejects.toThrow('lease write failed')
+
+    const teardownCalls = vi.mocked(unregisterSshPtyProvider).mock.calls.length
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockClear()
+    await session.detachAndPersist()
+
+    // Why: the retry re-issues the write only — re-running provider teardown would tear down
+    // whatever a replacement session has already registered for this target.
+    expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith(targetId, 'detached')
+    expect(unregisterSshPtyProvider).toHaveBeenCalledTimes(teardownCalls)
+    expect(clearPtyOwnershipForConnection).not.toHaveBeenCalled()
+  })
+
+  it('still upgrades to disposal after a rejected detach persistence', async () => {
+    const targetId = 'target-detach-write-failure-disposal'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockRejectedValueOnce(
+      new Error('lease write failed')
+    )
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    await expect(session.detachAndPersist()).rejects.toThrow('lease write failed')
+    await session.disposeAndPersist()
+
+    expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith(targetId, 'terminated')
+    expect(getSshPtyConsumerRecovery(targetId)).toBeUndefined()
   })
 })

--- a/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SshRelaySession } from './ssh-relay-session'
-import { createMockDeps } from './ssh-relay-session-test-fixtures'
+import {
+  createMismatchedOwnerRecoveryError,
+  createMockDeps
+} from './ssh-relay-session-test-fixtures'
+import { getSshPtyConsumerRecovery } from './ssh-pty-consumer-recovery'
 
 const { muxRequestMock, openConsumerSessionMock } = vi.hoisted(() => ({
   muxRequestMock: vi.fn(),
@@ -93,6 +97,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 }))
 
 const { deployAndLaunchRelay } = await import('./ssh-relay-deploy')
+const { clearPtyOwnershipForConnection } = await import('../ipc/pty')
 
 describe('SshRelaySession consumer recovery durability', () => {
   beforeEach(() => {
@@ -147,5 +152,165 @@ describe('SshRelaySession consumer recovery durability', () => {
     await establishing
     expect(established).toBe(true)
     session.dispose()
+  })
+
+  it('keeps destructive disposal pending until consumer recovery is removed', async () => {
+    const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.getSshPtyConsumerRecovery).mockReturnValue({
+      targetId: 'target-disposal-durability',
+      clientInstanceId: 'client-disposal-durability',
+      serverBuildId: 'test-relay-build',
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'owner-lease'
+    })
+    let settleRemoval!: () => void
+    vi.mocked(mockStore.removeSshPtyConsumerRecovery).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          settleRemoval = resolve
+        })
+    )
+    const session = new SshRelaySession(
+      'target-disposal-durability',
+      getMainWindow,
+      mockStore,
+      mockPortForward
+    )
+    let completed = false
+
+    const disposal = session.disposeAndPersist().then(() => {
+      completed = true
+    })
+    await Promise.resolve()
+
+    expect(session.getState()).toBe('disposed')
+    expect(completed).toBe(false)
+    expect(mockStore.markSshRemotePtyLeases).not.toHaveBeenCalled()
+    expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith(
+      'target-disposal-durability',
+      'terminated'
+    )
+
+    settleRemoval()
+    await disposal
+    expect(completed).toBe(true)
+  })
+
+  it('does not retry a stale owner after disposal wins the recovery-removal race', async () => {
+    const targetId = 'target-stale-owner-disposal'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.getSshPtyConsumerRecovery).mockReturnValue({
+      targetId,
+      clientInstanceId: 'persisted-client',
+      serverBuildId: 'test-relay-build',
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'stale-owner'
+    })
+    let signalRemovalStarted!: () => void
+    const removalStarted = new Promise<void>((resolve) => {
+      signalRemovalStarted = resolve
+    })
+    let settleRemoval!: () => void
+    vi.mocked(mockStore.removeSshPtyConsumerRecovery).mockImplementationOnce(() => {
+      signalRemovalStarted()
+      return new Promise<void>((resolve) => {
+        settleRemoval = resolve
+      })
+    })
+    openConsumerSessionMock.mockRejectedValueOnce(createMismatchedOwnerRecoveryError())
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+
+    const establishing = session.establish(mockConn)
+    const failed = expect(establishing).rejects.toThrow('Session disposed during establish')
+    await removalStarted
+    const disposal = session.disposeAndPersist()
+    settleRemoval()
+    await Promise.all([failed, disposal])
+
+    expect(openConsumerSessionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not remember a consumer opened after establish was disposed', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    let signalOpenStarted!: () => void
+    const openStarted = new Promise<void>((resolve) => {
+      signalOpenStarted = resolve
+    })
+    let finishOpen!: (value: unknown) => void
+    openConsumerSessionMock.mockImplementationOnce(() => {
+      signalOpenStarted()
+      return new Promise((resolve) => {
+        finishOpen = resolve
+      })
+    })
+    const session = new SshRelaySession(
+      'target-open-disposal',
+      getMainWindow,
+      mockStore,
+      mockPortForward
+    )
+
+    const establishing = session.establish(mockConn)
+    const failed = expect(establishing).rejects.toThrow('Session disposed during establish')
+    await openStarted
+    await session.disposeAndPersist()
+    finishOpen({
+      mode: 'negotiated',
+      clientInstanceId: 'late-client',
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'late-owner'
+    })
+    await failed
+
+    expect(mockStore.upsertSshPtyConsumerRecovery).not.toHaveBeenCalled()
+  })
+
+  it('upgrades a pending detach to a full disposal', async () => {
+    const targetId = 'target-teardown-upgrade'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    let settleDetachPersistence!: () => void
+    let settleDisposalPersistence!: () => void
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            settleDetachPersistence = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            settleDisposalPersistence = resolve
+          })
+      )
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    let detachCompleted = false
+    const detach = session.detachAndPersist().then(() => {
+      detachCompleted = true
+    })
+    const disposal = session.disposeAndPersist()
+
+    // Why: dispose supersedes the in-flight detach, so the destructive half must still run.
+    expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith(targetId, 'terminated')
+    expect(getSshPtyConsumerRecovery(targetId)).toBeUndefined()
+    // Why: 'shutdown' teardown, not detach's 'connection_lost' — PTY ownership is released for good.
+    expect(clearPtyOwnershipForConnection).toHaveBeenCalledWith(targetId)
+
+    settleDetachPersistence()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(detachCompleted).toBe(false)
+    settleDisposalPersistence()
+    await Promise.all([detach, disposal])
+
+    // Why: the reverse order is not an upgrade — a detach after disposal must not re-open ownership.
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockClear()
+    await session.detachAndPersist()
+    expect(mockStore.markSshRemotePtyLeasesAsync).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import { createMockDeps } from './ssh-relay-session-test-fixtures'
+
+const { muxRequestMock, openConsumerSessionMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  openConsumerSessionMock: vi.fn()
+}))
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 23),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {}),
+  applySshPtySourceCancellationProof: vi.fn(),
+  applySshPtySourceRecoveryCancellationProof: vi.fn()
+}))
+
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    notify = vi.fn()
+    notifyWithSettlement = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+  }
+}))
+
+vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
+  installRemoteManagedAgentHooks: vi.fn().mockResolvedValue([])
+}))
+
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: vi.fn().mockReturnValue(false),
+  isSshPtyIdentityMismatchError: vi.fn().mockReturnValue(false),
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    setPtyDeliveryPauseAdapter = vi.fn()
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  setPtyOwnership: vi.fn()
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { deployAndLaunchRelay } = await import('./ssh-relay-deploy')
+
+describe('SshRelaySession consumer recovery durability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    muxRequestMock.mockResolvedValue([])
+    openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
+      mode: 'negotiated',
+      clientInstanceId: options.clientInstanceId,
+      clientGeneration: 1,
+      ownerGeneration: 1,
+      ownerLease: 'test-owner-lease'
+    }))
+    vi.mocked(deployAndLaunchRelay).mockResolvedValue({
+      transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
+      platform: 'linux-x64',
+      serverBuildId: 'test-relay-build'
+    })
+  })
+
+  it('holds establish open until the consumer recovery write is durable', async () => {
+    const deps = createMockDeps()
+    let settleWrite!: () => void
+    let signalWriteStarted!: () => void
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve
+    })
+    vi.mocked(deps.mockStore.upsertSshPtyConsumerRecovery).mockImplementation(() => {
+      signalWriteStarted()
+      return new Promise<void>((resolve) => {
+        settleWrite = resolve
+      })
+    })
+
+    const session = new SshRelaySession(
+      'durability-barrier-target',
+      deps.getMainWindow,
+      deps.mockStore,
+      deps.mockPortForward
+    )
+    let established = false
+    const establishing = session.establish(deps.mockConn).then(() => {
+      established = true
+    })
+
+    await writeStarted
+    // Why a macrotask, not a microtask count: establish() has several awaits after the write starts,
+    // so only yielding past the whole microtask queue proves the write is the thing blocking it.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(established).toBe(false)
+
+    settleWrite()
+    await establishing
+    expect(established).toBe(true)
+    session.dispose()
+  })
+})

--- a/src/main/ssh/ssh-relay-session-recovery-races.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-races.test.ts
@@ -279,11 +279,7 @@ describe('SshRelaySession recovery race fencing', () => {
     expect(recoveryActivationLease.retire).not.toHaveBeenCalled()
     expect(muxRequestMock).not.toHaveBeenCalledWith('pty.cancelDelivery', expect.anything())
     expect(setPtyOwnership).not.toHaveBeenCalled()
-    expect(deps.mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
-      targetId,
-      'pty-1',
-      'attached'
-    )
+    expect(deps.mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
   })
 
   it('settles exact cancellation before publishing an exit with incomplete recovery data', async () => {
@@ -775,8 +771,10 @@ describe('SshRelaySession recovery race fencing', () => {
     expect(muxRequestMock.mock.calls.filter(([method]) => method === 'pty.cancelDelivery')).toEqual(
       []
     )
-    expect(deps.mockStore.markSshRemotePtyLease).toHaveBeenCalledTimes(1)
-    expect(deps.mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(targetId, 'pty-1', 'attached')
+    expect(deps.mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledOnce()
+    expect(deps.mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith(targetId, [
+      'pty-1'
+    ])
     expect(setPtyOwnership).toHaveBeenCalledTimes(1)
     expect(staleLease.transferToRecovery).toHaveBeenCalledOnce()
     expect(staleLease.commit).not.toHaveBeenCalled()

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -105,7 +105,9 @@ function createMockDeps(): {
     removeSshPtyConsumerRecovery: vi.fn(),
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
-    markSshRemotePtyLeases: vi.fn()
+    markSshRemotePtyLeases: vi.fn(),
+    markSshRemotePtyLeasesAsync: vi.fn(),
+    markSshRemotePtyLeasesAttachedAsync: vi.fn()
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -24,6 +24,8 @@ export function createMockDeps(): SshRelaySessionTestDeps {
     getSshRemotePtyLeases: vi.fn().mockReturnValue([]),
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),
+    markSshRemotePtyLeasesAsync: vi.fn(),
+    markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     persistPtyBinding: vi.fn()
   } as unknown as Store
   const mockPortForward = {

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -497,7 +497,9 @@ describe('SshRelaySession', () => {
 
     expect(mockAttach).toHaveBeenCalledWith('pty-1')
     expect(setPtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-1', 'target-1')
-    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-1', 'attached')
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith('target-1', [
+      'pty-1'
+    ])
   })
 
   it('establish re-attaches durable leases after app restart', async () => {
@@ -511,6 +513,7 @@ describe('SshRelaySession', () => {
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
       { targetId: 'target-1', ptyId: 'pty-live', state: 'detached' },
+      { targetId: 'target-1', ptyId: 'pty-live-2', state: 'detached' },
       { targetId: 'target-1', ptyId: 'pty-expired', state: 'expired' }
     ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
 
@@ -519,9 +522,14 @@ describe('SshRelaySession', () => {
     await session.establish(mockConn)
 
     expect(mockAttach).toHaveBeenCalledWith('pty-live')
+    expect(mockAttach).toHaveBeenCalledWith('pty-live-2')
     expect(mockAttach).not.toHaveBeenCalledWith('pty-expired')
     expect(setPtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-live', 'target-1')
-    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-live', 'attached')
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledOnce()
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith(
+      'target-1',
+      expect.arrayContaining(['pty-live', 'pty-live-2'])
+    )
   })
 
   it('forwards a lease tab identity to reattach so a reset relay cannot cross-wire it', async () => {
@@ -631,11 +639,7 @@ describe('SshRelaySession', () => {
 
     await expect(establish).rejects.toThrow('Session disposed during establish')
     expect(setPtyOwnership).not.toHaveBeenCalledWith('pty-1', 'target-1')
-    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
-      'target-1',
-      'pty-1',
-      'attached'
-    )
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
   })
 
   it('does not mark PTYs attached if detach wins while reattach is in flight', async () => {
@@ -665,11 +669,7 @@ describe('SshRelaySession', () => {
     await reconnect
 
     expect(setPtyOwnership).not.toHaveBeenCalledWith('pty-1', 'target-1')
-    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
-      'target-1',
-      'pty-1',
-      'attached'
-    )
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
   })
 
   it('invalidates and broadcasts remote PTYs that cannot reattach after relay reconnect', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -233,6 +233,27 @@ function normalizeRelayGracePeriodSeconds(graceTimeSeconds: number | undefined):
       )
 }
 
+// Why: teardown barriers are independent, so one failing store write must not hide the others —
+// settle them all and aggregate, rather than rethrowing only whichever rejected first.
+async function settleSshSessionTeardown(
+  barriers: (Promise<void> | null | undefined)[]
+): Promise<void> {
+  const results = await Promise.allSettled(barriers.map((barrier) => barrier ?? Promise.resolve()))
+  const errors = results.flatMap((result) =>
+    result.status === 'rejected' ? [result.reason as unknown] : []
+  )
+  if (errors.length === 1) {
+    throw errors[0]
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'SSH relay session teardown failed')
+  }
+}
+
+// Why: dispose is strictly more destructive than detach, so the mode records which teardown a
+// session has already committed to and lets dispose supersede an in-flight detach.
+type SshRelaySessionTeardownMode = 'detach' | 'dispose'
+
 export class SshRelaySession {
   private _state: RelaySessionState = 'idle'
   private mux: SshChannelMultiplexer | null = null
@@ -256,6 +277,8 @@ export class SshRelaySession {
   private activePtyProviderGeneration: number | null = null
   private sourceAckPublisherCleanup: (() => void) | null = null
   private sourceCancellationPublisherCleanup: (() => void) | null = null
+  private teardownMode: SshRelaySessionTeardownMode | null = null
+  private teardownCompletion: Promise<void> | null = null
   private ptyRecoveryNotificationCleanups: (() => void)[] = []
   private readonly sourceIdentityByRelayPtyId = new Map<
     string,
@@ -405,10 +428,24 @@ export class SshRelaySession {
 
       const mux = new SshChannelMultiplexer(transport)
       this.mux = mux
-      const ownsAttempt = (): boolean => this.mux === mux && !this.isDisposed()
+      const ownsAttempt = (): boolean => this.mux === mux && !mux.isDisposed() && !this.isDisposed()
 
-      this.ptyConsumerSessionState = await this.openPtyConsumerSession(mux, serverBuildId)
+      const ptyConsumerSessionState = await this.openPtyConsumerSession(
+        mux,
+        serverBuildId,
+        ownsAttempt
+      )
+      if (!ownsAttempt()) {
+        if (!mux.isDisposed()) {
+          mux.dispose()
+        }
+        throw new Error('Session disposed during establish')
+      }
+      this.ptyConsumerSessionState = ptyConsumerSessionState
       await this.rememberPtyConsumerRecovery(serverBuildId)
+      if (!ownsAttempt()) {
+        throw new Error('Session disposed during establish')
+      }
 
       await mux.request('session.resolveHome', { path: '~' })
       if (!ownsAttempt()) {
@@ -529,11 +566,24 @@ export class SshRelaySession {
       this.mux = mux
 
       const ownsAttempt = (): boolean =>
+        this.mux === mux &&
+        !mux.isDisposed() &&
         this.abortController === abortController &&
         !abortController.signal.aborted &&
         !this.isDisposed()
 
-      this.ptyConsumerSessionState = await this.openPtyConsumerSession(mux, serverBuildId)
+      const ptyConsumerSessionState = await this.openPtyConsumerSession(
+        mux,
+        serverBuildId,
+        ownsAttempt
+      )
+      if (!ownsAttempt()) {
+        if (!mux.isDisposed()) {
+          mux.dispose()
+        }
+        return
+      }
+      this.ptyConsumerSessionState = ptyConsumerSessionState
       await this.rememberPtyConsumerRecovery(serverBuildId)
       if (!ownsAttempt()) {
         if (!mux.isDisposed()) {
@@ -620,37 +670,108 @@ export class SshRelaySession {
     }
   }
 
+  /** Fire-and-forget disposal; prefer {@link disposeAndPersist} when the caller can await durability. */
   dispose(): void {
-    if (this._state === 'disposed') {
-      return
-    }
-    this.abortController?.abort()
-    this.stopPortScanning()
-    // Why: fire-and-forget — nothing rebinds after dispose, so no need to await port release.
-    void this.portForwardManager.removeAllForwards(this.targetId)
-    this.broadcastEmptyLists()
-    this.teardownProviders('shutdown')
-    this.store.markSshRemotePtyLeases(this.targetId, 'terminated')
-    this.currentConnection = null
-    this._state = 'disposed'
-    // Why: dispose() is synchronous; removal is cleanup, not an ordering barrier, and the
-    // in-memory entry is already deleted synchronously inside forget.
-    void forgetSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId, this.store)
+    void this.disposeAndPersist().catch((error) => {
+      console.warn(
+        `[ssh-relay-session] Failed to persist disposal for ${this.targetId}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    })
   }
 
-  detach(): void {
-    if (this._state === 'disposed') {
-      return
+  /**
+   * Destructive teardown: forgets the consumer recovery record and terminates the leases.
+   * Repeat calls share one completion, and a dispose requested after a detach supersedes it —
+   * the destructive half re-runs so detach-then-dispose still forgets recovery and terminates
+   * leases. (The reverse, detach after dispose, is a no-op.)
+   */
+  disposeAndPersist(): Promise<void> {
+    if (this.teardownMode === 'dispose') {
+      return this.teardownCompletion ?? Promise.resolve()
     }
+    const pendingDetach = this.teardownCompletion
+    this.teardownMode = 'dispose'
+    this.teardownCompletion = this.runDisposal(pendingDetach)
+    return this.teardownCompletion
+  }
+
+  private runDisposal(pendingDetach: Promise<void> | null): Promise<void> {
+    // Why: the whole in-memory half runs before any await so a concurrent connect can never observe
+    // a half-torn session; only the durability barriers below are deferred onto the returned promise.
     this.abortController?.abort()
     this.stopPortScanning()
     this.broadcastEmptyLists()
-    // Why: window disconnect is non-destructive — unregister local providers but keep PTY ownership so reattach works (relay owns the grace timer).
-    this.teardownProviders('connection_lost')
-    this.store.markSshRemotePtyLeases(this.targetId, 'detached')
+    this.teardownProviders('shutdown')
     this.currentConnection = null
     this._state = 'disposed'
+    const recoveryRemoval = forgetSshPtyConsumerRecovery(
+      this.targetId,
+      this.ptyConsumerClientInstanceId,
+      this.store
+    )
+    const leaseTermination = this.store.markSshRemotePtyLeasesAsync(this.targetId, 'terminated')
+    return settleSshSessionTeardown([
+      // Why: a superseded detach keeps its own rejection for its own caller; swallow it here so a
+      // failed detach write cannot fail the disposal that replaced it.
+      pendingDetach?.catch(() => undefined),
+      // Why: nothing rebinds after dispose, but direct callers (no IPC-side teardown) still need
+      // this session's local listeners released.
+      this.portForwardManager.removeAllForwards(this.targetId),
+      recoveryRemoval,
+      leaseTermination
+    ])
+  }
+
+  /** Fire-and-forget detach; prefer {@link detachAndPersist} when the caller can await durability. */
+  detach(): void {
+    void this.detachAndPersist().catch((error) => {
+      console.warn(
+        `[ssh-relay-session] Failed to persist detach for ${this.targetId}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    })
+  }
+
+  /**
+   * Non-destructive teardown: keeps PTY ownership so a later connect reclaims this consumer
+   * identity. Once dispose has been requested this is a no-op — see {@link disposeAndPersist}.
+   */
+  async detachAndPersist(): Promise<void> {
+    this.teardownCompletion ??= this.runDetach()
+    this.teardownMode ??= 'detach'
+    let completion = this.teardownCompletion
+    while (completion) {
+      try {
+        await completion
+      } catch (error) {
+        if (completion === this.teardownCompletion) {
+          throw error
+        }
+      }
+      if (completion === this.teardownCompletion) {
+        return
+      }
+      completion = this.teardownCompletion
+    }
+  }
+
+  private runDetach(): Promise<void> {
+    if (this._state === 'disposed') {
+      return Promise.resolve()
+    }
+    // Why first: same synchronous-half-first rule as runDisposal, and this is the highest-value
+    // step — a fast reconnect must reclaim this identity instead of minting one, even if a
+    // teardown call below throws unexpectedly.
     detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
+    this.abortController?.abort()
+    this.stopPortScanning()
+    this.broadcastEmptyLists()
+    // Why: disconnect keeps PTY ownership so a later manual connect can reattach.
+    this.teardownProviders('connection_lost')
+    this.currentConnection = null
+    this._state = 'disposed'
+    return settleSshSessionTeardown([
+      this.store.markSshRemotePtyLeasesAsync(this.targetId, 'detached')
+    ])
   }
 
   // ── Private ───────────────────────────────────────────────────────
@@ -834,7 +955,8 @@ export class SshRelaySession {
 
   private async openPtyConsumerSession(
     mux: SshChannelMultiplexer,
-    serverBuildId: string | undefined
+    serverBuildId: string | undefined,
+    ownsAttempt: () => boolean
   ): Promise<SshPtyConsumerSessionState> {
     const previousOwner = this.recoverablePtyConsumerOwner(serverBuildId)
     const options = {
@@ -883,6 +1005,9 @@ export class SshRelaySession {
         this.ptyConsumerClientInstanceId,
         this.store
       )
+      if (!ownsAttempt()) {
+        throw new Error('Session disposed during establish')
+      }
       this.ptyConsumerSessionState = null
       return openSshPtyConsumerSession(mux, options)
     }
@@ -1713,6 +1838,7 @@ export class SshRelaySession {
         })
         .filter((entry): entry is [string, ExpectedPtyIdentity] => entry !== null)
     )
+    const attachedLeaseIds = new Set<string>()
     // Why: after app restart ptyOwnership is empty, but durable SSH leases still describe grace-window survivors.
     const ptyIds = Array.from(
       new Set([
@@ -1740,6 +1866,7 @@ export class SshRelaySession {
             ptyId,
             activeLeaseByPtyId,
             expectedIdentityByPtyId,
+            attachedLeaseIds,
             mux,
             providerGeneration,
             shouldContinue
@@ -1759,6 +1886,12 @@ export class SshRelaySession {
     await Promise.all(
       Array.from({ length: Math.min(SSH_PTY_REATTACH_MAX_CONCURRENCY, ptyIds.length) }, worker)
     )
+    if (attachedLeaseIds.size > 0 && shouldContinue()) {
+      await this.store.markSshRemotePtyLeasesAttachedAsync(
+        this.targetId,
+        Array.from(attachedLeaseIds)
+      )
+    }
   }
 
   private async reattachKnownPty(args: {
@@ -1766,6 +1899,7 @@ export class SshRelaySession {
     ptyId: string
     activeLeaseByPtyId: Map<string, SshPtyLease>
     expectedIdentityByPtyId: Map<string, ExpectedPtyIdentity>
+    attachedLeaseIds: Set<string>
     mux: SshChannelMultiplexer
     providerGeneration: number
     shouldContinue: () => boolean
@@ -1775,6 +1909,7 @@ export class SshRelaySession {
       ptyId,
       activeLeaseByPtyId,
       expectedIdentityByPtyId,
+      attachedLeaseIds,
       mux,
       providerGeneration,
       shouldContinue
@@ -1890,7 +2025,7 @@ export class SshRelaySession {
           activeLeaseByPtyId.get(ptyId)
         )
       }
-      this.store.markSshRemotePtyLease(this.targetId, ptyId, 'attached')
+      attachedLeaseIds.add(ptyId)
       pendingReattach.activated = true
       recoveryActivationLease?.commit()
       recoveryActivationLease = undefined

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -279,6 +279,10 @@ export class SshRelaySession {
   private sourceCancellationPublisherCleanup: (() => void) | null = null
   private teardownMode: SshRelaySessionTeardownMode | null = null
   private teardownCompletion: Promise<void> | null = null
+  // Why: detach's in-memory half is one-shot but its lease write is retryable, so they are tracked
+  // apart — a rejected write can be re-issued without re-running provider teardown.
+  private detachedInMemory = false
+  private detachFlushRejected = false
   private ptyRecoveryNotificationCleanups: (() => void)[] = []
   private readonly sourceIdentityByRelayPtyId = new Map<
     string,
@@ -736,7 +740,12 @@ export class SshRelaySession {
    * identity. Once dispose has been requested this is a no-op — see {@link disposeAndPersist}.
    */
   async detachAndPersist(): Promise<void> {
-    this.teardownCompletion ??= this.runDetach()
+    // Why: a rejected lease write must not latch forever — re-issue just the write so the caller can
+    // retry. Never under 'dispose': that supersedes detach for good and re-issuing would resurrect
+    // the 'detached' state the disposal already replaced with 'terminated'.
+    if (!this.teardownCompletion || (this.teardownMode === 'detach' && this.detachFlushRejected)) {
+      this.teardownCompletion = this.runDetach()
+    }
     this.teardownMode ??= 'detach'
     let completion = this.teardownCompletion
     while (completion) {
@@ -755,23 +764,30 @@ export class SshRelaySession {
   }
 
   private runDetach(): Promise<void> {
-    if (this._state === 'disposed') {
-      return Promise.resolve()
+    if (!this.detachedInMemory) {
+      if (this._state === 'disposed') {
+        return Promise.resolve()
+      }
+      // Why first: same synchronous-half-first rule as runDisposal, and this is the highest-value
+      // step — a fast reconnect must reclaim this identity instead of minting one, even if a
+      // teardown call below throws unexpectedly.
+      detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
+      this.abortController?.abort()
+      this.stopPortScanning()
+      this.broadcastEmptyLists()
+      // Why: disconnect keeps PTY ownership so a later manual connect can reattach.
+      this.teardownProviders('connection_lost')
+      this.currentConnection = null
+      this._state = 'disposed'
+      this.detachedInMemory = true
     }
-    // Why first: same synchronous-half-first rule as runDisposal, and this is the highest-value
-    // step — a fast reconnect must reclaim this identity instead of minting one, even if a
-    // teardown call below throws unexpectedly.
-    detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
-    this.abortController?.abort()
-    this.stopPortScanning()
-    this.broadcastEmptyLists()
-    // Why: disconnect keeps PTY ownership so a later manual connect can reattach.
-    this.teardownProviders('connection_lost')
-    this.currentConnection = null
-    this._state = 'disposed'
+    this.detachFlushRejected = false
     return settleSshSessionTeardown([
       this.store.markSshRemotePtyLeasesAsync(this.targetId, 'detached')
-    ])
+    ]).catch((error: unknown) => {
+      this.detachFlushRejected = true
+      throw error
+    })
   }
 
   // ── Private ───────────────────────────────────────────────────────

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -408,7 +408,7 @@ export class SshRelaySession {
       const ownsAttempt = (): boolean => this.mux === mux && !this.isDisposed()
 
       this.ptyConsumerSessionState = await this.openPtyConsumerSession(mux, serverBuildId)
-      this.rememberPtyConsumerRecovery(serverBuildId)
+      await this.rememberPtyConsumerRecovery(serverBuildId)
 
       await mux.request('session.resolveHome', { path: '~' })
       if (!ownsAttempt()) {
@@ -534,7 +534,7 @@ export class SshRelaySession {
         !this.isDisposed()
 
       this.ptyConsumerSessionState = await this.openPtyConsumerSession(mux, serverBuildId)
-      this.rememberPtyConsumerRecovery(serverBuildId)
+      await this.rememberPtyConsumerRecovery(serverBuildId)
       if (!ownsAttempt()) {
         if (!mux.isDisposed()) {
           mux.dispose()
@@ -633,7 +633,9 @@ export class SshRelaySession {
     this.store.markSshRemotePtyLeases(this.targetId, 'terminated')
     this.currentConnection = null
     this._state = 'disposed'
-    forgetSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId, this.store)
+    // Why: dispose() is synchronous; removal is cleanup, not an ordering barrier, and the
+    // in-memory entry is already deleted synchronously inside forget.
+    void forgetSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId, this.store)
   }
 
   detach(): void {
@@ -876,18 +878,22 @@ export class SshRelaySession {
           )
         }
       }
-      removeSshPtyConsumerOwnerRecovery(this.targetId, this.ptyConsumerClientInstanceId, this.store)
+      await removeSshPtyConsumerOwnerRecovery(
+        this.targetId,
+        this.ptyConsumerClientInstanceId,
+        this.store
+      )
       this.ptyConsumerSessionState = null
       return openSshPtyConsumerSession(mux, options)
     }
   }
 
-  private rememberPtyConsumerRecovery(serverBuildId: string | undefined): void {
+  private async rememberPtyConsumerRecovery(serverBuildId: string | undefined): Promise<void> {
     const owner = this.activePtyConsumerOwner()
     if (!owner || !serverBuildId) {
       return
     }
-    rememberSshPtyConsumerRecovery({
+    await rememberSshPtyConsumerRecovery({
       targetId: this.targetId,
       clientInstanceId: this.ptyConsumerClientInstanceId,
       serverBuildId,

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -448,6 +448,9 @@ export class SshRelaySession {
       this.ptyConsumerSessionState = ptyConsumerSessionState
       await this.rememberPtyConsumerRecovery(serverBuildId)
       if (!ownsAttempt()) {
+        if (!mux.isDisposed()) {
+          mux.dispose()
+        }
         throw new Error('Session disposed during establish')
       }
 
@@ -695,7 +698,13 @@ export class SshRelaySession {
     }
     const pendingDetach = this.teardownCompletion
     this.teardownMode = 'dispose'
-    this.teardownCompletion = this.runDisposal(pendingDetach)
+    try {
+      this.teardownCompletion = this.runDisposal(pendingDetach)
+    } catch (error) {
+      // Why: a synchronous failure in the in-memory half must ride the completion promise, or a later
+      // disposeAndPersist reports success on a null completion and detachAndPersist re-runs runDetach.
+      this.teardownCompletion = Promise.reject(error)
+    }
     return this.teardownCompletion
   }
 


### PR DESCRIPTION
## Problem

Release-scan finding **P1-A** from the v1.4.164-rc.0 multi-panel scan. Two independent defects in the SSH PTY consumer-recovery path:

**A1 — main-thread freeze on establish/reconnect.**
`SshRelaySession.rememberPtyConsumerRecovery` → `rememberSshPtyConsumerRecovery` → `Store.upsertSshPtyConsumerRecovery` → `flushSshPtyConsumerRecovery` → `flushOrThrow()` → `writeToDiskSync()` → `writeFileDurableSync()`. That is a full synchronous serialize + `fsync` + rename of the entire profile state file, executed inline on **every** `establish()` and every `reconnect()`. On a stalled or slow profile mount (network home dir, contended disk) the Electron main thread parks for the duration — exactly during live SSH recovery, when the app most needs to stay responsive.

**A2 — a failed connect discards the consumer identity.**
`claimSshPtyConsumerRecovery` reuses an existing in-memory entry only when `detached === true`; otherwise it mints a fresh `clientInstanceId` and drops the persisted record's owner lease. The success path in `doConnect` detaches the outgoing session before replacing it (`src/main/ipc/ssh.ts:1068`), but both **failure** exits — the transport-connect catch and the establish catch — did a bare `activeSessions.delete(targetId)` with no `detach()`. So after any failed connect, the stale non-detached entry was still in `recoveryByTarget`, and the next attempt minted a new identity, losing the owner lease (`ownerGeneration` / `ownerLease`) that `pty.openClient`'s `resume` needs to reclaim relay session ownership.

## Design

Design doc: `docs/reference/plans/2026-08-01-P1-A-ssh-consumer-recovery.md` (local-only — `.gitignore` line 90 keeps `docs/**` planning docs out of the tree; the allow-list only covers the four AGENTS.md-linked reference docs). Its content is summarized here.

**A1 — awaited async durability, not fire-and-forget.** The original ordering guarantee ("ownership is durable before relay setup continues") is worth keeping; only the *blocking* is wrong. New private `Store.flushAsync()` mirrors `flushOrThrow()`'s debounce cancellation and `firstPendingSaveAt` reset, but chains `writeToDiskAsync()` onto the existing `pendingWrite` serialization chain (issue #1158 — backup rotation must not race two writers) instead of blocking. It deliberately does **not** bump `writeGeneration`: fencing is for the sync path, whereas this write chains. The tracked promise swallows rejections so it can't poison the next chained write or surface through `waitForPendingWrite()`; the caller still sees failures through the returned promise.

Rejected alternatives: a sidecar file for the recovery record (new format, new migration, new crash-consistency surface for one small record); dropping the barrier entirely and letting the debounce handle it (loses the durable-before-setup guarantee that motivated the original sync flush).

**A2 — `detach()`, not `dispose()`.** `dispose()` calls `forgetSshPtyConsumerRecovery`, which deletes both the in-memory and the persisted record — the exact identity loss being fixed. `detach()` marks the entry `detached = true`, which is precisely the state `claim` reclaims. Rejected alternative: a `claimSeq` fencing redesign in the recovery module — out of proportion to the bug, and noted as a follow-up in the doc's Non-goals.

## What changed

**A1**
- `src/main/persistence.ts` — new private `flushAsync()`; `upsertSshPtyConsumerRecovery` / `removeSshPtyConsumerRecovery` / `flushSshPtyConsumerRecovery` are now `async` and await it.
- `src/main/ssh/ssh-pty-consumer-recovery.ts` — `rememberSshPtyConsumerRecovery`, `removeSshPtyConsumerOwnerRecovery`, `forgetSshPtyConsumerRecovery` are now `async`.
- `src/main/ssh/ssh-relay-session.ts` — `rememberPtyConsumerRecovery` is `async`; both call sites (`establish()`, `reconnect()`) await it, as does the stale-owner branch of `openPtyConsumerSession`. `dispose()` stays synchronous and fire-and-forgets the removal.

Every in-memory mutation still lands **before the first `await`** in each of these functions, so the map entry, the `Store.state` array, and the `detached` flag all update synchronously. No caller can observe a torn record, `dispose()` remains synchronous from the caller's view, and a quit-time `flushOrThrow()` still writes the already-updated state.

**A2**
- `src/main/ipc/ssh.ts` — new `abandonFailedSshSession(targetId, session)` helper; both failure exits (`:1114`, `:1152`) route through it. It detaches first, tolerates a teardown throw so it can't mask the connect error being rethrown, and only deletes from `activeSessions` when the entry is still this session.

`detach()` was audited for safety on a never-established session: `abortController?.abort()` is optional-chained, `stopPortScanning()` is null-guarded, `broadcastEmptyLists()` is truthful (the connect failed, so there are no ports), `teardownProviders('connection_lost')` is idempotent and null-guards every handle, and `markSshRemotePtyLeases(targetId, 'detached')` is guarded on `state === 'attached'` so it can't resurrect a terminated lease. `establish()`'s own catch resets `_state` to `'idle'` (not `'disposed'`), so `detach()` does not early-return. This is also strictly safer than the old bare delete, which left a live non-disposed session whose `_onRelayLost` callback could still fire for a target no longer in `activeSessions`.

## Tests

Six new tests. **Each was negative-verified** by reverting the corresponding fix and confirming failure, then restoring.

`src/main/persistence-async-write-syscalls.test.ts` (3, following the existing no-sync-syscall harness):
- persists consumer recovery with no sync syscall, durable once awaited — without the fix: `expected [ …(13) ] to deeply equal []`
- removes consumer recovery with no sync syscall, durable once awaited — without the fix: `expected [ …(6) ] to deeply equal []`
- a main-thread timer keeps firing while the write is in flight (the freeze itself: 1000ms stalled write, 10ms heartbeat, asserts worst gap < 500ms) — without the fix: `expected 13123 to be less than 500`

`src/main/ssh/ssh-relay-session-recovery-durability.test.ts` (new file, 1):
- `establish()` stays open until the consumer-recovery write settles — without the barrier (`void` instead of `await`): `expected true to be false`

`src/main/ipc/ssh.test.ts` (2):
- reclaims the consumer identity after a failed transport connect
- resumes the remembered owner lease after a failed establish (asserts `pty.openClient` carries the same `clientInstanceId` **and** `resume: { ownerGeneration, ownerLease }`)

Both fail without the fix with a fresh-UUID mismatch, e.g. `expected 'dd5059d5-…' to be 'f6bd9242-…'`.

## Validation run

- `npx tsc --noEmit -p config/tsconfig.node.json` — clean
- `npx vitest run --config config/vitest.config.ts src/main` — **1338 files / 18074 tests passed**, 9 files / 58 tests skipped
- `npx oxfmt --check -c .oxfmtrc.json <8 touched files>` — all correct
- `npx oxlint <8 touched files>` — clean

**Not run:** Electron runtime and the Docker SSH e2e specs (`ORCA_E2E_SSH_DOCKER=1`). No runtime proof of the freeze relief is claimed beyond the event-loop heartbeat unit test above.

## Residual risk

- **Low.** The durability barrier is preserved, so establish/reconnect still wait the same wall-clock time on a stalled mount — the main thread is simply no longer blocked while it waits. The unbounded wait itself is pre-existing and out of scope; bounding it would be a behavior change.
- `flushAsync` chains onto `pendingWrite` rather than fencing via `writeGeneration`. A concurrent quit-time `flushOrThrow()` bumps the generation and the in-flight async write skips its rename — correct, because the sync flush already wrote the fresher state including this record, and the async promise resolves normally rather than rejecting.
- `dispose()` now fire-and-forgets the persisted removal. The logical removal (in-memory map + `Store.state`) is still synchronous, so only the disk write is deferred; a subsequent quit flush picks it up.

## RC context

Found by the v1.4.164-rc.0 release scan. Both defects are on the live SSH reconnect path, so the impact is concentrated on SSH workspaces recovering after a network blip — the freeze (A1) and a lost resume identity that forces a fresh consumer session (A2).

Made with [Orca](https://github.com/stablyai/orca) 🐋
