### PR TITLE
fix(ci): vet the adhoc build ref before running it with release secrets

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -33,6 +33,13 @@ name: Adhoc macOS Dev Build
 # Contents: Read and write. The secret names below are historical — one App, one
 # private key, both dev-channel repos — and rotating it stays a single operation.
 # Provision with `bash config/scripts/setup-hourly-release-token.sh`.
+#
+# The requested ref is vetted before checkout: it must be a branch or tag of this
+# repo, or a commit reachable from one. PR refs are refused outright — this
+# workflow runs the checked-out code next to MAC_CERTS and the notary password,
+# so "just build that community PR" must not become a way to hand fork code the
+# release identity. A branch here always belongs to someone with write access,
+# which is the same trust the dispatch button itself already requires.
 
 on:
   workflow_dispatch:
@@ -45,7 +52,7 @@ on:
         # than the one the workflow file itself is read from — normally leave the
         # picker on main and name your branch here, so a stale copy of this
         # workflow on an old branch is not what runs.
-        description: 'Branch, tag, or SHA to build (default: the branch selected above)'
+        description: 'Branch, tag, or SHA to build — must live in stablyai/orca; PR refs are refused (default: the branch selected above)'
         required: false
         default: ''
         type: string
@@ -77,6 +84,14 @@ env:
 jobs:
   build-adhoc-mac:
     if: github.repository == 'stablyai/orca'
+    # Why an environment: it gives the signing/notary/App secrets somewhere to
+    # live that a stale copy of this workflow on an old branch cannot reach.
+    # Referencing it is a no-op until repo settings give it teeth; the intended
+    # follow-up is to move MAC_CERTS, MAC_CERTS_PASSWORD, APPLE_ID,
+    # APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID, HOURLY_RELEASE_APP_ID, and
+    # HOURLY_RELEASE_APP_PRIVATE_KEY into it, then pin its deployment branch
+    # policy to main so only main's copy of this file can read them.
+    environment: adhoc-mac-build
     runs-on: blacksmith-6vcpu-macos-15
     # Why 150: it must exceed the worst case the retry budgets below can produce
     # (install 3x10 + publish 2x45 = 120, plus ~25 for checkout/build/verify), or
@@ -85,6 +100,57 @@ jobs:
     env:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
