### PR TITLE
feat(crash-reports): add byte attribution to renderer memory highwater breadcrumbs

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { collectRendererMemoryProfileCounts } from '../renderer-memory-profile'
 import {
   forEachLivePaneForDesyncSentinel,
   getLivePaneCensus,
+  getLivePaneMemoryProfileCounts,
   refitAndRefreshAllTerminalPanes,
   registerLivePaneManager,
   resetAndRefreshAllTerminalWebglAtlases,
@@ -263,5 +265,38 @@ describe('pane manager registry', () => {
     registeredManagers.push(healthy)
 
     expect(getLivePaneCensus()).toEqual({ managers: 2, panes: 1 })
+  })
+
+  it('estimates scrollback bytes from pane buffers, skipping non-buffer terminals', () => {
+    // 5000 rows x 200 cols x 16B/cell = 15.6MB -> 15625KB.
+    const buffered = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPanes: () => [
+        { id: 1, terminal: { cols: 200, buffer: { active: { length: 5000 } } } },
+        { id: 2, terminal: {} }
+      ]
+    }
+    registerLivePaneManager(buffered)
+    registeredManagers.push(buffered)
+
+    expect(getLivePaneMemoryProfileCounts()).toEqual({
+      managers: 1,
+      panes: 2,
+      estBufferKB: 15_625
+    })
+  })
+
+  it('contributes the pane census to renderer memory profile counts', () => {
+    const manager = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPanes: () => [{ id: 1, terminal: { cols: 100, buffer: { active: { length: 64 } } } }]
+    }
+    registerLivePaneManager(manager)
+    registeredManagers.push(manager)
+
+    const counts = collectRendererMemoryProfileCounts()
+    expect(counts['terminals.managers']).toBe(1)
+    expect(counts['terminals.panes']).toBe(1)
+    expect(counts['terminals.estBufferKB']).toBe(100)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -281,9 +281,44 @@ describe('pane manager registry', () => {
 
     expect(getLivePaneMemoryProfileCounts()).toEqual({
       managers: 1,
-      panes: 2,
+      estPanes: 2,
       estBufferKB: 15_625
     })
+  })
+
+  it('bounds manager and pane sampling while extrapolating totals', () => {
+    let sampledPaneWrappers = 0
+    const managers = Array.from({ length: 100 }, () => ({
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPaneCount: vi.fn(() => 100),
+      getPanes: vi.fn((limit = 100) => {
+        const count = Math.min(limit, 100)
+        sampledPaneWrappers += count
+        return Array.from({ length: count }, (_, id) => ({
+          id,
+          terminal: { cols: 100, buffer: { active: { length: 64 } } }
+        }))
+      })
+    }))
+    for (const manager of managers) {
+      registerLivePaneManager(manager)
+      registeredManagers.push(manager)
+    }
+
+    expect(getLivePaneMemoryProfileCounts()).toEqual({
+      managers: 100,
+      estPanes: 10_000,
+      estBufferKB: 1_000_000
+    })
+    expect(managers.reduce((sum, manager) => sum + manager.getPaneCount.mock.calls.length, 0)).toBe(
+      64
+    )
+    expect(managers.reduce((sum, manager) => sum + manager.getPanes.mock.calls.length, 0)).toBe(3)
+    expect(sampledPaneWrappers).toBe(256)
+    expect(managers[0].getPanes).toHaveBeenCalledWith(256)
+    expect(managers[1].getPanes).toHaveBeenCalledWith(156)
+    expect(managers[2].getPanes).toHaveBeenCalledWith(56)
+    expect(managers[3].getPanes).not.toHaveBeenCalled()
   })
 
   it('contributes the pane census to renderer memory profile counts', () => {
@@ -296,7 +331,7 @@ describe('pane manager registry', () => {
 
     const counts = collectRendererMemoryProfileCounts()
     expect(counts['terminals.managers']).toBe(1)
-    expect(counts['terminals.panes']).toBe(1)
+    expect(counts['terminals.estPanes']).toBe(1)
     expect(counts['terminals.estBufferKB']).toBe(100)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -7,7 +7,7 @@ type RegisteredPaneManager = {
   fitAllPanes?: () => void
   refreshAllPanes?: () => void
   getRenderingDiagnostics?: () => PaneRenderingDiagnostics[]
-  getPanes?: () => { id: number; terminal: unknown }[]
+  getPanes?: (limit?: number) => { id: number; terminal: unknown }[]
   getPaneCount?: () => number
   isVisibleForAtlasRecovery?: () => boolean
 }
@@ -163,6 +163,8 @@ export function refitAndRefreshAllTerminalPanes(): void {
 // matters, not accuracy.
 const BYTES_PER_TERMINAL_CELL = 16
 const BYTES_PER_KILOBYTE = 1024
+const MANAGER_SAMPLE_LIMIT = 64
+const PANE_SAMPLE_LIMIT = 256
 
 type BufferedTerminal = {
   cols?: number
@@ -176,26 +178,61 @@ type BufferedTerminal = {
  * mounted forever, each retaining rows x cols of scrollback.
  */
 export function getLivePaneMemoryProfileCounts(): Record<string, number> {
-  let panes = 0
-  let bufferKB = 0
+  let sampledManagers = 0
+  let paneCount = 0
+  let sampledPanes = 0
+  let sampledBufferBytes = 0
   for (const manager of liveManagers) {
+    if (sampledManagers >= MANAGER_SAMPLE_LIMIT) {
+      break
+    }
+    sampledManagers += 1
+    const remainingPaneSamples = Math.max(0, PANE_SAMPLE_LIMIT - sampledPanes)
     let managerPanes: { id: number; terminal: unknown }[] = []
     try {
-      managerPanes = manager.getPanes?.() ?? []
+      if (remainingPaneSamples > 0) {
+        managerPanes = manager.getPanes?.(remainingPaneSamples) ?? []
+      }
     } catch {
-      continue
+      managerPanes = []
     }
-    panes += managerPanes.length
-    for (const pane of managerPanes) {
+    let managerPaneCount: number | undefined
+    try {
+      managerPaneCount = manager.getPaneCount?.()
+    } catch {
+      managerPaneCount = undefined
+    }
+    paneCount +=
+      typeof managerPaneCount === 'number' && Number.isFinite(managerPaneCount)
+        ? Math.max(0, managerPaneCount)
+        : managerPanes.length
+    const panesToInspect = Math.min(managerPanes.length, remainingPaneSamples)
+    for (let index = 0; index < panesToInspect; index += 1) {
+      const pane = managerPanes[index]
       const terminal = pane.terminal as BufferedTerminal | null | undefined
       const rows = terminal?.buffer?.active?.length
       const cols = terminal?.cols
-      if (typeof rows === 'number' && typeof cols === 'number') {
-        bufferKB += Math.round((rows * cols * BYTES_PER_TERMINAL_CELL) / BYTES_PER_KILOBYTE)
+      if (
+        typeof rows === 'number' &&
+        Number.isFinite(rows) &&
+        rows > 0 &&
+        typeof cols === 'number' &&
+        Number.isFinite(cols) &&
+        cols > 0
+      ) {
+        sampledBufferBytes += rows * cols * BYTES_PER_TERMINAL_CELL
       }
     }
+    sampledPanes += panesToInspect
   }
-  return { managers: liveManagers.size, panes, estBufferKB: bufferKB }
+  const managerScale = sampledManagers === 0 ? 0 : liveManagers.size / sampledManagers
+  const estPanes = Math.round(paneCount * managerScale)
+  const paneScale = sampledPanes === 0 ? 0 : estPanes / sampledPanes
+  return {
+    managers: liveManagers.size,
+    estPanes,
+    estBufferKB: Math.round((sampledBufferBytes * paneScale) / BYTES_PER_KILOBYTE)
+  }
 }
 
 // Why here: contributors push in (crash-diagnostics stays a leaf); same-name

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -1,4 +1,5 @@
 import { recordTerminalWebglDiagnostic } from '../../../../shared/terminal-webgl-diagnostics'
+import { registerRendererMemoryProfileContributor } from '../renderer-memory-profile'
 import type { PaneRenderingDiagnostics } from './pane-manager-types'
 
 type RegisteredPaneManager = {
@@ -157,3 +158,46 @@ export function refitAndRefreshAllTerminalPanes(): void {
     }
   }
 }
+
+// Rough xterm BufferLine cost (3 uint32 per cell + object overhead); ranking
+// matters, not accuracy.
+const BYTES_PER_TERMINAL_CELL = 16
+const BYTES_PER_KILOBYTE = 1024
+
+type BufferedTerminal = {
+  cols?: number
+  buffer?: { active?: { length?: number } }
+}
+
+/**
+ * Memory-profile census over live pane managers. Mounted panes are the
+ * dominant highwater cost the store census can't see (97b9e86d: heap ~1.3GB
+ * while all store slices summed to ~15MB) — eviction-exempt panes accumulate
+ * mounted forever, each retaining rows x cols of scrollback.
+ */
+export function getLivePaneMemoryProfileCounts(): Record<string, number> {
+  let panes = 0
+  let bufferKB = 0
+  for (const manager of liveManagers) {
+    let managerPanes: { id: number; terminal: unknown }[] = []
+    try {
+      managerPanes = manager.getPanes?.() ?? []
+    } catch {
+      continue
+    }
+    panes += managerPanes.length
+    for (const pane of managerPanes) {
+      const terminal = pane.terminal as BufferedTerminal | null | undefined
+      const rows = terminal?.buffer?.active?.length
+      const cols = terminal?.cols
+      if (typeof rows === 'number' && typeof cols === 'number') {
+        bufferKB += Math.round((rows * cols * BYTES_PER_TERMINAL_CELL) / BYTES_PER_KILOBYTE)
+      }
+    }
+  }
+  return { managers: liveManagers.size, panes, estBufferKB: bufferKB }
+}
+
+// Why here: contributors push in (crash-diagnostics stays a leaf); same-name
+// re-registration on dev HMR overwrites, so no disposal hook is needed.
+registerRendererMemoryProfileContributor('terminals', getLivePaneMemoryProfileCounts)

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -209,8 +209,15 @@ export class PaneManager {
     })
   }
 
-  getPanes(): ManagedPane[] {
-    return Array.from(this.panes.values()).map(toPublicPane)
+  getPanes(limit = Number.POSITIVE_INFINITY): ManagedPane[] {
+    const panes: ManagedPane[] = []
+    for (const pane of this.panes.values()) {
+      if (panes.length >= limit) {
+        break
+      }
+      panes.push(toPublicPane(pane))
+    }
+    return panes
   }
 
   /** Why separate from getPanes: the census runs on the crash path, where

--- a/src/renderer/src/lib/state-collection-byte-estimate.test.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.test.ts
@@ -114,6 +114,12 @@ describe('estimateStateCollectionKB', () => {
     expect(result.__totalKB).toBeGreaterThan((result.a ?? 0) * 2.5)
   })
 
+  it('includes raw bytes from slices that round below one KB', () => {
+    expect(
+      estimateStateCollectionKB({ a: 'x'.repeat(200), b: 'x'.repeat(200), c: 'x'.repeat(200) }, 4)
+    ).toEqual({ __totalKB: 1 })
+  })
+
   it('skips a slice whose read throws without sinking the census', () => {
     const state = { healthy: 'x'.repeat(10_000) }
     Object.defineProperty(state, 'poisoned', {

--- a/src/renderer/src/lib/state-collection-byte-estimate.test.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { estimateStateCollectionKB } from './state-collection-byte-estimate'
+
+function kbOf(state: Record<string, unknown>, key: string): number {
+  return estimateStateCollectionKB(state, 32)[key] ?? 0
+}
+
+describe('estimateStateCollectionKB', () => {
+  it('ranks a value-fat slice above an entry-long slice', () => {
+    // The 97b9e86d OOM signature: counts said the many-entry slice was biggest.
+    const fat = { a: 'x'.repeat(200_000), b: 'y'.repeat(200_000) }
+    const long = Object.fromEntries(Array.from({ length: 500 }, (_, i) => [`k${i}`, i]))
+
+    const result = estimateStateCollectionKB({ fat, long }, 2)
+    const keys = Object.keys(result)
+    expect(keys[0]).toBe('fat')
+    expect(result.fat).toBeGreaterThan((result.long ?? 0) * 10)
+  })
+
+  it('extrapolates uniform arrays instead of measuring every element', () => {
+    const entry = (): { name: string } => ({ name: 'worktree-name-of-typical-length' })
+    const small = kbOf({ slice: Array.from({ length: 100 }, entry) }, 'slice')
+    const large = kbOf({ slice: Array.from({ length: 10_000 }, entry) }, 'slice')
+
+    expect(large).toBeGreaterThan(small * 80)
+    expect(large).toBeLessThan(small * 120)
+  })
+
+  it('extrapolates plain objects past the sample window', () => {
+    const value = (): string => 'v'.repeat(64)
+    const small = Object.fromEntries(Array.from({ length: 500 }, (_, i) => [`k${i}`, value()]))
+    const huge = Object.fromEntries(Array.from({ length: 5_000 }, (_, i) => [`k${i}`, value()]))
+
+    const smallKB = kbOf({ slice: small }, 'slice')
+    const hugeKB = kbOf({ slice: huge }, 'slice')
+    expect(hugeKB).toBeGreaterThan(smallKB * 8)
+    expect(hugeKB).toBeLessThan(smallKB * 12)
+  })
+
+  it('extrapolates Map and Set entries by size', () => {
+    const mapKB = kbOf(
+      { slice: new Map(Array.from({ length: 2_000 }, (_, i) => [`key${i}`, 'v'.repeat(128)])) },
+      'slice'
+    )
+    const setKB = kbOf(
+      { slice: new Set(Array.from({ length: 2_000 }, (_, i) => `member-${i}-${'v'.repeat(128)}`)) },
+      'slice'
+    )
+    // 2000 entries x ~128 chars ≈ >250KB either way; well above rounding noise.
+    expect(mapKB).toBeGreaterThan(250)
+    expect(setKB).toBeGreaterThan(250)
+  })
+
+  it('counts typed-array backing stores by byteLength', () => {
+    expect(kbOf({ slice: [new Uint32Array(64_000)] }, 'slice')).toBeGreaterThan(200)
+  })
+
+  it('survives cycles and self references', () => {
+    const cyclic: Record<string, unknown> = { name: 'x'.repeat(2048) }
+    cyclic.self = cyclic
+    const result = estimateStateCollectionKB({ cyclic }, 4)
+    expect(result.cyclic).toBeGreaterThan(1)
+    expect(Number.isFinite(result.cyclic)).toBe(true)
+  })
+
+  it('returns bounded work on pathological nesting', () => {
+    let deep: Record<string, unknown> = { leaf: true }
+    for (let i = 0; i < 10_000; i += 1) {
+      deep = { child: deep }
+    }
+    const wide = { slice: Array.from({ length: 100 }, () => ({ deep })) }
+    expect(() => estimateStateCollectionKB(wide, 4)).not.toThrow()
+  })
+
+  it('caps output at the limit, largest first, dropping sub-KB slices', () => {
+    const state = {
+      big: 'x'.repeat(300_000),
+      medium: 'x'.repeat(100_000),
+      smaller: 'x'.repeat(50_000),
+      tiny: 'x',
+      count: 7
+    }
+    const result = estimateStateCollectionKB(state, 2)
+    expect(Object.keys(result)).toEqual(['big', 'medium', '__totalKB'])
+    expect(result.big).toBeGreaterThan(result.medium)
+  })
+
+  it('reports the all-slices total beyond the top limit', () => {
+    const state = {
+      a: 'x'.repeat(100_000),
+      b: 'x'.repeat(100_000),
+      c: 'x'.repeat(100_000)
+    }
+    const result = estimateStateCollectionKB(state, 1)
+    expect(result.__totalKB).toBeGreaterThan((result.a ?? 0) * 2.5)
+  })
+
+  it('skips a slice whose read throws without sinking the census', () => {
+    const state = { healthy: 'x'.repeat(10_000) }
+    Object.defineProperty(state, 'poisoned', {
+      enumerable: true,
+      get: () => {
+        throw new Error('boom')
+      }
+    })
+    expect(Object.keys(estimateStateCollectionKB(state, 8))).toEqual(['healthy', '__totalKB'])
+  })
+
+  it('returns empty for non-object state', () => {
+    expect(estimateStateCollectionKB(null, 8)).toEqual({})
+    expect(estimateStateCollectionKB('text', 8)).toEqual({})
+  })
+})

--- a/src/renderer/src/lib/state-collection-byte-estimate.test.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { estimateStateCollectionKB } from './state-collection-byte-estimate'
 
 function kbOf(state: Record<string, unknown>, key: string): number {
@@ -35,6 +35,25 @@ describe('estimateStateCollectionKB', () => {
     const hugeKB = kbOf({ slice: huge }, 'slice')
     expect(hugeKB).toBeGreaterThan(smallKB * 8)
     expect(hugeKB).toBeLessThan(smallKB * 12)
+  })
+
+  it('bounds plain-object key inspection per slice', () => {
+    const slice = Object.fromEntries(Array.from({ length: 10_000 }, (_, i) => [`k${i}`, i]))
+    const hasOwn = vi.spyOn(Object, 'hasOwn')
+
+    expect(kbOf({ slice }, 'slice')).toBeGreaterThan(0)
+    expect(hasOwn).toHaveBeenCalledTimes(4097)
+    hasOwn.mockRestore()
+  })
+
+  it('reserves bounded descent for fat values after a saturated object scan', () => {
+    const slice = Object.fromEntries(
+      Array.from({ length: 10_000 }, (_, i) => [`k${i}`, { payload: 'x'.repeat(2048) }])
+    )
+
+    const result = estimateStateCollectionKB({ slice }, 4)
+    expect(result.slice).toBeGreaterThan(10_000)
+    expect(result.__budgetHitSlices).toBe(1)
   })
 
   it('extrapolates Map and Set entries by size', () => {

--- a/src/renderer/src/lib/state-collection-byte-estimate.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.ts
@@ -8,7 +8,7 @@
  * these estimates name what got FAT.
  *
  * Estimates are heuristic (sampled, extrapolated, shared references counted
- * per slice) — only the relative ranking between slices is meaningful.
+ * per slice). __budgetHitSlices marks totals that saturated the scan budget.
  */
 
 // Why sampling is capped and first-window biased: this runs at >=60% heap
@@ -17,6 +17,8 @@
 const SAMPLE_TARGET = 16
 const SAMPLE_WINDOW = 1024
 const NODE_BUDGET_PER_SLICE = 4096
+const ENTRY_SCAN_BUDGET_PER_SLICE = 4096
+const ENTRY_DESCENT_RESERVE = 1024
 const MAX_DEPTH = 12
 
 // Rough V8 object costs; absolute accuracy doesn't matter, stable ranking does.
@@ -32,6 +34,8 @@ const BYTES_PER_KILOBYTE = 1024
 
 type EstimateContext = {
   nodesLeft: number
+  entriesLeft: number
+  budgetHit: boolean
   seen: WeakSet<object>
 }
 
@@ -40,6 +44,7 @@ export function estimateStateCollectionKB(state: unknown, limit: number): Record
     return {}
   }
   const sizes: [string, number][] = []
+  let budgetHitSlices = 0
   for (const key in state) {
     if (!Object.hasOwn(state, key)) {
       continue
@@ -48,10 +53,16 @@ export function estimateStateCollectionKB(state: unknown, limit: number): Record
     // Why: one exotic slice (throwing getter, revoked proxy) must not sink the
     // whole census; the registry only sees the surviving slices.
     try {
-      const bytes = estimateValueBytes((state as Record<string, unknown>)[key], 0, {
+      const ctx: EstimateContext = {
         nodesLeft: NODE_BUDGET_PER_SLICE,
+        entriesLeft: ENTRY_SCAN_BUDGET_PER_SLICE + ENTRY_DESCENT_RESERVE,
+        budgetHit: false,
         seen: new WeakSet()
-      })
+      }
+      const bytes = estimateValueBytes((state as Record<string, unknown>)[key], 0, ctx)
+      if (ctx.budgetHit) {
+        budgetHitSlices += 1
+      }
       kb = Math.round(bytes / BYTES_PER_KILOBYTE)
     } catch {
       continue
@@ -61,19 +72,22 @@ export function estimateStateCollectionKB(state: unknown, limit: number): Record
     }
   }
   if (sizes.length === 0) {
-    return {}
+    return budgetHitSlices === 0 ? {} : { __budgetHitSlices: budgetHitSlices }
   }
   sizes.sort((a, b) => b[1] - a[1])
   const top = Object.fromEntries(sizes.slice(0, limit))
-  // Why __totalKB: a small total against a huge heap EXONERATES the whole
-  // state object (the 97b9e86d readout: heap 1.3GB, store ~15MB) — that
-  // negative evidence redirects the investigation and needs no local repro.
+  // Why __totalKB: a small unsaturated total can exonerate the whole state
+  // object and redirect investigation without a local repro.
   top.__totalKB = sizes.reduce((sum, [, kb]) => sum + kb, 0)
+  if (budgetHitSlices > 0) {
+    top.__budgetHitSlices = budgetHitSlices
+  }
   return top
 }
 
 function estimateValueBytes(value: unknown, depth: number, ctx: EstimateContext): number {
   if (ctx.nodesLeft <= 0) {
+    ctx.budgetHit = true
     return 0
   }
   ctx.nodesLeft -= 1
@@ -102,6 +116,7 @@ function estimateValueBytes(value: unknown, depth: number, ctx: EstimateContext)
   }
   ctx.seen.add(value)
   if (depth >= MAX_DEPTH) {
+    ctx.budgetHit = true
     return BYTES_OBJECT_BASE
   }
   if (Array.isArray(value)) {
@@ -159,6 +174,11 @@ function estimateIterableEntries(
     if (index >= windowLength) {
       break
     }
+    if (ctx.entriesLeft <= 0) {
+      ctx.budgetHit = true
+      break
+    }
+    ctx.entriesLeft -= 1
     if (index % stride === 0) {
       if (isKeyValuePair) {
         const [entryKey, entryValue] = entry as [unknown, unknown]
@@ -177,38 +197,32 @@ function estimateIterableEntries(
 }
 
 function estimatePlainObjectEntries(value: object, depth: number, ctx: EstimateContext): number {
-  // Why two for..in passes: Object.keys allocates an array proportional to the
-  // (possibly leaking) collection; for..in iterates allocation-free. The count
-  // pass is full so extrapolation covers entries the sample window never sees.
   let ownCount = 0
+  const sampledKeys: string[] = []
+  const entryFloor = depth === 0 ? ENTRY_DESCENT_RESERVE : 0
+  // Why: a leaking record must not turn a near-OOM breadcrumb into a full scan.
   for (const key in value) {
+    if (ctx.entriesLeft <= entryFloor) {
+      ctx.budgetHit = true
+      break
+    }
+    ctx.entriesLeft -= 1
     if (Object.hasOwn(value, key)) {
       ownCount += 1
+      if (sampledKeys.length < SAMPLE_TARGET) {
+        sampledKeys.push(key)
+      }
     }
   }
   if (ownCount === 0) {
     return 0
   }
-  const windowLength = Math.min(ownCount, SAMPLE_WINDOW)
-  const stride = Math.max(1, Math.floor(windowLength / SAMPLE_TARGET))
   let sampledBytes = 0
-  let sampledCount = 0
-  let index = 0
-  for (const key in value) {
-    if (!Object.hasOwn(value, key)) {
-      continue
-    }
-    if (index >= windowLength) {
-      break
-    }
-    if (index % stride === 0) {
-      sampledBytes += BYTES_STRING_BASE + key.length * BYTES_PER_CHAR
-      sampledBytes += estimateValueBytes((value as Record<string, unknown>)[key], depth + 1, ctx)
-      sampledCount += 1
-    }
-    index += 1
+  for (const key of sampledKeys) {
+    sampledBytes += BYTES_STRING_BASE + key.length * BYTES_PER_CHAR
+    sampledBytes += estimateValueBytes((value as Record<string, unknown>)[key], depth + 1, ctx)
   }
-  return sampledCount === 0
+  return sampledKeys.length === 0
     ? 0
-    : Math.round((sampledBytes / sampledCount + BYTES_ENTRY_OVERHEAD) * ownCount)
+    : Math.round((sampledBytes / sampledKeys.length + BYTES_ENTRY_OVERHEAD) * ownCount)
 }

--- a/src/renderer/src/lib/state-collection-byte-estimate.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.ts
@@ -44,6 +44,8 @@ export function estimateStateCollectionKB(state: unknown, limit: number): Record
     return {}
   }
   const sizes: [string, number][] = []
+  let totalBytes = 0
+  let successfulSlices = 0
   let budgetHitSlices = 0
   for (const key in state) {
     if (!Object.hasOwn(state, key)) {
@@ -60,6 +62,8 @@ export function estimateStateCollectionKB(state: unknown, limit: number): Record
         seen: new WeakSet()
       }
       const bytes = estimateValueBytes((state as Record<string, unknown>)[key], 0, ctx)
+      totalBytes += bytes
+      successfulSlices += 1
       if (ctx.budgetHit) {
         budgetHitSlices += 1
       }
@@ -71,14 +75,22 @@ export function estimateStateCollectionKB(state: unknown, limit: number): Record
       sizes.push([key, kb])
     }
   }
+  const totalKB = Math.round(totalBytes / BYTES_PER_KILOBYTE)
   if (sizes.length === 0) {
-    return budgetHitSlices === 0 ? {} : { __budgetHitSlices: budgetHitSlices }
+    const total: Record<string, number> = {}
+    if (successfulSlices > 0) {
+      total.__totalKB = totalKB
+    }
+    if (budgetHitSlices > 0) {
+      total.__budgetHitSlices = budgetHitSlices
+    }
+    return total
   }
   sizes.sort((a, b) => b[1] - a[1])
   const top = Object.fromEntries(sizes.slice(0, limit))
   // Why __totalKB: a small unsaturated total can exonerate the whole state
   // object and redirect investigation without a local repro.
-  top.__totalKB = sizes.reduce((sum, [, kb]) => sum + kb, 0)
+  top.__totalKB = totalKB
   if (budgetHitSlices > 0) {
     top.__budgetHitSlices = budgetHitSlices
   }

--- a/src/renderer/src/lib/state-collection-byte-estimate.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.ts
@@ -1,0 +1,214 @@
+/**
+ * Sampled byte estimates for the largest top-level collections in a state
+ * object, for renderer_memory_highwater breadcrumbs.
+ *
+ * Why bytes when summarizeStateCollectionSizes already reports counts: entry
+ * counts stay flat when a slice grows by VALUE weight — the 97b9e86d OOM leaked
+ * ~700MB while its biggest slice grew by 4 entries. Counts name what got LONG;
+ * these estimates name what got FAT.
+ *
+ * Estimates are heuristic (sampled, extrapolated, shared references counted
+ * per slice) — only the relative ranking between slices is meaningful.
+ */
+
+// Why sampling is capped and first-window biased: this runs at >=60% heap
+// pressure, so bounded work beats unbiased coverage. Iteration allocates
+// nothing beyond the sample window; there is no stringify.
+const SAMPLE_TARGET = 16
+const SAMPLE_WINDOW = 1024
+const NODE_BUDGET_PER_SLICE = 4096
+const MAX_DEPTH = 12
+
+// Rough V8 object costs; absolute accuracy doesn't matter, stable ranking does.
+const BYTES_STRING_BASE = 16
+const BYTES_PER_CHAR = 2
+const BYTES_NUMBER = 16
+const BYTES_PRIMITIVE = 8
+const BYTES_FUNCTION = 64
+const BYTES_OBJECT_BASE = 32
+const BYTES_ENTRY_OVERHEAD = 16
+const BYTES_ARRAY_SLOT = 8
+const BYTES_PER_KILOBYTE = 1024
+
+type EstimateContext = {
+  nodesLeft: number
+  seen: WeakSet<object>
+}
+
+export function estimateStateCollectionKB(state: unknown, limit: number): Record<string, number> {
+  if (typeof state !== 'object' || state === null) {
+    return {}
+  }
+  const sizes: [string, number][] = []
+  for (const key in state) {
+    if (!Object.hasOwn(state, key)) {
+      continue
+    }
+    let kb = 0
+    // Why: one exotic slice (throwing getter, revoked proxy) must not sink the
+    // whole census; the registry only sees the surviving slices.
+    try {
+      const bytes = estimateValueBytes((state as Record<string, unknown>)[key], 0, {
+        nodesLeft: NODE_BUDGET_PER_SLICE,
+        seen: new WeakSet()
+      })
+      kb = Math.round(bytes / BYTES_PER_KILOBYTE)
+    } catch {
+      continue
+    }
+    if (kb > 0) {
+      sizes.push([key, kb])
+    }
+  }
+  if (sizes.length === 0) {
+    return {}
+  }
+  sizes.sort((a, b) => b[1] - a[1])
+  const top = Object.fromEntries(sizes.slice(0, limit))
+  // Why __totalKB: a small total against a huge heap EXONERATES the whole
+  // state object (the 97b9e86d readout: heap 1.3GB, store ~15MB) — that
+  // negative evidence redirects the investigation and needs no local repro.
+  top.__totalKB = sizes.reduce((sum, [, kb]) => sum + kb, 0)
+  return top
+}
+
+function estimateValueBytes(value: unknown, depth: number, ctx: EstimateContext): number {
+  if (ctx.nodesLeft <= 0) {
+    return 0
+  }
+  ctx.nodesLeft -= 1
+  switch (typeof value) {
+    case 'string':
+      return BYTES_STRING_BASE + value.length * BYTES_PER_CHAR
+    case 'number':
+      return BYTES_NUMBER
+    case 'function':
+      return BYTES_FUNCTION
+    case 'object':
+      break
+    case 'bigint':
+    case 'boolean':
+    case 'symbol':
+    case 'undefined':
+      return BYTES_PRIMITIVE
+  }
+  if (value === null) {
+    return BYTES_PRIMITIVE
+  }
+  // Why: cycles and intra-slice shared references count once — retained-size
+  // semantics are out of scope for a breadcrumb heuristic.
+  if (ctx.seen.has(value)) {
+    return 0
+  }
+  ctx.seen.add(value)
+  if (depth >= MAX_DEPTH) {
+    return BYTES_OBJECT_BASE
+  }
+  if (Array.isArray(value)) {
+    return (
+      BYTES_OBJECT_BASE + value.length * BYTES_ARRAY_SLOT + estimateArrayElements(value, depth, ctx)
+    )
+  }
+  if (value instanceof Map) {
+    return (
+      BYTES_OBJECT_BASE + estimateIterableEntries(value.size, value.entries(), depth, ctx, true)
+    )
+  }
+  if (value instanceof Set) {
+    return (
+      BYTES_OBJECT_BASE + estimateIterableEntries(value.size, value.values(), depth, ctx, false)
+    )
+  }
+  if (ArrayBuffer.isView(value)) {
+    return BYTES_OBJECT_BASE + value.byteLength
+  }
+  return BYTES_OBJECT_BASE + estimatePlainObjectEntries(value, depth, ctx)
+}
+
+function estimateArrayElements(value: unknown[], depth: number, ctx: EstimateContext): number {
+  const windowLength = Math.min(value.length, SAMPLE_WINDOW)
+  if (windowLength === 0) {
+    return 0
+  }
+  const stride = Math.max(1, Math.floor(windowLength / SAMPLE_TARGET))
+  let sampledBytes = 0
+  let sampledCount = 0
+  for (let index = 0; index < windowLength; index += stride) {
+    sampledBytes += estimateValueBytes(value[index], depth + 1, ctx)
+    sampledCount += 1
+  }
+  return sampledCount === 0 ? 0 : Math.round((sampledBytes / sampledCount) * value.length)
+}
+
+function estimateIterableEntries(
+  size: number,
+  entries: IterableIterator<unknown>,
+  depth: number,
+  ctx: EstimateContext,
+  isKeyValuePair: boolean
+): number {
+  if (size === 0) {
+    return 0
+  }
+  const windowLength = Math.min(size, SAMPLE_WINDOW)
+  const stride = Math.max(1, Math.floor(windowLength / SAMPLE_TARGET))
+  let sampledBytes = 0
+  let sampledCount = 0
+  let index = 0
+  for (const entry of entries) {
+    if (index >= windowLength) {
+      break
+    }
+    if (index % stride === 0) {
+      if (isKeyValuePair) {
+        const [entryKey, entryValue] = entry as [unknown, unknown]
+        sampledBytes += estimateValueBytes(entryKey, depth + 1, ctx)
+        sampledBytes += estimateValueBytes(entryValue, depth + 1, ctx)
+      } else {
+        sampledBytes += estimateValueBytes(entry, depth + 1, ctx)
+      }
+      sampledCount += 1
+    }
+    index += 1
+  }
+  return sampledCount === 0
+    ? 0
+    : Math.round((sampledBytes / sampledCount + BYTES_ENTRY_OVERHEAD) * size)
+}
+
+function estimatePlainObjectEntries(value: object, depth: number, ctx: EstimateContext): number {
+  // Why two for..in passes: Object.keys allocates an array proportional to the
+  // (possibly leaking) collection; for..in iterates allocation-free. The count
+  // pass is full so extrapolation covers entries the sample window never sees.
+  let ownCount = 0
+  for (const key in value) {
+    if (Object.hasOwn(value, key)) {
+      ownCount += 1
+    }
+  }
+  if (ownCount === 0) {
+    return 0
+  }
+  const windowLength = Math.min(ownCount, SAMPLE_WINDOW)
+  const stride = Math.max(1, Math.floor(windowLength / SAMPLE_TARGET))
+  let sampledBytes = 0
+  let sampledCount = 0
+  let index = 0
+  for (const key in value) {
+    if (!Object.hasOwn(value, key)) {
+      continue
+    }
+    if (index >= windowLength) {
+      break
+    }
+    if (index % stride === 0) {
+      sampledBytes += BYTES_STRING_BASE + key.length * BYTES_PER_CHAR
+      sampledBytes += estimateValueBytes((value as Record<string, unknown>)[key], depth + 1, ctx)
+      sampledCount += 1
+    }
+    index += 1
+  }
+  return sampledCount === 0
+    ? 0
+    : Math.round((sampledBytes / sampledCount + BYTES_ENTRY_OVERHEAD) * ownCount)
+}

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -48,6 +48,7 @@ import {
   registerRendererMemoryProfileContributor,
   summarizeStateCollectionSizes
 } from '@/lib/renderer-memory-profile'
+import { estimateStateCollectionKB } from '@/lib/state-collection-byte-estimate'
 
 export const useAppStore = create<AppState>()((...a) => {
   // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
@@ -102,6 +103,12 @@ registerHttpLinkStoreAccessor(() => useAppStore.getState())
 // so OOM crash reports identify what grew without a local repro.
 registerRendererMemoryProfileContributor('store', () =>
   summarizeStateCollectionSizes(useAppStore.getState(), 20)
+)
+
+// Why bytes too: counts miss value-weight growth (97b9e86d leaked ~700MB while
+// its biggest slice grew by 4 entries); sampled KB names what got FAT.
+registerRendererMemoryProfileContributor('storeKB', () =>
+  estimateStateCollectionKB(useAppStore.getState(), 16)
 )
 
 export type { AppState } from './types'


### PR DESCRIPTION
## Summary

Renderer OOM crash reports currently name store slices by **entry count** only, which cannot attribute value-weight growth: crash `97b9e86d` (1.4.164, renderer OOM at the 4.2GB heap limit) leaked ~700MB in a window where its largest slice grew by 4 entries, leaving the report unable to say what filled the heap.

`renderer_memory_highwater` breadcrumbs now carry byte attribution:

- **`storeKB.*`** — sampled, extrapolated per-slice KB estimates for the top 16 store slices, plus `storeKB.__totalKB` so a report can exonerate the whole store at a glance. `storeKB.__budgetHitSlices` marks truncated estimates so a saturated scan cannot create false negative evidence. Live measurement on a 200-worktree session found a 1.3GB heap but only ~15MB of store state, redirecting investigation to non-store retainers.
- **`terminals.managers` / `terminals.estPanes` / `terminals.estBufferKB`** — bounded live pane-manager sampling with extrapolated pane and xterm scrollback estimates. Mounted panes are the dominant highwater cost the store census cannot see (eviction-exempt panes stay mounted indefinitely; observed 32→51 managers over 2h in the field session that motivated this).

The estimator is built for its call site (≥60% heap pressure): no `Object.keys` on large collections, no stringify, a 4096-node budget per slice, at most 4096 root-record entries plus 1024 entries reserved for sampled-value descent, cycle guard, depth cap, and per-slice containment. Terminal profiling samples at most 64 managers and materializes at most 256 pane wrappers. Live-injected into a production renderer it censused the full store in **7.9ms**; Electron QA on final HEAD measured five full profile collections at **0.6–5.4ms**.

## Screenshots

No visual product change. [Electron QA evidence with one-pane and split-pane screenshots](https://github.com/stablyai/orca/pull/12198#issuecomment-5162300347).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 43,540 passed; 23 failures in 9 files (`src/main/ipc/pty.test.ts`, relay/daemon PTY suites, `check-root-directory-entries`) are pre-existing on the base commit: verified by re-running the same files at parent `040734b18e` in the same environment with identical failures. No failing file overlaps this diff.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

14 estimator tests cover ranking, extrapolation, Map/Set/typed-array weighting, cycles, bounded nesting and flat-record scans, reserved fat-value descent, budget-hit signaling, raw-byte total accuracy, throwing-getter containment, and the top-limit/total contract. Three pane-census tests cover buffer estimation, contributor registration, and deterministic 64-manager/256-pane sampling limits. The extrapolation test was sabotage-verified: reintroducing the window-saturation bug it guards fails the suite.

## AI Review Report

Reviewed for allocation behavior at near-OOM, extrapolation correctness, total accuracy, contributor budgets, breadcrumb growth, and HMR registration. A same-model review fixed two P2 issues: plain-object counting could scan an unbounded leaking record, and terminal profiling could materialize every retained pane precisely when that population was the suspected leak. A refreshed review also caught per-slice KB rounding that omitted sub-KB slices from `__totalKB`; totals now sum raw bytes and round once. All three fixes have deterministic regression tests, truncated store estimates emit `__budgetHitSlices`, and pane counts are explicitly estimated. The same reviewer iterated on final HEAD until returning clean.

Contributor-registry maximum is 41/64 keys: 20 `store` counts, up to 18 `storeKB` counts (16 slices, total, budget-hit marker), and three terminal counts. Payload values remain numeric and bounded. Same-name registration still overwrites safely during dev HMR.

Cross-platform: explicitly checked for macOS, Linux, and Windows concerns — this change is renderer-only pure TypeScript with no file paths, keyboard shortcuts, shell invocation, labels, or Electron platform-specific APIs; the only platform-adjacent surface is `performance`/heap reporting, which was already in place and is unchanged.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or dependency surface. No IPC changes — the census rides the existing crash-breadcrumb recorder channel. Output contains only numbers keyed by code-level identifiers (store slice names, `managers`/`estPanes`/`estBufferKB`); no user data, file contents, or terminal contents are read into the payload — the estimator reads string *lengths*, never string values. Traversal of state is defensive: per-slice try/catch contains throwing getters/proxies, and the registry's existing contributor try/catch contains anything else.

## Notes

- Estimates are heuristic (sampled, first-window biased, shared references counted once per slice); only relative ranking between slices is meaningful. A `__budgetHitSlices` value means the aggregate is a bounded partial estimate and must not be used to exonerate the store.
- Byte constants are rough V8 costs; changing them shifts absolute values but tests pin ranking, extrapolation, and budget behavior, so tuning is safe.
- Follow-up (separate PRs): bound the eviction-exempt mounted-pane accumulation this census now measures, and fix three main-process exception bugs found during the same investigation (recurring `SyntaxError` in `runWaitBlockedCheck`, unhandled rejections in `onPtyData` pane-key handling, `__orcaTerminalFreezeReport` RPC failure).
