### PR TITLE
chore(lint): enable safe performance guard rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,6 +27,8 @@
     "app-store-performance/no-identity-selector": "error",
     "app-store-performance/no-fresh-selector-result": "error",
     "no-fallthrough": "error",
+    "eslint/no-useless-call": "error",
+    "oxc/no-accumulating-spread": "error",
     "quadratic-buffer-concat/no-loop-carried-concat": "error",
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-undef": "error",


### PR DESCRIPTION
## Summary

- Enable `eslint/no-useless-call` and `oxc/no-accumulating-spread` as errors in the native lint configuration.
- Both enabled rules currently report zero violations.

## Call-site audit decisions

- `oxc/no-map-spread`: reviewed all 10 findings. They are intentional immutable projections, view-model constructions, and API transformations. Replacing the spreads with `Object.assign` risks mutating shared state. Decision: keep disabled.
- `unicorn/prefer-set-has`: reviewed all 15 findings. They are mostly tiny allowlists, platform/status arrays, and one-shot test memberships; `Set` construction is not clearly faster or simpler at these call sites. Decision: keep disabled globally.
- The whole `perf` category was not enabled because it produced 8,485 findings and would require broad unrelated remediation.
- Existing custom guards remain in place for Zustand selectors, loop-carried `Buffer.concat`, lazy imports, and React Doctor checks.

## Verification

All passed:

- `pnpm run lint`
- `pnpm run audit:code-quality:native`
- `pnpm run audit:code-quality:type-aware`
- `pnpm run check:code-quality:changed -- origin/main`
- `pnpm run check:max-lines-ratchet` — 353 grandfathered suppressions, no new bypasses
- `git diff --check`