### PR TITLE
fix(watcher): prune nested ignored dirs on macOS and bound the flush fan-out

### DIFF
--- a/src/main/ipc/filesystem-watcher-flush-concurrency.test.ts
+++ b/src/main/ipc/filesystem-watcher-flush-concurrency.test.ts
@@ -1,0 +1,195 @@
+import { join, resolve } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock } = vi.hoisted(() => ({
+  handleMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('fs/promises', () => ({
+  stat: vi.fn()
+}))
+
+vi.mock('@parcel/watcher', () => ({
+  subscribe: vi.fn()
+}))
+
+vi.mock('./filesystem-watcher-wsl', () => ({
+  createWslWatcher: vi.fn()
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn(),
+  onSshFilesystemProviderRegistered: () => () => {}
+}))
+
+import { closeAllWatchers, registerFilesystemWatcherHandlers } from './filesystem-watcher'
+import { stat } from 'node:fs/promises'
+import { subscribe as subscribeParcelWatcher } from '@parcel/watcher'
+import type { Event as WatcherEvent } from '@parcel/watcher'
+import type { FsChangedPayload } from '../../shared/types'
+import {
+  WATCH_BATCH_MAX_WAIT_MS,
+  WATCH_BATCH_TRAILING_MS
+} from '../../shared/filesystem-watch-batch-window'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
+type WatcherCallback = (err: Error | null, events: WatcherEvent[]) => void
+
+// Mirrors DIRECTORY_STAT_CONCURRENCY in parcel-watcher-event-delivery.ts.
+const EXPECTED_STAT_CONCURRENCY = 8
+
+/** Holds every event-path stat open so a flush can be observed mid-fan-out. */
+function trackDeferredStats(): {
+  live: () => number
+  peak: () => number
+  settle: (rounds?: number) => Promise<void>
+} {
+  const pending: (() => void)[] = []
+  let live = 0
+  let peak = 0
+  vi.mocked(stat).mockImplementation((target: unknown) => {
+    if (!String(target).endsWith('.ts')) {
+      // The watch install stats the root itself; only event paths are deferred.
+      return Promise.resolve({ isDirectory: () => true } as never)
+    }
+    live += 1
+    peak = Math.max(peak, live)
+    return new Promise((resolveStat) => {
+      pending.push(() => {
+        live -= 1
+        resolveStat({ isDirectory: () => false } as never)
+      })
+    }) as never
+  })
+  return {
+    live: () => live,
+    peak: () => peak,
+    settle: async (rounds = 200): Promise<void> => {
+      for (let i = 0; i < rounds; i++) {
+        while (pending.length > 0) {
+          pending.shift()?.()
+        }
+        await vi.advanceTimersByTimeAsync(0)
+      }
+    }
+  }
+}
+
+function burst(worktreePath: string, prefix: string, count: number): WatcherEvent[] {
+  return Array.from({ length: count }, (_, index) => ({
+    type: 'create' as const,
+    path: join(worktreePath, `${prefix}-${index}.ts`)
+  }))
+}
+
+describe('local filesystem watcher flush fan-out', () => {
+  const handlers: HandlerMap = {}
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    handleMock.mockReset()
+    vi.mocked(stat).mockReset()
+    vi.mocked(subscribeParcelWatcher).mockReset()
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+    registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  async function watchRoot(
+    worktreePath: string
+  ): Promise<{ sender: { send: ReturnType<typeof vi.fn> }; emit: WatcherCallback }> {
+    let watcherCallback: WatcherCallback | undefined
+    vi.mocked(subscribeParcelWatcher).mockImplementation(async (_root, callback) => {
+      watcherCallback = callback as WatcherCallback
+      return { unsubscribe: vi.fn() } as never
+    })
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath })
+    return { sender, emit: (err, events) => watcherCallback?.(err, events) }
+  }
+
+  it('bounds concurrent stats in one flush to the watcher child limit', async () => {
+    vi.useFakeTimers()
+    const stats = trackDeferredStats()
+    const worktreePath = resolve('/tmp/repo-flush-bound')
+    const { sender, emit } = await watchRoot(worktreePath)
+
+    const events = burst(worktreePath, 'a', 64)
+    emit(null, events)
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+
+    expect(stats.peak()).toBeLessThanOrEqual(EXPECTED_STAT_CONCURRENCY)
+
+    await stats.settle()
+    expect(sender.send).toHaveBeenCalledTimes(1)
+    expect((sender.send.mock.calls[0][1] as FsChangedPayload).events).toHaveLength(events.length)
+    await closeAllWatchers()
+    vi.useRealTimers()
+  })
+
+  it('queues a flush that lands while another flush for the same root is awaiting stats', async () => {
+    vi.useFakeTimers()
+    const stats = trackDeferredStats()
+    const worktreePath = resolve('/tmp/repo-flush-overlap')
+    const { sender, emit } = await watchRoot(worktreePath)
+
+    emit(null, burst(worktreePath, 'a', 64))
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+
+    // Second burst arrives while the first flush is still awaiting its stats.
+    const secondBurst = burst(worktreePath, 'b', 64)
+    emit(null, secondBurst)
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_MAX_WAIT_MS)
+
+    const statPaths = vi.mocked(stat).mock.calls.map((call) => String(call[0]))
+    expect(statPaths.some((statPath) => statPath.includes('b-'))).toBe(false)
+    expect(stats.live()).toBeLessThanOrEqual(EXPECTED_STAT_CONCURRENCY)
+    expect(stats.peak()).toBeLessThanOrEqual(EXPECTED_STAT_CONCURRENCY)
+
+    await stats.settle()
+    expect(sender.send).toHaveBeenCalledTimes(2)
+    expect(
+      (sender.send.mock.calls[1][1] as FsChangedPayload).events.map((event) => event.absolutePath)
+    ).toEqual(secondBurst.map((event) => event.path))
+    await closeAllWatchers()
+    vi.useRealTimers()
+  })
+
+  it('keeps delivering after a flush throws instead of stranding the queued flush', async () => {
+    vi.useFakeTimers()
+    const stats = trackDeferredStats()
+    const worktreePath = resolve('/tmp/repo-flush-throws')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { sender, emit } = await watchRoot(worktreePath)
+    sender.send.mockImplementationOnce(() => {
+      throw new Error('renderer went away mid-flush')
+    })
+
+    emit(null, burst(worktreePath, 'a', 64))
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+
+    const secondBurst = burst(worktreePath, 'b', 64)
+    emit(null, secondBurst)
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_MAX_WAIT_MS)
+    await stats.settle()
+
+    expect(sender.send).toHaveBeenCalledTimes(2)
+    expect(
+      (sender.send.mock.calls[1][1] as FsChangedPayload).events.map((event) => event.absolutePath)
+    ).toEqual(secondBurst.map((event) => event.path))
+    consoleError.mockRestore()
+    await closeAllWatchers()
+    vi.useRealTimers()
+  })
+})

