### PR TITLE
fix(workspace-cleanup): read reflog timestamps to avoid git maintenance

### DIFF
--- a/src/main/ipc/workspace-cleanup-activity.test.ts
+++ b/src/main/ipc/workspace-cleanup-activity.test.ts
@@ -55,17 +55,18 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     expect(worktree.lastActivityAt).toBe(20_000)
   })
 
-  it('uses linked worktree gitdir metadata when the .git pointer is stale', async () => {
+  it('uses linked worktree commit metadata when the .git pointer is stale', async () => {
     const gitDirPath = path.join('/repo', '.git', 'worktrees', 'repo-feature')
     const gitDirHeadPath = path.join(gitDirPath, 'HEAD')
-    const gitDirLogsHeadPath = path.join(gitDirPath, 'logs', 'HEAD')
+    const commitEditMsgPath = path.join(gitDirPath, 'COMMIT_EDITMSG')
+    const origHeadPath = path.join(gitDirPath, 'ORIG_HEAD')
     const statPath = vi.fn(async (targetPath: string) => {
       const mtimes: Record<string, number> = {
         '/repo-feature': 10_000,
         [path.join('/repo-feature', '.git')]: 20_000,
-        [gitDirPath]: 50_000,
         [gitDirHeadPath]: 60_000,
-        [gitDirLogsHeadPath]: 70_000
+        [origHeadPath]: 65_000,
+        [commitEditMsgPath]: 70_000
       }
       return { mtimeMs: mtimes[targetPath] ?? 0 }
     })
@@ -79,17 +80,86 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     )
 
     expect(readTextFile).toHaveBeenCalledWith(path.join('/repo-feature', '.git'))
-    expect(statPath).toHaveBeenCalledWith(gitDirPath)
     expect(statPath).toHaveBeenCalledWith(gitDirHeadPath)
-    expect(statPath).toHaveBeenCalledWith(gitDirLogsHeadPath)
+    expect(statPath).toHaveBeenCalledWith(commitEditMsgPath)
+    expect(statPath).toHaveBeenCalledWith(origHeadPath)
     expect(worktree.lastActivityAt).toBe(70_000)
+  })
+
+  it('ignores gitdir metadata that git maintenance and git status restamp', async () => {
+    const gitDirPath = path.join('/repo', '.git', 'worktrees', 'repo-feature')
+    const statPath = vi.fn(async (targetPath: string) => {
+      const mtimes: Record<string, number> = {
+        '/repo-feature': 10_000,
+        [path.join('/repo-feature', '.git')]: 10_000,
+        [gitDirPath]: 90_000,
+        [path.join(gitDirPath, 'index')]: 90_000,
+        [path.join(gitDirPath, 'logs', 'HEAD')]: 90_000
+      }
+      return { mtimeMs: mtimes[targetPath] ?? 0 }
+    })
+    const readTextFile = vi.fn(async () => `gitdir: ${gitDirPath}\n`)
+
+    const worktree = await resolveWorkspaceCleanupActivityWorktree(
+      REPO,
+      makeWorktree(),
+      statPath,
+      readTextFile
+    )
+
+    expect(statPath).not.toHaveBeenCalledWith(gitDirPath)
+    expect(statPath).not.toHaveBeenCalledWith(path.join(gitDirPath, 'index'))
+    expect(statPath).not.toHaveBeenCalledWith(path.join(gitDirPath, 'logs', 'HEAD'))
+    expect(worktree.lastActivityAt).toBe(10_000)
+  })
+
+  it('reads the newest reflog entry timestamp instead of the reflog file mtime', async () => {
+    const gitDirPath = path.join('/repo', '.git', 'worktrees', 'repo-feature')
+    const reflogPath = path.join(gitDirPath, 'logs', 'HEAD')
+    const statPath = vi.fn(async () => ({ mtimeMs: 10_000 }))
+    const readTextFile = vi.fn(async (targetPath: string) =>
+      targetPath === reflogPath
+        ? [
+            '0000 1111 Dev <dev@example.com> 1700000000 -0700\tbranch: Created from HEAD',
+            '1111 2222 Dev <dev@example.com> 1700000900 -0700\tcommit: work',
+            ''
+          ].join('\n')
+        : `gitdir: ${gitDirPath}\n`
+    )
+
+    const worktree = await resolveWorkspaceCleanupActivityWorktree(
+      REPO,
+      makeWorktree(),
+      statPath,
+      readTextFile
+    )
+
+    expect(readTextFile).toHaveBeenCalledWith(reflogPath)
+    expect(worktree.lastActivityAt).toBe(1_700_000_900_000)
+  })
+
+  it('degrades to other probes when the reflog was expired to an empty file', async () => {
+    const gitDirPath = path.join('/repo', '.git', 'worktrees', 'repo-feature')
+    const statPath = vi.fn(async () => ({ mtimeMs: 10_000 }))
+    const readTextFile = vi.fn(async (targetPath: string) =>
+      targetPath === path.join(gitDirPath, 'logs', 'HEAD') ? '' : `gitdir: ${gitDirPath}\n`
+    )
+
+    const worktree = await resolveWorkspaceCleanupActivityWorktree(
+      REPO,
+      makeWorktree(),
+      statPath,
+      readTextFile
+    )
+
+    expect(worktree.lastActivityAt).toBe(10_000)
   })
 
   it('resolves relative linked worktree gitdir pointers from the worktree path', async () => {
     const gitDirPath = path.resolve('/repo-feature', '.repo/gitdir')
-    const gitDirLogsHeadPath = path.join(gitDirPath, 'logs', 'HEAD')
+    const commitEditMsgPath = path.join(gitDirPath, 'COMMIT_EDITMSG')
     const statPath = vi.fn(async (targetPath: string) => ({
-      mtimeMs: targetPath === gitDirLogsHeadPath ? 40_000 : 10_000
+      mtimeMs: targetPath === commitEditMsgPath ? 40_000 : 10_000
     }))
     const readTextFile = vi.fn(async () => 'gitdir: .repo/gitdir\n')
 
@@ -100,7 +170,7 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
       readTextFile
     )
 
-    expect(statPath).toHaveBeenCalledWith(gitDirLogsHeadPath)
+    expect(statPath).toHaveBeenCalledWith(commitEditMsgPath)
     expect(worktree.lastActivityAt).toBe(40_000)
   })
 
