### PR TITLE
fix(native-chat): stop clipping assistant text blocks at the tool-preview cap

### DIFF
--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -83,6 +83,10 @@ function makeMessage(text: string): NativeChatMessage {
   }
 }
 
+function makeTextMessage(text: string): NativeChatMessage {
+  return { ...makeMessage(''), blocks: [{ type: 'text', text }] }
+}
+
 function readSessionHandler(): (params: unknown, ctx: RpcContext) => Promise<unknown> {
   const method = NATIVE_CHAT_METHODS.find((m) => m.name === 'nativeChat.readSession')
   if (!method) {
@@ -146,6 +150,35 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     const output = firstOutput(result)
     expect(output.length).toBeLessThan(OVERSIZED.length)
     expect(output).toContain('truncated')
+  })
+
+  // STA-3230: a paired desktop or mobile client saw long assistant replies cut
+  // at the tool-preview cap with `… (truncated)` and no way to read the rest.
+  it('passes a long assistant text block through unclipped for mobile clients', async () => {
+    const text = 'prose '.repeat(1000)
+    cachedResult.value = { messages: [makeTextMessage(text)] }
+    const result = await readSessionHandler()(
+      { agent: 'claude', sessionId: 's' },
+      ctxWith('mobile')
+    )
+    const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0] as {
+      text: string
+    }
+    expect(block.text).toBe(text)
+  })
+
+  it('clips a pathological text block at the safety ceiling for mobile clients', async () => {
+    const text = 'y'.repeat(70_000)
+    cachedResult.value = { messages: [makeTextMessage(text)] }
+    const result = await readSessionHandler()(
+      { agent: 'claude', sessionId: 's' },
+      ctxWith('mobile')
+    )
+    const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0] as {
+      text: string
+    }
+    expect(block.text.length).toBeLessThan(text.length)
+    expect(block.text).toContain('truncated')
   })
 
   it('bounds raw tool-call inputs before sending them to mobile', async () => {

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -148,8 +148,7 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
       ctxWith('mobile')
     )
     const output = firstOutput(result)
-    expect(output.length).toBeLessThan(OVERSIZED.length)
-    expect(output).toContain('truncated')
+    expect(output).toBe(`${OVERSIZED.slice(0, 4000)}\n… (truncated)`)
   })
 
   // STA-3230: a paired desktop or mobile client saw long assistant replies cut
@@ -177,8 +176,7 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     const block = (result as { messages: NativeChatMessage[] }).messages[0].blocks[0] as {
       text: string
     }
