### PR TITLE
feat(editor): add responsive resizable Markdown tables

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -597,6 +597,9 @@
 .rich-markdown-editor .tableWrapper::-webkit-scrollbar,
 .xterm .xterm-viewport::-webkit-scrollbar {
   width: 14px;
+}
+
+.rich-markdown-editor .tableWrapper::-webkit-scrollbar {
   height: 14px;
 }
 

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -587,22 +587,27 @@
 /* ── Editor-style scrollbar (matches Monaco) ────────── */
 
 .scrollbar-editor,
+.rich-markdown-editor .tableWrapper,
 .xterm .xterm-viewport {
   scrollbar-width: thin;
   scrollbar-color: rgba(121, 121, 121, 0.4) transparent;
 }
 
 .scrollbar-editor::-webkit-scrollbar,
+.rich-markdown-editor .tableWrapper::-webkit-scrollbar,
 .xterm .xterm-viewport::-webkit-scrollbar {
   width: 14px;
+  height: 14px;
 }
 
 .scrollbar-editor::-webkit-scrollbar-track,
+.rich-markdown-editor .tableWrapper::-webkit-scrollbar-track,
 .xterm .xterm-viewport::-webkit-scrollbar-track {
   background: transparent;
 }
 
 .scrollbar-editor::-webkit-scrollbar-thumb,
+.rich-markdown-editor .tableWrapper::-webkit-scrollbar-thumb,
 .xterm .xterm-viewport::-webkit-scrollbar-thumb {
   background: rgba(121, 121, 121, 0.4);
   border: 3px solid transparent;
@@ -611,6 +616,7 @@
 }
 
 .scrollbar-editor::-webkit-scrollbar-thumb:hover,
+.rich-markdown-editor .tableWrapper::-webkit-scrollbar-thumb:hover,
 .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
   background: rgba(121, 121, 121, 0.7);
   border: 3px solid transparent;

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -802,19 +802,43 @@
   background: color-mix(in srgb, var(--foreground) 2%, transparent);
 }
 
+.rich-markdown-editor .tableWrapper {
+  width: 100%;
+  max-width: 100%;
+  margin: 1em 0;
+  overflow-x: auto;
+}
+
 .rich-markdown-editor table {
   width: 100%;
-  margin: 1em 0;
+  margin: 0;
   border-collapse: collapse;
   font-size: 0.95em;
 }
 
 .rich-markdown-editor th,
 .rich-markdown-editor td {
+  position: relative;
   padding: 8px 14px;
   border: 1px solid var(--border);
   text-align: left;
   vertical-align: top;
+}
+
+.rich-markdown-editor .column-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -2px;
+  bottom: -1px;
+  z-index: 1;
+  width: 4px;
+  background: var(--ring);
+  cursor: col-resize;
+}
+
+.rich-markdown-editor.resize-cursor,
+.rich-markdown-editor.resize-cursor * {
+  cursor: col-resize;
 }
 
 .rich-markdown-editor th {

--- a/src/renderer/src/assets/rich-markdown-table-style.test.ts
+++ b/src/renderer/src/assets/rich-markdown-table-style.test.ts
@@ -1,0 +1,38 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const editorCss = fs.readFileSync(new URL('./rich-markdown-editor.css', import.meta.url), 'utf8')
+const mainCss = fs.readFileSync(new URL('./main.css', import.meta.url), 'utf8')
+
+describe('rich Markdown table resize styling', () => {
+  it('keeps wide tables inside a local horizontal scroller', () => {
+    expect(editorCss).toMatch(
+      /\.rich-markdown-editor \.tableWrapper\s*{[^}]*width:\s*100%;[^}]*max-width:\s*100%;[^}]*margin:\s*1em 0;[^}]*overflow-x:\s*auto;/s
+    )
+    expect(editorCss).toMatch(
+      /\.rich-markdown-editor table\s*{[^}]*width:\s*100%;[^}]*margin:\s*0;/s
+    )
+  })
+
+  it('uses the native handle classes and Orca tokens', () => {
+    expect(editorCss).toMatch(
+      /\.rich-markdown-editor th,\s*\.rich-markdown-editor td\s*{[^}]*position:\s*relative;/s
+    )
+    expect(editorCss).toMatch(
+      /\.rich-markdown-editor \.column-resize-handle\s*{[^}]*width:\s*4px;[^}]*background:\s*var\(--ring\);[^}]*cursor:\s*col-resize;/s
+    )
+    expect(editorCss).toMatch(
+      /\.rich-markdown-editor\.resize-cursor,\s*\.rich-markdown-editor\.resize-cursor \*\s*{[^}]*cursor:\s*col-resize;/s
+    )
+    expect(editorCss).not.toMatch(/\.column-resize-handle[^}]*#[0-9a-f]{3,8}/i)
+  })
+
+  it('reuses the canonical editor scrollbar selectors', () => {
+    expect(mainCss).toMatch(
+      /\.scrollbar-editor,\s*\.rich-markdown-editor \.tableWrapper,\s*\.xterm \.xterm-viewport\s*{/s
+    )
+    expect(mainCss).toMatch(
+      /\.scrollbar-editor::-webkit-scrollbar,\s*\.rich-markdown-editor \.tableWrapper::-webkit-scrollbar,\s*\.xterm \.xterm-viewport::-webkit-scrollbar\s*{[^}]*height:\s*14px;/s
+    )
+  })
+})

