### PR TITLE
feat(preflight): show host-side gh/glab status on Integrations cards

### DIFF
--- a/src/main/ipc/preflight-remote-ssh.test.ts
+++ b/src/main/ipc/preflight-remote-ssh.test.ts
@@ -213,7 +213,7 @@ describe('preflight', () => {
   }
 
   describe('detectRemoteForgeClis', () => {
-    it('requests the relay method with both forge CLIs', async () => {
+    it('requests the relay method with both forge CLIs under a bounded timeout', async () => {
       const request = vi
         .fn()
         .mockResolvedValue({ results: { glab: { installed: true, authenticated: true } } })
@@ -221,8 +221,19 @@ describe('preflight', () => {
 
       const results = await detectRemoteForgeClis({ connectionId: 'ssh-1' })
 
-      expect(request).toHaveBeenCalledWith('preflight.detectForgeClis', { clis: ['gh', 'glab'] })
+      expect(request).toHaveBeenCalledWith(
+        'preflight.detectForgeClis',
+        { clis: ['gh', 'glab'] },
+        { timeoutMs: 8000 }
+      )
       expect(results?.glab).toEqual({ installed: true, authenticated: true })
+    })
+
+    it('returns null for a malformed relay response', async () => {
+      const request = vi.fn().mockResolvedValue({})
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => false, request })
+
+      expect(await detectRemoteForgeClis({ connectionId: 'ssh-1' })).toBeNull()
     })
 
     it('returns null when no live mux exists', async () => {
@@ -260,7 +271,37 @@ describe('preflight', () => {
       expect(status.hostForge?.connectionId).toBe('ssh-1')
       expect(status.hostForge?.hostLabel).toBe('work-box')
       expect(status.hostForge?.glab).toEqual({ installed: true, authenticated: true })
-      expect(request).toHaveBeenCalledWith('preflight.detectForgeClis', { clis: ['gh', 'glab'] })
+      expect(request).toHaveBeenCalledWith(
+        'preflight.detectForgeClis',
+        { clis: ['gh', 'glab'] },
+        { timeoutMs: 8000 }
+      )
+    })
+
+    it('omits hostForge when the host knows neither forge CLI', async () => {
+      mockAuthenticatedLocalProbes()
+      const request = vi.fn().mockResolvedValue({ results: {} })
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => false, request })
+
+      const status = await runPreflightCheck(true, contextWithSshHost('ssh-1', 'work-box'))
+
+      expect(status.hostForge).toBeUndefined()
+    })
+
+    it('keeps an SSH-host result out of the local cache slot', async () => {
+      mockAuthenticatedLocalProbes()
+      const request = vi
+        .fn()
+        .mockResolvedValue({ results: { glab: { installed: true, authenticated: true } } })
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => false, request })
+
+      await runPreflightCheck(true, contextWithSshHost('ssh-1', 'work-box'))
+      getActiveMultiplexerMock.mockClear()
+      mockAuthenticatedLocalProbes()
+      const local = await runPreflightCheck(false)
+
+      expect(local.hostForge).toBeUndefined()
+      expect(getActiveMultiplexerMock).not.toHaveBeenCalled()
     })
 
     it('omits hostForge entirely for local contexts', async () => {

--- a/src/main/ipc/preflight-remote-ssh.test.ts
+++ b/src/main/ipc/preflight-remote-ssh.test.ts
@@ -86,8 +86,9 @@ vi.mock('../gitea/client', () => ({
   getGiteaAuthStatus: getGiteaAuthStatusMock
 }))
 
-import { registerPreflightHandlers } from './preflight'
+import { detectRemoteForgeClis, registerPreflightHandlers, runPreflightCheck } from './preflight'
 import { resetPreflightMocks, type HandlerMap } from './preflight-test-harness'
+import type { PreflightRuntimeContext } from '../../preload/api/preflight-api'
 
 describe('preflight', () => {
   const originalPlatform = process.platform
@@ -193,5 +194,92 @@ describe('preflight', () => {
       hostPlatform: 'win32'
     })
     expect(request).toHaveBeenCalledWith('preflight.detectWindowsTerminalCapabilities', {})
+  })
+
+  function contextWithSshHost(connectionId: string, hostLabel: string): PreflightRuntimeContext {
+    return { sshHost: { connectionId, hostLabel } }
+  }
+
+  // Why: the standard local-probe sequence (git/gh/glab install checks, then
+  // gh/glab auth status) so hostForge cases don't also assert on unrelated
+  // local install/auth outcomes.
+  function mockAuthenticatedLocalProbes(): void {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
+  }
+
+  describe('detectRemoteForgeClis', () => {
+    it('requests the relay method with both forge CLIs', async () => {
+      const request = vi
+        .fn()
+        .mockResolvedValue({ results: { glab: { installed: true, authenticated: true } } })
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => false, request })
+
+      const results = await detectRemoteForgeClis({ connectionId: 'ssh-1' })
+
+      expect(request).toHaveBeenCalledWith('preflight.detectForgeClis', { clis: ['gh', 'glab'] })
+      expect(results?.glab).toEqual({ installed: true, authenticated: true })
+    })
+
+    it('returns null when no live mux exists', async () => {
+      getActiveMultiplexerMock.mockReturnValue(undefined)
+
+      expect(await detectRemoteForgeClis({ connectionId: 'ssh-1' })).toBeNull()
+    })
+
+    it('returns null when the multiplexer is disposed', async () => {
+      const request = vi.fn()
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => true, request })
+
+      expect(await detectRemoteForgeClis({ connectionId: 'ssh-1' })).toBeNull()
+      expect(request).not.toHaveBeenCalled()
+    })
+
+    it('returns null on method-not-found from an old relay', async () => {
+      const request = vi.fn().mockRejectedValue({ code: -32601 })
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => false, request })
+
+      expect(await detectRemoteForgeClis({ connectionId: 'ssh-1' })).toBeNull()
+    })
+  })
+
+  describe('runPreflightCheck hostForge', () => {
+    it('attaches hostForge when the context names an SSH execution host', async () => {
+      mockAuthenticatedLocalProbes()
+      const request = vi
+        .fn()
+        .mockResolvedValue({ results: { glab: { installed: true, authenticated: true } } })
+      getActiveMultiplexerMock.mockReturnValue({ isDisposed: () => false, request })
+
+      const status = await runPreflightCheck(true, contextWithSshHost('ssh-1', 'work-box'))
+
+      expect(status.hostForge?.connectionId).toBe('ssh-1')
+      expect(status.hostForge?.hostLabel).toBe('work-box')
+      expect(status.hostForge?.glab).toEqual({ installed: true, authenticated: true })
+      expect(request).toHaveBeenCalledWith('preflight.detectForgeClis', { clis: ['gh', 'glab'] })
+    })
+
+    it('omits hostForge entirely for local contexts', async () => {
+      mockAuthenticatedLocalProbes()
+
+      const status = await runPreflightCheck(true)
+
+      expect(status.hostForge).toBeUndefined()
+      expect(getActiveMultiplexerMock).not.toHaveBeenCalled()
+    })
+
+    it('omits hostForge when the remote probe returns null, leaving local status intact', async () => {
+      mockAuthenticatedLocalProbes()
+      getActiveMultiplexerMock.mockReturnValue(undefined)
+
+      const status = await runPreflightCheck(true, contextWithSshHost('ssh-1', 'work-box'))
+
+      expect(status.hostForge).toBeUndefined()
+      expect(status.glab).toEqual({ installed: true, authenticated: true })
+    })
   })
 })

