### PR TITLE
fix(native-chat): discover WSL Claude transcripts

### DIFF
--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   isGuestAbsoluteLinuxPath,
   resolveHostReadableTranscriptPath,
+  wslClaudeProjectsDirs,
   wslCodexSessionsDirs
 } from './host-readable-transcript-path'
 
@@ -129,6 +130,32 @@ describe('wslCodexSessionsDirs', () => {
   it('does not add WSL roots outside Windows', () => {
     expect(
       wslCodexSessionsDirs({
+        platform: 'linux',
+        listDistros: () => ['Ubuntu'],
+        getDistroHome: () => '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+      })
+    ).toEqual([])
+  })
+})
+
+describe('wslClaudeProjectsDirs', () => {
+  it('lists the Claude projects root for every readable WSL home', () => {
+    const ubuntuHome = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+    const debianHome = '\\\\wsl.localhost\\Debian\\home\\grace'
+
+    expect(
+      wslClaudeProjectsDirs({
+        platform: 'win32',
+        listDistros: () => ['Ubuntu', 'Missing', 'Debian'],
+        getDistroHome: (distro) =>
+          distro === 'Ubuntu' ? ubuntuHome : distro === 'Debian' ? debianHome : null
+      })
+    ).toEqual([`${ubuntuHome}\\.claude\\projects`, `${debianHome}\\.claude\\projects`])
+  })
+
+  it('does not add WSL roots outside Windows', () => {
+    expect(
+      wslClaudeProjectsDirs({
         platform: 'linux',
         listDistros: () => ['Ubuntu'],
         getDistroHome: () => '\\\\wsl.localhost\\Ubuntu\\home\\ada'

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -67,6 +67,17 @@ describe('resolveHostReadableTranscriptPath', () => {
     ).toBe(unc)
   })
 
+  it('translates a mounted drive path without requiring distro discovery', () => {
+    const hostPath = 'C:\\Users\\ada\\.claude\\projects\\repo\\session.jsonl'
+    expect(
+      resolveHostReadableTranscriptPath('/mnt/c/Users/ada/.claude/projects/repo/session.jsonl', {
+        platform: 'win32',
+        pathExists: (candidate) => candidate === hostPath,
+        listDistros: () => []
+      })
+    ).toBe(hostPath)
+  })
+
   it('leaves an existing local transcript path unchanged', () => {
     const local = '/Users/ada/.claude/projects/repo/session.jsonl'
     expect(

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isGuestAbsoluteLinuxPath,
+  resolveHostReadableTranscriptPath,
+  wslCodexSessionsDirs
+} from './host-readable-transcript-path'
+
+describe('isGuestAbsoluteLinuxPath', () => {
+  it('accepts absolute POSIX guest paths', () => {
+    expect(isGuestAbsoluteLinuxPath('/home/ada/.codex/sessions/rollout.jsonl')).toBe(true)
+    expect(isGuestAbsoluteLinuxPath('/tmp/x.jsonl')).toBe(true)
+  })
+
+  it('rejects UNC, relative, and drive-letter forms', () => {
+    expect(isGuestAbsoluteLinuxPath('\\\\wsl.localhost\\Ubuntu\\home\\ada\\x.jsonl')).toBe(false)
+    expect(isGuestAbsoluteLinuxPath('//wsl.localhost/Ubuntu/home/ada/x.jsonl')).toBe(false)
+    expect(isGuestAbsoluteLinuxPath('relative/path.jsonl')).toBe(false)
+    expect(isGuestAbsoluteLinuxPath('C:\\Users\\ada\\x.jsonl')).toBe(false)
+    expect(isGuestAbsoluteLinuxPath('/C:/Users/ada/x.jsonl')).toBe(false)
+  })
+})
+
+describe('resolveHostReadableTranscriptPath', () => {
+  it('returns a pre-existing Windows host path unchanged', () => {
+    const hostPath = 'C:\\Users\\ada\\session.jsonl'
+    expect(
+      resolveHostReadableTranscriptPath(hostPath, {
+        platform: 'win32',
+        pathExists: (candidate) => candidate === hostPath,
+        listDistros: () => ['Ubuntu']
+      })
+    ).toBe(hostPath)
+  })
+
+  it('does not accept a colliding local drive path for a guest transcript', () => {
+    const linux = '/exists'
+    const unc = '\\\\wsl.localhost\\Ubuntu\\exists'
+    const seen: string[] = []
+    expect(
+      resolveHostReadableTranscriptPath(linux, {
+        platform: 'win32',
+        pathExists: (candidate) => {
+          seen.push(candidate)
+          return candidate === linux || candidate === unc
+        },
+        listDistros: () => ['Ubuntu'],
+        getDistroHome: () => '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+      })
+    ).toBe(unc)
+    expect(seen).not.toContain(linux)
+  })
+
+  it('translates a Claude guest path to a readable WSL UNC path', () => {
+    const linux = '/home/ada/.claude/projects/-home-ada-repo/session.jsonl'
+    const unc =
+      '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.claude\\projects\\-home-ada-repo\\session.jsonl'
+
+    expect(
+      resolveHostReadableTranscriptPath(linux, {
+        platform: 'win32',
+        pathExists: (candidate) => candidate === unc,
+        listDistros: () => ['Ubuntu'],
+        getDistroHome: () => '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+      })
+    ).toBe(unc)
+  })
+
+  it('leaves an existing local transcript path unchanged', () => {
+    const local = '/Users/ada/.claude/projects/repo/session.jsonl'
+    expect(
+      resolveHostReadableTranscriptPath(local, {
+        platform: 'darwin',
+        pathExists: (candidate) => candidate === local,
+        listDistros: () => ['Ubuntu']
+      })
+    ).toBe(local)
+  })
+
+  it('prefers the distro whose home owns the guest path', () => {
+    const linux = '/home/ada/.claude/projects/repo/session.jsonl'
+    const ubuntuUnc = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.claude\\projects\\repo\\session.jsonl'
+    const debianUnc = '\\\\wsl.localhost\\Debian\\home\\ada\\.claude\\projects\\repo\\session.jsonl'
+    const seen: string[] = []
+    expect(
+      resolveHostReadableTranscriptPath(linux, {
+        platform: 'win32',
+        pathExists: (candidate) => {
+          seen.push(candidate)
+          return candidate === ubuntuUnc || candidate === debianUnc
+        },
+        listDistros: () => ['Debian', 'Ubuntu'],
+        getDistroHome: (distro) =>
+          distro === 'Ubuntu'
+            ? '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+            : '\\\\wsl.localhost\\Debian\\home\\other'
+      })
+    ).toBe(ubuntuUnc)
+    expect(seen).toEqual([ubuntuUnc])
+  })
+
+  it('returns null when no distro maps to an existing path', () => {
+    expect(
+      resolveHostReadableTranscriptPath('/home/ada/missing.jsonl', {
+        platform: 'win32',
+        pathExists: () => false,
+        listDistros: () => ['Ubuntu'],
+        getDistroHome: () => '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('wslCodexSessionsDirs', () => {
+  it('lists managed and system Codex roots for each readable WSL home', () => {
+    const home = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+    expect(
+      wslCodexSessionsDirs({
+        platform: 'win32',
+        listDistros: () => ['Ubuntu'],
+        getDistroHome: () => home
+      })
+    ).toEqual([
+      `${home}\\.local\\share\\orca\\codex-runtime-home\\home\\sessions`,
+      `${home}\\.codex\\sessions`
+    ])
+  })
+
+  it('does not add WSL roots outside Windows', () => {
+    expect(
+      wslCodexSessionsDirs({
+        platform: 'linux',
+        listDistros: () => ['Ubuntu'],
+        getDistroHome: () => '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+      })
+    ).toEqual([])
+  })
+})

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -111,6 +111,26 @@ describe('resolveHostReadableTranscriptPath', () => {
     expect(seen).toEqual([ubuntuUnc])
   })
 
+  it('does not prefer a distro whose reported home is the filesystem root', () => {
+    const linux = '/home/ada/.claude/projects/repo/session.jsonl'
+    const rootUnc = '\\\\wsl.localhost\\Root\\home\\ada\\.claude\\projects\\repo\\session.jsonl'
+    const ubuntuUnc = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.claude\\projects\\repo\\session.jsonl'
+    const seen: string[] = []
+    expect(
+      resolveHostReadableTranscriptPath(linux, {
+        platform: 'win32',
+        pathExists: (candidate) => {
+          seen.push(candidate)
+          return candidate === rootUnc || candidate === ubuntuUnc
+        },
+        listDistros: () => ['Root', 'Ubuntu'],
+        getDistroHome: (distro) =>
+          distro === 'Root' ? '\\\\wsl.localhost\\Root\\' : '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+      })
+    ).toBe(ubuntuUnc)
+    expect(seen).toEqual([ubuntuUnc])
+  })
+
   it('returns null when no distro maps to an existing path', () => {
     expect(
       resolveHostReadableTranscriptPath('/home/ada/missing.jsonl', {

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -44,6 +44,12 @@ export function resolveHostReadableTranscriptPath(
     return null
   }
 
+  // Why: drvfs paths map directly to a Windows drive even when WSL distro discovery is stale.
+  if (/^\/mnt\/[a-z](?:\/|$)/.test(path)) {
+    const hostPath = toWindowsWslPath(path, '')
+    return pathExists(hostPath) ? hostPath : null
+  }
+
   const listDistros = deps.listDistros ?? listWslDistros
   const getDistroHome = deps.getDistroHome ?? getWslHome
   const distros = listDistros()

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs'
-import { isAbsolute } from 'node:path'
 import { toWindowsWslPath } from '../../shared/wsl-paths'
 import { getWslHome, listWslDistros } from '../wsl'
 
@@ -11,7 +10,7 @@ export function isGuestAbsoluteLinuxPath(path: string): boolean {
   if (/^\/[A-Za-z]:(\/|$)/.test(path)) {
     return false
   }
-  return isAbsolute(path)
+  return true
 }
 
 export type HostReadableTranscriptPathDeps = {
@@ -83,7 +82,11 @@ function rankDistrosForLinuxPath(
       continue
     }
     const homeLinux = homeUnc.replace(/\\/g, '/').replace(/^\/\/(wsl\.localhost|wsl\$)\/[^/]+/i, '')
-    if (homeLinux && (linuxPath === homeLinux || linuxPath.startsWith(`${homeLinux}/`))) {
+    if (
+      homeLinux &&
+      homeLinux !== '/' &&
+      (linuxPath === homeLinux || linuxPath.startsWith(`${homeLinux}/`))
+    ) {
       preferred.push(distro)
     } else {
       others.push(distro)

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -1,0 +1,118 @@
+import { existsSync } from 'node:fs'
+import { isAbsolute } from 'node:path'
+import { toWindowsWslPath } from '../../shared/wsl-paths'
+import { getWslHome, listWslDistros } from '../wsl'
+
+/** True for guest-absolute Linux paths that Win32 cannot open as-is. */
+export function isGuestAbsoluteLinuxPath(path: string): boolean {
+  if (!path.startsWith('/') || path.startsWith('//')) {
+    return false
+  }
+  if (/^\/[A-Za-z]:(\/|$)/.test(path)) {
+    return false
+  }
+  return isAbsolute(path)
+}
+
+export type HostReadableTranscriptPathDeps = {
+  platform?: NodeJS.Platform
+  pathExists?: (path: string) => boolean
+  listDistros?: () => string[]
+  getDistroHome?: (distro: string) => string | null
+}
+
+/**
+ * Map a hook-reported transcript path to a path the local main process can open.
+ * WSL hooks report guest Linux paths, which Windows must open through the owning distro.
+ */
+export function resolveHostReadableTranscriptPath(
+  transcriptPath: string,
+  deps: HostReadableTranscriptPathDeps = {}
+): string | null {
+  const path = transcriptPath.trim()
+  if (!path) {
+    return null
+  }
+  const pathExists = deps.pathExists ?? existsSync
+  const platform = deps.platform ?? process.platform
+  // Why: Node can resolve `/path` against the current Windows drive before WSL translation.
+  const isWindowsGuestLinuxPath = platform === 'win32' && isGuestAbsoluteLinuxPath(path)
+  if (!isWindowsGuestLinuxPath && pathExists(path)) {
+    return path
+  }
+  if (!isWindowsGuestLinuxPath) {
+    return null
+  }
+
+  const listDistros = deps.listDistros ?? listWslDistros
+  const getDistroHome = deps.getDistroHome ?? getWslHome
+  const distros = listDistros()
+  if (distros.length === 0) {
+    return null
+  }
+
+  for (const distro of rankDistrosForLinuxPath(distros, path, getDistroHome)) {
+    const uncPath = toWindowsWslPath(path, distro)
+    if (pathExists(uncPath)) {
+      return uncPath
+    }
+  }
+  return null
+}
+
+function rankDistrosForLinuxPath(
+  distros: readonly string[],
+  linuxPath: string,
+  getDistroHome: (distro: string) => string | null
+): string[] {
+  if (distros.length <= 1) {
+    return [...distros]
+  }
+  const preferred: string[] = []
+  const others: string[] = []
+  for (const distro of distros) {
+    const homeUnc = getDistroHome(distro)
+    if (!homeUnc) {
+      others.push(distro)
+      continue
+    }
+    const homeLinux = homeUnc.replace(/\\/g, '/').replace(/^\/\/(wsl\.localhost|wsl\$)\/[^/]+/i, '')
+    if (homeLinux && (linuxPath === homeLinux || linuxPath.startsWith(`${homeLinux}/`))) {
+      preferred.push(distro)
+    } else {
+      others.push(distro)
+    }
+  }
+  return preferred.length > 0 ? [...preferred, ...others] : [...distros]
+}
+
+/** WSL Codex roots used when the exact hook path is absent. */
+export function wslCodexSessionsDirs(
+  deps: Pick<HostReadableTranscriptPathDeps, 'platform' | 'listDistros' | 'getDistroHome'> = {}
+): string[] {
+  const platform = deps.platform ?? process.platform
+  if (platform !== 'win32') {
+    return []
+  }
+  const listDistros = deps.listDistros ?? listWslDistros
+  const getDistroHome = deps.getDistroHome ?? getWslHome
+  const dirs: string[] = []
+  for (const distro of listDistros()) {
+    const home = getDistroHome(distro)
+    if (!home) {
+      continue
+    }
+    dirs.push(
+      joinWindowsUnc(home, '.local', 'share', 'orca', 'codex-runtime-home', 'home', 'sessions')
+    )
+    dirs.push(joinWindowsUnc(home, '.codex', 'sessions'))
+  }
+  return dirs
+}
+
+// Why: node:path.join can collapse a WSL UNC share prefix on some Node builds.
+function joinWindowsUnc(root: string, ...segments: string[]): string {
+  const base = root.replace(/[\\/]+$/, '')
+  const rest = segments.join('\\').replace(/^[\\/]+/, '')
+  return `${base}\\${rest}`
+}

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -86,6 +86,26 @@ function rankDistrosForLinuxPath(
   return preferred.length > 0 ? [...preferred, ...others] : [...distros]
 }
 
+/** WSL Claude roots used when the exact hook path is absent. */
+export function wslClaudeProjectsDirs(
+  deps: Pick<HostReadableTranscriptPathDeps, 'platform' | 'listDistros' | 'getDistroHome'> = {}
+): string[] {
+  const platform = deps.platform ?? process.platform
+  if (platform !== 'win32') {
+    return []
+  }
+  const listDistros = deps.listDistros ?? listWslDistros
+  const getDistroHome = deps.getDistroHome ?? getWslHome
+  const dirs: string[] = []
+  for (const distro of listDistros()) {
+    const home = getDistroHome(distro)
+    if (home) {
+      dirs.push(joinWindowsUnc(home, '.claude', 'projects'))
+    }
+  }
+  return dirs
+}
+
 /** WSL Codex roots used when the exact hook path is absent. */
 export function wslCodexSessionsDirs(
   deps: Pick<HostReadableTranscriptPathDeps, 'platform' | 'listDistros' | 'getDistroHome'> = {}

--- a/src/main/native-chat/session-file-resolver.test.ts
+++ b/src/main/native-chat/session-file-resolver.test.ts
@@ -214,6 +214,32 @@ describe('resolveSessionFilePath', () => {
     expect(resolved).toBe(realFile)
   })
 
+  it('resolves a Codex rollout under an injected WSL managed sessions root', async () => {
+    const root = await makeRoot('orca-native-chat-resolve-wsl-codex-')
+    const wslSessionsDir = join(
+      root,
+      'wsl',
+      'Ubuntu',
+      'home',
+      'ada',
+      '.local',
+      'share',
+      'orca',
+      'codex-runtime-home',
+      'home',
+      'sessions'
+    )
+    const dayDir = join(wslSessionsDir, '2026', '07', '24')
+    await mkdir(dayDir, { recursive: true })
+    const target = join(dayDir, 'rollout-2026-07-24T12-00-00-wsl-sess.jsonl')
+    await writeFile(target, '{}\n')
+
+    const resolved = await resolveSessionFilePath('codex', 'wsl-sess', {
+      codexSessionsDirs: [join(root, 'empty-managed'), wslSessionsDir]
+    })
+    expect(resolved).toBe(target)
+  })
+
   it('falls back to the id glob when the hook transcriptPath does not exist', async () => {
     const root = await makeRoot('orca-native-chat-resolve-path-stale-')
     const claudeProjectsDir = join(root, 'claude-projects')

--- a/src/main/native-chat/session-file-resolver.test.ts
+++ b/src/main/native-chat/session-file-resolver.test.ts
@@ -52,6 +52,23 @@ describe('resolveSessionFilePath', () => {
     ).resolves.toBe(target)
   })
 
+  it('searches an injected WSL Claude projects root after the local root', async () => {
+    const root = await makeRoot('orca-native-chat-resolve-wsl-claude-')
+    const localProjectsDir = join(root, 'local-claude-projects')
+    const wslProjectsDir = join(root, 'wsl', 'Ubuntu', 'home', 'ada', '.claude', 'projects')
+    const projectDir = join(wslProjectsDir, '-home-ada-repo')
+    await mkdir(localProjectsDir, { recursive: true })
+    await mkdir(projectDir, { recursive: true })
+    const target = join(projectDir, 'wsl-claude-session.jsonl')
+    await writeFile(target, '{}\n')
+
+    await expect(
+      resolveSessionFilePath('claude', 'wsl-claude-session', {
+        claudeProjectsDirs: [localProjectsDir, wslProjectsDir]
+      })
+    ).resolves.toBe(target)
+  })
+
   it('resolves Grok chat_history.jsonl under encodeURIComponent(cwd)/sessionId', async () => {
     const root = await makeRoot('orca-native-chat-resolve-grok-')
     const grokSessionsDir = join(root, 'grok-sessions')

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/grok-session-paths'
 import {
   resolveHostReadableTranscriptPath,
+  wslClaudeProjectsDirs,
   wslCodexSessionsDirs
 } from './host-readable-transcript-path'
 
@@ -19,8 +20,9 @@ import {
 // the remote main resolves its local home, so we never hardcode an absolute
 // user path — homedir()/CODEX_HOME resolution stays runtime-relative and is
 // computed per call (not at module load) so it tracks the live home.
-function claudeProjectsDir(): string {
-  return join(homedir(), '.claude', 'projects')
+function claudeProjectsDirs(): string[] {
+  const candidates = [join(homedir(), '.claude', 'projects'), ...wslClaudeProjectsDirs()]
+  return candidates.filter((dir, index) => candidates.indexOf(dir) === index)
 }
 
 // Why: Orca launches Codex with ORCA_CODEX_HOME pointing at its own managed
@@ -45,6 +47,8 @@ function grokSessionsDir(): string {
 export type ResolveSessionFileOptions = {
   /** Override the Claude projects root (used by tests / isolated scans). */
   claudeProjectsDir?: string
+  /** Override the ordered Claude projects roots (used by tests / isolated scans). */
+  claudeProjectsDirs?: string[]
   /** Override the Codex sessions roots, searched in order (tests / isolated
    *  scans). Defaults to the orca-managed home then CODEX_HOME/~/.codex. */
   codexSessionsDirs?: string[]
@@ -94,7 +98,10 @@ export async function resolveSessionFilePath(
   }
 
   if (transcriptAgent === 'claude') {
-    return resolveClaudeSessionFile(trimmedId, options.claudeProjectsDir ?? claudeProjectsDir())
+    const projectsDirs =
+      options.claudeProjectsDirs ??
+      (options.claudeProjectsDir ? [options.claudeProjectsDir] : claudeProjectsDirs())
+    return resolveClaudeSessionFile(trimmedId, projectsDirs)
   }
   if (transcriptAgent === 'codex') {
     return resolveCodexSessionFile(trimmedId, options.codexSessionsDirs ?? codexSessionsDirs())
@@ -107,14 +114,22 @@ export async function resolveSessionFilePath(
 
 async function resolveClaudeSessionFile(
   sessionId: string,
-  projectsDir: string
+  projectsDirs: string[]
 ): Promise<string | null> {
   const targetName = `${sessionId}.jsonl`
-  const files = await walkSessionFiles(projectsDir, 'claude', [], {
-    extensions: new Set(['.jsonl']),
-    filePredicate: (path) => basename(path) === targetName
-  })
-  return files[0] ?? null
+  for (const projectsDir of projectsDirs) {
+    if (!existsSync(projectsDir)) {
+      continue
+    }
+    const files = await walkSessionFiles(projectsDir, 'claude', [], {
+      extensions: new Set(['.jsonl']),
+      filePredicate: (path) => basename(path) === targetName
+    })
+    if (files[0]) {
+      return files[0]
+    }
+  }
+  return null
 }
 
 async function resolveCodexSessionFile(

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -9,6 +9,10 @@ import {
   findGrokChatHistoryBySessionId,
   resolveGrokSessionsDir
 } from '../../shared/grok-session-paths'
+import {
+  resolveHostReadableTranscriptPath,
+  wslCodexSessionsDirs
+} from './host-readable-transcript-path'
 
 // Why: these mirror the path constants in ai-vault/session-scanner.ts. Reads
 // run in the main process against the runtime's own home directory; over SSH
@@ -28,7 +32,8 @@ function claudeProjectsDir(): string {
 function codexSessionsDirs(): string[] {
   const candidates = [
     join(getOrcaManagedCodexHomePath(), 'sessions'),
-    join(process.env.CODEX_HOME?.trim() || join(homedir(), '.codex'), 'sessions')
+    join(process.env.CODEX_HOME?.trim() || join(homedir(), '.codex'), 'sessions'),
+    ...wslCodexSessionsDirs()
   ]
   return candidates.filter((dir, index) => candidates.indexOf(dir) === index)
 }
@@ -72,12 +77,15 @@ export async function resolveSessionFilePath(
     return null
   }
   // Why: the hook's transcript_path is the exact file the agent is writing, so it
-  // beats reconstructing a path from the session id. Guard with existsSync so a
-  // stale/remote path falls through to the id-based search rather than returning
-  // a non-existent file.
+  // beats reconstructing a path from the session id. Resolve through the host
+  // readability helper so a WSL Linux path becomes a readable UNC on Windows;
+  // missing/stale paths fall through to the id-based search.
   const hookPath = options.transcriptPath?.trim()
-  if (hookPath && extname(hookPath) === '.jsonl' && existsSync(hookPath)) {
-    return hookPath
+  if (hookPath && extname(hookPath) === '.jsonl') {
+    const hostReadable = resolveHostReadableTranscriptPath(hookPath)
+    if (hostReadable) {
+      return hostReadable
+    }
   }
 
   const trimmedId = sessionId.trim()

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -1,5 +1,6 @@
 import { extname } from 'node:path'
 import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { resolveHostReadableTranscriptPath } from './host-readable-transcript-path'
 import { resolveSessionFilePath } from './session-file-resolver'
 import { installTranscriptWatcher } from './transcript-watch-engine'
 import type {
@@ -39,7 +40,10 @@ const FALLBACK_RESOLVE_POLL_MS = 5_000
 
 function exactTranscriptPath(args: SubscribeNativeChatTranscriptArgs): string | null {
   const path = args.transcriptPath?.trim()
-  return path && extname(path) === '.jsonl' ? path : null
+  if (!path || extname(path) !== '.jsonl') {
+    return null
+  }
+  return resolveHostReadableTranscriptPath(path)
 }
 
 /**

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -1,6 +1,9 @@
 import { extname } from 'node:path'
 import type { NativeChatMessage } from '../../shared/native-chat-types'
-import { resolveHostReadableTranscriptPath } from './host-readable-transcript-path'
+import {
+  isGuestAbsoluteLinuxPath,
+  resolveHostReadableTranscriptPath
+} from './host-readable-transcript-path'
 import { resolveSessionFilePath } from './session-file-resolver'
 import { installTranscriptWatcher } from './transcript-watch-engine'
 import type {
@@ -38,12 +41,18 @@ const INITIAL_RESOLVE_POLL_MS = 500
 const MAX_RESOLVE_POLL_MS = 5_000
 const FALLBACK_RESOLVE_POLL_MS = 5_000
 
-function exactTranscriptPath(args: SubscribeNativeChatTranscriptArgs): string | null {
+function reportedTranscriptPath(args: SubscribeNativeChatTranscriptArgs): string | null {
   const path = args.transcriptPath?.trim()
-  if (!path || extname(path) !== '.jsonl') {
-    return null
+  return path && extname(path) === '.jsonl' ? path : null
+}
+
+function exactTranscriptPath(path: string): string | null {
+  const hostReadable = resolveHostReadableTranscriptPath(path)
+  if (hostReadable) {
+    return hostReadable
   }
-  return resolveHostReadableTranscriptPath(path)
+  // Why: a missing WSL guest path must be retranslated, not probed as a drive-local path.
+  return process.platform === 'win32' && isGuestAbsoluteLinuxPath(path) ? null : path
 }
 
 /**
@@ -63,13 +72,13 @@ function subscribeViaResolvePoll(
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let delay = args.resolvePollIntervalMs ?? INITIAL_RESOLVE_POLL_MS
   let lastFallbackResolveAt = Date.now()
-  const exactPath = exactTranscriptPath(args)
+  const reportedPath = reportedTranscriptPath(args)
 
   function scheduleAttempt(): void {
     if (closed) {
       return
     }
-    const untilFallbackResolve = exactPath
+    const untilFallbackResolve = reportedPath
       ? Math.max(0, FALLBACK_RESOLVE_POLL_MS - (Date.now() - lastFallbackResolveAt))
       : delay
     pollTimer = setTimeout(
@@ -95,10 +104,11 @@ function subscribeViaResolvePoll(
     }
     let result: NativeChatTranscriptSubscription | null
     try {
+      const exactPath = reportedPath ? exactTranscriptPath(reportedPath) : null
       result = exactPath ? await attemptInstall({ ...args, filePath: exactPath }, decode) : null
       if (
         !result &&
-        (!exactPath || Date.now() - lastFallbackResolveAt >= FALLBACK_RESOLVE_POLL_MS)
+        (!reportedPath || Date.now() - lastFallbackResolveAt >= FALLBACK_RESOLVE_POLL_MS)
       ) {
         lastFallbackResolveAt = Date.now()
         result = await attemptInstall(args, decode)


### PR DESCRIPTION
## Summary

Resolve WSL-backed Claude Code transcripts in Native Chat instead of leaving desktop and mobile clients on `Transcript unavailable`.

The main process now translates hook-reported Linux transcript paths to host-readable WSL UNC paths and searches each installed distro's `~/.claude/projects` root when the exact path is absent. Exact-path polling keeps its existing fast retry contract while re-evaluating WSL translation as a new transcript appears.

## Focused fix

- In scope: WSL transcript path translation, Claude project-root discovery, and exact-path polling compatibility.
- Out of scope: renderer agent/tab rehydration behavior and unrelated Native Chat UI changes.
- Dependency: #10639 contains the shared Codex path-resolution layer. This branch keeps that dependency locally testable; after #10639 merges, it will be rebased so the remaining diff is the Claude follow-up and polling compatibility.

## Preserves

- Existing macOS, Linux, local Windows, SSH, and non-WSL transcript paths remain unchanged.
- Missing WSL guest paths are never probed as drive-local Windows paths.
- Session-tree fallback remains throttled while exact transcript paths continue fast polling.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full suite not run; targeted Native Chat suite passed 127/127.
- [ ] `pnpm build` — no packaging or UI change.
- [x] Added regression coverage for WSL Claude roots, non-Windows exclusion, multi-root resolution, and exact-path polling.

Additional evidence:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat` — 127 passed.
- Changed-file type-aware oxlint with `--deny-warnings` — passed.
- Before fix: the new WSL Claude root test returned `null`, and the host-readable path module was absent on `upstream/main`.

## AI Review Report

Reviewed the change for focused scope, fallback ordering, polling behavior, and path ownership. The review caught that translating only once removed the existing exact-path fast-probe contract; the polling path was changed to re-resolve the WSL mapping on each retry while keeping recursive discovery throttled.

Cross-platform review covered macOS/Linux pass-through, Windows drive and UNC handling, WSL guest paths, SSH runtime-local home resolution, and Electron main-process filesystem behavior. No shortcut, label, shell-command, or renderer behavior changes are included.

## Security Audit

- Transcript candidates remain limited to `.jsonl` paths and existing files.
- WSL paths are derived only from installed distro names and their resolved home directories.
- Guest Linux paths on Windows skip the raw local-drive probe, preventing a colliding `C:\\...` path from winning.
- No new command execution, IPC surface, dependencies, credentials, or secret handling were added.

## User-regression-tradeoffs

- Windows may inspect cached WSL distro homes during transcript resolution; non-Windows and SSH hosts do not add WSL roots.
- Manual Windows 11 + WSL2 validation is still requested because this development environment is macOS; the issue reporters have offered to test a fix build.

## Notes

This is intentionally opened while #10639 is still under review so the Claude-specific follow-up can be reviewed and tracked under #11327. The shared dependency will be removed by rebase after #10639 lands.

Fixes #11327
