### PR TITLE
feat(mobile): syntax-highlight VHDL and SystemVerilog

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -46,6 +46,7 @@
     "expo-secure-store": "^55.0.13",
     "expo-splash-screen": "^55.0.20",
     "expo-status-bar": "^55.0.6",
+    "highlight.js": "^11.11.1",
     "lowlight": "^3.3.0",
     "lucide-react-native": "^1.14.0",
     "react": "^19.2.6",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       expo-status-bar:
         specifier: ^55.0.6
         version: 55.0.6(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0

--- a/mobile/src/session/mobile-file-language.ts
+++ b/mobile/src/session/mobile-file-language.ts
@@ -60,7 +60,23 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.lua': 'lua',
   '.r': 'r',
   '.R': 'r',
-  '.make': 'makefile'
+  '.make': 'makefile',
+  // HDL. Ids match the renderer's language-detect.ts; mobile-file-syntax.ts
+  // folds systemverilog onto highlight.js's single `verilog` grammar.
+  '.sv': 'systemverilog',
+  '.svh': 'systemverilog',
+  '.v': 'verilog',
+  '.vh': 'verilog',
+  '.vl': 'verilog',
+  '.veo': 'verilog',
+  '.vhd': 'vhdl',
+  '.vhdl': 'vhdl',
+  '.vhf': 'vhdl',
+  '.vhi': 'vhdl',
+  '.vho': 'vhdl',
+  '.vhs': 'vhdl',
+  '.vht': 'vhdl',
+  '.vhw': 'vhdl'
 }
 
 const FILENAME_TO_LANGUAGE: Record<string, string> = {

--- a/mobile/src/session/mobile-file-syntax.test.ts
+++ b/mobile/src/session/mobile-file-syntax.test.ts
@@ -20,6 +20,34 @@ describe('mobile file syntax highlighting', () => {
     expect(resolveMobileSyntaxLanguage('Dockerfile')).toBe('plaintext')
   })
 
+  it('resolves HDL files onto registered grammars instead of plaintext', () => {
+    expect(detectMobileFileLanguage('rtl/counter.vhd')).toBe('vhdl')
+    expect(detectMobileFileLanguage('gate/top.vho')).toBe('vhdl')
+    expect(detectMobileFileLanguage('C:\\rtl\\TOP.VHDL')).toBe('vhdl')
+    expect(detectMobileFileLanguage('rtl/cpu.sv')).toBe('systemverilog')
+    expect(detectMobileFileLanguage('rtl/alu.v')).toBe('verilog')
+
+    expect(resolveMobileSyntaxLanguage('rtl/counter.vhd')).toBe('vhdl')
+    // highlight.js has no SystemVerilog grammar of its own.
+    expect(resolveMobileSyntaxLanguage('rtl/cpu.sv')).toBe('verilog')
+    expect(resolveMobileSyntaxLanguage('rtl/alu.v')).toBe('verilog')
+  })
+
+  it('emits semantic syntax segments for VHDL and SystemVerilog', () => {
+    const vhdl = highlightMobileCode("q <= x\"FF\" when clk'event else '0';", 'vhdl')
+
+    expect(vhdl.highlighted).toBe(true)
+    expect(vhdl.segments).toContainEqual({ text: 'when', kind: 'keyword' })
+
+    const systemVerilog = highlightMobileCode(
+      'always_ff @(posedge clk) q <= d;',
+      resolveMobileSyntaxLanguage('rtl/cpu.sv')
+    )
+
+    expect(systemVerilog.highlighted).toBe(true)
+    expect(systemVerilog.segments).toContainEqual({ text: 'always_ff', kind: 'keyword' })
+  })
+
   it('emits semantic syntax segments for highlighted code', () => {
     const result = highlightMobileCode('const label: string = "Orca"', 'typescript')
 

--- a/mobile/src/session/mobile-file-syntax.ts
+++ b/mobile/src/session/mobile-file-syntax.ts
@@ -1,3 +1,5 @@
+import verilog from 'highlight.js/lib/languages/verilog'
+import vhdl from 'highlight.js/lib/languages/vhdl'
 import { common, createLowlight } from 'lowlight'
 import { detectMobileFileLanguage } from './mobile-file-language'
 
@@ -32,6 +34,9 @@ type LowlightNode = {
 }
 
 const lowlight = createLowlight(common)
+// lowlight's `common` set stops at web languages, so HDL sources — which people
+// do review from a phone — arrived here flat. Two grammars, ~20 KB.
+lowlight.register({ verilog, vhdl })
 const MAX_FILE_HIGHLIGHT_CHARS = 48_000
 const MAX_FILE_HIGHLIGHT_SEGMENTS = 3_000
 const MAX_DIFF_HIGHLIGHT_CHARS = 24_000
@@ -48,7 +53,9 @@ const LANGUAGE_ALIASES: Record<string, string> = {
   shell: 'bash',
   zsh: 'bash',
   fish: 'bash',
-  yml: 'yaml'
+  yml: 'yaml',
+  // highlight.js has no separate SystemVerilog grammar; `verilog` covers both.
+  systemverilog: 'verilog'
 }
 
 export function resolveMobileSyntaxLanguage(filePath: string, preferredLanguage?: string): string {


### PR DESCRIPTION
## What

Mobile's extension map (`mobile/src/session/mobile-file-language.ts`) carried no HDL at all, so `.vhd` **and** `.sv` files rendered flat in both the file viewer and the diff review pane.

Companion to #12123, which fixes the desktop renderer. The two surfaces are independent: mobile has its own extension map and uses lowlight/highlight.js rather than Monaco, so neither change helps the other.

## How

Two things were blocking it, and both had to go:

1. The extension map had no HDL entries — now the same set the renderer uses.
2. `createLowlight(common)` — lowlight's `common` bundle carries neither `vhdl` nor `verilog`, so even a correct language id resolved to `plaintext` via the existing `lowlight.registered(...)` guard. Both grammars are now registered explicitly.

highlight.js has no separate SystemVerilog grammar, so `systemverilog` joins the existing alias table (alongside `shell` → `bash`) and folds onto `verilog`, which covers both languages.

## Dependency

`highlight.js` becomes a direct dependency of the mobile workspace. It was already in the tree at the same version (11.11.1) as a transitive dependency of `lowlight`, so `mobile/pnpm-lock.yaml` gains 3 lines and no new package is downloaded. The two grammars add roughly 20 KB to the bundle.

## Testing

`mobile/src/session/mobile-file-syntax.test.ts` gains coverage for the extension mapping, the `systemverilog` → `verilog` fold, and actual segment output for both languages (`always_ff` colors as a keyword; so does VHDL `when`).

`pnpm run test` green (383 files, 2862 pass, 3 skipped), plus `typecheck`, `lint` and `format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
