### PR TITLE
perf(github): lengthen background no-PR refresh interval

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -220,6 +220,53 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps a 15-minute-old no-PR candidate fresh until the 60-minute background interval', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({
+          cachedHasPR: false,
+          cachedFetchedAt: Date.now() - 15 * 60_000
+        })
+      ],
+      1,
+      1
+    )
+
+    await vi.advanceTimersByTimeAsync(45 * 60_000 - 1)
+    expect(getPRForBranchOutcomeMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes no-PR candidates after the 60-minute background interval', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({
+          cachedHasPR: false,
+          cachedFetchedAt: Date.now() - 60 * 60_000
+        })
+      ],
+      1,
+      1
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+  })
+
   it('lets an active worktree refresh bypass a delayed visible follow-up', async () => {
     const { enqueuePRRefresh, reportVisiblePRRefreshCandidates } =
       await import('./pr-refresh-coordinator')

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -13,8 +13,8 @@ import { getOriginGitHubApiRepository } from './github-api-repository'
 import { ghRepoExecOptions, githubRepoContext } from './gh-utils'
 import { getRateLimit, repositoryRateLimitGuard, spendsSharedGitHubComQuota } from './rate-limit'
 import {
-  lookupBackoffDelayMs,
-  NO_REVIEW_REFRESH_INTERVAL_MS
+  BACKGROUND_NO_REVIEW_REFRESH_INTERVAL_MS,
+  lookupBackoffDelayMs
 } from '../source-control/hosted-review-refresh-pacing'
 import { recordCoalescedCrashBreadcrumb } from '../crash-reporting/crash-breadcrumb-store'
 import { sendToTrustedUIRenderer } from '../ipc/ui'
@@ -505,7 +505,7 @@ function refreshIntervalForCandidate(candidate: GitHubPRRefreshCandidate): numbe
     return 30 * 60_000
   }
   if (candidate.cachedHasPR === false) {
-    return NO_REVIEW_REFRESH_INTERVAL_MS
+    return BACKGROUND_NO_REVIEW_REFRESH_INTERVAL_MS
   }
   if (
     candidate.cachedHasPR === true &&

--- a/src/main/source-control/hosted-review-refresh-pacing.ts
+++ b/src/main/source-control/hosted-review-refresh-pacing.ts
@@ -2,13 +2,16 @@
  * Shared pacing policy for hosted-review lookups (#11532).
  *
  * The PR refresh coordinator's queue and the `hostedReview:forBranch` entry
- * point spend the same per-user API quota, so they must agree on how long an
- * answer stays good and how hard to back off after a failure. Keeping the
- * numbers here stops the two paths from drifting apart.
+ * point spend the same per-user API quota, so their tier-specific freshness
+ * intervals and shared failure backoff belong in one explicit policy. Keeping
+ * the numbers here makes intentional differences reviewable.
  */
 
 /** A branch with no review only gains one when a review is opened, which is not a per-minute event. */
 export const NO_REVIEW_REFRESH_INTERVAL_MS = 15 * 60_000
+
+/** O(N) card-list polling can wait longer without slowing the selected-worktree fast tier. */
+export const BACKGROUND_NO_REVIEW_REFRESH_INTERVAL_MS = 60 * 60_000
 
 /**
  * The worktree the user has selected is re-checked at the old cadence: a review


### PR DESCRIPTION
## Summary

Lengthen the GitHub PR refresh coordinator's background no-PR interval from 15 to 60 minutes, reducing repeated O(N) card-list lookups without slowing the selected-worktree path.

## Prior review context

PR #11569 originally proposed a longer no-PR background interval. It was closed as superseded after the broader tiered PR-lookup pacing in #12013 landed and closed #11532.

Following @nwparker's guidance on #11569, this is a new, current-`main` follow-up rather than a reopening of the previous branch or a re-claim of #11532. It keeps the architecture introduced by #12013 and isolates only the remaining interval adjustment into a smaller reviewable change.

## Focused fix

- In scope: the coordinator's background cadence for cached no-PR candidates and its 60-minute boundary tests.
- Out of scope: hosted-review branch-cache freshness, selected-worktree pacing, provider lookup semantics, and other PR-state refresh tiers.

## Preserves

- The shared hosted-review no-review cache remains at 15 minutes.
- The selected-worktree fast tier remains at 1 minute.
- Manual/active refresh behavior and found/open/closed PR refresh tiers remain unchanged.
- SSH, WSL, and non-GitHub hosted-review cache behavior remain unchanged.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full suite not run; targeted coordinator and branch-cache suites passed 77/77.
- [ ] `pnpm build` — not run; no UI, packaging, or dependency change.
- [x] Added boundary regression coverage that fails under the previous 15-minute background cadence.

Additional evidence:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts src/main/source-control/hosted-review-branch-cache.test.ts` — 2 files, 77 tests passed.
- `pnpm run check:code-quality:changed upstream/main` — all three changed-code scans passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — passed, including reliability gates and the max-lines ratchet.
- `git diff --check upstream/main...HEAD` — passed.

## AI Review Report

An independent review checked the interval split, shared-cache coupling, selected-worktree freshness, scope, and regression boundaries. It found one stale header comment that still described identical freshness as an invariant; the comment was updated to document intentional tier-specific intervals in one shared quota policy.

Cross-platform review confirmed this changes only GitHub background scheduling. It does not touch shortcuts, labels, paths, shell execution, Electron platform branches, SSH/WSL routing, or non-GitHub provider behavior on macOS, Linux, or Windows.

## Security Audit

- No input handling, command execution, path handling, authentication, secrets, dependencies, or IPC surfaces change.
- The coordinator still uses the existing shared rate-limit guard and lookup path.
- The longer O(N) background interval reduces provider quota pressure without weakening manual or selected-worktree refresh behavior.

## User-regression-tradeoffs

- An unselected worktree with a cached no-PR result may take up to 60 minutes to discover a PR opened externally through background polling.
- Selecting the worktree still uses the existing fast tier, while broad background no-PR polling runs four times less often.

Related: #11532, #11569, #12013

## Notes

Automated review comments that reference commit `9e454104c6` analyzed the pre-rewrite branch and are stale. The current head is `9c66aa1ea9`, based on current `main`, and contains only the three focused product/test files listed in this PR.