+      # Why vet before checkout: everything after this step runs the checked-out
+      # code with release signing credentials in reach. Branches and tags of this
+      # repo are the intended audience; refs/pull/* would smuggle in fork code,
+      # and a raw SHA is only accepted when some branch or tag of this repo can
+      # actually reach it. Resolving to a pinned SHA here also means the commit
+      # that was vetted is the commit that gets checked out — a push to the
+      # branch between the two steps cannot swap it.
+      - name: Vet the requested ref
+        id: vetted
+        shell: bash
+        env:
+          REQUESTED_REF: ${{ inputs.ref || github.ref_name }}
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          case "$REQUESTED_REF" in
+            refs/pull/*|pull/*)
+              echo "::error::Refusing to build PR ref '$REQUESTED_REF': this workflow signs with release credentials, so it only builds branches, tags, or commits of stablyai/orca. Push the code to a branch of this repo instead."
+              exit 1
+              ;;
+          esac
+          # Bare: a work-tree repo refuses to fetch over its own checked-out
+          # branch. tree:0 keeps the fetch to the commit graph — no trees, no
+          # blobs — so this stays cheap next to the build it fronts.
+          scratch="$RUNNER_TEMP/vet-requested-ref"
+          git init -q --bare "$scratch"
+          git -C "$scratch" fetch -q --filter=tree:0 "$REPO_URL" '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
+          # Branch first to keep actions/checkout's old tie-break: bare
+          # rev-parse would prefer the tag when a branch shares its name.
+          sha=""
+          for cand in "refs/heads/$REQUESTED_REF" "refs/tags/$REQUESTED_REF" "$REQUESTED_REF"; do
+            if sha="$(git -C "$scratch" rev-parse --verify --quiet "$cand^{commit}")"; then
+              break
+            fi
+            sha=""
+          done
+          if [[ -z "$sha" ]]; then
+            echo "::error::'$REQUESTED_REF' does not resolve to a branch, tag, or commit of stablyai/orca."
+            exit 1
+          fi
+          # The object resolving locally is not proof a branch or tag reaches
+          # it: a partial clone can lazily fetch a bare SHA on demand, and
+          # GitHub serves PR-only commits by SHA. Reachability is the actual
+          # trust test.
+          if [[ -z "$(git -C "$scratch" for-each-ref --contains "$sha" refs/heads refs/tags | head -1)" ]]; then
+            echo "::error::Commit $REQUESTED_REF is not reachable from any branch or tag of stablyai/orca; refusing to build it with release credentials."
+            exit 1
+          fi
+          echo "Vetted $REQUESTED_REF -> $sha"
+          echo "sha=$sha" >>"$GITHUB_OUTPUT"
+
       - name: Checkout the requested ref
         uses: actions/checkout@v6
         with:
@@ -92,7 +158,7 @@ jobs:
           # build code that has not landed, and the workflow definition itself
           # always comes from the dispatch ref — naming the branch here instead
           # applies main's current copy of this file to an arbitrary branch.
-          ref: ${{ inputs.ref || github.ref_name }}
+          ref: ${{ steps.vetted.outputs.sha }}
           fetch-depth: 0
           # This job only reads stablyai/orca and never pushes; every write goes
           # to the adhoc repo through a minted App token passed by env. Not


### PR DESCRIPTION
## Summary

Hardens the adhoc macOS build workflow (added in #12051) against the P1 flagged by the v1.4.165-rc.0 prod release scan: the workflow checked out **any** requested ref and ran that ref's scripts (`verify-macos-release-env.mjs`, `ensure-native-runtime.mjs`, `electron-builder.config.cjs`) with `MAC_CERTS`, the notary app-specific password, and the adhoc publisher token in reach. Dispatching a fork PR ref ("just build that community PR") would hand fork code the release signing identity.

Changes, all in `.github/workflows/adhoc-mac-build.yml`:

- New **"Vet the requested ref"** step before checkout:
  - `refs/pull/*` / `pull/*` refs are refused outright.
  - Branches/tags resolve in a bare `tree:0` scratch fetch of the repo's heads and tags (annotated tags peel to their commit).
  - Raw SHAs must be **reachable from a repo branch or tag**. This check is load-bearing, not belt-and-braces: a partial clone lazily fetches PR-only commits by SHA on demand, so "the object resolves" is not a trust test (verified live — see Testing).
  - Checkout now pins the vetted SHA, so a push to the branch between vetting and checkout cannot swap the commit.
- The job now references an `adhoc-mac-build` **environment**. This is a no-op until repo settings give it teeth; the intended follow-up (admin-only) is to move the 7 signing/notary/App secrets into it and pin its deployment branch policy to `main`, which fences stale copies of this workflow on old branches away from the secrets entirely.

Trust model note: a vetted branch always belongs to someone with write access — the same trust the dispatch button already requires. This PR removes the *escalation* from "can dispatch a build" to "can run unreviewed fork code with signing credentials".

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The four package commands don't exercise workflow YAML; instead the vetting script was extracted from the YAML (parse-validated) and run locally against the real `stablyai/orca` remote across 9 cases:

| input | result |
|---|---|
| `main` | vetted → `8c5371ebad` (current main head) |
| `refs/heads/main` | vetted → same SHA |
| `v1.4.164` (annotated tag) | vetted → `9cea094620` (peeled commit, not the tag object) |
| `8c5371ebad` (short SHA on main) | vetted → full SHA |
| `pull/12137/head` | refused (PR ref) |
| `refs/pull/12137/merge` | refused (PR ref) |
| `totally-made-up-branch-xyz` | refused (does not resolve) |
| `deadbeef…` (alien SHA) | refused (does not resolve) |
| real fork-PR head SHA (`94d88dbc60e1…`, exists only behind `refs/pull/*`) | **refused by the reachability check** — the partial clone *did* lazily resolve the object, confirming name resolution alone would have been bypassable |

## AI Review Report

Reviewed as part of the v1.4.164..v1.4.165-rc.0 prod release scan (7 orchestrated reviewers; the security and release/package workers independently converged on this finding). Risks checked for this fix: ref-name ambiguity (branch vs tag tie-break kept branch-first to match `actions/checkout` behavior; exact-name resolution avoids ls-remote tail-glob mismatches), TOCTOU between vet and checkout (closed by pinning the SHA), shell injection (untrusted values enter only via `env:`, per the file's existing zizmor conventions), and lazy promisor fetch resurrecting the fork-SHA hole (closed by the reachability check). Cross-platform: CI-only change, runs on the macOS runner's bash + git ≥2.20 (`--filter=tree:0`, `for-each-ref --contains` need 2.20/2.7); no app code, shortcuts, paths, or Electron surface touched.

## Security Audit

This PR is itself the security fix for the release-scan P1. Input handling: `inputs.ref` and `inputs.label` reach shell only through `env:` vars in quoted expansions (unchanged pattern). Command execution: the new step runs only `git` with argv arrays against `https://github.com/${{ github.repository }}`. Secrets: no new secret exposure; the step runs before any secret-bearing step. Residual risk, explicitly out of scope here and needing repo admin: (1) create/protect the `adhoc-mac-build` environment, move `MAC_CERTS`, `MAC_CERTS_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `HOURLY_RELEASE_APP_ID`, `HOURLY_RELEASE_APP_PRIVATE_KEY` into it, delete the repo-level copies, and set its deployment branch policy to `main`; until then a stale workflow copy on an old branch can still read repo-level secrets. (2) A vetted repo branch still runs its own lockfile/postinstall and electron-builder config with signing env — inherent to "sign someone's branch"; the environment policy plus write-access trust is the accepted boundary. (3) Repo-wide SHA-pinning of third-party actions (`nick-fields/retry`, `pnpm/action-setup`) is a separate consistent follow-up; this file matches house tag-pin style for now.

## Notes

- macOS-only CI workflow; no app runtime, packaging output, or updater behavior changes. The v1.4.165-rc.0 release does not need to wait on this — the workflow is not part of the shipped build.
- After merge, dispatches should keep using "Use workflow from: main"; once the environment branch policy lands, that becomes enforced rather than advisory.


## Post-Merge Action Items (repo admin — this PR alone does not finish the fix)

- [ ] **Configure the `adhoc-mac-build` environment** (auto-created on first dispatch, or create it under Settings → Environments): set **deployment branch policy to `main` only**. This is what actually fences stale copies of this workflow on old branches; until then the `environment:` line is advisory.
- [ ] *(Optional)* Add **required reviewers** to the environment if per-dispatch approval friction is wanted.
- [ ] **Move the 7 secrets into the environment**, then delete the repo-level copies: `MAC_CERTS`, `MAC_CERTS_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `HOURLY_RELEASE_APP_ID`, `HOURLY_RELEASE_APP_PRIVATE_KEY`. Requires the secret values, so admin-only.
- [ ] **⚠️ Before deleting the repo-level secrets:** `hourly-mac-build.yml` reads the same repo-level secrets and will break the moment they're deleted. Either give the hourly workflow its own environment first (separate PR, ask if wanted) and copy the secrets into both, or skip the deletion and keep only the branch-policy/reviewer gate — accepting that stale workflow copies can still read repo-level secrets.
- [ ] *(Only if warranted)* Rotate the Apple cert/notary credentials — needed only if an untrusted ref may already have been built. The workflow is new in the v1.4.165 cycle, so this is likely unnecessary.
- [ ] *(Follow-up, separate PR)* Repo-wide SHA-pinning of third-party actions (`nick-fields/retry`, `pnpm/action-setup`) across all workflows; house style is currently tag pins everywhere, so it should be done consistently rather than just here.
