### PR TITLE
fix(remote): deliver agent completion notifications from serve hosts

### DIFF
--- a/src/main/runtime/headless-agent-status-from-hooks.test.ts
+++ b/src/main/runtime/headless-agent-status-from-hooks.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { RuntimeMobileSessionTerminalTab } from '../../shared/runtime-types'
+
+const TAB_ID = '258c3b52-ed9c-4494-88d7-8577515b8987'
+const LEAF_ID = '57b25db0-75f7-4d6d-90d9-9d1d7b9a3466'
+const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
+
+const tab: RuntimeMobileSessionTerminalTab = {
+  type: 'terminal',
+  id: `${TAB_ID}::${LEAF_ID}`,
+  // The placeholder a headless host publishes for a pane it holds no live handle for.
+  title: 'Terminal',
+  parentTabId: TAB_ID,
+  leafId: LEAF_ID,
+  isActive: false
+}
+
+const WORKTREE_ID =
+  'cc1bd8a8-6e33-49f4-ae20-be69ba290954::/home/gal/dev/ai-projects::workspace:86c20dd7-9943-42a1-8868-3d71aac6a281'
+
+const hookRow = (state: 'working' | 'waiting' | 'done', now: number): AgentStatusIpcPayload =>
+  ({
+    paneKey: PANE_KEY,
+    state,
+    prompt: 'sleep for 10 min',
+    agentType: 'codex',
+    connectionId: null,
+    worktreeId: WORKTREE_ID,
+    receivedAt: now,
+    stateStartedAt: now - 5_000
+  }) as AgentStatusIpcPayload
+
+describe('headless agent status published from hook rows', () => {
+  it('publishes the working state the hook reported, not a title-derived done', () => {
+    // Reproduces the remote checkmark: hooks fire on the host and record `working`,
+    // but the published surface said `done`, so an unfocused tab rendered as idle and
+    // no working->done edge ever existed for notifications to fire on.
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { state: string; agentType?: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('working', now)] : []
+    )
+
+    expect(published.agentStatus?.state).toBe('working')
+  })
+
+  it('publishes a waiting hook state and keeps the agent type', () => {
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { state: string; agentType?: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('waiting', now)] : []
+    )
+
+    expect(published.agentStatus?.state).toBe('waiting')
+    expect(published.agentStatus?.agentType).toBe('codex')
+  })
+
+  it('still publishes done when the hook says done', () => {
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { state: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('done', now)] : []
+    )
+
+    expect(published.agentStatus?.state).toBe('done')
+  })
+})

--- a/src/main/runtime/headless-agent-status-from-hooks.test.ts
+++ b/src/main/runtime/headless-agent-status-from-hooks.test.ts
@@ -93,4 +93,26 @@ describe('headless agent status published from hook rows', () => {
 
     expect(published.agentStatus?.state).toBe('done')
   })
