### PR TITLE
fix(P1-C): gate FIDO2 system-SSH transport on an OpenSSH binary

### DIFF
--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -148,16 +148,22 @@ vi.mock('ssh2', () => {
 })
 
 const {
+  findSystemSshMock,
   getOrcaControlSocketPathMock,
   removeControlSocketPathMock,
   spawnSystemSshCommandMock,
   spawnSystemSshMock
 } = vi.hoisted(() => ({
+  findSystemSshMock: vi.fn<() => string | null>(),
   getOrcaControlSocketPathMock: vi.fn(),
   removeControlSocketPathMock: vi.fn(),
   spawnSystemSshMock: vi.fn(),
   spawnSystemSshCommandMock: vi.fn()
 }))
+
+// Why: security-key transport selection scans the real ~/.ssh defaults, so a developer's own
+// FIDO2 key would otherwise decide which transport these tests take.
+vi.mock('./system-ssh-binary', () => ({ findSystemSsh: findSystemSshMock }))
 
 vi.mock('./ssh-system-fallback', () => ({
   getOrcaControlSocketPath: getOrcaControlSocketPathMock,
@@ -331,6 +337,8 @@ describe('SshConnection', () => {
     vi.mocked(writeFileViaSystemSsh).mockResolvedValue(undefined)
     vi.mocked(resolveWithSshG).mockReset()
     vi.mocked(resolveWithSshG).mockResolvedValue(null)
+    findSystemSshMock.mockReset()
+    findSystemSshMock.mockReturnValue(null)
     vi.unstubAllEnvs()
   })
 
@@ -1697,6 +1705,7 @@ describe('SshConnection', () => {
   })
 
   it('uses system SSH before ssh2 parses a security-key private key', async () => {
+    findSystemSshMock.mockReturnValue('/usr/bin/ssh')
     const directory = mkdtempSync(join(tmpdir(), 'orca-security-key-connect-'))
     const keyPath = join(directory, 'id_ed25519_sk')
     writeFileSync(
@@ -1718,6 +1727,7 @@ describe('SshConnection', () => {
   })
 
   it('uses system SSH for an agent-backed security-key public identity', async () => {
+    findSystemSshMock.mockReturnValue('/usr/bin/ssh')
     const directory = mkdtempSync(join(tmpdir(), 'orca-security-key-agent-connect-'))
     const identityPath = join(directory, 'id_ed25519_sk')
     writeFileSync(

--- a/src/main/ssh/ssh-security-key-identity.test.ts
+++ b/src/main/ssh/ssh-security-key-identity.test.ts
@@ -53,6 +53,29 @@ async function writeKey(contents: Buffer, filename = 'security key'): Promise<st
   return keyPath
 }
 
+async function createDefaultKeyHome(files: Record<string, Buffer>): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'orca-default-key-home-'))
+  tempDirs.push(directory)
+  await mkdir(join(directory, '.ssh'))
+  for (const [name, contents] of Object.entries(files)) {
+    await writeFile(join(directory, '.ssh', name), contents)
+  }
+  return directory
+}
+
+// Why: `ssh -G` echoes this list, already home-expanded, for every host — configured or not.
+function listBuiltInDefaultIdentityFiles(home: string): string[] {
+  return [
+    'id_rsa',
+    'id_ecdsa',
+    'id_ecdsa_sk',
+    'id_ed25519',
+    'id_ed25519_sk',
+    'id_xmss',
+    'id_dsa'
+  ].map((name) => join(home, '.ssh', name))
+}
+
 afterEach(async () => {
   vi.unstubAllEnvs()
   await Promise.all(tempDirs.splice(0).map((directory) => rm(directory, { recursive: true })))
@@ -155,13 +178,9 @@ describe('isOpenSshSecurityKeyPrivateKey', () => {
 
 describe('requiresSystemSshForSecurityKey', () => {
   it('uses default FIDO2 identities only when config resolution is unavailable', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'orca-security-key-home-'))
-    tempDirs.push(directory)
-    await mkdir(join(directory, '.ssh'))
-    await writeFile(
-      join(directory, '.ssh', 'id_ed25519_sk'),
-      createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
-    )
+    const directory = await createDefaultKeyHome({
+      id_ed25519_sk: createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
+    })
     vi.stubEnv('ORCA_TEST_SSH_HOME', directory)
 
     await expect(requiresSystemSshForSecurityKey(createTarget(), null)).resolves.toBe(true)
@@ -170,28 +189,58 @@ describe('requiresSystemSshForSecurityKey', () => {
     ).resolves.toBe(false)
   })
 
-  it('keeps a regular default ahead of a dormant FIDO2 identity', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'orca-regular-key-home-'))
-    tempDirs.push(directory)
-    await mkdir(join(directory, '.ssh'))
-    await writeFile(join(directory, '.ssh', 'id_rsa'), createOpenSshPrivateKeyFixture(['ssh-rsa']))
-    await writeFile(
-      join(directory, '.ssh', 'id_ed25519_sk'),
-      createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
-    )
+  it('reaches a default FIDO2 identity that a regular default key precedes', async () => {
+    const directory = await createDefaultKeyHome({
+      id_rsa: createOpenSshPrivateKeyFixture(['ssh-rsa']),
+      id_ed25519_sk: createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
+    })
+    vi.stubEnv('ORCA_TEST_SSH_HOME', directory)
+
+    await expect(requiresSystemSshForSecurityKey(createTarget(), null)).resolves.toBe(true)
+
+    findSystemSshMock.mockReturnValue(null)
+    await expect(requiresSystemSshForSecurityKey(createTarget(), null)).resolves.toBe(false)
+  })
+
+  it('leaves regular-only defaults on ssh2', async () => {
+    const directory = await createDefaultKeyHome({
+      id_rsa: createOpenSshPrivateKeyFixture(['ssh-rsa'])
+    })
     vi.stubEnv('ORCA_TEST_SSH_HOME', directory)
 
     await expect(requiresSystemSshForSecurityKey(createTarget(), null)).resolves.toBe(false)
   })
 
-  it('keeps password and agent fallback when default FIDO2 needs unavailable OpenSSH', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'orca-no-system-ssh-home-'))
-    tempDirs.push(directory)
-    await mkdir(join(directory, '.ssh'))
-    await writeFile(
-      join(directory, '.ssh', 'id_ed25519_sk'),
-      createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
+  it('treats resolved built-in default identities as unconfigured, not as forced transport', async () => {
+    const directory = await createDefaultKeyHome({
+      id_rsa: createOpenSshPrivateKeyFixture(['ssh-rsa']),
+      id_ed25519_sk: createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
+    })
+    const identityFile = listBuiltInDefaultIdentityFiles(directory)
+
+    await expect(requiresSystemSshForSecurityKey(createTarget(), { identityFile })).resolves.toBe(
+      true
     )
+
+    findSystemSshMock.mockReturnValue(null)
+    await expect(requiresSystemSshForSecurityKey(createTarget(), { identityFile })).resolves.toBe(
+      false
+    )
+  })
+
+  it('keeps password and agent fallback when a configured FIDO2 identity has no OpenSSH', async () => {
+    const keyPath = await writeKey(createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY]))
+    findSystemSshMock.mockReturnValue(null)
+
+    await expect(
+      requiresSystemSshForSecurityKey(createTarget({ identityFile: keyPath }), null)
+    ).resolves.toBe(false)
+  })
+
+  it('keeps password and agent fallback when default FIDO2 needs unavailable OpenSSH', async () => {
+    const directory = await createDefaultKeyHome({
+      id_ed25519_sk: createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
+    })
     vi.stubEnv('ORCA_TEST_SSH_HOME', directory)
     findSystemSshMock.mockReturnValue(null)
 
@@ -199,17 +248,10 @@ describe('requiresSystemSshForSecurityKey', () => {
   })
 
   it('ignores an orphan regular sidecar before a valid default FIDO2 identity', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'orca-orphan-sidecar-home-'))
-    tempDirs.push(directory)
-    await mkdir(join(directory, '.ssh'))
-    await writeFile(
-      join(directory, '.ssh', 'id_ed25519.pub'),
-      createOpenSshPublicKeyFixture('ssh-ed25519')
-    )
-    await writeFile(
-      join(directory, '.ssh', 'id_ed25519_sk'),
-      createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
-    )
+    const directory = await createDefaultKeyHome({
+      'id_ed25519.pub': createOpenSshPublicKeyFixture('ssh-ed25519'),
+      id_ed25519_sk: createOpenSshPrivateKeyFixture([ED25519_SECURITY_KEY])
+    })
     vi.stubEnv('ORCA_TEST_SSH_HOME', directory)
 
     await expect(requiresSystemSshForSecurityKey(createTarget(), null)).resolves.toBe(true)

--- a/src/main/ssh/ssh-transport-selection.ts
+++ b/src/main/ssh/ssh-transport-selection.ts
@@ -21,8 +21,6 @@ const READ_CHUNK_BYTES = 64 * 1024
 const READ_OPEN_FLAGS =
   constants.O_RDONLY | (process.platform === 'win32' ? 0 : constants.O_NONBLOCK)
 
-type IdentityInspection = { privateIdentityExists: boolean; requiresSystemSsh: boolean }
-
 async function readBoundedKeyFile(path: string): Promise<Buffer | null> {
   let handle: Awaited<ReturnType<typeof open>> | undefined
   try {
@@ -59,21 +57,15 @@ async function readBoundedKeyFile(path: string): Promise<Buffer | null> {
   }
 }
 
-async function inspectIdentityPath(keyPath: string): Promise<IdentityInspection> {
+async function identityRequiresSystemSsh(keyPath: string): Promise<boolean> {
   const resolvedPath = resolveSshConfigHomePath(keyPath)
   const identity = await readBoundedKeyFile(resolvedPath)
+  // Why: a present private key wins; a `.pub` beside it may describe a key already replaced.
   if (identity !== null) {
-    return {
-      privateIdentityExists: true,
-      requiresSystemSsh:
-        isOpenSshSecurityKeyPublicKey(identity) || isOpenSshSecurityKeyPrivateKey(identity)
-    }
+    return isOpenSshSecurityKeyPublicKey(identity) || isOpenSshSecurityKeyPrivateKey(identity)
   }
   const publicIdentity = await readBoundedKeyFile(`${resolvedPath}.pub`)
-  return {
-    privateIdentityExists: false,
-    requiresSystemSsh: publicIdentity !== null && isOpenSshSecurityKeyPublicKey(publicIdentity)
-  }
+  return publicIdentity !== null && isOpenSshSecurityKeyPublicKey(publicIdentity)
 }
 
 export function shouldUseSystemSshTransport(
@@ -102,16 +94,19 @@ export async function requiresSystemSshForSecurityKey(
   target: SshTarget,
   resolved: Pick<SshResolvedConfig, 'identityFile'> | null
 ): Promise<boolean> {
-  const configuredPaths = resolveIdentityFilePaths(target, resolved)
-  const usesDefaultPaths = configuredPaths.length === 0 && !resolved && !target.identityFile
-  const identityPaths = usesDefaultPaths ? listDefaultIdentityFilePaths() : configuredPaths
+  const resolvedPaths = resolveIdentityFilePaths(target, resolved)
+  // Why: `ssh -G` already echoes OpenSSH's built-in defaults, so its list is the real candidate
+  // set; guess at the defaults only when config resolution failed outright.
+  const identityPaths =
+    resolvedPaths.length === 0 && !resolved && !target.identityFile
+      ? listDefaultIdentityFilePaths()
+      : resolvedPaths
   for (const keyPath of identityPaths) {
-    const inspection = await inspectIdentityPath(keyPath)
-    if (inspection.requiresSystemSsh) {
-      return !usesDefaultPaths || findSystemSsh() !== null
-    }
-    if (usesDefaultPaths && inspection.privateIdentityExists) {
-      return false
+    if (await identityRequiresSystemSsh(keyPath)) {
+      // Why: scan every candidate — an earlier normal key never rules out a security key the host
+      // requires — but forcing system transport with no binary hard-fails a connection ssh2 could
+      // still have served over agent or password auth.
+      return findSystemSsh() !== null
     }
   }
   return false


### PR DESCRIPTION
## Summary

Release-scan finding **P1-C** against the v1.4.164-rc.0 span. Two bugs in the FIDO2 transport gate
added by 33c14bc716 ("fix(ssh): fall back to OpenSSH for FIDO2 keys", #11913).

**C1 — `ssh -G` defaults look "configured", so the OpenSSH binary check is skipped.**
`requiresSystemSshForSecurityKey()` returned `!usesDefaultPaths || findSystemSsh() !== null`.
`ssh -G <host>` always echoes OpenSSH's built-in default identity list (`~/.ssh/id_rsa`,
`id_ecdsa`, `id_ecdsa_sk`, `id_ed25519`, `id_ed25519_sk`, `id_xmss`, `id_dsa`) even for a host the
user never configured, so `usesDefaultPaths` was effectively never true and the expression
short-circuited before checking for a binary. `spawnSystemSsh()` then throws
`No system ssh binary found.` — a hard connect failure on hosts that worked over ssh2 in 1.4.163.
Most reachable shape: no OpenSSH installed at all → `ssh -G` fails → `resolved` is `null`, but a
pinned `IdentityFile` (or a `.pub` sidecar) still makes `usesDefaultPaths` false, so the check is
still skipped. Also reachable via a Windows `ssh.cmd`/`ssh.bat` PATHEXT shim, which libuv resolves
for `ssh -G` but `findSshOnPath()` (literal `ssh.exe` only) does not.

**C2 — a normal default key short-circuits the FIDO2 scan.**
`if (usesDefaultPaths && inspection.privateIdentityExists) return false` stopped the default scan
at the first existing normal private key. Since `listDefaultIdentityFilePaths()` orders `*_sk`
last, a user with `~/.ssh/id_rsa` never reached system OpenSSH, and a host that only accepts the
FIDO2 key failed auth.

**Root cause (one, two faces):** both the binary check and the stop-scanning rule were made
conditional on a "did the user configure identities?" classification that is unreliable (`ssh -G`
output is indistinguishable from real configuration) and irrelevant to either decision.

No visual change.

## What changed

`src/main/ssh/ssh-transport-selection.ts` — the gate is now uniform for every source of identity
paths:

> If any identity candidate for this host is an OpenSSH security key, use system OpenSSH — but
> only if a system `ssh` binary can be found. Otherwise stay on ssh2.

- Always require `findSystemSsh() !== null` before forcing system transport (C1).
- Scan every candidate identity instead of stopping on the first normal key (C2).
- `IdentityInspection` collapses to a boolean; `inspectIdentityPath` → `identityRequiresSystemSsh`.
  Per-path classification is unchanged (a present private key beats a stale `.pub` sidecar; an
  orphan `.pub` still counts as an agent-backed security key).
- `shouldUseSystemSshTransport()` is untouched, so intentional system transport for
  ProxyCommand / ProxyJump / jumpHost / ProxyUseFdpass / `ORCA_SSH_FORCE_SYSTEM_TRANSPORT` still
  wins — `ssh-connection.ts` evaluates it first and skips this gate entirely when true.

### Behaviour delta vs rc.0

| Case | rc.0 | after |
| --- | --- | --- |
| Security key among `ssh -G` identities, no `ssh` binary | force system ssh → connect throws | stay on ssh2 |
| Security key at a configured `IdentityFile`, no `ssh` binary | force system ssh → connect throws | stay on ssh2 |
| `ssh -G` unavailable, `id_rsa` *and* `id_ed25519_sk` exist | stay on ssh2 (FIDO2-only host fails) | force system ssh (binary-gated) |
| Everything else | — | unchanged |

### On the brief's fix goal 1 (subtract built-in defaults from the resolved list)

Satisfied by construction rather than literally, and deliberately so. The classification is gone
from every decision the function makes, which is what that goal was protecting.

Literal subtraction was implemented on paper and **rejected**: it widens the scan set for a host
that deliberately pins a default-named identity (`IdentityFile ~/.ssh/id_ed25519` +
`IdentitiesOnly yes` → `ssh -G` returns exactly that one path → subtraction empties it →
default-scan mode → an unrelated `~/.ssh/id_ed25519_sk` on disk, which this host will never be
offered, forces system OpenSSH). That is a *new* instance of the very complaint C1 raises. The
chosen shape scans exactly what OpenSSH itself would offer: `ssh -G`'s list when it resolved, our
default list when it did not. Both lists contain `id_ed25519_sk` and `id_ecdsa_sk`, so the two
modes agree on security-key coverage.

### Design doc

`docs/**` is gitignored by explicit repo policy ("Local-only design/planning docs (not checked
in)"), so the doc is **not** in this PR by design. It lives on the branch worktree at
`docs/reference/plans/2026-08-01-P1-C-fido2-transport-gate.md` and its substance — problem, root
cause, options, rejected alternatives, edge cases, risks, non-goals, three review rounds — is
reproduced in this body.

## Testing

- [x] `pnpm lint` — passed
- [x] `pnpm typecheck` — passed (node + cli + web projects)
- [ ] `pnpm test` — ran the full **main-process** suite instead: `vitest run src/main/` →
      **1337 files / 18071 tests passed**, 9 files / 58 tests skipped. Renderer and mobile are
      untouched by this change.
- [ ] `pnpm build` — not run; no build-surface change (single main-process module + tests).
- [x] Added tests that fail without the fix

Targeted evidence:

- `src/main/ssh/` unit suite: 81 files / 1171 tests passed.
- `ssh-security-key-identity.test.ts`: 31 passed. Reverting **only**
  `ssh-transport-selection.ts` to HEAD and re-running fails exactly the three
  bug-locking tests:
  - `reaches a default FIDO2 identity that a regular default key precedes` (C2)
  - `treats resolved built-in default identities as unconfigured, not as forced transport` (C1)
  - `keeps password and agent fallback when a configured FIDO2 identity has no OpenSSH` (binary gate)
- Rewrote `keeps a regular default ahead of a dormant FIDO2 identity`, which locked C2's incorrect
  behaviour, into its fixed form; added a regular-keys-only guard so the fix can't over-correct
  into "always system ssh".
- `ssh-system-transport.integration.test.ts` (real `SshConnection` over a fake `ssh` binary):
  3 passed — the forced system-transport path still works end to end.

Not run, and not claimed: Playwright/Electron e2e and the Docker SSH specs. Neither has FIDO2 or
security-key coverage, and no e2e can exercise a hardware authenticator.

## AI Review Report

Three design rounds and three code rounds (Claude Opus, high effort). Checked: reachability of the
hard failure rather than assuming it (documented three concrete paths); the interaction between the
two fixes (they do not cancel — C2's fix preserves rc.0 behaviour for mixed-key users while C1's
adds the missing gate); blast radius (`requiresSystemSshForSecurityKey` has exactly one caller,
`SshConnection.attemptConnect`, and `shouldUseSystemSshTransport()` short-circuits it); and the
degradation path when we now stay on ssh2 with an `sk`-only identity — `resolvePrivateKeys()` /
`configurePrivateKeyAuthentication()` drop unparseable keys and the connection falls through to
agent/password auth rather than throwing.

The review's own material finding, fixed in the second commit: dropping the short-circuit made
`ssh-connection.test.ts` sensitive to the **developer's own** `~/.ssh`. A machine with both a
normal key and a `~/.ssh/id_ed25519_sk` would have had default-target tests silently select system
transport. `./system-ssh-binary` is now mocked in that file (null by default) with the two
security-key tests opting in.

Cross-platform: reviewed for macOS, Linux, and Windows. No new path construction — identity paths
keep flowing through `resolveSshConfigHomePath()` / `path.join`; test fixtures use `join()`. No
shortcuts, labels, or shell invocation touched. The Windows-specific angle is called out above
(PATHEXT shim resolving `ssh` for `ssh -G` while `findSshOnPath()` looks for a literal `ssh.exe`) —
this PR makes that case degrade to ssh2 instead of throwing; narrowing the `findSshOnPath()`
PATHEXT gap itself is left as follow-up. SSH-hosted workspaces, relay, and mobile inherit the fix
with no parity work: transport selection is main-process only, with no IPC, renderer, or persisted
surface.

## Security Audit

No new input handling, command execution, or IPC surface. The change is strictly *more*
conservative about spawning: system OpenSSH is now spawned only when a binary was actually located,
where rc.0 could attempt the spawn unconditionally. Identity files are still read through the
existing bounded reader (`MAX_SSH_IDENTITY_FILE_BYTES`, `O_NONBLOCK` on POSIX, `stat` + re-`stat`
after open); no key material is logged or sent anywhere, and the classifier only reads key *type*
strings. Path handling is unchanged. One pre-existing caveat, unchanged by this PR:
`findSystemSsh()` returns `ORCA_SYSTEM_SSH_PATH` unvalidated, so a bogus override still reaches the
spawn — acceptable because the gate's job is to agree with the spawner, which consults the same
function.

## Notes

Residual risk:

1. **Transport flip for mixed-key users when `ssh -G` is unavailable.** They move from ssh2 to
   system OpenSSH. Binary-gated, and system OpenSSH re-reads the user's config, so auth material is
   unchanged.
2. **Ordinary hosts still route to system OpenSSH when a stray `*_sk` exists.** Intended (goal 3 of
   the brief): with defaults in play OpenSSH would offer the security key too, and system OpenSSH is
   a capability superset. rc.0 already did this whenever `ssh -G` succeeded — i.e. almost always —
   so this is not a widening.
3. **Silent degradation with no binary.** A genuine FIDO2-only host on a machine without OpenSSH now
   surfaces an ssh2 auth failure rather than the explicit "Install OpenSSH" message. Deliberate
   trade: the false-positive population is far larger, and rc.0's clearer message was only reachable
   by breaking working connections. A user-facing "install OpenSSH to use your security key"
   diagnostic is a reasonable follow-up and is out of scope here.
4. **Extra fs work in default-scan mode**: up to 7 `stat`s and up to two bounded reads per existing
   key, once per connect attempt. The `ssh -G`-resolved path already had no short-circuit, so this
   only changes the no-OpenSSH case, where the walk is nearly all `ENOENT`.
5. An orphan `id_ed25519_sk.pub` with no private key still forces system OpenSSH — existing,
   intentional per-path behaviour for agent-resident keys, now reachable in default-scan mode where
   a normal key previously masked it. Binary-gated.

Base is `main` (branch is cut from `8fc892dd02`, inside the v1.4.164-rc.0 span; `main` has no
conflicting changes under `src/main/ssh/`).

Made with [Orca](https://github.com/stablyai/orca) 🐋
