### PR TITLE
fix(codex): restore the Windows sandbox helper next to a flattened codex.exe

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -70,6 +70,7 @@ import { getDefaultWslDistro, getWslHome } from '../wsl'
 import { isCodexSystemDefaultRealHomeEnabled } from '../codex/codex-real-home-flag'
 import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-path'
 import { invalidateCodexSessionBackfillMarker } from '../codex/codex-session-backfill-marker'
+import { repairCodexWindowsPackageLayout } from '../codex/codex-windows-package-layout'
 import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
 import {
   codexAuthIsFresher,
@@ -220,6 +221,10 @@ export class CodexRuntimeHomeService {
       this.startWslSessionBridgeForLaunch(wslTarget, runtimeHomePath)
       return runtimeHomePath
     }
+    // Why: an installer that flattens a standalone Codex release to `bin/` leaves
+    // codex-windows-sandbox-setup.exe unreachable, so every sandboxed tool call
+    // pops an OS "Windows cannot find" dialog. No-op off Windows and once healthy.
+    repairCodexWindowsPackageLayout()
     const selfContainedAccount = this.getSelfContainedManagedHostAccount()
     if (selfContainedAccount) {
       const perAccountHome = this.prepareSelfContainedManagedHomeForLaunch(

--- a/src/main/codex/codex-windows-package-layout-filesystem.ts
+++ b/src/main/codex/codex-windows-package-layout-filesystem.ts
@@ -1,0 +1,193 @@
+import { createHash } from 'node:crypto'
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { join } from 'node:path'
+
+const ENTRYPOINT_DIR_NAME = 'bin'
+const MANIFEST_FILE_NAME = 'codex-package.json'
+const HASH_CHUNK_BYTES = 1024 * 1024
+
+export function codexPackageDirectoryHasEntries(directoryPath: string): boolean {
+  try {
+    return statSync(directoryPath).isDirectory() && readdirSync(directoryPath).length > 0
+  } catch {
+    return false
+  }
+}
+
+export function findCodexWindowsPackageDonor({
+  entrypointPath,
+  homePath,
+  appDataPath,
+  packageRootPath,
+  requiredDirNames
+}: {
+  entrypointPath: string
+  homePath: string
+  appDataPath: string | null
+  packageRootPath: string
+  requiredDirNames: string[]
+}): string | null {
+  const entrypointSize = fileSize(entrypointPath)
+  if (entrypointSize === null) {
+    return null
+  }
+  const candidates = listReleaseRootPaths(homePath, appDataPath).filter(
+    (candidate) =>
+      candidate !== packageRootPath &&
+      requiredDirNames.every((dirName) =>
+        codexPackageDirectoryHasEntries(join(candidate, dirName))
+      ) &&
+      fileSize(candidateEntrypointPath(candidate)) === entrypointSize
+  )
+  if (candidates.length === 0) {
+    return null
+  }
+
+  const entrypointHash = hashFile(entrypointPath)
+  if (!entrypointHash) {
+    return null
+  }
+  return (
+    candidates.find(
+      (candidate) => hashFile(candidateEntrypointPath(candidate)) === entrypointHash
+    ) ?? null
+  )
+}
+
+export function restoreCodexPackageDirectory(sourcePath: string, targetPath: string): boolean {
+  const stagingPath = `${targetPath}.orca-restore-${process.pid}`
+  try {
+    rmSync(stagingPath, { recursive: true, force: true })
+    cpSync(sourcePath, stagingPath, { recursive: true })
+    // Why: a partial installer can leave an empty target directory behind.
+    if (existsSync(targetPath)) {
+      rmdirSync(targetPath)
+    }
+    renameSync(stagingPath, targetPath)
+    return true
+  } catch (error) {
+    // Why: another Orca process may have published the same directory first.
+    if (codexPackageDirectoryHasEntries(targetPath)) {
+      rmSync(stagingPath, { recursive: true, force: true })
+      return true
+    }
+    console.warn(
+      '[codex-package-layout] Failed to restore Codex package directory:',
+      targetPath,
+      error
+    )
+    try {
+      rmSync(stagingPath, { recursive: true, force: true })
+    } catch (cleanupError) {
+      console.warn(
+        '[codex-package-layout] Failed to remove staged copy:',
+        stagingPath,
+        cleanupError
+      )
+    }
+    return false
+  }
+}
+
+export function copyCodexPackageManifestIfMissing(
+  donorRootPath: string,
+  packageRootPath: string
+): void {
+  const targetPath = join(packageRootPath, MANIFEST_FILE_NAME)
+  if (existsSync(targetPath)) {
+    return
+  }
+  try {
+    writeFileSync(targetPath, readFileSync(join(donorRootPath, MANIFEST_FILE_NAME)))
+  } catch {
+    // Why: the resources are already in place; a missing manifest only costs the default-name fallback.
+  }
+}
+
+function candidateEntrypointPath(releaseRootPath: string): string {
+  return join(releaseRootPath, ENTRYPOINT_DIR_NAME, 'codex.exe')
+}
+
+function listReleaseRootPaths(homePath: string, appDataPath: string | null): string[] {
+  return [
+    ...listChildDirectories(join(homePath, '.codex', 'packages', 'standalone', 'releases')),
+    ...listNpmVendorRootPaths(appDataPath)
+  ]
+}
+
+function listNpmVendorRootPaths(appDataPath: string | null): string[] {
+  if (!appDataPath) {
+    return []
+  }
+  const platformPackagesDirPath = join(
+    appDataPath,
+    'npm',
+    'node_modules',
+    '@openai',
+    'codex',
+    'node_modules',
+    '@openai'
+  )
+  return listChildDirectories(platformPackagesDirPath).flatMap((platformPackagePath) =>
+    listChildDirectories(join(platformPackagePath, 'vendor'))
+  )
+}
+
+function listChildDirectories(directoryPath: string): string[] {
+  try {
+    return readdirSync(directoryPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(directoryPath, entry.name))
+  } catch {
+    return []
+  }
+}
+
+function fileSize(filePath: string): number | null {
+  try {
+    const stats = statSync(filePath)
+    return stats.isFile() ? stats.size : null
+  } catch {
+    return null
+  }
+}
+
+function hashFile(filePath: string): string | null {
+  let handle: number | null = null
+  try {
+    handle = openSync(filePath, 'r')
+    const hash = createHash('sha256')
+    const buffer = Buffer.allocUnsafe(HASH_CHUNK_BYTES)
+    for (;;) {
+      const bytesRead = readSync(handle, buffer, 0, HASH_CHUNK_BYTES, null)
+      if (bytesRead === 0) {
+        break
+      }
+      hash.update(buffer.subarray(0, bytesRead))
+    }
+    return hash.digest('hex')
+  } catch {
+    return null
+  } finally {
+    if (handle !== null) {
+      try {
+        closeSync(handle)
+      } catch {
+        // Why: a failed close must not mask the hash result.
+      }
+    }
+  }
+}

--- a/src/main/codex/codex-windows-package-layout.test.ts
+++ b/src/main/codex/codex-windows-package-layout.test.ts
@@ -12,6 +12,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { repairCodexWindowsPackageLayout } from './codex-windows-package-layout'
+import { resolveCodexCommand } from '../codex-cli/command'
+
+// The repair resolves the codex command when none is passed; that resolver can
+// throw on a version-manager readdir race. Mock it so a specific test can force
+// that throw. Every other test passes an explicit path, so the resolver is unused.
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: vi.fn(() => '') }))
 
 let root: string
 let homePath: string
