### PR TITLE
chore(audit): pin the dead-code audit to knip@5.88.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "audit:code-quality:native": "oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings",
     "audit:code-quality:type-aware": "oxlint --type-aware --config config/oxlint-code-quality-type-aware.json src config tests --deny-warnings",
     "audit:react-doctor": "pnpm dlx react-doctor@0.9.1 . --yes --no-supply-chain --no-telemetry --blocking none",
-    "audit:dead-code": "pnpm dlx knip@5 --config config/knip.json",
+    "audit:dead-code": "pnpm dlx knip@5.88.1 --config config/knip.json",
     "check:code-quality:changed": "node config/scripts/check-changed-code-quality.mjs",
     "check:react-doctor:changed": "node config/scripts/check-react-doctor-changed.mjs",
     "check:zustand-selector-fanout": "node config/scripts/zustand-selector-fanout-benchmark.mjs --check",


### PR DESCRIPTION
## Summary

Pins the manual dead-code audit script to an exact knip version: `pnpm dlx knip@5` → `pnpm dlx knip@5.88.1`. The floating major was a P2 in the v1.4.165-rc.0 prod release scan: `dlx` downloads and executes whatever the newest matching release is at invocation time, outside lockfile integrity review. This matches the exact-pin pattern already used by `audit:react-doctor` (`react-doctor@0.9.1`) one line up. One-token change; the script is manual-only (not wired into CI, release, or install paths).

**Why not a devDependency** (the otherwise-preferred fix): knip 5.x peer-depends on `typescript@^5`, and this repo is on `typescript@7.0.2`. Installed as a devDependency, pnpm resolves knip's peer against the workspace TS 7 and knip crashes at module load (`TypeError` in its `timerify` wrapper — it wraps a compiler-API function that no longer exists in the native TS 7). A/B-verified: the same knip 5.88.1 against a TS 5 peer runs clean. The `dlx` sandbox auto-installs knip's own TS 5, which is the environment the original #12077 sweep actually ran in — so `dlx` here is load-bearing, not laziness. If knip ships TS 7 support later, moving it into `devDependencies` + plain `knip` in the script becomes the right follow-up.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The four package commands don't exercise this manual script. Direct verification instead:
- `pnpm dlx knip@5.88.1 --config config/knip.json` runs against the repo and produces a normal findings report (exit 1 = findings present, knip's standard reporting behavior).
- devDependency probe: knip 5.88.1 with `typescript@7.0.2` as peer → crashes at module load; identical setup with `typescript@^5` → runs clean. This is why the PR keeps `dlx`.

## AI Review Report

Reviewed as a follow-up from the v1.4.165-rc.0 prod release scan (security worker flagged the floating version). Risks checked: whether the devDependency route was viable (no — TS 7 peer crash, verified empirically rather than assumed), whether the pinned version works against `config/knip.json` (yes, live run), and whether the script participates in CI/release paths (it does not; manual-only). Cross-platform: the script change is a version string inside an existing `pnpm dlx` invocation; no shortcuts, paths, shell behavior, or Electron surface involved — behavior is identical on macOS, Linux, and Windows.

## Security Audit

This PR is itself a supply-chain hygiene fix: it closes the window where a compromised future `knip@5.x` release would run on a developer machine via `pnpm dlx`'s fetch-and-execute. No new inputs, command execution, auth, secrets, or IPC surface. Residual: `dlx` still auto-installs knip's transitive deps and TS 5 peer unpinned inside its sandbox at the pinned knip version — fully closing that requires the devDependency route, blocked on knip supporting TS 7. The `$schema` URL in `config/knip.json` (`unpkg.com/knip@5/schema.json`) is editor-tooling metadata, never executed, and stays as-is.

## Notes

- Version updates are now deliberate: bump the pin and re-run the audit, exactly like `react-doctor`.
- Follow-up when knip gains TS 7 support: move to `devDependencies` + `pnpm exec` so the lockfile owns the integrity hash end to end.
