### PR TITLE
fix(browser): keep browser tabs rendering across worktree switches (STA-3228)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -45,7 +45,7 @@ import type {
 } from '../../../shared/types'
 import { hasFeatureInteraction } from '../../../shared/feature-interactions'
 import BrowserPane from './browser-pane/BrowserPane'
-import BrowserPaneOverlayLayer from './browser-pane/BrowserPaneOverlayLayer'
+import { RetainedBrowserPaneOverlayLayer } from './browser-pane/BrowserPaneOverlayLayer'
 import EmulatorPaneOverlayLayer from './emulator-pane/EmulatorPaneOverlayLayer'
 import { useBrowserAutomationVisibilityForAny } from './browser-pane/browser-automation-visibility'
 import { useBrowserMobileDriverForAny } from '@/lib/pane-manager/browser-mobile-driver-state'
@@ -2674,8 +2674,17 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         backgroundMountTabIds={backgroundMountTabIds}
         activationDeferredMountTabIds={activationDeferredMountTabIds}
       />
-      {/* Why: always mounted — its slots host persistent <webview> guests that die if the slot leaves the DOM (STA-3228); hidden worktrees park the pane subtree, so targeted background mounts only pay for empty slot divs. */}
-      <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
+      {/* Why: once eligible, retain slot DOM so hidden worktrees keep their Electron guests alive (STA-3228). */}
+      <RetainedBrowserPaneOverlayLayer
+        worktreeId={worktreeId}
+        isWorktreeActive={isVisible}
+        mountEligible={
+          isVisible ||
+          backgroundMountTabIds === null ||
+          hasAutomationVisibleBrowser ||
+          hasMobileDrivenBrowser
+        }
+      />
       {isVisible || backgroundMountTabIds === null ? (
         <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
       ) : null}

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -2674,11 +2674,10 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
         backgroundMountTabIds={backgroundMountTabIds}
         activationDeferredMountTabIds={activationDeferredMountTabIds}
       />
+      {/* Why: always mounted — its slots host persistent <webview> guests that die if the slot leaves the DOM (STA-3228); hidden worktrees park the pane subtree, so targeted background mounts only pay for empty slot divs. */}
+      <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
       {isVisible || backgroundMountTabIds === null ? (
-        <>
-          <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
-          <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
-        </>
+        <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
       ) : null}
       <AiVaultSessionDropLayer worktreeId={worktreeId} enabled={isVisible} />
     </div>

--- a/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
+++ b/src/renderer/src/components/browser-pane/BrowserPane.webview-preferences.test.ts
@@ -103,4 +103,36 @@ describe('BrowserPane webview preferences', () => {
     expect(ensuredWebview?.webview.style.pointerEvents).toBe('none')
     expect(refreshedContainer.lastElementChild).toBe(ensuredWebview?.webview as unknown as Element)
   })