--- a/src/main/ipc/filesystem-watcher-flush-concurrency.test.ts
+++ b/src/main/ipc/filesystem-watcher-flush-concurrency.test.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'node:path'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { handleMock } = vi.hoisted(() => ({
   handleMock: vi.fn()
@@ -75,7 +75,7 @@ function trackDeferredStats(): {
         while (pending.length > 0) {
           pending.shift()?.()
         }
-        await vi.advanceTimersByTimeAsync(0)
+        await (vi.isFakeTimers() ? vi.advanceTimersByTimeAsync(0) : Promise.resolve())
       }
     }
   }
@@ -90,6 +90,7 @@ function burst(worktreePath: string, prefix: string, count: number): WatcherEven
 
 describe('local filesystem watcher flush fan-out', () => {
   const handlers: HandlerMap = {}
+  let stats: ReturnType<typeof trackDeferredStats>
 
   beforeEach(async () => {
     vi.useRealTimers()
@@ -104,6 +105,15 @@ describe('local filesystem watcher flush fan-out', () => {
     })
     registerFilesystemWatcherHandlers()
     await closeAllWatchers()
+    vi.useFakeTimers()
+    stats = trackDeferredStats()
+  })
+
+  afterEach(async () => {
+    // Why: the directory-stat budget is process-wide, so a test that ends with stats still open
+    // (a failing assertion, say) would starve every later test in this file.
+    await Promise.all([closeAllWatchers(), stats.settle()])
+    vi.useRealTimers()
   })
 
   async function watchRoot(
@@ -120,8 +130,6 @@ describe('local filesystem watcher flush fan-out', () => {
   }
 
   it('bounds concurrent stats in one flush to the watcher child limit', async () => {
-    vi.useFakeTimers()
-    const stats = trackDeferredStats()
     const worktreePath = resolve('/tmp/repo-flush-bound')
     const { sender, emit } = await watchRoot(worktreePath)
 
@@ -134,13 +142,68 @@ describe('local filesystem watcher flush fan-out', () => {
     await stats.settle()
     expect(sender.send).toHaveBeenCalledTimes(1)
     expect((sender.send.mock.calls[0][1] as FsChangedPayload).events).toHaveLength(events.length)
-    await closeAllWatchers()
-    vi.useRealTimers()
+  })
+
+  it('caps concurrent stats across every watched root, not per root', async () => {
+    const roots: (Awaited<ReturnType<typeof watchRoot>> & { worktreePath: string })[] = []
+    for (let index = 0; index < 4; index++) {
+      const worktreePath = resolve(`/tmp/repo-flush-multi-${index}`)
+      roots.push({ worktreePath, ...(await watchRoot(worktreePath)) })
+    }
+
+    for (const root of roots) {
+      root.emit(null, burst(root.worktreePath, 'a', 24))
+    }
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+
+    expect(stats.live()).toBeLessThanOrEqual(EXPECTED_STAT_CONCURRENCY)
+    expect(stats.peak()).toBeLessThanOrEqual(EXPECTED_STAT_CONCURRENCY)
+
+    await stats.settle()
+    for (const root of roots) {
+      expect(root.sender.send).toHaveBeenCalledTimes(1)
+      expect((root.sender.send.mock.calls[0][1] as FsChangedPayload).events).toHaveLength(24)
+    }
+  })
+
+  it('leaves events that arrive after a flush is queued to their own trailing window', async () => {
+    const worktreePath = resolve('/tmp/repo-flush-orphan-timer')
+    const { sender, emit } = await watchRoot(worktreePath)
+
+    emit(null, burst(worktreePath, 'a', 4))
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+
+    // Second burst's timer fires while the first flush is still awaiting stats, creating the queued flush.
+    const secondBurst = burst(worktreePath, 'b', 4)
+    emit(null, secondBurst)
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+
+    // Third burst installs a newer trailing timer that the queued flush must not drain early.
+    const thirdBurst = burst(worktreePath, 'c', 4)
+    emit(null, thirdBurst)
+    await stats.settle()
+
+    expect(sender.send).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+    await stats.settle()
+    expect(sender.send).toHaveBeenCalledTimes(2)
+    expect(
+      (sender.send.mock.calls[1][1] as FsChangedPayload).events.map((event) => event.absolutePath)
+    ).toEqual([...secondBurst, ...thirdBurst].map((event) => event.path))
+
+    // A timer orphaned by the queued flush would fire mid-window and deliver this burst early.
+    emit(null, burst(worktreePath, 'd', 4))
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS - 1)
+    await stats.settle()
+    expect(sender.send).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await stats.settle()
+    expect(sender.send).toHaveBeenCalledTimes(3)
   })
 
   it('queues a flush that lands while another flush for the same root is awaiting stats', async () => {
-    vi.useFakeTimers()
-    const stats = trackDeferredStats()
     const worktreePath = resolve('/tmp/repo-flush-overlap')
     const { sender, emit } = await watchRoot(worktreePath)
 
@@ -162,13 +225,9 @@ describe('local filesystem watcher flush fan-out', () => {
     expect(
       (sender.send.mock.calls[1][1] as FsChangedPayload).events.map((event) => event.absolutePath)
     ).toEqual(secondBurst.map((event) => event.path))
-    await closeAllWatchers()
-    vi.useRealTimers()
   })
 
   it('keeps delivering after a flush throws instead of stranding the queued flush', async () => {
-    vi.useFakeTimers()
-    const stats = trackDeferredStats()
     const worktreePath = resolve('/tmp/repo-flush-throws')
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { sender, emit } = await watchRoot(worktreePath)
@@ -189,7 +248,5 @@ describe('local filesystem watcher flush fan-out', () => {
       (sender.send.mock.calls[1][1] as FsChangedPayload).events.map((event) => event.absolutePath)
     ).toEqual(secondBurst.map((event) => event.path))
     consoleError.mockRestore()
-    await closeAllWatchers()
-    vi.useRealTimers()
   })
 })

--- a/src/main/ipc/filesystem-watcher-flush-teardown.test.ts
+++ b/src/main/ipc/filesystem-watcher-flush-teardown.test.ts
@@ -1,0 +1,177 @@
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock } = vi.hoisted(() => ({
+  handleMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock
+  }
+}))
+
+vi.mock('fs/promises', () => ({
+  stat: vi.fn()
+}))
+
+vi.mock('@parcel/watcher', () => ({
+  subscribe: vi.fn()
+}))
+
+vi.mock('./filesystem-watcher-wsl', () => ({
+  createWslWatcher: vi.fn()
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn(),
+  onSshFilesystemProviderRegistered: () => () => {}
+}))
+
+import {
+  closeAllWatchers,
+  closeLocalWatcherForWorktreePath,
+  registerFilesystemWatcherHandlers
+} from './filesystem-watcher'
+import { stat } from 'node:fs/promises'
+import { subscribe as subscribeParcelWatcher } from '@parcel/watcher'
+import type { Event as WatcherEvent } from '@parcel/watcher'
+import { WATCH_BATCH_TRAILING_MS } from '../../shared/filesystem-watch-batch-window'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
+type WatcherCallback = (err: Error | null, events: WatcherEvent[]) => void
+
+/** Holds every event-path stat open so teardown can be driven mid-fan-out. */
+function trackDeferredStats(): {
+  live: () => number
+  settle: (rounds?: number) => Promise<void>
+} {
+  const pending: (() => void)[] = []
+  let live = 0
+  vi.mocked(stat).mockImplementation((target: unknown) => {
+    if (!String(target).endsWith('.ts')) {
+      // The watch install stats the root itself; only event paths are deferred.
+      return Promise.resolve({ isDirectory: () => true } as never)
+    }
+    live += 1
+    return new Promise((resolveStat) => {
+      pending.push(() => {
+        live -= 1
+        resolveStat({ isDirectory: () => false } as never)
+      })
+    }) as never
+  })
+  return {
+    live: () => live,
+    settle: async (rounds = 200): Promise<void> => {
+      for (let i = 0; i < rounds; i++) {
+        while (pending.length > 0) {
+          pending.shift()?.()
+        }
+        await (vi.isFakeTimers() ? vi.advanceTimersByTimeAsync(0) : Promise.resolve())
+      }
+    }
+  }
+}
+
+function burst(worktreePath: string, prefix: string, count: number): WatcherEvent[] {
+  return Array.from({ length: count }, (_, index) => ({
+    type: 'create' as const,
+    path: join(worktreePath, `${prefix}-${index}.ts`)
+  }))
+}
+
+function statPathsMatching(marker: string): string[] {
+  return vi
+    .mocked(stat)
+    .mock.calls.map((call) => String(call[0]))
+    .filter((statPath) => statPath.includes(marker))
+}
+
+describe('local filesystem watcher flush teardown', () => {
+  const handlers: HandlerMap = {}
+  let stats: ReturnType<typeof trackDeferredStats>
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    handleMock.mockReset()
+    vi.mocked(stat).mockReset()
+    vi.mocked(subscribeParcelWatcher).mockReset()
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+    registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+    vi.useFakeTimers()
+    stats = trackDeferredStats()
+  })
+
+  afterEach(async () => {
+    // Why: the directory-stat budget is process-wide, so a test that ends with stats still open
+    // (a failing assertion, say) would starve every later test in this file.
+    await Promise.all([closeAllWatchers(), stats.settle()])
+    vi.useRealTimers()
+  })
+
+  /** Leaves one flush awaiting stats and one flush queued behind it, neither settled. */
+  async function primeActiveAndQueuedFlush(
+    worktreePath: string
+  ): Promise<{ sender: { send: ReturnType<typeof vi.fn> } }> {
+    let watcherCallback: WatcherCallback | undefined
+    vi.mocked(subscribeParcelWatcher).mockImplementation(async (_root, callback) => {
+      watcherCallback = callback as WatcherCallback
+      return { unsubscribe: vi.fn() } as never
+    })
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath })
+
+    watcherCallback?.(null, burst(worktreePath, 'a', 16))
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+    watcherCallback?.(null, burst(worktreePath, 'b', 16))
+    await vi.advanceTimersByTimeAsync(WATCH_BATCH_TRAILING_MS)
+    return { sender }
+  }
+
+  it('does not emit or start a queued flush once closeAllWatchers has run', async () => {
+    const worktreePath = resolve('/tmp/repo-close-all-mid-flush')
+    const { sender } = await primeActiveAndQueuedFlush(worktreePath)
+
+    let closed = false
+    const closePromise = closeAllWatchers().then(() => {
+      closed = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(stats.live()).toBeGreaterThan(0)
+    expect(closed).toBe(false)
+
+    await stats.settle()
+    await closePromise
+
+    expect(sender.send).not.toHaveBeenCalled()
+    expect(statPathsMatching('b-')).toEqual([])
+  })
+
+  it('does not emit or start a queued flush once the worktree watcher is closed for deletion', async () => {
+    const worktreePath = resolve('/tmp/repo-close-local-mid-flush')
+    const { sender } = await primeActiveAndQueuedFlush(worktreePath)
+
+    let closed = false
+    const closePromise = closeLocalWatcherForWorktreePath(worktreePath).then(() => {
+      closed = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(stats.live()).toBeGreaterThan(0)
+    expect(closed).toBe(false)
+
+    await stats.settle()
+    await closePromise
+
+    expect(sender.send).not.toHaveBeenCalled()
+    expect(statPathsMatching('b-')).toEqual([])
+  })
+})

--- a/src/main/ipc/filesystem-watcher-ignore.test.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.test.ts
@@ -33,6 +33,22 @@ describe('buildParcelWatcherIgnoreOptions', () => {
     expect(options.ignoreGlobs?.[0]).not.toContain('?!')
   })
 
+  it('prunes nested ignored dirs on macOS, not just the daemon exclusion paths', () => {
+    setPlatform('darwin')
+    const options = buildParcelWatcherIgnoreOptions(WATCHER_IGNORE_DIRS)
+    expect(options.ignore?.length ?? 0).toBeLessThanOrEqual(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
+    // @parcel/watcher resolves plain `ignore` entries to <root>/<dir>, so a nested
+    // copy is only pruned if the userspace glob covers the full ignore list.
+    const regex = new RegExp(options.ignoreGlobs?.[0] ?? '(?!)')
+    for (const dir of WATCHER_IGNORE_DIRS) {
+      expect(regex.test(`packages/app/${dir}`)).toBe(true)
+      expect(regex.test(`packages/app/${dir}/index.ts`)).toBe(true)
+    }
+    expect(regex.test('packages/app/.github/workflows')).toBe(false)
+    expect(regex.test('packages/app/node_modules-cache/file.ts')).toBe(false)
+    expect(options.ignoreGlobs?.[0]).not.toContain('?!')
+  })
+
   it('uses one lookahead-free native regex for nested ignores on Linux/Windows', () => {
     for (const platform of ['linux', 'win32'] as const) {
       setPlatform(platform)

--- a/src/main/ipc/filesystem-watcher-ignore.ts
+++ b/src/main/ipc/filesystem-watcher-ignore.ts
@@ -56,9 +56,10 @@ export function buildParcelWatcherIgnoreOptions(
     return { ignoreGlobs: [buildNestedDirectoryRegex(ignoreDirs)] }
   }
   const daemonExcludedDirs = ignoreDirs.slice(0, MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
-  const remainingDirs = ignoreDirs.slice(MACOS_FSEVENTS_EXCLUSION_PATH_LIMIT)
   return {
     ignore: [...daemonExcludedDirs],
-    ...(remainingDirs.length > 0 ? { ignoreGlobs: [buildNestedDirectoryRegex(remainingDirs)] } : {})
+    // Why: plain entries only exclude <root>/<dir> at the daemon, so the glob must cover the
+    // FULL list — otherwise nested node_modules/.git churn reaches this process on macOS only.
+    ignoreGlobs: [buildNestedDirectoryRegex(ignoreDirs)]
   }
 }

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -16,6 +16,7 @@ import {
   onSshFilesystemProviderRegistered
 } from '../providers/ssh-filesystem-dispatch'
 import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import {
   createRemoteWatcherEventBatch,
   type RemoteWatcherEventBatch
@@ -300,7 +301,47 @@ function emitOverflowPayload(root: WatchedRoot): void {
   }
 }
 
-async function flushBatch(root: WatchedRoot): Promise<void> {
+// Why: mirrors DIRECTORY_STAT_CONCURRENCY in parcel-watcher-event-delivery.ts — the child bounds
+// the identical stat work, so main must too or one storm queues up to MAX_BATCHED_WATCHER_EVENTS
+// stats against the 4-thread libuv pool.
+const FLUSH_STAT_CONCURRENCY = 8
+
+// Why: a flush awaiting stats must not be overlapped by the next timer tick for the same root;
+// keep one running plus at most one queued so bursts coalesce instead of multiplying the fan-out.
+const inFlightFlushes = new WeakMap<WatchedRoot, Promise<void>>()
+const queuedFlushes = new WeakMap<WatchedRoot, Promise<void>>()
+
+function flushBatch(root: WatchedRoot): Promise<void> {
+  const inFlight = inFlightFlushes.get(root)
+  if (inFlight) {
+    const queued = queuedFlushes.get(root)
+    if (queued) {
+      return queued
+    }
+    const chained = inFlight.then(() => {
+      queuedFlushes.delete(root)
+      return flushBatch(root)
+    })
+    queuedFlushes.set(root, chained)
+    return chained
+  }
+
+  const running = runBatchFlush(root)
+    // Why: contain a flush failure here — a rejection would strand this root's queued promise and
+    // silently stop delivering its events for the rest of the session.
+    .catch((error) => {
+      console.error(`[filesystem-watcher] flush failed for ${root.rootPath}:`, error)
+    })
+    .finally(() => {
+      if (inFlightFlushes.get(root) === running) {
+        inFlightFlushes.delete(root)
+      }
+    })
+  inFlightFlushes.set(root, running)
+  return running
+}
+
+async function runBatchFlush(root: WatchedRoot): Promise<void> {
   const overflowed = root.batch.overflowed
   const rawEvents = root.batch.events.splice(0)
   root.batch.overflowed = false
@@ -319,8 +360,10 @@ async function flushBatch(root: WatchedRoot): Promise<void> {
 
   const coalesced = coalesceEvents(rawEvents)
 
-  const events: FsChangeEvent[] = await Promise.all(
-    coalesced.map(async (evt) => {
+  const events: FsChangeEvent[] = await mapWithConcurrency(
+    coalesced,
+    FLUSH_STAT_CONCURRENCY,
+    async (evt): Promise<FsChangeEvent> => {
       // Why: a deleted path can't be stat'd; leave isDirectory undefined and let the renderer infer from dirCache.
       const isDirectory = evt.type === 'delete' ? undefined : await tryStatIsDirectory(evt.path)
 
@@ -329,7 +372,7 @@ async function flushBatch(root: WatchedRoot): Promise<void> {
         absolutePath: evt.path,
         isDirectory
       }
-    })
+    }
   )
 
   const payload: FsChangedPayload = {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -17,6 +17,7 @@ import {
 } from '../providers/ssh-filesystem-dispatch'
 import { MAX_BATCHED_WATCHER_EVENTS, queueWatcherEvents } from './filesystem-watcher-event-batch'
 import { mapWithConcurrency } from '../../shared/map-with-concurrency'
+import { DIRECTORY_STAT_CONCURRENCY, withDirectoryStatSlot } from './watcher-directory-stat-limit'
 import {
   createRemoteWatcherEventBatch,
   type RemoteWatcherEventBatch
@@ -278,7 +279,9 @@ function coalesceEvents(
 
 async function tryStatIsDirectory(filePath: string): Promise<boolean | undefined> {
   try {
-    const s = await stat(filePath)
+    // Why the slot: the bound has to be process-wide, or N watched roots each flushing concurrently
+    // would fan out to N × the cap against the shared libuv threadpool.
+    const s = await withDirectoryStatSlot(() => stat(filePath))
     return s.isDirectory()
   } catch {
     // Why: stat failure (EPERM, vanished file) → undefined; renderer treats it as a file event, the safe default (§4.4).
@@ -301,17 +304,33 @@ function emitOverflowPayload(root: WatchedRoot): void {
   }
 }
 
-// Why: mirrors DIRECTORY_STAT_CONCURRENCY in parcel-watcher-event-delivery.ts — the child bounds
-// the identical stat work, so main must too or one storm queues up to MAX_BATCHED_WATCHER_EVENTS
-// stats against the 4-thread libuv pool.
-const FLUSH_STAT_CONCURRENCY = 8
-
 // Why: a flush awaiting stats must not be overlapped by the next timer tick for the same root;
 // keep one running plus at most one queued so bursts coalesce instead of multiplying the fan-out.
 const inFlightFlushes = new WeakMap<WatchedRoot, Promise<void>>()
 const queuedFlushes = new WeakMap<WatchedRoot, Promise<void>>()
+// Why: a torn-down root must not start queued work or emit afterwards. Removal always discards the
+// WatchedRoot object (a later watch builds a fresh one), so the fence is permanent per root.
+const fencedRoots = new WeakSet<WatchedRoot>()
+
+/** Stop a removed root's flush machinery: no queued flush starts, no payload is emitted. */
+function fenceRootFlushes(root: WatchedRoot): void {
+  fencedRoots.add(root)
+  clearBatchTimer(root)
+  root.batch.events.length = 0
+  root.batch.overflowed = false
+  root.batch.firstEventAt = 0
+}
+
+/** Flush work still outstanding for a root; the queued promise subsumes the in-flight one. */
+function outstandingFlush(root: WatchedRoot): Promise<void> | undefined {
+  return queuedFlushes.get(root) ?? inFlightFlushes.get(root)
+}
 
 function flushBatch(root: WatchedRoot): Promise<void> {
+  if (fencedRoots.has(root)) {
+    return Promise.resolve()
+  }
+
   const inFlight = inFlightFlushes.get(root)
   if (inFlight) {
     const queued = queuedFlushes.get(root)
@@ -320,6 +339,11 @@ function flushBatch(root: WatchedRoot): Promise<void> {
     }
     const chained = inFlight.then(() => {
       queuedFlushes.delete(root)
+      // Why: a newer trailing timer installed after we queued already owns the pending events —
+      // draining them here would deliver before its window closes and orphan the live handle.
+      if (root.batch.timer) {
+        return
+      }
       return flushBatch(root)
     })
     queuedFlushes.set(root, chained)
@@ -345,7 +369,9 @@ async function runBatchFlush(root: WatchedRoot): Promise<void> {
   const overflowed = root.batch.overflowed
   const rawEvents = root.batch.events.splice(0)
   root.batch.overflowed = false
-  root.batch.timer = null
+  // Why: this drains every pending event, so cancel the live trailing timer rather than dropping the
+  // only handle to it — a queued flush can enter here with a newer timer already scheduled.
+  clearBatchTimer(root)
   root.batch.firstEventAt = 0
 
   if ((rawEvents.length === 0 && !overflowed) || root.listeners.size === 0) {
@@ -362,10 +388,14 @@ async function runBatchFlush(root: WatchedRoot): Promise<void> {
 
   const events: FsChangeEvent[] = await mapWithConcurrency(
     coalesced,
-    FLUSH_STAT_CONCURRENCY,
+    DIRECTORY_STAT_CONCURRENCY,
     async (evt): Promise<FsChangeEvent> => {
       // Why: a deleted path can't be stat'd; leave isDirectory undefined and let the renderer infer from dirCache.
-      const isDirectory = evt.type === 'delete' ? undefined : await tryStatIsDirectory(evt.path)
+      // Why the fence check: teardown drops this payload anyway, so stop holding open stats on a tree being deleted.
+      const isDirectory =
+        evt.type === 'delete' || fencedRoots.has(root)
+          ? undefined
+          : await tryStatIsDirectory(evt.path)
 
       return {
         kind: evt.type,
@@ -374,6 +404,12 @@ async function runBatchFlush(root: WatchedRoot): Promise<void> {
       }
     }
   )
+
+  if (fencedRoots.has(root)) {
+    // Why: teardown landed while these stats were outstanding. Deletion copies the listener map rather
+    // than clearing it, so without this the closed watcher still emits into the renderer.
+    return
+  }
 
   const payload: FsChangedPayload = {
     worktreePath: root.rootPath,
@@ -387,7 +423,21 @@ async function runBatchFlush(root: WatchedRoot): Promise<void> {
   }
 }
 
+// Why: batch.timer must name a live timer and nothing else — a queued flush reads it to decide
+// whether a newer trailing window already owns the pending events.
+function clearBatchTimer(root: WatchedRoot): void {
+  if (root.batch.timer) {
+    clearTimeout(root.batch.timer)
+    root.batch.timer = null
+  }
+}
+
 function scheduleBatchFlush(root: WatchedRoot): void {
+  if (fencedRoots.has(root)) {
+    // Why: unsubscribe is async, so events can still land after teardown; don't retain them or arm a timer.
+    return
+  }
+
   const now = Date.now()
 
   if (root.batch.firstEventAt === 0) {
@@ -396,18 +446,21 @@ function scheduleBatchFlush(root: WatchedRoot): void {
 
   // If we've exceeded the max wait, flush immediately
   if (now - root.batch.firstEventAt >= WATCH_BATCH_MAX_WAIT_MS) {
-    if (root.batch.timer) {
-      clearTimeout(root.batch.timer)
-    }
+    clearBatchTimer(root)
     void flushBatch(root)
     return
   }
 
   // Trailing-edge debounce: reset timer on each new event
-  if (root.batch.timer) {
-    clearTimeout(root.batch.timer)
-  }
-  root.batch.timer = setTimeout(() => void flushBatch(root), WATCH_BATCH_TRAILING_MS)
+  clearBatchTimer(root)
+  const timer = setTimeout(() => {
+    // The handle is spent once it fires; drop it so a later event installs a fresh window.
+    if (root.batch.timer === timer) {
+      root.batch.timer = null
+    }
+    void flushBatch(root)
+  }, WATCH_BATCH_TRAILING_MS)
+  root.batch.timer = timer
 }
 
 // ── Watcher creation ─────────────────────────────────────────────────
@@ -448,9 +501,7 @@ async function createWatcher(
           console.error(`[filesystem-watcher] error for ${rootKey}:`, err)
           emitOverflowPayload(root)
           // Why: after an error the native subscription may be invalid (deleted root); tear down the dead watcher so it doesn't dangle (§7.3).
-          if (root.batch.timer) {
-            clearTimeout(root.batch.timer)
-          }
+          fenceRootFlushes(root)
           // Why: error callback can fire before subscribe() assigns root.subscription; guard against null so cleanup doesn't crash.
           if (root.subscription) {
             retainLocalWatcherPhysicalFailure(rootKey, err)
@@ -508,9 +559,7 @@ function cleanupLocalWatchersForSender(senderId: number): void {
           clearTimeout(pending)
           pendingTeardowns.delete(key)
         }
-        if (watchedRoot.batch.timer) {
-          clearTimeout(watchedRoot.batch.timer)
-        }
+        fenceRootFlushes(watchedRoot)
         trackLocalUnsubscribe(key, watchedRoot)
         watchedRoots.delete(key)
       }
@@ -837,6 +886,7 @@ function unsubscribe(worktreePath: string, senderId: number): void {
       if (!currentRoot || currentRoot.listeners.size > 0) {
         return
       }
+      fenceRootFlushes(currentRoot)
       void trackLocalUnsubscribe(rootKey, currentRoot)
       watchedRoots.delete(rootKey)
     }, WATCHER_TEARDOWN_GRACE_MS)
@@ -873,6 +923,21 @@ export async function closeLocalWatcherForWorktreePath(
   if (pendingTeardown) {
     clearTimeout(pendingTeardown)
     pendingTeardowns.delete(rootKey)
+  }
+
+  // Why fence before the first await: the drains below can take seconds, and until the root is fenced a
+  // queued flush can still start a fresh stat batch on — and emit events from — the tree being deleted.
+  const closingRoot = watchedRoots.get(rootKey)
+  if (closingRoot) {
+    fenceRootFlushes(closingRoot)
+    // Why drain rather than only cancel: Windows can't remove a directory with stats still open on it,
+    // and the deadline keeps a slow flush from wedging the removal gate.
+    await drainBeforeWatcherRemoval(
+      outstandingFlush(closingRoot),
+      deadline,
+      `local watcher flush for ${rootKey}`,
+      { reserveMs: WATCHER_REMOVAL_FINAL_DRAIN_RESERVE_MS }
+    )
   }
 
   const inFlight = inFlightLocalInstalls.get(rootKey)
@@ -923,6 +988,11 @@ export async function closeLocalWatcherForWorktreePath(
     }
   }
   if (failedLocalUnsubscribes.has(rootKey)) {
+    // Why: this close aborts with the watcher still installed and its root reused by a later
+    // subscribe/restore, so lift the fence instead of leaving a live root that can never flush.
+    if (closingRoot && watchedRoots.get(rootKey) === closingRoot) {
+      fencedRoots.delete(closingRoot)
+    }
     throw failedLocalUnsubscribes.get(rootKey)
   }
 
@@ -930,9 +1000,8 @@ export async function closeLocalWatcherForWorktreePath(
   if (!root) {
     return
   }
-  if (root.batch.timer) {
-    clearTimeout(root.batch.timer)
-  }
+  // Re-fence: a watch that reinstalled during the drains above hands back a different root object.
+  fenceRootFlushes(root)
   watchedRoots.delete(rootKey)
   // Why: the in-process Parcel fallback has no unsubscribe timeout of its own, so an unbounded await
   // here would hang delete forever and hold the removal gate. The promise stays tracked in
@@ -1979,14 +2048,19 @@ export async function closeAllWatchers(): Promise<void> {
     token.abortController.abort()
   }
 
+  const closingFlushes: Promise<void>[] = []
   for (const [rootKey, root] of watchedRoots) {
-    if (root.batch.timer) {
-      clearTimeout(root.batch.timer)
+    fenceRootFlushes(root)
+    const outstanding = outstandingFlush(root)
+    if (outstanding) {
+      closingFlushes.push(outstanding)
     }
     await trackLocalUnsubscribe(rootKey, root).catch(() => undefined)
   }
   watchedRoots.clear()
-  await Promise.allSettled(Array.from(pendingLocalUnsubscribes))
+  // Why include the flushes: callers treat this as the shutdown barrier and Electron tears the Node
+  // environment down right after, so no stat may still be open on a watched tree when it resolves.
+  await Promise.allSettled([...closingFlushes, ...pendingLocalUnsubscribes])
   failedLocalUnsubscribes.clear()
   // Why: kill the forked watcher process instead of watcher.node's crash-prone async teardown; process death frees native handles.
   disposeWatcherProcess()

--- a/src/main/ipc/parcel-watcher-event-delivery.ts
+++ b/src/main/ipc/parcel-watcher-event-delivery.ts
@@ -5,42 +5,15 @@ import type {
   WatcherProcessDeliveryOptions,
   WatcherProcessEvent
 } from './parcel-watcher-process-protocol'
-
-const DIRECTORY_STAT_CONCURRENCY = 8
-let activeDirectoryStats = 0
-const directoryStatWaiters: (() => void)[] = []
+import { DIRECTORY_STAT_CONCURRENCY, withDirectoryStatSlot } from './watcher-directory-stat-limit'
 
 export type WatcherProcessEventDeliveryQueue = {
   enqueue(events: readonly ParcelWatcherEvent[]): void
   close(): void
 }
 
-async function acquireDirectoryStatSlot(): Promise<void> {
-  if (activeDirectoryStats < DIRECTORY_STAT_CONCURRENCY) {
-    activeDirectoryStats++
-    return
-  }
-  await new Promise<void>((resolve) => directoryStatWaiters.push(resolve))
-}
-
-function releaseDirectoryStatSlot(): void {
-  const next = directoryStatWaiters.shift()
-  if (next) {
-    // Transfer the existing slot directly so a newly arriving task cannot
-    // overtake this waiter and temporarily exceed the global budget.
-    next()
-    return
-  }
-  activeDirectoryStats--
-}
-
 async function statWatcherEventPath(eventPath: string): Promise<boolean> {
-  await acquireDirectoryStatSlot()
-  try {
-    return (await stat(eventPath)).isDirectory()
-  } finally {
-    releaseDirectoryStatSlot()
-  }
+  return withDirectoryStatSlot(async () => (await stat(eventPath)).isDirectory())
 }
 
 async function mapWithConcurrency<T, R>(

--- a/src/main/ipc/watcher-directory-stat-limit.ts
+++ b/src/main/ipc/watcher-directory-stat-limit.ts
@@ -1,0 +1,35 @@
+// Why: one budget per process, not per watched root or per batch — the main-process flush and the
+// watcher child's delivery queue both stat event paths against the same 4-thread libuv pool, so a
+// storm across N roots must still queue behind a single cap.
+export const DIRECTORY_STAT_CONCURRENCY = 8
+
+let activeDirectoryStats = 0
+const directoryStatWaiters: (() => void)[] = []
+
+async function acquireDirectoryStatSlot(): Promise<void> {
+  if (activeDirectoryStats < DIRECTORY_STAT_CONCURRENCY) {
+    activeDirectoryStats++
+    return
+  }
+  await new Promise<void>((resolve) => directoryStatWaiters.push(resolve))
+}
+
+function releaseDirectoryStatSlot(): void {
+  const next = directoryStatWaiters.shift()
+  if (next) {
+    // Transfer the existing slot directly so a newly arriving task cannot
+    // overtake this waiter and temporarily exceed the global budget.
+    next()
+    return
+  }
+  activeDirectoryStats--
+}
+
+export async function withDirectoryStatSlot<T>(stat: () => Promise<T>): Promise<T> {
+  await acquireDirectoryStatSlot()
+  try {
+    return await stat()
+  } finally {
+    releaseDirectoryStatSlot()
+  }
+}


### PR DESCRIPTION
Fixes #11218

## ELI5

Orca watches your project folder so the file tree updates when files change. On Macs it was told to skip the noisy folders — `node_modules`, `.git`, build output — but only the copies sitting at the very top of the project. Any copy buried deeper (normal in a multi-package repo) was still watched, so an install or a build flooded the app with tens of thousands of change notifications. Windows and Linux never had this problem; they were already skipping nested copies.

Then, every time Orca processed a flood, it asked the operating system about every changed file at once — up to 5,000 questions in flight — and if the next flood arrived before the first finished, it started another pile on top. That is how the app ends up eating CPU and memory until the Mac freezes.

The fix makes Macs skip nested noisy folders exactly like the other platforms, and puts every one of those filesystem questions through a single queue of 8 for the whole app — the same queue the watcher's helper process already uses. A second batch waits its turn instead of piling on, and closing a folder now stops its queue and waits for it, instead of letting leftover work run after the folder is gone.

## Root cause

Two independent amplifiers that compose into the reported runaway.

**1. macOS pruned only top-level ignored dirs.** `buildParcelWatcherIgnoreOptions` passes the first 8 entries of `WATCHER_IGNORE_DIRS` as plain `ignore` entries, because `FSEventStreamSetExclusionPaths` silently drops *every* exclusion once you exceed its cap. The watcher resolves a non-glob `ignore` entry to `<root>/<dir>` only — it is a path, not a pattern. `ignoreGlobs` was then built from `ignoreDirs.slice(8)`, i.e. the *remainder*, which with a 9-entry list covered exactly one directory (`__pycache__`).

So on macOS, nested `node_modules`, `.git`, `dist`, `build`, `target`, `.venv`, `.next` and `.cache` were pruned by neither layer. Linux/Windows already received the full component-anchored regex via the early return, which is why this is macOS-only.

**2. Unbounded stat fan-out, no flush serialization, no teardown fence.** `flushBatch` stat'd every coalesced path with `Promise.all`, up to `MAX_BATCHED_WATCHER_EVENTS` (5,000) concurrently against libuv's 4-thread pool. `scheduleBatchFlush` called `void flushBatch(root)` with no in-flight guard, so a sustained stream could start another full fan-out for the same root while the previous one was still awaiting stats. And nothing tied that machinery to teardown: `closeLocalWatcherForWorktreePath` and `closeAllWatchers` neither cancelled nor awaited an outstanding flush.

## Fix

- `filesystem-watcher-ignore.ts`: build `ignoreGlobs` from the **full** ignore list on darwin. The 8 plain paths stay (daemon-side exclusion is still worth having, and the cap is real). The two layers are independent, so overlapping on the first 8 is harmless. The regex shape is unchanged — same `buildNestedDirectoryRegex`, still component-anchored and lookahead-free.
- **One stat budget per process.** The watcher child's existing limiter moves verbatim into `watcher-directory-stat-limit.ts` (same counter, same FIFO waiters, same slot-transfer-on-release so an arriving task cannot overtake a waiter and exceed the budget). `parcel-watcher-event-delivery.ts` and the main-process flush both consume it, so N watched roots share one budget of 8 rather than getting 8 each. The in-process Parcel fallback shares it too — same process, same libuv pool.
- **Per-root flush serialization.** The old body moves verbatim into `runBatchFlush`; `flushBatch` becomes a thin serializer keyed by `WeakMap` on the `WatchedRoot`. At most one flush runs plus one queued per root. Stats go through the shared `mapWithConcurrency`, which preserves index order — payload ordering and coalescing are byte-identical.
- **Teardown fences the flush machinery.** A `fencedRoots` WeakSet blocks entry to `flushBatch`, timer arming, remaining stats mid-map, and the payload send. Applied at every site that discards a root. The two close paths drain differently on purpose: `closeLocalWatcherForWorktreePath` fences *before* its first await and drains under the existing removal deadline, because Windows cannot delete a directory with stats still open on it; `closeAllWatchers` folds the flushes into its existing `Promise.allSettled` barrier, matching what it already does for pending unsubscribes — its sole production caller treats that promise as the Electron shutdown barrier. The fence bounds each drain to the ≤8 already-issued stats rather than up to 5,000. The `failedLocalUnsubscribes` throw path deliberately *lifts* the fence: that close aborts with the watcher still installed and `restoreLocalWatcherAfterFailedRemoval` reuses the same `WatchedRoot`, so a permanent fence would leave a live root that could never flush again.
- **`batch.timer` now names a live timer and nothing else.** The queued continuation reads it to decide whether a newer trailing window already owns the pending events; previously `runBatchFlush` unconditionally nulled it, orphaning a newer timer that then flushed a later burst early.
- A failed flush is contained rather than allowed to reject: a rejection would strand that root's queued promise and silently stop delivering its events for the rest of the session.

## Proof

New `filesystem-watcher-flush-concurrency.test.ts` and `filesystem-watcher-flush-teardown.test.ts`, plus a darwin case in `filesystem-watcher-ignore.test.ts`.

Each fix was verified by reverting only that change against the final code.

**Nested macOS pruning:**
```
     × prunes nested ignored dirs on macOS, not just the daemon exclusion paths
AssertionError: expected false to be true
 ❯ src/main/ipc/filesystem-watcher-ignore.test.ts:44:49
```

**Per-batch bound (reverting the serializer + `mapWithConcurrency`):**
```
     × bounds concurrent stats in one flush to the watcher child limit
AssertionError: expected 64 to be less than or equal to 8

     × queues a flush that lands while another flush for the same root is awaiting stats
AssertionError: expected true to be false
```

**Process-wide bound (reverting only the `withDirectoryStatSlot` wrapper):**
```
     × caps concurrent stats across every watched root, not per root
AssertionError: expected 32 to be less than or equal to 8
 ❯ src/main/ipc/filesystem-watcher-flush-concurrency.test.ts:159:26
```
32 = 4 roots × 8 — exactly the per-root multiplication.

**Teardown fence (reverting the fence and both drains).** Both tests set up one active plus one queued flush and do *not* settle the stats before closing:
```
     × does not emit or start a queued flush once closeAllWatchers has run
     × does not emit or start a queued flush once the worktree watcher is closed for deletion
AssertionError: expected true to be false
```
With that first assertion temporarily neutralised, the post-close emit assertion also fails, confirming the second half:
```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received: "fs:changed", { events: [ { absolutePath: "/tmp/repo-close-all-mid-flush/a-0.ts", … } ] }
```

**Orphaned timer (reverting the three timer edits):**
```
     × leaves events that arrive after a flush is queued to their own trailing window
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
```

**Flush-failure containment (reverting only the `.catch`):**
```
     × keeps delivering after a flush throws instead of stranding the queued flush
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
```

**After** — this branch:

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/ipc/filesystem-watcher-flush-concurrency.test.ts \
    src/main/ipc/filesystem-watcher-flush-teardown.test.ts \
    src/main/ipc/filesystem-watcher-ignore.test.ts \
    src/main/ipc/filesystem-watcher-large-batch.test.ts \
    src/main/ipc/filesystem-watcher.test.ts \
    src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts \
    src/main/ipc/filesystem-watcher-removal-deadline.test.ts \
    src/main/ipc/parcel-watcher-event-delivery.test.ts \
    src/main/runtime/file-watcher-host.test.ts

 Test Files  9 passed (9)
      Tests  91 passed (91)
```

The whole `src/main/ipc` directory plus `file-watcher-host`: 2669 passed | 10 skipped. The refactor of the child's limiter is confirmed non-behavioural — its pre-existing global-cap test (8 roots × 16 events, asserting 128 stat calls and `maxActiveStats === 8`) still asserts exactly `8` against the extracted module.

`pnpm tc` and `pnpm lint` pass on this branch.

## Release-readiness

| Scan | Result |
|---|---|
| Functional correctness | Ordering and coalescing byte-identical: `mapWithConcurrency` is untouched and still writes `results[index]`, and the semaphore sits strictly inside the mapper below the indexing. Flush rejection cannot wedge a root. Teardown cannot emit or start new work. |
| Cross-platform | (1) is darwin-only; the non-darwin early return is untouched and its test unchanged. Separators come from the existing `buildNestedDirectoryRegex` win32/POSIX branch; tests use `path.join`/`resolve`. (2) is platform-neutral. The removal drain specifically protects Windows, which cannot delete a directory with open stats. |
| SSH / relay | Remote watches go through `provider.watch` + `remote-watcher-event-batch` and never enter `flushBatch`. A macOS relay/SSH **host** does inherit (1) via `relay-filesystem-watch-registry.ts` and `file-watcher-host.ts` — the intended direction (fewer events over the link); both suites pass unchanged. |
| Folder workspace vs worktree | Both subscribe through the same `fs:watchWorktree` root. Nothing reads git state. Provider-neutral; no git commands touched. |
| Backcompat / data loss | No persisted state, schema, or IPC payload shape changes. The `fs:changed` payload is identical, so mixed renderer/main versions see no difference. |
| Security / supply chain | No new dependencies, no shell/exec, no network sink, no install hooks. |

## Residual risk

- **Attribution.** This removes a proven unbounded amplifier, but nothing in the reporter's logs ties the freeze to the watcher specifically. Worth confirming with a macOS monorepo user before closing.
- **A queued flush is delayed, never *lost* — but it can be dropped.** Two deliberate cases: when a newer trailing timer already owns the pending events (that timer flushes them), and when the root is being torn down. Events are always flushed by whichever timer owns them, unless the watcher is going away.
- **Latency.** One process-wide budget of 8 lengthens worst-case flush time when many roots are busy at once — that is the point, but it is a real tradeoff versus the previous 8-per-root. The existing >5,000-event overflow path still skips stats entirely, so the ceiling is bounded.
- **Timing, not content.** A burst landing mid-flush is delivered in the following flush rather than concurrently. Ordering within a batch is preserved.
- macOS now pays the per-event native regex cost it previously skipped for the first 8 dirs — a strict win versus delivering those events.
- Because the stat budget is module-global, a test that ends with stats still open starves later tests in the same file. Both flush test files build the deferred-stat tracker in `beforeEach` and settle it in `afterEach`.
- Not runtime-tested on a real macOS monorepo; evidence is the unit suite.

Made with [Orca](https://github.com/stablyai/orca) 🐋
