### PR TITLE
fix(agent-hooks): keep the pane provider-session binding across a transient clear

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: this suite exercises the full hook HTTP surface (Claude/Codex/Gemini parsing, transcript chunked scan, paneKey dispatch) and keeping the scenarios co-located avoids fixture drift across files. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import {
   existsSync,
   mkdirSync,
@@ -18,6 +18,7 @@ import {
   AgentHookServer,
   agentHookServer,
   CLOSED_AGENT_STATUS_TAB_IDS_MAX,
+  PROVIDER_SESSION_IDENTITIES_MAX,
   _internals
 } from './server'
 import {
@@ -6777,6 +6778,156 @@ describe('Last-status persistence', () => {
       ).toBeNull()
     } finally {
       retired.stop()
+    }
+  })
+
+  it('retains the pane provider-session binding through a transient SSH clear and restart', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    const receivedAt = recentTs()
+    const transcriptPath = 'C:\\Users\\me\\.claude\\projects\\x\\sess-1.jsonl'
+    // Why: a file written by the current app (no providerSessionIdentities section) must still restore the binding.
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          [PANE]: {
+            paneKey: PANE,
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            connectionId: 'ssh-target',
+            receivedAt,
+            stateStartedAt: receivedAt,
+            providerSession: { key: 'session_id', id: 'sess-1', transcriptPath },
+            payload: {
+              state: 'working',
+              prompt: 'remote conversation',
+              agentType: 'claude'
+            }
+          }
+        }
+      }),
+      'utf8'
+    )
+
+    const first = new AgentHookServer()
+    await first.start({ env: 'production', userDataPath })
+    expect(first.getProviderSessionIdentities()).toEqual([
+      { paneKey: PANE, sessionId: 'sess-1', transcriptPath, worktreeId: 'wt-1' }
+    ])
+    first.clearStatusEntriesForConnection('ssh-target')
+    first.flushStatusPersistSync()
+    first.stop()
+
+    const afterClear = JSON.parse(readFileSync(lastStatusPath(), 'utf8'))
+
+    const restored = new AgentHookServer()
+    await restored.start({ env: 'production', userDataPath })
+    try {
+      expect(restored.getStatusSnapshotForPane(PANE)).toEqual([])
+      expect(restored.getProviderSessionIdentities()).toEqual([
+        { paneKey: PANE, sessionId: 'sess-1', transcriptPath, worktreeId: 'wt-1' }
+      ])
+      expect(restored.getProviderSessionForPane(PANE)).toEqual({
+        paneKey: PANE,
+        sessionId: 'sess-1',
+        transcriptPath,
+        worktreeId: 'wt-1'
+      })
+      // Why: an older build only reads version/entries/authorityCommitments, so the new section must ride alongside them.
+      expect(afterClear.version).toBe(2)
+      expect(afterClear.entries).toEqual({})
+      expect(afterClear.providerSessionIdentities?.[PANE]).toMatchObject({
+        agent: 'claude',
+        sessionId: 'sess-1',
+        transcriptPath,
+        connectionId: 'ssh-target',
+        observedAt: expect.any(Number)
+      })
+    } finally {
+      restored.stop()
+    }
+  })
+
+  it('drops the retained provider-session binding on explicit pane retirement', async () => {
+    const first = new AgentHookServer()
+    await first.start({ env: 'production', userDataPath })
+    first.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        providerSession: { key: 'session_id', id: 'sess-retire' },
+        payload: { state: 'working', prompt: 'remote conversation', agentType: 'claude' }
+      },
+      'ssh-target'
+    )
+    first.retirePaneAuthority(PANE)
+    first.flushStatusPersistSync()
+    first.stop()
+
+    const restored = new AgentHookServer()
+    await restored.start({ env: 'production', userDataPath })
+    try {
+      expect(restored.getProviderSessionForPane(PANE)).toBeNull()
+      expect(restored.getProviderSessionIdentities()).toEqual([])
+    } finally {
+      restored.stop()
+    }
+  })
+
+  it('drops retained provider-session identities past the hydrate TTL', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {},
+        providerSessionIdentities: {
+          [PANE]: {
+            agent: 'claude',
+            sessionKey: 'session_id',
+            sessionId: 'sess-stale',
+            connectionId: 'ssh-target',
+            observedAt: Date.now() - 8 * 24 * 60 * 60 * 1000
+          }
+        }
+      }),
+      'utf8'
+    )
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getProviderSessionForPane(PANE)).toBeNull()
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('bounds retained provider-session identities', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      const overflow = PROVIDER_SESSION_IDENTITIES_MAX + 2
+      for (let index = 0; index < overflow; index += 1) {
+        server.ingestRemote(
+          {
+            paneKey: makePaneKey(`tab-${index}`, randomUUID()),
+            worktreeId: 'wt-1',
+            providerSession: { key: 'session_id', id: `sess-${index}` },
+            payload: { state: 'done', agentType: 'claude' }
+          },
+          'ssh-target'
+        )
+      }
+      server.clearStatusEntriesForConnection('ssh-target')
+      const retained = server.getProviderSessionIdentities()
+      expect(retained.length).toBe(PROVIDER_SESSION_IDENTITIES_MAX)
+      expect(retained.some((identity) => identity.sessionId === 'sess-0')).toBe(false)
+      expect(retained.some((identity) => identity.sessionId === `sess-${overflow - 1}`)).toBe(true)
+    } finally {
+      server.stop()
     }
   })
 

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -49,6 +49,7 @@ import {
 } from '../../shared/claude-statusline-rate-limits'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
