### PR TITLE
fix(codex): make quota probes credential-safe

### DIFF
--- a/src/main/codex-accounts/codex-credential-absence-grace.test.ts
+++ b/src/main/codex-accounts/codex-credential-absence-grace.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  CODEX_CREDENTIAL_ABSENCE_GRACE_MS,
+  CodexCredentialAbsenceGrace
+} from './codex-credential-absence-grace'
+
+const VALID_AUTH = JSON.stringify({
+  auth_mode: 'chatgpt',
+  tokens: { access_token: 'a', id_token: 'b', refresh_token: 'c' }
+})
+
+describe('CodexCredentialAbsenceGrace', () => {
+  let dir = ''
+  let authPath = ''
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'codex-absence-grace-'))
+    authPath = join(dir, 'auth.json')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('treats a torn mid-write read as transient until it outlives the grace window', () => {
+    const grace = new CodexCredentialAbsenceGrace()
+    writeFileSync(authPath, '{"tokens":{"acc', 'utf-8')
+
+    expect(grace.assess(authPath, 1_000)).toEqual({ state: 'unreadable', durable: false })
+    expect(grace.assess(authPath, 1_000 + CODEX_CREDENTIAL_ABSENCE_GRACE_MS - 1)).toEqual({
+      state: 'unreadable',
+      durable: false
+    })
+    expect(grace.assess(authPath, 1_000 + CODEX_CREDENTIAL_ABSENCE_GRACE_MS)).toEqual({
+      state: 'unreadable',
+      durable: true
+    })
+  })
+
+  it('clears the absence clock when a transient failure heals', () => {
+    const grace = new CodexCredentialAbsenceGrace()
+    writeFileSync(authPath, '{"tokens":{"acc', 'utf-8')
+    expect(grace.assess(authPath, 1_000).durable).toBe(false)
+
+    writeFileSync(authPath, VALID_AUTH, 'utf-8')
+    expect(grace.assess(authPath, 2_000)).toEqual({ state: 'present', durable: true })
+
+    // A later absence starts a fresh grace window instead of inheriting the old clock.
+    rmSync(authPath)
+    expect(grace.assess(authPath, 100_000)).toEqual({ state: 'missing', durable: false })
+    expect(grace.assess(authPath, 100_000 + CODEX_CREDENTIAL_ABSENCE_GRACE_MS)).toEqual({
+      state: 'missing',
+      durable: true
+    })
+  })
+
+  it('reports settled credential-free JSON as durable immediately', () => {
+    const grace = new CodexCredentialAbsenceGrace()
+    writeFileSync(authPath, '{}', 'utf-8')
+    expect(grace.assess(authPath, 1_000)).toEqual({ state: 'no-credential', durable: true })
+  })
+})