+
+  it('attributes the status to the hook worktree when the host holds no PTY for the pane', () => {
+    // Reproduces the missing remote notification: a pane the host is not streaming has no
+    // PTY record, so worktree attribution was dropped. Clients skip a mirrored status they
+    // cannot attribute, so the completion never notified until the pane materialized.
+    const runtime = new OrcaRuntimeService(null) as unknown as {
+      buildPtyMobileAgentStatus: (
+        pty: null,
+        tab: RuntimeMobileSessionTerminalTab,
+        terminalHandle: string | null,
+        retained: null,
+        getHookRowsForPane: (paneKey: string) => AgentStatusIpcPayload[]
+      ) => { agentStatus?: { worktreeId?: string } }
+    }
+
+    const now = Date.now()
+    const published = runtime.buildPtyMobileAgentStatus(null, tab, null, null, (paneKey) =>
+      paneKey === PANE_KEY ? [hookRow('done', now)] : []
+    )
+
+    expect(published.agentStatus?.worktreeId).toBe(WORKTREE_ID)
+  })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -29235,6 +29235,11 @@ export class OrcaRuntimeService {
     // as idle and erased the working->done edge completion notifications need.
     const now = hookRow.state ? hookRow.receivedAt : (pty?.lastOutputAt ?? Date.now())
     const agentType = ownerAgent ?? undefined
+    // Why: a pane the host is not streaming has no PTY record, so keying worktree
+    // attribution off one published this status with no `worktreeId` at all. Clients
+    // skip a mirrored status they cannot attribute, so every completion on an
+    // unfocused pane was dropped and only fired once the pane materialized.
+    const worktreeId = pty?.worktreeId ?? hookRow.worktreeId
     return {
       agentStatus: {
         state:
@@ -29250,7 +29255,7 @@ export class OrcaRuntimeService {
         paneKey,
         ...(terminalHandle ? { terminalHandle } : {}),
         ...(agentType ? { agentType } : {}),
-        ...(pty?.worktreeId ? { worktreeId: pty.worktreeId } : {}),
+        ...(worktreeId ? { worktreeId } : {}),
         tabId: tab.parentTabId,
         terminalTitle,
         stateHistory: [],
@@ -29282,6 +29287,9 @@ export class OrcaRuntimeService {
     prompt: string | null
     stateStartedAt: number | null
     receivedAt: number
+    // Why: the hook payload is the only worktree attribution a non-streamed pane has —
+    // there is no PTY record to read it from. Clients key completion notifications by it.
+    worktreeId: string | null
   } {
     let session: AgentStatusIpcPayload | null = null
     let agent: AgentStatusIpcPayload | null = null
@@ -29315,7 +29323,8 @@ export class OrcaRuntimeService {
       state: agent && agent.providerSessionOnly !== true ? (agent.state ?? null) : null,
       prompt: agent && agent.providerSessionOnly !== true ? (agent.prompt ?? null) : null,
       stateStartedAt: agent?.stateStartedAt ?? null,
-      receivedAt: agent?.receivedAt ?? Date.now()
+      receivedAt: agent?.receivedAt ?? Date.now(),
+      worktreeId: agent?.worktreeId ?? session?.worktreeId ?? null
     }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -41,7 +41,8 @@ import {
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload,
   type AgentStatusOrchestrationContext,
-  type AgentStatusEntry
+  type AgentStatusEntry,
+  type AgentStatusState
 } from '../../shared/agent-status-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
 import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
@@ -29227,21 +29228,25 @@ export class OrcaRuntimeService {
         )
       }
     }
-    // A hook-only pane has no PTY status to date the row from; `done` with a
-    // now-stamp is the honest projection — the hook proves identity, not liveness.
-    const now = pty?.lastOutputAt ?? Date.now()
+    // Why: a headless host holds no live handle for a pane it is not streaming, so its
+    // only liveness signal is the hook row — `pty.lastAgentStatus` is title-derived and
+    // the title is the 'Terminal' placeholder. Reading identity from the hook but state
+    // from the title published `done` over a running agent, which showed an unfocused tab
+    // as idle and erased the working->done edge completion notifications need.
+    const now = hookRow.state ? hookRow.receivedAt : (pty?.lastOutputAt ?? Date.now())
     const agentType = ownerAgent ?? undefined
     return {
       agentStatus: {
         state:
-          pty?.lastAgentStatus === 'working'
+          hookRow.state ??
+          (pty?.lastAgentStatus === 'working'
             ? 'working'
             : pty?.lastAgentStatus === 'permission'
               ? 'blocked'
-              : 'done',
-        prompt: '',
+              : 'done'),
+        prompt: hookRow.prompt ?? '',
         updatedAt: now,
-        stateStartedAt: now,
+        stateStartedAt: hookRow.stateStartedAt ?? now,
         paneKey,
         ...(terminalHandle ? { terminalHandle } : {}),
         ...(agentType ? { agentType } : {}),
@@ -29270,6 +29275,13 @@ export class OrcaRuntimeService {
     providerSessionAgentType: string | null
     providerSessionReceivedAt: number | null
     agentType: string | null
+    // Why: on a headless host the hook is the only live signal a non-streamed pane has.
+    // Returning identity without state forced callers to fall back to the title-derived
+    // status, which reads the 'Terminal' placeholder and reports a running agent as done.
+    state: AgentStatusState | null
+    prompt: string | null
+    stateStartedAt: number | null
+    receivedAt: number
   } {
     let session: AgentStatusIpcPayload | null = null
     let agent: AgentStatusIpcPayload | null = null
@@ -29296,7 +29308,14 @@ export class OrcaRuntimeService {
       providerSession: session?.providerSession ?? null,
       providerSessionAgentType: session?.agentType ?? null,
       providerSessionReceivedAt: session?.receivedAt ?? null,
-      agentType: agent?.agentType ?? null
+      agentType: agent?.agentType ?? null,
+      // Why: bounded by the same staleness window as agentType — an abandoned pane must
+      // not keep claiming `working` forever. `providerSessionOnly` rows are resume
+      // identity with placeholder status fields, so they never carry liveness.
+      state: agent && agent.providerSessionOnly !== true ? (agent.state ?? null) : null,
+      prompt: agent && agent.providerSessionOnly !== true ? (agent.prompt ?? null) : null,
+      stateStartedAt: agent?.stateStartedAt ?? null,
+      receivedAt: agent?.receivedAt ?? Date.now()
     }
   }
 

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1896,6 +1896,135 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.sortEpoch).toBe(1)
   })
 
+  it('keeps a running agent status when the host republishes the pane without one', () => {
+    // A headless host omits agentStatus for a pane it is not streaming. Dropping the
+    // entry made a working agent render as idle the moment the tab lost focus.
+    const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
+    const workingSurface = {
+      type: 'terminal' as const,
+      id: HOST_SURFACE_ID,
+      title: 'codex [working]',
+      parentTabId: 'host-tab-1',
+      leafId: LEAF_ID,
+      isActive: true,
+      status: 'ready' as const,
+      terminal: 'terminal-1',
+      agentStatus: {
+        state: 'working' as const,
+        prompt: 'fix web parity',
+        updatedAt: NOW - 100,
+        stateStartedAt: NOW - 1_000,
+        agentType: 'codex' as const,
+        paneKey: hostPaneKey,
+        tabId: 'host-tab-1',
+        worktreeId: WT,
+        terminalTitle: 'codex [working]',
+        stateHistory: []
+      }
+    }
+
+    const initial = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot([workingSurface]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const mirroredId = initial.tabsByWorktree?.[WT]?.[0]?.id
+    const mirroredPaneKey = makePaneKey(mirroredId!, LEAF_ID)
+    expect(initial.agentStatusByPaneKey?.[mirroredPaneKey]?.state).toBe('working')
+
+    // Same pane, still present — the host just has no live handle to report status from.
+    const next = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: initial.tabsByWorktree,
+        agentStatusByPaneKey: initial.agentStatusByPaneKey,
+        agentStatusEpoch: initial.agentStatusEpoch ?? 0,
+        ptyIdsByTabId: initial.ptyIdsByTabId
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'Terminal',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: false,
+          status: 'pending-handle',
+          terminal: null
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState> | null
+
+    const retained = (next?.agentStatusByPaneKey ?? initial.agentStatusByPaneKey)?.[mirroredPaneKey]
+    expect(retained?.state).toBe('working')
+  })
+
+  it('still clears agent status when a streamed pane reports none (stuck spinner guard)', () => {
+    // A `ready` pane the host IS streaming genuinely has no agent — a shell reclaimed it.
+    // That must still prune, or #1437 comes back for mirrored panes.
+    const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
+    const initial = applyWebSessionTabsSnapshot(
+      makeState(),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'codex [working]',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1',
+          agentStatus: {
+            state: 'working',
+            prompt: 'fix web parity',
+            updatedAt: NOW - 100,
+            stateStartedAt: NOW - 1_000,
+            agentType: 'codex',
+            paneKey: hostPaneKey,
+            tabId: 'host-tab-1',
+            worktreeId: WT,
+            terminalTitle: 'codex [working]',
+            stateHistory: []
+          }
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    const mirroredId = initial.tabsByWorktree?.[WT]?.[0]?.id
+    const mirroredPaneKey = makePaneKey(mirroredId!, LEAF_ID)
+
+    const next = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: initial.tabsByWorktree,
+        agentStatusByPaneKey: initial.agentStatusByPaneKey,
+        agentStatusEpoch: initial.agentStatusEpoch ?? 0,
+        ptyIdsByTabId: initial.ptyIdsByTabId
+      }),
+      makeSnapshot([
+        {
+          type: 'terminal',
+          id: HOST_SURFACE_ID,
+          title: 'gal@omarchy: ~/dev',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState> | null
+
+    expect(next?.agentStatusByPaneKey?.[mirroredPaneKey]).toBeUndefined()
+  })
+
   it('repairs mirrored same-state attribution and retains identity from an older snapshot', () => {
     const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
     const snapshot = makeSnapshot([

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -2694,16 +2694,72 @@ export function applyWebSessionTabsStorePatch(
   buildPatch: (state: AppState) => WebSessionTabsSyncState | Partial<WebSessionTabsSyncState>
 ): void {
   let mirroredAgentStatusChanged = false
+  let observedStatuses: { paneKey: string; worktreeId: string; entry: AgentStatusEntry }[] = []
   useAppStore.setState((state) => {
     const patch = buildPatch(state)
     mirroredAgentStatusChanged =
       patch !== state && Object.prototype.hasOwnProperty.call(patch, 'agentStatusByPaneKey')
+    if (mirroredAgentStatusChanged) {
+      observedStatuses = collectChangedMirroredAgentStatuses(
+        state.agentStatusByPaneKey,
+        (patch as Partial<WebSessionTabsSyncState>).agentStatusByPaneKey ?? {}
+      )
+    }
     return patch
   })
   // Why: paired-web snapshots bypass setAgentStatus, so arm the stale-boundary timer explicitly like local hook events do.
   if (mirroredAgentStatusChanged) {
     useAppStore.getState().scheduleAgentStatusFreshness()
   }
+  // Why: a remote `orca serve` host has no ingestRemote path (only SSH and WSL do), so its
+  // agent hooks never reach the local main-process IPC that drives completion
+  // notifications. The mirror is the only carrier, so feed it the same observer the local
+  // hook path uses — on every changed status, not just completions, so the coordinator
+  // sees the working->done sequence it needs rather than a bare terminal `done`.
+  if (observedStatuses.length > 0) {
+    // Why lazy: a static import of the notification observer pulls the terminal-pane and
+    // store graph in ahead of this module and deadlocks initialization (the store's
+    // getState is undefined at module scope). Notifications are fire-and-forget, so
+    // resolving the module on first use is harmless.
+    void import('@/hooks/agent-hook-completion-notifications')
+      .then(({ observeAgentHookCompletionForNotification }) => {
+        for (const observed of observedStatuses) {
+          observeAgentHookCompletionForNotification({
+            paneKey: observed.paneKey,
+            worktreeId: observed.worktreeId,
+            payload: observed.entry
+          })
+        }
+      })
+      .catch(() => {
+        // Best-effort: a missing notification must never break snapshot application.
+      })
+  }
+}
+
+/** Mirrored pane statuses that actually changed, so the notification observer sees each
+ *  transition once rather than on every republished snapshot. */
+function collectChangedMirroredAgentStatuses(
+  previous: Readonly<Record<string, AgentStatusEntry>>,
+  next: Readonly<Record<string, AgentStatusEntry>>
+): { paneKey: string; worktreeId: string; entry: AgentStatusEntry }[] {
+  const changed: { paneKey: string; worktreeId: string; entry: AgentStatusEntry }[] = []
+  for (const [paneKey, entry] of Object.entries(next)) {
+    const parsed = parsePaneKey(paneKey)
+    if (!parsed || !isWebTerminalSurfaceTabId(parsed.tabId)) {
+      continue
+    }
+    const worktreeId = entry.worktreeId
+    if (!worktreeId) {
+      continue
+    }
+    const before = previous[paneKey]
+    if (before && agentStatusEntryEqual(before, entry)) {
+      continue
+    }
+    changed.push({ paneKey, worktreeId, entry })
+  }
+  return changed
 }
 
 export function useWebSessionTabsSync(): void {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -738,10 +738,22 @@ function buildMirroredAgentStatusPatch(
     }
   }
   const nextByPaneKey = new Map<string, AgentStatusEntry>()
+  // Why: a pane the host has no live handle for carries no agentStatus, and that is
+  // "unknown", not "idle" — pruning on it made a running agent render as done the moment
+  // its tab lost focus. Scoped to `pending-handle` on purpose: a `ready` pane the host IS
+  // streaming genuinely has no agent, and must still prune so a shell that reclaimed the
+  // pane clears its spinner (#1437).
+  const unreportedPaneKeys = new Set<string>()
   for (const surface of terminalSurfaceTabs) {
     const retainedSurface = retainedSurfaceByHostTabAndPrunedLeafId
       ?.get(surface.parentTabId)
       ?.get(surface.leafId)
+    if (!surface.agentStatus && surface.status === 'pending-handle') {
+      const unreportedPaneKey = toMirroredPaneKey(surface, retainedSurface?.leafId)
+      if (unreportedPaneKey) {
+        unreportedPaneKeys.add(unreportedPaneKey)
+      }
+    }
     const entry = remapHostAgentStatus(surface, retainedSurface)
     if (!entry) {
       continue
@@ -778,6 +790,11 @@ function buildMirroredAgentStatusPatch(
       continue
     }
     if (nextByPaneKey.has(paneKey)) {
+      continue
+    }
+    // Why: the host has no live handle for this pane, so it reported no status.
+    // Keep what we know rather than reading silence as "the agent stopped".
+    if (unreportedPaneKeys.has(paneKey)) {
       continue
     }
     if (nextAgentStatusByPaneKey === state.agentStatusByPaneKey) {


### PR DESCRIPTION
> **Stacked on #12044.** Branched off it, so its diff appears here too. Review/merge that one first; this PR's own change is the last commit (`fix(remote): deliver agent completion notifications from serve hosts`).

## Problem

An agent finishing on a remote `orca serve` host produces no desktop notification. Local sessions always work.

## Cause

**Nothing was wired.** `observeAgentHookCompletionForNotification` is called from exactly one place — the local main-process hook IPC path. `ingestRemote` covers SSH and WSL but not serve, so a serve host's hooks never reach that IPC. Remote agent status arrives only through the snapshot mirror, which updates `agentStatusByPaneKey` — which is why spinners and badges *do* work remotely — but never dispatched a notification.

**Statuses were also unattributable.** The hook-only branch of `buildPtyMobileAgentStatus` derived worktree attribution from the PTY record:

```ts
...(pty?.worktreeId ? { worktreeId: pty.worktreeId } : {}),
```

A pane the host is not streaming has no PTY record, so the status went out with **no `worktreeId` at all**, and the client skips a mirrored status it cannot attribute. The `done` arrived on time and updated the spinner, then was dropped before it could notify. Switching back materialized the pane, a PTY appeared, and the notification fired tens of seconds late.

## Fix

- Feed the mirror's changed statuses to the same observer the local hook path uses.
- Fall back to the hook row's `worktreeId`, mirroring what the `retained` branch directly above already does.

Two details in the wiring are load-bearing and easy to break later:

- The observer sees **every** changed status, not just completions, so the completion coordinator observes the `working`→`done` sequence it needs rather than a bare terminal `done`.
- The import is **lazy**. A static import pulls the terminal-pane and store graph in ahead of this module and leaves `useAppStore.getState` undefined at module scope.

## Verification

Instrumented a live host and client. Before: the `done` snapshot arrived at 19:45:29 and the notification did not fire until 19:46:04, exactly when the workspace was reopened — 34.9s late. A streamed pane on the same host notified in 30ms. After: notifications arrive while the workspace is still backgrounded.

## Tests

A regression test asserts the hook-only branch carries `worktreeId` when the host holds no PTY (fails with `expected undefined` without the fix). Typecheck and the full 65-test sync suite pass.

## Notes

Adjacent and untouched: `mobileTerminalTabMatchesPty` gates the PTY lookup on an exact `pty.worktreeId === worktreeId` match, and the looser fallback beside it is disabled on headless hosts (`allowWorktreeOnlyMatch: !publicationEpoch.startsWith('headless')`). Workspaces whose id carries a suffix the PTY record was not created under therefore fail that lookup consistently — which is how this bug was first noticed. This PR removes the dependency on that lookup succeeding rather than changing it.