+  AGENT_TYPE_MAX_LENGTH,
   type AgentStatusClearIpcPayload,
   type AgentStatusIpcPayload,
   type AgentType,
@@ -167,11 +168,35 @@ export const CLOSED_AGENT_STATUS_TAB_IDS_MAX = 1024
 export const CLOSED_AGENT_STATUS_PANE_KEYS_MAX = 1024
 export const PANE_KEY_ALIASES_MAX = 1024
 
+// Why: identities outlive their status rows (they survive a transport clear), so they need their own insertion-order bound.
+export const PROVIDER_SESSION_IDENTITIES_MAX = 512
+
+// Why: optional so an existing v2 file still hydrates and an older build (which reads only version/entries/authorityCommitments) ignores it.
 type LastStatusFile = {
   version: number
   entries: Record<string, PersistedAgentHookEventPayload>
   authorityCommitments?: Record<string, PersistedAgentHookAuthorityCommitment>
+  providerSessionIdentities?: Record<string, PersistedProviderSessionIdentity>
 }
+
+type PersistedProviderSessionIdentity = {
+  agent?: AgentType
+  sessionKey?: AgentProviderSessionMetadata['key']
+  sessionId: string
+  transcriptPath?: string
+  connectionId: string | null
+  worktreeId?: string
+  observedAt: number
+}
+
+type RetainedProviderSessionIdentity = Readonly<{
+  paneKey: string
+  agent: AgentType | undefined
+  providerSession: AgentProviderSessionMetadata
+  connectionId: string | null
+  worktreeId?: string
+  observedAt: number
+}>
 
 type AgentPromptSentDedupeEntry = {
   agentKind: AgentKind
@@ -351,6 +376,60 @@ function sanitizePersistedAuthorityCommitment(
     ...(typeof record.worktreeId === 'string' ? { worktreeId: record.worktreeId } : {}),
     observedAt
   })