--- a/src/main/codex-accounts/codex-credential-absence-grace.ts
+++ b/src/main/codex-accounts/codex-credential-absence-grace.ts
@@ -26,7 +26,7 @@ export class CodexCredentialAbsenceGrace {
   assess(authPath: string, now = Date.now()): CodexCredentialAbsenceVerdict {
     const state = readStoredCodexCredentialState(authPath)
     const key = normalizeRuntimePathForComparison(authPath)
-    if (state === 'present' || state === 'no-credential') {
+    if (state === 'present' || state === 'incomplete' || state === 'no-credential') {
       this.firstAbsenceAtByPath.delete(key)
       return { state, durable: true }
     }

--- a/src/main/codex-accounts/codex-credential-absence-grace.ts
+++ b/src/main/codex-accounts/codex-credential-absence-grace.ts
@@ -1,0 +1,46 @@
+import { existsSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import {
+  readStoredCodexCredentialState,
+  type StoredCodexCredentialState
+} from './managed-codex-auth-readiness'
+
+export const CODEX_CREDENTIAL_ABSENCE_GRACE_MS = 5_000
+
+export type CodexCredentialAbsenceVerdict = {
+  state: StoredCodexCredentialState
+  /** For 'missing'/'unreadable': true once the absence outlived the grace window. */
+  durable: boolean
+}
+
+// Why: codex rotates auth.json in place, so one missing/unreadable read can be
+// a write in progress. Deselecting the managed account on that snapshot logs
+// the user out over a race; absence must persist across a grace window first.
+// Valid JSON (with or without a credential) is a settled file and needs none.
+export class CodexCredentialAbsenceGrace {
+  private readonly firstAbsenceAtByPath = new Map<string, number>()
+
+  constructor(private readonly graceMs = CODEX_CREDENTIAL_ABSENCE_GRACE_MS) {}
+
+  assess(authPath: string, now = Date.now()): CodexCredentialAbsenceVerdict {
+    const state = readStoredCodexCredentialState(authPath)
+    const key = normalizeRuntimePathForComparison(authPath)
+    if (state === 'present' || state === 'no-credential') {
+      this.firstAbsenceAtByPath.delete(key)
+      return { state, durable: true }
+    }
+    // Why: rotation replaces auth.json inside an existing home; the home
+    // directory itself being gone is structural, not a write in flight.
+    if (state === 'missing' && !existsSync(dirname(authPath))) {
+      this.firstAbsenceAtByPath.delete(key)
+      return { state, durable: true }
+    }
+    const firstAbsenceAt = this.firstAbsenceAtByPath.get(key)
+    if (firstAbsenceAt === undefined) {
+      this.firstAbsenceAtByPath.set(key, now)
+      return { state, durable: false }
+    }
+    return { state, durable: now - firstAbsenceAt >= this.graceMs }
+  }
+}

--- a/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
@@ -4,7 +4,10 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
-import { waitForManagedCodexAuthReady } from './managed-codex-auth-readiness'
+import {
+  readStoredCodexCredentialState,
+  waitForManagedCodexAuthReady
+} from './managed-codex-auth-readiness'
 
 const roots: string[] = []
 const testIdToken = 'e30.eyJlbWFpbCI6InVzZXJAZXhhbXBsZS5jb20ifQ.sig'
@@ -87,6 +90,7 @@ describe('waitForManagedCodexAuthReady', () => {
     writeAuth(fixture.home, {
       tokens: { access_token: 'access', id_token: testIdToken }
     })
+    expect(readStoredCodexCredentialState(join(fixture.home, 'auth.json'))).toBe('incomplete')
     let resolved = false
     const readiness = waitForManagedCodexAuthReady(fixture.args)
     void readiness?.then(() => {
@@ -99,6 +103,16 @@ describe('waitForManagedCodexAuthReady', () => {
     await vi.advanceTimersByTimeAsync(25)
 
     await expect(readiness).resolves.toBe(true)
+  })
+
+  it('does not treat empty ChatGPT token fields as credential material', () => {
+    const fixture = createFixture()
+    writeAuth(fixture.home, {
+      auth_mode: 'chatgpt',
+      tokens: { access_token: '', id_token: '', refresh_token: '' }
+    })
+
+    expect(readStoredCodexCredentialState(join(fixture.home, 'auth.json'))).toBe('no-credential')
   })
 
   it('waits for an empty managed ChatGPT refresh token to be restored', async () => {

--- a/src/main/codex-accounts/managed-codex-auth-readiness.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.ts
@@ -85,7 +85,12 @@ function isManagedHostCodexHome(
   )
 }
 
-export type StoredCodexCredentialState = 'present' | 'missing' | 'unreadable' | 'no-credential'
+export type StoredCodexCredentialState =
+  | 'present'
+  | 'incomplete'
+  | 'missing'
+  | 'unreadable'
+  | 'no-credential'
 
 // Why: callers deciding whether to deselect an account must tell a settled
 // logout ('no-credential') apart from a rotation in progress ('unreadable') or
@@ -114,7 +119,10 @@ export function readStoredCodexCredentialState(authPath: string): StoredCodexCre
     auth.auth_mode == null
       ? hasCredentialWithoutDeclaredMode(auth)
       : hasCredentialForDeclaredMode(auth)
-  return hasCredential ? 'present' : 'no-credential'
+  if (hasCredential) {
+    return 'present'
+  }
+  return hasIncompleteCredentialMaterial(auth) ? 'incomplete' : 'no-credential'
 }
 
 export function hasStoredCodexCredential(authPath: string): boolean {
@@ -156,6 +164,10 @@ function hasCredentialWithoutDeclaredMode(auth: StoredCodexAuth): boolean {
   return Object.keys(auth).some((key) => key !== 'auth_mode' && key !== 'last_refresh')
 }
 
+function hasIncompleteCredentialMaterial(auth: StoredCodexAuth): boolean {
+  return hasChatGptTokenMaterial(auth.tokens) || hasAgentIdentityMaterial(auth.agent_identity)
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0
 }
@@ -185,6 +197,17 @@ function hasAgentIdentityCredential(value: unknown): boolean {
 
 function hasBedrockApiKey(value: unknown): boolean {
   return isRecord(value) && isNonEmptyString(value.api_key)
+}
+
+function hasChatGptTokenMaterial(tokens: unknown): boolean {
+  return (
+    isRecord(tokens) &&
+    [tokens.access_token, tokens.id_token, tokens.refresh_token].some(isNonEmptyString)
+  )
+}
+
+function hasAgentIdentityMaterial(value: unknown): boolean {
+  return isNonEmptyString(value) || (isRecord(value) && Object.values(value).some(isNonEmptyString))
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/main/codex-accounts/managed-codex-auth-readiness.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.ts
@@ -85,19 +85,40 @@ function isManagedHostCodexHome(
   )
 }
 
-export function hasStoredCodexCredential(authPath: string): boolean {
+export type StoredCodexCredentialState = 'present' | 'missing' | 'unreadable' | 'no-credential'
+
+// Why: callers deciding whether to deselect an account must tell a settled
+// logout ('no-credential') apart from a rotation in progress ('unreadable') or
+// an absent file ('missing') — collapsing them to false logs users out on races.
+export function readStoredCodexCredentialState(authPath: string): StoredCodexCredentialState {
+  let raw: string
   try {
-    const parsed: unknown = JSON.parse(readFileSync(authPath, 'utf8'))
-    if (!isRecord(parsed) || Object.keys(parsed).length === 0) {
-      return false
-    }
-    const auth = parsed as StoredCodexAuth
-    return auth.auth_mode == null
+    raw = readFileSync(authPath, 'utf8')
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    // Why: Windows auth.json rotation can surface transient EPERM/EBUSY reads.
+    return code === 'ENOENT' || code === 'ENOTDIR' ? 'missing' : 'unreadable'
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    // Torn JSON means a write is in flight, not that the credential is gone.
+    return 'unreadable'
+  }
+  if (!isRecord(parsed) || Object.keys(parsed).length === 0) {
+    return 'no-credential'
+  }
+  const auth = parsed as StoredCodexAuth
+  const hasCredential =
+    auth.auth_mode == null
       ? hasCredentialWithoutDeclaredMode(auth)
       : hasCredentialForDeclaredMode(auth)
-  } catch {
-    return false
-  }
+  return hasCredential ? 'present' : 'no-credential'
+}
+
+export function hasStoredCodexCredential(authPath: string): boolean {
+  return readStoredCodexCredentialState(authPath) === 'present'
 }
 
 function hasCredentialForDeclaredMode(auth: StoredCodexAuth): boolean {

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -383,6 +383,90 @@ describe('CodexRuntimeHomeService', () => {
     ).toBe(false)
   })
 
+  it('deselects a shared-home account on settled credential-free JSON', async () => {
+    const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
+    const managedAuth = createCodexAuthJson('user@example.com', 'acct-user', 'managed')
+    writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-user',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-user',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+    store.updateSettings.mockClear()
+
+    writeFileSync(join(managedHomePath, 'auth.json'), '{}\n', 'utf-8')
+    service.syncForCurrentSelection()
+
+    expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBeNull()
+    expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe('{}\n')
+    expect(readFileSync(getRuntimeCodexAuthPath(), 'utf-8')).toBe(systemAuth)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[codex-runtime-home] Active managed account credential is unavailable, restoring system default'
+    )
+  })
+
+  it('deselects a shared-home account when unreadable auth outlives the grace window', async () => {
+    const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
+    const managedAuth = createCodexAuthJson('user@example.com', 'acct-user', 'managed')
+    writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-user',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-user',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+    store.updateSettings.mockClear()
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"tokens":{"acc', 'utf-8')
+    const observedAt = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(observedAt)
+
+    service.syncForCurrentSelection()
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+    expect(store.updateSettings).not.toHaveBeenCalled()
+
+    nowSpy.mockReturnValue(observedAt + 6_000)
+    service.syncForCurrentSelection()
+    nowSpy.mockRestore()
+    expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBeNull()
+  })
+
   it('repoints legacy active host CODEX_HOME to the shared runtime home on startup', async () => {
     const legacyLaunchHomePath = join(
       testState.userDataDir,
@@ -4782,11 +4866,11 @@ describe('CodexRuntimeHomeService', () => {
 
   it('rejects unverifiable Codex read-back on first sync after restart', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
-    writeFileSync(runtimeAuthPath, '{"tokens":"refreshed-while-down"}\n', 'utf-8')
+    writeFileSync(runtimeAuthPath, '{"credential":"refreshed-while-down"}\n', 'utf-8')
     const managedHomePath = createManagedAuth(
       testState.userDataDir,
       'account-1',
-      '{"tokens":"original"}\n'
+      '{"credential":"original"}\n'
     )
     const managedAuthPath = join(managedHomePath, 'auth.json')
     const store = createStore(
@@ -4811,8 +4895,8 @@ describe('CodexRuntimeHomeService', () => {
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     new CodexRuntimeHomeService(store as never)
 
-    expect(readFileSync(managedAuthPath, 'utf-8')).toBe('{"tokens":"original"}\n')
-    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe('{"tokens":"original"}\n')
+    expect(readFileSync(managedAuthPath, 'utf-8')).toBe('{"credential":"original"}\n')
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe('{"credential":"original"}\n')
   })
 
   it('reads back verified same-account refreshes on first sync after restart', async () => {
@@ -4887,12 +4971,12 @@ describe('CodexRuntimeHomeService', () => {
     const managedHomePath1 = createManagedAuth(
       testState.userDataDir,
       'account-1',
-      '{"tokens":"account1"}\n'
+      '{"credential":"account1"}\n'
     )
     const managedHomePath2 = createManagedAuth(
       testState.userDataDir,
       'account-2',
-      '{"tokens":"account2"}\n'
+      '{"credential":"account2"}\n'
     )
     const managedAuthPath2 = join(managedHomePath2, 'auth.json')
     const settings = createSettings({
@@ -4930,8 +5014,8 @@ describe('CodexRuntimeHomeService', () => {
     settings.activeCodexManagedAccountId = 'account-2'
     service.syncForCurrentSelection()
 
-    expect(readFileSync(managedAuthPath2, 'utf-8')).toBe('{"tokens":"account2"}\n')
-    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe('{"tokens":"account2"}\n')
+    expect(readFileSync(managedAuthPath2, 'utf-8')).toBe('{"credential":"account2"}\n')
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe('{"credential":"account2"}\n')
   })
 
   it('does not carry the reauth read-back skip across Codex account switches', async () => {

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -2389,11 +2389,27 @@ describe('CodexRuntimeHomeService', () => {
     expect(store.updateSettings).not.toHaveBeenCalled()
 
     rmSync(join(managedHomePath1, 'auth.json'), { force: true })
+    // Why: the first missing read may be a rotation in flight — the selection
+    // survives the grace window and the launch still targets the account home.
+    const absenceObservedAt = Date.now()
     expect(
       service.prepareForCodexLaunch(undefined, undefined, {
         unavailableManagedHomePath: managedHomePath1
       })
-    ).toBeNull()
+    ).toBe(managedHomePath1)
+    expect(store.updateSettings).not.toHaveBeenCalled()
+
+    // Once the absence outlives the grace window it is durable and deselects.
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => absenceObservedAt + 6_000)
+    try {
+      expect(
+        service.prepareForCodexLaunch(undefined, undefined, {
+          unavailableManagedHomePath: managedHomePath1
+        })
+      ).toBeNull()
+    } finally {
+      nowSpy.mockRestore()
+    }
     expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
     expect(store.getSettings().activeCodexManagedAccountIdsByRuntime).toEqual({
       host: null,
@@ -2404,6 +2420,66 @@ describe('CodexRuntimeHomeService', () => {
       expect.objectContaining({ activeCodexManagedAccountId: null })
     )
     expect(warnSpy).toHaveBeenCalledWith(
+      '[codex-runtime-home] Active managed account credential remained unavailable, clearing selection'
+    )
+  })
+
+  it('does not deselect the account when a transient unreadable auth.json heals', async () => {
+    const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
+    writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
+    const accountAuth = createCodexAuthJson('user@example.com', 'acct-user', 'managed')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', accountAuth)
+    const store = createStore(
+      createSettings({
+        codexSystemDefaultRealHomeEnabled: true,
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-user',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-user',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    // A mid-write read observes torn JSON: no deselect, and the launch still
+    // targets the account home so codex re-reads the settled file itself.
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"tokens":{"acc', 'utf-8')
+    expect(
+      service.prepareForCodexLaunch(undefined, undefined, {
+        unavailableManagedHomePath: managedHomePath
+      })
+    ).toBe(managedHomePath)
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+    expect(store.updateSettings).not.toHaveBeenCalled()
+
+    // The write completes; even past the grace window the selection is intact.
+    writeFileSync(join(managedHomePath, 'auth.json'), accountAuth, 'utf-8')
+    const healedAt = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => healedAt + 60_000)
+    try {
+      expect(
+        service.prepareForCodexLaunch(undefined, undefined, {
+          unavailableManagedHomePath: managedHomePath
+        })
+      ).toBe(managedHomePath)
+    } finally {
+      nowSpy.mockRestore()
+    }
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+    expect(store.updateSettings).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalledWith(
       '[codex-runtime-home] Active managed account credential remained unavailable, clearing selection'
     )
   })

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -739,7 +739,7 @@ export class CodexRuntimeHomeService {
 
     const activeAuthPath = join(activeAccount.managedHomePath, 'auth.json')
     const authAbsence = this.credentialAbsenceGrace.assess(activeAuthPath)
-    if (authAbsence.state !== 'present') {
+    if (authAbsence.state !== 'present' && authAbsence.state !== 'incomplete') {
       if (!authAbsence.durable) {
         // Why: mid-rotation reads look missing/unreadable for a moment; skip
         // this sync without deselecting and let a settled read decide later.

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -77,7 +77,7 @@ import {
   codexAuthMatchesSystemDefaultIdentity
 } from './codex-auth-identity'
 import { migrateLegacySharedAuthToPerAccountHome } from './legacy-shared-auth-migration'
-import { hasStoredCodexCredential } from './managed-codex-auth-readiness'
+import { CodexCredentialAbsenceGrace } from './codex-credential-absence-grace'
 import { syncLegacySharedCodexConfigForRetainedPanes } from './legacy-shared-config-compatibility'
 import {
   hasRecordedLegacySharedCodexPane,
@@ -179,6 +179,8 @@ export class CodexRuntimeHomeService {
   // provenance so a later deselect/rollback never adopts stale shared bytes.
   private lastHostAccountUsedSelfContainedHome = false
   private sharedAuthRefreshBlockedByManagedTransition = false
+  // Why: transient auth.json read/parse failures must not deselect an account.
+  private readonly credentialAbsenceGrace = new CodexCredentialAbsenceGrace()
 
   constructor(private readonly store: Store) {
     this.safeRecoverInterruptedRuntimeAuthOperation()
@@ -307,11 +309,15 @@ export class CodexRuntimeHomeService {
     if (
       unavailableManagedHomePath &&
       normalizeRuntimePathForComparison(unavailableManagedHomePath) ===
-        normalizeRuntimePathForComparison(perAccountHome) &&
-      !hasStoredCodexCredential(join(perAccountHome, 'auth.json'))
+        normalizeRuntimePathForComparison(perAccountHome)
     ) {
-      this.clearSelfContainedManagedSelection(account, 'credential remained unavailable')
-      return null
+      const absence = this.credentialAbsenceGrace.assess(join(perAccountHome, 'auth.json'))
+      if (absence.state !== 'present' && absence.durable) {
+        this.clearSelfContainedManagedSelection(account, 'credential remained unavailable')
+        return null
+      }
+      // Why: a transient missing/unreadable auth.json is usually codex rotating
+      // it; keep the selection and launch — the CLI re-reads the settled file.
     }
     // Why: link the user's real ~/.codex resources and mirror config into THIS
     // home (never symlinking into or mutating ~/.codex), so the per-account home
@@ -732,7 +738,16 @@ export class CodexRuntimeHomeService {
     }
 
     const activeAuthPath = join(activeAccount.managedHomePath, 'auth.json')
-    if (!existsSync(activeAuthPath)) {
+    const authAbsence = this.credentialAbsenceGrace.assess(activeAuthPath)
+    if (authAbsence.state === 'missing' || authAbsence.state === 'unreadable') {
+      if (authAbsence.state === 'unreadable' || !authAbsence.durable) {
+        // Why: mid-rotation reads look missing/unreadable for a moment; skip
+        // this sync without deselecting and let a settled read decide later.
+        console.warn(
+          '[codex-runtime-home] Active managed account auth.json unavailable, keeping selection through grace window'
+        )
+        return
+      }
       console.warn(
         '[codex-runtime-home] Active managed account is missing auth.json, restoring system default'
       )

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -739,8 +739,8 @@ export class CodexRuntimeHomeService {
 
     const activeAuthPath = join(activeAccount.managedHomePath, 'auth.json')
     const authAbsence = this.credentialAbsenceGrace.assess(activeAuthPath)
-    if (authAbsence.state === 'missing' || authAbsence.state === 'unreadable') {
-      if (authAbsence.state === 'unreadable' || !authAbsence.durable) {
+    if (authAbsence.state !== 'present') {
+      if (!authAbsence.durable) {
         // Why: mid-rotation reads look missing/unreadable for a moment; skip
         // this sync without deselecting and let a settled read decide later.
         console.warn(
@@ -749,9 +749,11 @@ export class CodexRuntimeHomeService {
         return
       }
       console.warn(
-        '[codex-runtime-home] Active managed account is missing auth.json, restoring system default'
+        '[codex-runtime-home] Active managed account credential is unavailable, restoring system default'
       )
-      if (this.lastSyncedAccountId === activeAccount.id) {
+      // Why: valid credential-free JSON is an explicit logout; never revive it
+      // from stale shared-home bytes while clearing the selection.
+      if (authAbsence.state !== 'no-credential' && this.lastSyncedAccountId === activeAccount.id) {
         outgoingReadBackResult = this.recoverRefreshForMissingActiveAccount(activeAccount)
       }
       this.store.updateSettings({

--- a/src/main/codex-cli/codex-home-process-lock.test.ts
+++ b/src/main/codex-cli/codex-home-process-lock.test.ts
@@ -85,6 +85,25 @@ describe('withCodexHomeProcessLock', () => {
     }
   })
 
+  it('keys a stripped child env to the real default home, not ambient CODEX_HOME', () => {
+    const previousCodexHome = process.env.CODEX_HOME
+    process.env.CODEX_HOME = '/nested-orca/managed-home'
+    try {
+      expect(resolveCodexHomeProcessLockKeyForSpawnEnv({ PATH: process.env.PATH })).toBe(
+        resolveCodexHomeProcessLockKey(join(homedir(), '.codex'))
+      )
+      expect(resolveCodexHomeProcessLockKeyForSpawnEnv(undefined)).toBe(
+        resolveCodexHomeProcessLockKey('/nested-orca/managed-home')
+      )
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME
+      } else {
+        process.env.CODEX_HOME = previousCodexHome
+      }
+    }
+  })
+
   it('keys a WSL UNC probe home and a WSL spawn env to the same lock', () => {
     const probeKey = resolveCodexHomeProcessLockKey('\\\\wsl$\\Ubuntu\\home\\user\\.codex')
     const spawnKey = resolveCodexHomeProcessLockKeyForSpawnEnv(
@@ -92,5 +111,24 @@ describe('withCodexHomeProcessLock', () => {
       'Ubuntu'
     )
     expect(spawnKey).toBe(probeKey)
+  })
+
+  it('uses the WSL default sentinel when launcher filtering strips an ambient home', () => {
+    const previousCodexHome = process.env.CODEX_HOME
+    process.env.CODEX_HOME = '/host-only/codex-home'
+    try {
+      const inheritedKey = resolveCodexHomeProcessLockKeyForSpawnEnv(
+        { CODEX_HOME: '/host-only/codex-home' },
+        'Ubuntu'
+      )
+      const strippedKey = resolveCodexHomeProcessLockKeyForSpawnEnv({}, 'Ubuntu')
+      expect(inheritedKey).toBe(strippedKey)
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME
+      } else {
+        process.env.CODEX_HOME = previousCodexHome
+      }
+    }
   })
 })

--- a/src/main/codex-cli/codex-home-process-lock.test.ts
+++ b/src/main/codex-cli/codex-home-process-lock.test.ts
@@ -1,0 +1,96 @@
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { describe, expect, it } from 'vitest'
+import {
+  resolveCodexHomeProcessLockKey,
+  resolveCodexHomeProcessLockKeyForSpawnEnv,
+  withCodexHomeProcessLock
+} from './codex-home-process-lock'
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('withCodexHomeProcessLock', () => {
+  it('serializes runs that share a lock key', async () => {
+    const events: string[] = []
+    const firstGate = deferred()
+
+    const first = withCodexHomeProcessLock('home-a', async () => {
+      events.push('first:start')
+      await firstGate.promise
+      events.push('first:end')
+      return 1
+    })
+    const second = withCodexHomeProcessLock('home-a', async () => {
+      events.push('second:start')
+      return 2
+    })
+
+    await Promise.resolve()
+    expect(events).toEqual(['first:start'])
+
+    firstGate.resolve()
+    await expect(first).resolves.toBe(1)
+    await expect(second).resolves.toBe(2)
+    expect(events).toEqual(['first:start', 'first:end', 'second:start'])
+  })
+
+  it('runs different lock keys concurrently', async () => {
+    const events: string[] = []
+    const firstGate = deferred()
+
+    const first = withCodexHomeProcessLock('home-a', async () => {
+      events.push('a:start')
+      await firstGate.promise
+    })
+    const second = withCodexHomeProcessLock('home-b', async () => {
+      events.push('b:start')
+    })
+
+    await second
+    expect(events).toEqual(['a:start', 'b:start'])
+    firstGate.resolve()
+    await first
+  })
+
+  it('releases the lock after a rejected run', async () => {
+    await expect(
+      withCodexHomeProcessLock('home-a', async () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+
+    await expect(withCodexHomeProcessLock('home-a', async () => 'after')).resolves.toBe('after')
+  })
+
+  it('keys explicit and default host homes consistently', () => {
+    const previousCodexHome = process.env.CODEX_HOME
+    delete process.env.CODEX_HOME
+    try {
+      const defaultKey = resolveCodexHomeProcessLockKey(null)
+      expect(resolveCodexHomeProcessLockKey(join(homedir(), '.codex'))).toBe(defaultKey)
+      expect(resolveCodexHomeProcessLockKeyForSpawnEnv(undefined)).toBe(defaultKey)
+      expect(resolveCodexHomeProcessLockKey('/somewhere/else')).not.toBe(defaultKey)
+    } finally {
+      if (previousCodexHome !== undefined) {
+        process.env.CODEX_HOME = previousCodexHome
+      }
+    }
+  })
+
+  it('keys a WSL UNC probe home and a WSL spawn env to the same lock', () => {
+    const probeKey = resolveCodexHomeProcessLockKey('\\\\wsl$\\Ubuntu\\home\\user\\.codex')
+    const spawnKey = resolveCodexHomeProcessLockKeyForSpawnEnv(
+      { CODEX_HOME: '/home/user/.codex' },
+      'Ubuntu'
+    )
+    expect(spawnKey).toBe(probeKey)
+  })
+})

--- a/src/main/codex-cli/codex-home-process-lock.ts
+++ b/src/main/codex-cli/codex-home-process-lock.ts
@@ -19,8 +19,10 @@ export function resolveCodexHomeProcessLockKeyForSpawnEnv(
   env: NodeJS.ProcessEnv | undefined,
   wslDistro?: string | null
 ): string {
-  const codexHome = env?.CODEX_HOME ?? null
   if (wslDistro) {
+    // buildWslLauncherEnv forwards only explicit values that differ from the
+    // host process; all other cases use the distro user's default home.
+    const codexHome = env?.CODEX_HOME !== process.env.CODEX_HOME ? (env?.CODEX_HOME ?? null) : null
     // Why: WSL spawns carry a Linux CODEX_HOME; key it through the same UNC
     // normalization the probe's \\wsl$ home path uses so both lanes collide.
     // Without an explicit home the distro default is unknowable from the host;
@@ -29,7 +31,10 @@ export function resolveCodexHomeProcessLockKeyForSpawnEnv(
       `//wsl$/${wslDistro}${codexHome ?? '/.orca-default-codex-home'}`
     )
   }
-  return resolveCodexHomeProcessLockKey(codexHome)
+  // An explicit env is the child's complete environment. If CODEX_HOME was
+  // deliberately stripped, the child uses ~/.codex regardless of our ambient env.
+  const codexHome = env === undefined ? process.env.CODEX_HOME : env.CODEX_HOME
+  return normalizeRuntimePathForComparison(codexHome ?? join(homedir(), '.codex'))
 }
 
 export function withCodexHomeProcessLock<T>(lockKey: string, fn: () => Promise<T>): Promise<T> {

--- a/src/main/codex-cli/codex-home-process-lock.ts
+++ b/src/main/codex-cli/codex-home-process-lock.ts
@@ -1,0 +1,50 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+
+// Why: Codex OAuth uses rotating refresh tokens stored in each home's auth.json.
+// Two Orca-spawned codex processes refreshing the same home concurrently can
+// consume one rotation twice and permanently invalidate the stored credential,
+// so Orca's own spawns (quota probes, commit-message runs) serialize per home.
+// User terminal panes are intentionally not serialized here.
+
+const lockTails = new Map<string, Promise<unknown>>()
+
+export function resolveCodexHomeProcessLockKey(codexHomePath?: string | null): string {
+  const home = codexHomePath ?? process.env.CODEX_HOME ?? join(homedir(), '.codex')
+  return normalizeRuntimePathForComparison(home)
+}
+
+export function resolveCodexHomeProcessLockKeyForSpawnEnv(
+  env: NodeJS.ProcessEnv | undefined,
+  wslDistro?: string | null
+): string {
+  const codexHome = env?.CODEX_HOME ?? null
+  if (wslDistro) {
+    // Why: WSL spawns carry a Linux CODEX_HOME; key it through the same UNC
+    // normalization the probe's \\wsl$ home path uses so both lanes collide.
+    // Without an explicit home the distro default is unknowable from the host;
+    // a sentinel still serializes same-distro default spawns with each other.
+    return normalizeRuntimePathForComparison(
+      `//wsl$/${wslDistro}${codexHome ?? '/.orca-default-codex-home'}`
+    )
+  }
+  return resolveCodexHomeProcessLockKey(codexHome)
+}
+
+export function withCodexHomeProcessLock<T>(lockKey: string, fn: () => Promise<T>): Promise<T> {
+  const prior = lockTails.get(lockKey) ?? Promise.resolve()
+  const run = prior.then(fn)
+  // Why: keep the queue alive past a failed run so later entrants still start.
+  const tail = run.then(
+    () => undefined,
+    () => undefined
+  )
+  lockTails.set(lockKey, tail)
+  void tail.then(() => {
+    if (lockTails.get(lockKey) === tail) {
+      lockTails.delete(lockKey)
+    }
+  })
+  return run
+}

--- a/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
+++ b/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
@@ -34,13 +34,24 @@ function makeRpcChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn> }
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
   }
   child.stdout = new EventEmitter()
   child.stderr = new EventEmitter()
-  child.stdin = { write: vi.fn() }
-  child.kill = vi.fn()
+  // Why: like the real app-server, the fake dies on stdin EOF or a signal —
+  // the graceful shutdown path resolves only once the child reports exit.
+  const exitNow = (): void => {
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+  }
+  child.stdin = { write: vi.fn(), end: vi.fn(exitNow) }
+  child.exitCode = null
+  child.kill = vi.fn(() => {
+    exitNow()
+    return true
+  })
   return child
 }
 

--- a/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
+++ b/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
@@ -34,7 +34,7 @@ function makeRpcChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
     exitCode: number | null
   }
@@ -46,7 +46,7 @@ function makeRpcChild() {
     child.exitCode = 0
     child.emit('exit', 0, null)
   }
-  child.stdin = { write: vi.fn(), end: vi.fn(exitNow) }
+  child.stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(exitNow) })
   child.exitCode = null
   child.kill = vi.fn(() => {
     exitNow()

--- a/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
+++ b/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
@@ -265,4 +265,74 @@ describe('fetchCodexRateLimits probe shutdown', () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
   })
+
+  it.each([
+    { failAt: 1, phase: 'initial request' },
+    { failAt: 2, phase: 'initialized notification' },
+    { failAt: 3, phase: 'rate-limit request' }
+  ])('keeps the home lock when the $phase stdin write throws', async ({ failAt, phase }) => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const firstChild = makeRpcChild()
+    let writeCount = 0
+    firstChild.stdin.write.mockImplementation((line: string) => {
+      writeCount += 1
+      if (writeCount === failAt) {
+        throw new Error(`${phase} stdin failed`)
+      }
+      const message = JSON.parse(line) as { id?: number; method?: string }
+      if (message.method === 'initialize') {
+        setTimeout(() => {
+          firstChild.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} })}\n`)
+          )
+        }, 0)
+      }
+    })
+    firstChild.stdin.end = vi.fn()
+    firstChild.kill = vi.fn((signal?: string) => {
+      if (signal === 'SIGKILL') {
+        firstChild.exitCode = 1
+        firstChild.emit('exit', 1, 'SIGKILL')
+      }
+      return true
+    })
+    const secondChild = makeRpcChild()
+    childSpawnMock.mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
+    respondToRpcRateLimitRead(secondChild, {
+      primary: { usedPercent: 3 },
+      secondary: { usedPercent: 4 }
+    })
+    const home = `/managed/home-stdin-error-${failAt}`
+
+    try {
+      const first = fetchCodexRateLimits({
+        allowPtyFallback: false,
+        codexHomePath: home
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(firstChild.kill).toHaveBeenCalledWith('SIGTERM')
+
+      const second = fetchCodexRateLimits({
+        allowPtyFallback: false,
+        codexHomePath: home
+      })
+      await vi.advanceTimersByTimeAsync(4_999)
+      expect(childSpawnMock).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(firstChild.kill).toHaveBeenCalledWith('SIGKILL')
+      await vi.advanceTimersByTimeAsync(1)
+      expect(childSpawnMock).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(first).resolves.toMatchObject({
+        status: 'error',
+        error: `${phase} stdin failed`
+      })
+      await expect(second).resolves.toMatchObject({ status: 'ok' })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
 })

--- a/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
+++ b/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
@@ -36,7 +36,7 @@ function makeRpcChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
     exitCode: number | null
   }
@@ -48,7 +48,7 @@ function makeRpcChild() {
     child.exitCode = 0
     child.emit('exit', 0, null)
   }
-  child.stdin = { write: vi.fn(), end: vi.fn(exitNow) }
+  child.stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(exitNow) })
   child.exitCode = null
   child.kill = vi.fn(() => {
     exitNow()
@@ -330,6 +330,51 @@ describe('fetchCodexRateLimits probe shutdown', () => {
         status: 'error',
         error: `${phase} stdin failed`
       })
+      await expect(second).resolves.toMatchObject({ status: 'ok' })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('observes asynchronous stdin failures and keeps the lock until the probe exits', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const firstChild = makeRpcChild()
+    firstChild.stdin.end = vi.fn()
+    firstChild.kill = vi.fn((signal?: string) => {
+      if (signal === 'SIGKILL') {
+        firstChild.exitCode = 1
+        firstChild.emit('exit', 1, 'SIGKILL')
+      }
+      return true
+    })
+    const secondChild = makeRpcChild()
+    childSpawnMock.mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
+    respondToRpcRateLimitRead(secondChild, {
+      primary: { usedPercent: 3 },
+      secondary: { usedPercent: 4 }
+    })
+
+    try {
+      const first = fetchCodexRateLimits({
+        allowPtyFallback: false,
+        codexHomePath: '/managed/home-async-stdin-error'
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      firstChild.stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+      const second = fetchCodexRateLimits({
+        allowPtyFallback: false,
+        codexHomePath: '/managed/home-async-stdin-error'
+      })
+
+      await vi.advanceTimersByTimeAsync(4_999)
+      expect(childSpawnMock).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(firstChild.kill).toHaveBeenCalledWith('SIGKILL')
+      await vi.advanceTimersByTimeAsync(1)
+      expect(childSpawnMock).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(first).resolves.toMatchObject({ status: 'error', error: 'write EPIPE' })
       await expect(second).resolves.toMatchObject({ status: 'ok' })
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })

--- a/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
+++ b/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
@@ -219,4 +219,50 @@ describe('fetchCodexRateLimits probe shutdown', () => {
     await expect(second).resolves.toMatchObject({ status: 'ok' })
     await first
   })
+
+  it('keeps the home lock through child errors until the failed probe exits', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const firstChild = makeRpcChild()
+    firstChild.stdin.end = vi.fn()
+    firstChild.kill = vi.fn((signal?: string) => {
+      if (signal === 'SIGKILL') {
+        firstChild.exitCode = 1
+        firstChild.emit('exit', 1, 'SIGKILL')
+      }
+      return true
+    })
+    const secondChild = makeRpcChild()
+    childSpawnMock.mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
+    respondToRpcRateLimitRead(secondChild, {
+      primary: { usedPercent: 3 },
+      secondary: { usedPercent: 4 }
+    })
+
+    try {
+      const first = fetchCodexRateLimits({
+        allowPtyFallback: false,
+        codexHomePath: '/managed/home-error'
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      firstChild.emit('error', new Error('stdio failed'))
+      const second = fetchCodexRateLimits({
+        allowPtyFallback: false,
+        codexHomePath: '/managed/home-error'
+      })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(firstChild.kill).toHaveBeenCalledWith('SIGTERM')
+      expect(childSpawnMock).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(firstChild.kill).toHaveBeenCalledWith('SIGKILL')
+      expect(childSpawnMock).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(1)
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(first).resolves.toMatchObject({ status: 'error', error: 'stdio failed' })
+      await expect(second).resolves.toMatchObject({ status: 'ok' })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
 })

--- a/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
+++ b/src/main/rate-limits/codex-fetcher-probe-shutdown.test.ts
@@ -1,0 +1,222 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  readFileMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: childSpawnMock
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+// Auth gate is covered by codex-auth-presence.test.ts; these tests assume a signed-in Codex.
+vi.mock('./codex-auth-presence', () => ({
+  probeCodexAuthPresence: vi.fn(() => 'present')
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { probeCodexAuthPresence } from './codex-auth-presence'
+
+function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  // Why: like the real app-server, the fake dies on stdin EOF or a signal —
+  // the graceful shutdown path resolves only once the child reports exit.
+  const exitNow = (): void => {
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+  }
+  child.stdin = { write: vi.fn(), end: vi.fn(exitNow) }
+  child.exitCode = null
+  child.kill = vi.fn(() => {
+    exitNow()
+    return true
+  })
+  return child
+}
+
+function respondToRpcRateLimitRead(
+  rpcChild: ReturnType<typeof makeRpcChild>,
+  rateLimits: unknown
+): void {
+  rpcChild.stdin.write.mockImplementation((line: string) => {
+    const msg = JSON.parse(line) as { id?: number; method?: string }
+    if (msg.method === 'initialize') {
+      setTimeout(() => {
+        rpcChild.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+        )
+      }, 0)
+    }
+    if (msg.method === 'account/rateLimits/read') {
+      setTimeout(() => {
+        rpcChild.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { rateLimits } })}\n`)
+        )
+      }, 0)
+    }
+  })
+}
+
+describe('fetchCodexRateLimits probe shutdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resolveCodexCommandMock.mockReturnValue('codex')
+    vi.mocked(probeCodexAuthPresence).mockResolvedValue('present')
+    readFileMock.mockRejectedValue(new Error('no auth fixture'))
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('gives a cold app-server the full boot budget before any deadline fires', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    rpcChild.stdin.write.mockImplementation((line: string) => {
+      const msg = JSON.parse(line) as { id?: number; method?: string }
+      if (msg.method === 'initialize') {
+        // Why: cold starts (auth refresh included) are documented at 10-25s;
+        // the old 10s deadline killed them mid-auth.
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+          )
+        }, 20_000)
+      }
+      if (msg.method === 'account/rateLimits/read') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(
+              `${JSON.stringify({
+                jsonrpc: '2.0',
+                id: msg.id,
+                result: {
+                  rateLimits: { primary: { usedPercent: 3 }, secondary: { usedPercent: 4 } }
+                }
+              })}\n`
+            )
+          )
+        }, 0)
+      }
+    })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(19_999)
+    expect(rpcChild.kill).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(2)
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'ok',
+      session: { usedPercent: 3 },
+      weekly: { usedPercent: 4 }
+    })
+  })
+
+  it('arms the read deadline after initialize and drains SIGTERM before SIGKILL', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const rpcChild = makeRpcChild()
+    // Stubborn child: it ignores stdin EOF, survives SIGTERM, dies on SIGKILL.
+    rpcChild.stdin.end = vi.fn()
+    rpcChild.kill = vi.fn((signal?: string) => {
+      if (signal === 'SIGKILL') {
+        rpcChild.exitCode = 0
+        rpcChild.emit('exit', 0, null)
+      }
+      return true
+    })
+    childSpawnMock.mockReturnValue(rpcChild)
+    rpcChild.stdin.write.mockImplementation((line: string) => {
+      const msg = JSON.parse(line) as { id?: number; method?: string }
+      if (msg.method === 'initialize') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+          )
+        }, 0)
+      }
+      // The rate-limits read never answers, so the request deadline expires.
+    })
+
+    try {
+      const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(9_999)
+      expect(rpcChild.kill).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(rpcChild.stdin.end).toHaveBeenCalledTimes(1)
+      expect(rpcChild.kill).toHaveBeenCalledWith('SIGTERM')
+      expect(rpcChild.kill).not.toHaveBeenCalledWith('SIGKILL')
+
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(rpcChild.kill).toHaveBeenCalledWith('SIGKILL')
+      await expect(resultPromise).resolves.toMatchObject({
+        status: 'error',
+        error: 'RPC timeout'
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('does not spawn a second probe for the same home while one is still running', async () => {
+    const firstChild = makeRpcChild()
+    const secondChild = makeRpcChild()
+    childSpawnMock.mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
+    respondToRpcRateLimitRead(secondChild, {
+      primary: { usedPercent: 3 },
+      secondary: { usedPercent: 4 }
+    })
+
+    const first = fetchCodexRateLimits({
+      allowPtyFallback: false,
+      codexHomePath: '/managed/home-a'
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    const second = fetchCodexRateLimits({
+      allowPtyFallback: false,
+      codexHomePath: '/managed/home-a'
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(childSpawnMock).toHaveBeenCalledTimes(1)
+
+    firstChild.emit('close')
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(childSpawnMock).toHaveBeenCalledTimes(2)
+    await expect(second).resolves.toMatchObject({ status: 'ok' })
+    await first
+  })
+})

--- a/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
@@ -20,13 +20,25 @@ function makeRpcChild(rateLimitResetCredits?: unknown) {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn> }
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
   }
   child.stdout = new EventEmitter()
   child.stderr = new EventEmitter()
-  child.kill = vi.fn()
+  child.exitCode = null
+  // Why: like the real app-server, the fake dies on stdin EOF or a signal —
+  // the graceful shutdown path resolves only once the child reports exit.
+  const exitNow = (): void => {
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+  }
+  child.kill = vi.fn(() => {
+    exitNow()
+    return true
+  })
   child.stdin = {
+    end: vi.fn(exitNow),
     write: vi.fn((line: string) => {
       const message = JSON.parse(line) as { id?: number; method?: string }
       if (message.method === 'initialize') {

--- a/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
+++ b/src/main/rate-limits/codex-fetcher-session-supplement.test.ts
@@ -20,7 +20,7 @@ function makeRpcChild(rateLimitResetCredits?: unknown) {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
     exitCode: number | null
   }
@@ -37,7 +37,7 @@ function makeRpcChild(rateLimitResetCredits?: unknown) {
     exitNow()
     return true
   })
-  child.stdin = {
+  child.stdin = Object.assign(new EventEmitter(), {
     end: vi.fn(exitNow),
     write: vi.fn((line: string) => {
       const message = JSON.parse(line) as { id?: number; method?: string }
@@ -69,7 +69,7 @@ function makeRpcChild(rateLimitResetCredits?: unknown) {
         }, 0)
       }
     })
-  }
+  })
   return child
 }
 

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -54,6 +54,7 @@ function makeRpcChild() {
   const exitNow = (): void => {
     child.exitCode = 0
     child.emit('exit', 0, null)
+    child.emit('close', 0, null)
   }
   child.stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(exitNow) })
   child.exitCode = null
@@ -336,6 +337,7 @@ describe('fetchCodexRateLimits', () => {
       weekly: null,
       status: 'error'
     })
+    expect(rpcChild.stdin.listenerCount('error')).toBe(0)
     expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -43,13 +43,24 @@ function makeRpcChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn> }
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
   }
   child.stdout = new EventEmitter()
   child.stderr = new EventEmitter()
-  child.stdin = { write: vi.fn() }
-  child.kill = vi.fn()
+  // Why: like the real app-server, the fake dies on stdin EOF or a signal —
+  // the graceful shutdown path resolves only once the child reports exit.
+  const exitNow = (): void => {
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+  }
+  child.stdin = { write: vi.fn(), end: vi.fn(exitNow) }
+  child.exitCode = null
+  child.kill = vi.fn(() => {
+    exitNow()
+    return true
+  })
   return child
 }
 
@@ -333,7 +344,8 @@ describe('fetchCodexRateLimits', () => {
     childSpawnMock.mockReturnValue(rpcChild)
 
     const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
-    await vi.advanceTimersByTimeAsync(10_000)
+    // Why: without an initialize response only the 30s boot deadline fires.
+    await vi.advanceTimersByTimeAsync(30_000)
 
     await expect(resultPromise).resolves.toMatchObject({
       provider: 'codex',

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -43,7 +43,7 @@ function makeRpcChild() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: EventEmitter
     stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
     kill: ReturnType<typeof vi.fn>
     exitCode: number | null
   }
@@ -55,7 +55,7 @@ function makeRpcChild() {
     child.exitCode = 0
     child.emit('exit', 0, null)
   }
-  child.stdin = { write: vi.fn(), end: vi.fn(exitNow) }
+  child.stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(exitNow) })
   child.exitCode = null
   child.kill = vi.fn(() => {
     exitNow()

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -818,18 +818,21 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     function onError(err: Error): void {
       const isEnoent = (err as NodeJS.ErrnoException).code === 'ENOENT'
       const isBareCommand = codexCommand === 'codex'
-      settle({
-        provider: 'codex',
-        session: null,
-        weekly: null,
-        updatedAt: Date.now(),
-        error: isEnoent
-          ? isBareCommand
-            ? 'Codex CLI not found'
-            : 'Codex CLI found but could not run — Node.js may not be in your PATH'
-          : withMacTailscaleDnsHint(err.message, stderr),
-        status: isEnoent && isBareCommand ? 'unavailable' : 'error'
-      })
+      settle(
+        {
+          provider: 'codex',
+          session: null,
+          weekly: null,
+          updatedAt: Date.now(),
+          error: isEnoent
+            ? isBareCommand
+              ? 'Codex CLI not found'
+              : 'Codex CLI found but could not run — Node.js may not be in your PATH'
+            : withMacTailscaleDnsHint(err.message, stderr),
+          status: isEnoent && isBareCommand ? 'unavailable' : 'error'
+        },
+        { kill: true }
+      )
     }
 
     function onClose(): void {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -719,6 +719,9 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       return id
     }
 
+    // Why: stdin EPIPE is emitted by the stream, including during shutdown.
+    child.stdin.on('error', onStdinError)
+
     // Why: send initialized after initialize or the server rejects methods.
     let rateLimitsId: number | null = null
 
@@ -845,6 +848,10 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
         },
         { kill: true }
       )
+    }
+
+    function onStdinError(err: Error): void {
+      onError(err)
     }
 
     function onClose(): void {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -36,9 +36,19 @@ import {
   createAuthFilesystemOperation,
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
+import { terminateCodexProbeChild } from './codex-probe-termination'
+import {
+  resolveCodexHomeProcessLockKey,
+  withCodexHomeProcessLock
+} from '../codex-cli/codex-home-process-lock'
 
 const RPC_TIMEOUT_MS = 10_000
 const WSL_RPC_TIMEOUT_MS = 25_000
+// Why: cold app-server starts (fresh token refresh included) are documented at
+// 10-25s; the request deadline is armed only after initialize responds, so
+// these boot budgets are what protect a slow cold start from a mid-auth kill.
+const RPC_INIT_TIMEOUT_MS = 30_000
+const WSL_RPC_INIT_TIMEOUT_MS = 40_000
 const PTY_TIMEOUT_MS = 15_000
 // Why: codex ≥0.145 renders a '›' composer with placeholder text after it, so a
 // prompt-anchored send can never fire; nudge /status after a short boot grace.
@@ -619,7 +629,8 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     const wslCodex = options?.codexHomePath
       ? buildWslCodexCommand(options.codexHomePath, codexArgs, { isolateRpcStdio: true })
       : null
-    // Why: cold WSL startup can exceed the host RPC budget.
+    // Why: cold WSL startup can exceed the host budgets.
+    const initTimeoutMs = wslCodex ? WSL_RPC_INIT_TIMEOUT_MS : RPC_INIT_TIMEOUT_MS
     const rpcTimeoutMs = wslCodex ? WSL_RPC_TIMEOUT_MS : RPC_TIMEOUT_MS
     const codexCommand = wslCodex ? 'codex' : resolveCodexCommand()
     // Why: launch .cmd/.bat files through cmd.exe /c; shell:true triggers DEP0190.
@@ -659,7 +670,13 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       resolved = true
       cleanupListeners()
       if (options?.kill) {
-        child.kill()
+        // Why: resolve only after the child is gone so the per-home lock can't
+        // release while a draining process may still rewrite auth.json.
+        void terminateCodexProbeChild(child).then(
+          () => resolve(result),
+          () => resolve(result)
+        )
+        return
       }
       resolve(result)
     }
@@ -676,19 +693,25 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       options.signal.addEventListener('abort', onAbort, { once: true })
     }
 
-    timeout = setTimeout(() => {
-      settle(
-        {
-          provider: 'codex',
-          session: null,
-          weekly: null,
-          updatedAt: Date.now(),
-          error: 'RPC timeout',
-          status: 'error'
-        },
-        { kill: true }
-      )
-    }, rpcTimeoutMs)
+    function armRpcDeadline(deadlineMs: number): void {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      timeout = setTimeout(() => {
+        settle(
+          {
+            provider: 'codex',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error: 'RPC timeout',
+            status: 'error'
+          },
+          { kill: true }
+        )
+      }, deadlineMs)
+    }
+    armRpcDeadline(initTimeoutMs)
 
     function sendRpc(method: string, params?: unknown): number {
       const id = ++rpcId
@@ -728,6 +751,8 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
           }
 
           if (msg.id === initId) {
+            // Why: the boot/auth-refresh budget ends here; the read gets its own deadline.
+            armRpcDeadline(rpcTimeoutMs)
             // Initialize succeeded — send `initialized`, then request rate limits.
             sendNotification('initialized')
             rateLimitsId = sendRpc('account/rateLimits/read')
@@ -1198,9 +1223,14 @@ export async function fetchCodexRateLimits(
     }
   }
 
+  // Why: probes spawn a real codex process inside the live credential home;
+  // the per-home lock keeps Orca's own spawns (probe vs probe, probe vs
+  // commit-message run) from refreshing one auth.json concurrently.
+  const homeLockKey = resolveCodexHomeProcessLockKey(options?.codexHomePath)
+
   // Path B: try RPC
   try {
-    const rpcResult = await fetchViaRpc(options)
+    const rpcResult = await withCodexHomeProcessLock(homeLockKey, () => fetchViaRpc(options))
     if (options?.signal?.aborted) {
       return abortedCodexRateLimitResult()
     }
@@ -1238,7 +1268,7 @@ export async function fetchCodexRateLimits(
     if (options?.signal?.aborted) {
       return abortedCodexRateLimitResult()
     }
-    const ptyResult = await fetchViaPty(options)
+    const ptyResult = await withCodexHomeProcessLock(homeLockKey, () => fetchViaPty(options))
     if (options?.signal?.aborted) {
       return abortedCodexRateLimitResult()
     }

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -721,6 +721,11 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
     // Why: stdin EPIPE is emitted by the stream, including during shutdown.
     child.stdin.on('error', onStdinError)
+    child.stdout.on('data', onStdoutData)
+    child.stderr.on('data', onStderrData)
+    child.on('error', onError)
+    child.once('close', detachStdinErrorListener)
+    child.on('close', onClose)
 
     // Why: send initialized after initialize or the server rejects methods.
     let rateLimitsId: number | null = null
@@ -854,6 +859,10 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       onError(err)
     }
 
+    function detachStdinErrorListener(): void {
+      child.stdin.off('error', onStdinError)
+    }
+
     function onClose(): void {
       settle({
         provider: 'codex',
@@ -864,11 +873,6 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
         status: 'error'
       })
     }
-
-    child.stdout.on('data', onStdoutData)
-    child.stderr.on('data', onStderrData)
-    child.on('error', onError)
-    child.on('close', onClose)
   })
 }
 

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -722,9 +722,17 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     // Why: send initialized after initialize or the server rejects methods.
     let rateLimitsId: number | null = null
 
-    const initId = sendRpc('initialize', {
-      clientInfo: { name: 'orca', version: '1.0.0' }
-    })
+    let initId: number
+    try {
+      initId = sendRpc('initialize', {
+        clientInfo: { name: 'orca', version: '1.0.0' }
+      })
+    } catch (error) {
+      // A child already exists, so a synchronous pipe failure must follow the
+      // same reaping path as an asynchronous ChildProcess error.
+      onError(error instanceof Error ? error : new Error(String(error)))
+      return
+    }
 
     function sendNotification(method: string): void {
       child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params: {} })}\n`)
@@ -753,9 +761,13 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
           if (msg.id === initId) {
             // Why: the boot/auth-refresh budget ends here; the read gets its own deadline.
             armRpcDeadline(rpcTimeoutMs)
-            // Initialize succeeded — send `initialized`, then request rate limits.
-            sendNotification('initialized')
-            rateLimitsId = sendRpc('account/rateLimits/read')
+            try {
+              // Initialize succeeded — send `initialized`, then request rate limits.
+              sendNotification('initialized')
+              rateLimitsId = sendRpc('account/rateLimits/read')
+            } catch (error) {
+              onError(error instanceof Error ? error : new Error(String(error)))
+            }
             continue
           }
 

--- a/src/main/rate-limits/codex-probe-termination.test.ts
+++ b/src/main/rate-limits/codex-probe-termination.test.ts
@@ -9,11 +9,15 @@ function makeFakeChild() {
     signalCode: null as NodeJS.Signals | null,
     stdin: { end: vi.fn() },
     kill: vi.fn((_signal?: NodeJS.Signals) => true),
+    on: emitter.on.bind(emitter),
     once: emitter.once.bind(emitter),
     off: emitter.off.bind(emitter),
     exit(code = 0) {
       child.exitCode = code
       emitter.emit('exit')
+    },
+    error() {
+      emitter.emit('error', new Error('signal delivery failed'))
     }
   }
   return child
@@ -63,6 +67,22 @@ describe('terminateCodexProbeChild', () => {
     })
 
     await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS + 1_000)
+    await done
+    expect(settled).toBe(true)
+  })
+
+  it('does not treat a child error as proof that the process exited', async () => {
+    const child = makeFakeChild()
+    let settled = false
+    const done = terminateCodexProbeChild(child, { platform: 'linux' }).then(() => {
+      settled = true
+    })
+
+    child.error()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    child.exit()
     await done
     expect(settled).toBe(true)
   })

--- a/src/main/rate-limits/codex-probe-termination.test.ts
+++ b/src/main/rate-limits/codex-probe-termination.test.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CODEX_PROBE_SHUTDOWN_DRAIN_MS, terminateCodexProbeChild } from './codex-probe-termination'
+
+function makeFakeChild() {
+  const emitter = new EventEmitter()
+  const child = {
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    stdin: { end: vi.fn() },
+    kill: vi.fn((_signal?: NodeJS.Signals) => true),
+    once: emitter.once.bind(emitter),
+    off: emitter.off.bind(emitter),
+    exit(code = 0) {
+      child.exitCode = code
+      emitter.emit('exit')
+    }
+  }
+  return child
+}
+
+describe('terminateCodexProbeChild', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('requests shutdown and never hard-kills a child that drains in time', async () => {
+    const child = makeFakeChild()
+    const done = terminateCodexProbeChild(child, { platform: 'darwin' })
+
+    expect(child.stdin.end).toHaveBeenCalledTimes(1)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+
+    await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS - 1)
+    child.exit()
+    await done
+
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.kill).not.toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('escalates to SIGKILL only after the drain window elapses', async () => {
+    const child = makeFakeChild()
+    const done = terminateCodexProbeChild(child, { platform: 'linux' })
+
+    await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS)
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+
+    child.exit()
+    await done
+    expect(child.kill.mock.calls.map((call) => call[0])).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+
+  it('resolves within the hard-kill bound even if the child never reports exit', async () => {
+    const child = makeFakeChild()
+    let settled = false
+    const done = terminateCodexProbeChild(child, { platform: 'linux' }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS + 1_000)
+    await done
+    expect(settled).toBe(true)
+  })
+
+  it('sends no signal during the drain window on Windows where kill is always forceful', async () => {
+    const child = makeFakeChild()
+    const done = terminateCodexProbeChild(child, { platform: 'win32' })
+
+    expect(child.stdin.end).toHaveBeenCalledTimes(1)
+    expect(child.kill).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS)
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.kill).toHaveBeenCalledWith()
+
+    child.exit()
+    await done
+  })
+
+  it('does nothing for a child that already exited', async () => {
+    const child = makeFakeChild()
+    child.exit()
+
+    await terminateCodexProbeChild(child, { platform: 'darwin' })
+
+    expect(child.stdin.end).not.toHaveBeenCalled()
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/codex-probe-termination.test.ts
+++ b/src/main/rate-limits/codex-probe-termination.test.ts
@@ -5,6 +5,7 @@ import { CODEX_PROBE_SHUTDOWN_DRAIN_MS, terminateCodexProbeChild } from './codex
 function makeFakeChild() {
   const emitter = new EventEmitter()
   const child = {
+    pid: 4321,
     exitCode: null as number | null,
     signalCode: null as NodeJS.Signals | null,
     stdin: { end: vi.fn() },
@@ -89,17 +90,47 @@ describe('terminateCodexProbeChild', () => {
 
   it('sends no signal during the drain window on Windows where kill is always forceful', async () => {
     const child = makeFakeChild()
-    const done = terminateCodexProbeChild(child, { platform: 'win32' })
+    const killWindowsProcessTree = vi.fn(async () => {})
+    const done = terminateCodexProbeChild(child, { platform: 'win32', killWindowsProcessTree })
 
     expect(child.stdin.end).toHaveBeenCalledTimes(1)
     expect(child.kill).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(CODEX_PROBE_SHUTDOWN_DRAIN_MS)
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(child.pid)
     expect(child.kill).toHaveBeenCalledTimes(1)
     expect(child.kill).toHaveBeenCalledWith()
 
     child.exit()
     await done
+  })
+
+  it('waits for the Windows descendant tree kill before releasing the probe', async () => {
+    const child = makeFakeChild()
+    let finishTreeKill!: () => void
+    const treeKill = new Promise<void>((resolve) => {
+      finishTreeKill = resolve
+    })
+    const killWindowsProcessTree = vi.fn(() => treeKill)
+    let settled = false
+    const done = terminateCodexProbeChild(child, {
+      platform: 'win32',
+      drainMs: 0,
+      killWindowsProcessTree
+    }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(child.pid)
+    child.exit()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    finishTreeKill()
+    await done
+    expect(settled).toBe(true)
+    expect(child.kill).not.toHaveBeenCalled()
   })
 
   it('does nothing for a child that already exited', async () => {

--- a/src/main/rate-limits/codex-probe-termination.ts
+++ b/src/main/rate-limits/codex-probe-termination.ts
@@ -10,6 +10,7 @@ export type TerminatableProbeChild = {
   exitCode: number | null
   signalCode?: NodeJS.Signals | null
   kill: (signal?: NodeJS.Signals) => boolean
+  on: (event: 'error', listener: () => void) => unknown
   once: (event: 'exit' | 'close' | 'error', listener: () => void) => unknown
   off: (event: 'exit' | 'close' | 'error', listener: () => void) => unknown
   stdin?: { end: () => void } | null
@@ -39,14 +40,18 @@ function waitForExit(child: TerminatableProbeChild, timeoutMs: number): Promise<
       }
       child.off('exit', onGone)
       child.off('close', onGone)
-      child.off('error', onGone)
+      child.off('error', onError)
       resolve(exited)
     }
     const onGone = (): void => settle(true)
-    // Why: 'error' covers children that never spawned and so never emit 'exit'.
+    const onError = (): void => {
+      // Keep ChildProcess errors observed, but only exit/close proves it is gone.
+    }
+    // Node emits 'close' after both exit and spawn failure. A later 'error'
+    // alone does not prove a successfully spawned child released auth.json.
     child.once('exit', onGone)
     child.once('close', onGone)
-    child.once('error', onGone)
+    child.on('error', onError)
     timer = setTimeout(() => settle(false), timeoutMs)
   })
 }

--- a/src/main/rate-limits/codex-probe-termination.ts
+++ b/src/main/rate-limits/codex-probe-termination.ts
@@ -1,3 +1,5 @@
+import { terminateWindowsProcessTree, type WindowsTreeKiller } from '../windows-process-tree-kill'
+
 // Why: Codex OAuth uses rotating refresh tokens. Hard-killing a probe's
 // app-server mid-refresh can strand auth.json between rotations and permanently
 // invalidate the stored credential, so termination always requests shutdown
@@ -7,6 +9,7 @@ export const CODEX_PROBE_SHUTDOWN_DRAIN_MS = 5_000
 const HARD_KILL_EXIT_WAIT_MS = 1_000
 
 export type TerminatableProbeChild = {
+  pid?: number
   exitCode: number | null
   signalCode?: NodeJS.Signals | null
   kill: (signal?: NodeJS.Signals) => boolean
@@ -21,6 +24,7 @@ export type TerminateCodexProbeOptions = {
   hardKillWaitMs?: number
   // Why: injectable so the Windows branch is testable from POSIX CI hosts.
   platform?: NodeJS.Platform
+  killWindowsProcessTree?: WindowsTreeKiller
 }
 
 function hasExited(child: TerminatableProbeChild): boolean {
@@ -80,6 +84,18 @@ export async function terminateCodexProbeChild(
     }
   }
   if (await waitForExit(child, options?.drainMs ?? CODEX_PROBE_SHUTDOWN_DRAIN_MS)) {
+    return
+  }
+  if (platform === 'win32' && child.pid) {
+    try {
+      // npm-installed Codex runs beneath cmd.exe; killing only that wrapper can
+      // leave app-server alive after the credential-home lock is released.
+      await (options?.killWindowsProcessTree ?? terminateWindowsProcessTree)(child.pid)
+    } catch {
+      // The direct-child fallback still applies if an injected killer rejects.
+    }
+  }
+  if (hasExited(child)) {
     return
   }
   try {

--- a/src/main/rate-limits/codex-probe-termination.ts
+++ b/src/main/rate-limits/codex-probe-termination.ts
@@ -1,0 +1,90 @@
+// Why: Codex OAuth uses rotating refresh tokens. Hard-killing a probe's
+// app-server mid-refresh can strand auth.json between rotations and permanently
+// invalidate the stored credential, so termination always requests shutdown
+// first and only escalates after a bounded drain window.
+
+export const CODEX_PROBE_SHUTDOWN_DRAIN_MS = 5_000
+const HARD_KILL_EXIT_WAIT_MS = 1_000
+
+export type TerminatableProbeChild = {
+  exitCode: number | null
+  signalCode?: NodeJS.Signals | null
+  kill: (signal?: NodeJS.Signals) => boolean
+  once: (event: 'exit' | 'close' | 'error', listener: () => void) => unknown
+  off: (event: 'exit' | 'close' | 'error', listener: () => void) => unknown
+  stdin?: { end: () => void } | null
+}
+
+export type TerminateCodexProbeOptions = {
+  drainMs?: number
+  hardKillWaitMs?: number
+  // Why: injectable so the Windows branch is testable from POSIX CI hosts.
+  platform?: NodeJS.Platform
+}
+
+function hasExited(child: TerminatableProbeChild): boolean {
+  return child.exitCode != null || child.signalCode != null
+}
+
+function waitForExit(child: TerminatableProbeChild, timeoutMs: number): Promise<boolean> {
+  if (hasExited(child)) {
+    return Promise.resolve(true)
+  }
+  return new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const settle = (exited: boolean): void => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      child.off('exit', onGone)
+      child.off('close', onGone)
+      child.off('error', onGone)
+      resolve(exited)
+    }
+    const onGone = (): void => settle(true)
+    // Why: 'error' covers children that never spawned and so never emit 'exit'.
+    child.once('exit', onGone)
+    child.once('close', onGone)
+    child.once('error', onGone)
+    timer = setTimeout(() => settle(false), timeoutMs)
+  })
+}
+
+export async function terminateCodexProbeChild(
+  child: TerminatableProbeChild,
+  options?: TerminateCodexProbeOptions
+): Promise<void> {
+  if (hasExited(child)) {
+    return
+  }
+  const platform = options?.platform ?? process.platform
+  // Why: stdin EOF is the graceful stop for a stdio JSON-RPC server and the
+  // only non-forceful request Windows has; SIGTERM backs it up where signals
+  // are real (Node's kill() on Windows is always TerminateProcess).
+  try {
+    child.stdin?.end()
+  } catch {
+    // stdin may already be destroyed; the signal/kill path still applies.
+  }
+  if (platform !== 'win32') {
+    try {
+      child.kill('SIGTERM')
+    } catch {
+      // Already-exited children can race the kill; the exit wait handles it.
+    }
+  }
+  if (await waitForExit(child, options?.drainMs ?? CODEX_PROBE_SHUTDOWN_DRAIN_MS)) {
+    return
+  }
+  try {
+    if (platform === 'win32') {
+      child.kill()
+    } else {
+      child.kill('SIGKILL')
+    }
+  } catch {
+    // Already-exited children can race the kill; the exit wait handles it.
+  }
+  await waitForExit(child, options?.hardKillWaitMs ?? HARD_KILL_EXIT_WAIT_MS)
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1987,6 +1987,51 @@ describe('RateLimitService', () => {
     expect(service.getState().inactiveCodexAccounts).toEqual([])
   })
 
+  it('keeps the inactive Codex debounce across an account switch instead of re-probing', async () => {
+    const service = new RateLimitService()
+    service.setInactiveCodexAccountsResolver(() => [
+      { id: 'account-b', managedHomePath: '/tmp/account-b/home' }
+    ])
+    vi.mocked(fetchCodexRateLimits).mockImplementation(async () => okProvider('codex', 10))
+
+    await service.fetchInactiveCodexAccountsOnOpen()
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+
+    // The switch triggers exactly one fetch: the newly active account's.
+    await service.refreshForCodexAccountChange('account-a')
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
+
+    // Why: re-opening the switcher inside the debounce window must not spawn
+    // codex in every inactive credential home again.
+    await service.fetchInactiveCodexAccountsOnOpen()
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
+  })
+
+  it('staggers inactive Codex probes instead of bursting every account at once', async () => {
+    vi.useFakeTimers()
+    try {
+      const service = new RateLimitService()
+      service.setInactiveCodexAccountsResolver(() => [
+        { id: 'account-a', managedHomePath: '/tmp/account-a/home' },
+        { id: 'account-b', managedHomePath: '/tmp/account-b/home' }
+      ])
+      vi.mocked(fetchCodexRateLimits).mockImplementation(async () => okProvider('codex', 5))
+
+      const fetchOnOpen = service.fetchInactiveCodexAccountsOnOpen()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1_999)
+      expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
+      await fetchOnOpen
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('preserves Gemini buckets through getState after fetch', async () => {
     const service = new RateLimitService()
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -90,6 +90,10 @@ const RATE_LIMITED_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
 // Why: statusline posts arrive on every turn; skip renderer pushes for identical windows so streaming sessions don't spam state updates.
 const LIVE_CLAUDE_INGEST_DEDUPE_MS = 30 * 1000
 const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
+// Why: each inactive Codex probe spawns a real codex process inside that
+// account's live credential home; pace them out instead of bursting every
+// account the moment the switcher opens.
+const INACTIVE_CODEX_PROBE_STAGGER_MS = 2_000
 const DEFERRED_STARTUP_ACTIVE_REFRESH_MS = 1000
 
 // Why: inactive account arrays are derived from provider caches on demand in getState()/pushToRenderer().
@@ -130,6 +134,23 @@ function normalizeClaudeConfigDir(dir: string | null | undefined): string | null
   // Why: normalize mixed Windows separators for path attribution; preserve Linux case sensitivity.
   const trimmed = dir?.trim().replace(/\\/g, '/').replace(/\/+$/, '')
   return trimmed || null
+}
+
+function delayUnlessAborted(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => {
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
 }
 
 function isSameUsageWindow(
@@ -393,7 +414,10 @@ export class RateLimitService {
     this.activeFailureStreakByProvider.codex = 0
     this.inactiveCodexAccountsGeneration += 1
     this.pruneInactiveCodexState()
-    this.lastInactiveCodexFetchAt = 0
+    // Why: the switch must NOT reset the inactive-fetch debounce — re-probing
+    // every inactive account per switch spawns codex in each credential home
+    // and endangers rotating refresh tokens; the switcher shows the cached
+    // snapshot (seeded above for the outgoing account) until the debounce ends.
     // Why: clear the old Codex view immediately, else the previous account's limits show under the newly selected identity until the next poll.
     this.updateState({
       ...this.state,
@@ -611,6 +635,7 @@ export class RateLimitService {
     }
     this.pushToRenderer()
 
+    let staggerNextProbe = false
     try {
       for (const account of accounts) {
         if (
@@ -625,6 +650,23 @@ export class RateLimitService {
           this.pushToRenderer()
           continue
         }
+        if (staggerNextProbe) {
+          await delayUnlessAborted(INACTIVE_CODEX_PROBE_STAGGER_MS, signal)
+          // Why: the account set can change while the stagger delay runs.
+          if (
+            signal.aborted ||
+            fetchGeneration !== this.inactiveCodexAccountsGeneration ||
+            !this.isCurrentInactiveCodexAccount(account.id)
+          ) {
+            this.inactiveCodexFetching.delete(account.id)
+            if (!this.isCurrentInactiveCodexAccount(account.id)) {
+              this.inactiveCodexCache.delete(account.id)
+            }
+            this.pushToRenderer()
+            continue
+          }
+        }
+        staggerNextProbe = true
         try {
           // Why: point fetchCodexRateLimits at the managed home directly, avoiding materializing credentials into the shared runtime location.
           // Why: no PTY fallback — the switcher preview shouldn't spawn hidden PTYs per account (can crash ConPTY on Windows); RPC-only is enough.

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: local/remote generation, cancellation, and
    env propagation share subprocess mocks; splitting would obscure the
    cross-path invariants these tests protect. */
-import { exec, spawn } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import type * as ChildProcess from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -20,21 +20,22 @@ import {
   trimGeneratedCommitMessage
 } from './commit-message-text-generation'
 
+const { terminateWindowsProcessTreeMock } = vi.hoisted(() => ({
+  terminateWindowsProcessTreeMock: vi.fn(async () => {})
+}))
+
+vi.mock('../windows-process-tree-kill', () => ({
+  terminateWindowsProcessTree: terminateWindowsProcessTreeMock
+}))
+
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof ChildProcess>()
   return {
     ...actual,
-    exec: vi.fn((_command, callback) => {
-      if (typeof callback === 'function') {
-        callback(null, '', '')
-      }
-      return new actual.ChildProcess()
-    }),
     spawn: vi.fn(actual.spawn)
   }
 })
 
-const execMock = vi.mocked(exec)
 const spawnMock = vi.mocked(spawn)
 
 type MockDiscoveryChild = EventEmitter & {
@@ -71,7 +72,7 @@ function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
 
 function expectChildTerminated(child: { pid: number; kill: ReturnType<typeof vi.fn> }): void {
   if (process.platform === 'win32') {
-    expect(execMock).toHaveBeenCalledWith(`taskkill /pid ${child.pid} /T /F`, expect.any(Function))
+    expect(terminateWindowsProcessTreeMock).toHaveBeenCalledWith(child.pid)
     expect(child.kill).not.toHaveBeenCalled()
     return
   }
@@ -79,7 +80,8 @@ function expectChildTerminated(child: { pid: number; kill: ReturnType<typeof vi.
 }
 
 beforeEach(() => {
-  execMock.mockClear()
+  terminateWindowsProcessTreeMock.mockClear()
+  terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
   spawnMock.mockClear()
 })
 
@@ -1688,6 +1690,51 @@ describe('generateCommitMessageFromContext', () => {
     secondChild.stdout.emit('data', Buffer.from('Update README\n'))
     secondChild.emit('close', 0)
     await expect(second).resolves.toMatchObject({ success: true, message: 'Update README' })
+  })
+
+  it('holds the Codex home lock until Windows tree termination and wrapper close', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    let finishTreeKill!: () => void
+    terminateWindowsProcessTreeMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishTreeKill = resolve
+      })
+    )
+    const firstChild = createMockDiscoveryChild()
+    const secondChild = createMockDiscoveryChild()
+    spawnMock.mockReturnValueOnce(firstChild as never).mockReturnValueOnce(secondChild as never)
+    const env = { CODEX_HOME: 'C:\\managed\\codex-generation-home' }
+    const context = { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' }
+    const params = { agentId: 'codex' as const, model: 'gpt-5.5' }
+
+    try {
+      const first = generateCommitMessageFromContext(context, params, {
+        kind: 'local',
+        cwd: 'C:\\repo',
+        env
+      })
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+      cancelGenerateCommitMessageLocal('C:\\repo')
+      await expect(first).resolves.toMatchObject({ canceled: true })
+
+      const second = generateCommitMessageFromContext(context, params, {
+        kind: 'local',
+        cwd: 'C:\\repo-2',
+        env
+      })
+      firstChild.emit('close', null)
+      await Promise.resolve()
+      expect(spawnMock).toHaveBeenCalledTimes(1)
+
+      finishTreeKill()
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      secondChild.stdout.emit('data', Buffer.from('Update README\n'))
+      secondChild.emit('close', 0)
+      await expect(second).resolves.toMatchObject({ success: true, message: 'Update README' })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
   })
 
   it('cancels Codex generation promptly while it is queued behind the home lock', async () => {

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -504,6 +504,40 @@ describe('discoverCommitMessageModelsLocal', () => {
     }
   })
 
+  it('keeps the Codex home locked after a discovery timeout until the child closes', async () => {
+    vi.useFakeTimers()
+    const firstChild = createMockDiscoveryChild()
+    const secondChild = createMockDiscoveryChild()
+    spawnMock.mockReturnValueOnce(firstChild as never).mockReturnValueOnce(secondChild as never)
+    const env = { CODEX_HOME: '/managed/codex-discovery-home' }
+
+    try {
+      const first = discoverCommitMessageModelsLocal('codex', env)
+      await vi.advanceTimersByTimeAsync(0)
+      const second = discoverCommitMessageModelsLocal('codex', env)
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      await expect(first).resolves.toMatchObject({
+        success: false,
+        error: 'Codex model discovery timed out after 60s.'
+      })
+      expectChildTerminated(firstChild)
+      expect(spawnMock).toHaveBeenCalledTimes(1)
+
+      firstChild.emit('close', null)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(spawnMock).toHaveBeenCalledTimes(2)
+      secondChild.stdout.emit(
+        'data',
+        Buffer.from(JSON.stringify({ models: [{ slug: 'gpt-5.5', display_name: 'GPT-5.5' }] }))
+      )
+      secondChild.emit('close', 0)
+      await expect(second).resolves.toMatchObject({ success: true, defaultModelId: 'gpt-5.5' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('settles and detaches model discovery when output exceeds the limit', async () => {
     const child = createMockDiscoveryChild()
     spawnMock.mockReturnValue(child as never)
@@ -1616,6 +1650,84 @@ describe('generateCommitMessageFromContext', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('publishes Codex cancellation immediately but holds its home lock until close', async () => {
+    const firstChild = createMockDiscoveryChild()
+    const secondChild = createMockDiscoveryChild()
+    spawnMock.mockReturnValueOnce(firstChild as never).mockReturnValueOnce(secondChild as never)
+    const env = { CODEX_HOME: '/managed/codex-generation-home' }
+    const context = { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' }
+    const params = { agentId: 'codex' as const, model: 'gpt-5.5' }
+
+    const first = generateCommitMessageFromContext(context, params, {
+      kind: 'local',
+      cwd: '/repo',
+      env
+    })
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+    cancelGenerateCommitMessageLocal('/repo')
+
+    await expect(first).resolves.toEqual({
+      success: false,
+      error: 'Generation canceled.',
+      canceled: true
+    })
+    expectChildTerminated(firstChild)
+
+    const second = generateCommitMessageFromContext(context, params, {
+      kind: 'local',
+      cwd: '/repo-2',
+      env
+    })
+    await Promise.resolve()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    firstChild.emit('close', null)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+    secondChild.stdout.emit('data', Buffer.from('Update README\n'))
+    secondChild.emit('close', 0)
+    await expect(second).resolves.toMatchObject({ success: true, message: 'Update README' })
+  })
+
+  it('cancels Codex generation promptly while it is queued behind the home lock', async () => {
+    const discoveryChild = createMockDiscoveryChild()
+    const laterChild = createMockDiscoveryChild()
+    spawnMock.mockReturnValueOnce(discoveryChild as never).mockReturnValueOnce(laterChild as never)
+    const env = { CODEX_HOME: '/managed/codex-queued-home' }
+    const blocker = discoverCommitMessageModelsLocal('codex', env)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+
+    const queued = generateCommitMessageFromContext(
+      { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' },
+      { agentId: 'codex', model: 'gpt-5.5' },
+      { kind: 'local', cwd: '/queued-repo', env }
+    )
+    cancelGenerateCommitMessageLocal('/queued-repo')
+
+    await expect(queued).resolves.toEqual({
+      success: false,
+      error: 'Generation canceled.',
+      canceled: true
+    })
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    discoveryChild.stdout.emit(
+      'data',
+      Buffer.from(JSON.stringify({ models: [{ slug: 'gpt-5.5', display_name: 'GPT-5.5' }] }))
+    )
+    discoveryChild.emit('close', 0)
+    await expect(blocker).resolves.toMatchObject({ success: true })
+
+    const later = generateCommitMessageFromContext(
+      { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+later' },
+      { agentId: 'codex', model: 'gpt-5.5' },
+      { kind: 'local', cwd: '/later-repo', env }
+    )
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+    laterChild.stdout.emit('data', Buffer.from('Update later\n'))
+    laterChild.emit('close', 0)
+    await expect(later).resolves.toMatchObject({ success: true, message: 'Update later' })
   })
 
   it('routes Windows batch-script agent commands through cmd.exe', async () => {

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -126,6 +126,11 @@ type InternalTextGenerationResult =
       failureOutput?: AgentGenerationFailureOutput
     }
 
+type LocalProcessExecution<T> = {
+  result: Promise<T>
+  processClosed: Promise<void>
+}
+
 export type CommitMessageModelDiscoveryLocalOptions = {
   cwd?: string
   wslDistro?: string
@@ -316,13 +321,18 @@ export async function discoverCommitMessageModelsLocal(
     return toModelDiscoveryCapability(spec)
   }
 
-  const runDiscovery = (): Promise<DiscoverCommitMessageModelsResult> =>
-    new Promise((resolve) => {
+  const startDiscovery = (): LocalProcessExecution<DiscoverCommitMessageModelsResult> => {
+    let markProcessClosed!: () => void
+    const processClosed = new Promise<void>((resolve) => {
+      markProcessClosed = resolve
+    })
+    const result = new Promise<DiscoverCommitMessageModelsResult>((resolve) => {
       let child: ChildProcess
       const spawnEnv = env ?? process.env
       try {
         const planned = planModelDiscovery(spec, agentCommandOverride)
         if (!planned.ok) {
+          markProcessClosed()
           resolve({ success: false, error: planned.error })
           return
         }
@@ -350,6 +360,7 @@ export async function discoverCommitMessageModelsLocal(
           })
         }
       } catch (error) {
+        markProcessClosed()
         console.error('[commit-message] Failed to spawn model discovery:', error)
         resolve({
           success: false,
@@ -374,6 +385,9 @@ export async function discoverCommitMessageModelsLocal(
           timer = null
         }
         detachChildListeners()
+        if (agentId !== 'codex') {
+          markProcessClosed()
+        }
         resolve(result)
       }
       timer = setTimeout(() => {
@@ -397,6 +411,9 @@ export async function discoverCommitMessageModelsLocal(
       const onStdoutData = (chunk: Buffer): void => onData(chunk, (text) => (stdout += text))
       const onStderrData = (chunk: Buffer): void => onData(chunk, (text) => (stderr += text))
       const onError = (error: Error): void => {
+        if (!child.pid) {
+          markProcessClosed()
+        }
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
           finish({
             success: false,
@@ -410,6 +427,7 @@ export async function discoverCommitMessageModelsLocal(
         })
       }
       const onClose = (code: number | null): void => {
+        markProcessClosed()
         if (outputLimitExceeded) {
           finish({ success: false, error: `${spec.label} returned too much model data.` })
           return
@@ -423,6 +441,11 @@ export async function discoverCommitMessageModelsLocal(
 
       child.stdout?.on('data', onStdoutData)
       child.stderr?.on('data', onStderrData)
+      if (agentId === 'codex') {
+        // Result publication stays prompt while the home lock follows the
+        // process lifetime after asynchronous timeout/output-limit kills.
+        child.once('close', markProcessClosed)
+      }
       child.on('error', onError)
       child.on('close', onClose)
       detachChildListeners = () => {
@@ -432,16 +455,18 @@ export async function discoverCommitMessageModelsLocal(
         child.off?.('close', onClose)
       }
     })
+    return { result, processClosed }
+  }
 
   if (agentId === 'codex') {
     // Why: discovery spawns a real codex process in the selected home; keep it
     // off an auth.json a quota probe may be refreshing at the same time.
-    return withCodexHomeProcessLock(
+    return runCodexProcessWithHomeLock(
       resolveCodexHomeProcessLockKeyForSpawnEnv(env, options.wslDistro),
-      runDiscovery
+      startDiscovery
     )
   }
-  return runDiscovery()
+  return startDiscovery().result
 }
 
 export async function discoverCommitMessageModelsRemote(
@@ -566,16 +591,21 @@ function buildWslLauncherEnv(explicitEnv: NodeJS.ProcessEnv | undefined): NodeJS
   return env
 }
 
-async function runLocalPlan(
+function runLocalPlan(
   plan: CommitMessagePlan,
   cwd: string,
   env: NodeJS.ProcessEnv | undefined,
   emptyResultName = 'message',
   operation: TextGenerationOperation = 'commit-message',
-  wslDistro?: string
-): Promise<InternalTextGenerationResult> {
+  wslDistro?: string,
+  holdHomeLockUntilClose = false
+): LocalProcessExecution<InternalTextGenerationResult> {
   const { binary, args, stdinPayload, label } = plan
-  return new Promise((resolve) => {
+  let markProcessClosed!: () => void
+  const processClosed = new Promise<void>((resolve) => {
+    markProcessClosed = resolve
+  })
+  const result = new Promise<InternalTextGenerationResult>((resolve) => {
     let child: ChildProcess
     try {
       const spawnEnv = env ?? process.env
@@ -602,6 +632,7 @@ async function runLocalPlan(
         })
       }
     } catch (error) {
+      markProcessClosed()
       if (error instanceof UnsafeWindowsBatchArgumentsError) {
         resolve({
           success: false,
@@ -640,6 +671,9 @@ async function runLocalPlan(
       detachChildListeners()
       if (cancelToken && cancelTokensByLane.get(laneKey) === cancelToken) {
         cancelTokensByLane.delete(laneKey)
+      }
+      if (!holdHomeLockUntilClose) {
+        markProcessClosed()
       }
       resolve(result)
     }
@@ -680,6 +714,9 @@ async function runLocalPlan(
       stderr += chunk.toString('utf-8')
     }
     const onError = (error: Error): void => {
+      if (!child.pid) {
+        markProcessClosed()
+      }
       const code = (error as NodeJS.ErrnoException).code
       if (code === 'ENOENT') {
         finalize({
@@ -695,6 +732,7 @@ async function runLocalPlan(
       })
     }
     const onClose = (code: number | null): void => {
+      markProcessClosed()
       if (canceledByUser) {
         finalize({ success: false, error: 'Generation canceled.', canceled: true })
         return
@@ -718,6 +756,9 @@ async function runLocalPlan(
     }
     child.stdout?.on('data', onStdoutData)
     child.stderr?.on('data', onStderrData)
+    if (holdHomeLockUntilClose) {
+      child.once('close', markProcessClosed)
+    }
     child.on('error', onError)
     child.on('close', onClose)
     detachChildListeners = () => {
@@ -727,8 +768,14 @@ async function runLocalPlan(
       child.off?.('close', onClose)
     }
 
-    child.stdin?.end(stdinPayload ?? undefined)
+    try {
+      child.stdin?.end(stdinPayload ?? undefined)
+    } catch (error) {
+      killProcessTree(child)
+      onError(error instanceof Error ? error : new Error(String(error)))
+    }
   })
+  return { result, processClosed }
 }
 
 type LocalGenerationTarget = Extract<CommitMessageGenerationTarget, { kind: 'local' }>
@@ -740,45 +787,101 @@ function runLocalPlanForAgent(
   emptyResultName: string,
   operation: TextGenerationOperation
 ): Promise<InternalTextGenerationResult> {
-  const run = (): Promise<InternalTextGenerationResult> =>
-    runLocalPlan(plan, target.cwd, target.env, emptyResultName, operation, target.wslDistro)
+  const start = (
+    holdHomeLockUntilClose = false
+  ): LocalProcessExecution<InternalTextGenerationResult> =>
+    runLocalPlan(
+      plan,
+      target.cwd,
+      target.env,
+      emptyResultName,
+      operation,
+      target.wslDistro,
+      holdHomeLockUntilClose
+    )
   if (agentId !== 'codex') {
     // Why: no extra promise hops here — cancellation timing for non-codex
     // agents must stay byte-identical to a direct runLocalPlan call.
-    return run()
+    return start().result
   }
-  return runCodexLocalPlanUnderHomeLock(run, target, operation)
+  return runCodexLocalPlanUnderHomeLock(() => start(true), target, operation)
 }
 
 // Why: codex rewrites rotating OAuth tokens in its home's auth.json; the
 // per-home lock keeps this run from racing Orca's own quota probes there.
-async function runCodexLocalPlanUnderHomeLock(
-  run: () => Promise<InternalTextGenerationResult>,
+function runCodexLocalPlanUnderHomeLock(
+  start: () => LocalProcessExecution<InternalTextGenerationResult>,
   target: LocalGenerationTarget,
   operation: TextGenerationOperation
 ): Promise<InternalTextGenerationResult> {
   const laneKey = localLaneKey(operation, target.cwd)
   let canceledWhileQueued = false
+  let publishResult!: (result: InternalTextGenerationResult) => void
+  let rejectResult!: (error: unknown) => void
+  let resultPublished = false
+  const result = new Promise<InternalTextGenerationResult>((resolve, reject) => {
+    publishResult = (value) => {
+      if (!resultPublished) {
+        resultPublished = true
+        resolve(value)
+      }
+    }
+    rejectResult = reject
+  })
   const queuedCancelToken = (): void => {
     canceledWhileQueued = true
+    publishResult({ success: false, error: 'Generation canceled.', canceled: true })
   }
   // Why: Stop must work while this run waits behind a probe holding the lock.
   cancelTokensByLane.set(laneKey, queuedCancelToken)
-  try {
-    return await withCodexHomeProcessLock(
-      resolveCodexHomeProcessLockKeyForSpawnEnv(target.env, target.wslDistro),
-      async () => {
-        if (canceledWhileQueued) {
-          return { success: false, error: 'Generation canceled.', canceled: true }
-        }
-        return run()
+  void withCodexHomeProcessLock(
+    resolveCodexHomeProcessLockKeyForSpawnEnv(target.env, target.wslDistro),
+    async () => {
+      if (canceledWhileQueued) {
+        publishResult({ success: false, error: 'Generation canceled.', canceled: true })
+        return
       }
-    )
-  } finally {
-    if (cancelTokensByLane.get(laneKey) === queuedCancelToken) {
-      cancelTokensByLane.delete(laneKey)
+      const execution = start()
+      try {
+        publishResult(await execution.result)
+      } catch (error) {
+        if (!resultPublished) {
+          rejectResult(error)
+        }
+      } finally {
+        await execution.processClosed
+      }
     }
-  }
+  )
+    .catch((error: unknown) => {
+      if (!resultPublished) {
+        rejectResult(error)
+      }
+    })
+    .finally(() => {
+      if (cancelTokensByLane.get(laneKey) === queuedCancelToken) {
+        cancelTokensByLane.delete(laneKey)
+      }
+    })
+  return result
+}
+
+function runCodexProcessWithHomeLock<T>(
+  lockKey: string,
+  start: () => LocalProcessExecution<T>
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    void withCodexHomeProcessLock(lockKey, async () => {
+      const execution = start()
+      try {
+        resolve(await execution.result)
+      } catch (error) {
+        reject(error)
+      } finally {
+        await execution.processClosed
+      }
+    }).catch(reject)
+  })
 }
 
 function finalizeFromAgentOutput(args: {

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: local and SSH generation share cancellation,
    spawn failure handling, and output normalization; keeping them together
    prevents those paths from drifting. */
-import { exec, spawn, type ChildProcess } from 'node:child_process'
+import { spawn, type ChildProcess } from 'node:child_process'
 import type { GlobalSettings, Repo, TuiAgent } from '../../shared/types'
 import {
   buildCommitMessagePrompt,
@@ -58,6 +58,7 @@ import {
 } from '../win32-utils'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { wslAwareSpawn } from '../git/runner'
+import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 
 const GENERATION_TIMEOUT_MS = 60_000
 const MAX_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024
@@ -374,7 +375,14 @@ export async function discoverCommitMessageModelsLocal(
       let outputLimitExceeded = false
       let settled = false
       let timer: ReturnType<typeof setTimeout> | null = null
+      let terminationComplete: Promise<void> | null = null
       let detachChildListeners = (): void => {}
+      const startTermination = (): void => {
+        terminationComplete ??= killProcessTree(child)
+      }
+      const markClosedAfterTermination = (): void => {
+        void (terminationComplete ?? Promise.resolve()).then(markProcessClosed)
+      }
       const finish = (result: DiscoverCommitMessageModelsResult): void => {
         if (settled) {
           return
@@ -391,7 +399,7 @@ export async function discoverCommitMessageModelsLocal(
         resolve(result)
       }
       timer = setTimeout(() => {
-        killProcessTree(child)
+        startTermination()
         finish({
           success: false,
           error: `${spec.label} model discovery timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
@@ -401,7 +409,7 @@ export async function discoverCommitMessageModelsLocal(
       const onData = (chunk: Buffer, append: (text: string) => void): void => {
         if (stdout.length + stderr.length + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
           outputLimitExceeded = true
-          killProcessTree(child)
+          startTermination()
           finish({ success: false, error: `${spec.label} returned too much model data.` })
           return
         }
@@ -427,7 +435,7 @@ export async function discoverCommitMessageModelsLocal(
         })
       }
       const onClose = (code: number | null): void => {
-        markProcessClosed()
+        markClosedAfterTermination()
         if (outputLimitExceeded) {
           finish({ success: false, error: `${spec.label} returned too much model data.` })
           return
@@ -444,7 +452,7 @@ export async function discoverCommitMessageModelsLocal(
       if (agentId === 'codex') {
         // Result publication stays prompt while the home lock follows the
         // process lifetime after asynchronous timeout/output-limit kills.
-        child.once('close', markProcessClosed)
+        child.once('close', markClosedAfterTermination)
       }
       child.on('error', onError)
       child.on('close', onClose)
@@ -533,16 +541,13 @@ export async function discoverCommitMessageModelsRemote(
 // `child.kill()` would only terminate the wrapper. `taskkill /T /F` walks the
 // process tree from the wrapper PID and force-kills every descendant, which is
 // what users expect when they hit "stop generating".
-function killProcessTree(child: ChildProcess): void {
+function killProcessTree(child: ChildProcess): Promise<void> {
   const pid = child.pid
   if (!pid) {
-    return
+    return Promise.resolve()
   }
   if (process.platform === 'win32') {
-    exec(`taskkill /pid ${pid} /T /F`, () => {
-      // Best-effort; the spawn's `close` listener fires once the tree exits.
-    })
-    return
+    return terminateWindowsProcessTree(pid)
   }
   try {
     child.kill('SIGKILL')
@@ -550,6 +555,7 @@ function killProcessTree(child: ChildProcess): void {
     // The child may have already exited between the in-flight check and the
     // kill - that race is benign and can be ignored.
   }
+  return Promise.resolve()
 }
 
 // Keying by operation plus `local:${cwd}` keeps local cancellation independent
@@ -658,7 +664,14 @@ function runLocalPlan(
     const laneKey = localLaneKey(operation, cwd)
     let cancelToken: (() => void) | null = null
     let timer: ReturnType<typeof setTimeout> | null = null
+    let terminationComplete: Promise<void> | null = null
     let detachChildListeners = (): void => {}
+    const startTermination = (): void => {
+      terminationComplete ??= killProcessTree(child)
+    }
+    const markClosedAfterTermination = (): void => {
+      void (terminationComplete ?? Promise.resolve()).then(markProcessClosed)
+    }
     const finalize = (result: InternalTextGenerationResult): void => {
       if (settled) {
         return
@@ -680,7 +693,7 @@ function runLocalPlan(
 
     cancelToken = () => {
       canceledByUser = true
-      killProcessTree(child)
+      startTermination()
       // Why: cancellation is a user-visible UI command; do not wait for a
       // wedged agent CLI to emit `close` before the request leaves loading.
       finalize({ success: false, error: 'Generation canceled.', canceled: true })
@@ -688,7 +701,7 @@ function runLocalPlan(
     cancelTokensByLane.set(laneKey, cancelToken)
 
     timer = setTimeout(() => {
-      killProcessTree(child)
+      startTermination()
       finalize({
         success: false,
         error: `Generation timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
@@ -699,7 +712,7 @@ function runLocalPlan(
       stdoutBytes += chunk.byteLength
       if (stdoutBytes > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
-        killProcessTree(child)
+        startTermination()
         return
       }
       stdout += chunk.toString('utf-8')
@@ -708,7 +721,7 @@ function runLocalPlan(
       stderrBytes += chunk.byteLength
       if (stderrBytes > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
-        killProcessTree(child)
+        startTermination()
         return
       }
       stderr += chunk.toString('utf-8')
@@ -732,7 +745,7 @@ function runLocalPlan(
       })
     }
     const onClose = (code: number | null): void => {
-      markProcessClosed()
+      markClosedAfterTermination()
       if (canceledByUser) {
         finalize({ success: false, error: 'Generation canceled.', canceled: true })
         return
@@ -757,7 +770,7 @@ function runLocalPlan(
     child.stdout?.on('data', onStdoutData)
     child.stderr?.on('data', onStderrData)
     if (holdHomeLockUntilClose) {
-      child.once('close', markProcessClosed)
+      child.once('close', markClosedAfterTermination)
     }
     child.on('error', onError)
     child.on('close', onClose)
@@ -771,7 +784,7 @@ function runLocalPlan(
     try {
       child.stdin?.end(stdinPayload ?? undefined)
     } catch (error) {
-      killProcessTree(child)
+      startTermination()
       onError(error instanceof Error ? error : new Error(String(error)))
     }
   })

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -48,6 +48,10 @@ import { formatLinkedIssueTemplateValue } from '../../shared/source-control-ai-a
 import { renderSourceControlActionCommandTemplate } from '../../shared/source-control-ai-actions'
 import { resolveCliCommand } from '../codex-cli/command'
 import {
+  resolveCodexHomeProcessLockKeyForSpawnEnv,
+  withCodexHomeProcessLock
+} from '../codex-cli/codex-home-process-lock'
+import {
   getSpawnArgsForWindows,
   UnsafeWindowsBatchArgumentsError,
   WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR
@@ -312,121 +316,132 @@ export async function discoverCommitMessageModelsLocal(
     return toModelDiscoveryCapability(spec)
   }
 
-  return new Promise((resolve) => {
-    let child: ChildProcess
-    const spawnEnv = env ?? process.env
-    try {
-      const planned = planModelDiscovery(spec, agentCommandOverride)
-      if (!planned.ok) {
-        resolve({ success: false, error: planned.error })
+  const runDiscovery = (): Promise<DiscoverCommitMessageModelsResult> =>
+    new Promise((resolve) => {
+      let child: ChildProcess
+      const spawnEnv = env ?? process.env
+      try {
+        const planned = planModelDiscovery(spec, agentCommandOverride)
+        if (!planned.ok) {
+          resolve({ success: false, error: planned.error })
+          return
+        }
+        if (process.platform === 'win32' && options.wslDistro) {
+          child = wslAwareSpawn(planned.plan.binary, planned.plan.args, {
+            cwd: options.cwd,
+            env: buildWslLauncherEnv(env),
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true,
+            wslDistro: options.wslDistro,
+            useWslLoginShell: true
+          })
+        } else {
+          const resolvedBinary =
+            process.platform === 'win32'
+              ? resolveCliCommand(planned.plan.binary, {
+                  pathEnv: spawnEnv.PATH ?? spawnEnv.Path ?? null
+                })
+              : planned.plan.binary
+          const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(resolvedBinary, planned.plan.args)
+          child = spawn(spawnCmd, spawnArgs, {
+            env: spawnEnv,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true
+          })
+        }
+      } catch (error) {
+        console.error('[commit-message] Failed to spawn model discovery:', error)
+        resolve({
+          success: false,
+          error: `${spec.label} model discovery could not be started. Check the agent CLI configuration and try again.`
+        })
         return
       }
-      if (process.platform === 'win32' && options.wslDistro) {
-        child = wslAwareSpawn(planned.plan.binary, planned.plan.args, {
-          cwd: options.cwd,
-          env: buildWslLauncherEnv(env),
-          stdio: ['ignore', 'pipe', 'pipe'],
-          windowsHide: true,
-          wslDistro: options.wslDistro,
-          useWslLoginShell: true
-        })
-      } else {
-        const resolvedBinary =
-          process.platform === 'win32'
-            ? resolveCliCommand(planned.plan.binary, {
-                pathEnv: spawnEnv.PATH ?? spawnEnv.Path ?? null
-              })
-            : planned.plan.binary
-        const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(resolvedBinary, planned.plan.args)
-        child = spawn(spawnCmd, spawnArgs, {
-          env: spawnEnv,
-          stdio: ['ignore', 'pipe', 'pipe'],
-          windowsHide: true
-        })
-      }
-    } catch (error) {
-      console.error('[commit-message] Failed to spawn model discovery:', error)
-      resolve({
-        success: false,
-        error: `${spec.label} model discovery could not be started. Check the agent CLI configuration and try again.`
-      })
-      return
-    }
 
-    let stdout = ''
-    let stderr = ''
-    let outputLimitExceeded = false
-    let settled = false
-    let timer: ReturnType<typeof setTimeout> | null = null
-    let detachChildListeners = (): void => {}
-    const finish = (result: DiscoverCommitMessageModelsResult): void => {
-      if (settled) {
-        return
+      let stdout = ''
+      let stderr = ''
+      let outputLimitExceeded = false
+      let settled = false
+      let timer: ReturnType<typeof setTimeout> | null = null
+      let detachChildListeners = (): void => {}
+      const finish = (result: DiscoverCommitMessageModelsResult): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        detachChildListeners()
+        resolve(result)
       }
-      settled = true
-      if (timer) {
-        clearTimeout(timer)
-        timer = null
-      }
-      detachChildListeners()
-      resolve(result)
-    }
-    timer = setTimeout(() => {
-      killProcessTree(child)
-      finish({
-        success: false,
-        error: `${spec.label} model discovery timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
-      })
-    }, GENERATION_TIMEOUT_MS)
-
-    const onData = (chunk: Buffer, append: (text: string) => void): void => {
-      if (stdout.length + stderr.length + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
-        outputLimitExceeded = true
+      timer = setTimeout(() => {
         killProcessTree(child)
-        finish({ success: false, error: `${spec.label} returned too much model data.` })
-        return
-      }
-      append(chunk.toString('utf-8'))
-    }
-
-    const onStdoutData = (chunk: Buffer): void => onData(chunk, (text) => (stdout += text))
-    const onStderrData = (chunk: Buffer): void => onData(chunk, (text) => (stderr += text))
-    const onError = (error: Error): void => {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         finish({
           success: false,
-          error: `${spec.modelDiscovery?.binary ?? spec.binary} not found on PATH. Install ${spec.label} to discover models.`
+          error: `${spec.label} model discovery timed out after ${GENERATION_TIMEOUT_MS / 1000}s.`
         })
-        return
-      }
-      finish({
-        success: false,
-        error: `${spec.label} model discovery failed to start. Check the agent CLI configuration and try again.`
-      })
-    }
-    const onClose = (code: number | null): void => {
-      if (outputLimitExceeded) {
-        finish({ success: false, error: `${spec.label} returned too much model data.` })
-        return
-      }
-      if (code !== 0) {
-        finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
-        return
-      }
-      finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
-    }
+      }, GENERATION_TIMEOUT_MS)
 
-    child.stdout?.on('data', onStdoutData)
-    child.stderr?.on('data', onStderrData)
-    child.on('error', onError)
-    child.on('close', onClose)
-    detachChildListeners = () => {
-      child.stdout?.off?.('data', onStdoutData)
-      child.stderr?.off?.('data', onStderrData)
-      child.off?.('error', onError)
-      child.off?.('close', onClose)
-    }
-  })
+      const onData = (chunk: Buffer, append: (text: string) => void): void => {
+        if (stdout.length + stderr.length + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
+          outputLimitExceeded = true
+          killProcessTree(child)
+          finish({ success: false, error: `${spec.label} returned too much model data.` })
+          return
+        }
+        append(chunk.toString('utf-8'))
+      }
+
+      const onStdoutData = (chunk: Buffer): void => onData(chunk, (text) => (stdout += text))
+      const onStderrData = (chunk: Buffer): void => onData(chunk, (text) => (stderr += text))
+      const onError = (error: Error): void => {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          finish({
+            success: false,
+            error: `${spec.modelDiscovery?.binary ?? spec.binary} not found on PATH. Install ${spec.label} to discover models.`
+          })
+          return
+        }
+        finish({
+          success: false,
+          error: `${spec.label} model discovery failed to start. Check the agent CLI configuration and try again.`
+        })
+      }
+      const onClose = (code: number | null): void => {
+        if (outputLimitExceeded) {
+          finish({ success: false, error: `${spec.label} returned too much model data.` })
+          return
+        }
+        if (code !== 0) {
+          finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
+          return
+        }
+        finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
+      }
+
+      child.stdout?.on('data', onStdoutData)
+      child.stderr?.on('data', onStderrData)
+      child.on('error', onError)
+      child.on('close', onClose)
+      detachChildListeners = () => {
+        child.stdout?.off?.('data', onStdoutData)
+        child.stderr?.off?.('data', onStderrData)
+        child.off?.('error', onError)
+        child.off?.('close', onClose)
+      }
+    })
+
+  if (agentId === 'codex') {
+    // Why: discovery spawns a real codex process in the selected home; keep it
+    // off an auth.json a quota probe may be refreshing at the same time.
+    return withCodexHomeProcessLock(
+      resolveCodexHomeProcessLockKeyForSpawnEnv(env, options.wslDistro),
+      runDiscovery
+    )
+  }
+  return runDiscovery()
 }
 
 export async function discoverCommitMessageModelsRemote(
@@ -716,6 +731,56 @@ async function runLocalPlan(
   })
 }
 
+type LocalGenerationTarget = Extract<CommitMessageGenerationTarget, { kind: 'local' }>
+
+function runLocalPlanForAgent(
+  agentId: string,
+  plan: CommitMessagePlan,
+  target: LocalGenerationTarget,
+  emptyResultName: string,
+  operation: TextGenerationOperation
+): Promise<InternalTextGenerationResult> {
+  const run = (): Promise<InternalTextGenerationResult> =>
+    runLocalPlan(plan, target.cwd, target.env, emptyResultName, operation, target.wslDistro)
+  if (agentId !== 'codex') {
+    // Why: no extra promise hops here — cancellation timing for non-codex
+    // agents must stay byte-identical to a direct runLocalPlan call.
+    return run()
+  }
+  return runCodexLocalPlanUnderHomeLock(run, target, operation)
+}
+
+// Why: codex rewrites rotating OAuth tokens in its home's auth.json; the
+// per-home lock keeps this run from racing Orca's own quota probes there.
+async function runCodexLocalPlanUnderHomeLock(
+  run: () => Promise<InternalTextGenerationResult>,
+  target: LocalGenerationTarget,
+  operation: TextGenerationOperation
+): Promise<InternalTextGenerationResult> {
+  const laneKey = localLaneKey(operation, target.cwd)
+  let canceledWhileQueued = false
+  const queuedCancelToken = (): void => {
+    canceledWhileQueued = true
+  }
+  // Why: Stop must work while this run waits behind a probe holding the lock.
+  cancelTokensByLane.set(laneKey, queuedCancelToken)
+  try {
+    return await withCodexHomeProcessLock(
+      resolveCodexHomeProcessLockKeyForSpawnEnv(target.env, target.wslDistro),
+      async () => {
+        if (canceledWhileQueued) {
+          return { success: false, error: 'Generation canceled.', canceled: true }
+        }
+        return run()
+      }
+    )
+  } finally {
+    if (cancelTokensByLane.get(laneKey) === queuedCancelToken) {
+      cancelTokensByLane.delete(laneKey)
+    }
+  }
+}
+
 function finalizeFromAgentOutput(args: {
   code: number | null
   stdout: string
@@ -890,13 +955,12 @@ export async function generateCommitMessageFromContext(
   const internalResult =
     target.kind === 'remote'
       ? await runRemotePlan(planned.plan, target)
-      : await runLocalPlan(
+      : await runLocalPlanForAgent(
+          params.agentId,
           planned.plan,
-          target.cwd,
-          target.env,
+          target,
           'message',
-          'commit-message',
-          target.wslDistro
+          'commit-message'
         )
   return formatCommitMessageGenerationResult(internalResult)
 }
@@ -967,13 +1031,12 @@ export async function generatePullRequestFieldsFromContext(
   const internalResult =
     target.kind === 'remote'
       ? await runRemotePlan(planned.plan, target, 'details', 'pull-request-fields')
-      : await runLocalPlan(
+      : await runLocalPlanForAgent(
+          params.agentId,
           planned.plan,
-          target.cwd,
-          target.env,
+          target,
           'details',
-          'pull-request-fields',
-          target.wslDistro
+          'pull-request-fields'
         )
   return formatPullRequestFieldsGenerationResult(internalResult, context)
 }
@@ -1014,13 +1077,12 @@ export async function generateBranchNameFromContext(
   const internalResult =
     target.kind === 'remote'
       ? await runRemotePlan(planned.plan, target, 'branch name', 'branch-name')
-      : await runLocalPlan(
+      : await runLocalPlanForAgent(
+          params.agentId,
           planned.plan,
-          target.cwd,
-          target.env,
+          target,
           'branch name',
-          'branch-name',
-          target.wslDistro
+          'branch-name'
         )
   if (!internalResult.success) {
     return internalResult


### PR DESCRIPTION
## Summary

Addresses #11969 (users repeatedly logged out of connected Codex accounts, correlated with account switching). Codex OAuth uses **rotating refresh tokens**, and Orca's quota probes handled them dangerously in four ways, each fixed here:

1. **Graceful probe shutdown.** The RPC probe spawned `codex app-server` inside the account's live credential home and hard-killed it at a 10s deadline, while cold starts (including an in-flight token refresh) are documented at 10–25s — a kill landing mid-rotation can permanently invalidate the stored credential. Now the request deadline is armed only after the app-server answers `initialize` (boot budget: 30s host / 40s WSL), and every probe termination first requests shutdown (stdin EOF + SIGTERM; stdin EOF alone on Windows, where Node's `kill()` is always forceful) with a bounded 5s drain window before any hard kill. The fetch resolves only once the child has actually exited.
2. **Per-credential-home serialization.** New `withCodexHomeProcessLock` FIFO mutex, keyed by the normalized codex home (WSL `\\wsl$` UNC and in-distro Linux paths collide onto one key). Quota probes (RPC and PTY paths) and Orca's own codex spawns for commit messages, PR fields, branch names, and model discovery all share it, so Orca never runs two of its own codex processes against one `auth.json`. Stop/cancel still works while a generation is queued behind a probe. User terminal panes are intentionally not serialized (out of scope).
3. **No more switch-storm.** Account switches no longer zero the inactive-probe debounce (previously every switch re-probed every inactive account's credential home at once). The 60s debounce holds, the switcher shows the cached snapshot (seeded from the outgoing account), inactive probes are staggered 2s apart, and the newly **active** account still gets its immediate refresh.
4. **Parse-error grace.** Credential reads now distinguish `present` / `missing` / `unreadable` / `no-credential`. A transient missing or torn (mid-write) `auth.json` no longer deselects the active managed account: absence must persist past a 5s grace window before deselection — unless the managed home directory itself is gone, which is structural (not a rotation) and still deselects immediately. Settled valid-JSON-without-credential (a real logout) also still deselects immediately.

## Screenshots

No visual change

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` (left to CI — desktop + native packaging)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm test` (node 24): 43,511 passed. The only failures on my machine (20 tests across 6 files: `ipc/pty`, `relay/*`, `daemon/pty-subprocess`, `setup-agent-sequencing`, `check-root-directory-entries`) are environment-sensitive and fail **identically at the parent commit on main** — verified by running the same files at `HEAD~1` under identical conditions and diffing the failure sets. Every suite touching this change passes.

New coverage: graceful-drain sequencing with a fake child (SIGTERM → drain → SIGKILL escalation, Windows stdin-EOF-only lane, bounded resolution for a child that never exits, already-exited no-op); boot-budget vs read-deadline arming (a 20s-cold app-server is no longer killed); per-home lock behavior (same-key queueing, cross-key concurrency, release after rejection, WSL UNC ↔ Linux-path key collision); fetcher-level "no second spawn for the same home while one probe runs"; switch-debounce and 2s stagger in `RateLimitService`; credential-absence grace transitions; and runtime-home-service "transient unreadable then valid auth.json does not deselect" plus grace-then-durable deselect.

## AI Review Report

Reviewed the change for lock leaks (per-home lock tail is rejection-safe and self-cleaning; probe resolution waits for child exit so the lock can't release mid-drain), cancellation races (a queued codex generation registers a pre-lock cancel token so Stop works while waiting), non-codex regression (the non-codex generation path keeps zero added promise hops, preserving cancellation timing byte-for-byte), and deselect-behavior regressions (structurally missing managed homes still deselect immediately at startup).

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows:
- **Windows:** Node's `kill()` is TerminateProcess, so the graceful phase uses stdin EOF only and escalates to `kill()` after the drain; the login-flow `taskkill /t` tree-kill path is untouched; the background-probe ConPTY PTY fallback remains disabled on Windows; `EPERM`/`EBUSY` reads during auth.json rotation are classified as transient `unreadable`.
- **WSL:** the boot budget is 40s (cold WSL starts exceed host budgets); stdin EOF propagates to the in-distro codex through the existing fd-isolated login-shell plumbing; lock keys normalize `\\wsl$`/`\\wsl.localhost` UNC and Linux paths onto one key per distro.
- **macOS/Linux:** stdin EOF + SIGTERM, then SIGKILL after the drain.
- **SSH:** remote generation goes through `runRemotePlan`/provider execution and is untouched; folder workspaces are unaffected (no worktree assumptions anywhere in the change).

## Security Audit

- No new command execution: the same codex binaries/arguments are spawned; the lock and grace logic are purely in-process.
- `auth.json` is only read (never written) by the new code, torn reads no longer influence deselection, and no credential material is logged.
- Path handling: `normalizeRuntimePathForComparison` output is used for comparison keys only, never spliced back into real paths.
- No IPC surface changes; no new dependencies.

## Notes

- The deadline error stays `RPC timeout` for both phases, so existing error classification is unchanged.
- Follow-ups (deliberately out of scope, per the one-theme rule):
  - WSL bidirectional auth mirroring fork
  - hook-lane flip handling
  - multi-pane token refresh coordination
  - graceful drain for the PTY fallback path (`cleanupHiddenRateLimitPty` still kills immediately; the per-home lock already prevents overlapping spawns there)
  - the WSL managed-account missing-auth deselect (`syncWslRuntimeForCurrentSelection`) still deselects without grace; the same grace could be applied
  - system-default WSL commit-message runs key the lock with a distro-scoped sentinel (the distro's `~/.codex` isn't resolvable from the host), so they serialize with each other but not with probes that pass an explicit UNC home
