### PR TITLE
fix(remote): fall back to getForegroundProcess on legacy daemons

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -927,6 +927,66 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     })
   })
 
+  describe('inspectProcess', () => {
+    // Why: daemons survive app updates, so a protocol-<27 remote daemon must
+    // still surface agent activity instead of throwing on every poll.
+    async function withLegacyDaemon(
+      fn: (adapter: DaemonPtyAdapter) => Promise<void>
+    ): Promise<void> {
+      const legacyDir = createTestDir()
+      const legacySocket = getDaemonSocketPath(legacyDir)
+      const legacyToken = join(legacyDir, 'legacy.token')
+      const legacyServer = new DaemonServer({
+        socketPath: legacySocket,
+        tokenPath: legacyToken,
+        log: daemonLog,
+        protocolVersion: 26,
+        spawnSubprocess: (opts) => {
+          lastSpawnOpts = opts
+          lastSubprocess = createMockSubprocess()
+          return lastSubprocess
+        }
+      })
+      await legacyServer.start()
+      const legacy = new DaemonPtyAdapter({
+        socketPath: legacySocket,
+        tokenPath: legacyToken,
+        protocolVersion: 26
+      })
+      try {
+        await fn(legacy)
+      } finally {
+        legacy.dispose()
+        await legacyServer.shutdown()
+        rmSync(legacyDir, { recursive: true, force: true })
+      }
+    }
+
+    it('falls back to getForegroundProcess on a pre-inspectProcess daemon protocol', async () => {
+      await withLegacyDaemon(async (legacy) => {
+        const { id } = await legacy.spawn({ cols: 80, rows: 24 })
+        vi.mocked(lastSubprocess.getForegroundProcess).mockReturnValue('codex')
+
+        await expect(legacy.inspectProcess(id)).resolves.toEqual({
+          foregroundProcess: 'codex',
+          hasChildProcesses: true
+        })
+      })
+    })
+
+    it('derives hasChildProcesses as false for a shell foreground on legacy protocols', async () => {
+      await withLegacyDaemon(async (legacy) => {
+        const { id } = await legacy.spawn({ cols: 80, rows: 24 })
+        vi.mocked(lastSubprocess.getForegroundProcess).mockReturnValue('bash')
+
+        await expect(legacy.inspectProcess(id)).resolves.toEqual({
+          foregroundProcess: 'bash',
+          hasChildProcesses: false
+        })
+      })
+    })
+  })
+
   describe('serialize / revive', () => {
     it('serialize returns JSON', async () => {
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -827,7 +827,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
     id: string
   ): Promise<{ foregroundProcess: string | null; hasChildProcesses: boolean }> {
     if (this.protocolVersion < COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION) {
-      throw new Error('terminal_liveness_unavailable')
+      // Why: daemons survive app updates, so a protocol-<27 daemon never learned
+      // the combined inspectProcess request. Fall back to getForegroundProcess
+      // (always supported) so agent activity still resolves instead of throwing
+      // terminal_liveness_unavailable on every poll.
+      const foregroundProcess = await this.getForegroundProcess(id)
+      return {
+        foregroundProcess,
+        hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess)
+      }
     }
     return this.client.request<{
       foregroundProcess: string | null


### PR DESCRIPTION
## Summary

Agent activity (working/done indicators, inline agent rows) stopped appearing **at all** on the desktop for terminals running on a **remote server** after #9263, while the **mobile app kept working**. Fixes #12087.

### Root cause

#9263 bumped the daemon protocol to 27 and gated the new combined `inspectProcess` request at `COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION = 27`. `DaemonPtyAdapter.inspectProcess` threw `terminal_liveness_unavailable` for any daemon at protocol `< 27`, with no fallback:

```ts
async inspectProcess(id) {
  if (this.protocolVersion < COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION) {
    throw new Error('terminal_liveness_unavailable')   // no fallback
  }
  return this.client.request('inspectProcess', { sessionId: id })
}
```

This contradicts the file's own contract — `daemon-protocol-version.ts` notes *"daemons survive app updates, so wire behavior must be version-gated."* A desktop on protocol 27 talking to a remote server whose daemon is still at protocol ≤ 26 is the **expected, supported** state; the gate should select legacy vs new call, not throw.

The throw then propagates the whole way:
`DaemonPtyAdapter.inspectProcess` → `inspectPtyProviderProcess` (deliberately preserves `inspectProcess` failures) → renderer path `window.api.pty.inspectProcess` (no try/catch) → `agent-completion-coordinator` catch block → agent is **never recognized** (`recognizeAgentProcess` never called).

Mobile is unaffected because it uses server-pushed agent status, not this renderer polling path.

### Fix

Fall back to `getForegroundProcess` (always supported, matching the existing legacy `hasChildProcesses()` derivation) when the daemon protocol is `< 27`, restoring pre-#9263 behavior for older daemons while keeping the atomic combined call for protocol-27 daemons.

The stale/gone-handle authority introduced by #9263 is **not** weakened: it is enforced by `resolveLiveLeafForHandle` + `isTerminalGoneError` → `unavailable`, not by this provider-level throw.

## Screenshots

No visual change. The fix restores agent activity indicators that were already shipped; no UI surface is added or altered.

## Testing

- [x] `pnpm typecheck` (all three tsconfigs: node, cli, web — clean)
- [x] `pnpm lint` (oxlint on changed files — clean)
- [ ] `pnpm test` — ran targeted suites, all green (see below); full suite not re-run
- [ ] `pnpm build` — not run (no build-graph change; only a runtime fallback branch)
- [x] Added regression tests that catch this exact regression

Targeted suites run green:
- `daemon-pty-adapter.test.ts` (incl. 2 new `inspectProcess` legacy-fallback cases) + `daemon-pty-router` + `degraded-daemon-pty-provider` + `terminal-host` + `pty-process-inspection` → 190 passing.
- `runtime-terminal-inspection` + `remote-agent-completion-authority` (renderer, via `config/vitest.config.ts`) → 27 passing.

## AI Review Report

Reviewed the diff with an AI coding agent. Risks checked and findings:

- **Correctness of the fallback branch**: the legacy path now returns `{ foregroundProcess, hasChildProcesses }` derived exactly like the existing `hasChildProcesses()` method (`foregroundProcess !== null && !isShellProcess(foregroundProcess)`), so behavior matches pre-#9263 for old daemons. Verified `isShellProcess` is already imported in the file and already used by `hasChildProcesses()`.
- **No weakening of #9263's authority**: the stale/gone-handle guarantee lives in `resolveLiveLeafForHandle` + the renderer's `isTerminalGoneError → unavailable` handling, not in this throw. Removing the throw for protocol-<27 daemons does not re-introduce false completion, because the renderer still requires consecutive authoritative idle samples.
- **Provider contract**: `inspectPtyProviderProcess` deliberately propagates `inspectProcess` failures, so the fix must live inside `DaemonPtyAdapter` (it does) rather than at the provider-agnostic layer.
- **Test fidelity**: regression tests stand up a dedicated protocol-26 daemon (server + adapter) so the version-skew scenario is exercised end-to-end rather than with a stubbed capability flag.

**Cross-platform compatibility (macOS / Linux / Windows)** explicitly reviewed:
- The change is in the daemon protocol layer, which is platform-independent; no platform-specific branch is touched.
- No keyboard shortcuts, shortcut labels, file paths, or shell behavior are involved.
- `isShellProcess` is existing shared agent-detection logic already used cross-platform by `hasChildProcesses()`; reusing it introduces no new platform dependency.
- No Electron-specific behavior or native-module surface is touched.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependencies, and IPC risks:

- **No new inputs**: the fallback calls the existing `this.getForegroundProcess(id)` (already hardened with try/catch → `null`) and the existing shared `isShellProcess` helper. No user-controlled data is parsed or executed.
- **No command execution / path handling**: purely a remote procedure selection based on a numeric protocol version.
- **No auth, secrets, or token changes**.
- **No new dependencies or IPC surfaces**: the `getForegroundProcess` daemon request already existed and was already authorized.
- **No follow-up needed**; the change strictly narrows a throw into an equivalent read.

## Notes

- **Version-skew follow-up (out of scope here)**: the same regression shape exists for a direct-SSH connection (`SshPtyProvider.inspectProcess` → relay `pty.inspectProcess`) when the remote relay CLI predates this method, since there is no relay-method capability gate. The daemon model is the primary remote-server mechanism and is covered by this PR; if a user reports the symptom over a direct-SSH (non-daemon) remote, `SshPtyProvider` would need an analogous fallback.
- Updating the remote server's daemon to protocol 27 also resolves the symptom; this PR makes the desktop client backward-compatible with older daemons as the project's compatibility policy requires.