### PR TITLE
Keep your New Linear and Jira creation drafts after an accidental dismissal

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -239,7 +239,13 @@ import {
   resolveUserRepoSwitchReset,
   resolveVanishedNewIssueRepoReset
 } from '@/components/task-page-new-issue-draft'
-import { isTaskCreationDraftContentful } from '@/store/slices/task-creation-drafts'
+import {
+  isTaskCreationDraftContentful,
+  type NewJiraIssueDraft,
+  type NewLinearIssueDraft,
+  type NewLinearProjectDraft
+} from '@/store/slices/task-creation-drafts'
+import { useTaskCreationDraftRetention } from '@/components/use-task-creation-draft-retention'
 import { findTaskPageJiraIssue } from '@/components/task-page-jira-cache-selectors'
 import { getRepoBackedTaskEmptyState } from '@/components/task-page-empty-state'
 import {
@@ -3046,6 +3052,33 @@ const hasUpstreamCandidateDivergence = (
   !!s.sources.upstreamCandidate &&
   !sameGitHubOwnerRepo(s.sources.originCandidate, s.sources.upstreamCandidate)
 
+function writeNewLinearProjectDraft(draft: NewLinearProjectDraft | null): void {
+  const state = useAppStore.getState()
+  if (draft && isTaskCreationDraftContentful(draft)) {
+    state.setNewLinearProjectDraft(draft)
+  } else {
+    state.clearNewLinearProjectDraft()
+  }
+}
+
+function writeNewLinearIssueDraft(draft: NewLinearIssueDraft | null): void {
+  const state = useAppStore.getState()
+  if (draft && isTaskCreationDraftContentful(draft)) {
+    state.setNewLinearIssueDraft(draft)
+  } else {
+    state.clearNewLinearIssueDraft()
+  }
+}
+
+function writeNewJiraIssueDraft(draft: NewJiraIssueDraft | null): void {
+  const state = useAppStore.getState()
+  if (draft && isTaskCreationDraftContentful(draft)) {
+    state.setNewJiraIssueDraft(draft)
+  } else {
+    state.clearNewJiraIssueDraft()
+  }
+}
+
 export default function TaskPage(): React.JSX.Element {
   useTranslation()
   const settings = useAppStore((s) => s.settings)
@@ -5639,31 +5672,15 @@ export default function TaskPage(): React.JSX.Element {
     setNewLinearProjectLabelIds([])
   }, [newLinearProjectTargetTeam?.id, newLinearProjectTargetTeam?.workspaceId])
 
-  // Why: session-only draft recovers typed text across dismissal; read imperatively on open so per-keystroke writes don't re-render TaskPage.
-  const setNewLinearProjectDraft = useAppStore((s) => s.setNewLinearProjectDraft)
-  const clearNewLinearProjectDraft = useAppStore((s) => s.clearNewLinearProjectDraft)
-  useEffect(() => {
-    if (!newLinearProjectOpen) {
-      return
-    }
-    const draft = {
+  const discardNewLinearProjectDraft = useTaskCreationDraftRetention({
+    open: newLinearProjectOpen,
+    draft: {
       name: newLinearProjectName,
       description: newLinearProjectDescription,
       content: newLinearProjectContent
-    }
-    if (isTaskCreationDraftContentful(draft)) {
-      setNewLinearProjectDraft(draft)
-    } else {
-      clearNewLinearProjectDraft()
-    }
-  }, [
-    newLinearProjectOpen,
-    newLinearProjectName,
-    newLinearProjectDescription,
-    newLinearProjectContent,
-    setNewLinearProjectDraft,
-    clearNewLinearProjectDraft
-  ])
+    },
+    writeDraft: writeNewLinearProjectDraft
+  })
 
   // New Linear issue dialog state
   const [newLinearIssueOpen, setNewLinearIssueOpen] = useState(false)
@@ -5678,26 +5695,11 @@ export default function TaskPage(): React.JSX.Element {
   const [newLinearIssueProjectId, setNewLinearIssueProjectId] = useState<string | null>(null)
   const [newLinearIssueLabelIds, setNewLinearIssueLabelIds] = useState<string[]>([])
 
-  // Why: session-only draft recovers typed text across dismissal; read imperatively on open so per-keystroke writes don't re-render TaskPage.
-  const setNewLinearIssueDraft = useAppStore((s) => s.setNewLinearIssueDraft)
-  const clearNewLinearIssueDraft = useAppStore((s) => s.clearNewLinearIssueDraft)
-  useEffect(() => {
-    if (!newLinearIssueOpen) {
-      return
-    }
-    const draft = { title: newLinearIssueTitle, body: newLinearIssueBody }
-    if (isTaskCreationDraftContentful(draft)) {
-      setNewLinearIssueDraft(draft)
-    } else {
-      clearNewLinearIssueDraft()
-    }
-  }, [
-    newLinearIssueOpen,
-    newLinearIssueTitle,
-    newLinearIssueBody,
-    setNewLinearIssueDraft,
-    clearNewLinearIssueDraft
-  ])
+  const discardNewLinearIssueDraft = useTaskCreationDraftRetention({
+    open: newLinearIssueOpen,
+    draft: { title: newLinearIssueTitle, body: newLinearIssueBody },
+    writeDraft: writeNewLinearIssueDraft
+  })
 
   const newLinearIssueTargetTeam = useMemo(
     () => availableTeams.find((t) => t.id === newLinearIssueTeamId) ?? availableTeams[0] ?? null,
@@ -5837,26 +5839,11 @@ export default function TaskPage(): React.JSX.Element {
     Record<string, string>
   >({})
 
-  // Why: session-only draft recovers typed text across dismissal; read imperatively on open so per-keystroke writes don't re-render TaskPage.
-  const setNewJiraIssueDraft = useAppStore((s) => s.setNewJiraIssueDraft)
-  const clearNewJiraIssueDraft = useAppStore((s) => s.clearNewJiraIssueDraft)
-  useEffect(() => {
-    if (!newJiraIssueOpen) {
-      return
-    }
-    const draft = { title: newJiraIssueTitle, body: newJiraIssueBody }
-    if (isTaskCreationDraftContentful(draft)) {
-      setNewJiraIssueDraft(draft)
-    } else {
-      clearNewJiraIssueDraft()
-    }
-  }, [
-    newJiraIssueOpen,
-    newJiraIssueTitle,
-    newJiraIssueBody,
-    setNewJiraIssueDraft,
-    clearNewJiraIssueDraft
-  ])
+  const discardNewJiraIssueDraft = useTaskCreationDraftRetention({
+    open: newJiraIssueOpen,
+    draft: { title: newJiraIssueTitle, body: newJiraIssueBody },
+    writeDraft: writeNewJiraIssueDraft
+  })
   const includeJiraSiteNameInProjectLabel = selectedJiraSiteId === 'all'
   const previousProviderRuntimeContextKeyRef = useRef(providerRuntimeContextKey)
 
@@ -6998,12 +6985,11 @@ export default function TaskPage(): React.JSX.Element {
             : undefined
         }
       )
+      discardNewLinearProjectDraft()
       setNewLinearProjectOpen(false)
       setNewLinearProjectName('')
       setNewLinearProjectDescription('')
       setNewLinearProjectContent('')
-      // Why: only a successful create discards the recovery draft.
-      clearNewLinearProjectDraft()
       setNewLinearProjectLeadId(null)
       setNewLinearProjectMemberIds([])
       setNewLinearProjectLabelIds([])
@@ -7043,7 +7029,7 @@ export default function TaskPage(): React.JSX.Element {
     openLinearProjectContext,
     linearTaskSourceContext,
     settings,
-    clearNewLinearProjectDraft
+    discardNewLinearProjectDraft
   ])
 
   const handleCreateNewLinearIssue = useCallback(async (): Promise<void> => {
@@ -7104,11 +7090,10 @@ export default function TaskPage(): React.JSX.Element {
             : undefined
         }
       )
+      discardNewLinearIssueDraft()
       setNewLinearIssueOpen(false)
       setNewLinearIssueTitle('')
       setNewLinearIssueBody('')
-      // Why: only a successful create discards the recovery draft.
-      clearNewLinearIssueDraft()
       setNewLinearIssueStateId(null)
       setNewLinearIssueAssigneeId(null)
       setNewLinearIssuePriority(0)
@@ -7152,7 +7137,7 @@ export default function TaskPage(): React.JSX.Element {
     setSelectedLinearIssue,
     linearTaskSourceContext,
     settings,
-    clearNewLinearIssueDraft
+    discardNewLinearIssueDraft
   ])
 
   const handleCreateNewJiraIssue = useCallback(async (): Promise<void> => {
@@ -7201,11 +7186,10 @@ export default function TaskPage(): React.JSX.Element {
             : undefined
         }
       )
+      discardNewJiraIssueDraft()
       setNewJiraIssueOpen(false)
       setNewJiraIssueTitle('')
       setNewJiraIssueBody('')
-      // Why: only a successful create discards the recovery draft.
-      clearNewJiraIssueDraft()
       setNewJiraIssueCustomFieldValues({})
       setJiraRefreshNonce((n) => n + 1)
 
@@ -7244,7 +7228,7 @@ export default function TaskPage(): React.JSX.Element {
     settings,
     setSelectedJiraIssue,
     visibleJiraCreateFields,
-    clearNewJiraIssueDraft
+    discardNewJiraIssueDraft
   ])
 
   const githubTasksBusy = tasksLoading || tasksRefreshing || tasksFiltering

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -239,6 +239,7 @@ import {
   resolveUserRepoSwitchReset,
   resolveVanishedNewIssueRepoReset
 } from '@/components/task-page-new-issue-draft'
+import { isTaskCreationDraftContentful } from '@/store/slices/task-creation-drafts'
 import { findTaskPageJiraIssue } from '@/components/task-page-jira-cache-selectors'
 import { getRepoBackedTaskEmptyState } from '@/components/task-page-empty-state'
 import {
@@ -5638,6 +5639,32 @@ export default function TaskPage(): React.JSX.Element {
     setNewLinearProjectLabelIds([])
   }, [newLinearProjectTargetTeam?.id, newLinearProjectTargetTeam?.workspaceId])
 
+  // Why: session-only draft recovers typed text across dismissal; read imperatively on open so per-keystroke writes don't re-render TaskPage.
+  const setNewLinearProjectDraft = useAppStore((s) => s.setNewLinearProjectDraft)
+  const clearNewLinearProjectDraft = useAppStore((s) => s.clearNewLinearProjectDraft)
+  useEffect(() => {
+    if (!newLinearProjectOpen) {
+      return
+    }
+    const draft = {
+      name: newLinearProjectName,
+      description: newLinearProjectDescription,
+      content: newLinearProjectContent
+    }
+    if (isTaskCreationDraftContentful(draft)) {
+      setNewLinearProjectDraft(draft)
+    } else {
+      clearNewLinearProjectDraft()
+    }
+  }, [
+    newLinearProjectOpen,
+    newLinearProjectName,
+    newLinearProjectDescription,
+    newLinearProjectContent,
+    setNewLinearProjectDraft,
+    clearNewLinearProjectDraft
+  ])
+
   // New Linear issue dialog state
   const [newLinearIssueOpen, setNewLinearIssueOpen] = useState(false)
   const [newLinearIssueTitle, setNewLinearIssueTitle] = useState('')
@@ -5650,6 +5677,27 @@ export default function TaskPage(): React.JSX.Element {
   const [newLinearIssuePriority, setNewLinearIssuePriority] = useState<number>(0)
   const [newLinearIssueProjectId, setNewLinearIssueProjectId] = useState<string | null>(null)
   const [newLinearIssueLabelIds, setNewLinearIssueLabelIds] = useState<string[]>([])
+
+  // Why: session-only draft recovers typed text across dismissal; read imperatively on open so per-keystroke writes don't re-render TaskPage.
+  const setNewLinearIssueDraft = useAppStore((s) => s.setNewLinearIssueDraft)
+  const clearNewLinearIssueDraft = useAppStore((s) => s.clearNewLinearIssueDraft)
+  useEffect(() => {
+    if (!newLinearIssueOpen) {
+      return
+    }
+    const draft = { title: newLinearIssueTitle, body: newLinearIssueBody }
+    if (isTaskCreationDraftContentful(draft)) {
+      setNewLinearIssueDraft(draft)
+    } else {
+      clearNewLinearIssueDraft()
+    }
+  }, [
+    newLinearIssueOpen,
+    newLinearIssueTitle,
+    newLinearIssueBody,
+    setNewLinearIssueDraft,
+    clearNewLinearIssueDraft
+  ])
 
   const newLinearIssueTargetTeam = useMemo(
     () => availableTeams.find((t) => t.id === newLinearIssueTeamId) ?? availableTeams[0] ?? null,
@@ -5788,6 +5836,27 @@ export default function TaskPage(): React.JSX.Element {
   const [newJiraIssueCustomFieldValues, setNewJiraIssueCustomFieldValues] = useState<
     Record<string, string>
   >({})
+
+  // Why: session-only draft recovers typed text across dismissal; read imperatively on open so per-keystroke writes don't re-render TaskPage.
+  const setNewJiraIssueDraft = useAppStore((s) => s.setNewJiraIssueDraft)
+  const clearNewJiraIssueDraft = useAppStore((s) => s.clearNewJiraIssueDraft)
+  useEffect(() => {
+    if (!newJiraIssueOpen) {
+      return
+    }
+    const draft = { title: newJiraIssueTitle, body: newJiraIssueBody }
+    if (isTaskCreationDraftContentful(draft)) {
+      setNewJiraIssueDraft(draft)
+    } else {
+      clearNewJiraIssueDraft()
+    }
+  }, [
+    newJiraIssueOpen,
+    newJiraIssueTitle,
+    newJiraIssueBody,
+    setNewJiraIssueDraft,
+    clearNewJiraIssueDraft
+  ])
   const includeJiraSiteNameInProjectLabel = selectedJiraSiteId === 'all'
   const previousProviderRuntimeContextKeyRef = useRef(providerRuntimeContextKey)
 
@@ -6933,6 +7002,8 @@ export default function TaskPage(): React.JSX.Element {
       setNewLinearProjectName('')
       setNewLinearProjectDescription('')
       setNewLinearProjectContent('')
+      // Why: only a successful create discards the recovery draft.
+      clearNewLinearProjectDraft()
       setNewLinearProjectLeadId(null)
       setNewLinearProjectMemberIds([])
       setNewLinearProjectLabelIds([])
@@ -6971,7 +7042,8 @@ export default function TaskPage(): React.JSX.Element {
     newLinearProjectTargetTeam,
     openLinearProjectContext,
     linearTaskSourceContext,
-    settings
+    settings,
+    clearNewLinearProjectDraft
   ])
 
   const handleCreateNewLinearIssue = useCallback(async (): Promise<void> => {
@@ -7035,6 +7107,8 @@ export default function TaskPage(): React.JSX.Element {
       setNewLinearIssueOpen(false)
       setNewLinearIssueTitle('')
       setNewLinearIssueBody('')
+      // Why: only a successful create discards the recovery draft.
+      clearNewLinearIssueDraft()
       setNewLinearIssueStateId(null)
       setNewLinearIssueAssigneeId(null)
       setNewLinearIssuePriority(0)
@@ -7077,7 +7151,8 @@ export default function TaskPage(): React.JSX.Element {
     selectedLinearProject,
     setSelectedLinearIssue,
     linearTaskSourceContext,
-    settings
+    settings,
+    clearNewLinearIssueDraft
   ])
 
   const handleCreateNewJiraIssue = useCallback(async (): Promise<void> => {
@@ -7129,6 +7204,8 @@ export default function TaskPage(): React.JSX.Element {
       setNewJiraIssueOpen(false)
       setNewJiraIssueTitle('')
       setNewJiraIssueBody('')
+      // Why: only a successful create discards the recovery draft.
+      clearNewJiraIssueDraft()
       setNewJiraIssueCustomFieldValues({})
       setJiraRefreshNonce((n) => n + 1)
 
@@ -7166,7 +7243,8 @@ export default function TaskPage(): React.JSX.Element {
     jiraTaskSourceContext,
     settings,
     setSelectedJiraIssue,
-    visibleJiraCreateFields
+    visibleJiraCreateFields,
+    clearNewJiraIssueDraft
   ])
 
   const githubTasksBusy = tasksLoading || tasksRefreshing || tasksFiltering
@@ -8595,9 +8673,11 @@ export default function TaskPage(): React.JSX.Element {
                               size="icon"
                               onClick={() => {
                                 if (linearMode === 'projects' && !selectedLinearProject) {
-                                  setNewLinearProjectName('')
-                                  setNewLinearProjectDescription('')
-                                  setNewLinearProjectContent('')
+                                  // Why: restore dismissed typed text (accidental dismissal recoverable); pickers keep their fresh open-time defaults.
+                                  const draft = useAppStore.getState().newLinearProjectDraft
+                                  setNewLinearProjectName(draft?.name ?? '')
+                                  setNewLinearProjectDescription(draft?.description ?? '')
+                                  setNewLinearProjectContent(draft?.content ?? '')
                                   setNewLinearProjectTeamId(availableTeams[0]?.id ?? null)
                                   setNewLinearProjectLeadId(null)
                                   setNewLinearProjectMemberIds([])
@@ -8608,8 +8688,10 @@ export default function TaskPage(): React.JSX.Element {
                                   setNewLinearProjectOpen(true)
                                   return
                                 }
-                                setNewLinearIssueTitle('')
-                                setNewLinearIssueBody('')
+                                // Why: restore dismissed typed text (accidental dismissal recoverable); pickers keep their fresh open-time defaults.
+                                const issueDraft = useAppStore.getState().newLinearIssueDraft
+                                setNewLinearIssueTitle(issueDraft?.title ?? '')
+                                setNewLinearIssueBody(issueDraft?.body ?? '')
                                 const projectTeamId =
                                   selectedLinearProject?.teams?.[0]?.id ??
                                   availableTeams.find(
@@ -8826,8 +8908,10 @@ export default function TaskPage(): React.JSX.Element {
                               variant="outline"
                               size="icon"
                               onClick={() => {
-                                setNewJiraIssueTitle('')
-                                setNewJiraIssueBody('')
+                                // Why: restore dismissed typed text (accidental dismissal recoverable); pickers keep their fresh open-time defaults.
+                                const draft = useAppStore.getState().newJiraIssueDraft
+                                setNewJiraIssueTitle(draft?.title ?? '')
+                                setNewJiraIssueBody(draft?.body ?? '')
                                 setNewJiraIssueProjectId(
                                   sortedAvailableJiraProjects[0]
                                     ? getJiraProjectSelectionKey(sortedAvailableJiraProjects[0])

--- a/src/renderer/src/components/task-page-task-creation-drafts.test.ts
+++ b/src/renderer/src/components/task-page-task-creation-drafts.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const taskPageSource = readFileSync(new URL('./TaskPage.tsx', import.meta.url), 'utf8')
+
+function sectionBetween(startAnchor: string, endAnchor: string): string {
+  const start = taskPageSource.indexOf(startAnchor)
+  expect(start, `missing anchor: ${startAnchor}`).toBeGreaterThanOrEqual(0)
+  const end = taskPageSource.indexOf(endAnchor, start)
+  expect(end, `missing anchor: ${endAnchor}`).toBeGreaterThan(start)
+  return taskPageSource.slice(start, end)
+}
+
+describe('TaskPage Linear/Jira creation drafts', () => {
+  it('mirrors typed text into each session draft behind the contentful gate', () => {
+    expect(taskPageSource.split('isTaskCreationDraftContentful(draft)')).toHaveLength(4)
+  })
+
+  it('restores dismissed typed text when each dialog reopens', () => {
+    expect(taskPageSource).toContain("setNewLinearProjectName(draft?.name ?? '')")
+    expect(taskPageSource).toContain("setNewLinearProjectDescription(draft?.description ?? '')")
+    expect(taskPageSource).toContain("setNewLinearProjectContent(draft?.content ?? '')")
+    expect(taskPageSource).toContain("setNewLinearIssueTitle(issueDraft?.title ?? '')")
+    expect(taskPageSource).toContain("setNewLinearIssueBody(issueDraft?.body ?? '')")
+    expect(taskPageSource).toContain("setNewJiraIssueTitle(draft?.title ?? '')")
+    expect(taskPageSource).toContain("setNewJiraIssueBody(draft?.body ?? '')")
+  })
+
+  it('discards each recovery draft only on a successful create', () => {
+    const linearProjectSection = sectionBetween(
+      'const handleCreateNewLinearProject',
+      'const handleCreateNewLinearIssue'
+    )
+    expect(linearProjectSection).toContain('clearNewLinearProjectDraft()')
+
+    const linearIssueSection = sectionBetween(
+      'const handleCreateNewLinearIssue',
+      'const handleCreateNewJiraIssue'
+    )
+    expect(linearIssueSection).toContain('clearNewLinearIssueDraft()')
+
+    const jiraIssueSection = sectionBetween(
+      'const handleCreateNewJiraIssue',
+      'const githubTasksBusy'
+    )
+    expect(jiraIssueSection).toContain('clearNewJiraIssueDraft()')
+  })
+})

--- a/src/renderer/src/components/task-page-task-creation-drafts.test.ts
+++ b/src/renderer/src/components/task-page-task-creation-drafts.test.ts
@@ -12,8 +12,15 @@ function sectionBetween(startAnchor: string, endAnchor: string): string {
 }
 
 describe('TaskPage Linear/Jira creation drafts', () => {
-  it('mirrors typed text into each session draft behind the contentful gate', () => {
+  it('uses the contentful gate for each session draft writer', () => {
     expect(taskPageSource.split('isTaskCreationDraftContentful(draft)')).toHaveLength(4)
+  })
+
+  it('retains all three drafts on dismissal without subscribing TaskPage to draft actions', () => {
+    expect(taskPageSource.split('useTaskCreationDraftRetention({')).toHaveLength(4)
+    expect(taskPageSource).not.toMatch(
+      /useAppStore\(\(s\) => s\.(?:set|clear)New(?:LinearProject|LinearIssue|JiraIssue)Draft\)/
+    )
   })
 
   it('restores dismissed typed text when each dialog reopens', () => {
@@ -31,18 +38,18 @@ describe('TaskPage Linear/Jira creation drafts', () => {
       'const handleCreateNewLinearProject',
       'const handleCreateNewLinearIssue'
     )
-    expect(linearProjectSection).toContain('clearNewLinearProjectDraft()')
+    expect(linearProjectSection).toContain('discardNewLinearProjectDraft()')
 
     const linearIssueSection = sectionBetween(
       'const handleCreateNewLinearIssue',
       'const handleCreateNewJiraIssue'
     )
-    expect(linearIssueSection).toContain('clearNewLinearIssueDraft()')
+    expect(linearIssueSection).toContain('discardNewLinearIssueDraft()')
 
     const jiraIssueSection = sectionBetween(
       'const handleCreateNewJiraIssue',
       'const githubTasksBusy'
     )
-    expect(jiraIssueSection).toContain('clearNewJiraIssueDraft()')
+    expect(jiraIssueSection).toContain('discardNewJiraIssueDraft()')
   })
 })

--- a/src/renderer/src/components/use-task-creation-draft-retention.test.ts
+++ b/src/renderer/src/components/use-task-creation-draft-retention.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useTaskCreationDraftRetention } from './use-task-creation-draft-retention'
+
+type Draft = { title: string; body: string }
+
+const emptyDraft = (): Draft => ({ title: '', body: '' })
+
+describe('useTaskCreationDraftRetention', () => {
+  it('does not fan out writes while typing and saves the latest text on dismissal', () => {
+    const writeDraft = vi.fn()
+    const view = renderHook(
+      ({ open, draft }) => useTaskCreationDraftRetention({ open, draft, writeDraft }),
+      { initialProps: { open: true, draft: emptyDraft() } }
+    )
+
+    view.rerender({ open: true, draft: { title: 'Bug', body: '' } })
+    view.rerender({ open: true, draft: { title: 'Bug', body: 'Latest details' } })
+
+    expect(writeDraft).not.toHaveBeenCalled()
+
+    view.rerender({ open: false, draft: emptyDraft() })
+
+    expect(writeDraft).toHaveBeenCalledOnce()
+    expect(writeDraft).toHaveBeenCalledWith({ title: 'Bug', body: 'Latest details' })
+  })
+
+  it('saves the latest text when an open composer unmounts', () => {
+    const writeDraft = vi.fn()
+    const view = renderHook(
+      ({ draft }) => useTaskCreationDraftRetention({ open: true, draft, writeDraft }),
+      { initialProps: { draft: { title: 'First', body: '' } } }
+    )
+    view.rerender({ draft: { title: 'Latest', body: 'Details' } })
+
+    view.unmount()
+
+    expect(writeDraft).toHaveBeenCalledOnce()
+    expect(writeDraft).toHaveBeenCalledWith({ title: 'Latest', body: 'Details' })
+  })
+
+  it('clears a successful draft without resurrecting it during close cleanup', () => {
+    const writeDraft = vi.fn()
+    const view = renderHook(
+      ({ open }) =>
+        useTaskCreationDraftRetention({
+          open,
+          draft: { title: 'Created', body: 'Details' },
+          writeDraft
+        }),
+      { initialProps: { open: true } }
+    )
+
+    act(() => view.result.current())
+    view.rerender({ open: false })
+    view.unmount()
+
+    expect(writeDraft).toHaveBeenCalledOnce()
+    expect(writeDraft).toHaveBeenCalledWith(null)
+  })
+
+  it('does not create a draft when an unopened composer unmounts', () => {
+    const writeDraft = vi.fn()
+    const view = renderHook(() =>
+      useTaskCreationDraftRetention({ open: false, draft: emptyDraft(), writeDraft })
+    )
+
+    view.unmount()
+
+    expect(writeDraft).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/use-task-creation-draft-retention.ts
+++ b/src/renderer/src/components/use-task-creation-draft-retention.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+type TaskCreationDraftRetentionOptions<Draft> = {
+  open: boolean
+  draft: Draft
+  writeDraft: (draft: Draft | null) => void
+}
+
+export function useTaskCreationDraftRetention<Draft>({
+  open,
+  draft,
+  writeDraft
+}: TaskCreationDraftRetentionOptions<Draft>): () => void {
+  const draftRef = useRef(draft)
+  const writeDraftRef = useRef(writeDraft)
+  const discardRef = useRef(false)
+  writeDraftRef.current = writeDraft
+  if (open) {
+    draftRef.current = draft
+  }
+
+  // Why: closing cleanup captures the latest render once without a global store write per keystroke.
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    discardRef.current = false
+    return () => {
+      if (!discardRef.current) {
+        writeDraftRef.current(draftRef.current)
+      }
+    }
+  }, [open])
+
+  return useCallback(() => {
+    discardRef.current = true
+    writeDraftRef.current(null)
+  }, [])
+}

--- a/src/renderer/src/components/use-task-creation-draft-retention.ts
+++ b/src/renderer/src/components/use-task-creation-draft-retention.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 
 type TaskCreationDraftRetentionOptions<Draft> = {
   open: boolean
@@ -14,10 +14,15 @@ export function useTaskCreationDraftRetention<Draft>({
   const draftRef = useRef(draft)
   const writeDraftRef = useRef(writeDraft)
   const discardRef = useRef(false)
-  writeDraftRef.current = writeDraft
-  if (open) {
+
+  // Why: every committed open render refreshes refs without letting discarded renders leak into cleanup.
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
     draftRef.current = draft
-  }
+    writeDraftRef.current = writeDraft
+  })
 
   // Why: closing cleanup captures the latest render once without a global store write per keystroke.
   useEffect(() => {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -39,6 +39,7 @@ import { createPinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-conf
 import { createRecentlyClosedTabsSlice } from './slices/recently-closed-tabs'
 import { createOrcaProfilesSlice } from './slices/orca-profiles'
 import { createNewIssueDraftSlice } from './slices/new-issue-draft'
+import { createTaskCreationDraftsSlice } from './slices/task-creation-drafts'
 import { createRemoteServerUpdatesSlice } from './slices/remote-server-updates'
 import { e2eConfig } from '@/lib/e2e-config'
 import type { createWebRuntimeSessionTerminal } from '@/runtime/web-runtime-session'
@@ -92,6 +93,7 @@ export const useAppStore = create<AppState>()((...a) => {
     ...createRecentlyClosedTabsSlice(...a),
     ...createOrcaProfilesSlice(...a),
     ...createNewIssueDraftSlice(...a),
+    ...createTaskCreationDraftsSlice(...a),
     ...createRemoteServerUpdatesSlice(...a)
   }
 })

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -144,6 +144,7 @@ import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
 import { createRecentlyClosedTabsSlice } from './recently-closed-tabs'
 import { createOrcaProfilesSlice } from './orca-profiles'
 import { createNewIssueDraftSlice } from './new-issue-draft'
+import { createTaskCreationDraftsSlice } from './task-creation-drafts'
 import { createRemoteServerUpdatesSlice } from './remote-server-updates'
 
 function createTestStore() {
@@ -187,6 +188,7 @@ function createTestStore() {
     ...createRecentlyClosedTabsSlice(...a),
     ...createOrcaProfilesSlice(...a),
     ...createNewIssueDraftSlice(...a),
+    ...createTaskCreationDraftsSlice(...a),
     ...createRemoteServerUpdatesSlice(...a)
   }))
 }

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -47,6 +47,7 @@ import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
 import { createRecentlyClosedTabsSlice } from './recently-closed-tabs'
 import { createOrcaProfilesSlice } from './orca-profiles'
 import { createNewIssueDraftSlice } from './new-issue-draft'
+import { createTaskCreationDraftsSlice } from './task-creation-drafts'
 import { createRemoteServerUpdatesSlice } from './remote-server-updates'
 import { translate } from '@/i18n/i18n'
 
@@ -99,6 +100,7 @@ export function createTestStore() {
     ...createRecentlyClosedTabsSlice(...a),
     ...createOrcaProfilesSlice(...a),
     ...createNewIssueDraftSlice(...a),
+    ...createTaskCreationDraftsSlice(...a),
     ...createRemoteServerUpdatesSlice(...a)
   }))
 }

--- a/src/renderer/src/store/slices/task-creation-drafts.test.ts
+++ b/src/renderer/src/store/slices/task-creation-drafts.test.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand'
+import { describe, expect, it } from 'vitest'
+import {
+  createTaskCreationDraftsSlice,
+  isTaskCreationDraftContentful
+} from './task-creation-drafts'
+import type { AppState } from '../types'
+
+function makeStore() {
+  return create<
+    Pick<
+      AppState,
+      | 'newLinearIssueDraft'
+      | 'setNewLinearIssueDraft'
+      | 'clearNewLinearIssueDraft'
+      | 'newLinearProjectDraft'
+      | 'setNewLinearProjectDraft'
+      | 'clearNewLinearProjectDraft'
+      | 'newJiraIssueDraft'
+      | 'setNewJiraIssueDraft'
+      | 'clearNewJiraIssueDraft'
+    >
+  >()((...args) =>
+    createTaskCreationDraftsSlice(...(args as Parameters<typeof createTaskCreationDraftsSlice>))
+  )
+}
+
+describe('createTaskCreationDraftsSlice', () => {
+  it('starts with no drafts', () => {
+    const state = makeStore().getState()
+    expect(state.newLinearIssueDraft).toBeNull()
+    expect(state.newLinearProjectDraft).toBeNull()
+    expect(state.newJiraIssueDraft).toBeNull()
+  })
+
+  it('stores and clears each draft independently', () => {
+    const store = makeStore()
+
+    store.getState().setNewLinearIssueDraft({ title: 'Linear bug', body: 'details' })
+    store.getState().setNewLinearProjectDraft({
+      name: 'Roadmap',
+      description: 'summary',
+      content: 'brief'
+    })
+    store.getState().setNewJiraIssueDraft({ title: 'Jira bug', body: 'steps' })
+
+    store.getState().clearNewLinearIssueDraft()
+
+    expect(store.getState().newLinearIssueDraft).toBeNull()
+    expect(store.getState().newLinearProjectDraft).toEqual({
+      name: 'Roadmap',
+      description: 'summary',
+      content: 'brief'
+    })
+    expect(store.getState().newJiraIssueDraft).toEqual({ title: 'Jira bug', body: 'steps' })
+  })
+
+  it('replaces a draft wholesale on set', () => {
+    const store = makeStore()
+    store.getState().setNewJiraIssueDraft({ title: 'first', body: 'text' })
+
+    store.getState().setNewJiraIssueDraft({ title: 'second', body: '' })
+
+    expect(store.getState().newJiraIssueDraft).toEqual({ title: 'second', body: '' })
+  })
+})
+
+describe('isTaskCreationDraftContentful', () => {
+  it('rejects an all-empty or whitespace-only form', () => {
+    expect(isTaskCreationDraftContentful({ title: '', body: '' })).toBe(false)
+    expect(isTaskCreationDraftContentful({ title: '  ', body: '\n\t' })).toBe(false)
+  })
+
+  it('accepts any field with typed text', () => {
+    expect(isTaskCreationDraftContentful({ title: 'Bug', body: '' })).toBe(true)
+    expect(isTaskCreationDraftContentful({ name: '', description: '', content: 'brief' })).toBe(
+      true
+    )
+  })
+})

--- a/src/renderer/src/store/slices/task-creation-drafts.ts
+++ b/src/renderer/src/store/slices/task-creation-drafts.ts
@@ -1,0 +1,49 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+
+/** In-progress New Linear issue / New Linear project / New Jira issue composer
+ *  drafts. Session-only (never `persist`-wrapped, no disk surface): they exist
+ *  so an accidental dismissal (outside click / Escape / Cancel) doesn't discard
+ *  typed text, and are cleared on a successful submit or app restart. Mirrors
+ *  `newIssueDraft` (GitHub) but text-only — picker selections keep their
+ *  existing open-time defaults. */
+export type NewLinearIssueDraft = { title: string; body: string }
+export type NewLinearProjectDraft = { name: string; description: string; content: string }
+export type NewJiraIssueDraft = { title: string; body: string }
+
+/** A draft is worth keeping only once some field carries real typed text; a
+ *  whitespace-only form never pins a draft, so an "opened but never edited"
+ *  dialog can't hijack a later open. Shared by every write-through gate so
+ *  mirror and clear agree on "has content". */
+export function isTaskCreationDraftContentful(fields: Record<string, string>): boolean {
+  return Object.values(fields).some((value) => value.trim().length > 0)
+}
+
+export type TaskCreationDraftsSlice = {
+  newLinearIssueDraft: NewLinearIssueDraft | null
+  setNewLinearIssueDraft: (draft: NewLinearIssueDraft) => void
+  clearNewLinearIssueDraft: () => void
+  newLinearProjectDraft: NewLinearProjectDraft | null
+  setNewLinearProjectDraft: (draft: NewLinearProjectDraft) => void
+  clearNewLinearProjectDraft: () => void
+  newJiraIssueDraft: NewJiraIssueDraft | null
+  setNewJiraIssueDraft: (draft: NewJiraIssueDraft) => void
+  clearNewJiraIssueDraft: () => void
+}
+
+export const createTaskCreationDraftsSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  TaskCreationDraftsSlice
+> = (set) => ({
+  newLinearIssueDraft: null,
+  setNewLinearIssueDraft: (draft) => set({ newLinearIssueDraft: draft }),
+  clearNewLinearIssueDraft: () => set({ newLinearIssueDraft: null }),
+  newLinearProjectDraft: null,
+  setNewLinearProjectDraft: (draft) => set({ newLinearProjectDraft: draft }),
+  clearNewLinearProjectDraft: () => set({ newLinearProjectDraft: null }),
+  newJiraIssueDraft: null,
+  setNewJiraIssueDraft: (draft) => set({ newJiraIssueDraft: draft }),
+  clearNewJiraIssueDraft: () => set({ newJiraIssueDraft: null })
+})

--- a/src/renderer/src/store/slices/task-creation-drafts.ts
+++ b/src/renderer/src/store/slices/task-creation-drafts.ts
@@ -1,20 +1,12 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 
-/** In-progress New Linear issue / New Linear project / New Jira issue composer
- *  drafts. Session-only (never `persist`-wrapped, no disk surface): they exist
- *  so an accidental dismissal (outside click / Escape / Cancel) doesn't discard
- *  typed text, and are cleared on a successful submit or app restart. Mirrors
- *  `newIssueDraft` (GitHub) but text-only — picker selections keep their
- *  existing open-time defaults. */
+/** Session-only text drafts for Linear/Jira creation dialogs; picker selections stay fresh. */
 export type NewLinearIssueDraft = { title: string; body: string }
 export type NewLinearProjectDraft = { name: string; description: string; content: string }
 export type NewJiraIssueDraft = { title: string; body: string }
 
-/** A draft is worth keeping only once some field carries real typed text; a
- *  whitespace-only form never pins a draft, so an "opened but never edited"
- *  dialog can't hijack a later open. Shared by every write-through gate so
- *  mirror and clear agree on "has content". */
+/** Empty forms do not replace a later open with a meaningless draft. */
 export function isTaskCreationDraftContentful(fields: Record<string, string>): boolean {
   return Object.values(fields).some((value) => value.trim().length > 0)
 }

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -37,6 +37,7 @@ import type { PinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confi
 import type { RecentlyClosedTabsSlice } from './slices/recently-closed-tabs'
 import type { OrcaProfilesSlice } from './slices/orca-profiles'
 import type { NewIssueDraftSlice } from './slices/new-issue-draft'
+import type { TaskCreationDraftsSlice } from './slices/task-creation-drafts'
 import type { RemoteServerUpdatesSlice } from './slices/remote-server-updates'
 
 export type AppState = RepoSlice &
@@ -78,4 +79,5 @@ export type AppState = RepoSlice &
   RecentlyClosedTabsSlice &
   OrcaProfilesSlice &
   NewIssueDraftSlice &
+  TaskCreationDraftsSlice &
   RemoteServerUpdatesSlice


### PR DESCRIPTION
## Summary

Dismissing the **New Linear issue**, **New Linear project**, or **New Jira issue** dialog by clicking outside it (or pressing Escape, or clicking Cancel) no longer discards the typed text. Each dialog now retains its latest text in a session-only draft when dismissed or unmounted and restores it when the dialog reopens, exactly like the New GitHub issue dialog does since #7778:

- **New Linear issue**: title + description
- **New Linear project**: name, summary, and the project brief
- **New Jira issue**: title + description

The draft is cleared only after a **successful create**. Scope is deliberately **text-only**: picker selections (team, project, lead/members, labels, priority, dates, issue type, custom fields) keep their existing open-time defaults, so no repo/team/project staleness guards are needed. Drafts are in-memory only (the new `taskCreationDrafts` slice is not `persist`-wrapped) and do not survive an app restart, matching the #7778 boundary.

Closes #7696 — the GitHub dialog (the originally reported case) was already fixed by #7778; this covers the remaining creation dialogs the issue's second paragraph asks about.

## Screenshots

No visual layout change. Electron evidence for all three reopened dialogs is attached in [this PR comment](https://github.com/stablyai/orca/pull/12167#issuecomment-5161541573).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — ran the draft-related and affected suites locally (54 tests across 7 files, all green); full suite left to CI
- [ ] `pnpm build` — not run locally; no build-surface changes (renderer-only state wiring)
- [x] `pnpm run check:zustand-selector-fanout` — 2,500 subscribers × 2,000 writes, 0.0144 ms/write against the 5 ms budget, 0 render invalidations
- [x] Electron QA on final commit `b4faaa2046` — Escape, Cancel, and outside-click dismissal restored every text field; each flow recorded 0 draft writes while typing and 1 on close
- [x] Added or updated focused regression tests
  - `store/slices/task-creation-drafts.test.ts`: slice isolation, wholesale replacement, clearing, and the whitespace-only content gate.
  - `components/use-task-creation-draft-retention.test.ts`: no writes across typing renders, one latest-value write on dismissal/unmount, and successful-create discard without cleanup resurrection.
  - `components/task-page-task-creation-drafts.test.ts`: pins all three retention hooks, restore-on-open wiring, and success-only discard calls.
## AI Review Report

A same-model, same-reasoning subagent reviewed the final diff, fixed one meaningful in-scope performance regression, reran validation, and re-reviewed to **CLEAN**:

- **Dismissal/unmount retention**: `useTaskCreationDraftRetention` keeps the latest committed form values locally and writes to the global store once when an open composer closes or unmounts. Provider-context force-closes therefore retain the last open values even when local fields reset in the same update.
- **Successful create**: each success handler discards the draft before closing/resetting fields. The hook marks that close as discarded, so cleanup cannot resurrect the submitted text. Failed creates and stale-provider returns never discard the draft.
- **Emptied-then-dismissed form**: the shared content gate clears a prior draft when all text is empty or whitespace-only, so the next open is fresh.
- **Performance**: the original implementation wrote the app-wide Zustand store on every keystroke and added six live action subscriptions. The final implementation performs zero draft-store writes while typing, removes those subscriptions, and writes once on dismissal.
- **Scope**: only text for New Linear issue/project and New Jira issue is retained. Picker selections, provider ownership, persistence, mobile sync, IPC, SSH, and folder-workspace behavior are unchanged.
- **Cross-platform**: renderer-only state with no shortcut, path, shell, or Electron-main changes; behavior is platform-neutral across macOS, Linux, and Windows.
## Security Audit

No IPC, command execution, path handling, or auth changes. Draft text stays in the in-memory renderer store — never written to disk, logs, or telemetry — so no new retention surface for sensitive text. The credential dialogs (Jira connect, Linear API key) are deliberately untouched: they clear secrets on open by design and were explicitly excluded from draft preservation.

## Notes

- Follow-ups (out of scope, from the same audit): detail-sheet composers discard in-progress comments/edits on outside click (`GitLabItemDialog`, `JiraIssueWorkspace`, `LinearItemDrawer`, GitHub Project slug sheet) — better served by a "don't dismiss while a draft has text" guard like `DiffCommentPopover`'s; and the crash-report dialog, where an outside click both loses typed notes and permanently dismisses the report.
- Jira custom-field values are not preserved: the create-fields effect wipes them on every open/project/type change, and preserving them would require restructuring that effect for marginal benefit.
