### PR TITLE
fix(orchestration): worker-start launches the configured agent CLI, not the raw agent id

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12611,8 +12611,48 @@ describe('OrcaRuntimeService', () => {
     await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, { startupAgent: 'cursor' })
 
     const spawnCall = spawn.mock.calls[0]?.[0] as { command?: string } | undefined
-    expect(spawnCall?.command).toMatch(/^cursor-agent(\s|$)/)
+    // Why: assert the cmd.exe double quoting too — a platform-insensitive prefix
+    // match would pass on any OS and prove nothing about the reported platform.
+    expect(spawnCall?.command).toBe('cursor-agent "--yolo"')
   })
+
+  // Why: claude-agent-teams is the only agent whose launcher name varies by
+  // platform (launchCmdByPlatform), so it is what proves resolution is
+  // platform-aware rather than a fixed string.
+  it.each([
+    { platform: 'win32' as const, expected: 'orca.cmd claude-teams' },
+    { platform: 'linux' as const, expected: 'orca-ide claude-teams' },
+    { platform: 'darwin' as const, expected: 'orca claude-teams' }
+  ])(
+    'resolves a startupAgent through the $platform launcher name',
+    async ({ platform, expected }) => {
+      setPlatform(platform)
+      const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+      const runtime = new OrcaRuntimeService({
+        ...store,
+        getSettings: () => ({
+          ...store.getSettings(),
+          disabledTuiAgents: [],
+          agentCmdOverrides: {},
+          agentDefaultArgs: { 'claude-agent-teams': '' },
+          agentDefaultEnv: {}
+        })
+      })
+      runtime.setPtyController({
+        spawn,
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+
+      await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        startupAgent: 'claude-agent-teams'
+      })
+
+      const spawnCall = spawn.mock.calls[0]?.[0] as { command?: string } | undefined
+      expect(spawnCall?.command).toBe(expected)
+    }
+  )
 
   // Why: folder workspaces have no repo, so command sniffing skipped them entirely
   // and spawned the bare string; an explicit agent must still resolve.
