### PR TITLE
fix(NO-ISSUE): center repo emoji icon glyph

### DIFF
--- a/src/renderer/src/components/repo/repo-icon.tsx
+++ b/src/renderer/src/components/repo/repo-icon.tsx
@@ -166,7 +166,9 @@ export function RepoIconGlyph({
         className={cn('inline-flex items-center justify-center leading-none', className)}
         aria-hidden="true"
       >
-        <span className={cn('text-[0.9em]', iconClassName)}>{repoIcon.emoji}</span>
+        <span className={cn('inline-flex items-center justify-center text-[0.9em]', iconClassName)}>
+          {repoIcon.emoji}
+        </span>
       </span>
     )
   }


### PR DESCRIPTION
## Summary

- In `RepoIconGlyph` (`src/renderer/src/components/repo/repo-icon.tsx`), the emoji branch's inner `<span>` receives a fixed size via `iconClassName` (e.g. `size-5`) but had no self-centering, so the emoji glyph rendered toward the top-left corner of its box instead of centered.
- The outer `inline-flex items-center justify-center` only centers the inner span's own box within the container — it does not center the text glyph *inside* that box. Added the same `inline-flex items-center justify-center` to the inner span, so the fix is a structural flex-based centering with no arbitrary `translate` or platform-specific pixel offsets. (Verified with computed-style checks that `line-height` doesn't need to be re-declared on the inner span — it already inherits `leading-none` from the outer span, so the diff only adds the two centering classes plus `inline-flex`.)
- The `image` and `lucide` branches are unaffected by this bug (`image` fills its box with `size-full`; the lucide icon itself is the flex item), so they were left unchanged.
- `RepositoryIconTabs`'s 12-emoji picker grid is a separate implementation that doesn't use `RepoIconGlyph`, so it's out of scope and was not touched.
- Blast radius checked: this shared component is used in the Repo Icon preview (`RepositoryIconPicker`), the settings sidebar (`SettingsSidebar`), the worktree list/card (`WorktreeList`, `WorktreeCard`), and the dashboard kanban card (`AgentKanbanCard`) — all pick up the centering fix automatically.

## Screenshots

Without launching the real Electron app or the Vite dev server, captured the before/after markup with Playwright (Chromium) against the production CSS bundle from `pnpm run build:electron-vite`. Same layout as the user-reported repro (Settings > Repo Icon preview, 🚀 emoji), captured in English locale ("Repo Icon" / "🚀 emoji") since this is an open-source project.

- Before: emoji shifted toward the top-left of the box (matches the reported bug)
- After: emoji centered in the box

The `gh` CLI (`gh pr create`/`gh pr edit`) only supports a text body and has no way to actually upload/attach a local image file to a PR body, so no image is actually attached to this PR. The capture file only exists locally (`full-compare.png`) and can be shared with reviewers separately on request.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm run typecheck:web`
- [ ] `pnpm test` (ran targeted tests only, not the full suite — see below)
- [ ] `pnpm build` (only ran `pnpm run build:electron-vite`, to produce the CSS bundle for the capture; did not run the full build with native modules)
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Why no test was added:** this change adds Tailwind alignment classes (`inline-flex items-center justify-center`) to `RepoIconGlyph`'s emoji rendering markup — a pure CSS structural fix with no branching logic or state change. The regression was verified visually via the before/after capture above.

**Commands actually run against the final diff:**

- `pnpm run typecheck:web` — passed
- `npx oxlint src/renderer/src/components/repo/repo-icon.tsx` — passed, no findings
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings (code quality / type-aware / React Doctor, scoped to the 1 changed file)
- Re-ran existing tests that reference `RepoIconGlyph`: `WorktreeCard.pinned-repo-icon.test.tsx`, `AgentKanbanCard.test.tsx`, `AgentKanbanBoard.test.tsx`, `useDashboardPopoutBridge.test.tsx`, `repository-icon-github.test.ts` — all passed, no regressions
- `pnpm run build:electron-vite` — succeeded, used to produce the CSS bundle for the screenshot capture above

Full `pnpm lint` and `pnpm typecheck` (all three tsconfig targets) were not re-run against this exact final commit, so those checklist boxes are left unchecked rather than claimed.

## AI Review Report

Root-caused and fixed directly with an AI coding agent (Claude Code). Key risks checked:

- **Shared rendering regression**: `RepoIconGlyph` is reused across the settings preview, settings sidebar, worktree list/card, and dashboard kanban card. The change only adds `inline-flex items-center justify-center` to the emoji branch's inner span; confirmed by code reading and by re-running existing tests that the `image`/`lucide` branches and `RepositoryIconTabs` (separate implementation, untouched) are unaffected.
- **Cross-platform emoji rendering (macOS/Linux/Windows)**: this fix is pure CSS (flex) structural alignment — no font-specific or platform-specific pixel offsets, and no `transform: translate` hacks. Even though macOS (Apple Color Emoji), Windows (Segoe UI Emoji), and Linux (Noto Color Emoji) render glyphs with different actual sizes/metrics, flex alignment always centers based on the glyph's own bounding box, so it isn't tied to a specific OS. Pixel-level verification on all three platforms wasn't possible in this single-machine macOS environment — noted as a remaining risk below.
- **No scope creep**: `RepositoryIconTabs`'s 12-emoji picker grid and its selection UX were not touched at all.

## Security Audit

- Input handling: the changed code only adds CSS classes to existing logic that renders the emoji string as a text node as-is; no new user-input handling path.
- Execution/IPC dependency: this change doesn't call any IPC/Electron bridge such as `window.api`. It's a Tailwind class change in a pure renderer presentation component (`RepoIconGlyph`), unrelated to command execution, filesystem access, or network calls.
- Secrets/dependencies: no new dependency added, no package changes.
- Follow-up: no security follow-up needed.

## Notes

- Pixel-level visual verification on real macOS/Linux/Windows native emoji fonts wasn't possible in this environment (single macOS machine, headless). The fix should still be platform-agnostic since it's pure flex-based structural alignment, independent of platform-specific emoji glyph metrics.
- Did not use the Vite dev server; the capture used the production CSS bundle from `pnpm run build:electron-vite` plus a static Playwright (Chromium) page capture instead.
