### PR TITLE
docs: drop dangling preload-typecheck-hole references

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ If your change affects UI or interaction behavior, verify it on the platforms it
 
 Project-owned type declarations belong in `.ts` files. `.d.ts` is reserved for ambient shims (e.g., `env.d.ts`, `vite/client.d.ts`). TypeScript's `skipLibCheck: true` setting applies globally, including to our own `.d.ts` files, which means any unresolved type reference in a `.d.ts` silently becomes `any` at its call sites. Write your types in `.ts` files so the compiler actually checks them.
 
-CI enforces this for `src/preload/` and `src/shared/` — see `docs/preload-typecheck-hole.md`.
+CI enforces this for `src/preload/` and `src/shared/`.
 
 ## Pull Requests
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,14 +74,13 @@ jobs:
       # actually checks them. TypeScript's skipLibCheck: true (inherited
       # from @electron-toolkit/tsconfig) silently widens unresolved names
       # in .d.ts to `any`, which is how #1186 shipped a broken IPC signature
-      # past typecheck. See docs/preload-typecheck-hole.md.
+      # past typecheck.
       - name: Guard against project-owned .d.ts in preload/shared
         run: |
           matches=$(find src/preload src/shared -name '*.d.ts' 2>/dev/null || true)
           if [ -n "$matches" ]; then
             echo "::error::Project-owned .d.ts files are not allowed under src/preload or src/shared."
             echo "Move type declarations into a .ts file so skipLibCheck does not hide errors."
-            echo "See docs/preload-typecheck-hole.md."
             echo "Found:"
             echo "$matches"
             exit 1


### PR DESCRIPTION
## Summary

`docs/preload-typecheck-hole.md` was deleted in #1425 and is not committable under the `docs/**` .gitignore policy introduced in #2004 (it is not on the allow-list), so three tracked references to it resolved to nothing. This PR removes the dead pointers:

- `.github/CONTRIBUTING.md:55` — dropped the ` — see docs/preload-typecheck-hole.md` suffix
- `.github/workflows/pr.yml:77` — dropped the `See docs/preload-typecheck-hole.md.` comment suffix
- `.github/workflows/pr.yml:84` — removed the `echo "See docs/preload-typecheck-hole.md."` line from the CI failure block

The inline rationale at `pr.yml:73-76` and the `.d.ts` CI guard (`find src/preload src/shared`, `::error::`, `exit 1`) are unchanged.

This matches the maintainers' direction in #2004 (docs/** is ephemeral / local-only) — restoring the file as tracked would go against that policy, so removing the references is the fix.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — green; none of the gates lint `CONTRIBUTING.md` or `pr.yml`
- [x] `pnpm typecheck` — n/a (no TypeScript changed)
- [x] `pnpm test` — n/a (no behavior changed)
- [x] `pnpm build` — n/a (no code changed)
- [x] Tests not needed — pure prose/comment cleanup, no behavior change

Verified: `grep -rcF "docs/preload-typecheck-hole.md" .github/CONTRIBUTING.md .github/workflows/pr.yml` → `0` / `0`; `pr.yml` still parses as valid YAML; the `.d.ts` guard block is byte-identical apart from the removed `See docs/…` echo.

## AI Review Report

Docs/comment-only change. Reviewed explicitly for:
- **Cross-platform (macOS/Linux/Windows):** no code path touched — a prose line in CONTRIBUTING.md, a comment suffix, and one echo line in a CI workflow. N/A.
- **SSH/remote/local + folder-workspace:** no runtime surface touched. N/A.
- **Provider/agent neutrality:** no source-control or agent code touched. N/A.
- **Performance / hot path:** none. N/A.
- **UI quality:** no UI change. N/A.

## Security Audit

No code, IPC, auth, path, or dependency surface touched. The CI guard this sits next to (`find src/preload src/shared -name '*.d.ts'` → `::error::` → `exit 1`) is unchanged.

## Notes

- This is my first contribution to Orca — happy to adjust if you'd prefer a different approach.
- Driven by the dangling-reference cleanup the deleting PR #1425 flagged ("link should be updated separately") and the `docs/**` policy in #2004 made permanent.
- A maintainer may need to approve-and-run the CI workflows for this first fork-PR; let me know if anything else is needed from my side.
