### PR TITLE
fix(mobile): gate native chat approval card on a paused agent (STA-3144)

### DIFF
--- a/mobile/src/session/use-mobile-native-chat-prompts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.test.ts
@@ -1,0 +1,62 @@
+import { createElement } from 'react'
+import TestRenderer from 'react-test-renderer'
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
+import { useMobileNativeChatPrompts } from './use-mobile-native-chat-prompts'
+
+const APPROVAL = JSON.stringify({
+  approval: { tool: 'Bash', summary: 'pnpm build > build.log 2>&1' }
+})
+
+function permissionFor(status: Partial<AgentStatusEntry> | null): unknown {
+  let captured: unknown
+  function Probe(): null {
+    captured = useMobileNativeChatPrompts({
+      enabled: true,
+      status: status as AgentStatusEntry | null,
+      messages: []
+    }).permission
+    return null
+  }
+  TestRenderer.act(() => {
+    TestRenderer.create(createElement(Probe))
+  })
+  return captured
+}
+
+describe('useMobileNativeChatPrompts approval-envelope state gate', () => {
+  it('renders no approval card while the agent is working', () => {
+    expect(permissionFor({ state: 'working', interactivePrompt: APPROVAL })).toBeNull()
+  })
+
+  it('renders no approval card after the turn is done', () => {
+    expect(permissionFor({ state: 'done', interactivePrompt: APPROVAL })).toBeNull()
+  })
+
+  it('renders no approval card without a status', () => {
+    expect(permissionFor(null)).toBeNull()
+  })
+
+  it('renders the approval card while the agent is waiting', () => {
+    expect(permissionFor({ state: 'waiting', interactivePrompt: APPROVAL })).toMatchObject({
+      title: 'Allow Bash?',
+      detail: 'pnpm build > build.log 2>&1'
+    })
+  })
+
+  it('renders the approval card while the agent is blocked', () => {
+    expect(permissionFor({ state: 'blocked', interactivePrompt: APPROVAL })).toMatchObject({
+      title: 'Allow Bash?'
+    })
+  })
+
+  it('prefers the heuristic numbered menu over the envelope while paused', () => {
+    const permission = permissionFor({
+      state: 'waiting',
+      interactivePrompt: APPROVAL,
+      lastAssistantMessage: 'Allow this Bash command?\n1. Yes\n2. No'
+    }) as { options: Array<{ label: string }> } | null
+    expect(permission).toMatchObject({ title: 'Permission requested' })
+    expect(permission?.options.map((o) => o.label)).toEqual(['Yes', 'No'])
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-prompts.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.ts
@@ -19,15 +19,18 @@ export function useMobileNativeChatPrompts(args: {
 }): MobileNativeChatPrompts {
   const { enabled, status, messages } = args
   const blocked = status?.state === 'waiting' || status?.state === 'blocked'
+  // Both permission paths sit inside the paused gate: an approval envelope can
+  // outlive its answer (the host keeps it sticky), so only a waiting/blocked
+  // agent may surface it — never a working or done one (STA-3144).
   const permission =
-    (blocked && status
-      ? detectAgentPermission({
+    blocked && status
+      ? (detectAgentPermission({
           state: status.state,
           lastAssistantMessage: status.lastAssistantMessage,
           toolName: status.toolName,
           toolInput: status.toolInput
-        })
-      : null) ?? parseApprovalFromStatus(status?.interactivePrompt)
+        }) ?? parseApprovalFromStatus(status.interactivePrompt))
+      : null
   const question =
     blocked && status && !permission ? parseAgentQuestion(status.lastAssistantMessage ?? '') : null
   const askFromStatus = useMemo(


### PR DESCRIPTION
## Summary

Fixes STA-3144 ([#11928](https://github.com/stablyai/orca/issues/11928)): on Orca Mobile's native chat, the tool-approval card (`Allow Bash?` with Allow/Deny) was derived purely from the presence of an approval envelope in `agentStatus.interactivePrompt`, with no check that the agent is actually paused. Because the host deliberately keeps a real permission wait sticky, the card stayed pinned above the composer while the agent kept working and after the turn was done — on a phone there is no terminal to compare against, so a stale card was indistinguishable from a live one.

The fix moves the envelope path (`parseApprovalFromStatus`) inside the same `blocked && status` gate the heuristic path (`detectAgentPermission`) already honours, which is the documented contract in `mobile-native-chat-permission.ts` ("only fire when the agent is actually paused"). The card now exists exactly while the agent is `waiting`/`blocked` and dismisses on its own when the state clears. Heuristic detection still takes precedence over the envelope inside the gate, unchanged.

Deliberately NOT included (per the adversarial review on the issue): client-side dismiss-on-answer. A content-keyed dismissal cannot distinguish "stale because answered" from "the same command is being asked again", and hiding a live prompt is strictly worse than showing a stale one. That needs a host-side request id and belongs in its own issue.

## Screenshots

iOS Simulator (iPhone 17 Pro, dev client + mock native-chat host), driving `agentStatus` through the states from the report:

Before — card shown while the agent is **working** (note the working indicator + Stop button), and still shown after the turn is **done**:

![bug: card while working](https://github.com/user-attachments/assets/2c8f8a22-b91e-41f2-a157-901bb221f662)
![bug: card after done](https://github.com/user-attachments/assets/3b917a9a-1170-4a2b-b85f-4f47b6d22aa0)

After — a genuine approval (`waiting` + envelope) still shows the card, and flipping to `working` with the envelope still sticky dismisses it:

![fixed: card while waiting](https://github.com/user-attachments/assets/782d3e91-d6d5-487d-90ed-65cf8edae202)
![fixed: no card once working](https://github.com/user-attachments/assets/e8b0c9b8-2c1f-478e-89b6-3a20df3fa0b6)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Ran inside `mobile/` (the changed code is mobile-only; the root vitest config excludes `mobile/**`): `pnpm typecheck`, `pnpm lint` (oxlint), `oxfmt --check src`, and targeted vitest over `use-mobile-native-chat-prompts.test.ts`, `mobile-native-chat-permission.test.ts`, and `use-mobile-native-chat-controller.test.ts` — 36 tests pass. The new `use-mobile-native-chat-prompts.test.ts` locks the gate down: no card for `working`/`done`/missing status, card for `waiting`/`blocked`, and heuristic-over-envelope precedence while paused. Both failing cases reproduce on `main` before the fix. `pnpm build` not run: mobile has no build script (Expo dev client); desktop build is untouched.

## AI Review Report

Reviewed the gate change for: (1) suppressing legitimate approvals — the envelope now renders for exactly the `waiting`/`blocked` states, verified live on the simulator and by test; (2) precedence regressions — `detectAgentPermission` still wins over the envelope when both fire, covered by a new test; (3) the phantom-card path from the issue (child-driven payload re-emitting a cached envelope with `state: 'working'`) — now filtered by the gate; (4) the sibling `question`/`ask` cards — untouched, `ask` intentionally remains outside this gate because AskUserQuestion has its own dismissal protocol. Cross-platform: the change is pure TypeScript state derivation in the shared mobile app (iOS/Android identical); no shortcuts, labels, paths, shell, or Electron surfaces are touched, and desktop hosts on macOS/Linux/Windows only feed it the same serialized `agentStatus`.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependencies, or IPC. The change narrows when an existing UI affordance renders; it strictly reduces the states in which a tap can write approval bytes (`1`/Escape) into a pane — previously a stale card invited writes into a working agent's PTY, which is the riskier behavior. Parsing of `interactivePrompt` (untrusted host-provided JSON) is unchanged and already guarded.

## Notes

- The desktop `NativeChatInteractiveCard` shares the missing state gate but has the pane's terminal as ground truth; if desired that is a separate, lower-severity ticket.
- Dismiss-on-answer (retiring an answered card while the agent stays paused) is deferred pending a host-side per-request id, per the analysis on #11928.
