### PR TITLE
refactor(worktrees): reuse the shared push-target helpers on the SSH path

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -38,7 +38,6 @@ import type { ForgeProviderId } from '../source-control/forge-provider'
 import { validateGitPushTarget } from '../git/push-target-validation'
 import { assertGitPushTargetShape } from '../../shared/git-push-target-validation'
 import { gitExecFileAsync } from '../git/runner'
-import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type {
   OrcaRuntimeService,
   RemoteFetchResult,
@@ -93,10 +92,13 @@ import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-
 import {
   cleanupUnusedWorktreePushTargetRemoteWithExec,
   sameGitHubRemoteUrl,
+  type GitRemoteExec,
   type WorktreePushTargetStore
 } from './worktree-push-target-cleanup'
 import {
   configureCreatedWorktreePushTargetWithExec,
+  ensureUniqueRemoteName,
+  findRemoteForUrl,
   prepareWorktreePushTargetWithExec
 } from './worktree-push-target-setup'
 import { isENOENT, registerWorktreeRootsForRepo } from './filesystem-auth'
@@ -1048,67 +1050,6 @@ export async function configureCreatedWorktreePushTarget(
   )
 }
 
-async function findRemoteForUrlSsh(
-  provider: SshGitProvider,
-  repoPath: string,
-  remoteUrl: string
-): Promise<string | null> {
-  const target = parseGitHubOwnerRepo(remoteUrl)
-  try {
-    const { stdout } = await provider.exec(['remote'], repoPath)
-    for (const remote of stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)) {
-      try {
-        const { stdout: urlStdout } = await provider.exec(['remote', 'get-url', remote], repoPath)
-        const candidateUrl = urlStdout.trim()
-        const candidate = parseGitHubOwnerRepo(candidateUrl)
-        if (
-          target &&
-          candidate &&
-          target.owner.toLowerCase() === candidate.owner.toLowerCase() &&
-          target.repo.toLowerCase() === candidate.repo.toLowerCase()
-        ) {
-          return remote
-        }
-        if (candidateUrl === remoteUrl) {
-          return remote
-        }
-      } catch {
-        // Ignore a remote that disappeared or has no fetch URL.
-      }
-    }
-  } catch {
-    return null
-  }
-  return null
-}
-
-async function ensureUniqueRemoteNameSsh(
-  provider: SshGitProvider,
-  repoPath: string,
-  preferred: string
-): Promise<string> {
-  const { stdout } = await provider.exec(['remote'], repoPath)
-  const existing = new Set(
-    stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-  )
-  if (!existing.has(preferred)) {
-    return preferred
-  }
-  for (let suffix = 2; suffix < 100; suffix += 1) {
-    const candidate = `${preferred}-${suffix}`
-    if (!existing.has(candidate)) {
-      return candidate
-    }
-  }
-  throw new Error(`Could not find an available remote name for ${preferred}.`)
-}
-
 async function prepareWorktreePushTargetSsh(
   provider: SshGitProvider,
   repoPath: string,
@@ -1117,12 +1058,13 @@ async function prepareWorktreePushTargetSsh(
   repoId?: string
 ): Promise<GitPushTarget> {
   assertGitPushTargetShape(target)
+  const execGit: GitRemoteExec = (args, cwd) => provider.exec(args, cwd)
   const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
   let remoteName = target.remoteName
   let remoteCreated = false
   if (target.remoteUrl) {
-    const existingRemote = await findRemoteForUrlSsh(provider, repoPath, target.remoteUrl)
+    const existingRemote = await findRemoteForUrl(execGit, repoPath, target.remoteUrl)
     if (existingRemote) {
       remoteName = existingRemote
       // Why: a reused Orca-created fork remote must inherit ownership so deleting the final user can remove it.
@@ -1137,7 +1079,7 @@ async function prepareWorktreePushTargetSsh(
           )
         : false
     } else {
-      remoteName = await ensureUniqueRemoteNameSsh(provider, repoPath, target.remoteName)
+      remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
       await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
       remoteCreated = true
     }
@@ -1172,19 +1114,6 @@ export async function cleanupUnusedWorktreePushTargetRemoteSsh(
       error
     )
   }
-}
-
-async function configureCreatedWorktreePushTargetSsh(
-  provider: SshGitProvider,
-  worktreePath: string,
-  branchName: string,
-  target: GitPushTarget
-): Promise<GitPushTarget> {
-  await provider.exec(
-    ['branch', '--set-upstream-to', `${target.remoteName}/${target.branchName}`, branchName],
-    worktreePath
-  )
-  return target
 }
 
 async function readRemoteEffectiveHooks(
@@ -1825,8 +1754,8 @@ export async function createRemoteWorktree(
   const metadataBaseRef = args.compareBaseRef ?? remoteTrackingBase?.ref ?? baseBranch
   let configuredPushTarget: GitPushTarget | undefined
   if (preparedPushTarget) {
-    configuredPushTarget = await configureCreatedWorktreePushTargetSsh(
-      provider,
+    configuredPushTarget = await configureCreatedWorktreePushTargetWithExec(
+      (args, cwd) => provider.exec(args, cwd),
       created.path,
       branchName,
       preparedPushTarget


### PR DESCRIPTION
## What

Three functions in `src/main/ipc/worktree-remote.ts` were byte-identical to helpers sitting ~250 lines above them in `src/main/ipc/worktree-push-target-setup.ts`, differing only in calling `provider.exec(...)` instead of the injected `execGit(...)`:

| SSH copy (`worktree-remote.ts`) | Shared original (`worktree-push-target-setup.ts`) |
| --- | --- |
| `findRemoteForUrlSsh` :1051 | `findRemoteForUrl` :11 |
| `ensureUniqueRemoteNameSsh` :1088 | `ensureUniqueRemoteName` :48 |
| `configureCreatedWorktreePushTargetSsh` :1177 | `configureCreatedWorktreePushTargetWithExec` :113 |

Substituting `provider.exec(` → `execGit(` makes all three diff to zero against their shared counterpart (verified mechanically, not by eye). Feed `provider.exec` through the existing `GitRemoteExec` seam instead and delete the copies.

## Why this is drift, not design

`528a887ab5` extracted `worktree-push-target-setup.ts` **out of** `worktree-remote.ts` and left the SSH twin untouched — an unfinished extraction. Compatibility of the seam is already proven in this same file: `cleanupUnusedWorktreePushTargetRemoteSsh:1167` passes `(args, cwd) => provider.exec(args, cwd)` into the shared cleanup helper.

## Explicitly not touched

`prepareWorktreePushTargetSsh` **stays as-is.** It substitutes `provider.fetchRemoteTrackingRef` (a narrow RPC that forces `--no-tags` and pre-validates refs) for a raw `git fetch` refspec, and carries its own `check-ref-format` preamble. That is a real behavior difference on the relay path, not a clone — merging it would be a refactor with actual risk.

## Regression safety

- The three substituted bodies are byte-identical; this is code motion, not a rewrite.
- `tsc --noEmit` clean on all three projects (node, cli, web).
- `oxlint`, `oxfmt --check`, and both code-quality audits (`native-plugins`, `--type-aware --deny-warnings`) clean.
- 2,746 tests across 237 files pass (`vitest run worktree`), including `worktree-push-target-setup.test.ts` and `worktree-push-target-cleanup.test.ts`.
- Drops the now-unused `parseGitHubOwnerRepo` import.

Net: **-79 / +8**.

## Pre-existing coverage gap (not introduced here)

The SSH variants had no direct unit coverage of their own — which is precisely how they were able to sit byte-identical to the shared helpers without anyone noticing. After this change that path is covered by the shared helpers' existing tests.

Made with [Orca](https://github.com/stablyai/orca) 🐋
