### PR TITLE
fix(browser): import __Host- cookies host-only so Chromium keeps them

### DIFF
--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -223,6 +223,34 @@ describe('importCookiesFromFile', () => {
     expect(firstCall.sameSite).toBe('lax')
   })
 
+  it('sets __Host- cookies host-only so Chromium does not reject them', async () => {
+    const filePath = writeCookieFile([
+      {
+        domain: 'github.com',
+        name: '__Host-user_session_same_site',
+        value: 'sess',
+        path: '/',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'lax'
+      },
+      { domain: '.github.com', name: '_gh_sess', value: 'abc', path: '/', secure: true }
+    ])
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+    expect(result.ok).toBe(true)
+
+    const hostCall = cookiesSetMock.mock.calls
+      .map((c) => c[0])
+      .find((c) => c.name === '__Host-user_session_same_site')
+    // __Host- prefix requires no Domain attribute and path=/, or Chromium drops it.
+    expect(hostCall.domain).toBeUndefined()
+    expect(hostCall.path).toBe('/')
+
+    const normalCall = cookiesSetMock.mock.calls.map((c) => c[0]).find((c) => c.name === '_gh_sess')
+    expect(normalCall.domain).toBe('.github.com')
+  })
+
   it('rejects non-JSON files', async () => {
     const filePath = join(tmpDir, 'bad.json')
     writeFileSync(filePath, 'not json at all')

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -229,7 +229,7 @@ describe('importCookiesFromFile', () => {
         domain: 'github.com',
         name: '__Host-user_session_same_site',
         value: 'sess',
-        path: '/',
+        path: '/account',
         secure: true,
         httpOnly: true,
         sameSite: 'lax'
@@ -244,7 +244,7 @@ describe('importCookiesFromFile', () => {
       .map((c) => c[0])
       .find((c) => c.name === '__Host-user_session_same_site')
     // __Host- prefix requires no Domain attribute and path=/, or Chromium drops it.
-    expect(hostCall.domain).toBeUndefined()
+    expect(hostCall).not.toHaveProperty('domain')
     expect(hostCall.path).toBe('/')
 
     const normalCall = cookiesSetMock.mock.calls.map((c) => c[0]).find((c) => c.name === '_gh_sess')

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -234,7 +234,7 @@ describe('importCookiesFromFile', () => {
         httpOnly: true,
         sameSite: 'lax'
       },
-      { domain: '.github.com', name: '_gh_sess', value: 'abc', path: '/', secure: true }
+      { domain: '.github.com', name: '_gh_sess', value: 'abc', path: '/settings', secure: true }
     ])
 
     const result = await importCookiesFromFile(filePath, 'persist:test')
@@ -249,6 +249,7 @@ describe('importCookiesFromFile', () => {
 
     const normalCall = cookiesSetMock.mock.calls.map((c) => c[0]).find((c) => c.name === '_gh_sess')
     expect(normalCall.domain).toBe('.github.com')
+    expect(normalCall.path).toBe('/settings')
   })
 
   it('rejects non-JSON files', async () => {

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -567,12 +567,14 @@ async function importValidatedCookies(
 
   for (const cookie of cookies) {
     try {
+      // Why: Chromium rejects __Host- cookies unless they omit domain and use path=/.
+      const isHostPrefixed = cookie.name.startsWith('__Host-')
       await targetSession.cookies.set({
         url: cookie.url,
         name: cookie.name,
         value: stripNonPrintable(cookie.value),
-        domain: cookie.domain,
-        path: cookie.path,
+        ...(isHostPrefixed ? {} : { domain: cookie.domain }),
+        path: isHostPrefixed ? '/' : cookie.path,
         secure: cookie.secure,
         httpOnly: cookie.httpOnly,
         sameSite: cookie.sameSite,


### PR DESCRIPTION
## Summary

The cookie file/JSON import path (`importValidatedCookies`) passed a `domain` attribute for **every** cookie. Chromium rejects any `__Host-`-prefixed cookie that carries a Domain attribute — the `__Host-` prefix requires the cookie to be host-only, `path=/`, and `Secure`. As a result, importing a cookie file silently dropped `__Host-` session cookies (e.g. GitHub's `__Host-user_session_same_site`), so users stayed logged out after importing.

The browser-native import path already shapes `__Host-` cookies host-only; this brings the file/JSON import path to parity: when the cookie name starts with `__Host-`, omit `domain` and force `path=/`. Normal cookies are unchanged.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — exit 0 (oxlint + native/type-aware code-quality audits + verify steps)
- [x] `pnpm typecheck` — exit 0 (all three tsconfig projects)
- [x] `pnpm test` — the changed file's suite passes 26/26. The full local suite shows failures only in unrelated, environment-sensitive files (`pty.test.ts`, `codex-accounts/runtime-home-service.test.ts`, `codex/codex-real-home-path.test.ts`, `check-root-directory-entries`, relay/daemon socket tests). These key off real `HOME`/`ORCA_*` env and local filesystem state, the failing set varies run-to-run, and none touch cookie import. They reproduce identically without this change (those files are untouched here); CI's clean environment is the authoritative gate.
- [ ] `pnpm build` — not run locally (packaging is unaffected by this logic-only change); CI covers it
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added a regression test that imports a `__Host-` cookie alongside a normal domain cookie in one file and asserts the `__Host-` cookie is set with no `domain` and `path=/`, while the normal cookie keeps its `.domain`.

## AI Review Report

Reviewed the diff with an AI coding agent. Main risks checked:
- **Parity with the browser-native path** — the same `__Host-` shaping already exists there; this makes the file/JSON path consistent rather than inventing new behavior.
- **Normal cookies unaffected** — only names starting with `__Host-` skip the `domain`/override `path`; the test asserts a normal cookie still receives `.github.com`.
- **Detection correctness** — `__Host-` is matched by name prefix, matching Chromium's prefix rule.

Cross-platform: this is pure main-process cookie-shaping logic with no keyboard shortcuts, UI labels, filesystem paths, shell invocation, or Electron platform-specific APIs. Behavior is identical on macOS, Linux, and Windows.

## Security Audit

Cookie import already validates each entry (`validateCookieEntry`) and strips non-printable bytes before `cookies.set`. This change only removes the `domain` attribute (and forces `path=/`) for `__Host-`-named cookies — it does not broaden what can be imported, add command/path execution, touch IPC, or expose secrets. If anything it enforces the stricter host-only scoping the `__Host-` prefix is designed to guarantee. No follow-up needed.

## Notes

`importValidatedCookies` is the shared file/JSON import path (Settings "Import Cookies from file" and JSON import entrypoints). The browser-native import path already had this handling, so no change was needed there.
