### PR TITLE
Stop reporting supported Linux hosts as an unsupported remote platform

### DIFF
--- a/src/main/ssh/ssh-remote-platform-detection.test.ts
+++ b/src/main/ssh/ssh-remote-platform-detection.test.ts
@@ -212,6 +212,20 @@ describe('detectRemoteHostPlatform failure reporting', () => {
     await expect(detectRemoteHostPlatform(conn)).resolves.toBeNull()
   })
 
+  it('does not call an unmappable uname unsupported when PowerShell was refused', async () => {
+    // Cygwin sh on a win32-x64 host: only PowerShell can settle it, and it never ran.
+    execCommandMock
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ CYGWIN_NT-10.0 x86_64\n')
+      .mockRejectedValueOnce(maxSessionsError())
+
+    const error = await detectRemoteHostPlatform(conn).catch((err: unknown) => err)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toMatch(/open failed/iu)
+    expect((error as Error).message).not.toMatch(/unsupported/iu)
+    expect((error as Error).cause).toMatchObject({ reason: 2 })
+  })
+
   it('falls through to PowerShell for a Cygwin uname it cannot map', async () => {
     execCommandMock
       .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ CYGWIN_NT-10.0 x86_64\n')

--- a/src/main/ssh/ssh-remote-platform-detection.test.ts
+++ b/src/main/ssh/ssh-remote-platform-detection.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SshConnection } from './ssh-connection'
 
 const execCommandMock = vi.hoisted(() => vi.fn())
@@ -16,9 +16,19 @@ function decodePowerShellCommand(command: string): string {
   return match ? Buffer.from(match[1], 'base64').toString('utf16le') : ''
 }
 
+/** OpenSSH refuses session channels past MaxSessions with reason 2 + "open failed". */
+function maxSessionsError(): Error {
+  return Object.assign(new Error('(SSH) Channel open failure: open failed'), { reason: 2 })
+}
+
 describe('detectRemoteHostPlatform', () => {
   beforeEach(() => {
     execCommandMock.mockReset()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('detects POSIX hosts from uname output', async () => {
@@ -107,5 +117,108 @@ describe('detectRemoteHostPlatform', () => {
     )
     splitSpy.mockRestore()
     expect(usedWhitespaceFieldSplit).toBe(false)
+  })
+})
+
+describe('detectRemoteHostPlatform failure reporting', () => {
+  beforeEach(() => {
+    execCommandMock.mockReset()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not misreport a refused exec channel as an unsupported platform', async () => {
+    execCommandMock.mockRejectedValue(maxSessionsError())
+
+    // The host is linux-x64 and fully supported; the probe never ran.
+    await expect(detectRemoteHostPlatform(conn)).rejects.toThrow(/open failed/iu)
+    await expect(detectRemoteHostPlatform(conn)).rejects.toMatchObject({
+      cause: expect.objectContaining({ reason: 2 })
+    })
+    // Both probes run: the second gets a fresh session-channel retry budget.
+    expect(execCommandMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('still detects Windows when the uname probe hits the session limit', async () => {
+    execCommandMock
+      .mockRejectedValueOnce(maxSessionsError())
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Windows AMD64\r\n')
+
+    await expect(detectRemoteHostPlatform(conn)).resolves.toMatchObject({
+      relayPlatform: 'win32-x64'
+    })
+  })
+
+  it('skips the second probe when the first channel never confirmed close', async () => {
+    const error = Object.assign(new Error('boom'), { sshChannelCloseConfirmed: false })
+    execCommandMock.mockRejectedValueOnce(error)
+
+    await expect(detectRemoteHostPlatform(conn)).rejects.toBe(error)
+    expect(execCommandMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the second probe when the first was cancelled', async () => {
+    const error = Object.assign(new Error('SSH operation was cancelled'), { name: 'AbortError' })
+    execCommandMock.mockRejectedValueOnce(error)
+
+    await expect(detectRemoteHostPlatform(conn)).rejects.toBe(error)
+    expect(execCommandMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers a refused channel over the other probe non-zero exit', async () => {
+    execCommandMock
+      .mockRejectedValueOnce(new Error('Command "sh -c ..." failed (exit 127): sh: not found'))
+      .mockRejectedValueOnce(maxSessionsError())
+
+    await expect(detectRemoteHostPlatform(conn)).rejects.toThrow(/open failed/u)
+    await expect(detectRemoteHostPlatform(conn)).rejects.not.toThrow(/exit 127/u)
+  })
+
+  it('prefers unrecognized uname output over a failed PowerShell probe', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Linux')
+      .mockRejectedValueOnce(new Error('powershell.exe: not found'))
+
+    await expect(detectRemoteHostPlatform(conn)).rejects.toThrow(/__ORCA_REMOTE_PLATFORM__ Linux/u)
+  })
+
+  it('reports the raw probe output when a POSIX host yields no marker line', async () => {
+    // Restricted shell / ForceCommand: the probe command is swallowed, banner only.
+    execCommandMock.mockResolvedValue('Welcome to pc-server05\n')
+
+    await expect(detectRemoteHostPlatform(conn)).rejects.toThrow(/pc-server05/u)
+  })
+
+  it('truncates a long banner in the thrown message but logs a longer tail', async () => {
+    execCommandMock.mockResolvedValue(`${'banner line\n'.repeat(500)}goodbye\n`)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const error = await detectRemoteHostPlatform(conn).catch((err: Error) => err)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain('\n')
+    expect((error as Error).message.length).toBeLessThanOrEqual(300)
+    expect(String(warnSpy.mock.calls[0]?.[0]).length).toBeGreaterThan(600)
+  })
+
+  it('returns null when a parsed uname is genuinely unsupported', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ FreeBSD x86_64\n')
+      .mockRejectedValueOnce(new Error('powershell.exe: not found'))
+
+    await expect(detectRemoteHostPlatform(conn)).resolves.toBeNull()
+  })
+
+  it('falls through to PowerShell for a Cygwin uname it cannot map', async () => {
+    execCommandMock
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ CYGWIN_NT-10.0 x86_64\n')
+      .mockResolvedValueOnce('__ORCA_REMOTE_PLATFORM__ Windows AMD64\r\n')
+
+    await expect(detectRemoteHostPlatform(conn)).resolves.toMatchObject({
+      relayPlatform: 'win32-x64'
+    })
   })
 })

--- a/src/main/ssh/ssh-remote-platform-detection.ts
+++ b/src/main/ssh/ssh-remote-platform-detection.ts
@@ -5,27 +5,121 @@ import {
 } from '../../shared/process-output-field-scanner'
 import { parseUnameToRelayPlatform, type RelayPlatform } from './relay-protocol'
 import { execCommand } from './ssh-relay-deploy-helpers'
+import { isUnconfirmedSshCommandTermination } from './ssh-relay-exec-command'
+import { isSshSessionLimitError } from './ssh-session-limit-error'
 import { getRemoteHostPlatform, type RemoteHostPlatform } from './ssh-remote-platform'
 import { powerShellCommand } from './ssh-remote-powershell'
 
 const PLATFORM_PROBE_MARKER = '__ORCA_REMOTE_PLATFORM__'
+const MAX_UNAME_FIELD_CHARS = 64
+const MAX_THROWN_OUTPUT_CHARS = 200
+const MAX_LOGGED_OUTPUT_CHARS = 1000
+const EXEC_TIMEOUT_MESSAGE = /timed out after \d+s$/u
+
+type PlatformProbeOutcome =
+  | { kind: 'detected'; platform: RelayPlatform }
+  | { kind: 'unsupported'; uname: string }
+  | { kind: 'unparsed'; output: string }
+  | { kind: 'failed'; error: unknown }
 
 export async function detectRemoteHostPlatform(
   conn: SshConnection,
   options?: { signal?: AbortSignal }
 ): Promise<RemoteHostPlatform | null> {
-  const unamePlatform = await detectUnamePlatform(conn, options?.signal)
-  if (unamePlatform) {
-    return getRemoteHostPlatform(unamePlatform)
+  const uname = await detectUnamePlatform(conn, options?.signal)
+  if (uname.kind === 'detected') {
+    return getRemoteHostPlatform(uname.platform)
   }
-  const windowsPlatform = await detectWindowsPlatform(conn, options?.signal)
-  return windowsPlatform ? getRemoteHostPlatform(windowsPlatform) : null
+  if (uname.kind === 'failed' && shouldAbandonAfterUnameProbe(uname.error)) {
+    throw uname.error
+  }
+  const windows = await detectWindowsPlatform(conn, options?.signal)
+  if (windows.kind === 'detected') {
+    return getRemoteHostPlatform(windows.platform)
+  }
+  if (uname.kind === 'unsupported' || windows.kind === 'unsupported') {
+    const reported = uname.kind === 'unsupported' ? uname.uname : probeUname(windows)
+    console.warn(`[ssh-relay] Remote reported an unsupported platform: ${reported}`)
+    return null
+  }
+  console.warn(
+    `[ssh-relay] Remote platform detection failed (uname probe: ${uname.kind}, PowerShell probe: ${windows.kind}). ` +
+      `Remote output: "${summarizeProbeOutput(probeOutput(uname) || probeOutput(windows), MAX_LOGGED_OUTPUT_CHARS)}"`
+  )
+  throw undetectedPlatformError(uname, windows)
+}
+
+// Why: an unconfirmed close still holds the sshd session slot, so a second
+// probe only burns another exec timeout before being refused too.
+function shouldAbandonAfterUnameProbe(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.name === 'AbortError') ||
+    isUnconfirmedSshCommandTermination(error)
+  )
+}
+
+/** Precedence: transport failure from either probe, then uname, then PowerShell. */
+function undetectedPlatformError(
+  uname: PlatformProbeOutcome,
+  windows: PlatformProbeOutcome
+): Error {
+  for (const outcome of [uname, windows]) {
+    if (outcome.kind === 'failed' && isTransportShapedError(outcome.error)) {
+      return wrapProbeError(outcome.error)
+    }
+  }
+  if (uname.kind === 'failed') {
+    return wrapProbeError(uname.error)
+  }
+  if (uname.kind === 'unparsed') {
+    return unrecognizedOutputError(uname.output)
+  }
+  if (windows.kind === 'failed') {
+    return wrapProbeError(windows.error)
+  }
+  return unrecognizedOutputError(probeOutput(windows))
+}
+
+// Why: a refused or timed-out channel explains the failure better than the
+// other probe's mundane non-zero exit (e.g. "sh: not found" on Windows).
+function isTransportShapedError(error: unknown): boolean {
+  return (
+    isSshSessionLimitError(error) ||
+    isUnconfirmedSshCommandTermination(error) ||
+    (error instanceof Error && EXEC_TIMEOUT_MESSAGE.test(error.message))
+  )
+}
+
+function wrapProbeError(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error)
+  return new Error(`Could not detect the remote platform: ${message}`, { cause: error })
+}
+
+function unrecognizedOutputError(output: string): Error {
+  return new Error(
+    `Remote platform probe returned no recognizable output. Remote output: "${summarizeProbeOutput(output, MAX_THROWN_OUTPUT_CHARS)}"`
+  )
+}
+
+function probeOutput(outcome: PlatformProbeOutcome): string {
+  return outcome.kind === 'unparsed' ? outcome.output : ''
+}
+
+function probeUname(outcome: PlatformProbeOutcome): string {
+  return outcome.kind === 'unsupported' ? outcome.uname : ''
+}
+
+// Why: the marker is printed last, so the tail holds the evidence; collapsing
+// CR/LF keeps a Windows banner from becoming a multi-line renderer message.
+function summarizeProbeOutput(output: string, maxChars: number): string {
+  const collapsed = output.replace(/\s+/gu, ' ').trim()
+  return collapsed.length > maxChars ? `…${collapsed.slice(-maxChars)}` : collapsed
 }
 
 async function detectUnamePlatform(
   conn: SshConnection,
   signal?: AbortSignal
-): Promise<RelayPlatform | null> {
+): Promise<PlatformProbeOutcome> {
   try {
     // Why: Remote startup output may omit its trailing newline and must not absorb the marker.
     const command = `printf '\\n%s ' '${PLATFORM_PROBE_MARKER}'; uname -sm`
@@ -33,16 +127,16 @@ async function detectUnamePlatform(
       ? await execCommand(conn, command, { signal })
       : await execCommand(conn, command)
     return parseRemotePlatformOutput(output)
-  } catch {
+  } catch (error) {
     signal?.throwIfAborted()
-    return null
+    return { kind: 'failed', error }
   }
 }
 
 async function detectWindowsPlatform(
   conn: SshConnection,
   signal?: AbortSignal
-): Promise<RelayPlatform | null> {
+): Promise<PlatformProbeOutcome> {
   try {
     const script = [
       '$arch = $env:PROCESSOR_ARCHITECTURE',
@@ -56,13 +150,14 @@ async function detectWindowsPlatform(
       ...(signal ? { signal } : {})
     })
     return parseRemotePlatformOutput(output)
-  } catch {
+  } catch (error) {
     signal?.throwIfAborted()
-    return null
+    return { kind: 'failed', error }
   }
 }
 
-function parseRemotePlatformOutput(output: string): RelayPlatform | null {
+function parseRemotePlatformOutput(output: string): PlatformProbeOutcome {
+  let unsupportedUname = ''
   // Why: SSH startup noise can resemble valid probe output and select the wrong relay.
   for (const line of iterateProcessOutputLines(output)) {
     const parts = getProcessOutputFields(line, 3)
@@ -71,8 +166,16 @@ function parseRemotePlatformOutput(output: string): RelayPlatform | null {
     }
     const platform = parseUnameToRelayPlatform(parts[1], parts[2])
     if (platform) {
-      return platform
+      return { kind: 'detected', platform }
     }
+    unsupportedUname = `${clampUnameField(parts[1])} ${clampUnameField(parts[2])}`
   }
-  return null
+  return unsupportedUname
+    ? { kind: 'unsupported', uname: unsupportedUname }
+    : { kind: 'unparsed', output }
+}
+
+// Why: a single field can be kilobytes — the scanner reads up to 4096 chars.
+function clampUnameField(field: string): string {
+  return field.length > MAX_UNAME_FIELD_CHARS ? `${field.slice(0, MAX_UNAME_FIELD_CHARS)}…` : field
 }

--- a/src/main/ssh/ssh-remote-platform-detection.ts
+++ b/src/main/ssh/ssh-remote-platform-detection.ts
@@ -37,14 +37,17 @@ export async function detectRemoteHostPlatform(
   if (windows.kind === 'detected') {
     return getRemoteHostPlatform(windows.platform)
   }
-  if (uname.kind === 'unsupported' || windows.kind === 'unsupported') {
+  // Why: only the PowerShell probe can settle a uname the parser cannot map
+  // (Cygwin, say), so a refused or timed-out channel leaves it unsettled.
+  const windowsProbeNeverRan = windows.kind === 'failed' && isTransportShapedError(windows.error)
+  if ((uname.kind === 'unsupported' && !windowsProbeNeverRan) || windows.kind === 'unsupported') {
     const reported = uname.kind === 'unsupported' ? uname.uname : probeUname(windows)
     console.warn(`[ssh-relay] Remote reported an unsupported platform: ${reported}`)
     return null
   }
   console.warn(
     `[ssh-relay] Remote platform detection failed (uname probe: ${uname.kind}, PowerShell probe: ${windows.kind}). ` +
-      `Remote output: "${summarizeProbeOutput(probeOutput(uname) || probeOutput(windows), MAX_LOGGED_OUTPUT_CHARS)}"`
+      `Remote output: "${summarizeProbeOutput(probeEvidence(uname) || probeEvidence(windows), MAX_LOGGED_OUTPUT_CHARS)}"`
   )
   throw undetectedPlatformError(uname, windows)
 }
@@ -107,6 +110,10 @@ function probeOutput(outcome: PlatformProbeOutcome): string {
 
 function probeUname(outcome: PlatformProbeOutcome): string {
   return outcome.kind === 'unsupported' ? outcome.uname : ''
+}
+
+function probeEvidence(outcome: PlatformProbeOutcome): string {
+  return probeOutput(outcome) || probeUname(outcome)
 }
 
 // Why: the marker is printed last, so the tail holds the evidence; collapsing


### PR DESCRIPTION
## Summary

Connecting to a perfectly supported Linux x86_64 host could fail with `Unsupported remote platform. Orca relay supports: linux-x64, ...`, and nothing in the logs said why.

`detectRemoteHostPlatform` collapsed four very different outcomes into a single `null`: `src/main/ssh/ssh-remote-platform-detection.ts:36` swallowed *every* non-abort failure of the `uname` probe (a session channel refused past `MaxSessions`, the 30s exec timeout, a non-zero exit, a transport drop), `:59` did the same for the PowerShell fall-back probe, and `parseRemotePlatformOutput` at `:65` dropped the remote's raw stdout on the floor when no marker line was found (restricted shell / `ForceCommand`). `src/main/ssh/ssh-relay-deploy.ts:363-366` (reached from the sole call site at `:362`) then turned every one of those `null`s into the hardcoded "Unsupported remote platform" message. Those line numbers are on the base commit, `c9a37f5`.

The probe now classifies its outcome — `detected` / `unsupported` / `unparsed` / `failed` — and `null` is reserved for the one case the message is actually true for: a marker line that parsed but named a platform the relay does not ship (e.g. `FreeBSD x86_64`). Everything else throws:

- a transport-shaped failure from **either** probe wins (`Could not detect the remote platform: (SSH) Channel open failure: open failed`), with the original error attached as `cause`. This is deliberate: on a Windows remote whose PowerShell probe is refused, the old ordering would have surfaced the `uname` probe's mundane non-zero exit instead — `Command "printf '\n%s ' '__ORCA_REMOTE_PLATFORM__'; uname -sm" failed (exit 127): sh: not found` — and told the user their Windows box is missing a shell;
- otherwise the `uname` probe's error, then its unrecognized output, then the PowerShell probe's error;
- unrecognized output is reported verbatim (whitespace-collapsed, last 200 chars, with a leading `…` when truncated) so `ForceCommand`/banner cases are actionable.

One `console.warn` on the failure path carries a longer (1000-char) tail of whatever the remote actually printed — the diagnostic that was missing when #8324 (same symptom, still open) was triaged.

The Windows fall-through is preserved for every ordinary `uname` failure, **including** a session-limit refusal: `SshConnection.exec` routes through `openSessionChannelWithRetry` on the ssh2 transport, so probe 2 gets its own retry-with-backoff budget after probe 1's channel slot is released. There is exactly one new case where the PowerShell probe is skipped: the `uname` probe rejected with an `AbortError`, or with an error whose channel close was never confirmed (`sshChannelCloseConfirmed === false` — the system-ssh timeout/abort/stream-error path). An ordinary non-zero exit never carries that flag, so a Windows remote answering `sh: not found` still falls through exactly as before. `ssh-relay-deploy.ts` is unchanged.

Closes #11104

## ELI5

Orca asks your remote machine "what kind of computer are you?" before it installs its helper. If that question failed for any reason at all — the server was too busy to open another channel, the answer timed out, the login banner ate the reply — Orca shrugged and told you "your computer isn't supported", even when it was a completely ordinary Linux machine. That message was almost always a lie, and it hid the real problem.

Now Orca tells you what actually went wrong, and shows you what the remote machine really printed back. It only says "unsupported" when the machine genuinely answered with a platform Orca has no helper for.

## Fix proof

Before — from a scratch repro file run against `main` (`ssh-remote-platform-detection.bug-11104.test.ts`; it is deliberately **not** part of this diff, both of its cases were folded into the real suite):

```
 FAIL  src/main/ssh/ssh-remote-platform-detection.bug-11104.test.ts > bug #11104: Linux x86_64 reported as an unsupported remote platform > does not misreport a refused exec channel as an unsupported platform
AssertionError: promise resolved "null" instead of rejecting

- Expected:
Error {
  "message": "rejected promise",
}

+ Received:
null

 ❯ src/main/ssh/ssh-remote-platform-detection.bug-11104.test.ts:25:49
     23|
     24|     // The host is linux-x64 and fully supported; the probe never ran.
     25|     await expect(detectRemoteHostPlatform(conn)).rejects.toThrow(/open…
       |                                                 ^
     26|   })
     27|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  src/main/ssh/ssh-remote-platform-detection.bug-11104.test.ts > bug #11104: Linux x86_64 reported as an unsupported remote platform > reports the raw probe output when a POSIX host yields no marker line
AssertionError: promise resolved "null" instead of rejecting

- Expected:
Error {
  "message": "rejected promise",
}

+ Received:
null

 ❯ src/main/ssh/ssh-remote-platform-detection.bug-11104.test.ts:35:49
     33|     // Correct behaviour surfaces what the remote actually printed so …
     34|     // can act; today every failure collapses into "Unsupported remote…
     35|     await expect(detectRemoteHostPlatform(conn)).rejects.toThrow(/pc-s…
       |                                                 ^
     36|   })
     37| })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed (2)
   Start at  21:59:26
   Duration  179ms (transform 74ms, setup 0ms, import 94ms, tests 4ms, environment 0ms)
```

After — both repro cases now live in `src/main/ssh/ssh-remote-platform-detection.test.ts` alongside 9 more classification cases (11 new `it`s; the file goes from 6 to 17 tests):

```
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_fc305741-745-1


 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  02:07:12
   Duration  184ms (transform 72ms, setup 0ms, import 109ms, tests 7ms, environment 0ms)
```

## No regressions

Every SSH suite plus the SSH IPC suite (`src/main/ssh/`, `src/main/ipc/ssh.test.ts`) — this covers `ssh-relay-deploy`, `ssh-relay-native-deps-install`, `ssh-relay-sftp-namespace-install`, `ssh-relay-gc-retry`, `ssh-relay-cross-version-isolation`, `ssh-remote-platform`, `relay-protocol` and the rest:

```
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_fc305741-745-1

[ssh-relay] GC: lock at /home/u/.orca-remote/relay-0.1.0+aaa/.install-lock is stale; treating as recoverable
[ssh-relay] GC: lock at /home/u/.orca-remote/relay-0.1.0+aaa/.install-lock is stale; treating as recoverable

 Test Files  87 passed | 2 skipped (89)
      Tests  1302 passed | 13 skipped (1315)
   Start at  02:03:21
   Duration  16.28s (transform 27.14s, setup 0ms, import 51.39s, tests 28.27s, environment 5ms)
```

`src/shared/process-output-field-scanner.test.ts` (the parser this file consumes): `Test Files 1 passed (1) / Tests 5 passed (5)`.

**CI:** currently green — no failing checks on head `7aad524`. The first attempt of the PR Checks run had exactly one red check, shard `tests node 26 15/16`, failing `src/renderer/src/components/activity/activity-portal-readiness-loop.react185.test.tsx > releases a latched readiness once the terminal attaches` with `expected 'unavailable' to be 'ready'`. That is the repo-wide happy-dom `MutationObserver` flake (the test's own comments note that "under CI load MutationObserver may miss one replaceChildren"); it is a renderer test with no connection to this main-process SSH diff, and the identical failure hit unrelated branch #12212 the same day. The re-run passed with no code change.

**Trade-offs**

- The error text is rawer. Where users used to get one tidy (wrong) sentence, they can now get up to 200 characters of their own host's banner or shell error, plus the probe command string in an exec-failure message — the same shape every other relay exec failure already surfaces. It is the user's own output, shown only to them, collapsed to a single line and length-capped.
- Some connects that used to fail with a friendly-sounding message now fail with something the user has to act on (raise `MaxSessions`, fix `ForceCommand`, install `/bin/sh`). That is the point, but it is a change in tone.
- Latency on the pathological path is unchanged (still up to two 30s probes). Short-circuiting the second probe on a session-limit refusal would have halved it, but that refusal is exactly the case where the second probe still has a real chance of succeeding, so the second attempt is kept.
- Honest scope: this does not by itself prove the reporter's connect will now succeed — the remote-side trigger was never reproducible from field data, because the code logged nothing about the probe. It removes the misdiagnosis and makes the true cause visible. #11104 asks that a supported Linux x86_64 host stop being reported as unsupported; that is what this closes — the message is now unreachable unless the remote genuinely named a platform the relay does not ship. #8324 is the same symptom and is intentionally left open until a field report confirms the new diagnostics.
- Verification scope: unit tests only, with `execCommand` mocked throughout — run locally on **macOS** and on Linux (`ubuntu-latest`) in CI. No live SSH connection, no real Windows or Cygwin remote, and no `MaxSessions`-saturated sshd was exercised end to end; the session-limit, timeout and unconfirmed-close shapes are reproduced from the error objects those code paths construct, not from a real server.

## Cross-platform

Main-process Node only. No keyboard handling, no `metaKey`, no Electron accelerators, no shortcut labels, no path construction (`joinRemotePath` and `getRemoteHostPlatform` are untouched), no UI code. Identical behavior on macOS, Linux and Windows **clients**.

Remote-side platform handling is the subject of the change and is preserved for all six relay targets: POSIX remotes via the unchanged `uname -sm` probe (same command string, still asserted by the existing test), Windows remotes via the unchanged PowerShell fall-back (still reached whenever the `uname` probe fails to detect, including its `/bin/sh` non-zero exit; still `wrapCommand: false`, same `-EncodedCommand` payload). The one new gate on that fall-back is the abort / unconfirmed-close short-circuit described in the summary. The new `unsupported` classification deliberately runs *after* `detected` on both probes, so a Cygwin remote whose `uname -s` reports `CYGWIN_NT-10.0` still falls through to PowerShell and is detected as win32 — covered by a new test. CRLF is handled by `iterateProcessOutputLines`, and the summarizer collapses both CR and LF so a Windows banner cannot produce a multi-line message.

SSH-remote: this is entirely the SSH path; nothing here assumes local execution. Both transports are covered because the change sits downstream of `execCommand` and only reclassifies its rejections — ssh2 (`conn.exec` → `openSessionChannelWithRetry`) and system-ssh (`conn.exec` → `spawnTrackedSystemSshCommand`, which has no session-channel retry of its own). The "unconfirmed channel close" short-circuit is transport-aware by construction: `execCommand` deliberately leaves `sshChannelCloseConfirmed` false for system-ssh channels because a local OpenSSH child exit does not prove the remote command stopped, so on system-ssh we skip a probe that would race a still-held ControlMaster slot.

Folder workspaces (non-git): platform detection runs before any workspace exists. No git command is added, changed or version-gated; no `GitCapabilityCache` interaction, no git-provider surface, no `-c`-leading git command affected.

## Performance

No new remote round trips. The happy path is byte-for-byte unchanged: a `detected` uname probe returns after exactly one exec, as before. One 30s exec is *saved* only where the first probe is abandoned: the unconfirmed-termination case (where the second probe was near-certain to be refused anyway) and an `AbortError` that the caller's own signal does not already re-throw. No round-trip saving on session-limit — that "saving" would have been a lost retry, and is given back deliberately.

`summarizeProbeOutput` runs at most twice per **failed** connect, on a string already bounded to 1 MiB by `appendExecOutputTail`; a single bounded pass on an error path only. No polling, no timers, no new spawns, no extra IPC (the error travels on the existing `ssh:connect` reply — `ssh-relay-deploy.ts:362` is the only call site), no renderer re-renders.

## Security

No change to IPC surface, auth, or path handling. Command execution is unchanged — same two probe command strings, same wrapping flags. The one new exposure is diagnostic: up to 200 chars of the remote's own probe output in the thrown message and 1000 chars in the local log. It is the connecting user's own host output, shown only to that user; install-marker redaction is not needed because detection runs before any install marker exists, and `execCommand` already redacts marker tokens in its own non-zero-exit and timeout messages.

## AI Review Report

Reviewed by independent subagents in a loop until clean, across two hostile lenses — **correctness/regressions** and **cross-platform + remote + performance**.

- **Review loop count:** 2 round(s)
- **Final verdict:** CLEAN
- **Outstanding findings:** none — the final round returned zero blocker/major findings from both lenses.

**Remediation applied between rounds:** 1 pass(es) — it produced the second commit, which lets a refused PowerShell probe outrank an unmappable `uname`, plus its test. Findings judged false-positive were rejected with evidence rather than coded around.

Made with [Orca](https://github.com/stablyai/orca) 🐋
