### PR TITLE
fix(ime): stop terminal shortcuts firing on keystrokes the IME owns

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
@@ -31,6 +31,7 @@ function keyboardEvent(
 function createHarness(): {
   deps: KeyboardHandlersDeps
   editable: HTMLInputElement
+  sendInput: ReturnType<typeof vi.fn>
   startComposition: () => void
   terminalInput: HTMLTextAreaElement
   dispose: () => void
@@ -97,6 +98,7 @@ function createHarness(): {
   return {
     deps,
     editable,
+    sendInput,
     terminalInput,
     startComposition: () => {
       terminalElement.dispatchEvent(
@@ -271,6 +273,82 @@ describe('Windows IME keyboard ownership', () => {
     harness.terminalInput.dispatchEvent(redispatch)
 
     expect(redispatch.defaultPrevented).toBe(true)
+    hook.unmount()
+    harness.dispose()
+  })
+})
+
+describe('terminal shortcuts yield to a composition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('X11; Linux x86_64')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // The chord resolves to a real control sequence, so the only thing standing between a
+  // preedit keystroke and the PTY is a composition check above the dispatch.
+  it.each([
+    { name: 'Ctrl+Backspace', init: { key: 'Backspace', code: 'Backspace', ctrlKey: true } },
+    { name: 'Alt+Backspace', init: { key: 'Backspace', code: 'Backspace', altKey: true } },
+    { name: 'Alt+ArrowLeft', init: { key: 'ArrowLeft', code: 'ArrowLeft', altKey: true } }
+  ])('does not send $name to the PTY while composing', ({ init }) => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', { ...init, keyCode: 229, timeStamp: 10, isComposing: true })
+    )
+
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('still sends Ctrl+Backspace when nothing is composing', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Backspace',
+        code: 'Backspace',
+        keyCode: 8,
+        timeStamp: 10,
+        ctrlKey: true
+      })
+    )
+
+    expect(harness.sendInput).toHaveBeenCalled()
+    hook.unmount()
+    harness.dispose()
+  })
+
+  // 'Process' means the IME already consumed this keystroke, but the non-Latin fallback
+  // re-derives the binding from event.code, so the chord matches by physical key anyway.
+  it('does not close the pane on a Ctrl+W the IME consumed', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'KeyW',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true,
+        ctrlKey: true
+      })
+    )
+
+    expect(harness.deps.onRequestClosePane).not.toHaveBeenCalled()
     hook.unmount()
     harness.dispose()
   })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -9,6 +9,7 @@ import { safeFind } from '../terminal-search-safe-find'
 import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
 import { createTerminalNativeOnlyShortcutTracker } from './terminal-native-only-shortcut'
