### PR TITLE
feat(repo-icon): expand the project emoji picker

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1628,6 +1628,17 @@ html.native-shell .app-layout {
   animation: settings-shell-enter 180ms ease-out;
 }
 
+.repo-icon-emoji-picker .EmojiPickerReact {
+  --epr-bg-color: var(--card);
+  --epr-category-label-bg-color: var(--card);
+  --epr-text-color: var(--card-foreground);
+  --epr-search-input-bg-color: var(--input);
+  --epr-search-border-color: var(--border);
+  --epr-hover-bg-color: var(--accent);
+  border: none;
+  font-family: var(--font-sans);
+}
+
 .collapsible-height-content {
   overflow: hidden;
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1633,10 +1633,23 @@ html.native-shell .app-layout {
   --epr-category-label-bg-color: var(--card);
   --epr-text-color: var(--card-foreground);
   --epr-search-input-bg-color: var(--input);
+  --epr-search-input-bg-color-active: var(--input);
   --epr-search-border-color: var(--border);
+  --epr-search-border-color-active: var(--ring);
   --epr-hover-bg-color: var(--accent);
+  --epr-highlight-color: var(--ring);
+  --epr-picker-border-color: var(--border);
   border: none;
+}
+
+/* The library sets `font-family: sans-serif` on every descendant, so inheriting from the root never lands. */
+.repo-icon-emoji-picker .EmojiPickerReact * {
   font-family: var(--font-sans);
+}
+
+.repo-icon-emoji-picker .epr-body {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--muted-foreground, #737373) 34%, transparent) transparent;
 }
 
 .collapsible-height-content {

--- a/src/renderer/src/components/settings/RepositoryIconEmojiPicker.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconEmojiPicker.test.tsx
@@ -31,13 +31,15 @@ vi.mock('@/components/terminal-pane/use-system-prefers-dark', () => ({
 type MockEmojiClickHandler = (data: { emoji: string }) => void
 
 const emojiPickerMocks = vi.hoisted(() => ({
-  onEmojiClick: null as MockEmojiClickHandler | null
+  onEmojiClick: null as MockEmojiClickHandler | null,
+  searchPlaceholder: null as string | null
 }))
 
 vi.mock('emoji-picker-react', () => ({
   __esModule: true,
-  default: (props: { onEmojiClick: MockEmojiClickHandler }) => {
+  default: (props: { onEmojiClick: MockEmojiClickHandler; searchPlaceholder: string }) => {
     emojiPickerMocks.onEmojiClick = props.onEmojiClick
+    emojiPickerMocks.searchPlaceholder = props.searchPlaceholder
     return null
   },
   EmojiStyle: { NATIVE: 'native' },
@@ -62,6 +64,7 @@ describe('RepositoryIconEmojiPicker', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     emojiPickerMocks.onEmojiClick = null
+    emojiPickerMocks.searchPlaceholder = null
     toastMocks.error.mockReset()
   })
 
@@ -74,6 +77,7 @@ describe('RepositoryIconEmojiPicker', () => {
   it('renders the full native emoji picker in place of the static grid', () => {
     renderPicker()
     expect(emojiPickerMocks.onEmojiClick).not.toBeNull()
+    expect(emojiPickerMocks.searchPlaceholder).toBe('Search emoji')
     expect(container.querySelector('.repo-icon-emoji-picker')).not.toBeNull()
   })
 

--- a/src/renderer/src/components/settings/RepositoryIconEmojiPicker.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconEmojiPicker.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store'
+import { RepositoryIconEmojiPicker } from './RepositoryIconEmojiPicker'
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastMocks.error }
+}))
+
+// Mock store exposing only the theme value, to verify the minimal-selector subscription.
+const storeMocks = vi.hoisted(() => ({
+  state: { settings: { theme: 'light' } } as Partial<AppState>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Partial<AppState>) => unknown) => selector(storeMocks.state)
+}))
+
+vi.mock('@/components/terminal-pane/use-system-prefers-dark', () => ({
+  useSystemPrefersDark: () => false
+}))
+
+/** Signature of the onEmojiClick callback captured by the emoji-picker-react mock. */
+type MockEmojiClickHandler = (data: { emoji: string }) => void
+
+const emojiPickerMocks = vi.hoisted(() => ({
+  onEmojiClick: null as MockEmojiClickHandler | null
+}))
+
+vi.mock('emoji-picker-react', () => ({
+  __esModule: true,
+  default: (props: { onEmojiClick: MockEmojiClickHandler }) => {
+    emojiPickerMocks.onEmojiClick = props.onEmojiClick
+    return null
+  },
+  EmojiStyle: { NATIVE: 'native' },
+  Theme: { DARK: 'dark', LIGHT: 'light' }
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+/** Renders RepositoryIconEmojiPicker with default props and returns the spy callback. */
+function renderPicker(overrides: Partial<Parameters<typeof RepositoryIconEmojiPicker>[0]> = {}) {
+  const onSetIcon = vi.fn()
+  act(() => {
+    root.render(<RepositoryIconEmojiPicker selectedEmoji="" onSetIcon={onSetIcon} {...overrides} />)
+  })
+  return { onSetIcon }
+}
+
+describe('RepositoryIconEmojiPicker', () => {
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    emojiPickerMocks.onEmojiClick = null
+    toastMocks.error.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    document.body.replaceChildren()
+  })
+
+  it('renders the full native emoji picker in place of the static grid', () => {
+    renderPicker()
+    expect(emojiPickerMocks.onEmojiClick).not.toBeNull()
+    expect(container.querySelector('.repo-icon-emoji-picker')).not.toBeNull()
+  })
+
+  it('saves a valid emoji click through the existing RepoIcon contract', () => {
+    const { onSetIcon } = renderPicker()
+    act(() => {
+      emojiPickerMocks.onEmojiClick?.({ emoji: '🚀' })
+    })
+    expect(onSetIcon).toHaveBeenCalledExactlyOnceWith({ type: 'emoji', emoji: '🚀' })
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it('rejects an emoji sequence over the sanitizeRepoIcon 16-char cap instead of silently dropping it', () => {
+    const { onSetIcon } = renderPicker()
+    // Two ZWJ family sequences back to back: valid codepoints, well over 16 UTF-16 units.
+    const overlong = '👨‍👩‍👧‍👦👨‍👩‍👧‍👦'
+    expect(overlong.length).toBeGreaterThan(16)
+
+    act(() => {
+      emojiPickerMocks.onEmojiClick?.({ emoji: overlong })
+    })
+
+    expect(onSetIcon).not.toHaveBeenCalled()
+    expect(toastMocks.error).toHaveBeenCalledTimes(1)
+  })
+
+  // Guards the skinTonesDisabled removal: skin-toned picks must save like any other emoji, not be blocked.
+  it('saves a valid skin-tone emoji selection instead of blocking it for global inclusivity', () => {
+    const { onSetIcon } = renderPicker()
+    // Base emoji + skin-tone modifier: well within the 16 UTF-16 unit cap.
+    const thumbsUpMediumSkinTone = '👍🏽'
+    expect(thumbsUpMediumSkinTone.length).toBeLessThanOrEqual(16)
+
+    act(() => {
+      emojiPickerMocks.onEmojiClick?.({ emoji: thumbsUpMediumSkinTone })
+    })
+
+    expect(onSetIcon).toHaveBeenCalledExactlyOnceWith({
+      type: 'emoji',
+      emoji: thumbsUpMediumSkinTone
+    })
+    expect(toastMocks.error).not.toHaveBeenCalled()
+  })
+
+  it('shows the currently selected emoji as trailing metadata', () => {
+    renderPicker({ selectedEmoji: '🎨' })
+    expect(container.textContent).toContain('🎨')
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryIconEmojiPicker.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconEmojiPicker.tsx
@@ -52,7 +52,7 @@ export function RepositoryIconEmojiPicker({
           lazyLoadEmojis
           onEmojiClick={handleEmojiClick}
           previewConfig={{ showPreview: true }}
-          searchPlaceHolder={translate(
+          searchPlaceholder={translate(
             'auto.components.settings.RepositoryIconPicker.searchEmojiPlaceholder',
             'Search emoji'
           )}

--- a/src/renderer/src/components/settings/RepositoryIconEmojiPicker.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconEmojiPicker.tsx
@@ -46,6 +46,9 @@ export function RepositoryIconEmojiPicker({
     <>
       <div className="repo-icon-emoji-picker overflow-hidden rounded-md border border-border">
         <EmojiPicker
+          // Off by default here: this picker is inline, and can mount with the panel
+          // (emoji repos open on this tab), so autofocus would steal the settings search.
+          autoFocusSearch={false}
           emojiStyle={EmojiStyle.NATIVE}
           height={340}
           width="100%"

--- a/src/renderer/src/components/settings/RepositoryIconEmojiPicker.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconEmojiPicker.tsx
@@ -1,0 +1,73 @@
+import { toast } from 'sonner'
+import EmojiPicker, { EmojiStyle, Theme, type EmojiClickData } from 'emoji-picker-react'
+import type { RepoIcon } from '../../../../shared/repo-icon'
+import { sanitizeRepoIcon } from '../../../../shared/repo-icon'
+import { useAppStore } from '../../store'
+import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
+import { translate } from '@/i18n/i18n'
+
+type RepositoryIconEmojiPickerProps = {
+  selectedEmoji: string
+  onSetIcon: (repoIcon: RepoIcon | null) => void
+}
+
+/**
+ * Full native emoji picker for the repo icon "Emoji" tab. Kept in its own
+ * module (lazy-loaded by RepositoryIconTabs) so emoji-picker-react's ~500KB
+ * chunk only loads once this tab actually renders.
+ */
+export function RepositoryIconEmojiPicker({
+  selectedEmoji,
+  onSetIcon
+}: RepositoryIconEmojiPickerProps): React.JSX.Element {
+  // Minimal selector: only the theme string is needed; default to system before settings load.
+  const settingsTheme = useAppStore((state) => state.settings?.theme ?? 'system')
+  const systemPrefersDark = useSystemPrefersDark()
+  // Theme.AUTO only follows the OS setting, which can disagree with Orca's manual theme.
+  const isDarkTheme = settingsTheme === 'dark' || (settingsTheme === 'system' && systemPrefersDark)
+
+  /** Saves the picked emoji, rejecting anything over sanitizeRepoIcon's 16-char cap. */
+  const handleEmojiClick = (emojiData: EmojiClickData): void => {
+    // ZWJ/skin-tone sequences can exceed the 16-char cap even without skinTonesDisabled.
+    const repoIcon = sanitizeRepoIcon({ type: 'emoji', emoji: emojiData.emoji })
+    if (!repoIcon) {
+      toast.error(
+        translate(
+          'auto.components.settings.RepositoryIconPicker.emojiTooLongForRepoIcon',
+          "This emoji can't be used as a repo icon."
+        )
+      )
+      return
+    }
+    onSetIcon(repoIcon)
+  }
+
+  return (
+    <>
+      <div className="repo-icon-emoji-picker overflow-hidden rounded-md border border-border">
+        <EmojiPicker
+          emojiStyle={EmojiStyle.NATIVE}
+          height={340}
+          width="100%"
+          lazyLoadEmojis
+          onEmojiClick={handleEmojiClick}
+          previewConfig={{ showPreview: true }}
+          searchPlaceHolder={translate(
+            'auto.components.settings.RepositoryIconPicker.searchEmojiPlaceholder',
+            'Search emoji'
+          )}
+          theme={isDarkTheme ? Theme.DARK : Theme.LIGHT}
+        />
+      </div>
+      {selectedEmoji ? (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          {translate(
+            'auto.components.settings.RepositoryIconPicker.currentEmojiSelection',
+            'Current: {{value0}}',
+            { value0: selectedEmoji }
+          )}
+        </p>
+      ) : null}
+    </>
+  )
+}

--- a/src/renderer/src/components/settings/RepositoryIconTabs.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconTabs.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react'
+import { Suspense, useState } from 'react'
 import { toast } from 'sonner'
 import { Github, Image, Link2 } from 'lucide-react'
 import type { RepoIcon } from '../../../../shared/repo-icon'
@@ -10,12 +10,15 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { getRepoLucideIconOptions } from '../repo/repo-icon'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
+import { lazyWithRetry } from '@/lib/lazy-with-retry'
 
 // Deferred so emoji-picker-react's ~500KB chunk only loads once the Emoji tab renders.
-const RepositoryIconEmojiPicker = lazy(() =>
-  import('./RepositoryIconEmojiPicker').then((module) => ({
-    default: module.RepositoryIconEmojiPicker
-  }))
+const RepositoryIconEmojiPicker = lazyWithRetry(
+  () =>
+    import('./RepositoryIconEmojiPicker').then((module) => ({
+      default: module.RepositoryIconEmojiPicker
+    })),
+  { reloadKey: 'repo-icon-emoji-picker' }
 )
 
 type RepositoryIconTabsProps = {

--- a/src/renderer/src/components/settings/RepositoryIconTabs.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconTabs.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { lazy, Suspense, useState } from 'react'
 import { toast } from 'sonner'
 import { Github, Image, Link2 } from 'lucide-react'
 import type { RepoIcon } from '../../../../shared/repo-icon'
@@ -11,7 +11,12 @@ import { getRepoLucideIconOptions } from '../repo/repo-icon'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
-const EMOJI_OPTIONS = ['🚀', '✨', '💻', '🧠', '📦', '🔧', '🎨', '🌐', '📊', '🔒', '⚡', '✅']
+// Deferred so emoji-picker-react's ~500KB chunk only loads once the Emoji tab renders.
+const RepositoryIconEmojiPicker = lazy(() =>
+  import('./RepositoryIconEmojiPicker').then((module) => ({
+    default: module.RepositoryIconEmojiPicker
+  }))
+)
 
 type RepositoryIconTabsProps = {
   initialTab: 'avatar' | 'icon' | 'emoji'
@@ -180,24 +185,10 @@ export function RepositoryIconTabs({
         </div>
       </TabsContent>
 
-      <TabsContent value="emoji" className="grid grid-cols-12 gap-1.5">
-        {EMOJI_OPTIONS.map((emoji) => (
-          <Button
-            key={emoji}
-            type="button"
-            variant={selectedEmoji === emoji ? 'secondary' : 'ghost'}
-            size="icon-xs"
-            className="size-8 text-base"
-            onClick={() => onSetIcon({ type: 'emoji', emoji })}
-            aria-label={translate(
-              'auto.components.settings.RepositoryIconPicker.2b7d27b93c',
-              'Use {{value0}} repo icon',
-              { value0: emoji }
-            )}
-          >
-            {emoji}
-          </Button>
-        ))}
+      <TabsContent value="emoji">
+        <Suspense fallback={null}>
+          <RepositoryIconEmojiPicker selectedEmoji={selectedEmoji} onSetIcon={onSetIcon} />
+        </Suspense>
       </TabsContent>
     </Tabs>
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6566,7 +6566,10 @@
           "f79972271a": "No GitHub remote found for this repo.",
           "4d039317f4": "Website favicon",
           "acf31559a0": "Enter a valid website URL.",
-          "868c5c9b56": "Failed to import repo icon"
+          "868c5c9b56": "Failed to import repo icon",
+          "emojiTooLongForRepoIcon": "This emoji can't be used as a repo icon.",
+          "currentEmojiSelection": "Current: {{value0}}",
+          "searchEmojiPlaceholder": "Search emoji"
         },
         "RepositoryPane": {
           "15a99d9b9f": "Relative paths resolve from this project root.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6477,7 +6477,10 @@
           "f79972271a": "No se encontró ningún control remoto de GitHub para este repositorio.",
           "4d039317f4": "Favicon del sitio web",
           "acf31559a0": "Ingresa una URL de sitio web válida.",
-          "868c5c9b56": "No se pudo importar el icono del repositorio"
+          "868c5c9b56": "No se pudo importar el icono del repositorio",
+          "emojiTooLongForRepoIcon": "Este emoji no se puede usar como icono del repositorio.",
+          "currentEmojiSelection": "Actual: {{value0}}",
+          "searchEmojiPlaceholder": "Buscar emoji"
         },
         "RepositoryPane": {
           "15a99d9b9f": "Las rutas relativas se resuelven desde la raíz de este proyecto.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6499,7 +6499,10 @@
           "f79972271a": "この repo の GitHub リモートが見つかりません。",
           "4d039317f4": "ウェブサイトのファビコン",
           "acf31559a0": "有効な Web サイトの URL を入力。",
-          "868c5c9b56": "repo のインポートに失敗しましたアイコン"
+          "868c5c9b56": "repo のインポートに失敗しましたアイコン",
+          "emojiTooLongForRepoIcon": "この絵文字は repo アイコンとして使用できません。",
+          "currentEmojiSelection": "現在: {{value0}}",
+          "searchEmojiPlaceholder": "絵文字を検索"
         },
         "RepositoryPane": {
           "15a99d9b9f": "相対パスは、このプロジェクトのルートから解決されます。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6462,7 +6462,10 @@
           "f79972271a": "이 repo에 대한 GitHub 원격을 찾을 수 없습니다.",
           "4d039317f4": "웹사이트 파비콘",
           "acf31559a0": "유효한 웹사이트 URL을 입력하세요.",
-          "868c5c9b56": "repo 아이콘을 가져오지 못했습니다."
+          "868c5c9b56": "repo 아이콘을 가져오지 못했습니다.",
+          "emojiTooLongForRepoIcon": "이 이모티콘은 repo 아이콘으로 사용할 수 없습니다.",
+          "currentEmojiSelection": "현재: {{value0}}",
+          "searchEmojiPlaceholder": "이모티콘 검색"
         },
         "RepositoryPane": {
           "15a99d9b9f": "상대 경로는 이 프로젝트 루트에서 확인됩니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6462,7 +6462,10 @@
           "f79972271a": "找不到此仓库的 GitHub 远程。",
           "4d039317f4": "网站图标",
           "acf31559a0": "输入有效的网站 URL。",
-          "868c5c9b56": "无法导入仓库图标"
+          "868c5c9b56": "无法导入仓库图标",
+          "emojiTooLongForRepoIcon": "此表情符号无法用作仓库图标。",
+          "currentEmojiSelection": "当前：{{value0}}",
+          "searchEmojiPlaceholder": "搜索表情符号"
         },
         "RepositoryPane": {
           "15a99d9b9f": "相对路径从该项目根解析。",

--- a/tests/e2e/repo-icon-emoji-picker.spec.ts
+++ b/tests/e2e/repo-icon-emoji-picker.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Coverage for the full native emoji picker that replaced the hardcoded
+ * 12-emoji grid in the repo icon settings (RepositoryIconTabs "Emoji" tab).
+ * Verifies search + selection persist through the existing RepoIcon
+ * contract, and captures the new picker for the PR screenshot record.
+ */
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { getStoreState, waitForSessionReady } from './helpers/store'
+import type { Repo } from '../../src/shared/types'
+
+/** Opens the repo settings panel and pins the UI language to English. */
+async function openRepoSettings(page: Page, repoId: string): Promise<void> {
+  // Why: the host OS locale (e.g. ko-KR) drives Orca's default UI language.
+  // Pin English so this spec's locators are stable across dev machines and CI.
+  await page.evaluate(() => window.__store!.getState().updateSettings({ uiLanguage: 'en' }))
+  await page.evaluate((repoId) => {
+    const state = window.__store!.getState()
+    state.openSettingsTarget({ pane: 'repo', repoId })
+    state.openSettingsPage()
+  }, repoId)
+  await expect(page.getByPlaceholder('Search settings')).toBeVisible({ timeout: 10_000 })
+  const maybeLaterButton = page.getByRole('button', { name: 'Maybe Later' })
+  if (await maybeLaterButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await maybeLaterButton.click()
+  }
+}
+
+/** Captures a full-page screenshot and attaches it to the test report. */
+async function attachScreenshot(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const screenshotPath = testInfo.outputPath(`${name}.png`)
+  await page.screenshot({ path: screenshotPath })
+  await testInfo.attach(name, { path: screenshotPath, contentType: 'image/png' })
+}
+
+test.describe('Repository icon emoji picker', () => {
+  test('search selects a native emoji and persists it as the repo icon', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+
+    const repos = await getStoreState<Repo[]>(orcaPage, 'repos')
+    expect(repos.length).toBeGreaterThan(0)
+    const repo = repos[0]
+
+    await openRepoSettings(orcaPage, repo.id)
+
+    const repoSection = orcaPage.locator(`[data-settings-section="repo-${repo.id}"]`)
+    await repoSection.getByRole('tab', { name: 'Emoji' }).click()
+
+    const picker = repoSection.locator('.repo-icon-emoji-picker')
+    await expect(picker).toBeVisible({ timeout: 10_000 })
+
+    // Full catalog with search — the removed grid only ever offered 12 fixed emoji.
+    const searchInput = picker.getByPlaceholder('Search emoji')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('rocket')
+
+    await attachScreenshot(orcaPage, testInfo, 'repo-icon-emoji-picker-search')
+
+    const rocketResult = picker.getByRole('button', { name: /rocket/i }).first()
+    await expect(rocketResult).toBeVisible({ timeout: 10_000 })
+    await rocketResult.click()
+
+    await expect
+      .poll(
+        async () => {
+          const current = await getStoreState<Repo[]>(orcaPage, 'repos')
+          return current.find((entry) => entry.id === repo.id)?.repoIcon
+        },
+        { timeout: 5_000, message: 'repo icon did not persist the picked emoji' }
+      )
+      .toEqual({ type: 'emoji', emoji: '🚀' })
+
+    await attachScreenshot(orcaPage, testInfo, 'repo-icon-emoji-picker-selected')
+  })
+})

--- a/tests/e2e/repo-icon-emoji-picker.spec.ts
+++ b/tests/e2e/repo-icon-emoji-picker.spec.ts
@@ -72,6 +72,9 @@ test.describe('Repository icon emoji picker', () => {
       )
       .toEqual({ type: 'emoji', emoji: '🚀' })
 
+    // The store round-trip alone would pass even if the panel rendered nothing.
+    await expect(repoSection.getByText('Current: 🚀')).toBeVisible()
+
     await attachScreenshot(orcaPage, testInfo, 'repo-icon-emoji-picker-selected')
   })
 })


### PR DESCRIPTION
## Summary

Closes #7989.

Replace the hardcoded 12-emoji grid in the repo icon settings ("Emoji" tab of `RepositoryIconTabs.tsx`) with the full, native, searchable, category-navigable emoji picker, letting users freely select from the full set of system-provided emojis instead of only the limited presets. No new dependency: it reuses `emoji-picker-react`, which is already a dependency and already used by `RichMarkdownEmojiMenu` in the markdown editor.

**Design choice**: compared reusing `RichMarkdownEmojiMenu`'s `emoji-picker-react` setup (search, categories, lazy-loading built in) against hand-building a shadcn `Popover + Command` picker over the full emojibase dataset. Went with the former — it's the minimal design that matches STYLEGUIDE's "sibling components should read as one design" guidance, and a `Command`-based rebuild would need its own virtualization (cmdk has none) plus a from-scratch category-navigation implementation, which is unnecessary scope and a real performance risk for a multi-thousand-emoji catalog.

Other changes in this PR:
- The picker itself lives in a new `RepositoryIconEmojiPicker` component, lazy-loaded (`React.lazy` + `Suspense`) from `RepositoryIconTabs`. `emoji-picker-react` is a ~500KB chunk; without this split it was pulled into the eager settings bundle every time the repo icon settings render, not just when the Emoji tab is opened. This also keeps `RepositoryIconTabs.tsx` itself focused on tab wiring instead of mixing in picker-specific state.
- Added a `.repo-icon-emoji-picker`-scoped CSS variable block in `main.css` using `--card` / `--card-foreground` tokens (this picker is embedded inline in a settings panel, not a popover, so it doesn't reuse `RichMarkdownEmojiMenu`'s `--popover` tokens) and the `--font-sans` token instead of a hardcoded font-family.
- Every pick is re-validated through `sanitizeRepoIcon` before being saved, so a ZWJ/skin-tone sequence over its 16-char cap surfaces a `toast.error` instead of silently no-op'ing through `sanitizeRepoUpdate`. Skin tones are left selectable (not disabled) for global inclusivity.
- `Theme.DARK`/`Theme.LIGHT` is computed explicitly from a minimal `useAppStore((state) => state.settings?.theme ?? 'system')` selector plus the existing `useSystemPrefersDark` hook, instead of `Theme.AUTO` (which only follows the OS `prefers-color-scheme` setting and can disagree with Orca's own manual theme choice). Scoping these subscriptions to the new lazy component also means they only re-render while the Emoji tab is actually mounted.
- The search placeholder is routed through `translate(...)` instead of being a hardcoded string.
- `repo-icon.tsx`'s centering logic is untouched.

## Screenshots

Captured from a real Electron build (`electron-vite build --mode e2e`) + Playwright E2E (`tests/e2e/repo-icon-emoji-picker.spec.ts`), so the glyphs are the actual native macOS emoji font, not a mock render.

### Before — hardcoded 12-emoji grid (main)
![before-hardcoded-12-emoji-grid.png](https://github.com/user-attachments/assets/2335f1a8-feea-4af2-b315-e0aa208092bf)

### After — full searchable emoji picker (search "rocket")
![after-emoji-picker-search.png](https://github.com/user-attachments/assets/87feb586-838c-4380-97a1-781aa69b6471)

### After — 🚀 selected with Current metadata
![after-emoji-picker-selected.png](https://github.com/user-attachments/assets/8b32f7a3-9fed-46d1-9d9f-d5ba98f52a59)

## Testing

- [x] `pnpm lint` (oxlint, native/type-aware code-quality audits, reliability gates, max-lines ratchet, and all three localization checks — catalog/extraction/coverage)
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite; see Notes for pre-existing failures unrelated to this change
- [x] Added `RepositoryIconEmojiPicker.test.tsx` (5 tests): the full picker renders in place of the old grid, a valid emoji selection persists via the existing `onSetIcon` contract, an over-16-char sequence is rejected with a toast instead of a silent no-op, a valid skin-tone emoji is saved normally, and the "Current" trailing metadata renders
- [x] Added `tests/e2e/repo-icon-emoji-picker.spec.ts`: real Electron build, search → select → store persistence; doubles as the screenshot capture above
- [ ] `pnpm build` — not run; out of proportional scope for a renderer-only change. `electron-vite build --mode e2e` was run instead to produce the real build used for the E2E test/screenshots above.

## AI Review Report

Implemented directly with Claude Code (Sonnet 5). Review covered:
- **Cross-platform (macOS/Linux/Windows)**: pure renderer UI change with no modifier-key, path, or shell-specific code. `EmojiStyle.NATIVE` delegates glyph rendering to each OS's own emoji font — no image sprites, no platform branching needed.
- **SSH / remote / local compatibility**: no IPC or filesystem access was added; the component only reads store state and calls the existing `onSetIcon`/`updateRepo` path, which already works uniformly across local, SSH, and folder-workspace repos.
- **Agent / integration / git-provider compatibility**: N/A — this is a settings-UI-only change with no agent, provider, or CLI-integration surface.
- **Performance**: no new dependency. `emoji-picker-react` (~500KB) is now dynamically imported via a dedicated lazy `RepositoryIconEmojiPicker` chunk, confirmed in the real build output, so it only loads once a user opens the Emoji tab rather than on every repo-settings visit. `lazyLoadEmojis` avoids rendering the whole catalog eagerly once it does load.
- **UI quality**: only STYLEGUIDE tokens are used (`--card`, `--border`, `--accent`, `--font-sans`) — no hardcoded colors or fonts. Verified in light theme via the real-Electron-build screenshots above; dark-theme is driven by the same CSS variables and the new explicit `Theme.DARK`/`Theme.LIGHT` selector logic, but was not separately screenshotted (see Notes).
- **Security**: see Security Audit below.

No other issues were flagged during review.

## Security Audit

- **Input handling**: the value picked by the user is `EmojiClickData.emoji` from `emoji-picker-react`'s own built-in dataset, not free-text input. It is re-validated by `sanitizeRepoIcon` before persistence (16-char cap, fixed `type: 'emoji'` shape).
- **Command execution / IPC**: none added. This is a renderer-only UI change; no new IPC channel or command-execution path, and no external input reaches a shell or process.
- **Path handling**: N/A — no file paths are touched.
- **Auth / secrets**: N/A.
- **Dependencies**: no `package.json` changes. `emoji-picker-react` and `emojibase-data` are both pre-existing dependencies, reused as-is.
- **Follow-up**: none.

## Notes

- No platform-specific, SSH/remote-specific, agent-specific, integration-specific, or git-provider-specific behavior in this change — it's a settings-panel UI swap.
- `pnpm test` (full suite): the only failures observed are pre-existing and unrelated to this diff — `src/relay/agent-exec-handler.test.ts` (native spawn-args assertions) and an isolated `config/scripts/check-root-directory-entries.test.mjs` failure caused by this machine's system `/bin/bash` being 3.2 (no `declare -A` support), which the guard script this test exercises requires. Neither file is touched by this PR.
- Remaining risk: dark-theme rendering was not separately screenshotted (only light theme, see Screenshots). The follow-up commit closes the concrete dark-mode gaps found by review (search-active, highlight and picker-border variables were falling through to the library's raw defaults), but there is still no dedicated dark-theme visual capture.
- Three new i18n strings were added. They are now translated in all four non-English locales (es/ja/ko/zh) in this PR rather than left to the backfill pipeline — see the maintainer follow-up below. Each locale goes from 11774 to 11777 of 11862 keys.



## Maintainer follow-up (`fef6cc6db8`)

Reviewed against the readiness checklist with a fan-out of parallel reviewers (correctness/crash, UI + STYLEGUIDE, performance + cross-platform, localization, tests), each finding then adversarially verified. 22 candidate findings, 9 survived verification, all P2 — no P0/P1, nothing release-blocking. All nine are fixed here:

- **`lazyWithRetry` instead of raw `React.lazy`** — `RepositoryIconTabs.tsx` was the only renderer call site importing raw `lazy`; every other one uses `@/lib/lazy-with-retry`. React permanently caches a rejected dynamic import, so a transient chunk fetch failure (SSH/remote-served renderer, or stale chunk hashes right after an update) would blank the whole Settings page via the `page.*` boundary, and its Retry button would replay the cached rejection. It also filed a genuine `reportReactErrorBoundaryCrash` because the suppression path only recognises `LazyChunkLoadError`. This bites without a tab click: `RepositoryIconPicker` passes `initialTab: 'emoji'` for repos that already have an emoji icon.
- **`autoFocusSearch={false}`** — the library defaults it to `true`. Because the picker can mount with the panel, it stole focus from the settings search and scrolled the pane.
- **`font-family` was inert** — the library emits `font-family: sans-serif` on *every* descendant, so a root-level declaration never reaches the search input, category labels or preview text. Now scoped to descendants, so the picker actually renders in `--font-sans`.
- **Dark-mode variable gaps** — `--epr-search-input-bg-color-active`, `--epr-search-border-color-active`, `--epr-highlight-color` and `--epr-picker-border-color` were uncovered and fell back to the library's defaults (search input flipping to pure black on focus, invisible preview divider).
- **Scrollbar** — the picker's `.epr-body` used the raw Chromium scrollbar instead of the app's sleek one.
- **E2E asserted the store, not the DOM** — `tests/e2e/AGENTS.md` ("E2E Assertions Must Target the DOM, Not the Store") requires the final `expect()` to be user-observable. Added a DOM assertion on the rendered "Current:" caption alongside the store poll.

Two review comments were checked and need no action: Greptile's `--epr-search-input-border-color` note was already fixed by `894eaa2ddf` (`--epr-search-border-color` is the correct variable in the installed `emoji-picker-react@4.19.1`), and the descriptive i18n key names are consistent with the 2887 non-hash keys already in `en.json`.

**Translations** — `emojiTooLongForRepoIcon`, `currentEmojiSelection` and `searchEmojiPlaceholder` translated into es/ja/ko/zh, each matched against the terminology already established in that locale's catalog (e.g. es expands repo to "repositorio"; ja/ko keep "repo" in Latin script per their existing `RepositoryIconPicker` entries; zh uses the majority "仓库" form; the `{{value0}}` placeholder is preserved verbatim and zh/ja/ko follow the catalog's colon conventions).

**Gates re-run after the follow-up** — `pnpm lint` (full pipeline: oxlint, both code-quality audits, reliability gates, max-lines ratchet, skill-bundle verifies, all three localization checks), `pnpm typecheck` (all three tsconfigs), and `pnpm exec vitest run src/renderer/src/components/settings/` (138 files, 908 tests). All pass.

Note for the record: this PR's `PR Checks` runs had all been sitting at `action_required` (fork PR gating), so CI had never actually run on it before this follow-up — it has now been approved and run.