@@ -250,6 +256,19 @@ describe('repairCodexWindowsPackageLayout', () => {
 
     vi.advanceTimersByTime(60_001)
     expect(repair(commandPath).status).toBe('restored')
+  })
+
+  it('never throws out of the best-effort repair when command resolution fails', () => {
+    vi.mocked(resolveCodexCommand).mockImplementationOnce(() => {
+      throw new Error('version-manager readdir raced')
+    })
+
+    // No codexCommandPath forces the guarded resolveCodexCommand call, which throws.
+    expect(repairCodexWindowsPackageLayout({ platform: 'win32', homePath, appDataPath })).toEqual({
+      status: 'not-applicable',
+      packageRootPath: null,
+      restoredDirectories: []
+    })
   })
 
   // POSIX-only: forces a real publish failure via a read-only root. On win32 the

--- a/src/main/codex/codex-windows-package-layout.test.ts
+++ b/src/main/codex/codex-windows-package-layout.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { repairCodexWindowsPackageLayout } from './codex-windows-package-layout'
+
+let root: string
+let homePath: string
+let appDataPath: string
+
+const ENTRYPOINT_BYTES = 'codex-entrypoint-build-a'
+const OTHER_BUILD_BYTES = 'codex-entrypoint-build-b'
+
+function writeReleaseLayout(
+  packageRootPath: string,
+  {
+    entrypointBytes = ENTRYPOINT_BYTES,
+    resourcesDirName = 'codex-resources',
+    pathDirName = 'codex-path',
+    withResources = true,
+    withManifest = true
+  }: {
+    entrypointBytes?: string
+    resourcesDirName?: string
+    pathDirName?: string
+    withResources?: boolean
+    withManifest?: boolean
+  } = {}
+): void {
+  mkdirSync(join(packageRootPath, 'bin'), { recursive: true })
+  writeFileSync(join(packageRootPath, 'bin', 'codex.exe'), entrypointBytes)
+  if (withManifest) {
+    writeFileSync(
+      join(packageRootPath, 'codex-package.json'),
+      JSON.stringify({
+        layoutVersion: 1,
+        version: '0.145.0',
+        target: 'x86_64-pc-windows-msvc',
+        entrypoint: 'bin/codex.exe',
+        resourcesDir: resourcesDirName,
+        pathDir: pathDirName
+      })
+    )
+  }
+  if (!withResources) {
+    return
+  }
+  mkdirSync(join(packageRootPath, resourcesDirName), { recursive: true })
+  writeFileSync(
+    join(packageRootPath, resourcesDirName, 'codex-windows-sandbox-setup.exe'),
+    'setup-helper'
+  )
+  mkdirSync(join(packageRootPath, pathDirName), { recursive: true })
+  writeFileSync(join(packageRootPath, pathDirName, 'rg.exe'), 'ripgrep')
+}
+
+function getStandaloneReleasePath(name: string): string {
+  return join(homePath, '.codex', 'packages', 'standalone', 'releases', name)
+}
+
+function getNpmVendorPath(target: string): string {
+  return join(
+    appDataPath,
+    'npm',
+    'node_modules',
+    '@openai',
+    'codex',
+    'node_modules',
+    '@openai',
+    'codex-win32-x64',
+    'vendor',
+    target
+  )
+}
+
+function repair(codexCommandPath: string): ReturnType<typeof repairCodexWindowsPackageLayout> {
+  return repairCodexWindowsPackageLayout({
+    platform: 'win32',
+    homePath,
+    appDataPath,
+    codexCommandPath
+  })
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-codex-layout-'))
+  homePath = join(root, 'home')
+  appDataPath = join(homePath, 'AppData', 'Roaming')
+  mkdirSync(appDataPath, { recursive: true })
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('repairCodexWindowsPackageLayout', () => {
+  it('does nothing off Windows', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+
+    expect(
+      repairCodexWindowsPackageLayout({
+        platform: 'darwin',
+        homePath,
+        appDataPath,
+        codexCommandPath: join(installPath, 'bin', 'codex.exe')
+      })
+    ).toEqual({ status: 'not-applicable', packageRootPath: null, restoredDirectories: [] })
+    expect(existsSync(join(installPath, 'codex-resources'))).toBe(false)
+  })
+
+  it('ignores commands that are not a release entrypoint', () => {
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'))
+
+    for (const command of [
+      'codex',
+      join(root, 'npm', 'codex.cmd'),
+      join(root, 'tools', 'codex.exe')
+    ]) {
+      expect(repair(command).status).toBe('not-applicable')
+    }
+  })
+
+  it('leaves a complete install untouched', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath)
+
+    expect(repair(join(installPath, 'bin', 'codex.exe'))).toEqual({
+      status: 'already-complete',
+      packageRootPath: installPath,
+      restoredDirectories: []
+    })
+  })
+
+  it('restores the sandbox helper from a byte-identical standalone release', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false, withManifest: false })
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'))
+
+    const result = repair(join(installPath, 'bin', 'codex.exe'))
+
+    expect(result.status).toBe('restored')
+    expect(result.restoredDirectories).toEqual(['codex-resources', 'codex-path'])
+    expect(
+      readFileSync(join(installPath, 'codex-resources', 'codex-windows-sandbox-setup.exe'), 'utf-8')
+    ).toBe('setup-helper')
+    expect(readFileSync(join(installPath, 'codex-path', 'rg.exe'), 'utf-8')).toBe('ripgrep')
+    // Why: the restored manifest keeps the next check on the declared names.
+    expect(existsSync(join(installPath, 'codex-package.json'))).toBe(true)
+  })
+
+  it('restores only the directory that is missing', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath)
+    rmSync(join(installPath, 'codex-resources'), { recursive: true, force: true })
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'))
+
+    expect(repair(join(installPath, 'bin', 'codex.exe')).restoredDirectories).toEqual([
+      'codex-resources'
+    ])
+  })
+
+  it('honours directory names declared by the manifest', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, {
+      withResources: false,
+      resourcesDirName: 'helpers',
+      pathDirName: 'tools'
+    })
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'), {
+      resourcesDirName: 'helpers',
+      pathDirName: 'tools'
+    })
+
+    expect(repair(join(installPath, 'bin', 'codex.exe')).restoredDirectories).toEqual([
+      'helpers',
+      'tools'
+    ])
+    expect(existsSync(join(installPath, 'helpers', 'codex-windows-sandbox-setup.exe'))).toBe(true)
+  })
+
+  it('refuses a release built from a different codex binary', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+    writeReleaseLayout(getStandaloneReleasePath('0.140.0-x86_64-pc-windows-msvc'), {
+      entrypointBytes: OTHER_BUILD_BYTES
+    })
+
+    expect(repair(join(installPath, 'bin', 'codex.exe'))).toEqual({
+      status: 'no-donor',
+      packageRootPath: installPath,
+      restoredDirectories: []
+    })
+    expect(existsSync(join(installPath, 'codex-resources'))).toBe(false)
+  })
+
+  it('falls back to the npm vendor layout when no standalone release is cached', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+    writeReleaseLayout(getNpmVendorPath('x86_64-pc-windows-msvc'))
+
+    expect(repair(join(installPath, 'bin', 'codex.exe')).status).toBe('restored')
+    expect(
+      existsSync(join(installPath, 'codex-resources', 'codex-windows-sandbox-setup.exe'))
+    ).toBe(true)
+  })
+
+  it('reports no donor when nothing on the host carries the resources', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+
+    expect(repair(join(installPath, 'bin', 'codex.exe')).status).toBe('no-donor')
+  })
+})

