### PR TITLE
feat(agents): hibernate Hermes sessions

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -3526,6 +3526,7 @@ describe('AgentHookServer listener replay', () => {
         body: JSON.stringify(
           buildBody({
             hook_event_name: 'pre_llm_call',
+            session_id: 'hermes-session',
             user_message: 'verify Hermes route'
           })
         )
@@ -3541,6 +3542,10 @@ describe('AgentHookServer listener replay', () => {
           tabId: 'tab-1',
           worktreeId: 'wt-1',
           connectionId: null,
+          providerSession: {
+            key: 'session_id',
+            id: 'hermes-session'
+          },
           payload: expect.objectContaining({
             state: 'working',
             prompt: 'verify Hermes route',

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -195,6 +195,17 @@ describe('agent sleep planner', () => {
     }
   )
 
+  it('hibernates completed Hermes sessions with a resume id', () => {
+    const hermes = entry({
+      agentType: 'hermes',
+      providerSession: { key: 'session_id', id: 'hermes-session' }
+    })
+
+    expect(
+      plannedWorktrees(snapshot({ agentStatusByPaneKey: { [hermes.paneKey]: hermes } }))
+    ).toEqual(['wt-bg'])
+  })
+
   it('requires the idle threshold and blocks input after done', () => {
     const fresh = entry({ updatedAt: NOW - 1_000 })
     expect(

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -16,6 +16,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('omp')).toBe(true)
   })
 
+  it('treats hermes as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('hermes')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -35,7 +39,8 @@ describe('agent session resume metadata', () => {
     ['droid', { session_id: 'droid-session' }, { key: 'session_id', id: 'droid-session' }],
     ['grok', { sessionId: 'grok-session' }, { key: 'session_id', id: 'grok-session' }],
     ['devin', { session_id: 'devin-session' }, { key: 'session_id', id: 'devin-session' }],
-    ['omp', { session_id: 'omp-session' }, { key: 'session_id', id: 'omp-session' }]
+    ['omp', { session_id: 'omp-session' }, { key: 'session_id', id: 'omp-session' }],
+    ['hermes', { session_id: 'hermes-session' }, { key: 'session_id', id: 'hermes-session' }]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -55,7 +60,8 @@ describe('agent session resume metadata', () => {
     ['droid', { key: 'session_id', id: 's1' }, ['droid', '--resume', 's1']],
     ['grok', { key: 'session_id', id: 's1' }, ['grok', '--resume', 's1']],
     ['devin', { key: 'session_id', id: 'abc12345' }, ['devin', '--resume', 'abc12345']],
-    ['omp', { key: 'session_id', id: 's1' }, ['omp', '--resume', 's1']]
+    ['omp', { key: 'session_id', id: 's1' }, ['omp', '--resume', 's1']],
+    ['hermes', { key: 'session_id', id: 's1' }, ['hermes', '--resume', 's1']]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -13,7 +13,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'droid',
   'grok',
   'devin',
-  'omp'
+  'omp',
+  'hermes'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -193,6 +194,7 @@ export function extractAgentProviderSession(
     }
     case 'gemini':
     case 'droid':
+    case 'hermes':
     // Why: Kimi Code posts a Claude-shaped `session_id` (e.g. session_<uuid>).
     // falls through
     case 'kimi': {
@@ -232,7 +234,6 @@ export function extractAgentProviderSession(
     case 'cursor':
     case 'command-code':
     case 'copilot':
-    case 'hermes':
       return null
   }
 }
@@ -270,5 +271,7 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
+    case 'hermes':
+      return providerSession.key === 'session_id' ? ['hermes', '--resume', id] : null
   }
 }

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -195,9 +195,10 @@ export function extractAgentProviderSession(
     case 'gemini':
     case 'droid':
     case 'hermes':
-    // Why: Kimi Code posts a Claude-shaped `session_id` (e.g. session_<uuid>).
+    // Why: Hermes reports the managed-hook session id used by `--resume`.
     // falls through
     case 'kimi': {
+      // Why: Kimi Code posts a Claude-shaped `session_id` (e.g. session_<uuid>).
       const id = readSessionId(payload, ['session_id'])
       return id ? { key: 'session_id', id } : null
     }

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -604,6 +604,30 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe("codex --profile work 'resume' 's1'")
   })
 
+  it.each(['linux', 'win32'] as const)(
+    'resumes Hermes in its TUI with captured launch settings on %s',
+    (platform) => {
+      const plan = buildAgentResumeStartupPlan({
+        agent: 'hermes',
+        providerSession: { key: 'session_id', id: 'hermes-session' },
+        cmdOverrides: { hermes: 'hermes --tui' },
+        agentCommand: "hermes --tui '--model' 'test-model'",
+        agentArgs: '--model test-model',
+        agentEnv: { HERMES_HOME: '/tmp/hermes-work' },
+        platform
+      })
+
+      expect(plan?.launchCommand).toBe(
+        "hermes --tui '--model' 'test-model' '--resume' 'hermes-session'"
+      )
+      expect(plan?.launchConfig).toEqual({
+        agentCommand: "hermes --tui '--model' 'test-model'",
+        agentArgs: '--model test-model',
+        agentEnv: { HERMES_HOME: '/tmp/hermes-work' }
+      })
+    }
+  )
+
   it('uses a captured launch command when building resume plans after overrides change', () => {
     const plan = buildAgentResumeStartupPlan({
       agent: 'codex',

--- a/src/shared/workspace-session-schema.sleeping-agent.test.ts
+++ b/src/shared/workspace-session-schema.sleeping-agent.test.ts
@@ -14,13 +14,13 @@ describe('parseWorkspaceSession sleeping agents', () => {
           paneKey: 'tab1:pane-1',
           tabId: 'tab1',
           worktreeId: 'wt',
-          agent: 'codex',
-          providerSession: { key: 'session_id', id: 'codex-session' },
+          agent: 'hermes',
+          providerSession: { key: 'session_id', id: 'hermes-session' },
           prompt: 'continue',
           state: 'working',
           capturedAt: 10,
           updatedAt: 9,
-          terminalTitle: 'Codex',
+          terminalTitle: 'Hermes',
           lastAssistantMessage: 'done',
           launchConfig: {
             agentArgs: '',
@@ -32,7 +32,7 @@ describe('parseWorkspaceSession sleeping agents', () => {
     })
     expect(result.ok).toBe(true)
     if (result.ok) {
-      expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.agent).toBe('codex')
+      expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.agent).toBe('hermes')
       expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.origin).toBe('live')
       expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.launchConfig).toEqual({
         agentArgs: '',


### PR DESCRIPTION
## In plain English

Completed local Hermes sessions can return after Orca restarts instead of losing their resumable session identity.

## Summary

- treat Hermes as an existing resumable TUI agent
- persist its managed-hook `session_id` through Orca's sleeping-agent record
- relaunch the captured command as `hermes --tui --resume <session-id>` while preserving the original working directory and environment
- cover identity extraction, hibernation planning, persistence, and captured Linux/Windows launch settings

This does not install Hermes, change AI Vault scanning, add a persistence format, or alter remote-session ownership.

## Screenshots

No visual change.

## Testing

Exact published head: `3d66f2a1115215b31f8b337bdfa9aff3dfe7c41e` on base `f71373953baa1d384b75bbdf4845fda17a847da5`.

- focused session-resume suite: 34/34
- focused formatting and Oxlint passed
- reviewer clarification fixed: Hermes and Kimi session-ID comments now describe their own cases
- the equivalent pre-rebase feature stack previously passed full lint, typecheck, build, five focused suites (407/407), and the full test suite

Combined integration acceptance is current at `e13fa51f38102e1c3bf972e206e68fd323927406`: lint and all three TypeScript projects passed; its predecessor passed 3,563 focused desktop tests and 55 mobile tests; the final #10046-only delta passed 8/8 plus web typecheck; packaging passed the glibc-floor, daemon-entry, and bundled-plugin gates.

On the installed candidate, two live Hermes TUIs reattached after the desktop restart with unchanged handles and incarnation IDs, and all five persisted Hermes provider session IDs remained present. A historical 39.7-million-token Hermes session also loaded to `ready` through the current standalone Hermes loader. These are loader/reattachment checks; the detached daemon intentionally stayed alive to protect active PTYs, so no claim of a new manual daemon-cold-start auto-resume is made.

## Compatibility notes

- Resume argv remains an argument array, not a shell string.
- Existing local/SSH/runtime ownership guards are unchanged.
- Folder workspaces use the same worktree-scoped persistence path and do not require Git.
- Other resumable agents and git providers are unaffected.

## AI Review Report

The review traced managed Hermes identity through normalization, hibernation planning, durable serialization, and relaunch. The implementation rewrites only captured resume arguments, preserving the user's command, model/profile flags, environment, and working directory.

## Security Audit

The session ID passes through the existing managed-hook validation path and becomes one discrete process argument. It is not shell-interpolated. No dependency, credential path, filesystem authority, network request, or IPC message is added.

## Notes

- Current Hermes `0.19.0` successfully loads the previously failing large session; no separate Orca loader repair was required.
- Remote-host Hermes installation and AI Vault history scanning remain out of scope.
- X handle: not provided.
