### PR TITLE
Separate the terminal IME platform checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ These rules bind any change to keyboard handling, the chat composer, the termina
 - `attachCustomKeyEventHandler` returning `false` does **not** call `preventDefault()`, and it bypasses xterm's `CompositionHelper` entirely. Pair the two deliberately.
 - Never normalize IME output at commit. Normalize only at path handling and equality/search comparison.
 - Add a recorded event-trace fixture for the trace that motivated the change, plus a paired negative test proving non-IME behavior is unchanged.
+- Test a shortcut guard with the marked-but-real key shape (`key: 'Enter'`, `keyCode: 13`, `isComposing: true`), not `key: 'Process'`. A `Process` chord never resolves to an action, so the test passes with the guard deleted. Delete the guard and watch it fail before trusting it.
 
 ## Git Provider Compatibility
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-state.ts
@@ -55,6 +55,10 @@ function acquirePhysicalKeyTracker(
       pressedCodes.delete(code)
     }
   }
+  // A key held across the blur then released on return reads as orphaned and arms the
+  // guard for one digit. Deliberate: not clearing would strand the code as pressed, and
+  // treating post-blur keyups as unknowable would miss the orphan on the first commit
+  // after focus, which is the common case.
   const reset = (): void => pressedCodes.clear()
   // Why: bubble-phase keyup cleanup runs after xterm's target handler, so the
   // pane can still classify that release against the shared pressed-key set.