+import { terminalShortcutIsOwnedByIme } from './terminal-shortcut-composition-guard'
 import {
   createTerminalImeDeferredNewlineSender,
   createTerminalImeModifiedEnterChordOwner,
@@ -453,6 +454,10 @@ export function useTerminalKeyboardShortcuts({
         // Chromium can drop the modifier when re-dispatching the committing Enter.
         e.preventDefault()
         e.stopImmediatePropagation()
+        return
+      }
+
+      if (terminalShortcutIsOwnedByIme(e, resolveShortcutEvent)) {
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { terminalShortcutIsOwnedByIme } from './terminal-shortcut-composition-guard'
+
+function keydown(init: KeyboardEventInit & { keyCode?: number }): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  if (init.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  return event
+}
+
+const sendInput = (): { type: string } => ({ type: 'sendInput' })
+const switchInputSource = (): { type: string } => ({ type: 'switchInputSource' })
+const noAction = (): null => null
+
+describe('terminalShortcutIsOwnedByIme', () => {
+  it.each([
+    ['isComposing', { key: 'Backspace', code: 'Backspace', ctrlKey: true, isComposing: true }],
+    ['keyCode 229', { key: 'Backspace', code: 'Backspace', ctrlKey: true, keyCode: 229 }],
+    ['key Process', { key: 'Process', code: 'KeyW', ctrlKey: true }]
+  ])('claims a chord marked by %s', (_marker, init) => {
+    expect(terminalShortcutIsOwnedByIme(keydown(init), sendInput)).toBe(true)
+  })
+
+  it('leaves an unmarked chord alone', () => {
+    const event = keydown({ key: 'Backspace', code: 'Backspace', ctrlKey: true, keyCode: 8 })
+    expect(terminalShortcutIsOwnedByIme(event, sendInput)).toBe(false)
+  })
+
+  // Both exemptions matter in the same direction: claiming them would break a path that
+  // already handles composition, rather than merely declining to fix one.
+  it('releases Enter so the send path can defer it to the commit', () => {
+    const event = keydown({ key: 'Process', code: 'Enter', keyCode: 229, isComposing: true })
+    expect(terminalShortcutIsOwnedByIme(event, sendInput)).toBe(false)
+  })
+
+  it('releases the input-source switch so the OS still receives it', () => {
+    const event = keydown({ key: 'Process', code: 'Space', ctrlKey: true, keyCode: 229 })
+    expect(terminalShortcutIsOwnedByIme(event, switchInputSource)).toBe(false)
+  })
+
+  it('claims a marked chord that resolves to nothing, so no later matcher sees it', () => {
+    const event = keydown({ key: 'Process', code: 'KeyF', ctrlKey: true, keyCode: 229 })
+    expect(terminalShortcutIsOwnedByIme(event, noAction)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.ts
@@ -1,0 +1,35 @@
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
+
+type ResolvedShortcutAction = { readonly type: string } | null
+
+/**
+ * True when an IME owns this keydown, so no terminal shortcut may act on it.
+ *
+ * The window-capture handler runs before the pane's own key handler and stops
+ * propagation on a match, so a chord resolved here is the only thing the keystroke
+ * will ever do. Ctrl+Backspace mid-preedit reaches the PTY as `\x17` and erases a word
+ * of the real command line behind the candidate window; the IME's buffer is untouched.
+ * The non-Latin fallback makes it worse by re-deriving bindings from `event.code`, so
+ * even a keystroke reported as `Process` still matches Ctrl+W and closes the pane.
+ *
+ * Two exemptions, both paths that already handle a live composition:
+ *
+ * - **Enter** — the send path defers it until the commit lands, so it must get through.
+ * - **Input-source switch** — it only hands the key back to the OS. Dropping it here
+ *   would let xterm see the chord instead and write its control byte to the PTY, which
+ *   is the very failure this guard exists to prevent.
+ *
+ * Resolution is pure, so asking for the action before deciding costs nothing.
+ */
+export function terminalShortcutIsOwnedByIme(
+  event: KeyboardEvent,
+  resolveAction: (event: KeyboardEvent) => ResolvedShortcutAction
+): boolean {
+  if (!isImeCompositionKeyDown(event)) {
+    return false
+  }
+  if (event.code === 'Enter') {
+    return false
+  }
+  return resolveAction(event)?.type !== 'switchInputSource'
+}


### PR DESCRIPTION
## Summary

The window-capture keydown handler resolved and dispatched terminal chords with no check for a live composition, so a keystroke meant for the candidate window drove a terminal action instead.

This is a pre-existing defect on `main`, not something this stack introduced — no commit in the stack touches `keyboard-handlers.ts`. It sits at the top of the stack because it is the same rule the rest of the stack enforces, stated in AGENTS.md: *guard above the key dispatch, not inside each key branch.*

## Why it reaches the user

`onKeyDown` is registered at `window` with `{capture: true}`, so it runs **before** the pane's `attachCustomKeyEventHandler`, and on a match it calls `stopImmediatePropagation()`. The pane handler never runs. Whatever this function resolves is the only thing the keystroke does.

The only composition awareness in the entire function lived inside the `sendInput` branch and covered `Enter` alone — the one key that was already handled correctly.

**Leak 1 — resolved chords go straight to the PTY.** Preedit open, user presses Ctrl+Backspace meaning "erase what I'm composing":

| chord | sent to PTY | effect |
| --- | ---: | --- |
| Ctrl+Backspace | `\x17` | erases a word of the **real** command line behind the candidate window |
| Alt+Backspace | `\x1b\x7f` | same |
| Alt+←/→ | `\x1bb` / `\x1bf` | moves the shell cursor mid-composition |
| Ctrl+←/→ (non-Mac) | word-motion | same |
| Cmd+Backspace / Cmd+Delete / Cmd+←→ (Mac) | `\x15` / `\x0b` / `\x01` / `\x05` | same |

The composition is untouched in every row — the damage lands on the line the user cannot currently see.

**Leak 2 — `Process` still matches by physical key.** `shouldUseNonLatinShortcutPhysicalFallback` returns true for `key: 'Process'` on non-darwin, because `normalizeKeyToken` returns null for it and the fallback then matches on `event.code`. So an IME-consumed Ctrl-chord still resolves against the Linux/Windows defaults: Ctrl+K clears the terminal, Ctrl+F opens search, and **Ctrl+W closes the pane** — out from under a live composition. This one is not fixed by any Enter-shaped change, which is why it is called out separately.

`terminal-shortcut-policy.ts` has no composition, `Process`, or 229 filter anywhere in it, by design — resolution is meant to be pure. The guard belongs at the dispatch, which is where this PR puts it.

## The disagreement this resolves

`xterm-bypass-policy.ts` declares Backspace, Delete and the arrows IME-owned while composing (`TERMINAL_IME_OWNED_KEYS`). The window-capture handler decided the opposite for the same physical keystroke, and because it runs first and stops propagation, it won. Two files, one keystroke, opposite answers.

## The fix

One guard, above the dispatch, in a new `terminal-shortcut-composition-guard.ts`:

```ts
if (terminalShortcutIsOwnedByIme(e, resolveShortcutEvent)) {
  return
}
```

It sits above `matchFileSearchShortcut` deliberately — that matcher calls `keybindingMatchesAction`, so leak 2 reaches it too. It sits below the Windows Enter-redispatch absorber, which handles the committing Enter (`!isComposing`) and must still run.

Two exemptions, both paths that already handle a live composition, and both of which would **break** if claimed:

- **Enter** — the `sendInput` branch defers it via `deferredNewlineSender` until the commit lands. Swallowing it here would drop the newline entirely.
- **Input-source switch** — it only arms the native-only tracker and hands the key back to the OS. Returning early instead would let xterm see the chord and write its control byte to the PTY, which is exactly the failure this guard exists to prevent.

Resolution is pure, so asking for the action before deciding costs nothing.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — full `terminal-pane` suite: **220 files / 2,919 tests**, no regressions
- [x] Added or updated high-quality tests that would catch regressions

Four new integration assertions, each of which **fails on `main` with the exact predicted symptom** and passes after:

| test | before |
| --- | --- |
| Ctrl+Backspace while composing | `sendInput` called |
| Alt+Backspace while composing | `sendInput` called |
| Alt+ArrowLeft while composing | `sendInput` called |
| Ctrl+W reported as `Process` | `onRequestClosePane` called with pane 1 |

Paired negative, passing before **and** after, proving the guard does not over-correct: **Ctrl+Backspace with nothing composing still reaches the PTY.**

Plus unit coverage for the guard itself, including both exemptions — the two cases the integration tests cannot reach, and the two where a wrong answer silently breaks a working path rather than merely failing to fix a broken one.

## Screenshots

No visual change.

## AI Review Report

- Cross-platform: no hardcoded `metaKey`. The macOS Cmd chords and the non-Mac Ctrl chords are both listed above and both covered by the same guard. The `Process` marker is the Windows/Android spelling and is handled by the shared predicate rather than re-derived here.
- The guard reuses `isImeCompositionKeyDown`, which already existed and whose doc comment already said *"Call this above the key dispatch, not inside each key branch"* — the predicate was correct, it simply was not called from the terminal's own dispatcher. It is called from ~25 text inputs across the app and, before this PR, from neither terminal key dispatcher.
- SSH and folder workspaces: keyboard-only change, no path or transport assumptions.
- Risk checked and accepted: the guard runs on every terminal keydown. It short-circuits on `isImeCompositionKeyDown` returning false, which is three field reads for the overwhelmingly common non-IME case, before any resolution happens.

## Security Audit

No auth, secrets, IPC, or filesystem surface. The change strictly *reduces* what an IME-marked keystroke can trigger.

## Notes

Base: #12037.

A second `attachCustomKeyEventHandler` — the dashboard preview terminal — has no composition policy at all and writes to a live PTY. It is a different surface and is not in this PR.

Made with [Orca](https://github.com/stablyai/orca) 🐋
