### PR TITLE
fix(terminal): stop Shift+jamo from injecting a newline while an IME composes

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -325,6 +325,7 @@ describe('isTerminalImeProcessEnter', () => {
   const event = (overrides: Partial<KeyboardEvent> = {}) =>
     ({
       key: 'Process',
+      code: 'Enter',
       keyCode: 229,
       metaKey: false,
       ctrlKey: false,
@@ -340,6 +341,10 @@ describe('isTerminalImeProcessEnter', () => {
     }
   )
 
+  it('recognizes the numpad Enter while composing', () => {
+    expect(isTerminalImeProcessEnter(event({ code: 'NumpadEnter' }))).toBe(true)
+  })
+
   it.each([
     { key: 'Enter' },
     { keyCode: 13 },
@@ -348,6 +353,19 @@ describe('isTerminalImeProcessEnter', () => {
     { altKey: true }
   ])('rejects a non-IME or ambiguous Process key', (override) => {
     expect(isTerminalImeProcessEnter(event(override))).toBe(false)
+  })
+
+  // Regression: while an IME composes, Windows reports key 'Process' + keyCode 229 for
+  // every key. Shift+<jamo> on 2-beolsik produces the double consonants ㄸ/ㄲ/ㅆ/ㅉ and
+  // used to be rewritten into Shift+Enter, injecting a newline mid-word.
+  it.each([
+    { code: 'KeyE', jamo: 'ㄸ' },
+    { code: 'KeyR', jamo: 'ㄲ' },
+    { code: 'KeyT', jamo: 'ㅆ' },
+    { code: 'KeyW', jamo: 'ㅉ' },
+    { code: 'KeyQ', jamo: 'ㅃ' }
+  ])('rejects Shift+$jamo composed on 2-beolsik ($code)', ({ code }) => {
+    expect(isTerminalImeProcessEnter(event({ code }))).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -107,11 +107,19 @@ export function getTerminalImeModifiedEnterKind(
 }
 
 export function isTerminalImeProcessEnter(
-  event: Pick<KeyboardEvent, 'key' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+  event: Pick<
+    KeyboardEvent,
+    'key' | 'code' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'
+  >
 ): boolean {
   return (
     event.key === 'Process' &&
     event.keyCode === 229 &&
+    // Why: while an IME composes, Windows reports key 'Process' and keyCode 229 for
+    // every key, not just Enter. Without the physical key, Shift+<jamo> (the 2-beolsik
+    // double consonants ㄸ/ㄲ/ㅆ/ㅉ) is indistinguishable from Shift+Enter and gets
+    // rewritten into a newline. `code` survives composition and identifies the key.
+    (event.code === 'Enter' || event.code === 'NumpadEnter') &&
     getTerminalImeModifiedEnterKind(event) !== null
   )
 }


### PR DESCRIPTION
## Summary

Fixes #11878.

Typing Korean double consonants (ㄸ ㄲ ㅆ ㅉ ㅃ) in a Windows terminal pane injected a stray newline mid-word, as if Enter had been pressed partway through typing.

`isTerminalImeProcessEnter` identified a composed Shift+Enter as "key is `Process`, keyCode is 229, exactly one of Shift or Ctrl held":

```ts
event.key === 'Process' && event.keyCode === 229 && getTerminalImeModifiedEnterKind(event) !== null
```

While a Windows IME composes, that description fits **every** key, not just Enter. On the 2-beolsik layout each double consonant is Shift + a base key, so it matched. `keyboard-handlers.ts` then synthesizes `key: 'Enter'` for anything that matches and hands it to the shortcut resolver:

```ts
const imeProcessEnter = isWindows && hasPendingImeComposition && isTerminalImeProcessEnter(e)
const shortcutEvent = imeProcessEnter ? { key: 'Enter', code: e.code, ... } : e
```

So typing ㄸ fired the Shift+Enter newline shortcut. This matches the isolation in the linked reports exactly: plain Shift+letter is fine, because English input is not IME-composed and reports its real key.

The fix requires the physical key to actually be Enter. `code` is unaffected by composition, so it separates a genuine Shift+Enter from a composed jamo without touching the Shift+Enter path itself. `code` was already being read one line later, it just was not part of the test.

### Likely duplicates

Several recent reports appear to share this cause. Worth a triage pass rather than my assertion:

#12179, #12156, #12152, #12151, #12184

I did **not** include #12164 (IME syllable duplication in rendering) or #12171 (macOS Korean input latency). Those look like different code paths and I have not verified them.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (one pre-existing unrelated failure, see Notes)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full suite does not pass on this machine before or after, see Notes)
- [ ] `pnpm build` (not run locally)
- [x] Added regression tests

- `src/renderer/src/components/terminal-pane/`: **2892 passed, 218 files, 0 failed**
- New cases cover all five 2-beolsik double consonants by physical `code`, plus NumpadEnter to keep the real Shift+Enter path covered.
- **Confirmed to fail against the previous implementation**: reverting the source fails exactly the 5 new jamo cases and nothing else.

### Verification caveat, stated plainly

I do not have a Korean IME on Windows and **could not reproduce the original symptom first-hand**. This fix was derived from reading the input path and is verified by tests and by the reporters' own isolation (single Shift+key fine, consecutive ones break; English Shift unaffected), not by observing the bug. Confirmation from any of the reporters on a real 2-beolsik setup would be worth having before merge.

## AI Review Report

Reviewed with Claude. Risks checked:

- **Cross-platform.** The only caller is already gated behind `isWindows && hasPendingImeComposition`. macOS and Linux never reach it. No platform branch added or removed.
- **Does not narrow the real Shift+Enter path.** The synthesized-Enter branch still triggers for `code === 'Enter'` and now also explicitly for `NumpadEnter`, which the previous predicate accepted only incidentally. A test pins that.
- **Other IMEs.** The fix keys on the physical key rather than on anything Korean-specific, so Japanese and Chinese IMEs that also report `Process`/229 get the same correction. Nothing in the change is layout-specific.
- **Flagged and addressed.** The review noted the shared test factory omitted `code`, which would have made every existing case pass vacuously against the new condition. The factory now defaults `code: 'Enter'`, so the existing assertions still mean what they claim.

## Security Audit

- **Input handling.** This strictly narrows which key events are rewritten into a synthetic Enter. No input is newly trusted or forwarded.
- **Command execution, path handling, auth, secrets, IPC, dependencies.** Untouched. No dependency changes.
- No user-controlled string reaches a shell, filesystem, or network path from this code.

## Notes

- **Pre-existing lint failure.** `pnpm lint` fails at `verify:skill-bundle-manifest` with stale `resources/skills/*.json`. Reproduces on a clean `main`, so it is not introduced here, and those are generated artifacts I did not want to churn.
- **`pnpm test` and `pnpm build` not completed locally.** A clean `main` on this Windows machine fails 167 tests across 57 files, so a green local suite is not achievable either way. The affected area is fully green.
- **Scope held deliberately narrow.** #12179 also mentions a `--resume` argument arriving as literal typed text after a restart. That is a different mechanism (session replay, not key handling) and is not addressed here.
