### PR TITLE
fix(ime): give the dashboard preview terminal a composition policy

### DIFF
--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import type { DashboardCardTerminalInput } from '../../../../shared/dashboard-snapshot'
+import { installPreviewTerminalKeyHandler } from './preview-terminal-key-handler'
+
+const LOCAL_MAC: DashboardCardTerminalInput = {
+  hostPlatform: 'darwin',
+  localWindowsConpty: false,
+  windowsShiftEnterEncoding: 'alt-enter',
+  kittyKeyboardAdvertised: true
+}
+
+function installHandler(): {
+  handle: (event: KeyboardEvent) => boolean
+  sendInput: ReturnType<typeof vi.fn>
+  dispose: () => void
+} {
+  let handle: (event: KeyboardEvent) => boolean = () => true
+  const sendInput = vi.fn()
+  const terminal = {
+    attachCustomKeyEventHandler: (handler: (event: KeyboardEvent) => boolean) => {
+      handle = handler
+    },
+    element: document.createElement('div'),
+    getSelection: () => '',
+    scrollToTop: vi.fn(),
+    scrollToBottom: vi.fn()
+  } as unknown as Terminal
+  const dispose = installPreviewTerminalKeyHandler({
+    terminal,
+    claimImeKeyEvent: () => false,
+    pasteClipboardText: vi.fn(),
+    sendInput,
+    getShortcutContext: () => ({
+      clientPlatform: 'darwin',
+      macOptionAsAlt: 'false',
+      keybindings: undefined,
+      terminalInput: LOCAL_MAC,
+      kittyKeyboardActive: () => false,
+      terminalShortcutPolicy: 'orca-first'
+    })
+  })
+  return { handle: (event) => handle(event), sendInput, dispose }
+}
+
+function keydown(init: KeyboardEventInit & { keyCode?: number }): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  if (init.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  return event
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('preview terminal key handler yields to a composition', () => {
+  // This preview writes to a live pty, so a chord that escapes here reaches the agent's
+  // shell exactly as it would from a pane.
+  it('does not send Ctrl+Backspace to the pty while composing', () => {
+    const handler = installHandler()
+
+    const handled = handler.handle(
+      keydown({ key: 'Backspace', code: 'Backspace', ctrlKey: true, keyCode: 229 })
+    )
+
+    expect(handler.sendInput).not.toHaveBeenCalled()
+    expect(handled).toBe(true)
+    handler.dispose()
+  })
+
+  // No deferred-newline path exists here, so the newline cannot be replayed after the
+  // commit — the only correct move is to let the keystroke close the composition.
+  it('does not send Shift+Enter to the pty while composing', () => {
+    const handler = installHandler()
+
+    handler.handle(
+      keydown({ key: 'Enter', code: 'Enter', shiftKey: true, keyCode: 13, isComposing: true })
+    )
+
+    expect(handler.sendInput).not.toHaveBeenCalled()
+    handler.dispose()
+  })
+
+  it('still sends Ctrl+Backspace when nothing is composing', () => {
+    const handler = installHandler()
+
+    handler.handle(keydown({ key: 'Backspace', code: 'Backspace', ctrlKey: true, keyCode: 8 }))
+
+    expect(handler.sendInput).toHaveBeenCalledWith('\x17')
+    handler.dispose()
+  })
+
+  it('still sends Shift+Enter when nothing is composing', () => {
+    const handler = installHandler()
+
+    handler.handle(keydown({ key: 'Enter', code: 'Enter', shiftKey: true, keyCode: 13 }))
+
+    expect(handler.sendInput).toHaveBeenCalledWith('\x1b\r')
+    handler.dispose()
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -4,6 +4,7 @@ import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { useAppStore } from '@/store'
 import { prefetchLayoutBaseCharacters } from '@/lib/keyboard-layout/layout-base-character'
 import { createTerminalNativeOnlyShortcutTracker } from '@/components/terminal-pane/terminal-native-only-shortcut'
+import { terminalShortcutIsOwnedByIme } from '@/components/terminal-pane/terminal-shortcut-composition-guard'
 import {
   resolvePreviewShortcutAction,
   type PreviewShortcutContext
@@ -101,6 +102,18 @@ export function installPreviewTerminalKeyHandler(args: {
       return true
     }
     nativeOnlyShortcutTracker.prepareKeyDown(event)
+    const resolveAction = (
+      candidate: KeyboardEvent
+    ): ReturnType<typeof resolvePreviewShortcutAction> =>
+      resolvePreviewShortcutAction(candidate, {
+        ...args.getShortcutContext(),
+        optionKeyLocation
+      })
+    // Why: returning true keeps xterm's own composition handling intact; this preview has
+    // no deferred-newline path, so Enter is claimed too and commits rather than submits.
+    if (terminalShortcutIsOwnedByIme(event, resolveAction)) {
+      return true
+    }
     const keybindings = useAppStore.getState().keybindings
     if (keybindingMatchesAction('terminal.copySelection', event, platform, keybindings)) {
       const keyIdentity = event.code || event.key
@@ -129,10 +142,7 @@ export function installPreviewTerminalKeyHandler(args: {
       return consumeEvent(event)
     }
 
-    const action = resolvePreviewShortcutAction(event, {
-      ...args.getShortcutContext(),
-      optionKeyLocation
-    })
+    const action = resolveAction(event)
     if (!action) {
       return true
     }

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -457,7 +457,9 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
-      if (terminalShortcutIsOwnedByIme(e, resolveShortcutEvent)) {
+      if (
+        terminalShortcutIsOwnedByIme(e, resolveShortcutEvent, { enterIsDeferredToCommit: true })
+      ) {
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.test.ts
@@ -30,9 +30,16 @@ describe('terminalShortcutIsOwnedByIme', () => {
 
   // Both exemptions matter in the same direction: claiming them would break a path that
   // already handles composition, rather than merely declining to fix one.
-  it('releases Enter so the send path can defer it to the commit', () => {
+  it('releases Enter for a caller that defers it to the commit', () => {
     const event = keydown({ key: 'Process', code: 'Enter', keyCode: 229, isComposing: true })
-    expect(terminalShortcutIsOwnedByIme(event, sendInput)).toBe(false)
+    expect(terminalShortcutIsOwnedByIme(event, sendInput, { enterIsDeferredToCommit: true })).toBe(
+      false
+    )
+  })
+
+  it('claims Enter for a caller with no defer path, so it commits instead of submitting', () => {
+    const event = keydown({ key: 'Process', code: 'Enter', keyCode: 229, isComposing: true })
+    expect(terminalShortcutIsOwnedByIme(event, sendInput)).toBe(true)
   })
 
   it('releases the input-source switch so the OS still receives it', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-composition-guard.ts
@@ -12,23 +12,27 @@ type ResolvedShortcutAction = { readonly type: string } | null
  * The non-Latin fallback makes it worse by re-deriving bindings from `event.code`, so
  * even a keystroke reported as `Process` still matches Ctrl+W and closes the pane.
  *
- * Two exemptions, both paths that already handle a live composition:
+ * The input-source switch is always exempt: it only hands the key back to the OS.
+ * Dropping it here would let xterm see the chord instead and write its control byte to
+ * the PTY, which is the very failure this guard exists to prevent.
  *
- * - **Enter** — the send path defers it until the commit lands, so it must get through.
- * - **Input-source switch** — it only hands the key back to the OS. Dropping it here
- *   would let xterm see the chord instead and write its control byte to the PTY, which
- *   is the very failure this guard exists to prevent.
+ * Enter is exempt only for a caller that defers it, which is a property of the caller
+ * and not of the key. A surface with a defer path needs Enter to arrive so the newline
+ * can be released after the commit; a surface without one needs Enter suppressed, so
+ * the keystroke commits the composition instead of submitting a line the user was
+ * still composing.
  *
  * Resolution is pure, so asking for the action before deciding costs nothing.
  */
 export function terminalShortcutIsOwnedByIme(
   event: KeyboardEvent,
-  resolveAction: (event: KeyboardEvent) => ResolvedShortcutAction
+  resolveAction: (event: KeyboardEvent) => ResolvedShortcutAction,
+  { enterIsDeferredToCommit = false }: { enterIsDeferredToCommit?: boolean } = {}
 ): boolean {
   if (!isImeCompositionKeyDown(event)) {
     return false
   }
-  if (event.code === 'Enter') {
+  if (enterIsDeferredToCommit && event.code === 'Enter') {
     return false
   }
   return resolveAction(event)?.type !== 'switchInputSource'


### PR DESCRIPTION
## Summary

The dashboard preview terminal is the app's **second** `attachCustomKeyEventHandler`, and it was the one with no IME policy at all. It resolves the full pane shortcut policy and writes the result to a live pty — `AgentTerminalPreview.tsx` wires `sendInput: (data) => terminal?.input(data)`, so this is not a read-only view.

Pre-existing on `main`. Follows #12052, which fixes the same class of defect on the pane's window-capture handler and adds the guard this PR reuses.

## What was missing

The handler ran `claimImeKeyEvent` — the **macOS-only** native-text bridge — then clipboard chords, then `resolvePreviewShortcutAction` → `sendInput`. No composition tracker, no bypass policy, no deferred-newline path. On Linux and Windows the surface had no IME handling whatsoever.

| keystroke mid-preedit | before | why it hurts |
| --- | --- | --- |
| Ctrl+Backspace | `\x17` to the pty | erases a word of the agent's real command line, preedit untouched |
| Shift+Enter | `\x1b\r` to the pty | the newline lands *before* the text it was meant to follow |

The Shift+Enter case is the sharper one: on the main pane that exact keystroke is deferred by `deferredNewlineSender`. Same chord, same composition, two different outcomes depending on which window it was typed into.

## Enter is claimed here, not exempted

This is the one place this PR deliberately differs from #12052.

The pane exempts Enter because it *defers* it — the newline is replayed once the commit lands. This surface has no defer path, so exempting Enter would just reproduce the bug. Claiming it means the keystroke closes the composition instead, which is what a user pressing Enter over a candidate window is asking for anyway.

That made the exemption a property of the **caller**, not of the key, so it became an argument rather than an assumption baked into the guard:

```ts
// pane — has deferredNewlineSender
terminalShortcutIsOwnedByIme(e, resolveShortcutEvent, { enterIsDeferredToCommit: true })

// preview — does not
terminalShortcutIsOwnedByIme(event, resolveAction)
```

The guard returns `true` from the handler rather than consuming the event, so xterm's own composition handling stays intact. Returning `false` would have suppressed the chord *and* bypassed `CompositionHelper`, which is the opposite of what is wanted here.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — `dashboard-popout` + `terminal-pane`: **230 files / 3,001 tests**, no regressions
- [x] Added or updated high-quality tests that would catch regressions

Two defect assertions and two paired negatives, all mutation-checked by disabling the guard and re-running:

| test | guard disabled | guard enabled |
| --- | --- | --- |
| Ctrl+Backspace while composing | **fails** | passes |
| Shift+Enter while composing | **fails** | passes |
| Ctrl+Backspace, nothing composing | passes | passes |
| Shift+Enter, nothing composing | passes | passes |

Worth recording: the first draft of the Shift+Enter test used `key: 'Process'` and **passed with the guard disabled** — with that key the chord never resolves to an action, so the test proved nothing. The mutation check is what caught it. It now uses the shape the failure actually has on macOS (`key: 'Enter'`, `isComposing: true`), and fails without the fix.

Guard-level unit coverage for both Enter directions lives in `terminal-shortcut-composition-guard.test.ts`.

## Screenshots

No visual change.

## AI Review Report

- Cross-platform: the defect was *worst* off macOS, since the only pre-existing IME wiring here (`installPreviewImeBridge`) returns null unless `getShortcutPlatform() === 'darwin'`. The guard is platform-independent and keys off the shared marker predicate.
- The duplicated `resolvePreviewShortcutAction(event, {...})` call is now a single `resolveAction` closure used by both the guard and the switch, so the guard cannot drift from the action the handler goes on to run.
- SSH and folder workspaces: keyboard-only, no path or transport assumptions.
- Risk checked and accepted: the preview's Enter behavior changes during composition only. With nothing composing, Shift+Enter still sends `\x1b\r` — covered by a negative test.

## Security Audit

No auth, secrets, IPC, or filesystem surface. Strictly reduces what an IME-marked keystroke can send to a live pty.

## Notes

Base: #12052.

Made with [Orca](https://github.com/stablyai/orca) 🐋
