### PR TITLE
fix(windows): keep browser close marker URL absolute

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -147,6 +147,12 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.loadURL).not.toHaveBeenCalled()
   })
 
+  it('keeps the browser close-policy marker absolute under Windows URL rules', () => {
+    expect(fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD, { windows: true })).toBe(
+      'C:\\__orca_window_close_allowed__'
+    )
+  })
+
   it('enables renderer sandboxing and opens external links safely', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/shared/browser-window-close-policy.ts
+++ b/src/shared/browser-window-close-policy.ts
@@ -1,2 +1,2 @@
-// Why: this marker carries the CLI's explicit close policy across <webview> attach before the guest exists.
-export const BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD = 'file:///__orca_window_close_allowed__'
+// Why: the synthetic drive keeps this marker absolute under Windows file-URL rules; main removes it before guest load.
+export const BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD = 'file:///C:/__orca_window_close_allowed__'


### PR DESCRIPTION
## Summary

- Fix the all-black Windows window introduced in `v1.4.164-rc.0` by making the synthetic browser close-policy preload marker absolute under Windows file-URL rules.
- `createMainWindow()` previously constructed the `BrowserWindow`, then threw `ERR_INVALID_FILE_URL_PATH` while converting `file:///__orca_window_close_allowed__`, before the renderer document could load.
- Add a regression test that runs `fileURLToPath()` with Windows semantics and pins the resulting absolute path.

## ELI5

The previous browser fix needed a pretend “special permission sticker” for certain browser pages. It used the fake file address `file:///__orca_window_close_allowed__` as that sticker.

Mac accepts that address as an absolute path. Windows requires a drive letter such as `C:/`, so it threw an error while reading the sticker. Orca had already created its window but had not loaded the UI yet, leaving a real but completely empty black window.

This PR makes the sticker Windows-valid (`file:///C:/__orca_window_close_allowed__`) and adds a test that reads it using Windows URL rules.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation completed:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts src/preload/browser-window-close.test.ts src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts`
- `pnpm run typecheck:node`
- `pnpm run check:code-quality:changed`
- `pnpm run check:reliability-gates`
- `pnpm run build:electron-vite`

## AI Review Report

No findings remain. The review traced startup from `BrowserWindow` construction through the close-policy marker conversion and renderer load, and verified both raw-URL and normalized-path policy comparisons. Cross-platform review confirmed the marker converts to `C:\\__orca_window_close_allowed__` under Windows rules and remains a valid absolute POSIX path on macOS/Linux; no shortcuts, labels, shell behavior, SSH routing, or workspace-path behavior changes.

## Security Audit

The synthetic URL remains a policy marker only and is removed before the guest preload can run. The change does not broaden accepted navigation origins, add command execution, alter IPC authority, process user-controlled paths, touch auth or secrets, or add dependencies. The existing fail-closed webview policy remains intact.

## Notes

The cause was confirmed from `main.trace.ndjson`: `fileURLToPath()` raised `ERR_INVALID_FILE_URL_PATH` in `getPathFromURLWin32` immediately after the RC update. This is unrelated to GPU capability; the renderer was never loaded.
