### PR TITLE
test(emulator-paste): restore real timers between chunk-delay tests

### DIFF
--- a/src/renderer/src/components/emulator-pane/emulator-keyboard-paste.test.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-keyboard-paste.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildEmulatorKeyboardPastePlan,
   EMULATOR_KEYBOARD_PASTE_MAX_BYTES,
@@ -9,6 +9,12 @@ import {
 } from './emulator-keyboard-paste'
 
 describe('emulator keyboard paste', () => {
+  // Why: chunk-delay tests arm fake timers with no teardown; restore so the leak can't
+  // hang a later test. Sibling idiom: src/shared/pty-startup-ingress.test.ts.
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('splits accepted text into bounded keyboard-frame chunks', () => {
     const plan = buildEmulatorKeyboardPastePlan('ab\r\nc', { maxFramesPerChunk: 4 })
 


### PR DESCRIPTION
## Summary

`emulator-keyboard-paste.test.ts` arms `vi.useFakeTimers()` in the two chunk-delay tests (`sends chunks only after the previous chunk delay elapses`, `cancels before sending the next chunk`) but never restores, and the file has no `afterEach`. The repo's `config/vitest.config.ts` sets no `restoreMocks`/`setupFiles`, so those faked timers persist across every later `it()` in the file — a latent leak that would hang any future timer-dependent test added below them.

Add the same `afterEach(() => { vi.useRealTimers() })` idiom ~14 other test files in the repo already use (e.g. `src/shared/pty-startup-ingress.test.ts`, `src/renderer/src/components/right-sidebar/plugin-panel-watchdog.test.ts`, `src/renderer/src/components/terminal/physical-exit-tracker.test.ts`).

The leak is **latent** — no test is red today, because the trailing `reports target-unavailable` test happens to take a synchronous rejection path (`pasteTextIntoEmulatorKeyboard` returns before the only `window.setTimeout` in the SUT). It is mechanically real, though: a probe test that awaits a 50ms real `setTimeout` hangs to the 30s vitest timeout without the restore, and completes in ~0.5s with it.

Changes:
- `src/renderer/src/components/emulator-pane/emulator-keyboard-paste.test.ts` — import `afterEach`; add an `afterEach(() => { vi.useRealTimers() })` with a `// Why` comment at the top of the describe block.

One file, test-only. No SUT change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/emulator-pane/emulator-keyboard-paste.test.ts` — 9/9 green.
- **Red proof (the leak is real):** temporarily adding a probe `it()` that does `await new Promise(r => setTimeout(r, 50)); expect(elapsed).toBeGreaterThanOrEqual(40)` after the chunk-delay tests, with the `afterEach` body emptied, FAILS — the probe hangs to the 30000ms timeout because the leaked fake timers never advance the real `setTimeout`. Restoring the `afterEach` makes the same probe pass in ~0.5s. (The probe is not part of the committed diff.)
- **Mutation (the restore is load-bearing):** emptying only the `vi.useRealTimers()` call re-triggers the probe failure.
- `pnpm typecheck` green (all three projects; the file is renderer-side under the web config).
- `pnpm exec oxlint <file>` green.

No new durable test was added: the fix is test-hygiene that prevents a future hang; the red proof above demonstrates the mechanism but is removed before commit (a permanent probe would just re-test vitest's own timer behaviour).

## AI Review Report

Test-only change to one test file. Reviewed for:
- **Cross-platform (macOS/Linux/Windows):** no platform surface; vitest timer behaviour is platform-independent.
- **SSH/remote/local + folder-workspace:** no runtime surface; the SUT is unchanged.
- **Provider/agent neutrality:** N/A.
- **Performance / hot path:** none; `vi.useRealTimers()` in `afterEach` is the standard cheap teardown.
- **UI quality:** N/A.

## Security Audit

No code, IPC, auth, path, or dependency surface touched — one `afterEach` in a test file.

## Notes

- **Empirical honesty:** this is a latent leak, not a currently-failing test — the trailing test avoids it by taking a synchronous path. The fix is motivated by the codebase CONVENTION (~14 files use the same `afterEach(() => vi.useRealTimers())` idiom, and the vitest config has no auto-restore), and the red proof above shows the leak is mechanically real (a 50ms real-`setTimeout` probe hangs to the 30s timeout without the restore).
- Convention sources cited in the `// Why` comment: `pty-startup-ingress.test.ts`, `plugin-panel-watchdog.test.ts`.
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.