### PR TITLE
fix(terminal): disarm mouse tracking when seeding a session over a dead one (#12101)

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2432,6 +2432,58 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       })
     })
 
+    it('disarms mouse tracking in the cold-restore seed so a fresh shell does not echo motion (#12101)', async () => {
+      const sessionId = 'cold-restore-mouse-disarm'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/projects/agent',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-07-25T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      // A dead agent session that armed any-motion + SGR mouse for its TUI and
+      // was killed before it could disarm them.
+      writeFileSync(
+        join(sessionDir, 'checkpoint.json'),
+        JSON.stringify({
+          snapshotAnsi: 'user@host:~$ ',
+          scrollbackAnsi: '',
+          rehydrateSequences: '\x1b[?1003h\x1b[?1006h',
+          cwd: '/projects/agent',
+          cols: 80,
+          rows: 24,
+          modes: {
+            bracketedPaste: false,
+            mouseTracking: true,
+            mouseTrackingMode: 'any',
+            sgrMouseMode: true,
+            applicationCursor: false,
+            alternateScreen: false
+          },
+          scrollbackLines: 0,
+          generation: 0,
+          checkpointedAt: '2026-07-25T10:00:00Z'
+        })
+      )
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+
+      const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+
+      expect(result.coldRestore?.scrollback).toContain('user@host:~$')
+      // The disarm must follow the re-armed enable so the net state is off.
+      const scrollback = result.coldRestore!.scrollback
+      expect(scrollback.lastIndexOf('\x1b[?1003l')).toBeGreaterThan(
+        scrollback.lastIndexOf('\x1b[?1003h')
+      )
+      expect(scrollback).toContain('\x1b[?1006l')
+    })
+
     it('uploads a large cold-restore seed in bounded protocol chunks', async () => {
       const sessionId = 'chunked-cold-restore'
       const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -15,6 +15,10 @@ import {
 } from './history-manager'
 import { HistoryReader, type ColdRestoreInfo } from './history-reader'
 import { getRecoveredHistorySeedSegments } from './terminal-history-seed-segments'
+import {
+  DISARM_MOUSE_TRACKING_SEQUENCE,
+  restoreHasMouseTrackingArmed
+} from './terminal-mode-rehydrate-sequences'
 import { mintPtySessionId, parsePtySessionId } from './pty-session-id'
 import { supportsPtyStartupBarrier } from './shell-ready'
 import { CODEX_SHELL_READY_TIMEOUT_MS } from './session'
@@ -1074,7 +1078,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return null
     }
     return {
-      scrollback,
+      // Why the disarm suffix: this seeds a fresh main-runtime emulator that
+      // replaces a dead session (cold restore after relaunch). Its content can
+      // carry the dead session's mouse-tracking DECSET, which would echo raw
+      // SGR motion bytes into the new shell on every pointer move (#12101).
+      scrollback: restoreHasMouseTrackingArmed(restoreInfo.modes)
+        ? scrollback + DISARM_MOUSE_TRACKING_SEQUENCE
+        : scrollback,
       cwd: restoreInfo.cwd,
       cols: restoreInfo.cols,
       rows: restoreInfo.rows,

--- a/src/main/daemon/repro-12101-seeded-session-mouse-tracking.test.ts
+++ b/src/main/daemon/repro-12101-seeded-session-mouse-tracking.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { Session } from './session'
+import { HeadlessEmulator } from './headless-emulator'
+import { coldRestoreInfoFromSnapshot } from './terminal-history-cold-restore-info'
+import { getRecoveredHistorySeedSegments } from './terminal-history-seed-segments'
+import { DISARM_MOUSE_TRACKING_SEQUENCE } from './terminal-mode-rehydrate-sequences'
+import type { SessionMeta } from './terminal-history-metadata'
+import type { ColdRestoreInfo } from './terminal-history-cold-restore-info'
+
+// Repro/regression for #12101: a session that dies with mouse tracking armed
+// (Claude Code's own TUI, vim, tmux, ...) leaves that mode mirrored in its
+// last checkpoint. When a later session is created in its place and seeded
+// from that checkpoint (the `historySeedChunks` path used to restore
+// scrollback into a freshly spawned shell after e.g. workspace Sleep
+// force-kills the old PTY, see #11160), the new session must not inherit
+// mouse tracking — its own real subprocess never requested it, and nothing
+// would consume the SGR motion reports xterm.js starts sending on every
+// pointer move otherwise. Before the fix, the seed's own content (xterm's
+// SerializeAddon embeds the DECSET the dead session had armed directly in
+// snapshotAnsi/scrollbackAnsi, not just in rehydrateSequences) left the new
+// session's mirrored mode stuck on.
+
+const meta: SessionMeta = { cwd: '/home/user' } as SessionMeta
+
+function createMockSubprocess() {
+  let onExit: ((code: number) => void) | null = null
+  return {
+    pid: 12345,
+    write() {},
+    resize() {},
+    pause() {},
+    resume() {},
+    clear() {},
+    kill() {
+      onExit?.(0)
+    },
+    forceKill() {},
+    signal() {},
+    getForegroundProcess() {
+      return null
+    },
+    onData() {},
+    onExit(cb: (code: number) => void) {
+      onExit = cb
+    },
+    dispose() {}
+  }
+}
+
+function coldRestoreInfoFrom(write: (emu: HeadlessEmulator) => void): ColdRestoreInfo {
+  const emu = new HeadlessEmulator({ cols: 80, rows: 24 })
+  write(emu)
+  const snapshot = emu.getSnapshot({ scrollbackRows: 0 })
+  emu.dispose()
+  return coldRestoreInfoFromSnapshot(snapshot, null, meta)
+}
+
+describe('#12101 seeded session does not inherit stale mouse tracking', () => {
+  let session: Session | undefined
+
+  afterEach(() => {
+    session?.dispose()
+    session = undefined
+  })
+
+  it('does not arm mouse tracking on a freshly created session seeded from a dead agent checkpoint', () => {
+    // The dead session: Claude Code armed any-motion + SGR mouse for its own
+    // TUI and was killed (idle timeout / Sleep) before it could disarm them.
+    const restoreInfo = coldRestoreInfoFrom((emu) => {
+      emu.write('\x1b[?1003h\x1b[?1006h')
+      emu.write('user@host:~$ ')
+    })
+    expect(restoreInfo.modes.mouseTracking).toBe(true)
+
+    const seedSegments = getRecoveredHistorySeedSegments(restoreInfo)
+    const seed = seedSegments.join('')
+    // The dead session's enable sequence is still in the recovered content
+    // (SerializeAddon bakes it into snapshotAnsi) but the seed now disarms
+    // it afterward, so a session built from these exact bytes ends up off.
+    expect(seed).toContain('\x1b[?1003h')
+    expect(seed.lastIndexOf('\x1b[?1003l')).toBeGreaterThan(seed.lastIndexOf('\x1b[?1003h'))
+    expect(seedSegments).toContain(DISARM_MOUSE_TRACKING_SEQUENCE)
+
+    // A brand new session (new PID, plain shell) seeded with that history,
+    // exactly like the daemon does when it re-creates a pane's PTY.
+    session = new Session({
+      sessionId: 'wake-replacement-session',
+      cols: 80,
+      rows: 24,
+      subprocess: createMockSubprocess(),
+      shellReadySupported: false,
+      historySeedChunks: seedSegments
+    })
+
+    const snapshot = session.getSnapshot()
+    expect(snapshot?.modes.mouseTracking).toBe(false)
+
+    // The scrollback content itself (the prompt text) still restores.
+    expect(seed).toContain('user@host:~$')
+  })
+
+  it('does not carry mouse tracking forward when the dead checkpoint had none armed', () => {
+    const restoreInfo = coldRestoreInfoFrom((emu) => emu.write('user@host:~$ '))
+    expect(restoreInfo.modes.mouseTracking).toBe(false)
+
+    session = new Session({
+      sessionId: 'wake-replacement-session-clean',
+      cols: 80,
+      rows: 24,
+      subprocess: createMockSubprocess(),
+      shellReadySupported: false,
+      historySeedChunks: getRecoveredHistorySeedSegments(restoreInfo)
+    })
+
+    expect(session.getSnapshot()?.modes.mouseTracking).toBe(false)
+  })
+
+  it('disarms mouse tracking left armed in alternate-screen content too', () => {
+    // vim/tmux-style TUIs run in the alt screen; that branch of
+    // getRecoveredHistorySeedSegments used to skip rehydrateSequences
+    // entirely, but SerializeAddon still embeds the DECSET in the alt
+    // buffer's own serialized content.
+    const restoreInfo = coldRestoreInfoFrom((emu) => {
+      emu.write('\x1b[?1049h\x1b[?1000h')
+      emu.write(':wq')
+    })
+    expect(restoreInfo.modes.alternateScreen).toBe(true)
+    expect(restoreInfo.modes.mouseTracking).toBe(true)
+
+    session = new Session({
+      sessionId: 'wake-replacement-session-altscreen',
+      cols: 80,
+      rows: 24,
+      subprocess: createMockSubprocess(),
+      shellReadySupported: false,
+      historySeedChunks: getRecoveredHistorySeedSegments(restoreInfo)
+    })
+
+    expect(session.getSnapshot()?.modes.mouseTracking).toBe(false)
+  })
+
+  it('keeps the dangling partial-escape tail as the last seed segment, after the disarm', () => {
+    // Bug E / #7329: a mid-escape tail must stay last so the new subprocess's
+    // own first live bytes complete it, not the disarm sequence.
+    const emu = new HeadlessEmulator({ cols: 80, rows: 24 })
+    emu.write('\x1b[?1003h')
+    emu.write('prompt$ ')
+    emu.write('\x1b[3') // dangling partial SGR, no continuation ever arrives
+    const snapshot = emu.getSnapshot({ scrollbackRows: 0 })
+    emu.dispose()
+    expect(snapshot.pendingEscapeTailAnsi).toBe('\x1b[3')
+
+    const restoreInfo = coldRestoreInfoFromSnapshot(snapshot, null, meta)
+    const seedSegments = getRecoveredHistorySeedSegments(restoreInfo)
+    expect(seedSegments.at(-1)).toBe('\x1b[3')
+    // The disarm still lands, before the tail.
+    const disarmIndex = seedSegments.indexOf(DISARM_MOUSE_TRACKING_SEQUENCE)
+    expect(disarmIndex).toBeGreaterThanOrEqual(0)
+    expect(disarmIndex).toBeLessThan(seedSegments.length - 1)
+  })
+
+  it('preserves a tail-only normal restore without dropping the seed (#7329)', () => {
+    // A normal-screen checkpoint whose only content is a dangling escape:
+    // snapshotAnsi and rehydrateSequences are empty. The seed must still carry
+    // the tail so the next live bytes complete it. No disarm is added because
+    // nothing in the seed armed mouse tracking.
+    const restoreInfo: ColdRestoreInfo = {
+      snapshotAnsi: '',
+      scrollbackAnsi: '',
+      rehydrateSequences: '',
+      cwd: '/home/user',
+      cols: 80,
+      rows: 24,
+      modes: {
+        alternateScreen: false,
+        applicationCursor: false,
+        bracketedPaste: false,
+        mouseTracking: false
+      },
+      pendingEscapeTailAnsi: '\x1b[3'
+    }
+    const seedSegments = getRecoveredHistorySeedSegments(restoreInfo)
+    expect(seedSegments).toEqual(['\x1b[3'])
+    expect(seedSegments).not.toContain(DISARM_MOUSE_TRACKING_SEQUENCE)
+  })
+
+  it('does not append an escape tail from a discarded alternate-screen frame', () => {
+    // The alt-screen branch restores only the normal buffer; a mid-escape tail
+    // belongs to the discarded dead-TUI frame and must not leak into the fresh
+    // shell where its next bytes would complete the stale sequence.
+    const restoreInfo: ColdRestoreInfo = {
+      snapshotAnsi: 'alt frame body',
+      scrollbackAnsi: 'normal buffer$ ',
+      rehydrateSequences: '\x1b[?1049h\x1b[?1000h',
+      cwd: '/home/user',
+      cols: 80,
+      rows: 24,
+      modes: {
+        alternateScreen: true,
+        applicationCursor: false,
+        bracketedPaste: false,
+        mouseTracking: true,
+        mouseTrackingMode: 'vt200'
+      },
+      pendingEscapeTailAnsi: '\x1b[3'
+    }
+    const seedSegments = getRecoveredHistorySeedSegments(restoreInfo)
+    expect(seedSegments).toEqual(['normal buffer$ ', DISARM_MOUSE_TRACKING_SEQUENCE])
+    expect(seedSegments).not.toContain('\x1b[3')
+  })
+})

--- a/src/main/daemon/terminal-history-seed-segments.ts
+++ b/src/main/daemon/terminal-history-seed-segments.ts
@@ -1,13 +1,35 @@
 import type { ColdRestoreInfo } from './terminal-history-cold-restore-info'
+import {
+  DISARM_MOUSE_TRACKING_SEQUENCE,
+  restoreHasMouseTrackingArmed
+} from './terminal-mode-rehydrate-sequences'
 
 export function getRecoveredHistorySeedSegments(restoreInfo: ColdRestoreInfo): readonly string[] {
+  const disarmMouse = restoreHasMouseTrackingArmed(restoreInfo.modes)
   if (restoreInfo.modes.alternateScreen) {
+    // Why only the normal buffer (and no escape tail): the dead TUI's alt
+    // frame and any mid-escape tail it left belong to a process that is gone;
+    // restoring them into the fresh shell would corrupt its first live bytes.
     const normalBuffer = restoreInfo.scrollbackAnsi || restoreInfo.snapshotAnsi
-    return normalBuffer ? [normalBuffer] : []
+    if (!normalBuffer) {
+      return []
+    }
+    // Why the disarm: SerializeAddon can bake the dead session's mouse-tracking
+    // DECSET into the restored content, so the new shell would echo raw SGR
+    // motion bytes on every pointer move without it (#12101).
+    return disarmMouse ? [normalBuffer, DISARM_MOUSE_TRACKING_SEQUENCE] : [normalBuffer]
   }
+  const body = [restoreInfo.rehydrateSequences, restoreInfo.snapshotAnsi].filter(
+    (segment) => segment.length > 0
+  )
   return [
-    restoreInfo.rehydrateSequences,
-    restoreInfo.snapshotAnsi,
+    ...body,
+    // Why gated on body: an empty body seeded no enable to undo, and nothing
+    // may precede a lone escape tail.
+    ...(disarmMouse && body.length > 0 ? [DISARM_MOUSE_TRACKING_SEQUENCE] : []),
+    // Why the tail stays last, even when body is empty: it's a dangling
+    // partial escape the live subprocess's own next bytes must complete
+    // (#7329); anything after it would be consumed by the dangling sequence.
     ...(restoreInfo.pendingEscapeTailAnsi ? [restoreInfo.pendingEscapeTailAnsi] : [])
-  ].filter((segment) => segment.length > 0)
+  ]
 }

--- a/src/main/daemon/terminal-mode-rehydrate-sequences.ts
+++ b/src/main/daemon/terminal-mode-rehydrate-sequences.ts
@@ -1,5 +1,23 @@
 import type { TerminalModes } from './types'
 
+// Disarms every mouse-tracking protocol + SGR encoding a snapshot can re-arm
+// (9/1000/1002/1003 + 1006/1016). Appended after content that seeds a
+// brand-new session/emulator replacing a dead one (workspace Sleep, cold
+// restore into a fresh runtime): that process never asked for mouse reports,
+// so a plain shell left armed echoes raw SGR motion bytes on every pointer
+// move (#12101). Must NOT be used on a live-session reattach, where the
+// running agent legitimately owns mouse tracking.
+export const DISARM_MOUSE_TRACKING_SEQUENCE =
+  '\x1b[?9l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1016l'
+
+// True when a restored snapshot had any mouse-tracking protocol or SGR mouse
+// encoding armed — the only case where seeded content can carry an enable that
+// a fresh session would otherwise keep (#12101). Legacy scrollback restores
+// hardcode these off, so they pass through untouched.
+export function restoreHasMouseTrackingArmed(modes: TerminalModes): boolean {
+  return modes.mouseTracking || modes.sgrMouseMode === true || modes.sgrMousePixelsMode === true
+}
+
 // Why no kitty flags here: rehydrateSequences feeds renderer xterms, and
 // POST_REPLAY_REATTACH_RESET's deliberate kitty reset (stale CSI-u Ctrl+C
 // hazard) must stay authoritative. modes.kittyKeyboardFlags exists for


### PR DESCRIPTION
## What this fixes

Fixes #12101.

If you leave Orca idle and a Claude Code session (or vim, tmux, htop, any TUI that arms terminal mouse tracking) gets torn down while the app is asleep, then come back, the pane can be replaced by a bare shell that echoes raw mouse escape codes. Every time you move the mouse over that pane it prints garbage like `^[[<35;80;24M` into the prompt. The only recovery today is recreating the terminal, which loses the session.

## Root cause

A TUI arms mouse tracking via DECSET (`?1000h`/`?1002h`/`?1003h` + SGR `?1006h`/`?1016h`). Orca mirrors that mode into the session's `TerminalModes` (xterm's headless build doesn't expose it) and persists it in the checkpoint. When the process dies without a clean shutdown — workspace Sleep force-kills it, or the app relaunches and cold-restores — nothing ever resets the mode. The kill path sends SIGKILL / `taskkill`, so the dying process never gets to emit its own disarm.

The stale enable then rides the recovered content into a brand new PTY through two seed paths:

- `getRecoveredHistorySeedSegments` — the daemon `historySeedChunks` path (Sleep replaces the PTY in place)
- `buildColdRestorePayload` → `seedHeadlessTerminal` — the cold-restore-after-relaunch path

The new shell's emulator mirrors the enable from the seeded bytes and starts reporting mouse motion that nothing consumes.

This mirrors an existing, deliberate omission in the codebase: `buildRehydrateSequences` already strips kitty keyboard flags from seeds for the same reseed-parity reason. Mouse tracking was the same category, missing the same guard.

## The fix

Append a mouse-tracking disarm (`?9l?1000l?1002l?1003l?1006l?1016l`) after seeded content on both paths, gated on the restored modes actually having mouse tracking armed (`restoreHasMouseTrackingArmed`). Legacy scrollback restores and clean sessions pass through untouched.

Two restore contracts are preserved:
- **#7329 escape tail**: the disarm lands *before* any dangling partial escape, so the live subprocess's next bytes still complete the tail.
- **Alternate-screen**: the alt branch still restores only the normal buffer and no longer leaks the discarded TUI frame's escape tail.

A live-session reattach is untouched — a genuinely running agent keeps owning mouse tracking (mobile scroll gestures, OpenCode/OpenTUI panes).

## Tests

- `repro-12101-seeded-session-mouse-tracking.test.ts` (new): drives real `HeadlessEmulator` + `Session` through the `historySeedChunks` path; covers armed→disarmed, clean→untouched, alternate-screen, tail-only-restore (#7329), and disarm-before-tail ordering.
- `daemon-pty-adapter.test.ts`: added an integration test that writes an armed checkpoint to disk and asserts `spawn().coldRestore.scrollback` disarms the mode through the real cold-restore spawn path.

Full `src/main/daemon` suite: 1228 passing. `pnpm lint`, `pnpm typecheck`, `pnpm build` all pass.

## No visual change

No UI changes. This only affects the byte stream seeded into a restored terminal.

## AI coding agent review summary

- **Cross-platform**: the seed assembly (`terminal-history-seed-segments.ts`, `buildColdRestorePayload`) has no `process.platform` branching. The only OS-specific code is the kill mechanism (POSIX signals vs. `taskkill`), which is unchanged. Fix applies identically to macOS, Linux, Windows.
- **SSH / remote / local**: the affected paths are daemon-side cold-restore/seed logic shared by local, remote-server, and SSH sessions. The disarm is plain DECSET bytes with no host assumptions.
- **Agent / integration compatibility**: provider-neutral. Triggered by any TUI that arms mouse tracking (Claude Code, Codex, vim, tmux); no agent-specific branching. Live-agent reattach is explicitly not touched.
- **Performance**: adds at most one short constant string to a seed that only runs on session restore (not a hot path); gated so unarmed sessions allocate nothing extra.
- **Security**: no new inputs, no shell execution, no credential/path handling. Emits a fixed control sequence.
- **UI quality**: N/A (no visual change).

## Testing notes

Reproduces on any platform: run a mouse-tracking TUI, let its process die while backgrounded (workspace Sleep, or force-kill + relaunch), return to the pane. Before the fix the restored shell echoes `^[[<...M` on pointer movement; after, it doesn't. Live sessions still scroll/click normally.

X handle: Seeun Park (@chappse6)


