### PR TITLE
fix(notifications): open floating terminal when its notification is clicked

### DIFF
--- a/src/main/ipc/native-notification-delivery.ts
+++ b/src/main/ipc/native-notification-delivery.ts
@@ -5,6 +5,7 @@ import type {
   NotificationSettings
 } from '../../shared/notification-settings-types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 import { parsePaneKey } from '../../shared/stable-pane-id'
 import type { buildNotificationOptions } from './notification-options'
 import { getEffectiveNotificationSoundId } from './notification-sound-selection'
@@ -103,6 +104,26 @@ export function deliverNativeNotification(
           scrollToBottomIfOutputSinceLastView: true
         })
       }
+    }
+    notification.on('click', clickHandler)
+  } else if (args.worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    clickHandler = () => {
+      release()
+      const win = getTrustedUIRendererWindow()
+      if (!win || win.isDestroyed()) {
+        return
+      }
+      if (process.platform === 'darwin') {
+        app.focus({ steal: true })
+      }
+      if (win.isMinimized()) {
+        win.restore()
+      }
+      win.show()
+      win.focus()
+      // Why: open the floating terminal panel — the same `ui:toggleFloatingTerminal`
+      // channel the main window's toggleFloatingTerminal action sends.
+      win.webContents.send('ui:toggleFloatingTerminal')
     }
     notification.on('click', clickHandler)
   }

--- a/src/main/ipc/notifications-retention-lifecycle.test.ts
+++ b/src/main/ipc/notifications-retention-lifecycle.test.ts
@@ -29,6 +29,7 @@ vi.mock('../tray/system-tray', async () =>
 )
 
 import { registerNotificationHandlers } from './notifications'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 
 describe('registerNotificationHandlers', () => {
   beforeEach(() => {
@@ -103,6 +104,52 @@ describe('registerNotificationHandlers', () => {
       flashFocusedPane: true,
       scrollToBottomIfOutputSinceLastView: true
     })
+  })
+
+  it('opens the floating terminal when a floating-workspace notification is clicked', async () => {
+    const webContentsSend = vi.fn()
+    const restore = vi.fn()
+    const show = vi.fn()
+    const focus = vi.fn()
+    const mainWindow = {
+      isDestroyed: () => false,
+      isFocused: () => false,
+      isMinimized: () => true,
+      restore,
+      show,
+      focus,
+      webContents: { send: webContentsSend }
+    }
+    getAllWindowsMock.mockReturnValue([mainWindow] as never)
+    getTrustedUIRendererWindowMock.mockReturnValue(mainWindow)
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: true
+        }
+      })
+    } as never)
+
+    const handler = getDispatchHandler()
+    expect(
+      await handler({}, { source: 'agent-task-complete', worktreeId: FLOATING_TERMINAL_WORKTREE_ID })
+    ).toEqual({ delivered: true })
+    expect(vi.getTimerCount()).toBe(1)
+
+    getNotificationEventHandler('click')()
+
+    expect(restore).toHaveBeenCalledTimes(1)
+    expect(show).toHaveBeenCalledTimes(1)
+    expect(focus).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    // Why: release() must unregister the click handler so it can't leak; mirrors the repo-scoped sibling test.
+    expect(notificationRemoveListenerMock).toHaveBeenCalledWith('click', expect.any(Function))
+    expect(webContentsSend).toHaveBeenCalledWith('ui:toggleFloatingTerminal')
+    // Why: a floating notification must not pollute the repo-scoped main view.
+    expect(webContentsSend).not.toHaveBeenCalledWith('ui:activateWorktree', expect.anything())
   })
 
   it('clears the retained notification fallback timer when the native notification closes', async () => {


### PR DESCRIPTION
## Summary

Clicking a native notification that comes from the **Floating Workspace** (the global floating terminal) does nothing — Orca isn't even brought to the front. Every repo-scoped notification (`worktreeId = "repoId::worktreePath"`) already focuses its pane on click, but the floating terminal is skipped.

Root cause: in `src/main/ipc/notifications.ts` the click handler is bound only inside `if (args.worktreeId && args.worktreeId.includes('::')) { ... notification.on('click', clickHandler) }`. The floating terminal's worktree id is `FLOATING_TERMINAL_WORKTREE_ID` = `'global-floating-terminal'` (`src/shared/constants.ts`), which has no `::` separator, so the guard is false and **no click handler is bound at all**.

Fix: add an `else if (args.worktreeId === FLOATING_TERMINAL_WORKTREE_ID)` branch that reuses the existing focus-app/window preamble and sends the `ui:toggleFloatingTerminal` IPC channel — the same channel the main window's toggle action already sends (`src/main/window/createMainWindow.ts`, `src/main/browser/browser-guest-ui.ts`). The renderer already listens (`window.api.ui.onToggleFloatingTerminal` → dispatches `orca-toggle-floating-terminal`), so no renderer change is needed. Fixes #11965.

Changes:
- `src/main/ipc/notifications.ts` — import `FLOATING_TERMINAL_WORKTREE_ID`; add the `else if` click branch sending `ui:toggleFloatingTerminal`.
- `src/main/ipc/notifications.test.ts` — regression test mirroring the existing repo-scoped click test, asserting a floating-workspace notification focuses the window and sends `ui:toggleFloatingTerminal` (and does NOT send `ui:activateWorktree`, which would pollute the repo-scoped main view).

## Screenshots

No visual change in the notification itself; behaviour change is that clicking a floating-workspace notification now opens/focuses the floating terminal panel.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:
- New regression test added to `src/main/ipc/notifications.test.ts`, written FIRST and confirmed **red on pre-fix code** (no click handler bound for the floating id → `focus` not called / `ui:toggleFloatingTerminal` not sent), then **green after the fix**.
- Mutation: pointing the new branch at a wrong channel re-triggers the failure.
- Existing repo-scoped click-handler tests (`focuses the originating terminal pane when a notification with paneKey is clicked`, etc.) still pass.
- `pnpm typecheck` green (notifications.ts is main-process under the node tsconfig).
- `pnpm exec oxlint` green on both changed files.

## AI Review Report

One new click-handler branch in the main-process notification path. Reviewed for:
- **Cross-platform (macOS/Linux/Windows):** the focus preamble is copied verbatim from the existing repo-scoped branch — `app.focus({ steal: true })` runs only on macOS (guarded by `process.platform === 'darwin'`), `restore()`/`focus()` run on all. Same shape as the proven branch beside it.
- **SSH/remote/local + folder-workspace:** the floating terminal is a local-desktop surface; on a remote/headless host native notifications are not surfaced the same way, but the change only adds a click binding where none existed — no regression for other surfaces.
- **Provider/agent neutrality:** N/A — notification routing, not agent behaviour.
- **Performance / hot path:** none — runs only on a user click.
- **UI quality:** the click now opens the floating panel, matching the reporter's expectation and the behaviour of every other notification.

## Security Audit

The change sends one existing, renderer-side IPC channel (`ui:toggleFloatingTerminal`) that the app already trusts from its own main window; no new IPC surface, no untrusted input handling, no auth/path/dependency change. The worktree id is compared by strict equality to a constant.

## Notes

- The `ui:toggleFloatingTerminal` channel is the same one `createMainWindow.ts` and `browser-guest-ui.ts` already send — this PR routes a notification click through the identical, already-trusted path.
- The reporter of #11965 mentions a local patch but no PR was open against this click binding when this was filed (`gh pr list --search "11965"` / `"floating notification click"` / `"ui:toggleFloatingTerminal"` returned no fixing PR).
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.