### PR TITLE
fix(i18n): localize the integration card status pills

### DIFF
--- a/src/renderer/src/components/settings/jira-integration-card.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.tsx
@@ -99,7 +99,14 @@ export function JiraIntegrationCard(): React.JSX.Element {
       }
       checking={checking}
       statusTone={connected ? 'connected' : 'attention'}
-      statusLabel={connected ? 'Connected' : 'Not connected'}
+      statusLabel={
+        connected
+          ? translate('auto.components.settings.jira.integration.card.statusConnected', 'Connected')
+          : translate(
+              'auto.components.settings.jira.integration.card.statusNotConnected',
+              'Not connected'
+            )
+      }
       actions={
         !checking ? (
           <Button

--- a/src/renderer/src/components/settings/task-tracker-integration-cards.tsx
+++ b/src/renderer/src/components/settings/task-tracker-integration-cards.tsx
@@ -91,7 +91,17 @@ export function LinearIntegrationCard(): React.JSX.Element {
       }
       checking={checking}
       statusTone={connected ? 'connected' : 'attention'}
-      statusLabel={connected ? 'Connected' : 'Not connected'}
+      statusLabel={
+        connected
+          ? translate(
+              'auto.components.settings.task.tracker.integration.cards.statusConnected',
+              'Connected'
+            )
+          : translate(
+              'auto.components.settings.task.tracker.integration.cards.statusNotConnected',
+              'Not connected'
+            )
+      }
       actions={
         !checking ? (
           <Button

--- a/src/renderer/src/components/settings/token-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/token-source-control-integration-cards.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button'
 import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
 import { translate } from '@/i18n/i18n'
+import { tokenProviderStatusLabel } from './token-source-control-status'
 
 export function BitbucketIntegrationCard(): React.JSX.Element {
   const { statuses, unavailable, refresh } = usePreflightCardStatuses('bitbucket')
@@ -32,15 +33,7 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
       }
       checking={status === 'checking'}
       statusTone={connected ? 'connected' : 'attention'}
-      statusLabel={
-        connected
-          ? 'Connected'
-          : status === 'unavailable'
-            ? 'Unavailable'
-            : status === 'not-configured'
-              ? 'Not configured'
-              : 'Auth failed'
-      }
+      statusLabel={tokenProviderStatusLabel({ configured: connected, status })}
     >
       {status !== 'checking' && !connected ? (
         <IntegrationCardDetails>
@@ -154,17 +147,11 @@ export function AzureDevOpsIntegrationCard(): React.JSX.Element {
       }
       checking={status === 'checking'}
       statusTone={configured ? 'connected' : 'attention'}
-      statusLabel={
-        configured
-          ? statuses.azureDevOpsAccount
-            ? 'Connected'
-            : 'Configured'
-          : status === 'unavailable'
-            ? 'Unavailable'
-            : status === 'not-configured'
-              ? 'Not configured'
-              : 'Auth failed'
-      }
+      statusLabel={tokenProviderStatusLabel({
+        configured,
+        hasAccount: Boolean(statuses.azureDevOpsAccount),
+        status
+      })}
     >
       {status !== 'checking' && !configured ? (
         <IntegrationCardDetails>
@@ -283,17 +270,12 @@ export function GiteaIntegrationCard(): React.JSX.Element {
       }
       checking={status === 'checking'}
       statusTone={configured ? 'connected' : 'attention'}
-      statusLabel={
-        configured
-          ? statuses.giteaAccount
-            ? 'Connected'
-            : 'Configured'
-          : status === 'unavailable'
-            ? 'Unavailable'
-            : status === 'not-configured'
-              ? 'Optional setup'
-              : 'Auth failed'
-      }
+      statusLabel={tokenProviderStatusLabel({
+        configured,
+        hasAccount: Boolean(statuses.giteaAccount),
+        status,
+        optional: true
+      })}
     >
       {status !== 'checking' && !configured ? (
         <IntegrationCardDetails>

--- a/src/renderer/src/components/settings/token-source-control-status.ts
+++ b/src/renderer/src/components/settings/token-source-control-status.ts
@@ -1,4 +1,11 @@
 import { translate } from '@/i18n/i18n'
+import type { AzureDevOpsStatus, BitbucketStatus, GiteaStatus } from './integrations-pane-status'
+
+/**
+ * Card status as the pane computes it: the provider's own state, or
+ * `'unavailable'` when the runtime cannot report on it at all.
+ */
+export type TokenProviderStatus = BitbucketStatus | AzureDevOpsStatus | GiteaStatus | 'unavailable'
 
 const NS = 'auto.components.settings.token.source.control.integration.cards'
 
@@ -11,7 +18,7 @@ export function tokenProviderStatusLabel(input: {
   configured: boolean
   /** An account was resolved with those credentials. */
   hasAccount?: boolean
-  status: string
+  status: TokenProviderStatus
   /** Gitea works read-only without a token, so its unconfigured state is softer. */
   optional?: boolean
 }): string {

--- a/src/renderer/src/components/settings/token-source-control-status.ts
+++ b/src/renderer/src/components/settings/token-source-control-status.ts
@@ -1,0 +1,32 @@
+import { translate } from '@/i18n/i18n'
+
+const NS = 'auto.components.settings.token.source.control.integration.cards'
+
+/**
+ * Status copy for the token-configured source-control cards (Bitbucket, Azure
+ * DevOps, Gitea). They share the same states, so the labels live in one place.
+ */
+export function tokenProviderStatusLabel(input: {
+  /** Credentials present for the provider. */
+  configured: boolean
+  /** An account was resolved with those credentials. */
+  hasAccount?: boolean
+  status: string
+  /** Gitea works read-only without a token, so its unconfigured state is softer. */
+  optional?: boolean
+}): string {
+  if (input.configured) {
+    return input.hasAccount === false
+      ? translate(`${NS}.statusConfigured`, 'Configured')
+      : translate(`${NS}.statusConnected`, 'Connected')
+  }
+  if (input.status === 'unavailable') {
+    return translate(`${NS}.statusUnavailable`, 'Unavailable')
+  }
+  if (input.status === 'not-configured') {
+    return input.optional
+      ? translate(`${NS}.statusOptionalSetup`, 'Optional setup')
+      : translate(`${NS}.statusNotConfigured`, 'Not configured')
+  }
+  return translate(`${NS}.statusAuthFailed`, 'Auth failed')
+}

--- a/src/renderer/src/i18n/integration-card-status-localization.test.ts
+++ b/src/renderer/src/i18n/integration-card-status-localization.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Integration cards build their status pill inside the JSX call, which the
+ * coverage audit does not inspect — it looks at JSX attributes and object
+ * properties, not conditional expressions passed to a prop. These assertions
+ * pin the catalog contract so a card that goes back to a bare literal fails here.
+ */
+import { describe, expect, it } from 'vitest'
+import en from './locales/en.json'
+
+function lookup(key: string): string | undefined {
+  const value = key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
+      en as unknown
+    )
+  return typeof value === 'string' ? value : undefined
+}
+
+const REQUIRED_KEYS: Record<string, string> = {
+  // Linear and other task trackers
+  'auto.components.settings.task.tracker.integration.cards.statusConnected': 'Connected',
+  'auto.components.settings.task.tracker.integration.cards.statusNotConnected': 'Not connected',
+  // Jira
+  'auto.components.settings.jira.integration.card.statusConnected': 'Connected',
+  'auto.components.settings.jira.integration.card.statusNotConnected': 'Not connected',
+  // Bitbucket, Azure DevOps, Gitea
+  'auto.components.settings.token.source.control.integration.cards.statusConnected': 'Connected',
+  'auto.components.settings.token.source.control.integration.cards.statusConfigured': 'Configured',
+  'auto.components.settings.token.source.control.integration.cards.statusUnavailable':
+    'Unavailable',
+  'auto.components.settings.token.source.control.integration.cards.statusNotConfigured':
+    'Not configured',
+  'auto.components.settings.token.source.control.integration.cards.statusOptionalSetup':
+    'Optional setup',
+  'auto.components.settings.token.source.control.integration.cards.statusAuthFailed': 'Auth failed'
+}
+
+describe('integration card status labels', () => {
+  it.each(Object.entries(REQUIRED_KEYS))('keeps %s in the English catalog', (key, expected) => {
+    expect(lookup(key)).toBe(expected)
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8450,7 +8450,9 @@
               "d5c5b47bb9": "update",
               "fb854902d9": "connecting",
               "9a9f8d4910": "Connect Jira Cloud to browse, create, and link issues.",
-              "74f3063026": "{{value0}} site{{value1}} connected"
+              "74f3063026": "{{value0}} site{{value1}} connected",
+              "statusConnected": "Connected",
+              "statusNotConnected": "Not connected"
             }
           }
         },
@@ -9273,7 +9275,9 @@
                 "disconnect_all": "Disconnect",
                 "account_scope_prefix": "Account scope",
                 "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
-                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are stored locally and encrypted when local runtime storage supports it."
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are stored locally and encrypted when local runtime storage supports it.",
+                "statusConnected": "Connected",
+                "statusNotConnected": "Not connected"
               }
             }
           }
@@ -9314,7 +9318,13 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "Bitbucket status is not available in this runtime yet.",
                   "a924e8dcd1": "Pull requests and build statuses via Bitbucket Cloud API tokens.",
-                  "0fa5629dad": "Pull requests and build statuses"
+                  "0fa5629dad": "Pull requests and build statuses",
+                  "statusConnected": "Connected",
+                  "statusUnavailable": "Unavailable",
+                  "statusNotConfigured": "Not configured",
+                  "statusAuthFailed": "Auth failed",
+                  "statusConfigured": "Configured",
+                  "statusOptionalSetup": "Optional setup"
                 }
               }
             }


### PR DESCRIPTION
## Summary

Every card under **Settings → Integrations** builds its status pill from bare string literals inside the JSX call, so the pill stays English with a language pack active while the description right beside it is translated.

#11826 fixed the CLI source-control cards. These are the ones it did not reach:

| Card | Literals |
|---|---|
| Task trackers (Linear and friends) | `Connected`, `Not connected` |
| Jira | `Connected`, `Not connected` |
| Bitbucket, Azure DevOps, Gitea | `Connected`, `Configured`, `Unavailable`, `Not configured`, `Optional setup`, `Auth failed` |

Same blind spot as before: `audit-localization-coverage.mjs` inspects JSX attributes and object properties, not conditional expressions handed to a prop, so `pnpm verify:localization-coverage` stays green while the strings ship untranslated.

### Shared helper for the token providers

The three token-configured cards carried near-identical ternaries. Their copy moved into `tokenProviderStatusLabel()`:

```ts
statusLabel={tokenProviderStatusLabel({ configured, hasAccount: Boolean(statuses.giteaAccount), status, optional: true })}
```

One source for states they share, and it keeps `token-source-control-integration-cards.tsx` under the 400-line gate. Gitea passes `optional: true` because it works read-only without a token — that is why its unconfigured state reads *Optional setup* rather than *Not configured*, and the distinction is now explicit instead of duplicated.

10 keys added by `sync:localization-catalog`; no existing key was removed or reworded.

## Screenshots

**No visual change in English** — every string keeps its exact wording.

With a Russian language pack on current `main`, the pills read `Not connected`, `Not configured` and `Optional setup` while everything around them is translated:

| Task providers | Review providers |
|---|---|
| ![Task providers](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-task-providers.png) | ![Review providers](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/settings-review-providers.png) |

Note the second screenshot: `GitHub` already reads `Подключено` and `GitLab` reads `Не установлено` — those came from #11826 — while `Bitbucket`, `Azure DevOps` and `Gitea` below them are still English. This PR closes that gap.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added `src/renderer/src/i18n/integration-card-status-localization.test.ts` — 10 assertions pinning the catalog contract, so a card that goes back to a bare literal drops its key from `en.json` and fails here.

`pnpm test`: 44 085 passed, 79 skipped. Three files fail on this machine — `ssh-posix-command-wrapper` (3), `agent-exec-handler` (2) and `updater` (1). All three fail identically on a clean `main` with this branch stashed, so they are pre-existing environment failures.

> **Note on CI:** this PR comes from a fork, so `PR Checks` sits at `action_required` until a maintainer approves the workflow run — nothing has failed. The checks above were run locally.

## AI Review Report

Reviewed with Claude Opus 5.

- **Cross-platform.** No platform branching, no shortcuts, labels, or path handling touched. The helper is pure string selection.
- **SSH / remote / local.** The cards already render per-provider status from existing state; no process, credential, or network path changed. The `Account scope` details block below each pill is untouched.
- **Agents / integrations / git providers.** Behaviour-neutral per provider: each card passes the same conditions it evaluated inline. Gitea's softer unconfigured wording is preserved through the explicit `optional` flag rather than being flattened into the shared path — worth a look during review, since that is the one place where the three cards genuinely differ.
- **Performance.** Same number of string lookups as before, on a settings pane that is not a hot path.
- **UI quality.** English wording is byte-identical, so pill widths and tones are unchanged.
- **Catalog integrity.** 10 keys added, 0 removed, 0 existing values modified; `verify:localization-catalog` and `verify:localization-extraction` pass.

## Security Audit

Reviewed with Claude Opus 5. No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The diff converts literals into catalog lookups; no credential or token value reaches the changed code — the cards receive only booleans and a status string. No follow-up needed.

## Notes

Found while maintaining a full Russian language pack — [smwbev/orca-russian](https://github.com/smwbev/orca-russian), 11 721 strings, 98.2 % of `en.json`. Translating the whole catalog is what surfaces strings that never reach it.

Related: #11826 (merged, same class of defect), #12105 (open, date formatting), #12106 (open, plural forms).

X: [@silentmegawatt](https://x.com/silentmegawatt) · GitHub: [@smwbev](https://github.com/smwbev)
