### PR TITLE
fix(linear): order Issues board columns Backlog -> Done

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -176,6 +176,7 @@ import {
 } from '@/lib/new-workspace'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
+import { orderLinearStatusSections, type LinearGroupSection } from '@/lib/linear-issue-grouping'
 import {
   readLinearBoardIssueDragData,
   writeLinearBoardIssueDragData
@@ -600,12 +601,6 @@ function formatRelativeTime(input: string): string {
 
 type LinearProjectTab = 'overview' | 'issues'
 
-type LinearGroupSection = {
-  key: string
-  label: string
-  issues: LinearIssue[]
-}
-
 type LinearIssueListRow =
   | { type: 'section'; key: string; label: string; count: number }
   | { type: 'issue'; issue: LinearIssue }
@@ -879,7 +874,9 @@ function groupLinearIssues(
       sections.set(group.key, { key: group.key, label: group.label, issues: [issue] })
     }
   }
-  return [...sections.values()]
+  const ordered = [...sections.values()]
+  // Status sections follow workflow order (Backlog ... Done) instead of first-appearance.
+  return groupBy === 'status' ? orderLinearStatusSections(ordered) : ordered
 }
 
 function TaskPageJiraErrorBanner({

--- a/src/renderer/src/lib/linear-issue-grouping.test.ts
+++ b/src/renderer/src/lib/linear-issue-grouping.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { orderLinearStatusSections } from './linear-issue-grouping'
+
+type StateType = 'backlog' | 'started' | 'completed' | 'canceled' | string
+
+type TestSection = {
+  key: string
+  label: string
+  issues: { state: { type: StateType } }[]
+}
+
+function statusSection(name: string, type: StateType): TestSection {
+  return { key: `status:${name}`, label: name, issues: [{ state: { type } }] }
+}
+
+describe('orderLinearStatusSections', () => {
+  it('orders status sections backlog -> started -> completed -> canceled', () => {
+    const sections = [
+      statusSection('In Progress', 'started'),
+      statusSection('Done', 'completed'),
+      statusSection('Backlog', 'backlog'),
+      statusSection('Canceled', 'canceled')
+    ]
+
+    expect(orderLinearStatusSections(sections).map((s) => s.label)).toEqual([
+      'Backlog',
+      'In Progress',
+      'Done',
+      'Canceled'
+    ])
+  })
+
+  it('fixes the board regression where Done appeared before Backlog', () => {
+    // Reproduces the bug: Done surfaced first because its issues were updated more recently.
+    const sections = [statusSection('Done', 'completed'), statusSection('Backlog', 'backlog')]
+
+    expect(orderLinearStatusSections(sections).map((s) => s.label)).toEqual(['Backlog', 'Done'])
+  })
+
+  it('tie-breaks sections of the same type alphabetically by label', () => {
+    const sections = [statusSection('In Review', 'started'), statusSection('In Progress', 'started')]
+
+    expect(orderLinearStatusSections(sections).map((s) => s.label)).toEqual([
+      'In Progress',
+      'In Review'
+    ])
+  })
+
+  it('sorts unknown state types after known workflow types', () => {
+    const sections = [
+      statusSection('Triage', 'triage'),
+      statusSection('Done', 'completed'),
+      statusSection('Backlog', 'backlog')
+    ]
+
+    expect(orderLinearStatusSections(sections).map((s) => s.label)).toEqual([
+      'Backlog',
+      'Done',
+      'Triage'
+    ])
+  })
+
+  it('returns a new array and does not mutate the input', () => {
+    const sections = [statusSection('Done', 'completed'), statusSection('Backlog', 'backlog')]
+    const original = [...sections]
+
+    const result = orderLinearStatusSections(sections)
+
+    expect(sections).toEqual(original)
+    expect(result).not.toBe(sections)
+  })
+
+  it('handles an empty list', () => {
+    expect(orderLinearStatusSections([])).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/linear-issue-grouping.ts
+++ b/src/renderer/src/lib/linear-issue-grouping.ts
@@ -1,0 +1,36 @@
+import type { LinearIssue } from '../../../shared/types'
+
+export type LinearGroupSection = {
+  key: string
+  label: string
+  issues: LinearIssue[]
+}
+
+// Linear workflow state.type rank: backlog first, terminal states last.
+// Matches the ordering the Linear API already returns (states sorted by position).
+const LINEAR_STATE_TYPE_RANK: Record<string, number> = {
+  backlog: 0,
+  started: 1,
+  completed: 2,
+  canceled: 3
+}
+
+const UNKNOWN_LINEAR_STATE_TYPE_RANK = 9
+
+// Ordering only needs each section's workflow type; the section shape is kept generic so
+// callers don't have to materialize a full LinearIssue. Returns a new array; input is not mutated.
+type StatusRankableSection = {
+  label: string
+  issues: { state: { type: string } }[]
+}
+
+export function orderLinearStatusSections<T extends StatusRankableSection>(
+  sections: T[]
+): T[] {
+  return [...sections].sort((a, b) => {
+    const rankA = LINEAR_STATE_TYPE_RANK[a.issues[0]?.state.type ?? ''] ?? UNKNOWN_LINEAR_STATE_TYPE_RANK
+    const rankB = LINEAR_STATE_TYPE_RANK[b.issues[0]?.state.type ?? ''] ?? UNKNOWN_LINEAR_STATE_TYPE_RANK
+    return rankA - rankB || a.label.localeCompare(b.label)
+  })
+}
+


### PR DESCRIPTION
## What
Tasks → Linear → Issues → **Board** mode now shows status columns in workflow order (**Backlog … Done**) instead of the previous **Done → Backlog** artifact.

## Why
Board columns were rendered in the order their sections were *first inserted*, which followed the per-issue priority/`updatedAt` sort — so recently-touched **Done** issues landed before **Backlog**, hiding the intended left-to-right workflow.

## Root cause
`groupLinearIssues()` (`src/renderer/src/components/TaskPage.tsx`) returned `[...sections.values()]` directly from the insertion-order `Map`, discarding the workflow-state ordering the Linear API already returns sorted by `position`. This affected both the board and the grouped list (both call `groupLinearIssues`).

## Fix
- New `src/renderer/src/lib/linear-issue-grouping.ts` exports `orderLinearStatusSections()`, which sorts status sections by Linear workflow `state.type` rank (`backlog=0, started=1, completed=2, canceled=3`), tie-breaking alphabetically by label. Unknown types degrade safely (sorted after known ones). The function is generic over the section shape so it only depends on `state.type`.
- `groupLinearIssues()` now applies `orderLinearStatusSections()` **only when `groupBy === 'status'`** — assignee/priority/team/none groupings are untouched.
- `LinearGroupSection` moved to the new module and is re-imported in `TaskPage`.

## How to verify
Tasks → Linear → Issues → switch to **Board** mode → columns read left-to-right Backlog … Done. The grouped list view benefits from the same change.

## Tests
- New `linear-issue-grouping.test.ts` (6 cases): full ordering, the Done-before-Backlog regression repro, alphabetical tie-break, unknown-type fallback, non-mutation, empty list.
- Existing Linear suites stay green: `src/main/linear/teams.test.ts`, `linear-board-drag-payload.test.ts`, `linear-issue-context-snapshot.test.ts`, `linear-linked-work-item.test.ts` (27 tests).
- `pnpm run typecheck:web` clean; changed-file quality gate (`oxlint` + type-aware + react-doctor) reports 0 new findings.

No behavioral change for non-status groupings; no new data fetching.