### PR TITLE
fix(repo-icon): center emoji glyph within its sized icon box

### DIFF
--- a/src/renderer/src/components/repo/repo-icon.emoji-centering.test.tsx
+++ b/src/renderer/src/components/repo/repo-icon.emoji-centering.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RepoIconGlyph } from './repo-icon'
+
+afterEach(() => {
+  cleanup()
+})
+
+// Every RepoIconGlyph call site passes a fixed `size-*` in iconClassName, so the
+// span carrying it is a sized box holding a bare text node. The image branch
+// (`size-full object-contain`) and the lucide branch (the svg fills its own box)
+// centre structurally; only the emoji branch has to ask for it.
+describe('RepoIconGlyph emoji centering', () => {
+  it('centers the glyph inside the box iconClassName sizes', () => {
+    const { container } = render(
+      <RepoIconGlyph
+        repoIcon={{ type: 'emoji', emoji: '🐙' }}
+        className="size-10"
+        iconClassName="size-5"
+      />
+    )
+
+    const glyphBox = container.querySelector('.size-5')
+    expect(glyphBox?.textContent).toBe('🐙')
+    expect(glyphBox?.className).toContain('inline-flex')
+    expect(glyphBox?.className).toContain('items-center')
+    expect(glyphBox?.className).toContain('justify-center')
+  })
+
+  it('renders the glyph as the only child so justify-center has one flex item', () => {
+    const { container } = render(
+      <RepoIconGlyph repoIcon={{ type: 'emoji', emoji: '🐙' }} iconClassName="size-5" />
+    )
+
+    // Stray JSX whitespace would become a second anonymous flex item and shift the glyph.
+    expect(container.querySelector('.size-5')?.childNodes).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/repo/repo-icon.tsx
+++ b/src/renderer/src/components/repo/repo-icon.tsx
@@ -166,7 +166,9 @@ export function RepoIconGlyph({
         className={cn('inline-flex items-center justify-center leading-none', className)}
         aria-hidden="true"
       >
-        <span className={cn('text-[0.9em]', iconClassName)}>{repoIcon.emoji}</span>
+        <span className={cn('inline-flex items-center justify-center text-[0.9em]', iconClassName)}>
+          {repoIcon.emoji}
+        </span>
       </span>
     )
   }


### PR DESCRIPTION
## Summary

`RepoIconGlyph` (`src/renderer/src/components/repo/repo-icon.tsx`) renders custom repo emoji icons off-center — the glyph sits toward the top-left of its box instead of centered. This shows up anywhere a repo uses an emoji icon: the Repo Icon preview in Settings, the settings sidebar, the worktree list/cards, and the dashboard kanban cards.

**Root cause:** in the emoji branch, the inner `<span>` that wraps the glyph gets a fixed size from `iconClassName` (e.g. `size-5`), but nothing centers the glyph *inside* that box. The outer span's `inline-flex items-center justify-center` only centers the inner span's box as a whole within the outer container — it has no effect on the text glyph inside that inner box, so the glyph renders at its default top-left position.

**Fix:** add the same `inline-flex items-center justify-center` to the inner span, so it centers its own content structurally via flexbox. No `transform: translate` or platform-specific pixel offsets involved.

The `image` branch (fills its box with `size-full`) and the `lucide` branch (the icon itself is the flex item, not wrapped) were never affected by this bug and are unchanged. `RepositoryIconTabs`'s 12-emoji picker grid is a separate implementation that doesn't use `RepoIconGlyph` and was not touched.

## Screenshots

<img width="500" height="300" alt="repo-emoji-centering-before-after" src="https://github.com/user-attachments/assets/8b7d6277-0af9-4b9c-a462-a367d6ff662c" />

## Testing

- [ ] `pnpm lint`
- [x] `pnpm run typecheck:web`
- [ ] `pnpm test` (ran targeted tests only, not the full suite — see below)
- [ ] `pnpm build` (only ran `pnpm run build:electron-vite`, to produce the CSS bundle used for the screenshot capture)
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Why no test was added:** the fix adds Tailwind alignment classes (`inline-flex items-center justify-center`) to existing emoji-rendering markup — a pure CSS structural change with no branching logic or state to exercise. Regression was verified visually via the before/after capture above.

**Commands actually run against this commit:**

- `pnpm run typecheck:web` — passed
- `npx oxlint src/renderer/src/components/repo/repo-icon.tsx` — passed, no findings
- `node config/scripts/check-changed-code-quality.mjs` — 0 new findings (code quality / type-aware / React Doctor, scoped to the 1 changed file)
- Re-ran existing tests that reference `RepoIconGlyph`: `WorktreeCard.pinned-repo-icon.test.tsx`, `AgentKanbanCard.test.tsx`, `AgentKanbanBoard.test.tsx`, `useDashboardPopoutBridge.test.tsx`, `repository-icon-github.test.ts` — all passed
- `pnpm run build:electron-vite` — succeeded, used to produce the CSS bundle for the capture above

Full `pnpm lint` and `pnpm typecheck` (all three tsconfig targets) were not run against this exact commit, so those boxes are left unchecked rather than claimed.

## AI Review Report

Root-caused and fixed with an AI coding agent (Claude Code). Review covered:

- **Cross-platform (macOS/Linux/Windows):** the fix is pure CSS (flexbox) structural alignment — no font-specific or platform-specific pixel offsets, no `transform: translate`. Flex centering always centers on the glyph's own bounding box regardless of how macOS (Apple Color Emoji), Windows (Segoe UI Emoji), or Linux (Noto Color Emoji) render the glyph's actual size/metrics, so it isn't tied to a specific OS. Pixel-level verification on all three platforms wasn't possible in this single-machine macOS environment.
- **SSH / remote / local:** not applicable — this is a pure renderer presentation change with no dependency on where the repo or worktree lives (local, SSH, or remote runtime).
- **Agent / integration / git-provider compatibility:** not applicable — `RepoIconGlyph` has no dependency on any CLI agent, git provider, or integration; it only renders a `RepoIcon` value already resolved elsewhere.
- **Performance:** negligible — two additional static Tailwind classes on an existing span, no new renders or state.
- **UI quality / shared-component regression risk:** `RepoIconGlyph` is reused across the settings preview, settings sidebar, worktree list/card, and dashboard kanban card. Confirmed by code reading and by re-running existing tests that only the emoji branch changed and the `image`/`lucide` branches and `RepositoryIconTabs` (separate implementation) are unaffected.
- **Security:** see Security Audit below.

## Security Audit

- **Input handling:** unchanged — the code still renders the emoji string as a text node as-is; this PR only adds CSS classes, no new input path.
- **Execution / IPC:** none — `RepoIconGlyph` doesn't call `window.api` or any IPC/Electron bridge; it's a pure renderer presentation component.
- **Secrets / dependencies:** no new dependency, no package changes.
- **Follow-up:** none needed.

## Notes

- No platform-specific, SSH/remote-specific, agent-specific, integration-specific, or git-provider-specific behavior is involved in this change.
- Pixel-level visual verification on real macOS/Linux/Windows native emoji fonts wasn't possible in this environment (single macOS machine, headless); the fix should be platform-agnostic since it's pure flex-based structural alignment.
- Vite dev server was not used; the capture used the production CSS bundle from `pnpm run build:electron-vite` plus a static Playwright (Chromium) page capture instead.