--- a/src/main/ipc/preflight-runtime-target.ts
+++ b/src/main/ipc/preflight-runtime-target.ts
@@ -5,6 +5,11 @@ export type PreflightRuntimeContext = {
   wslDistro?: string | null
   wslDefault?: boolean
   projectRuntime?: ProjectExecutionRuntimeResolution
+  // Why: names the SSH execution host so runPreflightCheck can additionally
+  // probe forge CLIs there — rides the context the same way wslDistro/
+  // wslDefault ride the WSL target, but needs no derivation function since
+  // it is a single flat shape rather than several fallback sources.
+  sshHost?: { connectionId: string; hostLabel: string }
 }
 
 export function getPreflightWslTarget(

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -112,6 +112,8 @@ let preflightRunCounter = 0
 let preflightCacheEpoch = 0
 
 const LOCAL_PREFLIGHT_CACHE_KEY = 'local'
+// Why: keep a wedged remote host from delaying local integration status.
+const REMOTE_FORGE_PROBE_TIMEOUT_MS = 8000
 
 function preflightCacheKey(
   wslTarget: WslPreflightTarget | null,
@@ -271,10 +273,12 @@ export async function detectRemoteForgeClis(args: {
     return null
   }
   try {
-    const result = (await mux.request('preflight.detectForgeClis', {
-      clis: ['gh', 'glab']
-    })) as { results: Record<string, { installed: boolean; authenticated: boolean }> }
-    return result.results
+    const result = (await mux.request(
+      'preflight.detectForgeClis',
+      { clis: ['gh', 'glab'] },
+      { timeoutMs: REMOTE_FORGE_PROBE_TIMEOUT_MS }
+    )) as { results?: Record<string, { installed: boolean; authenticated: boolean }> } | null
+    return result?.results ?? null
   } catch {
     // Old relays do not implement this optional RPC; unknown must not read false.
     return null
@@ -416,7 +420,7 @@ async function executePreflightCheck(
     gitea
   }
 
-  if (sshHost && hostForgeResults) {
+  if (sshHost && (hostForgeResults?.gh || hostForgeResults?.glab)) {
     result.hostForge = {
       connectionId: sshHost.connectionId,
       hostLabel: sshHost.hostLabel,

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -69,6 +69,14 @@ export type PreflightStatus = {
     baseUrl: string | null
     tokenConfigured: boolean
   }
+  // Why: only present when the SSH execution host answers the forge CLI probe.
+  // A missing value means unavailable, never unauthenticated.
+  hostForge?: {
+    connectionId: string
+    hostLabel: string
+    gh?: { installed: boolean; authenticated: boolean }
+    glab?: { installed: boolean; authenticated: boolean }
+  }
 }
 
 export { detectRemoteWindowsTerminalCapabilities }
@@ -105,8 +113,12 @@ let preflightCacheEpoch = 0
 
 const LOCAL_PREFLIGHT_CACHE_KEY = 'local'
 
-function preflightCacheKey(wslTarget: WslPreflightTarget | null): string {
-  return wslTarget ? `wsl:${wslTarget.distro ?? ''}` : LOCAL_PREFLIGHT_CACHE_KEY
+function preflightCacheKey(
+  wslTarget: WslPreflightTarget | null,
+  sshConnectionId?: string
+): string {
+  const runtimeKey = wslTarget ? `wsl:${wslTarget.distro ?? ''}` : LOCAL_PREFLIGHT_CACHE_KEY
+  return sshConnectionId ? `${runtimeKey}:ssh:${sshConnectionId}` : runtimeKey
 }
 
 /** @internal - tests need a clean preflight cache between cases. */
@@ -251,6 +263,24 @@ export async function detectRemoteAgents(args: { connectionId: string }): Promis
   return uniqueAgentIds(result.agents)
 }
 
+export async function detectRemoteForgeClis(args: {
+  connectionId: string
+}): Promise<Record<string, { installed: boolean; authenticated: boolean }> | null> {
+  const mux = getActiveMultiplexer(args.connectionId)
+  if (!mux || mux.isDisposed()) {
+    return null
+  }
+  try {
+    const result = (await mux.request('preflight.detectForgeClis', {
+      clis: ['gh', 'glab']
+    })) as { results: Record<string, { installed: boolean; authenticated: boolean }> }
+    return result.results
+  } catch {
+    // Old relays do not implement this optional RPC; unknown must not read false.
+    return null
+  }
+}
+
 async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
   try {
     await (wslTarget
@@ -291,9 +321,11 @@ export async function runPreflightCheck(
   context?: PreflightRuntimeContext
 ): Promise<PreflightStatus> {
   const wslTarget = getPreflightWslTarget(context)
-  const cacheKey = preflightCacheKey(wslTarget)
+  const sshHost = context?.sshHost
+  const cacheable = !sshHost
+  const cacheKey = preflightCacheKey(wslTarget, sshHost?.connectionId)
 
-  if (!force) {
+  if (!force && cacheable) {
     if (wslTarget) {
       const entry = cachedByWslDistro.get(cacheKey)
       if (entry && entry.expiresAt > Date.now()) {
@@ -320,7 +352,7 @@ export async function runPreflightCheck(
     // return what we probed, but do not let it become the cached answer.
     const isCurrent =
       latestPreflightRun.get(cacheKey) === runId && epochAtStart === preflightCacheEpoch
-    if (isCurrent) {
+    if (isCurrent && cacheable) {
       if (wslTarget) {
         cachedByWslDistro.set(cacheKey, {
           result,
@@ -359,10 +391,12 @@ async function executePreflightCheck(
     _resetKnownHostsCache()
   }
 
-  const [gitProbe, ghProbe, glabProbe] = await Promise.all([
+  const sshHost = context?.sshHost
+  const [gitProbe, ghProbe, glabProbe, hostForgeResults] = await Promise.all([
     detectCommandRuntime('git', context),
     detectCommandRuntime('gh', context),
-    detectCommandRuntime('glab', context)
+    detectCommandRuntime('glab', context),
+    sshHost ? detectRemoteForgeClis({ connectionId: sshHost.connectionId }) : Promise.resolve(null)
   ])
 
   const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea] = await Promise.all([
@@ -373,13 +407,22 @@ async function executePreflightCheck(
     getGiteaAuthStatus()
   ])
 
-  const result = {
+  const result: PreflightStatus = {
     git: { installed: gitProbe.installed },
     gh: { installed: ghProbe.installed, authenticated: ghAuthenticated },
     glab: { installed: glabProbe.installed, authenticated: glabAuthenticated },
     bitbucket,
     azureDevOps,
     gitea
+  }
+
+  if (sshHost && hostForgeResults) {
+    result.hostForge = {
+      connectionId: sshHost.connectionId,
+      hostLabel: sshHost.hostLabel,
+      gh: hostForgeResults.gh,
+      glab: hostForgeResults.glab
+    }
   }
 
   return result

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -15,7 +15,6 @@ import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
-import { getActiveMultiplexer } from '../ssh/ssh-target-registry'
 import {
   detectWslCommandsOnPath,
   type WslPreflightTarget
@@ -28,13 +27,7 @@ import {
 
 export type { PreflightRuntimeContext }
 import { hydrateShellPathForAgentDetection } from '../ipc/agent-detection-shell-path'
-import {
-  execCommandInWslOrThrow,
-  execLocalPreflightCommandOrThrow,
-  isCommandAvailable,
-  isCommandOnPath,
-  shellQuote
-} from '../ipc/preflight-command-exec'
+import { isCommandAvailable, isCommandOnPath } from '../ipc/preflight-command-exec'
 import {
   detectRemoteWindowsTerminalCapabilities,
   type RemoteWindowsTerminalCapabilities
@@ -45,6 +38,14 @@ import {
   resolveDetectedTuiAgentIds
 } from '../ipc/tui-agent-detection-commands'
 import { invalidateWslGuestEnvironment } from '../wsl/wsl-guest-environment'
+import {
+  detectRemoteAgents,
+  detectRemoteForgeClis,
+  isGhAuthenticated,
+  isGlabAuthenticated
+} from './agent-forge-detection-probes'
+
+export { detectRemoteAgents, detectRemoteForgeClis }
 
 export type PreflightStatus = {
   git: { installed: boolean }
@@ -112,8 +113,6 @@ let preflightRunCounter = 0
 let preflightCacheEpoch = 0
 
 const LOCAL_PREFLIGHT_CACHE_KEY = 'local'
-// Why: keep a wedged remote host from delaying local integration status.
-const REMOTE_FORGE_PROBE_TIMEOUT_MS = 8000
 
 function preflightCacheKey(
   wslTarget: WslPreflightTarget | null,
@@ -132,10 +131,6 @@ export function _resetPreflightCache(): void {
   // Why bump rather than just clear: a probe already in flight would otherwise
   // settle after this and repopulate the cache an integration just invalidated.
   preflightCacheEpoch += 1
-}
-
-function uniqueAgentIds(ids: Iterable<string>): string[] {
-  return [...new Set(ids)]
 }
 
 async function detectCommandRuntime(
@@ -249,74 +244,6 @@ export async function refreshShellPathAndDetectAgents(
     shellHydrationOk: hydration.ok,
     pathSource: hydration.ok ? 'shell_hydrate' : 'sync_seed_only',
     pathFailureReason: hydration.failureReason
-  }
-}
-
-export async function detectRemoteAgents(args: { connectionId: string }): Promise<string[]> {
-  const mux = getActiveMultiplexer(args.connectionId)
-  if (!mux || mux.isDisposed()) {
-    // Why: remote agent detection is passive UI polling. A disconnected host has
-    // no detectable agents until reconnect, but should not spam IPC errors.
-    return []
-  }
-  const result = (await mux.request('preflight.detectAgents', {
-    commands: KNOWN_TUI_AGENT_DETECTION_COMMANDS
-  })) as { agents: string[] }
-  return uniqueAgentIds(result.agents)
-}
-
-export async function detectRemoteForgeClis(args: {
-  connectionId: string
-}): Promise<Record<string, { installed: boolean; authenticated: boolean }> | null> {
-  const mux = getActiveMultiplexer(args.connectionId)
-  if (!mux || mux.isDisposed()) {
-    return null
-  }
-  try {
-    const result = (await mux.request(
-      'preflight.detectForgeClis',
-      { clis: ['gh', 'glab'] },
-      { timeoutMs: REMOTE_FORGE_PROBE_TIMEOUT_MS }
-    )) as { results?: Record<string, { installed: boolean; authenticated: boolean }> } | null
-    return result?.results ?? null
-  } catch {
-    // Old relays do not implement this optional RPC; unknown must not read false.
-    return null
-  }
-}
-
-async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
-  try {
-    await (wslTarget
-      ? execCommandInWslOrThrow(wslTarget, `${shellQuote('gh')} auth status`)
-      : execLocalPreflightCommandOrThrow('gh', ['auth', 'status']))
-    // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
-    // authentication issues for the checked hosts/accounts.
-    return true
-  } catch (error) {
-    // Why: some environments may surface partial command output on the thrown
-    // error object. Keep a compatibility fallback so we avoid a false auth
-    // warning if success markers are present despite a non-zero result.
-    const stdout = (error as { stdout?: string }).stdout ?? ''
-    const stderr = (error as { stderr?: string }).stderr ?? ''
-    const output = `${stdout}\n${stderr}`
-    return output.includes('Logged in') || output.includes('Active account: true')
-  }
-}
-
-// Why: parallel to isGhAuthenticated for the glab CLI. glab writes auth
-// status to stderr in some versions and stdout in others; check both.
-async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
-  try {
-    await (wslTarget
-      ? execCommandInWslOrThrow(wslTarget, `${shellQuote('glab')} auth status`)
-      : execLocalPreflightCommandOrThrow('glab', ['auth', 'status']))
-    return true
-  } catch (error) {
-    const stdout = (error as { stdout?: string }).stdout ?? ''
-    const stderr = (error as { stderr?: string }).stderr ?? ''
-    const output = `${stdout}\n${stderr}`
-    return output.includes('Logged in')
   }
 }
 

--- a/src/main/preflight/agent-forge-detection-probes.ts
+++ b/src/main/preflight/agent-forge-detection-probes.ts
@@ -1,0 +1,83 @@
+import type { WslPreflightTarget } from '../ipc/preflight-wsl-agent-detection'
+import { getActiveMultiplexer } from '../ssh/ssh-target-registry'
+import {
+  execCommandInWslOrThrow,
+  execLocalPreflightCommandOrThrow,
+  shellQuote
+} from '../ipc/preflight-command-exec'
+import { KNOWN_TUI_AGENT_DETECTION_COMMANDS } from '../ipc/tui-agent-detection-commands'
+
+// Why: keep a wedged remote host from delaying local integration status.
+const REMOTE_FORGE_PROBE_TIMEOUT_MS = 8000
+
+function uniqueAgentIds(ids: Iterable<string>): string[] {
+  return [...new Set(ids)]
+}
+
+export async function detectRemoteAgents(args: { connectionId: string }): Promise<string[]> {
+  const mux = getActiveMultiplexer(args.connectionId)
+  if (!mux || mux.isDisposed()) {
+    // Why: remote agent detection is passive UI polling. A disconnected host has
+    // no detectable agents until reconnect, but should not spam IPC errors.
+    return []
+  }
+  const result = (await mux.request('preflight.detectAgents', {
+    commands: KNOWN_TUI_AGENT_DETECTION_COMMANDS
+  })) as { agents: string[] }
+  return uniqueAgentIds(result.agents)
+}
+
+export async function detectRemoteForgeClis(args: {
+  connectionId: string
+}): Promise<Record<string, { installed: boolean; authenticated: boolean }> | null> {
+  const mux = getActiveMultiplexer(args.connectionId)
+  if (!mux || mux.isDisposed()) {
+    return null
+  }
+  try {
+    const result = (await mux.request(
+      'preflight.detectForgeClis',
+      { clis: ['gh', 'glab'] },
+      { timeoutMs: REMOTE_FORGE_PROBE_TIMEOUT_MS }
+    )) as { results?: Record<string, { installed: boolean; authenticated: boolean }> } | null
+    return result?.results ?? null
+  } catch {
+    // Old relays do not implement this optional RPC; unknown must not read false.
+    return null
+  }
+}
+
+export async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
+  try {
+    await (wslTarget
+      ? execCommandInWslOrThrow(wslTarget, `${shellQuote('gh')} auth status`)
+      : execLocalPreflightCommandOrThrow('gh', ['auth', 'status']))
+    // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
+    // authentication issues for the checked hosts/accounts.
+    return true
+  } catch (error) {
+    // Why: some environments may surface partial command output on the thrown
+    // error object. Keep a compatibility fallback so we avoid a false auth
+    // warning if success markers are present despite a non-zero result.
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    const output = `${stdout}\n${stderr}`
+    return output.includes('Logged in') || output.includes('Active account: true')
+  }
+}
+
+// Why: parallel to isGhAuthenticated for the glab CLI. glab writes auth
+// status to stderr in some versions and stdout in others; check both.
+export async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
+  try {
+    await (wslTarget
+      ? execCommandInWslOrThrow(wslTarget, `${shellQuote('glab')} auth status`)
+      : execLocalPreflightCommandOrThrow('glab', ['auth', 'status']))
+    return true
+  } catch (error) {
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    const output = `${stdout}\n${stderr}`
+    return output.includes('Logged in')
+  }
+}

--- a/src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-probe-failure-swallow-allowlist.txt
@@ -29,3 +29,9 @@ main/wsl.ts
 # point of the module (#16463). A failed stat drops to the next candidate for
 # that one call and is re-asked on the next, so there is no value to pin.
 main/wsl-interop-spawn-directory.ts
+# gh/glab forge-CLI auth probes for host-side Integrations status (#12028). The
+# swallowed value (an absent/null forge result) is pinned only inside the
+# TTL-bounded local preflight cache (`cachedByWslDistro`, `expiresAt`) and is
+# re-probed after the entry expires -- the bounded form accepted in #17350, not
+# an unbounded gate.
+main/preflight/agent-forge-detection-probes.ts

--- a/src/preload/api/preflight-api.ts
+++ b/src/preload/api/preflight-api.ts
@@ -48,6 +48,8 @@ export type PreflightRuntimeContext = {
   wslDistro?: string | null
   wslDefault?: boolean
   projectRuntime?: ProjectExecutionRuntimeResolution
+  /** Names the SSH execution host whose forge CLIs preflight should additionally probe. */
+  sshHost?: { connectionId: string; hostLabel: string }
 }
 
 export type PreflightApi = {

--- a/src/preload/api/preflight-api.ts
+++ b/src/preload/api/preflight-api.ts
@@ -24,6 +24,13 @@ export type PreflightStatus = {
     baseUrl: string | null
     tokenConfigured: boolean
   }
+  /** Optional — present only when the context names an SSH execution host and the remote gh/glab probe succeeds. */
+  hostForge?: {
+    connectionId: string
+    hostLabel: string
+    gh?: { installed: boolean; authenticated: boolean }
+    glab?: { installed: boolean; authenticated: boolean }
+  }
 }
 
 export type RefreshAgentsResult = {

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -428,6 +428,26 @@ describe('preflight.detectForgeClis', () => {
     expect(result.results.glab.authenticated).toBe(true)
   })
 
+  it('treats gh "Active account: true" marker as authenticated', async () => {
+    isCommandOnPathSpy.mockResolvedValue(true)
+    execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'Active account: true\n' })
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['gh'] })
+
+    expect(result.results.gh.authenticated).toBe(true)
+  })
+
+  it('does not treat glab "Active account: true" marker as authenticated (gh-only marker)', async () => {
+    isCommandOnPathSpy.mockResolvedValue(true)
+    execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'Active account: true\n' })
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['glab'] })
+
+    expect(result.results.glab.authenticated).toBe(false)
+  })
+
   it('reports an installed CLI that is not logged in as unauthenticated', async () => {
     isCommandOnPathSpy.mockResolvedValue(true)
     execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'not logged in' })

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -428,6 +428,33 @@ describe('preflight.detectForgeClis', () => {
     expect(result.results.glab.authenticated).toBe(true)
   })
 
+  it('reports an installed CLI that is not logged in as unauthenticated', async () => {
+    isCommandOnPathSpy.mockResolvedValue(true)
+    execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'not logged in' })
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['gh'] })
+
+    expect(result).toEqual({ results: { gh: { installed: true, authenticated: false } } })
+  })
+
+  it('probes each allowlisted CLI once regardless of duplicate requests', async () => {
+    isCommandOnPathSpy.mockResolvedValue(false)
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', {
+      clis: [...Array<string>(500).fill('gh'), 'glab', 'glab']
+    })
+
+    expect(isCommandOnPathSpy).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({
+      results: {
+        gh: { installed: false, authenticated: false },
+        glab: { installed: false, authenticated: false }
+      }
+    })
+  })
+
   it('reports not-installed without running auth', async () => {
     isCommandOnPathSpy.mockResolvedValue(false)
     const request = requestFromNewHandler()

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
 
 const { execFileAsyncMock } = vi.hoisted(() => ({
@@ -355,5 +355,98 @@ describe('PreflightHandler', () => {
         value: originalPlatform
       })
     }
+  })
+})
+
+// Why: spy on the prototype method rather than the underlying exec calls —
+// install detection goes through platform-specific shell probing that's
+// already covered by isCommandOnPathForRelay's own tests.
+type PreflightHandlerWithCommandProbe = { isCommandOnPath: (command: string) => Promise<boolean> }
+
+type ForgeCliDetectionResult = {
+  results: Record<string, { installed: boolean; authenticated: boolean }>
+}
+
+function requestFromNewHandler(): (
+  method: string,
+  params: Record<string, unknown>
+) => Promise<ForgeCliDetectionResult> {
+  const requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+  const dispatcher = {
+    onRequest: vi.fn(
+      (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+        requestHandlers.set(method, handler)
+      }
+    )
+  }
+  new PreflightHandler(dispatcher as never)
+  return (method, params) => {
+    const handler = requestHandlers.get(method)
+    if (!handler) {
+      throw new Error(`no handler registered for ${method}`)
+    }
+    return handler(params) as Promise<ForgeCliDetectionResult>
+  }
+}
+
+describe('preflight.detectForgeClis', () => {
+  let isCommandOnPathSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    isCommandOnPathSpy = vi.spyOn(
+      PreflightHandler.prototype as unknown as PreflightHandlerWithCommandProbe,
+      'isCommandOnPath'
+    )
+  })
+
+  afterEach(() => {
+    isCommandOnPathSpy.mockRestore()
+  })
+
+  it('probes install and auth for allowlisted forge CLIs', async () => {
+    isCommandOnPathSpy.mockResolvedValue(true)
+    execFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['glab'] })
+
+    expect(result).toEqual({ results: { glab: { installed: true, authenticated: true } } })
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      'glab',
+      ['auth', 'status'],
+      expect.objectContaining({ timeout: 10_000 })
+    )
+  })
+
+  it('treats non-zero auth exit with "Logged in" marker as authenticated', async () => {
+    isCommandOnPathSpy.mockResolvedValue(true)
+    execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'Logged in as octocat\n' })
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['glab'] })
+
+    expect(result.results.glab.authenticated).toBe(true)
+  })
+
+  it('reports not-installed without running auth', async () => {
+    isCommandOnPathSpy.mockResolvedValue(false)
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['gh'] })
+
+    expect(result).toEqual({ results: { gh: { installed: false, authenticated: false } } })
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('silently ignores non-allowlisted binaries', async () => {
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', {
+      clis: ['bash', '../glab', 'gh; rm -rf /']
+    })
+
+    expect(result).toEqual({ results: {} })
+    expect(isCommandOnPathSpy).not.toHaveBeenCalled()
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
   })
 })

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -35,7 +35,7 @@ import {
   buildCommandLookupSpec,
   buildCommandLookupSpecs,
   hasAbsoluteCommandPath,
-  isCommandOnPathForRelay,
+  resolveRelayCommandPath,
   PreflightHandler
 } from './preflight-handler'
 
