### PR TITLE
fix(gitlab): expire negative project-ref cache + key on SSH generation

### DIFF
--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,5 +1,6 @@
 import { glabExecFileAsync } from '../git/runner'
 import { isTransientGitProbeError, readRemoteUrl } from '../git/remote-url-probe'
+import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
 import type { IssueSourcePreference } from '../../shared/types'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 import {
@@ -25,7 +26,16 @@ export {
 export type { LocalGitExecOptions } from './gitlab-known-host-probe'
 
 const PROJECT_REF_CACHE_MAX_ENTRIES = 512
-const projectRefCache = new Map<string, ProjectRef | null>()
+
+// Why: a repo first probed with no GitLab remote answers "not mine" for the whole
+// process otherwise, so a remote added mid-session is invisible until restart.
+// Negatives expire instead; positives stay, as they did before. Mirrors the shared
+// remote-ref-probe-cache every other forge uses (Azure/Bitbucket/Gitea/GitHub).
+export const GITLAB_NEGATIVE_CACHE_TTL_MS = 5 * 60_000
+
+type CachedProjectRef = { value: ProjectRef | null; expiresAt: number }
+
+const projectRefCache = new Map<string, CachedProjectRef>()
 
 /** @internal - exposed for tests only */
 export function _resetProjectRefCache(): void {
@@ -39,7 +49,10 @@ export function _getProjectRefCacheSize(): number {
 }
 
 function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
-  projectRefCache.set(cacheKey, value)
+  projectRefCache.set(cacheKey, {
+    value,
+    expiresAt: value === null ? Date.now() + GITLAB_NEGATIVE_CACHE_TTL_MS : Number.POSITIVE_INFINITY
+  })
   while (projectRefCache.size > PROJECT_REF_CACHE_MAX_ENTRIES) {
     const oldestKey = projectRefCache.keys().next().value
     if (oldestKey === undefined) {
@@ -56,10 +69,18 @@ export async function getProjectRefForRemote(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
-  const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
+  // Why: a reconnect retires the connection an answer came from — stamping the
+  // generation stops a caller on the new connection adopting a stale probe.
+  const runtimeKey = connectionId
+    ? `${connectionId}:${getSshGitProviderGeneration(connectionId)}`
+    : `local:${localGitOptions.wslDistro ?? 'host'}`
   const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}\0${knownHosts.join(',')}`
-  if (projectRefCache.has(cacheKey)) {
-    return projectRefCache.get(cacheKey)!
+  const cached = projectRefCache.get(cacheKey)
+  if (cached) {
+    if (cached.expiresAt > Date.now()) {
+      return cached.value
+    }
+    projectRefCache.delete(cacheKey)
   }
 
   return runProjectRefProbeOnce(cacheKey, () =>

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -12,6 +12,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import {
+  GITLAB_NEGATIVE_CACHE_TTL_MS,
   _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,
@@ -690,5 +691,93 @@ describe('getGlabKnownHosts', () => {
     ])
     expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
     unregisterSshGitProvider(connectionId)
+  })
+})
+
+describe('project ref cache negative TTL + SSH generation', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    sshExecMock.mockReset()
+    _resetProjectRefCache()
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    unregisterSshGitProvider('conn-1')
+  })
+
+  it('re-probes a repo whose null result has aged past the negative TTL', async () => {
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error("error: No such remote 'origin'"))
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:team/repo.git\n' })
+
+    await expect(getProjectRefForRemote('/repo', 'origin')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    // Within the TTL the negative is served from cache — no re-probe.
+    await expect(getProjectRefForRemote('/repo', 'origin')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+
+    // Past the TTL the negative has expired; the now-present remote is picked up.
+    vi.setSystemTime(1_000_000 + GITLAB_NEGATIVE_CACHE_TTL_MS + 1)
+    await expect(getProjectRefForRemote('/repo', 'origin')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'team/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a resolved ref past the TTL without re-probing', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:team/repo.git\n' })
+
+    await expect(getProjectRefForRemote('/repo', 'origin')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'team/repo'
+    })
+    vi.setSystemTime(1_000_000 + GITLAB_NEGATIVE_CACHE_TTL_MS * 10)
+    await expect(getProjectRefForRemote('/repo', 'origin')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'team/repo'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes after an SSH provider reconnect bumps the generation', async () => {
+    sshExecMock.mockResolvedValue({ stdout: 'git@gitlab.com:remote/orca.git\n', stderr: '' })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'remote/orca'
+    })
+    expect(sshExecMock).toHaveBeenCalledTimes(1)
+
+    // A reconnect under the same id bumps the generation; the cached value for the
+    // old connection must not serve a caller on the new one.
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'remote/orca'
+    })
+    expect(sshExecMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-caches a still-null result for another full negative TTL after expiry', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(new Error("error: No such remote 'origin'"))
+
+    await getProjectRefForRemote('/repo', 'origin')
+    await getProjectRefForRemote('/repo', 'origin')
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+
+    // Past the TTL the negative expired; the second probe is still "not GitLab",
+    // and that answer must be re-cached for a fresh interval — not probed every call.
+    vi.setSystemTime(1_000_000 + GITLAB_NEGATIVE_CACHE_TTL_MS + 1)
+    await getProjectRefForRemote('/repo', 'origin')
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+
+    vi.setSystemTime(1_000_000 + GITLAB_NEGATIVE_CACHE_TTL_MS + 2)
+    await getProjectRefForRemote('/repo', 'origin')
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -5,6 +5,7 @@ export { glabExecFileAsync, gitExecFileAsync }
 export { classifyGlabError, classifyListIssuesError } from './glab-error-classification'
 export {
   DEFAULT_GITLAB_HOSTS,
+  GITLAB_NEGATIVE_CACHE_TTL_MS,
   _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,


### PR DESCRIPTION
## Summary

`getProjectRefForRemote` in `src/main/gitlab/gitlab-project-ref-resolution.ts` resolves whether a repo's remote points at GitLab (drives MR/issue features). It cached its answer in a process-lifetime `Map<string, ProjectRef | null>` keyed only on `connectionId` — two problems the other forge integrations do not have:

1. **A negative (`null`, "not GitLab") lived forever.** A repo first probed with no remote configured stayed "not GitLab" for the whole session, so a GitLab remote added mid-session was invisible (no MR/issue features) until app restart.
2. **No SSH-provider generation in the key.** A probe answered over an SSH connection that later dropped and reconnected to a different host stayed adopted under the same `connectionId`.

Every other forge already does both halves:
- `src/main/git/remote-ref-probe-cache.ts:22` `NEGATIVE_ENTRY_TTL_MS = 5 * 60_000`, `:24` `{ value, expiresAt }`, `:47-51` `expiresAt = value === null ? now+TTL : Infinity`, `:117-119` `${connectionId}:${getSshGitProviderGeneration(connectionId)}`.
- `src/main/github/github-repository-identity.ts:55,114-115` — same TTL + generation keying.
- `src/main/gitlab/gitlab-known-host-probe.ts:20` — GitLab's **own** known-host cache keys on the generation; the project-ref cache (same provider) did not. Intra-provider inconsistency.

Azure/Bitbucket/Gitea all consume the shared `createRemoteRefProbeCache`, so they inherit both behaviours — GitLab's project-ref cache is genuinely the lone outlier.

## Fix

- Cache value type: `Map<string, { value: ProjectRef | null; expiresAt: number }>`.
- `GITLAB_NEGATIVE_CACHE_TTL_MS = 5 * 60_000` (exported; positives get `Number.POSITIVE_INFINITY`, unchanged).
- `rememberProjectRefCacheEntry` stamps `expiresAt`; the lookup returns the cached value only while `expiresAt > Date.now()`, otherwise deletes and re-probes.
- `runtimeKey = connectionId ? \`${connectionId}:${getSshGitProviderGeneration(connectionId)}\` : \`local:${wslDistro ?? 'host'}\`` — a reconnect bumps the generation, invalidating the old entry.

Negatives that represent a transient/SSH failure are **not** cached (they already returned `null` without calling `rememberProjectRefCacheEntry`, matching the sibling), so a reconnecting host is re-probed immediately rather than waiting out the TTL — identical to `remote-ref-probe-cache.ts`.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions

Passed:
- New `describe('project ref cache negative TTL + SSH generation')` in `gl-utils.test.ts` — 4 tests: negative-TTL re-probe, positive-stays-cached-past-TTL, generation-bump re-probe, and **rolling re-cache** (a still-null result re-cached for a fresh interval after expiry).
- **Mutation-checked (RED-before-GREEN), each isolated:**
  - collapsing `expiresAt` to always `Infinity` → exactly **1 test fails** (the TTL re-probe).
  - dropping `getSshGitProviderGeneration` from the runtime key → exactly **1 test fails** (the generation-bump re-probe).
  - "only cache the first negative miss" (a plausible dedup optimization) → caught by the **rolling re-cache** test (the only test that probes a null a second time after expiry and asserts the second interval is served from cache).
  - reverted: **53/53 green** (49 pre-existing + 4 new).
- All pre-existing `gl-utils.test.ts` tests stay green (53 total), including `coalesces concurrent missing remote probes`, `does not cache a missing SSH provider as a permanent null`, and `does not cache transient SSH exec failures as permanent null` — the negative-TTL does not change their behaviour because transient/SSH-disconnect nulls were never cached in the first place.
- `pnpm typecheck` green across all three tsconfigs (node, tc.cli, tc.web).
- `pnpm exec oxlint` clean (exit 0).

## AI Review Report

- **Cross-platform (macOS/Linux/Windows):** no platform-specific code; the `wslDistro`/`connectionId` keying is unchanged for the local path. macOS/Linux/Windows parity preserved.
- **SSH/remote/local + folder-workspace:** the fix *improves* SSH-reconnect handling (stale entries invalidate on reconnect) and preserves the local/WSL `local:<wslDistro>` key. Folder workspaces unaffected (per-folder repo paths are already distinct in the key).
- **Provider/agent neutrality:** GitLab-specific forge detection; does not touch GitHub/provider behaviour.
- **Performance / hot path:** the probe is still bounded by the existing `project-ref-inflight` coalescing; a negative now costs at most one re-probe per repo per 5 min instead of zero — the trade-off that lets a mid-session remote be picked up.
- **UI quality:** MR/issue features appear for a repo whose GitLab remote was added after the first probe, without a restart.

## Security Audit

Cache-key + TTL change on an internal in-memory probe cache. No new input handling, IPC surface, auth, path traversal, or dependency. `getSshGitProviderGeneration` is an existing internal helper already used by every sibling cache. Probe rate is bounded by coalescing.

## Notes

- GitHub's negative TTL is `configSignature`-conditional (it watches `.git/config`); that refinement is GitHub-specific and intentionally not copied here — GitLab matches the shared `remote-ref-probe-cache` policy used by Azure/Bitbucket/Gitea.
- `_getProjectRefCacheSize()` still returns the entry count (Map size), unchanged.
- **One faithfulness gap is intentionally out of scope:** the sibling wraps every cache write in `publish = (v) => { if (ownsKey()) remember(...) }` so a probe abandoned as stale (>60s) cannot overwrite a fresher successor (`remote-ref-probe-cache.ts:72-76`, tested at `:113-131`). GitLab's `runProjectRefProbeOnce` (`project-ref-inflight.ts:10-17`) drops the `ownsKey` callback `runCoalescedProbe` passes, so its writes are unconditional. This is **pre-existing** (unchanged by this PR) and threading `ownsKey` through changes a helper signature + needs the stale-overwrite test — a cleaner separate follow-up than a scope expansion here.
- An SSH repo whose probe definitively reports "no such remote" is **intentionally** not cached (the existing `if (connectionId || isTransientGitProbeError(error)) return null` guard, per the P1-D comment). This is stricter than the sibling (which caches that one negative) and trades a cache hit for an extra probe on SSH repos lacking the remote — deliberate, to avoid misdetecting the forge on a wedged SSH transport.
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.
