### PR TITLE
docs(tasks): trim the search-window error pattern comment

### DIFF
--- a/src/shared/github-work-items-query-bounds.ts
+++ b/src/shared/github-work-items-query-bounds.ts
@@ -3,13 +3,8 @@ import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
 export const GITHUB_WORK_ITEMS_QUERY_MAX_BYTES = 8 * 1024
 
 /**
- * GitHub's Search API only pages through the first 1000 matches; beyond that it
- * 422s with "Only the first 1000 search results are available". Matching that
- * free-text wording is the ONLY signal separating a permanently unreachable page
- * from a transient failure (#11485), so the phrase is pinned here rather than
- * inlined: if GitHub rewords it, window 422s silently demote to generic
- * failures and the advertised page count stops being capped.
- * `gh-utils.test.ts` asserts the classified message still carries this phrase.
+ * The Search API's free-text 422 wording is the only signal separating a
+ * permanently unreachable page (past the first 1000 matches) from a transient failure.
  */
 export const GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN = /first 1000 search results/i
 


### PR DESCRIPTION
Follow-up to #11584 review feedback: the `GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN` doc comment carried issue history, downstream behavior, and a test-file reference. Trimmed to the one non-obvious point — GitHub's free-text 422 wording is the only signal separating a permanently unreachable page from a transient failure.

Comment-only change. `gh-utils.test.ts` (36 tests) passes; oxlint/oxfmt clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