@@ -153,19 +153,19 @@ describe('buildCommandLookupSpecs', () => {
   })
 })
 
-describe('isCommandOnPathForRelay', () => {
+describe('resolveRelayCommandPath', () => {
   it('falls back to inherited PATH when shell startup returns no absolute command path', async () => {
     execFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'welcome\ncodex is a function\n' })
       .mockResolvedValueOnce({ stdout: '__ORCA_AGENT_PATH__/relay/path/codex\n' })
 
     await expect(
-      isCommandOnPathForRelay('codex', {
+      resolveRelayCommandPath('codex', {
         platform: 'linux',
         env: { SHELL: '/bin/zsh', PATH: '/usr/bin' },
         accountLoginShell: '/bin/zsh'
       })
-    ).resolves.toBe(true)
+    ).resolves.toBe('/relay/path/codex')
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, '/bin/zsh', lookupArgs('codex', '-ilc'), {
       encoding: 'utf-8',
       env: expect.objectContaining({ SHELL: '/bin/zsh' }),
@@ -184,12 +184,12 @@ describe('isCommandOnPathForRelay', () => {
       .mockResolvedValueOnce({ stdout: '__ORCA_AGENT_PATH__/relay/path/codex\n' })
 
     await expect(
-      isCommandOnPathForRelay('codex', {
+      resolveRelayCommandPath('codex', {
         platform: 'linux',
         env: { SHELL: '/bin/bash', PATH: '/usr/bin' },
         accountLoginShell: '/bin/bash'
       })
-    ).resolves.toBe(true)
+    ).resolves.toBe('/relay/path/codex')
     expect(execFileAsyncMock).toHaveBeenCalledTimes(2)
   })
 
@@ -197,12 +197,12 @@ describe('isCommandOnPathForRelay', () => {
     execFileAsyncMock.mockResolvedValueOnce({ stdout: '__ORCA_AGENT_PATH__/relay/path/codex\n' })
 
     await expect(
-      isCommandOnPathForRelay('codex', {
+      resolveRelayCommandPath('codex', {
         platform: 'linux',
         env: { SHELL: '/tmp/zsh', PATH: '/usr/bin' },
         accountLoginShell: '/bin/bash'
       })
-    ).resolves.toBe(true)
+    ).resolves.toBe('/relay/path/codex')
     expect(execFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(execFileAsyncMock).toHaveBeenCalledWith('/bin/sh', lookupArgs('codex'), {
       encoding: 'utf-8',
@@ -360,8 +360,10 @@ describe('PreflightHandler', () => {
 
 // Why: spy on the prototype method rather than the underlying exec calls —
 // install detection goes through platform-specific shell probing that's
-// already covered by isCommandOnPathForRelay's own tests.
-type PreflightHandlerWithCommandProbe = { isCommandOnPath: (command: string) => Promise<boolean> }
+// already covered by resolveRelayCommandPath's own tests.
+type PreflightHandlerWithCommandProbe = {
+  resolveCommandPath: (command: string) => Promise<string | null>
+}
 
 type ForgeCliDetectionResult = {
   results: Record<string, { installed: boolean; authenticated: boolean }>
@@ -390,29 +392,32 @@ function requestFromNewHandler(): (
 }
 
 describe('preflight.detectForgeClis', () => {
-  let isCommandOnPathSpy: ReturnType<typeof vi.spyOn>
+  let resolveCommandPathSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    isCommandOnPathSpy = vi.spyOn(
+    resolveCommandPathSpy = vi.spyOn(
       PreflightHandler.prototype as unknown as PreflightHandlerWithCommandProbe,
-      'isCommandOnPath'
+      'resolveCommandPath'
     )
   })
 
   afterEach(() => {
-    isCommandOnPathSpy.mockRestore()
+    resolveCommandPathSpy.mockRestore()
   })
 
   it('probes install and auth for allowlisted forge CLIs', async () => {
-    isCommandOnPathSpy.mockResolvedValue(true)
+    resolveCommandPathSpy.mockResolvedValue('/usr/local/bin/forge-cli')
     execFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
     const request = requestFromNewHandler()
 
     const result = await request('preflight.detectForgeClis', { clis: ['glab'] })
 
     expect(result).toEqual({ results: { glab: { installed: true, authenticated: true } } })
+    // Why: detection resolves through a login shell, so the auth probe must
+    // spawn the resolved executable — a bare name would ENOENT whenever PATH
+    // came from a shell startup file, reporting installed-but-unauthenticated.
     expect(execFileAsyncMock).toHaveBeenCalledWith(
-      'glab',
+      '/usr/local/bin/forge-cli',
       ['auth', 'status'],
       // Why: must stay under the caller's 8s REMOTE_FORGE_PROBE_TIMEOUT_MS.
       expect.objectContaining({ timeout: 6_000 })
@@ -420,7 +425,7 @@ describe('preflight.detectForgeClis', () => {
   })
 
   it('treats non-zero auth exit with "Logged in" marker as authenticated', async () => {
-    isCommandOnPathSpy.mockResolvedValue(true)
+    resolveCommandPathSpy.mockResolvedValue('/usr/local/bin/forge-cli')
     execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'Logged in as octocat\n' })
     const request = requestFromNewHandler()
 
@@ -433,7 +438,7 @@ describe('preflight.detectForgeClis', () => {
   // hung `auth status` that had already printed the marker must not read as a
   // yes. A killed probe is "unknown".
   it('rejects a timed-out auth probe even when partial output carries the marker', async () => {
-    isCommandOnPathSpy.mockResolvedValue(true)
+    resolveCommandPathSpy.mockResolvedValue('/usr/local/bin/forge-cli')
     execFileAsyncMock.mockRejectedValueOnce({
       stdout: 'Logged in as octocat\n',
       stderr: '',
@@ -448,7 +453,7 @@ describe('preflight.detectForgeClis', () => {
   })
 
   it('treats gh "Active account: true" marker as authenticated', async () => {
-    isCommandOnPathSpy.mockResolvedValue(true)
+    resolveCommandPathSpy.mockResolvedValue('/usr/local/bin/forge-cli')
     execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'Active account: true\n' })
     const request = requestFromNewHandler()
 
@@ -458,7 +463,7 @@ describe('preflight.detectForgeClis', () => {
   })
 
   it('does not treat glab "Active account: true" marker as authenticated (gh-only marker)', async () => {
-    isCommandOnPathSpy.mockResolvedValue(true)
+    resolveCommandPathSpy.mockResolvedValue('/usr/local/bin/forge-cli')
     execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'Active account: true\n' })
     const request = requestFromNewHandler()
 
@@ -468,7 +473,7 @@ describe('preflight.detectForgeClis', () => {
   })
 
   it('reports an installed CLI that is not logged in as unauthenticated', async () => {
-    isCommandOnPathSpy.mockResolvedValue(true)
+    resolveCommandPathSpy.mockResolvedValue('/usr/local/bin/forge-cli')
     execFileAsyncMock.mockRejectedValueOnce({ stdout: '', stderr: 'not logged in' })
     const request = requestFromNewHandler()
 
@@ -478,14 +483,14 @@ describe('preflight.detectForgeClis', () => {
   })
 
   it('probes each allowlisted CLI once regardless of duplicate requests', async () => {
-    isCommandOnPathSpy.mockResolvedValue(false)
+    resolveCommandPathSpy.mockResolvedValue(null)
     const request = requestFromNewHandler()
 
     const result = await request('preflight.detectForgeClis', {
       clis: [...Array<string>(500).fill('gh'), 'glab', 'glab']
     })
 
-    expect(isCommandOnPathSpy).toHaveBeenCalledTimes(2)
+    expect(resolveCommandPathSpy).toHaveBeenCalledTimes(2)
     expect(result).toEqual({
       results: {
         gh: { installed: false, authenticated: false },
@@ -495,7 +500,7 @@ describe('preflight.detectForgeClis', () => {
   })
 
   it('reports not-installed without running auth', async () => {
-    isCommandOnPathSpy.mockResolvedValue(false)
+    resolveCommandPathSpy.mockResolvedValue(null)
     const request = requestFromNewHandler()
 
     const result = await request('preflight.detectForgeClis', { clis: ['gh'] })
@@ -512,7 +517,7 @@ describe('preflight.detectForgeClis', () => {
     })
 
     expect(result).toEqual({ results: {} })
-    expect(isCommandOnPathSpy).not.toHaveBeenCalled()
+    expect(resolveCommandPathSpy).not.toHaveBeenCalled()
     expect(execFileAsyncMock).not.toHaveBeenCalled()
   })
 })

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -414,7 +414,8 @@ describe('preflight.detectForgeClis', () => {
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'glab',
       ['auth', 'status'],
-      expect.objectContaining({ timeout: 10_000 })
+      // Why: must stay under the caller's 8s REMOTE_FORGE_PROBE_TIMEOUT_MS.
+      expect.objectContaining({ timeout: 6_000 })
     )
   })
 
@@ -426,6 +427,24 @@ describe('preflight.detectForgeClis', () => {
     const result = await request('preflight.detectForgeClis', { clis: ['glab'] })
 
     expect(result.results.glab.authenticated).toBe(true)
+  })
+
+  // Why: execFile preserves stdout/stderr when `timeout` kills the child, so a
+  // hung `auth status` that had already printed the marker must not read as a
+  // yes. A killed probe is "unknown".
+  it('rejects a timed-out auth probe even when partial output carries the marker', async () => {
+    isCommandOnPathSpy.mockResolvedValue(true)
+    execFileAsyncMock.mockRejectedValueOnce({
+      stdout: 'Logged in as octocat\n',
+      stderr: '',
+      killed: true,
+      signal: 'SIGTERM'
+    })
+    const request = requestFromNewHandler()
+
+    const result = await request('preflight.detectForgeClis', { clis: ['glab'] })
+
+    expect(result.results.glab.authenticated).toBe(false)
   })
 
   it('treats gh "Active account: true" marker as authenticated', async () => {

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -169,12 +169,12 @@ describe('resolveRelayCommandPath', () => {
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(1, '/bin/zsh', lookupArgs('codex', '-ilc'), {
       encoding: 'utf-8',
       env: expect.objectContaining({ SHELL: '/bin/zsh' }),
-      timeout: 5000
+      timeout: 2000
     })
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, '/bin/sh', lookupArgs('codex'), {
       encoding: 'utf-8',
       env: expect.objectContaining({ SHELL: '/bin/zsh' }),
-      timeout: 5000
+      timeout: 2000
     })
   })
 
@@ -207,7 +207,7 @@ describe('resolveRelayCommandPath', () => {
     expect(execFileAsyncMock).toHaveBeenCalledWith('/bin/sh', lookupArgs('codex'), {
       encoding: 'utf-8',
       env: expect.objectContaining({ SHELL: '/tmp/zsh' }),
-      timeout: 5000
+      timeout: 2000
     })
   })
 })
@@ -419,8 +419,8 @@ describe('preflight.detectForgeClis', () => {
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       '/usr/local/bin/forge-cli',
       ['auth', 'status'],
-      // Why: must stay under the caller's 8s REMOTE_FORGE_PROBE_TIMEOUT_MS.
-      expect.objectContaining({ timeout: 6_000 })
+      // Why: lookup + auth together must stay under the caller's 8s budget.
+      expect.objectContaining({ timeout: 5_000 })
     )
   })
 

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -35,6 +35,8 @@ type AgentDetectionCommand = {
 const SUPPORTED_POSIX_SHELLS = new Set(['sh', 'dash', 'bash', 'zsh', 'fish'])
 const CONSERVATIVE_SYSTEM_SHELL_DIRS = new Set(['/bin', '/usr/bin'])
 const AGENT_PATH_PREFIX = '__ORCA_AGENT_PATH__'
+const FORGE_CLI_ALLOWLIST = new Set(['gh', 'glab'])
+const FORGE_AUTH_TIMEOUT_MS = 10_000
 
 export class PreflightHandler {
   private dispatcher: RelayDispatcher
@@ -49,6 +51,7 @@ export class PreflightHandler {
     this.dispatcher.onRequest('preflight.detectWindowsTerminalCapabilities', () =>
       this.detectWindowsTerminalCapabilities()
     )
+    this.dispatcher.onRequest('preflight.detectForgeClis', (p) => this.detectForgeClis(p))
   }
 
   // Why: the client sends the command list rather than importing TUI_AGENT_CONFIG
@@ -121,6 +124,44 @@ export class PreflightHandler {
   // Windows has no POSIX shell on native OpenSSH hosts, so use where.exe there.
   private async isCommandOnPath(command: string): Promise<boolean> {
     return isCommandOnPathForRelay(command)
+  }
+
+  // Why: ignore rather than error on non-allowlisted entries — a newer desktop
+  // probing a CLI this relay doesn't know must degrade, mirroring how missing
+  // methods degrade.
+  private async detectForgeClis(
+    params: Record<string, unknown>
+  ): Promise<{ results: Record<string, { installed: boolean; authenticated: boolean }> }> {
+    const requested = Array.isArray(params.clis) ? (params.clis as string[]) : []
+    const clis = requested.filter((cli) => FORGE_CLI_ALLOWLIST.has(cli))
+    const results: Record<string, { installed: boolean; authenticated: boolean }> = {}
+    await Promise.all(
+      clis.map(async (cli) => {
+        const installed = await this.isCommandOnPath(cli)
+        results[cli] = {
+          installed,
+          authenticated: installed && (await isForgeCliAuthenticated(cli))
+        }
+      })
+    )
+    return { results }
+  }
+}
+
+// Why: glab writes auth status to stderr in some versions and can exit
+// non-zero while still logged in, so check output markers on failure too.
+async function isForgeCliAuthenticated(cli: string): Promise<boolean> {
+  try {
+    await execFileAsync(cli, ['auth', 'status'], {
+      env: buildRelayCommandEnv(),
+      timeout: FORGE_AUTH_TIMEOUT_MS
+    })
+    return true
+  } catch (error) {
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    const output = `${stdout}\n${stderr}`
+    return output.includes('Logged in') || output.includes('Active account: true')
   }
 }
 

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -36,10 +36,11 @@ const SUPPORTED_POSIX_SHELLS = new Set(['sh', 'dash', 'bash', 'zsh', 'fish'])
 const CONSERVATIVE_SYSTEM_SHELL_DIRS = new Set(['/bin', '/usr/bin'])
 const AGENT_PATH_PREFIX = '__ORCA_AGENT_PATH__'
 const FORGE_CLI_ALLOWLIST = new Set(['gh', 'glab'])
-// Why: the caller (REMOTE_FORGE_PROBE_TIMEOUT_MS in src/main/ipc/preflight.ts)
-// abandons this request at 8s. Finishing under that leaves the relay a window
-// to answer instead of working on a result nobody is waiting for.
-const FORGE_AUTH_TIMEOUT_MS = 6_000
+// Why: the caller abandons at 8s (REMOTE_FORGE_PROBE_TIMEOUT_MS in
+// src/main/ipc/preflight.ts), and a forge probe pays lookup then auth, so both
+// budgets together must stay under it.
+const RELAY_COMMAND_LOOKUP_TIMEOUT_MS = 2_000
+const FORGE_AUTH_TIMEOUT_MS = 5_000
 
 export class PreflightHandler {
   private dispatcher: RelayDispatcher
@@ -171,9 +172,8 @@ async function isForgeCliAuthenticated(cli: 'gh' | 'glab', executable: string): 
     })
     return true
   } catch (error) {
-    // Why: execFile preserves stdout/stderr when `timeout` kills the child, so
-    // a hung `auth status` that had already printed "Logged in" would otherwise
-    // read as authenticated. A killed probe is "unknown", never a yes.
+    // Why: killed or timed-out probes keep partial output, so a hung `auth status`
+    // that already printed "Logged in" must read as unknown, never a yes.
     const failure = error as {
       stdout?: string
       stderr?: string
@@ -253,7 +253,7 @@ export async function resolveRelayCommandPath(
       const { stdout } = await execFileAsync(spec.file, spec.args, {
         encoding: 'utf-8',
         env: buildRelayCommandEnv(env, platform),
-        timeout: 5000,
+        timeout: RELAY_COMMAND_LOOKUP_TIMEOUT_MS,
         ...(spec.windowsHide ? { windowsHide: true } : {})
       })
       const resolved = firstAbsoluteCommandPath(stdout, platform)

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -132,8 +132,10 @@ export class PreflightHandler {
   private async detectForgeClis(
     params: Record<string, unknown>
   ): Promise<{ results: Record<string, { installed: boolean; authenticated: boolean }> }> {
-    const requested = Array.isArray(params.clis) ? (params.clis as string[]) : []
-    const clis = requested.filter((cli) => FORGE_CLI_ALLOWLIST.has(cli))
+    // Why: iterate the allowlist, not the request — duplicated names would
+    // otherwise spawn one probe per repetition.
+    const requested = new Set(Array.isArray(params.clis) ? (params.clis as string[]) : [])
+    const clis = [...FORGE_CLI_ALLOWLIST].filter((cli) => requested.has(cli))
     const results: Record<string, { installed: boolean; authenticated: boolean }> = {}
     await Promise.all(
       clis.map(async (cli) => {
@@ -153,6 +155,7 @@ export class PreflightHandler {
 async function isForgeCliAuthenticated(cli: string): Promise<boolean> {
   try {
     await execFileAsync(cli, ['auth', 'status'], {
+      encoding: 'utf-8',
       env: buildRelayCommandEnv(),
       timeout: FORGE_AUTH_TIMEOUT_MS
     })

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -76,7 +76,7 @@ export class PreflightHandler {
     const results = await Promise.all(
       probeCommands.map(async (cmd) => ({
         cmd,
-        installed: await this.isCommandOnPath(cmd)
+        installed: (await this.resolveCommandPath(cmd)) !== null
       }))
     )
     const foundCommands = new Set(
@@ -125,8 +125,8 @@ export class PreflightHandler {
   // startup files sourced. Ask the user's configured shell so agent dirs added
   // by zsh/bash/fish startup hooks match the remote terminal experience.
   // Windows has no POSIX shell on native OpenSSH hosts, so use where.exe there.
-  private async isCommandOnPath(command: string): Promise<boolean> {
-    return isCommandOnPathForRelay(command)
+  private async resolveCommandPath(command: string): Promise<string | null> {
+    return resolveRelayCommandPath(command)
   }
 
   // Why: ignore rather than error on non-allowlisted entries — a newer desktop
@@ -142,10 +142,15 @@ export class PreflightHandler {
     const results: Record<string, { installed: boolean; authenticated: boolean }> = {}
     await Promise.all(
       clis.map(async (cli) => {
-        const installed = await this.isCommandOnPath(cli)
+        // Why: detection resolves through a login shell, so a PATH set in a
+        // shell startup file is visible here but not to a bare execFile. Reuse
+        // the resolved executable so "installed" and "authenticated" can never
+        // disagree about which binary they mean.
+        const executable = await this.resolveCommandPath(cli)
         results[cli] = {
-          installed,
-          authenticated: installed && (await isForgeCliAuthenticated(cli as 'gh' | 'glab'))
+          installed: executable !== null,
+          authenticated:
+            executable !== null && (await isForgeCliAuthenticated(cli as 'gh' | 'glab', executable))
         }
       })
     )
@@ -157,9 +162,9 @@ export class PreflightHandler {
 // non-zero while still logged in, so check output markers on failure too.
 // Markers mirror the main-process per-CLI checks (isGhAuthenticated /
 // isGlabAuthenticated in src/main/ipc/preflight.ts).
-async function isForgeCliAuthenticated(cli: 'gh' | 'glab'): Promise<boolean> {
+async function isForgeCliAuthenticated(cli: 'gh' | 'glab', executable: string): Promise<boolean> {
   try {
-    await execFileAsync(cli, ['auth', 'status'], {
+    await execFileAsync(executable, ['auth', 'status'], {
       encoding: 'utf-8',
       env: buildRelayCommandEnv(),
       timeout: FORGE_AUTH_TIMEOUT_MS
@@ -230,10 +235,15 @@ export function buildCommandLookupSpecs(
   return specs
 }
 
-export async function isCommandOnPathForRelay(
+/**
+ * Resolve `command` to an absolute path using the same shell-aware probes as
+ * detection, so callers that spawn it cannot disagree with detection about
+ * which binary they mean when PATH comes from a shell startup file.
+ */
+export async function resolveRelayCommandPath(
   command: string,
   options: RelayCommandLookupOptions = {}
-): Promise<boolean> {
+): Promise<string | null> {
   const platform = options.platform ?? process.platform
   const env = options.env ?? process.env
   const specs = buildCommandLookupSpecs(command, platform, env, options.accountLoginShell)
@@ -246,31 +256,37 @@ export async function isCommandOnPathForRelay(
         timeout: 5000,
         ...(spec.windowsHide ? { windowsHide: true } : {})
       })
-      if (hasAbsoluteCommandPath(stdout, platform)) {
-        return true
+      const resolved = firstAbsoluteCommandPath(stdout, platform)
+      if (resolved !== null) {
+        return resolved
       }
     } catch {
-      // Try the inherited-PATH fallback before reporting the agent missing.
+      // Try the inherited-PATH fallback before reporting the command missing.
     }
   }
 
-  return false
+  return null
 }
 
 export function hasAbsoluteCommandPath(output: string, platform: NodeJS.Platform): boolean {
+  return firstAbsoluteCommandPath(output, platform) !== null
+}
+
+export function firstAbsoluteCommandPath(output: string, platform: NodeJS.Platform): string | null {
   const pathOps = platform === 'win32' ? win32 : path
-  return output
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .some((line) => {
-      const resolvedPath =
-        platform === 'win32'
-          ? line
-          : line.startsWith(AGENT_PATH_PREFIX)
-            ? line.slice(AGENT_PATH_PREFIX.length)
-            : ''
-      return pathOps.isAbsolute(resolvedPath)
-    })
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim()
+    const resolvedPath =
+      platform === 'win32'
+        ? line
+        : line.startsWith(AGENT_PATH_PREFIX)
+          ? line.slice(AGENT_PATH_PREFIX.length)
+          : ''
+    if (pathOps.isAbsolute(resolvedPath)) {
+      return resolvedPath
+    }
+  }
+  return null
 }
 
 function buildPosixCommandLookupSpec(command: string, shell: string): CommandLookupSpec {

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -36,7 +36,10 @@ const SUPPORTED_POSIX_SHELLS = new Set(['sh', 'dash', 'bash', 'zsh', 'fish'])
 const CONSERVATIVE_SYSTEM_SHELL_DIRS = new Set(['/bin', '/usr/bin'])
 const AGENT_PATH_PREFIX = '__ORCA_AGENT_PATH__'
 const FORGE_CLI_ALLOWLIST = new Set(['gh', 'glab'])
-const FORGE_AUTH_TIMEOUT_MS = 10_000
+// Why: the caller (REMOTE_FORGE_PROBE_TIMEOUT_MS in src/main/ipc/preflight.ts)
+// abandons this request at 8s. Finishing under that leaves the relay a window
+// to answer instead of working on a result nobody is waiting for.
+const FORGE_AUTH_TIMEOUT_MS = 6_000
 
 export class PreflightHandler {
   private dispatcher: RelayDispatcher
@@ -163,9 +166,20 @@ async function isForgeCliAuthenticated(cli: 'gh' | 'glab'): Promise<boolean> {
     })
     return true
   } catch (error) {
-    const stdout = (error as { stdout?: string }).stdout ?? ''
-    const stderr = (error as { stderr?: string }).stderr ?? ''
-    const output = `${stdout}\n${stderr}`
+    // Why: execFile preserves stdout/stderr when `timeout` kills the child, so
+    // a hung `auth status` that had already printed "Logged in" would otherwise
+    // read as authenticated. A killed probe is "unknown", never a yes.
+    const failure = error as {
+      stdout?: string
+      stderr?: string
+      killed?: boolean
+      signal?: string
+      code?: string
+    }
+    if (failure.killed === true || failure.signal != null || failure.code === 'ETIMEDOUT') {
+      return false
+    }
+    const output = `${failure.stdout ?? ''}\n${failure.stderr ?? ''}`
     return cli === 'gh'
       ? output.includes('Logged in') || output.includes('Active account: true')
       : output.includes('Logged in')

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -142,7 +142,7 @@ export class PreflightHandler {
         const installed = await this.isCommandOnPath(cli)
         results[cli] = {
           installed,
-          authenticated: installed && (await isForgeCliAuthenticated(cli))
+          authenticated: installed && (await isForgeCliAuthenticated(cli as 'gh' | 'glab'))
         }
       })
     )
@@ -152,7 +152,9 @@ export class PreflightHandler {
 
 // Why: glab writes auth status to stderr in some versions and can exit
 // non-zero while still logged in, so check output markers on failure too.
-async function isForgeCliAuthenticated(cli: string): Promise<boolean> {
+// Markers mirror the main-process per-CLI checks (isGhAuthenticated /
+// isGlabAuthenticated in src/main/ipc/preflight.ts).
+async function isForgeCliAuthenticated(cli: 'gh' | 'glab'): Promise<boolean> {
   try {
     await execFileAsync(cli, ['auth', 'status'], {
       encoding: 'utf-8',
@@ -164,7 +166,9 @@ async function isForgeCliAuthenticated(cli: string): Promise<boolean> {
     const stdout = (error as { stdout?: string }).stdout ?? ''
     const stderr = (error as { stderr?: string }).stderr ?? ''
     const output = `${stdout}\n${stderr}`
-    return output.includes('Logged in') || output.includes('Active account: true')
+    return cli === 'gh'
+      ? output.includes('Logged in') || output.includes('Active account: true')
+      : output.includes('Logged in')
   }
 }
 

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -1,21 +1,20 @@
 import { execFile } from 'node:child_process'
-import { userInfo } from 'node:os'
 import { promisify } from 'node:util'
-import path, { win32 } from 'node:path'
 import type { RelayDispatcher } from './dispatcher'
 import { buildRelayCommandEnv } from './relay-command-env'
 import { isPwshAvailableAsync } from '../main/pwsh'
 import { isWslAvailableAsync, listWslDistrosAsync } from '../main/wsl'
 import { isGitBashAvailable } from '../main/git-bash'
-import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
+import {
+  buildCommandLookupSpec,
+  buildCommandLookupSpecs,
+  firstAbsoluteCommandPath,
+  hasAbsoluteCommandPath
+} from './relay-command-lookup'
+
+export { buildCommandLookupSpec, buildCommandLookupSpecs, firstAbsoluteCommandPath, hasAbsoluteCommandPath }
 
 const execFileAsync = promisify(execFile)
-
-type CommandLookupSpec = {
-  file: string
-  args: string[]
-  windowsHide?: true
-}
 
 type RelayCommandLookupOptions = {
   platform?: NodeJS.Platform
@@ -32,9 +31,6 @@ type AgentDetectionCommand = {
   unsupportedRuntimes?: readonly AgentDetectionRuntime[]
 }
 
-const SUPPORTED_POSIX_SHELLS = new Set(['sh', 'dash', 'bash', 'zsh', 'fish'])
-const CONSERVATIVE_SYSTEM_SHELL_DIRS = new Set(['/bin', '/usr/bin'])
-const AGENT_PATH_PREFIX = '__ORCA_AGENT_PATH__'
 const FORGE_CLI_ALLOWLIST = new Set(['gh', 'glab'])
 // Why: the caller abandons at 8s (REMOTE_FORGE_PROBE_TIMEOUT_MS in
 // src/main/ipc/preflight.ts), and a forge probe pays lookup then auth, so both
@@ -168,7 +164,8 @@ async function isForgeCliAuthenticated(cli: 'gh' | 'glab', executable: string): 
     await execFileAsync(executable, ['auth', 'status'], {
       encoding: 'utf-8',
       env: buildRelayCommandEnv(),
-      timeout: FORGE_AUTH_TIMEOUT_MS
+      timeout: FORGE_AUTH_TIMEOUT_MS,
+      windowsHide: true
     })
     return true
   } catch (error) {
@@ -196,43 +193,6 @@ function isDetectionUnsupportedInRuntime(
   runtime: AgentDetectionRuntime
 ): boolean {
   return command.unsupportedRuntimes?.includes(runtime) === true
-}
-
-export function buildCommandLookupSpec(
-  command: string,
-  platform: NodeJS.Platform,
-  env: NodeJS.ProcessEnv = process.env,
-  accountLoginShell?: string | null
-): CommandLookupSpec {
-  const [spec] = buildCommandLookupSpecs(command, platform, env, accountLoginShell)
-  return spec ?? buildPosixCommandLookupSpec(command, '/bin/sh')
-}
-
-export function buildCommandLookupSpecs(
-  command: string,
-  platform: NodeJS.Platform,
-  env: NodeJS.ProcessEnv = process.env,
-  accountLoginShell?: string | null
-): CommandLookupSpec[] {
-  if (platform === 'win32') {
-    return [{ file: 'where.exe', args: [command], windowsHide: true }]
-  }
-  const trustedShell = pickTrustedPosixShell(
-    env,
-    resolveAccountLoginShell(platform, accountLoginShell)
-  )
-  const specs: CommandLookupSpec[] = []
-
-  if (trustedShell) {
-    specs.push(buildPosixCommandLookupSpec(command, trustedShell))
-  }
-
-  const inheritedPathSpec = buildPosixCommandLookupSpec(command, '/bin/sh')
-  if (!trustedShell || trustedShell !== inheritedPathSpec.file) {
-    specs.push(inheritedPathSpec)
-  }
-
-  return specs
 }
 
 /**
@@ -277,99 +237,4 @@ export async function isCommandOnPathForRelay(
   options: RelayCommandLookupOptions = {}
 ): Promise<boolean> {
   return (await resolveRelayCommandPath(command, options)) !== null
-}
-
-export function hasAbsoluteCommandPath(output: string, platform: NodeJS.Platform): boolean {
-  return firstAbsoluteCommandPath(output, platform) !== null
-}
-
-export function firstAbsoluteCommandPath(output: string, platform: NodeJS.Platform): string | null {
-  const pathOps = platform === 'win32' ? win32 : path
-  for (const raw of output.split(/\r?\n/)) {
-    const line = raw.trim()
-    const resolvedPath =
-      platform === 'win32'
-        ? line
-        : line.startsWith(AGENT_PATH_PREFIX)
-          ? line.slice(AGENT_PATH_PREFIX.length)
-          : ''
-    if (pathOps.isAbsolute(resolvedPath)) {
-      return resolvedPath
-    }
-  }
-  return null
-}
-
-function buildPosixCommandLookupSpec(command: string, shell: string): CommandLookupSpec {
-  const shellName = path.posix.basename(shell).toLowerCase()
-  if (shellName === 'fish') {
-    return { file: shell, args: ['-ilc', buildFishCommandLookupScript(command)] }
-  }
-  return { file: shell, args: [getShellCommandMode(shell), buildShCommandLookupScript(command)] }
-}
-
-function buildShCommandLookupScript(command: string): string {
-  // Why: login shells may define aliases or functions that mask the PATH executable.
-  return [
-    buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
-    'if [ -n "$resolved" ]; then',
-    `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
-    'fi'
-  ].join('\n')
-}
-
-function buildFishCommandLookupScript(command: string): string {
-  const quotedCommand = shellQuote(command)
-  return [
-    `set -l resolved (command -v ${quotedCommand} 2>/dev/null)`,
-    'if test -n "$resolved"',
-    `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
-    'end'
-  ].join('\n')
-}
-
-function resolveAccountLoginShell(
-  platform: NodeJS.Platform,
-  accountLoginShell?: string | null
-): string | null {
-  if (accountLoginShell !== undefined) {
-    return accountLoginShell
-  }
-  if (platform === 'win32') {
-    return null
-  }
-  try {
-    return userInfo().shell ?? null
-  } catch {
-    return null
-  }
-}
-
-function pickTrustedPosixShell(
-  env: NodeJS.ProcessEnv,
-  accountLoginShell: string | null
-): string | null {
-  const shell = env.SHELL
-  if (!shell || !path.posix.isAbsolute(shell)) {
-    return null
-  }
-  const shellName = path.posix.basename(shell).toLowerCase()
-  if (!SUPPORTED_POSIX_SHELLS.has(shellName)) {
-    return null
-  }
-  if (accountLoginShell) {
-    return shell === accountLoginShell ? shell : null
-  }
-  return CONSERVATIVE_SYSTEM_SHELL_DIRS.has(path.posix.dirname(shell)) ? shell : null
-}
-
-function getShellCommandMode(shell: string): '-lc' | '-ilc' {
-  const shellName = path.posix.basename(shell).toLowerCase()
-  // Why: bash/zsh/fish users commonly add package-manager bins from interactive
-  // startup files. POSIX sh/dash may not support interactive login flags.
-  return shellName === 'sh' || shellName === 'dash' ? '-lc' : '-ilc'
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`
 }

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -268,6 +268,17 @@ export async function resolveRelayCommandPath(
   return null
 }
 
+/**
+ * Boolean form of {@link resolveRelayCommandPath} for callers that only need to
+ * know whether `command` is on PATH (e.g. TUI agent detection).
+ */
+export async function isCommandOnPathForRelay(
+  command: string,
+  options: RelayCommandLookupOptions = {}
+): Promise<boolean> {
+  return (await resolveRelayCommandPath(command, options)) !== null
+}
+
 export function hasAbsoluteCommandPath(output: string, platform: NodeJS.Platform): boolean {
   return firstAbsoluteCommandPath(output, platform) !== null
 }

--- a/src/relay/relay-command-lookup.ts
+++ b/src/relay/relay-command-lookup.ts
@@ -1,0 +1,145 @@
+import { userInfo } from 'node:os'
+import path, { win32 } from 'node:path'
+import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
+
+export type CommandLookupSpec = {
+  file: string
+  args: string[]
+  windowsHide?: true
+}
+
+const SUPPORTED_POSIX_SHELLS = new Set(['sh', 'dash', 'bash', 'zsh', 'fish'])
+const CONSERVATIVE_SYSTEM_SHELL_DIRS = new Set(['/bin', '/usr/bin'])
+const AGENT_PATH_PREFIX = '__ORCA_AGENT_PATH__'
+
+export function buildCommandLookupSpec(
+  command: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv = process.env,
+  accountLoginShell?: string | null
+): CommandLookupSpec {
+  const [spec] = buildCommandLookupSpecs(command, platform, env, accountLoginShell)
+  return spec ?? buildPosixCommandLookupSpec(command, '/bin/sh')
+}
+
+export function buildCommandLookupSpecs(
+  command: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv = process.env,
+  accountLoginShell?: string | null
+): CommandLookupSpec[] {
+  if (platform === 'win32') {
+    return [{ file: 'where.exe', args: [command], windowsHide: true }]
+  }
+  const trustedShell = pickTrustedPosixShell(
+    env,
+    resolveAccountLoginShell(platform, accountLoginShell)
+  )
+  const specs: CommandLookupSpec[] = []
+
+  if (trustedShell) {
+    specs.push(buildPosixCommandLookupSpec(command, trustedShell))
+  }
+
+  const inheritedPathSpec = buildPosixCommandLookupSpec(command, '/bin/sh')
+  if (!trustedShell || trustedShell !== inheritedPathSpec.file) {
+    specs.push(inheritedPathSpec)
+  }
+
+  return specs
+}
+
+export function hasAbsoluteCommandPath(output: string, platform: NodeJS.Platform): boolean {
+  return firstAbsoluteCommandPath(output, platform) !== null
+}
+
+export function firstAbsoluteCommandPath(output: string, platform: NodeJS.Platform): string | null {
+  const pathOps = platform === 'win32' ? win32 : path
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim()
+    const resolvedPath =
+      platform === 'win32'
+        ? line
+        : line.startsWith(AGENT_PATH_PREFIX)
+          ? line.slice(AGENT_PATH_PREFIX.length)
+          : ''
+    if (pathOps.isAbsolute(resolvedPath)) {
+      return resolvedPath
+    }
+  }
+  return null
+}
+
+function buildPosixCommandLookupSpec(command: string, shell: string): CommandLookupSpec {
+  const shellName = path.posix.basename(shell).toLowerCase()
+  if (shellName === 'fish') {
+    return { file: shell, args: ['-ilc', buildFishCommandLookupScript(command)] }
+  }
+  return { file: shell, args: [getShellCommandMode(shell), buildShCommandLookupScript(command)] }
+}
+
+function buildShCommandLookupScript(command: string): string {
+  // Why: login shells may define aliases or functions that mask the PATH executable.
+  return [
+    buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
+    'if [ -n "$resolved" ]; then',
+    `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
+    'fi'
+  ].join('\n')
+}
+
+function buildFishCommandLookupScript(command: string): string {
+  const quotedCommand = shellQuote(command)
+  return [
+    `set -l resolved (command -v ${quotedCommand} 2>/dev/null)`,
+    'if test -n "$resolved"',
+    `printf '${AGENT_PATH_PREFIX}%s\\n' "$resolved"`,
+    'end'
+  ].join('\n')
+}
+
+function resolveAccountLoginShell(
+  platform: NodeJS.Platform,
+  accountLoginShell?: string | null
+): string | null {
+  if (accountLoginShell !== undefined) {
+    return accountLoginShell
+  }
+  if (platform === 'win32') {
+    return null
+  }
+  try {
+    return userInfo().shell ?? null
+  } catch {
+    return null
+  }
+}
+
+function pickTrustedPosixShell(
+  env: NodeJS.ProcessEnv,
+  accountLoginShell: string | null
+): string | null {
+  const shell = env.SHELL
+  if (!shell || !path.posix.isAbsolute(shell)) {
+    return null
+  }
+  const shellName = path.posix.basename(shell).toLowerCase()
+  if (!SUPPORTED_POSIX_SHELLS.has(shellName)) {
+    return null
+  }
+  if (accountLoginShell) {
+    return shell === accountLoginShell ? shell : null
+  }
+  return CONSERVATIVE_SYSTEM_SHELL_DIRS.has(path.posix.dirname(shell)) ? shell : null
+}
+
+function getShellCommandMode(shell: string): '-lc' | '-ilc' {
+  const shellName = path.posix.basename(shell).toLowerCase()
+  // Why: bash/zsh/fish users commonly add package-manager bins from interactive
+  // startup files. POSIX sh/dash may not support interactive login flags.
+  return shellName === 'sh' || shellName === 'dash' ? '-lc' : '-ilc'
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
@@ -31,6 +31,14 @@ const mocks = vi.hoisted(() => ({
       giteaAccount: null
     },
     unavailable: false,
+    hostForge: undefined as
+      | {
+          connectionId: string
+          hostLabel: string
+          gh?: { installed: boolean; authenticated: boolean }
+          glab?: { installed: boolean; authenticated: boolean }
+        }
+      | undefined,
     refresh: vi.fn()
   }
 }))
@@ -75,6 +83,7 @@ describe('CLI source-control integration card account scope', () => {
     mocks.preflight.statuses.ghStatus = 'connected'
     mocks.preflight.statuses.glabStatus = 'connected'
     mocks.preflight.unavailable = false
+    mocks.preflight.hostForge = undefined
     mocks.preflight.refresh.mockClear()
   })
 
@@ -125,5 +134,42 @@ describe('CLI source-control integration card account scope', () => {
       'Credentials and account checks for this provider are owned by this remote server. Use Settings > Remote Orca Servers > Advanced to edit another default runtime scope.'
     )
     expect(rendered.textContent).toContain('glab auth login')
+  })
+
+  it('shows the host-side hint when the SSH host has an authed CLI the local card lacks', async () => {
+    mocks.store.current = {
+      settings: { activeRuntimeEnvironmentId: null },
+      openSettingsPage: vi.fn(),
+      openSettingsTarget: vi.fn()
+    }
+    mocks.preflight.statuses.glabStatus = 'not-installed'
+    mocks.preflight.hostForge = {
+      connectionId: 'ssh-1',
+      hostLabel: 'work-box',
+      glab: { installed: true, authenticated: true }
+    }
+
+    const rendered = await renderCard(<GitLabIntegrationCard />)
+
+    expect(rendered.textContent).toContain(
+      'glab is installed and authenticated on work-box — these features currently run locally.'
+    )
+  })
+
+  it('omits the host-side hint once the local CLI is connected', async () => {
+    mocks.store.current = {
+      settings: { activeRuntimeEnvironmentId: null },
+      openSettingsPage: vi.fn(),
+      openSettingsTarget: vi.fn()
+    }
+    mocks.preflight.hostForge = {
+      connectionId: 'ssh-1',
+      hostLabel: 'work-box',
+      gh: { installed: true, authenticated: true }
+    }
+
+    const rendered = await renderCard(<GitHubIntegrationCard />)
+
+    expect(rendered.textContent).not.toContain('is installed and authenticated on')
   })
 })

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -6,7 +6,7 @@ import {
   useIntegrationCommandRowClass,
   useIntegrationSubordinateRowClass
 } from './integration-card-presentation'
-import { deriveHostForgeHint } from './integrations-pane-status'
+import { deriveHostForgeHint, type ForgeCliName } from './integrations-pane-status'
 import { getProviderAccountScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
@@ -45,7 +45,7 @@ function HostForgeHint({
   cli,
   hint
 }: {
-  cli: 'gh' | 'glab'
+  cli: ForgeCliName
   hint: { hostLabel: string } | null
 }): React.JSX.Element | null {
   if (!hint) {

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -6,6 +6,7 @@ import {
   useIntegrationCommandRowClass,
   useIntegrationSubordinateRowClass
 } from './integration-card-presentation'
+import { deriveHostForgeHint } from './integrations-pane-status'
 import { getProviderAccountScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
@@ -40,6 +41,27 @@ function integrationStatusLabel(
   }
 }
 
+function HostForgeHint({
+  cli,
+  hint
+}: {
+  cli: 'gh' | 'glab'
+  hint: { hostLabel: string } | null
+}): React.JSX.Element | null {
+  if (!hint) {
+    return null
+  }
+  return (
+    <p className="text-xs text-muted-foreground">
+      {translate(
+        'auto.components.settings.cli.source.control.integration.cards.hostForgeHint',
+        '{{value0}} is installed and authenticated on {{value1}} — these features currently run locally.',
+        { value0: cli, value1: hint.hostLabel }
+      )}
+    </p>
+  )
+}
+
 function ProviderAccountScopeDetails({
   children
 }: {
@@ -65,10 +87,11 @@ function ProviderAccountScopeDetails({
 }
 
 export function GitHubIntegrationCard(): React.JSX.Element {
-  const { statuses, unavailable, refresh } = usePreflightCardStatuses('gh')
+  const { statuses, unavailable, hostForge, refresh } = usePreflightCardStatuses('gh')
   const status = unavailable ? 'unavailable' : statuses.ghStatus
   const connected = status === 'connected'
   const commandRowClass = useIntegrationCommandRowClass()
+  const hostHint = deriveHostForgeHint('gh', status, hostForge)
 
   return (
     <IntegrationCardShell
@@ -180,16 +203,18 @@ export function GitHubIntegrationCard(): React.JSX.Element {
             </>
           )
         ) : null}
+        <HostForgeHint cli="gh" hint={hostHint} />
       </ProviderAccountScopeDetails>
     </IntegrationCardShell>
   )
 }
 
 export function GitLabIntegrationCard(): React.JSX.Element {
-  const { statuses, unavailable, refresh } = usePreflightCardStatuses('glab')
+  const { statuses, unavailable, hostForge, refresh } = usePreflightCardStatuses('glab')
   const status = unavailable ? 'unavailable' : statuses.glabStatus
   const connected = status === 'connected'
   const commandRowClass = useIntegrationCommandRowClass()
+  const hostHint = deriveHostForgeHint('glab', status, hostForge)
 
   return (
     <IntegrationCardShell
@@ -305,6 +330,7 @@ export function GitLabIntegrationCard(): React.JSX.Element {
             </>
           )
         ) : null}
+        <HostForgeHint cli="glab" hint={hostHint} />
       </ProviderAccountScopeDetails>
     </IntegrationCardShell>
   )

--- a/src/renderer/src/components/settings/integrations-pane-status.test.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { PreflightStatus } from '../../../../preload/api-types'
 import {
+  deriveHostForgeHint,
   getPreflightIntegrationStatuses,
   giteaStatusFromPreflight,
   tokenApiStatusFromPreflight
@@ -95,5 +96,38 @@ describe('getPreflightIntegrationStatuses', () => {
       bitbucketStatus: 'connected',
       giteaStatus: 'checking'
     })
+  })
+})
+
+describe('deriveHostForgeHint', () => {
+  const hostForge = {
+    connectionId: 'ssh-1',
+    hostLabel: 'work-box',
+    glab: { installed: true, authenticated: true }
+  }
+
+  it('hints when local is not-installed but the host has an authed CLI', () => {
+    expect(deriveHostForgeHint('glab', 'not-installed', hostForge)).toEqual({
+      hostLabel: 'work-box'
+    })
+  })
+
+  it('hints when local is not-authenticated but the host is authed', () => {
+    expect(deriveHostForgeHint('glab', 'not-authenticated', hostForge)).toEqual({
+      hostLabel: 'work-box'
+    })
+  })
+
+  it('stays quiet when local is already connected', () => {
+    expect(deriveHostForgeHint('glab', 'connected', hostForge)).toBeNull()
+  })
+
+  it('stays quiet when the host CLI is not authenticated', () => {
+    const unauthed = { ...hostForge, glab: { installed: true, authenticated: false } }
+    expect(deriveHostForgeHint('glab', 'not-installed', unauthed)).toBeNull()
+  })
+
+  it('stays quiet without hostForge data', () => {
+    expect(deriveHostForgeHint('glab', 'not-installed', undefined)).toBeNull()
   })
 })

--- a/src/renderer/src/components/settings/integrations-pane-status.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.ts
@@ -1,5 +1,6 @@
 import type { PreflightStatus } from '../../../../preload/api-types'
 
+export type ForgeCliName = 'gh' | 'glab'
 export type GhStatus = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
 // Why: parallel to GhStatus — GitLab uses glab and the same three failure
 // modes (probe in-flight / installed-but-unauth / missing entirely).
@@ -82,6 +83,37 @@ function bitbucketStatusFromPreflight(status: PreflightStatus['bitbucket']): Bit
     return 'not-configured'
   }
   return status.authenticated ? 'connected' : 'not-authenticated'
+}
+
+// Local card state as reported by the two CLI cards; kept structurally
+// compatible with CliProviderCardState (source-control-preflight-card-status.ts)
+// without importing it, to avoid a cross-module type cycle.
+type LocalCliCardState = GhStatus | 'unavailable'
+
+/** Host answer for one CLI, as attached to `PreflightStatus.hostForge`. */
+type HostForgeStatus = NonNullable<PreflightStatus['hostForge']>
+
+/**
+ * Hint to show on a CLI card when the SSH execution host already has the
+ * CLI installed and authenticated, but the local card state hasn't caught
+ * up yet — i.e. the host answer is strictly better than the local one.
+ */
+export function deriveHostForgeHint(
+  cli: ForgeCliName,
+  cardState: LocalCliCardState,
+  hostForge: HostForgeStatus | undefined
+): { hostLabel: string } | null {
+  if (cardState !== 'not-installed' && cardState !== 'not-authenticated') {
+    return null
+  }
+  if (!hostForge) {
+    return null
+  }
+  const hostCliStatus = hostForge[cli]
+  if (!hostCliStatus?.installed || !hostCliStatus.authenticated) {
+    return null
+  }
+  return { hostLabel: hostForge.hostLabel }
 }
 
 function maybeChecking<T extends string>(

--- a/src/renderer/src/components/settings/integrations-pane-status.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.ts
@@ -85,19 +85,13 @@ function bitbucketStatusFromPreflight(status: PreflightStatus['bitbucket']): Bit
   return status.authenticated ? 'connected' : 'not-authenticated'
 }
 
-// Local card state as reported by the two CLI cards; kept structurally
-// compatible with CliProviderCardState (source-control-preflight-card-status.ts)
-// without importing it, to avoid a cross-module type cycle.
+// Structurally compatible with CliProviderCardState, not imported, to avoid a type cycle.
 type LocalCliCardState = GhStatus | 'unavailable'
 
 /** Host answer for one CLI, as attached to `PreflightStatus.hostForge`. */
 type HostForgeStatus = NonNullable<PreflightStatus['hostForge']>
 
-/**
- * Hint to show on a CLI card when the SSH execution host already has the
- * CLI installed and authenticated, but the local card state hasn't caught
- * up yet — i.e. the host answer is strictly better than the local one.
- */
+/** Hint for a CLI card when the SSH host's answer is strictly better than the local one. */
 export function deriveHostForgeHint(
   cli: ForgeCliName,
   cardState: LocalCliCardState,

--- a/src/renderer/src/components/settings/source-control-preflight-card-status.ts
+++ b/src/renderer/src/components/settings/source-control-preflight-card-status.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { PreflightStatus } from '../../../../preload/api-types'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { getLocalPreflightContext, localPreflightContextKey } from '@/lib/local-preflight-context'
 import { useAppStore } from '@/store'
@@ -47,6 +48,7 @@ export function deriveCliProviderCardState(input: {
 export type PreflightCardStatuses = {
   statuses: PreflightIntegrationStatuses
   unavailable: boolean
+  hostForge: PreflightStatus['hostForge']
   refresh: () => void
 }
 
@@ -90,6 +92,7 @@ export function usePreflightCardStatuses(
   return {
     statuses: getPreflightIntegrationStatuses(statusInput, refreshingProviders),
     unavailable,
+    hostForge: statusInput?.hostForge,
     refresh
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10647,7 +10647,8 @@
                   "statusConnected": "Connected",
                   "statusUnavailable": "Unavailable",
                   "statusNotInstalled": "Not installed",
-                  "statusNotAuthenticated": "Not authenticated"
+                  "statusNotAuthenticated": "Not authenticated",
+                  "hostForgeHint": "{{value0}} is installed and authenticated on {{value1}} — these features currently run locally."
                 }
               }
             }

--- a/src/renderer/src/lib/local-preflight-context-cache.ts
+++ b/src/renderer/src/lib/local-preflight-context-cache.ts
@@ -6,6 +6,9 @@ export type LocalPreflightContext =
       wslDefault?: boolean
       runtimeContextKey?: string
       projectRuntime?: ProjectExecutionRuntimeResolution
+      /** Mirrors `PreflightRuntimeContext.sshHost`: names the SSH execution host
+       *  whose forge CLIs preflight should additionally probe. */
+      sshHost?: { connectionId: string; hostLabel: string }
     }
   | undefined
 
@@ -13,15 +16,18 @@ export type LocalPreflightContext =
 // churn as repos are added and removed during a long-lived renderer session.
 const WSL_PREFLIGHT_CONTEXT_CACHE_MAX = 128
 const PROJECT_RUNTIME_PREFLIGHT_CONTEXT_CACHE_MAX = 2048
+const SSH_HOST_PREFLIGHT_CONTEXT_CACHE_MAX = 128
 
 // Why: these reads run inside broad store selectors. Insertion-order eviction
 // keeps cache hits read-only instead of adding Map mutations to every store update.
 const wslPreflightContextsByDistro = new Map<string, NonNullable<LocalPreflightContext>>()
 const projectRuntimePreflightContextsByKey = new Map<string, NonNullable<LocalPreflightContext>>()
+const sshHostPreflightContextsByKey = new Map<string, NonNullable<LocalPreflightContext>>()
 
 export function resetLocalPreflightContextCachesForTests(): void {
   wslPreflightContextsByDistro.clear()
   projectRuntimePreflightContextsByKey.clear()
+  sshHostPreflightContextsByKey.clear()
 }
 
 export function _getWslPreflightContextCacheSizeForTest(): number {
@@ -50,6 +56,28 @@ export function getWslPreflightContext(wslDistro: string): NonNullable<LocalPref
   // here triggers a useSyncExternalStore loop when Settings observes WSL repos.
   const context = Object.freeze({ wslDistro })
   storeCacheEntry(wslPreflightContextsByDistro, wslDistro, context, WSL_PREFLIGHT_CONTEXT_CACHE_MAX)
+  return context
+}
+
+export function getSshHostPreflightContext(
+  connectionId: string,
+  hostLabel: string
+): NonNullable<LocalPreflightContext> {
+  // Why: the label is part of the key — a renamed target must produce a fresh
+  // snapshot so the card stops showing the old host name.
+  const cacheKey = JSON.stringify([connectionId, hostLabel])
+  const cached = sshHostPreflightContextsByKey.get(cacheKey)
+  if (cached) {
+    return cached
+  }
+
+  const context = Object.freeze({ sshHost: Object.freeze({ connectionId, hostLabel }) })
+  storeCacheEntry(
+    sshHostPreflightContextsByKey,
+    cacheKey,
+    context,
+    SSH_HOST_PREFLIGHT_CONTEXT_CACHE_MAX
+  )
   return context
 }
 

--- a/src/renderer/src/lib/local-preflight-context-key.ts
+++ b/src/renderer/src/lib/local-preflight-context-key.ts
@@ -6,6 +6,7 @@ type LocalPreflightContextKeyInput =
       wslDefault?: boolean
       runtimeContextKey?: string
       projectRuntime?: ProjectExecutionRuntimeResolution
+      sshHost?: { connectionId: string; hostLabel: string }
     }
   | undefined
 
@@ -17,6 +18,11 @@ export function localPreflightContextKey(context: LocalPreflightContextKeyInput)
   }
   if (context?.runtimeContextKey) {
     return context.runtimeContextKey
+  }
+  // Why: two SSH hosts answer differently, so a host switch must invalidate the
+  // cached status instead of leaving the previous host's label on the card.
+  if (context?.sshHost) {
+    return `ssh:${context.sshHost.connectionId}`
   }
   if (context?.wslDistro) {
     return `wsl:${context.wslDistro}`

--- a/src/renderer/src/lib/local-preflight-context-key.ts
+++ b/src/renderer/src/lib/local-preflight-context-key.ts
@@ -20,9 +20,11 @@ export function localPreflightContextKey(context: LocalPreflightContextKeyInput)
     return context.runtimeContextKey
   }
   // Why: two SSH hosts answer differently, so a host switch must invalidate the
-  // cached status instead of leaving the previous host's label on the card.
+  // cached status instead of leaving the previous host's label on the card. A
+  // rename (same connectionId, new hostLabel) must also invalidate, not just a
+  // host switch — otherwise the card keeps showing the old label.
   if (context?.sshHost) {
-    return `ssh:${context.sshHost.connectionId}`
+    return `ssh:${JSON.stringify([context.sshHost.connectionId, context.sshHost.hostLabel])}`
   }
   if (context?.wslDistro) {
     return `wsl:${context.wslDistro}`

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -132,7 +132,7 @@ describe('local preflight context', () => {
     const context = getLocalPreflightContext(state, 'darwin')
 
     expect(context).toEqual({ sshHost: { connectionId: 'builder', hostLabel: 'Build Box' } })
-    expect(localPreflightContextKey(context)).toBe('ssh:builder')
+    expect(localPreflightContextKey(context)).toBe('ssh:["builder","Build Box"]')
     expect(getLocalPreflightContext(state, 'darwin')).toBe(context)
   })
 
@@ -163,6 +163,20 @@ describe('local preflight context', () => {
 
     expect(first).not.toBe(second)
     expect(localPreflightContextKey(first)).not.toBe(localPreflightContextKey(second))
+  })
+
+  it('keys a renamed SSH target apart so the rename invalidates the card', () => {
+    const beforeRename = getLocalPreflightContext(
+      makeSshState({ connectionId: 'builder', labels: { builder: 'Build Box' } }),
+      'darwin'
+    )
+    const afterRename = getLocalPreflightContext(
+      makeSshState({ connectionId: 'builder', labels: { builder: 'Renamed Box' } }),
+      'darwin'
+    )
+
+    expect(afterRename).not.toBe(beforeRename)
+    expect(localPreflightContextKey(afterRename)).not.toBe(localPreflightContextKey(beforeRename))
   })
 
   it('omits the SSH host for local and WSL repos', () => {

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -53,6 +53,23 @@ function makeState(args: {
   } as AppState
 }
 
+function makeSshState(args: {
+  connectionId: string
+  labels?: Record<string, string>
+  removedLabels?: Record<string, string>
+}): AppState {
+  return {
+    ...makeState({
+      repoPath: '/home/alice/repo',
+      repo: { connectionId: args.connectionId, executionHostId: `ssh:${args.connectionId}` }
+    }),
+    ...(args.labels ? { sshTargetLabels: new Map(Object.entries(args.labels)) } : {}),
+    ...(args.removedLabels
+      ? { removedSshTargetLabels: new Map(Object.entries(args.removedLabels)) }
+      : {})
+  } as AppState
+}
+
 describe('local preflight context', () => {
   it('extracts WSL distro names from supported UNC forms', () => {
     expect(getWslDistroFromPath(String.raw`\\wsl.localhost\Ubuntu\home\alice\repo`)).toBe('Ubuntu')
@@ -107,6 +124,55 @@ describe('local preflight context', () => {
     expect(getLocalPreflightContext(state)).toBeUndefined()
     expect(getLocalPreflightContext(state)).toBeUndefined()
     expect(localPreflightContextKey(getLocalPreflightContext(state))).toBe('host')
+  })
+
+  it('derives the SSH execution host for an active remote repo', () => {
+    const state = makeSshState({ connectionId: 'builder', labels: { builder: 'Build Box' } })
+
+    const context = getLocalPreflightContext(state, 'darwin')
+
+    expect(context).toEqual({ sshHost: { connectionId: 'builder', hostLabel: 'Build Box' } })
+    expect(localPreflightContextKey(context)).toBe('ssh:builder')
+    expect(getLocalPreflightContext(state, 'darwin')).toBe(context)
+  })
+
+  it('falls back to the SSH target id when no label has hydrated yet', () => {
+    const context = getLocalPreflightContext(makeSshState({ connectionId: 'builder' }), 'darwin')
+
+    expect(context).toEqual({ sshHost: { connectionId: 'builder', hostLabel: 'builder' } })
+  })
+
+  it('uses the last known label for a removed SSH target', () => {
+    const context = getLocalPreflightContext(
+      makeSshState({ connectionId: 'builder', removedLabels: { builder: 'Old Build Box' } }),
+      'darwin'
+    )
+
+    expect(context).toEqual({ sshHost: { connectionId: 'builder', hostLabel: 'Old Build Box' } })
+  })
+
+  it('keys two SSH execution hosts apart so a host switch invalidates the card', () => {
+    const first = getLocalPreflightContext(
+      makeSshState({ connectionId: 'builder', labels: { builder: 'Build Box' } }),
+      'darwin'
+    )
+    const second = getLocalPreflightContext(
+      makeSshState({ connectionId: 'staging', labels: { staging: 'Build Box' } }),
+      'darwin'
+    )
+
+    expect(first).not.toBe(second)
+    expect(localPreflightContextKey(first)).not.toBe(localPreflightContextKey(second))
+  })
+
+  it('omits the SSH host for local and WSL repos', () => {
+    expect(getLocalPreflightContext(makeState({ repoPath: '/Users/alice/repo' }))).toBeUndefined()
+    expect(
+      getLocalPreflightContext(
+        makeState({ repoPath: String.raw`\\wsl.localhost\Ubuntu\home\alice\repo` }),
+        'darwin'
+      )
+    ).toEqual({ wslDistro: 'Ubuntu' })
   })
 
   it('keys preflight by active runtime before local WSL or host context', () => {
@@ -595,7 +661,9 @@ describe('local preflight context', () => {
 
     expect(getLocalProjectExecutionRuntimeContext(state, undefined, 'win32')).toBeUndefined()
     expect(getLocalRepoProjectExecutionRuntimeContext(state, 'repo-1', 'win32')).toBeUndefined()
-    expect(getLocalPreflightContext(state, 'win32')).toBeUndefined()
+    expect(getLocalPreflightContext(state, 'win32')).toEqual({
+      sshHost: { connectionId: 'builder', hostLabel: 'builder' }
+    })
   })
 
   it('uses the requested worktree repo owner before resolving a local project runtime', () => {

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -6,7 +6,11 @@ import {
   resolveProjectExecutionRuntime,
   type ProjectExecutionRuntimeResolution
 } from '../../../shared/project-execution-runtime'
-import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId
+} from '../../../shared/execution-host'
 import type { Repo } from '../../../shared/repo-types'
 import type { Worktree } from '../../../shared/worktree/types'
 import { getIndexedRepoMap, getIndexedWorktreeById } from '@/store/worktree-repo-index'
@@ -18,6 +22,7 @@ import {
 } from './windows-terminal-capabilities'
 import {
   getProjectRuntimePreflightContext,
+  getSshHostPreflightContext,
   getWslPreflightContext,
   type LocalPreflightContext
 } from './local-preflight-context-cache'
@@ -157,6 +162,10 @@ export function getLocalPreflightContext(
   if (state.settings?.activeRuntimeEnvironmentId?.trim()) {
     return { runtimeContextKey: getProviderRuntimeContextKey(state.settings) }
   }
+  const sshHost = getActiveSshExecutionHost(state)
+  if (sshHost) {
+    return getSshHostPreflightContext(sshHost.connectionId, sshHost.hostLabel)
+  }
   const projectRuntime = getLocalProjectExecutionRuntimeContext(
     state,
     undefined,
@@ -258,6 +267,31 @@ function getCachedLocalProjectRuntimeWslContext(): LocalProjectRuntimeWslContext
   return {
     wslAvailable: capabilities.wslAvailable,
     availableWslDistros: capabilities.wslDistros
+  }
+}
+
+// Why: preflight probes the machine that actually runs gh/glab for the active
+// repo. An SSH repo runs them on its host, so name that host for the remote
+// probe; the label mirrors the sidebar fallback chain (live label, last known
+// label for a removed target, then the raw target id).
+function getActiveSshExecutionHost(
+  state: AppState
+): { connectionId: string; hostLabel: string } | null {
+  const repo = getLocalRuntimeRepoForWorktree(state, getLocalWorktree(state))
+  if (!repo) {
+    return null
+  }
+  const executionHost = parseExecutionHostId(getRepoExecutionHostId(repo))
+  if (executionHost?.kind !== 'ssh') {
+    return null
+  }
+  const connectionId = executionHost.targetId
+  return {
+    connectionId,
+    hostLabel:
+      state.sshTargetLabels?.get(connectionId) ??
+      state.removedSshTargetLabels?.get(connectionId) ??
+      connectionId
   }
 }
 

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -6,14 +6,8 @@ import {
   resolveProjectExecutionRuntime,
   type ProjectExecutionRuntimeResolution
 } from '../../../shared/project-execution-runtime'
-import {
-  getRepoExecutionHostId,
-  LOCAL_EXECUTION_HOST_ID,
-  parseExecutionHostId
-} from '../../../shared/execution-host'
-import type { Repo } from '../../../shared/repo-types'
-import type { Worktree } from '../../../shared/worktree/types'
-import { getIndexedRepoMap, getIndexedWorktreeById } from '@/store/worktree-repo-index'
+import { getRepoExecutionHostId, parseExecutionHostId } from '../../../shared/execution-host'
+import { getIndexedRepoMap } from '@/store/worktree-repo-index'
 import { getProviderRuntimeContextKey } from './provider-runtime-context'
 import { getRendererAppPlatform } from './renderer-app-platform'
 import {
@@ -26,6 +20,16 @@ import {
   getWslPreflightContext,
   type LocalPreflightContext
 } from './local-preflight-context-cache'
+import {
+  EMPTY_REPOS,
+  getLocalPreflightProjectId,
+  getLocalRuntimeProject,
+  getLocalRuntimeRepoForWorktree,
+  getLocalWorktree,
+  isLocalRuntimeRepo,
+  isLocalRuntimeWorktree,
+  type LocalProjectRuntimeState
+} from './local-runtime-worktree-lookup'
 
 export { localPreflightContextKey } from './local-preflight-context-key'
 export type { LocalPreflightContext } from './local-preflight-context-cache'
@@ -36,16 +40,6 @@ export {
   _hasWslPreflightContextCacheEntryForTest,
   resetLocalPreflightContextCachesForTests
 } from './local-preflight-context-cache'
-
-type LocalProjectRuntimeState = Pick<
-  AppState,
-  'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
->
-
-// Why: the shared indexes are WeakMap-keyed on slice identity, so a fresh `{}`
-// or `[]` fallback would miss the cache on every read.
-const EMPTY_WORKTREES_BY_REPO: AppState['worktreesByRepo'] = {}
-const EMPTY_REPOS: AppState['repos'] = []
 
 type LocalProjectRuntimeWslContext = {
   wslAvailable?: boolean
@@ -303,60 +297,4 @@ function getLocalPreflightWslDistro(state: AppState, worktreeId?: string | null)
   }
   const activePath = activeWorktree?.path ?? repo.path
   return getWslDistroFromPath(activePath)
-}
-
-function getLocalRuntimeRepoForWorktree(
-  state: LocalProjectRuntimeState,
-  worktree?: Pick<Worktree, 'repoId'> | null
-): Pick<Repo, 'id' | 'path' | 'connectionId' | 'executionHostId'> | undefined {
-  const repoId = worktree?.repoId ?? state.activeRepoId
-  return repoId ? getIndexedRepoMap(state.repos ?? EMPTY_REPOS).get(repoId) : undefined
-}
-
-function isLocalRuntimeRepo(
-  repo?: Pick<Repo, 'connectionId' | 'executionHostId'> | null
-): repo is Pick<Repo, 'id' | 'path' | 'connectionId' | 'executionHostId'> {
-  if (!repo) {
-    return false
-  }
-  return getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID
-}
-
-function isLocalRuntimeWorktree(worktree?: Pick<Worktree, 'hostId'> | null): boolean {
-  return !worktree?.hostId || worktree.hostId === LOCAL_EXECUTION_HOST_ID
-}
-
-function getLocalRuntimeProject(
-  state: LocalProjectRuntimeState,
-  projectId: string,
-  repoId: string
-) {
-  return state.projects?.find(
-    (entry) =>
-      entry.id === projectId || entry.id === repoId || entry.sourceRepoIds?.includes(repoId)
-  )
-}
-
-function getLocalWorktree(
-  state: LocalProjectRuntimeState,
-  worktreeId?: string | null
-): Pick<Worktree, 'id' | 'repoId' | 'projectId' | 'path' | 'hostId'> | null {
-  const targetWorktreeId = worktreeId ?? state.activeWorktreeId
-  if (!targetWorktreeId) {
-    return null
-  }
-  return (
-    getIndexedWorktreeById(state.worktreesByRepo ?? EMPTY_WORKTREES_BY_REPO, targetWorktreeId) ??
-    null
-  )
-}
-
-function getLocalPreflightProjectId(
-  state: LocalProjectRuntimeState,
-  worktreeId?: string | null
-): string {
-  const activeWorktree = getLocalWorktree(state, worktreeId)
-  return (
-    activeWorktree?.projectId ?? activeWorktree?.repoId ?? state.activeRepoId ?? 'local-project'
-  )
 }

--- a/src/renderer/src/lib/local-runtime-worktree-lookup.ts
+++ b/src/renderer/src/lib/local-runtime-worktree-lookup.ts
@@ -1,0 +1,71 @@
+import type { AppState } from '@/store/types'
+import { getIndexedRepoMap, getIndexedWorktreeById } from '@/store/worktree-repo-index'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import type { Repo } from '../../../shared/repo-types'
+import type { Worktree } from '../../../shared/worktree/types'
+
+export type LocalProjectRuntimeState = Pick<
+  AppState,
+  'activeRepoId' | 'activeWorktreeId' | 'projects' | 'repos' | 'settings' | 'worktreesByRepo'
+>
+
+// Why: the shared indexes are WeakMap-keyed on slice identity, so a fresh `{}`
+// or `[]` fallback would miss the cache on every read.
+const EMPTY_WORKTREES_BY_REPO: AppState['worktreesByRepo'] = {}
+export const EMPTY_REPOS: AppState['repos'] = []
+
+export function getLocalRuntimeRepoForWorktree(
+  state: LocalProjectRuntimeState,
+  worktree?: Pick<Worktree, 'repoId'> | null
+): Pick<Repo, 'id' | 'path' | 'connectionId' | 'executionHostId'> | undefined {
+  const repoId = worktree?.repoId ?? state.activeRepoId
+  return repoId ? getIndexedRepoMap(state.repos ?? EMPTY_REPOS).get(repoId) : undefined
+}
+
+export function isLocalRuntimeRepo(
+  repo?: Pick<Repo, 'connectionId' | 'executionHostId'> | null
+): repo is Pick<Repo, 'id' | 'path' | 'connectionId' | 'executionHostId'> {
+  if (!repo) {
+    return false
+  }
+  return getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID
+}
+
+export function isLocalRuntimeWorktree(worktree?: Pick<Worktree, 'hostId'> | null): boolean {
+  return !worktree?.hostId || worktree.hostId === LOCAL_EXECUTION_HOST_ID
+}
+
+export function getLocalRuntimeProject(
+  state: LocalProjectRuntimeState,
+  projectId: string,
+  repoId: string
+) {
+  return state.projects?.find(
+    (entry) =>
+      entry.id === projectId || entry.id === repoId || entry.sourceRepoIds?.includes(repoId)
+  )
+}
+
+export function getLocalWorktree(
+  state: LocalProjectRuntimeState,
+  worktreeId?: string | null
+): Pick<Worktree, 'id' | 'repoId' | 'projectId' | 'path' | 'hostId'> | null {
+  const targetWorktreeId = worktreeId ?? state.activeWorktreeId
+  if (!targetWorktreeId) {
+    return null
+  }
+  return (
+    getIndexedWorktreeById(state.worktreesByRepo ?? EMPTY_WORKTREES_BY_REPO, targetWorktreeId) ??
+    null
+  )
+}
+
+export function getLocalPreflightProjectId(
+  state: LocalProjectRuntimeState,
+  worktreeId?: string | null
+): string {
+  const activeWorktree = getLocalWorktree(state, worktreeId)
+  return (
+    activeWorktree?.projectId ?? activeWorktree?.repoId ?? state.activeRepoId ?? 'local-project'
+  )
+}

--- a/src/renderer/src/store/slices/preflight.test.ts
+++ b/src/renderer/src/store/slices/preflight.test.ts
@@ -325,6 +325,97 @@ describe('createPreflightSlice', () => {
     expect(store.getState().preflightStatus?.glab?.installed).toBe(true)
   })
 
+  it('forwards the SSH execution host so the host-side forge probe can run', async () => {
+    resetPreflightMocks()
+    preflightCheck.mockResolvedValueOnce(makeStatus(true))
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        makeRepo({
+          id: 'repo-1',
+          path: '/home/alice/repo',
+          connectionId: 'builder',
+          executionHostId: 'ssh:builder'
+        })
+      ],
+      worktreesByRepo: {},
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null,
+      sshTargetLabels: new Map([['builder', 'Build Box']])
+    } as Partial<AppState>)
+
+    await store.getState().refreshPreflightStatus()
+
+    expect(preflightCheck).toHaveBeenCalledWith({
+      sshHost: { connectionId: 'builder', hostLabel: 'Build Box' }
+    })
+  })
+
+  it('keeps preflight request dedupe scoped by SSH execution host', async () => {
+    resetPreflightMocks()
+    const builder = deferred<PreflightStatus>()
+    const staging = deferred<PreflightStatus>()
+    preflightCheck.mockReturnValueOnce(builder.promise).mockReturnValueOnce(staging.promise)
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        makeRepo({
+          id: 'repo-1',
+          path: '/home/alice/repo',
+          connectionId: 'builder',
+          executionHostId: 'ssh:builder'
+        })
+      ],
+      worktreesByRepo: {},
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null,
+      sshTargetLabels: new Map([
+        ['builder', 'Build Box'],
+        ['staging', 'Staging Box']
+      ])
+    } as Partial<AppState>)
+
+    const first = store.getState().refreshPreflightStatus()
+    store.setState({
+      repos: [
+        makeRepo({
+          id: 'repo-1',
+          path: '/home/alice/repo',
+          connectionId: 'staging',
+          executionHostId: 'ssh:staging'
+        })
+      ]
+    } as Partial<AppState>)
+    const second = store.getState().refreshPreflightStatus()
+
+    expect(preflightCheck).toHaveBeenNthCalledWith(1, {
+      sshHost: { connectionId: 'builder', hostLabel: 'Build Box' }
+    })
+    expect(preflightCheck).toHaveBeenNthCalledWith(2, {
+      sshHost: { connectionId: 'staging', hostLabel: 'Staging Box' }
+    })
+    builder.resolve(makeStatus(false))
+    staging.resolve(makeStatus(true))
+    await Promise.all([first, second])
+    expect(store.getState().preflightStatus?.glab?.installed).toBe(true)
+  })
+
+  it('leaves local preflight args untouched without an SSH repo', async () => {
+    resetPreflightMocks()
+    preflightCheck.mockResolvedValueOnce(makeStatus(true))
+    const store = createTestStore()
+    store.setState({
+      repos: [makeRepo({ id: 'repo-1', path: '/home/alice/repo' })],
+      worktreesByRepo: {},
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null
+    } as Partial<AppState>)
+
+    await store.getState().refreshPreflightStatus()
+
+    expect(preflightCheck).toHaveBeenCalledWith(undefined)
+  })
+
   it('checks integrations through the active runtime environment', async () => {
     resetPreflightMocks()
     const firstRuntime = deferred<PreflightStatus>()

--- a/src/renderer/src/store/slices/preflight.ts
+++ b/src/renderer/src/store/slices/preflight.ts
@@ -34,14 +34,16 @@ function buildPreflightArgs(
   const wslDistro = context?.wslDistro
   const wslDefault = context?.wslDefault === true
   const projectRuntime = context?.projectRuntime
-  if (!force && !wslDistro && !wslDefault && !projectRuntime) {
+  const sshHost = context?.sshHost
+  if (!force && !wslDistro && !wslDefault && !projectRuntime && !sshHost) {
     return undefined
   }
   return {
     ...(force ? { force: true } : {}),
     ...(projectRuntime ? { projectRuntime } : {}),
     ...(wslDistro ? { wslDistro } : {}),
-    ...(wslDefault ? { wslDefault: true } : {})
+    ...(wslDefault ? { wslDefault: true } : {}),
+    ...(sshHost ? { sshHost } : {})
   }
 }
 


### PR DESCRIPTION
**What:** Integrations cards stop reporting "Not installed" when `gh`/`glab` actually live on the workspace's SSH execution host.
**Risk:** Additive probe, fail-open on every path — no mux, old relay, or timeout all render exactly today's cards. Greptile: **5/5 "Safe to merge"**.
**State:** Rebased on `main` today (0 behind, 0 conflicts); all review-bot findings fixed (timeout budget, killed-probe verdict, resolved-path spawn).

---

## Summary

- Integrations cards (GitHub/GitLab) now show when `gh`/`glab` is installed **and authenticated on the active workspace's SSH execution host**, so local "Not installed" stops being a dead-end diagnosis for teams whose forge credentials live only on the remote box.
- New hard-allowlisted relay method `preflight.detectForgeClis` (exactly `gh`/`glab`, argv-only, allowlist iterated as the spawn source so duplicated requests can't amplify), following the existing `preflight.detectAgents` pattern in the same file.
- Main-process probe `detectRemoteForgeClis` attaches an optional `PreflightStatus.hostForge` only when the preflight context names an SSH execution host **and** the probe succeeds. Every transport failure — no mux, disposed mux, `-32601` from an older relay, timeout — degrades to exactly today's payload; `null` is never an auth verdict.
- Renderer: pure `deriveHostForgeHint` gates the hint to strictly-better-than-local (`not-installed`/`not-authenticated` locally, installed+authenticated on host):

  > glab is installed and authenticated on work-box — these features currently run locally.

## Fixes

Implements v1 of #12020 (status companion to #10559; deliberately independent of #10653 — when that PR lands, its routing can consume this same probe so card status follows execution).

## No behavior change when...

- ...no SSH-execution-host workspace is active: the context carries no `sshHost`, IPC args are unchanged, and `runPreflightCheck`'s payload is byte-identical (covered by explicit tests, including a two-call cache-scoping regression test proving an SSH-context run can't pollute the shared local cache slot).
- ...the host's relay predates the method: `-32601` → silent degrade, card identical to today (capability behavior covered by tests).

## Design notes

- The remote probe runs inside `runPreflightCheck` under an explicit 8s cap (`timeoutMs: 8000`) rather than the mux default 30s, so a wedged host can't stall local card status. Moving it fully off the critical path (the `detectRemoteAgents` precedent) is a sensible follow-up; kept out of this PR to stay minimal.
- SSH-context preflights are deliberately not cached in the shared local cache slot.
- Host label resolves through the same chain the sidebar uses (`sshTargetLabels` → removed-target tombstones → target id). Until labels hydrate, the hint can transiently show the raw target id — same behavior as the existing `ForgetSshWorkspaceDialog` fallback; happy to tighten in a follow-up if preferred.

## Test plan

- [x] Relay: allowlist (incl. injection-shaped input rejected before any spawn), dedupe (500×'gh' probes once), auth-marker parsing incl. installed-but-unauthed, not-installed short-circuit
- [x] Main: SSH context attaches `hostForge`; local context byte-identical; old-relay/-32601, missing/disposed mux, empty-results, one-CLI-only all degrade; cache-scoping two-call regression
- [x] Renderer: `deriveHostForgeHint` truth table; card renders hint text for both cards; context key distinguishes two SSH hosts (stale-label regression)
- [x] `typecheck:node` + `typecheck:web`, oxlint, all three localization gates
- [ ] Manual on a real SSH host (creds only on host): card shows the hint; downgraded relay shows no hint and no errors

## ELI5

If your GitLab/GitHub login lives on your work server instead of your laptop, Orca's Integrations page used to just say "Not installed" — technically true, totally unhelpful. Now it checks the server you're working on and tells you the CLI is ready over there.
