### PR TITLE
fix(sidebar): preserve manual order during refresh

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -571,6 +571,55 @@ describe('fetchWorktrees', () => {
     expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
   })
 
+  it('does not merge stale manual order over a reorder completed during refresh', async () => {
+    const store = createTestStore()
+    const daily = makeWorktree({
+      id: 'repo1::/path/daily',
+      repoId: 'repo1',
+      path: '/path/daily',
+      manualOrder: 20
+    })
+    const relay = makeWorktree({
+      id: 'repo1::/path/relay',
+      repoId: 'repo1',
+      path: '/path/relay',
+      manualOrder: 10
+    })
+    const refreshedDaily = { ...daily, head: 'def456' }
+    const detected = makeDetectedResult('repo1', [daily, relay])
+    let resolveListing!: (worktrees: Worktree[]) => void
+    const listing = new Promise<Worktree[]>((resolve) => {
+      resolveListing = resolve
+    })
+    worktreeListMock.mockReturnValueOnce(listing)
+    store.setState({
+      worktreesByRepo: { repo1: [daily, relay] },
+      detectedWorktreesByRepo: { repo1: detected }
+    } as Partial<AppState>)
+
+    const refresh = store.getState().fetchWorktrees('repo1')
+    await vi.waitFor(() => expect(worktreeListMock).toHaveBeenCalledTimes(1))
+    await store.getState().updateWorktreesMeta(
+      new Map([
+        [daily.id, { manualOrder: 100 }],
+        [relay.id, { manualOrder: 200 }]
+      ])
+    )
+    resolveListing([refreshedDaily, relay])
+
+    await refresh
+
+    expect(store.getState().worktreesByRepo.repo1.map((worktree) => worktree.manualOrder)).toEqual([
+      100, 200
+    ])
+    expect(
+      store
+        .getState()
+        .detectedWorktreesByRepo.repo1.worktrees.map((worktree) => worktree.manualOrder)
+    ).toEqual([100, 200])
+    expect(store.getState().worktreesByRepo.repo1[0]?.head).toBe('def456')
+  })
+
   it('updates the repo entry when only the persisted base ref changes', async () => {
     const store = createTestStore()
     const existing = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2852,6 +2852,32 @@ function staleDetectedWorktreeProviderResult(
     : undefined
 }
 
+function preserveConcurrentManualOrder<T extends Worktree>(
+  incoming: readonly T[],
+  requestStarted: readonly Worktree[] | undefined,
+  current: readonly Worktree[] | undefined,
+  matchesRefreshHost: (worktree: Worktree) => boolean
+): T[] {
+  if (!requestStarted || !current) {
+    return [...incoming]
+  }
+  const startedById = new Map(
+    requestStarted.filter(matchesRefreshHost).map((worktree) => [worktree.id, worktree])
+  )
+  const currentById = new Map(
+    current.filter(matchesRefreshHost).map((worktree) => [worktree.id, worktree])
+  )
+  return incoming.map((worktree) => {
+    const started = startedById.get(worktree.id)
+    const latest = currentById.get(worktree.id)
+    if (!started || !latest || started.manualOrder === latest.manualOrder) {
+      return worktree
+    }
+    // Why: a refresh response may predate a completed drag; the renderer's optimistic rank is newer.
+    return { ...worktree, manualOrder: latest.manualOrder }
+  })
+}
+
 type FencedWorktreeMergeArgs = {
   repoId: string
   hostId: ExecutionHostId
@@ -2883,7 +2909,17 @@ function mergeFetchedWorktrees(
     }
     admitted = true
     const matchOptions = worktreeHostMatchOptions(s, args.repoId, args.hostId)
-    let incoming = toVisibleWorktrees(args.refresh.result, args.hostId, args.setup)
+    const currentWorktrees = s.worktreesByRepo[args.repoId]
+    const refreshResult = {
+      ...args.refresh.result,
+      worktrees: preserveConcurrentManualOrder(
+        args.refresh.result.worktrees,
+        args.requestStartedWorktrees,
+        currentWorktrees,
+        (worktree) => worktreeMatchesHost(worktree, args.hostId, matchOptions)
+      )
+    }
+    let incoming = toVisibleWorktrees(refreshResult, args.hostId, args.setup)
     incoming = routeListingBranchSwitchesThroughGitIdentity({
       requestStarted: args.requestStartedWorktrees,
       current: s.worktreesByRepo[args.repoId],
@@ -2901,7 +2937,7 @@ function mergeFetchedWorktrees(
     )
     const mergedDetected = mergeDetectedWorktreesForHost(
       s.detectedWorktreesByRepo[args.repoId],
-      args.refresh.result,
+      refreshResult,
       args.hostId,
       args.setup,
       matchOptions


### PR DESCRIPTION
## Summary

- Preserve a manual sidebar reorder when an older in-flight worktree refresh completes afterward.
- Apply the fence to both visible and detected worktree catalogs, scoped to the owning execution host.
- Continue accepting fresh Git identity data from the same refresh.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts` — 248 passed
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts src/renderer/src/components/sidebar/smart-sort.test.ts -t 'stale manual order|manualOrder'` — 4 passed
- `pnpm run typecheck:web`
- Targeted oxlint and formatting checks
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`

## AI Review Report

Reviewed the refresh lifecycle as a three-state race: request-start snapshot, optimistic renderer reorder, and stale provider completion. The main risks checked were blocking legitimate Git updates, diverging the visible and detected catalogs, and copying a same-ID rank across local, SSH, or paired-runtime hosts. The implementation preserves only a concurrently changed `manualOrder`, updates both catalogs, remains host-scoped, and the regression test proves a newer Git head still lands. Cross-platform review found no platform-specific shortcuts, labels, paths, shell behavior, or Electron APIs changed; the shared renderer state path is identical on macOS, Linux, and Windows.

## Security Audit

This changes only in-memory worktree refresh merging and adds no new input surface, command execution, filesystem/path handling, authentication, secrets, dependency, network, or IPC behavior. Host qualification is retained when reconciling metadata, preventing cross-runtime state contamination. No security follow-up is required.

## Notes

The separate behavior where raw `orca terminal create` reveals and scrolls to its target workspace is not changed by this PR.
