### PR TITLE
feat(browser): add Aside as a Chromium cookie-import source

### DIFF
--- a/src/main/browser/browser-cookie-detection-types.ts
+++ b/src/main/browser/browser-cookie-detection-types.ts
@@ -80,6 +80,14 @@ export const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
     keychainAccount: 'Helium',
     macRoot: 'net.imput.helium'
     // winRoot/linuxRoot intentionally omitted — only the macOS install is verified
+  },
+  {
+    family: 'aside',
+    label: 'Aside',
+    keychainService: 'Aside Safe Storage',
+    keychainAccount: 'Aside',
+    macRoot: 'Aside'
+    // winRoot/linuxRoot intentionally omitted — only the macOS install is verified
   }
 ]
 

--- a/src/main/browser/browser-cookie-import.aside.test.ts
+++ b/src/main/browser/browser-cookie-import.aside.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as fsModule from 'node:fs'
+
+const { sessionFromPartitionMock, dialogShowOpenDialogMock } = vi.hoisted(() => ({
+  sessionFromPartitionMock: vi.fn(),
+  dialogShowOpenDialogMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: { showOpenDialog: dialogShowOpenDialogMock },
+  session: { fromPartition: sessionFromPartitionMock }
+}))
+
+import { BROWSER_FAMILY_LABELS } from '../../shared/constants'
+
+function slashPath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/')
+}
+
+describe('detectInstalledBrowsers — Aside', () => {
+  const originalPlatform = process.platform
+  const originalHome = process.env.HOME
+
+  beforeEach(() => {
+    // Why: browser-cookie-import.ts uses destructured named imports from
+    // 'node:fs' which are bound at module-load time. resetModules must run
+    // BEFORE each doMock so the next import() picks up the fresh mock factory.
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    process.env.HOME = '/Users/test'
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    process.env.HOME = originalHome
+    vi.restoreAllMocks()
+  })
+
+  it('detects Aside under its data dir via the legacy Cookies path', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => {
+          const normalizedPath = slashPath(p)
+          // Why: Aside stores cookies at the legacy <Profile>/Cookies path, so the
+          // newer Network/Cookies probe must miss and the legacy fallback must fire.
+          if (normalizedPath.includes('Support/Aside/Default/Network/Cookies')) {
+            return false
+          }
+          if (normalizedPath.endsWith('Support/Aside/Default/Cookies')) {
+            return true
+          }
+          if (normalizedPath.includes('Support/Aside/Local State')) {
+            return true
+          }
+          return false
+        },
+        readFileSync: (p: string, enc?: string) => {
+          if (typeof p === 'string' && slashPath(p).includes('Support/Aside/Local State')) {
+            return JSON.stringify({ profile: { info_cache: { Default: { name: 'Default' } } } })
+          }
+          return actual.readFileSync(p as never, enc as never)
+        }
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    const aside = detected.find((b) => b.family === 'aside')
+    expect(aside).toBeDefined()
+    expect(aside?.label).toBe('Aside')
+    expect(slashPath(aside?.cookiesPath ?? '')).toContain('Support/Aside/Default/Cookies')
+    expect(slashPath(aside?.cookiesPath ?? '')).not.toContain('Network/Cookies')
+    expect(aside?.keychainService).toBe('Aside Safe Storage')
+    expect(aside?.keychainAccount).toBe('Aside')
+  })
+
+  it('does not list Aside when its data directory is absent', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: () => false
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    expect(detected.find((b) => b.family === 'aside')).toBeUndefined()
+  })
+
+  it('enumerates all Aside profiles from Local State info_cache', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => {
+          const normalizedPath = slashPath(p)
+          if (normalizedPath.endsWith('Support/Aside/Default/Cookies')) {
+            return true
+          }
+          if (normalizedPath.includes('Support/Aside/Local State')) {
+            return true
+          }
+          return false
+        },
+        readFileSync: (p: string, enc?: string) => {
+          if (typeof p === 'string' && slashPath(p).includes('Support/Aside/Local State')) {
+            return JSON.stringify({
+              profile: {
+                info_cache: {
+                  Default: { name: 'Personal' },
+                  'Profile 1': { name: 'Work' }
+                }
+              }
+            })
+          }
+          return actual.readFileSync(p as never, enc as never)
+        }
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    const aside = detected.find((b) => b.family === 'aside')
+    expect(aside).toBeDefined()
+    const directories = aside!.profiles.map((p) => p.directory).sort()
+    expect(directories).toEqual(['Default', 'Profile 1'])
+  })
+
+  it('rejects explicit Aside profile selections that escape the browser root', async () => {
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => slashPath(p).includes('Application Support/Outside/Cookies')
+      }
+    })
+
+    const { selectBrowserProfile } = await import('./browser-cookie-import')
+    const selected = selectBrowserProfile(
+      {
+        family: 'aside',
+        label: 'Aside',
+        cookiesPath: '/Users/test/Library/Application Support/Aside/Default/Cookies',
+        keychainService: 'Aside Safe Storage',
+        keychainAccount: 'Aside',
+        profiles: [{ name: 'Outside', directory: '../Outside' }],
+        selectedProfile: 'Default'
+      },
+      '../Outside'
+    )
+
+    expect(selected).toBeNull()
+  })
+})
+
+describe('BROWSER_FAMILY_LABELS — Aside', () => {
+  it('maps the aside family key to the user-facing label "Aside"', () => {
+    expect(BROWSER_FAMILY_LABELS.aside).toBe('Aside')
+  })
+})

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -842,7 +842,8 @@ describe('detectInstalledBrowsers', () => {
       'firefox',
       'safari',
       'comet',
-      'helium'
+      'helium',
+      'aside'
     ]
     for (const browser of browsers) {
       expect(validFamilies).toContain(browser.family)

--- a/src/renderer/src/components/browser-pane/assemble-chrome/browser-detected-browsers-summary.test.ts
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/browser-detected-browsers-summary.test.ts
@@ -8,6 +8,7 @@ const SUPPORTED_LABELS = [
   'Brave',
   'Comet',
   'Helium',
+  'Aside',
   'Firefox',
   'Safari'
 ]
@@ -47,7 +48,7 @@ describe('formatBrowserImportSummary', () => {
         detectedBrowsersLoaded: false,
         supportedImportLabels: SUPPORTED_LABELS
       })
-    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +4 more.')
+    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +5 more.')
   })
 
   it('falls back to supported import sources when detection finds nothing', () => {
@@ -57,6 +58,6 @@ describe('formatBrowserImportSummary', () => {
         detectedBrowsersLoaded: true,
         supportedImportLabels: SUPPORTED_LABELS
       })
-    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +4 more.')
+    ).toBe('Import from: Google Chrome, Microsoft Edge, Arc, Brave, +5 more.')
   })
 })

