### PR TITLE
feat(editor): preserve PDF scroll position across tab switches

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -180,6 +180,12 @@ export function EditorContent({
     viewStateScopeId === activeFile.id
       ? `${activeFile.id}:preview`
       : `${activeFile.id}::${viewStateScopeId}:preview`
+  // Why: only the single-pane edit path gets PDF scroll memory — the diff and
+  // conflict-review paths mount several viewers on one path (see PdfViewer).
+  const pdfViewStateKey =
+    viewStateScopeId === activeFile.id
+      ? `${activeFile.filePath}:pdf`
+      : `${activeFile.filePath}::${viewStateScopeId}:pdf`
   const monacoLanguage = resolvedLanguage === 'notebook' ? 'json' : resolvedLanguage
 
   const openConflictReviewFile = useAppStore((s) => s.openConflictReviewFile)
@@ -740,7 +746,12 @@ export function EditorContent({
     if (fc.isBinary) {
       if (fc.isImage) {
         return (
-          <ImageViewer content={fc.content} filePath={activeFile.filePath} mimeType={fc.mimeType} />
+          <ImageViewer
+            content={fc.content}
+            filePath={activeFile.filePath}
+            mimeType={fc.mimeType}
+            scrollCacheKey={pdfViewStateKey}
+          />
         )
       }
       return (

--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -154,6 +154,51 @@ function pngBase64(width: number): string {
   return bytes.toString('base64')
 }
 
+async function renderPdfViewerProps(
+  scrollCacheKey?: string | null
+): Promise<Record<string, unknown>> {
+  reactHookRuntime.index = 0
+  const module = await import('./ImageViewer')
+  const rendered = expandNode(
+    module.default({
+      content: 'JVBERi0xLjQK',
+      filePath: '/repo/report.pdf',
+      mimeType: 'application/pdf',
+      ...(scrollCacheKey === undefined ? {} : { scrollCacheKey })
+    })
+  )
+  const [pdf] = findElementsByType(rendered, 'PdfViewer')
+  if (!pdf) {
+    throw new Error('PdfViewer not rendered')
+  }
+  return pdf.props
+}
+
+describe('ImageViewer PDF scroll cache key', () => {
+  beforeEach(() => {
+    reactHookRuntime.states = []
+    reactHookRuntime.index = 0
+    vi.clearAllMocks()
+  })
+
+  // Why: nothing else pins the wiring, so a dropped prop anywhere between
+  // EditorContent and PdfViewer would ship as silently amnesiac scrolling.
+  it('forwards the scroll cache key to PdfViewer', async () => {
+    expect(await renderPdfViewerProps('/repo/report.pdf::tab-2:pdf')).toMatchObject({
+      filePath: '/repo/report.pdf',
+      scrollCacheKey: '/repo/report.pdf::tab-2:pdf'
+    })
+  })
+
+  it('passes null when no key is supplied, so unkeyed callers stay opted out', async () => {
+    expect((await renderPdfViewerProps()).scrollCacheKey).toBeNull()
+  })
+
+  it('passes an explicit null through unchanged', async () => {
+    expect((await renderPdfViewerProps(null)).scrollCacheKey).toBeNull()
+  })
+})
+
 describe('ImageViewer preview source retry', () => {
   beforeEach(() => {
     reactHookRuntime.states = []

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -29,13 +29,17 @@ type ImageViewerProps = {
   filePath: string
   mimeType?: string
   layout?: 'fill' | 'intrinsic'
+  // Why: absent means "no PDF scroll memory" — diff and conflict-review callers
+  // mount several viewers on one path, so they deliberately pass nothing.
+  scrollCacheKey?: string | null
 }
 
 export default function ImageViewer({
   content,
   filePath,
   mimeType = FALLBACK_IMAGE_MIME_TYPE,
-  layout = 'fill'
+  layout = 'fill',
+  scrollCacheKey = null
 }: ImageViewerProps): JSX.Element {
   const [isPopupOpen, setIsPopupOpen] = useState(false)
   const [inlineZoom, setInlineZoom] = useState(1)
@@ -210,7 +214,9 @@ export default function ImageViewer({
   }, [isPopupOpen])
 
   if (isPdf) {
-    return <PdfViewer content={cleanedContent} filePath={filePath} />
+    return (
+      <PdfViewer content={cleanedContent} filePath={filePath} scrollCacheKey={scrollCacheKey} />
+    )
   }
 
   if (imageError) {

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -22,6 +22,12 @@ import {
   stepPdfScalePreference,
   type PdfScalePreference
 } from './pdf-scale-preference'
+import { pdfViewPositionCache, setWithLRU } from '@/lib/scroll-cache'
+import {
+  buildPdfScrollDestination,
+  clampPdfViewPosition,
+  createPdfViewPositionRecorder
+} from './pdf-view-position'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl
 
@@ -30,12 +36,23 @@ const MAX_SCALE = 5
 const SCALE_STEP = 1.25
 const SCALE_BOUNDS = { min: MIN_SCALE, max: MAX_SCALE, step: SCALE_STEP }
 
+// Why: these are the inputs that actually move this container's scroll; a
+// window-level keydown would also fire for typing in an unrelated pane.
+const USER_SCROLL_INPUT_EVENTS = ['wheel', 'touchstart', 'keydown', 'pointerdown'] as const
+
 type PdfViewerProps = {
   content: string
   filePath: string
+  // Why: absent means "no scroll memory" — the diff and conflict-review callers
+  // mount several viewers on one path, so a shared key would cross-write.
+  scrollCacheKey?: string | null
 }
 
-export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.Element {
+export default function PdfViewer({
+  content,
+  filePath,
+  scrollCacheKey = null
+}: PdfViewerProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const viewerDivRef = useRef<HTMLDivElement>(null)
   const [pdfError, setPdfError] = useState<string | null>(null)
@@ -115,6 +132,66 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
     }
     eventBus.on('scalechanging', handleScaleChanging)
 
+    // Why: read the key from this effect's own closure, never a ref — the ref
+    // would already hold the next file's key by the time this setup runs.
+    const recorder = scrollCacheKey
+      ? createPdfViewPositionRecorder({
+          key: scrollCacheKey,
+          write: (key, position) => setWithLRU(pdfViewPositionCache, key, position)
+        })
+      : null
+
+    const handleUpdateViewArea = (evt: { location?: unknown }): void => {
+      recorder?.record(evt?.location)
+    }
+
+    let restored: ReturnType<typeof buildPdfScrollDestination> | null = null
+    let userMoved = false
+    let detachInputWatcher: (() => void) | null = null
+    const markUserMoved = (): void => {
+      userMoved = true
+      detachInputWatcher?.()
+    }
+
+    const handlePagesInit = (): void => {
+      const cached = scrollCacheKey ? pdfViewPositionCache.get(scrollCacheKey) : undefined
+      const clamped = cached ? clampPdfViewPosition(cached, viewer.pagesCount) : null
+      if (clamped) {
+        restored = buildPdfScrollDestination(clamped)
+        viewer.scrollPageIntoView(restored)
+        for (const type of USER_SCROLL_INPUT_EVENTS) {
+          container.addEventListener(type, markUserMoved, { passive: true })
+        }
+        detachInputWatcher = (): void => {
+          detachInputWatcher = null
+          for (const type of USER_SCROLL_INPUT_EVENTS) {
+            container.removeEventListener(type, markUserMoved)
+          }
+        }
+      }
+      // Why: arm after the restore so its own scroll is not recorded as the
+      // reader's position — but on every path, so a PDF with nothing cached
+      // still starts recording.
+      recorder?.arm()
+    }
+
+    // Why: pagesinit lays every page out with page 1's dimensions, so on a
+    // mixed-page-size document the restore above lands short. pagesloaded is the
+    // first point with real per-page heights — but it can arrive seconds later,
+    // so re-apply only if the reader has not touched the scroller since.
+    const handlePagesLoaded = (): void => {
+      const destination = restored
+      restored = null
+      detachInputWatcher?.()
+      if (!cancelled && destination && !userMoved) {
+        viewer.scrollPageIntoView(destination)
+      }
+    }
+
+    eventBus.on('pagesinit', handlePagesInit)
+    eventBus.on('pagesloaded', handlePagesLoaded)
+    eventBus.on('updateviewarea', handleUpdateViewArea)
+
     const loadingTask = pdfjsLib.getDocument({ data: bytes })
 
     loadingTask.promise
@@ -142,6 +219,13 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
 
     return () => {
       cancelled = true
+      // Why: flush before setDocument(null) below, so nothing dispatched during
+      // pdf.js teardown can overwrite the position we just persisted.
+      detachInputWatcher?.()
+      recorder?.dispose()
+      eventBus.off('pagesinit', handlePagesInit)
+      eventBus.off('pagesloaded', handlePagesLoaded)
+      eventBus.off('updateviewarea', handleUpdateViewArea)
       setFindOpen(false)
       loadingTask.destroy().catch(() => {})
       if (pdfDocument) {
@@ -158,7 +242,10 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
       findControllerRef.current = null
       pdfViewerRef.current = null
     }
-  }, [cleanedContent])
+    // Why: scrollCacheKey is a dependency because two distinct paths can hold
+    // identical bytes — without it this effect would not re-run on the switch,
+    // and the second file would restore to the first file's position.
+  }, [cleanedContent, scrollCacheKey])
 
   const closeFindBar = useCallback(() => {
     const eventBus = eventBusRef.current

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -179,23 +179,47 @@ export default function PdfViewer({
       }
     }
 
+    let visibilityObserver: ResizeObserver | null = null
+    const disconnectVisibilityObserver = (): void => {
+      visibilityObserver?.disconnect()
+      visibilityObserver = null
+    }
+    // Why: a display:none pane regaining a layout box fires no scroll or resize
+    // event — ResizeObserver's no-box/box transition is the only signal for it.
+    const observeVisibility = (): void => {
+      if (visibilityObserver) {
+        return
+      }
+      visibilityObserver = new ResizeObserver(() => {
+        if (container.clientHeight > 0) {
+          handlePagesLoaded()
+        }
+      })
+      visibilityObserver.observe(container)
+    }
+
     // Why: pagesinit lays every page out with page 1's dimensions, so on a
     // mixed-page-size document the restore above lands short. pagesloaded is the
     // first point with real per-page heights — but it can arrive seconds later,
     // so re-apply only if the reader has not touched the scroller since.
     const handlePagesLoaded = (): void => {
-      const destination = restored
-      restored = null
       // Why: an editor in a background worktree stays mounted under display:none,
       // where pdf.js can neither scroll nor recompute its location. Arming there
       // would let the reader's first zoom persist a page-1 position over the
-      // cached one, so stay disarmed and keep the input watcher until this pane
-      // is actually on screen.
+      // cached one, so stay disarmed — and hold `restored` and the input watcher
+      // — until the observer above sees this pane land on screen.
       if (container.clientHeight === 0) {
+        observeVisibility()
         return
       }
+      disconnectVisibilityObserver()
+      const destination = restored
+      restored = null
       detachInputWatcher?.()
-      if (!cancelled && destination && !userMoved) {
+      if (cancelled) {
+        return
+      }
+      if (destination && !userMoved) {
         viewer.scrollPageIntoView(destination)
         // Why: scrollPageIntoView nulls pdf.js's own `_location` whenever
         // `currentScaleValue` is unset, and it stays unset here because
@@ -247,6 +271,7 @@ export default function PdfViewer({
       // Why: flush before setDocument(null) below, so nothing dispatched during
       // pdf.js teardown can overwrite the position we just persisted.
       detachInputWatcher?.()
+      disconnectVisibilityObserver()
       recorder?.dispose()
       eventBus.off('pagesinit', handlePagesInit)
       eventBus.off('pagesloaded', handlePagesLoaded)

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -189,6 +189,14 @@ export default function PdfViewer({
       detachInputWatcher?.()
       if (!cancelled && destination && !userMoved) {
         viewer.scrollPageIntoView(destination)
+        // Why: scrollPageIntoView nulls pdf.js's own `_location` whenever
+        // `currentScaleValue` is unset, and it stays unset here because
+        // page-width resolves against a not-yet-built page list. A null
+        // `_location` makes the next zoom fall back to scrolling the page top,
+        // losing the intra-page offset. update() recomputes it; on a
+        // uniform-page document the re-apply moves nothing, so no scroll event
+        // would otherwise fire to do it for us.
+        viewer.update()
       }
       recorder?.arm()
     }
@@ -196,6 +204,10 @@ export default function PdfViewer({
     eventBus.on('pagesinit', handlePagesInit)
     eventBus.on('pagesloaded', handlePagesLoaded)
     eventBus.on('updateviewarea', handleUpdateViewArea)
+    // Why: the find controller scrolls to a match programmatically, and the find
+    // bar sits outside this container — so a search is reader movement that no
+    // input listener above can see.
+    eventBus.on('find', markUserMoved)
 
     const loadingTask = pdfjsLib.getDocument({ data: bytes })
 
@@ -231,6 +243,7 @@ export default function PdfViewer({
       eventBus.off('pagesinit', handlePagesInit)
       eventBus.off('pagesloaded', handlePagesLoaded)
       eventBus.off('updateviewarea', handleUpdateViewArea)
+      eventBus.off('find', markUserMoved)
       setFindOpen(false)
       loadingTask.destroy().catch(() => {})
       if (pdfDocument) {

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -186,6 +186,14 @@ export default function PdfViewer({
     const handlePagesLoaded = (): void => {
       const destination = restored
       restored = null
+      // Why: an editor in a background worktree stays mounted under display:none,
+      // where pdf.js can neither scroll nor recompute its location. Arming there
+      // would let the reader's first zoom persist a page-1 position over the
+      // cached one, so stay disarmed and keep the input watcher until this pane
+      // is actually on screen.
+      if (container.clientHeight === 0) {
+        return
+      }
       detachInputWatcher?.()
       if (!cancelled && destination && !userMoved) {
         viewer.scrollPageIntoView(destination)

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -151,28 +151,32 @@ export default function PdfViewer({
     const markUserMoved = (): void => {
       userMoved = true
       detachInputWatcher?.()
+      recorder?.arm()
     }
 
     const handlePagesInit = (): void => {
       const cached = scrollCacheKey ? pdfViewPositionCache.get(scrollCacheKey) : undefined
       const clamped = cached ? clampPdfViewPosition(cached, viewer.pagesCount) : null
-      if (clamped) {
-        restored = buildPdfScrollDestination(clamped)
-        viewer.scrollPageIntoView(restored)
+      if (!clamped) {
+        recorder?.arm()
+        return
+      }
+      restored = buildPdfScrollDestination(clamped)
+      viewer.scrollPageIntoView(restored)
+      // Why: stays disarmed until the restore settles (below). pdf.js dispatches
+      // updateviewarea synchronously after this handler, so arming here would
+      // record the restore's own scroll — which on a mixed-page-size document is
+      // the provisional, wrong position, and a tab switch before pagesloaded
+      // would then flush it over the good cached one.
+      for (const type of USER_SCROLL_INPUT_EVENTS) {
+        container.addEventListener(type, markUserMoved, { passive: true })
+      }
+      detachInputWatcher = (): void => {
+        detachInputWatcher = null
         for (const type of USER_SCROLL_INPUT_EVENTS) {
-          container.addEventListener(type, markUserMoved, { passive: true })
-        }
-        detachInputWatcher = (): void => {
-          detachInputWatcher = null
-          for (const type of USER_SCROLL_INPUT_EVENTS) {
-            container.removeEventListener(type, markUserMoved)
-          }
+          container.removeEventListener(type, markUserMoved)
         }
       }
-      // Why: arm after the restore so its own scroll is not recorded as the
-      // reader's position — but on every path, so a PDF with nothing cached
-      // still starts recording.
-      recorder?.arm()
     }
 
     // Why: pagesinit lays every page out with page 1's dimensions, so on a
@@ -186,6 +190,7 @@ export default function PdfViewer({
       if (!cancelled && destination && !userMoved) {
         viewer.scrollPageIntoView(destination)
       }
+      recorder?.arm()
     }
 
     eventBus.on('pagesinit', handlePagesInit)

--- a/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.test.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { PdfViewPosition } from '@/lib/scroll-cache'
+import { sweepClosedPdfViewPositions } from './closed-editor-tab-cache-sweep'
+
+const position = (pageNumber: number): PdfViewPosition => ({ pageNumber, top: 0, left: 0 })
+
+describe('sweepClosedPdfViewPositions', () => {
+  it('deletes the unscoped :pdf entry', () => {
+    const cache = new Map([['/a.pdf:pdf', position(4)]])
+    sweepClosedPdfViewPositions(cache, '/a.pdf')
+    expect(cache.size).toBe(0)
+  })
+
+  it('deletes pane-scoped entries for the same file', () => {
+    const cache = new Map([
+      ['/a.pdf:pdf', position(4)],
+      ['/a.pdf::tab-2:pdf', position(9)],
+      ['/a.pdf::tab-3:pdf', position(11)]
+    ])
+    sweepClosedPdfViewPositions(cache, '/a.pdf')
+    expect(cache.size).toBe(0)
+  })
+
+  it('leaves other files untouched', () => {
+    const cache = new Map([
+      ['/a.pdf:pdf', position(4)],
+      ['/b.pdf:pdf', position(7)],
+      ['/b.pdf::tab-2:pdf', position(8)]
+    ])
+    sweepClosedPdfViewPositions(cache, '/a.pdf')
+    expect([...cache.keys()]).toEqual(['/b.pdf:pdf', '/b.pdf::tab-2:pdf'])
+  })
+
+  it('does not delete a different file that shares a path prefix', () => {
+    const cache = new Map([
+      ['/report.pdf:pdf', position(2)],
+      ['/report.pdf.bak:pdf', position(3)]
+    ])
+    sweepClosedPdfViewPositions(cache, '/report.pdf')
+    expect([...cache.keys()]).toEqual(['/report.pdf.bak:pdf'])
+  })
+
+  it('is a no-op when the file has no cached position', () => {
+    const cache = new Map([['/b.pdf:pdf', position(7)]])
+    sweepClosedPdfViewPositions(cache, '/a.pdf')
+    expect(cache.size).toBe(1)
+  })
+})

--- a/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.ts
+++ b/src/renderer/src/components/editor/closed-editor-tab-cache-sweep.ts
@@ -1,0 +1,23 @@
+import type { PdfViewPosition } from '@/lib/scroll-cache'
+
+function deleteCacheEntriesByPrefix<T>(cache: Map<string, T>, prefix: string): void {
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) {
+      cache.delete(key)
+    }
+  }
+}
+
+/**
+ * Release the PDF positions a closed edit tab owns. Split out from the cleanup
+ * hook so it is testable without pulling in the hook's `monaco-editor` import.
+ */
+export function sweepClosedPdfViewPositions(
+  cache: Map<string, PdfViewPosition>,
+  filePath: string
+): void {
+  // Why: the `::`-scoped sweep does not cover the single-colon suffix, so the
+  // unscoped key needs its own delete (same shape as :rich / :preview).
+  cache.delete(`${filePath}:pdf`)
+  deleteCacheEntriesByPrefix(cache, `${filePath}::`)
+}

--- a/src/renderer/src/components/editor/pdf-view-position.test.ts
+++ b/src/renderer/src/components/editor/pdf-view-position.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PdfViewPosition } from '@/lib/scroll-cache'
+import {
+  buildPdfScrollDestination,
+  clampPdfViewPosition,
+  createPdfViewPositionRecorder,
+  PDF_POSITION_FLUSH_MS,
+  readPdfViewPosition
+} from './pdf-view-position'
+
+describe('readPdfViewPosition', () => {
+  it('normalizes a well-formed updateviewarea location', () => {
+    expect(
+      readPdfViewPosition({ pageNumber: 12, top: 431, left: 62, scale: 1.5, rotation: 0 })
+    ).toEqual({ pageNumber: 12, top: 431, left: 62 })
+  })
+
+  it('accepts negative offsets (inter-page gap positions)', () => {
+    expect(readPdfViewPosition({ pageNumber: 3, top: -14, left: -2 })).toEqual({
+      pageNumber: 3,
+      top: -14,
+      left: -2
+    })
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a non-object', 'page 12'],
+    ['a number', 7]
+  ])('returns null for %s', (_label, input) => {
+    expect(readPdfViewPosition(input)).toBeNull()
+  })
+
+  it('returns null when top is missing', () => {
+    expect(readPdfViewPosition({ pageNumber: 2, left: 0 })).toBeNull()
+  })
+
+  it('returns null when left is missing', () => {
+    expect(readPdfViewPosition({ pageNumber: 2, top: 0 })).toBeNull()
+  })
+
+  it.each([
+    ['NaN top', { pageNumber: 2, top: Number.NaN, left: 0 }],
+    ['Infinity left', { pageNumber: 2, top: 0, left: Number.POSITIVE_INFINITY }],
+    ['NaN pageNumber', { pageNumber: Number.NaN, top: 0, left: 0 }]
+  ])('returns null for %s', (_label, input) => {
+    expect(readPdfViewPosition(input)).toBeNull()
+  })
+
+  it('returns null for pageNumber 0', () => {
+    expect(readPdfViewPosition({ pageNumber: 0, top: 0, left: 0 })).toBeNull()
+  })
+
+  it('returns null for a fractional pageNumber', () => {
+    expect(readPdfViewPosition({ pageNumber: 2.5, top: 0, left: 0 })).toBeNull()
+  })
+
+  it('preserves a top-of-page-1 position verbatim', () => {
+    // Why: `top` is a bottom-origin PDF coordinate, so the top of a Letter page
+    // is ~792, not 0. Nothing may treat this as a "document start" sentinel.
+    expect(readPdfViewPosition({ pageNumber: 1, top: 792, left: 0 })).toEqual({
+      pageNumber: 1,
+      top: 792,
+      left: 0
+    })
+  })
+})
+
+describe('buildPdfScrollDestination', () => {
+  it('emits the 5-element XYZ destArray with left and top in slots 2 and 3', () => {
+    expect(buildPdfScrollDestination({ pageNumber: 12, top: 431, left: 62 })).toEqual({
+      pageNumber: 12,
+      destArray: [null, { name: 'XYZ' }, 62, 431, null],
+      ignoreDestinationZoom: true,
+      allowNegativeOffset: true
+    })
+  })
+
+  it('always sets both flags', () => {
+    const destination = buildPdfScrollDestination({ pageNumber: 1, top: 0, left: 0 })
+    expect(destination.ignoreDestinationZoom).toBe(true)
+    expect(destination.allowNegativeOffset).toBe(true)
+  })
+})
+
+describe('clampPdfViewPosition', () => {
+  const position = { pageNumber: 40, top: 100, left: 10 }
+
+  it('clamps a page beyond the document to the last page', () => {
+    expect(clampPdfViewPosition(position, 12)).toEqual({ pageNumber: 12, top: 100, left: 10 })
+  })
+
+  it('returns an in-range position untouched', () => {
+    const inRange = { pageNumber: 5, top: 100, left: 10 }
+    expect(clampPdfViewPosition(inRange, 12)).toBe(inRange)
+  })
+
+  it('returns null when the document reports no pages', () => {
+    expect(clampPdfViewPosition(position, 0)).toBeNull()
+  })
+
+  it('returns null for a non-finite page count', () => {
+    expect(clampPdfViewPosition(position, Number.NaN)).toBeNull()
+  })
+
+  it('preserves top and left while clamping the page', () => {
+    const clamped = clampPdfViewPosition(position, 3)
+    expect(clamped).toEqual({ pageNumber: 3, top: 100, left: 10 })
+  })
+})
+
+describe('createPdfViewPositionRecorder', () => {
+  let writes: [string, PdfViewPosition][]
+
+  const makeRecorder = (key = 'a.pdf:pdf') =>
+    createPdfViewPositionRecorder({
+      key,
+      write: (writtenKey, position) => writes.push([writtenKey, position])
+    })
+
+  const location = (pageNumber: number) => ({ pageNumber, top: 400, left: 20, scale: 1 })
+
+  beforeEach(() => {
+    writes = []
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ignores records before arm, so a pre-restore scroll cannot overwrite the cache', () => {
+    const recorder = makeRecorder()
+    recorder.record(location(1))
+    vi.advanceTimersByTime(PDF_POSITION_FLUSH_MS * 2)
+    recorder.dispose()
+    expect(writes).toEqual([])
+  })
+
+  it('disposing without any record is a strict no-op (StrictMode double-mount)', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.dispose()
+    expect(writes).toEqual([])
+  })
+
+  it('flushes the last recorded position on dispose', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(7))
+    recorder.dispose()
+    expect(writes).toEqual([['a.pdf:pdf', { pageNumber: 7, top: 400, left: 20 }]])
+  })
+
+  it('fires the debounced write once and reflects the latest of several rapid records', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(2))
+    recorder.record(location(3))
+    recorder.record(location(4))
+    expect(writes).toEqual([])
+    vi.advanceTimersByTime(PDF_POSITION_FLUSH_MS)
+    expect(writes).toEqual([['a.pdf:pdf', { pageNumber: 4, top: 400, left: 20 }]])
+  })
+
+  it('ignores a malformed location without clearing the last good position', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(5))
+    recorder.record({ pageNumber: Number.NaN, top: 1, left: 1 })
+    recorder.dispose()
+    expect(writes.at(-1)).toEqual(['a.pdf:pdf', { pageNumber: 5, top: 400, left: 20 }])
+  })
+
+  it('only ever writes under the key it was constructed with', () => {
+    const recorder = makeRecorder('b.pdf::tab-2:pdf')
+    recorder.arm()
+    recorder.record(location(9))
+    recorder.dispose()
+    expect(writes).toEqual([['b.pdf::tab-2:pdf', { pageNumber: 9, top: 400, left: 20 }]])
+  })
+
+  it('cancels the pending timer on dispose so teardown writes exactly once', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(6))
+    recorder.dispose()
+    vi.advanceTimersByTime(PDF_POSITION_FLUSH_MS * 2)
+    expect(writes).toHaveLength(1)
+  })
+
+  it('record after dispose schedules no timer and writes nothing', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(6))
+    recorder.dispose()
+    recorder.record(location(99))
+    vi.advanceTimersByTime(PDF_POSITION_FLUSH_MS * 2)
+    expect(writes).toEqual([['a.pdf:pdf', { pageNumber: 6, top: 400, left: 20 }]])
+  })
+
+  it('disposing twice does not write twice', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(6))
+    recorder.dispose()
+    recorder.dispose()
+    expect(writes).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/components/editor/pdf-view-position.test.ts
+++ b/src/renderer/src/components/editor/pdf-view-position.test.ts
@@ -164,6 +164,19 @@ describe('createPdfViewPositionRecorder', () => {
     expect(writes).toEqual([['a.pdf:pdf', { pageNumber: 4, top: 400, left: 20 }]])
   })
 
+  // Why: the timer is deliberately trailing-from-first-record, not a restarting
+  // debounce — a restarting one would starve the LRU refresh under continuous
+  // scrolling, which is exactly when the entry most needs to stay warm.
+  it('does not restart the pending timer when a later record arrives', () => {
+    const recorder = makeRecorder()
+    recorder.arm()
+    recorder.record(location(2))
+    vi.advanceTimersByTime(PDF_POSITION_FLUSH_MS - 50)
+    recorder.record(location(3))
+    vi.advanceTimersByTime(50)
+    expect(writes).toEqual([['a.pdf:pdf', { pageNumber: 3, top: 400, left: 20 }]])
+  })
+
   it('ignores a malformed location without clearing the last good position', () => {
     const recorder = makeRecorder()
     recorder.arm()

--- a/src/renderer/src/components/editor/pdf-view-position.ts
+++ b/src/renderer/src/components/editor/pdf-view-position.ts
@@ -87,20 +87,11 @@ export type PdfViewPositionRecorder = {
  */
 export function createPdfViewPositionRecorder({
   key,
-  write,
-  timers
+  write
 }: {
   key: string
   write: (key: string, position: PdfViewPosition) => void
-  // Why: paired, because a caller-supplied handle must go back to its own
-  // canceller — mixing halves hands a foreign handle to clearTimeout.
-  timers?: {
-    schedule: (fn: () => void, ms: number) => TimerHandle
-    cancel: (h: TimerHandle) => void
-  }
 }): PdfViewPositionRecorder {
-  const schedule = timers?.schedule ?? ((fn, ms) => setTimeout(fn, ms))
-  const cancel = timers?.cancel ?? ((handle) => clearTimeout(handle))
   let armed = false
   let disposed = false
   let pending: PdfViewPosition | null = null
@@ -134,7 +125,7 @@ export function createPdfViewPositionRecorder({
       }
       // Why: the debounced write only refreshes LRU recency — teardown is what
       // actually persists the position — so a pending timer need not restart.
-      timer = schedule(() => {
+      timer = setTimeout(() => {
         timer = null
         flush()
       }, PDF_POSITION_FLUSH_MS)
@@ -146,7 +137,7 @@ export function createPdfViewPositionRecorder({
       }
       disposed = true
       if (timer !== null) {
-        cancel(timer)
+        clearTimeout(timer)
         timer = null
       }
       flush()

--- a/src/renderer/src/components/editor/pdf-view-position.ts
+++ b/src/renderer/src/components/editor/pdf-view-position.ts
@@ -1,0 +1,155 @@
+import type { PdfViewPosition } from '@/lib/scroll-cache'
+
+/** Argument object for pdf.js `PDFViewer.scrollPageIntoView`. */
+export type PdfScrollDestination = {
+  pageNumber: number
+  destArray: unknown[]
+  ignoreDestinationZoom: true
+  allowNegativeOffset: true
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/**
+ * Normalize an `updateviewarea` payload's `location`. pdf.js does not type
+ * EventBus payloads, so this is the validation boundary — a pdf.js upgrade that
+ * reshapes the payload degrades to "no restore" rather than throwing.
+ */
+export function readPdfViewPosition(location: unknown): PdfViewPosition | null {
+  if (typeof location !== 'object' || location === null) {
+    return null
+  }
+  const { pageNumber, top, left } = location as Record<string, unknown>
+  // Why: scrollPageIntoView itself guards on Number.isInteger and silently
+  // logs-and-returns, so a fractional page would fail the restore invisibly.
+  if (!isFiniteNumber(pageNumber) || !Number.isInteger(pageNumber) || pageNumber < 1) {
+    return null
+  }
+  if (!isFiniteNumber(top) || !isFiniteNumber(left)) {
+    return null
+  }
+  return { pageNumber, top, left }
+}
+
+/**
+ * Build the XYZ destination pdf.js uses for its own scale-change position
+ * restore (`pdf_viewer.mjs:8843-8853`).
+ */
+export function buildPdfScrollDestination(position: PdfViewPosition): PdfScrollDestination {
+  return {
+    pageNumber: position.pageNumber,
+    // Why: slot 0 (page ref) is never read on this path; the trailing null zoom
+    // pairs with ignoreDestinationZoom so the destination cannot overwrite scale.
+    destArray: [null, { name: 'XYZ' }, position.left, position.top, null],
+    ignoreDestinationZoom: true,
+    // Why: a position in the inter-page gap transforms to a negative offset;
+    // clamping it would land at the page top instead, off by the gap height.
+    allowNegativeOffset: true
+  }
+}
+
+/**
+ * Clamp a cached page against a document that shrank on disk. Not a safety
+ * guard — pdf.js already ignores an out-of-range page — this just lands the
+ * reader on the last page instead of nowhere.
+ */
+export function clampPdfViewPosition(
+  position: PdfViewPosition,
+  pagesCount: number
+): PdfViewPosition | null {
+  if (!isFiniteNumber(pagesCount) || pagesCount < 1) {
+    return null
+  }
+  const pageNumber = Math.min(Math.max(position.pageNumber, 1), Math.floor(pagesCount))
+  return pageNumber === position.pageNumber ? position : { ...position, pageNumber }
+}
+
+export const PDF_POSITION_FLUSH_MS = 150
+
+type TimerHandle = ReturnType<typeof setTimeout>
+
+export type PdfViewPositionRecorder = {
+  arm: () => void
+  record: (location: unknown) => void
+  dispose: () => void
+}
+
+/**
+ * Owns the record half of PDF scroll preservation: the arm gate and the
+ * trailing debounce. Extracted from `PdfViewer` because the effect itself is
+ * untestable (node vitest env, and ImageViewer.test mocks useEffect), so every
+ * race guard below would otherwise ship uncovered.
+ *
+ * `dispose` is terminal: afterwards `record` is inert, so a late timer can
+ * never resurrect an entry `useClosedEditorTabCleanup` just swept.
+ */
+export function createPdfViewPositionRecorder({
+  key,
+  write,
+  timers
+}: {
+  key: string
+  write: (key: string, position: PdfViewPosition) => void
+  // Why: paired, because a caller-supplied handle must go back to its own
+  // canceller — mixing halves hands a foreign handle to clearTimeout.
+  timers?: {
+    schedule: (fn: () => void, ms: number) => TimerHandle
+    cancel: (h: TimerHandle) => void
+  }
+}): PdfViewPositionRecorder {
+  const schedule = timers?.schedule ?? ((fn, ms) => setTimeout(fn, ms))
+  const cancel = timers?.cancel ?? ((handle) => clearTimeout(handle))
+  let armed = false
+  let disposed = false
+  let pending: PdfViewPosition | null = null
+  let timer: TimerHandle | null = null
+
+  // Why: a strict no-op when nothing was recorded — writing here would clobber a
+  // good cached position on a StrictMode double-mount, whose cleanup runs before
+  // the reader has scrolled at all.
+  const flush = (): void => {
+    if (pending) {
+      write(key, pending)
+    }
+  }
+
+  return {
+    arm: () => {
+      armed = true
+    },
+
+    record: (location) => {
+      if (!armed || disposed) {
+        return
+      }
+      const position = readPdfViewPosition(location)
+      if (!position) {
+        return
+      }
+      pending = position
+      if (timer !== null) {
+        return
+      }
+      // Why: the debounced write only refreshes LRU recency — teardown is what
+      // actually persists the position — so a pending timer need not restart.
+      timer = schedule(() => {
+        timer = null
+        flush()
+      }, PDF_POSITION_FLUSH_MS)
+    },
+
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      if (timer !== null) {
+        cancel(timer)
+        timer = null
+      }
+      flush()
+    }
+  }
+}

--- a/src/renderer/src/components/editor/useClosedEditorTabCleanup.ts
+++ b/src/renderer/src/components/editor/useClosedEditorTabCleanup.ts
@@ -1,11 +1,17 @@
 import { useEffect, useRef } from 'react'
 import * as monaco from 'monaco-editor'
 import type { OpenFile } from '@/store/slices/editor'
-import { cursorPositionCache, diffViewStateCache, scrollTopCache } from '@/lib/scroll-cache'
+import {
+  cursorPositionCache,
+  diffViewStateCache,
+  pdfViewPositionCache,
+  scrollTopCache
+} from '@/lib/scroll-cache'
 import {
   disposeUnattachedMonacoModelsByPathPrefix,
   getDiffViewerMonacoModelPathPrefixes
 } from './diff-monaco-model-disposal'
+import { sweepClosedPdfViewPositions } from './closed-editor-tab-cache-sweep'
 
 function deleteCacheEntriesByPrefix<T>(cache: Map<string, T>, prefix: string): void {
   for (const key of cache.keys()) {
@@ -43,6 +49,8 @@ function disposeClosedEditorTab(prevId: string, prevFile: OpenFile): void {
       scrollTopCache.delete(`${prevFile.filePath}:mermaid-diagram`)
       cursorPositionCache.delete(prevFile.filePath)
       deleteCacheEntriesByPrefix(cursorPositionCache, `${prevFile.filePath}::`)
+      // Why: only 'edit' tabs ever get a PDF scroll key (see EditorContent).
+      sweepClosedPdfViewPositions(pdfViewPositionCache, prevFile.filePath)
       break
     case 'markdown-preview':
       // Why: preview tabs own pane-scoped preview scroll cache entries even

--- a/src/renderer/src/lib/scroll-cache.test.ts
+++ b/src/renderer/src/lib/scroll-cache.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it, beforeEach } from 'vitest'
-import { cursorPositionCache, diffViewStateCache, setWithLRU, scrollTopCache } from './scroll-cache'
+import {
+  cursorPositionCache,
+  diffViewStateCache,
+  pdfViewPositionCache,
+  setWithLRU,
+  scrollTopCache
+} from './scroll-cache'
 
 beforeEach(() => {
   scrollTopCache.clear()
   cursorPositionCache.clear()
   diffViewStateCache.clear()
+  pdfViewPositionCache.clear()
 })
 
 describe('setWithLRU', () => {
@@ -110,6 +117,48 @@ describe('scrollTopCache', () => {
     expect(scrollTopCache.get('/path/to/file.ts:preview')).toBe(200)
     expect(scrollTopCache.get('/path/to/file.ts:rich')).toBe(300)
     expect(scrollTopCache.size).toBe(3)
+  })
+})
+
+describe('pdfViewPositionCache', () => {
+  it('is an empty Map on import', () => {
+    expect(pdfViewPositionCache).toBeInstanceOf(Map)
+    expect(pdfViewPositionCache.size).toBe(0)
+  })
+
+  it('round-trips pageNumber, top, and left intact', () => {
+    setWithLRU(pdfViewPositionCache, '/doc.pdf:pdf', { pageNumber: 12, top: 431.5, left: 62 })
+    expect(pdfViewPositionCache.get('/doc.pdf:pdf')).toEqual({
+      pageNumber: 12,
+      top: 431.5,
+      left: 62
+    })
+  })
+
+  it('keeps pane-scoped keys for the same file independent', () => {
+    setWithLRU(pdfViewPositionCache, '/doc.pdf:pdf', { pageNumber: 3, top: 700, left: 0 })
+    setWithLRU(pdfViewPositionCache, '/doc.pdf::tab-2:pdf', { pageNumber: 40, top: 120, left: 0 })
+    expect(pdfViewPositionCache.get('/doc.pdf:pdf')?.pageNumber).toBe(3)
+    expect(pdfViewPositionCache.get('/doc.pdf::tab-2:pdf')?.pageNumber).toBe(40)
+  })
+
+  it('evicts the oldest entry at the default cap of 20', () => {
+    for (let i = 0; i <= 20; i++) {
+      setWithLRU(pdfViewPositionCache, `/doc-${i}.pdf:pdf`, { pageNumber: i, top: 0, left: 0 })
+    }
+    expect(pdfViewPositionCache.size).toBe(20)
+    expect(pdfViewPositionCache.has('/doc-0.pdf:pdf')).toBe(false)
+    expect(pdfViewPositionCache.has('/doc-20.pdf:pdf')).toBe(true)
+  })
+
+  it('refreshes recency when an existing PDF key is re-set', () => {
+    for (let i = 0; i < 20; i++) {
+      setWithLRU(pdfViewPositionCache, `/doc-${i}.pdf:pdf`, { pageNumber: i, top: 0, left: 0 })
+    }
+    setWithLRU(pdfViewPositionCache, '/doc-0.pdf:pdf', { pageNumber: 99, top: 0, left: 0 })
+    setWithLRU(pdfViewPositionCache, '/doc-new.pdf:pdf', { pageNumber: 1, top: 0, left: 0 })
+    expect(pdfViewPositionCache.get('/doc-0.pdf:pdf')?.pageNumber).toBe(99)
+    expect(pdfViewPositionCache.has('/doc-1.pdf:pdf')).toBe(false)
   })
 })
 

--- a/src/renderer/src/lib/scroll-cache.ts
+++ b/src/renderer/src/lib/scroll-cache.ts
@@ -40,6 +40,12 @@ export const scrollTopCache = new Map<string, number>()
 // re-renders on every cursor move.
 export const cursorPositionCache = new Map<string, { lineNumber: number; column: number }>()
 
+// Why: PDFs store a pdf.js location in PDF user space, not a scrollTop — page
+// layout is rebuilt at a scale that depends on container width, so a pixel
+// offset restores to the wrong place at a different zoom or pane width.
+export type PdfViewPosition = { pageNumber: number; top: number; left: number }
+export const pdfViewPositionCache = new Map<string, PdfViewPosition>()
+
 // Why: Diff editors need more than a numeric scroll offset to restore the same
 // working context. Monaco's diff view state also carries cursor/selection state
 // for both sides plus diff model state, which matches VS Code's restore path


### PR DESCRIPTION
Closes #12117

PDF scroll position was lost on every tab switch and reset to the start of the file. This restores the reader to where they were.

## Scope

Session-lifetime only: positions live in an in-memory LRU keyed by file path, survive tab switches, close-and-reopen, and pane switches, and are cleared on restart. No disk or schema work. Precision is page **plus intra-page offset**, so a reader mid-page lands mid-page.

Out of scope: scroll memory for images, markdown preview, or other viewers; any change to zoom behavior.

## Design

**Position is stored in PDF user space, not as `scrollTop`.** pdf.js rebuilds page layout at a scale derived from container width, so a pixel offset restores to the wrong place at a different pane width. The stored `{ pageNumber, top, left }` is scale-independent. Restore builds the same XYZ destination pdf.js uses for its own scale-change restore, with `ignoreDestinationZoom` so the destination cannot overwrite the reader's zoom and `allowNegativeOffset` so a position in an inter-page gap isn't clamped to the page top.

**Restore happens at `pagesinit`, then once more at `pagesloaded`.** `pagesinit` lays every page out with page 1's dimensions, so on a mixed-page-size document the first restore lands short. `pagesloaded` is the first point with real per-page heights, but it can arrive seconds later — so the re-apply is skipped if the reader has moved in the meantime.

**Keying is opt-in.** Only the single-pane edit path passes a `scrollCacheKey`. The diff and conflict-review paths mount several viewers on one file path, where a shared key would cross-write, so they pass none. That also makes `case 'edit':` provably the only cleanup branch that needs the sweep.

## Review

Three dimensions reviewed across two rounds, which turned up four defects in my own implementation:

- The recorder armed before the restore settled, so the provisional page-1-geometry landing could be flushed over a good cached position.
- `scrollPageIntoView` nulls pdf.js's `_location` when `currentScaleValue` is unset. On a uniform-page document the re-apply moves nothing, so no scroll event recomputed it, and the reader's next zoom scrolled to the page top **and persisted it** over their saved offset. Fixed with an explicit `update()`.
- The user-moved guard missed find: the find controller scrolls programmatically and the find bar renders outside the watched container, so searching during load yanked the reader back.
- Editors in background worktrees stay mounted under `display:none`, where pdf.js can neither scroll nor recompute location. Arming there let a later zoom overwrite the cached position, turning "fails to restore" into "destroys saved state".

Coverage: 1056 tests green, plus typecheck, oxlint and oxfmt. The wiring test was verified non-vacuous by deleting the forwarded prop and confirming it fails.

## Known limitations

- `top` is not clamped when a document shrinks on disk and has mixed page sizes; the page number is.
- Renaming an open file from within Orca leaks its entry until LRU eviction — a gap shared with the three existing scroll caches, not introduced here.
- On documents past pdf.js's lazy-init threshold (>5000 pages), `pagesloaded` arrives on page-1 geometry, so the re-applied position can be wrong rather than absent.
- The restore and arm policy live in an effect that isn't unit-testable in this harness; extracting a coordinator is a follow-up.

## Pre-existing bugs found, deliberately not fixed

Both are out of scope and reported separately:

- `applyPdfScalePreference` is a no-op for `page-width` — it runs before pdf.js builds its page list, so `#setScale` early-returns. PDFs open at 100%, not fit-to-width, and the footer reads 100% until the reader zooms. This is also the precondition for the `_location` bug above.
- A viewer that fails to decode one PDF can never recover for the next file in that pane: the error state unmounts the container, so the effect returns before clearing the error.

Made with [Orca](https://github.com/stablyai/orca) 🐋
