### PR TITLE
fix(orchestration): resolve bare agent ids when launch binary differs

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12734,6 +12734,107 @@ describe('OrcaRuntimeService', () => {
     expect(spawnCall?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
   })
 
+  it('resolves bare agent ids whose launch binary differs from the id', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: {},
+        agentDefaultArgs: { antigravity: '--dangerously-skip-permissions' },
+        agentDefaultEnv: {}
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    // Why: orchestration worker-start passes command: <agent id>; antigravity's
+    // binary is `agy`, so matching only launchCmd left this path as a raw shell
+    // string without launchAgent / launch token.
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'antigravity',
+      title: 'worker'
+    })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as
+      | { command?: string; env?: Record<string, string>; launchAgent?: string }
+      | undefined
+    expect(spawnCall?.command).toBe("agy '--dangerously-skip-permissions'")
+    expect(spawnCall?.launchAgent).toBe('antigravity')
+    expect(spawnCall?.env?.ORCA_AGENT_LAUNCH_TOKEN).toMatch(UUID_RE)
+  })
+
+  it('resolves bare cursor agent ids to the cursor-agent launch binary', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: [],
+        agentCmdOverrides: {},
+        agentDefaultArgs: { cursor: '--yolo' },
+        agentDefaultEnv: {}
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'cursor',
+      title: 'worker'
+    })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as
+      | { command?: string; launchAgent?: string; env?: Record<string, string> }
+      | undefined
+    expect(spawnCall?.command).toBe("cursor-agent '--yolo'")
+    expect(spawnCall?.launchAgent).toBe('cursor')
+    expect(spawnCall?.env?.ORCA_AGENT_LAUNCH_TOKEN).toMatch(UUID_RE)
+  })
+
+  it('keeps disabled bare agent id terminal creates unchanged', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        disabledTuiAgents: ['antigravity' as const],
+        agentCmdOverrides: {},
+        agentDefaultArgs: { antigravity: '--dangerously-skip-permissions' },
+        agentDefaultEnv: {}
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'antigravity'
+    })
+
+    const spawnCall = spawn.mock.calls[0]?.[0] as
+      | { command?: string; env?: Record<string, string>; launchAgent?: string }
+      | undefined
+    expect(spawnCall?.command).toBe('antigravity')
+    expect(spawnCall?.launchAgent).toBeUndefined()
+    expect(spawnCall?.env?.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
+  })
+
   it('sends Settings agent defaults through renderer-backed bare agent terminal creates', async () => {
     const runtimeStore = {
       ...store,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1374,6 +1374,14 @@ function resolveBareAgentLaunchCommand(args: {
     return null
   }
 
+  // Why: worker-start / federation pass the agent id (`antigravity`, `cursor`) as
+  // createTerminal `command`, while UI launches use the real binary (`agy`,
+  // `cursor-agent`). Accept the bare id so Settings defaults, launchAgent, and
+  // ORCA_AGENT_LAUNCH_TOKEN attach the same way as a picker launch.
+  if (isTuiAgent(command) && isTuiAgentEnabled(command, args.settings.disabledTuiAgents)) {
+    return command
+  }
+
   const cmdOverrides = args.settings.agentCmdOverrides ?? {}
   for (const agent of Object.keys(TUI_AGENT_CONFIG) as TuiAgent[]) {
     if (!isTuiAgentEnabled(agent, args.settings.disabledTuiAgents)) {


### PR DESCRIPTION
## Summary

`orca orchestration worker-start --agent <id>` creates a worker terminal with `command` set to the **agent id** (e.g. `antigravity`, `cursor`). Bare-agent resolution only matched **launch binaries** (`agy`, `cursor-agent`), so agents whose id ≠ binary were treated as raw shell commands:

- no `launchAgent` / `launchConfig`
- no `ORCA_AGENT_LAUNCH_TOKEN` (weaker hook attribution)
- Settings YOLO / default args not applied via the normal startup plan
- readiness fell back to slow screen scraping → frequent `agent_readiness` timeouts and `runtime_unavailable` races (especially Antigravity)

This change accepts an enabled bare `TuiAgent` id in `resolveBareAgentLaunchCommand`, so worker-start/federation launches resolve the real launch command the same way as the agent picker (e.g. `antigravity` → `agy --dangerously-skip-permissions` with launch metadata).

Agents where id already equals the binary (`claude`, `codex`, …) are unchanged. Disabled agents still run as raw commands (same as before for disabled bare binaries).

### Current workaround (pre-fix / still useful locally)

Until this lands, operators often paper over the missing `antigravity` PATH entry with a wrapper, because worker-start literally execs the string `antigravity` instead of `agy`:

```bash
#!/usr/bin/env bash
exec agy --dangerously-skip-permissions "$@"
```
(write to /usr/local/bin/antigravity)

What that workaround does and does **not** fix:

| | With wrapper only | After this PR |
|---|---|---|
| `worker-start --agent antigravity` finds a command on PATH | yes (runs wrapper → `agy`) | yes (Orca launches `agy` directly) |
| Settings defaults / YOLO via `buildAgentStartupPlan` | no | yes |
| `launchAgent` + `ORCA_AGENT_LAUNCH_TOKEN` (hooks) | no | yes |
| Same path as UI agent picker | no | yes |

So the wrapper is a **local PATH shim**, not a substitute for proper agent-id resolution. After this fix, `worker-start --agent antigravity` should not need `/usr/local/bin/antigravity`. The wrapper can remain for manual `orca terminal create --command antigravity` if someone still types the id as a shell command.

## Screenshots

No visual change

## Testing

- [x] `pnpm lint` — passed
- [x] `pnpm typecheck` — passed
- [ ] `pnpm test` — 43520 passed, 81 skipped; **2 failed unrelated to this PR** (see Notes)
- [x] `pnpm build` — passed
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New coverage in `orca-runtime.test.ts`:

- bare `antigravity` id → `agy` + YOLO args + `launchAgent` + launch token
- bare `cursor` id → `cursor-agent` + YOLO args + launch metadata
- disabled bare `antigravity` id stays a raw `antigravity` command (no agent wrapping)

Targeted: `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts -t "bare agent"` → 9 passed

## AI Review Report

Reviewed the change for orchestration worker-start / federation terminal create paths.

**Main risks checked**

- **Cross-platform (macOS / Linux / Windows):** resolution is string-level before shell quoting; Windows quoting still goes through existing `buildAgentStartupPlan` / shell helpers. No shortcut, label, or path changes.
- **SSH / remote / local:** still uses `getTuiAgentLaunchCommand(..., { isRemote })` and the same Settings defaults path as other bare agent creates; remote Windows shell quoting behavior unchanged.
- **Agent compatibility:** fixes agents where id ≠ launch binary (`antigravity`→`agy`, `cursor`→`cursor-agent`, and the same class for `kiro`, `aug`, etc.). Agents with id === binary keep matching via the existing launchCmd loop. Multi-token commands (`codex exec …`) still fail bare match and stay raw shell.
- **Performance:** one extra `isTuiAgent` check on bare creates only; no hot-path render/PTY work.
- **UI quality:** N/A (no UI).
- **Security:** only enables agent startup wrapping for known enabled `TuiAgent` ids; does not broaden arbitrary command execution. Disabled agents are not auto-wrapped.

**Flagged / verified**

- Confirmed worker-start still passes `command: args.agent` (id string); fixing resolution is the minimal durable fix vs. only changing the worker topology call site.
- Confirmed UI picker already used `buildAgentStartupPlan({ agent })` and was not broken; this aligns the bare-command path with that behavior.
- Confirmed the historical `/usr/local/bin/antigravity` workaround only papered over PATH lookup and does not attach launch metadata — documented above for reviewers who have seen that shim in the wild.

## Security Audit

- **Command execution:** bare create still only auto-wraps when the entire command string is an enabled agent id or a known launch binary/override. User-authored multi-arg commands remain untouched.
- **No new IPC, auth, secrets, or dependency surface.**
- **Path handling:** unchanged.
- **Follow-up:** none required for this fix. Optional later cleanup: worker-start could pass a structured `agent` field instead of overloading `command`, but that is a larger API change and not required once id resolution works.

## Notes

- **Unrelated test failures on this machine:** `src/relay/agent-exec-handler.test.ts` (2 tests) failed because the host shell already exports `GIT_CONFIG_COUNT=2` / `GIT_CONFIG_KEY_*`, so the handler ends up with `GIT_CONFIG_COUNT=4` while the test expects `2`. Not touched by this PR; re-run those tests in a clean env (unset `GIT_CONFIG_*`) to confirm green. Full suite otherwise: 4074 files passed.
