### PR TITLE
refactor(runtime): dedup UTF-8 byte counters to shared measureUtf8ByteLength

### DIFF
--- a/src/renderer/src/runtime/runtime-file-search-bounds.ts
+++ b/src/renderer/src/runtime/runtime-file-search-bounds.ts
@@ -1,5 +1,7 @@
 import type { SearchOptions, SearchResult } from '../../../shared/types'
 
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
+
 export const RUNTIME_FILE_SEARCH_TEXT_MAX_BYTES = 8 * 1024
 
 export type RuntimeFileSearchRejectedField = 'query' | 'includePattern' | 'excludePattern'
@@ -8,35 +10,11 @@ export function createEmptyRuntimeFileSearchResult(): SearchResult {
   return { files: [], totalMatches: 0, truncated: false }
 }
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
-
 export function isRuntimeFileSearchTextWithinLimit(
   text: string,
   maxBytes = RUNTIME_FILE_SEARCH_TEXT_MAX_BYTES
 ): boolean {
-  let byteLength = 0
-  for (let index = 0; index < text.length; index += 1) {
-    const codePoint = text.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return false
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return true
+  return !measureUtf8ByteLength(text, { stopAfterBytes: maxBytes }).exceededLimit
 }
 
 export function getRuntimeFileSearchRejectedField(

--- a/src/renderer/src/runtime/runtime-provider-search-bounds.ts
+++ b/src/renderer/src/runtime/runtime-provider-search-bounds.ts
@@ -1,17 +1,6 @@
-export const RUNTIME_PROVIDER_SEARCH_QUERY_MAX_BYTES = 8 * 1024
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
+export const RUNTIME_PROVIDER_SEARCH_QUERY_MAX_BYTES = 8 * 1024
 
 export function isRuntimeProviderSearchQueryWithinLimit(
   query: string | null | undefined,
@@ -20,16 +9,5 @@ export function isRuntimeProviderSearchQueryWithinLimit(
   if (query === null || query === undefined) {
     return true
   }
-  let byteLength = 0
-  for (let index = 0; index < query.length; index += 1) {
-    const codePoint = query.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return false
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return true
+  return !measureUtf8ByteLength(query, { stopAfterBytes: maxBytes }).exceededLimit
 }

--- a/src/renderer/src/runtime/runtime-repo-search-bounds.ts
+++ b/src/renderer/src/runtime/runtime-repo-search-bounds.ts
@@ -1,32 +1,10 @@
-export const RUNTIME_REPO_REF_SEARCH_QUERY_MAX_BYTES = 2 * 1024
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
+export const RUNTIME_REPO_REF_SEARCH_QUERY_MAX_BYTES = 2 * 1024
 
 export function isRuntimeRepoRefSearchQueryWithinLimit(
   query: string,
   maxBytes = RUNTIME_REPO_REF_SEARCH_QUERY_MAX_BYTES
 ): boolean {
-  let byteLength = 0
-  for (let index = 0; index < query.length; index += 1) {
-    const codePoint = query.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return false
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return true
+  return !measureUtf8ByteLength(query, { stopAfterBytes: maxBytes }).exceededLimit
 }


### PR DESCRIPTION
## Summary

Three co-located modules in `src/renderer/src/runtime/` each carried a byte-identical private `getCodePointUtf8ByteLength` **and** a byte-identical ~12-line UTF-8 byte-counting loop:
- `runtime-provider-search-bounds.ts` (`isRuntimeProviderSearchQueryWithinLimit`)
- `runtime-repo-search-bounds.ts` (`isRuntimeRepoRefSearchQueryWithinLimit`)
- `runtime-file-search-bounds.ts` (`isRuntimeFileSearchTextWithinLimit`)

The canonical `src/shared/utf8-byte-limits.ts` already exports `measureUtf8ByteLength` — the same loop, with the same `stopAfterBytes` early-exit and the same surrogate-pair `index += 1` step. This finishes the extraction the shared module was clearly meant to replace (same shape as the recent #12078 FrameDecoder collapse, #12082 provider-contract share, #12091 push-target reuse).

Each bound helper now delegates:
```ts
return !measureUtf8ByteLength(text, { stopAfterBytes: maxBytes }).exceededLimit
```
The `provider` variant keeps its `null | undefined → true` guard; the `repo` and `file` variants take non-nullable input and delegate directly.

## Screenshots

No visual change — pure refactor.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:
- **Behaviour is 1:1 — proven by the existing regression net, not new tests.** The three co-located `*.test.ts` suites already pin the multibyte + ASCII-oversize + null/undefined behaviour each helper must preserve:
  - `runtime-provider-search-bounds.test.ts` — `undefined`/`null` → true; `'😀'` @ 3 → false; `'x'.repeat(9*1024)` → false.
  - `runtime-repo-search-bounds.test.ts` — `'😀'` @ 3 → false; `'x'.repeat(3*1024)` → false.
  - `runtime-file-search-bounds.test.ts` — `'😀'` @ 3 → false; oversized `includePattern` → `'includePattern'`.
  - All **8/8 stay green** after the refactor — the delegation is logically identical to the old `byteLength > maxBytes` check, including the surrogate `index += 1` step.
- `pnpm typecheck` green across all three tsconfigs (node, tc.cli, tc.web).
- `pnpm exec oxlint` clean (exit 0).
- `git diff --stat` = 3 files, **-66 net lines** (8 insertions, 74 deletions).

## AI Review Report

- **Cross-platform (macOS/Linux/Windows):** pure renderer TypeScript string math; no platform assumptions. The bounds apply identically for Linear/Jira/repo/file callers.
- **SSH/remote/local + folder-workspace:** N/A — renderer-side query length guards, no SSH/folder/git path.
- **Provider/agent neutrality:** N/A — byte-budget guard shared by Linear/Jira/repo/file search.
- **Performance / hot path:** if anything marginally faster (one early-exit helper vs three); the `stopAfterBytes` short-circuit matches the old `> maxBytes` check exactly.
- **UI quality:** none — internal bound check.

## Security Audit

Pure refactor: three private byte-counter copies replaced by a call to an existing, already-tested shared helper. No new input handling, IPC, auth, path, or dependency surface. The shared `measureUtf8ByteLength` is already imported across the codebase (`clipboard-text.ts`, `terminal-input.ts`, etc.).

## Notes

- `measureUtf8ByteLength` returns `{ byteLength, exceededLimit }`; the bound helpers consume only `.exceededLimit`, which is exactly the old `byteLength > maxBytes` outcome.
- A few more private `getCodePointUtf8ByteLength` copies exist elsewhere (e.g. `monaco-large-text-paste.ts`, `comment-body-submit-state.ts`); they carry additional logic (`getNextChunkBoundary`) and are a cleaner separate follow-up, intentionally out of scope to keep this PR small.
- No open or closed PR deduplicates these three counters.
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.
