### PR TITLE
fix(workspace): keep the workspace selected when its last tab closes

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1621,7 +1621,8 @@ function Terminal(): React.JSX.Element | null {
               setActiveTab(terminalTab.id)
               setActiveTabType('terminal')
             } else {
-              setActiveWorktree(null)
+              // Why: no tabs left, but the workspace stays selected so file/Git browsing survives (issue #11699).
+              setActiveTabType('terminal')
             }
           }
         }
@@ -1637,14 +1638,7 @@ function Terminal(): React.JSX.Element | null {
       destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
       closeBrowserTab(tabId)
     },
-    [
-      closeBrowserTab,
-      setActiveBrowserTab,
-      setActiveFile,
-      setActiveTab,
-      setActiveTabType,
-      setActiveWorktree
-    ]
+    [closeBrowserTab, setActiveBrowserTab, setActiveFile, setActiveTab, setActiveTabType]
   )
 
   const handlePtyExit = useCallback(

--- a/src/renderer/src/components/shared/kill-all-terminal-surfaces.ts
+++ b/src/renderer/src/components/shared/kill-all-terminal-surfaces.ts
@@ -173,7 +173,7 @@ export async function runKillAllTerminalSurfaces(
     }
     const activeWorktreeId = state.activeWorktreeId
     // Why: keeping the active worktree until its targets close lets the existing
-    // tab action choose editor/browser/deactivation without spawning a replacement.
+    // tab action fall back to an editor/browser tab without spawning a replacement.
     const closeOrder = [
       ...presentTargetIds.filter((targetId) => ownerByTargetId.get(targetId) !== activeWorktreeId),
       ...presentTargetIds.filter((targetId) => ownerByTargetId.get(targetId) === activeWorktreeId)

--- a/src/renderer/src/components/tab-group/TabGroupEmptyState.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupEmptyState.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TabGroupEmptyState } from './TabGroupEmptyState'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutKeyDetails: () => ({ keys: ['Ctrl', 'T'], doubleTap: false })
+}))
+
+afterEach(cleanup)
+
+describe('TabGroupEmptyState', () => {
+  it('offers a direct new-terminal action when the workspace has no tabs left', () => {
+    const onNewTerminalTab = vi.fn()
+    render(<TabGroupEmptyState onNewTerminalTab={onNewTerminalTab} />)
+
+    expect(screen.getByText('No open tabs')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /New terminal/ }))
+
+    expect(onNewTerminalTab).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the platform shortcut chips supplied by the keybinding hook', () => {
+    render(<TabGroupEmptyState onNewTerminalTab={vi.fn()} />)
+
+    expect(screen.getByText('Ctrl')).toBeDefined()
+    expect(screen.getByText('T')).toBeDefined()
+  })
+})

