### PR TITLE
fix(sidebar): show collapse chevron on pinned section headers

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts
@@ -917,6 +917,30 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(markup).toContain('aria-expanded="true"')
   })
 
+  it('renders a collapse chevron on the pinned section header with worktrees', async () => {
+    setPinnedFixtureState()
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('Pinned')
+    expect(markup).toContain('data-workspace-pin-drop-target=""')
+    expect(markup).toContain('data-repo-header-collapse-affordance=""')
+    expect(markup).toContain('aria-expanded="true"')
+  })
+
+  it('renders collapsed pinned section header affordance state', async () => {
+    setPinnedFixtureState()
+    mockStore.state = {
+      ...mockStore.state,
+      collapsedGroups: new Set(['pinned'])
+    }
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('data-workspace-pin-drop-target=""')
+    expect(markup).toContain('data-repo-header-collapse-affordance=""')
+    expect(markup).toContain('aria-expanded="false"')
+    expect(markup).toContain('-rotate-90')
+  })
+
   it('renders a collapse chevron on grouped repo headers with worktrees', async () => {
     setLineageFixtureState('repo')
     const markup = await renderWorktreeListMarkup()

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4196,10 +4196,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   projectGroupPathStatus.reason === 'ambiguous-connection')
               const projectGroupDepth = row.projectGroupDepth ?? 0
               const isHeaderCollapsed = collapsedGroups.has(row.key)
-              // Why: repo/project and status headers share compact section chrome; flat "All" stays a simple label.
+              // Why: repo/project/status/pinned share compact section chrome; flat "All" stays a simple label.
               const showHeaderCollapseAffordance =
                 row.count > 0 &&
-                (isRepoHeader || isProjectGroupHeader || headerWorkspaceStatus !== null)
+                (isRepoHeader ||
+                  isProjectGroupHeader ||
+                  headerWorkspaceStatus !== null ||
+                  isPinnedHeader)
               // Why: non-project headers like "All" are flat-list labels; don't reserve project hierarchy indent.
               const headerPaddingLeft =
                 isRepoHeader || isProjectGroupHeader


### PR DESCRIPTION
## Summary
- Pinned workspace sections were collapsible but never showed the same hover collapse chevron used by status / repo / project group headers.
- Include `isPinnedHeader` in `showHeaderCollapseAffordance` so hover reveals the arrow and `aria-expanded` reflects collapse state.
- Add unit coverage for expanded and collapsed pinned header affordances.

## Test plan
- [x] Unit: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeList.lineage-child-card.test.ts -t "pinned section"`
- [x] Electron (CDP `agent-browser`): status grouping with a pinned workspace — Pinned header shows collapse chevron on hover, matching Todo / In progress
- [x] Collapse Pinned — chevron rotates to point right; expand restores down chevron

## Proof screenshots (Electron)

**After fix — Pinned expanded with chevron (matches Todo):**

![pinned-and-status-chevrons-visible-sidebar.png](https://github.com/user-attachments/assets/84e5d588-e257-4497-86ab-b5395c30bc66)

**Pinned collapsed (chevron points right):**

![pinned-collapsed-hover-sidebar.png](https://github.com/user-attachments/assets/33f051e2-c6e6-4f7c-9c04-7a8155dd9e05)

**Status section (Todo) for comparison:**

![todo-header-hover-sidebar.png](https://github.com/user-attachments/assets/07e916a0-2a6b-4814-b6dd-029b98ce0f53)