### PR TITLE
fix(terminal): stabilize scroll through grid resize

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3173,6 +3173,137 @@
       "demotionRule": "Demote or quarantine if the unit gate flakes without a product bug or harness bug filed to the owner."
     },
     {
+      "id": "terminal-scroll.resize-bottom-lock",
+      "title": "Terminal column resize deterministically follows output",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-rendering",
+      "layer": "renderer-unit-and-electron-e2e",
+      "surfaces": [
+        "terminal geometry",
+        "split layout",
+        "window resize",
+        "xterm reflow",
+        "scrollback"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon"],
+      "coverageNotes": "Headless xterm coverage proves the renderer-owned policy independent of PTY provider. Electron coverage exercises local daemon-backed terminals on macOS, including window and split-divider resize paths; live SSH, WSL, remote-runtime, Linux, and Windows remain unproved.",
+      "motivatingLinks": ["manual-repro:terminal-scroll-resize"],
+      "invariant": "A successful fit that changes terminal columns moves the normal-buffer viewport to the live bottom and records follow-output intent. Row-only, pixel-only, failed, or grid-identical fits preserve pinned scroll, and a delayed split settle never overwrites newer user scroll intent.",
+      "oracle": "Renderer tests require failed and row-only fits to preserve a pinned viewport, column-changing fits to reach the live bottom after bounded scrollbar settlement, no-grid fits to remain no-ops, and split-settle retries to stop after user intent changes. Headless xterm and Electron journeys require narrow/wide window and one-column split resizes to finish at viewportY === baseY while live output continues.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-fit.test.ts src/renderer/src/lib/pane-manager/pane-scroll.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/renderer/src/lib/pane-manager/xterm-scroll-resize-bottom-lock.test.ts",
+        "pnpm run ensure:electron-runtime && pnpm exec playwright test tests/e2e/terminal-scroll-resize-bottom-lock.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+        "pnpm run ensure:electron-runtime && pnpm exec playwright test tests/e2e/terminal-split-scroll-resize-bottom-lock.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1"
+      ],
+      "testFiles": [
+        "src/renderer/src/lib/pane-manager/pane-fit.test.ts",
+        "src/renderer/src/lib/pane-manager/pane-scroll.test.ts",
+        "src/renderer/src/lib/pane-manager/pane-split-close.test.ts",
+        "src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts",
+        "src/renderer/src/lib/pane-manager/xterm-scroll-resize-bottom-lock.test.ts",
+        "tests/e2e/terminal-scroll-resize-bottom-lock.spec.ts",
+        "tests/e2e/terminal-split-scroll-resize-bottom-lock.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/lib/pane-manager/pane-fit.test.ts",
+          "assertions": [
+            "a fit failure that leaves the grid unchanged preserves pinned scroll instead of bottom-locking"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/pane-manager/pane-scroll.test.ts",
+          "assertions": [
+            "bottom lock retries when xterm accepts scrolling before its scrollbar geometry settles"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts",
+          "assertions": [
+            "the authoritative split settle does not overwrite user scroll intent recorded after the first restore"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/pane-manager/xterm-scroll-resize-bottom-lock.test.ts",
+          "assertions": [
+            "real xterm preserves a pinned row-only resize, while column reflow at ordinary and capped scrollback sizes ends at the current bottom"
+          ]
+        },
+        {
+          "file": "tests/e2e/terminal-scroll-resize-bottom-lock.spec.ts",
+          "assertions": [
+            "narrow and wide window grid changes finish bottom-locked with the ready marker visible"
+          ]
+        },
+        {
+          "file": "tests/e2e/terminal-split-scroll-resize-bottom-lock.spec.ts",
+          "assertions": [
+            "a one-column split widen bottom-locks a wrapped live-output pane and output continues"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/pane-fit.test.ts src/renderer/src/lib/pane-manager/pane-scroll.test.ts src/renderer/src/lib/pane-manager/pane-split-close.test.ts src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts src/renderer/src/lib/pane-manager/xterm-scroll-resize-bottom-lock.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.7,
+          "summary": "Five focused renderer files passed with 44 tests covering column-change bottom lock, row-only and failed-fit preservation, bounded retry, split cancellation, and real headless xterm reflow."
+        },
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm run ensure:electron-runtime && pnpm exec playwright test tests/e2e/terminal-scroll-resize-bottom-lock.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 14.6,
+          "summary": "The local Electron terminal passed narrow and wide window grid changes with the viewport at the live bottom and the final transcript marker visible."
+        },
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm run ensure:electron-runtime && pnpm exec playwright test tests/e2e/terminal-split-scroll-resize-bottom-lock.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 11.6,
+          "summary": "The headful split journey passed immediate post-split resize and one-column live-output reflow with the viewport bottom-locked."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 120,
+        "scope": "focused renderer tests plus two isolated Electron journeys"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "Focused renderer coverage and local Electron journeys passed during implementation; CI soak history is not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Manual real-terminal reproduction showed logical anchor restoration could land on different content after a one-column reflow. The failed-fit and stale split-intent regression tests were added from independent review, but saved intentional-break runs are not attached."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Column-changing fits add constant-time intent capture, one immediate scroll, and at most two requestAnimationFrame retries. Row-only pinned fits retain the existing logical-line marker capture. Split reparent keeps its bounded double-frame and 200 ms settle work; the intent guard adds constant-time revision checks and no polling, output parsing, provider calls, IPC, subprocesses, or full-buffer scans."
+      },
+      "promotionCriteria": [
+        "Collect stable CI soak history for the renderer and Electron commands.",
+        "Attach saved red/green evidence for failed-fit and stale split-intent regressions.",
+        "Run the Electron journeys on Linux and Windows and exercise live SSH and WSL terminals."
+      ],
+      "knownGaps": [
+        "Electron runtime evidence is local macOS only.",
+        "Live SSH, WSL, remote-runtime, Linux, and Windows terminal resize paths are not covered.",
+        "No packaged-build frame-time measurement was recorded during sustained live-output resize storms."
+      ],
+      "demotionRule": "Demote or quarantine if the renderer gate flakes without a product or harness bug, or if a grid-identical fit changes scroll position."
+    },
+    {
       "id": "terminal-scroll.streaming-refocus-intent",
       "title": "Streaming refocus preserves follow-output viewport intent",
       "maturity": "experimental",

--- a/src/renderer/src/lib/pane-manager/pane-fit-scroll-restore.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-scroll-restore.ts
@@ -1,0 +1,93 @@
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
+import {
+  captureTerminalStructuralScrollIntent,
+  isTerminalStructuralScrollIntentCurrent,
+  markTerminalFollowOutput,
+  markTerminalPinnedViewport,
+  restoreTerminalStructuralScrollIntent
+} from './terminal-scroll-intent'
+import {
+  captureBottomLockedScrollState,
+  captureScrollState,
+  releaseScrollStateMarker,
+  restoreScrollStateAfterFit,
+  resumePendingFitScrollRestoreAfterFit
+} from './pane-scroll'
+import { isTerminalScrollIntentRebuildInFlight } from './terminal-scroll-intent-rebuild'
+
+export type PaneFitScrollCapture = {
+  cols: number
+  intent: NonNullable<ReturnType<typeof captureTerminalStructuralScrollIntent>>
+  pinnedState: ReturnType<typeof captureScrollState> | null
+}
+
+export function capturePaneFitScroll(
+  pane: ManagedPane,
+  capturePinnedState: boolean
+): PaneFitScrollCapture | null {
+  if ('pendingSplitScrollState' in pane && (pane as ManagedPaneInternal).pendingSplitScrollState) {
+    return null
+  }
+  const intent = captureTerminalStructuralScrollIntent(pane.terminal)
+  return intent
+    ? {
+        cols: pane.terminal.cols,
+        intent,
+        pinnedState:
+          capturePinnedState && intent.kind === 'pinnedViewport'
+            ? captureScrollState(pane.terminal)
+            : null
+      }
+    : null
+}
+
+export function restorePaneFitScroll(pane: ManagedPane, capture: PaneFitScrollCapture): void {
+  let pinnedState = capture.pinnedState
+  try {
+    // Why: row-only fits do not reflow logical lines, so keep the user's pin.
+    const columnsChanged = pane.terminal.cols !== capture.cols
+    if (resumePendingFitScrollRestoreAfterFit(pane.terminal)) {
+      return
+    }
+    if (columnsChanged) {
+      if (pinnedState) {
+        releaseScrollStateMarker(pinnedState)
+        pinnedState = null
+      }
+      const state = captureBottomLockedScrollState(pane.terminal)
+      restoreScrollStateAfterFit(pane.terminal, state, {
+        onRestored: () => markTerminalFollowOutput(pane.terminal),
+        shouldRestore: () => canRestore(pane, capture)
+      })
+      return
+    }
+    if (!pinnedState) {
+      restoreTerminalStructuralScrollIntent(pane.terminal, capture.intent)
+      return
+    }
+    const state = pinnedState
+    pinnedState = null
+    restoreScrollStateAfterFit(pane.terminal, state, {
+      onRestored: () => {
+        // Why: transient replay geometry must not replace the durable pin with 0/0.
+        if (!state.wasAtBottom) {
+          markTerminalPinnedViewport(pane.terminal)
+        }
+      },
+      shouldRestore: () => canRestore(pane, capture)
+    })
+  } catch {
+    // Why: SSH reattach can briefly expose xterm without renderer dimensions.
+  } finally {
+    if (pinnedState) {
+      releaseScrollStateMarker(pinnedState)
+    }
+  }
+}
+
+function canRestore(pane: ManagedPane, capture: PaneFitScrollCapture): boolean {
+  return (
+    !isTerminalScrollIntentRebuildInFlight(pane.terminal) &&
+    isTerminalStructuralScrollIntentCurrent(pane.terminal, capture.intent)
+  )
+}

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -188,6 +188,25 @@ describe('safeFitAndThen unmeasurable-pane retry', () => {
 })
 
 describe('paneFitClientSizeChanged (reveal fit gate)', () => {
+  it('preserves pinned scroll when fit fails before changing the grid', () => {
+    const pane = createPane({ rect: { width: 800, height: 600 } })
+    const scrollToBottom = vi.fn()
+    const activeBuffer = { type: 'normal', viewportY: 42, baseY: 100 }
+    Object.assign(pane.terminal, {
+      buffer: { active: activeBuffer },
+      element: {},
+      scrollToBottom,
+      scrollToLine: vi.fn()
+    })
+    vi.mocked(pane.fitAddon.fit).mockImplementation(() => {
+      throw new Error('fit failed')
+    })
+
+    expect(safeFit(pane)).toBe(false)
+    expect(activeBuffer.viewportY).toBe(42)
+    expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+
   it('treats a pane with no recorded fit size as changed', () => {
     const pane = createPane({ rect: { width: 800, height: 600 } })
     expect(paneFitClientSizeChanged(pane)).toBe(true)

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -1,25 +1,16 @@
-import type { ManagedPane, ManagedPaneInternal, ScrollState } from './pane-manager-types'
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
 import { getFitOverrideForPty } from './mobile-fit-overrides'
 import {
   armPaneFitContinuationRetry,
   clearPaneFitContinuationRetry
 } from './pane-fit-continuation-retry'
+import { resumePendingFitScrollRestoreAfterFit } from './pane-scroll'
+import { deferTerminalGeometryMutationDuringRebuild } from './terminal-scroll-intent-rebuild'
 import {
-  captureTerminalStructuralScrollIntent,
-  isTerminalStructuralScrollIntentCurrent,
-  markTerminalPinnedViewport,
-  restoreTerminalStructuralScrollIntent
-} from './terminal-scroll-intent'
-import {
-  captureScrollState,
-  releaseScrollStateMarker,
-  restoreScrollStateAfterFit,
-  resumePendingFitScrollRestoreAfterFit
-} from './pane-scroll'
-import {
-  deferTerminalGeometryMutationDuringRebuild,
-  isTerminalScrollIntentRebuildInFlight
-} from './terminal-scroll-intent-rebuild'
+  capturePaneFitScroll,
+  restorePaneFitScroll,
+  type PaneFitScrollCapture
+} from './pane-fit-scroll-restore'
 
 const MIN_PANE_FIT_WIDTH_PX = 48
 const MIN_PANE_FIT_HEIGHT_PX = 24
@@ -87,13 +78,6 @@ export function canMeasurePaneForFit(pane: ManagedPane): boolean {
   return dims.cols >= MIN_PANE_FIT_COLS && dims.rows >= MIN_PANE_FIT_ROWS
 }
 
-function canPreserveScrollIntentForFit(pane: ManagedPane): boolean {
-  // Why: split reparent has its own delayed restore; restoring here can fight that timer.
-  return !(
-    'pendingSplitScrollState' in pane && (pane as ManagedPaneInternal).pendingSplitScrollState
-  )
-}
-
 function performSafeFit(pane: ManagedPane): boolean {
   if (deferTerminalGeometryMutationDuringRebuild(pane.terminal, 'safe-fit', () => safeFit(pane))) {
     return false
@@ -101,26 +85,14 @@ function performSafeFit(pane: ManagedPane): boolean {
   if (!canMeasurePaneForFit(pane)) {
     return false
   }
-  let scrollIntent = null as ReturnType<typeof captureTerminalStructuralScrollIntent>
-  let pinnedScrollState: ScrollState | null = null
-  let shouldRestoreScroll = false
-  const captureScrollForFit = (): void => {
-    scrollIntent = captureTerminalStructuralScrollIntent(pane.terminal)
-    // Why: fit can reflow and renumber every buffer row; a marker tracks the
-    // pinned content itself, while a numeric line would point elsewhere after.
-    pinnedScrollState =
-      scrollIntent?.kind === 'pinnedViewport' ? captureScrollState(pane.terminal) : null
-    shouldRestoreScroll = true
-  }
+  let scrollCapture: PaneFitScrollCapture | null = null
   try {
     // Why: a mobile-owned PTY must stay at its phone grid on passive desktop panes.
     const ptyId = pane.container?.dataset?.ptyId
     const override = ptyId ? getFitOverrideForPty(ptyId) : null
     if (override) {
       if (pane.terminal.cols !== override.cols || pane.terminal.rows !== override.rows) {
-        if (canPreserveScrollIntentForFit(pane)) {
-          captureScrollForFit()
-        }
+        scrollCapture = capturePaneFitScroll(pane, pane.terminal.cols === override.cols)
         pane.terminal.resize(override.cols, override.rows)
       } else {
         resumePendingFitScrollRestoreAfterFit(pane.terminal)
@@ -134,42 +106,15 @@ function performSafeFit(pane: ManagedPane): boolean {
       resumePendingFitScrollRestoreAfterFit(pane.terminal)
       return true
     }
-    if (canPreserveScrollIntentForFit(pane)) {
-      captureScrollForFit()
-    }
+    scrollCapture = capturePaneFitScroll(pane, dims?.cols === pane.terminal.cols)
     pane.fitAddon.fit()
     return true
   } catch {
     // Container may not have dimensions yet.
     return false
   } finally {
-    if (shouldRestoreScroll) {
-      try {
-        if (resumePendingFitScrollRestoreAfterFit(pane.terminal)) {
-        } else if (pinnedScrollState) {
-          const state: ScrollState = pinnedScrollState
-          pinnedScrollState = null
-          restoreScrollStateAfterFit(pane.terminal, state, {
-            onRestored: () => {
-              // Why: do not replace a durable pre-replay pin with transient 0/0 geometry.
-              if (!state.wasAtBottom) {
-                markTerminalPinnedViewport(pane.terminal)
-              }
-            },
-            shouldRestore: () =>
-              !isTerminalScrollIntentRebuildInFlight(pane.terminal) &&
-              isTerminalStructuralScrollIntentCurrent(pane.terminal, scrollIntent)
-          })
-        } else {
-          restoreTerminalStructuralScrollIntent(pane.terminal, scrollIntent)
-        }
-      } catch {
-        // Why: SSH reattach can briefly expose xterm without renderer dimensions.
-      } finally {
-        if (pinnedScrollState) {
-          releaseScrollStateMarker(pinnedScrollState)
-        }
-      }
+    if (scrollCapture) {
+      restorePaneFitScroll(pane, scrollCapture)
     }
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { Terminal as HeadlessTerminal } from '@xterm/headless'
 import type { IMarker, Terminal } from '@xterm/xterm'
 import {
+  captureBottomLockedScrollState,
   captureScrollState,
   getTerminalOutputEpoch,
   recordTerminalOutput,
@@ -95,6 +96,18 @@ describe('scroll state', () => {
       baseY: 100
     })
     expect(terminal.registerMarker).toHaveBeenCalledWith(-65)
+  })
+
+  it('captures deterministic bottom-locked state', () => {
+    const terminal = createTerminal({ viewportY: 42, baseY: 100 })
+
+    expect(captureBottomLockedScrollState(terminal)).toEqual({
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 100,
+      baseY: 100
+    })
+    expect(terminal.registerMarker).not.toHaveBeenCalled()
   })
 
   it('tracks output epochs per terminal', () => {
@@ -359,6 +372,38 @@ describe('scroll state', () => {
 
     expect(() => frameCallbacks.shift()?.(0)).toThrow('unexpected asynchronous renderer failure')
     expect(marker.isDisposed).toBe(true)
+  })
+
+  it('retries bottom-lock when xterm scrollbar geometry has not settled', () => {
+    const frameCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    const terminal = createTerminal({ viewportY: 10, baseY: 100 })
+    const activeBuffer = terminal.buffer.active as { viewportY: number }
+    vi.mocked(terminal.scrollToBottom)
+      .mockImplementationOnce(() => {})
+      .mockImplementation(() => {
+        activeBuffer.viewportY = 100
+      })
+    const onRestored = vi.fn()
+
+    restoreScrollStateAfterFit(
+      terminal,
+      {
+        bufferType: 'normal',
+        wasAtBottom: true,
+        viewportY: 100,
+        baseY: 100
+      },
+      { onRestored, shouldRestore: () => true }
+    )
+
+    expect(activeBuffer.viewportY).toBe(10)
+    frameCallbacks.shift()?.(0)
+    expect(activeBuffer.viewportY).toBe(100)
+    expect(onRestored).toHaveBeenCalledTimes(1)
   })
 
   it('scrolls to the current bottom when the pane was previously at bottom', () => {

--- a/src/renderer/src/lib/pane-manager/pane-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-scroll.ts
@@ -1,10 +1,16 @@
 import type { Terminal } from '@xterm/xterm'
 import type { ScrollState } from './pane-manager-types'
 import {
-  captureLogicalLineAnchor,
-  resolveLogicalCellOffsetLine
-} from './terminal-reflow-scroll-anchor'
-import { forceTerminalViewportScrollbarSync } from './terminal-viewport-scrollbar-sync'
+  releaseScrollStateMarker,
+  restoreScrollStateNow,
+  type ScrollRestoreResult
+} from './terminal-scroll-state'
+
+export {
+  captureBottomLockedScrollState,
+  captureScrollState,
+  releaseScrollStateMarker
+} from './terminal-scroll-state'
 
 const terminalOutputEpochs = new WeakMap<Terminal, number>()
 const deferredScrollRestores = new WeakMap<
@@ -27,8 +33,6 @@ const pendingFitScrollRestores = new WeakMap<
   }
 >()
 const FIT_SCROLL_RESTORE_MAX_FRAMES = 2
-
-type ScrollRestoreResult = 'restored' | 'retry' | 'skipped'
 
 export function recordTerminalOutput(terminal: Terminal): void {
   terminalOutputEpochs.set(terminal, getTerminalOutputEpoch(terminal) + 1)
@@ -55,37 +59,6 @@ export function cancelDeferredScrollRestore(terminal: object): void {
   }
   releaseScrollStateMarker(pending.state)
   deferredScrollRestores.delete(terminal)
-}
-
-export function captureScrollState(terminal: Terminal): ScrollState {
-  const buf = terminal.buffer.active
-  const viewportY = buf.viewportY
-  const wasAtBottom = viewportY >= buf.baseY
-  const logicalAnchor =
-    !wasAtBottom && buf.type === 'normal'
-      ? captureLogicalLineAnchor(terminal, viewportY)
-      : undefined
-  const firstVisibleLineMarker =
-    !wasAtBottom && buf.type === 'normal'
-      ? terminal.registerMarker?.(viewportY - (buf.baseY + buf.cursorY))
-      : undefined
-  return {
-    bufferType: buf.type,
-    wasAtBottom,
-    viewportY,
-    baseY: buf.baseY,
-    // Why: continuation-row markers can be deleted or drift during reflow.
-    // Keep the physical marker for no-reflow ConPTY/cursor-line cases, and
-    // anchor reflowing content at the logical line's stable first row.
-    firstVisibleLineMarker,
-    firstVisibleLogicalLineMarker:
-      logicalAnchor?.lineY === viewportY
-        ? firstVisibleLineMarker
-        : logicalAnchor
-          ? terminal.registerMarker?.(logicalAnchor.lineY - (buf.baseY + buf.cursorY))
-          : undefined,
-    firstVisibleLogicalCellOffset: logicalAnchor?.cellOffset
-  }
 }
 
 export function restoreScrollState(terminal: Terminal, state: ScrollState): boolean {
@@ -245,82 +218,6 @@ export function restoreScrollStateAfterLayout(terminal: Terminal, state: ScrollS
   pending.rafIds.push(firstRaf)
   pending.timeoutIds.push(timeoutId)
   deferredScrollRestores.set(terminal, pending)
-}
-
-function restoreScrollStateNow(terminal: Terminal, state: ScrollState): ScrollRestoreResult {
-  if (!terminal.element) {
-    return 'retry'
-  }
-  const buf = terminal.buffer.active
-  if (state.bufferType === 'alternate' || buf.type !== state.bufferType) {
-    return 'skipped'
-  }
-
-  // Why: WebGL suspend disposes xterm's render service while leaving
-  // terminal.element attached, so scrollToBottom/scrollToLine/scrollLines all
-  // throw "cannot read dimensions" until the pane re-attaches. Swallow that
-  // window quietly — the next visibility flip re-fits and re-restores.
-  if (state.wasAtBottom) {
-    if (safeScrollCall(() => terminal.scrollToBottom())) {
-      forceTerminalViewportScrollbarSync(terminal)
-      return 'restored'
-    }
-    return 'retry'
-  }
-
-  const logicalMarkerLine =
-    state.firstVisibleLogicalLineMarker && !state.firstVisibleLogicalLineMarker.isDisposed
-      ? state.firstVisibleLogicalLineMarker.line
-      : -1
-  const markerLine =
-    state.firstVisibleLineMarker && !state.firstVisibleLineMarker.isDisposed
-      ? state.firstVisibleLineMarker.line
-      : -1
-  const logicalTargetLine =
-    logicalMarkerLine >= 0 && state.firstVisibleLogicalCellOffset !== undefined
-      ? resolveLogicalCellOffsetLine(
-          terminal,
-          logicalMarkerLine,
-          state.firstVisibleLogicalCellOffset
-        )
-      : null
-  const targetLine = Math.min(
-    logicalTargetLine ?? (markerLine >= 0 ? markerLine : state.viewportY),
-    buf.baseY
-  )
-  state.viewportY = targetLine
-  // Why: deferred rAF/timeout restores re-invoke this function after xterm
-  // reflow settles; keep the marker alive so each call consults the live
-  // line. Callers (restoreScrollState, the timeout in
-  // restoreScrollStateAfterLayout, cancelDeferredScrollRestore) own disposal.
-  if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
-    forceTerminalViewportScrollbarSync(terminal)
-    return 'restored'
-  }
-  return 'retry'
-}
-
-function safeScrollCall(fn: () => void): boolean {
-  try {
-    fn()
-    return true
-  } catch (err) {
-    // Why: xterm's renderer can null out internal dimensions during WebGL
-    // teardown, throwing "Cannot read properties of undefined (reading
-    // 'dimensions')". Tolerate that; surface anything else.
-    if (err instanceof TypeError && /dimensions/.test(err.message)) {
-      return false
-    }
-    throw err
-  }
-}
-
-export function releaseScrollStateMarker(state: ScrollState): void {
-  state.firstVisibleLineMarker?.dispose()
-  if (state.firstVisibleLogicalLineMarker !== state.firstVisibleLineMarker) {
-    state.firstVisibleLogicalLineMarker?.dispose()
-  }
-  state.firstVisibleLineMarker = state.firstVisibleLogicalLineMarker = undefined
 }
 
 function cancelPendingFitScrollRestore(terminal: object): void {

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 
-const captureScrollState = vi.hoisted(() => vi.fn())
+const captureBottomLockedScrollState = vi.hoisted(() => vi.fn())
 const wrapInSplit = vi.hoisted(() => vi.fn())
 const openTerminal = vi.hoisted(() => vi.fn())
 const disposeWebgl = vi.hoisted(() => vi.fn())
@@ -13,7 +13,7 @@ const applyPaneOpacity = vi.hoisted(() => vi.fn())
 const applyDividerStyles = vi.hoisted(() => vi.fn())
 
 vi.mock('./pane-tree-ops', () => ({
-  captureScrollState,
+  captureBottomLockedScrollState,
   findPaneChildren: vi.fn(),
   promoteSibling: vi.fn(),
   removeDividers: vi.fn(),
@@ -135,7 +135,7 @@ describe('splitManagedPane', () => {
     ])
     const fallbackScrollState = createScrollState(11)
     const siblingScrollState = createScrollState(22)
-    captureScrollState
+    captureBottomLockedScrollState
       .mockReturnValueOnce(fallbackScrollState)
       .mockReturnValueOnce(siblingScrollState)
 
@@ -159,8 +159,8 @@ describe('splitManagedPane', () => {
     })
 
     expect(result?.id).toBe(newPane.id)
-    expect(captureScrollState).toHaveBeenCalledWith(fallbackPane.terminal)
-    expect(captureScrollState).toHaveBeenCalledWith(siblingPane.terminal)
+    expect(captureBottomLockedScrollState).toHaveBeenCalledWith(fallbackPane.terminal)
+    expect(captureBottomLockedScrollState).toHaveBeenCalledWith(siblingPane.terminal)
     expect(clearPendingSplitScrollRestore).toHaveBeenCalledWith(fallbackPane)
     expect(clearPendingSplitScrollRestore).toHaveBeenCalledWith(siblingPane)
     expect(fallbackPane.pendingSplitScrollState).toBe(fallbackScrollState)
@@ -181,7 +181,11 @@ describe('splitManagedPane', () => {
       fallbackPane.id,
       fallbackScrollState,
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.objectContaining({
+        onRestored: expect.any(Function),
+        shouldRestore: expect.any(Function)
+      })
     )
     expect(scheduleSplitScrollRestore).toHaveBeenNthCalledWith(
       2,
@@ -189,7 +193,11 @@ describe('splitManagedPane', () => {
       siblingPane.id,
       siblingScrollState,
       expect.any(Function),
-      expect.any(Function)
+      expect.any(Function),
+      expect.objectContaining({
+        onRestored: expect.any(Function),
+        shouldRestore: expect.any(Function)
+      })
     )
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -7,7 +7,7 @@ import type {
 import type { DragReorderCallbacks } from './pane-drag-reorder'
 import { updateMultiPaneState } from './pane-drag-reorder'
 import {
-  captureScrollState,
+  captureBottomLockedScrollState,
   findPaneChildren,
   promoteSibling,
   removeDividers,
@@ -17,13 +17,23 @@ import {
 import { applyDividerStyles, applyPaneOpacity } from './pane-divider'
 import { disposePane, openTerminal } from './pane-lifecycle'
 import { disposeWebgl } from './pane-webgl-renderer'
-import { clearPendingSplitScrollRestore, scheduleSplitScrollRestore } from './pane-split-scroll'
+import {
+  clearPendingSplitScrollRestore,
+  scheduleSplitScrollRestore,
+  type SplitScrollRestoreGuard
+} from './pane-split-scroll'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
 import { toPublicPane } from './pane-public-view'
+import {
+  captureTerminalStructuralScrollIntent,
+  isTerminalStructuralScrollIntentCurrent,
+  markTerminalFollowOutput
+} from './terminal-scroll-intent'
 
 type MovedPaneSplitState = {
   pane: ManagedPaneInternal
-  scrollState: ReturnType<typeof captureScrollState>
+  restoreGuard: SplitScrollRestoreGuard
+  scrollState: ReturnType<typeof captureBottomLockedScrollState>
   hadWebgl: boolean
 }
 
@@ -73,7 +83,8 @@ export function splitManagedPane(args: SplitManagedPaneArgs): ManagedPane | null
       movedPaneState.pane.id,
       movedPaneState.scrollState,
       args.isDestroyed,
-      movedPaneState.hadWebgl ? reattachWebglIfNeeded : undefined
+      movedPaneState.hadWebgl ? reattachWebglIfNeeded : undefined,
+      movedPaneState.restoreGuard
     )
   }
 
@@ -93,7 +104,16 @@ function prepareMovedPanesForSplit(
   return movedPanes.map((pane) => {
     clearPendingSplitScrollRestore(pane)
     // Why: wrapInSplit reparents moved containers, resetting browser scrollTop.
-    const scrollState = captureScrollState(pane.terminal)
+    const scrollState = captureBottomLockedScrollState(pane.terminal)
+    let scrollIntent = captureTerminalStructuralScrollIntent(pane.terminal)
+    const restoreGuard: SplitScrollRestoreGuard = {
+      onRestored: () => {
+        markTerminalFollowOutput(pane.terminal)
+        scrollIntent = captureTerminalStructuralScrollIntent(pane.terminal)
+      },
+      shouldRestore: () =>
+        !scrollIntent || isTerminalStructuralScrollIntentCurrent(pane.terminal, scrollIntent)
+    }
     // Why: lock prevents safeFit/fitAllPanes from restoring scroll during the
     // async settle window; scheduleSplitScrollRestore owns the restore.
     pane.pendingSplitScrollState = scrollState
@@ -102,7 +122,7 @@ function prepareMovedPanesForSplit(
     // firing contextlost, so dispose before the move and reattach after settle.
     const hadWebgl = !!pane.webglAddon
     disposeWebgl(pane)
-    return { pane, scrollState, hadWebgl }
+    return { pane, restoreGuard, scrollState, hadWebgl }
   })
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-scroll.test.ts
@@ -95,6 +95,7 @@ describe('scheduleSplitScrollRestore', () => {
       return 1
     })
     restoreScrollState.mockClear()
+    restoreScrollState.mockReturnValue(true)
     releaseScrollStateMarker.mockClear()
   })
 
@@ -125,6 +126,34 @@ describe('scheduleSplitScrollRestore', () => {
     expect(reattachWebgl).toHaveBeenCalledWith(pane)
     expect(restoreScrollState).toHaveBeenCalledTimes(2)
     expect(pane.terminal.refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not overwrite user scroll intent during the split settle window', () => {
+    const { pane } = createPane('normal')
+    const reattachWebgl = vi.fn()
+    let shouldRestore = true
+    const guard = {
+      onRestored: vi.fn(),
+      shouldRestore: vi.fn(() => shouldRestore)
+    }
+
+    scheduleSplitScrollRestore(
+      () => pane,
+      pane.id,
+      scrollState,
+      () => false,
+      reattachWebgl,
+      guard
+    )
+    expect(restoreScrollState).toHaveBeenCalledTimes(1)
+    expect(guard.onRestored).toHaveBeenCalledTimes(1)
+
+    shouldRestore = false
+    vi.advanceTimersByTime(200)
+
+    expect(restoreScrollState).toHaveBeenCalledTimes(1)
+    expect(pane.pendingSplitScrollState).toBeNull()
+    expect(reattachWebgl).toHaveBeenCalledWith(pane)
   })
 
   it('defers WebGL reattach and skips scroll restore for alternate-screen panes', () => {

--- a/src/renderer/src/lib/pane-manager/pane-split-scroll.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-scroll.ts
@@ -2,6 +2,11 @@ import type { IBuffer, IDisposable } from '@xterm/xterm'
 import type { ManagedPaneInternal, ScrollState } from './pane-manager-types'
 import { releaseScrollStateMarker, restoreScrollState } from './pane-scroll'
 
+export type SplitScrollRestoreGuard = {
+  onRestored: () => void
+  shouldRestore: () => boolean
+}
+
 function refreshAfterReparent(pane: ManagedPaneInternal): void {
   try {
     pane.terminal.refresh(0, pane.terminal.rows - 1)
@@ -69,14 +74,21 @@ function runAfterNormalBuffer(
 function restoreCapturedScrollState(
   pane: ManagedPaneInternal,
   scrollState: ScrollState,
-  reattachWebgl?: (pane: ManagedPaneInternal) => void
+  reattachWebgl?: (pane: ManagedPaneInternal) => void,
+  guard?: SplitScrollRestoreGuard
 ): void {
   clearPendingSplitScrollBufferDisposable(pane)
   pane.pendingSplitScrollState = null
   if (reattachWebgl) {
     reattachWebgl(pane)
   }
-  restoreScrollState(pane.terminal, scrollState)
+  if (!guard || guard.shouldRestore()) {
+    if (restoreScrollState(pane.terminal, scrollState)) {
+      guard?.onRestored()
+    }
+  } else {
+    releaseScrollStateMarker(scrollState)
+  }
   refreshAfterReparent(pane)
 }
 
@@ -96,7 +108,8 @@ export function scheduleSplitScrollRestore(
   paneId: number,
   scrollState: ScrollState,
   isDestroyed: () => boolean,
-  reattachWebgl?: (pane: ManagedPaneInternal) => void
+  reattachWebgl?: (pane: ManagedPaneInternal) => void,
+  guard?: SplitScrollRestoreGuard
 ): void {
   const scheduledPane = getPaneById(paneId)
   if (scheduledPane) {
@@ -124,7 +137,12 @@ export function scheduleSplitScrollRestore(
       ) {
         return
       }
-      restoreScrollState(live.terminal, scrollState)
+      if (guard && !guard.shouldRestore()) {
+        return
+      }
+      if (restoreScrollState(live.terminal, scrollState)) {
+        guard?.onRestored()
+      }
       refreshAfterReparent(live)
     })
     if (liveAfterFirstFrame) {
@@ -172,11 +190,11 @@ export function scheduleSplitScrollRestore(
     }
     if (live.terminal.buffer.active.type === 'alternate') {
       runAfterNormalBuffer(live, getPaneById, paneId, isDestroyed, (normalPane) => {
-        restoreCapturedScrollState(normalPane, scrollState, reattachWebgl)
+        restoreCapturedScrollState(normalPane, scrollState, reattachWebgl, guard)
       })
       return
     }
-    restoreCapturedScrollState(live, scrollState, reattachWebgl)
+    restoreCapturedScrollState(live, scrollState, reattachWebgl, guard)
   }, 200)
   if (scheduledPane) {
     scheduledPane.pendingSplitScrollTimerId = settleTimerId

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -243,12 +243,12 @@ describe('safeFit', () => {
     expect(pane.fitAddon.fit).not.toHaveBeenCalled()
   })
 
-  it('restores the viewport if fit clobbers it during resize', () => {
+  it('restores the viewport if a row-only fit clobbers it', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as { viewportY: number; baseY: number }
     activeBuffer.viewportY = 42
@@ -264,12 +264,12 @@ describe('safeFit', () => {
     expect(activeBuffer.viewportY).toBe(42)
   })
 
-  it('restores pinned content via marker when fit reflow renumbers buffer lines', () => {
+  it('restores pinned content via marker when a row-only fit renumbers buffer lines', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number
@@ -296,12 +296,12 @@ describe('safeFit', () => {
     expect(marker.dispose).toHaveBeenCalled()
   })
 
-  it('records the restored post-reflow pin when widening lowers baseY', () => {
+  it('records the restored pin when a row-only fit lowers baseY', () => {
     const pane = createPane({
       proposedCols: 160,
       proposedRows: 32,
-      terminalCols: 80,
-      terminalRows: 32
+      terminalCols: 160,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number
@@ -332,7 +332,7 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 80,
+      terminalCols: 100,
       terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
@@ -360,8 +360,8 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as { viewportY: number; baseY: number }
     activeBuffer.viewportY = 100
@@ -385,8 +385,8 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number
@@ -436,8 +436,8 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number
@@ -477,8 +477,8 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number
@@ -525,8 +525,8 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number
@@ -537,7 +537,11 @@ describe('safeFit', () => {
     activeBuffer.baseY = 100
     activeBuffer.cursorY = 0
     const marker = { line: 30, isDisposed: false, dispose: vi.fn() }
-    ;(pane.terminal as unknown as { registerMarker: unknown }).registerMarker = vi.fn(() => marker)
+    const replacementMarker = { line: 30, isDisposed: false, dispose: vi.fn() }
+    ;(pane.terminal as unknown as { registerMarker: unknown }).registerMarker = vi
+      .fn()
+      .mockReturnValueOnce(marker)
+      .mockReturnValueOnce(replacementMarker)
     vi.mocked(pane.fitAddon.fit).mockImplementation(() => {
       activeBuffer.baseY = 70
       activeBuffer.viewportY = 0
@@ -559,6 +563,7 @@ describe('safeFit', () => {
     safeFit(pane)
     expect(activeBuffer.viewportY).toBe(30)
     expect(marker.dispose).toHaveBeenCalledTimes(1)
+    expect(replacementMarker.dispose).toHaveBeenCalledTimes(1)
   })
 
   it('releases a replacement marker when a resumed retry throws', () => {
@@ -571,8 +576,8 @@ describe('safeFit', () => {
     const pane = createPane({
       proposedCols: 100,
       proposedRows: 32,
-      terminalCols: 120,
-      terminalRows: 32
+      terminalCols: 100,
+      terminalRows: 24
     })
     const activeBuffer = pane.terminal.buffer.active as {
       viewportY: number

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -15,7 +15,11 @@ export {
   safeFitAndThen,
   type SafeFitContinuationHandle
 } from './pane-fit'
-export { captureScrollState, restoreScrollState } from './pane-scroll'
+export {
+  captureBottomLockedScrollState,
+  captureScrollState,
+  restoreScrollState
+} from './pane-scroll'
 
 // ---------------------------------------------------------------------------
 // Split-tree manipulation: detach, insert, promote sibling

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-state.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-state.ts
@@ -1,0 +1,114 @@
+import type { Terminal } from '@xterm/xterm'
+import type { ScrollState } from './pane-manager-types'
+import {
+  captureLogicalLineAnchor,
+  resolveLogicalCellOffsetLine
+} from './terminal-reflow-scroll-anchor'
+import { forceTerminalViewportScrollbarSync } from './terminal-viewport-scrollbar-sync'
+
+export type ScrollRestoreResult = 'restored' | 'retry' | 'skipped'
+
+export function captureBottomLockedScrollState(terminal: Terminal): ScrollState {
+  const { baseY, type: bufferType } = terminal.buffer.active
+  // Why: reflowed TUI history has no stable content identity; resize must land predictably.
+  return {
+    bufferType,
+    wasAtBottom: true,
+    viewportY: baseY,
+    baseY
+  }
+}
+
+export function captureScrollState(terminal: Terminal): ScrollState {
+  const buf = terminal.buffer.active
+  const viewportY = buf.viewportY
+  const wasAtBottom = viewportY >= buf.baseY
+  const logicalAnchor =
+    !wasAtBottom && buf.type === 'normal'
+      ? captureLogicalLineAnchor(terminal, viewportY)
+      : undefined
+  const firstVisibleLineMarker =
+    !wasAtBottom && buf.type === 'normal'
+      ? terminal.registerMarker?.(viewportY - (buf.baseY + buf.cursorY))
+      : undefined
+  return {
+    bufferType: buf.type,
+    wasAtBottom,
+    viewportY,
+    baseY: buf.baseY,
+    firstVisibleLineMarker,
+    firstVisibleLogicalLineMarker:
+      logicalAnchor?.lineY === viewportY
+        ? firstVisibleLineMarker
+        : logicalAnchor
+          ? terminal.registerMarker?.(logicalAnchor.lineY - (buf.baseY + buf.cursorY))
+          : undefined,
+    firstVisibleLogicalCellOffset: logicalAnchor?.cellOffset
+  }
+}
+
+export function restoreScrollStateNow(terminal: Terminal, state: ScrollState): ScrollRestoreResult {
+  if (!terminal.element) {
+    return 'retry'
+  }
+  const buf = terminal.buffer.active
+  if (state.bufferType === 'alternate' || buf.type !== state.bufferType) {
+    return 'skipped'
+  }
+
+  if (state.wasAtBottom) {
+    if (safeScrollCall(() => terminal.scrollToBottom())) {
+      forceTerminalViewportScrollbarSync(terminal)
+      return buf.viewportY >= buf.baseY ? 'restored' : 'retry'
+    }
+    return 'retry'
+  }
+
+  const logicalMarkerLine =
+    state.firstVisibleLogicalLineMarker && !state.firstVisibleLogicalLineMarker.isDisposed
+      ? state.firstVisibleLogicalLineMarker.line
+      : -1
+  const markerLine =
+    state.firstVisibleLineMarker && !state.firstVisibleLineMarker.isDisposed
+      ? state.firstVisibleLineMarker.line
+      : -1
+  const logicalTargetLine =
+    logicalMarkerLine >= 0 && state.firstVisibleLogicalCellOffset !== undefined
+      ? resolveLogicalCellOffsetLine(
+          terminal,
+          logicalMarkerLine,
+          state.firstVisibleLogicalCellOffset
+        )
+      : null
+  const targetLine = Math.min(
+    logicalTargetLine ?? (markerLine >= 0 ? markerLine : state.viewportY),
+    buf.baseY
+  )
+  state.viewportY = targetLine
+  if (safeScrollCall(() => terminal.scrollToLine(targetLine))) {
+    forceTerminalViewportScrollbarSync(terminal)
+    // Why: xterm can silently clamp against stale pre-fit scrollbar geometry.
+    return buf.viewportY === targetLine ? 'restored' : 'retry'
+  }
+  return 'retry'
+}
+
+function safeScrollCall(fn: () => void): boolean {
+  try {
+    fn()
+    return true
+  } catch (err) {
+    if (err instanceof TypeError && /dimensions/.test(err.message)) {
+      return false
+    }
+    throw err
+  }
+}
+
+export function releaseScrollStateMarker(state: ScrollState): void {
+  state.firstVisibleLineMarker?.dispose()
+  if (state.firstVisibleLogicalLineMarker !== state.firstVisibleLineMarker) {
+    state.firstVisibleLogicalLineMarker?.dispose()
+  }
+  state.firstVisibleLineMarker = state.firstVisibleLogicalLineMarker = undefined
+}

--- a/src/renderer/src/lib/pane-manager/xterm-scroll-resize-bottom-lock.test.ts
+++ b/src/renderer/src/lib/pane-manager/xterm-scroll-resize-bottom-lock.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
+import type { Terminal as RendererTerminal } from '@xterm/xterm'
+import type { ManagedPane } from './pane-manager-types'
+import { safeFit } from './pane-fit'
+import { getTerminalScrollIntentKind } from './terminal-scroll-intent'
+
+function write(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve))
+}
+
+function findBufferLineContaining(term: Terminal, text: string): number {
+  const buf = term.buffer.active
+  for (let lineY = 0; lineY < buf.length; lineY += 1) {
+    if (buf.getLine(lineY)?.translateToString(true).includes(text)) {
+      return lineY
+    }
+  }
+  return -1
+}
+
+function topOfViewportText(term: Terminal): string {
+  const buf = term.buffer.active
+  return buf.getLine(buf.viewportY)?.translateToString(true) ?? ''
+}
+
+function makeSafeFitPane(term: Terminal): {
+  pane: ManagedPane
+  setGrid: (cols: number, rows: number) => void
+} {
+  let proposed = { cols: term.cols, rows: term.rows }
+  Object.defineProperty(term, 'element', { configurable: true, value: {} })
+  const pane = {
+    terminal: term as unknown as RendererTerminal,
+    container: {
+      dataset: {},
+      getBoundingClientRect: () => ({ width: 1_320, height: 820 })
+    },
+    fitAddon: {
+      proposeDimensions: () => proposed,
+      fit: () => term.resize(proposed.cols, proposed.rows)
+    },
+    pendingSplitScrollState: null
+  } as unknown as ManagedPane
+  return {
+    pane,
+    setGrid: (cols, rows) => {
+      proposed = { cols, rows }
+    }
+  }
+}
+
+describe('xterm scroll behavior through safe fit', () => {
+  it('bottom-locks a pinned chat viewport through the product safe-fit path', async () => {
+    const term = new Terminal({
+      cols: 159,
+      rows: 69,
+      scrollback: 5000,
+      allowProposedApi: true
+    })
+
+    try {
+      for (let row = 0; row < 420; row += 1) {
+        await write(
+          term,
+          `ROW${String(row).padStart(4, '0')} CODEX_CHAT_HISTORY_${'a'.repeat(36)} assistant response ${'x'.repeat(92)}\r\n`
+        )
+      }
+      const pinMarker = 'ROW0249'
+      const pinLineY = findBufferLineContaining(term, pinMarker)
+      term.scrollToLine(pinLineY)
+      expect(term.buffer.active.viewportY).toBeLessThan(term.buffer.active.baseY)
+      expect(topOfViewportText(term)).toContain(pinMarker)
+
+      const { pane, setGrid } = makeSafeFitPane(term)
+      setGrid(159, 47)
+      expect(safeFit(pane)).toBe(true)
+      expect(term.buffer.active.viewportY).toBeLessThan(term.buffer.active.baseY)
+      expect(topOfViewportText(term)).toContain(pinMarker)
+      expect(getTerminalScrollIntentKind(pane.terminal)).toBe('pinnedViewport')
+
+      setGrid(14, 47)
+      expect(safeFit(pane)).toBe(true)
+      expect(term.buffer.active.baseY).toBe(5000)
+      expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+      expect(getTerminalScrollIntentKind(pane.terminal)).toBe('followOutput')
+
+      setGrid(84, 47)
+      expect(safeFit(pane)).toBe(true)
+      expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('bottom-locks when reflow fills the scrollback cap', async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 5,
+      scrollback: 20,
+      allowProposedApi: true
+    })
+
+    try {
+      for (let row = 0; row < 30; row += 1) {
+        await write(term, `ROW${String(row).padStart(4, '0')} ${'x'.repeat(60)}\r\n`)
+      }
+      const pinLineY = findBufferLineContaining(term, 'ROW0010')
+      term.scrollToLine(pinLineY)
+      expect(term.buffer.active.viewportY).toBeLessThan(term.buffer.active.baseY)
+
+      const { pane, setGrid } = makeSafeFitPane(term)
+      setGrid(8, 5)
+      expect(safeFit(pane)).toBe(true)
+
+      expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+      expect(getTerminalScrollIntentKind(pane.terminal)).toBe('followOutput')
+    } finally {
+      term.dispose()
+    }
+  })
+})

--- a/tests/e2e/terminal-scroll-resize-bottom-lock.spec.ts
+++ b/tests/e2e/terminal-scroll-resize-bottom-lock.spec.ts
@@ -1,0 +1,223 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { nodeTerminalCommand } from './terminal-node-command'
+import { waitForPtyShellEcho } from './terminal-pty-readiness'
+
+type TerminalViewportSnapshot = {
+  cols: number
+  rows: number
+  viewportY: number
+  baseY: number
+  firstVisibleLine: string
+}
+
+function transcriptFixture(runId: string): string {
+  return `
+const rows = 420
+for (let row = 0; row < rows; row += 1) {
+  const history = 'CODEX_CHAT_HISTORY_${runId}_' + String(row).padStart(4, '0')
+  const body = ' assistant response ' + 'x'.repeat(92)
+  process.stdout.write(history + body + '\\r\\n')
+}
+process.stdout.write('CODEX_CHAT_HISTORY_${runId}_READY\\r\\n')
+process.stdout.on('resize', () => {
+  process.stdout.write('CODEX_CHAT_HISTORY_${runId}_RESIZED\\r\\n')
+})
+setInterval(() => {}, 1_000)
+`
+}
+
+async function readActiveTerminalViewport(page: Page): Promise<TerminalViewportSnapshot> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Active terminal pane unavailable')
+    }
+    const buffer = pane.terminal.buffer.active
+    return {
+      cols: pane.terminal.cols,
+      rows: pane.terminal.rows,
+      viewportY: buffer.viewportY,
+      baseY: buffer.baseY,
+      firstVisibleLine: buffer.getLine(buffer.viewportY)?.translateToString(true) ?? ''
+    }
+  })
+}
+
+async function enableTerminalAccessibilityDom(page: Page, ptyId: string): Promise<void> {
+  await page.evaluate((targetPtyId) => {
+    const pane = Array.from(window.__paneManagers?.values() ?? [])
+      .flatMap((manager) => manager.getPanes?.() ?? [])
+      .find((candidate) => candidate.container.dataset.ptyId === targetPtyId)
+    if (!pane) {
+      throw new Error(`Terminal pane ${targetPtyId} is unavailable`)
+    }
+    // xterm paints to canvas by default; screen-reader mode mirrors visible rows into the DOM.
+    pane.terminal.options.screenReaderMode = true
+    pane.terminal.refresh(0, pane.terminal.rows - 1)
+  }, ptyId)
+  await expect(
+    page.locator(`[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`)
+  ).toBeAttached({ timeout: 10_000 })
+}
+
+async function scrollActiveTerminalToMarker(page: Page, marker: string): Promise<void> {
+  await page.evaluate((searchMarker) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Active terminal pane unavailable')
+    }
+    const target = pane.container.querySelector<HTMLElement>('.xterm') ?? pane.container
+    target.dispatchEvent(
+      new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+        deltaY: -1200
+      })
+    )
+    const buffer = pane.terminal.buffer.active
+    const markerLine = Array.from(
+      { length: buffer.baseY + buffer.length },
+      (_, lineY) => lineY
+    ).find((lineY) => buffer.getLine(lineY)?.translateToString(true).includes(searchMarker))
+    if (markerLine === undefined) {
+      throw new Error(`Terminal marker not found: ${searchMarker}`)
+    }
+    pane.terminal.scrollToLine(markerLine)
+    pane.container
+      .querySelector<HTMLElement>('.xterm-viewport')
+      ?.dispatchEvent(new Event('scroll', { bubbles: true }))
+  }, marker)
+  await page.waitForTimeout(50)
+}
+
+test.describe('Terminal scroll resize behavior', () => {
+  test('bottom-locks scrolled Codex history across a narrow/wide resize', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo: TestInfo) => {
+    test.setTimeout(120_000)
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyShellEcho(orcaPage, ptyId, 15_000)
+
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-scroll-resize-${runId}.mjs`)
+    writeFileSync(scriptPath, transcriptFixture(runId))
+
+    try {
+      await sendToTerminal(orcaPage, ptyId, `${nodeTerminalCommand([scriptPath])}\r`)
+      await expect
+        .poll(() => getTerminalContent(orcaPage, 30_000), {
+          timeout: 15_000,
+          message: 'Codex-shaped transcript did not reach the terminal'
+        })
+        .toContain(`CODEX_CHAT_HISTORY_${runId}_READY`)
+
+      const pinMarker = `CODEX_CHAT_HISTORY_${runId}_0249`
+      await enableTerminalAccessibilityDom(orcaPage, ptyId)
+      const terminalDom = orcaPage.locator(
+        `[data-pty-id=${JSON.stringify(ptyId)}] .xterm-accessibility-tree`
+      )
+      await scrollActiveTerminalToMarker(orcaPage, pinMarker)
+      await expect(terminalDom).toContainText(pinMarker, { timeout: 10_000 })
+      const beforeResize = await readActiveTerminalViewport(orcaPage)
+      expect(beforeResize.viewportY).toBeGreaterThan(0)
+      expect(beforeResize.viewportY).toBeLessThan(beforeResize.baseY)
+      const beforeScreenshotPath = testInfo.outputPath('terminal-scroll-resize-before.png')
+      await orcaPage.screenshot({ path: beforeScreenshotPath, fullPage: true })
+      await testInfo.attach('terminal-scroll-resize-before', {
+        path: beforeScreenshotPath,
+        contentType: 'image/png'
+      })
+
+      await orcaPage.setViewportSize({ width: 760, height: 820 })
+      await expect
+        .poll(() => readActiveTerminalViewport(orcaPage).then((snapshot) => snapshot.cols), {
+          timeout: 15_000,
+          message: 'terminal did not settle after narrowing the window'
+        })
+        .not.toBe(beforeResize.cols)
+
+      const narrowResize = await readActiveTerminalViewport(orcaPage)
+      expect(narrowResize.viewportY).toBe(narrowResize.baseY)
+      await orcaPage.setViewportSize({ width: 1_320, height: 820 })
+      await expect
+        .poll(() => readActiveTerminalViewport(orcaPage).then((snapshot) => snapshot.cols), {
+          timeout: 15_000,
+          message: 'terminal did not settle after widening the window'
+        })
+        .not.toBe(narrowResize.cols)
+
+      const afterResize = await readActiveTerminalViewport(orcaPage)
+      expect(afterResize.viewportY).toBe(afterResize.baseY)
+      console.log(
+        '[terminal-scroll-resize-bottom-lock]',
+        JSON.stringify({
+          before: {
+            cols: beforeResize.cols,
+            rows: beforeResize.rows,
+            viewportY: beforeResize.viewportY,
+            baseY: beforeResize.baseY,
+            firstVisibleLine: beforeResize.firstVisibleLine
+          },
+          narrow: { cols: narrowResize.cols, rows: narrowResize.rows },
+          after: {
+            cols: afterResize.cols,
+            rows: afterResize.rows,
+            viewportY: afterResize.viewportY,
+            baseY: afterResize.baseY,
+            firstVisibleLine: afterResize.firstVisibleLine
+          }
+        })
+      )
+      await expect(terminalDom).toContainText(`CODEX_CHAT_HISTORY_${runId}_READY`, {
+        timeout: 10_000
+      })
+      const afterScreenshotPath = testInfo.outputPath('terminal-scroll-resize-after.png')
+      await orcaPage.screenshot({ path: afterScreenshotPath, fullPage: true })
+      await testInfo.attach('terminal-scroll-resize-after', {
+        path: afterScreenshotPath,
+        contentType: 'image/png'
+      })
+      console.log(
+        '[terminal-scroll-resize-bottom-lock-screenshots]',
+        JSON.stringify({ before: beforeScreenshotPath, after: afterScreenshotPath })
+      )
+    } finally {
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})

--- a/tests/e2e/terminal-split-scroll-resize-bottom-lock.spec.ts
+++ b/tests/e2e/terminal-split-scroll-resize-bottom-lock.spec.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  sendToTerminal,
+  splitActiveTerminalPane,
+  waitForActiveTerminalManager,
+  waitForPaneCount
+} from './helpers/terminal'
+import { nodeTerminalCommand } from './terminal-node-command'
+import { waitForPtyShellEcho } from './terminal-pty-readiness'
+
+type SplitPaneSnapshot = {
+  baseY: number
+  cols: number
+  firstVisibleLine: string
+  firstVisibleLineIsWrapped: boolean
+  ptyId: string
+  rows: number
+  viewportY: number
+}
+
+function transcriptFixture(runId: string): string {
+  return `
+for (let row = 0; row < 420; row += 1) {
+  const marker = 'SPLIT_CODEX_HISTORY_${runId}_' + String(row).padStart(4, '0')
+  process.stdout.write(marker + ' assistant response ' + 'x'.repeat(92) + '\\r\\n')
+}
+process.stdout.write('SPLIT_CODEX_HISTORY_${runId}_READY\\r\\n')
+process.stdout.on('resize', () => {
+  process.stdout.write('SPLIT_CODEX_HISTORY_${runId}_RESIZED\\r\\n')
+})
+let liveRow = 0
+setInterval(() => {
+  process.stdout.write('SPLIT_CODEX_LIVE_${runId}_' + String(liveRow).padStart(4, '0') + '\\r\\n')
+  liveRow += 1
+}, 20)
+`
+}
+
+async function readFirstSplitPane(page: Page): Promise<SplitPaneSnapshot> {
+  return page.evaluate(() => {
+    const divider = document.querySelector<HTMLElement>('.pane-divider.is-vertical')
+    const subtree = divider?.previousElementSibling as HTMLElement | null
+    const paneElement = subtree?.matches('.pane[data-pty-id]')
+      ? subtree
+      : subtree?.querySelector<HTMLElement>('.pane[data-pty-id]')
+    const ptyId = paneElement?.dataset.ptyId
+    const pane = ptyId
+      ? Array.from(window.__paneManagers?.values() ?? [])
+          .flatMap((manager) => manager.getPanes())
+          .find((candidate) => candidate.container.dataset.ptyId === ptyId)
+      : null
+    if (!pane || !ptyId) {
+      throw new Error('First split terminal pane unavailable')
+    }
+    const buffer = pane.terminal.buffer.active
+    return {
+      baseY: buffer.baseY,
+      cols: pane.terminal.cols,
+      firstVisibleLine: buffer.getLine(buffer.viewportY)?.translateToString(true) ?? '',
+      firstVisibleLineIsWrapped: buffer.getLine(buffer.viewportY)?.isWrapped ?? false,
+      ptyId,
+      rows: pane.terminal.rows,
+      viewportY: buffer.viewportY
+    }
+  })
+}
+
+async function pinFirstSplitPaneToMarker(page: Page, marker: string): Promise<void> {
+  await page.evaluate((searchMarker) => {
+    const divider = document.querySelector<HTMLElement>('.pane-divider.is-vertical')
+    const subtree = divider?.previousElementSibling as HTMLElement | null
+    const paneElement = subtree?.matches('.pane[data-pty-id]')
+      ? subtree
+      : subtree?.querySelector<HTMLElement>('.pane[data-pty-id]')
+    const ptyId = paneElement?.dataset.ptyId
+    const pane = ptyId
+      ? Array.from(window.__paneManagers?.values() ?? [])
+          .flatMap((manager) => manager.getPanes())
+          .find((candidate) => candidate.container.dataset.ptyId === ptyId)
+      : null
+    if (!pane) {
+      throw new Error('First split terminal pane unavailable')
+    }
+    pane.terminal.options.screenReaderMode = true
+    const target = pane.container.querySelector<HTMLElement>('.xterm') ?? pane.container
+    target.dispatchEvent(
+      new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+        deltaY: -1_200
+      })
+    )
+    const buffer = pane.terminal.buffer.active
+    for (let lineY = 0; lineY < buffer.length; lineY += 1) {
+      if (buffer.getLine(lineY)?.translateToString(true).includes(searchMarker)) {
+        pane.terminal.scrollToLine(lineY + 1)
+        pane.terminal.refresh(0, pane.terminal.rows - 1)
+        pane.container
+          .querySelector<HTMLElement>('.xterm-viewport')
+          ?.dispatchEvent(new Event('scroll', { bubbles: true }))
+        return
+      }
+    }
+    throw new Error(`Terminal marker not found: ${searchMarker}`)
+  }, marker)
+}
+
+async function dragFirstDividerBy(page: Page, deltaX: number): Promise<void> {
+  const divider = page.locator('.pane-divider.is-vertical').first()
+  const box = await divider.boundingBox()
+  if (!box) {
+    throw new Error('Split divider has no bounding box')
+  }
+  const startX = box.x + box.width / 2
+  const startY = box.y + box.height / 2
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+  await page.mouse.move(startX + deltaX, startY, { steps: 4 })
+  await page.mouse.up()
+}
+
+test('@headful bottom-locks a pinned live Codex continuation after a tiny split widen', async ({
+  orcaPage,
+  testRepoPath
+}, testInfo: TestInfo) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+  await splitActiveTerminalPane(orcaPage, 'vertical')
+  await waitForPaneCount(orcaPage, 2, 30_000)
+
+  const initialPane = await readFirstSplitPane(orcaPage)
+  await dragFirstDividerBy(orcaPage, 8)
+  await expect
+    .poll(() => readFirstSplitPane(orcaPage).then((snapshot) => snapshot.cols), {
+      timeout: 10_000,
+      message: 'Immediate post-split divider drag did not resize the terminal'
+    })
+    .not.toBe(initialPane.cols)
+  const immediatelyResized = await readFirstSplitPane(orcaPage)
+  expect(immediatelyResized.viewportY).toBe(immediatelyResized.baseY)
+  await waitForPtyShellEcho(orcaPage, initialPane.ptyId, 15_000)
+  const runId = randomUUID()
+  const scriptPath = path.join(testRepoPath, `.orca-split-scroll-resize-${runId}.mjs`)
+  writeFileSync(scriptPath, transcriptFixture(runId))
+
+  try {
+    await sendToTerminal(orcaPage, initialPane.ptyId, `${nodeTerminalCommand([scriptPath])}\r`)
+    await expect
+      .poll(() => readFirstSplitPane(orcaPage).then((snapshot) => snapshot.baseY), {
+        timeout: 15_000,
+        message: 'Split-pane transcript did not fill scrollback'
+      })
+      .toBeGreaterThan(400)
+
+    const pinMarker = `SPLIT_CODEX_HISTORY_${runId}_0249`
+    await pinFirstSplitPaneToMarker(orcaPage, pinMarker)
+    const paneDom = orcaPage
+      .locator('.pane-divider.is-vertical')
+      .first()
+      .locator('xpath=preceding-sibling::*[1]')
+      .locator('.xterm-accessibility-tree')
+    await expect
+      .poll(() =>
+        readFirstSplitPane(orcaPage).then((snapshot) => snapshot.firstVisibleLineIsWrapped)
+      )
+      .toBe(true)
+    const before = await readFirstSplitPane(orcaPage)
+    expect(before.firstVisibleLine).not.toContain(pinMarker)
+    expect(before.firstVisibleLineIsWrapped).toBe(true)
+    expect(before.viewportY).toBeLessThan(before.baseY)
+    await orcaPage.screenshot({
+      path: testInfo.outputPath('split-scroll-resize-before.png'),
+      fullPage: true
+    })
+
+    await dragFirstDividerBy(orcaPage, 12)
+
+    await expect
+      .poll(() => readFirstSplitPane(orcaPage).then((snapshot) => snapshot.cols), {
+        timeout: 10_000,
+        message: 'Tiny divider drag did not widen the target terminal grid'
+      })
+      .toBeGreaterThan(before.cols)
+    const after = await readFirstSplitPane(orcaPage)
+    expect(after.viewportY).toBe(after.baseY)
+    await expect(paneDom).toContainText(`SPLIT_CODEX_LIVE_${runId}_`, {
+      timeout: 10_000
+    })
+    await orcaPage.screenshot({
+      path: testInfo.outputPath('split-scroll-resize-after.png'),
+      fullPage: true
+    })
+  } finally {
+    rmSync(scriptPath, { force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- bottom-lock normal-buffer terminals only when a fit actually changes columns
- preserve pinned scroll for row-only, failed, and grid-identical fits
- prevent delayed split settlement from overwriting newer user scroll intent and skip alternate-screen restoration
- extract fit scroll restoration and register focused reliability evidence

## Verification

- pnpm run lint
- pnpm run typecheck:web
- 73 focused renderer tests across six suites
- Electron headless narrow/wide window resize journey
- Electron headful one-column split resize journey

## Notes

xterm public row markers cannot reliably preserve the same logical viewport content through width reflow, especially when reflow reaches the scrollback cap. Column changes therefore use a deterministic follow-output fallback; row-only changes retain the user's pin.