--- a/src/renderer/src/components/tab-group/TabGroupEmptyState.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupEmptyState.tsx
@@ -1,0 +1,52 @@
+import { SquareTerminal } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ShortcutKeyCombo } from '../ShortcutKeyCombo'
+import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { translate } from '@/i18n/i18n'
+
+/**
+ * Shown in a tab group whose tabs are all closed. The workspace deliberately
+ * stays selected at zero tabs (issue #11699) so the file tree, editor, and Git
+ * keep working, which leaves this pane body with nothing else to render.
+ */
+export function TabGroupEmptyState({
+  onNewTerminalTab
+}: {
+  onNewTerminalTab: () => void
+}): React.JSX.Element {
+  const newTerminalShortcut = useShortcutKeyDetails('tab.newTerminal')
+
+  return (
+    <div
+      data-testid="tab-group-empty-state"
+      className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center"
+    >
+      <SquareTerminal className="size-7 text-muted-foreground" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">
+          {translate('auto.components.tab.group.TabGroupEmptyState.title', 'No open tabs')}
+        </p>
+        <p className="max-w-xs text-[13px] leading-5 text-muted-foreground">
+          {translate(
+            'auto.components.tab.group.TabGroupEmptyState.description',
+            'Files, search, and Git are still available for this workspace in the sidebar.'
+          )}
+        </p>
+      </div>
+      {/* Why: half the stack's gap binds the chip to the button it describes, so it doesn't read as a fourth item. */}
+      <div className="flex flex-col items-center gap-1.5">
+        <Button variant="outline" size="sm" onClick={onNewTerminalTab}>
+          <SquareTerminal aria-hidden="true" />
+          {translate('auto.components.tab.group.TabGroupEmptyState.newTerminal', 'New terminal')}
+        </Button>
+        {newTerminalShortcut.keys.length > 0 ? (
+          <ShortcutKeyCombo
+            keys={newTerminalShortcut.keys}
+            doubleTap={newTerminalShortcut.doubleTap}
+            separatorClassName="mx-0.5 text-[10px] text-muted-foreground"
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -13,6 +13,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import TabBar from '../tab-bar/TabBar'
 
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
+import { TabGroupEmptyState } from './TabGroupEmptyState'
+import { useTabGroupEmptyStateVisible } from './tab-group-empty-state-visibility'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
@@ -58,6 +60,7 @@ export default function TabGroupPanel({
 
   const model = useTabGroupWorkspaceModel({ groupId, worktreeId })
   const { activeTab, browserItems, commands, editorItems, tabBarOrder, terminalTabs } = model
+  const emptyStateVisible = useTabGroupEmptyStateVisible(worktreeId, model.groupTabs.length)
   const { setNodeRef: setBodyDropRef } = useDroppable({
     id: getTabPaneBodyDroppableId(groupId),
     data: {
@@ -307,6 +310,10 @@ export default function TabGroupPanel({
             className="pointer-events-none absolute inset-x-0 top-1/4 h-px"
             data-contextual-tour-target="workspace-agent-terminal-tip"
           />
+        ) : null}
+        {/* Why: closing the last tab keeps the workspace selected, so this pane body would otherwise render nothing at all. */}
+        {emptyStateVisible ? (
+          <TabGroupEmptyState onNewTerminalTab={commands.newTerminalTab} />
         ) : null}
         {activeTab &&
           activeTab.contentType !== 'terminal' &&

--- a/src/renderer/src/components/tab-group/tab-group-empty-state-reactivity.test.tsx
+++ b/src/renderer/src/components/tab-group/tab-group-empty-state-reactivity.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeBox = vi.hoisted(() => ({ state: {} as Record<string, unknown> }))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(storeBox.state)
+}))
+
+vi.mock('../../lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: (state: { runtimeEnvironmentId?: string | null }) =>
+    state.runtimeEnvironmentId ?? null
+}))
+
+import {
+  clearWebSessionTabsTrackingForEnvironment,
+  shouldApplyWebSessionTabsSnapshot
+} from '../../runtime/web-session-tabs-sync'
+import { useTabGroupEmptyStateVisible } from './tab-group-empty-state-visibility'
+
+const ENV = 'env-reactivity-1'
+const WT = 'repo::/tmp/remote-wt'
+
+function Probe(): React.JSX.Element {
+  const visible = useTabGroupEmptyStateVisible(WT, 0)
+  return <span data-testid="state">{visible ? 'empty-state' : 'hidden'}</span>
+}
+
+/** A host snapshot carrying no tabs — the case that moves no store slice. */
+function zeroTabSnapshot(): Parameters<typeof shouldApplyWebSessionTabsSnapshot>[0] {
+  return {
+    worktree: WT,
+    tabs: [],
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1
+  } as unknown as Parameters<typeof shouldApplyWebSessionTabsSnapshot>[0]
+}
+
+beforeEach(() => {
+  clearWebSessionTabsTrackingForEnvironment(ENV)
+  storeBox.state = { workspaceSessionReady: true, runtimeEnvironmentId: ENV }
+})
+
+afterEach(() => {
+  cleanup()
+  clearWebSessionTabsTrackingForEnvironment(ENV)
+})
+
+describe('tab group empty state reactivity', () => {
+  it('hides while a runtime-owned worktree still awaits its first host snapshot', () => {
+    render(<Probe />)
+
+    expect(screen.getByTestId('state').textContent).toBe('hidden')
+  })
+
+  // Why: this is the regression the pure-predicate tests cannot see. A zero-tab snapshot
+  // writes no store slice, so only the publication subscription can re-render the pane.
+  it('reveals the empty state when a zero-tab snapshot publishes, with no other state change', () => {
+    render(<Probe />)
+    expect(screen.getByTestId('state').textContent).toBe('hidden')
+    const storeStateBefore = storeBox.state
+
+    // Real sync path: records the publication epoch and notifies subscribers.
+    act(() => {
+      expect(shouldApplyWebSessionTabsSnapshot(zeroTabSnapshot(), ENV)).toBe(true)
+    })
+
+    expect(storeBox.state).toBe(storeStateBefore)
+    expect(screen.getByTestId('state').textContent).toBe('empty-state')
+  })
+
+  it('shows immediately for a local worktree, which never awaits a host', () => {
+    storeBox.state = { workspaceSessionReady: true, runtimeEnvironmentId: null }
+    render(<Probe />)
+
+    expect(screen.getByTestId('state').textContent).toBe('empty-state')
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-group-empty-state-visibility.test.ts
+++ b/src/renderer/src/components/tab-group/tab-group-empty-state-visibility.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { getLatestEpochMock } = vi.hoisted(() => ({ getLatestEpochMock: vi.fn() }))
+
+vi.mock('../../runtime/web-session-tabs-sync', () => ({
+  getLatestWebSessionTabsPublicationEpoch: getLatestEpochMock
+}))
+
+import {
+  isAwaitingFirstHostTabs,
+  shouldShowTabGroupEmptyState
+} from './tab-group-empty-state-visibility'
+
+const ready = { workspaceSessionReady: true, awaitingFirstHostTabs: false }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('shouldShowTabGroupEmptyState', () => {
+  it('shows as soon as a group reaches zero tabs', () => {
+    expect(shouldShowTabGroupEmptyState({ ...ready, tabCount: 0 })).toBe(true)
+  })
+
+  it('stays hidden while a group still has tabs', () => {
+    expect(shouldShowTabGroupEmptyState({ ...ready, tabCount: 1 })).toBe(false)
+  })
+
+  it('stays hidden while the host mirror owes us its first snapshot', () => {
+    expect(
+      shouldShowTabGroupEmptyState({ ...ready, tabCount: 0, awaitingFirstHostTabs: true })
+    ).toBe(false)
+  })
+
+  it('stays hidden until the workspace session has hydrated', () => {
+    expect(
+      shouldShowTabGroupEmptyState({ ...ready, workspaceSessionReady: false, tabCount: 0 })
+    ).toBe(false)
+  })
+
+  // Why: the predicate takes no mount-local state, so a reparent or renderer reload
+  // cannot strand a resting workspace with a blank pane and no "New terminal" action.
+  it('depends only on its arguments, so a remount cannot change the answer', () => {
+    const args = { ...ready, tabCount: 0 }
+    expect(shouldShowTabGroupEmptyState(args)).toBe(true)
+    expect(shouldShowTabGroupEmptyState(args)).toBe(true)
+  })
+})
+
+describe('isAwaitingFirstHostTabs', () => {
+  it('never waits for a local worktree', () => {
+    expect(isAwaitingFirstHostTabs(null, 'wt-1')).toBe(false)
+    expect(getLatestEpochMock).not.toHaveBeenCalled()
+  })
+
+  it('waits while a runtime-owned worktree has published no snapshot', () => {
+    getLatestEpochMock.mockReturnValue(null)
+    expect(isAwaitingFirstHostTabs('env-1', 'wt-1')).toBe(true)
+  })
+
+  // Why: a zero-tab host snapshot still publishes an epoch — the remote resting state
+  // must read as empty, not pending, or it would render nothing at all.
+  it('stops waiting once the host publishes, even reporting zero tabs', () => {
+    getLatestEpochMock.mockReturnValue('epoch-1')
+    expect(isAwaitingFirstHostTabs('env-1', 'wt-1')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-group-empty-state-visibility.ts
+++ b/src/renderer/src/components/tab-group/tab-group-empty-state-visibility.ts
@@ -1,0 +1,57 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import { useAppStore } from '../../store'
+import { getRuntimeEnvironmentIdForWorktree } from '../../lib/worktree-runtime-owner'
+import { isWebRuntimeSessionActive } from '../../runtime/web-runtime-session'
+import {
+  getLatestWebSessionTabsPublicationEpoch,
+  subscribeWebSessionTabsPublication
+} from '../../runtime/web-session-tabs-sync'
+
+/**
+ * A group sits at zero tabs in two very different situations, and only one of
+ * them is "empty". `ensureWorktreeRootGroup` creates the root group before any
+ * tab exists; locally the auto-create effect fills it in the same effect flush,
+ * but a runtime-owned worktree defers to the host's session-tab mirror, so the
+ * wait scales with remote latency. Suppress the empty state for exactly that
+ * wait — never on a clock, and never on mount-local state, which a reparent or
+ * a reload would reset, stranding the pane with no way to open a terminal.
+ */
+export function shouldShowTabGroupEmptyState(args: {
+  workspaceSessionReady: boolean
+  tabCount: number
+  awaitingFirstHostTabs: boolean
+}): boolean {
+  return args.workspaceSessionReady && args.tabCount === 0 && !args.awaitingFirstHostTabs
+}
+
+/** True only until the host publishes its first session-tab snapshot for this worktree. */
+export function isAwaitingFirstHostTabs(
+  runtimeEnvironmentId: string | null,
+  worktreeId: string
+): boolean {
+  if (!runtimeEnvironmentId || !isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+    return false
+  }
+  // Why: a snapshot reporting zero tabs still publishes an epoch, so a remote workspace
+  // genuinely resting at zero tabs reads as empty rather than perpetually pending.
+  return getLatestWebSessionTabsPublicationEpoch(runtimeEnvironmentId, worktreeId) === null
+}
+
+export function useTabGroupEmptyStateVisible(worktreeId: string, tabCount: number): boolean {
+  const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
+  const runtimeEnvironmentId = useAppStore((state) =>
+    getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  )
+  // Why: the publication epoch lives in module-local maps, so a zero-tab snapshot moves no
+  // store slice — without this subscription the pane would never re-ask and stay blank.
+  const getAwaiting = useCallback(
+    () => isAwaitingFirstHostTabs(runtimeEnvironmentId, worktreeId),
+    [runtimeEnvironmentId, worktreeId]
+  )
+  const awaitingFirstHostTabs = useSyncExternalStore(
+    subscribeWebSessionTabsPublication,
+    getAwaiting,
+    getAwaiting
+  )
+  return shouldShowTabGroupEmptyState({ workspaceSessionReady, tabCount, awaitingFirstHostTabs })
+}

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -546,4 +546,135 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     )
     expect(mocks.closeUnifiedTab).toHaveBeenCalledWith('browser-unified-1')
   })
+
+  // Why: issue #11699 — split-group closes used to deselect the emptied workspace,
+  // which blanked the file explorer and Git panel until the user re-opened it.
+  it('keeps the workspace selected when the last terminal tab in a group closes', async () => {
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.closeItem('unified-terminal-1')
+
+    expect(mocks.closeTab).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+  })
+
+  it('keeps the workspace selected when the last browser tab in a group closes', async () => {
+    storeBox.state = {
+      ...storeBox.state,
+      browserPagesByWorkspace: {},
+      browserTabsByWorktree: { 'wt-1': [] },
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-1',
+            worktreeId: 'wt-1',
+            activeTabId: 'browser-unified-1',
+            tabOrder: ['browser-unified-1']
+          }
+        ]
+      },
+      tabsByWorktree: { 'wt-1': [] },
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'browser-unified-1',
+            entityId: 'browser-workspace-1',
+            groupId: 'group-1',
+            worktreeId: 'wt-1',
+            contentType: 'browser',
+            label: 'New Browser Tab',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    }
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.closeItem('browser-unified-1')
+
+    expect(mocks.closeUnifiedTab).toHaveBeenCalledWith('browser-unified-1')
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+  })
+
+  it('keeps the workspace selected when the sole group is closed', async () => {
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
+
+    model.commands.closeGroup()
+
+    expect(mocks.closeEmptyGroup).toHaveBeenCalledWith('wt-1', 'group-1')
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+  })
+
+  // Why: split-group closes were the path that bypassed Terminal.tsx, so cover the
+  // real two-group shape — collapse the emptied pane, leave the survivor's tab alone.
+  it('collapses one of two split groups without touching the survivor or the selection', async () => {
+    const secondUnifiedTab = {
+      id: 'unified-terminal-2',
+      entityId: 'terminal-2',
+      groupId: 'group-2',
+      worktreeId: 'wt-1',
+      contentType: 'terminal',
+      label: 'Terminal 2',
+      customLabel: null,
+      color: null,
+      sortOrder: 1,
+      createdAt: 1
+    }
+    const currentState = storeBox.state as {
+      tabsByWorktree: Record<string, unknown[]>
+      unifiedTabsByWorktree: Record<string, { id: string }[]>
+    }
+    const firstUnified = currentState.unifiedTabsByWorktree['wt-1'][0]
+    storeBox.state = {
+      ...storeBox.state,
+      tabsByWorktree: {
+        'wt-1': [
+          ...currentState.tabsByWorktree['wt-1'],
+          {
+            id: 'terminal-2',
+            ptyId: 'pty-2',
+            worktreeId: 'wt-1',
+            title: 'Terminal 2',
+            defaultTitle: 'Terminal 2',
+            customTitle: null,
+            color: null,
+            sortOrder: 1,
+            createdAt: 1
+          }
+        ]
+      },
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-1',
+            worktreeId: 'wt-1',
+            activeTabId: firstUnified.id,
+            tabOrder: [firstUnified.id]
+          },
+          {
+            id: 'group-2',
+            worktreeId: 'wt-1',
+            activeTabId: secondUnifiedTab.id,
+            tabOrder: [secondUnifiedTab.id]
+          }
+        ]
+      },
+      unifiedTabsByWorktree: { 'wt-1': [firstUnified, secondUnifiedTab] }
+    }
+    const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
+    const model = useTabGroupWorkspaceModel({ groupId: 'group-2', worktreeId: 'wt-1' })
+
+    model.commands.closeGroup()
+
+    expect(mocks.closeTab).toHaveBeenCalledWith('terminal-2')
+    expect(mocks.closeTab).not.toHaveBeenCalledWith('terminal-1')
+    expect(mocks.closeEmptyGroup).toHaveBeenCalledWith('wt-1', 'group-2')
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -95,7 +95,6 @@ export function useTabGroupWorkspaceModel({
   const pinFile = useAppStore((state) => state.pinFile)
   const closeBrowserTab = useAppStore((state) => state.closeBrowserTab)
   const setActiveBrowserTab = useAppStore((state) => state.setActiveBrowserTab)
-  const setActiveWorktree = useAppStore((state) => state.setActiveWorktree)
   const createEmptySplitGroup = useAppStore((state) => state.createEmptySplitGroup)
   const setTabCustomTitle = useAppStore((state) => state.setTabCustomTitle)
   const setTabColor = useAppStore((state) => state.setTabColor)
@@ -209,20 +208,8 @@ export function useTabGroupWorkspaceModel({
     [closeFile, worktreeId]
   )
 
-  const leaveWorktreeIfEmpty = useCallback(() => {
-    const state = useAppStore.getState()
-    if (state.activeWorktreeId !== worktreeId) {
-      return
-    }
-    // Why: split-group closes bypass legacy Terminal.tsx; deselect the emptied worktree here or the window goes blank instead of landing.
-    const { renderableTabCount } = state.reconcileWorktreeTabModel(worktreeId)
-    if (renderableTabCount === 0) {
-      setActiveWorktree(null)
-    }
-  }, [setActiveWorktree, worktreeId])
-
   const closeItem = useCallback(
-    (itemId: string, opts?: { skipEmptyCheck?: boolean }) => {
+    (itemId: string) => {
       const item = groupTabs.find((candidate) => candidate.id === itemId)
       if (!item) {
         return
@@ -236,9 +223,6 @@ export function useTabGroupWorkspaceModel({
       )
       if (item.contentType === 'terminal') {
         closeTerminalTab(item.entityId)
-        if (!opts?.skipEmptyCheck) {
-          leaveWorktreeIfEmpty()
-        }
         return
       }
       if (item.contentType === 'browser') {
@@ -269,18 +253,8 @@ export function useTabGroupWorkspaceModel({
         }
         closeUnifiedTab(item.id)
       }
-      if (!opts?.skipEmptyCheck) {
-        leaveWorktreeIfEmpty()
-      }
     },
-    [
-      closeBrowserTab,
-      closeEditorIfUnreferenced,
-      closeUnifiedTab,
-      groupTabs,
-      leaveWorktreeIfEmpty,
-      worktreeId
-    ]
+    [closeBrowserTab, closeEditorIfUnreferenced, closeUnifiedTab, groupTabs, worktreeId]
   )
 
   const closeMany = useCallback(
@@ -472,12 +446,11 @@ export function useTabGroupWorkspaceModel({
       (item) => item.groupId === groupId
     )
     for (const item of items) {
-      closeItem(item.id, { skipEmptyCheck: true })
+      closeItem(item.id)
     }
     // Why: closing tabs doesn't remove the group shell; empty split groups are layout state, collapse the placeholder pane here.
     closeEmptyGroup(worktreeId, groupId)
-    leaveWorktreeIfEmpty()
-  }, [closeEmptyGroup, closeItem, groupId, leaveWorktreeIfEmpty, worktreeId])
+  }, [closeEmptyGroup, closeItem, groupId, worktreeId])
 
   const closeAllEditorTabsInGroup = useCallback(() => {
     for (const item of groupTabs) {

--- a/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalOverlaySlot.tsx
@@ -44,7 +44,6 @@ type TerminalOverlaySlotProps = {
   activityTerminalPortal: ActivityTerminalPortalTarget | null
   onFocusOwningGroup: ((groupId: string) => void) | undefined
   consumeSuppressedPtyExit: (ptyId: string) => boolean
-  leaveWorktreeIfEmpty: () => void
 }
 
 export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
@@ -59,8 +58,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   isActive,
   activityTerminalPortal,
   onFocusOwningGroup,
-  consumeSuppressedPtyExit,
-  leaveWorktreeIfEmpty
+  consumeSuppressedPtyExit
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
   const overlayRef = useRef<HTMLDivElement | null>(null)
@@ -239,15 +237,14 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
         }
         closeTerminalTab(terminalTabId, {
           reason: 'pty-exit',
-          lifecyclePtyId: ptyId,
-          onClosed: leaveWorktreeIfEmpty
+          lifecyclePtyId: ptyId
         })
       }}
       onCloseTab={() => {
         // Why: route through closeTerminalTab (not the raw store closeTab) so a
         // pinned tab hits the confirmation guard. The overlay's direct
         // store.closeTab was the path that closed pinned terminals silently.
-        closeTerminalTab(terminalTabId, { onClosed: leaveWorktreeIfEmpty })
+        closeTerminalTab(terminalTabId)
       }}
     />
   )

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -77,7 +77,6 @@ function renderSlot(): void {
         activityTerminalPortal={null}
         onFocusOwningGroup={vi.fn()}
         consumeSuppressedPtyExit={() => false}
-        leaveWorktreeIfEmpty={vi.fn()}
       />
     )
   })

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -56,21 +56,8 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   )
   const focusGroup = useAppStore((state) => state.focusGroup)
   const consumeSuppressedPtyExit = useAppStore((state) => state.consumeSuppressedPtyExit)
-  const setActiveWorktree = useAppStore((state) => state.setActiveWorktree)
-  const reconcileWorktreeTabModel = useAppStore((state) => state.reconcileWorktreeTabModel)
 
   useNativeChatToggleShortcut(worktreeId, isWorktreeActive)
-
-  const leaveWorktreeIfEmpty = useCallback(() => {
-    const state = useAppStore.getState()
-    if (state.activeWorktreeId !== worktreeId) {
-      return
-    }
-    const { renderableTabCount } = reconcileWorktreeTabModel(worktreeId)
-    if (renderableTabCount === 0) {
-      setActiveWorktree(null)
-    }
-  }, [reconcileWorktreeTabModel, setActiveWorktree, worktreeId])
 
   const focusOwningGroup = useCallback(
     (groupId: string) => focusGroup(worktreeId, groupId),
@@ -148,7 +135,6 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
               activityTerminalPortal={activityTerminalPortal}
               onFocusOwningGroup={focusOwningGroup}
               consumeSuppressedPtyExit={consumeSuppressedPtyExit}
-              leaveWorktreeIfEmpty={leaveWorktreeIfEmpty}
             />
           )
         })}

--- a/src/renderer/src/components/terminal/terminal-tab-actions-kill-all.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions-kill-all.test.ts
@@ -120,15 +120,30 @@ describe('closeTerminalTab kill-all routing', () => {
     expect(state.createTab).not.toHaveBeenCalled()
   })
 
-  it('deactivates after the last active terminal when no other content exists', () => {
+  // Why: issue #11699 — deselecting here emptied the file explorer and Git panel.
+  it('keeps the workspace selected after the last active terminal when no other content exists', () => {
     const state = baseState()
     getStateMock.mockReturnValue(state)
 
     closeTerminalTab('terminal-1', { force: true })
 
-    expect(state.setActiveWorktree).toHaveBeenCalledWith(null)
+    expect(state.setActiveWorktree).not.toHaveBeenCalled()
     expect(state.setActiveFile).not.toHaveBeenCalled()
     expect(state.setActiveBrowserTab).not.toHaveBeenCalled()
     expect(state.createTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps a remote worktree selected when the host owns the last terminal tab', () => {
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    const state = baseState({
+      settings: { activeRuntimeEnvironmentId: 'remote-env', confirmClosePinnedTab: true },
+      repos: [{ id: 'repo', executionHostId: 'runtime:remote-env', connectionId: null }]
+    })
+    getStateMock.mockReturnValue(state)
+
+    closeTerminalTab('terminal-1', { force: true })
+
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalled()
+    expect(state.setActiveWorktree).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -181,9 +181,9 @@ export function closeTerminalTab(
         : {})
     })
     if (state.activeWorktreeId === owningWorktreeId) {
-      // Why: only deactivate the worktree when no tabs of any kind remain.
-      // Editor files are a separate tab type; closing the last terminal tab
-      // should switch to the editor view instead of tearing down the workspace.
+      // Why: editor/browser tabs are separate tab types, so reveal one instead of
+      // leaving the empty terminal view up. With none left the workspace stays
+      // selected (issue #11699) — file/Git browsing must survive a zero-tab state.
       const worktreeFile = state.openFiles.find((f) => f.worktreeId === owningWorktreeId)
       if (worktreeFile) {
         state.setActiveFile(worktreeFile.id)
@@ -193,8 +193,6 @@ export function closeTerminalTab(
         if (browserTab) {
           state.setActiveBrowserTab(browserTab.id)
           state.setActiveTabType('browser')
-        } else {
-          state.setActiveWorktree(null)
         }
       }
     }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2895,6 +2895,11 @@
           },
           "TabGroupDropOverlay": {
             "paneColumnLabel": "New split"
+          },
+          "TabGroupEmptyState": {
+            "title": "No open tabs",
+            "description": "Files, search, and Git are still available for this workspace in the sidebar.",
+            "newTerminal": "New terminal"
           }
         },
         "bar": {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -194,6 +194,21 @@ export function getLastKnownHostTerminalTabCount(
   )
 }
 
+// Why: the freshness maps are module-local, so readers of the publication epoch get no
+// store notification. Expose an explicit subscription for useSyncExternalStore consumers.
+const publicationListeners = new Set<() => void>()
+
+export function subscribeWebSessionTabsPublication(listener: () => void): () => void {
+  publicationListeners.add(listener)
+  return () => publicationListeners.delete(listener)
+}
+
+function notifyWebSessionTabsPublication(): void {
+  for (const listener of publicationListeners) {
+    listener()
+  }
+}
+
 export function getLatestWebSessionTabsPublicationEpoch(
   environmentId: string,
   worktreeId: string
@@ -257,6 +272,9 @@ export function shouldApplyWebSessionTabsSnapshot(
     publicationEpoch: snapshot.publicationEpoch,
     snapshotVersion: snapshot.snapshotVersion
   })
+  // Why: a zero-tab snapshot changes no store slice, so this is the only signal that
+  // tells the UI the host has spoken and the worktree is genuinely empty, not pending.
+  notifyWebSessionTabsPublication()
   // Why: a mounted mirror that exhausted bounded polling needs fresh host evidence without subscribing to every store write.
   queueAcceptedWebSessionTerminalSnapshot(snapshot, environmentId)
   return true
@@ -330,6 +348,7 @@ export function resetWebSessionTabsSnapshotFreshnessForTests(): void {
   replayableSessionTabsSnapshotByWorktree.clear()
   lastHostTerminalTabCountByWorktree.clear()
   hostSessionTabIdByLocalKey.clear()
+  notifyWebSessionTabsPublication()
 }
 
 export function _getWebSessionTabsTrackingCountsForTest(): {
@@ -357,6 +376,8 @@ function clearWebSessionTabsTrackingForWorktree(environmentId: string, worktreeI
       hostSessionTabIdByLocalKey.delete(key)
     }
   }
+  // Why: dropping the epoch returns this worktree to "awaiting the host", so readers must re-ask.
+  notifyWebSessionTabsPublication()
 }
 
 export function clearWebSessionTabsTrackingForEnvironment(environmentId: string): void {
@@ -387,6 +408,7 @@ export function clearWebSessionTabsTrackingForEnvironment(environmentId: string)
   }
   clearWebAgentSessionHandoffsForEnvironment(trimmedEnvironmentId)
   clearAllWebRuntimeWakeTerminalRespawn()
+  notifyWebSessionTabsPublication()
 }
 
 function hostSessionTabMappingKey(args: {

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -2335,7 +2335,8 @@ describe('createEditorSlice editor drafts', () => {
     expect(store.getState().activeBrowserTabId).toBe('browser-1')
   })
 
-  it('returns to the landing state when closing the last editor in a worktree with no other surfaces', () => {
+  // Why: issue #11699 — the workspace stays selected so file/Git browsing survives zero tabs.
+  it('keeps the workspace selected when closing the last editor in a worktree with no other surfaces', () => {
     const store = createEditorStore()
 
     store.getState().openFile({
@@ -2348,7 +2349,7 @@ describe('createEditorSlice editor drafts', () => {
 
     store.getState().closeFile('/repo/notes.md')
 
-    expect(store.getState().activeWorktreeId).toBeNull()
+    expect(store.getState().activeWorktreeId).toBe('wt-1')
     expect(store.getState().activeFileId).toBeNull()
     expect(store.getState().activeBrowserTabId).toBeNull()
     expect(store.getState().activeTabType).toBe('terminal')
@@ -2391,7 +2392,7 @@ describe('createEditorSlice editor drafts', () => {
     expect(store.getState().activeBrowserTabId).toBe('browser-1')
   })
 
-  it('returns to the landing state when closing all editors and no other surfaces remain', () => {
+  it('keeps the workspace selected when closing all editors and no other surfaces remain', () => {
     const store = createEditorStore()
 
     store.getState().openFile({
@@ -2404,7 +2405,7 @@ describe('createEditorSlice editor drafts', () => {
 
     store.getState().closeAllFiles()
 
-    expect(store.getState().activeWorktreeId).toBeNull()
+    expect(store.getState().activeWorktreeId).toBe('wt-1')
     expect(store.getState().activeFileId).toBeNull()
     expect(store.getState().activeBrowserTabId).toBeNull()
     expect(store.getState().activeTabType).toBe('terminal')

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -2153,7 +2153,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         newActiveTabTypeByWorktree[activeWorktreeId] =
           browserTabsForWorktree.length > 0 ? 'browser' : 'terminal'
       }
-      const shouldDeactivateWorktree =
+      const worktreeBecameEmpty =
         activeWorktreeId !== null &&
         remainingForWorktree.length === 0 &&
         browserTabsForWorktree.length === 0 &&
@@ -2207,9 +2207,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         editorDrafts: newEditorDrafts,
         editorCursorLine: newEditorCursorLine,
         activeFileId: newActiveId,
-        // Why: if the last editor closes with no browser/terminal surface left, return to the landing state like the terminal/browser close handlers do.
-        activeWorktreeId: shouldDeactivateWorktree ? null : s.activeWorktreeId,
-        activeBrowserTabId: shouldDeactivateWorktree
+        // Why: the workspace stays selected at zero surfaces (issue #11699) so file/Git browsing survives; only the surface actives clear.
+        activeBrowserTabId: worktreeBecameEmpty
           ? null
           : activeWorktreeId && remainingForWorktree.length === 0
             ? fallbackBrowserTabId
@@ -2346,7 +2345,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       const terminalTabsForWorktree = s.tabsByWorktree[activeWorktreeId] ?? []
       newActiveTabTypeByWorktree[activeWorktreeId] =
         browserTabsForWorktree.length > 0 ? 'browser' : 'terminal'
-      const shouldDeactivateWorktree =
+      const worktreeBecameEmpty =
         browserTabsForWorktree.length === 0 && terminalTabsForWorktree.length === 0
 
       // Why: mirrored tabs use host tab ids in tab order while local entries use file ids; remove both shapes.
@@ -2387,9 +2386,8 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         editorDrafts: newEditorDrafts,
         editorCursorLine: newEditorCursorLine,
         activeFileId: null,
-        // Why: closing every editor can leave no renderable surface; clear the active worktree so the renderer shows the landing page, not a blank workspace.
-        activeWorktreeId: shouldDeactivateWorktree ? null : s.activeWorktreeId,
-        activeBrowserTabId: shouldDeactivateWorktree
+        // Why: closing every editor leaves the workspace selected (issue #11699); the tab group's empty state covers the pane that used to go blank.
+        activeBrowserTabId: worktreeBecameEmpty
           ? null
           : browserTabsForWorktree.length > 0
             ? (s.activeBrowserTabIdByWorktree[activeWorktreeId] ??

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -2712,7 +2712,8 @@ describe('setActiveWorktree', () => {
     expect(s.activeTabType).toBe('browser')
   })
 
-  it('returns to the landing state when closing the last terminal tab in the active worktree', () => {
+  // Why: issue #11699 — the workspace stays selected at zero tabs so file/Git browsing survives.
+  it('clears the tab surfaces but keeps the workspace selected when its last terminal tab closes', () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'
     const groupId = 'group-1'
@@ -2762,7 +2763,7 @@ describe('setActiveWorktree', () => {
     store.getState().closeTab(tabId)
 
     const s = store.getState()
-    expect(s.activeWorktreeId).toBeNull()
+    expect(s.activeWorktreeId).toBe(wt)
     expect(s.activeTabId).toBeNull()
     expect(s.tabsByWorktree[wt]).toEqual([])
     expect(s.unifiedTabsByWorktree[wt]).toEqual([])

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Tab, TabGroup } from '../../../../shared/types'
 import type * as AgentStatusModule from '@/lib/agent-status'
 import { FLOATING_TERMINAL_WORKTREE_ID, getDefaultUIState } from '../../../../shared/constants'
+import { worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import { buildMobileSessionTabSnapshots } from '../../runtime/sync-runtime-graph'
 import { closeMobileSessionTabInStore } from '../../runtime/mobile-session-tab-close'
 
@@ -301,6 +302,57 @@ describe('TabsSlice', () => {
     it('returns null for nonexistent tab', () => {
       const result = store.getState().closeUnifiedTab('nonexistent')
       expect(result).toBeNull()
+    })
+
+    // Why: issue #11699 — deselecting the emptied workspace here blanked the file explorer and Git panel.
+    it('keeps the workspace selected but clears surface actives when the last tab closes', () => {
+      const groupId = 'editor-group'
+      const file = makeOpenFile({
+        id: '/tmp/feature/src/app.ts',
+        filePath: '/tmp/feature/src/app.ts',
+        relativePath: 'src/app.ts',
+        language: 'typescript',
+        worktreeId: WT
+      })
+      const tab = makeUnifiedTab({
+        id: 'app-unified',
+        entityId: file.id,
+        contentType: 'editor',
+        label: 'app.ts',
+        worktreeId: WT,
+        groupId
+      })
+      store.setState({
+        openFiles: [],
+        unifiedTabsByWorktree: { [WT]: [tab] },
+        groupsByWorktree: {
+          [WT]: [
+            makeTabGroup({
+              id: groupId,
+              worktreeId: WT,
+              activeTabId: tab.id,
+              tabOrder: [tab.id],
+              recentTabIds: [tab.id]
+            })
+          ]
+        },
+        activeGroupIdByWorktree: { [WT]: groupId },
+        activeFileId: file.id,
+        activeFileIdByWorktree: { [WT]: file.id },
+        activeWorktreeId: WT,
+        activeWorkspaceKey: worktreeWorkspaceKey(WT),
+        activeTabType: 'editor',
+        activeTabTypeByWorktree: { [WT]: 'editor' }
+      })
+
+      store.getState().closeUnifiedTab(tab.id)
+
+      const state = store.getState()
+      expect(state.activeWorktreeId).toBe(WT)
+      expect(state.activeWorkspaceKey).toBe(worktreeWorkspaceKey(WT))
+      expect(state.activeTabId).toBeNull()
+      expect(state.activeFileId).toBeNull()
+      expect(state.activeBrowserTabId).toBeNull()
     })
 
     it('removes a mobile-closed markdown tab from open files so it is not republished', () => {

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -961,7 +961,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         nextLayoutByWorktree = collapsedState.layoutByWorktree
         nextActiveGroupIdByWorktree = collapsedState.activeGroupIdByWorktree
       }
-      const shouldDeactivateWorktree =
+      const worktreeBecameEmpty =
         current.activeWorktreeId === worktreeId &&
         nextTabs.length === 0 &&
         (current.tabsByWorktree[worktreeId] ?? []).length === 0 &&
@@ -979,12 +979,9 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         ...(nextUnreadTerminalTabs !== current.unreadTerminalTabs
           ? { unreadTerminalTabs: nextUnreadTerminalTabs }
           : {}),
-        // Why: closing the last tab can leave the worktree selected but render-empty, so write the landing-state fallback directly.
-        ...(shouldDeactivateWorktree
+        // Why: the workspace stays selected at zero tabs so file/Git browsing survives; only the per-surface actives are cleared.
+        ...(worktreeBecameEmpty
           ? {
-              activeWorktreeId: null,
-              activeWorkspaceKey: null,
-              activeWorkspaceExecutionHostId: null,
               activeTabId: null,
               activeBrowserTabId: null,
               activeFileId: null,
@@ -1007,7 +1004,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               }
             }
           : {}),
-        ...(!shouldDeactivateWorktree && current.activeWorktreeId === worktreeId
+        ...(!worktreeBecameEmpty && current.activeWorktreeId === worktreeId
           ? buildActiveSurfacePatch(
               {
                 ...current,

--- a/tests/e2e/tab-close-navigation.spec.ts
+++ b/tests/e2e/tab-close-navigation.spec.ts
@@ -7,12 +7,15 @@
  *   fixed a regression where closing the active editor tab jumped to an
  *   arbitrary file. The existing `tabs.spec.ts` only covers terminal tab
  *   close; the editor/diff close path has no E2E guard today.
- * - PR #677 (`return to Orca landing screen after closing last terminal`)
- *   plus editor.ts's `shouldDeactivateWorktree` branch (also hardened in
- *   tabs.ts's `closeUnifiedTab`) require that when a worktree's last visible
- *   surface closes, the app clears `activeWorktreeId` instead of leaving a
- *   selected worktree with nothing to render. Any regression here shows up
- *   as a blank workspace.
+ * - Issue #11699 supersedes PR #677 (`return to Orca landing screen after
+ *   closing last terminal`). #677 cleared `activeWorktreeId` when a worktree's
+ *   last visible surface closed, because a selected worktree with no surfaces
+ *   rendered a blank workspace. But deselecting also tore down file browsing
+ *   and Git for a workspace the user had not left, which is the bug #11699
+ *   reports. The workspace now stays selected and the tab group renders an
+ *   empty state with a "New terminal" action, so the blank workspace #677 was
+ *   avoiding no longer exists and the landing fallback is no longer needed.
+ *   Sleeping a workspace is now the route back to Landing.
  * - PR #532 had to be patched because `closeFile` forgot to keep
  *   `activeFileIdByWorktree` honest. This spec covers the user-visible
  *   invariant: after closing the active editor tab, the replacement active
@@ -234,11 +237,14 @@ test.describe('Tab Close Navigation', () => {
   })
 
   /**
-   * Covers PR #677 and the `shouldDeactivateWorktree` branch in closeFile:
-   * when the last editor closes and no terminal/browser surface remains for
-   * the worktree, the app must return to Landing (activeWorktreeId === null).
+   * Covers issue #11699, which reverses PR #677: when the last editor closes
+   * and no terminal/browser surface remains, the workspace stays selected so
+   * file browsing and Git keep working, and the tab group renders its empty
+   * state so the pane still offers a way to open a terminal.
    */
-  test('closing the last visible surface returns the app to Landing', async ({ orcaPage }) => {
+  test('closing the last visible surface keeps the workspace selected and offers a terminal', async ({
+    orcaPage
+  }) => {
     const worktreeId = await waitForActiveWorktree(orcaPage)
 
     // Prepare the worktree so only a single editor tab is present as a
@@ -321,13 +327,25 @@ test.describe('Tab Close Navigation', () => {
 
     await closeFile(orcaPage, editorIds[0])
 
-    // The worktree should be deselected. Landing renders when
-    // activeWorktreeId === null.
+    // The workspace stays selected (issue #11699) — deselecting is what emptied
+    // the file explorer and Git panel for a workspace the user had not left.
     await expect
       .poll(async () => getActiveWorktreeId(orcaPage), {
         timeout: 5_000,
-        message: 'activeWorktreeId was not cleared after closing the last visible surface'
+        message: 'activeWorktreeId must survive closing the last visible surface'
+      })
+      .toBe(worktreeId)
+
+    // The per-surface actives still clear, so nothing stale renders.
+    await expect
+      .poll(async () => getActiveFileId(orcaPage), {
+        timeout: 5_000,
+        message: 'activeFileId was not cleared after closing the last editor'
       })
       .toBeNull()
+
+    // The pane is not blank: the empty state offers a reachable way back in.
+    await expect(orcaPage.getByTestId('tab-group-empty-state')).toBeVisible({ timeout: 10_000 })
+    await expect(orcaPage.getByRole('button', { name: /New terminal/i })).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #11699.

Closing every tab in a workspace deselected the workspace itself. The file explorer fell back to *"Select a workspace to browse files"* and the Git panel emptied, so browsing files or using source control required re-clicking the workspace **and** opening a terminal — even when the user only wanted to read a file.

`FileExplorer` gates on `activeWorktreeId`, and seven separate close paths were clearing it once the last surface went away:

| Site | Path |
| --- | --- |
| `store/slices/tabs.ts` | unified tab model (`closeUnifiedTab`) |
| `store/slices/editor.ts` ×2 | `closeFile` and `closeAllFiles` |
| `components/terminal/terminal-tab-actions.ts` | last terminal tab |
| `components/Terminal.tsx` | last browser tab |
| `components/tab-group/useTabGroupWorkspaceModel.ts` | `leaveWorktreeIfEmpty` (split groups) |
| `components/terminal-pane/TerminalPaneOverlayLayer.tsx` | second `leaveWorktreeIfEmpty` |

All seven now leave `activeWorktreeId` intact and clear only the per-surface actives (`activeTabId`, `activeBrowserTabId`, `activeFileId`). The two `leaveWorktreeIfEmpty` hooks are removed outright, along with the now-dead `skipEmptyCheck` option.

### Why the deselection existed, and why removing it is safe now

This intentionally supersedes **PR #677** (*"return to Orca landing screen after closing last terminal"*). That behavior existed for a good reason, recorded in `tests/e2e/tab-close-navigation.spec.ts`:

> …require that when a worktree's last visible surface closes, the app clears `activeWorktreeId` instead of leaving a selected worktree with nothing to render. **Any regression here shows up as a blank workspace.**

That was accurate — the pane body renders only `activeTab`-driven content, so at zero tabs it was a tab strip over empty space. Keeping the workspace selected therefore required giving the pane something to show, so this PR adds `TabGroupEmptyState`: the hero icon, a short explanation that the sidebar still works, and a direct **New terminal** action with its platform shortcut.

Sleeping a workspace is now the route back to Landing. Deliberate deselections are untouched: sleep, worktree delete, repo removal, and folder-workspace delete.

### Empty-state visibility is derived, never timed

A group also sits at zero tabs *before* its first tab arrives — `ensureWorktreeRootGroup` creates the root group first, and a runtime-owned worktree then waits on the host's session-tab mirror for however long the link takes. Showing the empty state during that wait would be wrong.

Visibility is `workspaceSessionReady && tabCount === 0 && !awaitingFirstHostTabs`, where `awaitingFirstHostTabs` is true only while a runtime-owned worktree has no published snapshot epoch. No timer and no mount-local state — a reparent or reload can't strand the pane with no way to open a terminal. Because the epoch lives in module-local maps and a zero-tab snapshot moves no store slice, `web-session-tabs-sync.ts` gained an explicit publication subscription consumed via `useSyncExternalStore`; without it the predicate would be correct but the UI would never re-ask.

## Screenshots

Light-mode full window — the workspace stays highlighted in the sidebar and the file explorer stays populated, which is the reported bug going away. Plus light/dark detail shots of the empty state.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New/updated coverage:

- `tab-group-empty-state-visibility.test.ts` — the visibility predicate, including a remote worktree resting at zero tabs reading as *empty* rather than perpetually pending, and remount-invariance.
- `tab-group-empty-state-reactivity.test.tsx` — renders the real hook and publishes a zero-tab snapshot through the real sync path, asserting the empty state appears **with no other state change**. Pure-predicate tests can't catch a missing subscription; this one can.
- `useTabGroupWorkspaceModel.focus.test.ts` — last terminal tab, last browser tab, sole group closed, and two-group split where only the emptied pane collapses.
- `tabs.test.ts`, `store-cascades.test.ts`, `editor.test.ts`, `terminal-tab-actions-kill-all.test.ts` — existing assertions that encoded the old deselection are retitled and inverted, each with a `Why:` pointing at this issue. Also a remote/host-owned close case.
- `tests/e2e/tab-close-navigation.spec.ts` — the last-surface test now asserts the workspace stays selected and the empty state offers a terminal. Its header documented #677's rationale as current truth and has been rewritten.

Verified fail-on-main: the four behavior test files produce **7 failures** against `main`'s source and pass on this branch.

## AI Review Report

Reviewed across five rounds, each verified against the code rather than accepted on assertion.

- **Cross-platform (macOS/Linux/Windows):** no `metaKey` hardcoding. The shortcut chip renders through `useShortcutKeyDetails` + `ShortcutKeyCombo`, which resolve the platform internally — the screenshots show `Ctrl + T` with the Linux/Windows `+` separator; macOS renders adjacent glyphs. No new path handling.
- **SSH / remote / local:** the first design used a 250ms settle timer, which would have flashed the empty state mid-hydration on any link slower than the timeout — rejected. The second used a mount-local latch, which a reload would reset and strand a remote workspace with no recovery affordance; `shouldBootstrapInitialWebRuntimeTerminal`'s guard is closure-local and consumed once, so a remote workspace resting at zero tabs is a real state, and this fix makes it a common one. Both replaced by the derived predicate above. `terminal-tab-actions.ts`'s host-authoritative branch returns before the last-tab logic and is covered by its own test.
- **Folder workspaces:** the empty state's action routes through `openNewTerminalTabInActiveWorkspace`, the same action the tab bar's `+` uses, which already handles folder-workspace keys and remote runtimes. No new assumption that a workspace is a git worktree.
- **Git providers:** copy says "Git", matching the `source-control` sidebar tab. Nothing GitHub-specific.
- **Performance:** no new polling or timers. One `useSyncExternalStore` subscription per mounted tab group, notified only when a session-tab snapshot is recorded or cleared.
- **UI quality:** `docs/STYLEGUIDE.md` throughout — `size-7` hero icon (its documented empty-state use), `muted-foreground`, `outline`/`sm` button, lucide `SquareTerminal`, no invented values. Rendered and inspected in both themes; the shortcut chip was regrouped after review because it read as a floating element rather than the button's shortcut.
- **Caught in review:** the E2E suite is not part of `pnpm test`. Running it revealed the fix was incomplete — the two `editor.ts` sites were still deselecting, so closing the last *editor* reproduced the original bug on a path no unit test covered.

## Security Audit

No new IPC surface, no command execution, no path handling, no auth or credential handling, no network calls, and no new dependencies. Changes are renderer-local state transitions plus one in-process listener set (`publicationListeners`), whose unsubscribe is returned to `useSyncExternalStore` and cleared on all three teardown paths, so listeners can't accumulate across worktree or environment churn. The empty state renders static translated copy — no user-controlled interpolation. No follow-up needed.

## Notes

- Reverses PR #677 deliberately; sleeping a workspace is now the route back to Landing.
- One narrow, pre-existing limitation left alone: if a runtime-owned host never publishes a snapshot at all (unreachable remote), the pane stays blank. That is a disconnected-runtime state surfaced by `TerminalRemoteRuntimeReconnectBanner` / `TerminalSshReconnectOverlay`; the empty state was deliberately not made to double as a connectivity error surface.
- A throwaway Playwright spec produced the screenshots and was intentionally left out of the commit — its behavioral assertion is already covered by `tab-close-navigation.spec.ts`, and it added ~19s to CI for evidence capture.