-    expect(block.text.length).toBeLessThan(text.length)
-    expect(block.text).toContain('truncated')
+    expect(block.text).toBe(`${text.slice(0, 64_000)}\n… (truncated)`)
   })
 
   it('bounds raw tool-call inputs before sending them to mobile', async () => {
@@ -357,6 +355,33 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
 })
 
 describe('nativeChat.subscribe initial snapshot', () => {
+  it('preserves long assistant text across mobile stream frame types', async () => {
+    watcher.watching = true
+    watcher.args = null
+    const emitted: unknown[] = []
+    const text = 'prose '.repeat(1000)
+    const message = makeTextMessage(text)
+    await subscribeHandler()(
+      { agent: 'claude', sessionId: 's' },
+      streamingContext('mobile'),
+      (value) => emitted.push(value)
+    )
+
+    const callbacks = activeWatcherArgs()
+    callbacks.onInitialSnapshot?.([message], false, 123)
+    callbacks.onReplace?.([message], false, 123)
+    callbacks.onAppend([message])
+
+    expect(emitted.map((frame) => (frame as { type: string }).type)).toEqual([
+      'snapshot',
+      'replacement',
+      'appended'
+    ])
+    for (const frame of emitted as { messages: NativeChatMessage[] }[]) {
+      expect(frame.messages[0].blocks[0]).toEqual({ type: 'text', text })
+    }
+  })
+
   it('emits one windowed snapshot with pagination state before live appends', async () => {
     watcher.watching = true
     watcher.args = null

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -62,26 +62,32 @@ const NativeChatUnsubscribe = z.object({
 const MOBILE_NATIVE_CHAT_DEFAULT_WINDOW = 40
 const MOBILE_NATIVE_CHAT_MAX_WINDOW = 2000
 // Why: a single tool result (a big file read, a long diff) can be hundreds of KB.
-// The mobile view only previews block bodies, so truncate them on the wire to
-// keep the payload small; the marker tells the user content was clipped.
+// The mobile view only previews tool block bodies, so truncate them on the wire
+// to keep the payload small; the marker tells the user content was clipped.
 const MOBILE_BLOCK_CHAR_CAP = 4000
+// Why: text blocks are the message body itself, rendered in full by the chat
+// view — a preview-sized cap cut long assistant replies mid-sentence with no way
+// to read on (STA-3230). Keep only a generous safety ceiling: a transcript
+// record can legally reach 2MB, and shipping that much markdown in one block
+// would freeze the phone.
+const MOBILE_TEXT_BLOCK_CHAR_CAP = 64_000
 const MOBILE_TOOL_INPUT_ITEMS_CAP = 20
 const MOBILE_TOOL_INPUT_NODE_CAP = 100
 const TRUNCATION_MARKER = '\n… (truncated)'
 
-function clip(text: string): string {
-  return text.length > MOBILE_BLOCK_CHAR_CAP
-    ? text.slice(0, MOBILE_BLOCK_CHAR_CAP) + TRUNCATION_MARKER
-    : text
+function clip(text: string, cap: number): string {
+  return text.length > cap ? text.slice(0, cap) + TRUNCATION_MARKER : text
 }
 
 function clipBlock(block: NativeChatBlock): NativeChatBlock {
   if (block.type === 'text') {
-    return block.text.length > MOBILE_BLOCK_CHAR_CAP ? { ...block, text: clip(block.text) } : block
+    return block.text.length > MOBILE_TEXT_BLOCK_CHAR_CAP
+      ? { ...block, text: clip(block.text, MOBILE_TEXT_BLOCK_CHAR_CAP) }
+      : block
   }
   if (block.type === 'tool-result') {
     return block.output.length > MOBILE_BLOCK_CHAR_CAP
-      ? { ...block, output: clip(block.output) }
+      ? { ...block, output: clip(block.output, MOBILE_BLOCK_CHAR_CAP) }
       : block
   }
   if (block.type === 'tool-call') {


### PR DESCRIPTION
## Summary

Long assistant messages viewed over a paired connection (headless `orca serve` viewed from a paired desktop client or the mobile app) were cut short with a `… (truncated)` marker and no way to read the rest (STA-3230, GitHub #12138). The mobile payload diet in the `nativeChat.readSession`/`nativeChat.subscribe` runtime RPC applied the 4,000-char tool-preview cap to `text` blocks — the fully rendered message body — for any connection whose paired device token has scope `mobile` (which includes desktops that redeem a `--serve-mobile-pairing` offer, so both clients truncated identically). The reporter's "exactly 60 chars of the code block" was `4000 − prose length`; the collapsed newline was the broken markdown left by a mid-code-block cut.

Fix at the source, shared by both clients: `text` blocks now get their own generous 64k-char safety ceiling (real replies pass through whole), while tool-result/tool-call bodies keep the 4,000-char preview diet that the cap was designed for. No renderer changes needed on desktop or mobile.

## Screenshots

No visual change (transport fix; the chat views simply receive the full message text they already render).

## Testing

- [x] `pnpm lint` (oxlint clean on the repo sweep)
- [x] `pnpm typecheck`
- [x] `pnpm test` (targeted: `vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/native-chat.test.ts` — 18/18, including 2 new regression tests)
- [x] `pnpm build` (`build:electron-vite` + `build:cli`, used for the live repro/verify rig)
- [x] Added or updated high-quality tests that would catch regressions: a >4k assistant text block must pass through unclipped for `mobile` clients, and a 70k pathological block must still clip at the ceiling.

Live end-to-end verification on an isolated `orca serve` rig (temp `HOME` + `ORCA_USER_DATA_PATH`; the primary daemon untouched), with a planted Claude transcript engineered so the 4,000-char boundary lands 60 chars into a trailing fenced code block, mirroring the ticket exactly:
- Before: mobile-scope device token → text length 4,014 ending `plans/lessons-cont\n… (truncated)`; runtime-scope token → full 4,149 chars. Reproduced identically through a real paired desktop instance (`addFromPairingCode` → `runtimeEnvironments.call`, the same bridge the chat view's transport uses).
- After: same mobile-scope token and same paired desktop both receive the full 4,149-char message with the closing fence intact and no marker.

## AI Review Report

Reviewed the change for: regression risk to the mobile payload diet (tool-result/tool-call clipping is byte-for-byte unchanged, verified by the existing 16 tests), wire-size risk from unclipped text (bounded by the new 64k ceiling, the 40-message window, and the upstream 2MB transcript-record cap), and parity with the desktop IPC path (which has never clipped). Confirmed both the read and subscribe paths flow through the same `clipBlock`, so snapshots, replacements, and appends all benefit. Cross-platform: the change is pure main-process string handling with no shortcuts, labels, paths, shell, or Electron platform APIs; it is identical on macOS, Linux, and Windows hosts and for SSH/WSL-backed runtimes, and applies equally to folder workspaces and git worktrees.

## Security Audit

No new input surfaces: the RPC schema is unchanged, and the modified code only alters the char budget applied to already-parsed transcript strings before serialization. No command execution, path handling, auth, secrets, or dependency changes. The clip remains a bound (now 64k for text), so a hostile transcript still cannot ship unbounded payloads to paired clients; tool-input sanitization (depth/node/key budgets) is untouched. IPC/RPC gating by `clientKind` is unchanged.

## Notes

- The 60-char figure in the ticket was a red herring — it is the remainder of the reporter's ~3,940-char prose against the 4,000-char cap.
- Related follow-up (not in scope): a desktop client that redeems a mobile-scope pairing offer is treated as a `mobile` client for every payload-diet decision, not just this one. If we want full-fidelity desktop behavior over mobile-scoped pairings, scope negotiation deserves its own ticket.

Fixes STA-3230 (https://linear.app/stably/issue/STA-3230). Closes #12138.
