### PR TITLE
fix(relay): answer an over-capacity response instead of closing the client

### DIFF
--- a/src/relay/dispatcher-capacity-degradation.test.ts
+++ b/src/relay/dispatcher-capacity-degradation.test.ts
@@ -41,6 +41,35 @@ function makeSaturatingClient(highWaterMark: number): BoundedClient {
   return client
 }
 
+type DrainableClient = BoundedClient & { drain: () => boolean }
+
+// Why: a saturating sink that can be released one frame at a time, so queued frames become observable.
+function makeDrainableSaturatingClient(highWaterMark: number): DrainableClient {
+  const client = makeSaturatingClient(highWaterMark) as DrainableClient
+  let pending: (() => void) | null = null
+  client.options.waitWriteDrain = (callback) => {
+    pending = callback
+    return () => {
+      if (pending === callback) {
+        pending = null
+      }
+    }
+  }
+  client.drain = () => {
+    const callback = pending
+    pending = null
+    callback?.()
+    return callback !== null
+  }
+  return client
+}
+
+// Why: a real reattach replay is ANSI-dense, so JSON escaping inflates it well past its character count.
+function makeAnsiReplay(chars: number): string {
+  const cell = '\u001b[2K\u001b[1;32mhello\u001b[0m \r\n'
+  return cell.repeat(Math.ceil(chars / cell.length)).slice(0, chars)
+}
+
 function makeBoundedClient(highWaterMark: number): BoundedClient {
   const client: BoundedClient = {
     frames: [],
@@ -406,6 +435,53 @@ describe('RelayDispatcher bounded-capacity degradation', () => {
         error: new Error('Relay response exceeded the bounded transport capacity')
       })
     } finally {
+      bounded.dispose()
+    }
+  })
+
+  it('answers every reattach response instead of closing when the batch exceeds the control budget', async () => {
+    const primary = makeDrainableSaturatingClient(65536)
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const replay = makeAnsiReplay(100 * 1024)
+      bounded.onRequest('pty.attach', async () => ({ incarnationId: 'inc-1', replay }))
+      for (let id = 1; id <= 8; id += 1) {
+        bounded.feed(
+          encodeJsonRpcFrame(
+            {
+              jsonrpc: '2.0',
+              id,
+              method: 'pty.attach',
+              params: { id: `pty-${id}`, suppressReplayNotification: true }
+            },
+            id,
+            0
+          )
+        )
+      }
+      await vi.advanceTimersByTimeAsync(0)
+
+      // The reattach burst must degrade per request, never take the link down.
+      expect(primary.closes).toBe(0)
+
+      for (let step = 0; step < 64 && primary.drain(); step += 1) {
+        await vi.advanceTimersByTimeAsync(0)
+      }
+
+      const responses = primary.frames.map(
+        (frame) => decodePayload(frame) as unknown as { id: number; error?: { code: number } }
+      )
+      expect(responses.map((response) => response.id).sort((a, b) => a - b)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8
+      ])
+      expect(
+        responses.filter((response) => response.error?.code === RelayErrorCode.ResponseOverCapacity)
+          .length
+      ).toBeGreaterThan(0)
+      expect(primary.closes).toBe(0)
+    } finally {
+      stderr.mockRestore()
       bounded.dispose()
     }
   })

--- a/src/relay/dispatcher-capacity-degradation.test.ts
+++ b/src/relay/dispatcher-capacity-degradation.test.ts
@@ -4,7 +4,10 @@ import {
   type RelayClientSinkOptions,
   type SinkWriteSettlement
 } from './dispatcher'
-import { DISPATCHER_CONTROL_QUEUE_MAX_FRAMES } from './dispatcher-writer-admission'
+import {
+  DISPATCHER_CONTROL_QUEUE_MAX_BYTES,
+  DISPATCHER_CONTROL_QUEUE_MAX_FRAMES
+} from './dispatcher-writer-admission'
 import { LEGACY_CLIENT_RETAINED_BYTES_LOW } from './legacy-relay-publication-ledger'
 import type * as ProtocolModule from './protocol'
 import { encodeJsonRpcFrame, RelayErrorCode } from './protocol'