--- a/src/renderer/src/components/terminal-pane/terminal-ime-platform.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-platform.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTerminalImePlatform } from './terminal-ime-platform'
+
+const DESKTOP_LINUX =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+const CHROME_OS =
+  'Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+const ANDROID =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36'
+const MACOS =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+const WINDOWS =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+
+describe('resolveTerminalImePlatform', () => {
+  it('treats desktop Linux as both Chromium-family and ibus/fcitx-bearing', () => {
+    expect(resolveTerminalImePlatform(DESKTOP_LINUX)).toEqual({
+      isMac: false,
+      isLinux: true,
+      isDesktopLinux: true
+    })
+  })
+
+  // The split exists for these two: their UA says Linux, so they share the 229 behavior,
+  // but neither runs the input methods the candidate-key guards are written against.
+  it.each([
+    ['ChromeOS', CHROME_OS],
+    ['Android', ANDROID]
+  ])('keeps %s in the Chromium family but out of the desktop guards', (_name, userAgent) => {
+    expect(resolveTerminalImePlatform(userAgent)).toEqual({
+      isMac: false,
+      isLinux: true,
+      isDesktopLinux: false
+    })
+  })
+
+  it.each([
+    ['macOS', MACOS, true],
+    ['Windows', WINDOWS, false]
+  ])('reports %s as neither Linux flavour', (_name, userAgent, isMac) => {
+    expect(resolveTerminalImePlatform(userAgent)).toEqual({
+      isMac,
+      isLinux: false,
+      isDesktopLinux: false
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-platform.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-platform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { resolveShortcutPlatform } from '@/lib/shortcut-platform'
 import { resolveTerminalImePlatform } from './terminal-ime-platform'
 
 const DESKTOP_LINUX =
@@ -11,6 +12,8 @@ const MACOS =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
 const WINDOWS =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+const FREEBSD =
+  'Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
 
 describe('resolveTerminalImePlatform', () => {
   it('treats desktop Linux as both Chromium-family and ibus/fcitx-bearing', () => {
@@ -44,4 +47,25 @@ describe('resolveTerminalImePlatform', () => {
       isDesktopLinux: false
     })
   })
+
+  // Only Windows has a reason to suppress a standalone 229, so an unrecognised desktop
+  // belongs on the passing side rather than in whichever bucket a UA guess lands it in.
+  it('treats an unrecognised desktop as Linux', () => {
+    expect(resolveTerminalImePlatform(FREEBSD)).toEqual({
+      isMac: false,
+      isLinux: true,
+      isDesktopLinux: true
+    })
+  })
+
+  it.each([DESKTOP_LINUX, CHROME_OS, ANDROID, MACOS, WINDOWS, FREEBSD])(
+    'agrees with the renderer-wide platform mapping (%#)',
+    (userAgent) => {
+      const { isMac, isLinux } = resolveTerminalImePlatform(userAgent)
+      expect({ isMac, isLinux }).toEqual({
+        isMac: resolveShortcutPlatform(userAgent) === 'darwin',
+        isLinux: resolveShortcutPlatform(userAgent) === 'linux'
+      })
+    }
+  )
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-platform.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-platform.ts
@@ -1,0 +1,31 @@
+export type TerminalImePlatform = {
+  isMac: boolean
+  /** Chromium on a Linux kernel — ChromeOS and Android included. */
+  isLinux: boolean
+  /** Desktop Linux only — the platforms actually running ibus or fcitx. */
+  isDesktopLinux: boolean
+}
+
+// ChromeOS reports `X11; CrOS x86_64`, with no "Linux" anywhere in it, so a plain
+// substring test puts it on the Windows side of every policy below.
+const LINUX_KERNEL_PLATFORM = /Linux|CrOS/
+const NON_DESKTOP_LINUX_PLATFORM = /Android|CrOS/
+
+/**
+ * Splits the two platform questions the terminal's IME policy asks, which are not the
+ * same question and had been sharing one answer.
+ *
+ * Standalone keydown 229 is Chromium-family behavior, so ChromeOS and Android belong
+ * with desktop Linux. The candidate-key guards read ibus/fcitx specifics that neither
+ * shares, so they are scoped tighter. Deriving both here keeps one user agent from
+ * getting two different platform verdicts in two different files.
+ */
+export function resolveTerminalImePlatform(userAgent: string): TerminalImePlatform {
+  const isMac = userAgent.includes('Mac')
+  const isLinux = !isMac && LINUX_KERNEL_PLATFORM.test(userAgent)
+  return {
+    isMac,
+    isLinux,
+    isDesktopLinux: isLinux && !NON_DESKTOP_LINUX_PLATFORM.test(userAgent)
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-platform.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-platform.ts
@@ -1,30 +1,34 @@
+import { resolveShortcutPlatform } from '@/lib/shortcut-platform'
+
 export type TerminalImePlatform = {
   isMac: boolean
-  /** Chromium on a Linux kernel — ChromeOS and Android included. */
+  /** Everything that is neither macOS nor Windows, matching `getShortcutPlatform`. */
   isLinux: boolean
   /** Desktop Linux only — the platforms actually running ibus or fcitx. */
   isDesktopLinux: boolean
 }
 
-// ChromeOS reports `X11; CrOS x86_64`, with no "Linux" anywhere in it, so a plain
-// substring test puts it on the Windows side of every policy below.
-const LINUX_KERNEL_PLATFORM = /Linux|CrOS/
 const NON_DESKTOP_LINUX_PLATFORM = /Android|CrOS/
 
 /**
  * Splits the two platform questions the terminal's IME policy asks, which are not the
  * same question and had been sharing one answer.
  *
- * Standalone keydown 229 is Chromium-family behavior, so ChromeOS and Android belong
- * with desktop Linux. The candidate-key guards read ibus/fcitx specifics that neither
- * shares, so they are scoped tighter. Deriving both here keeps one user agent from
- * getting two different platform verdicts in two different files.
+ * Standalone keydown 229 is really a question about Windows, whose preedit-diff race is
+ * the only reason to suppress it, so every other platform passes. Sharing the renderer's
+ * one user-agent mapping is what keeps that set from drifting: enumerating Linux-ish
+ * user agents here instead is how ChromeOS — which reports `X11; CrOS x86_64`, with no
+ * "Linux" in it — ended up on the Windows side of this policy while the rest of the
+ * renderer treated it as Linux.
+ *
+ * The candidate-key guards read ibus/fcitx specifics that ChromeOS and Android do not
+ * share, so they are scoped tighter. That narrowing is the only intended difference.
  */
 export function resolveTerminalImePlatform(userAgent: string): TerminalImePlatform {
-  const isMac = userAgent.includes('Mac')
-  const isLinux = !isMac && LINUX_KERNEL_PLATFORM.test(userAgent)
+  const platform = resolveShortcutPlatform(userAgent)
+  const isLinux = platform === 'linux'
   return {
-    isMac,
+    isMac: platform === 'darwin',
     isLinux,
     isDesktopLinux: isLinux && !NON_DESKTOP_LINUX_PLATFORM.test(userAgent)
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -79,6 +79,7 @@ import { parseOsc7 } from './parse-osc7'
 import { guardParserHandler } from './terminal-parser-handler-guard'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
+import { resolveTerminalImePlatform } from './terminal-ime-platform'
 import { installTerminalImeLinuxCandidateState } from './terminal-ime-linux-candidate-state'
 import {
   armTerminalImePendingCandidateKeyRelease,
@@ -887,13 +888,8 @@ export function useTerminalPaneLifecycle({
         let pendingTerminalInterruptKeyup = false
         const pendingTerminalImeCandidateKeyReleases =
           createTerminalImePendingCandidateKeyReleases()
-        const isMac = navigator.userAgent.includes('Mac')
-        // Why: Android/ChromeOS UAs also contain "Linux"; scope the fcitx candidate-key policy to desktop Linux.
-        const isLinux =
-          !isMac &&
-          navigator.userAgent.includes('Linux') &&
-          !/Android|CrOS/.test(navigator.userAgent)
-        const linuxImeCandidateState = isLinux
+        const { isMac, isLinux, isDesktopLinux } = resolveTerminalImePlatform(navigator.userAgent)
+        const linuxImeCandidateState = isDesktopLinux
           ? installTerminalImeLinuxCandidateState(pane.terminal.element)
           : null
         const macNativeTextInputSourceTracker = isMac ? getMacNativeTextInputSourceTracker() : null
@@ -943,7 +939,8 @@ export function useTerminalPaneLifecycle({
             linuxOrphanCandidateDigitGuardActive:
               linuxCandidateClassification.candidateDigitGuardActive,
             isMac,
-            isLinux
+            isLinux,
+            isDesktopLinux
           }
           if (shouldSuppressTerminalImeKeyboardEvent(e, imeKeyboardOptions)) {
             // Why: clear before arm so a fresh keydown drops any stale pending release before arming its own.

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts
@@ -215,6 +215,32 @@ describe('shouldSuppressTerminalImeKeyboardEvent — Windows/Linux', () => {
     ).toBe(false)
   })
 
+  // A Chromebook's UA contains "Linux", so it is the same Chromium/229 platform, but it
+  // is not running ibus/fcitx. The two policies need different answers for it.
+  const chromeOsIdle = { ...linuxIdle, isDesktopLinux: false }
+
+  it('lets standalone ChromeOS 229 keydowns reach xterm, as on desktop Linux', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Process', code: 'KeyN', keyCode: 229 }),
+        chromeOsIdle
+      )
+    ).toBe(false)
+  })
+
+  it('does not apply the fcitx candidate-key guards on ChromeOS', () => {
+    const guarded = { ...chromeOsIdle, candidateKeyGuardActive: true }
+    expect(
+      shouldPreventDefaultTerminalImeCandidateKey(event({ key: '1', code: 'Digit1' }), guarded)
+    ).toBe(false)
+    expect(
+      shouldPreventDefaultTerminalImeCandidateKey(event({ key: '1', code: 'Digit1' }), {
+        ...guarded,
+        isDesktopLinux: true
+      })
+    ).toBe(true)
+  })
+
   it('suppresses Linux 229 keydowns while the composition tracker is active', () => {
     expect(
       shouldSuppressTerminalImeKeyboardEvent(

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -54,7 +54,12 @@ export type XtermImeKeyboardOptions = {
   // Required Linux/Windows split: Linux passes standalone 229 keydowns like
   // macOS; the Windows-only suppression guards its preedit-diff race (preedit
   // can hit the textarea before compositionstart and be flushed by the diff).
+  // Chromium-family, so ChromeOS and Android count — they share that behavior.
   isLinux: boolean
+  /** Desktop Linux only. The candidate-key guards read ibus/fcitx behavior that
+   *  a Chromebook's IME does not share, so they are scoped tighter than the 229
+   *  policy above. Defaults to `isLinux` for callers on a known desktop. */
+  isDesktopLinux?: boolean
 }
 
 export const TERMINAL_INTERRUPT_INPUT = '\x03'
@@ -114,12 +119,15 @@ export function shouldSuppressTerminalImeKeyboardEvent(
     pendingCandidateKeyReleaseActive,
     linuxOrphanCandidateDigitGuardActive = false,
     isMac,
-    isLinux
+    isLinux,
+    isDesktopLinux = isLinux
   } = options
   const suppressOrphanCandidateDigit =
-    isLinux && linuxOrphanCandidateDigitGuardActive && isTerminalImeCandidateDigitKeyEvent(event)
+    isDesktopLinux &&
+    linuxOrphanCandidateDigitGuardActive &&
+    isTerminalImeCandidateDigitKeyEvent(event)
   const suppressCandidateKey =
-    isLinux &&
+    isDesktopLinux &&
     (pendingCandidateKeyReleaseActive ||
       (candidateKeyGuardActive && isTerminalImeCandidateSelectionKeyEvent(event)) ||
       suppressOrphanCandidateDigit)
@@ -162,7 +170,7 @@ export function shouldPreventDefaultTerminalImeCandidateKey(
   // the leaked selector to the PTY.
   return (
     event.type === 'keydown' &&
-    options.isLinux &&
+    (options.isDesktopLinux ?? options.isLinux) &&
     ((options.candidateKeyGuardActive && isTerminalImeCandidateSelectionKeyEvent(event)) ||
       (options.linuxOrphanCandidateDigitGuardActive === true &&
         isTerminalImeCandidateDigitKeyEvent(event)))

--- a/src/renderer/src/lib/shortcut-platform.ts
+++ b/src/renderer/src/lib/shortcut-platform.ts
@@ -1,6 +1,11 @@
-export function getShortcutPlatform(): NodeJS.Platform {
-  if (navigator.userAgent.includes('Mac')) {
+/** Maps a user agent to the platform whose conventions the renderer should follow. */
+export function resolveShortcutPlatform(userAgent: string): NodeJS.Platform {
+  if (userAgent.includes('Mac')) {
     return 'darwin'
   }
-  return navigator.userAgent.includes('Windows') ? 'win32' : 'linux'
+  return userAgent.includes('Windows') ? 'win32' : 'linux'
+}
+
+export function getShortcutPlatform(): NodeJS.Platform {
+  return resolveShortcutPlatform(navigator.userAgent)
 }


### PR DESCRIPTION
## Summary

The terminal's IME code asks two different platform questions and was answering them with one flag:

1. **May a standalone keydown 229 reach xterm's `CompositionHelper`?** Windows must suppress it, because of its preedit-diff race. Everywhere else must pass it.
2. **Is an ibus/fcitx-style candidate window in play?** The candidate-key guards in `xterm-bypass-policy.ts` read behavior specific to those input methods, so they belong to desktop Linux only.

Both read one `isLinux`, derived inline in `use-terminal-pane-lifecycle.ts`. Tightening it for question 2 moved question 1 too, and moved it the wrong way.

## The derivation was also wrong about ChromeOS

The inline comment claimed:

```ts
// Why: Android/ChromeOS UAs also contain "Linux"; scope the fcitx candidate-key policy to desktop Linux.
const isLinux =
  !isMac && navigator.userAgent.includes('Linux') && !/Android|CrOS/.test(navigator.userAgent)
```

True of Android (`Linux; Android 14; Pixel 8`), **not** of ChromeOS, which reports `X11; CrOS x86_64 14541.0.0` — no `Linux` substring anywhere. So `includes('Linux')` was already false and the `CrOS` half of the exclusion was unreachable. ChromeOS landed in the Windows bucket for *both* policies: right answer for the candidate guards, wrong for 229.

Meanwhile `getShortcutPlatform()` maps that same user agent to `'linux'`. Two mappings, two answers.

## Change

The fix is not a better substring test — it's not having a second mapping. `shortcut-platform.ts` gains a pure `resolveShortcutPlatform(userAgent)`; `getShortcutPlatform()` becomes its `navigator.userAgent` caller. The new `terminal-ime-platform.ts` derives from it:

```ts
export function resolveTerminalImePlatform(userAgent: string): TerminalImePlatform {
  const platform = resolveShortcutPlatform(userAgent)
  const isLinux = platform === 'linux'
  return {
    isMac: platform === 'darwin',
    isLinux,
    isDesktopLinux: isLinux && !NON_DESKTOP_LINUX_PLATFORM.test(userAgent)
  }
}
```

`isMac`/`isLinux` now cannot disagree with the rest of the renderer. `isDesktopLinux` narrows from there, and that narrowing is the only intended difference.

This also drops the enumeration problem rather than re-solving it. Question 1 is really "is this Windows?", so an unrecognised desktop passes 229 instead of landing in whichever bucket a UA guess picks — which is how ChromeOS got here in the first place.

`XtermImeKeyboardOptions` gains an optional `isDesktopLinux` (defaulting to `isLinux`, so existing callers are unaffected); `suppressOrphanCandidateDigit`, `suppressCandidateKey`, and `shouldPreventDefaultTerminalImeCandidateKey` switch to it. `passesStandalone229Keydown = isMac || isLinux` is untouched and now correctly includes ChromeOS.

Extracting the derivation is what made this testable at all — the bug lived in a string expression inline in a 1000-line effect.

## Tests

`terminal-ime-platform.test.ts` (12) pins real user agents for desktop Linux X11, ChromeOS, Android, macOS, Windows, and an unrecognised X11 desktop, plus a case asserting `isMac`/`isLinux` agree with `resolveShortcutPlatform` for every one of them — so the two mappings can't drift back apart silently.

Two cases added to `xterm-bypass-policy-non-mac.test.ts`: ChromeOS 229 keydowns reach xterm as on desktop Linux, and the candidate-key guards do not fire for it.

Mutation-checked at the intermediate step: with a plain `/Linux/` test the ChromeOS case fails (`isLinux: false`) while Android still passes — the asymmetry the old comment had backwards.

terminal-pane + lib suites: 589 files, 6452 tests, green. Typecheck green.

## Confidence

**Latent inconsistency, not an observed user-facing bug.** Orca does not ship Android, and Electron on a Chromebook runs inside the Linux container, which reports `X11; Linux x86_64` and was always on the correct path. I have no ChromeOS or Gboard event trace; the dropped-character consequence is reasoned from the code path, not observed.

What is verifiable without a device is the rest: one flag answered two questions, its `CrOS` exclusion was dead code contradicted by the comment above it, and it disagreed with `getShortcutPlatform()` on the same input.

## Also: one comment on the adjacent Linux candidate policy

Reviewing `terminal-ime-linux-candidate-state.ts` alongside this, the window-blur reset looks like a bug and is not one. Clearing `pressedCodes` on blur means a key held across the blur and released on return reads as an orphaned keyup and arms the candidate-digit guard, swallowing one digit.

The apparent fix — treat post-blur keyups as unknowable rather than orphaned — costs more than it saves. The genuine orphan signal it exists to catch is a keyup whose keydown the IME consumed, and the first composition after focusing the window is exactly when that happens: click into the terminal, type, pick candidate `1`. Ignoring post-blur keyups would miss that common case to fix a rare one (holding a letter across a focus change).

No logic change — the existing test already pins the behavior. Added the reasoning, because the test asserts the outcome without stating why, and the wrong conclusion is the easy one to reach.

## Also: one line in the IME rules

While writing #12053 I built a composing-Shift+Enter fixture from `key: 'Process'`. It passed with the guard deleted — a `Process` chord never resolves to an action, so nothing was ever sent regardless, and the test certified a guard it had never exercised. The shape with teeth is the marked-but-real key (`key: 'Enter'`, `keyCode: 13`, `isComposing: true`), which is also what the recorded hangul trace carries.

Added as a rule under `AGENTS.md` → IME Composition, next to the existing fixture requirement. The section is the stated home for these; the rules PR earlier in this stack is where it would otherwise go, but putting it here avoids a 13-branch cascade for one line.
