### PR TITLE
fix(remote): report a running agent as busy on a headless host

### DIFF
--- a/src/main/runtime/headless-agent-status-from-hooks.test.ts
+++ b/src/main/runtime/headless-agent-status-from-hooks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { RuntimeMobileSessionTerminalTab } from '../../shared/runtime-types'
+
+const TAB_ID = '258c3b52-ed9c-4494-88d7-8577515b8987'
+const LEAF_ID = '57b25db0-75f7-4d6d-90d9-9d1d7b9a3466'
+const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
+
+const tab: RuntimeMobileSessionTerminalTab = {
+  type: 'terminal',
+  id: `${TAB_ID}::${LEAF_ID}`,
+  // The placeholder a headless host publishes for a pane it holds no live handle for.
+  title: 'Terminal',
+  parentTabId: TAB_ID,
+  leafId: LEAF_ID,
+  isActive: false
+}
+
+const WORKTREE_ID =
+  'cc1bd8a8-6e33-49f4-ae20-be69ba290954::/home/gal/dev/ai-projects::workspace:86c20dd7-9943-42a1-8868-3d71aac6a281'
+
+const hookRow = (state: 'working' | 'waiting' | 'done', now: number): AgentStatusIpcPayload =>
+  ({
+    paneKey: PANE_KEY,
+    state,
+    prompt: 'sleep for 10 min',
+    agentType: 'codex',
+    connectionId: null,
+    worktreeId: WORKTREE_ID,
+    receivedAt: now,
+    stateStartedAt: now - 5_000
+  }) as AgentStatusIpcPayload
+
+describe('headless agent status published from hook rows', () => {
+  it('publishes the working state the hook reported, not a title-derived done', () => {
+    // Reproduces the remote checkmark: hooks fire on the host and record `working`,
+    // but the published surface said `done`, so an unfocused tab rendered as idle and
+    // no working->done edge ever existed for notifications to fire on.
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { state: string; agentType?: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('working', now)] : []
+    )
+
+    expect(published.agentStatus?.state).toBe('working')
+  })
+
+  it('publishes a waiting hook state and keeps the agent type', () => {
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { state: string; agentType?: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('waiting', now)] : []
+    )
+
+    expect(published.agentStatus?.state).toBe('waiting')
+    expect(published.agentStatus?.agentType).toBe('codex')
+  })
+
+  it('still publishes done when the hook says done', () => {
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { state: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('done', now)] : []
+    )
+
+    expect(published.agentStatus?.state).toBe('done')
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -41,7 +41,8 @@ import {
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload,
   type AgentStatusOrchestrationContext,
-  type AgentStatusEntry
+  type AgentStatusEntry,
+  type AgentStatusState
 } from '../../shared/agent-status-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
 import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
@@ -29227,21 +29228,25 @@ export class OrcaRuntimeService {
         )
       }
     }
