### PR TITLE
fix(agent-status): restore status in reused terminal panes

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2219,6 +2219,97 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it('accepts a new local prompt after launch authority retires in a reusable pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload, { launchToken: 'retired-launch-token' }))
+        })
+
+      await postHook({ hook_event_name: 'UserPromptSubmit', prompt: 'first launch' })
+      server.retirePaneAuthority(PANE)
+      await postHook({ hook_event_name: 'Stop', last_assistant_message: 'late prior hook' })
+      expect(server.getStatusSnapshot()).toEqual([])
+
+      await postHook({ hook_event_name: 'UserPromptSubmit', prompt: 'manual restart' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, state: 'working', prompt: 'manual restart' })
+      ])
+      expect(
+        server.attestCompatibilityAuthority({
+          paneKey: PANE,
+          launchTokenHash: createHash('sha256').update('retired-launch-token').digest('hex'),
+          connectionId: null,
+          terminalProvenance: 'current_runtime'
+        })
+      ).toBeNull()
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('accepts a live remote prompt but not replay after launch authority retires', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'UserPromptSubmit',
+        launchToken: 'retired-remote-launch-token',
+        payload: { state: 'working', prompt: 'first launch', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+    server.retirePaneAuthority(PANE)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'UserPromptSubmit',
+        launchToken: 'retired-remote-launch-token',
+        isReplay: true,
+        payload: { state: 'working', prompt: 'stale replay', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+    expect(server.getStatusSnapshot()).toEqual([])
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'UserPromptSubmit',
+        launchToken: 'retired-remote-launch-token',
+        payload: { state: 'working', prompt: 'remote manual restart', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'working',
+        prompt: 'remote manual restart',
+        connectionId: 'conn-1'
+      })
+    ])
+    expect(
+      server.attestCompatibilityAuthority({
+        paneKey: PANE,
+        launchTokenHash: createHash('sha256').update('retired-remote-launch-token').digest('hex'),
+        connectionId: 'conn-1',
+        terminalProvenance: 'current_runtime'
+      })
+    ).toBeNull()
+  })
+
   it('hydrates cached statuses as not observed in the current runtime', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-agent-hooks-'))
     const firstServer = new AgentHookServer()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -924,19 +924,28 @@ export class AgentHookServer {
     }
   }
 