--- a/src/main/codex/codex-windows-package-layout.test.ts
+++ b/src/main/codex/codex-windows-package-layout.test.ts
@@ -93,6 +93,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   rmSync(root, { recursive: true, force: true })
 })
@@ -164,6 +165,19 @@ describe('repairCodexWindowsPackageLayout', () => {
     ])
   })
 
+  it('restores over empty sibling directories left by a partial install', () => {
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+    mkdirSync(join(installPath, 'codex-resources'))
+    mkdirSync(join(installPath, 'codex-path'))
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'))
+
+    expect(repair(join(installPath, 'bin', 'codex.exe')).status).toBe('restored')
+    expect(
+      existsSync(join(installPath, 'codex-resources', 'codex-windows-sandbox-setup.exe'))
+    ).toBe(true)
+  })
+
   it('honours directory names declared by the manifest', () => {
     const installPath = join(root, 'install')
     writeReleaseLayout(installPath, {
@@ -214,5 +228,19 @@ describe('repairCodexWindowsPackageLayout', () => {
     writeReleaseLayout(installPath, { withResources: false })
 
     expect(repair(join(installPath, 'bin', 'codex.exe')).status).toBe('no-donor')
+  })
+
+  it('retries a failed donor lookup after its brief cache expires', () => {
+    vi.useFakeTimers()
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+    const commandPath = join(installPath, 'bin', 'codex.exe')
+
+    expect(repair(commandPath).status).toBe('no-donor')
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'))
+    expect(repair(commandPath).status).toBe('no-donor')
+
+    vi.advanceTimersByTime(60_001)
+    expect(repair(commandPath).status).toBe('restored')
   })
 })

--- a/src/main/codex/codex-windows-package-layout.test.ts
+++ b/src/main/codex/codex-windows-package-layout.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -242,5 +250,33 @@ describe('repairCodexWindowsPackageLayout', () => {
 
     vi.advanceTimersByTime(60_001)
     expect(repair(commandPath).status).toBe('restored')
+  })
+
+  // POSIX-only: forces a real publish failure via a read-only root. On win32 the
+  // suite would need ACL manipulation; the cached-backoff logic is platform-agnostic.
+  const itWithChmod = process.platform === 'win32' ? it.skip : it
+  itWithChmod('caches a failed restore and retries only after the cache expires', () => {
+    vi.useFakeTimers()
+    const installPath = join(root, 'install')
+    writeReleaseLayout(installPath, { withResources: false })
+    writeReleaseLayout(getStandaloneReleasePath('0.145.0-x86_64-pc-windows-msvc'))
+    const commandPath = join(installPath, 'bin', 'codex.exe')
+
+    // A read-only root makes the staged copy unpublishable, so restore fails
+    // even though a byte-identical donor was found.
+    chmodSync(installPath, 0o500)
+    try {
+      expect(repair(commandPath).status).toBe('failed')
+
+      // Within the TTL the backoff short-circuits: the second call returns the
+      // cached failure without re-scanning, even though the root is writable again.
+      chmodSync(installPath, 0o700)
+      expect(repair(commandPath).status).toBe('failed')
+
+      vi.advanceTimersByTime(60_001)
+      expect(repair(commandPath).status).toBe('restored')
+    } finally {
+      chmodSync(installPath, 0o700)
+    }
   })
 })

