### PR TITLE
fix(updater): use channel display labels in the mac-only pinned-build error

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -225,6 +225,34 @@ describe('updater', () => {
     expect(powerMonitorOnMock).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['hourly', 'v1.4.160-hourly.202607281400', 'Hourly builds are produced only for macOS.'],
+    ['adhoc', 'v1.4.160-adhoc.20260728140533', 'Adhoc builds are produced only for macOS.']
+  ] as const)(
+    'uses the display label in the mac-only %s pinned-build error',
+    async (channel, tag, message) => {
+      const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+      try {
+        const send = vi.fn()
+        const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+        setupAutoUpdater({ webContents: { send } } as never, {
+          getLastUpdateCheckAt: () => Date.now()
+        })
+
+        checkForUpdatesFromMenu({ channel, targetTag: tag })
+
+        expect(send).toHaveBeenCalledWith('updater:status', {
+          state: 'error',
+          message,
+          userInitiated: true
+        })
+        expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
+      } finally {
+        platformSpy.mockRestore()
+      }
+    }
+  )
+
   it.runIf(process.platform === 'darwin')(
     'allows a validated local build to downgrade through the normal updater lifecycle',
     async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -48,6 +48,7 @@ import { listReleaseBuilds, resolveTargetBuild } from './updater-release-builds'
 import {
   hasDedicatedReleaseRepo,
   isChannelSupportedOnPlatform,
+  RELEASE_CHANNEL_LABELS,
   type ReleaseBuild,
   type ReleaseChannel
 } from '../shared/release-channel'
@@ -1534,7 +1535,7 @@ async function checkForPinnedBuild(channel: ReleaseChannel, tag: string): Promis
   if (!isChannelSupportedOnPlatform(channel, process.platform)) {
     sendStatus({
       state: 'error',
-      message: `${channel} builds are produced only for macOS.`,
+      message: `${RELEASE_CHANNEL_LABELS[channel]} builds are produced only for macOS.`,
       userInitiated: true
     })
     return

--- a/src/renderer/src/components/settings/ReleaseChannelSection.tsx
+++ b/src/renderer/src/components/settings/ReleaseChannelSection.tsx
@@ -11,6 +11,7 @@ import { translate } from '@/i18n/i18n'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import {
   RELEASE_CHANNELS,
+  RELEASE_CHANNEL_LABELS,
   getVersionChannel,
   hasDedicatedReleaseRepo,
   isChannelSupportedOnPlatform,
@@ -18,13 +19,6 @@ import {
   type ReleaseBuild,
   type ReleaseChannel
 } from '../../../../shared/release-channel'
-
-const CHANNEL_LABELS: Record<ReleaseChannel, string> = {
-  stable: 'Stable',
-  rc: 'RC',
-  hourly: 'Hourly',
-  adhoc: 'Adhoc'
-}
 
 const CHANNEL_DESCRIPTIONS: Record<ReleaseChannel, string> = {
   stable: 'Shipped releases. What everyone else is running.',
@@ -200,10 +194,10 @@ export function ReleaseChannelSection(): React.JSX.Element {
             return {
               value: channel,
               label: supported ? (
-                CHANNEL_LABELS[channel]
+                RELEASE_CHANNEL_LABELS[channel]
               ) : (
                 <span className="inline-flex items-center gap-1">
-                  {CHANNEL_LABELS[channel]}
+                  {RELEASE_CHANNEL_LABELS[channel]}
                   <Apple className="size-3" aria-hidden="true" />
                 </span>
               ),
@@ -213,14 +207,14 @@ export function ReleaseChannelSection(): React.JSX.Element {
                 : translate(
                     'auto.components.settings.ReleaseChannelSection.devChannelMacOnlyAria',
                     '{{value0}} (macOS only)',
-                    { value0: CHANNEL_LABELS[channel] }
+                    { value0: RELEASE_CHANNEL_LABELS[channel] }
                   ),
               tooltip: supported
                 ? undefined
                 : translate(
                     'auto.components.settings.ReleaseChannelSection.devChannelMacOnly',
                     '{{value0}} builds are produced only for macOS. Linux and Windows stay on Stable or RC.',
-                    { value0: CHANNEL_LABELS[channel] }
+                    { value0: RELEASE_CHANNEL_LABELS[channel] }
                   )
             }
           })}

--- a/src/shared/release-channel.ts
+++ b/src/shared/release-channel.ts
@@ -4,6 +4,13 @@ export type ReleaseChannel = 'stable' | 'rc' | 'hourly' | 'adhoc'
 
 export const RELEASE_CHANNELS: readonly ReleaseChannel[] = ['stable', 'rc', 'hourly', 'adhoc']
 
+export const RELEASE_CHANNEL_LABELS: Readonly<Record<ReleaseChannel, string>> = {
+  stable: 'Stable',
+  rc: 'RC',
+  hourly: 'Hourly',
+  adhoc: 'Adhoc'
+}
+
 /** Dev builds live in their own repos so their tags never enter the main
  *  releases atom feed, which only exposes the 10 newest entries — 24 hourly
  *  tags a day would evict every stable/RC entry and strand real users. */


### PR DESCRIPTION
## Summary

Centralize release-channel display labels in the shared release-channel module so the main process and renderer use the same copy.
Off-macOS pinned Hourly and Adhoc selections now preserve the prior sentence shape with display labels instead of raw lowercase channel ids.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck` (via `pnpm tc`)
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- `pnpm vitest run --config config/vitest.config.ts src/shared/release-channel.test.ts src/main/updater.test.ts`
- `pnpm exec oxlint src/shared/release-channel.ts src/renderer/src/components/settings/ReleaseChannelSection.tsx src/main/updater.ts src/main/updater.test.ts`

## AI Review Report

Reviewed the shared-label ownership, the exact updater IPC status payload, and the platform guard for both Hourly and Adhoc. The review found no additional issues; targeted tests verify the display-label messages and confirm unsupported builds never reach electron-updater. Cross-platform compatibility was explicitly checked: macOS behavior remains unchanged, Linux and Windows receive the corrected labels, and this change touches no shortcuts, paths, shell behavior, or other Electron platform differences.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, or IPC channels were introduced. Existing typed release-channel input and the existing platform gate remain in place, with no follow-up needed.

## Notes

Follow-up polish for #12051. The status message remains a plain main-process error string interpolated into the renderer localized error wrapper, so no localization catalog changes were needed.