-  private shouldSuppressClosedTabStatus(paneKey: string): boolean {
+  private getAgentStatusDisposition(
+    paneKey: string,
+    event?: { hookEventName?: string; isReplay?: boolean }
+  ): 'accept' | 'restart' | 'suppress' {
     const ownerPaneKey = this.resolvePaneKeyAlias(paneKey)
-    if (
+    const paneRetired =
       this.closedAgentStatusPaneKeys.has(paneKey) ||
       this.closedAgentStatusPaneKeys.has(ownerPaneKey)
-    ) {
-      return true
-    }
     const tabId = parsePaneKey(ownerPaneKey)?.tabId
-    if (!tabId) {
-      return false
+    if (tabId && this.closedAgentStatusTabIds.has(tabId)) {
+      return 'suppress'
     }
-    return this.closedAgentStatusTabIds.has(tabId)
+    if (!paneRetired) {
+      return 'accept'
+    }
+    // Why: command completion retires launch authority but leaves its shell pane reusable.
+    if (event?.hookEventName === 'UserPromptSubmit' && event.isReplay !== true) {
+      this.closedAgentStatusPaneKeys.delete(paneKey)
+      this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
+      return 'restart'
+    }
+    return 'suppress'
   }
 
   private markPaneClosedForAgentStatus(paneKey: string): void {
@@ -1716,7 +1725,7 @@ export class AgentHookServer {
       return
     }
     const tabId = paneKey !== physicalPaneKey ? parsedPaneKey.tabId : reportedTabId
-    if (this.shouldSuppressClosedTabStatus(paneKey)) {
+    if (this.getAgentStatusDisposition(paneKey) !== 'accept') {
       return
     }
     const worktreeId =
@@ -1836,16 +1845,20 @@ export class AgentHookServer {
       return
     }
     const tabId = paneKey !== physicalPaneKey ? parsedPaneKey.tabId : reportedTabId
-    if (this.shouldSuppressClosedTabStatus(paneKey)) {
+    const hookEventName =
+      typeof envelope.hookEventName === 'string' && envelope.hookEventName.trim().length > 0
+        ? envelope.hookEventName.trim()
+        : undefined
+    const statusDisposition = this.getAgentStatusDisposition(paneKey, {
+      hookEventName,
+      isReplay: envelope.isReplay === true
+    })
+    if (statusDisposition === 'suppress') {
       return
     }
     const worktreeId =
       envelope.worktreeId !== undefined && envelope.worktreeId.trim().length > 0
         ? envelope.worktreeId.trim()
-        : undefined
-    const hookEventName =
-      typeof envelope.hookEventName === 'string' && envelope.hookEventName.trim().length > 0
-        ? envelope.hookEventName.trim()
         : undefined
     const promptInteractionKey =
       typeof envelope.promptInteractionKey === 'string' &&
@@ -1895,7 +1908,7 @@ export class AgentHookServer {
     })
     const event: AgentHookEventPayload = {
       paneKey,
-      launchToken: envelope.launchToken,
+      launchToken: statusDisposition === 'restart' ? undefined : envelope.launchToken,
       tabId,
       worktreeId,
       connectionId: trimmedConnectionId,
@@ -1997,9 +2010,19 @@ export class AgentHookServer {
         trackEmptyPaneKeyHook(body)
         const aliasedBody = this.normalizeHookBodyPaneKeyAlias(body)
         const normalized = this.normalizeLocalHookPayload(source, aliasedBody)
-        if (normalized.event && !this.shouldSuppressClosedTabStatus(normalized.event.paneKey)) {
-          this.recordCurrentAuthorityObservation(normalized.event)
-          const enriched = this.applyNormalizedStatus(normalized.event, normalized.onAccepted)
+        const statusDisposition = normalized.event
+          ? this.getAgentStatusDisposition(normalized.event.paneKey, {
+              hookEventName: normalized.event.hookEventName,
+              isReplay: normalized.event.isReplay
+            })
+          : 'suppress'
+        if (normalized.event && statusDisposition !== 'suppress') {
+          const event =
+            statusDisposition === 'restart'
+              ? { ...normalized.event, launchToken: undefined }
+              : normalized.event
+          this.recordCurrentAuthorityObservation(event)
+          const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
           this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
           this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
         }


### PR DESCRIPTION
## Summary

Restore agent status when Claude starts in a terminal pane whose original launch authority has already been retired.

The fix distinguishes three cases at the agent-hook boundary:

- normal live events remain accepted;
- late events, closed-tab events, and relay replays remain suppressed;
- a fresh live `UserPromptSubmit` may reopen status for a still-live reusable pane, without reviving its retired launch token.

## Production reproduction

Observed in Orca `1.4.164-rc.2`:

- terminal: `term_e49e1ab2-e94d-4314-9925-7ae7a757770e`
- pane: `d22ca15c-4169-4b83-a8b6-ac846eb552c5:bc9ac435-330c-4615-b6df-337279c5d408`
- Claude Code `2.1.220` was visibly working and running tools for more than ten minutes;
- the Claude process had the correct Orca pane, tab, worktree, endpoint, port, environment, protocol, and launch-token variables;
- Orca's hook listener was reachable and Claude hooks were installed;
- `orca worktree ps` contained no agent row for the pane, and production `last-status.json` contained no entry for it.

Two clean control panes both reported `done` correctly:

1. plain `claude --debug hooks ...`;
2. the reporter's exact `claude --append-system-prompt-file ... --debug hooks ...` launch shape.

That ruled out the alias, Claude settings, hook installation, endpoint transport, normalization, and rendering. The material difference was the affected reusable pane's retired launch lifecycle.

## Root cause

`retirePaneAuthority()` correctly revoked launch authority and suppressed late hook writes, but it also left the pane in the suppression set for the entire server lifetime. The PTY's shell can remain live and start Claude again in that same pane, so every valid hook from the new run was discarded before normalization or rendering.

## Fix

- Replace the boolean suppression decision with explicit `accept`, `restart`, and `suppress` outcomes.
- Treat a non-replayed `UserPromptSubmit` as a new status lifecycle for a retired-but-live pane.
- Keep truly closed tabs authoritative: they still suppress every later event.
- Keep late `Stop` events and SSH/relay replay envelopes suppressed.
- Strip the inherited retired launch token from the restarted status lifecycle, so status recovery cannot recreate orchestration authority.

## ELI5

Orca put a permanent "ignore messages from this terminal" sticker on the pane when the original launch was retired. The terminal itself was still usable, so the next Claude kept sending valid updates that Orca threw away. This change removes that sticker only when a person submits a genuinely new prompt. It does not accept old replayed messages and does not restore the old security credential.

## Proof of fix

The new regression tests were run before the implementation and failed with the production behavior:

```text
expected [working status for "manual restart"]
received []

expected [working status for "remote manual restart"]
received []
```

After the fix, both local HTTP and SSH/relay lifecycle regressions pass. They cover:

- late prior-process `Stop` remains ignored;
- a fresh local prompt restores `working` status;
- replayed remote prompt remains ignored;
- a fresh live remote prompt restores `working` status;
- the retired local and remote launch tokens cannot attest authority afterward.

## Proof of no regression

Run after rebasing onto current `origin/main` (`2fe655de72`):

```text
npm test -- --run src/main/agent-hooks/server.test.ts src/main/runtime/orca-runtime.test.ts
Test Files  2 passed (2)
Tests       1249 passed | 1 skipped (1250)

npm run typecheck
passed

npx oxlint src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts
passed

git diff --check origin/main...HEAD
passed
```

Compatibility review:

- **Performance:** constant-time `Set` lookups/deletes per hook; no polling, timers, I/O, or new retained state.
- **macOS/Linux/Windows:** pure main-process TypeScript with no platform APIs, paths, shells, or key handling.
- **SSH/relay:** explicit live-vs-replay regression coverage exercises both recovery and suppression.
- **Mobile:** mobile consumes the same canonical agent-status snapshot, so the recovered row flows through the existing path.
- **Folder workspaces:** the decision is pane-key based and does not inspect Git or worktree metadata.

## Scope

Two files only: the agent-hook listener and its lifecycle regression tests. No UI, schema, persistence format, Git command, or provider-specific rendering changes.
