### PR TITLE
fix(orchestration): launch the agent's command, not its id

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15660,6 +15660,22 @@ export class OrcaRuntimeService {
     }
   }
 
+  async resolveTuiAgentLaunchCommand(worktreeSelector: string, agent: TuiAgent): Promise<string> {
+    // Why: an agent id is not a shell command. `cursor` is the Cursor IDE launcher;
+    // the agent binary is `cursor-agent`. Resolve against the execution host, since
+    // launch commands vary by platform and by local vs remote.
+    const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
+    const override = this.store?.getSettings()?.agentCmdOverrides?.[agent]?.trim()
+    return (
+      override ||
+      getTuiAgentLaunchCommand(
+        TUI_AGENT_CONFIG[agent],
+        this.getAgentLaunchPlatformForWorkspace(workspace),
+        { isRemote: workspace.repo ? repoIsRemote(workspace.repo) : false }
+      )
+    )
+  }
+
   resolveTerminalPane(paneKey: string, expectedWorktreeId?: string): RuntimeTerminalResolvePane {
     // Why: the renderer context menu only knows the stable pane key; main owns
     // the runtime terminal handle that agents and CLI commands can address.

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { createExistingWorktreeWorkerTerminal } from './orchestration-worker-topology'
+
+function runtimeStub(launchCommand: string) {
+  return {
+    resolveTuiAgentLaunchCommand: vi.fn().mockResolvedValue(launchCommand),
+    createTerminal: vi.fn().mockResolvedValue({ handle: 'handle-1', surface: 'background' })
+  } as unknown as OrcaRuntimeService
+}
+
+describe('createExistingWorktreeWorkerTerminal', () => {
+  it('spawns the resolved launch command instead of the raw agent id', async () => {
+    // Regression: `command: args.agent` ran the agent id as a shell command, so on
+    // Windows `cursor` resolved to Cursor IDE's cursor.cmd and opened the desktop app.
+    const runtime = runtimeStub('cursor-agent')
+
+    await createExistingWorktreeWorkerTerminal({
+      runtime,
+      worktreeId: 'wt-1',
+      agent: 'cursor',
+      taskId: 'task-1',
+      effects: []
+    })
+
+    expect(runtime.resolveTuiAgentLaunchCommand).toHaveBeenCalledWith('id:wt-1', 'cursor')
+    expect(runtime.createTerminal).toHaveBeenCalledWith(
+      'id:wt-1',
+      expect.objectContaining({ command: 'cursor-agent' })
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -59,7 +59,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
   effects: WorkerEffect[]
 }): Promise<{ handle: string; warning?: string }> {
   const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
-    command: args.agent,
+    command: await args.runtime.resolveTuiAgentLaunchCommand(`id:${args.worktreeId}`, args.agent),
     title: `worker-${args.taskId}`,
     // Why: dispatching a worker is background work; it must not pull the sidebar
     // to the worker's workspace while the user is reading somewhere else.

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -9,6 +9,7 @@ import { OrcaRuntimeService } from '../../orca-runtime'
 import type { RuntimeTerminalSummary } from '../../../../shared/runtime-types'
 import { ORCHESTRATION_ASK_MAX_TIMEOUT_MS } from '../../../../shared/orchestration-ask-timeout'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 
 function lifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
   return `${type} messages belong to one exact Dispatch and cannot target a group address.`
@@ -2129,6 +2130,9 @@ describe('orchestration RPC methods', () => {
             : null
       )
       vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+      vi.spyOn(runtime, 'resolveTuiAgentLaunchCommand').mockImplementation(
+        async (_worktreeSelector, agent) => TUI_AGENT_CONFIG[agent].launchCmd
+      )
       vi.spyOn(runtime, 'showTerminal').mockImplementation(
         async (handle) => ({ handle, worktreeId: 'repo::worktree', status: 'running' }) as never
       )


### PR DESCRIPTION
## Summary

Fixes #11926.

`orca orchestration worker-start --worktree current --agent cursor` launched the Cursor **desktop app** instead of the `cursor-agent` CLI, left the worker terminal as a bare PowerShell session, and timed out at `agent_readiness`.

`createExistingWorktreeWorkerTerminal` passed the agent **id** where `createTerminal` expects a shell **command**:

```ts
command: args.agent,   // 'cursor'
```

There is already a safety net for bare agent launches. `resolveAgentTerminalCreateOptions` upgrades a bare agent command into a full startup plan, but it identifies the agent by matching the string against each agent's *resolved launch command*. It compared `'cursor'` against `'cursor-agent'`, found no match, returned `null`, and handed the raw string to the shell. Windows then resolved `cursor` to Cursor IDE's `cursor.cmd`.

That failed match is also why the rest of the symptom appeared: with the agent unidentified, the terminal never received trust-preset marking or the agent's default args, so it sat blank until `agent_readiness` gave up.

The fix resolves the id to its launch command against the execution host before spawning, so the correct command flows back through the existing startup-plan path.

### Scope is wider than the report

`--agent <id>` works by accident whenever an agent's id equals its launch command (`claude`, `codex`, `opencode`). Enumerating all 35 configured agents, **12 are affected**:

| Agent id | Launch command |
|---|---|
| `cursor` | `cursor-agent` |
| `claude-agent-teams` | `orca claude-teams` |
| `kiro` | `kiro-cli chat --tui` |
| `command-code` | `command-code --trust` |
| `hermes` | `hermes --tui` |
| `continue` | `cn` |
| `antigravity` | `agy` |
| `trae` | `traecli` |
| `aug` | `auggie` |
| `qwen-code` | `qwen` |
| `mistral-vibe` | `vibe` |
| `mimo-code` | `mimo` |

Four carry arguments, so this is not a binary rename.

**It is also not Windows-only.** Windows is where it is most visible, because Cursor IDE puts `cursor.cmd` on PATH and the failure surfaces as a desktop app opening. On macOS and Linux the same code path fails as command-not-found for `agy`, `cn`, `vibe`, `qwen`. The fix is therefore deliberately **not** platform-guarded.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (one pre-existing unrelated failure, see Notes)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full suite does not pass on this machine before or after, see Notes)
- [ ] `pnpm build` (not run locally)
- [x] Added a regression test

New `orchestration-worker-topology.test.ts` asserts the resolved launch command reaches `createTerminal`. **Confirmed to fail against the previous implementation** (`expected "vi.fn()" to be called with arguments: [ 'id:wt-1', 'cursor' ]`), so it catches the regression rather than passing alongside the fix.

`src/main/runtime/rpc/methods/`: **654 passed, 2 failed**, both in `ai-vault.test.ts`, which also fails on a clean `main` checkout.

## AI Review Report

Reviewed with Claude. Risks checked:

- **Cross-platform compatibility.** Resolution goes through the existing `getTuiAgentLaunchCommand`, which already honours `launchCmdByPlatform` and the remote-Linux carve-out. No new platform branches. macOS, Linux and Windows all take the same path, which is the intent here since the bug affects all three.
- **SSH, remote and local.** The launch command is resolved against the *execution host* via `resolveTerminalWorkspaceLaunchScope` plus `getAgentLaunchPlatformForWorkspace`, not the local machine, so an SSH worktree resolves with the remote's platform and remote flag. This mirrors what `resolveAgentTerminalCreateOptions` already does.
- **User overrides.** `agentCmdOverrides` is honoured and takes precedence, matching existing behavior elsewhere.
- **Flagged and addressed.** The review flagged that fixing this inside `resolveBareAgentLaunchCommand` (making it also match bare agent ids) would be a smaller diff but wrong: a user typing `cursor` in a normal terminal means Cursor IDE, and hijacking that into `cursor-agent` would be a regression. The fix is therefore confined to the orchestration path, where the value is known to be an agent id rather than user-authored shell.
- **Test-only changes.** Two existing `orchestration.test.ts` worker tests needed a spy for the new runtime method. The spy resolves through the real `TUI_AGENT_CONFIG` rather than a hardcoded string, so it cannot mask a wrong command.

## Security Audit

- **Command execution.** This strictly narrows what reaches the shell. Previously an agent id was executed verbatim; now only a value derived from `TUI_AGENT_CONFIG` or the user's own configured override is executed. No new subprocess is introduced.
- **Input handling.** The agent id is already validated upstream by `isTuiAgent` and `validateOrchestrationAgentLauncher` before reaching this path, so the config lookup cannot be driven to an arbitrary key.
- **Path handling, secrets, auth, IPC, dependencies.** Untouched. No dependency changes.
- Worth a maintainer's eye on the remote case, since command resolution for SSH hosts is the highest-consequence part of this change.

## Notes

- **Pre-existing lint failure.** `pnpm lint` fails at `verify:skill-bundle-manifest` with stale `resources/skills/*.json`. This reproduces on a clean checkout of `main`, so it is not introduced here, and those are generated artifacts I did not want to churn in a focused fix.
- **`pnpm test` and `pnpm build` were not completed locally.** For reference, a clean `main` on this Windows machine fails 167 tests across 57 files, so a green local suite is not currently achievable either way. The affected area is green apart from the pre-existing `ai-vault` failures.
- **Follow-up not taken here.** `createWorkerWorktree` (the `new-child` / `new-top-level` path) passes `startupAgent` and is resolved downstream, so it is unaffected. I left it alone rather than widening this diff.
