### PR TITLE
fix(remote): keep tab order and titles stable on a headless host

### DIFF
--- a/src/main/runtime/headless-tab-order-stability.test.ts
+++ b/src/main/runtime/headless-tab-order-stability.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import type {
+  RuntimeMobileSessionTabsSnapshot,
+  RuntimeMobileSessionTerminalTab
+} from '../../shared/runtime-types'
+
+const WT = 'repo-1::/home/gal/dev/orca'
+const GROUP = `headless-terminals:${WT}`
+
+const terminalTab = (n: number, isActive = false): RuntimeMobileSessionTerminalTab => ({
+  type: 'terminal',
+  id: `tab-${n}::leaf-${n}`,
+  title: `terminal ${n}`,
+  parentTabId: `tab-${n}`,
+  leafId: `leaf-${n}`,
+  ptyId: `pty-${n}`,
+  isActive
+})
+
+const snapshotOf = (
+  tabs: RuntimeMobileSessionTerminalTab[],
+  tabOrder: string[],
+  activeTabId: string | null
+): RuntimeMobileSessionTabsSnapshot => ({
+  worktree: WT,
+  publicationEpoch: 'headless:seed',
+  snapshotVersion: 1,
+  activeGroupId: GROUP,
+  activeTabId,
+  activeTabType: 'terminal',
+  tabGroups: [{ id: GROUP, activeTabId: activeTabId?.split('::')[0] ?? null, tabOrder }],
+  tabs
+})
+
+describe('headless tab order stability', () => {
+  it('keeps the user tab order when a materialized surface is re-appended to the tabs array', () => {
+    // Four tabs the user arranged as 1,2,3,4. Clicking an idle tab makes the host
+    // materialize its PTY, and every publish path that re-publishes a surface drops it
+    // from the tabs array and pushes it back on the end -- here, tab 2.
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+      activateHeadlessMobileSessionTerminalTab: (
+        worktreeId: string,
+        snapshot: RuntimeMobileSessionTabsSnapshot,
+        activeTab: RuntimeMobileSessionTerminalTab
+      ) => void
+      emitMobileSessionTabsSnapshot: (snapshot: RuntimeMobileSessionTabsSnapshot) => void
+      persistHeadlessTerminalActiveLeaf: (...args: unknown[]) => void
+    }
+    runtime.emitMobileSessionTabsSnapshot = () => {}
+    runtime.persistHeadlessTerminalActiveLeaf = () => {}
+
+    const tabs = [terminalTab(1), terminalTab(3), terminalTab(4), terminalTab(2, true)]
+    const seeded = snapshotOf(tabs, ['tab-1', 'tab-2', 'tab-3', 'tab-4'], 'tab-2::leaf-2')
+    runtime.mobileSessionTabsByWorktree.set(WT, seeded)
+
+    runtime.activateHeadlessMobileSessionTerminalTab(WT, seeded, tabs[3]!)
+
+    const next = runtime.mobileSessionTabsByWorktree.get(WT)!
+    expect(next.tabGroups![0]!.tabOrder).toEqual(['tab-1', 'tab-2', 'tab-3', 'tab-4'])
+  })
+
+  it('does not rotate the order across a sequence of activations', () => {
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+      activateHeadlessMobileSessionTerminalTab: (
+        worktreeId: string,
+        snapshot: RuntimeMobileSessionTabsSnapshot,
+        activeTab: RuntimeMobileSessionTerminalTab
+      ) => void
+      emitMobileSessionTabsSnapshot: (snapshot: RuntimeMobileSessionTabsSnapshot) => void
+      persistHeadlessTerminalActiveLeaf: (...args: unknown[]) => void
+    }
+    runtime.emitMobileSessionTabsSnapshot = () => {}
+    runtime.persistHeadlessTerminalActiveLeaf = () => {}
+
+    runtime.mobileSessionTabsByWorktree.set(
+      WT,
+      snapshotOf(
+        [terminalTab(1, true), terminalTab(2), terminalTab(3), terminalTab(4)],
+        ['tab-1', 'tab-2', 'tab-3', 'tab-4'],
+        'tab-1::leaf-1'
+      )
+    )
+
+    // Click 3, then 2, then 4 -- each click materializes and re-appends that surface.
+    for (const n of [3, 2, 4]) {
+      const current = runtime.mobileSessionTabsByWorktree.get(WT)!
+      const target = current.tabs.find(
+        (tab): tab is RuntimeMobileSessionTerminalTab =>
+          tab.type === 'terminal' && tab.parentTabId === `tab-${n}`
+      )!
+      // The re-append the publish paths perform before the group rebuild runs.
+      const reappended: RuntimeMobileSessionTabsSnapshot = {
+        ...current,
+        tabs: [...current.tabs.filter((tab) => tab.id !== target.id), target]
+      }
+      runtime.mobileSessionTabsByWorktree.set(WT, reappended)
+      runtime.activateHeadlessMobileSessionTerminalTab(WT, reappended, target)
+    }
+
+    const next = runtime.mobileSessionTabsByWorktree.get(WT)!
+    expect(next.tabGroups![0]!.tabOrder).toEqual(['tab-1', 'tab-2', 'tab-3', 'tab-4'])
+  })
+
+  it('keeps the stored order when merging a re-appended surface into existing groups', () => {
+    // The second order builder, used by the PTY-backed publish path.
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      mergeMobileSessionTabGroups: (
+        worktreeId: string,
+        groups: { id: string; activeTabId: string | null; tabOrder: string[] }[],
+        terminalTabs: RuntimeMobileSessionTerminalTab[],
+        activeTab: RuntimeMobileSessionTerminalTab | null
+      ) => { id: string; tabOrder: string[] }[]
+    }
+
+    const reappended = [terminalTab(1), terminalTab(3), terminalTab(4), terminalTab(2, true)]
+    const merged = runtime.mergeMobileSessionTabGroups(
+      WT,
+      [{ id: GROUP, activeTabId: 'tab-1', tabOrder: ['tab-1', 'tab-2', 'tab-3', 'tab-4'] }],
+      reappended,
+      reappended[3]!
+    )
+
+    expect(merged[0]!.tabOrder).toEqual(['tab-1', 'tab-2', 'tab-3', 'tab-4'])
+  })
+
+  it('appends a genuinely new tab at the end', () => {
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      mergeMobileSessionTabGroups: (
+        worktreeId: string,
+        groups: { id: string; activeTabId: string | null; tabOrder: string[] }[],
+        terminalTabs: RuntimeMobileSessionTerminalTab[],
+        activeTab: RuntimeMobileSessionTerminalTab | null
+      ) => { id: string; tabOrder: string[] }[]
+    }
+
+    const withNew = [terminalTab(1), terminalTab(2), terminalTab(5, true)]
+    const merged = runtime.mergeMobileSessionTabGroups(
+      WT,
+      [{ id: GROUP, activeTabId: 'tab-1', tabOrder: ['tab-1', 'tab-2'] }],
+      withNew,
+      withNew[2]!
+    )
+
+    expect(merged[0]!.tabOrder).toEqual(['tab-1', 'tab-2', 'tab-5'])
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6202,9 +6202,27 @@ export class OrcaRuntimeService {
     const activeGroupId =
       (activeParentId ? ownerGroupId.get(activeParentId) : undefined) ?? nextGroups[0]!.id
     const retainedOrder = new Map<string, string[]>(nextGroups.map((group) => [group.id, []]))
+    // Why: tabOrder is the canonical user-visible order, so it must survive a republish.
+    // Deriving it from the tabs-array order instead let any republished surface land at the
+    // end — activating an idle pending-handle tab materializes and republishes it, which
+    // reshuffled the client's tab bar on every click. Keep the stored order for still-live
+    // tabs and append only genuinely-new ones.
+    const placed = new Set<string>()
+    for (const group of nextGroups) {
+      for (const tabId of group.tabOrder) {
+        if (liveTabIds.has(tabId) && !placed.has(tabId)) {
+          retainedOrder.get(group.id)?.push(tabId)
+          placed.add(tabId)
+        }
+      }
+    }
     for (const tabId of parentTabOrder) {
+      if (placed.has(tabId)) {
+        continue
+      }
       const groupId = ownerGroupId.get(tabId) ?? activeGroupId
       retainedOrder.get(groupId)?.push(tabId)
+      placed.add(tabId)
     }
     return nextGroups
       .map((group) => {
@@ -6855,7 +6873,29 @@ export class OrcaRuntimeService {
   ): RuntimeMobileSessionTabGroup[] {
     // Why: order across terminals and browsers in their actual array order so a
     // tab opened after a browser tab lands to its right, not regrouped before it.
-    const tabOrder = this.collectHeadlessTopLevelTabOrder(tabs)
+    const arrivalOrder = this.collectHeadlessTopLevelTabOrder(tabs)
+    // Why: tabOrder is the user-visible order and must survive a republish. Deriving it
+    // from the tabs array alone let any republished surface land last — activating an idle
+    // tab materializes it, and the publish paths re-append that surface — so the tab bar
+    // rotated on every click. Keep the stored order for still-live tabs (per group, so a
+    // split keeps its internal order) and append only genuinely-new ones.
+    const liveTopLevelIds = new Set(arrivalOrder)
+    const tabOrder: string[] = []
+    const placed = new Set<string>()
+    for (const group of existingGroups ?? []) {
+      for (const tabId of group.tabOrder) {
+        if (liveTopLevelIds.has(tabId) && !placed.has(tabId)) {
+          tabOrder.push(tabId)
+          placed.add(tabId)
+        }
+      }
+    }
+    for (const tabId of arrivalOrder) {
+      if (!placed.has(tabId)) {
+        tabOrder.push(tabId)
+        placed.add(tabId)
+      }
+    }
     const topLevelOf = (tab: RuntimeMobileSessionSnapshotTab): string =>
       tab.type === 'terminal' ? tab.parentTabId : tab.id
     const activeTopLevelId =

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1224,6 +1224,88 @@ describe('applyWebSessionTabsSnapshot', () => {
     ).toBe('chat')
   })
 
+  it('keeps the real title when the host publishes its pending-handle placeholder', () => {
+    // A headless host has no live PTY for an unfocused pane, so it publishes the literal
+    // 'Terminal'. Adopting it relabelled every idle tab until it was clicked.
+    const mirroredId = toWebTerminalSurfaceTabId('host-tab-1')
+    const existingTab: TerminalTab = {
+      id: mirroredId,
+      ptyId: 'remote:web-env-1@@terminal-1',
+      worktreeId: WT,
+      title: 'pnpm dev',
+      defaultTitle: 'pnpm dev',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: { [WT]: [existingTab] },
+        ptyIdsByTabId: { [mirroredId]: ['remote:web-env-1@@terminal-1'] }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          // Exactly what a headless host publishes for an unfocused pane.
+          title: 'Terminal',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          viewMode: 'chat',
+          status: 'pending-handle',
+          terminal: null
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState>
+
+    const title = patch.tabsByWorktree?.[WT]?.[0]?.title ?? existingTab.title
+    expect(title).toBe('pnpm dev')
+    expect(title).not.toBe('Terminal')
+  })
+
+  it('still adopts a real host title once the pane becomes ready', () => {
+    const mirroredId = toWebTerminalSurfaceTabId('host-tab-1')
+    const existingTab: TerminalTab = {
+      id: mirroredId,
+      ptyId: 'remote:web-env-1@@terminal-1',
+      worktreeId: WT,
+      title: 'pnpm dev',
+      defaultTitle: 'pnpm dev',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: { [WT]: [existingTab] },
+        ptyIdsByTabId: { [mirroredId]: ['remote:web-env-1@@terminal-1'] }
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'gal@omarchy: ~/dev',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.tabsByWorktree?.[WT]?.[0]?.title).toBe('gal@omarchy: ~/dev')
+  })
+
   it('preserves quick command labels from host terminal surfaces', () => {
     const patch = applyWebSessionTabsSnapshot(
       makeState(),

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -616,16 +616,24 @@ function buildMirroredTerminalTabs(
       siblingHookAgent: surfaces.find((surface) => surface.agentStatus?.agentType)?.agentStatus
         ?.agentType
     })
-    const title = normalizeCompatibleAgentTitleForOwner(
-      activeSurface.title.trim() || surfaces[0]?.title.trim() || 'Terminal',
-      ownerAgent
-    )
     const existing =
       existingById.get(localTabId) ??
       existingById.get(parentTabId) ??
       surfaces
         .map((surface) => existingById.get(toWebTerminalSurfaceTabId(surface.id)))
         .find((tab): tab is TerminalTab => Boolean(tab))
+    // Why: a headless host has no live PTY for a pane it is not streaming, so it publishes
+    // the literal placeholder 'Terminal' rather than an empty title. Adopting it discarded
+    // the real title the client already had, relabelling every idle tab until it was
+    // clicked. Treat the placeholder as "unknown" and keep what we know.
+    const hostTitle = activeSurface.title.trim() || surfaces[0]?.title.trim() || ''
+    const hostTitleIsPlaceholder =
+      hostTitle === '' || (activeSurface.status === 'pending-handle' && hostTitle === 'Terminal')
+    const retainedTitle = existing?.title?.trim() || existing?.defaultTitle?.trim() || ''
+    const title = normalizeCompatibleAgentTitleForOwner(
+      (hostTitleIsPlaceholder ? retainedTitle || hostTitle : hostTitle) || 'Terminal',
+      ownerAgent
+    )
     const quickCommandLabel =
       activeSurface.quickCommandLabel?.trim() ||
       surfaces.find((surface) => surface.quickCommandLabel?.trim())?.quickCommandLabel?.trim() ||


### PR DESCRIPTION
## Problem

On a remote `orca serve` host the tab bar is unstable:

- **Order rotates.** Whichever tab you click jumps to the rightmost slot, so repeated clicking permutes the tab bar.
- **Idle tabs get relabelled** to the literal string `Terminal`, losing their real title until you click them.

Both come from the same root: the host publishes degraded state for a pane it is not actively streaming, and the client reads it as fact.

## Cause

**Order.** Every publish path re-materializes a surface by dropping it from the tabs array and pushing it back on the end. Both order builders then rebuilt `tabOrder` from that array order, keeping only the existing group's *id* and discarding its stored order — so activating an idle tab moved it to the end.

**Titles.** A pane with no live PTY carries the placeholder `Terminal` rather than an empty title, and the client adopted it over the real title it already held.

## Fix

- `buildHeadlessMobileSessionTabGroups` (activation path) and `mergeMobileSessionTabGroups` (PTY-publish path) both retain the stored per-group order for still-live tabs and append only genuinely-new ids. Per-group, so a split keeps its internal order.
- `buildMirroredTerminalTabs` treats the `Terminal` placeholder on a `pending-handle` surface as unknown and keeps the retained title. A `ready` surface still adopts whatever the host reports.

## Tests

`headless-tab-order-stability.test.ts` (4 tests) reproduces the rotation across a sequence of activations and pins both builders — 3 of 4 fail before the fix. Two `web-session-tabs-sync` tests cover the placeholder and confirm a `ready` pane still adopts a real host title.

Typecheck and the full `web-session-tabs-sync` suite (65 tests) pass.

## Notes

Found while running agents on a headless `orca serve` host. No upstream issue tracks this. Two sibling PRs follow, covering agent status and completion notifications on the same host type; this one is independent of both.