--- a/src/main/codex/codex-windows-package-layout.ts
+++ b/src/main/codex/codex-windows-package-layout.ts
@@ -1,0 +1,353 @@
+import { createHash } from 'node:crypto'
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, dirname, extname, join } from 'node:path'
+import { resolveCodexCommand } from '../codex-cli/command'
+
+/**
+ * Restores the sibling directories a standalone Codex release declares next to
+ * its entrypoint.
+ *
+ * Why: a release ships `bin/`, `codex-resources/` and `codex-path/` side by side
+ * (declared in `codex-package.json`), but installers that copy only `bin/` leave
+ * `codex-windows-sandbox-setup.exe` unreachable. Codex's elevated Windows sandbox
+ * launches that helper through `ShellExecuteW`, which pops its own OS-level
+ * "Windows cannot find ..." dialog on every tool call instead of surfacing an
+ * error Orca or Codex could handle.
+ */
+
+const MANIFEST_FILE_NAME = 'codex-package.json'
+const DEFAULT_RESOURCES_DIR_NAME = 'codex-resources'
+const DEFAULT_PATH_DIR_NAME = 'codex-path'
+const ENTRYPOINT_DIR_NAME = 'bin'
+const HASH_CHUNK_BYTES = 1024 * 1024
+
+export type CodexWindowsPackageLayoutStatus =
+  | 'not-applicable'
+  | 'already-complete'
+  | 'restored'
+  | 'no-donor'
+  | 'failed'
+
+export type CodexWindowsPackageLayoutResult = {
+  status: CodexWindowsPackageLayoutStatus
+  packageRootPath: string | null
+  restoredDirectories: string[]
+}
+
+type PackageLayout = {
+  resourcesDirName: string
+  pathDirName: string
+}
+
+type RepairOptions = {
+  platform?: NodeJS.Platform
+  homePath?: string
+  appDataPath?: string
+  codexCommandPath?: string
+}
+
+export function repairCodexWindowsPackageLayout(
+  options: RepairOptions = {}
+): CodexWindowsPackageLayoutResult {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'win32') {
+    return notApplicable()
+  }
+
+  const entrypointPath = options.codexCommandPath ?? resolveCodexCommand()
+  const packageRootPath = resolvePackageRootPath(entrypointPath)
+  if (!packageRootPath) {
+    return notApplicable()
+  }
+
+  const layout = readPackageLayout(packageRootPath)
+  const missingDirNames = [layout.resourcesDirName, layout.pathDirName].filter(
+    (dirName) => !directoryHasEntries(join(packageRootPath, dirName))
+  )
+  if (missingDirNames.length === 0) {
+    return { status: 'already-complete', packageRootPath, restoredDirectories: [] }
+  }
+
+  const donorRootPath = findDonorPackageRootPath({
+    entrypointPath,
+    homePath: options.homePath ?? homedir(),
+    appDataPath: options.appDataPath ?? process.env.APPDATA ?? null,
+    packageRootPath,
+    requiredDirNames: missingDirNames
+  })
+  if (!donorRootPath) {
+    console.warn(
+      '[codex-package-layout] Codex install is missing sandbox resources and no matching release was found:',
+      packageRootPath,
+      missingDirNames
+    )
+    return { status: 'no-donor', packageRootPath, restoredDirectories: [] }
+  }
+
+  const restoredDirectories: string[] = []
+  for (const dirName of missingDirNames) {
+    if (copyPackageDirectory(join(donorRootPath, dirName), join(packageRootPath, dirName))) {
+      restoredDirectories.push(dirName)
+    }
+  }
+  if (restoredDirectories.length !== missingDirNames.length) {
+    return { status: 'failed', packageRootPath, restoredDirectories }
+  }
+  copyManifestIfMissing(donorRootPath, packageRootPath)
+  console.log(
+    '[codex-package-layout] Restored Codex sandbox resources from',
+    donorRootPath,
+    'into',
+    packageRootPath,
+    restoredDirectories
+  )
+  return { status: 'restored', packageRootPath, restoredDirectories }
+}
+
+function notApplicable(): CodexWindowsPackageLayoutResult {
+  return { status: 'not-applicable', packageRootPath: null, restoredDirectories: [] }
+}
+
+// Why: only a release-layout entrypoint (`<root>/bin/codex.exe`) has declared
+// siblings. A bare `codex`, a shim (`codex.cmd`/`codex.ps1`) or an exe outside a
+// `bin/` directory is some other packaging that Orca must not write next to.
+function resolvePackageRootPath(entrypointPath: string): string | null {
+  if (extname(entrypointPath).toLowerCase() !== '.exe') {
+    return null
+  }
+  const entrypointDirPath = dirname(entrypointPath)
+  if (basename(entrypointDirPath).toLowerCase() !== ENTRYPOINT_DIR_NAME) {
+    return null
+  }
+  const packageRootPath = dirname(entrypointDirPath)
+  return packageRootPath === entrypointDirPath ? null : packageRootPath
+}
+
+function readPackageLayout(packageRootPath: string): PackageLayout {
+  const manifest = readManifest(packageRootPath)
+  return {
+    resourcesDirName: manifest?.resourcesDirName ?? DEFAULT_RESOURCES_DIR_NAME,
+    pathDirName: manifest?.pathDirName ?? DEFAULT_PATH_DIR_NAME
+  }
+}
+
+function readManifest(packageRootPath: string): PackageLayout | null {
+  try {
+    const parsed: unknown = JSON.parse(
+      readFileSync(join(packageRootPath, MANIFEST_FILE_NAME), 'utf-8')
+    )
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+    const record = parsed as Record<string, unknown>
+    return {
+      resourcesDirName: readRelativeDirName(record.resourcesDir) ?? DEFAULT_RESOURCES_DIR_NAME,
+      pathDirName: readRelativeDirName(record.pathDir) ?? DEFAULT_PATH_DIR_NAME
+    }
+  } catch {
+    return null
+  }
+}
+
+// Why: the manifest is attacker-adjacent only in the sense that a corrupt value
+// would make Orca copy into an arbitrary path. Accept single path segments only.
+function readRelativeDirName(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null
+  }
+  if (value === '.' || value === '..' || /[\\/]/.test(value)) {
+    return null
+  }
+  return value
+}
+
+function directoryHasEntries(directoryPath: string): boolean {
+  try {
+    return statSync(directoryPath).isDirectory() && readdirSync(directoryPath).length > 0
+  } catch {
+    return false
+  }
+}
+
+function findDonorPackageRootPath({
+  entrypointPath,
+  homePath,
+  appDataPath,
+  packageRootPath,
+  requiredDirNames
+}: {
+  entrypointPath: string
+  homePath: string
+  appDataPath: string | null
+  packageRootPath: string
+  requiredDirNames: string[]
+}): string | null {
+  const entrypointSize = fileSize(entrypointPath)
+  if (entrypointSize === null) {
+    return null
+  }
+  const candidates = listReleaseRootPaths(homePath, appDataPath).filter(
+    (candidate) =>
+      candidate !== packageRootPath &&
+      requiredDirNames.every((dirName) => directoryHasEntries(join(candidate, dirName))) &&
+      fileSize(candidateEntrypointPath(candidate)) === entrypointSize
+  )
+  if (candidates.length === 0) {
+    return null
+  }
+
+  // Why: a helper from a different Codex build can be incompatible with the
+  // running one, so only donate from a release whose entrypoint is byte-identical.
+  const entrypointHash = hashFile(entrypointPath)
+  if (!entrypointHash) {
+    return null
+  }
+  return (
+    candidates.find(
+      (candidate) => hashFile(candidateEntrypointPath(candidate)) === entrypointHash
+    ) ?? null
+  )
+}
+
+function candidateEntrypointPath(releaseRootPath: string): string {
+  return join(releaseRootPath, ENTRYPOINT_DIR_NAME, 'codex.exe')
+}
+
+// Why: Codex keeps every downloaded standalone release under the user's real
+// `~/.codex`, and the npm distribution vendors the same layout per target. Both
+// are untouched copies of what the installer flattened into `bin/`.
+function listReleaseRootPaths(homePath: string, appDataPath: string | null): string[] {
+  return [
+    ...listChildDirectories(join(homePath, '.codex', 'packages', 'standalone', 'releases')),
+    ...listNpmVendorRootPaths(appDataPath)
+  ]
+}
+
+// Why: the npm distribution nests the same release layout under a per-target
+// platform package, so enumerate both levels instead of assuming an architecture.
+function listNpmVendorRootPaths(appDataPath: string | null): string[] {
+  if (!appDataPath) {
+    return []
+  }
+  const platformPackagesDirPath = join(
+    appDataPath,
+    'npm',
+    'node_modules',
+    '@openai',
+    'codex',
+    'node_modules',
+    '@openai'
+  )
+  return listChildDirectories(platformPackagesDirPath).flatMap((platformPackagePath) =>
+    listChildDirectories(join(platformPackagePath, 'vendor'))
+  )
+}
+
+function listChildDirectories(directoryPath: string): string[] {
+  try {
+    return readdirSync(directoryPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(directoryPath, entry.name))
+  } catch {
+    return []
+  }
+}
+
+function fileSize(filePath: string): number | null {
+  try {
+    const stats = statSync(filePath)
+    return stats.isFile() ? stats.size : null
+  } catch {
+    return null
+  }
+}
+
+// Why: Codex entrypoints are ~100 MB. Read in chunks so comparing candidates
+// never holds the whole binary in memory.
+function hashFile(filePath: string): string | null {
+  let handle: number | null = null
+  try {
+    handle = openSync(filePath, 'r')
+    const hash = createHash('sha256')
+    const buffer = Buffer.allocUnsafe(HASH_CHUNK_BYTES)
+    for (;;) {
+      const bytesRead = readSync(handle, buffer, 0, HASH_CHUNK_BYTES, null)
+      if (bytesRead === 0) {
+        break
+      }
+      hash.update(buffer.subarray(0, bytesRead))
+    }
+    return hash.digest('hex')
+  } catch {
+    return null
+  } finally {
+    if (handle !== null) {
+      try {
+        closeSync(handle)
+      } catch {
+        // Why: a failed close must not mask the hash result.
+      }
+    }
+  }
+}
+
+// Why: publish through a rename so a Codex launch racing this repair never sees
+// a half-copied resources directory and re-triggers the missing-helper dialog.
+function copyPackageDirectory(sourcePath: string, targetPath: string): boolean {
+  const stagingPath = `${targetPath}.orca-restore-${process.pid}`
+  try {
+    rmSync(stagingPath, { recursive: true, force: true })
+    cpSync(sourcePath, stagingPath, { recursive: true })
+    renameSync(stagingPath, targetPath)
+    return true
+  } catch (error) {
+    // Why: another Orca process may have published the same directory first.
+    if (directoryHasEntries(targetPath)) {
+      rmSync(stagingPath, { recursive: true, force: true })
+      return true
+    }
+    console.warn(
+      '[codex-package-layout] Failed to restore Codex package directory:',
+      targetPath,
+      error
+    )
+    try {
+      rmSync(stagingPath, { recursive: true, force: true })
+    } catch (cleanupError) {
+      console.warn(
+        '[codex-package-layout] Failed to remove staged copy:',
+        stagingPath,
+        cleanupError
+      )
+    }
+    return false
+  }
+}
+
+// Why: without the manifest the next check falls back to the default directory
+// names, which would miss a release that renames them.
+function copyManifestIfMissing(donorRootPath: string, packageRootPath: string): void {
+  const targetPath = join(packageRootPath, MANIFEST_FILE_NAME)
+  if (existsSync(targetPath)) {
+    return
+  }
+  try {
+    writeFileSync(targetPath, readFileSync(join(donorRootPath, MANIFEST_FILE_NAME)))
+  } catch {
+    // Why: the resources are already in place; a missing manifest only costs the
+    // default-name fallback on the next launch.
+  }
+}

