### PR TITLE
feat(bitbucket): support Bitbucket Data Center for hosted-review status

### DIFF
--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -61,6 +61,8 @@ describe('Bitbucket client', () => {
     process.env.ORCA_BITBUCKET_EMAIL = 'user@example.com'
     process.env.ORCA_BITBUCKET_API_TOKEN = 'token'
     delete process.env.ORCA_BITBUCKET_ACCESS_TOKEN
+    delete process.env.ORCA_BITBUCKET_SERVER_URL
+    delete process.env.ORCA_BITBUCKET_SERVER_TOKEN
     gitExecFileAsyncMock.mockReset()
     gitExecFileAsyncMock.mockResolvedValue({
       stdout: 'git@bitbucket.org:team/repo.git\n',
@@ -329,7 +331,9 @@ describe('Bitbucket client', () => {
     await expect(getBitbucketAuthStatus()).resolves.toEqual({
       configured: true,
       authenticated: true,
-      account: 'bitbucket-user'
+      account: 'bitbucket-user',
+      baseUrl: 'https://api.test.local/2.0',
+      tokenConfigured: true
     })
   })
 
@@ -346,5 +350,210 @@ describe('Bitbucket client', () => {
 
     expect(fetchMock).toHaveBeenCalled()
     expect(cancelledBodies).toBe(fetchMock.mock.calls.length)
+  })
+
+  describe('Data Center', () => {
+    function serverPr(id = 7) {
+      return {
+        id,
+        title: 'Add Data Center',
+        state: 'OPEN',
+        updatedDate: Date.parse('2026-05-10T00:00:00.000Z'),
+        fromRef: { id: 'refs/heads/feature/dc', displayId: 'feature/dc', latestCommit: 'abc123' },
+        toRef: { id: 'refs/heads/main', displayId: 'main' }
+      }
+    }
+
+    beforeEach(() => {
+      process.env.ORCA_BITBUCKET_SERVER_URL = 'https://bb.corp.example/bitbucket'
+      process.env.ORCA_BITBUCKET_SERVER_TOKEN = 'pat-123'
+      gitExecFileAsyncMock.mockResolvedValue({
+        stdout: 'https://bb.corp.example/bitbucket/scm/PRJ/repo.git\n',
+        stderr: ''
+      })
+      _resetBitbucketRepoRefCache()
+    })
+
+    it('queries outgoing pull requests by fully-qualified ref and builds the web URL', async () => {
+      const fetchMock = vi.fn(async (url: URL, _init?: RequestInit) => {
+        if (String(url).includes('/build-status/')) {
+          return Response.json({ successful: 2 })
+        }
+        return Response.json({ values: [serverPr()], isLastPage: true })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(
+        getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/dc')
+      ).resolves.toEqual({
+        number: 7,
+        title: 'Add Data Center',
+        state: 'open',
+        url: 'https://bb.corp.example/bitbucket/projects/PRJ/repos/repo/pull-requests/7',
+        status: 'success',
+        updatedAt: '2026-05-10T00:00:00.000Z',
+        mergeable: 'UNKNOWN',
+        headSha: 'abc123'
+      })
+
+      const listUrl = new URL(String(fetchMock.mock.calls[0]?.[0]))
+      expect(listUrl.pathname).toBe('/bitbucket/rest/api/1.0/projects/PRJ/repos/repo/pull-requests')
+      expect(listUrl.searchParams.get('at')).toBe('refs/heads/feature/dc')
+      // Why: the API defaults to INCOMING, which returns PRs targeting the branch.
+      expect(listUrl.searchParams.get('direction')).toBe('OUTGOING')
+      expect(listUrl.searchParams.get('state')).toBe('ALL')
+      expect(
+        (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers as Record<string, string>
+      ).toMatchObject({ Authorization: 'Bearer pat-123' })
+
+      const statsUrl = new URL(String(fetchMock.mock.calls[1]?.[0]))
+      expect(statsUrl.pathname).toBe('/bitbucket/rest/build-status/1.0/commits/stats/abc123')
+    })
+
+    it('derives a failing rollup from aggregated build stats', async () => {
+      const fetchMock = vi.fn(async (url: URL) =>
+        String(url).includes('/build-status/')
+          ? Response.json({ successful: 1, failed: 1 })
+          : Response.json({ values: [serverPr()] })
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(
+        getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/dc')
+      ).resolves.toMatchObject({ status: 'failure' })
+    })
+
+    it('surfaces the Data Center error envelope instead of a bare status', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          Response.json({ errors: [{ message: 'Project PRJ does not exist.' }] }, { status: 404 })
+        )
+      )
+
+      await expect(
+        getBitbucketPullRequestForBranchOrThrow('/repo', 'refs/heads/feature/dc')
+      ).rejects.toThrow('Bitbucket request failed: Project PRJ does not exist.')
+    })
+
+    // Why: `Number(null)` is 0, so an absent Retry-After used to pass the
+    // wait-budget guard and retry a rate-limited request immediately.
+    it('does not retry a 429 that carries no Retry-After header', async () => {
+      const fetchMock = vi.fn(async (_url: URL, _init?: RequestInit) =>
+        Response.json({ errors: [{ message: 'Too many requests' }] }, { status: 429 })
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(
+        getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/dc')
+      ).resolves.toBeNull()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries once when a 429 carries a Retry-After inside the wait budget', async () => {
+      let call = 0
+      const fetchMock = vi.fn(async (url: URL) => {
+        if (String(url).includes('/build-status/')) {
+          return Response.json({ successful: 1 })
+        }
+        call += 1
+        return call === 1
+          ? new Response('{}', { status: 429, headers: { 'retry-after': '0' } })
+          : Response.json({ values: [serverPr()] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(
+        getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/dc')
+      ).resolves.toMatchObject({ number: 7 })
+      expect(call).toBe(2)
+    })
+
+    // Why: Number.isFinite admits epochs past ±8.64e15, where toISOString
+    // throws RangeError out of the mapper instead of yielding a review.
+    it('keeps an out-of-range updatedDate from throwing out of the mapper', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: URL) =>
+          String(url).includes('/build-status/')
+            ? Response.json({ successful: 1 })
+            : Response.json({ values: [{ ...serverPr(), updatedDate: 8.65e15 }] })
+        )
+      )
+
+      await expect(
+        getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/dc')
+      ).resolves.toMatchObject({ number: 7, updatedAt: '' })
+    })
+
+    // Why: preflight carries one Bitbucket status, so a stray server token must
+    // not blank the card of a working Cloud account. A configured site URL is an
+    // unambiguous "I run Data Center" and does take precedence.
+    it('keeps reporting Cloud when only a bare server token joins a Cloud setup', async () => {
+      delete process.env.ORCA_BITBUCKET_SERVER_URL
+      process.env.ORCA_BITBUCKET_SERVER_TOKEN = 'pat-123'
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => Response.json({ username: 'cloud-user' }))
+      )
+
+      await expect(getBitbucketAuthStatus()).resolves.toMatchObject({
+        account: 'cloud-user',
+        baseUrl: 'https://api.test.local/2.0'
+      })
+    })
+
+    it('lets a configured server site take precedence over Cloud credentials', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response('{"values":[]}', { status: 200, headers: { 'x-ausername': 'dc-user' } })
+        )
+      )
+
+      await expect(getBitbucketAuthStatus()).resolves.toMatchObject({
+        account: 'dc-user',
+        baseUrl: 'https://bb.corp.example/bitbucket'
+      })
+    })
+
+    it('reports auth status from /users with the account name off X-AUSERNAME', async () => {
+      const fetchMock = vi.fn(
+        async (_url: URL, _init?: RequestInit) =>
+          new Response('{"values":[]}', {
+            status: 200,
+            headers: { 'x-ausername': 'j.smith%40corp.example' }
+          })
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(getBitbucketAuthStatus()).resolves.toEqual({
+        configured: true,
+        authenticated: true,
+        account: 'j.smith@corp.example',
+        baseUrl: 'https://bb.corp.example/bitbucket',
+        tokenConfigured: true
+      })
+      expect(new URL(String(fetchMock.mock.calls[0]?.[0])).pathname).toBe(
+        '/bitbucket/rest/api/1.0/users'
+      )
+    })
+
+    it('reports an unauthenticated but reachable site when only a base URL is set', async () => {
+      delete process.env.ORCA_BITBUCKET_SERVER_TOKEN
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => Response.json({ version: '9.6.0' }))
+      )
+
+      await expect(getBitbucketAuthStatus()).resolves.toEqual({
+        configured: true,
+        authenticated: false,
+        account: null,
+        baseUrl: 'https://bb.corp.example/bitbucket',
+        tokenConfigured: false
+      })
+    })
   })
 })

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -1,186 +1,115 @@
-import type { CheckStatus } from '../../shared/github/pull-request-types'
 import {
-  deriveBitbucketBuildStatus,
-  mapBitbucketPullRequest,
+  fetchBitbucketCloudPullRequestById,
+  fetchBitbucketCloudPullRequestForBranch,
+  getBitbucketCloudAuthStatus,
+  hasCloudCredentials,
+  normalizeBitbucketCloudPullRequest
+} from './cloud-client'
+import {
   mapBitbucketPullRequestState,
   type BitbucketPullRequestInfo,
-  type RawBitbucketBuildStatus,
   type RawBitbucketPullRequest
 } from './pull-request-mappers'
-import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
 import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
+import {
+  getBitbucketRepoRef,
+  type BitbucketCloudRepoRef,
+  type BitbucketRepoRef,
+  type BitbucketServerRepoRef
+} from './repository-ref'
 import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
-import { cancelUnreadResponseBody } from '../lib/unread-response-body'
-import { authHeaders, getEnvAuthConfig, hasAuth } from './bitbucket-auth-config'
-import { accountNameFromUser, fetchBitbucketUserResult } from './user-request'
+import { getBitbucketServerConfig } from './server-config'
 import {
-  getStoredBitbucketCredentialError,
-  getStoredBitbucketMetadata,
-  hasStoredBitbucketCredential,
-  loadStoredBitbucketSecret
-} from './credential-store'
-import { resolveBitbucketAuthConfig, storedAuthConfig } from './resolve-auth'
-
-const REQUEST_TIMEOUT_MS = 5000
-const ALL_PULL_REQUEST_STATES = ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'] as const
+  fetchBitbucketServerPullRequestById,
+  fetchBitbucketServerPullRequestForBranch,
+  getBitbucketServerAuthStatus,
+  normalizeBitbucketServerPullRequest
+} from './server-client'
+import {
+  mapBitbucketServerPullRequestState,
+  type RawBitbucketServerPullRequest
+} from './server-pull-request-mappers'
 
 export type BitbucketAuthStatus = {
   configured: boolean
   authenticated: boolean
   account: string | null
+  /** Data Center site base URL, or the Cloud API override when one is set. */
+  baseUrl: string | null
+  tokenConfigured: boolean
 }
 