--- a/src/renderer/src/assets/rich-markdown-table-style.test.ts
+++ b/src/renderer/src/assets/rich-markdown-table-style.test.ts
@@ -27,12 +27,17 @@ describe('rich Markdown table resize styling', () => {
     expect(editorCss).not.toMatch(/\.column-resize-handle[^}]*#[0-9a-f]{3,8}/i)
   })
 
-  it('reuses the canonical editor scrollbar selectors', () => {
+  it('keeps horizontal scrollbar sizing scoped to rich Markdown tables', () => {
     expect(mainCss).toMatch(
       /\.scrollbar-editor,\s*\.rich-markdown-editor \.tableWrapper,\s*\.xterm \.xterm-viewport\s*{/s
     )
+    const sharedScrollbarRule = mainCss.match(
+      /\.scrollbar-editor::-webkit-scrollbar,\s*\.rich-markdown-editor \.tableWrapper::-webkit-scrollbar,\s*\.xterm \.xterm-viewport::-webkit-scrollbar\s*{([^}]*)}/s
+    )
+    expect(sharedScrollbarRule?.[1]).toContain('width: 14px')
+    expect(sharedScrollbarRule?.[1]).not.toContain('height:')
     expect(mainCss).toMatch(
-      /\.scrollbar-editor::-webkit-scrollbar,\s*\.rich-markdown-editor \.tableWrapper::-webkit-scrollbar,\s*\.xterm \.xterm-viewport::-webkit-scrollbar\s*{[^}]*height:\s*14px;/s
+      /\.rich-markdown-editor \.tableWrapper::-webkit-scrollbar\s*{[^}]*height:\s*14px;/s
     )
   })
 })

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -196,7 +196,9 @@ export function createRichMarkdownExtensions({
     }),
     ...createOrcaDetailsExtensions(),
     Table.configure({
-      resizable: false
+      resizable: true,
+      renderWrapper: true,
+      cellMinWidth: 96
     }),
     TableRow,
     TableHeader,