--- a/src/main/codex/codex-windows-package-layout.ts
+++ b/src/main/codex/codex-windows-package-layout.ts
@@ -65,6 +65,18 @@ type RepairOptions = {
 export function repairCodexWindowsPackageLayout(
   options: RepairOptions = {}
 ): CodexWindowsPackageLayoutResult {
+  // Best-effort repair on the launch-critical path (the caller ignores the result).
+  // resolveCodexCommand enumerates version-manager dirs with an unguarded readdir,
+  // so an EPERM/ENOENT race there could throw; swallow it rather than abort launch.
+  try {
+    return runRepair(options)
+  } catch (error) {
+    console.warn('[codex-package-layout] Unexpected error during repair:', error)
+    return notApplicable()
+  }
+}
+
+function runRepair(options: RepairOptions): CodexWindowsPackageLayoutResult {
   const platform = options.platform ?? process.platform
   if (platform !== 'win32') {
     return notApplicable()

--- a/src/main/codex/codex-windows-package-layout.ts
+++ b/src/main/codex/codex-windows-package-layout.ts
@@ -1,20 +1,13 @@
-import { createHash } from 'node:crypto'
-import {
-  closeSync,
-  cpSync,
-  existsSync,
-  openSync,
-  readdirSync,
-  readFileSync,
-  readSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync
-} from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, extname, join } from 'node:path'
 import { resolveCodexCommand } from '../codex-cli/command'
+import {
+  codexPackageDirectoryHasEntries,
+  copyCodexPackageManifestIfMissing,
+  findCodexWindowsPackageDonor,
+  restoreCodexPackageDirectory
+} from './codex-windows-package-layout-filesystem'
 
 /**
  * Restores the sibling directories a standalone Codex release declares next to
@@ -32,7 +25,9 @@ const MANIFEST_FILE_NAME = 'codex-package.json'
 const DEFAULT_RESOURCES_DIR_NAME = 'codex-resources'
 const DEFAULT_PATH_DIR_NAME = 'codex-path'
 const ENTRYPOINT_DIR_NAME = 'bin'
-const HASH_CHUNK_BYTES = 1024 * 1024
+const NO_DONOR_CACHE_TTL_MS = 60_000
+
+let noDonorCache: { key: string; expiresAt: number } | null = null
 
 export type CodexWindowsPackageLayoutStatus =
   | 'not-applicable'
@@ -75,20 +70,38 @@ export function repairCodexWindowsPackageLayout(
 
   const layout = readPackageLayout(packageRootPath)
   const missingDirNames = [layout.resourcesDirName, layout.pathDirName].filter(
-    (dirName) => !directoryHasEntries(join(packageRootPath, dirName))
+    (dirName) => !codexPackageDirectoryHasEntries(join(packageRootPath, dirName))
   )
   if (missingDirNames.length === 0) {
     return { status: 'already-complete', packageRootPath, restoredDirectories: [] }
   }
 
-  const donorRootPath = findDonorPackageRootPath({
+  const homePath = options.homePath ?? homedir()
+  const appDataPath = options.appDataPath ?? process.env.APPDATA ?? null
+  const noDonorCacheKey = getNoDonorCacheKey({
     entrypointPath,
-    homePath: options.homePath ?? homedir(),
-    appDataPath: options.appDataPath ?? process.env.APPDATA ?? null,
+    homePath,
+    appDataPath,
+    missingDirNames
+  })
+  if (noDonorCacheKey && noDonorCache?.key === noDonorCacheKey) {
+    if (noDonorCache.expiresAt > Date.now()) {
+      return { status: 'no-donor', packageRootPath, restoredDirectories: [] }
+    }
+    noDonorCache = null
+  }
+
+  const donorRootPath = findCodexWindowsPackageDonor({
+    entrypointPath,
+    homePath,
+    appDataPath,
     packageRootPath,
     requiredDirNames: missingDirNames
   })
   if (!donorRootPath) {
+    if (noDonorCacheKey) {
+      noDonorCache = { key: noDonorCacheKey, expiresAt: Date.now() + NO_DONOR_CACHE_TTL_MS }
+    }
     console.warn(
       '[codex-package-layout] Codex install is missing sandbox resources and no matching release was found:',
       packageRootPath,
@@ -99,14 +112,16 @@ export function repairCodexWindowsPackageLayout(
 
   const restoredDirectories: string[] = []
   for (const dirName of missingDirNames) {
-    if (copyPackageDirectory(join(donorRootPath, dirName), join(packageRootPath, dirName))) {
+    if (
+      restoreCodexPackageDirectory(join(donorRootPath, dirName), join(packageRootPath, dirName))
+    ) {
       restoredDirectories.push(dirName)
     }
   }
   if (restoredDirectories.length !== missingDirNames.length) {
     return { status: 'failed', packageRootPath, restoredDirectories }
   }
-  copyManifestIfMissing(donorRootPath, packageRootPath)
+  copyCodexPackageManifestIfMissing(donorRootPath, packageRootPath)
   console.log(
     '[codex-package-layout] Restored Codex sandbox resources from',
     donorRootPath,
@@ -174,180 +189,31 @@ function readRelativeDirName(value: unknown): string | null {
   return value
 }
 
-function directoryHasEntries(directoryPath: string): boolean {
-  try {
-    return statSync(directoryPath).isDirectory() && readdirSync(directoryPath).length > 0
-  } catch {
-    return false
-  }
-}
-
-function findDonorPackageRootPath({
+function getNoDonorCacheKey({
   entrypointPath,
   homePath,
   appDataPath,
-  packageRootPath,
-  requiredDirNames
+  missingDirNames
 }: {
   entrypointPath: string
   homePath: string
   appDataPath: string | null
-  packageRootPath: string
-  requiredDirNames: string[]
+  missingDirNames: string[]
 }): string | null {
-  const entrypointSize = fileSize(entrypointPath)
-  if (entrypointSize === null) {
-    return null
-  }
-  const candidates = listReleaseRootPaths(homePath, appDataPath).filter(
-    (candidate) =>
-      candidate !== packageRootPath &&
-      requiredDirNames.every((dirName) => directoryHasEntries(join(candidate, dirName))) &&
-      fileSize(candidateEntrypointPath(candidate)) === entrypointSize
-  )
-  if (candidates.length === 0) {
-    return null
-  }
-
-  // Why: a helper from a different Codex build can be incompatible with the
-  // running one, so only donate from a release whose entrypoint is byte-identical.
-  const entrypointHash = hashFile(entrypointPath)
-  if (!entrypointHash) {
-    return null
-  }
-  return (
-    candidates.find(
-      (candidate) => hashFile(candidateEntrypointPath(candidate)) === entrypointHash
-    ) ?? null
-  )
-}
-
-function candidateEntrypointPath(releaseRootPath: string): string {
-  return join(releaseRootPath, ENTRYPOINT_DIR_NAME, 'codex.exe')
-}
-
-// Why: Codex keeps every downloaded standalone release under the user's real
-// `~/.codex`, and the npm distribution vendors the same layout per target. Both
-// are untouched copies of what the installer flattened into `bin/`.
-function listReleaseRootPaths(homePath: string, appDataPath: string | null): string[] {
-  return [
-    ...listChildDirectories(join(homePath, '.codex', 'packages', 'standalone', 'releases')),
-    ...listNpmVendorRootPaths(appDataPath)
-  ]
-}
-
-// Why: the npm distribution nests the same release layout under a per-target
-// platform package, so enumerate both levels instead of assuming an architecture.
-function listNpmVendorRootPaths(appDataPath: string | null): string[] {
-  if (!appDataPath) {
-    return []
-  }
-  const platformPackagesDirPath = join(
-    appDataPath,
-    'npm',
-    'node_modules',
-    '@openai',
-    'codex',
-    'node_modules',
-    '@openai'
-  )
-  return listChildDirectories(platformPackagesDirPath).flatMap((platformPackagePath) =>
-    listChildDirectories(join(platformPackagePath, 'vendor'))
-  )
-}
-
-function listChildDirectories(directoryPath: string): string[] {
   try {
-    return readdirSync(directoryPath, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => join(directoryPath, entry.name))
-  } catch {
-    return []
-  }
-}
-
-function fileSize(filePath: string): number | null {
-  try {
-    const stats = statSync(filePath)
-    return stats.isFile() ? stats.size : null
+    const stats = statSync(entrypointPath)
+    if (!stats.isFile()) {
+      return null
+    }
+    return JSON.stringify([
+      entrypointPath,
+      stats.size,
+      stats.mtimeMs,
+      homePath,
+      appDataPath,
+      missingDirNames
+    ])
   } catch {
     return null
-  }
-}
-
-// Why: Codex entrypoints are ~100 MB. Read in chunks so comparing candidates
-// never holds the whole binary in memory.
-function hashFile(filePath: string): string | null {
-  let handle: number | null = null
-  try {
-    handle = openSync(filePath, 'r')
-    const hash = createHash('sha256')
-    const buffer = Buffer.allocUnsafe(HASH_CHUNK_BYTES)
-    for (;;) {
-      const bytesRead = readSync(handle, buffer, 0, HASH_CHUNK_BYTES, null)
-      if (bytesRead === 0) {
-        break
-      }
-      hash.update(buffer.subarray(0, bytesRead))
-    }
-    return hash.digest('hex')
-  } catch {
-    return null
-  } finally {
-    if (handle !== null) {
-      try {
-        closeSync(handle)
-      } catch {
-        // Why: a failed close must not mask the hash result.
-      }
-    }
-  }
-}
-
-// Why: publish through a rename so a Codex launch racing this repair never sees
-// a half-copied resources directory and re-triggers the missing-helper dialog.
-function copyPackageDirectory(sourcePath: string, targetPath: string): boolean {
-  const stagingPath = `${targetPath}.orca-restore-${process.pid}`
-  try {
-    rmSync(stagingPath, { recursive: true, force: true })
-    cpSync(sourcePath, stagingPath, { recursive: true })
-    renameSync(stagingPath, targetPath)
-    return true
-  } catch (error) {
-    // Why: another Orca process may have published the same directory first.
-    if (directoryHasEntries(targetPath)) {
-      rmSync(stagingPath, { recursive: true, force: true })
-      return true
-    }
-    console.warn(
-      '[codex-package-layout] Failed to restore Codex package directory:',
-      targetPath,
-      error
-    )
-    try {
-      rmSync(stagingPath, { recursive: true, force: true })
-    } catch (cleanupError) {
-      console.warn(
-        '[codex-package-layout] Failed to remove staged copy:',
-        stagingPath,
-        cleanupError
-      )
-    }
-    return false
-  }
-}
-
-// Why: without the manifest the next check falls back to the default directory
-// names, which would miss a release that renames them.
-function copyManifestIfMissing(donorRootPath: string, packageRootPath: string): void {
-  const targetPath = join(packageRootPath, MANIFEST_FILE_NAME)
-  if (existsSync(targetPath)) {
-    return
-  }
-  try {
-    writeFileSync(targetPath, readFileSync(join(donorRootPath, MANIFEST_FILE_NAME)))
-  } catch {
-    // Why: the resources are already in place; a missing manifest only costs the
-    // default-name fallback on the next launch.
   }
 }

--- a/src/main/codex/codex-windows-package-layout.ts
+++ b/src/main/codex/codex-windows-package-layout.ts
@@ -25,9 +25,17 @@ const MANIFEST_FILE_NAME = 'codex-package.json'
 const DEFAULT_RESOURCES_DIR_NAME = 'codex-resources'
 const DEFAULT_PATH_DIR_NAME = 'codex-path'
 const ENTRYPOINT_DIR_NAME = 'bin'
-const NO_DONOR_CACHE_TTL_MS = 60_000
+const UNREPAIRED_ATTEMPT_TTL_MS = 60_000
 
-let noDonorCache: { key: string; expiresAt: number } | null = null
+// Backs off after an unsuccessful repair — no donor found, or a donor found but
+// the copy could not be published (read-only Program Files, an antivirus lock).
+// Without this the failed case re-scans releases and re-hashes the ~100MB+
+// entrypoint on every PTY spawn, blocking the main process indefinitely.
+let lastUnrepairedAttempt: {
+  key: string
+  expiresAt: number
+  status: 'no-donor' | 'failed'
+} | null = null
 
 export type CodexWindowsPackageLayoutStatus =
   | 'not-applicable'
@@ -78,17 +86,21 @@ export function repairCodexWindowsPackageLayout(
 
   const homePath = options.homePath ?? homedir()
   const appDataPath = options.appDataPath ?? process.env.APPDATA ?? null
-  const noDonorCacheKey = getNoDonorCacheKey({
+  const attemptKey = getUnrepairedAttemptKey({
     entrypointPath,
     homePath,
     appDataPath,
     missingDirNames
   })
-  if (noDonorCacheKey && noDonorCache?.key === noDonorCacheKey) {
-    if (noDonorCache.expiresAt > Date.now()) {
-      return { status: 'no-donor', packageRootPath, restoredDirectories: [] }
+  if (attemptKey && lastUnrepairedAttempt?.key === attemptKey) {
+    if (lastUnrepairedAttempt.expiresAt > Date.now()) {
+      return {
+        status: lastUnrepairedAttempt.status,
+        packageRootPath,
+        restoredDirectories: []
+      }
     }
-    noDonorCache = null
+    lastUnrepairedAttempt = null
   }
 
   const donorRootPath = findCodexWindowsPackageDonor({
@@ -99,9 +111,7 @@ export function repairCodexWindowsPackageLayout(
     requiredDirNames: missingDirNames
   })
   if (!donorRootPath) {
-    if (noDonorCacheKey) {
-      noDonorCache = { key: noDonorCacheKey, expiresAt: Date.now() + NO_DONOR_CACHE_TTL_MS }
-    }
+    cacheUnrepairedAttempt(attemptKey, 'no-donor')
     console.warn(
       '[codex-package-layout] Codex install is missing sandbox resources and no matching release was found:',
       packageRootPath,
@@ -119,8 +129,13 @@ export function repairCodexWindowsPackageLayout(
     }
   }
   if (restoredDirectories.length !== missingDirNames.length) {
+    // A donor exists but publishing it failed (locked/read-only target). Back off
+    // like the no-donor case so a wedged install can't re-hash on every spawn.
+    cacheUnrepairedAttempt(attemptKey, 'failed')
     return { status: 'failed', packageRootPath, restoredDirectories }
   }
+  // A later restore succeeds after e.g. the lock clears; drop any stale backoff.
+  lastUnrepairedAttempt = null
   copyCodexPackageManifestIfMissing(donorRootPath, packageRootPath)
   console.log(
     '[codex-package-layout] Restored Codex sandbox resources from',
@@ -189,7 +204,14 @@ function readRelativeDirName(value: unknown): string | null {
   return value
 }
 
-function getNoDonorCacheKey({
+function cacheUnrepairedAttempt(key: string | null, status: 'no-donor' | 'failed'): void {
+  if (!key) {
+    return
+  }
+  lastUnrepairedAttempt = { key, status, expiresAt: Date.now() + UNREPAIRED_ATTEMPT_TTL_MS }
+}
+
+function getUnrepairedAttemptKey({
   entrypointPath,
   homePath,
   appDataPath,


### PR DESCRIPTION
## Summary

On Windows, Codex agents repeatedly popped a native OS dialog:

> **codex-windows-sandbox-setup.exe** — Windows cannot find 'codex-windows-sandbox-setup.exe'. Make sure you typed the name correctly, and then try again.

Every standalone Codex release declares a three-directory layout in `codex-package.json` — `bin/`, `codex-resources/` and `codex-path/` as siblings. `codex-windows-sandbox-setup.exe` lives in `codex-resources/`. Installers that flatten a release by copying only `bin/` (e.g. `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin\codex.exe`) leave that helper unreachable from the running `codex.exe`. Because Codex's elevated Windows sandbox launches the helper through `ShellExecuteW`, the OS shows its own `ERROR_FILE_NOT_FOUND` dialog — bypassing Codex's and Orca's error handling — and the sandbox setup marker is never written, so it fires again on every sandboxed tool call.

Before each native Codex launch, Orca now checks the resolved entrypoint's package root and restores any missing declared sibling directory from a donor whose `bin/codex.exe` is byte-identical to the one being launched. Donors are the untouched copies already on the host: cached standalone releases under `~/.codex/packages/standalone/releases/` and the npm platform package's `vendor/<target>/` layout.

Fixes STA-3125. Reported as #11874 (related to #7555, which is a different mechanism — helper present but `ERROR_MOD_NOT_FOUND` under a console-less nested spawn — and is not addressed here).

Behavior notes:

- Windows-only: `repairCodexWindowsPackageLayout()` returns `not-applicable` immediately on macOS/Linux, before touching the filesystem or resolving the Codex command.
- Only acts on a release-layout entrypoint (`<root>/bin/codex.exe`). A bare `codex`, a `.cmd`/`.ps1` shim, or an `.exe` outside a `bin/` directory is left alone.
- Only ever adds missing directories. Nothing is overwritten or deleted, and a healthy install costs two `stat` calls.
- Refuses to donate from a release built from a different Codex binary, so a mismatched helper is never installed. If no matching donor exists it logs a warning and leaves the install untouched.
- WSL launches are untouched (the repair runs after the WSL branch returns).

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — ran `oxlint` across the repo: clean.
- [x] `pnpm typecheck` — `tsc --noEmit -p config/tsconfig.node.json`: clean.
- [x] `pnpm test` — targeted: `src/main/codex/codex-windows-package-layout.test.ts` (9 passed), plus `runtime-home-service`, `runtime-home-service-per-account-migration` and `codex-home-paths` for regression. One failure in `runtime-home-service-per-account-migration.test.ts` ("keeps E in-place auth when selection becomes real-home without an explicit sync") reproduces identically on a clean tree with this PR's `runtime-home-service.ts` change stashed, so it is pre-existing and unrelated.
- [ ] `pnpm build` — not run; this is main-process TypeScript with no packaging or asset changes, and the host is low-spec.
- [x] Added or updated high-quality tests that would catch regressions

**Manual reproduction and verification (Windows 11 Pro 26200, Codex 0.145.0):**

1. Built a flattened install — copied only `bin/codex.exe` out of a release — plus a `CODEX_HOME` with `[windows] sandbox = "elevated"`.
2. Ran `codex sandbox -P ws -- cmd /c echo ...` against it. The process blocked with a top-level window titled `codex-windows-sandbox-setup.exe` (the `ShellExecuteW` not-found dialog), and `.sandbox/sandbox.<date>.log` logged `sandbox setup required: sandbox setup marker missing or incompatible` with no completion — the reported bug.
3. Restored `codex-resources/` and `codex-path/` as siblings of `bin/`, re-ran the same command: no dialog. The run reached an actual UAC consent prompt instead, proving it got past `ERROR_FILE_NOT_FOUND` into real elevation.
4. Re-emptied the flattened install and ran the shipped `repairCodexWindowsPackageLayout()` against it. It selected the byte-identical npm vendor donor by SHA-256 and restored `codex-resources`, `codex-path` and `codex-package.json` — the exact state proven healthy in step 3.

## AI Review Report

Self-review focused on the risks this change introduces: writing into a third-party install directory, donor selection correctness, cross-platform safety, and launch-path cost.

- **Cross-platform (macOS / Linux / Windows):** verified the `process.platform !== 'win32'` guard is the first statement, so nothing else in the module — including `resolveCodexCommand()` — runs off Windows; a unit test asserts the `darwin` no-op leaves the filesystem untouched. All paths go through `node:path` `join`/`dirname`/`basename`; no separators or shell invocations are hardcoded. No keyboard shortcuts, labels, or Electron platform APIs are touched. WSL and SSH launch paths are unaffected — the repair is placed after the WSL early-return, and it only inspects the locally resolved entrypoint.
- **Wrong-donor risk:** flagged that copying a helper from a mismatched Codex build could be worse than the popup. Addressed by requiring the donor's `bin/codex.exe` to be byte-identical (size prefilter, then SHA-256); a unit test asserts a different-build release is refused and nothing is copied.
- **Destructive-write risk:** flagged that Orca writes into a directory it does not own. Addressed by only ever creating absent directories — no overwrite, no delete — and by publishing each directory via staged copy + `rename`, so a concurrent Codex launch never observes a partially-copied `codex-resources/`. A losing race falls back to accepting the directory the other process published.
- **Path traversal from the manifest:** flagged that `resourcesDir`/`pathDir` are read from an on-disk JSON file. `readRelativeDirName` rejects anything containing a separator, plus `.` and `..`, so the copy target is always a single segment under the package root.
- **Launch-path cost:** hashing is gated behind a size match against a candidate that actually has the missing directories, and the whole donor search only runs when the layout is already broken; a healthy install costs two `stat` calls per launch. Hashing streams in 1 MiB chunks so a ~100 MB entrypoint is never buffered whole.
- **Failure containment:** every filesystem read is wrapped so a malformed manifest, an unreadable release cache, or a permission error degrades to "no repair" and a warning instead of blocking a Codex launch.

## Security Audit

- **Command execution:** none. The module performs filesystem operations only — no `spawn`, `exec`, or shell strings — and never runs the helper it restores.
- **Path handling:** the write target is derived from the Orca-resolved Codex entrypoint (`dirname(dirname(exe))`), constrained to entrypoints literally under a `bin/` directory, and joined only with manifest-supplied names that are validated as single path segments. Donor roots come from fixed, user-owned locations (`~/.codex/packages/standalone/releases/`, the npm `@openai/codex` vendor tree).
- **Input handling:** `codex-package.json` is parsed defensively — non-object, array, and malformed JSON all fall back to the built-in default directory names.
- **Privilege:** all writes stay in per-user directories; nothing elevates, and no ACLs are modified. The change reduces UAC noise rather than adding any.
- **Integrity:** restored binaries are only ever copied from a release whose entrypoint hashes identically to the one about to run, so this cannot introduce a helper from an untrusted or mismatched source.
- **Secrets / auth / IPC / dependencies:** none touched; no new dependencies, no IPC surface, no credential or network access.

Follow-up: none required for this fix.

## Notes

- Windows-only behavior; no-op on macOS and Linux.
- This does not address #7555, whose popup is `ERROR_MOD_NOT_FOUND` with the helper verifiably present under a console-less nested spawn. That remains open and likely needs a Codex-side fix.
- The underlying packaging gap is Codex-side (its installer flattens the release). This is a defensive repair on Orca's launch path so users stop seeing the dialog; it becomes a no-op once the upstream installer copies all declared directories.
- If a host has a flattened install and no matching release cached anywhere, Orca logs `[codex-package-layout] Codex install is missing sandbox resources and no matching release was found` and leaves it alone — the user still needs to reinstall Codex.
