### PR TITLE
fix(browser): remove unsafe window close bypass

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -74,8 +74,6 @@ import {
 } from './createMainWindow'
 import { ipcMain } from 'electron'
 import { shouldRecoverRendererAfterProcessGone } from '../crash-reporting/process-gone-classification'
-import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../shared/browser-window-close-policy'
-import { fileURLToPath } from 'node:url'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = process.platform
@@ -145,12 +143,6 @@ describe('createMainWindow', () => {
 
     expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(1)
     expect(browserWindowInstance.loadURL).not.toHaveBeenCalled()
-  })
-
-  it('keeps the browser close-policy marker absolute under Windows URL rules', () => {
-    expect(fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD, { windows: true })).toBe(
-      'C:\\__orca_window_close_allowed__'
-    )
   })
 
   it('enables renderer sandboxing and opens external links safely', () => {
@@ -272,35 +264,26 @@ describe('createMainWindow', () => {
     windowHandlers['did-attach-webview']({} as never, guest as never)
     expect(attachGuestPoliciesMock).toHaveBeenCalledWith(guest)
 
-    const allowWindowCloseEvent = { preventDefault: vi.fn() }
-    const allowWindowCloseParams = {
+    const untrustedPreloadParams = {
       src: 'data:text/html,',
-      preload: BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD
+      preload: 'file:///tmp/untrusted-preload.js'
     }
-    const allowWindowClosePrefs = { partition: 'persist:orca-browser' }
-    windowHandlers['will-attach-webview'](
-      allowWindowCloseEvent as never,
-      allowWindowClosePrefs as never,
-      allowWindowCloseParams as never
-    )
-    expect(allowWindowCloseEvent.preventDefault).not.toHaveBeenCalled()
-    expect(allowWindowCloseParams.preload).toBeUndefined()
-    expect(allowWindowClosePrefs).not.toHaveProperty('preload')
-
-    const allowWindowClosePathPrefs = {
+    const hardenedPrefs = {
       partition: 'persist:orca-browser',
-      preload: fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
+      preload: '/tmp/untrusted-preload.js'
     }
     windowHandlers['will-attach-webview'](
       { preventDefault: vi.fn() } as never,
-      allowWindowClosePathPrefs as never,
-      { src: 'data:text/html,', preload: '' } as never
+      hardenedPrefs as never,
+      untrustedPreloadParams as never
     )
-    expect(allowWindowClosePathPrefs).not.toHaveProperty('preload')
+    expect(untrustedPreloadParams.preload).toBeUndefined()
+    expect(hardenedPrefs.preload).toMatch(/browser-window-close-preload\.js$/)
+    expect(hardenedPrefs.preload).not.toContain('untrusted-preload')
 
-    const cliGuest = { marker: 'cli-guest' }
-    windowHandlers['did-attach-webview']({} as never, cliGuest as never)
-    expect(attachGuestPoliciesMock).toHaveBeenLastCalledWith(cliGuest)
+    const secondGuest = { marker: 'second-guest' }
+    windowHandlers['did-attach-webview']({} as never, secondGuest as never)
+    expect(attachGuestPoliciesMock).toHaveBeenLastCalledWith(secondGuest)
   })
 
   it('sets platform-specific titlebar and frame options for every desktop platform', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -10,7 +10,6 @@ import {
   screen
 } from 'electron'
 import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { is } from '@electron-toolkit/utils'
 import type { Store } from '../persistence'
 import { getAppIconPath } from '../app-icon'
@@ -19,7 +18,6 @@ import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { translateMain } from '../i18n/main-i18n'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
-import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../shared/browser-window-close-policy'
 import { isCrashReportReason } from '../../shared/crash-reporting'
 import {
   DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES,
@@ -444,7 +442,6 @@ export function createMainWindow(
   registerPluginPanelNavigationGuard(mainWindow.webContents)
 
   const browserWindowClosePreload = join(__dirname, 'browser-window-close-preload.js')
-  const browserWindowCloseAllowedPreloadPath = fileURLToPath(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
   mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
     const src = typeof params.src === 'string' ? params.src : ''
     const normalizedSrc = normalizeBrowserNavigationUrl(src)
@@ -456,18 +453,9 @@ export function createMainWindow(
       return
     }
 
-    const allowWindowClose = [params.preload, webPreferences.preload].some(
-      (preload) =>
-        preload === BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD ||
-        preload === browserWindowCloseAllowedPreloadPath
-    )
     delete params.preload
-    if (allowWindowClose) {
-      delete webPreferences.preload
-    } else {
-      // Why: preload runs in the page's main world before inline scripts can call window.close().
-      webPreferences.preload = browserWindowClosePreload
-    }
+    // Why: preload runs in the page's main world before inline scripts can call window.close().
+    webPreferences.preload = browserWindowClosePreload
     // Why: older Electron builds expose preloadURL alongside preload; delete both so the guest can't inherit the main preload bridge.
     delete (webPreferences as Record<string, unknown>).preloadURL
     webPreferences.nodeIntegration = false

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -3693,7 +3693,6 @@ function BrowserPagePane({
       container,
       inputLocked: inputLockedRef.current,
       webviewPartition,
-      allowWindowClose: browserTab.allowWindowClose === true,
       resolveContainer: () =>
         ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
     })

--- a/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
+++ b/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES_ATTRIBUTE } from '../../../../shared/browser-guest-web-preferences'
-import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../../../shared/browser-window-close-policy'
 
 const registryMocks = vi.hoisted(() => ({
   destroyPersistentWebview: vi.fn(),
@@ -103,23 +102,5 @@ describe('BrowserPane webview preferences', () => {
     )
     expect(ensuredWebview?.webview.style.pointerEvents).toBe('none')
     expect(refreshedContainer.lastElementChild).toBe(ensuredWebview?.webview as unknown as Element)
-  })
-
-  it('marks explicitly allowed CLI pages before the guest attaches', () => {
-    const container = createContainer('cli-page')
-
-    const ensuredWebview = ensureBrowserPageWebview({
-      browserTabId: 'browser-page-cli',
-      container,
-      inputLocked: false,
-      webviewPartition: 'persist:orca-browser',
-      allowWindowClose: true,
-      resolveContainer: () => container
-    })
-
-    expect(ensuredWebview?.webview.getAttribute('preload')).toBe(
-      BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD
-    )
-    expect(BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD).toMatch(/^file:/)
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-page-webview.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-webview.ts
@@ -1,5 +1,4 @@
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES_ATTRIBUTE } from '../../../../shared/browser-guest-web-preferences'
-import { BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD } from '../../../../shared/browser-window-close-policy'
 import {
   destroyPersistentWebview,
   registerPersistentWebview,
@@ -11,14 +10,12 @@ export function ensureBrowserPageWebview({
   container,
   inputLocked,
   webviewPartition,
-  allowWindowClose,
   resolveContainer
 }: {
   browserTabId: string
   container: HTMLDivElement
   inputLocked: boolean
   webviewPartition: string
-  allowWindowClose?: boolean
   resolveContainer: () => HTMLDivElement | null
 }): { container: HTMLDivElement; created: boolean; webview: Electron.WebviewTag } | null {
   let webview = webviewRegistry.get(browserTabId)
@@ -49,10 +46,6 @@ export function ensureBrowserPageWebview({
 
   webview = document.createElement('webview') as Electron.WebviewTag
   webview.setAttribute('partition', webviewPartition)
-  if (allowWindowClose) {
-    // Why: main consumes and removes this marker in will-attach-webview before the guest sees any preload.
-    webview.setAttribute('preload', BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD)
-  }
   webview.setAttribute('allowpopups', '')
   // Why: Electron spreads the webpreferences keys verbatim, so the shared
   // camelCase attribute must stay intact for fullscreen containment to work.

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1080,8 +1080,9 @@ describe('useIpcEvents browser tab create routing', () => {
     expect(state.createBrowserTab).toHaveBeenCalledWith(
       'wt-1',
       'https://example.com',
-      expect.objectContaining({ allowWindowClose: true })
+      expect.objectContaining({ activate: false })
     )
+    expect(state.createBrowserTab.mock.calls[0]?.[2]).not.toHaveProperty('allowWindowClose')
     expect(replyTabCreate).toHaveBeenCalledWith({
       requestId: 'req-create',
       browserPageId: 'page-new'

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2266,7 +2266,6 @@ export function useIpcEvents(): void {
           // Agent/automation opens stay in the background (activate:false) in the active browser group.
           const workspace = store.createBrowserTab(worktreeId, data.url, {
             title: data.url,
-            allowWindowClose: true,
             targetGroupId: data.activate ? undefined : activeBrowserUnifiedTab?.groupId,
             sessionProfileId: data.sessionProfileId,
             sessionPartition: data.sessionPartition,

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -1644,14 +1644,21 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
               createdAt: tab.createdAt
             } satisfies BrowserPage
           ]
-          const nextPages = persistedPages.map((page) => ({
-            ...page,
-            workspaceId: tab.id,
-            worktreeId,
-            url: normalizeUrl(page.url),
-            loading: false,
-            loadError: page.loadError ?? null
-          }))
+          const nextPages = persistedPages.map((page) => {
+            // Why: in-memory hydration callers can bypass the persistence schema's unknown-key stripping.
+            const { allowWindowClose: _legacyAllowWindowClose, ...persistedPage } =
+              page as typeof page & {
+                allowWindowClose?: boolean
+              }
+            return {
+              ...persistedPage,
+              workspaceId: tab.id,
+              worktreeId,
+              url: normalizeUrl(page.url),
+              loading: false,
+              loadError: page.loadError ?? null
+            }
+          })
           browserPagesByWorkspace[tab.id] = nextPages
           hydratedTabs.push(
             mirrorWorkspaceFromActivePage(

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -57,7 +57,6 @@ import { buildValidWorktreeIdsForSessionHydration } from './degraded-repo-worktr
 type CreateBrowserTabOptions = {
   activate?: boolean
   title?: string
-  allowWindowClose?: boolean
   sessionProfileId?: string | null
   sessionPartition?: string | null
   // Place the new tab in a specific group (e.g. "Open Preview to the Side"); defaults to the worktree's active group.
@@ -70,7 +69,6 @@ type CreateBrowserTabOptions = {
 type CreateBrowserPageOptions = {
   activate?: boolean
   title?: string
-  allowWindowClose?: boolean
   browserRuntimeEnvironmentId?: string | null
 }
 
@@ -343,8 +341,7 @@ function buildBrowserPage(
   worktreeId: string,
   url: string,
   title?: string,
-  browserRuntimeEnvironmentId?: string | null,
-  allowWindowClose?: boolean
+  browserRuntimeEnvironmentId?: string | null
 ): BrowserPage {
   const normalizedUrl = normalizeUrl(url)
   return {
@@ -360,7 +357,6 @@ function buildBrowserPage(
     canGoForward: false,
     loadError: null,
     createdAt: Date.now(),
-    ...(allowWindowClose !== undefined ? { allowWindowClose } : {}),
     ...(browserRuntimeEnvironmentId !== undefined ? { browserRuntimeEnvironmentId } : {})
   }
 }
@@ -558,8 +554,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       worktreeId,
       url,
       options?.title,
-      options?.browserRuntimeEnvironmentId,
-      options?.allowWindowClose
+      options?.browserRuntimeEnvironmentId
     )
     // Why: with no explicit profile, inherit the user's default so a Settings preference applies to new tabs.
     const sessionProfileId =
@@ -907,15 +902,13 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       activate: true,
       sessionProfileId,
       sessionPartition,
-      browserRuntimeEnvironmentId: firstPage.browserRuntimeEnvironmentId,
-      allowWindowClose: firstPage.allowWindowClose
+      browserRuntimeEnvironmentId: firstPage.browserRuntimeEnvironmentId
     })
 
     for (const p of restPages) {
       get().createBrowserPage(restored.id, p.url, {
         activate: false,
         title: p.title,
-        allowWindowClose: p.allowWindowClose,
         browserRuntimeEnvironmentId: p.browserRuntimeEnvironmentId
       })
     }
@@ -994,8 +987,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       workspace.worktreeId,
       url,
       options?.title,
-      options?.browserRuntimeEnvironmentId,
-      options?.allowWindowClose
+      options?.browserRuntimeEnvironmentId
     )
 
     set((s) => {
@@ -1177,7 +1169,6 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     return get().createBrowserPage(workspaceId, pageToRestore.url, {
       title: pageToRestore.title,
       activate: true,
-      allowWindowClose: pageToRestore.allowWindowClose,
       browserRuntimeEnvironmentId: pageToRestore.browserRuntimeEnvironmentId
     })
   },

--- a/src/renderer/src/store/slices/store-session-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-session-cascades.test.ts
@@ -1,7 +1,12 @@
 /* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type * as AgentStatusModule from '@/lib/agent-status'
-import type { BrowserTab, DetectedWorktreeListResult, Worktree } from '../../../../shared/types'
+import type {
+  BrowserPage,
+  BrowserTab,
+  DetectedWorktreeListResult,
+  Worktree
+} from '../../../../shared/types'
 import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
 import {
   FLOATING_TERMINAL_WORKTREE_ID,
@@ -717,6 +722,52 @@ describe('hydrateBrowserSession', () => {
     expect(s.browserTabsByWorktree[validWt]).toHaveLength(2)
     expect(s.activeBrowserTabIdByWorktree[validWt]).toBe('browser-1')
     expect(s.activeBrowserTabId).toBe('browser-1')
+  })
+
+  it('drops legacy window close bypass state during hydration', () => {
+    const store = createTestStore()
+    const validWt = 'repo1::/path/wt1'
+    const legacyPage: BrowserPage & { allowWindowClose: boolean } = {
+      id: 'page-1',
+      workspaceId: 'browser-1',
+      worktreeId: validWt,
+      url: 'https://example.com',
+      title: 'Example',
+      loading: false,
+      faviconUrl: null,
+      canGoBack: false,
+      canGoForward: false,
+      loadError: null,
+      createdAt: 1,
+      allowWindowClose: true
+    }
+
+    store.setState({
+      repos: [
+        { id: 'repo1', path: '/repo1', displayName: 'Repo 1', badgeColor: '#000', addedAt: 0 }
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: validWt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      activeWorktreeId: validWt
+    })
+
+    store.getState().hydrateBrowserSession({
+      activeRepoId: 'repo1',
+      activeWorktreeId: validWt,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      browserTabsByWorktree: {
+        [validWt]: [makeBrowserTab({ id: 'browser-1', worktreeId: validWt, url: legacyPage.url })]
+      },
+      browserPagesByWorkspace: { 'browser-1': [legacyPage] },
+      activeBrowserTabIdByWorktree: { [validWt]: 'browser-1' }
+    })
+
+    expect(store.getState().browserPagesByWorkspace['browser-1']?.[0]).not.toHaveProperty(
+      'allowWindowClose'
+    )
   })
 
   it('restores floating workspace browser tabs without a repo worktree', () => {

--- a/src/shared/browser-window-close-policy.ts
+++ b/src/shared/browser-window-close-policy.ts
@@ -1,2 +1,0 @@
-// Why: the synthetic drive keeps this marker absolute under Windows file-URL rules; main removes it before guest load.
-export const BROWSER_WINDOW_CLOSE_ALLOWED_PRELOAD = 'file:///C:/__orca_window_close_allowed__'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -982,8 +982,6 @@ export type BrowserPage = {
   canGoForward: boolean
   loadError: BrowserLoadError | null
   createdAt: number
-  // Why: CLI-created pages retain Chromium's native window.close behavior; ordinary embedded pages are guarded.
-  allowWindowClose?: boolean
   // Why: remote-owned worktrees can still host client-local fallback browser
   // pages until headless remote runtimes support real browser panes.
   browserRuntimeEnvironmentId?: string | null

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -225,7 +225,6 @@ const browserPageSchema = z.object({
   canGoForward: z.boolean(),
   loadError: browserLoadErrorSchema.nullable(),
   createdAt: z.number(),
-  allowWindowClose: z.boolean().optional(),
   // Why: explicit null marks a browser page as client-local even when its
   // worktree is remote-owned; older sessions omit it and keep inferred runtime.
   browserRuntimeEnvironmentId: z.string().nullable().optional(),

--- a/tests/e2e/browser-tab.spec.ts
+++ b/tests/e2e/browser-tab.spec.ts
@@ -29,11 +29,10 @@ async function createBrowserTab(
   page: Parameters<typeof getActiveWorktreeId>[0],
   worktreeId: string,
   url?: string,
-  title = 'New Browser Tab',
-  allowWindowClose?: boolean
+  title = 'New Browser Tab'
 ): Promise<CreatedBrowserTab | null> {
   return page.evaluate(
-    ({ targetWorktreeId, targetUrl, targetTitle, allowClose }) => {
+    ({ targetWorktreeId, targetUrl, targetTitle }) => {
       const store = window.__store
       if (!store) {
         return null
@@ -45,18 +44,12 @@ async function createBrowserTab(
         targetUrl ?? state.browserDefaultUrl ?? 'about:blank',
         {
           title: targetTitle,
-          activate: true,
-          allowWindowClose: allowClose
+          activate: true
         }
       )
       return { id: tab.id, pageId: tab.activePageId ?? null }
     },
-    {
-      targetWorktreeId: worktreeId,
-      targetUrl: url,
-      targetTitle: title,
-      allowClose: allowWindowClose
-    }
+    { targetWorktreeId: worktreeId, targetUrl: url, targetTitle: title }
   )
 }
 
@@ -802,18 +795,23 @@ test.describe('Browser Tab', () => {
     }
   })
 
-  test('explicitly allowed browser tabs retain replaceable window.close', async ({ orcaPage }) => {
+  test('directly created browser tabs block window.close and remain usable', async ({
+    orcaPage
+  }) => {
     const closeServer = await startBrowserWindowCloseServer()
     try {
       const worktreeId = (await getActiveWorktreeId(orcaPage))!
-      const allowedTab = await createBrowserTab(
+      const directTab = await createBrowserTab(
         orcaPage,
         worktreeId,
-        closeServer.sourceUrl,
-        'Allowed close tab',
-        true
+        closeServer.url,
+        'Direct close tab'
       )
-      expect(allowedTab?.id).toBeTruthy()
+      expect(directTab?.id).toBeTruthy()
+
+      await expect
+        .poll(() => readBrowserWindowCloseStatus(orcaPage, directTab!.id), { timeout: 5_000 })
+        .toContain('window.close() was blocked')
 
       await expect
         .poll(
@@ -834,10 +832,10 @@ test.describe('Browser Tab', () => {
               } catch {
                 return 'guest unavailable'
               }
-            }, allowedTab!.id),
+            }, directTab!.id),
           { timeout: 5_000 }
         )
-        .toBe('replacement-called')
+        .toBe('blocked')
     } finally {
       await closeServer.close()
     }


### PR DESCRIPTION
## Summary

- Keep the guest lifecycle cleanup and early `window.close()` guard from #11910.
- Remove the CLI-only guard bypass, its synthetic preload marker, and persisted `allowWindowClose` state.
- Apply the guard uniformly to every embedded browser webview and retain focused coverage for link-created and directly created tabs.

## ELI5

The first fix installed a child lock so web pages could not accidentally destroy their little browser window inside Orca. It also gave CLI-created tabs a secret key to bypass that lock. Adversarial testing showed the key did not cleanly close the Orca tab: it killed the browser engine underneath while leaving a dead-looking tab behind. That dead tab stayed on screen but every later operation failed with `Invalid guestInstanceId`.

This PR takes away the unsafe secret key. Every embedded browser tab gets the same child lock. We keep the important part of #11910 that throws away stale pointers when a guest really dies, so the original #11763 crash remains fixed. Removing the synthetic file-URL key also removes the path mechanism that caused the Windows black screen fixed in #12038.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] Electron production bundle (`pnpm exec electron-vite build --mode e2e`)
- [x] Added or updated high-quality tests that would catch regressions
- [x] 283 focused Vitest tests
- [x] 2 focused Electron E2E tests covering link-created and directly created `window.close()` attempts
- [x] Changed-code quality gate
- [x] 61 reliability-gate manifest checks
- [x] max-lines ratchet

## AI Review Report

The review split #11910 into its independent lifecycle-cleanup and close-policy layers, traced all creation/restoration paths, and tested the claimed CLI self-close behavior instead of relying on the existing replaceability test. Calling native `window.close()` on a bypassed tab resolved, destroyed its Electron guest, left the `<webview>` connected, and made the next guest call fail with `Invalid guestInstanceId`. The bypass was therefore removed while the identity-guarded forward/reverse map cleanup was retained.

Cross-platform review covered macOS, Linux, and Windows Electron preload handling and file-URL semantics. The resulting implementation has no platform-specific marker or path conversion.

## Security Audit

The renderer can no longer use a synthetic preload value to opt a guest out of the main-process close policy. `will-attach-webview` strips any renderer-requested preload and always replaces it with the standalone sandboxed guard after validating the URL and registered partition. Node integration remains disabled, context isolation and sandboxing remain enabled, and no auth, secrets, dependencies, shell commands, or external input formats changed.

## Notes

This is a targeted partial revert of #11910, not a full revert. A full revert would reintroduce #11763's stale guest pointer and main-process crash.
