### PR TITLE
refactor(ime): remove two duplicated pieces of the terminal IME surface

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   _resetMacNativeTextInputSourceTrackerForTests,
   createMacNativeTextInputSourceTracker,
+  DISABLED_MAC_NATIVE_TEXT_INPUT_SOURCE_FEATURES,
   getMacNativeTextInputSourceFeatures,
   getMacNativeTextInputSourceTracker
 } from './terminal-ime-input-source'
@@ -86,9 +87,7 @@ describe('createMacNativeTextInputSourceTracker', () => {
       readInputSourceId: async () => sourceId
     })
 
-    expect(tracker.isActive()).toBe(false)
     await tracker.refresh()
-    expect(tracker.isActive()).toBe(false)
     expect(tracker.getFeatures()).toEqual({
       forwardAsciiPunctuation: false,
       forwardShortTextReplacements: false
@@ -96,7 +95,6 @@ describe('createMacNativeTextInputSourceTracker', () => {
 
     sourceId = 'com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese'
     await tracker.refresh()
-    expect(tracker.isActive()).toBe(true)
     expect(tracker.getFeatures()).toEqual({
       forwardAsciiPunctuation: true,
       forwardShortTextReplacements: false
@@ -104,7 +102,6 @@ describe('createMacNativeTextInputSourceTracker', () => {
 
     sourceId = 'com.apple.inputmethod.Vietnamese.Telex'
     await tracker.refresh()
-    expect(tracker.isActive()).toBe(true)
     expect(tracker.getFeatures()).toEqual({
       forwardAsciiPunctuation: false,
       forwardShortTextReplacements: true
@@ -123,7 +120,7 @@ describe('createMacNativeTextInputSourceTracker', () => {
     sourceId = 'com.apple.inputmethod.TCIM.Pinyin'
     window.dispatchEvent(new Event('focus'))
 
-    await vi.waitFor(() => expect(tracker.isActive()).toBe(true))
+    await vi.waitFor(() => expect(tracker.getFeatures().forwardAsciiPunctuation).toBe(true))
     tracker.dispose()
   })
 
@@ -133,7 +130,7 @@ describe('createMacNativeTextInputSourceTracker', () => {
       readInputSourceId: async () => sourceId
     })
     await tracker.refresh()
-    expect(tracker.isActive()).toBe(false)
+    expect(tracker.getFeatures()).toEqual(DISABLED_MAC_NATIVE_TEXT_INPUT_SOURCE_FEATURES)
 
     sourceId = 'com.apple.inputmethod.SCIM.ITABC'
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'd' }))
@@ -168,7 +165,7 @@ describe('createMacNativeTextInputSourceTracker', () => {
       now.mockReturnValue(2001)
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c' }))
       await vi.waitFor(() => expect(readInputSourceId).toHaveBeenCalledTimes(2))
-      expect(tracker.isActive()).toBe(true)
+      expect(tracker.getFeatures().forwardAsciiPunctuation).toBe(true)
     } finally {
       now.mockRestore()
       tracker.dispose()
@@ -181,12 +178,14 @@ describe('createMacNativeTextInputSourceTracker', () => {
       readInputSourceId: async () => sourceId
     })
     await tracker.refresh()
-    expect(tracker.isActive()).toBe(true)
+    expect(tracker.getFeatures().forwardAsciiPunctuation).toBe(true)
 
     sourceId = 'com.apple.keylayout.ABC'
     window.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', ctrlKey: true }))
 
-    await vi.waitFor(() => expect(tracker.isActive()).toBe(false))
+    await vi.waitFor(() =>
+      expect(tracker.getFeatures()).toEqual(DISABLED_MAC_NATIVE_TEXT_INPUT_SOURCE_FEATURES)
+    )
     tracker.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-source.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-source.ts
@@ -6,8 +6,8 @@ export type MacNativeTextInputSourceFeatures = Readonly<{
 }>
 
 export type MacNativeTextInputSourceTracker = IDisposable & {
-  isActive: () => boolean
   getFeatures: () => MacNativeTextInputSourceFeatures
+  /** Test seam: awaits one read so specs need not race the fire-and-forget refresh. */
   refresh: () => Promise<void>
 }
 
@@ -175,7 +175,6 @@ export function createMacNativeTextInputSourceTracker(
   requestRefresh()
 
   return {
-    isActive: () => features.forwardAsciiPunctuation || features.forwardShortTextReplacements,
     getFeatures: () => features,
     refresh,
     dispose: () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-state.ts
@@ -1,4 +1,5 @@
 import type { XtermBypassEvent } from './xterm-bypass-policy'
+import { isTerminalImeCandidateDigitKeyEvent } from './terminal-ime-candidate-key-release-guard'
 
 type TerminalImeLinuxCandidateState = {
   /** Classifies an event before the state observes it. */
@@ -21,7 +22,6 @@ type TerminalImeLinuxPhysicalKeyTracker = {
 
 const CANDIDATE_DIGIT_WINDOW_MS = 1500
 const ASCII_LOWERCASE_LETTER = /^[a-z]$/
-const ASCII_DIGIT = /^[0-9]$/
 const PHYSICAL_ASCII_LETTER_CODE = /^Key[A-Z]$/
 const physicalKeyTrackers = new WeakMap<
   EventTarget,
@@ -104,17 +104,6 @@ function isPlainAsciiLetterKey(event: XtermBypassEvent): boolean {
   )
 }
 
-/** Returns whether an event is an unmodified ASCII digit. */
-function isPlainAsciiDigitKey(event: XtermBypassEvent): boolean {
-  return (
-    ASCII_DIGIT.test(event.key) &&
-    !event.ctrlKey &&
-    !event.altKey &&
-    !event.metaKey &&
-    !event.shiftKey
-  )
-}
-
 /** Tracks legacy desktop Linux IME candidate-selection event sequences. */
 export function createTerminalImeLinuxCandidateState(
   now: () => number = () => Date.now(),
@@ -139,7 +128,9 @@ export function createTerminalImeLinuxCandidateState(
       const at = now()
       return {
         candidateDigitGuardActive:
-          event.type === 'keydown' && isPlainAsciiDigitKey(event) && candidateDigitUntil > at
+          event.type === 'keydown' &&
+          isTerminalImeCandidateDigitKeyEvent(event) &&
+          candidateDigitUntil > at
       }
     },
     /** Records the current event after its classification is consumed. */
@@ -155,7 +146,7 @@ export function createTerminalImeLinuxCandidateState(
       }
 
       if (event.type === 'keydown') {
-        if (!isPlainAsciiDigitKey(event)) {
+        if (!isTerminalImeCandidateDigitKeyEvent(event)) {
           candidateDigitUntil = 0
         }
         const physicalCode = event.code


### PR DESCRIPTION
## Summary

Two small reductions in the terminal IME surface, found while reviewing the rest of this stack. No behavior change; both are covered by the existing suites.

**1. One candidate-digit predicate instead of two.** `terminal-ime-linux-candidate-state.ts` carried a private `isPlainAsciiDigitKey`, and `terminal-ime-candidate-key-release-guard.ts` exports `isTerminalImeCandidateDigitKeyEvent`. The two were extensionally identical — unmodified ASCII digit, same four modifier checks — written twice and free to drift. The Linux state now imports the exported one.

Only the *predicate* is shared. The two guards deliberately keep their separate state: the Linux state is a 1500 ms suspicion window inferred from an orphaned keyup when there is **no** composition, and the release guard is a 250 ms post-composition window for a key the IME is known to own. Those are different evidence regimes, and fusing them would let a heuristic's confidence leak into the evidence-based path. A stateless, clockless predicate is the safe thing to share; the state machines are not.

**2. `isActive()` removed from the input-source tracker.** Nothing in the app ever called it — only its own spec did. Every one of those assertions is more precise stated against `getFeatures()`, which is the real production surface, so the spec got better rather than merely shorter. The `refresh()` export stays: it is a genuine test seam that lets specs await one read instead of racing the fire-and-forget refresh, and it now says so in a comment.

## Screenshots

No UI change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 228 files / 2979 tests across the terminal-pane and dashboard-popout suites
- [ ] `pnpm build` — not run
- [x] Existing tests cover both changes; the input-source spec was tightened as part of (2)

## AI Review Report

Checked for an import cycle before (1): `terminal-ime-linux-candidate-state` → `terminal-ime-candidate-key-release-guard` → `terminal-ime-composition-tracker`, and nothing in that chain imports back. Clean.

Deliberately **not** done: the unmodified-modifier idiom appears in ten files under `terminal-pane/`, each with a different modifier combination because each has different semantics (Ctrl chords, Shift+Space width toggle, and so on). Hoisting that into one shared helper would be a cross-cutting change to non-IME keyboard code and exactly the kind of generic catch-all module the repo's naming rule warns about. Only the two predicates that were genuinely the same were merged.

Cross-platform: (1) is Linux-path code but the predicate is platform-neutral and unchanged in behavior. (2) is macOS-only code; the removed accessor had no callers on any platform.

## Security Audit

No IPC, path handling, auth, secrets, command execution, or dependency changes. Both changes are internal API reductions in the renderer.

## Notes

Top of stack #11899, on #12021. Independent of the rest of the stack — it touches no file any other PR in the stack modifies.
