### PR TITLE
fix(cmd-j): center palette row icons on the first text line

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1838,7 +1838,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
                     )}
                   >
-                    <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5">
+                    <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start">
                       <StatusIndicator status={status} aria-hidden="true" />
                       <span className="sr-only">{statusLabel}</span>
                     </div>
@@ -1966,7 +1966,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
                     )}
                   >
-                    <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground/85">
+                    <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <FolderTree className="size-3.5" aria-hidden="true" />
                     </div>
                     <div className="min-w-0 flex-1">
@@ -2013,7 +2013,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
                     )}
                   >
-                    <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground/85">
+                    <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <Icon className="size-3.5" aria-hidden="true" />
                     </div>
                     <div className="min-w-0 flex-1">
@@ -2054,7 +2054,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
                     )}
                   >
-                    <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground/85">
+                    <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <WorkspaceTabIcon className="size-3.5" aria-hidden="true" />
                     </div>
                     <div className="min-w-0 flex-1">
@@ -2135,7 +2135,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                       'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
                     )}
                   >
-                    <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground/85">
+                    <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                       <Smartphone className="size-3.5" aria-hidden="true" />
                     </div>
                     <div className="min-w-0 flex-1">
@@ -2213,7 +2213,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                     'data-[selected=true]:border-border data-[selected=true]:bg-accent data-[selected=true]:text-foreground'
                   )}
                 >
-                  <div className="flex w-4 shrink-0 items-center justify-center self-start pt-0.5 text-muted-foreground/85">
+                  <div className="flex h-5 w-4 shrink-0 items-center justify-center self-start text-muted-foreground/85">
                     <Globe className="size-3.5" aria-hidden="true" />
                   </div>
                   <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

In the Cmd+J palette, the leading icons (worktree status dots, terminal/globe/folder/etc. icons) sat 1–2px above the vertical center of their row's title line. The icon gutter used `self-start` with a hand-tuned `pt-0.5` nudge and no fixed height, so the icon centered inside its own collapsed box instead of the 20px title line box: status dots (12px box) landed at 8px vs. the text center at 10px, lucide `size-3.5` icons at 9px. Giving the gutter `h-5` (20px, matching the title line box) and dropping the padding nudge centers every icon on the first text line — for single- and two-line rows alike — and puts dots and tab icons on one shared vertical center across sections. Same one-class change across all six row types (worktree, project/group, settings/quick-action, workspace tab, simulator tab, browser page).

## Screenshots

Visual change is a 1–2px vertical nudge of the left gutter icons — imperceptible in an unmagnified screenshot, so none attached. The Summary above gives the exact before/after pixel positions.

## Testing

- [ ] `pnpm lint` — ran `oxlint` + `oxfmt --check` on the changed file directly, and the pre-commit lint-staged hook ran `oxlint` and the react-doctor config against it; all clean. Full repo lint not run.
- [ ] `pnpm typecheck` — ran the renderer project (`pnpm typecheck:tsc:web`, `--composite false`): clean. Node/CLI projects untouched by this change.
- [ ] `pnpm test` — not run: className-only change, no logic or behavior to test.
- [ ] `pnpm build` — not run for the same reason.
- No tests added: the change is a Tailwind class swap with no testable logic.

## AI Review Report

Reviewed the change against the palette's row anatomy: confirmed all six row types share the identical gutter recipe and all get the same fix; verified the 20px first-line box (14px title text at the inherited `text-sm` line-height) is what `h-5` matches; confirmed `self-start` is preserved so two-line rows (worktree supporting text, settings/quick-action descriptions) keep the icon pinned to the first line rather than centering over both lines; confirmed the create-worktree row's `h-5 w-5` circular Plus badge is a deliberately different treatment and was left alone. Cross-platform (macOS/Linux/Windows): the change is pure Tailwind classNames in the renderer — no keyboard shortcuts, labels, paths, shell, or Electron platform APIs involved; rendering is identical on all platforms.

## Security Audit

No security surface: the diff swaps `pt-0.5` for `h-5` in six static className strings. No input handling, command execution, path handling, auth, secrets, dependencies, or IPC touched.

## Notes

The create-worktree row's Plus badge uses a `w-5` gutter (4px wider than the `w-4` gutters), so its icon's left edge intentionally differs; out of scope here. No follow-up needed.