### PR TITLE
fix(terminal): require a physical Enter for the Windows IME Process key

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -325,6 +325,7 @@ describe('isTerminalImeProcessEnter', () => {
   const event = (overrides: Partial<KeyboardEvent> = {}) =>
     ({
       key: 'Process',
+      code: 'Enter',
       keyCode: 229,
       metaKey: false,
       ctrlKey: false,
@@ -340,6 +341,10 @@ describe('isTerminalImeProcessEnter', () => {
     }
   )
 
+  it('recognizes the numeric keypad Enter', () => {
+    expect(isTerminalImeProcessEnter(event({ code: 'NumpadEnter' }))).toBe(true)
+  })
+
   it.each([
     { key: 'Enter' },
     { keyCode: 13 },
@@ -348,6 +353,20 @@ describe('isTerminalImeProcessEnter', () => {
     { altKey: true }
   ])('rejects a non-IME or ambiguous Process key', (override) => {
     expect(isTerminalImeProcessEnter(event(override))).toBe(false)
+  })
+
+  // Regression: a Korean double consonant is Shift + a jamo key. The IME masks
+  // key/keyCode to Process/229 exactly as it does for Enter, so without the
+  // physical-key check the syllable was synthesized into Shift+Enter and a
+  // newline was sent mid-word.
+  it.each([
+    { code: 'KeyT', jamo: 'ㅆ' },
+    { code: 'KeyR', jamo: 'ㄲ' },
+    { code: 'KeyE', jamo: 'ㄸ' },
+    { code: 'KeyQ', jamo: 'ㅃ' },
+    { code: 'KeyW', jamo: 'ㅉ' }
+  ])('rejects Shift+$jamo typed on $code, which is not a physical Enter', ({ code }) => {
+    expect(isTerminalImeProcessEnter(event({ code, shiftKey: true }))).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -107,11 +107,20 @@ export function getTerminalImeModifiedEnterKind(
 }
 
 export function isTerminalImeProcessEnter(
-  event: Pick<KeyboardEvent, 'key' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+  event: Pick<
+    KeyboardEvent,
+    'key' | 'code' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'
+  >
 ): boolean {
   return (
     event.key === 'Process' &&
     event.keyCode === 229 &&
+    // key/keyCode are masked to Process/229 for *every* keystroke the IME
+    // consumes, not just Enter, so they cannot identify the key on their own.
+    // code reports the physical key and is not masked by the IME, which keeps a
+    // Shift+jamo (Korean double consonants ㄲ ㄸ ㅃ ㅆ ㅉ) from being mistaken
+    // for Shift+Enter and emitting a newline mid-word.
+    (event.code === 'Enter' || event.code === 'NumpadEnter') &&
     getTerminalImeModifiedEnterKind(event) !== null
   )
 }


### PR DESCRIPTION
Fixes #11878.

## The bug

On Windows, typing a Korean double consonant (쌍자음 — `ㄲ ㄸ ㅃ ㅆ ㅉ`, all of which are **Shift + a jamo key**) inserts a newline into the terminal mid-word. No Enter is pressed. English input is unaffected.

```
orca 에서 [\n] 쓰고 [\n] 있는데      <- breaks land right before 쓰/있 (ㅆ)
줄뀜 [\n] 자꾸                       <- ㄲ
에디트할라고 [\n] 뜨는데              <- ㄸ
```

## Root cause

```ts
export function isTerminalImeProcessEnter(event) {
  return (
    event.key === 'Process' &&
    event.keyCode === 229 &&
    getTerminalImeModifiedEnterKind(event) !== null
  )
}
```

`key === 'Process'` / `keyCode === 229` is the generic signal Windows raises for **every** keystroke an IME consumes — it is not specific to Enter. The predicate therefore has no idea which key was actually pressed.

Pressing Shift + a jamo during composition raises precisely that event with `shiftKey: true`, so:

1. `getTerminalImeModifiedEnterKind(event)` returns `'shift'` (not null)
2. `isTerminalImeProcessEnter(event)` returns **true**
3. `keyboard-handlers.ts:502` sets `imeProcessEnter`, and the handler synthesizes a fake `{ key: 'Enter', shiftKey: true }`
4. `resolveShortcutEvent` resolves that to `sendInput`, and `deferredNewlineSender.defer(...)` writes a Shift+Enter newline to the pty

## The fix

`event.code` reports the **physical** key and is not masked by the IME. A jamo reports `KeyT`/`KeyR`/`KeyE`/…; only a real Enter reports `Enter` or `NumpadEnter`. Gating on it lets the rest of the IME Enter machinery work unchanged.

Worth noting the existing handler tests in `keyboard-handlers-ime.test.tsx` already build their Process events with `code: 'Enter'` — the data needed to disambiguate was there, the predicate just never looked at it.

## Tests

- `terminal-ime-deferred-newline.test.ts`: added `code: 'Enter'` to the `isTerminalImeProcessEnter` event factory, a `NumpadEnter` acceptance case, and a regression table asserting Shift + each of the five double consonants is rejected.
- `keyboard-handlers-ime.test.tsx` needs no change (already sets `code: 'Enter'`).

**I was not able to run the suite locally** — this was developed against the shipped bundle on a Windows box without the full pnpm workspace installed, so please let CI verify. The change is confined to one predicate and its direct tests.

## Verification

Verified by byte-patching the released 1.4.163 `app.asar` with the equivalent change (swapping the `keyCode === 229` probe for the `code === 'Enter'` check) and restarting Orca: Korean input became correct immediately, and the newline injection stopped. An earlier attempt that instead cleared the stale-modifier fallback in `getImeEnterModifier()` had **no effect**, because that path is bypassed whenever `event.shiftKey` is genuinely true — which it is while Shift is held for the double consonant.