-type RequestOptions = {
-  searchParams?: Record<string, string | readonly string[]>
-  timeoutMs?: number
-}
+/** Raw payload paired with the ref that produced it, so the Cloud and Data
+ *  Center shapes stay type-safe through the shared lookup flow. */
+type PullRequestCandidate =
+  | { kind: 'cloud'; repo: BitbucketCloudRepoRef; raw: RawBitbucketPullRequest }
+  | { kind: 'server'; repo: BitbucketServerRepoRef; raw: RawBitbucketServerPullRequest }
 
-function isStringArray(value: string | readonly string[]): value is readonly string[] {
-  return Array.isArray(value)
-}
-
-function apiUrl(
-  baseUrl: string,
-  path: string,
-  searchParams?: RequestOptions['searchParams']
-): string {
-  const base = baseUrl.replace(/\/+$/, '')
-  const url = new URL(`${base}${path}`)
-  if (searchParams) {
-    for (const [key, value] of Object.entries(searchParams)) {
-      if (isStringArray(value)) {
-        for (const item of value) {
-          url.searchParams.append(key, item)
-        }
-      } else {
-        url.searchParams.set(key, value)
-      }
-    }
-  }
-  return url.toString()
-}
-
-async function requestJson<T>(
-  path: string,
-  options: RequestOptions = {},
-  // Why: the existing-review lookup behind Create must distinguish a real
-  // transport/auth failure from an accepted "no PR". When true, a failed request
-  // throws instead of collapsing to null so callers never report false not_found.
-  throwOnFailure = false,
-  // Why: a linked PR number can be stale (deleted PR, wrong repo). A 404 there
-  // must fall through to the branch lookup rather than throw and hide the
-  // branch's real review, so only that caller opts into it.
-  notFoundIsNull = false
-): Promise<T | null> {
-  const config = resolveBitbucketAuthConfig()
-  // Why: a denied keychain prompt leaves no usable credential. Issuing the
-  // request anyway gets a 404 on private repos, which reads as "no pull
-  // request" and offers Create for a branch that already has one.
-  if (!hasAuth(config)) {
-    if (throwOnFailure) {
-      throw new Error('Bitbucket request failed: no usable credential')
-    }
-    return null
-  }
-  try {
-    const response = await fetch(apiUrl(config.baseUrl, path, options.searchParams), {
-      headers: {
-        Accept: 'application/json',
-        ...authHeaders(config)
-      },
-      signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
-    })
-    if (!response.ok) {
-      await cancelUnreadResponseBody(response)
-      if (response.status === 404 && notFoundIsNull) {
-        return null
-      }
-      if (throwOnFailure) {
-        throw new Error(`Bitbucket request failed: HTTP ${response.status}`)
-      }
-      return null
-    }
-    return (await response.json()) as T
-  } catch (error) {
-    if (throwOnFailure) {
-      throw error
-    }
-    return null
-  }
-}
-
-function encodedRepoPath(repo: BitbucketRepoRef): string {
-  return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
-}
-
-function escapeBitbucketQueryString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-}
-
-function allStateFilter(): string {
-  return `(${ALL_PULL_REQUEST_STATES.map((state) => `state = "${state}"`).join(' OR ')})`
-}
-
-async function getBuildStatus(
-  repo: BitbucketRepoRef,
-  headSha: string | undefined
-): Promise<CheckStatus> {
-  if (!headSha) {
-    return 'neutral'
-  }
-  const data = await requestJson<{ values?: RawBitbucketBuildStatus[] }>(
-    `/repositories/${encodedRepoPath(repo)}/commit/${encodeURIComponent(headSha)}/statuses/build`,
-    { searchParams: { pagelen: '100' } }
-  )
-  return deriveBitbucketBuildStatus(data?.values ?? [])
-}
-
-async function normalizePullRequest(
-  repo: BitbucketRepoRef,
-  raw: RawBitbucketPullRequest
+function normalizeCandidate(
+  candidate: PullRequestCandidate
 ): Promise<BitbucketPullRequestInfo | null> {
-  const headSha = raw.source?.commit?.hash?.trim()
-  const status = await getBuildStatus(repo, headSha)
-  return mapBitbucketPullRequest(raw, status)
+  return candidate.kind === 'server'
+    ? normalizeBitbucketServerPullRequest(candidate.repo, candidate.raw)
+    : normalizeBitbucketCloudPullRequest(candidate.repo, candidate.raw)
 }
 
-// Never decrypts. Env credentials are checked live; a stored credential is
-// revalidated only when its secret already sits in memory from an earlier API
-// call, and otherwise trusted from plaintext metadata — decrypting here would
-// prompt for keychain access every time Settings opens.
-export async function getBitbucketAuthStatus(): Promise<BitbucketAuthStatus> {
-  const env = getEnvAuthConfig()
-  if (hasAuth(env)) {
-    const result = await fetchBitbucketUserResult(env)
-    return {
-      configured: true,
-      // Why (STA-3944): only a rejection means the credential is bad. An
-      // unreachable host must not render as "Auth failed" and send the user
-      // off to regenerate a token that still works.
-      authenticated: result.ok || result.reason === 'unreachable',
-      account: result.ok ? accountNameFromUser(result.user) : null
-    }
+function candidateState(candidate: PullRequestCandidate): BitbucketPullRequestInfo['state'] {
+  return candidate.kind === 'server'
+    ? mapBitbucketServerPullRequestState(candidate.raw.state)
+    : mapBitbucketPullRequestState(candidate.raw.state)
+}
+
+async function fetchCandidateForBranch(
+  repo: BitbucketRepoRef,
+  branchName: string,
+  throwOnFailure: boolean
+): Promise<PullRequestCandidate | null> {
+  if (repo.kind === 'server') {
+    const raw = await fetchBitbucketServerPullRequestForBranch(repo, branchName, throwOnFailure)
+    return raw ? { kind: 'server', repo, raw } : null
   }
-  const metadata = getStoredBitbucketMetadata()
-  if (metadata && hasStoredBitbucketCredential()) {
-    if (getStoredBitbucketCredentialError()) {
-      return { configured: true, authenticated: false, account: metadata.account }
-    }
-    const cached = loadStoredBitbucketSecret()
-    if (!cached) {
-      return { configured: true, authenticated: true, account: metadata.account }
-    }
-    const result = await fetchBitbucketUserResult(storedAuthConfig(metadata, cached))
-    return {
-      configured: true,
-      authenticated: result.ok || result.reason === 'unreachable',
-      account: (result.ok ? accountNameFromUser(result.user) : null) ?? metadata.account
-    }
+  const raw = await fetchBitbucketCloudPullRequestForBranch(repo, branchName, throwOnFailure)
+  return raw ? { kind: 'cloud', repo, raw } : null
+}
+
+async function fetchCandidateById(
+  repo: BitbucketRepoRef,
+  prNumber: number,
+  throwOnFailure: boolean,
+  notFoundIsNull = false
+): Promise<PullRequestCandidate | null> {
+  if (repo.kind === 'server') {
+    const raw = await fetchBitbucketServerPullRequestById(
+      repo,
+      prNumber,
+      throwOnFailure,
+      notFoundIsNull
+    )
+    return raw ? { kind: 'server', repo, raw } : null
   }
-  return { configured: false, authenticated: false, account: null }
+  const raw = await fetchBitbucketCloudPullRequestById(
+    repo,
+    prNumber,
+    throwOnFailure,
+    notFoundIsNull
+  )
+  return raw ? { kind: 'cloud', repo, raw } : null
+}
+
+export function getBitbucketAuthStatus(): Promise<BitbucketAuthStatus> {
+  const serverConfig = getBitbucketServerConfig()
+  // Why: preflight carries one Bitbucket status, so a deployment has to win.
+  // A configured site URL is an unambiguous "I run Data Center" and takes it.
+  // A bare token is not: it is enough for `/scm/` remotes, but on its own it
+  // must not silently displace a fully configured Cloud account — a stray
+  // ORCA_BITBUCKET_SERVER_TOKEN would blank the card of a working Cloud setup.
+  // An unconfigured install falls to Cloud, which reports "not configured".
+  const serverWins =
+    serverConfig.baseUrl !== null || (serverConfig.token !== null && !hasCloudCredentials())
+  return serverWins ? getBitbucketServerAuthStatus() : getBitbucketCloudAuthStatus()
 }
 
 export async function getBitbucketPullRequest(
@@ -197,10 +126,8 @@ export async function getBitbucketPullRequest(
   if (!repo) {
     return null
   }
-  const raw = await requestJson<RawBitbucketPullRequest>(
-    `/repositories/${encodedRepoPath(repo)}/pullrequests/${encodeURIComponent(String(prNumber))}`
-  )
-  return raw ? normalizePullRequest(repo, raw) : null
+  const candidate = await fetchCandidateById(repo, prNumber, false)
+  return candidate ? normalizeCandidate(candidate) : null
 }
 
 export async function getBitbucketPullRequestForBranch(
@@ -226,37 +153,16 @@ export async function getBitbucketPullRequestForBranch(
   }
 
   if (typeof linkedPRNumber === 'number') {
-    const raw = await requestJson<RawBitbucketPullRequest>(
-      `/repositories/${encodedRepoPath(repo)}/pullrequests/${encodeURIComponent(String(linkedPRNumber))}`,
-      {},
-      throwOnFailure,
-      true
-    )
-    if (raw) {
-      return normalizePullRequest(repo, raw)
+    const candidate = await fetchCandidateById(repo, linkedPRNumber, throwOnFailure, true)
+    if (candidate) {
+      return normalizeCandidate(candidate)
     }
   }
 
   if (branchName) {
-    const query = [
-      `source.branch.name = "${escapeBitbucketQueryString(branchName)}"`,
-      allStateFilter()
-    ].join(' AND ')
-    const list = await requestJson<{ values?: RawBitbucketPullRequest[] }>(
-      `/repositories/${encodedRepoPath(repo)}/pullrequests`,
-      {
-        searchParams: {
-          pagelen: '1',
-          sort: '-updated_on',
-          q: query,
-          state: ALL_PULL_REQUEST_STATES
-        }
-      },
-      throwOnFailure
-    )
-    const raw = list?.values?.[0]
-    if (raw) {
-      const state = mapBitbucketPullRequestState(raw.state)
+    const candidate = await fetchCandidateForBranch(repo, branchName, throwOnFailure)
+    if (candidate) {
+      const state = candidateState(candidate)
       // Why: a merged PR we only matched by branch name is history, not review
       // context (GitHub's isMergedImplicitPR rule). Keeping it reported "a pull
       // request already exists" and blocked the branch's next PR. Scoped to
@@ -266,7 +172,7 @@ export async function getBitbucketPullRequestForBranch(
       const isMergedImplicitMatch = state === 'merged'
       const hideOnDefaultBranch = await shouldHideNonOpenReviewOnDefaultBranch({
         state,
-        reviewNumber: raw.id ?? null,
+        reviewNumber: candidate.raw.id ?? null,
         linkedReviewNumber: linkedPRNumber,
         branchName,
         repoPath,
@@ -274,7 +180,7 @@ export async function getBitbucketPullRequestForBranch(
         localGitOptions: getHostedReviewLocalGitOptions(options)
       })
       if (!isMergedImplicitMatch && !hideOnDefaultBranch) {
-        return normalizePullRequest(repo, raw)
+        return normalizeCandidate(candidate)
       }
     }
   }
@@ -305,7 +211,7 @@ export function getBitbucketPullRequestForBranchOrThrow(
   )
 }
 
-export async function getBitbucketRepoSlug(
+export function getBitbucketRepoSlug(
   repoPath: string,
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}

--- a/src/main/bitbucket/cloud-client.ts
+++ b/src/main/bitbucket/cloud-client.ts
@@ -1,0 +1,226 @@
+import type { CheckStatus } from '../../shared/github/pull-request-types'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import type { BitbucketAuthStatus } from './client'
+import {
+  deriveBitbucketBuildStatus,
+  mapBitbucketPullRequest,
+  type BitbucketPullRequestInfo,
+  type RawBitbucketBuildStatus,
+  type RawBitbucketPullRequest
+} from './pull-request-mappers'
+import type { BitbucketCloudRepoRef } from './repository-ref'
+import { authHeaders, envValue, getEnvAuthConfig, hasAuth } from './bitbucket-auth-config'
+import { accountNameFromUser, fetchBitbucketUserResult } from './user-request'
+import {
+  getStoredBitbucketCredentialError,
+  getStoredBitbucketMetadata,
+  hasStoredBitbucketCredential,
+  loadStoredBitbucketSecret
+} from './credential-store'
+import { resolveBitbucketAuthConfig, storedAuthConfig } from './resolve-auth'
+
+const REQUEST_TIMEOUT_MS = 5000
+const ALL_PULL_REQUEST_STATES = ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'] as const
+
+type RequestOptions = {
+  searchParams?: Record<string, string | readonly string[]>
+  timeoutMs?: number
+}
+
+/** Only an explicitly overridden base URL is worth reporting; the Cloud default is noise. */
+function baseUrlOverride(): string | null {
+  return envValue('ORCA_BITBUCKET_API_BASE_URL')
+}
+
+function apiUrl(
+  baseUrl: string,
+  path: string,
+  searchParams?: RequestOptions['searchParams']
+): string {
+  const base = baseUrl.replace(/\/+$/, '')
+  const url = new URL(`${base}${path}`)
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          url.searchParams.append(key, item)
+        }
+      } else {
+        url.searchParams.set(key, value as string)
+      }
+    }
+  }
+  return url.toString()
+}
+
+async function requestJson<T>(
+  path: string,
+  options: RequestOptions = {},
+  // Why: the existing-review lookup behind Create must distinguish a real
+  // transport/auth failure from an accepted "no PR". When true, a failed request
+  // throws instead of collapsing to null so callers never report false not_found.
+  throwOnFailure = false,
+  // Why: a linked PR number can be stale (deleted PR, wrong repo). A 404 there
+  // must fall through to the branch lookup rather than throw and hide the
+  // branch's real review, so only that caller opts into it.
+  notFoundIsNull = false
+): Promise<T | null> {
+  const config = resolveBitbucketAuthConfig()
+  // Why: a denied keychain prompt leaves no usable credential. Issuing the
+  // request anyway gets a 404 on private repos, which reads as "no pull
+  // request" and offers Create for a branch that already has one.
+  if (!hasAuth(config)) {
+    if (throwOnFailure) {
+      throw new Error('Bitbucket request failed: no usable credential')
+    }
+    return null
+  }
+  try {
+    const response = await fetch(apiUrl(config.baseUrl, path, options.searchParams), {
+      headers: {
+        Accept: 'application/json',
+        ...authHeaders(config)
+      },
+      signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+    })
+    if (!response.ok) {
+      await cancelUnreadResponseBody(response)
+      if (response.status === 404 && notFoundIsNull) {
+        return null
+      }
+      if (throwOnFailure) {
+        throw new Error(`Bitbucket request failed: HTTP ${response.status}`)
+      }
+      return null
+    }
+    try {
+      return (await response.json()) as T
+    } catch (error) {
+      // Why (orca#8695): a malformed success body can leave the stream unread,
+      // which undici can turn into a process-level crash.
+      await cancelUnreadResponseBody(response)
+      throw error
+    }
+  } catch (error) {
+    if (throwOnFailure) {
+      throw error
+    }
+    return null
+  }
+}
+
+function encodedRepoPath(repo: BitbucketCloudRepoRef): string {
+  return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
+}
+
+async function getBuildStatus(
+  repo: BitbucketCloudRepoRef,
+  headSha: string | undefined
+): Promise<CheckStatus> {
+  if (!headSha) {
+    return 'neutral'
+  }
+  const data = await requestJson<{ values?: RawBitbucketBuildStatus[] }>(
+    `/repositories/${encodedRepoPath(repo)}/commit/${encodeURIComponent(headSha)}/statuses/build`,
+    { searchParams: { pagelen: '100' } }
+  )
+  return deriveBitbucketBuildStatus(data?.values ?? [])
+}
+
+export async function normalizeBitbucketCloudPullRequest(
+  repo: BitbucketCloudRepoRef,
+  raw: RawBitbucketPullRequest
+): Promise<BitbucketPullRequestInfo | null> {
+  const status = await getBuildStatus(repo, raw.source?.commit?.hash?.trim())
+  return mapBitbucketPullRequest(raw, status)
+}
+
+export async function fetchBitbucketCloudPullRequestForBranch(
+  repo: BitbucketCloudRepoRef,
+  branchName: string,
+  throwOnFailure: boolean
+): Promise<RawBitbucketPullRequest | null> {
+  const escapedBranch = branchName.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  const stateFilter = ALL_PULL_REQUEST_STATES.map((state) => `state = "${state}"`).join(' OR ')
+  const list = await requestJson<{ values?: RawBitbucketPullRequest[] }>(
+    `/repositories/${encodedRepoPath(repo)}/pullrequests`,
+    {
+      searchParams: {
+        pagelen: '1',
+        sort: '-updated_on',
+        q: `source.branch.name = "${escapedBranch}" AND (${stateFilter})`,
+        state: ALL_PULL_REQUEST_STATES
+      }
+    },
+    throwOnFailure
+  )
+  return list?.values?.[0] ?? null
+}
+
+export function fetchBitbucketCloudPullRequestById(
+  repo: BitbucketCloudRepoRef,
+  prNumber: number,
+  throwOnFailure: boolean,
+  notFoundIsNull = false
+): Promise<RawBitbucketPullRequest | null> {
+  return requestJson<RawBitbucketPullRequest>(
+    `/repositories/${encodedRepoPath(repo)}/pullrequests/${encodeURIComponent(String(prNumber))}`,
+    {},
+    throwOnFailure,
+    notFoundIsNull
+  )
+}
+
+/** Cloud is usable with an access token or the email + API-token pair, from the
+ *  environment or a credential saved in Orca. Presence only — never decrypts, so
+ *  the Data Center tie-break cannot trigger a keychain prompt. */
+export function hasCloudCredentials(): boolean {
+  return hasAuth(getEnvAuthConfig()) || hasStoredBitbucketCredential()
+}
+
+// Never decrypts. Env credentials are checked live; a stored credential is
+// revalidated only when its secret already sits in memory from an earlier API
+// call, and otherwise trusted from plaintext metadata — decrypting here would
+// prompt for keychain access every time Settings opens.
+export async function getBitbucketCloudAuthStatus(): Promise<BitbucketAuthStatus> {
+  const override = baseUrlOverride()
+  const env = getEnvAuthConfig()
+  if (hasAuth(env)) {
+    const result = await fetchBitbucketUserResult(env)
+    return {
+      configured: true,
+      // Why (STA-3944): only a rejection means the credential is bad. An
+      // unreachable host must not render as "Auth failed" and send the user
+      // off to regenerate a token that still works.
+      authenticated: result.ok || result.reason === 'unreachable',
+      account: result.ok ? accountNameFromUser(result.user) : null,
+      baseUrl: override,
+      tokenConfigured: true
+    }
+  }
+  const metadata = getStoredBitbucketMetadata()
+  if (metadata && hasStoredBitbucketCredential()) {
+    const stored = { baseUrl: metadata.baseUrl ?? override, tokenConfigured: true }
+    if (getStoredBitbucketCredentialError()) {
+      return { configured: true, authenticated: false, account: metadata.account, ...stored }
+    }
+    const cached = loadStoredBitbucketSecret()
+    if (!cached) {
+      return { configured: true, authenticated: true, account: metadata.account, ...stored }
+    }
+    const result = await fetchBitbucketUserResult(storedAuthConfig(metadata, cached))
+    return {
+      configured: true,
+      authenticated: result.ok || result.reason === 'unreachable',
+      account: (result.ok ? accountNameFromUser(result.user) : null) ?? metadata.account,
+      ...stored
+    }
+  }
+  return {
+    configured: false,
+    authenticated: false,
+    account: null,
+    baseUrl: null,
+    tokenConfigured: false
+  }
+}

--- a/src/main/bitbucket/pull-request-creation.ts
+++ b/src/main/bitbucket/pull-request-creation.ts
@@ -15,7 +15,7 @@ import { resolveBitbucketAuthConfig } from './resolve-auth'
 import { hasStoredBitbucketCredential } from './credential-store'
 import { getBitbucketPullRequestForBranch } from './client'
 import { mapBitbucketPullRequest, type RawBitbucketPullRequest } from './pull-request-mappers'
-import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
+import { getBitbucketRepoRef, type BitbucketCloudRepoRef } from './repository-ref'
 import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
 import { getHostedReviewLocalGitOptions } from '../source-control/hosted-review-git-options'
 
@@ -29,7 +29,7 @@ export function isBitbucketReviewCreationAuthenticated(): boolean {
   return hasAuth(getEnvAuthConfig()) || hasStoredBitbucketCredential()
 }
 
-function encodedRepoPath(repo: BitbucketRepoRef): string {
+function encodedRepoPath(repo: BitbucketCloudRepoRef): string {
   return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
 }
 
@@ -144,6 +144,17 @@ export async function createBitbucketPullRequest(
       ok: false,
       code: 'unsupported_provider',
       error: 'Creating pull requests requires a Bitbucket remote.'
+    }
+  }
+  // Why: the create payload below is Cloud's REST 2.0 shape. Data Center wants
+  // /rest/api/1.0 with fromRef/toRef, so fail closed here rather than POST a
+  // Cloud-shaped body at a Data Center site and report a confusing 404.
+  if (repo.kind === 'server') {
+    return {
+      ok: false,
+      code: 'unsupported_provider',
+      error:
+        'Creating pull requests is not supported for Bitbucket Data Center yet. Next step: open the pull request in Bitbucket.'
     }
   }
 

--- a/src/main/bitbucket/repository-ref.test.ts
+++ b/src/main/bitbucket/repository-ref.test.ts
@@ -25,22 +25,29 @@ describe('Bitbucket repository refs', () => {
     sshExecMock.mockReset()
     unregisterSshGitProvider('conn-1')
     _resetBitbucketRepoRefCache()
+    delete process.env.ORCA_BITBUCKET_SERVER_URL
+    delete process.env.ORCA_BITBUCKET_SERVER_TOKEN
   })
 
   afterEach(() => {
     unregisterSshGitProvider('conn-1')
+    delete process.env.ORCA_BITBUCKET_SERVER_URL
+    delete process.env.ORCA_BITBUCKET_SERVER_TOKEN
   })
 
   it('parses HTTPS, SSH, and ssh:// Bitbucket remotes', () => {
     expect(parseBitbucketRepoRef('https://bitbucket.org/team/project.git')).toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
     expect(parseBitbucketRepoRef('git@bitbucket.org:team/project.git')).toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
     expect(parseBitbucketRepoRef('ssh://git@bitbucket.org/team/project.git')).toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
@@ -49,10 +56,12 @@ describe('Bitbucket repository refs', () => {
 
   it('strips trailing slashes after .git suffixes', () => {
     expect(parseBitbucketRepoRef('https://bitbucket.org/team/project.git/')).toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
     expect(parseBitbucketRepoRef('git@bitbucket.org:team/project.git/')).toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
@@ -60,6 +69,7 @@ describe('Bitbucket repository refs', () => {
 
   it('keeps malformed percent sequences as literal repo path text', async () => {
     expect(parseBitbucketRepoRef('git@bitbucket.org:team/project%zz.git')).toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project%zz'
     })
@@ -70,6 +80,7 @@ describe('Bitbucket repository refs', () => {
     })
 
     await expect(getBitbucketRepoRef('/repo')).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project%zz'
     })
@@ -82,10 +93,12 @@ describe('Bitbucket repository refs', () => {
     })
 
     await expect(getBitbucketRepoRef('/repo')).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
     await expect(getBitbucketRepoRef('/repo')).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'team',
       repoSlug: 'project'
     })
@@ -108,14 +121,17 @@ describe('Bitbucket repository refs', () => {
       })
 
     await expect(getBitbucketRepoRef('/repo')).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'host',
       repoSlug: 'project'
     })
     await expect(getBitbucketRepoRef('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'wsl',
       repoSlug: 'project'
     })
     await expect(getBitbucketRepoRef('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'wsl',
       repoSlug: 'project'
     })
@@ -153,6 +169,7 @@ describe('Bitbucket repository refs', () => {
     registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
 
     await expect(getBitbucketRepoRefForRemote('/repo', 'origin', 'conn-1')).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'remote',
       repoSlug: 'project'
     })
@@ -172,11 +189,110 @@ describe('Bitbucket repository refs', () => {
 
     await expect(getBitbucketRepoRefForRemote('/repo', 'origin', 'conn-1')).resolves.toBeNull()
     await expect(getBitbucketRepoRefForRemote('/repo', 'origin', 'conn-1')).resolves.toEqual({
+      kind: 'cloud',
       workspace: 'remote',
       repoSlug: 'project'
     })
 
     expect(sshExecMock).toHaveBeenCalledTimes(2)
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  describe('Data Center remotes', () => {
+    it('claims /scm/ clone URLs and recovers the context path', () => {
+      expect(parseBitbucketRepoRef('https://bb.corp.example/scm/PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+      expect(parseBitbucketRepoRef('https://bb.corp.example/bitbucket/scm/PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example/bitbucket',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+    })
+
+    it('keeps the tilde on personal-repository project keys', () => {
+      expect(parseBitbucketRepoRef('https://bb.corp.example/scm/~jsmith/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example',
+        projectKey: '~jsmith',
+        repoSlug: 'repo'
+      })
+    })
+
+    it('prefers the configured site base over the origin the remote implies', () => {
+      process.env.ORCA_BITBUCKET_SERVER_URL = 'https://bb.corp.example/bitbucket'
+
+      expect(parseBitbucketRepoRef('https://bb.corp.example/scm/PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example/bitbucket',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+    })
+
+    it('resolves SSH remotes only against a configured site', () => {
+      expect(parseBitbucketRepoRef('ssh://git@bb.corp.example:7999/PRJ/repo.git')).toBeNull()
+
+      process.env.ORCA_BITBUCKET_SERVER_URL = 'https://bb.corp.example/bitbucket'
+
+      expect(parseBitbucketRepoRef('ssh://git@bb.corp.example:7999/PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example/bitbucket',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+      expect(parseBitbucketRepoRef('git@bb.corp.example:PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example/bitbucket',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+    })
+
+    // Why: url.host keeps the SSH port, so an unconfigured `/scm/` ssh remote
+    // would derive https://host:7999 and aim every REST call at sshd.
+    it('drops the SSH port when deriving the site base from an ssh /scm/ remote', () => {
+      expect(parseBitbucketRepoRef('ssh://git@bb.corp.example:7999/scm/PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+    })
+
+    it('keeps a real https port in the derived site base', () => {
+      expect(parseBitbucketRepoRef('https://bb.corp.example:8443/scm/PRJ/repo.git')).toEqual({
+        kind: 'server',
+        baseUrl: 'https://bb.corp.example:8443',
+        projectKey: 'PRJ',
+        repoSlug: 'repo'
+      })
+    })
+
+    // Why: Bitbucket resolves before Gitea, whose resolver claims every host
+    // outside a five-entry denylist. Claiming unconfigured hosts here would
+    // silently steal Gitea and Forgejo remotes.
+    it('leaves unconfigured hosts without a /scm/ segment to other forges', () => {
+      expect(parseBitbucketRepoRef('https://git.corp.example/team/repo.git')).toBeNull()
+      expect(parseBitbucketRepoRef('https://git.corp.example/scm/repo.git')).toBeNull()
+
+      process.env.ORCA_BITBUCKET_SERVER_URL = 'https://bb.corp.example'
+
+      expect(parseBitbucketRepoRef('https://git.corp.example/team/repo.git')).toBeNull()
+    })
+
+    it('keeps Bitbucket Cloud remotes on the cloud ref', () => {
+      process.env.ORCA_BITBUCKET_SERVER_URL = 'https://bb.corp.example'
+
+      expect(parseBitbucketRepoRef('https://bitbucket.org/team/project.git')).toEqual({
+        kind: 'cloud',
+        workspace: 'team',
+        repoSlug: 'project'
+      })
+    })
   })
 })

--- a/src/main/bitbucket/repository-ref.ts
+++ b/src/main/bitbucket/repository-ref.ts
@@ -1,9 +1,22 @@
 import { createRemoteRefProbeCache } from '../git/remote-ref-probe-cache'
+import { getBitbucketServerConfig } from './server-config'
 
-export type BitbucketRepoRef = {
+export type BitbucketCloudRepoRef = {
+  kind: 'cloud'
   workspace: string
   repoSlug: string
 }
+
+export type BitbucketServerRepoRef = {
+  kind: 'server'
+  /** Site base URL including any context path, without a trailing slash. */
+  baseUrl: string
+  /** Data Center project key; `~user` for personal repositories. */
+  projectKey: string
+  repoSlug: string
+}
+
+export type BitbucketRepoRef = BitbucketCloudRepoRef | BitbucketServerRepoRef
 
 type LocalGitExecOptions = {
   wslDistro?: string
@@ -29,42 +42,98 @@ function decodeSegment(value: string): string {
   }
 }
 
-function parseBitbucketPath(pathname: string): BitbucketRepoRef | null {
-  const withoutSuffix = pathname.replace(/\/+$/, '').replace(/\.git$/i, '')
-  const parts = withoutSuffix
+function pathSegments(pathname: string): string[] {
+  return pathname
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '')
     .split('/')
     .map((part) => part.trim())
     .filter(Boolean)
-  if (parts.length < 2) {
+    .map(decodeSegment)
+}
+
+type RemoteLocation = { host: string; origin: string; pathname: string }
+
+function parseRemoteLocation(remoteUrl: string): RemoteLocation | null {
+  const scpLike = remoteUrl.match(/^(?:[^@\s/]+@)?([^@\s/:]+):(?!\/)(.+)$/)
+  if (scpLike) {
+    const host = scpLike[1].toLowerCase()
+    return { host, origin: `https://${host}`, pathname: `/${scpLike[2]}` }
+  }
+  try {
+    const url = new URL(remoteUrl)
+    const host = url.hostname.toLowerCase()
+    // Why: Bitbucket web/REST URLs are https regardless of clone scheme, and
+    // URL.origin is the literal string "null" for non-special schemes. An
+    // ssh:// remote's port is the SSH port (7999 by default), which must not
+    // survive into the REST base URL — but a real http(s) port must.
+    const origin =
+      url.protocol === 'http:' || url.protocol === 'https:' ? url.origin : `https://${url.hostname}`
+    return { host, origin, pathname: url.pathname }
+  } catch {
     return null
   }
+}
+
+function parseBitbucketCloudRepoRef(location: RemoteLocation): BitbucketCloudRepoRef | null {
+  if (location.host !== 'bitbucket.org') {
+    return null
+  }
+  const parts = pathSegments(location.pathname)
   const workspace = parts.at(-2)
   const repoSlug = parts.at(-1)
   if (!workspace || !repoSlug) {
     return null
   }
+  return { kind: 'cloud', workspace, repoSlug }
+}
+
+/**
+ * Data Center is claimed on two positive signals only — the configured site
+ * host, or the `/scm/` clone path that Atlassian fixes for every HTTPS remote.
+ * A looser rule would make Bitbucket a second catch-all and steal the remotes
+ * Gitea claims (it resolves after Bitbucket in FORGE_PROVIDERS).
+ */
+function parseBitbucketServerRepoRef(location: RemoteLocation): BitbucketServerRepoRef | null {
+  const config = getBitbucketServerConfig()
+  const matchesConfiguredHost = config.host !== null && config.host === location.host
+  const parts = pathSegments(location.pathname)
+  const scmIndex = parts.indexOf('scm')
+
+  if (scmIndex !== -1 && parts.length >= scmIndex + 3) {
+    const contextPath = parts.slice(0, scmIndex).join('/')
+    return {
+      kind: 'server',
+      baseUrl:
+        matchesConfiguredHost && config.baseUrl
+          ? config.baseUrl
+          : contextPath
+            ? `${location.origin}/${contextPath}`
+            : location.origin,
+      projectKey: parts[scmIndex + 1],
+      repoSlug: parts[scmIndex + 2]
+    }
+  }
+
+  // SSH remotes carry neither `/scm` nor the context path, so they are only
+  // resolvable against a configured site.
+  if (!matchesConfiguredHost || !config.baseUrl || parts.length < 2) {
+    return null
+  }
   return {
-    workspace: decodeSegment(workspace),
-    repoSlug: decodeSegment(repoSlug)
+    kind: 'server',
+    baseUrl: config.baseUrl,
+    projectKey: parts.at(-2)!,
+    repoSlug: parts.at(-1)!
   }
 }
 
 export function parseBitbucketRepoRef(remoteUrl: string): BitbucketRepoRef | null {
-  const trimmed = remoteUrl.trim()
-  const scpLike = trimmed.match(/^(?:[^@]+@)?bitbucket\.org:([^\s]+?)(?:\.git)?$/i)
-  if (scpLike) {
-    return parseBitbucketPath(scpLike[1])
-  }
-
-  try {
-    const url = new URL(trimmed)
-    if (url.hostname.toLowerCase() !== 'bitbucket.org') {
-      return null
-    }
-    return parseBitbucketPath(url.pathname)
-  } catch {
+  const location = parseRemoteLocation(remoteUrl.trim())
+  if (!location) {
     return null
   }
+  return parseBitbucketCloudRepoRef(location) ?? parseBitbucketServerRepoRef(location)
 }
 
 export async function getBitbucketRepoRefForRemote(

--- a/src/main/bitbucket/server-client.ts
+++ b/src/main/bitbucket/server-client.ts
@@ -1,0 +1,270 @@
+import type { CheckStatus } from '../../shared/github/pull-request-types'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import type { BitbucketAuthStatus } from './client'
+import type { BitbucketPullRequestInfo } from './pull-request-mappers'
+import type { BitbucketServerRepoRef } from './repository-ref'
+import { getBitbucketServerConfig } from './server-config'
+import {
+  deriveBitbucketServerBuildStatus,
+  mapBitbucketServerPullRequest,
+  type RawBitbucketServerBuildStats,
+  type RawBitbucketServerPullRequest
+} from './server-pull-request-mappers'
+
+const REQUEST_TIMEOUT_MS = 5000
+const AUTH_PROBE_TIMEOUT_MS = 4000
+const MAX_RATE_LIMIT_WAIT_MS = 3000
+
+type RequestOptions = {
+  searchParams?: Record<string, string>
+  timeoutMs?: number
+}
+
+/** Data Center paginates with `start`/`limit` and reports `nextPageStart`. */
+type RestPage<T> = {
+  values?: T[]
+  size?: number
+  limit?: number
+  isLastPage?: boolean
+  nextPageStart?: number
+}
+
+function authHeaders(token: string | null): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+function restUrl(baseUrl: string, path: string, searchParams?: RequestOptions['searchParams']) {
+  const url = new URL(`${baseUrl.replace(/\/+$/, '')}/rest${path}`)
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value)
+    }
+  }
+  return url
+}
+
+/** Data Center returns `{ errors: [{ message }] }`, which beats a bare status. */
+async function errorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { errors?: { message?: string }[] }
+    const message = body?.errors?.[0]?.message?.trim()
+    if (message) {
+      return message
+    }
+  } catch {
+    // Why (orca#8695): a body left unread after a failed parse can crash the
+    // process from inside undici. Fall through to the status-only message.
+    await cancelUnreadResponseBody(response)
+  }
+  return `HTTP ${response.status}`
+}
+
+/**
+ * Rate limiting is an admin-toggled filter that sits ahead of the REST layer,
+ * so 429 can surface on any endpoint and is not declared in the API schema.
+ */
+function rateLimitWaitMs(response: Response): number | null {
+  // Why: an absent header reads as `Number(null) === 0`, which would retry a
+  // rate-limited request instantly. No header means no retry budget.
+  const header = response.headers.get('retry-after')?.trim()
+  if (!header) {
+    return null
+  }
+  const seconds = Number(header)
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return null
+  }
+  const waitMs = seconds * 1000
+  return waitMs <= MAX_RATE_LIMIT_WAIT_MS ? waitMs : null
+}
+
+async function requestJson<T>(
+  baseUrl: string,
+  path: string,
+  options: RequestOptions = {},
+  // Why: the existing-review lookup behind Create must distinguish a real
+  // transport/auth failure from an accepted "no PR". When true, a failed request
+  // throws instead of collapsing to null so callers never report false not_found.
+  throwOnFailure = false,
+  // Why: a linked PR number can be stale (deleted PR, wrong repo). A 404 there
+  // must fall through to the branch lookup rather than throw and hide the
+  // branch's real review, so only that caller opts into it.
+  notFoundIsNull = false
+): Promise<T | null> {
+  const { token } = getBitbucketServerConfig()
+  const url = restUrl(baseUrl, path, options.searchParams)
+  try {
+    for (let attempt = 0; ; attempt += 1) {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json', ...authHeaders(token) },
+        signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
+      })
+      if (response.ok) {
+        try {
+          return (await response.json()) as T
+        } catch (error) {
+          // Why (orca#8695): a malformed success body can leave the stream
+          // unread, which undici can turn into a process-level crash.
+          await cancelUnreadResponseBody(response)
+          throw error
+        }
+      }
+      const retryAfterMs =
+        attempt === 0 && response.status === 429 ? rateLimitWaitMs(response) : null
+      if (retryAfterMs !== null) {
+        await cancelUnreadResponseBody(response)
+        const retryDelay = Promise.withResolvers<void>()
+        setTimeout(retryDelay.resolve, retryAfterMs)
+        await retryDelay.promise
+        continue
+      }
+      if (response.status === 404 && notFoundIsNull) {
+        await cancelUnreadResponseBody(response)
+        return null
+      }
+      if (!throwOnFailure) {
+        await cancelUnreadResponseBody(response)
+        return null
+      }
+      throw new Error(`Bitbucket request failed: ${await errorMessage(response)}`)
+    }
+  } catch (error) {
+    if (throwOnFailure) {
+      throw error
+    }
+    return null
+  }
+}
+
+function repoPath(repo: BitbucketServerRepoRef): string {
+  return `/api/1.0/projects/${encodeURIComponent(repo.projectKey)}/repos/${encodeURIComponent(repo.repoSlug)}`
+}
+
+async function getBuildStatus(
+  repo: BitbucketServerRepoRef,
+  headSha: string | undefined
+): Promise<CheckStatus> {
+  if (!headSha) {
+    return 'neutral'
+  }
+  const stats = await requestJson<RawBitbucketServerBuildStats>(
+    repo.baseUrl,
+    `/build-status/1.0/commits/stats/${encodeURIComponent(headSha)}`
+  )
+  return deriveBitbucketServerBuildStatus(stats)
+}
+
+export async function normalizeBitbucketServerPullRequest(
+  repo: BitbucketServerRepoRef,
+  raw: RawBitbucketServerPullRequest
+): Promise<BitbucketPullRequestInfo | null> {
+  const status = await getBuildStatus(repo, raw.fromRef?.latestCommit?.trim())
+  return mapBitbucketServerPullRequest(raw, repo, status)
+}
+
+/**
+ * `at` must be a fully-qualified ref, and `direction` defaults to INCOMING —
+ * which would return the pull requests *targeting* the branch.
+ *
+ * Accepts either a short name or an already-qualified ref so callers cannot
+ * silently produce `refs/heads/refs/heads/x`.
+ */
+export async function fetchBitbucketServerPullRequestForBranch(
+  repo: BitbucketServerRepoRef,
+  branchName: string,
+  throwOnFailure = false
+): Promise<RawBitbucketServerPullRequest | null> {
+  const qualifiedRef = branchName.startsWith('refs/') ? branchName : `refs/heads/${branchName}`
+  const page = await requestJson<RestPage<RawBitbucketServerPullRequest>>(
+    repo.baseUrl,
+    `${repoPath(repo)}/pull-requests`,
+    {
+      searchParams: {
+        at: qualifiedRef,
+        direction: 'OUTGOING',
+        state: 'ALL',
+        order: 'NEWEST',
+        limit: '1',
+        withAttributes: 'false',
+        withProperties: 'false'
+      }
+    },
+    throwOnFailure
+  )
+  return page?.values?.[0] ?? null
+}
+
+export function fetchBitbucketServerPullRequestById(
+  repo: BitbucketServerRepoRef,
+  prNumber: number,
+  throwOnFailure = false,
+  notFoundIsNull = false
+): Promise<RawBitbucketServerPullRequest | null> {
+  return requestJson<RawBitbucketServerPullRequest>(
+    repo.baseUrl,
+    `${repoPath(repo)}/pull-requests/${encodeURIComponent(String(prNumber))}`,
+    {},
+    throwOnFailure,
+    notFoundIsNull
+  )
+}
+
+/**
+ * Data Center has no `/user` endpoint. `/users` is the documented
+ * authenticated-only resource, and the username rides back on `X-AUSERNAME`.
+ */
+async function probeAuthenticatedAccount(
+  baseUrl: string,
+  token: string
+): Promise<{ authenticated: boolean; account: string | null }> {
+  try {
+    const response = await fetch(restUrl(baseUrl, '/api/1.0/users', { limit: '1' }), {
+      headers: { Accept: 'application/json', ...authHeaders(token) },
+      signal: AbortSignal.timeout(AUTH_PROBE_TIMEOUT_MS)
+    })
+    await cancelUnreadResponseBody(response)
+    if (!response.ok) {
+      return { authenticated: false, account: null }
+    }
+    const rawAccount = response.headers.get('x-ausername')
+    return {
+      authenticated: true,
+      account: rawAccount ? decodeURIComponent(rawAccount) : null
+    }
+  } catch {
+    return { authenticated: false, account: null }
+  }
+}
+
+export async function getBitbucketServerAuthStatus(): Promise<BitbucketAuthStatus> {
+  const { baseUrl, token } = getBitbucketServerConfig()
+  if (!baseUrl) {
+    // Why: with no site URL there is no endpoint to probe — the base is
+    // recovered per-repo from each `/scm/` remote. Reporting `configured` here
+    // is a claim about configuration, not a verified session; a bad token
+    // surfaces on the first real lookup. Mirrors getGiteaAuthStatus.
+    return {
+      configured: true,
+      authenticated: true,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: true
+    }
+  }
+  if (!token) {
+    const properties = await requestJson<{ version?: string }>(
+      baseUrl,
+      '/api/1.0/application-properties',
+      { timeoutMs: AUTH_PROBE_TIMEOUT_MS }
+    )
+    return {
+      configured: properties !== null,
+      authenticated: false,
+      account: null,
+      baseUrl,
+      tokenConfigured: false
+    }
+  }
+  const { authenticated, account } = await probeAuthenticatedAccount(baseUrl, token)
+  return { configured: true, authenticated, account, baseUrl, tokenConfigured: true }
+}

--- a/src/main/bitbucket/server-config.ts
+++ b/src/main/bitbucket/server-config.ts
@@ -1,0 +1,52 @@
+/**
+ * Bitbucket Data Center (Server) deployment settings.
+ *
+ * Data Center is reached at an arbitrary host that may sit under a context
+ * path (`https://host/bitbucket`), so — unlike Bitbucket Cloud — the base URL
+ * is part of the user's configuration rather than a constant.
+ */
+export type BitbucketServerConfig = {
+  /** Site base URL including any context path, without a trailing slash. */
+  baseUrl: string | null
+  /** Lowercased hostname of `baseUrl`, used to claim matching git remotes. */
+  host: string | null
+  /** HTTP access token (PAT) sent as a bearer token. */
+  token: string | null
+}
+
+function envValue(name: string): string | null {
+  const value = process.env[name]?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+/**
+ * Accepts a bare host, a site URL, or a pasted REST URL, and returns the site
+ * base every Data Center URL is built from.
+ */
+function normalizeBitbucketServerBaseUrl(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  try {
+    const url = new URL(/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`)
+    const path = url.pathname.replace(/\/+$/, '').replace(/\/rest(?:\/api\/(?:1\.0|latest))?$/i, '')
+    return `${url.origin}${path}`
+  } catch {
+    return null
+  }
+}
+
+export function getBitbucketServerConfig(): BitbucketServerConfig {
+  const rawBaseUrl = envValue('ORCA_BITBUCKET_SERVER_URL')
+  const baseUrl = rawBaseUrl ? normalizeBitbucketServerBaseUrl(rawBaseUrl) : null
+  let host: string | null = null
+  if (baseUrl) {
+    try {
+      host = new URL(baseUrl).hostname.toLowerCase()
+    } catch {
+      host = null
+    }
+  }
+  return { baseUrl, host, token: envValue('ORCA_BITBUCKET_SERVER_TOKEN') }
+}

--- a/src/main/bitbucket/server-pull-request-mappers.ts
+++ b/src/main/bitbucket/server-pull-request-mappers.ts
@@ -1,0 +1,105 @@
+import type { CheckStatus } from '../../shared/github/pull-request-types'
+import type { BitbucketPullRequestInfo } from './pull-request-mappers'
+import type { BitbucketServerRepoRef } from './repository-ref'
+
+/**
+ * Data Center's REST payload shares no field names with Bitbucket Cloud's:
+ * camelCase instead of snake_case, epoch-millis dates instead of ISO strings,
+ * and fully-qualified refs instead of bare branch names.
+ */
+export type RawBitbucketServerPullRequest = {
+  id?: number
+  title?: string
+  state?: string | null
+  updatedDate?: number | null
+  fromRef?: {
+    id?: string | null
+    displayId?: string | null
+    latestCommit?: string | null
+  } | null
+  toRef?: {
+    id?: string | null
+    displayId?: string | null
+  } | null
+}
+
+/** `GET /rest/build-status/1.0/commits/stats/{sha}` — pre-aggregated counts. */
+export type RawBitbucketServerBuildStats = {
+  successful?: number
+  inProgress?: number
+  failed?: number
+  cancelled?: number
+  unknown?: number
+}
+
+export function mapBitbucketServerPullRequestState(
+  state: string | null | undefined
+): BitbucketPullRequestInfo['state'] {
+  switch (state?.trim().toUpperCase()) {
+    case 'MERGED':
+      return 'merged'
+    case 'DECLINED':
+      return 'closed'
+    case 'OPEN':
+    case undefined:
+    default:
+      return 'open'
+  }
+}
+
+export function deriveBitbucketServerBuildStatus(
+  stats: RawBitbucketServerBuildStats | null
+): CheckStatus {
+  const successful = stats?.successful ?? 0
+  const inProgress = stats?.inProgress ?? 0
+  const failed = stats?.failed ?? 0
+  const cancelled = stats?.cancelled ?? 0
+  const unknown = stats?.unknown ?? 0
+  if (successful + inProgress + failed + cancelled + unknown === 0) {
+    return 'neutral'
+  }
+  if (failed > 0 || cancelled > 0) {
+    return 'failure'
+  }
+  if (inProgress > 0) {
+    return 'pending'
+  }
+  return unknown === 0 ? 'success' : 'neutral'
+}
+
+/**
+ * Data Center's web UI addresses personal repositories as `/users/{slug}`
+ * while REST keeps the `~` prefix on the project key.
+ */
+export function bitbucketServerRepoWebUrl(repo: BitbucketServerRepoRef): string {
+  const owner = repo.projectKey.startsWith('~')
+    ? `users/${encodeURIComponent(repo.projectKey.slice(1))}`
+    : `projects/${encodeURIComponent(repo.projectKey)}`
+  return `${repo.baseUrl}/${owner}/repos/${encodeURIComponent(repo.repoSlug)}`
+}
+
+export function mapBitbucketServerPullRequest(
+  raw: RawBitbucketServerPullRequest,
+  repo: BitbucketServerRepoRef,
+  status: CheckStatus
+): BitbucketPullRequestInfo | null {
+  // Why: `links` is an undocumented, write-only object in the Data Center
+  // OpenAPI schema, so the PR URL is constructed rather than read.
+  if (typeof raw.id !== 'number' || !raw.title) {
+    return null
+  }
+  const headSha = raw.fromRef?.latestCommit?.trim()
+  // Why: Number.isFinite admits epochs beyond ±8.64e15, where toISOString
+  // throws RangeError and the error escapes into the review lookup.
+  const updatedAt = typeof raw.updatedDate === 'number' ? new Date(raw.updatedDate) : null
+  return {
+    number: raw.id,
+    title: raw.title,
+    state: mapBitbucketServerPullRequestState(raw.state),
+    url: `${bitbucketServerRepoWebUrl(repo)}/pull-requests/${raw.id}`,
+    status,
+    updatedAt: updatedAt && !Number.isNaN(updatedAt.getTime()) ? updatedAt.toISOString() : '',
+    mergeable: 'UNKNOWN',
+    ...(headSha ? { headSha } : {})
+  }
+}

--- a/src/main/bitbucket/status-no-decrypt.test.ts
+++ b/src/main/bitbucket/status-no-decrypt.test.ts
@@ -83,7 +83,13 @@ describe('Bitbucket status reads never decrypt the stored secret', () => {
     const auth = await client.getBitbucketAuthStatus()
     const status = connection.getBitbucketConnectionStatus()
 
-    expect(auth).toEqual({ configured: true, authenticated: true, account: 'ada' })
+    expect(auth).toEqual({
+      configured: true,
+      authenticated: true,
+      account: 'ada',
+      baseUrl: null,
+      tokenConfigured: true
+    })
     expect(status).toMatchObject({ source: 'stored', account: 'ada', authMode: 'basic' })
     expect(decryptSpy).not.toHaveBeenCalled()
     // A stored credential is trusted from metadata rather than revalidated.
@@ -119,7 +125,9 @@ describe('Bitbucket status reads never decrypt the stored secret', () => {
     await expect(client.getBitbucketAuthStatus()).resolves.toEqual({
       configured: true,
       authenticated: false,
-      account: 'ada'
+      account: 'ada',
+      baseUrl: null,
+      tokenConfigured: true
     })
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     expect(decryptSpy).not.toHaveBeenCalled()

--- a/src/main/global-fetch-call-site-audit.test.ts
+++ b/src/main/global-fetch-call-site-audit.test.ts
@@ -17,7 +17,8 @@ const AUDITED_GLOBAL_FETCH_LINES = new Map<string, number>([
   // HTTP call sites — body consumed or cancelled on every path, including !ok
   ['main/artifacts/artifact-cloud-request.ts', 1],
   ['main/azure-devops/azure-devops-api-request.ts', 1],
-  ['main/bitbucket/client.ts', 1],
+  ['main/bitbucket/cloud-client.ts', 1],
+  ['main/bitbucket/server-client.ts', 2],
   ['main/bitbucket/user-request.ts', 1],
   ['main/gitea/client.ts', 1],
   ['main/orca-profiles/profile-cloud-client.ts', 1],

--- a/src/main/ipc/preflight-test-harness.ts
+++ b/src/main/ipc/preflight-test-harness.ts
@@ -20,7 +20,13 @@ export type PreflightMocks = {
   mergePersistedWindowsPathMock: Mock
 }
 
-export const defaultBitbucketStatus = { configured: false, authenticated: false, account: null }
+export const defaultBitbucketStatus = {
+  configured: false,
+  authenticated: false,
+  account: null,
+  baseUrl: null,
+  tokenConfigured: false
+}
 
 export const defaultAzureDevOpsStatus = {
   configured: false,

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -54,7 +54,13 @@ export type PreflightStatus = {
   // affordances (the GitLab tab in the source picker, MR list, etc.)
   // gate on `glab?.authenticated`.
   glab?: { installed: boolean; authenticated: boolean }
-  bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  bitbucket?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
   azureDevOps?: {
     configured: boolean
     authenticated: boolean

--- a/src/main/source-control/hosted-review-bitbucket.integration.test.ts
+++ b/src/main/source-control/hosted-review-bitbucket.integration.test.ts
@@ -28,6 +28,8 @@ describe('Bitbucket hosted review integration', () => {
     process.env = { ...OLD_ENV, ORCA_BITBUCKET_ACCESS_TOKEN: 'local-token' }
     delete process.env.ORCA_BITBUCKET_EMAIL
     delete process.env.ORCA_BITBUCKET_API_TOKEN
+    delete process.env.ORCA_BITBUCKET_SERVER_URL
+    delete process.env.ORCA_BITBUCKET_SERVER_TOKEN
     _resetBitbucketRepoRefCache()
     __resetHostedReviewBranchCacheForTests()
   })
@@ -203,6 +205,113 @@ describe('Bitbucket hosted review integration', () => {
       expect(pullRequestCalls).toBe(2)
       // The failed lookup never reaches build status, so the recovery owns this call.
       expect(buildStatusCalls).toBe(1)
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+})
+
+describe('Bitbucket Data Center hosted review integration', () => {
+  beforeEach(() => {
+    process.env = { ...OLD_ENV }
+    delete process.env.ORCA_BITBUCKET_ACCESS_TOKEN
+    delete process.env.ORCA_BITBUCKET_EMAIL
+    delete process.env.ORCA_BITBUCKET_API_TOKEN
+    delete process.env.ORCA_BITBUCKET_API_BASE_URL
+    _resetBitbucketRepoRefCache()
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+    _resetBitbucketRepoRefCache()
+  })
+
+  it('resolves a Data Center PR from an /scm/ remote through the 1.0 REST API', async () => {
+    const seen: SeenRequest[] = []
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      seen.push({
+        pathname: url.pathname,
+        search: url.search,
+        authorization: req.headers.authorization
+      })
+
+      if (url.pathname === '/rest/api/1.0/projects/PRJ/repos/repo/pull-requests') {
+        sendJson(res, {
+          size: 1,
+          limit: 1,
+          isLastPage: true,
+          start: 0,
+          values: [
+            {
+              id: 12,
+              title: 'Local Data Center branch',
+              state: 'OPEN',
+              version: 3,
+              updatedDate: Date.parse('2026-05-15T00:00:00.000Z'),
+              fromRef: {
+                id: 'refs/heads/feature/dc',
+                displayId: 'feature/dc',
+                latestCommit: 'abc123'
+              },
+              toRef: { id: 'refs/heads/main', displayId: 'main' }
+            }
+          ]
+        })
+        return
+      }
+
+      if (url.pathname === '/rest/build-status/1.0/commits/stats/abc123') {
+        sendJson(res, { successful: 2, inProgress: 0, failed: 0, cancelled: 0, unknown: 0 })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ errors: [{ message: 'not found' }] }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-dc-review-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+      const site = `http://127.0.0.1:${address.port}`
+
+      process.env.ORCA_BITBUCKET_SERVER_URL = site
+      process.env.ORCA_BITBUCKET_SERVER_TOKEN = 'local-pat'
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync('git', ['remote', 'add', 'origin', `${site}/scm/PRJ/repo.git`], {
+        cwd: repoPath
+      })
+
+      await expect(
+        getHostedReviewForBranch({ repoPath, executionHostId: 'local', branch: 'refs/heads/feature/dc' })
+      ).resolves.toEqual({
+        provider: 'bitbucket',
+        number: 12,
+        title: 'Local Data Center branch',
+        state: 'open',
+        url: `${site}/projects/PRJ/repos/repo/pull-requests/12`,
+        status: 'success',
+        updatedAt: '2026-05-15T00:00:00.000Z',
+        mergeable: 'UNKNOWN',
+        headSha: 'abc123'
+      })
+
+      expect(seen.map((request) => request.pathname)).toEqual([
+        '/rest/api/1.0/projects/PRJ/repos/repo/pull-requests',
+        '/rest/build-status/1.0/commits/stats/abc123'
+      ])
+      expect(seen.every((request) => request.authorization === 'Bearer local-pat')).toBe(true)
+      const query = new URLSearchParams(seen[0].search)
+      expect(query.get('at')).toBe('refs/heads/feature/dc')
+      expect(query.get('direction')).toBe('OUTGOING')
+      expect(query.get('state')).toBe('ALL')
     } finally {
       await rm(repoPath, { recursive: true, force: true })
       await new Promise<void>((resolve, reject) => {

--- a/src/preload/api/preflight-api.ts
+++ b/src/preload/api/preflight-api.ts
@@ -9,7 +9,13 @@ export type PreflightStatus = {
   gh: { installed: boolean; authenticated: boolean }
   /** Optional — older preload payloads predating GitLab support omit it; consumers gate on `glab?.installed`. */
   glab?: { installed: boolean; authenticated: boolean }
-  bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  bitbucket?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
   azureDevOps?: {
     configured: boolean
     authenticated: boolean

--- a/src/preload/api/preflight-bridge.ts
+++ b/src/preload/api/preflight-bridge.ts
@@ -8,7 +8,13 @@ export const preflightApi = {
     git: { installed: boolean }
     gh: { installed: boolean; authenticated: boolean }
     glab?: { installed: boolean; authenticated: boolean }
-    bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+    bitbucket?: {
+      configured: boolean
+      authenticated: boolean
+      account: string | null
+      baseUrl: string | null
+      tokenConfigured: boolean
+    }
     azureDevOps?: {
       configured: boolean
       authenticated: boolean

--- a/src/renderer/src/components/feature-wall/ConnectIntegrationsList.test.tsx
+++ b/src/renderer/src/components/feature-wall/ConnectIntegrationsList.test.tsx
@@ -60,7 +60,9 @@ function makePreflightStatus(overrides: Partial<PreflightStatus> = {}): Prefligh
     bitbucket: {
       configured: false,
       authenticated: false,
-      account: null
+      account: null,
+      baseUrl: null,
+      tokenConfigured: false
     },
     azureDevOps: {
       configured: false,
@@ -192,7 +194,13 @@ describe('ConnectIntegrationsList', () => {
     // offer the code hosts as connectable task sources alongside the trackers.
     installStore(
       makePreflightStatus({
-        bitbucket: { configured: true, authenticated: true, account: 'acme' }
+        bitbucket: {
+          configured: true,
+          authenticated: true,
+          account: 'acme',
+          baseUrl: null,
+          tokenConfigured: true
+        }
       })
     )
 

--- a/src/renderer/src/components/settings/bitbucket-integration-card.test.tsx
+++ b/src/renderer/src/components/settings/bitbucket-integration-card.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PreflightIntegrationStatuses } from './integrations-pane-status'
+import { BitbucketIntegrationCard } from './bitbucket-integration-card'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mocks = vi.hoisted(() => ({
+  statuses: { current: null as PreflightIntegrationStatuses | null }
+}))
+
+vi.mock('./source-control-preflight-card-status', () => ({
+  usePreflightCardStatuses: () => {
+    if (!mocks.statuses.current) {
+      throw new Error('Preflight statuses were not installed')
+    }
+    return { statuses: mocks.statuses.current, unavailable: false, refresh: vi.fn() }
+  }
+}))
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function installStatuses(bitbucket: {
+  bitbucketStatus: PreflightIntegrationStatuses['bitbucketStatus']
+  bitbucketAccount: string | null
+  bitbucketBaseUrl: string | null
+}): void {
+  mocks.statuses.current = {
+    ghStatus: 'connected',
+    glabStatus: 'connected',
+    azureDevOpsStatus: 'not-configured',
+    azureDevOpsAccount: null,
+    azureDevOpsBaseUrl: null,
+    giteaStatus: 'not-configured',
+    giteaAccount: null,
+    giteaBaseUrl: null,
+    ...bitbucket
+  }
+}
+
+async function renderCard(): Promise<HTMLDivElement> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<BitbucketIntegrationCard />)
+  })
+  return container
+}
+
+describe('BitbucketIntegrationCard', () => {
+  beforeEach(() => {
+    // The card reads stored-credential metadata on mount; no saved credential
+    // here, so only the preflight-driven parts render.
+    Object.assign(window, {
+      api: { bitbucket: { status: vi.fn().mockResolvedValue(null), disconnect: vi.fn() } }
+    })
+  })
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    root = null
+    container?.remove()
+    container = null
+    mocks.statuses.current = null
+  })
+
+  it('documents the Data Center environment variables when unconfigured', async () => {
+    installStatuses({
+      bitbucketStatus: 'not-configured',
+      bitbucketAccount: null,
+      bitbucketBaseUrl: null
+    })
+
+    const rendered = await renderCard()
+
+    expect(rendered.textContent).toContain('ORCA_BITBUCKET_SERVER_URL')
+    expect(rendered.textContent).toContain('ORCA_BITBUCKET_SERVER_TOKEN')
+    // Cloud keeps its Connect flow; the env vars are named generically there.
+    expect(rendered.textContent).toContain('ORCA_BITBUCKET_*')
+  })
+
+  // Why: a Data Center token has no account name until a request carries
+  // X-AUSERNAME, so the site base URL is the only identifying detail available.
+  it('identifies a connected Data Center site by its base URL when no account is known', async () => {
+    installStatuses({
+      bitbucketStatus: 'connected',
+      bitbucketAccount: null,
+      bitbucketBaseUrl: 'https://bb.corp.example/bitbucket'
+    })
+
+    const rendered = await renderCard()
+
+    expect(rendered.textContent).toContain('https://bb.corp.example/bitbucket')
+    expect(rendered.textContent).toContain('Connected')
+  })
+
+  it('prefers the account name over the base URL once one is known', async () => {
+    installStatuses({
+      bitbucketStatus: 'connected',
+      bitbucketAccount: 'j.smith',
+      bitbucketBaseUrl: 'https://bb.corp.example/bitbucket'
+    })
+
+    const rendered = await renderCard()
+
+    expect(rendered.textContent).toContain('j.smith · Pull requests and build statuses')
+    expect(rendered.textContent).not.toContain('https://bb.corp.example/bitbucket')
+  })
+})

--- a/src/renderer/src/components/settings/bitbucket-integration-card.tsx
+++ b/src/renderer/src/components/settings/bitbucket-integration-card.tsx
@@ -44,7 +44,10 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
 
   const envManaged = connection?.source === 'environment'
   const storedCredential = connection?.source === 'stored'
-  const account = connection?.account ?? statuses.bitbucketAccount
+  // Data Center sites often expose no account name, so fall back to the site URL
+  // rather than dropping to the anonymous description. `||`, not `??`: an empty
+  // account string is falsy but not nullish and would render a blank name.
+  const account = connection?.account || statuses.bitbucketAccount || statuses.bitbucketBaseUrl
   // Only surface a base URL the user actually overrode; the default is noise.
   const baseUrlOverride =
     connection?.baseUrl && connection.baseUrl !== DEFAULT_API_BASE_URL ? connection.baseUrl : null
@@ -111,7 +114,7 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
               )
           : translate(
               'auto.components.settings.bitbucket.integration.card.description',
-              'Pull requests and build statuses for Bitbucket Cloud.'
+              'Pull requests and build statuses for Bitbucket Cloud or Data Center.'
             )
       }
       checking={status === 'checking'}
@@ -266,7 +269,7 @@ function BitbucketCardNote(props: {
     <p className="text-xs text-muted-foreground">
       {translate(
         'auto.components.settings.bitbucket.integration.card.notConfigured',
-        'Connect a Bitbucket Cloud account with an Atlassian API token or an access token. ORCA_BITBUCKET_* environment variables work too and take precedence.'
+        'Connect a Bitbucket Cloud account with an Atlassian API token or an access token. ORCA_BITBUCKET_* environment variables work too and take precedence. For Bitbucket Data Center, set ORCA_BITBUCKET_SERVER_URL and ORCA_BITBUCKET_SERVER_TOKEN.'
       )}
     </p>
   )

--- a/src/renderer/src/components/settings/integrations-pane-status.test.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.test.ts
@@ -10,7 +10,13 @@ const connectedPreflight: PreflightStatus = {
   git: { installed: true },
   gh: { installed: true, authenticated: true },
   glab: { installed: true, authenticated: true },
-  bitbucket: { configured: true, authenticated: true, account: 'bb-user' },
+  bitbucket: {
+    configured: true,
+    authenticated: true,
+    account: 'bb-user',
+    baseUrl: null,
+    tokenConfigured: true
+  },
   azureDevOps: {
     configured: true,
     authenticated: true,

--- a/src/renderer/src/components/settings/integrations-pane-status.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.ts
@@ -14,6 +14,7 @@ export type PreflightIntegrationStatuses = {
   glabStatus: GlabStatus
   bitbucketStatus: BitbucketStatus
   bitbucketAccount: string | null
+  bitbucketBaseUrl: string | null
   azureDevOpsStatus: AzureDevOpsStatus
   azureDevOpsAccount: string | null
   azureDevOpsBaseUrl: string | null
@@ -102,6 +103,7 @@ export function getPreflightIntegrationStatuses(
       glabStatus: 'checking',
       bitbucketStatus: 'checking',
       bitbucketAccount: null,
+      bitbucketBaseUrl: null,
       azureDevOpsStatus: 'checking',
       azureDevOpsAccount: null,
       azureDevOpsBaseUrl: null,
@@ -127,6 +129,7 @@ export function getPreflightIntegrationStatuses(
       bitbucketStatusFromPreflight(bitbucket)
     ),
     bitbucketAccount: bitbucket?.account ?? null,
+    bitbucketBaseUrl: bitbucket?.baseUrl ?? null,
     azureDevOpsStatus: maybeChecking(
       'azureDevOps',
       refreshingProviders,

--- a/src/renderer/src/components/settings/integrations-search.ts
+++ b/src/renderer/src/components/settings/integrations-search.ts
@@ -56,8 +56,8 @@ export const getIntegrationsPaneSearchEntries = createLocalizedCatalog(() => [
       'Bitbucket Integration'
     ),
     description: translate(
-      'auto.components.settings.integrations.search.760e2446e0',
-      'Bitbucket Cloud authentication with a saved API token or environment variables.'
+      'auto.components.settings.integrations.search.b7790a4b9f',
+      'Bitbucket Cloud and Data Center authentication with a saved API token or environment variables.'
     ),
     keywords: [
       ...translateSearchKeyword(
@@ -91,7 +91,12 @@ export const getIntegrationsPaneSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword(
         'auto.components.settings.integrations.search.af5ae87847',
         'access token'
-      )
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.integrations.search.0a64f45950',
+        'data center'
+      ),
+      ...translateSearchKeyword('auto.components.settings.integrations.search.cf1e8c14e5', 'server')
     ]
   },
   {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9765,8 +9765,8 @@
             "b79c21bd42": "github",
             "7166b9090c": "GitHub authentication via the gh CLI.",
             "f16e41cc72": "GitHub Integration",
-            "760e2446e0": "Bitbucket Cloud authentication with a saved API token or environment variables.",
-            "af5ae87847": "access token"
+            "af5ae87847": "access token",
+            "b7790a4b9f": "Bitbucket Cloud and Data Center authentication with a saved API token or environment variables."
           }
         },
         "jira": {
@@ -10728,7 +10728,12 @@
                   "statusNotConfigured": "Not configured",
                   "statusAuthFailed": "Auth failed",
                   "statusConfigured": "Configured",
-                  "statusOptionalSetup": "Optional setup"
+                  "statusOptionalSetup": "Optional setup",
+                  "2ec6eeae8a": "Pull requests and build statuses via Bitbucket Cloud or Data Center.",
+                  "347f5be5e5": "For Bitbucket Cloud, set",
+                  "2330a1e7a3": "For Bitbucket Data Center, set",
+                  "18d24502a8": "ORCA_BITBUCKET_SERVER_URL",
+                  "87e9409058": "ORCA_BITBUCKET_SERVER_TOKEN"
                 }
               }
             }
@@ -11795,7 +11800,7 @@
           },
           "integration": {
             "card": {
-              "description": "Pull requests and build statuses for Bitbucket Cloud.",
+              "description": "Pull requests and build statuses for Bitbucket Cloud or Data Center.",
               "edit": "Edit credentials",
               "connect": "Connect",
               "accountUnknown": "Bitbucket Cloud",
@@ -11805,7 +11810,7 @@
               "envManaged": "Configured via environment variables. Unset the ORCA_BITBUCKET_* variables to manage this credential in Orca.",
               "storedAuthFailed": "The saved Bitbucket credential could not authenticate. Edit it, or check that the token still has pull request access.",
               "storedCredential": "Saved in Orca on this machine. ORCA_BITBUCKET_* environment variables take precedence when set.",
-              "notConfigured": "Connect a Bitbucket Cloud account with an Atlassian API token or an access token. ORCA_BITBUCKET_* environment variables work too and take precedence.",
+              "notConfigured": "Connect a Bitbucket Cloud account with an Atlassian API token or an access token. ORCA_BITBUCKET_* environment variables work too and take precedence. For Bitbucket Data Center, set ORCA_BITBUCKET_SERVER_URL and ORCA_BITBUCKET_SERVER_TOKEN.",
               "disconnectFailed": "Could not remove the saved Bitbucket credential."
             }
           }

--- a/src/renderer/src/web/preload-api/web-host-capability-api.ts
+++ b/src/renderer/src/web/preload-api/web-host-capability-api.ts
@@ -20,7 +20,13 @@ export function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight
     git: { installed: false },
     gh: { installed: false, authenticated: false },
     glab: { installed: false, authenticated: false },
-    bitbucket: { configured: false, authenticated: false, account: null },
+    bitbucket: {
+      configured: false,
+      authenticated: false,
+      account: null,
+      baseUrl: null,
+      tokenConfigured: false
+    },
     azureDevOps: {
       configured: false,
       authenticated: false,


### PR DESCRIPTION
**What:** Bitbucket Data Center (self-hosted) pull-request status — DC remotes stop being mis-claimed by the Gitea resolver.
**Risk:** Config-gated: claims only `/scm/` remotes or an explicitly configured host; zero changes to provider enums, persisted fields, or other forges. Greptile 4/5; both flagged items since addressed (auth routing fixed, token-only path documented).
**State:** Rebased on `main` today (0 behind, 0 conflicts); all 10 review threads resolved; suites green incl. end-to-end integration test.

---

Fixes #12031.

Bitbucket Cloud already shipped; Data Center remotes were being claimed by the Gitea resolver's catch-all, so self-hosted users saw a spurious "Set `ORCA_GITEA_TOKEN`" instead of their pull requests.

## Approach: keep the `bitbucket` id, make the ref host-aware

Data Center is the same product family as Cloud but a different API dialect, so this mirrors how GitHub Enterprise reuses `github` and carries its host on the repository ref.

A separate `bitbucket-server` id would have cost a new `HostedReviewProvider` member, a parallel `linkedBitbucketServerPR` field threaded through ~14 main and ~30 renderer files, and two hand-duplicated zod enums — for no user-visible gain. It also would never have won detection: `FORGE_PROVIDERS` is ordered and Gitea claims any unknown host, whereas `bitbucket` already resolves ahead of it.

Net effect: **zero changes** to the provider enums, `linked*PR` persistence, worktree schemas, RPC/preload channels, or any of the provider `switch` ladders.

## Detection is deliberately narrow

Data Center is claimed on two positive signals only:

1. the configured site host (`ORCA_BITBUCKET_SERVER_URL`), or
2. the `/scm/` clone path Atlassian fixes for every HTTPS remote.

Anything looser makes Bitbucket a second catch-all and steals the remotes Gitea legitimately claims. There is an explicit negative test for this.

## API delta

Verified against the Atlassian Bitbucket Data Center OpenAPI spec, `info.version` 9.6 and 10.4 (identical on every point). The wire formats share no field names, so Data Center gets its own mapper and client rather than conditionals.

| Concern | Cloud v2.0 | Data Center |
| --- | --- | --- |
| Base URL | `api.bitbucket.org/2.0` | `{site}/rest/api/1.0`, arbitrary host + optional context path |
| Repo addressing | `/repositories/{workspace}/{slug}` | `/projects/{KEY}/repos/{slug}` |
| Auth | Bearer, or Basic `email:apiToken` | Bearer PAT |
| Current user | `GET /user` | none — probe `/users?limit=1`, name from `X-AUSERNAME` |
| Branch lookup | BBQL `q=source.branch.name` | `?at=refs/heads/x&direction=OUTGOING&state=ALL` |
| Branch refs | plain name | fully-qualified `refs/heads/…` |
| Dates | `updated_on` ISO string | `updatedDate` epoch millis |
| Naming | `snake_case` | `camelCase` |
| Web URL | `links.html.href` | undocumented — constructed |
| State enum | includes `SUPERSEDED` | no `SUPERSEDED` |
| Build status | `/statuses/build` | `/build-status/1.0/commits/stats/{sha}` |
| Pagination | `pagelen`/`page` | `start`/`limit`/`nextPageStart` |
| Errors | `{ error: { message } }` | `{ errors: [{ message }] }` |

Two details bite if missed, and both are covered by tests:

- The list endpoint **defaults to `direction=INCOMING`**, which returns the pull requests *targeting* a branch rather than those from it — a silent wrong-answer bug.
- `links` is a **write-only object** in the published schema, so the PR URL is constructed. The Cloud mapper's `links.html.href` guard would otherwise reject every Data Center pull request.

Build status uses the aggregated `/build-status/1.0/commits/stats/{sha}` endpoint: one request, and its counts are exactly what the rollup needs. The per-commit list endpoint is deprecated as of 7.14 and its replacement requires a build key and returns a single status.

## Files

New, under `src/main/bitbucket/`:

- `server-config.ts` — `ORCA_BITBUCKET_SERVER_URL` / `ORCA_BITBUCKET_SERVER_TOKEN`; normalizes a bare host, a site URL, or a pasted `/rest/api/1.0` URL down to the site base.
- `server-pull-request-mappers.ts` — Data Center payload shape, state map, aggregated build-stats rollup, constructed web URL (`/users/{slug}` for personal repos).
- `server-client.ts` — `{base}/rest` request layer: bearer PAT, `RestPage` envelope, one `Retry-After`-honouring retry on 429, `errors[0].message` surfacing.
- `cloud-client.ts` — the existing Cloud implementation, extracted so `client.ts` stays a dispatcher under the 300-line cap.

Changed: `repository-ref.ts` (cloud|server union, rebuilt on `createRemoteRefProbeCache` from #12030), `client.ts` (dispatches on `ref.kind` via a `PullRequestCandidate` union so the #9171 default-branch suppression and linked-number fallback stay shared), `PreflightStatus.bitbucket` gains `baseUrl`/`tokenConfigured` (mirrored in both preload declarations), settings card and search copy now cover both deployments.

The `client.ts` split adds global-fetch call sites, so `global-fetch-call-site-audit.test.ts` is updated and the Data Center error path cancels an unread body when the envelope fails to parse.

## Verification

End-to-end on Windows in `hosted-review-bitbucket.integration.test.ts`: a real `git init` with an `/scm/PRJ/repo.git` remote against a live HTTP server, driven through `getHostedReviewForBranch`. Asserts forge detection picks `bitbucket` over Gitea's catch-all, plus the REST paths, `direction=OUTGOING`, bearer auth, and the constructed PR URL.

- 6 new ref-parsing cases including the negative "leave unconfigured hosts to other forges" guard
- 5 new Data Center client cases; 3 new settings-card render cases
- 1,098 tests green across bitbucket / source-control / preflight / renderer settings
- `tsc` clean on node, web, cli; oxlint clean; max-lines ratchet unchanged; localization catalog synced

The only failures in the affected suites are `hosted-review-creation-shared-symlinks.test.ts`, which EPERMs on `symlinkSync` on Windows without Developer Mode and fails identically on `main`.

## Follow-ups (not in scope)

- **Deep links** — `hosted-remote-url.ts` and its renderer twin are hardcoded host allowlists producing Cloud-shaped paths; Data Center needs `/projects/K/repos/s/browse/…?at=`. The renderer has no env access, so the host must be plumbed through preflight.
- **PR creation** — would add `bitbucket` to `HostedReviewCreationProvider` and implement `createReview`, gated on `ref.kind === 'server'`.
- In-app Checks tab, comment threads, and merge UI stay out: `ChecksPanel` is hard-forked GitHub-vs-GitLab and every other provider falls back to an external link.

## Note on overlap

This touches `preload/api-types.ts`, `integrations-pane-status.ts`, `en.json`, and `preflight.ts`, which #12028 also touches. Both are rebased on current `main` and are individually clean; whichever lands second will need a small rebase.
