### PR TITLE
fix(agent-hooks): exit Windows hook guards instead of draining a foreign stdin

### DIFF
--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -28,9 +28,13 @@ export const WINDOWS_HOOK_STDIN_DRAIN_LABEL = 'orca_agent_hook_drain_stdin'
 export const WINDOWS_HOOK_STDIN_READER = '"%SystemRoot%\\System32\\more.com"'
 export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = `${WINDOWS_HOOK_STDIN_READER} >nul 2>nul`
 
-// Why: missing Orca env means the caller is not Orca, so Orca owes it no stdin drain —
-// the #8430 EPIPE contract only covers hooks Orca invokes (payload written, stdin closed).
-// A non-Orca caller may hold stdin open forever, wedging more.com and its console (#11549).
+// Why: these guards deliberately exit instead of draining, walking back part of #8430.
+// #8430 did cover callers without Orca env, but it assumed every caller eventually closes
+// stdin. A non-Orca caller need not, and more.com then blocks forever: an immortal
+// cmd.exe/more.com pair plus a console window on every hook event (#11549). A transient
+// broken pipe on a caller that would never close stdin is the cheaper of the two failures.
+// Orca-invoked hooks keep the #8430 guarantee — their env is set, so they fall through to
+// the post command, which reads stdin to EOF.
 export function buildWindowsHookEnvironmentGuardLines(): string[] {
   return [
     'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -28,14 +28,14 @@ export const WINDOWS_HOOK_STDIN_DRAIN_LABEL = 'orca_agent_hook_drain_stdin'
 export const WINDOWS_HOOK_STDIN_READER = '"%SystemRoot%\\System32\\more.com"'
 export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = `${WINDOWS_HOOK_STDIN_READER} >nul 2>nul`
 
-// Why: batch payloads stream directly to curl and cannot be buffered safely in
-// environment variables, so guard failures share one EOF-draining epilogue.
+// Why: missing Orca env means the caller is not Orca, so Orca owes it no stdin drain —
+// the #8430 EPIPE contract only covers hooks Orca invokes (payload written, stdin closed).
+// A non-Orca caller may hold stdin open forever, wedging more.com and its console (#11549).
 export function buildWindowsHookEnvironmentGuardLines(): string[] {
-  const drainTarget = `goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`
   return [
-    `if "%ORCA_AGENT_HOOK_PORT%"=="" ${drainTarget}`,
-    `if "%ORCA_AGENT_HOOK_TOKEN%"=="" ${drainTarget}`,
-    `if "%ORCA_PANE_KEY%"=="" ${drainTarget}`
+    'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',
+    'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
+    'if "%ORCA_PANE_KEY%"=="" exit /b 0'
   ]
 }
 

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -1,10 +1,15 @@
 // Why: stdin ownership is a cross-agent process contract; one executable
 // matrix catches an unread early exit without duplicating template assertions.
+// Windows batch guards are the one exception: an Orca-less caller gets an
+// immediate exit and may see a broken pipe, because more.com would otherwise
+// block forever on a caller that never closes stdin (#11549).
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { AddressInfo } from 'node:net'
 import type { SFTPWrapper } from 'ssh2'
 import type * as osModule from 'node:os'
 
@@ -222,6 +227,41 @@ async function generatePosixScripts(): Promise<Map<string, string>> {
   return scripts
 }
 
+const WINDOWS_DRAIN_LABEL_LINE = ':orca_agent_hook_drain_stdin'
+const WINDOWS_DRAIN_COMMAND_LINE = '"%SystemRoot%\\System32\\more.com" >nul 2>nul'
+// Why: Node surfaces a closed Windows pipe under several codes; anything else
+// (EACCES, ENOENT) would mean the script failed rather than exited early.
+const BROKEN_PIPE_CODES = new Set(['EPIPE', 'ECONNRESET', 'ERR_STREAM_DESTROYED', 'EOF'])
+// Why: these two capture stdin before any guard, so the #8430 no-EPIPE guarantee
+// still holds for them even without Orca environment.
+const CAPTURES_BEFORE_GUARDS = new Set(['copilot-hook.ps1', 'kimi-hook.sh'])
+
+function orcaHookEnvironment(port: number): NodeJS.ProcessEnv {
+  return {
+    ORCA_AGENT_HOOK_PORT: String(port),
+    ORCA_AGENT_HOOK_TOKEN: 'test-token',
+    ORCA_PANE_KEY: 'tab-1:00000000-0000-4000-8000-000000000000',
+    // Why: the Grok template substrings %GROK_HOME%; leave it defined so this
+    // case exercises the post path rather than undefined-variable expansion.
+    GROK_HOME: 'C:\\orca-test-grok-home'
+  }
+}
+
+// Why: a live reader is what makes the with-Orca-env assertion meaningful — the
+// post command must consume the whole payload, not fail before touching stdin.
+async function withLoopbackHookServer<T>(run: (port: number) => Promise<T>): Promise<T> {
+  const server = createServer((request, response) => {
+    request.resume()
+    request.on('end', () => response.end('{}'))
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  try {
+    return await run((server.address() as AddressInfo).port)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = Object.getOwnPropertyDescriptor(process, 'platform')
   Object.defineProperty(process, 'platform', { configurable: true, value: platform })
@@ -235,7 +275,7 @@ function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
 }
 
 describe('Windows managed hook stdin structure', () => {
-  it('exits missing-Orca-env batch guards without entering the drain', () => {
+  it('exits missing-Orca-env guards and keeps a drain epilogue only where a jump survives', () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-'))
     homedirMock.mockReturnValue(home)
     const previousGrokHome = process.env.GROK_HOME
@@ -256,31 +296,65 @@ describe('Windows managed hook stdin structure', () => {
       mainBatchScripts.push('antigravity-hook.cmd')
       expect(mainBatchScripts).toHaveLength(10)
       for (const fileName of mainBatchScripts) {
-        const script = readFileSync(join(hooksDir, fileName), 'utf8')
+        const lines = readFileSync(join(hooksDir, fileName), 'utf8').split('\r\n')
         // Why: a caller without Orca env is not Orca, so it may never close stdin —
         // more.com would then block forever and leak a cmd.exe/more.com pair (#11549).
-        expect(script, `${fileName} port guard`).toContain(
+        expect(lines, `${fileName} port guard`).toContain(
           'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0'
         )
-        expect(script, `${fileName} token guard`).toContain(
+        expect(lines, `${fileName} token guard`).toContain(
           'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0'
         )
-        expect(script, `${fileName} pane guard`).toContain('if "%ORCA_PANE_KEY%"=="" exit /b 0')
-        expect(script, `${fileName} port guard drain`).not.toContain(
-          'if "%ORCA_AGENT_HOOK_PORT%"=="" goto :orca_agent_hook_drain_stdin'
+        expect(lines, `${fileName} pane guard`).toContain('if "%ORCA_PANE_KEY%"=="" exit /b 0')
+        // Why: text presence proved nothing once the guards stopped jumping. Emit the
+        // epilogue only where a jump survives, so a dead label cannot pose as coverage.
+        const jumpIndex = lines.findIndex((line) =>
+          line.endsWith(`goto :${WINDOWS_DRAIN_LABEL_LINE.slice(1)}`)
         )
-        expect(script, `${fileName} token guard drain`).not.toContain(
-          'if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto :orca_agent_hook_drain_stdin'
-        )
-        expect(script, `${fileName} pane guard drain`).not.toContain(
-          'if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin'
-        )
-        expect(script, `${fileName} drain epilogue`).toContain(
-          [
-            ':orca_agent_hook_drain_stdin',
-            '"%SystemRoot%\\System32\\more.com" >nul 2>nul',
+        const labelIndex = lines.indexOf(WINDOWS_DRAIN_LABEL_LINE)
+        expect(labelIndex > -1, `${fileName} drain epilogue reachable`).toBe(jumpIndex > -1)
+        if (labelIndex > -1) {
+          expect(lines.slice(labelIndex, labelIndex + 3), `${fileName} drain epilogue`).toEqual([
+            WINDOWS_DRAIN_LABEL_LINE,
+            WINDOWS_DRAIN_COMMAND_LINE,
             'exit /b 0'
-          ].join('\r\n')
+          ])
+        }
+      }
+
+      // Why: Claude's Devin skip is the one surviving jump, and it must sit after the
+      // Orca-env guards — only an Orca-invoked hook is guaranteed to close stdin.
+      const claude = readFileSync(join(hooksDir, 'claude-hook.cmd'), 'utf8').split('\r\n')
+      const claudePaneGuardIndex = claude.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')
+      const claudeDevinIndex = claude.findIndex((line) =>
+        line.startsWith('if not "%DEVIN_PROJECT_DIR%"==""')
+      )
+      expect(claudePaneGuardIndex, 'claude pane guard').toBeGreaterThan(-1)
+      expect(claudeDevinIndex, 'claude Devin skip after Orca guards').toBeGreaterThan(
+        claudePaneGuardIndex
+      )
+      expect(claude.indexOf(WINDOWS_DRAIN_LABEL_LINE), 'claude drain epilogue').toBeGreaterThan(
+        claudeDevinIndex
+      )
+      // Why: OpenClaude has no Devin skip, so nothing can reach a drain there.
+      const openClaude = readFileSync(join(hooksDir, 'openclaude-hook.cmd'), 'utf8')
+      expect(openClaude, 'openclaude drain').not.toContain(WINDOWS_DRAIN_LABEL_LINE.slice(1))
+
+      // Why: a partially removed install leaves these wrappers behind with the core
+      // script gone, which is exactly the never-EOF path #11549 reported.
+      const wrapperFileNames = fileNames.filter(
+        (name) => name.startsWith('antigravity-') && name !== 'antigravity-hook.cmd'
+      )
+      expect(wrapperFileNames, 'antigravity event wrappers').toHaveLength(4)
+      for (const fileName of wrapperFileNames) {
+        const lines = readFileSync(join(hooksDir, fileName), 'utf8').split('\r\n')
+        const guardIndex = lines.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')
+        const drainIndex = lines.indexOf(WINDOWS_DRAIN_COMMAND_LINE)
+        expect(guardIndex, `${fileName} Orca env guard`).toBeGreaterThan(-1)
+        expect(drainIndex, `${fileName} drain after Orca env guard`).toBeGreaterThan(guardIndex)
+        // Why: the JSON protocol reply must still precede the guard, or Antigravity stalls.
+        expect(lines.indexOf('  echo {}'), `${fileName} protocol reply before guard`).toBeLessThan(
+          guardIndex
         )
       }
 
@@ -309,7 +383,7 @@ describe('Windows managed hook stdin structure', () => {
   })
 
   it.skipIf(process.platform !== 'win32')(
-    'executes every local script and missing-script launcher without a broken writer',
+    'exits without Orca env and never breaks an Orca writer',
     async () => {
       const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-live-'))
       homedirMock.mockReturnValue(home)
@@ -319,6 +393,9 @@ describe('Windows managed hook stdin structure', () => {
           expect(entry.install().state, `${entry.agent} install status`).toBe('installed')
         }
         const hooksDir = join(home, '.orca', 'agent-hooks')
+        const eventWrappers = readdirSync(hooksDir).filter(
+          (name) => name.startsWith('antigravity-') && name !== 'antigravity-hook.cmd'
+        )
         const mainScripts = readdirSync(hooksDir).filter(
           (name) =>
             name === 'antigravity-hook.cmd' ||
@@ -327,28 +404,78 @@ describe('Windows managed hook stdin structure', () => {
             (name.endsWith('-hook.cmd') && !name.startsWith('antigravity-'))
         )
         expect(mainScripts).toHaveLength(12)
-        for (const fileName of mainScripts) {
+        expect(eventWrappers).toHaveLength(4)
+        const spawnArgsFor = (
+          fileName: string
+        ): { executable: string; args: string[]; scriptPath: string } => {
           const scriptPath = join(hooksDir, fileName)
-          const executable = fileName.endsWith('.cmd')
-            ? 'cmd.exe'
-            : fileName.endsWith('.ps1')
-              ? join(
-                  process.env.SystemRoot ?? 'C:\\Windows',
-                  'System32',
-                  'WindowsPowerShell',
-                  'v1.0',
-                  'powershell.exe'
-                )
-              : gitBash
-          const args = fileName.endsWith('.cmd')
-            ? ['/d', '/c', scriptPath]
-            : fileName.endsWith('.ps1')
-              ? ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath]
-              : [scriptPath]
-          const result = await runHookProcess(executable, args, hookEnvironment())
-          expect(result.exitCode, `${fileName} exit code`).toBe(0)
-          expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
+          if (fileName.endsWith('.cmd')) {
+            return { executable: 'cmd.exe', args: ['/d', '/c', scriptPath], scriptPath }
+          }
+          if (fileName.endsWith('.ps1')) {
+            return {
+              executable: join(
+                process.env.SystemRoot ?? 'C:\\Windows',
+                'System32',
+                'WindowsPowerShell',
+                'v1.0',
+                'powershell.exe'
+              ),
+              args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath],
+              scriptPath
+            }
+          }
+          return { executable: gitBash, args: [scriptPath], scriptPath }
         }
+
+        // Why: the wrappers are only a hang risk once the core script is gone, which is
+        // what a partially removed install leaves behind.
+        rmSync(join(hooksDir, 'antigravity-hook.cmd'))
+        for (const fileName of [...mainScripts, ...eventWrappers]) {
+          if (fileName === 'antigravity-hook.cmd') {
+            continue
+          }
+          const { executable, args } = spawnArgsFor(fileName)
+          const result = await runHookProcess(executable, args, hookEnvironment())
+          // Why: the run must end on its own — a hung more.com is the #11549 leak, and
+          // runHookProcess rejects rather than resolving if it never closes.
+          expect(result.exitCode, `${fileName} exit code`).toBe(0)
+          if (CAPTURES_BEFORE_GUARDS.has(fileName)) {
+            expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
+          } else {
+            // Why: batch guards exit before reading, so a caller that is not Orca gets a
+            // broken pipe by design; any other errno would mean the script itself failed.
+            const unexpected = result.stdinErrors
+              .map((error) => error.code ?? 'unknown')
+              .filter((code) => !BROKEN_PIPE_CODES.has(code))
+            expect(unexpected, `${fileName} unexpected stdin errors`).toEqual([])
+          }
+        }
+
+        // Why: the #8430 guarantee still has to hold for hooks Orca invokes — nothing
+        // about the missing-env exit may cost an Orca-launched agent its payload write.
+        for (const entry of LOCAL_INSTALLERS) {
+          expect(entry.install().state, `${entry.agent} reinstall status`).toBe('installed')
+        }
+        await withLoopbackHookServer(async (port) => {
+          const orcaEnv = orcaHookEnvironment(port)
+          for (const fileName of mainScripts) {
+            const { executable, args } = spawnArgsFor(fileName)
+            const result = await runHookProcess(executable, args, hookEnvironment(orcaEnv))
+            expect(result.exitCode, `${fileName} Orca-env exit code`).toBe(0)
+            expect(result.stdinErrors, `${fileName} Orca-env stdin errors`).toHaveLength(0)
+          }
+          // Why: the Devin skip is the only guard that still drains; it runs after the
+          // Orca-env guards, so reaching it proves the surviving epilogue is live.
+          const claude = spawnArgsFor('claude-hook.cmd')
+          const devinSkip = await runHookProcess(
+            claude.executable,
+            claude.args,
+            hookEnvironment({ ...orcaEnv, DEVIN_PROJECT_DIR: 'C:\\devin-project' })
+          )
+          expect(devinSkip.exitCode, 'claude Devin skip exit code').toBe(0)
+          expect(devinSkip.stdinErrors, 'claude Devin skip stdin errors').toHaveLength(0)
+        })
 
         const missingScript = 'C:\\missing\\orca-hook.cmd'
         // Why: the cmd fast path is intentionally a bare, directly-spawnable .cmd

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -235,7 +235,7 @@ function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
 }
 
 describe('Windows managed hook stdin structure', () => {
-  it('routes every batch guard to a shared drain epilogue', () => {
+  it('exits missing-Orca-env batch guards without entering the drain', () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-'))
     homedirMock.mockReturnValue(home)
     const previousGrokHome = process.env.GROK_HOME
@@ -257,13 +257,22 @@ describe('Windows managed hook stdin structure', () => {
       expect(mainBatchScripts).toHaveLength(10)
       for (const fileName of mainBatchScripts) {
         const script = readFileSync(join(hooksDir, fileName), 'utf8')
+        // Why: a caller without Orca env is not Orca, so it may never close stdin —
+        // more.com would then block forever and leak a cmd.exe/more.com pair (#11549).
         expect(script, `${fileName} port guard`).toContain(
-          'if "%ORCA_AGENT_HOOK_PORT%"=="" goto :orca_agent_hook_drain_stdin'
+          'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0'
         )
         expect(script, `${fileName} token guard`).toContain(
+          'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0'
+        )
+        expect(script, `${fileName} pane guard`).toContain('if "%ORCA_PANE_KEY%"=="" exit /b 0')
+        expect(script, `${fileName} port guard drain`).not.toContain(
+          'if "%ORCA_AGENT_HOOK_PORT%"=="" goto :orca_agent_hook_drain_stdin'
+        )
+        expect(script, `${fileName} token guard drain`).not.toContain(
           'if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto :orca_agent_hook_drain_stdin'
         )
-        expect(script, `${fileName} pane guard`).toContain(
+        expect(script, `${fileName} pane guard drain`).not.toContain(
           'if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin'
         )
         expect(script, `${fileName} drain epilogue`).toContain(

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -28,7 +28,6 @@ import {
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_COMMAND
 } from '../agent-hooks/hook-stdin-contract'
 
@@ -102,7 +101,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAntigravityHookPostCommand(),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }
@@ -165,6 +163,10 @@ function getWindowsWrapperScript(eventName: string): string {
     ') else (',
     '  echo {}',
     ')',
+    // Why: guard before the drain below — a stale wrapper left by a partial uninstall is
+    // still reachable outside Orca, and more.com would hang on a caller that never closes
+    // stdin, leaking a cmd.exe/more.com pair per event (#11549).
+    ...buildWindowsHookEnvironmentGuardLines(),
     // Why: when the shared core script is missing, this wrapper becomes the
     // stdin owner and must finish the agent's payload write before returning.
     WINDOWS_HOOK_STDIN_DRAIN_COMMAND,

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -58,22 +58,27 @@ function getManagedScript(
   options: { skipWhenDevinImportsClaude?: boolean } = {}
 ): string {
   if (target === 'local' && process.platform === 'win32') {
+    const skipsDevinImport = options.skipWhenDevinImportsClaude === true
     return [
       '@echo off',
       'setlocal',
-      ...(options.skipWhenDevinImportsClaude
+      // Why: refresh endpoint coordinates for PTYs surviving an Orca restart.
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      // Why: the Orca-env guards run before the Devin skip so the skip is reachable only
+      // when Orca invoked this hook — only then is a payload written and stdin closed,
+      // which is what makes the skip's drain safe rather than a #11549 hang.
+      ...buildWindowsHookEnvironmentGuardLines(),
+      ...(skipsDevinImport
         ? [
             // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.
             `if not "%DEVIN_PROJECT_DIR%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`
           ]
         : []),
-      // Why: refresh endpoint coordinates for PTYs surviving an Orca restart.
-      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
-      ...buildWindowsHookEnvironmentGuardLines(),
       // Why: use curl.exe to avoid an extra PowerShell startup per hook.
       buildWindowsAgentHookCurlPostCommand('claude'),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
+      // Why: the Devin skip is the only remaining jump here; without it this would be dead code.
+      ...(skipsDevinImport ? buildWindowsHookStdinDrainEpilogue() : []),
       ''
     ].join('\r\n')
   }

--- a/src/main/claude/statusline-script.test.ts
+++ b/src/main/claude/statusline-script.test.ts
@@ -89,17 +89,24 @@ describe('getManagedStatusLineScript (win32 local)', () => {
     stubPlatform('win32')
     const script = getManagedStatusLineScript('local')
     // Why: no pane key means Claude was not launched by Orca, so its stdin may never
-    // reach EOF; draining it would wedge more.com and leak a console window (#11549).
+    // reach EOF; draining it would wedge more.com and leak a console window on every
+    // streaming tick (#11549).
     const paneGuardIndex = script.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')
     const captureIndex = script.indexOf('more.com')
     expect(paneGuardIndex).toBeGreaterThan(-1)
     expect(paneGuardIndex).toBeLessThan(captureIndex)
-    expect(script).not.toContain('if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin')
-    // Orca-launched ticks still capture the payload, and the shared drain tail stays intact.
+    // Orca-launched ticks still capture the payload before any other guard runs.
     expect(script).toContain(
       '"%SystemRoot%\\System32\\more.com" >"%ORCA_STATUSLINE_PAYLOAD_FILE%" 2>nul'
     )
-    expect(script).toContain(':orca_agent_hook_drain_stdin')
+    // Why: the pane guard was the only jump into the shared drain, and every later path
+    // reaches cleanup + exit first — keeping the label would ship an unreachable epilogue.
+    expect(script).not.toContain('orca_agent_hook_drain_stdin')
+    const lines = script.split('\r\n')
+    expect(lines.at(-2), 'last executable line').toBe('exit /b 0')
+    expect(lines.at(-3), 'cleanup precedes the final exit').toBe(
+      'del "%ORCA_STATUSLINE_PAYLOAD_FILE%" >nul 2>nul'
+    )
   })
 
   it('throttles with an all-builtin seconds-of-day stamp that fails open to posting', () => {

--- a/src/main/claude/statusline-script.test.ts
+++ b/src/main/claude/statusline-script.test.ts
@@ -85,15 +85,20 @@ describe('getManagedStatusLineScript (win32 local)', () => {
     expect(script).not.toContain('"configDir=%CLAUDE_CONFIG_DIR%"')
   })
 
-  it('drains stdin before exiting when the pane key is missing', () => {
+  it('exits without reading stdin when the pane key is missing', () => {
     stubPlatform('win32')
     const script = getManagedStatusLineScript('local')
-    const paneGuardIndex = script.indexOf(
-      'if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin'
-    )
+    // Why: no pane key means Claude was not launched by Orca, so its stdin may never
+    // reach EOF; draining it would wedge more.com and leak a console window (#11549).
+    const paneGuardIndex = script.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')
     const captureIndex = script.indexOf('more.com')
     expect(paneGuardIndex).toBeGreaterThan(-1)
     expect(paneGuardIndex).toBeLessThan(captureIndex)
+    expect(script).not.toContain('if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin')
+    // Orca-launched ticks still capture the payload, and the shared drain tail stays intact.
+    expect(script).toContain(
+      '"%SystemRoot%\\System32\\more.com" >"%ORCA_STATUSLINE_PAYLOAD_FILE%" 2>nul'
+    )
     expect(script).toContain(':orca_agent_hook_drain_stdin')
   })
 

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -1,6 +1,5 @@
 import {
   buildWindowsHookStdinDrainEpilogue,
-  WINDOWS_HOOK_STDIN_DRAIN_LABEL,
   WINDOWS_HOOK_STDIN_READER
 } from '../agent-hooks/hook-stdin-contract'
 import {
@@ -20,7 +19,8 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
       '@echo off',
       'setlocal',
       // Why: pane key is static PTY env (the endpoint file never sets it), so it can gate before stdin is consumed.
-      `if "%ORCA_PANE_KEY%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
+      // Why exit, not drain: no pane key means Orca did not launch this Claude, so its stdin may never hit EOF and more.com would hang per tick (#11549).
+      'if "%ORCA_PANE_KEY%"=="" exit /b 0',
       // Why: current keys end in a UUID; replacing the legacy delimiter also keeps surviving numeric-pane keys filename-safe.
       'set "ORCA_STATUSLINE_PANE_ID=%ORCA_PANE_KEY:~-36%"',
       'set "ORCA_STATUSLINE_PANE_ID=%ORCA_STATUSLINE_PANE_ID::=_%"',

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -1,7 +1,4 @@
-import {
-  buildWindowsHookStdinDrainEpilogue,
-  WINDOWS_HOOK_STDIN_READER
-} from '../agent-hooks/hook-stdin-contract'
+import { WINDOWS_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 import {
   CLAUDE_STATUSLINE_MIN_POST_INTERVAL_SECONDS,
   CLAUDE_STATUSLINE_PATHNAME
@@ -72,7 +69,6 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
       `:${STATUSLINE_CLEANUP_LABEL}`,
       'del "%ORCA_STATUSLINE_PAYLOAD_FILE%" >nul 2>nul',
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -31,7 +31,6 @@ import {
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue,
   POSIX_HOOK_STDIN_DRAIN_COMMAND
 } from '../agent-hooks/hook-stdin-contract'
 import {
@@ -773,7 +772,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookCurlPostCommand('codex'),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/command-code/command-code-managed-script.ts
+++ b/src/main/command-code/command-code-managed-script.ts
@@ -1,8 +1,7 @@
 import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookEnvironmentGuardLines
 } from '../agent-hooks/hook-stdin-contract'
 
 export type CommandCodeManagedScriptTarget = 'local' | 'posix'
@@ -28,7 +27,6 @@ export function buildCommandCodeManagedScript(
       'if not "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
       'for /f "tokens=2 delims==" %%P in (\'findstr /b /c:"set ORCA_AGENT_HOOK_PORT=" "%~1" 2^>nul\') do if "%%P"=="%ORCA_AGENT_HOOK_PORT%" call "%~1" 2>nul',
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -22,8 +22,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookEnvironmentGuardLines
 } from '../agent-hooks/hook-stdin-contract'
 
 // Subscribe only to Cursor hooks needed for spinner and turn detection.
@@ -67,7 +66,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookPostCommand('cursor'),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/devin/hook-service.ts
+++ b/src/main/devin/hook-service.ts
@@ -12,8 +12,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookEnvironmentGuardLines
 } from '../agent-hooks/hook-stdin-contract'
 import {
   applyDevinManagedHooks,
@@ -44,7 +43,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookPostCommand('devin'),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -23,8 +23,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookEnvironmentGuardLines
 } from '../agent-hooks/hook-stdin-contract'
 
 // Why: SessionStart is installed (not just listened for) so that resuming a
@@ -85,7 +84,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookPostCommand('droid'),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -23,8 +23,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookEnvironmentGuardLines
 } from '../agent-hooks/hook-stdin-contract'
 
 // Why: Gemini has no permission-prompt hook (approvals are inline UI), so Orca can't show a waiting state — upstream limitation.
@@ -61,7 +60,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookPostCommand('gemini'),
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -22,8 +22,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookEnvironmentGuardLines
 } from '../agent-hooks/hook-stdin-contract'
 
 // Why: Grok's tool-event matcher is a real regex (see Grok hooks docs). Bare
@@ -128,7 +127,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
       WINDOWS_GROK_HOOK_POST_COMMAND,
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
       ''
     ].join('\r\n')
   }


### PR DESCRIPTION
Fixes #11549

## ELI5

On Windows, Orca installs little script files that AI coding tools run whenever something happens. Because those scripts are installed for the whole user account, tools launched *outside* Orca run them too.

Each script started by checking "did Orca launch me?" — and when the answer was no, instead of just quitting, it jumped to a cleanup step that waits for the caller to finish sending data. A caller that isn't Orca never signals it's done, so that wait never ended: the script and a helper program sat there forever, along with a black console window. A new pair piled up on every event. The worst offender was Claude's status line script, which gets re-run several times a second while Claude is typing.

The fix is: when the Orca environment is missing, exit immediately instead of waiting. The waiting step is kept only where something can still reach it *and* Orca really did send data — one script, plus the wrappers that take over when the shared script is missing.

## Root cause

`buildWindowsHookEnvironmentGuardLines()` emitted all three missing-env guards as `goto :orca_agent_hook_drain_stdin`:

```bat
if "%ORCA_AGENT_HOOK_PORT%"=="" goto :orca_agent_hook_drain_stdin
if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto :orca_agent_hook_drain_stdin
if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin
```

The epilogue at that label is `"%SystemRoot%\System32\more.com" >nul 2>nul` + `exit /b 0`. `more.com` blocks until stdin reaches EOF.

The drain exists to honor the EPIPE contract from #8430 (`c3ab805d12`). That contract explicitly covered ordinary launches with no Orca environment — but it *assumed every caller eventually closes stdin*, and where that failed it relied on "the existing config-level timeout terminates the hook". A caller that is not Orca has no Orca timeout and need not ever close the pipe, so the hook wedges forever, leaking a `cmd.exe` / `more.com` pair and a visible console window per hook event.

`statusline-script.ts` carried the identical `ORCA_PANE_KEY` guard. It is the highest-frequency leak because Claude re-invokes the statusline several times a second while streaming a response.

Two further paths reproduced the same leak class and were **not** addressed by simply changing the shared guard:
- `claude-hook.cmd` emitted its `DEVIN_PROJECT_DIR` skip as a `goto` to the drain **before** any Orca-env validation, so a Windows Devin process outside Orca reached `more.com` first.
- Every Antigravity event wrapper runs the drain command directly when the shared `antigravity-hook.cmd` is missing, so a stale or partially-removed install invoked outside Orca kept the same hang primitive.

## Fix

- **Missing Orca env exits immediately** (`exit /b 0`) in the shared guard builder and the statusline script.
- **Claude's guard order is inverted.** Emission is now endpoint refresh → Orca-env guards → Devin skip → curl post → `exit /b 0` → epilogue. The Devin skip is therefore reachable only when Orca invoked the hook — exactly when a payload was written and stdin will be closed — which makes its drain legitimate rather than a hang. Moving the endpoint refresh ahead of the skip is a `setlocal`-scoped no-op. OpenClaude uses the same template without the Devin skip, so it gets no epilogue.
- **Antigravity event wrappers are guarded** before their standalone drain, placed *after* the `echo {}` protocol reply so Antigravity never stalls parsing stdout. A stale wrapper invoked outside Orca now exits; an Orca-invoked one still drains.
- **The epilogue is no longer emitted where nothing can jump to it** — removed from the antigravity, codex, command-code, cursor, devin, droid, gemini and grok scripts and from the statusline, kept in `claude-hook.cmd`. `WINDOWS_HOOK_STDIN_DRAIN_COMMAND`, `installer-utils.ts` and `wrapWindowsGitBashHookCommand` are untouched.
- **The rationale is corrected in source.** The previous comment claimed #8430 covered only Orca-invoked hooks. It did not. The honest framing, now in `hook-stdin-contract.ts`, is that #8430's *assumption* — every caller eventually closes stdin — does not hold for a foreign caller, and a transient broken pipe is the cheaper of the two failures.

## Proof

Each fix verified by reverting only that production change.

**Antigravity wrapper guards:**
```
AssertionError: antigravity-post-invocation.cmd Orca env guard: expected -1 to be greater than -1
 ❯ src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts:353:58
```

**Devin-guard reorder:**
```
AssertionError: claude Devin skip after Orca guards: expected 3 to be greater than 6
 ❯ src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts:333:71
```

**Dead epilogue (restored in grok only):**
```
AssertionError: grok-hook.cmd drain epilogue reachable: expected true to be false
 ❯ src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts:315:73
```

**Dead epilogue in statusline:**
```
AssertionError: expected '@echo off\r\nsetlocal\r\nif "%ORCA_PA…' not to contain 'orca_agent_hook_drain_stdin'
 ❯ src/main/claude/statusline-script.test.ts:104:24
```

**Original missing-env guards, against `main`:**
```
     × exits missing-Orca-env batch guards without entering the drain
     × exits without reading stdin when the pane key is missing

AssertionError: claude-hook.cmd port guard: expected '@echo off\r\nsetlocal\r\nif not "%DEV…'
  to contain 'if "%ORCA_AGENT_HOOK_PORT%"=="" exit …'
AssertionError: expected -1 to be greater than -1
```

The structural tests now assert **reachability**, not text presence — `expect(labelIndex > -1).toBe(jumpIndex > -1)` per script, plus guard ordering — and the loop covers the Antigravity event wrappers instead of excluding them.

**After** — this branch:

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts \
    src/main/claude/statusline-script.test.ts \
    src/main/claude/hook-service.test.ts \
    src/main/agent-hooks/installer-utils.test.ts \
    src/main/antigravity/ src/main/codex/ src/main/grok/ src/main/command-code/

 Test Files  46 passed | 1 skipped (47)
      Tests  749 passed | 13 skipped (762)
```

The other touched agents (devin, droid, cursor, gemini, openclaude, copilot, kimi, agent-hooks): 40 files passed, 576 passed | 6 skipped.

`pnpm tc` and `pnpm lint` pass on this branch.

**The Windows-gated runtime test is skipped on the macOS host used here — it is not proof.** See Residual risk.

## Release-readiness

| Scan | Result |
|---|---|
| Functional correctness | Every remaining drain is reachable only behind a confirmed Orca invocation. The no-env path is proved to terminate: `runHookProcess` rejects after 10s rather than resolving, so a hung `more.com` fails the test — that is the #11549 regression gate. |
| Cross-platform | Windows-only script generation, gated by `target === 'local' && process.platform === 'win32'`. POSIX scripts `cat` the payload before any exit, so their semantics are untouched — confirmed by the unchanged, still-passing POSIX suites. |
| SSH / relay | Unaffected. Remote installs go through `installRemote()` / `writeManagedScriptRemote()` with target `'posix'`, which never reaches the win32 branch. |
| Folder workspace vs worktree | No dependence on repo shape — user-wide managed scripts under `~/.orca/agent-hooks`. Provider-neutral. All test paths use `path.join`. |
| Backcompat | On-disk `.cmd` files are content-compared and atomically rewritten by `writeManagedScript()`, so an existing leaked-shape script self-refreshes at the next install/reconcile. Downgrading rewrites the old shape back. No schema or settings format changed. |
| Security / supply chain | No new dependencies. The change strictly *removes* blocking reads from generated scripts; no new exec, network sink, or install hook. |

## Residual risk

- **This narrows the #8430 EPIPE guarantee on the missing-env path, and that path was in scope for #8430.** A non-Orca Windows agent that streams a payload into the hook can now see a broken pipe instead of a silent drain. Deliberate tradeoff: a transient warning beats an immortal `cmd.exe`/`more.com` pair and a console window on every hook event. The no-env test accordingly allows only broken-pipe errnos (`EPIPE`/`ECONNRESET`/`ERR_STREAM_DESTROYED`/`EOF`) — any other errno fails, meaning the script itself broke. `copilot-hook.ps1` and `kimi-hook.sh` capture stdin before any guard and are still held to the old zero-writer-errors bar.
- **No live Windows runtime proof.** The behavioural lifecycle test is `it.skipIf(process.platform !== 'win32')` and skipped on this host; its new with-Orca-env block (a real loopback HTTP reader running all 12 scripts asserting zero `stdinErrors`, plus a `claude-hook.cmd` + `DEVIN_PROJECT_DIR` case that only passes if the surviving epilogue actually consumes the 1MB payload) will execute for the first time on a Windows machine. **PR CI will not catch it either** — `.github/workflows/pr.yml` runs Vitest on Ubuntu only; the Windows job builds and packages without running Vitest. Coverage here is structural plus a Windows-only runtime gate that no CI lane executes.
- Other never-EOF drains remain as hang primitives for stale `hooks.json` entries: `installer-utils.ts` (`[Console]::In.ReadToEnd()` missing-script launcher) and `wrapWindowsGitBashHookCommand`. This narrows the leak; it does not remove the primitive.
- `docs/reference/agent-hook-stdin-lifecycle.md` documented this contract but was deleted in #9480 as no longer maintained. The contract now lives in the `hook-stdin-contract.ts` comment. Restoring a maintained doc is a reasonable follow-up.
- Already-leaked processes on affected machines still need a manual kill; this only stops new ones. The brief `cmd.exe` window flash from `cmd.exe /C hook.cmd` is unchanged.

Made with [Orca](https://github.com/stablyai/orca) 🐋
