### PR TITLE
fix(browser): preserve tab zoom across parent-drift webview repair

### DIFF
--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -182,6 +182,34 @@ describe('webview registry drag listeners', () => {
     expect(webview.style.pointerEvents).toBe('auto')
   })
 
+  it('preserves explicit zoom across a parent-drift rebuild (preserveViewport)', async () => {
+    const { destroyPersistentWebview, registerPersistentWebview } =
+      await import('./webview-registry')
+    const { getExplicitBrowserPageZoomLevel, rememberExplicitBrowserPageZoomLevel } =
+      await import('./browser-page-zoom')
+
+    registerPersistentWebview('page-1', createWebview())
+    rememberExplicitBrowserPageZoomLevel('page-1', 1.5)
+
+    destroyPersistentWebview('page-1', { preserveViewport: true })
+
+    expect(getExplicitBrowserPageZoomLevel('page-1')).toBe(1.5)
+  })
+
+  it('forgets explicit zoom on a real tab close', async () => {
+    const { destroyPersistentWebview, registerPersistentWebview } =
+      await import('./webview-registry')
+    const { getExplicitBrowserPageZoomLevel, rememberExplicitBrowserPageZoomLevel } =
+      await import('./browser-page-zoom')
+
+    registerPersistentWebview('page-1', createWebview())
+    rememberExplicitBrowserPageZoomLevel('page-1', 1.5)
+
+    destroyPersistentWebview('page-1')
+
+    expect(getExplicitBrowserPageZoomLevel('page-1')).toBeNull()
+  })
+
   it('moves focus back to the renderer before detaching the focused webview', async () => {
     const { moveFocusToRendererBeforeWebviewDetach } = await import('./webview-registry')
     const webview = createWebview()

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -194,9 +194,11 @@ export function destroyPersistentWebview(
   { preserveViewport = false }: { preserveViewport?: boolean } = {}
 ): void {
   const webview = webviewRegistry.get(browserTabId)
-  // The guest is gone, so its user-applied zoom must not be inherited by a
-  // later tab that reuses the id.
-  forgetExplicitBrowserPageZoomLevel(browserTabId)
+  // Why: only a real close forgets user zoom; preserveViewport marks a
+  // same-tab rebuild (parent-drift repair) whose zoom must survive.
+  if (!preserveViewport) {
+    forgetExplicitBrowserPageZoomLevel(browserTabId)
+  }
   if (!webview) {
     // Why: the viewport can outlive a missing webview entry; tear it down on
     // explicit close paths so overlay slots do not leak parked shells.


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #12137: the parent-drift webview repair (same-tab teardown/rebuild with `preserveViewport: true`) unconditionally ran `forgetExplicitBrowserPageZoomLevel`, wiping the tab's user-set zoom. Since `browser-page-zoom.ts` is the only store of explicit zoom, BrowserPane re-seeded the next mount from the Settings default — so a user's per-tab zoom silently reset after a parent-drift repair (visible after switching away from the pane and back).

`destroyPersistentWebview` now forgets explicit zoom only when `preserveViewport` is not set: a real tab close still forgets, a same-tab rebuild keeps it.

## Screenshots

No visual change (the fix prevents an unwanted zoom reset; nothing new is drawn).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — ran targeted suites instead: `pnpm vitest run --config config/vitest.config.ts` on `webview-registry.test.ts`, `browser-page-zoom.test.ts`, `BrowserPane.webview-preferences.test.ts` (39 passed)
- [ ] `pnpm build` — not run (renderer-only two-file change; lint + typecheck + targeted tests cover it)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Two new regression tests in `webview-registry.test.ts`: one asserting explicit zoom survives a `preserveViewport: true` rebuild, one asserting a real close still forgets it. Verified the survival test fails against the pre-fix code.

## AI Review Report

Reviewed every `destroyPersistentWebview` call site: `preserveViewport: true` is passed only by the parent-drift repair in `browser-page-webview.ts`; all real close paths (`BrowserPane.tsx` tab close / onDestroyWebview, `useIpcEvents.ts` page-close events, `browser-webview-cleanup.ts` worktree shutdown) use the default and still forget zoom, so the explicit-zoom map cannot leak entries for closed tabs. The partition-mismatch rebuild path intentionally still forgets (different session). Cross-platform: the change gates deletion of renderer-local state keyed by an internal tab id — no shortcuts, labels, paths, shell behavior, or Electron platform differences involved; identical on macOS, Linux, and Windows, and unaffected by SSH or folder-workspace modes.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The diff only makes an existing in-renderer `Map.delete` conditional on an existing boolean option; the IPC calls in `destroyPersistentWebview` are untouched. No follow-up needed.

## Notes

- Cherry-pick target: v1.4.165 release (regression introduced by #12137 which shipped in the RC).
- Diff intentionally kept minimal to the zoom path: a concurrent change is adding a guest-retention eviction budget that also touches `webview-registry.ts` / `BrowserPane.tsx`.
