### PR TITLE
feat(speech): add GPT Transcribe model

### DIFF
--- a/src/main/speech/model-catalog.test.ts
+++ b/src/main/speech/model-catalog.test.ts
@@ -34,6 +34,19 @@ describe('SPEECH_MODEL_CATALOG', () => {
     expect(model?.streaming).toBe(false)
   })
 
+  it('registers GPT Transcribe as a non-streaming OpenAI model', () => {
+    const model = getCatalogModel('openai-gpt-transcribe')
+
+    expect(model).toMatchObject({
+      label: 'GPT Transcribe',
+      type: 'openai',
+      provider: 'openai',
+      language: 'multilingual',
+      sampleRate: 16000,
+      streaming: false
+    })
+  })
+
   it('ships the single-file SenseVoice model layout the loader resolves', () => {
     const model = getCatalogModel('sense-voice-zh-en-ja-ko-yue')
     expect(model?.files).toEqual(['model.int8.onnx', 'tokens.txt'])

--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -124,6 +124,17 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     streaming: false
   },
   {
+    id: 'openai-gpt-transcribe',
+    label: 'GPT Transcribe',
+    description:
+      'High-accuracy cloud transcription with multilingual language detection. Requires an OpenAI API key.',
+    type: 'openai',
+    provider: 'openai',
+    language: 'multilingual',
+    sampleRate: 16000,
+    streaming: false
+  },
+  {
     id: 'openai-gpt-4o-mini-transcribe',
     label: 'GPT-4o mini Transcribe',
     description:

--- a/src/main/speech/openai-transcription-client.test.ts
+++ b/src/main/speech/openai-transcription-client.test.ts
@@ -1,5 +1,47 @@
-import { describe, expect, it } from 'vitest'
-import { sanitizeOpenAiTranscriptionErrorMessage } from './openai-transcription-client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  OPENAI_TRANSCRIPTION_MODEL_BY_ID,
+  OpenAiTranscriptionSession,
+  sanitizeOpenAiTranscriptionErrorMessage
+} from './openai-transcription-client'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('OPENAI_TRANSCRIPTION_MODEL_BY_ID', () => {
+  it('maps the GPT Transcribe catalog id to the API model id', () => {
+    expect(OPENAI_TRANSCRIPTION_MODEL_BY_ID['openai-gpt-transcribe']).toBe('gpt-transcribe')
+  })
+})
+
+describe('OpenAiTranscriptionSession', () => {
+  it('sends GPT Transcribe audio using the JSON response format', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData
+      expect(form.get('model')).toBe('gpt-transcribe')
+      expect(form.get('response_format')).toBe('json')
+      expect(form.get('file')).toBeInstanceOf(Blob)
+      return new Response(JSON.stringify({ text: '  test transcript  ' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const session = new OpenAiTranscriptionSession('openai-gpt-transcribe', () => 'test-key')
+
+    session.feedAudio(new Float32Array(160), 16000)
+
+    await expect(session.finish()).resolves.toBe('test transcript')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/audio/transcriptions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-key' }
+      })
+    )
+  })
+})
 
 describe('sanitizeOpenAiTranscriptionErrorMessage', () => {
   it('does not expose the invalid OpenAI API key echoed by the provider', () => {

--- a/src/main/speech/openai-transcription-client.ts
+++ b/src/main/speech/openai-transcription-client.ts
@@ -1,6 +1,7 @@
 import { resampleToRate } from './stt-audio-resample'
 
 export const OPENAI_TRANSCRIPTION_MODEL_BY_ID: Record<string, string> = {
+  'openai-gpt-transcribe': 'gpt-transcribe',
   'openai-gpt-4o-mini-transcribe': 'gpt-4o-mini-transcribe',
   'openai-gpt-4o-transcribe': 'gpt-4o-transcribe'
 }


### PR DESCRIPTION
## Summary

- register GPT Transcribe in the shared speech model catalog so desktop and paired mobile settings can surface it
- map the catalog ID to OpenAI's gpt-transcribe Audio API model
- add regression coverage for the catalog metadata and multipart transcription request contract

## Screenshots

No visual changes. The model uses the existing speech model picker UI.

## Testing

- [x] pnpm lint
- [x] pnpm typecheck
- [x] Speech suite: 16 files and 97 tests passed
- [x] Desktop, relay, CLI, renderer, web, and macOS native production builds passed
- [x] Live OpenAI API smoke test returned HTTP 200 for a synthetic Korean audio clip
- [ ] pnpm test: 43,491 passed; 3 unrelated root-directory guard tests fail locally because they require Bash 4+ while macOS ships Bash 3.2

## AI Review Report

- Cross-platform: the change only adds provider metadata and a model ID mapping; it introduces no OS-specific paths, shortcuts, binaries, or Git behavior.
- Local, SSH, and folder workspaces: no workspace execution or filesystem assumptions changed.
- Agents and integrations: no agent lifecycle, provider integration, or IPC behavior changed; existing OpenAI models remain available.
- Performance: no dependency or hot-path work was added. The only runtime change is one catalog entry and one constant lookup entry.
- UI: the existing model picker renders the new catalog entry; no layout, tokens, or styling changed.
- Result: no additional changes were required after review.

## Security Audit

- Reuses the existing OpenAI API key retrieval and error sanitization paths.
- Sends requests to the existing fixed OpenAI HTTPS transcription endpoint.
- Tests use a fake key, and the committed diff contains no API keys, local environment paths, dependencies, or new IPC surface.

## Notes

- Existing GPT-4o transcription models and the default model selection are unchanged.
- X handle: not provided on the contributor's GitHub profile.

Made with [Orca](https://github.com/stablyai/orca) 🐋
