### PR TITLE
test(usage): align cached-render benchmark with the CI-loose sibling convention

### DIFF
--- a/src/renderer/src/store/slices/usage-snapshot-refresh.benchmark.test.ts
+++ b/src/renderer/src/store/slices/usage-snapshot-refresh.benchmark.test.ts
@@ -118,7 +118,13 @@ describe('Codex usage cached snapshot benchmark', () => {
     expect(store.getState().codexUsageSummary?.totalTokens).toBe(100)
     const cachedRenderMs = performance.now() - startedAt
 
-    expect(cachedRenderMs).toBeLessThan(10)
+    // Why CI-loose: full-suite CI runs this cached-render bench beside thousands of
+    // tests on shared runners, so the 10ms budget from #4528 (~5ms cached path on a
+    // warm local disk) trips on scheduling contention. Match the same-domain sibling
+    // store-snapshot.benchmark.test.ts (1s) and the terminal-history-async-delete CI
+    // idiom — 1s still flags accidental scan-like fan-out, which is all this guards;
+    // the structural totalTokens assertion below is the real correctness proof.
+    expect(cachedRenderMs).toBeLessThan(process.env.CI ? 1_000 : 10)
     expect(refresh).toHaveBeenCalledTimes(1)
     expect(getSnapshot).toHaveBeenCalledTimes(1)
 

--- a/src/renderer/src/store/slices/usage-snapshot-refresh.benchmark.test.ts
+++ b/src/renderer/src/store/slices/usage-snapshot-refresh.benchmark.test.ts
@@ -123,7 +123,7 @@ describe('Codex usage cached snapshot benchmark', () => {
     // warm local disk) trips on scheduling contention. Match the same-domain sibling
     // store-snapshot.benchmark.test.ts (1s) and the terminal-history-async-delete CI
     // idiom — 1s still flags accidental scan-like fan-out, which is all this guards;
-    // the structural totalTokens assertion below is the real correctness proof.
+    // the structural totalTokens assertion above is the real correctness proof.
     expect(cachedRenderMs).toBeLessThan(process.env.CI ? 1_000 : 10)
     expect(refresh).toHaveBeenCalledTimes(1)
     expect(getSnapshot).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

The cached-render benchmark `usage-snapshot-refresh.benchmark.test.ts` guards its perf with a hard-coded `expect(cachedRenderMs).toBeLessThan(10)`. That 10ms budget came from #4528, which measured the new cached snapshot path at ~5.26ms on a warm local disk and set 10ms as a ~2x development-time headroom. It is the only benchmark guard in the repo at that tightness, and it is a latent CI flake: a shared CI runner executing the full suite beside thousands of other tests can stall even a sub-millisecond cached path past 10ms.

The same-domain sibling benchmark — `src/main/codex-usage/store-snapshot.benchmark.test.ts`, the main-process counterpart of this renderer cached-snapshot path — already uses `toBeLessThan(1_000)` with an explicit comment that "full-suite CI runs this beside thousands of tests on shared runners ... [keep] a coarse guard so this catches accidental scan-like work without treating runner contention as a product regression." The CI-loose idiom is also codified in `terminal-history-async-delete.test.ts` (`process.env.CI || win32 ? 1_000 : 100`).

Make this renderer outlier consistent: keep the tight 10ms guard for local/non-CI runs (so #4528's development-time regression catch is preserved) and use a loose 1s bound only under CI. The structural assertion (`totalTokens` === 100, i.e. the cached path returns persisted data before refresh) is untouched and remains the real correctness check; the perf bound only flags accidental scan-like fan-out.

Changes:
- `src/renderer/src/store/slices/usage-snapshot-refresh.benchmark.test.ts:121` — `expect(cachedRenderMs).toBeLessThan(10)` → `expect(cachedRenderMs).toBeLessThan(process.env.CI ? 1_000 : 10)`, with a `// Why` comment citing the sibling.

One file, one assertion line (+ comment). No production code touched.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/store/slices/usage-snapshot-refresh.benchmark.test.ts` (green; without `CI` set the local 10ms branch still applies and passes).
- `CI=1` run of the same file FAILS at the assertion when the CI branch is mutated to `0`, proving the CI branch is exercised and the bound is real (not a no-op).
- `pnpm typecheck` green.
- `pnpm lint` green on the change.

The full `pnpm test` baseline has 3 pre-existing `check-root-directory-entries` failures that are unrelated worktree-meta artifacts (the root-directory guard runs green in CI; locally a non-clean checkout trips it) — verified to pre-exist on clean main and not caused by this change.

No new test was added: this PR makes an existing benchmark guard CI-safe; the guard itself is the regression catcher, and its mutation-leg proves it still bites.

## AI Review Report

Test-only change to a single benchmark assertion's perf bound. Reviewed explicitly for:
- **Cross-platform (macOS/Linux/Windows):** the change reads `process.env.CI`, which GitHub Actions and the repo's own `terminal-history-async-delete.test.ts` already rely on the same way; no platform-specific path.
- **SSH/remote/local + folder-workspace:** no runtime surface; the SUT is unchanged.
- **Provider/agent neutrality:** N/A — usage-snapshot is provider-agnostic analytics.
- **Performance / hot path:** none in product code; the benchmark's structural correctness assertion is unchanged, so a real regression (cached path no longer returning persisted data) still fails loudly.
- **UI quality:** N/A.

## Security Audit

No code, IPC, auth, path, or dependency surface touched — one assertion bound in a test file.

## Notes

- **Empirical honesty:** I could not reproduce a failure locally — the cached path is sub-millisecond on a fast machine and passed 20/20 runs even under an 8-core CPU spin. This change is motivated by the codebase **convention** (the sibling `store-snapshot` already chose 1s precisely because shared-CI-runner contention makes a 10ms budget flake-prone), not by a locally-observed flake. The renderer sibling is the inconsistent outlier.
- Cites #4528 (added the benchmark and the 10ms bound) and the sibling `store-snapshot.benchmark.test.ts` (the convention source).
- If maintainers prefer a flat `1_000` (dropping the local 10ms development guard) instead of the CI-adaptive form, that is a one-line follow-up — happy to switch.
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.