### PR TITLE
fix(settings): open the deep-linked project setup, not the host's first

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -668,9 +668,7 @@ function Settings(): React.JSX.Element {
         setSettingsProjectHostSelection(
           hostSelection.projectId,
           hostSelection.hostId,
-          'setupId' in hostSelection && typeof hostSelection.setupId === 'string'
-            ? hostSelection.setupId
-            : undefined
+          hostSelection.setupId
         )
       }
     }

--- a/src/renderer/src/components/settings/settings-project-list.test.ts
+++ b/src/renderer/src/components/settings/settings-project-list.test.ts
@@ -152,11 +152,14 @@ describe('deep-link resolution', () => {
     expect(map.get('local-1')).toBe('local-1')
   })
 
-  it('maps a repoId to its owning project + host for selection', () => {
+  // Why: #11689 added setupId — a host can own several setups (two clones), so
+  // the selection has to name the exact setup row, not just the host.
+  it('maps a repoId to its owning project + host + setup for selection', () => {
     const map = buildRepoIdToHostSelection(projects)
     expect(map.get('remote-9')).toEqual({
       projectId: projects[0].projectId,
-      hostId: 'runtime:home-mac'
+      hostId: 'runtime:home-mac',
+      setupId: 'remote-9'
     })
   })
 
@@ -203,6 +206,26 @@ describe('deep-link resolution', () => {
     expect(
       resolveSettingsTargetRepoId({ repoId: null, sectionId: 'repo-app-2-icon' }, ['app', 'app-2'])
     ).toBe('app-2')
+  })
+
+  // Why: #11689 — two clones of one remote on the same host collapse into a
+  // single project, so a deep link that only named the host opened the host's
+  // first setup, i.e. the third project's settings showed the first project's.
+  it('opens the deep-linked clone, not the host first setup, for same-host clones', () => {
+    const clonedRepos: Repo[] = [
+      makeRepo({ id: 'clone-1', gitRemoteIdentity: gitRemote, path: '/repos/one' }),
+      makeRepo({ id: 'solo-2', path: '/repos/two' }),
+      makeRepo({ id: 'clone-3', gitRemoteIdentity: gitRemote, path: '/repos/three' })
+    ]
+    const clonedProjects = buildSettingsProjectList(clonedRepos)
+    const representative = buildRepoIdToRepresentative(clonedProjects).get('clone-3')
+    const selection = buildRepoIdToHostSelection(clonedProjects).get('clone-3')
+    const target = clonedProjects.find((p) => p.representativeRepoId === representative)
+
+    expect(selection?.setupId).toBe('clone-3')
+    expect(
+      getSettingsProjectHostRepo(target!, clonedRepos, selection?.hostId, selection?.setupId)?.path
+    ).toBe('/repos/three')
   })
 
   it('resolves the remote host repo row when a remote host is selected', () => {

--- a/src/renderer/src/components/settings/settings-project-list.ts
+++ b/src/renderer/src/components/settings/settings-project-list.ts
@@ -13,6 +13,13 @@ export type SettingsProject = {
   representativeRepoId: string
 }
 
+/** Which project + host + setup row a Settings deep link should open. */
+export type SettingsProjectHostSelection = {
+  projectId: string
+  hostId: ExecutionHostId
+  setupId: string
+}
+
 /**
  * Which repo row identifies a project's single Settings nav row + pane. Pure
  * over the project's setups so nav and panes derive the same id. Prefers the
@@ -107,16 +114,22 @@ export function buildRepoIdToRepresentative(
   return map
 }
 
-/** Maps each host's repoId to its owning project + host, so a deep link can
- *  select that host in the pane's "Available Hosts" switcher. */
+/** Maps each host's repoId to its owning project + host + setup, so a deep link
+ *  can select that host in the pane's "Available Hosts" switcher. The setup id
+ *  is required: one host can own several setups (two clones of the same remote),
+ *  and naming only the host opens the host's first setup — the wrong project. */
 export function buildRepoIdToHostSelection(
   projects: readonly SettingsProject[]
-): Map<string, { projectId: string; hostId: ExecutionHostId }> {
-  const map = new Map<string, { projectId: string; hostId: ExecutionHostId }>()
+): Map<string, SettingsProjectHostSelection> {
+  const map = new Map<string, SettingsProjectHostSelection>()
   for (const settingsProject of projects) {
     for (const setup of settingsProject.setups) {
       if (setup.repoId.trim().length > 0 && !map.has(setup.repoId)) {
-        map.set(setup.repoId, { projectId: settingsProject.projectId, hostId: setup.hostId })
+        map.set(setup.repoId, {
+          projectId: settingsProject.projectId,
+          hostId: setup.hostId,
+          setupId: setup.id
+        })
       }
     }
   }
@@ -127,7 +140,7 @@ export function getSettingsTargetHostSelection(
   projects: readonly SettingsProject[],
   repoId: string,
   hostId: ExecutionHostId
-): { projectId: string; hostId: ExecutionHostId; setupId: string } | null {
+): SettingsProjectHostSelection | null {
   for (const settingsProject of projects) {
     const setup = settingsProject.setups.find(
       (candidate) => candidate.repoId === repoId && candidate.hostId === hostId

--- a/tests/e2e/project-settings-same-host-clone-deep-link.spec.ts
+++ b/tests/e2e/project-settings-same-host-clone-deep-link.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression test for #11689: editing the third project's properties opened the
+ * first project's pane.
+ *
+ * Two clones of one remote collapse into a single project by design, so both
+ * live on the same host. The `{pane:'repo', repoId}` deep link only carried the
+ * host, and the pane then fell back to that host's *first* setup — so "Project
+ * Settings" on the second clone rendered the first clone's properties.
+ */
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+const SHARED_REMOTE = {
+  canonicalKey: 'github.com/acme/app',
+  remoteName: 'origin',
+  remoteUrl: 'git@github.com:acme/app.git'
+}
+
+// The collapsed project's single pane is keyed by its representative repo row.
+const COLLAPSED_PANE = '[data-settings-section="repo-clone-1"]'
+
+async function openProjectSettings(page: Page, repoId: string): Promise<void> {
+  await page.evaluate((targetRepoId) => {
+    const state = window.__store!.getState()
+    state.setSettingsSearchQuery('')
+    state.openSettingsTarget({ pane: 'repo', repoId: targetRepoId })
+    state.openSettingsPage()
+  }, repoId)
+  await expect(page.getByPlaceholder('Search settings')).toBeVisible({ timeout: 10_000 })
+  // Why: first-run announcements can cover the settings pane on fresh profiles.
+  const maybeLaterButton = page.getByRole('button', { name: 'Maybe Later' })
+  if (await maybeLaterButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+    await maybeLaterButton.click()
+  }
+}
+
+test.describe('Project Settings deep link with same-host clones', () => {
+  test('opens the clone that was asked for, not the host first setup', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+
+    await orcaPage.evaluate(async (sharedRemote) => {
+      const store = window.__store!
+      // Why: the spec asserts on English strings; the host may run another locale.
+      await store.getState().updateSettings({ uiLanguage: 'en' })
+      store.setState({
+        repos: [
+          {
+            id: 'clone-1',
+            path: '/repos/one',
+            displayName: 'One',
+            badgeColor: '#111111',
+            addedAt: 1,
+            gitRemoteIdentity: sharedRemote
+          },
+          {
+            id: 'solo-2',
+            path: '/repos/two',
+            displayName: 'Two',
+            badgeColor: '#222222',
+            addedAt: 2
+          },
+          {
+            id: 'clone-3',
+            path: '/repos/three',
+            displayName: 'Three',
+            badgeColor: '#333333',
+            addedAt: 3,
+            gitRemoteIdentity: sharedRemote
+          }
+        ],
+        projects: [],
+        projectHostSetups: []
+      })
+    }, SHARED_REMOTE)
+
+    await openProjectSettings(orcaPage, 'clone-3')
+    await expect(orcaPage.locator(COLLAPSED_PANE)).toContainText('/repos/three')
+    await expect(orcaPage.locator(COLLAPSED_PANE)).not.toContainText('/repos/one')
+
+    // The first clone still resolves to itself, so this is a real selection and
+    // not a blanket switch to the last setup.
+    await openProjectSettings(orcaPage, 'clone-1')
+    await expect(orcaPage.locator(COLLAPSED_PANE)).toContainText('/repos/one')
+    await expect(orcaPage.locator(COLLAPSED_PANE)).not.toContainText('/repos/three')
+  })
+})


### PR DESCRIPTION
## Summary

Addresses the reproducible half of #11689: *"Editing third project's properties shows first project's data."*

**Precondition:** two setups sharing one identity on one host — two clones of the same remote, the same repo added twice, or sibling folder workspaces inside one repo. Local + SSH copies are unaffected, because their `hostId`s differ and the host-only lookup is unambiguous there.

**Root cause.** #8650 collapsed the Settings Projects list to one row + pane per project, so a project set up on several hosts (or cloned twice from one remote) renders a single pane whose content follows an ephemeral per-project host selection. `buildRepoIdToHostSelection` fed that selection from a `{pane:'repo', repoId}` deep link but recorded only `{projectId, hostId}`. `getSettingsProjectHostRepo` then resolved the row with `setups.find(s => s.hostId === effectiveHostId)`, which is unambiguous only while a host owns one setup. Two clones of one remote are both on `local`, so "Project Settings" on the second clone opened the **first** clone's setup.

**Fix.** Carry `setup.id` through the selection so the pane mounts the exact repo row the link named. `getSettingsTargetHostSelection` (the explicit-`hostId` path) already returned a `setupId`; both now share a `SettingsProjectHostSelection` type, and `Settings.tsx` drops the `'setupId' in hostSelection` narrowing that existed only because the two shapes disagreed.

### What this does NOT close

The issue also reports *"only two projects visible in the lower right corner."* That half is **not** explained by this change, and I'm flagging it rather than quietly implying it's handled:

- The main-window sidebar enumerates repos directly and never touches the projection #8650 introduced (`buildSettingsProjectList` appears only in `useSettingsNavigationMetadata.ts`, `settings-project-list.ts`, and `Settings.tsx`). All three projects render there.
- The lower-right corner of the main window holds status metrics and the workspace-board toggle — there is no project list there at all. `WorkspaceKanbanDrawer` groups by workspace status, not by repo.
- The only surface where a count of two appears is the **Settings Projects nav**, which sits at the bottom of that column — consistent with "lower" and "two instead of three", but not with "right".

The issue's attachment is a WeChat screenshot of the machine-translated report, not a UI capture, so the reporter's intended surface can't be determined from it. **Worth asking the reporter to confirm before closing #11689.** Using "Addresses" rather than "Fixes" deliberately, so merging this doesn't auto-close an issue that may be half-open.

## Screenshots

**No visual change** — no new or modified UI. The change is which repo row a deep link resolves to; the pane itself is unchanged. The behavior difference is covered by an E2E spec, which is stronger evidence here than an image.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

- `settings-project-list.test.ts` — a new regression test for the same-host-clone deep link, plus one existing test updated: `buildRepoIdToHostSelection` entries now include `setupId`, and its `toEqual` assertion pinned the exact two-field shape. Updated with a `Why:` comment naming this issue rather than silently reshaped.
- `tests/e2e/project-settings-same-host-clone-deep-link.spec.ts` — new, drives the real app.

Fail-before / pass-after, verified by running both ways rather than asserted:

| | without fix | with fix |
|---|---|---|
| `settings-project-list.test.ts` | 2 failed / 20 passed | 22 passed (exit 0) |
| `project-settings-same-host-clone-deep-link.spec.ts` | 1 failed (exit 1) | 1 passed (exit 0) |

Three existing E2E specs use the `pane:'repo'` deep link (`settings-display-name-ime`, `setup-script-import`, `windows-project-runtime-smoke`); none encoded the buggy behavior, and the two non-Windows ones pass. No existing E2E spec was changed.

## AI Review Report

Reviewed across two rounds, each claim checked against the code rather than accepted.

- **The diagnosis was initially an inference and was tested as one.** The first pass assumed the reporter had same-identity clones. That is not stated anywhere in the issue, so the literal reported scenario was then built on unfixed source — three genuinely distinct projects, separate remotes, one host — and driven in the real app. Neither symptom reproduces there: all three nav rows render and the third project opens its own pane. The precondition therefore holds by elimination, and it is now recorded in the commit message instead of left implied.
- **An early "one root cause explains both symptoms" framing was wrong and was retracted**, which is where the "does not close" section above comes from.
- **Cross-platform (macOS/Linux/Windows):** pure data mapping — no key handling, no path logic, no shortcut labels. Test paths are opaque store strings.
- **SSH / remote / local:** the multi-host case is exactly what this map exists for, and the selection is now more precise. `getSettingsProjectHostRepo` matches on `setupId` **and** `hostId`, so same-id rows on different hosts stay distinguished; the existing "resolves the remote host repo row" test still passes.
- **Folder workspaces:** no remote → `repo:<id>` identity → one setup per project, behavior unchanged, covered by the existing folder test.
- **Git providers:** the unit regression uses the file's GitLab fixture; the E2E uses GitHub.
- **Performance:** one extra string field per map entry, built once per Settings render. No new work in any hot path.
- A genuine `?? repos[0]` fallback at `useSettingsNavigationMetadata.ts:593` was found and deliberately left alone: it is unreachable (the representative always exists in the map) and only feeds description/search text.

## Security Audit

No IPC surface, command execution, path handling, auth, secrets, network calls, or new dependencies. The change adds one identifier to an in-memory renderer map used for Settings navigation. Deep-link input is unchanged and still resolved through the existing lookup, which now matches more precisely rather than more loosely — if anything it narrows what a crafted `repoId` can select. No follow-up needed.

## Notes

- Deliberately out of scope: the same-identity collapse itself, and the project `displayName` coming from the first repo (so the nav row can read "One" while the pane correctly shows `/repos/three`). Both are #8650's documented design with dedicated tests; changing them is a product decision, not a bug fix.
- Related: `setupsByOwnedExecutionHost` dedupes the "Available Hosts" switcher by host, so two same-host clones still can't be toggled from inside the pane. That makes the deep link the only route to the second clone's settings — which is precisely what this restores. Worth a follow-up if those clones should be distinguishable in the UI.
