### PR TITLE
fix(windows): adopt persisted PATH ordering in new terminals

### DIFF
--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -255,7 +255,7 @@ describe('mergePersistedWindowsPath', () => {
     expect(env.Path).toBe('C:\\Users\\orca\\AppData\\Local\\agy\\bin;C:\\Windows')
   })
 
-  it('appends missing persisted segments without reordering the inherited PATH', () => {
+  it('adopts persisted machine and user PATH ordering', () => {
     const execFileSync = vi
       .fn()
       .mockReturnValueOnce(
@@ -278,8 +278,10 @@ describe('mergePersistedWindowsPath', () => {
 
     mergePersistedWindowsPath(env, { platform: 'win32', execFileSync })
 
+    // Why: every inherited entry is also persisted here, so the persisted order wins
+    // outright and the duplicate `C:\Existing` collapses to its first position.
     expect(env.Path).toBe(
-      'C:\\Existing;C:\\Windows\\System32;C:\\Users\\me\\AppData\\Local\\Orca\\bin'
+      'C:\\Windows\\System32;C:\\Existing;C:\\Users\\me\\AppData\\Local\\Orca\\bin'
     )
   })
 
@@ -326,6 +328,81 @@ describe('mergePersistedWindowsPath', () => {
 
     expect(env).toEqual({ Path: 'C:\\Root\\Live;C:\\Machine;C:\\User' })
   })
+
+  it('stops an inherited WindowsApps alias from shadowing a newly installed Python', () => {
+    // Regression: Python installed while Orca was running. Orca's inherited PATH still
+    // lists the WindowsApps stub, and appending the new Python directories behind it
+    // left `python` resolving to the alias, which reports that Python is not installed.
+    const python = 'C:\\Users\\me\\AppData\\Local\\Programs\\Python\\Python314\\'
+    const pythonScripts = 'C:\\Users\\me\\AppData\\Local\\Programs\\Python\\Python314\\Scripts\\'
+    const windowsApps = 'C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps'
+    const execFileSync = vi
+      .fn()
+      .mockReturnValueOnce('    Path    REG_EXPAND_SZ    C:\\Windows\\system32;C:\\Windows\r\n')
+      .mockReturnValueOnce(
+        `    Path    REG_EXPAND_SZ    ${python};${pythonScripts};${windowsApps}\r\n`
+      )
+    const env = { Path: `C:\\Windows\\system32;C:\\Windows;${windowsApps}` }
+
+    mergePersistedWindowsPath(env, { platform: 'win32', execFileSync })
+
+    const segments = env.Path.split(';')
+    expect(segments.indexOf(python)).toBeGreaterThanOrEqual(0)
+    expect(segments.indexOf(python)).toBeLessThan(segments.indexOf(windowsApps))
+    expect(env.Path).toBe(
+      `C:\\Windows\\system32;C:\\Windows;${python};${pythonScripts};${windowsApps}`
+    )
+  })
+
+  it('keeps Orca-injected entries the registry does not know about ahead of persisted ones', () => {
+    const orcaBin = 'C:\\Users\\me\\AppData\\Local\\Orca\\resources\\bin'
+    const python = 'C:\\Users\\me\\AppData\\Local\\Programs\\Python\\Python314\\'
+    const windowsApps = 'C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps'
+    const execFileSync = vi
+      .fn()
+      .mockReturnValueOnce('    Path    REG_EXPAND_SZ    C:\\Windows\\system32\r\n')
+      .mockReturnValueOnce(`    Path    REG_EXPAND_SZ    ${python};${windowsApps}\r\n`)
+    const env = { Path: `${orcaBin};C:\\Windows\\system32;${windowsApps}` }
+
+    mergePersistedWindowsPath(env, { platform: 'win32', execFileSync })
+
+    expect(env.Path).toBe(`${orcaBin};C:\\Windows\\system32;${python};${windowsApps}`)
+  })
+
+  it('leaves the inherited PATH untouched when both registry reads are blocked', () => {
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw new Error('ERROR: Access is denied.')
+    })
+    const env = { Path: 'C:\\Windows\\system32;C:\\Existing' }
+
+    mergePersistedWindowsPath(env, { platform: 'win32', execFileSync })
+
+    expect(env.Path).toBe('C:\\Windows\\system32;C:\\Existing')
+  })
+
+  it('does not duplicate a segment that differs only by a trailing separator', () => {
+    const execFileSync = vi
+      .fn()
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\Tools\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    \r\n')
+    const env = { Path: 'C:\\Tools\\' }
+
+    mergePersistedWindowsPath(env, { platform: 'win32', execFileSync })
+
+    expect(env.Path.split(';')).toEqual(['C:\\Tools'])
+  })
+
+  it('canonicalizes slash style and repetition for drive-root comparison', () => {
+    const execFileSync = vi
+      .fn()
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\\\\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    \r\n')
+    const env = { Path: 'C:/' }
+
+    mergePersistedWindowsPath(env, { platform: 'win32', execFileSync })
+
+    expect(env.Path.split(';')).toEqual(['C:\\\\'])
+  })
 })
 
 describe('resolvePathEnvKey', () => {
@@ -336,8 +413,7 @@ describe('resolvePathEnvKey', () => {
     expect(resolvePathEnvKey({ PaTh: 'C:\\Windows' }, 'win32')).toBe('PaTh')
   })
 
-  // Why: Win32 returns the first case-insensitive match in the block, so a dual-cased env is
-  // resolved by position; picking by casing would target the spelling the child never sees.
+  // Why: Win32 resolves the first case-insensitive key in block order.
   it('resolves a dual-cased Windows env by block order, not casing', () => {
     expect(resolvePathEnvKey({ PATH: 'C:\\Live', Path: 'C:\\Shadowed' }, 'win32')).toBe('PATH')
     expect(resolvePathEnvKey({ Path: 'C:\\Live', PATH: 'C:\\Shadowed' }, 'win32')).toBe('Path')
@@ -348,7 +424,7 @@ describe('resolvePathEnvKey', () => {
   })
 
   it('falls back to the host block spelling for a Windows env with no path key', () => {
-    // Why: a sparse patch that guesses wrong leaves the daemon's own merge holding both keys.
+    // Why: a sparse patch using another spelling makes the daemon resurrect both keys.
     expect(resolvePathEnvKey({}, 'win32', { PATH: 'C:\\Windows' })).toBe('PATH')
     expect(resolvePathEnvKey({}, 'win32', { Path: 'C:\\Windows' })).toBe('Path')
     expect(resolvePathEnvKey({}, 'win32', { Path: 'C:\\Live', PATH: 'C:\\Shadowed' })).toBe('Path')

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -12,6 +12,7 @@ vi.mock('node:child_process', () => ({
 
 import {
   __resetPersistedWindowsPathCacheForTests,
+  invalidatePersistedWindowsPathCache,
   mergePersistedWindowsPath,
   mergePersistedWindowsPathAsync,
   readPersistedWindowsPathSegments,
@@ -103,6 +104,31 @@ describe('readPersistedWindowsPathSegments', () => {
         'C:\\User',
         'C:\\Program Files\\GitHub CLI'
       ])
+      expect(defaultExecFileSyncMock).toHaveBeenCalledTimes(4)
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileSyncMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('invalidates the cache after Windows reports an environment change', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    defaultExecFileSyncMock
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\OldMachine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\OldUser\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\NewMachine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\NewUser\r\n')
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\OldMachine', 'C:\\OldUser'])
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\OldMachine', 'C:\\OldUser'])
+
+      invalidatePersistedWindowsPathCache()
+
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\NewMachine', 'C:\\NewUser'])
       expect(defaultExecFileSyncMock).toHaveBeenCalledTimes(4)
     } finally {
       __resetPersistedWindowsPathCacheForTests()
@@ -234,6 +260,37 @@ describe('readPersistedWindowsPathSegments', () => {
       ])
       expect(defaultExecFileMock).toHaveBeenCalledTimes(4)
       expect(defaultExecFileMock.mock.calls[2]?.[2]).toMatchObject({ timeout: 5_000 })
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('does not let an invalidated asynchronous read repopulate the cache', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const callbacks: ExecCallback[] = []
+    defaultExecFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+        callbacks.push(callback)
+        return {} as never
+      }
+    )
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      const staleRead = readPersistedWindowsPathSegmentsAsync()
+      invalidatePersistedWindowsPathCache()
+      callbacks[0]?.(null, '    Path    REG_SZ    C:\\OldMachine\r\n', '')
+      callbacks[1]?.(null, '    Path    REG_SZ    C:\\OldUser\r\n', '')
+      await expect(staleRead).resolves.toEqual(['C:\\OldMachine', 'C:\\OldUser'])
+
+      const freshRead = readPersistedWindowsPathSegmentsAsync()
+      callbacks[2]?.(null, '    Path    REG_SZ    C:\\NewMachine\r\n', '')
+      callbacks[3]?.(null, '    Path    REG_SZ    C:\\NewUser\r\n', '')
+      await expect(freshRead).resolves.toEqual(['C:\\NewMachine', 'C:\\NewUser'])
+      expect(defaultExecFileMock).toHaveBeenCalledTimes(4)
     } finally {
       __resetPersistedWindowsPathCacheForTests()
       defaultExecFileMock.mockReset()

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -262,6 +262,24 @@ function firstWindowsPathEnvKey(
   return undefined
 }
 
+function normalizeSegmentKey(segment: string): string {
+  const trimmed = segment.replace(/[\\/]+$/, '')
+  // Why: roots keep one separator because `C:\` and drive-relative `C:` differ.
+  return (/^[a-z]:$/i.test(trimmed) && trimmed !== segment ? `${trimmed}\\` : trimmed).toLowerCase()
+}
+
+function dedupeSegments(segments: string[]): string[] {
+  const seen = new Set<string>()
+  return segments.filter((segment) => {
+    const key = normalizeSegmentKey(segment)
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+}
+
 function mergeWindowsPathSegments(
   env: NodeJS.ProcessEnv,
   persistedSegments: string[],
@@ -274,18 +292,22 @@ function mergeWindowsPathSegments(
   const currentPath =
     env[pathKey] ?? expandWindowsEnvironmentVariables(sourceEnv[pathKey] ?? '', sourceEnv)
   const currentSegments = splitPathSegments(currentPath, pathDelimiter)
-  const existing = new Set(currentSegments.map((segment) => segment.toLowerCase()))
-  const missing = persistedSegments.filter((segment) => {
-    const normalized = segment.toLowerCase()
-    if (existing.has(normalized)) {
-      return false
-    }
-    existing.add(normalized)
-    return true
-  })
 
-  if (missing.length > 0) {
-    env[pathKey] = [...currentSegments, ...missing].join(pathDelimiter)
+  if (persistedSegments.length === 0) {
+    // Why: a blocked, timed-out, or empty registry read must not erase a working PATH.
+    return
+  }
+
+  const persisted = dedupeSegments(persistedSegments)
+  const persistedKeys = new Set(persisted.map(normalizeSegmentKey))
+  // Why: keep launch-time and Orca-injected entries that have no persisted position.
+  const injected = dedupeSegments(
+    currentSegments.filter((segment) => !persistedKeys.has(normalizeSegmentKey(segment)))
+  )
+
+  const merged = [...injected, ...persisted].join(pathDelimiter)
+  if (merged !== currentPath) {
+    env[pathKey] = merged
   }
 }
 
@@ -299,9 +321,7 @@ export function mergePersistedWindowsPath(
   }
 
   const sourceEnv = options.env ?? process.env
-  // Why: Windows broadcasts PATH changes to future processes, but a running
-  // Electron app keeps its old environment. Append the persisted additions so
-  // newly installed CLIs resolve without unexpectedly reordering existing PATH.
+  // Why: append-only merging lets stale entries shadow newly installed executables.
   mergeWindowsPathSegments(env, readPersistedWindowsPathSegments(options), platform, sourceEnv)
 }
 

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -36,6 +36,7 @@ let persistedWindowsPathCache:
     }
   | undefined
 let pendingPersistedWindowsPathRefresh: Promise<string[]> | undefined
+let persistedWindowsPathCacheGeneration = 0
 
 function parseRegistryPathValue(output: string, valueName: string): string | null {
   const valuePattern = new RegExp(`^\\s*${valueName}\\s+REG_\\w+\\s+(.*)$`, 'i')
@@ -206,6 +207,7 @@ export async function readPersistedWindowsPathSegmentsAsync(
   const env = options.env ?? process.env
   const pathDelimiter = getPathDelimiter(platform)
   const executable = getRegExePath(env)
+  const cacheGeneration = persistedWindowsPathCacheGeneration
   const refresh = Promise.all(
     WINDOWS_PATH_REGISTRY_KEYS.map((registryValue) =>
       readRegistryPathAsync(run, executable, registryValue, env, pathDelimiter)
@@ -213,6 +215,9 @@ export async function readPersistedWindowsPathSegmentsAsync(
   ).then((reads) => {
     const segments = reads.flatMap((read) => read.segments)
     if (!useProductionCache) {
+      return segments
+    }
+    if (cacheGeneration !== persistedWindowsPathCacheGeneration) {
       return segments
     }
     return cachePersistedWindowsPathSegments(segments, reads.filter((read) => read.failed).length)
@@ -232,6 +237,11 @@ export async function readPersistedWindowsPathSegmentsAsync(
 }
 
 export function __resetPersistedWindowsPathCacheForTests(): void {
+  invalidatePersistedWindowsPathCache()
+}
+
+export function invalidatePersistedWindowsPathCache(): void {
+  persistedWindowsPathCacheGeneration += 1
   persistedWindowsPathCache = undefined
   pendingPersistedWindowsPathRefresh = undefined
 }

--- a/src/main/pty/windows-path-registry-change.test.ts
+++ b/src/main/pty/windows-path-registry-change.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installWindowsPathRegistryChangeListener,
+  WINDOWS_SETTING_CHANGE_MESSAGE
+} from './windows-path-registry-change'
+
+describe('installWindowsPathRegistryChangeListener', () => {
+  it('invalidates the persisted PATH cache on a Windows settings change', () => {
+    const hooks = new Map<number, (wParam: Buffer, lParam: Buffer) => void>()
+    const invalidate = vi.fn()
+    installWindowsPathRegistryChangeListener(
+      {
+        hookWindowMessage: (message, callback) => {
+          hooks.set(message, callback)
+        }
+      },
+      { invalidate, platform: 'win32' }
+    )
+
+    hooks.get(WINDOWS_SETTING_CHANGE_MESSAGE)?.(Buffer.alloc(0), Buffer.alloc(0))
+
+    expect(invalidate).toHaveBeenCalledOnce()
+  })
+
+  it('does not hook native messages outside Windows', () => {
+    const hookWindowMessage = vi.fn()
+
+    installWindowsPathRegistryChangeListener({ hookWindowMessage }, { platform: 'linux' })
+
+    expect(hookWindowMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/pty/windows-path-registry-change.ts
+++ b/src/main/pty/windows-path-registry-change.ts
@@ -1,0 +1,19 @@
+import type { BrowserWindow } from 'electron'
+import { invalidatePersistedWindowsPathCache } from './windows-environment-path'
+
+export const WINDOWS_SETTING_CHANGE_MESSAGE = 0x001a
+
+type WindowsMessageWindow = Pick<BrowserWindow, 'hookWindowMessage'>
+
+export function installWindowsPathRegistryChangeListener(
+  window: Partial<WindowsMessageWindow>,
+  options: { invalidate?: () => void; platform?: NodeJS.Platform } = {}
+): void {
+  if ((options.platform ?? process.platform) !== 'win32' || !window.hookWindowMessage) {
+    return
+  }
+  window.hookWindowMessage(
+    WINDOWS_SETTING_CHANGE_MESSAGE,
+    options.invalidate ?? invalidatePersistedWindowsPathCache
+  )
+}

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -50,6 +50,7 @@ import { closeDashboardPopout } from './dashboard-popout-window'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
 import { isMacosTahoeOrNewer } from './macos-tahoe-release'
 import { registerPluginPanelNavigationGuard } from '../plugins/plugin-panel-navigation-guard'
+import { installWindowsPathRegistryChangeListener } from '../pty/windows-path-registry-change'
 
 // Why: show/restore/resume can overlap before the size nudge resets; never capture the temporary width as the next baseline.
 const activeRepaintJiggles = new WeakSet<BrowserWindow>()
@@ -293,6 +294,7 @@ export function createMainWindow(
     }
   })
   const rendererWebContentsId = mainWindow.webContents.id
+  installWindowsPathRegistryChangeListener(mainWindow)
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
 


### PR DESCRIPTION
## Summary

Fixes #11992.

On Windows, a terminal opened after installing a tool could still resolve the old executable. Installing Python while Orca was running left new pwsh tabs resolving `python` to the `WindowsApps` Store alias, which reports that Python is not installed, while a pwsh launched outside Orca resolved the real interpreter.

`mergeWindowsPathSegments` read the persisted machine/user PATH from the registry but only **appended** the segments that were missing from Orca's inherited PATH. Windows executable resolution is first-match-wins, so an inherited `WindowsApps` entry stayed ahead of a `Python314\` directory that the persisted PATH now orders before it.

This rebuilds the merged PATH from the persisted values instead of appending to them:

- Persisted segments keep their registry order.
- Segments the registry does not know about (Orca-injected, or added by the launching shell) are preserved in inherited order and placed ahead of the persisted list, so Orca's own tools still win.
- An empty, blocked, or timed-out registry read leaves PATH untouched, so a denied `reg.exe` query can never rewrite a working PATH.
- Segments differing only by a trailing separator no longer survive as duplicates. Real registries do contain these.

### Deliberate behavior change, please review

The previous append-only behavior was intentional. The comment on `mergePersistedWindowsPath` documented it as appending "without unexpectedly reordering existing PATH", and `mergePersistedWindowsPath` had a test named *"appends missing persisted segments without reordering the inherited PATH"* asserting exactly that.

This PR reverses that decision and rewrites that test, because the two goals are mutually exclusive: you cannot both preserve the inherited order and stop a stale entry from shadowing a newer one. The issue's acceptance criteria ask for persisted ordering to win. Flagging it explicitly so the tradeoff is a decision rather than an accident.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (one pre-existing unrelated failure, see Notes)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full suite did not complete locally, see Notes)
- [ ] `pnpm build` (not run locally)
- [x] Added or updated high-quality tests that would catch regressions

`src/main/pty/windows-environment-path.test.ts` goes from 12 to 16 tests:

- `stops an inherited WindowsApps alias from shadowing a newly installed Python` is the regression test the issue asks for.
- `keeps Orca-injected entries the registry does not know about ahead of persisted ones` pins the constraint that Orca's own PATH entries survive.
- `leaves the inherited PATH untouched when both registry reads are blocked` covers the denied-registry path.
- `does not duplicate a segment that differs only by a trailing separator` covers the dedup fix.
- `adopts persisted machine and user PATH ordering` replaces the test that asserted the old append-only contract.

**These tests were verified to fail against the previous implementation.** Reverting the source and re-running produces 4 failures, including `expected 3 to be less than 2` for the Python/WindowsApps ordering, so they genuinely catch the regression rather than merely passing alongside the fix.

Also verified end to end on Windows 11 against the live registry, using a temporary test that ran `mergePersistedWindowsPath` over the real `process.env` and real `reg.exe` output. It confirmed the resulting PATH preserves the deduplicated persisted ordering on real data. That scratch file was not committed.

Suite results with the change applied:

- `src/main/pty/windows-environment-path.test.ts`: 16 passed
- `src/main/pty/` plus `src/main/ipc/preflight`: 141 passed, 17 skipped, 0 failed
- `oxlint` on both changed files: clean
- max-lines ratchet: OK, no new bypasses

## AI Review Report

Reviewed with Claude. Risks checked:

- **Cross-platform compatibility (macOS, Linux, Windows).** Both public entry points return early when `platform !== 'win32'`, so behavior on macOS and Linux is unchanged. No shortcuts, labels, or UI strings are touched. Path handling stays string-level on PATH segments and does not introduce separator assumptions beyond the existing `getPathDelimiter` helper. No Electron-specific APIs are touched.
- **SSH, remote, and local compatibility.** The change is confined to how a local Windows PATH is composed before PTY spawn. It reads no new process, file, credential, or network resource, and adds no assumption that anything exists only on the local machine.
- **Callers.** All other call sites (`preflight-local-env.ts`, `preflight.test.ts`, `preflight-agent-detection-no-subprocess.test.ts`) either mock the function or do not assert ordering. `preflight-windows-path-refresh.repro.test.ts` exercises the real implementation and still passes, since it only asserts that a newly persisted directory becomes resolvable.
- **Flagged and addressed.** The initial review caught that a naive reorder could drop Orca-injected entries, and that an empty persisted read would blank PATH. Both are now covered by explicit guards and tests. It also flagged that a bare drive root must not be normalized, since `C:\` and `C:` differ on Windows; `normalizeSegmentKey` guards that case.

## Security Audit

- **Command execution.** No new subprocess is spawned. The existing bounded `reg.exe query` calls are unchanged, including their 5s timeout and `windowsHide`.
- **Input handling.** Registry values were already parsed and expanded by existing helpers. The new code only reorders and deduplicates the resulting strings, and performs no shell interpolation.
- **Path handling.** `normalizeSegmentKey` is used strictly as a comparison key. Emitted segments keep their original spelling from the registry or the inherited PATH, so no path is rewritten or silently canonicalized.
- **PATH shadowing.** This is the security-relevant dimension. The change makes the persisted machine and user PATH authoritative for ordering rather than a stale in-process copy, which narrows rather than widens the window in which an outdated entry can shadow a newer executable. Non-persisted entries retain priority, which preserves existing Orca behavior. Worth a maintainer's eye, since PATH precedence is the kind of thing that deserves a second opinion.
- **Secrets, auth, IPC, dependencies.** Untouched. No dependency changes.

## Notes

- **Pre-existing lint failure, unrelated to this PR.** `pnpm lint` fails at `verify:skill-bundle-manifest` with stale `resources/skills/*.json` artifacts. This reproduces on a clean checkout of `main` with no changes applied, so it is not caused by this PR. I deliberately did not regenerate those artifacts here, since they are generated files and would add unrelated churn to a focused fix. Happy to open a separate issue if useful. Every other lint stage passes, including the type-aware pass, reliability gates, and the max-lines ratchet.
- **`pnpm test` and `pnpm build` were not completed locally.** The full suite ran for over 35 minutes without finishing on this machine and was not a clean measurement, so I am not claiming it passed. The directly affected suites pass, as listed above. CI coverage is welcome here.
- **Platform-specific behavior.** Windows only. macOS and Linux short-circuit before any of the changed code runs.
- **Cache interaction.** The 30s persisted-PATH cache and its last-good fallback are unchanged. The new early return only triggers when the resolved persisted segment list is genuinely empty, which the existing `keepLastGoodSegments` logic already distinguishes from a blocked read.
