### PR TITLE
feat(NO-ISSUE): expand the project emoji picker

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1628,6 +1628,17 @@ html.native-shell .app-layout {
   animation: settings-shell-enter 180ms ease-out;
 }
 
+.repo-icon-emoji-picker .EmojiPickerReact {
+  --epr-bg-color: var(--card);
+  --epr-category-label-bg-color: var(--card);
+  --epr-text-color: var(--card-foreground);
+  --epr-search-input-bg-color: var(--input);
+  --epr-search-input-border-color: var(--border);
+  --epr-hover-bg-color: var(--accent);
+  border: none;
+  font-family: var(--font-sans);
+}
+
 .collapsible-height-content {
   overflow: hidden;
 }

--- a/src/renderer/src/components/settings/RepositoryIconTabs.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconTabs.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store'
+import { RepositoryIconTabs } from './RepositoryIconTabs'
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastMocks.error }
+}))
+
+// Mock store exposing only the theme value, to verify the minimal-selector subscription.
+const storeMocks = vi.hoisted(() => ({
+  state: { settings: { theme: 'light' } } as Partial<AppState>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Partial<AppState>) => unknown) => selector(storeMocks.state)
+}))
+
+vi.mock('@/components/terminal-pane/use-system-prefers-dark', () => ({
+  useSystemPrefersDark: () => false
+}))
+
+/** Signature of the onEmojiClick callback captured by the emoji-picker-react mock. */
+type MockEmojiClickHandler = (data: { emoji: string }) => void
+
+const emojiPickerMocks = vi.hoisted(() => ({
+  onEmojiClick: null as MockEmojiClickHandler | null
+}))
+
+vi.mock('emoji-picker-react', () => ({
+  __esModule: true,
+  default: (props: { onEmojiClick: MockEmojiClickHandler }) => {
+    emojiPickerMocks.onEmojiClick = props.onEmojiClick
+    return null
+  },
+  EmojiStyle: { NATIVE: 'native' },
+  Theme: { DARK: 'dark', LIGHT: 'light' }
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+/** Renders RepositoryIconTabs with default props and returns the spy callbacks. */
+function renderTabs(overrides: Partial<Parameters<typeof RepositoryIconTabs>[0]> = {}) {
+  const onSetIcon = vi.fn()
+  const onUseGitHubAvatar = vi.fn()
+  act(() => {
+    root.render(
+      <RepositoryIconTabs
+        initialTab="emoji"
+        selectedLucideName={null}
+        selectedEmoji=""
+        loadingGitHub={false}
+        onSetIcon={onSetIcon}
+        onUseGitHubAvatar={onUseGitHubAvatar}
+        {...overrides}
+      />
+    )
+  })
+  return { onSetIcon, onUseGitHubAvatar }
+}
+
+describe('RepositoryIconTabs emoji picker', () => {
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    emojiPickerMocks.onEmojiClick = null
+    toastMocks.error.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    document.body.replaceChildren()
+  })
+
+  it('no longer ships the hardcoded 12-emoji list', () => {
+    const source = readFileSync(path.join(__dirname, 'RepositoryIconTabs.tsx'), 'utf8')
+    expect(source).not.toContain('EMOJI_OPTIONS')
+    expect(source).not.toContain("'🚀', '✨', '💻'")
+  })
+
+  it('renders the full native emoji picker in place of the static grid', () => {
+    renderTabs()
+    expect(emojiPickerMocks.onEmojiClick).not.toBeNull()
+    expect(container.querySelector('.repo-icon-emoji-picker')).not.toBeNull()
+  })
+
+  it('saves a valid emoji click through the existing RepoIcon contract', () => {
+    const { onSetIcon } = renderTabs()
+    act(() => {
+      emojiPickerMocks.onEmojiClick?.({ emoji: '🚀' })
+    })
+    expect(onSetIcon).toHaveBeenCalledExactlyOnceWith({ type: 'emoji', emoji: '🚀' })
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it('rejects an emoji sequence over the sanitizeRepoIcon 16-char cap instead of silently dropping it', () => {
+    const { onSetIcon } = renderTabs()
+    // Two ZWJ family sequences back to back: valid codepoints, well over 16 UTF-16 units.
+    const overlong = '👨‍👩‍👧‍👦👨‍👩‍👧‍👦'
+    expect(overlong.length).toBeGreaterThan(16)
+
+    act(() => {
+      emojiPickerMocks.onEmojiClick?.({ emoji: overlong })
+    })
+
+    expect(onSetIcon).not.toHaveBeenCalled()
+    expect(toastMocks.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('saves a valid skin-tone emoji selection instead of blocking it for global inclusivity', () => {
+    const { onSetIcon } = renderTabs()
+    // Base emoji + skin-tone modifier: well within the 16 UTF-16 unit cap.
+    const thumbsUpMediumSkinTone = '👍🏽'
+    expect(thumbsUpMediumSkinTone.length).toBeLessThanOrEqual(16)
+
+    act(() => {
+      emojiPickerMocks.onEmojiClick?.({ emoji: thumbsUpMediumSkinTone })
+    })
+
+    expect(onSetIcon).toHaveBeenCalledExactlyOnceWith({
+      type: 'emoji',
+      emoji: thumbsUpMediumSkinTone
+    })
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it('shows the currently selected emoji as trailing metadata', () => {
+    renderTabs({ selectedEmoji: '🎨' })
+    expect(container.textContent).toContain('🎨')
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryIconTabs.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconTabs.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { Github, Image, Link2 } from 'lucide-react'
+import EmojiPicker, { EmojiStyle, Theme, type EmojiClickData } from 'emoji-picker-react'
 import type { RepoIcon } from '../../../../shared/repo-icon'
-import { faviconUrlFromWebsite } from '../../../../shared/repo-icon'
+import { faviconUrlFromWebsite, sanitizeRepoIcon } from '../../../../shared/repo-icon'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
@@ -10,8 +11,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { getRepoLucideIconOptions } from '../repo/repo-icon'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
-
-const EMOJI_OPTIONS = ['🚀', '✨', '💻', '🧠', '📦', '🔧', '🎨', '🌐', '📊', '🔒', '⚡', '✅']
+import { useAppStore } from '../../store'
+import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 
 type RepositoryIconTabsProps = {
   initialTab: 'avatar' | 'icon' | 'emoji'
@@ -32,6 +33,11 @@ export function RepositoryIconTabs({
 }: RepositoryIconTabsProps): React.JSX.Element {
   const [website, setWebsite] = useState('')
   const mountedRef = useMountedRef()
+  // Minimal selector: only the theme string is needed; default to system before settings load.
+  const settingsTheme = useAppStore((state) => state.settings?.theme ?? 'system')
+  const systemPrefersDark = useSystemPrefersDark()
+  // Theme.AUTO only follows the OS setting, which can disagree with Orca's manual theme.
+  const isDarkTheme = settingsTheme === 'dark' || (settingsTheme === 'system' && systemPrefersDark)
 
   const handleUploadImage = async () => {
     try {
@@ -77,6 +83,22 @@ export function RepositoryIconTabs({
         'Website favicon'
       )
     })
+  }
+
+  /** Saves the picked emoji, rejecting anything over sanitizeRepoIcon's 16-char cap. */
+  const handleEmojiClick = (emojiData: EmojiClickData): void => {
+    // ZWJ/skin-tone sequences can exceed the 16-char cap even without skinTonesDisabled.
+    const repoIcon = sanitizeRepoIcon({ type: 'emoji', emoji: emojiData.emoji })
+    if (!repoIcon) {
+      toast.error(
+        translate(
+          'auto.components.settings.RepositoryIconPicker.emojiTooLongForRepoIcon',
+          "This emoji can't be used as a repo icon."
+        )
+      )
+      return
+    }
+    onSetIcon(repoIcon)
   }
 
   return (
@@ -180,24 +202,31 @@ export function RepositoryIconTabs({
         </div>
       </TabsContent>
 
-      <TabsContent value="emoji" className="grid grid-cols-12 gap-1.5">
-        {EMOJI_OPTIONS.map((emoji) => (
-          <Button
-            key={emoji}
-            type="button"
-            variant={selectedEmoji === emoji ? 'secondary' : 'ghost'}
-            size="icon-xs"
-            className="size-8 text-base"
-            onClick={() => onSetIcon({ type: 'emoji', emoji })}
-            aria-label={translate(
-              'auto.components.settings.RepositoryIconPicker.2b7d27b93c',
-              'Use {{value0}} repo icon',
-              { value0: emoji }
+      <TabsContent value="emoji">
+        <div className="repo-icon-emoji-picker overflow-hidden rounded-md border border-border">
+          <EmojiPicker
+            emojiStyle={EmojiStyle.NATIVE}
+            height={340}
+            width="100%"
+            lazyLoadEmojis
+            onEmojiClick={handleEmojiClick}
+            previewConfig={{ showPreview: true }}
+            searchPlaceHolder={translate(
+              'auto.components.settings.RepositoryIconPicker.searchEmojiPlaceholder',
+              'Search emoji'
             )}
-          >
-            {emoji}
-          </Button>
-        ))}
+            theme={isDarkTheme ? Theme.DARK : Theme.LIGHT}
+          />
+        </div>
+        {selectedEmoji ? (
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            {translate(
+              'auto.components.settings.RepositoryIconPicker.currentEmojiSelection',
+              'Current: {{value0}}',
+              { value0: selectedEmoji }
+            )}
+          </p>
+        ) : null}
       </TabsContent>
     </Tabs>
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6566,7 +6566,10 @@
           "f79972271a": "No GitHub remote found for this repo.",
           "4d039317f4": "Website favicon",
           "acf31559a0": "Enter a valid website URL.",
-          "868c5c9b56": "Failed to import repo icon"
+          "868c5c9b56": "Failed to import repo icon",
+          "emojiTooLongForRepoIcon": "This emoji can't be used as a repo icon.",
+          "currentEmojiSelection": "Current: {{value0}}",
+          "searchEmojiPlaceholder": "Search emoji"
         },
         "RepositoryPane": {
           "15a99d9b9f": "Relative paths resolve from this project root.",

--- a/tests/e2e/repo-icon-emoji-picker.spec.ts
+++ b/tests/e2e/repo-icon-emoji-picker.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Coverage for the full native emoji picker that replaced the hardcoded
+ * 12-emoji grid in the repo icon settings (RepositoryIconTabs "Emoji" tab).
+ * Verifies search + selection persist through the existing RepoIcon
+ * contract, and captures the new picker for the PR screenshot record.
+ */
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { getStoreState, waitForSessionReady } from './helpers/store'
+import type { Repo } from '../../src/shared/types'
+
+/** Opens the repo settings panel and pins the UI language to English. */
+async function openRepoSettings(page: Page, repoId: string): Promise<void> {
+  // Why: the host OS locale (e.g. ko-KR) drives Orca's default UI language.
+  // Pin English so this spec's locators are stable across dev machines and CI.
+  await page.evaluate(() => window.__store!.getState().updateSettings({ uiLanguage: 'en' }))
+  await page.evaluate((repoId) => {
+    const state = window.__store!.getState()
+    state.openSettingsTarget({ pane: 'repo', repoId })
+    state.openSettingsPage()
+  }, repoId)
+  await expect(page.getByPlaceholder('Search settings')).toBeVisible({ timeout: 10_000 })
+  const maybeLaterButton = page.getByRole('button', { name: 'Maybe Later' })
+  if (await maybeLaterButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await maybeLaterButton.click()
+  }
+}
+
+/** Captures a full-page screenshot and attaches it to the test report. */
+async function attachScreenshot(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const screenshotPath = testInfo.outputPath(`${name}.png`)
+  await page.screenshot({ path: screenshotPath })
+  await testInfo.attach(name, { path: screenshotPath, contentType: 'image/png' })
+}
+
+test.describe('Repository icon emoji picker', () => {
+  test('search selects a native emoji and persists it as the repo icon', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+
+    const repos = await getStoreState<Repo[]>(orcaPage, 'repos')
+    expect(repos.length).toBeGreaterThan(0)
+    const repo = repos[0]
+
+    await openRepoSettings(orcaPage, repo.id)
+
+    const repoSection = orcaPage.locator(`[data-settings-section="repo-${repo.id}"]`)
+    await repoSection.getByRole('tab', { name: 'Emoji' }).click()
+
+    const picker = repoSection.locator('.repo-icon-emoji-picker')
+    await expect(picker).toBeVisible({ timeout: 10_000 })
+
+    // Full catalog with search — the removed grid only ever offered 12 fixed emoji.
+    const searchInput = picker.getByPlaceholder('Search emoji')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('rocket')
+
+    await attachScreenshot(orcaPage, testInfo, 'repo-icon-emoji-picker-search')
+
+    const rocketResult = picker.getByRole('button', { name: /rocket/i }).first()
+    await expect(rocketResult).toBeVisible({ timeout: 10_000 })
+    await rocketResult.click()
+
+    await expect
+      .poll(
+        async () => {
+          const current = await getStoreState<Repo[]>(orcaPage, 'repos')
+          return current.find((entry) => entry.id === repo.id)?.repoIcon
+        },
+        { timeout: 5_000, message: 'repo icon did not persist the picked emoji' }
+      )
+      .toEqual({ type: 'emoji', emoji: '🚀' })
+
+    await attachScreenshot(orcaPage, testInfo, 'repo-icon-emoji-picker-selected')
+  })
+})


### PR DESCRIPTION
## Summary

Replace the hardcoded 12-emoji grid in the repo icon settings ("Emoji" tab of `RepositoryIconTabs.tsx`) with the full, native, searchable, category-navigable emoji picker. No new dependency: it reuses `emoji-picker-react`, which is already a dependency and already used by `RichMarkdownEmojiMenu` in the markdown editor.

**Design choice**: compared reusing `RichMarkdownEmojiMenu`'s `emoji-picker-react` setup (search, categories, lazy-loading built in) against hand-building a shadcn `Popover + Command` picker over the full emojibase dataset. Went with the former — it's the minimal design that matches STYLEGUIDE's "sibling components should read as one design" guidance, and a `Command`-based rebuild would need its own virtualization (cmdk has none) plus a from-scratch category-navigation implementation, which is unnecessary scope and a real performance risk for a multi-thousand-emoji catalog.

Other changes in this PR:
- Added a `.repo-icon-emoji-picker`-scoped CSS variable block in `main.css` using `--card` / `--card-foreground` tokens (this picker is embedded inline in a settings panel, not a popover, so it doesn't reuse `RichMarkdownEmojiMenu`'s `--popover` tokens) and the `--font-sans` token instead of a hardcoded font-family.
- Every pick is re-validated through `sanitizeRepoIcon` before being saved, so a ZWJ/skin-tone sequence over its 16-char cap surfaces a `toast.error` instead of silently no-op'ing through `sanitizeRepoUpdate`. Skin tones are left selectable (not disabled) for global inclusivity.
- `Theme.DARK`/`Theme.LIGHT` is computed explicitly from a minimal `useAppStore((state) => state.settings?.theme ?? 'system')` selector plus the existing `useSystemPrefersDark` hook, instead of `Theme.AUTO` (which only follows the OS `prefers-color-scheme` setting and can disagree with Orca's own manual theme choice).
- The search placeholder is routed through `translate(...)` instead of being a hardcoded string.
- `repo-icon.tsx`'s centering logic is untouched.

## Screenshots

Captured from a real Electron build (`electron-vite build --mode e2e`) + Playwright E2E (`tests/e2e/repo-icon-emoji-picker.spec.ts`), so the glyphs are the actual native macOS emoji font, not a mock render. The CLI environment this PR was authored in can't inline-upload images into a GitHub PR body/comment, so they were delivered directly to the requester as files:
- `before-hardcoded-12-emoji-grid.png` — the removed 12-emoji grid
- `after-emoji-picker-search-v2.png` — the new picker, "rocket" search results, category bar, and the skin-tone swatch button
- `after-emoji-picker-selected-v2.png` — after picking 🚀, showing the "Current: 🚀" trailing metadata line

## Testing

- [x] `pnpm lint` (oxlint, native/type-aware code-quality audits, reliability gates, max-lines ratchet, and all three localization checks — catalog/extraction/coverage)
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite; see Notes for pre-existing failures unrelated to this change
- [x] Added `RepositoryIconTabs.test.tsx` (6 tests): hardcoded-list removal, a valid emoji selection persists via the existing `onSetIcon` contract, an over-16-char sequence is rejected with a toast instead of a silent no-op, a valid skin-tone emoji is saved normally, and the "Current" trailing metadata renders
- [x] Added `tests/e2e/repo-icon-emoji-picker.spec.ts`: real Electron build, search → select → store persistence; doubles as the screenshot capture above
- [ ] `pnpm build` — not run; out of proportional scope for a renderer-only change. `electron-vite build --mode e2e` was run instead to produce the real build used for the E2E test/screenshots above.

## AI Review Report

Implemented directly with Claude Code (Sonnet 5). Review covered:
- **Cross-platform (macOS/Linux/Windows)**: pure renderer UI change with no modifier-key, path, or shell-specific code. `EmojiStyle.NATIVE` delegates glyph rendering to each OS's own emoji font — no image sprites, no platform branching needed.
- **SSH / remote / local compatibility**: no IPC or filesystem access was added; the component only reads store state and calls the existing `onSetIcon`/`updateRepo` path, which already works uniformly across local, SSH, and folder-workspace repos.
- **Agent / integration / git-provider compatibility**: N/A — this is a settings-UI-only change with no agent, provider, or CLI-integration surface.
- **Performance**: no new dependency; `emoji-picker-react` was already bundled via `RichMarkdownEmojiMenu`, so this adds no bundle-size growth. `lazyLoadEmojis` avoids rendering the whole catalog eagerly.
- **UI quality**: only STYLEGUIDE tokens are used (`--card`, `--border`, `--accent`, `--font-sans`) — no hardcoded colors or fonts. Verified in light theme via the real-Electron-build screenshots above; dark-theme is driven by the same CSS variables and the new explicit `Theme.DARK`/`Theme.LIGHT` selector logic, but was not separately screenshotted (see Notes).
- **Security**: see Security Audit below.

No other issues were flagged during review.

## Security Audit

- **Input handling**: the value picked by the user is `EmojiClickData.emoji` from `emoji-picker-react`'s own built-in dataset, not free-text input. It is re-validated by `sanitizeRepoIcon` before persistence (16-char cap, fixed `type: 'emoji'` shape).
- **Command execution / IPC**: none added. This is a renderer-only UI change; no new IPC channel or command-execution path, and no external input reaches a shell or process.
- **Path handling**: N/A — no file paths are touched.
- **Auth / secrets**: N/A.
- **Dependencies**: no `package.json` changes. `emoji-picker-react` and `emojibase-data` are both pre-existing dependencies, reused as-is.
- **Follow-up**: none.

## Notes

- No platform-specific, SSH/remote-specific, agent-specific, integration-specific, or git-provider-specific behavior in this change — it's a settings-panel UI swap.
- `pnpm test` (full suite): the only failures observed are pre-existing and unrelated to this diff — `src/relay/agent-exec-handler.test.ts` (native spawn-args assertions) and an isolated `config/scripts/check-root-directory-entries.test.mjs` failure caused by this machine's system `/bin/bash` being 3.2 (no `declare -A` support), which the guard script this test exercises requires. Neither file is touched by this PR.
- Remaining risk: dark-theme rendering was not separately screenshotted (only light theme, see Screenshots) — it's driven by CSS variables and the new theme-selector logic, which is covered by typecheck/lint but not by a dedicated visual capture in this pass.
- Three new i18n strings were added; they're present in `en.json` and pass `verify:localization-catalog`/`verify:localization-extraction`/`verify:localization-coverage`, but are not yet translated in es/ja/ko/zh — this project's existing automated translation pipeline backfills those, it doesn't block PRs.