@@ -68,6 +71,47 @@ function makeDrainableSaturatingClient(highWaterMark: number): DrainableClient {
 function makeAnsiReplay(chars: number): string {
   const cell = '\u001b[2K\u001b[1;32mhello\u001b[0m \r\n'
   return cell.repeat(Math.ceil(chars / cell.length)).slice(0, chars)
+}
+
+const OVER_CAPACITY_MESSAGE = 'Relay response exceeded the bounded transport capacity'
+const CONTROL_PAD_METHOD = 'control.pad'
+
+// Why: control admission is sized in encoded frame bytes, so pad a notification to an exact frame size.
+function controlPadParams(frameBytes: number): { pad: string } {
+  const empty = encodeJsonRpcFrame(
+    { jsonrpc: '2.0', method: CONTROL_PAD_METHOD, params: { pad: '' } },
+    0,
+    0
+  ).length
+  return { pad: 'x'.repeat(frameBytes - empty) }
+}
+
+function fillControlLaneToByteBound(dispatcher: RelayDispatcher, clientId: number): void {
+  const padFrameBytes = 64 * 1024
+  const params = controlPadParams(padFrameBytes)
+  for (let index = 0; index < DISPATCHER_CONTROL_QUEUE_MAX_BYTES / padFrameBytes; index += 1) {
+    expect(
+      dispatcher.tryNotifyClient(clientId, CONTROL_PAD_METHOD, params, () => {}, {
+        controlOverflow: 'reject'
+      })
+    ).toBe(true)
+  }
+}
+
+// A bare notification is smaller than the error substitute, so its rejection proves the substitute cannot
+// fit either — anything that still gets through afterwards can only have come from the reserve.
+function expectControlLaneFull(dispatcher: RelayDispatcher, clientId: number): void {
+  expect(
+    dispatcher.tryNotifyClient(clientId, 'control.probe', undefined, () => {}, {
+      controlOverflow: 'reject'
+    })
+  ).toBe(false)
+}
+
+async function drainFully(client: DrainableClient, steps: number): Promise<void> {
+  for (let step = 0; step < steps && client.drain(); step += 1) {
+    await vi.advanceTimersByTimeAsync(0)
+  }
 }
 
 function makeBoundedClient(highWaterMark: number): BoundedClient {
@@ -482,6 +526,103 @@ describe('RelayDispatcher bounded-capacity degradation', () => {
       expect(primary.closes).toBe(0)
     } finally {
       stderr.mockRestore()
+      bounded.dispose()
+    }
+  })
+
+  it('answers from the control byte reserve when the lane is filled to the 1MiB bound', async () => {
+    const primary = makeDrainableSaturatingClient(65536)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const clientId = bounded.activeClientIds()[0]
+      // 16 x 64KiB lands controlBytes on the bound exactly while using only 16 of the 256 frame slots,
+      // so the byte bound is the only thing that can reject the substitute.
+      fillControlLaneToByteBound(bounded, clientId)
+      expectControlLaneFull(bounded, clientId)
+
+      bounded.onRequest('pty.attach', async () => ({
+        incarnationId: 'inc-1',
+        replay: makeAnsiReplay(4 * 1024)
+      }))
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 91, method: 'pty.attach' }, 1, 0))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(primary.closes).toBe(0)
+
+      await drainFully(primary, 64)
+      const payloads = primary.frames.map((frame) => decodePayload(frame))
+      expect(payloads.filter((payload) => payload.id === 91)).toEqual([
+        {
+          jsonrpc: '2.0',
+          id: 91,
+          error: { code: RelayErrorCode.ResponseOverCapacity, message: OVER_CAPACITY_MESSAGE }
+        }
+      ])
+      expect(primary.closes).toBe(0)
+    } finally {
+      bounded.dispose()
+    }
+  })
+
+  it('answers from the control frame reserve when all 256 frame slots are taken', async () => {
+    const primary = makeDrainableSaturatingClient(65536)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const clientId = bounded.activeClientIds()[0]
+      // Tiny frames leave the byte bound untouched, so only the frame bound can reject the substitute.
+      for (let index = 0; index < DISPATCHER_CONTROL_QUEUE_MAX_FRAMES; index += 1) {
+        expect(
+          bounded.tryNotifyClient(clientId, `control.${index}`, undefined, () => {}, {
+            controlOverflow: 'reject'
+          })
+        ).toBe(true)
+      }
+      expectControlLaneFull(bounded, clientId)
+
+      bounded.onRequest('pty.attach', async () => ({ incarnationId: 'inc-1', replay: 'ok' }))
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 92, method: 'pty.attach' }, 1, 0))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(primary.closes).toBe(0)
+
+      await drainFully(primary, DISPATCHER_CONTROL_QUEUE_MAX_FRAMES + 32)
+      const payloads = primary.frames.map((frame) => decodePayload(frame))
+      expect(payloads.filter((payload) => payload.id === 92)).toEqual([
+        {
+          jsonrpc: '2.0',
+          id: 92,
+          error: { code: RelayErrorCode.ResponseOverCapacity, message: OVER_CAPACITY_MESSAGE }
+        }
+      ])
+      expect(primary.closes).toBe(0)
+    } finally {
+      bounded.dispose()
+    }
+  })
+
+  it('settles a control-rejected response exactly once, when the reserved substitute is written', async () => {
+    const primary = makeDrainableSaturatingClient(65536)
+    const bounded = new RelayDispatcher(primary.write, primary.options)
+    try {
+      const clientId = bounded.activeClientIds()[0]
+      fillControlLaneToByteBound(bounded, clientId)
+
+      const settlements: SinkWriteSettlement[] = []
+      bounded.onRequest('pty.attach', async (_params, context) => {
+        context.onResponseSettled?.((result) => settlements.push(result))
+        return { incarnationId: 'inc-1', replay: makeAnsiReplay(4 * 1024) }
+      })
+      bounded.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: 93, method: 'pty.attach' }, 1, 0))
+      await vi.advanceTimersByTimeAsync(0)
+
+      // The reserve admitted the substitute, so the fence waits on its write instead of failing admission.
+      expect(primary.closes).toBe(0)
+      expect(settlements).toHaveLength(0)
+
+      await drainFully(primary, 64)
+      expect(settlements).toEqual([{ ok: false, error: new Error(OVER_CAPACITY_MESSAGE) }])
+      expect(primary.closes).toBe(0)
+    } finally {
       bounded.dispose()
     }
   })