--- a/src/shared/browser-cookie-import-sources.test.ts
+++ b/src/shared/browser-cookie-import-sources.test.ts
@@ -10,6 +10,7 @@ describe('getBrowserCookieImportSourceLabels', () => {
       'Brave',
       'Comet',
       'Helium',
+      'Aside',
       'Firefox',
       'Safari'
     ])

--- a/src/shared/browser-cookie-import-sources.ts
+++ b/src/shared/browser-cookie-import-sources.ts
@@ -6,7 +6,8 @@ const CHROMIUM_COOKIE_IMPORT_SOURCES = [
   { label: 'Arc', mac: true, win: false, linux: false },
   { label: 'Brave', mac: true, win: true, linux: true },
   { label: 'Comet', mac: true, win: true, linux: false },
-  { label: 'Helium', mac: true, win: false, linux: false }
+  { label: 'Helium', mac: true, win: false, linux: false },
+  { label: 'Aside', mac: true, win: false, linux: false }
 ] as const
 
 export function getBrowserCookieImportSourceLabels(

--- a/src/shared/browser-workspace-types.ts
+++ b/src/shared/browser-workspace-types.ts
@@ -172,6 +172,7 @@ export type BrowserSessionProfileSource = {
     | 'safari'
     | 'comet'
     | 'helium'
+    | 'aside'
     | 'manual'
   profileName?: string
   importedAt: number

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -56,6 +56,7 @@ export const BROWSER_FAMILY_LABELS: Record<string, string> = {
   chromium: 'Chromium',
   comet: 'Comet',
   helium: 'Helium',
+  aside: 'Aside',
   arc: 'Arc',
   edge: 'Microsoft Edge',
   brave: 'Brave',


### PR DESCRIPTION
## Summary

Adds **Aside** (`at.studio.AsideBrowser`) to the browser cookie-import sources, so an Orca browser profile can adopt a logged-in Aside session the same way it already can for Chrome, Edge, Arc, Brave, Comet, and Helium. It shows up as **Import Cookies → From Aside** in the browser toolbar menu and in Settings → Browser → Session & Cookies. macOS only.

Aside is Chromium-based and follows every layout convention, so detection, profile enumeration from `Local State`, and the macOS PBKDF2/AES-128-CBC decryption path all reuse the existing code unchanged. Its Keychain entry uses the usual naming (`Aside Safe Storage` / `Aside`), unlike Helium. Its cookie DB sits at the legacy `<Profile>/Cookies` path rather than `<Profile>/Network/Cookies`; `resolveChromiumCookiesPath` already falls back, so no new code was needed, but a test pins the behavior.

Every constant — bundle id, `macRoot`, Keychain service and account, cookie DB location, `v10` encrypted-value prefix — was read off a real macOS install rather than inferred from the Helium entry.

Worth noting for reviewers: Aside would have been an instance of the bug fixed in #12849. Its `Info.plist` reports the product version (`1.0.728.1`), not the Chromium version (`150.0.7871.183`), and the framework plist repeats the same value, so the old import-time UA synthesis would have presented `Chrome/1.0.728.1` for exactly the same reason Arc presented `Chrome/1.x` in STA-3514. Since #12849 deleted that synthesis, this PR needs no UA handling at all; the profile keeps the engine-derived UA like every other source.

## Screenshots

<!-- Drag the "Import Cookies → From Aside" screenshot here. -->

Settings → Browser → Session & Cookies → **Import Cookies** now lists **From Aside** alongside the other detected sources.

## Testing

Rebased onto `main` at `38bde20121` and re-run there.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 72572 passed. The same 4 files / 7 tests fail on a clean checkout of `main` at the rebase base, with identical counts: the three `tests/e2e/cross-version-wire/*` suites (they materialize release checkouts through `resolveCommit`) and `config/scripts/renderer-boot-graph.test.mjs`. Nothing in this change touches either area.
- [x] `pnpm build` — `build:desktop` passes. `build:native → build:computer-macos` aborts on my machine because `swift-package` cannot load `BuildServerProtocol.framework`; that is a broken local Command Line Tools install and reproduces on a clean checkout of `main`.
- [x] Added or updated high-quality tests

New `src/main/browser/browser-cookie-import.aside.test.ts` mirrors the Helium suite: detection via the legacy `Cookies` path with the `Network/Cookies` probe deliberately missing, absence when the data dir is gone, multi-profile enumeration from `info_cache`, rejection of a profile selection that escapes the browser root, and the family-label mapping. Existing suites were updated for the new family and label.

Beyond the unit tests, the change was exercised against a real local Aside install with Aside running, so the source DB had uncheckpointed WAL: `detectInstalledBrowsers()` → `importCookiesFromBrowser()` imported **3808 of 3922 cookies across 765 domains with 0 decryption failures**, all loaded in-memory with no restart needed. Every one of the 114 skipped rows is a deliberate exclusion — 5 Google integrity cookies and 109 non-transplantable-domain cookies — not a decryption or parse failure.

## AI Review Report

Reviewed with Claude Code, reading the diff adversarially rather than for confirmation.

**Cross-platform (macOS / Linux / Windows).** `winRoot` and `linuxRoot` are intentionally omitted, so `browserRootPath()` returns `null` for Aside off macOS and `detectInstalledBrowsers()` skips it — the source can never be offered on a platform whose layout is unverified. `CHROMIUM_COOKIE_IMPORT_SOURCES` marks it `mac: true, win: false, linux: false`, so the pre-detection hint text agrees. All paths go through `path.join`; no separator is assumed. No keyboard shortcuts, accelerators, or shortcut labels are touched.

**Collateral risk to existing browsers.** The only shared mutation is one more entry in `CHROMIUM_BROWSERS` (`browser-cookie-detection-types.ts`), consumed by `detectInstalledBrowsers` (guarded by an `existsSync` on the resolved root), `selectBrowserProfile` (family lookup), and the Windows key lookup (family lookup, and Aside cannot be detected on Windows in the first place). No existing browser's detection or decryption behavior changes. Appending Aside last shifts the `+N more` count in the import-hint summary, which the updated renderer test covers.

**SSH / remote / folder workspaces.** Cookie import reads the local machine's browser data directory and Keychain; that is true for every existing source and this change does not alter it. Nothing here assumes a git worktree, so folder workspaces behave identically.

**Agents, integrations, git providers.** No provider-specific or agent-specific surface is touched.

**Performance.** One extra entry in a small array walked once during detection. No hot path, no new I/O outside detection.

**UI quality.** No new components, colors, or tokens. The new source renders through the existing `Import Cookies` submenu and the existing `BROWSER_FAMILY_LABELS` mapping, so light/dark and spacing follow the current design system unchanged.

## Security Audit

**Input handling.** No new parsing or file reads are introduced. Aside's `Local State` goes through the same `discoverProfiles` JSON read as every other Chromium source, and profile directories still pass through the existing `isSafeBrowserProfileDirectory()` traversal guard. A test asserts that an Aside profile selection of `../Outside` is rejected.

**Path handling.** The only new path input is the `macRoot` string `'Aside'`, a compile-time constant joined under `~/Library/Application Support`. No user-supplied segment reaches it.

**Command execution.** None added. The Keychain lookup reuses the existing `execFileSync('security', [...])` call with a fixed argument vector and no shell; only the service and account strings differ.

**Secrets.** No cookie values, Keychain material, or derived keys are logged. The existing diagnostics log counts and paths only, and this change adds no logging.

**IPC / dependencies.** No IPC surface changed; no dependency added or bumped.

No follow-up required.

## Notes

- **macOS only, by design.** `winRoot`/`linuxRoot` are omitted because those layouts were not verified on a real install. Someone with an Aside install on Windows or Linux can add them in a follow-up; nothing here blocks that.
- **Legacy cookie path.** Aside writes `<Profile>/Cookies`, not `<Profile>/Network/Cookies`. That needed no new code because `resolveChromiumCookiesPath` already falls back, but the test pins it so a future refactor of that helper cannot silently break Aside.
- **No visual change beyond the new menu entry.**