-    // A hook-only pane has no PTY status to date the row from; `done` with a
-    // now-stamp is the honest projection — the hook proves identity, not liveness.
-    const now = pty?.lastOutputAt ?? Date.now()
+    // Why: a headless host holds no live handle for a pane it is not streaming, so its
+    // only liveness signal is the hook row — `pty.lastAgentStatus` is title-derived and
+    // the title is the 'Terminal' placeholder. Reading identity from the hook but state
+    // from the title published `done` over a running agent, which showed an unfocused tab
+    // as idle and erased the working->done edge completion notifications need.
+    const now = hookRow.state ? hookRow.receivedAt : (pty?.lastOutputAt ?? Date.now())
     const agentType = ownerAgent ?? undefined
     return {
       agentStatus: {
         state:
-          pty?.lastAgentStatus === 'working'
+          hookRow.state ??
+          (pty?.lastAgentStatus === 'working'
             ? 'working'
             : pty?.lastAgentStatus === 'permission'
               ? 'blocked'
-              : 'done',
-        prompt: '',
+              : 'done'),
+        prompt: hookRow.prompt ?? '',
         updatedAt: now,
-        stateStartedAt: now,
+        stateStartedAt: hookRow.stateStartedAt ?? now,
         paneKey,
         ...(terminalHandle ? { terminalHandle } : {}),
         ...(agentType ? { agentType } : {}),
@@ -29270,6 +29275,13 @@ export class OrcaRuntimeService {
     providerSessionAgentType: string | null
     providerSessionReceivedAt: number | null
     agentType: string | null
+    // Why: on a headless host the hook is the only live signal a non-streamed pane has.
+    // Returning identity without state forced callers to fall back to the title-derived
+    // status, which reads the 'Terminal' placeholder and reports a running agent as done.
+    state: AgentStatusState | null
+    prompt: string | null
+    stateStartedAt: number | null
+    receivedAt: number
   } {
     let session: AgentStatusIpcPayload | null = null
     let agent: AgentStatusIpcPayload | null = null
@@ -29296,7 +29308,14 @@ export class OrcaRuntimeService {
       providerSession: session?.providerSession ?? null,
       providerSessionAgentType: session?.agentType ?? null,
       providerSessionReceivedAt: session?.receivedAt ?? null,
-      agentType: agent?.agentType ?? null
+      agentType: agent?.agentType ?? null,
+      // Why: bounded by the same staleness window as agentType — an abandoned pane must
+      // not keep claiming `working` forever. `providerSessionOnly` rows are resume
+      // identity with placeholder status fields, so they never carry liveness.
+      state: agent && agent.providerSessionOnly !== true ? (agent.state ?? null) : null,
+      prompt: agent && agent.providerSessionOnly !== true ? (agent.prompt ?? null) : null,
+      stateStartedAt: agent?.stateStartedAt ?? null,
+      receivedAt: agent?.receivedAt ?? Date.now()
     }
   }
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1896,6 +1896,135 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.sortEpoch).toBe(1)
   })
 
