### PR TITLE
fix(native-chat): drop stale version from the Claude opus picker label

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -356,7 +356,7 @@ describe('NativeChatComposer', () => {
     expect(mocks.createClaudeModelSwitchConfirmationObserver).toHaveBeenCalledWith({
       ptyId: 'pty-1',
       settings: {},
-      expectedModelLabel: 'Opus 4.8'
+      expectedModelLabel: 'Opus'
     })
     expect(onSwitchToTerminal).not.toHaveBeenCalled()
   })

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -74,7 +74,7 @@ export const CLAUDE_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     },
     {
       id: 'opus',
-      label: 'Opus 4.8',
+      label: 'Opus',
       options: [claudeEffort(true), CLAUDE_FAST_MODE]
     },
     {

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -19,6 +19,16 @@ describe('agent session option catalog', () => {
     expect(catalog?.models.find((model) => model.id === 'haiku')?.options).toEqual([])
   })
 
+  it('labels the opus entry without pinning a version', () => {
+    // Regression (#12084): `opus` resolves to whatever the CLI ships, so a
+    // version-pinned label goes stale — stay versionless like Haiku.
+    const label = getAgentSessionOptionCatalog('claude')?.models.find(
+      (model) => model.id === 'opus'
+    )?.label
+    expect(label).toBe('Opus')
+    expect(label).not.toMatch(/\d/)
+  })
+
   it('merges discovered labels while preserving cataloged option shapes', () => {
     const seed = getAgentSessionOptionCatalog('cursor')!.models
     const merged = mergeCatalogModels(seed, [


### PR DESCRIPTION
## Summary

The Claude model picker catalog hardcodes the `opus` entry's label as `Opus 4.8`, but the `opus` id resolves via the CLI to `claude-opus-5` — so the label is stale and reads as "Orca doesn't support Opus 5 yet". This is the only 4.8 leftover in the Claude path (`MODEL_PRICING` and the alias resolver are already Opus 5-aware).

Make the label versionless (`Opus`), mirroring the existing `Haiku` entry, so the next Opus rename doesn't re-stale it. Fixes #12084.

Changes:
- `src/shared/agent-session-option-catalog-claude-codex.ts:77` — `label: 'Opus 4.8'` → `label: 'Opus'` (1 line).
- `src/shared/agent-session-option-catalog.test.ts` — new regression test asserting the opus label is `'Opus'` and contains no digit (fails on any version-pinned string).
- `src/renderer/src/components/native-chat/NativeChatComposer.test.tsx:359` — update `expectedModelLabel` from `'Opus 4.8'` to `'Opus'`. This existing test asserts the catalog label that the composer surfaces to the user, so it had pinned the stale value; it is part of the same change, not a drive-by.

The Cursor-provider catalog (`agent-session-option-catalog-gemini-cursor.ts:89`, `label: 'Claude Opus 4.8'`, `id: 'claude-opus-4-8'`) is intentionally left alone — that is a different provider where the model id literally is `claude-opus-4-8`, so its label is correct.

## Screenshots

No visual change. (The opus row's label text changes from "Opus 4.8" to "Opus"; no layout or interaction change.)

## Testing

- [x] `pnpm test` — the catalog suite is green; the full run has 5 pre-existing failures unrelated to this change (verified by stashing the diff and re-running on clean `main` — the same 5 fail). No new failures introduced.
- [x] `pnpm typecheck` — green (node + web project references).
- [x] `pnpm lint` — green.
- [x] Added a high-quality, regression-catching test.

The new test was written first and confirmed **red on pre-fix code** (`label === 'Opus 4.8'` fails both `toBe('Opus')` and `not.toMatch(/\d/)`), then **green after the fix**. Mutation-checked: flipping the label back to a versioned string (e.g. `Opus 5`) re-triggers the failure, so the guard is real.

## AI Review Report

One-line display-string change + one regression test + one fixture update. Reviewed explicitly for:
- **Cross-platform (macOS/Linux/Windows):** a catalog label string surfaced in the picker UI; no platform-specific path. N/A.
- **SSH/remote/local + folder-workspace:** no runtime surface. N/A.
- **Provider/agent neutrality:** change is Claude-catalog-only; the Cursor provider's correct `claude-opus-4-8` label is deliberately untouched.
- **Performance / hot path:** none. N/A.
- **UI quality:** label text only; no layout/token change.

## Security Audit

No code, IPC, auth, path, or dependency surface touched — a display string in a static option catalog.

## Notes

- 3 files rather than 1 because `NativeChatComposer.test.tsx` had pinned the old label as the expected display value the composer surfaces; updating it is part of the same fix.
- This is my second contribution to Orca; happy to adjust if you'd prefer the label derived from the resolved model id at runtime instead of a static versionless string (the reporter's preferred minimal fix matches the existing `Haiku` precedent, which is what I went with).
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.