@@ -108,14 +178,13 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     const worktreePath = String.raw`\\wsl.localhost\Ubuntu\home\me\repo-feature`
     const gitDirPath = String.raw`\\wsl.localhost\Ubuntu\home\me\repo\.git\worktrees\repo-feature`
     const gitDirHeadPath = path.join(gitDirPath, 'HEAD')
-    const gitDirLogsHeadPath = path.join(gitDirPath, 'logs', 'HEAD')
+    const commitEditMsgPath = path.join(gitDirPath, 'COMMIT_EDITMSG')
     const statPath = vi.fn(async (targetPath: string) => {
       const mtimes: Record<string, number> = {
         [worktreePath]: 10_000,
         [path.join(worktreePath, '.git')]: 20_000,
-        [gitDirPath]: 50_000,
         [gitDirHeadPath]: 60_000,
-        [gitDirLogsHeadPath]: 70_000
+        [commitEditMsgPath]: 70_000
       }
       return { mtimeMs: mtimes[targetPath] ?? 0 }
     })
@@ -129,10 +198,11 @@ describe('resolveWorkspaceCleanupActivityWorktree', () => {
     )
 
     expect(readTextFile).toHaveBeenCalledWith(path.join(worktreePath, '.git'))
-    expect(statPath).toHaveBeenCalledWith(gitDirPath)
     expect(statPath).toHaveBeenCalledWith(gitDirHeadPath)
-    expect(statPath).toHaveBeenCalledWith(gitDirLogsHeadPath)
-    expect(statPath).not.toHaveBeenCalledWith('/home/me/repo/.git/worktrees/repo-feature')
+    expect(statPath).toHaveBeenCalledWith(commitEditMsgPath)
+    expect(statPath).not.toHaveBeenCalledWith(
+      path.join('/home/me/repo/.git/worktrees/repo-feature', 'HEAD')
+    )
     expect(worktree.lastActivityAt).toBe(70_000)
   })
 

