### PR TITLE
test(shared): cover the codex account selection-lane helpers

### DIFF
--- a/src/shared/codex-selection-lane.test.ts
+++ b/src/shared/codex-selection-lane.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCodexSelectionLaneKey,
+  getWslSelectionKey,
+  normalizeCodexAccountSelectionTarget
+} from './codex-selection-lane'
+
+describe('normalizeCodexAccountSelectionTarget', () => {
+  it('defaults an absent target to the host lane', () => {
+    expect(normalizeCodexAccountSelectionTarget(undefined)).toEqual({
+      runtime: 'host',
+      wslDistro: null
+    })
+    expect(normalizeCodexAccountSelectionTarget(null)).toEqual({ runtime: 'host', wslDistro: null })
+  })
+
+  it('defaults a target with no runtime to the host lane', () => {
+    expect(normalizeCodexAccountSelectionTarget({})).toEqual({ runtime: 'host', wslDistro: null })
+  })
+
+  it('keeps an explicit host target on the host lane and ignores a wslDistro', () => {
+    expect(normalizeCodexAccountSelectionTarget({ runtime: 'host', wslDistro: 'Ubuntu' })).toEqual({
+      runtime: 'host',
+      wslDistro: null
+    })
+  })
+
+  it('routes a wsl target without a distro to the default wsl lane', () => {
+    expect(normalizeCodexAccountSelectionTarget({ runtime: 'wsl' })).toEqual({
+      runtime: 'wsl',
+      wslDistro: null
+    })
+    expect(normalizeCodexAccountSelectionTarget({ runtime: 'wsl', wslDistro: null })).toEqual({
+      runtime: 'wsl',
+      wslDistro: null
+    })
+  })
+
+  it('trims surrounding whitespace from a wsl distro', () => {
+    expect(
+      normalizeCodexAccountSelectionTarget({ runtime: 'wsl', wslDistro: '  Ubuntu  ' })
+    ).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('treats a whitespace-only wsl distro as the default lane', () => {
+    expect(normalizeCodexAccountSelectionTarget({ runtime: 'wsl', wslDistro: '   ' })).toEqual({
+      runtime: 'wsl',
+      wslDistro: null
+    })
+  })
+})
+
+describe('getCodexSelectionLaneKey', () => {
+  it('keys a host target to "host"', () => {
+    expect(getCodexSelectionLaneKey(undefined)).toBe('host')
+    expect(getCodexSelectionLaneKey({ runtime: 'host' })).toBe('host')
+  })
+
+  it('keys a wsl target without a distro to the default wsl lane', () => {
+    expect(getCodexSelectionLaneKey({ runtime: 'wsl' })).toBe('wsl:__default__')
+    expect(getCodexSelectionLaneKey({ runtime: 'wsl', wslDistro: null })).toBe('wsl:__default__')
+  })
+
+  it('keys a wsl target with a distro to that distro lane, trimmed', () => {
+    expect(getCodexSelectionLaneKey({ runtime: 'wsl', wslDistro: 'Ubuntu' })).toBe('wsl:Ubuntu')
+    expect(getCodexSelectionLaneKey({ runtime: 'wsl', wslDistro: '  Debian  ' })).toBe('wsl:Debian')
+  })
+
+  it('keys a whitespace-only wsl distro to the default lane', () => {
+    expect(getCodexSelectionLaneKey({ runtime: 'wsl', wslDistro: '   ' })).toBe('wsl:__default__')
+  })
+})
+
+describe('getWslSelectionKey', () => {
+  it('returns the default sentinel for an absent or empty distro', () => {
+    expect(getWslSelectionKey(undefined)).toBe('__default__')
+    expect(getWslSelectionKey(null)).toBe('__default__')
+    expect(getWslSelectionKey('')).toBe('__default__')
+    expect(getWslSelectionKey('   ')).toBe('__default__')
+  })
+
+  it('returns a non-empty distro, trimmed', () => {
+    expect(getWslSelectionKey('Ubuntu')).toBe('Ubuntu')
+    expect(getWslSelectionKey('  Ubuntu  ')).toBe('Ubuntu')
+  })
+
+  it('preserves internal whitespace (only surrounding whitespace is trimmed)', () => {
+    expect(getWslSelectionKey('Ubuntu 22.04')).toBe('Ubuntu 22.04')
+    expect(getCodexSelectionLaneKey({ runtime: 'wsl', wslDistro: 'Ubuntu 22.04' })).toBe(
+      'wsl:Ubuntu 22.04'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`src/shared/codex-selection-lane.ts` exports three pure helpers that route codex accounts between the host and WSL lanes:

- `normalizeCodexAccountSelectionTarget` — defaults an absent/host target to the host lane; routes `wsl`; trims *surrounding* whitespace from `wslDistro` (internal whitespace preserved); collapses empty/whitespace to `null`.
- `getCodexSelectionLaneKey` — `'host'` | `'wsl:<distro>'` | `'wsl:__default__'`.
- `getWslSelectionKey` — the distro, or the `'__default__'` sentinel.

They are core routing logic, consumed across the main process (`codex-accounts/service.ts`, `runtime-selection.ts`, `rate-limits/service.ts` + `codex-rate-limit-target.ts`, `codex-pane-launch-account.ts`, `runtime-home-service.ts`) and the renderer (`codex-pane-selection-lane.ts`), but had **no direct unit tests**. The only existing coverage is `src/renderer/src/lib/codex-pane-selection-lane.test.ts`, which exercises them *indirectly* through the `resolveLocalPaneSelectionTarget` / pane-resolution wrapper, and only references `getCodexSelectionLaneKey({ runtime: 'host' })` (lines 252, 265) as a comparison helper. The `wslDistro` trim, the `'__default__'` sentinel, and `normalizeCodexAccountSelectionTarget` are not exercised in isolation.

This PR adds direct, isolated unit tests mirroring the co-located `branch-prefix.test.ts` sibling: one `describe` per export, exact-value assertions.

## Screenshots

No visual change — test-only.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:
- New `src/shared/codex-selection-lane.test.ts` — 13 tests, one `describe` per export.
- **Mutation-checked** (each logical branch proven to have teeth, not for-show):
  - dropping `.trim()` in `normalizeWslDistro` → **6 tests fail** (every trim-dependent case).
  - swapping the `'__default__'` sentinel → **3 tests fail** (the default-lane cases).
  - flipping the host default (`'host'` → `'wsl'`) → **4 tests fail** (the host-default cases).
  - `.replace(/\s+/g, '')` (strip *all* whitespace instead of trimming) → **1 test fails** — the internal-whitespace case; this is the one mutation invisible to the surrounding-trim assertions, which is exactly why that case is pinned explicitly.
  - reverted: **13/13 green**.
- `pnpm typecheck` green across all three tsconfigs (node, tc.cli, tc.web).
- `pnpm exec oxlint` clean on the new file (no rule suppression added).
- `git diff --stat` = exactly one new file (+96), zero production changes.

## AI Review Report

Pure additive test coverage — one new `*.test.ts` file, zero production edits. Reviewed for:
- **Cross-platform (macOS/Linux/Windows):** the SUT is the WSL/host lane router (a Windows-critical path); the tests assert its exact outputs and run identically on all platforms. No platform-specific code introduced.
- **SSH/remote/local + folder-workspace:** N/A — pure unit tests on a dependency-free module.
- **Provider/agent neutrality:** N/A — account-selection routing, not agent behaviour.
- **Performance / hot path:** none — test-only, runs once per suite.
- **UI quality:** N/A.

## Security Audit

Test-only change: adds assertions on a pure, zero-dependency module. No code/IPC/auth/path/dependency surface, no new input handling, no untrusted data.

## Notes

- The three exports are the single source of truth for the `'host'` / `'wsl:<distro>'` / `'wsl:__default__'` lane keys consumed by account resolution, rate-limit targeting, and stale-pane detection — a regression in `normalizeWslDistro` (e.g. dropping the trim, or renaming the sentinel) would silently mis-key WSL accounts. These tests lock that contract directly, separate from the pane-resolution wrapper.
- No open or closed PR adds a test for this module (`gh pr list --search "codex-selection-lane"` returns 18 results, all behaviour fixes for the account/lanes system — none add this test).
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.