--- a/src/renderer/src/components/editor/rich-markdown-table-resize.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-table-resize.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import { Editor } from '@tiptap/core'
+import { afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+
+const TABLE = `| A | B |
+| --- | --- |
+| alpha | beta |
+`
+
+function createEditor(content = TABLE): Editor {
+  const element = document.createElement('div')
+  document.body.appendChild(element)
+  return new Editor({
+    element,
+    extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+    content,
+    contentType: 'markdown'
+  })
+}
+
+function firstCellPosition(editor: Editor): number {
+  let position: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (!node.isText || node.text !== 'A') {
+      return true
+    }
+    position = pos
+    return false
+  })
+  if (position === null) {
+    throw new Error('Expected a table header cell')
+  }
+  return position
+}
+
+beforeAll(() => {
+  document.open()
+  document.write('<!doctype html><html><body></body></html>')
+  document.close()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('rich Markdown table resizing', () => {
+  it('configures TipTap native resizing with a stable wrapper and minimum width', () => {
+    const extensions = createRichMarkdownExtensions({
+      codec: createRichMarkdownEditorCodec()
+    })
+    const table = extensions.find((extension) => extension.name === 'table')
+
+    expect(table?.options).toMatchObject({
+      resizable: true,
+      renderWrapper: true,
+      cellMinWidth: 96
+    })
+
+    const editor = createEditor()
+    try {
+      expect(editor.view.dom.querySelector('.tableWrapper')).not.toBeNull()
+      expect(editor.view.dom.querySelectorAll('colgroup > col')).toHaveLength(2)
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('keeps resized column widths in memory and out of serialized Markdown', () => {
+    const editor = createEditor()
+    try {
+      editor.commands.setTextSelection(firstCellPosition(editor))
+      const before = editor.getMarkdown()
+
+      expect(editor.commands.setCellAttribute('colwidth', [160])).toBe(true)
+      expect((editor.view.dom.querySelector('col') as HTMLElement | null)?.style.width).toBe(
+        '160px'
+      )
+      const after = editor.getMarkdown()
+      expect(after).toBe(before)
+
+      const reopened = createEditor(after)
+      try {
+        expect((reopened.view.dom.querySelector('col') as HTMLElement | null)?.style.width).not.toBe(
+          '160px'
+        )
+      } finally {
+        reopened.destroy()
+      }
+    } finally {
+      editor.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Part of #11901.

- keep wide rich Markdown tables inside a table-local horizontal scroller
- let users resize columns by dragging TipTap's native column boundaries
- keep resized widths session-only so Markdown source is not rewritten with Orca-specific width metadata
- reuse the existing editor scrollbar treatment and design tokens

This is intentionally separate from #11985, which covers adding and deleting rows and columns for #11580.

## Screenshots

Windows manual verification recording:

https://github.com/user-attachments/assets/6b872a0b-b2fa-4814-b5c4-d6a41aea8596

Verified on Windows:

- wide tables stay inside a table-local horizontal scroller
- columns can be resized by dragging their boundaries
- narrow tables continue to render normally
- resizing does not add width metadata to Markdown source
- resized widths reset after reopening the document, as intended

## Testing

- [ ] `pnpm lint` — all code-quality, reliability, max-lines, bundled-guide, and localization checks reached by the command pass; the aggregate command stops on pre-existing stale `resources/skills/{current-manifest,snapshot-registry,release-mapping}.json` artifacts on current `main`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 59/59 focused editor tests pass; the full Windows suite reports 287 unrelated baseline failures dominated by PTY, SSH, `/bin/sh`, path-separator, and source-boundary cases
- [x] `pnpm build`
- [x] Added regression coverage for native resize configuration, wrapper/colgroup rendering, in-memory column widths, Markdown non-persistence, table-local overflow, resize handles, and scrollbar reuse

Focused command:

```text
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-table-resize.test.ts src/renderer/src/components/editor/rich-markdown-table-keyboard.test.ts src/renderer/src/components/editor/markdown-round-trip.test.ts src/renderer/src/assets/rich-markdown-table-style.test.ts
```

Result: 4 files passed, 59 tests passed.

Additional passing checks:

- `pnpm run audit:code-quality:native`
- `pnpm run audit:code-quality:type-aware`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- localization catalog, extraction, and coverage checks
- `git diff --check upstream/main...HEAD`

## AI Review Report

Reviewed the implementation against #11901's responsive table and drag-resize requirements. The review checked:

- TipTap 3.22.4's native `TableView` is used rather than a custom node view
- `cellMinWidth` is fixed at 96 px
- column widths remain ProseMirror session state and are absent from serialized Markdown
- existing Tab/Shift-Tab and Markdown round-trip behavior remain covered
- the generated table wrapper contains overflow without widening the editor
- resize styling uses existing `--border` and `--ring` tokens and the canonical editor scrollbar rules
- no platform-specific shortcuts, labels, paths, shell behavior, IPC, or Electron process behavior were added for macOS, Linux, or Windows

No implementation issue was found in the focused review. The branch was rebased onto current `upstream/main` before publication.

## Security Audit

- no new IPC, permissions, persistence, network calls, dependencies, command execution, path handling, auth, secret handling, or untrusted evaluation
- resize interactions update only the active ProseMirror table transaction and TipTap node view
- Markdown output is explicitly regression-tested to remain free of width metadata

## Notes

- resized widths intentionally reset when the document is reopened
- Windows automated and manual pointer verification are complete; macOS/Linux manual verification is not claimed
- #11985 remains unchanged and can be reviewed independently