--- a/src/main/ipc/workspace-cleanup-activity.ts
+++ b/src/main/ipc/workspace-cleanup-activity.ts
@@ -98,7 +98,8 @@ async function readNewestReflogEntryAt(
   try {
     const lines = (await readTextFile(reflogPath)).split('\n')
     for (let index = lines.length - 1; index >= 0; index -= 1) {
-      const seconds = /\s(\d{9,11})\s[-+]\d{4}\t/.exec(lines[index] ?? '')?.[1]
+      // The trailing timezone + tab anchors the capture, so no digit-count floor is needed.
+      const seconds = /\s(\d{1,11})\s[-+]\d{4}\t/.exec(lines[index] ?? '')?.[1]
       if (seconds) {
         return Number(seconds) * 1000
       }

--- a/src/main/ipc/workspace-cleanup-activity.ts
+++ b/src/main/ipc/workspace-cleanup-activity.ts
@@ -1,19 +1,12 @@
 import { lstat, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import type { Repo, Worktree } from '../../shared/types'
+import { getPersistedWorkspaceCleanupActivityAt } from '../../shared/workspace-cleanup'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
 
 type StatPath = (targetPath: string) => Promise<{ mtimeMs: number }>
 type ReadTextFile = (targetPath: string) => Promise<string>
-
-export function getPersistedWorkspaceCleanupActivityAt(
-  worktree: Pick<Worktree, 'createdAt' | 'lastActivityAt'>
-): number {
-  const persistedActivityAt = Number.isFinite(worktree.lastActivityAt) ? worktree.lastActivityAt : 0
-  const createdAt = Number.isFinite(worktree.createdAt) ? (worktree.createdAt ?? 0) : 0
-  return Math.max(persistedActivityAt, createdAt)
-}
 
 export function resolvePersistedWorkspaceCleanupActivityWorktree(worktree: Worktree): Worktree {
   const persistedActivityAt = getPersistedWorkspaceCleanupActivityAt(worktree)
@@ -56,7 +49,7 @@ async function resolveWorkspaceCleanupActivityAt(
     return persistedActivityAt
   }
 
-  const filesystemActivityAt = await getNewestLocalWorktreeStatMtime(
+  const filesystemActivityAt = await getNewestLocalWorktreeActivityAt(
     worktree.path,
     statPath,
     readTextFile
@@ -67,26 +60,53 @@ async function resolveWorkspaceCleanupActivityAt(
 // Why: best-effort only. Win32 stat over \\wsl.localhost (9P) can falsely
 // report ENOENT (see wslUncDirectoryExists), so a failed stat degrades to the
 // persisted activity timestamp instead of blocking or mislabeling the row.
-async function getNewestLocalWorktreeStatMtime(
+async function getNewestLocalWorktreeActivityAt(
   worktreePath: string,
   statPath: StatPath,
   readTextFile: ReadTextFile
 ): Promise<number> {
   const gitPath = path.join(worktreePath, '.git')
   const gitDirPath = await readLocalWorktreeGitDir(worktreePath, gitPath, readTextFile)
-  const gitDirMtimePromises = gitDirPath
+  // Why: every entry here must move only on a user action. Excluded on purpose:
+  // the gitdir directory and logs/HEAD (restamped for every linked worktree at
+  // once by `git gc` / `git reflog expire`, which made one maintenance run look
+  // like activity everywhere), and index (rewritten by `git status` — this scan
+  // runs one per candidate, so it would erase the evidence it just read).
+  const gitDirProbes = gitDirPath
     ? [
-        readMtime(gitDirPath, statPath),
         readMtime(path.join(gitDirPath, 'HEAD'), statPath),
-        readMtime(path.join(gitDirPath, 'logs', 'HEAD'), statPath)
+        readMtime(path.join(gitDirPath, 'COMMIT_EDITMSG'), statPath),
+        readMtime(path.join(gitDirPath, 'ORIG_HEAD'), statPath),
+        readNewestReflogEntryAt(path.join(gitDirPath, 'logs', 'HEAD'), readTextFile)
       ]
     : []
-  const mtimes = await Promise.all([
+  const timestamps = await Promise.all([
     readMtime(worktreePath, statPath),
     readMtime(gitPath, statPath),
-    ...gitDirMtimePromises
+    ...gitDirProbes
   ])
-  return Math.max(0, ...mtimes)
+  return Math.max(0, ...timestamps)
+}
+
+// Why: the reflog records when HEAD actually moved, so it survives the mtime
+// churn that makes logs/HEAD itself unreadable as a signal. Expired reflogs are
+// truncated to an empty file, which degrades to the other probes.
+async function readNewestReflogEntryAt(
+  reflogPath: string,
+  readTextFile: ReadTextFile
+): Promise<number> {
+  try {
+    const lines = (await readTextFile(reflogPath)).split('\n')
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const seconds = /\s(\d{9,11})\s[-+]\d{4}\t/.exec(lines[index] ?? '')?.[1]
+      if (seconds) {
+        return Number(seconds) * 1000
+      }
+    }
+    return 0
+  } catch {
+    return 0
+  }
 }
 
 async function readLocalWorktreeGitDir(

--- a/src/main/ipc/workspace-cleanup-scan.ts
+++ b/src/main/ipc/workspace-cleanup-scan.ts
@@ -13,8 +13,8 @@ import type {
   WorkspaceCleanupScanProgress,
   WorkspaceCleanupScanResult
 } from '../../shared/workspace-cleanup'
+import { getPersistedWorkspaceCleanupActivityAt } from '../../shared/workspace-cleanup'
 import {
-  getPersistedWorkspaceCleanupActivityAt,
   resolvePersistedWorkspaceCleanupActivityWorktree,
   resolveWorkspaceCleanupActivityWorktree
 } from './workspace-cleanup-activity'

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -34,8 +34,7 @@ import { useDaemonActions, DaemonActionDialog } from '../shared/useDaemonActions
 import type { AppMemory, BrowserWorkspace, UsageValues, Worktree } from '../../../../shared/types'
 import { ORPHAN_WORKTREE_ID } from '../../../../shared/constants'
 import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared/execution-host'
-import { isFolderRepo } from '../../../../shared/repo-kind'
-import { isWorkspaceOldForCleanup } from '../../../../shared/workspace-cleanup'
+import { countEstimatedInactiveWorkspaces } from '../workspace-cleanup/inactive-workspace-estimate'
 import { mergeSnapshotAndSessions, UNATTRIBUTED_REPO_ID } from './mergeSnapshotAndSessions'
 import type {
   Metric,
@@ -917,20 +916,10 @@ export function ResourceUsageStatusSegment({
     [allWorktrees]
   )
 
-  const oldWorkspaceCount = useMemo(() => {
-    const now = Date.now()
-    let count = 0
-    for (const worktree of allWorktrees) {
-      const repo = repoById.get(worktree.repoId)
-      if (!repo || isFolderRepo(repo) || worktree.isMainWorktree) {
-        continue
-      }
-      if (isWorkspaceOldForCleanup(worktree, now)) {
-        count += 1
-      }
-    }
-    return count
-  }, [allWorktrees, repoById])
+  const oldWorkspaceCount = useMemo(
+    () => countEstimatedInactiveWorkspaces(allWorktrees, repoById, Date.now()),
+    [allWorktrees, repoById]
+  )
 
   // Why: skip the merge when closed; the always-mounted segment recomputing on every keystroke-driven store mutation made the app laggy.
   const unifiedRepos = useMemo(

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -4,6 +4,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertTriangle,
+  Info,
   Loader2,
   RefreshCcw,
   Search,
@@ -68,7 +69,8 @@ import {
   startWorkspaceCleanupBackgroundRemoval,
   type WorkspaceCleanupRemovalProgress
 } from './workspace-cleanup-background-removal'
-import { CandidateRow } from './workspace-cleanup-candidate-row'
+import { countEstimatedInactiveWorkspaces } from './inactive-workspace-estimate'
+import { CandidateRow, type WorkspaceCleanupDeletionPhase } from './workspace-cleanup-candidate-row'
 import { WorkspaceCleanupCandidateList } from './workspace-cleanup-candidate-list'
 import {
   getCandidateStatus,
@@ -198,15 +200,20 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
   const removeCandidates = useAppStore((s) => s.removeWorkspaceCleanupCandidates)
   const markWorktreesQueuedForDeletion = useAppStore((s) => s.markWorktreesQueuedForDeletion)
   const clearWorktreeDeleteState = useAppStore((s) => s.clearWorktreeDeleteState)
-  const deletingWorktreeIds = useAppStore(
-    useShallow(
-      (s) =>
-        new Set(
-          Object.entries(s.deleteStateByWorktreeId)
-            .filter(([, state]) => state.isDeleting)
-            .map(([worktreeId]) => worktreeId)
-        )
-    )
+  const deletionPhaseByWorktreeId = useAppStore(
+    useShallow((s) => {
+      const phases: Record<string, WorkspaceCleanupDeletionPhase> = {}
+      for (const [worktreeId, state] of Object.entries(s.deleteStateByWorktreeId)) {
+        if (state.isDeleting) {
+          phases[worktreeId] = state.phase ?? 'deleting'
+        }
+      }
+      return phases
+    })
+  )
+  const deletingWorktreeIds = useMemo(
+    () => new Set(Object.keys(deletionPhaseByWorktreeId)),
+    [deletionPhaseByWorktreeId]
   )
 
   const open = activeModal === 'workspace-cleanup'
@@ -351,6 +358,31 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     }
     return candidates.filter((candidate) => effectiveRepoSelection.has(candidate.repoId))
   }, [candidates, effectiveRepoSelection, eligibleRepoIds.length])
+  // Why: the Resource Manager button counts from the renderer's activity record only,
+  // so it routinely disagrees with the scanned list. Reconcile it rather than leaving
+  // the user to wonder which number is real.
+  const estimatedInactiveCount = useMemo(() => {
+    if (!open) {
+      return null
+    }
+    return countEstimatedInactiveWorkspaces(
+      Object.values(reviewStateInputs.worktreesByRepo).flat(),
+      new Map(reviewStateInputs.repos.map((repo) => [repo.id, repo])),
+      Date.now()
+    )
+  }, [open, reviewStateInputs])
+  const estimateMismatchNotice =
+    !loading &&
+    scan &&
+    estimatedInactiveCount !== null &&
+    estimatedInactiveCount !== candidates.length &&
+    filteredCandidates.length === candidates.length
+      ? translate(
+          'auto.components.workspace.cleanup.WorkspaceCleanupDialog.f637f63882',
+          "Resource Manager counts {{value0}}; this list found {{value1}}. That counter reads Orca's activity record alone, while this scan also checks each workspace's git history and skips disconnected remotes.",
+          { value0: estimatedInactiveCount, value1: candidates.length }
+        )
+      : null
 
   useEffect(() => {
     if (loading || !scan || selectedDefaultsScanAtRef.current === scan.scannedAt) {
@@ -556,6 +588,13 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     setConfirming(false)
     setConfirmCandidates([])
   }, [closeModal, removalProgress])
+
+  // Why: the header X reads as "leave this screen", not "abandon the dialog". The batch
+  // keeps running in the background either way, and the list shows each row's progress.
+  const backToWorkspaceCleanupList = useCallback(() => {
+    setConfirming(false)
+    setConfirmCandidates([])
+  }, [])
 
   const clearQueuedDeleteState = useCallback(
     (worktreeId: string) => {
@@ -779,7 +818,9 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
                     variant="destructive"
                     size="sm"
                     onClick={() => openConfirmRemove(selectedCandidates)}
-                    disabled={selectedCount === 0 || loading}
+                    // Why: leaving the progress view no longer closes the dialog, so the
+                    // list is reachable mid-batch; a second batch would silently no-op.
+                    disabled={selectedCount === 0 || loading || removalProgress !== null}
                   >
                     <Trash2 className="size-3.5" />
                     {translate(
@@ -816,6 +857,13 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
               <div className="flex items-center gap-2 border-b border-border bg-muted/25 px-5 py-2 text-xs text-muted-foreground">
                 <AlertTriangle className="size-3.5 shrink-0" />
                 <span>{scanNoticeMessage}</span>
+              </div>
+            ) : null}
+
+            {estimateMismatchNotice ? (
+              <div className="flex items-start gap-2 border-b border-border bg-muted/25 px-5 py-2 text-xs text-muted-foreground">
+                <Info className="mt-0.5 size-3.5 shrink-0" />
+                <span>{estimateMismatchNotice}</span>
               </div>
             ) : null}
 
@@ -927,6 +975,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
                           last={activeRows.length > 1 && index === activeRows.length - 1}
                           expanded={expandedRowIds.has(candidate.worktreeId)}
                           lastActivityLabel={formatRelativeTime(candidate.lastActivityAt)}
+                          deletionPhase={deletionPhaseByWorktreeId[candidate.worktreeId]}
                           removing={loading || deletingWorktreeIds.has(candidate.worktreeId)}
                           selected={
                             selectedIds.has(candidate.worktreeId) &&
@@ -952,6 +1001,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
             candidates={confirmCandidates}
             reviewInfoByWorktreeId={reviewInfoByWorktreeId}
             progress={removalProgress}
+            onBack={backToWorkspaceCleanupList}
             onCancel={cancelConfirmRemove}
             onConfirm={confirmRemove}
           />
@@ -1275,12 +1325,14 @@ function ConfirmRemove({
   candidates,
   reviewInfoByWorktreeId,
   progress,
+  onBack,
   onCancel,
   onConfirm
 }: {
   candidates: WorkspaceCleanupCandidate[]
   reviewInfoByWorktreeId: ReadonlyMap<string, WorkspaceCleanupReviewInfo>
   progress: WorkspaceCleanupRemovalProgress | null
+  onBack: () => void
   onCancel: () => void
   onConfirm: () => void
 }): React.JSX.Element {
@@ -1332,10 +1384,10 @@ function ConfirmRemove({
             variant="ghost"
             size="icon-sm"
             aria-label={translate(
-              'auto.components.workspace.cleanup.WorkspaceCleanupDialog.191f0bc98e',
-              'Close'
+              'auto.components.workspace.cleanup.WorkspaceCleanupDialog.74f6c16279',
+              'Back'
             )}
-            onClick={onCancel}
+            onClick={onBack}
           >
             <X className="size-4" />
           </Button>

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -227,6 +227,9 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
   const [removalProgress, setRemovalProgress] = useState<WorkspaceCleanupRemovalProgress | null>(
     null
   )
+  // Why: `removalProgress` only arrives once the batch reports, so rendering
+  // needs its own in-flight flag; removalInFlightRef stays the synchronous guard.
+  const [removalInFlight, setRemovalInFlight] = useState(false)
   const [rowFailures, setRowFailures] = useState<Record<string, string>>({})
   const [repoSelection, setRepoSelection] = useState<ReadonlySet<string>>(() => new Set())
   const [filters, setFilters] = useState<WorkspaceCleanupFilters>(DEFAULT_FILTERS)
@@ -349,6 +352,10 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     }
     return new Set(eligibleRepoIds)
   }, [eligibleRepoIds, repoSelection])
+  const selectedScanErrors = useMemo(
+    () => (scan?.errors ?? []).filter((error) => effectiveRepoSelection.has(error.repoId)),
+    [effectiveRepoSelection, scan?.errors]
+  )
   const filteredCandidates = useMemo(() => {
     if (
       effectiveRepoSelection.size === 0 ||
@@ -371,8 +378,12 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       Date.now()
     )
   }, [open, reviewStateInputs])
+  // Why: the reconciliation only holds for a complete scan; a failed or partial
+  // one would blame the difference on git-history checks instead of the error.
   const estimateMismatchNotice =
     !loading &&
+    !error &&
+    selectedScanErrors.length === 0 &&
     scan &&
     estimatedInactiveCount !== null &&
     estimatedInactiveCount !== candidates.length &&
@@ -438,10 +449,6 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
   const repoNameById = useMemo(
     () => new Map(repos.map((repo) => [repo.id, repo.displayName || repo.path])),
     [repos]
-  )
-  const selectedScanErrors = useMemo(
-    () => (scan?.errors ?? []).filter((error) => effectiveRepoSelection.has(error.repoId)),
-    [effectiveRepoSelection, scan?.errors]
   )
   const scanNoticeMessage = useMemo(
     () => formatScanNoticeMessage(selectedScanErrors, repoNameById),
@@ -562,7 +569,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
   // instances from re-rendering on scan stream-in and selection changes.
   const handleRemoveRow = useCallback(
     (candidate: WorkspaceCleanupCandidate) => {
-      if (loading) {
+      if (loading || removalInFlightRef.current) {
         return
       }
       setSelectedIds(new Set([candidate.worktreeId]))
@@ -591,6 +598,8 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
 
   // Why: the header X reads as "leave this screen", not "abandon the dialog". The batch
   // keeps running in the background either way, and the list shows each row's progress.
+  // Diverges from cancelConfirmRemove, which closes the dialog mid-batch: here
+  // removalProgress stays set until the batch settles, so re-entry is still blocked.
   const backToWorkspaceCleanupList = useCallback(() => {
     setConfirming(false)
     setConfirmCandidates([])
@@ -636,6 +645,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       return
     }
     removalInFlightRef.current = true
+    setRemovalInFlight(true)
     removalBatchIdRef.current += 1
     const removalBatchId = removalBatchIdRef.current
     // Why: a hung late settlement retains these callbacks for the renderer's
@@ -664,6 +674,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
           setRowFailures(nextFailures)
           deselectRemovedIds(result.removedIds)
           setRemovalProgress(null)
+          setRemovalInFlight(false)
           setConfirming(false)
           setConfirmCandidates([])
         }
@@ -696,6 +707,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
         }
         if (mountedRef.current) {
           setRemovalProgress(null)
+          setRemovalInFlight(false)
           setConfirming(false)
           setConfirmCandidates([])
         }
@@ -820,7 +832,9 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
                     onClick={() => openConfirmRemove(selectedCandidates)}
                     // Why: leaving the progress view no longer closes the dialog, so the
                     // list is reachable mid-batch; a second batch would silently no-op.
-                    disabled={selectedCount === 0 || loading || removalProgress !== null}
+                    disabled={
+                      selectedCount === 0 || loading || removalProgress !== null || removalInFlight
+                    }
                   >
                     <Trash2 className="size-3.5" />
                     {translate(
@@ -976,7 +990,11 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
                           expanded={expandedRowIds.has(candidate.worktreeId)}
                           lastActivityLabel={formatRelativeTime(candidate.lastActivityAt)}
                           deletionPhase={deletionPhaseByWorktreeId[candidate.worktreeId]}
-                          removing={loading || deletingWorktreeIds.has(candidate.worktreeId)}
+                          removing={
+                            loading ||
+                            removalInFlight ||
+                            deletingWorktreeIds.has(candidate.worktreeId)
+                          }
                           selected={
                             selectedIds.has(candidate.worktreeId) &&
                             !loading &&

--- a/src/renderer/src/components/workspace-cleanup/inactive-workspace-estimate.test.ts
+++ b/src/renderer/src/components/workspace-cleanup/inactive-workspace-estimate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo, Worktree } from '../../../../shared/types'
+import { countEstimatedInactiveWorkspaces } from './inactive-workspace-estimate'
+
+const NOW = 1_800_000_000_000
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const GIT_REPO = { id: 'repo-1', path: '/repo', displayName: 'Repo' } as Repo
+const FOLDER_REPO = {
+  id: 'folder-1',
+  path: '/folder',
+  displayName: 'Folder',
+  kind: 'folder'
+} as Repo
+
+const REPOS = new Map<string, Repo>([
+  [GIT_REPO.id, GIT_REPO],
+  [FOLDER_REPO.id, FOLDER_REPO]
+])
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::/repo-feature',
+    repoId: 'repo-1',
+    path: '/repo-feature',
+    isMainWorktree: false,
+    isArchived: false,
+    lastActivityAt: NOW - 90 * DAY_MS,
+    ...overrides
+  } as Worktree
+}
+
+describe('countEstimatedInactiveWorkspaces', () => {
+  it('counts workspaces idle past the cleanup threshold', () => {
+    expect(countEstimatedInactiveWorkspaces([makeWorktree()], REPOS, NOW)).toBe(1)
+  })
+
+  it('does not count a missing activity stamp as ancient', () => {
+    const worktrees = [
+      makeWorktree({ lastActivityAt: 0 }),
+      makeWorktree({ lastActivityAt: Number.NaN })
+    ]
+
+    expect(countEstimatedInactiveWorkspaces(worktrees, REPOS, NOW)).toBe(0)
+  })
+
+  it('falls back to the creation stamp when activity was never recorded', () => {
+    const recent = makeWorktree({ lastActivityAt: 0, createdAt: NOW - DAY_MS })
+    const old = makeWorktree({ lastActivityAt: 0, createdAt: NOW - 90 * DAY_MS })
+
+    expect(countEstimatedInactiveWorkspaces([recent, old], REPOS, NOW)).toBe(1)
+  })
+
+  it('skips main worktrees, folder workspaces, and unknown repos', () => {
+    const worktrees = [
+      makeWorktree({ isMainWorktree: true }),
+      makeWorktree({ repoId: FOLDER_REPO.id }),
+      makeWorktree({ repoId: 'gone' })
+    ]
+
+    expect(countEstimatedInactiveWorkspaces(worktrees, REPOS, NOW)).toBe(0)
+  })
+
+  it('uses the shorter archived threshold', () => {
+    const worktree = makeWorktree({ isArchived: true, lastActivityAt: NOW - 10 * DAY_MS })
+
+    expect(countEstimatedInactiveWorkspaces([worktree], REPOS, NOW)).toBe(1)
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/inactive-workspace-estimate.ts
+++ b/src/renderer/src/components/workspace-cleanup/inactive-workspace-estimate.ts
@@ -1,0 +1,37 @@
+import type { Repo, Worktree } from '../../../../shared/types'
+import { isFolderRepo } from '../../../../shared/repo-kind'
+import {
+  getPersistedWorkspaceCleanupActivityAt,
+  isWorkspaceOldForCleanup
+} from '../../../../shared/workspace-cleanup'
+
+/**
+ * Renderer-side estimate of how many workspaces the cleanup scan would list. It
+ * sees only Orca's persisted activity record, so it disagrees with the scan by
+ * design — the scan additionally reads each worktree's git history and cannot
+ * inspect disconnected remotes.
+ */
+export function countEstimatedInactiveWorkspaces(
+  worktrees: readonly Worktree[],
+  repoById: ReadonlyMap<string, Repo>,
+  now: number
+): number {
+  let count = 0
+  for (const worktree of worktrees) {
+    const repo = repoById.get(worktree.repoId)
+    if (!repo || isFolderRepo(repo) || worktree.isMainWorktree) {
+      continue
+    }
+    // Why: an unstamped workspace (externally created, or never opened here) reads as
+    // epoch 0, which counted every one of them as idle and inflated the estimate far
+    // past what the scan lists. Unknown is not old.
+    const lastActivityAt = getPersistedWorkspaceCleanupActivityAt(worktree)
+    if (
+      lastActivityAt > 0 &&
+      isWorkspaceOldForCleanup({ isArchived: worktree.isArchived, lastActivityAt }, now)
+    ) {
+      count += 1
+    }
+  }
+  return count
+}

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.test.tsx
@@ -62,4 +62,40 @@ describe('CandidateRow', () => {
     expect(container?.querySelector(`[aria-label="Select ${candidate.displayName}"]`)).toBeNull()
     expect(container?.querySelector(`[aria-label="Remove ${candidate.displayName}"]`)).toBeNull()
   })
+
+  it.each([
+    ['deleting' as const, 'Deleting…'],
+    ['queued' as const, 'Queued for deletion']
+  ])('replaces the status pill with the %s state', (deletionPhase, label) => {
+    const candidate = makeCandidate()
+
+    act(() => {
+      root?.render(
+        <CandidateRow
+          candidate={candidate}
+          deletionPhase={deletionPhase}
+          expanded={false}
+          last
+          lastActivityLabel="1d ago"
+          removing
+          reviewInfo={{
+            hasReview: false,
+            label: null,
+            provider: null,
+            state: null,
+            title: null
+          }}
+          selected
+          onIgnore={vi.fn()}
+          onRemove={vi.fn()}
+          onToggleExpanded={vi.fn()}
+          onToggleSelected={vi.fn()}
+          onView={vi.fn()}
+        />
+      )
+    })
+
+    expect(container?.textContent).toContain(label)
+    expect(container?.textContent).not.toContain('Ready')
+  })
 })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
@@ -8,6 +8,7 @@ import {
   FileWarning,
   GitBranch,
   GitPullRequest,
+  Loader2,
   Search,
   SquareTerminal,
   Trash2,
@@ -40,8 +41,11 @@ import {
 } from './workspace-cleanup-candidate-row-data'
 import { StatusPill } from './workspace-cleanup-status-pill'
 
+export type WorkspaceCleanupDeletionPhase = 'deleting' | 'queued'
+
 type CandidateRowProps = {
   candidate: WorkspaceCleanupCandidate
+  deletionPhase?: WorkspaceCleanupDeletionPhase
   expanded: boolean
   failure?: string
   last: boolean
@@ -99,6 +103,7 @@ function MetadataIconChip({
 // prop identity changes); virtualization, not memo, bounds that cost.
 export const CandidateRow = React.memo(function CandidateRow({
   candidate,
+  deletionPhase,
   expanded,
   failure,
   last,
@@ -113,6 +118,7 @@ export const CandidateRow = React.memo(function CandidateRow({
   onView
 }: CandidateRowProps): React.JSX.Element {
   const selectable = canQueueWorkspaceCleanupCandidate(candidate) && !removing
+  const deleting = deletionPhase !== undefined
   const ignored = candidate.blockers.includes('dismissed')
   const blockers = getWorkspaceCleanupBlockerLabels(candidate)
   const contextDetails = formatContextDetails(candidate)
@@ -133,6 +139,7 @@ export const CandidateRow = React.memo(function CandidateRow({
       className={cn(
         'group w-full border-b border-border/60 px-3 py-2.5 text-left text-foreground transition-colors hover:bg-accent/40',
         selected && 'bg-accent/30',
+        deleting && 'opacity-70',
         last && 'border-b-0'
       )}
     >
@@ -152,6 +159,8 @@ export const CandidateRow = React.memo(function CandidateRow({
           >
             {selected ? <Check className="size-3" strokeWidth={3} /> : null}
           </button>
+        ) : deleting ? (
+          <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-muted-foreground" />
         ) : (
           <div className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
         )}
@@ -159,7 +168,21 @@ export const CandidateRow = React.memo(function CandidateRow({
         <div className="min-w-0">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
             <span className="min-w-0 truncate text-sm font-medium">{candidate.displayName}</span>
-            <StatusPill tone={status.tone}>{status.label}</StatusPill>
+            {deletionPhase ? (
+              <StatusPill tone="destructive">
+                {deletionPhase === 'queued'
+                  ? translate(
+                      'auto.components.workspace.cleanup.workspace.cleanup.candidate.row.e1135728e3',
+                      'Queued for deletion'
+                    )
+                  : translate(
+                      'auto.components.workspace.cleanup.workspace.cleanup.candidate.row.b5d2b33e47',
+                      'Deleting…'
+                    )}
+              </StatusPill>
+            ) : (
+              <StatusPill tone={status.tone}>{status.label}</StatusPill>
+            )}
             <MetadataIconChip
               icon={Clock3}
               label={`${translate(

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
@@ -117,8 +117,10 @@ export const CandidateRow = React.memo(function CandidateRow({
   onToggleSelected,
   onView
 }: CandidateRowProps): React.JSX.Element {
-  const selectable = canQueueWorkspaceCleanupCandidate(candidate) && !removing
   const deleting = deletionPhase !== undefined
+  // Why: derive from `deleting` too, so the row never offers a checkbox or
+  // Remove button while it is queuing/deleting, even if `removing` was omitted.
+  const selectable = canQueueWorkspaceCleanupCandidate(candidate) && !removing && !deleting
   const ignored = candidate.blockers.includes('dismissed')
   const blockers = getWorkspaceCleanupBlockerLabels(candidate)
   const contextDetails = formatContextDetails(candidate)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2524,7 +2524,9 @@
             "selectedForDeletionCount": "Selected for deletion: {{value0}}",
             "deleteButtonCount": "Delete {{value0}}",
             "archivedStatus": "Archived",
-            "readyStatus": "Ready"
+            "readyStatus": "Ready",
+            "f637f63882": "Resource Manager counts {{value0}}; this list found {{value1}}. That counter reads Orca's activity record alone, while this scan also checks each workspace's git history and skips disconnected remotes.",
+            "74f6c16279": "Back"
           },
           "backgroundRemoval": {
             "removed": "Removed workspaces: {{value0}}",
@@ -2571,6 +2573,16 @@
             "dirtyFilesBlocker": "Changed files",
             "unknownBaseBlocker": "Could not verify unpushed commits",
             "dismissedBlocker": "Ignored"
+          },
+          "workspace": {
+            "cleanup": {
+              "candidate": {
+                "row": {
+                  "b5d2b33e47": "Deleting…",
+                  "e1135728e3": "Queued for deletion"
+                }
+              }
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2488,7 +2488,9 @@
             "selectedForDeletionCount": "已选择删除：{{value0}}",
             "deleteButtonCount": "删除 {{value0}}",
             "archivedStatus": "已归档",
-            "readyStatus": "就绪"
+            "readyStatus": "就绪",
+            "f637f63882": "资源管理器统计到 {{value0}} 个，此列表找到 {{value1}} 个。该计数仅依据 Orca 的活动记录，而此次扫描还会检查每个工作区的 git 历史，并跳过未连接的远程主机。",
+            "74f6c16279": "返回"
           },
           "backgroundRemoval": {
             "removed": "已删除工作区：{{value0}}",
@@ -2535,6 +2537,16 @@
             "dirtyFilesBlocker": "已更改文件",
             "unknownBaseBlocker": "无法验证未推送提交",
             "dismissedBlocker": "已忽略"
+          },
+          "workspace": {
+            "cleanup": {
+              "candidate": {
+                "row": {
+                  "b5d2b33e47": "正在删除…",
+                  "e1135728e3": "已加入删除队列"
+                }
+              }
+            }
           }
         }
       },

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -226,6 +226,28 @@ describe('Claude background task status', () => {
     expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
+  it('drains a reported cron inventory mid-turn, not only at a turn boundary', () => {
+    const state = createHookListenerState()
+
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      session_crons: [{ id: 'cron-1' }]
+    })
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'PostToolUse',
+        session_crons: []
+      })?.state
+    ).toBe('working')
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(false)
+
+    // Why: the mid-turn drain must survive to the next boundary — a Stop that reports
+    // nothing is the case where a stale cron flag would pin the pane 'working'.
+    expect(claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop' })?.state).toBe('done')
+  })
+
   it('only infers an omitted cron inventory is drained from modern lead Stop payloads', () => {
     const createCronState = (): HookListenerState => {
       const state = createHookListenerState()

--- a/src/shared/workspace-cleanup.ts
+++ b/src/shared/workspace-cleanup.ts
@@ -221,6 +221,16 @@ export function getWorkspaceCleanupInactivityReasons(
   return reasons
 }
 
+/** Newest activity stamp Orca itself persisted; 0 when it never observed the workspace. */
+export function getPersistedWorkspaceCleanupActivityAt(workspace: {
+  createdAt?: number
+  lastActivityAt: number
+}): number {
+  const lastActivityAt = Number.isFinite(workspace.lastActivityAt) ? workspace.lastActivityAt : 0
+  const createdAt = Number.isFinite(workspace.createdAt) ? (workspace.createdAt ?? 0) : 0
+  return Math.max(lastActivityAt, createdAt)
+}
+
 export function isWorkspaceOldForCleanup(
   workspace: WorkspaceCleanupInactivityInput,
   scannedAt: number


### PR DESCRIPTION
## Summary

Reads reflog entry timestamps instead of reflog file mtime to avoid false activity signals from `git maintenance` and `git status` restamping file modification times in linked worktrees.

## Changes

- Replace `logs/HEAD` mtime probe with `readNewestReflogEntryAt()` to read actual timestamp from reflog entries
- Exclude git-maintained files (`gitdir`, `index`, `logs/HEAD`) from activity probes
- Use commit metadata (`HEAD`, `COMMIT_EDITMSG`, `ORIG_HEAD`) for redundant signals
- Degrade gracefully when reflog is expired to empty file
- Move `getPersistedWorkspaceCleanupActivityAt()` to shared module for renderer-side use

## UI improvements

- Show deletion phase (`queued` / `deleting`) on candidate rows during batch removal
- Display mismatch notice when Resource Manager's estimate differs from scan results, explaining why they disagree
- Add back button on confirmation view to return to list without canceling batch
- Refactor candidate row state tracking to use deletion phase map

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added tests: reflog entry parsing, reflog expiration degradation, deletion phase display, renderer-side inactive estimate

## Notes

Reflog timestamp extraction uses regex to parse Unix timestamps from reflog format, compatible across macOS, Linux, and Windows.

## Related

Related to #10769 (worktree count degrades git performance; the inactive-workspaces surface doesn't catch it). This PR does **not** close that issue — it fixes one mechanic the issue documents, and leaves the rest.

- Fixed here: `git maintenance run --auto` runs `pack-objects --all --reflog`, which restamps every linked worktree's `logs/HEAD`. That made the mtime probe read one maintenance run as activity everywhere, so the scan reported far fewer inactive workspaces than existed. Reading reflog *entry* timestamps removes that false signal.
- Still open in #10769: a git-cost (worktree-count) recommendation signal, an alert at the point of pain (the slow commit), and reframing the surface as hygiene rather than disk.

⚠️ Overlaps #10771 (`fix(workspace): add git-cost cleanup signal and report total worktrees`), which claims #10769. Both PRs touch:

- `src/main/ipc/workspace-cleanup-scan.ts`
- `src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx`
- `src/renderer/src/i18n/locales/en.json`
- `src/shared/workspace-cleanup.ts`

Both also rework the same Resource Manager count, in different directions: #10771 shows inactive-vs-total so the numbers can't disagree, while this PR explains the disagreement in a notice. Whichever lands second needs a merge and a call on which of the two the segment should say.