+}
+
+function sanitizePersistedProviderSessionIdentity(
+  paneKey: string,
+  value: unknown
+): RetainedProviderSessionIdentity | null {
+  if (!isValidPaneKey(paneKey) || typeof value !== 'object' || value === null) {
+    return null
+  }
+  const record = value as Record<string, unknown>
+  // Why: reuse the canonical normalizer so a tampered file can't smuggle unsafe ids/paths past the same trust boundary.
+  const providerSession = normalizeAgentProviderSession({
+    key: typeof record.sessionKey === 'string' ? record.sessionKey : 'session_id',
+    id: record.sessionId,
+    transcriptPath: record.transcriptPath
+  })
+  const connectionId = record.connectionId
+  const observedAt = record.observedAt
+  if (
+    !providerSession ||
+    (connectionId !== null && connectionId !== undefined && typeof connectionId !== 'string') ||
+    typeof observedAt !== 'number' ||
+    !Number.isFinite(observedAt)
+  ) {
+    return null
+  }
+  const rawAgent = typeof record.agent === 'string' ? record.agent.trim() : ''
+  const agent =
+    rawAgent.length > 0 && rawAgent.length <= AGENT_TYPE_MAX_LENGTH && !/[\r\n]/.test(rawAgent)
+      ? rawAgent
+      : undefined
+  return Object.freeze({
+    paneKey,
+    agent,
+    providerSession,
+    connectionId: typeof connectionId === 'string' ? connectionId : null,
+    ...(typeof record.worktreeId === 'string' && record.worktreeId
+      ? { worktreeId: record.worktreeId }
+      : {}),
+    observedAt
+  })
+}
+
+function toProviderSessionIdentity(
+  retained: RetainedProviderSessionIdentity
+): AgentHookProviderSessionIdentity {
+  return {
+    paneKey: retained.paneKey,
+    sessionId: retained.providerSession.id,
+    ...(retained.providerSession.transcriptPath
+      ? { transcriptPath: retained.providerSession.transcriptPath }
+      : {}),
+    ...(retained.worktreeId ? { worktreeId: retained.worktreeId } : {})
+  }
 }
 
 function authorityCommitmentsMatch(
@@ -580,6 +659,8 @@ export class AgentHookServer {
   private hydratedAuthorityCommitments: readonly AgentHookAuthorityEvidence[] = Object.freeze([])
   private hydratedLaunchTokenHashByPaneKey = new Map<string, string>()
   private persistedAuthorityCommitmentsByPaneKey = new Map<string, AgentHookAuthorityEvidence>()
+  // Why: the pane->session binding must outlive a transient SSH clear, or a restart before replay resolves native chat to sessionId=null.
+  private retainedProviderSessionsByPaneKey = new Map<string, RetainedProviderSessionIdentity>()
   private revokedHydratedAuthorityCommitments = new WeakSet<AgentHookAuthorityEvidence>()
   private currentAuthorityObservations = new Map<string, AgentHookAuthorityEvidence>()
   private legacyPaneKeyAliases = new Map<string, PaneKeyAliasEntry>()
@@ -655,9 +736,33 @@ export class AgentHookServer {
     )
   }
 
-  /** Provider-session identities, including Pi's metadata-only rows. */
+  /** Provider-session identities, including Pi's metadata-only rows and bindings retained past a transport clear. */
   getProviderSessionIdentities(): AgentHookProviderSessionIdentity[] {
     return this.buildStatusChangeNotification().providerSessions
+  }
+
+  /** The pane's resume/transcript identity, falling back to the retained binding when its live status row is gone. */
+  getProviderSessionForPane(paneKey: string): AgentHookProviderSessionIdentity | null {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+    const live = this.state.lastStatusByPaneKey.get(resolvedPaneKey) as
+      | EnrichedAgentHookEventPayload
+      | undefined
+    if (live?.providerSession) {
+      return {
+        paneKey: resolvedPaneKey,
+        sessionId: live.providerSession.id,
+        ...(live.providerSession.transcriptPath
+          ? { transcriptPath: live.providerSession.transcriptPath }
+          : {}),
+        ...(live.worktreeId ? { worktreeId: live.worktreeId } : {})
+      }
+    }
+    // Why: a live row without providerSession is the authority for this pane; a retained binding would be a stale conversation.
+    if (live) {
+      return null
+    }
+    const retained = this.retainedProviderSessionsByPaneKey.get(resolvedPaneKey)
+    return retained ? toProviderSessionIdentity(retained) : null
   }
 
   getStatusSnapshotForPane(paneKey: string): AgentStatusIpcPayload[] {
@@ -880,6 +985,12 @@ export class AgentHookServer {
         })
       }
     }
+    for (const [paneKey, retained] of this.retainedProviderSessionsByPaneKey) {
+      // Why: only panes with no live row — the live row (even one without a session) is the current authority.
+      if (!this.state.lastStatusByPaneKey.has(paneKey)) {
+        providerSessions.push(toProviderSessionIdentity(retained))
+      }
+    }
     return { statuses, providerSessions }
   }
 
@@ -1043,6 +1154,36 @@ export class AgentHookServer {
     }
   }
 
