### PR TITLE
fix(test): restore Azure DevOps and Bitbucket remote-url probe assertions

### DIFF
--- a/src/main/azure-devops/pull-request-creation.test.ts
+++ b/src/main/azure-devops/pull-request-creation.test.ts
@@ -130,7 +130,9 @@ describe('Azure DevOps pull request creation', () => {
       ok: true,
       number: 38
     })
-    expect(remoteGit.exec).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/remote/repo')
+    expect(remoteGit.exec).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/remote/repo', {
+      signal: expect.any(AbortSignal)
+    })
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/azure-devops/repository-ref.test.ts
+++ b/src/main/azure-devops/repository-ref.test.ts
@@ -118,7 +118,9 @@ describe('parseAzureDevOpsRepoRef', () => {
       webBaseUrl: 'https://dev.azure.com/acme/Project/_git/repo'
     })
 
-    expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo')
+    expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo', {
+      signal: expect.any(AbortSignal)
+    })
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/bitbucket/repository-ref.test.ts
+++ b/src/main/bitbucket/repository-ref.test.ts
@@ -157,7 +157,9 @@ describe('Bitbucket repository refs', () => {
       repoSlug: 'project'
     })
 
-    expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo')
+    expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo', {
+      signal: expect.any(AbortSignal)
+    })
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
**main is currently red.** Three test files fail on `origin/main` @ `73c5009b82`:

```
src/main/azure-devops/pull-request-creation.test.ts
src/main/azure-devops/repository-ref.test.ts
src/main/bitbucket/repository-ref.test.ts
```

## Cause

#12065 bounded the SSH branch of `readRemoteUrl` with a deadline (`src/main/git/remote-url-probe.ts:37`):

```ts
const { stdout } = await provider.exec(['remote', 'get-url', remoteName], context.repoPath, {
  signal: AbortSignal.timeout(REMOTE_URL_PROBE_TIMEOUT_MS)
})
```

That adds a third argument to every SSH-branch `provider.exec` call. #12065 updated the Gitea, GitHub and GitLab assertions to expect it — Azure DevOps and Bitbucket were missed:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ …(2) ]
+   { "signal": AbortSignal { … } }
```

Bisected to confirm: passes at `711491b40a`, fails at `1562f12f78` (#12065).

## Fix

Test-only. The three stale assertions adopt the exact `expect.any(AbortSignal)` shape #12065 already used for the other three providers:

```ts
expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo', {
  signal: expect.any(AbortSignal)
})
```

The production change from #12065 is correct and untouched — an unbounded `get-url` against a wedged SSH host is exactly what it set out to fix.

The two `gitExecFileAsyncMock` assertions in the same files are the *local* branch, which still passes `{cwd, timeout}` and is unaffected.

## Checks

`src/main/{azure-devops,bitbucket,gitea,gitlab,git}` + `github/gh-utils` — **109 files, 1,580 tests, all pass.**

## Note

This is the provider-compatibility footgun AGENTS.md warns about: a change to shared source-control plumbing was verified against three of five providers. Azure DevOps and Bitbucket ride the same `readRemoteUrl` path and only surface at their own call sites.

Made with [Orca](https://github.com/stablyai/orca) 🐋
