### PR TITLE
fix(mobile): deliver the agent launch command when a create settles over a bare renderer PTY

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31204,6 +31204,125 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('delivers the agent launch command when a create settles over a bare renderer PTY', async () => {
+    vi.useFakeTimers()
+    try {
+      const leafId = '77777777-7777-4777-8777-777777777777'
+      const write = vi.fn((_ptyId: string, _data: string) => true)
+      const runtime = new OrcaRuntimeService({
+        ...store,
+        getSettings: () => ({
+          ...store.getSettings(),
+          disabledTuiAgents: [],
+          agentCmdOverrides: {}
+        })
+      } as never)
+      runtime.setPtyController({
+        spawn: vi.fn(),
+        write,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      runtime.setNotifier(createMobileCreateTestNotifier(vi.fn()))
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        // Why: the pane spawned before its startup queue landed (the #7587
+        // renderer-stall class), so no spawn command is recorded for the PTY.
+        runtime.registerPty('pty-bare', TEST_WORKTREE_ID, null, { tabId: 'tab-bare', leafId })
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-bare', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        agent: 'codex',
+        activate: true
+      })
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+      await vi.advanceTimersByTimeAsync(50)
+      const result = await create
+
+      expect(result.tab).toMatchObject({
+        type: 'terminal',
+        parentTabId: 'tab-bare',
+        leafId,
+        status: 'ready'
+      })
+      // Why: the adopted PTY never launched codex, so the settle must type the
+      // launch command (Enter as its own write) instead of succeeding silently.
+      expect(write).toHaveBeenCalledTimes(2)
+      expect(write.mock.calls[0][0]).toBe('pty-bare')
+      expect(String(write.mock.calls[0][1])).toMatch(/codex/)
+      expect(write.mock.calls[1]).toEqual(['pty-bare', '\r'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not re-deliver the agent launch command when the adopted renderer PTY spawned with one', async () => {
+    vi.useFakeTimers()
+    try {
+      const leafId = '88888888-8888-4888-8888-888888888888'
+      const write = vi.fn((_ptyId: string, _data: string) => true)
+      const runtime = new OrcaRuntimeService({
+        ...store,
+        getSettings: () => ({
+          ...store.getSettings(),
+          disabledTuiAgents: [],
+          agentCmdOverrides: {}
+        })
+      } as never)
+      runtime.setPtyController({
+        spawn: vi.fn(),
+        write,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      runtime.setNotifier(createMobileCreateTestNotifier(vi.fn()))
+      const webContents = { send: vi.fn() }
+      const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+        // Why: mirrors the spawn IPC handler — a command-carrying spawn records
+        // its launch command right after registering the PTY.
+        runtime.registerPty('pty-carried', TEST_WORKTREE_ID, null, { tabId: 'tab-carried', leafId })
+        runtime.noteTerminalSpawnCommand('pty-carried', 'codex')
+        ipcMain.emit(
+          'terminal:tabCreateReply',
+          { sender: webContents },
+          { requestId: payload.requestId, tabId: 'tab-carried', title: 'Terminal' }
+        )
+      })
+      webContents.send = send
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+      electronMocks.BrowserWindow.fromId.mockReturnValue({
+        isDestroyed: () => false,
+        webContents
+      })
+
+      const create = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        agent: 'codex',
+        activate: true
+      })
+      await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+      await vi.advanceTimersByTimeAsync(50)
+      const result = await create
+
+      expect(result.tab).toMatchObject({ type: 'terminal', parentTabId: 'tab-carried' })
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps a mobile-created terminal alive when the renderer snapshot is rejected by the version guard', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2716,6 +2716,9 @@ export class OrcaRuntimeService {
       paired: boolean
       selectIfNoActiveTab: boolean
       viewMode?: 'terminal' | 'chat'
+      /** Resolved agent launch command, kept so a settle over a bare renderer
+       *  PTY can still deliver the launch instead of succeeding silently (STA-3214). */
+      startupCommand?: string
     }
   >()
   private mobileSessionTabListeners = new Set<{
@@ -25094,6 +25097,7 @@ export class OrcaRuntimeService {
         activate: opts.activate !== false,
         paired: pairedCreate,
         selectIfNoActiveTab: true,
+        ...(startupCommand.command ? { startupCommand: startupCommand.command } : {}),
         ...(opts.viewMode ? { viewMode: opts.viewMode } : {})
       })
       try {
@@ -25106,6 +25110,7 @@ export class OrcaRuntimeService {
           signal: opts.signal
         })
         if (this.isReadyMobileTerminalSurface(surface)) {
+          this.deliverPendingStartupCommandToBareRendererPty(worktreeId, reply.tabId)
           return surface
         }
         const readySurface = await this.waitForMobileTerminalSurface(worktreeId, reply.tabId, {
@@ -25114,6 +25119,7 @@ export class OrcaRuntimeService {
           signal: opts.signal
         }).catch(() => null)
         if (readySurface) {
+          this.deliverPendingStartupCommandToBareRendererPty(worktreeId, reply.tabId)
           return readySurface
         }
         if (opts.signal?.aborted) {
@@ -25148,6 +25154,7 @@ export class OrcaRuntimeService {
         if (this.findLiveRegisteredPtyForRendererTab(worktreeId, reply.tabId)) {
           const rescued = this.ensurePtyBackedMobileSurfaceForRendererTab(worktreeId, reply.tabId)
           if (rescued) {
+            this.deliverPendingStartupCommandToBareRendererPty(worktreeId, reply.tabId)
             return rescued
           }
         }
@@ -25623,6 +25630,30 @@ export class OrcaRuntimeService {
       typeof surface.tab.terminal === 'string' &&
       surface.tab.terminal.length > 0
     )
+  }
+
+  // Why: a create can settle over a renderer PTY that spawned without its
+  // startup command (the create's renderer stalled, #7587), silently binding
+  // the client to a plain shell under an agent tab forever — once the surface
+  // is ready, the activation-time materialize recovery (#7837) never runs
+  // (STA-3214). Spawn commands are recorded per PTY at spawn time, so a
+  // missing record on the locally registered live PTY proves the launch never
+  // ran; type it into the shell like the create would have.
+  private deliverPendingStartupCommandToBareRendererPty(worktreeId: string, tabId: string): void {
+    const pending = this.pendingMobileTerminalCreatesByKey.get(`${worktreeId}::${tabId}`)
+    const command = pending?.startupCommand
+    if (!command) {
+      return
+    }
+    const pty = this.findLiveRegisteredPtyForRendererTab(worktreeId, tabId)
+    if (!pty || this.terminalSpawnCommandsByPtyId.has(pty.ptyId)) {
+      return
+    }
+    if (this.ptyController?.write(pty.ptyId, command)) {
+      // Why: Enter rides its own write so a long command cannot swallow it.
+      this.ptyController.write(pty.ptyId, '\r')
+      this.noteTerminalSpawnCommand(pty.ptyId, command)
+    }
   }
 
   private waitForTerminalHandle(tabId: string, timeoutMs = 10_000): Promise<string> {


### PR DESCRIPTION
## Summary

Fixes STA-3214 (Linear) / #12109: on Orca Mobile, "New Tab → Codex" could open a terminal tab in which the Codex session never started — the tab stayed a bare shell named "Terminal N", accepted input, and never showed the Codex banner.

Root cause: the mobile create resolves the agent launch command and delegates tab creation to the renderer. When the renderer's startup queue is lost (the #7587 renderer-stall class the codebase already documents), the pane spawns a **plain shell**, and the create still settles **ready** by adopting that live PTY (`ensurePtyBackedMobileSurfaceForRendererTab`). That success is silent and permanent: because the surface is ready, the #7837 activation-time materialize recovery is bypassed too, so the phone stays bound to a bare shell forever.

Fix (runtime-side, `src/main/runtime/orca-runtime.ts`):
- Record the resolved agent launch command on the pending mobile create.
- At every renderer-backed settle point (ready wait, ready fallback, catch-path rescue), check whether the backing PTY ever received a spawn command — both spawn IPC handlers already record per-PTY launch commands via `noteTerminalSpawnCommand`.
- If the locally registered live PTY has no recorded spawn command, the launch provably never ran: type the launch command into the shell (Enter as its own write) and record it so repeated settles cannot double-deliver.

The healthy path is untouched: a pane that spawned with its startup command has a recorded spawn command and is skipped; runtime-owned/materialize spawns already carry the command; remote-runtime PTYs are excluded because they are not locally registered.

## Screenshots

No visual change (main-process fix). QA evidence: with the renderer's startup queue deliberately dropped (simulating the #7587 stall), before the fix the mobile create settled into a permanently bare "Terminal 12"; after the fix the same sequence boots Codex (banner + tab renamed) on a real paired iOS-simulator client.

## Testing

- [x] `pnpm lint` — full `oxlint` clean; pre-commit ran oxlint + react-doctor + oxfmt on staged files
- [x] `pnpm typecheck`
- [x] `pnpm test` — targeted: full `src/main/runtime/orca-runtime.test.ts` (1006 passed | 1 skipped) via `vitest --config config/vitest.config.ts`
- [ ] `pnpm build` — not run; `electron-vite` main/preload/renderer bundles built and booted in the live QA rig
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New regression tests (verified to fail without the fix — the delivery write is never made — and pass with it):
- `delivers the agent launch command when a create settles over a bare renderer PTY`
- `does not re-deliver the agent launch command when the adopted renderer PTY spawned with one`

Live QA on an isolated dev desktop (own HOME + ORCA_USER_DATA_PATH) paired to the real mobile app in an iOS simulator, plus a wire-protocol paired client:
- Baseline: New Tab → Codex booted Codex in all environmental variants tried (worktree open/closed on desktop, window visible/hidden/minimized, sequential and concurrent creates, chat-by-default settings, 10+ existing tabs) — the mainline delivery path is unchanged.
- Repro + fix: with the renderer startup queue dropped once, pre-fix the create settled ready over a bare shell (exact ticket symptom); post-fix the identical sequence delivers the Codex launch and the tab boots (verified on the paired phone UI).

## AI Review Report

Reviewed the settle-path change for: double-delivery (guarded by the per-PTY spawn-command record, which is also written after delivery), delivery into the wrong PTY (lookup is scoped to the pending create's worktree + renderer tab id and requires a locally registered, connected PTY with a valid pane key), interaction with the client-disconnect path (pending record is deleted in the same `finally` as before; disconnected creates still throw before the delivery points), and the race between `registerPty` and `noteTerminalSpawnCommand` (both run in one synchronous block in the spawn IPC handlers; delivery runs from promise continuations, which cannot preempt that block).

Cross-platform: main-process-only change; the delivered command comes from the same `buildAgentStartupPlan` output the create already ships to the renderer, so host-shell quoting (macOS/Linux/Windows, WSL, SSH) is unchanged. `\r` submits across supported shells and is written separately so a long command cannot swallow it. SSH spawns record their spawn commands through the same IPC handlers, so SSH panes are discriminated identically; remote-runtime PTYs are excluded (not locally registered). No shortcuts, labels, or path handling touched.

## Security Audit

No new input surfaces. The delivered text is the create's own resolved startup command: either built by `buildAgentStartupPlan` from host-side settings, or the `command` a paired client already supplies today (which the renderer would have executed at spawn) — paired clients can already write to these terminals via `terminal.send`, so no privilege change. No secrets logged or persisted; the spawn-command record reuses the existing `terminalSpawnCommandsByPtyId` map. IPC surface unchanged (no new channels or schema changes).

## Notes

- The renderer-side trigger (losing the queued startup) was reproduced synthetically; the mainline renderer path delivers correctly in every environment variant tested. The runtime-side guarantee added here closes the entire class regardless of which renderer anomaly drops the startup, matching the recovery philosophy of #7837 (which fixed the same symptom for the activation/materialize path only).
- Delivery types into the shell even if the shell is still initializing; the kernel input queue holds it until the prompt is ready — same behavior as a user typing immediately after opening a terminal.