+  /** Mirror an accepted status row's session identity into the durable binding (survives a transport clear). */
+  private retainProviderSessionIdentity(entry: EnrichedAgentHookEventPayload): void {
+    if (!entry.providerSession) {
+      return
+    }
+    this.storeRetainedProviderSession(
+      Object.freeze({
+        paneKey: entry.paneKey,
+        agent: entry.payload.agentType,
+        providerSession: entry.providerSession,
+        connectionId: entry.connectionId,
+        ...(entry.worktreeId ? { worktreeId: entry.worktreeId } : {}),
+        observedAt: entry.receivedAt
+      })
+    )
+  }
+
+  private storeRetainedProviderSession(retained: RetainedProviderSessionIdentity): void {
+    // Why: re-insert so insertion-order eviction behaves as least-recently-observed.
+    this.retainedProviderSessionsByPaneKey.delete(retained.paneKey)
+    this.retainedProviderSessionsByPaneKey.set(retained.paneKey, retained)
+    while (this.retainedProviderSessionsByPaneKey.size > PROVIDER_SESSION_IDENTITIES_MAX) {
+      const oldestKey = this.retainedProviderSessionsByPaneKey.keys().next().value
+      if (!oldestKey) {
+        break
+      }
+      this.retainedProviderSessionsByPaneKey.delete(oldestKey)
+    }
+  }
+
   private applyNormalizedStatus(
     payload: AgentHookEventPayload,
     onAccepted?: () => void
@@ -1065,6 +1206,7 @@ export class AgentHookServer {
       this.clearAssistantMessageRetry(enriched.paneKey)
       this.runtimeObservedStatusPaneKeys.delete(enriched.paneKey)
       this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
+      this.retainProviderSessionIdentity(enriched)
       this.scheduleStatusPersist()
       this.notifyStatusChangeListeners()
       this.emitEnrichedStatus(enriched)
@@ -1178,6 +1320,7 @@ export class AgentHookServer {
     const enriched = this.attachStatusTiming(effectivePayload, now)
     this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
     this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
+    this.retainProviderSessionIdentity(enriched)
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
     this.emitEnrichedStatus(enriched)
@@ -1469,6 +1612,14 @@ export class AgentHookServer {
       this.hydratedLaunchTokenHashByPaneKey.delete(previousOwnerPaneKey)
       this.hydratedLaunchTokenHashByPaneKey.set(toPaneKey, hydratedLaunchTokenHash)
     }
+    const retainedProviderSession = this.retainedProviderSessionsByPaneKey.get(previousOwnerPaneKey)
+    if (retainedProviderSession) {
+      this.retainedProviderSessionsByPaneKey.delete(previousOwnerPaneKey)
+      this.retainedProviderSessionsByPaneKey.set(
+        toPaneKey,
+        Object.freeze({ ...retainedProviderSession, paneKey: toPaneKey })
+      )
+    }
     const persistedAuthority = this.persistedAuthorityCommitmentsByPaneKey.get(previousOwnerPaneKey)
     if (persistedAuthority) {
       const owner = parsePaneKey(toPaneKey)
@@ -1543,6 +1694,7 @@ export class AgentHookServer {
       this.runtimeObservedStatusPaneKeys.delete(key)
       this.currentAuthorityObservations.delete(key)
       this.promptSentDedupeByPaneKey.delete(key)
+      this.retainedProviderSessionsByPaneKey.delete(key)
     }
     if (aliasChanged) {
       this.notifyPaneKeyAliasPersistenceListener()
@@ -1585,6 +1737,7 @@ export class AgentHookServer {
           this.runtimeObservedStatusPaneKeys.delete(entry.stablePaneKey)
           this.currentAuthorityObservations.delete(entry.stablePaneKey)
           this.promptSentDedupeByPaneKey.delete(entry.stablePaneKey)
+          this.retainedProviderSessionsByPaneKey.delete(entry.stablePaneKey)
         }
         aliasChanged = true
       }
@@ -2061,6 +2214,7 @@ export class AgentHookServer {
     this.hydratedAuthorityCommitments = Object.freeze([])
     this.hydratedLaunchTokenHashByPaneKey.clear()
     this.persistedAuthorityCommitmentsByPaneKey.clear()
+    this.retainedProviderSessionsByPaneKey.clear()
     this.revokedHydratedAuthorityCommitments = new WeakSet()
     this.currentAuthorityObservations.clear()
     this.promptSentDedupeByPaneKey.clear()
@@ -2147,6 +2301,7 @@ export class AgentHookServer {
     if (!options?.preserveAuthority) {
       this.hydratedLaunchTokenHashByPaneKey.delete(resolvedPaneKey)
       this.persistedAuthorityCommitmentsByPaneKey.delete(resolvedPaneKey)
+      this.retainedProviderSessionsByPaneKey.delete(resolvedPaneKey)
     }
     this.clearAssistantMessageRetry(resolvedPaneKey)
     this.clearCodexSubagentPoll(resolvedPaneKey)
@@ -2227,6 +2382,7 @@ export class AgentHookServer {
       this.runtimeObservedStatusPaneKeys.delete(paneKey)
       this.currentAuthorityObservations.delete(paneKey)
       this.promptSentDedupeByPaneKey.delete(paneKey)
+      this.retainedProviderSessionsByPaneKey.delete(paneKey)
     }
     if (aliasChanged) {
       this.notifyPaneKeyAliasPersistenceListener()
@@ -2247,6 +2403,7 @@ export class AgentHookServer {
     clearPaneCacheState(this.state, resolvedPaneKey)
     this.currentAuthorityObservations.delete(resolvedPaneKey)
     this.promptSentDedupeByPaneKey.delete(resolvedPaneKey)
+    this.retainedProviderSessionsByPaneKey.delete(resolvedPaneKey)
     let clearedAlias = false
     for (const [legacyPaneKey, stablePaneKey] of this.legacyPaneKeyAliases) {
       if (stablePaneKey.stablePaneKey === resolvedPaneKey) {
@@ -2256,6 +2413,7 @@ export class AgentHookServer {
         clearPaneCacheState(this.state, legacyPaneKey)
         this.currentAuthorityObservations.delete(legacyPaneKey)
         this.promptSentDedupeByPaneKey.delete(legacyPaneKey)
+        this.retainedProviderSessionsByPaneKey.delete(legacyPaneKey)
         clearedAlias = true
       }
     }
@@ -2405,6 +2563,7 @@ export class AgentHookServer {
     this.state.lastStatusByPaneKey.clear()
     this.hydratedLaunchTokenHashByPaneKey.clear()
     this.persistedAuthorityCommitmentsByPaneKey.clear()
+    this.retainedProviderSessionsByPaneKey.clear()
     let raw: string
     try {
       raw = readFileSync(this.lastStatusFilePath, 'utf8')
@@ -2476,6 +2635,8 @@ export class AgentHookServer {
           entry.payload = hydratedPayload
         }
         this.state.lastStatusByPaneKey.set(resolvedPaneKey, entry)
+        // Why: back-compat — a file written before providerSessionIdentities existed still carries the binding on its rows.
+        this.retainProviderSessionIdentity(entry)
         if (entry.connectionId) {
           // Why: a restart can see an earlier wall clock; seed ordering so new events stay after disk state.
           const previousWatermark = this.connectionTimestampWatermarkById.get(entry.connectionId)
@@ -2515,6 +2676,19 @@ export class AgentHookServer {
       }
       this.persistedAuthorityCommitmentsByPaneKey.set(resolvedPaneKey, commitment)
       this.hydratedLaunchTokenHashByPaneKey.set(resolvedPaneKey, commitment.launchTokenHash)
+    }
+    for (const [paneKey, rawIdentity] of Object.entries(file.providerSessionIdentities ?? {})) {
+      const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+      const identity = sanitizePersistedProviderSessionIdentity(resolvedPaneKey, rawIdentity)
+      if (!identity || identity.observedAt < ttlCutoff) {
+        dropped += 1
+        continue
+      }
+      const seeded = this.retainedProviderSessionsByPaneKey.get(resolvedPaneKey)
+      // Why: a live row's own binding is newer evidence than the retained section for the same pane.
+      if (!seeded || seeded.observedAt <= identity.observedAt) {
+        this.storeRetainedProviderSession(identity)
+      }
     }
     if (dropped > 0) {
       console.warn(
@@ -2612,10 +2786,29 @@ export class AgentHookServer {
         }
       }
     }
+    const providerSessionIdentities: Record<string, PersistedProviderSessionIdentity> = {}
+    for (const [paneKey, retained] of this.retainedProviderSessionsByPaneKey) {
+      if (!isValidPaneKey(paneKey)) {
+        continue
+      }
+      providerSessionIdentities[paneKey] = {
+        ...(retained.agent ? { agent: retained.agent } : {}),
+        sessionKey: retained.providerSession.key,
+        sessionId: retained.providerSession.id,
+        ...(retained.providerSession.transcriptPath
+          ? // Why: store the remote path verbatim — it belongs to the execution host, not this machine's path syntax.
+            { transcriptPath: retained.providerSession.transcriptPath }
+          : {}),
+        connectionId: retained.connectionId,
+        ...(retained.worktreeId ? { worktreeId: retained.worktreeId } : {}),
+        observedAt: retained.observedAt
+      }
+    }
     const file: LastStatusFile = {
       version: LAST_STATUS_FILE_VERSION,
       entries,
-      authorityCommitments
+      authorityCommitments,
+      providerSessionIdentities
     }
     return JSON.stringify(file)
   }


### PR DESCRIPTION
Fixes #11546

## ELI5

When you chat with an agent in a pane, Orca doesn't keep the conversation in the window — it keeps a little sticky note saying "this pane is conversation #sess-1, whose transcript file lives here". The chat is then read from that transcript file.

Every time an SSH connection dropped, Orca threw away all the sticky notes for that connection — and saved that deletion to disk — betting the remote machine would hand them back on reconnect. If the app restarted before that happened, the terminal came back fine, but the sticky note was gone. The chat had no idea which conversation it was and showed empty history, even though the transcript was still sitting on the remote machine.

The fix keeps the sticky notes in their own section of Orca's saved-state file, copying the same trick an existing "who owns this pane" record already uses to survive disconnects. A dropped connection no longer erases them; only actually closing or retiring the pane does. Old saved-state files still work, new files won't break an older version of Orca, and the note pile is capped and expires after a week.

## Root cause

`clearStatusEntriesForConnection` deletes every status row stamped with the lost `connectionId` and calls `scheduleStatusPersist()`. `serializeStatusFile()` rebuilds `entries` purely from the live map, so **the wipe reaches disk**. `hydrateLastStatusFromDisk()` then finds no row for the pane after a restart.

The status row is the only thing carrying a pane's `providerSession` — the `sessionId` + `transcriptPath` binding that native chat resolves a conversation from. Deleting it is a safe bet *while the app keeps running*, because reconnect re-publishes the rows. It is not safe across a renderer restart, which is exactly the reported sequence: `SshRelaySession.detach()`/`reconnect()` route through `teardownProviders('connection_lost')` → `clearStatusEntriesForConnection`, then the app restarts before reconnect completes. PTYs reattach because ownership lives elsewhere; chat resolves `sessionId=null` and the conversation reads as gone.

`authorityCommitments` in the same file already solves exactly this problem for pane authority, so this follows that pattern rather than inventing a new one.

## Fix

- New optional `providerSessionIdentities` section on `LastStatusFile`, keyed by paneKey: `{ agent?, sessionKey?, sessionId, transcriptPath?, connectionId, worktreeId?, observedAt }`.
- In-memory `retainedProviderSessionsByPaneKey`, populated from `applyNormalizedStatus` — both the full-status and `providerSessionOnly` branches, so every accepted payload carrying a `providerSession` seeds it, including the relay `ingestRemote` path which funnels through the same place.
- **The transient path keeps it.** `clearStatusEntriesForConnection` goes through `deleteStatusEntry(..., { preserveAuthority: true })`; the binding is only dropped on the non-`preserveAuthority` branch. Real teardown does drop it: `retirePaneAuthority`, `dropStatusEntriesByTabPrefix`, `clearPaneState`, and `clearPaneKeyAliasesForPty` when the dying PTY still owns the stable pane key. `transferPaneAuthority` **moves** the binding to the new owner key alongside the authority commitment, so it follows a pane rebind instead of being orphaned.
- Hydrate clears the map first (idempotent, matching the existing hydrate contract), seeds it from any hydrated entry carrying a `providerSession` — this is what makes an existing on-disk file restore the binding with no migration — then applies the file's own section through a sanitizer reusing `normalizeAgentProviderSession` (same trust boundary as relay/persisted input) and the existing `HYDRATE_MAX_AGE_MS` cutoff. The section only wins over an entry-seeded row when its `observedAt` is not older.
- `getProviderSessionForPane(paneKey)` returns the live row's session; else `null` if a live row exists without one (a live row is the current authority — never resurrect an older conversation over it); else the retained binding.
- Bounded at 512 entries with insertion-order (least-recently-observed) eviction, same shape as `boundPaneKeyAliases`, plus the 7-day hydrate TTL.

Deliberately **not** done: widening `isValidPiProviderSessionOnly`, and surfacing hydrated identities as `providerSessionOnly` status rows. Both would risk resurrecting stale status (a phantom "working" badge). Retention is also not gated on the `launchTokenHash` commitment — agents that never emit a launch token would lose the binding entirely. Pane reuse is handled by the live-row-wins rule plus deletion on real teardown.

## Proof

**Before** — new tests against `server.ts` as it exists on `main`:

```
$ npx vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts
   (server.ts restored from origin/main)

     × retains the pane provider-session binding through a transient SSH clear and restart
     × drops the retained provider-session binding on explicit pane retirement
     × drops retained provider-session identities past the hydrate TTL
     × bounds retained provider-session identities

AssertionError: expected [] to deeply equal [ { …(4) } ]
AssertionError: expected +0 to be undefined // Object.is equality

 Test Files  1 failed (1)
      Tests  4 failed | 259 passed (263)
```

**After** — this branch:

```
$ npx vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts

 Test Files  1 passed (1)
      Tests  263 passed (263)
```

The headline test uses a **legacy-shaped** on-disk file (no `providerSessionIdentities` section) to prove existing state hydrates without migration. Its fixture deliberately uses a Windows remote transcript path while the test runs on macOS/Linux, pinning that remote paths are never normalized with local `path` helpers.

`pnpm tc` and `pnpm lint` pass on this branch.

## Release-readiness

| Scan | Result |
|---|---|
| **Backcompat / data loss (mandatory)** | Version stays at `LAST_STATUS_FILE_VERSION = 2`; the section is optional. **Old file → new code**: hydrate reads `file.providerSessionIdentities ?? {}` *and* seeds from each hydrated entry's own `providerSession`, so today's on-disk file restores conversations with no migration. **New file → old code**: an older build reads only `version`/`entries`/`authorityCommitments` and ignores the extra key, dropping it on its next write — downgrade-safe. This PR *reduces* data loss; it introduces no new persisted-state failure mode. |
| Functional correctness | Live row always wins over a retained binding, so a reused pane cannot resurrect an older conversation. Binding follows `transferPaneAuthority` rather than being orphaned. Sanitized through the existing `normalizeAgentProviderSession` trust boundary. |
| Cross-platform | Pure main-process state plus JSON under `<userData>/agent-hooks/last-status.json`, path built with the existing `join()` usage. `transcriptPath` is stored and returned **verbatim, never normalized** — for SSH/relay panes it is a remote path in the remote host's syntax. |
| SSH / relay | The targeted path. `detach()`/`reconnect()` → `teardownProviders('connection_lost')` → `clearStatusEntriesForConnection` now preserves the binding; the shutdown path (`clearPtyOwnershipForConnection` → pane teardown) still drops it. `connectionId` is retained so a consumer can tell which host owns the session. |
| Folder workspace vs worktree | Keyed by paneKey, which both workspace kinds use. `worktreeId` is carried only when the payload had one; nothing assumes a git worktree. Provider-neutral. |
| Security / supply chain | No new dependencies, no shell/exec, no network sink. Persisted input is sanitized on hydrate and bounded (512 entries + 7-day TTL), so a tampered or bloated state file cannot grow memory without limit. |

## Residual risk

- **Renderer wiring is not in this PR.** Native chat still resolves `sessionId` from the agent-status IPC row (`native-chat-pane-resolution.ts`). This change makes the binding *survive and be resolvable* — via the new `getProviderSessionForPane` and the retained rows now included in `getProviderSessionIdentities()` — but does not itself change what the renderer asks for. The end-user symptom closes fully once a consumer reads it. Flagging clearly so this isn't mistaken for an end-to-end fix.
- Retained rows now appear in the provider-session change notification for panes with no live row, flowing into `publishProviderSessionChanges` → mobile session-tabs invalidation. Net effect is *fewer* spurious invalidations (a transient clear no longer looks like "session disappeared"), but it is a behavior change on that channel.
- A pane torn down in a way that bypasses `retirePaneAuthority`/`clearPaneState`/`dropStatusEntriesByTabPrefix` — e.g. an Orca crash before teardown — could keep a stale binding until the 7-day TTL. The live-row-wins rule prevents it from overriding a real session.
- A user with more than 512 session-bearing panes in one run could lose the oldest bindings before their TTL expires.
- Not exercised against a real SSH host or the live app; evidence is the main-process unit suite.

Made with [Orca](https://github.com/stablyai/orca) 🐋