+
+  it('keeps a replacement viewport while rebuilding a parent-drifted webview (STA-3228)', () => {
+    const staleContainer = createContainer('stale')
+    const staleWebview = document.createElement('webview') as Electron.WebviewTag
+    staleWebview.setAttribute('partition', 'persist:orca-browser')
+    staleContainer.appendChild(staleWebview)
+    registryMocks.webviewRegistry.set('browser-page-1', staleWebview)
+    const replacementContainer = createContainer('replacement')
+    const resolveContainer = vi.fn(() => replacementContainer)
+    registryMocks.destroyPersistentWebview.mockImplementation(() => {
+      staleWebview.remove()
+      staleContainer.remove()
+      registryMocks.webviewRegistry.delete('browser-page-1')
+    })
+
+    const ensuredWebview = ensureBrowserPageWebview({
+      browserTabId: 'browser-page-1',
+      container: replacementContainer,
+      inputLocked: false,
+      webviewPartition: 'persist:orca-browser',
+      resolveContainer
+    })
+
+    expect(registryMocks.destroyPersistentWebview).toHaveBeenCalledWith('browser-page-1', {
+      preserveViewport: true
+    })
+    expect(ensuredWebview?.container).toBe(replacementContainer)
+    expect(replacementContainer.isConnected).toBe(true)
+    expect(replacementContainer.lastElementChild).toBe(
+      ensuredWebview?.webview as unknown as Element
+    )
+  })
 })

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { cleanup, render } from '@testing-library/react'
+import { Suspense } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserTab as BrowserTabState, Tab, TabGroup } from '../../../../shared/types'
@@ -92,6 +93,33 @@ describe('BrowserPaneOverlayLayer', () => {
       />
     )
     expect(view.container.querySelectorAll('[data-browser-overlay-tab-id]')).toHaveLength(2)
+  })
+
+  it('does not retain browser slots from an eligible render that never commits', () => {
+    const pending = new Promise<never>(() => {})
+    const BlockCommit = ({ blocked }: { blocked: boolean }): null => {
+      if (blocked) {
+        throw pending
+      }
+      return null
+    }
+    const renderBoundary = (mountEligible: boolean, blocked: boolean) => (
+      <Suspense fallback={<span data-suspended />}>
+        <RetainedBrowserPaneOverlayLayer
+          worktreeId="wt-1"
+          isWorktreeActive={mountEligible}
+          mountEligible={mountEligible}
+        />
+        <BlockCommit blocked={blocked} />
+      </Suspense>
+    )
+    const view = render(renderBoundary(false, false))
+
+    view.rerender(renderBoundary(true, true))
+    expect(view.container.querySelector('[data-suspended]')).not.toBeNull()
+
+    view.rerender(renderBoundary(false, false))
+    expect(view.container.querySelectorAll('[data-browser-overlay-tab-id]')).toHaveLength(0)
   })
 
   it('keeps inactive browser panes mounted for a visible worktree', () => {

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -1,5 +1,7 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BrowserTab as BrowserTabState, Tab, TabGroup } from '../../../../shared/types'
 
 type MockAppState = {
@@ -54,7 +56,7 @@ vi.mock('./BrowserPane', () => ({
   )
 }))
 
-import BrowserPaneOverlayLayer from './BrowserPaneOverlayLayer'
+import BrowserPaneOverlayLayer, { RetainedBrowserPaneOverlayLayer } from './BrowserPaneOverlayLayer'
 
 describe('BrowserPaneOverlayLayer', () => {
   beforeEach(() => {
@@ -62,6 +64,34 @@ describe('BrowserPaneOverlayLayer', () => {
     mocks.mobileDrivenPageIds.clear()
     mocks.focusGroup.mockClear()
     mocks.state = createState()
+  })
+
+  afterEach(() => cleanup())
+
+  it('defers browser slots for a restricted hidden mount, then retains them after activation', () => {
+    const view = render(
+      <RetainedBrowserPaneOverlayLayer
+        worktreeId="wt-1"
+        isWorktreeActive={false}
+        mountEligible={false}
+      />
+    )
+
+    expect(view.container.querySelectorAll('[data-browser-overlay-tab-id]')).toHaveLength(0)
+
+    view.rerender(
+      <RetainedBrowserPaneOverlayLayer worktreeId="wt-1" isWorktreeActive mountEligible />
+    )
+    expect(view.container.querySelectorAll('[data-browser-overlay-tab-id]')).toHaveLength(2)
+
+    view.rerender(
+      <RetainedBrowserPaneOverlayLayer
+        worktreeId="wt-1"
+        isWorktreeActive={false}
+        mountEligible={false}
+      />
+    )
+    expect(view.container.querySelectorAll('[data-browser-overlay-tab-id]')).toHaveLength(2)
   })
 
   it('keeps inactive browser panes mounted for a visible worktree', () => {

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { registerBrowserOverlaySlotViewport } from './browser-page-viewport'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
@@ -203,11 +203,14 @@ export const RetainedBrowserPaneOverlayLayer = memo(function RetainedBrowserPane
   isWorktreeActive: boolean
   mountEligible: boolean
 }): React.JSX.Element | null {
-  const hasMountedRef = useRef(mountEligible)
-  if (mountEligible) {
-    hasMountedRef.current = true
-  }
-  if (!hasMountedRef.current) {
+  const [hasCommittedMount, setHasCommittedMount] = useState(false)
+  // Why: commit the latch with the persistent slot DOM so discarded renders cannot retain a guest host.
+  useLayoutEffect(() => {
+    if (mountEligible && !hasCommittedMount) {
+      setHasCommittedMount(true)
+    }
+  }, [hasCommittedMount, mountEligible])
+  if (!mountEligible && !hasCommittedMount) {
     return null
   }
   return <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isWorktreeActive} />

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo, useRef } from 'react'
 import { registerBrowserOverlaySlotViewport } from './browser-page-viewport'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
@@ -192,6 +192,25 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
       })}
     </>
   )
+})
+
+export const RetainedBrowserPaneOverlayLayer = memo(function RetainedBrowserPaneOverlayLayer({
+  worktreeId,
+  isWorktreeActive,
+  mountEligible
+}: {
+  worktreeId: string
+  isWorktreeActive: boolean
+  mountEligible: boolean
+}): React.JSX.Element | null {
+  const hasMountedRef = useRef(mountEligible)
+  if (mountEligible) {
+    hasMountedRef.current = true
+  }
+  if (!hasMountedRef.current) {
+    return null
+  }
+  return <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isWorktreeActive} />
 })
 
 export default BrowserPaneOverlayLayer

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
@@ -46,6 +46,41 @@ describe('ensureBrowserPageViewport', () => {
   it('returns null until the slot viewport root is registered', () => {
     expect(ensureBrowserPageViewport('page-1', 'workspace-missing')).toBeNull()
   })
+
+  it('reuses the cached viewport while the slot root is unchanged', () => {
+    mountSlotViewport('workspace-1')
+    const first = ensureBrowserPageViewport('page-1', 'workspace-1')
+    const second = ensureBrowserPageViewport('page-1', 'workspace-1')
+
+    expect(second).toBe(first)
+  })
+
+  it('keeps the parked viewport while the slot root is unregistered', () => {
+    const root = mountSlotViewport('workspace-1')
+    const parked = ensureBrowserPageViewport('page-1', 'workspace-1')
+    root.remove()
+    registerBrowserOverlaySlotViewport('workspace-1', null)
+
+    expect(ensureBrowserPageViewport('page-1', 'workspace-1')).toBe(parked)
+  })
+
+  it('rebuilds under a replacement slot root instead of returning the stranded shell (STA-3228)', () => {
+    const oldRoot = mountSlotViewport('workspace-1')
+    const stale = ensureBrowserPageViewport('page-1', 'workspace-1')!
+    // Worktree overlay unmounts while hidden: slot root leaves the DOM with the shell inside.
+    oldRoot.remove()
+    registerBrowserOverlaySlotViewport('workspace-1', null)
+    const newRoot = mountSlotViewport('workspace-1')
+
+    const rebuilt = ensureBrowserPageViewport('page-1', 'workspace-1')
+
+    expect(rebuilt).not.toBeNull()
+    expect(rebuilt).not.toBe(stale)
+    expect(rebuilt!.shell.parentElement).toBe(newRoot)
+    expect(rebuilt!.shell.isConnected).toBe(true)
+    expect(stale.shell.isConnected).toBe(false)
+    expect(getBrowserPageViewportContainer('page-1')).toBe(rebuilt!.container)
+  })
 })
 
 describe('syncBrowserPageChromeInset', () => {

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.ts
@@ -65,11 +65,18 @@ export function ensureBrowserPageViewport(
   browserPageId: string,
   workspaceTabId: string
 ): BrowserPageViewport | null {
+  const root = slotViewportRoots.get(workspaceTabId)
   const existing = browserPageViewports.get(browserPageId)
   if (existing) {
-    return existing
+    if (!root || existing.shell.parentElement === root) {
+      return existing
+    }
+    // Why: a remounted slot root (overlay unmount while hidden, cross-worktree tab move) strands
+    // the cached shell in a removed subtree where its guest is already dead; drop it so the caller
+    // rebuilds against the live root instead of rendering into detached DOM forever (STA-3228).
+    existing.shell.remove()
+    browserPageViewports.delete(browserPageId)
   }
-  const root = slotViewportRoots.get(workspaceTabId)
   if (!root) {
     return null
   }

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.ts
@@ -71,9 +71,7 @@ export function ensureBrowserPageViewport(
     if (!root || existing.shell.parentElement === root) {
       return existing
     }
-    // Why: a remounted slot root (overlay unmount while hidden, cross-worktree tab move) strands
-    // the cached shell in a removed subtree where its guest is already dead; drop it so the caller
-    // rebuilds against the live root instead of rendering into detached DOM forever (STA-3228).
+    // Why: a remounted slot strands this shell after Electron destroys its detached guest (STA-3228).
     existing.shell.remove()
     browserPageViewports.delete(browserPageId)
   }

--- a/src/renderer/src/components/browser-pane/browser-page-webview.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-webview.ts
@@ -21,17 +21,19 @@ export function ensureBrowserPageWebview({
   let webview = webviewRegistry.get(browserTabId)
   let created = false
   let activeContainer = container
+  const parentDrifted = webview?.parentElement !== container
 
   // Why: a persisted guest must be torn down and rebuilt when its DOM parent
   // drifted (moving a <webview> across parents can recreate the guest document)
   // or when its partition no longer matches — Electron partitions are immutable
-  // after creation, so reuse would keep the stale session. Re-resolve the
-  // viewport container the teardown may have detached; bail if it is gone.
-  if (
-    webview &&
-    (webview.parentElement !== container || webview.getAttribute('partition') !== webviewPartition)
-  ) {
-    destroyPersistentWebview(browserTabId)
+  // after creation, so reuse would keep the stale session. Parent-drift repair
+  // preserves the newly replaced viewport; always verify the resolved container.
+  if (webview && (parentDrifted || webview.getAttribute('partition') !== webviewPartition)) {
+    if (parentDrifted) {
+      destroyPersistentWebview(browserTabId, { preserveViewport: true })
+    } else {
+      destroyPersistentWebview(browserTabId)
+    }
     webview = undefined
     const refreshedContainer = resolveContainer()
     if (!refreshedContainer) {

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -189,7 +189,10 @@ export function moveFocusToRendererBeforeWebviewDetach(webview: Electron.Webview
   moveFocusToRendererIfWebviewOwnsFocus(webview)
 }
 
-export function destroyPersistentWebview(browserTabId: string): void {
+export function destroyPersistentWebview(
+  browserTabId: string,
+  { preserveViewport = false }: { preserveViewport?: boolean } = {}
+): void {
   const webview = webviewRegistry.get(browserTabId)
   // The guest is gone, so its user-applied zoom must not be inherited by a
   // later tab that reuses the id.
@@ -197,7 +200,9 @@ export function destroyPersistentWebview(browserTabId: string): void {
   if (!webview) {
     // Why: the viewport can outlive a missing webview entry; tear it down on
     // explicit close paths so overlay slots do not leak parked shells.
-    removeBrowserPageViewport(browserTabId)
+    if (!preserveViewport) {
+      removeBrowserPageViewport(browserTabId)
+    }
     registeredWebContentsIds.delete(browserTabId)
     clearLiveBrowserUrl(browserTabId)
     return
@@ -206,7 +211,9 @@ export function destroyPersistentWebview(browserTabId: string): void {
   moveFocusToRendererBeforeWebviewDetach(webview)
   webview.remove()
   unregisterPersistentWebview(browserTabId)
-  removeBrowserPageViewport(browserTabId)
+  if (!preserveViewport) {
+    removeBrowserPageViewport(browserTabId)
+  }
   registeredWebContentsIds.delete(browserTabId)
   clearLiveBrowserUrl(browserTabId)
 }


### PR DESCRIPTION
## Summary

Fixes STA-3228: a browser tab that was open in a worktree went permanently blank after switching to another worktree and back — the URL bar still showed the address, but the page area rendered nothing, and reload silently did nothing.

Two layered defects:

1. **Trigger** — `WorktreeSplitSurface` unmounted `BrowserPaneOverlayLayer` for hidden worktrees whenever a targeted background mount restriction existed (agent wake/resume sets one constantly). Unmounting the overlay pulls the persistent `<webview>` slot divs out of the DOM, and Electron destroys the guest the moment a `<webview>` leaves the DOM — defeating the design from #6408 that renders browser panes at worktree level precisely so guests survive switches.
2. **Permanence** — `ensureBrowserPageViewport` returned the cached viewport shell even after its slot root had been unmounted, so when the worktree came back, the webview subtree was never re-appended to the live DOM. The tab stayed blank forever and the reload button threw `The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called` (observed in the renderer console during repro).

Fix:

- Keep `BrowserPaneOverlayLayer` mounted for hidden worktrees. Slots already park their pane subtrees when the worktree is hidden (`shouldMountPane`), so a background-woken worktree only pays for empty slot divs. `EmulatorPaneOverlayLayer` keeps the old gating — it doesn't use the persistent-slot pattern.
- Make `ensureBrowserPageViewport` detect a replaced slot root and drop the stranded shell so the caller rebuilds against the live root. This also self-heals any remaining path that unmounts slots (cross-worktree tab moves, surface eviction): the existing parent-drift check in `ensureBrowserPageWebview` then rebuilds the webview, turning "blank forever" into "reloads once".

## Screenshots

Repro on main (tab created, worktree switched away and back — blank, reload dead):

![before: blank browser pane after worktree switch](https://github.com/user-attachments/assets/58bdb211-6747-4a9a-ac3a-81cb607cf7e7)

Same sequence with the fix (guest survives without reloading — same in-page JS timestamp, no new HTTP request; reload button works):

![after: page still rendered after worktree switch](https://github.com/user-attachments/assets/ac9cd479-27ec-46e1-bfc8-d0a2b9fdaf79)

## Testing

- [x] `pnpm lint` (oxlint + react-doctor changed-lines on touched files)
- [x] `pnpm typecheck`
- [x] `pnpm test` (browser-pane suite 32 files/191 tests; `Terminal` substring sweep 462 files/5156 tests)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests in `browser-page-viewport.test.ts`: cached-viewport reuse under a stable root, parked viewport preserved while the root is unregistered, and rebuild under a replacement root (asserts the stale shell is detached and the rebuilt shell is connected to the new root).

Live Electron QA (dev build, CDP): reproduced the blank pane + dead reload on unfixed code, then verified with the fix that (a) slot/shell/webview stay in the DOM while the worktree is hidden, (b) the page renders after switching back with the guest's state intact (unchanged in-page timestamp, no new server request), (c) reload issues a real request, and (d) a session-restored tab renders after app restart.

## AI Review Report

Reviewed the mount-gating change for perf regressions (background wakes previously skipped the overlay): slots park pane subtrees for hidden worktrees, so no webview guests or BrowserPane chrome mount from this change alone. Reviewed the viewport self-heal for interactions with `destroyPersistentWebview` (which removes the current viewport before `resolveContainer` rebuilds it) and the floating-panel slot registration (`FloatingBrowserSlot` mints new tab ids, so no cross-host root swap for a live id). Checked the no-root case keeps returning the parked viewport so hidden-state callers see unchanged behavior. Cross-platform: renderer-only DOM/React change, no shortcuts, labels, paths, or shell behavior touched; nothing platform-conditional on macOS/Linux/Windows is affected.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or dependency changes. No new IPC: the change only alters when existing renderer components mount and how a renderer-side DOM cache invalidates. Webview partitions are untouched (partition mismatch still forces a rebuild via the pre-existing check in `ensureBrowserPageWebview`).

## Notes

- The surface-eviction path (a hidden worktree fully unmounting after long parking) still destroys guests by design; with the self-heal the tab now recovers with one reload instead of dying. If we want guests to survive that too, that's a follow-up.
- `EmulatorPaneOverlayLayer` may have an analogous issue on the same conditional; left untouched to keep this PR scoped (worth a separate look).