@@ -12672,7 +12712,10 @@ describe('OrcaRuntimeService', () => {
       { command: 'cursor-agent --resume' },
       // Why: resume identity paired with a freshly built launch is incoherent.
       { resumeProviderSession: { key: 'session_id', id: 'prior-session' } as never },
-      { launchAgent: 'cursor' as const }
+      { launchAgent: 'cursor' as const },
+      { launchConfig: { agentArgs: '', agentEnv: {} } as never },
+      { startupCommandDelivery: 'provider' as never },
+      { claudeAgentTeamsSourceCommand: 'claude' }
     ]) {
       await expect(
         runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12614,6 +12614,76 @@ describe('OrcaRuntimeService', () => {
     expect(spawnCall?.command).toMatch(/^cursor-agent(\s|$)/)
   })
 
+  // Why: folder workspaces have no repo, so command sniffing skipped them entirely
+  // and spawned the bare string; an explicit agent must still resolve.
+  it('resolves a startupAgent in a repo-less folder workspace', async () => {
+    const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-startup-agent-'))
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const folderWorkspace = makeFolderWorkspace({ folderPath })
+    const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
+    const runtime = new OrcaRuntimeService({
+      ...createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup),
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: {},
+        agentDefaultArgs: { cursor: '--force' },
+        agentDefaultEnv: {}
+      })
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`id:${TEST_FOLDER_WORKSPACE_KEY}`, { startupAgent: 'cursor' })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as
+      | { command?: string; launchAgent?: string }
+      | undefined
+    expect(spawnCall?.command).toBe("cursor-agent '--force'")
+    expect(spawnCall?.launchAgent).toBe('cursor')
+  })
+
+  // Why: silently returning the caller's opts would spawn a bare shell that can
+  // only time out at agent readiness — the failure startupAgent exists to stop.
+  it('rejects a startupAgent create that also supplies its own launch', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: {}
+      })
+    })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    for (const conflicting of [
+      { env: { SOME_VAR: 'set' } },
+      // Why: a raw command would be silently overwritten by the built launch.
+      { command: 'cursor-agent --resume' },
+      // Why: resume identity paired with a freshly built launch is incoherent.
+      { resumeProviderSession: { key: 'session_id', id: 'prior-session' } as never },
+      { launchAgent: 'cursor' as const }
+    ]) {
+      await expect(
+        runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+          startupAgent: 'cursor',
+          ...conflicting
+        })
+      ).rejects.toThrow(/cannot combine/)
+    }
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('rejects a startupAgent create for a disabled agent', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
     const runtimeStore = {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12550,6 +12550,94 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  // Why: `cursor` on PATH is the Cursor desktop launcher; only `cursor-agent` is
+  // the CLI Orca can host (issue #11926).
+  it('launches the configured agent CLI for a startupAgent id, not the raw id', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: {},
+        agentDefaultArgs: { cursor: '--force' },
+        agentDefaultEnv: { cursor: { CURSOR_PROFILE: 'captured' } }
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      startupAgent: 'cursor',
+      title: 'worker'
+    })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as
+      | { command?: string; launchAgent?: string; env?: Record<string, string> }
+      | undefined
+    expect(spawnCall?.command).toBe("cursor-agent '--force'")
+    expect(spawnCall?.launchAgent).toBe('cursor')
+    expect(spawnCall?.env).toMatchObject({ CURSOR_PROFILE: 'captured' })
+    expect(markCursorWorkspaceTrustedMock).toHaveBeenCalledWith(TEST_WORKTREE_PATH)
+  })
+
+  it('resolves a startupAgent to the CLI binary on Windows, where `cursor` is the IDE', async () => {
+    setPlatform('win32')
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        terminalWindowsShell: 'cmd.exe',
+        agentCmdOverrides: {},
+        agentDefaultArgs: {},
+        agentDefaultEnv: {}
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, { startupAgent: 'cursor' })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as { command?: string } | undefined
+    expect(spawnCall?.command).toMatch(/^cursor-agent(\s|$)/)
+  })
+
+  it('rejects a startupAgent create for a disabled agent', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: ['cursor' as const],
+        agentCmdOverrides: {}
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await expect(
+      runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, { startupAgent: 'cursor' })
+    ).rejects.toThrow(/disabled/)
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('quotes local Windows bare agent command defaults for cmd.exe terminal creates', async () => {
     setPlatform('win32')
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12596,7 +12596,9 @@ describe('OrcaRuntimeService', () => {
         disabledTuiAgents: [],
         terminalWindowsShell: 'cmd.exe',
         agentCmdOverrides: {},
-        agentDefaultArgs: {},
+        // Why: pin the arg here rather than inherit the shared yolo default, so
+        // this test tracks Windows quoting and not an unrelated default's value.
+        agentDefaultArgs: { cursor: '--force' },
         agentDefaultEnv: {}
       })
     }
@@ -12613,7 +12615,7 @@ describe('OrcaRuntimeService', () => {
     const spawnCall = spawn.mock.calls[0]?.[0] as { command?: string } | undefined
     // Why: assert the cmd.exe double quoting too — a platform-insensitive prefix
     // match would pass on any OS and prove nothing about the reported platform.
-    expect(spawnCall?.command).toBe('cursor-agent "--yolo"')
+    expect(spawnCall?.command).toBe('cursor-agent "--force"')
   })
 
   // Why: claude-agent-teams is the only agent whose launcher name varies by

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12683,6 +12683,23 @@ describe('OrcaRuntimeService', () => {
     expect(spawnCall?.command).toBe("cursor-agent --beta '--force'")
   })
 
+  // Why: with no selector the launch is never resolved, so a dropped startupAgent
+  // would reach the renderer as a bare shell — the failure this option prevents.
+  it('rejects a startupAgent create with no workspace selector', async () => {
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: {}
+      })
+    })
+
+    await expect(
+      runtime.createTerminal(undefined, { startupAgent: 'cursor', rendererBacked: true })
+    ).rejects.toThrow(/requires a workspace selector/)
+  })
+
   // Why: folder workspaces have no repo, so command sniffing skipped them entirely
   // and spawned the bare string; an explicit agent must still resolve.
   it('resolves a startupAgent in a repo-less folder workspace', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12656,6 +12656,33 @@ describe('OrcaRuntimeService', () => {
     }
   )
 
+  // Why: a user who worked around this bug by pointing the override at their own
+  // cursor-agent path must keep that override once the id resolves properly.
+  it('honors an agentCmdOverrides entry for a startupAgent', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: { cursor: 'cursor-agent --beta' },
+        agentDefaultArgs: { cursor: '--force' },
+        agentDefaultEnv: {}
+      })
+    })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, { startupAgent: 'cursor' })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as { command?: string } | undefined
+    expect(spawnCall?.command).toBe("cursor-agent --beta '--force'")
+  })
+
   // Why: folder workspaces have no repo, so command sniffing skipped them entirely
   // and spawned the bare string; an explicit agent must still resolve.
   it('resolves a startupAgent in a repo-less folder workspace', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1273,6 +1273,10 @@ type TerminalCreateOptions = {
   resumeProviderSession?: AgentProviderSessionMetadata
   launchToken?: string
   launchAgent?: TuiAgent
+  // Why: agent ids are not shell commands (`cursor` is the Cursor desktop app; its
+  // CLI is `cursor-agent`). Callers that know the agent name it here instead of
+  // guessing a command, and the runtime builds the configured launch.
+  startupAgent?: TuiAgent
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   viewMode?: 'terminal' | 'chat'
   startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
@@ -23873,32 +23877,40 @@ export class OrcaRuntimeService {
     // Why: raw shell commands like `codex exec` must remain user-authored shell.
     // Only unmanaged, repo-backed, bare agent launches get Settings defaults.
     if (
-      !opts.command ||
       opts.env ||
       opts.launchConfig ||
       opts.launchAgent ||
       opts.startupCommandDelivery ||
       opts.claudeAgentTeamsSourceCommand ||
-      !workspace.repo ||
       !this.store
     ) {
+      return opts
+    }
+    // An explicit startupAgent is already the agent's identity, so it needs no
+    // command sniffing and works for repo-less folder workspaces too.
+    if (!opts.startupAgent && (!opts.command || !workspace.repo)) {
       return opts
     }
 
     const settings = this.store.getSettings()
     const platform = this.getAgentLaunchPlatformForWorkspace(workspace)
-    const isRemote = repoIsRemote(workspace.repo)
+    const isRemote = workspace.repo ? repoIsRemote(workspace.repo) : Boolean(workspace.connectionId)
     const queuedShell = resolveLocalWindowsAgentStartupShell({
       platform,
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell
     })
-    const agent = resolveBareAgentLaunchCommand({
-      command: opts.command,
-      settings,
-      platform,
-      isRemote
-    })
+    if (opts.startupAgent && !isTuiAgentEnabled(opts.startupAgent, settings.disabledTuiAgents)) {
+      throw new Error(`Agent ${opts.startupAgent} is disabled. Choose an enabled agent.`)
+    }
+    const agent =
+      opts.startupAgent ??
+      resolveBareAgentLaunchCommand({
+        command: opts.command,
+        settings,
+        platform,
+        isRemote
+      })
     if (!agent) {
       return opts
     }
@@ -23915,6 +23927,11 @@ export class OrcaRuntimeService {
       allowEmptyPromptLaunch: true
     })
     if (!startupPlan) {
+      // Why: an explicit agent that yields no plan would otherwise spawn a bare
+      // shell that never reaches agent readiness.
+      if (opts.startupAgent) {
+        throw new Error(`Could not build launch command for ${opts.startupAgent}.`)
+      }
       return opts
     }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23884,13 +23884,10 @@ export class OrcaRuntimeService {
       opts.claudeAgentTeamsSourceCommand
     const store = this.store
     if (opts.startupAgent) {
-      // Why: returning opts unresolved here would spawn a bare shell that can only
-      // time out waiting for an agent — the silent failure startupAgent exists to
-      // prevent. An explicit agent needs no command sniffing and no repo, so the
-      // only unresolvable cases are a contradictory caller or a dead runtime.
-      // `command` and `resumeProviderSession` count as contradictions too: the
-      // first would be silently overwritten, the second would pair resume identity
-      // with a freshly built launch.
+      // Why: falling through unresolved would spawn a bare shell that can only time
+      // out waiting for an agent. A caller-supplied launch contradicts the agent:
+      // `command` would be overwritten, `resumeProviderSession` would pair resume
+      // identity with a fresh launch.
       if (callerSuppliedLaunch || opts.command || opts.resumeProviderSession) {
         throw new Error(
           `startupAgent ${opts.startupAgent} cannot combine with a caller-supplied launch.`

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23876,23 +23876,34 @@ export class OrcaRuntimeService {
   ): Promise<TerminalCreateOptions> {
     // Why: raw shell commands like `codex exec` must remain user-authored shell.
     // Only unmanaged, repo-backed, bare agent launches get Settings defaults.
-    if (
+    const callerSuppliedLaunch =
       opts.env ||
       opts.launchConfig ||
       opts.launchAgent ||
       opts.startupCommandDelivery ||
-      opts.claudeAgentTeamsSourceCommand ||
-      !this.store
-    ) {
-      return opts
-    }
-    // An explicit startupAgent is already the agent's identity, so it needs no
-    // command sniffing and works for repo-less folder workspaces too.
-    if (!opts.startupAgent && (!opts.command || !workspace.repo)) {
+      opts.claudeAgentTeamsSourceCommand
+    const store = this.store
+    if (opts.startupAgent) {
+      // Why: returning opts unresolved here would spawn a bare shell that can only
+      // time out waiting for an agent — the silent failure startupAgent exists to
+      // prevent. An explicit agent needs no command sniffing and no repo, so the
+      // only unresolvable cases are a contradictory caller or a dead runtime.
+      // `command` and `resumeProviderSession` count as contradictions too: the
+      // first would be silently overwritten, the second would pair resume identity
+      // with a freshly built launch.
+      if (callerSuppliedLaunch || opts.command || opts.resumeProviderSession) {
+        throw new Error(
+          `startupAgent ${opts.startupAgent} cannot combine with a caller-supplied launch.`
+        )
+      }
+      if (!store) {
+        throw new Error('runtime_unavailable')
+      }
+    } else if (callerSuppliedLaunch || !store || !opts.command || !workspace.repo) {
       return opts
     }
 
-    const settings = this.store.getSettings()
+    const settings = store.getSettings()
     const platform = this.getAgentLaunchPlatformForWorkspace(workspace)
     const isRemote = workspace.repo ? repoIsRemote(workspace.repo) : Boolean(workspace.connectionId)
     const queuedShell = resolveLocalWindowsAgentStartupShell({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -24340,6 +24340,11 @@ export class OrcaRuntimeService {
     worktreeSelector?: string,
     opts: TerminalCreateOptions = {}
   ): Promise<RuntimeTerminalCreate> {
+    if (opts.startupAgent && worktreeSelector === undefined) {
+      // Why: the launch is resolved against a workspace, so with no selector
+      // startupAgent is silently dropped and the terminal is a bare shell.
+      throw new Error(`startupAgent ${opts.startupAgent} requires a workspace selector.`)
+    }
     const presentation = resolveTerminalPresentation(opts)
     const requiresRendererFocus = opts.presentation === 'focused' || opts.focus === true
     const availableAuthoritativeWindow = this.getAvailableAuthoritativeWindow()

--- a/src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+// Why: a federated worker terminal is created from an agent id. Passing that id
+// as a shell command launched Cursor's desktop app instead of `cursor-agent`
+// (issue #11926), so the remote path must resolve through the TUI agent config
+// exactly like the local one.
+describe('federated worker agent launch', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+    vi.restoreAllMocks()
+  })
+
+  it('creates the remote worker terminal from the agent id, never as a command', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
+      id: 'repo::remote-worktree'
+    } as never)
+    const createTerminal = vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term_remote_worker',
+      worktreeId: 'repo::remote-worktree',
+      title: 'worker'
+    })
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_remote_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.federationAttachStart'
+    )
+    if (!method) {
+      throw new Error('federationAttachStart method is not registered')
+    }
+
+    await method.handler(
+      method.params!.parse({
+        dispatchId: 'ctx_remote',
+        taskId: 'task_remote',
+        taskSpec: 'remote cursor worker',
+        protocolVersion: 1,
+        worktree: 'id:repo::remote-worktree',
+        agent: 'cursor'
+      }),
+      {
+        runtime,
+        orchestrationMutation: {
+          callerFingerprint: 'home_peer',
+          requestId: 'request_remote',
+          method: 'orchestration.federationAttachStart',
+          payloadHash: 'remote_payload'
+        }
+      }
+    )
+
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:repo::remote-worktree',
+      expect.objectContaining({ startupAgent: 'cursor' })
+    )
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:repo::remote-worktree',
+      expect.not.objectContaining({ command: expect.anything() })
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-agent-launch.test.ts
@@ -35,6 +35,18 @@ describe('federated worker agent launch', () => {
       status: 'running',
       exitCode: null
     })
+    // Why: without a stable pane the handler bails at agent_readiness, so the
+    // assertions below would pass against a worker that never actually started.
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_remote:leaf_remote')
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockReturnValue(
+      'runtime_test:term_remote_worker:1'
+    )
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_remote_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
     const method = ORCHESTRATION_METHODS.find(
       (candidate) => candidate.name === 'orchestration.federationAttachStart'
     )
@@ -42,7 +54,7 @@ describe('federated worker agent launch', () => {
       throw new Error('federationAttachStart method is not registered')
     }
 
-    await method.handler(
+    const result = (await method.handler(
       method.params!.parse({
         dispatchId: 'ctx_remote',
         taskId: 'task_remote',
@@ -60,8 +72,11 @@ describe('federated worker agent launch', () => {
           payloadHash: 'remote_payload'
         }
       }
-    )
+    )) as { state: string; failedStage?: string; lastError?: string }
 
+    // Why: assert the worker actually reached ready — a spy-only assertion would
+    // stay green even if every stage after terminal_create regressed.
+    expect(result).toMatchObject({ state: 'ready' })
     expect(createTerminal).toHaveBeenCalledWith(
       'id:repo::remote-worktree',
       expect.objectContaining({ startupAgent: 'cursor' })

--- a/src/main/runtime/rpc/methods/orchestration-federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.ts
@@ -191,7 +191,9 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
           } else {
             failedStage = 'terminal_create'
             const terminal = await runtime.createTerminal(`id:${worktree.id}`, {
-              command: agent,
+              // Why: agent ids are not shell commands (`cursor` is the desktop app,
+              // its CLI is `cursor-agent`); resolve through the TUI agent config.
+              startupAgent: agent as TuiAgent,
               title: `worker-${params.taskId}`,
               presentation: 'background'
             })

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -59,7 +59,10 @@ export async function createExistingWorktreeWorkerTerminal(args: {
   effects: WorkerEffect[]
 }): Promise<{ handle: string; warning?: string }> {
   const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
-    command: args.agent,
+    // Why: the agent id is not a shell command — `cursor` resolves to the Cursor
+    // desktop app while its CLI is `cursor-agent`. Let the runtime build the
+    // configured launcher instead of executing the raw id.
+    startupAgent: args.agent,
     title: `worker-${args.taskId}`,
     // Why: dispatching a worker is background work; it must not pull the sidebar
     // to the worker's workspace while the user is reading somewhere else.

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -2186,13 +2186,36 @@ describe('orchestration RPC methods', () => {
       // Why: dispatching a worker is background work — surfaceOwner:false adopts
       // the tab without scrolling the sidebar to the worker's workspace.
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
-        command: 'codex',
+        startupAgent: 'codex',
         title: `worker-${task.id}`,
         surfaceOwner: false
       })
       expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledWith(
         'term_worker',
         expect.stringContaining('--dispatch-capability dcap_')
+      )
+    })
+
+    // Why: `cursor` on PATH is the Cursor desktop app; passing the agent id as a
+    // shell command opened the IDE and left a blank shell (issue #11926).
+    it('never passes the agent id to the worker terminal as a shell command', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      const task = db.createTask({ spec: 'start a cursor worker' })
+
+      await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'cursor'
+      })
+
+      expect(runtime.createTerminal).toHaveBeenCalledWith(
+        'id:repo::worktree',
+        expect.objectContaining({ startupAgent: 'cursor' })
+      )
+      expect(runtime.createTerminal).toHaveBeenCalledWith(
+        'id:repo::worktree',
+        expect.not.objectContaining({ command: expect.anything() })
       )
     })
 
@@ -2289,7 +2312,7 @@ describe('orchestration RPC methods', () => {
         'id:repo::other',
         // Why: starting a worker in an existing worktree must not pull the sidebar
         // away from whatever the user is looking at.
-        expect.objectContaining({ command: 'codex', surfaceOwner: false })
+        expect.objectContaining({ startupAgent: 'codex', surfaceOwner: false })
       )
       expect(createWorktree).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
Fixes #11926

## Problem

On Windows, `orca orchestration worker-start --worktree current --agent cursor` opened the **Cursor desktop app** instead of the Cursor Agent CLI, left a blank PowerShell session, and failed at `agent_readiness` with `timeout`.

The worker terminal was created by passing the Orca **agent id** straight through as a shell command:

```ts
runtime.createTerminal(`id:${worktreeId}`, { command: args.agent, ... })
```

`createTerminal` tries to recover the agent from that string via `resolveBareAgentLaunchCommand`, but that matches against *launch commands*, not ids. `cursor`'s launch command is `cursor-agent`, so nothing matched, the string fell through as user-authored shell, and Windows PATH resolved `cursor` → `cursor.cmd` → the IDE.

It worked for `claude`/`codex`/`gemini` only because their id happens to equal their launch command. The same gap hit every agent where they differ: `cursor`→`cursor-agent`, `continue`→`cn`, `aug`→`auggie`, `kiro`→`kiro-cli chat --tui`, `qwen-code`→`qwen`, `mistral-vibe`→`vibe`, `antigravity`→`agy`, `trae`→`traecli`, `mimo-code`→`mimo`, `hermes`→`hermes --tui`, `command-code`→`command-code --trust`, `claude-agent-teams`→`orca claude-teams`.

## Fix

Added `TerminalCreateOptions.startupAgent` so a caller that already knows the agent names it outright instead of encoding it as a command string. `resolveAgentTerminalCreateOptions` then builds the launch from the TUI agent config — resolved command, `agentCmdOverrides`, default args/env, and preflight trust (`cursor` needs its `.workspace-trusted` marker or the first-launch menu swallows the dispatch preamble).

Both orchestration worker-start terminal creates use it: the local path (`orchestration-worker-topology.ts`) and the federated one (`orchestration-federation.ts`).

Two side benefits:
- **Folder workspaces** are covered. They have `repo: null`, so the old `!workspace.repo` guard skipped agent resolution entirely and spawned the bare string.
- An explicit agent that cannot resolve now **fails loudly** instead of silently spawning a plain shell that can only time out at `agent_readiness` — the exact symptom in the report. That covers a disabled agent, an unbuildable launch plan, a missing workspace selector, and a caller that contradicts itself by also supplying `env`/`launchConfig`/`launchAgent`/`startupCommandDelivery`/`claudeAgentTeamsSourceCommand`/`command`/`resumeProviderSession`.

New-worktree worker-start (`--worktree new-child` / `new-top-level`) was already correct; it goes through `createManagedWorktree({ startupAgent })`.

## Verification

Reproduced first — `createTerminal(path, { command: 'cursor' })` spawned the literal `cursor`.

**The non-`startupAgent` path is provably unchanged.** The guard was restructured, so I enumerated all 256 combinations of its eight inputs: zero divergences from the original. `isRemote` is likewise unchanged there, since `repo` is guaranteed truthy on that path.

**No regressions.** Full `src/main` is 167 failures on this branch and 167 on a clean baseline — identical. Those are pre-existing Windows path/symlink/fsync assumptions in untouched areas (`orca-runtime-files`, `ai-vault`, `node-markdown-document-discovery`), verified by stashing.

**Tests are not tautological** — verified by mutation, not assumption. Reverting the local call site fails 3 tests; neutering the resolver fails 3; reverting the federated call site fails its test. Each restored and re-confirmed.

New coverage:
- Agent id resolves to `cursor-agent` with configured args/env, `launchAgent`, and trust marked before spawn.
- Windows (`cmd.exe`) quoting, asserted exactly — confirmed platform-sensitive by flipping to `darwin`, which fails on quote style.
- Platform matrix over `claude-agent-teams`, the only agent with `launchCmdByPlatform` (`orca.cmd` / `orca-ide` / `orca claude-teams`).
- `agentCmdOverrides` honored, so anyone who set an override as a workaround keeps it.
- Repo-less folder workspace.
- All seven contradictory-caller combinations, plus disabled agent and missing selector.
- The federated call site, which had zero coverage; asserts the handler reaches `state: 'ready'`, not just the spy.

Checks: `tsc` clean (node/cli/web); oxlint code-quality native + type-aware clean; max-lines ratchet and reliability gates pass; PR CI green.

Not verified by hand: I don't have the Cursor Agent CLI installed, so the end-to-end desktop-vs-CLI launch is covered by spawn-level assertions rather than a live run.

## Out of scope

Two **pre-existing** issues surfaced during review and deliberately left alone, as neither is caused by this change:
1. `detectUnsupportedRuntimes` is never enforced, so `--agent claude-agent-teams` builds a launch on Windows despite win32 being marked unsupported. Shared with `worktree create --agent`.
2. `agent-catalog.tsx` shows `detectCmd` in the settings override placeholder, so editing from it drops required flags (`kiro-cli` vs `kiro-cli chat --tui`).
