### PR TITLE
fix(agent-status): clear Claude question indicator after Escape

### DIFF
--- a/src/main/agent-hooks/server.claude-interactive-question.test.ts
+++ b/src/main/agent-hooks/server.claude-interactive-question.test.ts
@@ -11,6 +11,7 @@ function ingestClaudeStatus(
     hookEventName: 'PermissionRequest' | 'PreToolUse'
     toolName: string
     toolUseId: string
+    interactivePrompt?: string
   }
 ): void {
   server.ingestRemote(
@@ -23,7 +24,8 @@ function ingestClaudeStatus(
       payload: {
         state: event.state,
         agentType: 'claude',
-        toolName: event.toolName
+        toolName: event.toolName,
+        ...(event.interactivePrompt ? { interactivePrompt: event.interactivePrompt } : {})
       }
     },
     'connection-1'
@@ -126,6 +128,72 @@ function answeredRequestFromSnapshot(
     baselineAgentType: entry.agentType
   }
 }
+
+function escapeRequestFromSnapshot(
+  server: AgentHookServer
+): Parameters<AgentHookServer['inferInterrupt']>[0] {
+  return {
+    ...answeredRequestFromSnapshot(server),
+    intent: 'plain-escape'
+  }
+}
+
+describe('inferInterrupt for Claude interactive questions', () => {
+  it.each(['PreToolUse', 'PermissionRequest'] as const)(
+    'clears a %s AskUserQuestion wait after Escape',
+    (hookEventName) => {
+      const server = new AgentHookServer()
+      ingestClaudeStatus(server, {
+        state: 'waiting',
+        hookEventName,
+        toolName: 'AskUserQuestion',
+        toolUseId: 'tool-question',
+        interactivePrompt: '{"questions":[{"question":"Pick one"}]}'
+      })
+
+      expect(server.inferInterrupt(escapeRequestFromSnapshot(server))).toBe(true)
+      const [entry] = server.getStatusSnapshot()
+      expect(entry).toMatchObject({ paneKey: PANE_KEY, state: 'working', agentType: 'claude' })
+      expect(entry.toolName).toBeUndefined()
+      expect(entry.interactivePrompt).toBeUndefined()
+      expect(entry.interrupted).toBeUndefined()
+    }
+  )
+
+  it('rejects Escape when the question baseline is stale', () => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PreToolUse',
+      toolName: 'AskUserQuestion',
+      toolUseId: 'tool-question'
+    })
+    const request = { ...escapeRequestFromSnapshot(server), baselineUpdatedAt: 1 }
+
+    expect(server.inferInterrupt(request)).toBe(false)
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ state: 'waiting', toolName: 'AskUserQuestion' })
+    ])
+  })
+
+  it.each([
+    ['plain-escape', 'Bash'],
+    ['ctrl-c', 'AskUserQuestion']
+  ] as const)('does not clear a Claude wait from %s on %s', (intent, toolName) => {
+    const server = new AgentHookServer()
+    ingestClaudeStatus(server, {
+      state: 'waiting',
+      hookEventName: 'PermissionRequest',
+      toolName,
+      toolUseId: 'tool-wait'
+    })
+
+    expect(server.inferInterrupt({ ...escapeRequestFromSnapshot(server), intent })).toBe(false)
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({ state: 'waiting', toolName })
+    ])
+  })
+})
 
 describe('inferQuestionAnswered', () => {
   it('clears an AskUserQuestion wait when the submit keystroke is reported', () => {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -742,6 +742,14 @@ export class AgentHookServer {
     ) {
       return false
     }
+    const dismissesClaudeQuestion =
+      agentType === 'claude' &&
+      request.intent === 'plain-escape' &&
+      payload.state === 'waiting' &&
+      isAskUserQuestionTool(payload.toolName)
+    if (dismissesClaudeQuestion) {
+      return this.inferQuestionAnswered(request)
+    }
     // Why: inference is a fallback for a missing final hook; a strict baseline match keeps a delayed timer from clobbering any newer hook.
     if (
       payload.state !== 'working' ||
@@ -797,8 +805,7 @@ export class AgentHookServer {
     return true
   }
 
-  /** Guarded fallback for a hook Claude never sends: answering AskUserQuestion produces no event, so re-validate the
-   *  renderer's baseline against the cached status (a racing real hook wins) and synthesize the post-answer state. */
+  /** Guarded fallback for the hook Claude omits after answering or dismissing AskUserQuestion. */
   inferQuestionAnswered(request: AgentQuestionAnsweredInferenceRequest): boolean {
     if (!isValidPaneKey(request.paneKey)) {
       return false
@@ -843,7 +850,7 @@ export class AgentHookServer {
         ...(payload.subagents ? { subagents: payload.subagents } : {})
       }
     })
-    console.debug('[agent-hooks] inferred answered question status', {
+    console.debug('[agent-hooks] inferred resolved question status', {
       paneKey: inferred.paneKey,
       state: inferred.payload.state
     })

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -101,6 +101,51 @@ describe('agent interrupt inference', () => {
     }
   )
 
+  it('reports Escape while Claude is waiting on AskUserQuestion', () => {
+    vi.useFakeTimers()
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () =>
+        makeEntry({ state: 'waiting', agentType: 'claude', toolName: 'AskUserQuestion' }),
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).toHaveBeenCalledWith({
+      paneKey: PANE_KEY,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'write tests',
+      baselineAgentType: 'claude',
+      intent: 'plain-escape'
+    })
+    tracker.dispose()
+  })
+
+  it.each([
+    ['ctrl-c', 'AskUserQuestion'],
+    ['plain-escape', 'Bash']
+  ] as const)('does not dismiss a Claude wait from %s on %s', (intent, toolName) => {
+    vi.useFakeTimers()
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => makeEntry({ state: 'waiting', agentType: 'claude', toolName }),
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent(intent)
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
+    tracker.dispose()
+  })
+
   it('emits when the working row has no agent type', () => {
     vi.useFakeTimers()
     let entry: AgentStatusEntry | undefined = makeEntry({ agentType: undefined })

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -7,6 +7,7 @@ import {
   type AgentInterruptInferenceRequest,
   type AgentInterruptInputIntent
 } from '../../../../shared/agent-interrupt-intent'
+import { isAskUserQuestionTool } from '../../../../shared/agent-question-answered-intent'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 
 export type AgentInterruptInference = {
@@ -54,6 +55,16 @@ function shouldIgnoreInterruptIntent(
   intent: AgentInterruptInputIntent
 ): boolean {
   return agentType === 'droid' && intent === 'ctrl-c'
+}
+
+function canInferInterrupt(entry: AgentStatusEntry, intent: AgentInterruptInputIntent): boolean {
+  return (
+    entry.state === 'working' ||
+    (intent === 'plain-escape' &&
+      entry.state === 'waiting' &&
+      entry.agentType === 'claude' &&
+      isAskUserQuestionTool(entry.toolName))
+  )
 }
 
 function isSameTurnBaseline(
@@ -133,7 +144,7 @@ export function createAgentInterruptInference({
   ): CapturedInterruptBaseline | null => {
     const agentType = entry.agentType
     if (
-      entry.state !== 'working' ||
+      !canInferInterrupt(entry, intent) ||
       !isExplicitAgentStatusFresh(entry, now(), AGENT_STATUS_STALE_AFTER_MS)
     ) {
       return null
@@ -158,7 +169,7 @@ export function createAgentInterruptInference({
     const entry = getStatusEntry()
     if (
       entry &&
-      (entry.state !== 'working' ||
+      (!canInferInterrupt(entry, baseline.intent) ||
         entry.agentType !== baseline.agentType ||
         entry.prompt !== baseline.prompt ||
         entry.updatedAt !== baseline.updatedAt ||


### PR DESCRIPTION
## Summary

Fixes Claude's question/waiting status remaining visible after the user dismisses an `AskUserQuestion` prompt with Escape.

- Allows the renderer's existing interrupt-inference path to capture a plain Escape only when the live row is a fresh Claude `AskUserQuestion` wait.
- Re-validates the exact pane, prompt, agent, timestamps, question tool, and freshness in the main process before changing authoritative status.
- Reuses the normal question-resolution cleanup so the tool name, interactive question card, and listener lead state are cleared together.
- Preserves existing behavior for Ctrl+C, ordinary working-turn interrupts, real permission requests, stale observations, child-agent state, and both `PreToolUse` and newer `PermissionRequest` question shapes.

## ELI5

Orca receives a message when Claude puts up a question sign, but Claude does not send another message when Escape takes that sign down. Orca therefore kept showing the old sign.

Now, after Escape reaches the terminal, Orca waits for the normal 500 ms settle window and asks: “Is this still the exact same Claude question I saw?” If yes, it removes the sign and restores the status from before the question. If any newer event has arrived, Orca does nothing, so a delayed Escape can never erase newer work or a real permission prompt.

## Proof of fix

The regression tests were added first and failed in the two missing lifecycle gates:

- renderer: the `waiting` row did not schedule Escape inference;
- main process: interrupt inference rejected every non-`working` row.

After the fix:

- `server.claude-interactive-question.test.ts` proves Escape clears both `PreToolUse` and `PermissionRequest`-shaped Claude questions, removes `toolName` and `interactivePrompt`, restores `working`, and does not mark the turn interrupted;
- `agent-interrupt-inference.test.ts` proves the renderer sends the strict baseline request after the existing settle window.

Focused result: **34/34 tests passed**.

## Proof of no regression

- **955/955 adjacent tests passed** across agent-hook normalization/server behavior, terminal input/inference, PTY connection, and SSH relay integration.
- **43,313 tests passed, 80 skipped** in the full `pnpm test` run. The command reported one unrelated post-teardown TanStack Virtual timer exception in `SourceControl.virtual-file-list.test.tsx`; that untouched file passed **7/7** when rerun alone.
- `pnpm lint` passed, including native/type-aware audits, reliability gates, localization checks, and the max-lines ratchet.
- `pnpm typecheck` passed for node, CLI, and web targets.
- `pnpm run build:electron-vite` passed for main, preload, desktop renderer, and web renderer bundles.
- Changed-code quality gate: **0 new findings** across all four changed files.

## Performance

No polling, global listeners, or additional IPC round trips were added. The only extra work is a constant-time state/tool predicate when an interrupt keystroke is observed; successful question dismissal reuses the already-existing 500 ms timer, IPC request, and cleanup path.

## Cross-platform and remote support

- **macOS / Linux / Windows:** uses the existing platform-neutral `KeyboardEvent.key === 'Escape'` and terminal `\x1b` path; no modifier, shortcut-label, shell, filesystem, or path assumptions were introduced.
- **SSH / relay:** the authoritative cleanup runs in the same main-process server for local and `ingestRemote` statuses; the regression fixture uses a remote connection id, and the SSH relay integration suite passed.
- **Folder workspaces / git worktrees:** status handling is pane-key based and does not inspect repository layout or invoke Git.
- **Mobile:** native chat already has a dedicated accepted cancel-card action that sends Escape; this desktop terminal-key change does not alter that path or its transport contract.

## Screenshots

No static layout change. This is a behavior-only status transition, covered by the lifecycle regression tests above.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — all 43,313 tests passed, but Vitest exited nonzero for the unrelated teardown exception documented above; isolated rerun passed 7/7
- [ ] `pnpm build` — full native packaging was not run; `pnpm run build:electron-vite` passed
- [x] Added high-quality regression tests that fail without the fix

## AI Review Report

Codex performed a repository review after the implementation. It traced terminal input acceptance through renderer inference, IPC, authoritative cached status, listener lead-state cleanup, and remote hook ingestion. It specifically checked stale/racing events, permission-request isolation, Ctrl+C behavior, active child state, provider-session state, failure/no-op behavior, performance, and macOS/Linux/Windows/SSH/mobile/folder-workspace assumptions. No remaining findings were identified; the review led to explicit negative tests for stale baselines, Ctrl+C, and real permission waits.

## Security Audit

No command execution, filesystem paths, credentials, dependencies, or new external inputs are introduced. The renderer only proposes an inference; the main process retains authority and validates the pane key, input intent, Claude provider, waiting state, question tool identity, exact baseline timestamps/prompt, and freshness before mutating cached status. Malformed, stale, or mismatched requests fail closed.

## Notes

Rebased cleanly onto `origin/main` at `25fefa4072` before the final validation pass; no conflicts with the latest merged SSH consumer-recovery change.