+  it('keeps a running agent status when the host republishes the pane without one', () => {
+    // A headless host omits agentStatus for a pane it is not streaming. Dropping the
+    // entry made a working agent render as idle the moment the tab lost focus.
+    const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
+    const workingSurface = {
+      type: 'terminal' as const,
+      id: HOST_SURFACE_ID,
+      title: 'codex [working]',
+      parentTabId: 'host-tab-1',
+      leafId: LEAF_ID,
+      isActive: true,
+      status: 'ready' as const,
+      terminal: 'terminal-1',
+      agentStatus: {
+        state: 'working' as const,
+        prompt: 'fix web parity',
+        updatedAt: NOW - 100,
+        stateStartedAt: NOW - 1_000,
+        agentType: 'codex' as const,
+        paneKey: hostPaneKey,
+        tabId: 'host-tab-1',
+        worktreeId: WT,
+        terminalTitle: 'codex [working]',
+        stateHistory: []
+      }
+    }
+
+    const initial = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot([workingSurface]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const mirroredId = initial.tabsByWorktree?.[WT]?.[0]?.id
+    const mirroredPaneKey = makePaneKey(mirroredId!, LEAF_ID)
+    expect(initial.agentStatusByPaneKey?.[mirroredPaneKey]?.state).toBe('working')
+
+    // Same pane, still present — the host just has no live handle to report status from.
+    const next = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: initial.tabsByWorktree,
+        agentStatusByPaneKey: initial.agentStatusByPaneKey,
+        agentStatusEpoch: initial.agentStatusEpoch ?? 0,
+        ptyIdsByTabId: initial.ptyIdsByTabId
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Terminal',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: false,
+          status: 'pending-handle',
+          terminal: null
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState> | null
+
+    const retained = (next?.agentStatusByPaneKey ?? initial.agentStatusByPaneKey)?.[mirroredPaneKey]
+    expect(retained?.state).toBe('working')
+  })
+
+  it('still clears agent status when a streamed pane reports none (stuck spinner guard)', () => {
+    // A `ready` pane the host IS streaming genuinely has no agent — a shell reclaimed it.
+    // That must still prune, or #1437 comes back for mirrored panes.
+    const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
+    const initial = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'codex [working]',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1',
+          agentStatus: {
+            state: 'working',
+            prompt: 'fix web parity',
+            updatedAt: NOW - 100,
+            stateStartedAt: NOW - 1_000,
+            agentType: 'codex',
+            paneKey: hostPaneKey,
+            tabId: 'host-tab-1',
+            worktreeId: WT,
+            terminalTitle: 'codex [working]',
+            stateHistory: []
+          }
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const mirroredId = initial.tabsByWorktree?.[WT]?.[0]?.id
+    const mirroredPaneKey = makePaneKey(mirroredId!, LEAF_ID)
+
+    const next = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: initial.tabsByWorktree,
+        agentStatusByPaneKey: initial.agentStatusByPaneKey,
+        agentStatusEpoch: initial.agentStatusEpoch ?? 0,
+        ptyIdsByTabId: initial.ptyIdsByTabId
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'gal@omarchy: ~/dev',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState> | null
+
+    expect(next?.agentStatusByPaneKey?.[mirroredPaneKey]).toBeUndefined()
+  })
+
   it('repairs mirrored same-state attribution and retains identity from an older snapshot', () => {
     const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
     const snapshot = makeSnapshot([

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -738,10 +738,22 @@ function buildMirroredAgentStatusPatch(
     }
   }
   const nextByPaneKey = new Map<string, AgentStatusEntry>()
+  // Why: a pane the host has no live handle for carries no agentStatus, and that is
+  // "unknown", not "idle" — pruning on it made a running agent render as done the moment
+  // its tab lost focus. Scoped to `pending-handle` on purpose: a `ready` pane the host IS
+  // streaming genuinely has no agent, and must still prune so a shell that reclaimed the
+  // pane clears its spinner (#1437).
+  const unreportedPaneKeys = new Set<string>()
   for (const surface of terminalSurfaceTabs) {
     const retainedSurface = retainedSurfaceByHostTabAndPrunedLeafId
       ?.get(surface.parentTabId)
       ?.get(surface.leafId)
+    if (!surface.agentStatus && surface.status === 'pending-handle') {
+      const unreportedPaneKey = toMirroredPaneKey(surface, retainedSurface?.leafId)
+      if (unreportedPaneKey) {
+        unreportedPaneKeys.add(unreportedPaneKey)
+      }
+    }
     const entry = remapHostAgentStatus(surface, retainedSurface)
     if (!entry) {
       continue
@@ -778,6 +790,11 @@ function buildMirroredAgentStatusPatch(
       continue
     }
     if (nextByPaneKey.has(paneKey)) {
+      continue
+    }
+    // Why: the host has no live handle for this pane, so it reported no status.
+    // Keep what we know rather than reading silence as "the agent stopped".
+    if (unreportedPaneKeys.has(paneKey)) {
       continue
     }
     if (nextAgentStatusByPaneKey === state.agentStatusByPaneKey) {


### PR DESCRIPTION
## Problem

On a remote `orca serve` host, a running agent flips to the idle checkmark the moment its tab loses focus, and returns to a spinner when the tab is clicked again. The agent is still working the whole time.

## Cause

Two compounding defects, both about a pane the host is not streaming.

**The host published a title-derived status.** `buildPtyMobileAgentStatus` reads *identity* from the agent hook but *state* from the PTY title. A pane with no live handle carries the literal `Terminal` placeholder, which classifies as non-agent — so the branch published `done` over a running agent.

**The client then deleted what it held.** A pane the host reports without an `agentStatus` is *unknown*, not *idle*, but the mirror pruned the entry — so even a correct status was dropped on the next republish.

## Fix

- `getHookAgentRowForPane` returns the hook's `state`/`prompt`/`stateStartedAt` alongside the identity it already returned, and the hook-only branch prefers them over the title-derived fallback. Hook state is bounded by the same staleness window as `agentType`, so an abandoned pane cannot keep claiming `working`; `providerSessionOnly` rows never contribute liveness.
- `buildMirroredAgentStatusPatch` retains status when a `pending-handle` surface reports none.

The retention is deliberately scoped to `pending-handle`: a `ready` surface the host *is* streaming genuinely has no agent and must still prune, or a shell that reclaimed the pane keeps a stuck spinner (#1437). There is a regression test for exactly that.

## Verification

Confirmed against a live host by comparing its `agent-hooks/last-status.json` (two panes `working`, two `waiting`) with what it published for the same panes (`done` for all four). After the fix the published state matches the hook.

## Tests

`headless-agent-status-from-hooks.test.ts` covers `working`/`waiting`/`done` from the hook row. Two `web-session-tabs-sync` tests cover retention and the streamed-pane prune guard. Typecheck and the full 65-test sync suite pass.

## Notes

No upstream issue tracks this. Independent of the tab-order PR. A follow-up PR adds completion notifications for serve hosts and **depends on this one** — wiring notifications while the host still reports `done` for unfocused panes would fire a false completion on every tab switch.