--- a/src/relay/dispatcher-client-writer.ts
+++ b/src/relay/dispatcher-client-writer.ts
@@ -88,7 +88,8 @@ export class DispatcherClientWriter {
     encode: () => Buffer,
     estimatedBytes: number,
     onSettled: (result: SinkWriteSettlement) => void = () => {},
-    overflowIsNonFatal = false
+    overflowIsNonFatal = false,
+    usesControlReserve = false
   ): boolean {
     if (this.closed) {
       onSettled({ ok: false, error: new Error('Relay writer is closed') })
@@ -100,7 +101,8 @@ export class DispatcherClientWriter {
       estimatedBytes,
       onSettled: onceDispatcherWriterSettlement(onSettled),
       settled: false,
-      overflowIsNonFatal
+      overflowIsNonFatal,
+      usesControlReserve
     }
     const admission = this.admission.admit(entry, this.sink.frameCapacity(lane, this.saturated))
     if (!admission.accepted) {

--- a/src/relay/dispatcher-writer-admission.ts
+++ b/src/relay/dispatcher-writer-admission.ts
@@ -17,6 +17,9 @@ export type DispatcherWriterEntry = {
   settled: boolean
   // Why: control overflow closes the client by default; best-effort frames opt out of that instead.
   overflowIsNonFatal?: boolean
+  // Why: a rejected response's tiny error substitute must still reach the caller when the lane is
+  // full, so it alone may draw on a small reserve past the bound. See RelayDispatcher.sendResponse.
+  usesControlReserve?: boolean
 }
 
 type AdmissionResult =
@@ -25,6 +28,9 @@ type AdmissionResult =
 
 export const DISPATCHER_CONTROL_QUEUE_MAX_FRAMES = 256
 export const DISPATCHER_CONTROL_QUEUE_MAX_BYTES = 1024 * 1024
+// Why: sized for a handful of ~110-byte JSON-RPC error frames, not for carrying real payloads.
+const CONTROL_RESERVE_FRAMES = 16
+const CONTROL_RESERVE_BYTES = 64 * 1024
 const LIVENESS_QUEUE_MAX_FRAMES = 2
 
 export const DEFAULT_PRODUCER_QUEUE_MAX_BYTES = 2 * 1024 * 1024
@@ -70,11 +76,13 @@ export class DispatcherWriterAdmission {
     return this.producerBytes
   }
 
-  canAdmitControl(bytes: number): boolean {
-    return (
-      this.controlFrames < DISPATCHER_CONTROL_QUEUE_MAX_FRAMES &&
-      this.controlBytes + bytes <= DISPATCHER_CONTROL_QUEUE_MAX_BYTES
-    )
+  canAdmitControl(bytes: number, usesReserve = false): boolean {
+    // Why: the reserve is additive headroom for the error substitute only — widening the bound here
+    // rather than shrinking it for everyone keeps every frame that fits today still fitting.
+    const frameLimit =
+      DISPATCHER_CONTROL_QUEUE_MAX_FRAMES + (usesReserve ? CONTROL_RESERVE_FRAMES : 0)
+    const byteLimit = DISPATCHER_CONTROL_QUEUE_MAX_BYTES + (usesReserve ? CONTROL_RESERVE_BYTES : 0)
+    return this.controlFrames < frameLimit && this.controlBytes + bytes <= byteLimit
   }
 
   get queuedEntries(): number {
@@ -154,7 +162,7 @@ export class DispatcherWriterAdmission {
   private admitControl(entry: DispatcherWriterEntry): AdmissionResult {
     // Why: best-effort controls may fail soft without weakening protocol-critical admission.
     const overflowIsNonFatal = entry.overflowIsNonFatal === true
-    if (!this.canAdmitControl(entry.estimatedBytes)) {
+    if (!this.canAdmitControl(entry.estimatedBytes, entry.usesControlReserve === true)) {
       if (overflowIsNonFatal) {
         return { accepted: false }
       }

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -992,12 +992,15 @@ export class RelayDispatcher {
     }
     const estimatedBytes = this.estimateFrameBytes(msg)
     const lane = estimatedBytes > DISPATCHER_CONTROL_QUEUE_MAX_BYTES ? 'legacy-response' : 'control'
-    const accepted = this.enqueueFrame(client, msg, lane, onSettled)
+    // Why: a response is fenced by its request, so overflow must fail that request only — closing would
+    // kill every pane on the host and a reattach burst would re-kill the link on every reconnect.
+    const accepted = this.enqueueFrame(client, msg, lane, onSettled, estimatedBytes, 'reject')
     if (accepted) {
       return true
     }
-    // Why: an oversized response must fail its own request; closing would kill every pane on the host.
-    // A rejected first enqueue either left onSettled untouched or closed the client, so exactly one settlement happens.
+    // Why: the substitute draws on the control lane's reserve, so a lane saturated by bulky replay
+    // responses can still answer. A rejected first enqueue left onSettled untouched, so exactly one
+    // settlement happens.
     return this.enqueueFrame(
       client,
       {
@@ -1016,7 +1019,10 @@ export class RelayDispatcher {
           settlement.ok
             ? { ok: false, error: new Error(RESPONSE_OVER_CAPACITY_MESSAGE) }
             : settlement
-        )
+        ),
+      undefined,
+      'close-client',
+      true
     )
   }
 
@@ -1027,7 +1033,8 @@ export class RelayDispatcher {
     onSettled: (result: SinkWriteSettlement) => void = () => {},
     // Why: publish paths already sized the frame; avoid a redundant encode.
     estimatedBytes?: number,
-    controlOverflow: 'close-client' | 'reject' = 'close-client'
+    controlOverflow: 'close-client' | 'reject' = 'close-client',
+    usesControlReserve = false
   ): boolean {
     if (this.disposed || client.closed) {
       return false
@@ -1042,7 +1049,8 @@ export class RelayDispatcher {
       encode,
       frameBytes,
       onSettled,
-      lane === 'control' && controlOverflow === 'reject'
+      lane === 'control' && controlOverflow === 'reject',
+      usesControlReserve
     )
   }
 


### PR DESCRIPTION
Fixes #11943

## ELI5

When your laptop reconnects to a remote machine, it asks the remote helper program to hand back the recent screen contents for every terminal you had open — all at once. Each of those answers can be fairly big, and the helper has a fixed-size outbox for important messages. If the answers didn't fit, the helper's rule was "outbox full, something is badly wrong, hang up the whole connection." So your laptop reconnected, asked for everything again, overflowed the outbox again, and got hung up on again — forever. The more terminals you had, the more certain it became.

The fix changes the rule for *answers* specifically: if an answer doesn't fit, the helper sends back a tiny "sorry, too big" note for that one request instead of hanging up, and your laptop just asks again. To make sure that tiny note itself always fits, the outbox keeps a small corner free that only the note is allowed to use.

Broadcast messages nobody is waiting on — like pushed screen history — still hang up on overflow, because there is no one to tell and no one who would retry.

## Root cause

`RelayDispatcher.sendResponse` puts every sub-1MB JSON-RPC response on the bounded `control` lane. `enqueueFrame` defaults `controlOverflow` to `'close-client'`, so `admitControl` returns a **fatal** `Error` at the 256-frame / 1MB bound, `DispatcherClientWriter.enqueue` turns that into `this.close(...)`, and `RelayDispatcher.closeClient` destroys the socket.

Control bytes are only released on write settlement, so a saturated socket keeps every queued frame charged against the bound.

The pre-existing "substitute a `ResponseOverCapacity` error" fallback right below could never run for this case: the *first* enqueue already closed the client and returned.

This makes the loop permanent rather than transient. On reconnect the client reattaches every pane at once, and each `pty.attach` answers with an inline replay buffer — so the burst scales with pane count. The more panes a host accumulates, the more certainly the link is killed mid-reattach, and every retry reproduces the identical burst. That is the reconnect/dispose loop in the report, and it is why manually cleaning the remote host is what breaks it.

Note on scope: the *ordinary*-lane leg of this issue was already addressed (#11999, #11917). The control-lane leg above was untouched and is what this PR fixes.

## Fix

1. `sendResponse` enqueues the primary response with `controlOverflow: 'reject'`. A response is fenced by its request, so overflow must fail **that one request** rather than the whole link. The caller's mux surfaces it as a failed attach and retries via the existing `attachPtyWithRetry`.
2. So the substitute is admittable on a lane the bulky responses just saturated, it alone may draw on a small additive reserve past the bound (`usesControlReserve`, 16 frames / 64KB — sized for a handful of ~110-byte JSON-RPC error frames, not for payloads). The reserve **widens** the limit for that one frame rather than shrinking it for everyone, so **every frame admitted today is still admitted**. The pending request is therefore always settled, never left hanging.
3. `pty.replay` notifications keep their fatal control overflow. #11999 made that deliberate, and it stays correct: a notification has no request to fail and no caller to retry it, so there is nothing to report to. Both existing fatal-close tests are unchanged and still pass.

An earlier iteration implemented the reserve by making large frames stop *short* of the bound. That was a tightening — it rejected a legitimate large control frame that fits today, and broke `relay-watcher-event-emitter.test.ts > waits until the control byte budget can admit the retained marker`. The additive form above has no such effect.

## Proof

The headline test `answers every reattach response instead of closing when the batch exceeds the control budget` models the reattach burst — 8 concurrent `pty.attach` requests each returning a 100KB ANSI-dense replay (~175KB encoded) against a saturating sink — and asserts the link stays open and every id 1..8 gets a frame back, at least one of them a `ResponseOverCapacity` error.

It needed a `makeDrainableSaturatingClient` helper (a saturating sink whose drain can be released one frame at a time) so queued-but-unwritten frames become observable; without it only the first frame is ever encoded and "every request was answered" cannot be asserted.

That test alone proves only half the fix. Sized exactly against the same JSON shape, five successful responses consume 890,865 bytes and the three 128-byte substitutes still land at 891,249 bytes over 8 frames — under both the 1MiB and 256-frame bounds. It fails without `'reject'` but would pass with the reserve deleted. Three further cases close that gap:

- `answers from the control byte reserve when the lane is filled to the 1MiB bound` — 16 × 64KiB frames land `controlBytes` exactly on the bound while using only 16 of 256 frame slots, isolating the byte limit. It first asserts a bare `control.probe` notification (smaller than the substitute) is refused, so anything admitted afterwards can only have come from the reserve.
- `answers from the control frame reserve when all 256 frame slots are taken` — the inverse: tiny frames fill every slot with the byte bound barely touched.
- `settles a control-rejected response exactly once, when the reserved substitute is written` — registers `onResponseSettled` on the control-rejection path, asserts zero settlements while the substitute is queued, then exactly one `{ok:false}` after drain.

**Before** — the new test against the production files as they exist on `main`:

```
$ npx vitest run --config config/vitest.config.ts src/relay/dispatcher-capacity-degradation.test.ts
   (dispatcher.ts, dispatcher-writer-admission.ts, dispatcher-client-writer.ts restored from origin/main)

     × answers every reattach response instead of closing when the batch exceeds the control budget
AssertionError: expected 1 to be +0 // Object.is equality

 Test Files  1 failed (1)
      Tests  1 failed | 18 passed (19)
```

One client close where zero are expected — the link dies mid-reattach.

**The reserve, proved by mutation.** Three separate mutations, each reverted immediately after:

`CONTROL_RESERVE_BYTES = 0` — the two byte-bound cases fail, the frame case correctly stays green:
```
     × answers from the control byte reserve when the lane is filled to the 1MiB bound
     × settles a control-rejected response exactly once, when the reserved substitute is written
AssertionError: expected 1 to be +0 // Object.is equality
 ❯ src/relay/dispatcher-capacity-degradation.test.ts:550:30
```
with `[relay] Client write closed: Relay control queue exceeded its bounded capacity` on stderr — the #11943 regression itself.

`CONTROL_RESERVE_FRAMES = 0` — the exact inverse:
```
     × answers from the control frame reserve when all 256 frame slots are taken
AssertionError: expected 1 to be +0
 ❯ src/relay/dispatcher-capacity-degradation.test.ts:586:30
```

`usesControlReserve` flipped to `false` at the substitute enqueue (reserve constants intact) — all three fail, at `:550`, `:586`, `:619`.

**After** — the entire relay suite on this branch:

```
$ npx vitest run --config config/vitest.config.ts src/relay/

 Test Files  102 passed (102)
      Tests  1219 passed (1219)
```

That includes both tests pinning fatal control overflow (`still closes on protocol-critical control queue overflow`, `closes the client when pty.replay overflows the control queue`) and the watcher-emitter budget test, all unmodified.

`pnpm tc` and `pnpm lint` pass on this branch.

## Release-readiness

| Scan | Result |
|---|---|
| Functional correctness | The pending request is always settled — either the real response, or the substitute, or (last resort) client close, which fails in-flight requests immediately rather than hanging them for the 10s timeout. The settlement fence still never reports the substitute's successful write as "the peer received your result". |
| Cross-platform | Pure dispatcher/admission logic: no paths, separators, shells, or OS calls. Identical on macOS, Linux, Windows. |
| SSH / relay | This *is* the remote surface. Runs inside the relay binary on the host; agnostic to workspace kind and git provider. |
| Backcompat | No wire-protocol change. The substitute reuses the already-shipped `RelayErrorCode.ResponseOverCapacity` code and message that existing clients handle. New client ↔ old relay and old client ↔ new relay both behave exactly as before. No persisted state. |
| Security / supply chain | No new dependencies, no shell/exec, no network sink. The reserve is a fixed 64KB / 16 frames and cannot be drawn on by attacker-chosen frames — only by the dispatcher's own error substitute. |

## Residual risk

- **Deployed relays keep the old behavior until the relay binary is redeployed.** Nothing here helps an unupgraded host.
- If the control lane is saturated and even the reserve is exhausted, the client is still closed. Deliberate — it fails in-flight requests fast rather than hanging them — but the link can still drop under a sustained flood.
- A `pty.attach` whose response is replaced by a capacity error now relies on the caller retrying (10s deadline). Reattach is slower for affected panes, and if every retry lands inside the same saturation window those panes surface an attach failure instead of a reconnect loop. That is a strictly better failure mode, but it is a different one.
- Client-side mitigation — bounding inline replay, or serializing replay-bearing reattaches — is out of scope and still open. That is the change that would stop the burst from being generated at all.
- Orphan relay PTY accumulation (#8585 / #9819) is untouched and keeps amplifying burst size on long-lived hosts.
- Verified at the dispatcher unit level; no real-socket integration test of the 8-way reattach burst.
- Issue #11943's literal logged reason, `Relay control publication capacity exceeded`, names the separate `notifyControl` close path, which is unchanged here; response admission closes with `Relay control queue exceeded its bounded capacity`. The inline-reattach response path independently reproduces a fatal close, but sole-cause attribution to the historical report is not proven.
- In all three reserve mutations the failure lands on the surviving-client assertion, so the exactly-once settlement assertion is never *reached* under mutation. That test's discriminating power comes from the surviving client and the zero-settlements-while-queued check, not from the settlement count — which is 1 either way, just with a different error.

Made with [Orca](https://github.com/stablyai/orca) 🐋
