### PR TITLE
Stop a duplicate headless orca serve from crash-looping and exhausting AppImage FUSE mounts

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -155,6 +155,8 @@ display `:99` when no display exists:
 Description=Orca runtime server
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -165,6 +167,7 @@ ExecStart=/opt/orca/orca-linux.AppImage serve --port 6768 --pairing-address 100.
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure
+RestartPreventExitStatus=3
 RestartSec=5
 
 [Install]
@@ -173,6 +176,15 @@ WantedBy=multi-user.target
 
 Replace `100.64.1.20` with the LAN, Tailscale, tunnel, or public hostname that
 clients should use.
+
+Exit status `3` means another process already owns this userData profile, so
+`RestartPreventExitStatus=3` stops the unit instead of retrying a launch that
+cannot succeed. Any other permanent startup fault is capped at 5 starts per
+5 minutes; systemd's defaults (10s window, 5 starts) can never trip at
+`RestartSec=5`, which is how one bad launch could restart thousands of times.
+On systemd older than 230 those two directives are spelled
+`StartLimitInterval=`/`StartLimitBurst=` and belong in `[Service]`; Ubuntu
+20.04, Orca's oldest supported base, ships systemd 245.
 
 Enable the service:
 
@@ -228,6 +240,8 @@ Then add the display dependency to the Orca service:
 Description=Orca runtime server
 After=network-online.target orca-xvfb.service
 Wants=network-online.target orca-xvfb.service
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -237,6 +251,7 @@ Environment=DISPLAY=:99
 Environment=LIBGL_ALWAYS_SOFTWARE=1
 ExecStart=/opt/orca/orca-linux.AppImage serve --port 6768 --pairing-address 100.64.1.20
 Restart=on-failure
+RestartPreventExitStatus=3
 RestartSec=5
 
 [Install]
@@ -805,6 +820,19 @@ refuse to run there and print the command to run on the machine you want.
   `orca` user and that `/opt/orca` is readable by that user.
 - Clients cannot connect: make sure `--pairing-address` is an address reachable
   from the client, and make sure firewalls allow the selected `--port`.
+- Journal shows `Another Orca instance is already running for this userData
+  profile` and the unit exits `3`: another process already owns the profile, so
+  `RestartPreventExitStatus=3` leaves the unit `failed` on purpose. Find the
+  owner with `systemctl status orca-serve` and `pgrep -af orca`. Stop it (or
+  keep it and leave the unit down), then run
+  `sudo systemctl reset-failed orca-serve && sudo systemctl start orca-serve` —
+  `reset-failed` is required because a tripped `StartLimitBurst` refuses a plain
+  `start`. If no owner exists, the lock is stale (Chromium recorded a pid that
+  has since been reused): remove `SingletonLock` and `SingletonSocket` from the
+  userData directory and start again. If an earlier crash-loop already leaked
+  AppImage mounts, list them with `findmnt -rn -t fuse.orca-linux.AppImage` and
+  release only the ones with no live owner using `fusermount -uz <target>` (or
+  `umount -l <target>`), leaving the running instance's mount alone.
 - Service crash-loops right after an upgrade: use [Roll back](#roll-back) with
   the pre-upgrade `.ready` bundle. Do not rerun the upgrade first; doing so would
   make the crashing version the next rollback binary.

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -182,6 +182,10 @@ Exit status `3` means another process already owns this userData profile, so
 cannot succeed. Any other permanent startup fault is capped at 5 starts per
 5 minutes; systemd's defaults (10s window, 5 starts) can never trip at
 `RestartSec=5`, which is how one bad launch could restart thousands of times.
+The start limit counts operator-initiated starts too, so once it trips systemd
+refuses a plain `systemctl start` until the 5-minute window rolls over. Run
+`sudo systemctl reset-failed orca-serve.service` first to clear it — the
+[Upgrade](#upgrade-steps) and [Roll back](#roll-back) scripts already do.
 On systemd older than 230 those two directives are spelled
 `StartLimitInterval=`/`StartLimitBurst=` and belong in `[Service]`; Ubuntu
 20.04, Orca's oldest supported base, ships systemd 245.
@@ -430,6 +434,8 @@ recover_failed_upgrade() {
     sudo rm -f /opt/orca/orca-linux.AppImage.recovering \
       /opt/orca/VERSION.recovering
     if ((recovery_ok)); then
+      # A tripped StartLimitBurst refuses a plain start
+      sudo systemctl reset-failed orca-serve.service || true
       sudo systemctl start orca-serve.service || true
     else
       echo 'Upgrade recovery failed; service remains stopped' >&2
@@ -497,6 +503,8 @@ sudo mv "$ORCA_ROLLBACK_NEW" "$ORCA_ROLLBACK"
 ORCA_BINARY_PROMOTED=1
 sudo mv -f /opt/orca/orca-linux.AppImage.new /opt/orca/orca-linux.AppImage
 sudo mv -f /opt/orca/VERSION.new /opt/orca/VERSION
+# Clears a start-limit hit left by the version being replaced
+sudo systemctl reset-failed orca-serve.service
 sudo systemctl start orca-serve.service
 ORCA_SERVICE_STOPPED=0
 trap - EXIT
@@ -629,6 +637,8 @@ restart_after_rollback_error() {
       fi
     fi
     if ((recovery_ok)); then
+      # A tripped StartLimitBurst refuses a plain start
+      sudo systemctl reset-failed orca-serve.service || true
       sudo systemctl start orca-serve.service || true
     else
       echo 'Rollback recovery failed; service remains stopped' >&2
@@ -729,6 +739,8 @@ if ((ORCA_ROLLBACK_HAS_VERSION)); then
 else
   sudo rm -f /opt/orca/VERSION
 fi
+# The crash-looping build you are rolling back from tripped StartLimitBurst
+sudo systemctl reset-failed orca-serve.service
 sudo systemctl start orca-serve.service
 ORCA_SERVICE_STOPPED=0
 sudo rm -rf -- "$ORCA_RESTORE"
@@ -826,8 +838,8 @@ refuse to run there and print the command to run on the machine you want.
   owner with `systemctl status orca-serve` and `pgrep -af orca`. Stop it (or
   keep it and leave the unit down), then run
   `sudo systemctl reset-failed orca-serve && sudo systemctl start orca-serve` —
-  `reset-failed` is required because a tripped `StartLimitBurst` refuses a plain
-  `start`. If no owner exists, the lock is stale (Chromium recorded a pid that
+  `reset-failed` clears the failed state and any start-limit counter. If no owner
+  exists, the lock is stale (Chromium recorded a pid that
   has since been reused): remove `SingletonLock` and `SingletonSocket` from the
   userData directory and start again. If an earlier crash-loop already leaked
   AppImage mounts, list them with `findmnt -rn -t fuse.orca-linux.AppImage` and
@@ -835,7 +847,9 @@ refuse to run there and print the command to run on the machine you want.
   `umount -l <target>`), leaving the running instance's mount alone.
 - Service crash-loops right after an upgrade: use [Roll back](#roll-back) with
   the pre-upgrade `.ready` bundle. Do not rerun the upgrade first; doing so would
-  make the crashing version the next rollback binary.
+  make the crashing version the next rollback binary. The loop trips
+  `StartLimitBurst`, so any manual `systemctl start` outside that script needs
+  `sudo systemctl reset-failed orca-serve.service` first.
 - Diagnosing other missing libraries: extract the AppImage without launching it
   with `./orca-linux.AppImage --appimage-extract`, then run
   `ldd squashfs-root/orca` to list any shared libraries the host is missing.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -160,8 +160,10 @@ import {
   acquireSingleInstanceLock,
   logSingleInstanceLockBypass,
   logSingleInstanceLockFailure,
+  shouldActivateDesktopForSecondInstance,
   shouldBypassSingleInstanceLock,
-  shouldSkipSingleInstanceLock
+  shouldSkipSingleInstanceLock,
+  SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE
 } from './startup/single-instance-lock'
 import { startEventLoopStallProbe } from './startup/event-loop-stall-probe'
 import { startMainThreadChurnProbe } from './diagnostics/main-thread-churn-probe'
@@ -606,7 +608,11 @@ function focusExistingWindow(): void {
   })
 }
 
-function requestDesktopActivation(): void {
+function requestDesktopActivation(argv: readonly string[] = []): void {
+  // Why: a duplicate `orca serve` must not drag a headless server into opening a desktop window (#11935).
+  if (!shouldActivateDesktopForSecondInstance(argv)) {
+    return
+  }
   desktopActivationGate.requestActivation()
 }
 
@@ -726,10 +732,11 @@ if (startupDiagnosticsEnabled) {
 if (!hasSingleInstanceLock) {
   // Why: a false-negative lock loss otherwise looks like a silent crash on packaged macOS; `open --stderr` can capture this line.
   logSingleInstanceLockFailure()
-  app.quit()
+  // Why: a graceful quit is deferred pre-ready, so this launch would still walk into Linux display init and SIGSEGV (#11935).
+  app.exit(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)
 }
 
-// Why: when another process holds the lock we've already quit; skip file-writing side effects so this transient process never touches userData.
+// Why: when another process holds the lock we've already exited; skip file-writing side effects so this transient process never touches userData.
 if (hasSingleInstanceLock) {
   // Why: couple to dev-parent only for electron-vite desktop runs; `orca serve`'s parent (CLI shim/background shell) isn't the intended server lifetime.
   const shouldCoupleToDevParent = is.dev && !isServeMode

--- a/src/main/startup/single-instance-lock-exit.electron.test.ts
+++ b/src/main/startup/single-instance-lock-exit.electron.test.ts
@@ -111,9 +111,16 @@ beforeAll(async () => {
   await waitFor(() => readLines(ownerMarker).includes(OWNER_ACQUIRED), 'the owner to take the lock')
 }, 90_000)
 
-afterAll(() => {
-  owner?.kill('SIGKILL')
-  rmSync(root, { recursive: true, force: true })
+afterAll(async () => {
+  if (owner && owner.exitCode === null) {
+    const exited = new Promise<void>((resolve) => {
+      owner?.once('exit', () => resolve())
+    })
+    owner.kill('SIGKILL')
+    await exited
+  }
+  // Why: Windows keeps the profile's handles open for a beat after the kill, which fails an immediate rm.
+  rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
 })
 
 type DuplicateRun = { status: number | null; markers: string[]; ownerSawArgv: string[] }

--- a/src/main/startup/single-instance-lock-exit.electron.test.ts
+++ b/src/main/startup/single-instance-lock-exit.electron.test.ts
@@ -126,7 +126,13 @@ afterAll(async () => {
 
 type DuplicateRun = { status: number | null; markers: string[]; ownerSawArgv: string[] }
 
-async function launchDuplicate(termination: string, argv: string[]): Promise<DuplicateRun> {
+// Why: only the activation case needs the owner's notification, so the exit-contract cases do not
+// hang on it — they are about the duplicate's own process, which has already terminated by here.
+async function launchDuplicate(
+  termination: string,
+  argv: string[],
+  awaitOwnerNotification = false
+): Promise<DuplicateRun> {
   const name = `duplicate-${Math.random().toString(36).slice(2)}`
   const dir = writeFixture(root, name, buildDuplicateMain(termination))
   const marker = join(root, `${name}.log`)
@@ -143,17 +149,18 @@ async function launchDuplicate(termination: string, argv: string[]): Promise<Dup
     }
   )
   expect(result.error).toBeUndefined()
-  await waitFor(
-    () => readForwardedArgvLines().length > seen,
-    'the owner to receive the second-instance notification'
-  )
+  if (awaitOwnerNotification) {
+    await waitFor(
+      () => readForwardedArgvLines().length > seen,
+      'the owner to receive the second-instance notification'
+    )
+  }
 
-  const forwarded = readForwardedArgvLines()
-  const latest = forwarded.at(-1)
+  const latest = readForwardedArgvLines().at(-1)
   return {
     status: result.status,
     markers: readLines(marker),
-    ownerSawArgv: JSON.parse((latest ?? '').slice(SECOND_INSTANCE_ARGV.length)) as string[]
+    ownerSawArgv: latest ? (JSON.parse(latest.slice(SECOND_INSTANCE_ARGV.length)) as string[]) : []
   }
 }
 
@@ -173,11 +180,11 @@ describe('#11935 duplicate headless serve against a live owner', () => {
   }, 90_000)
 
   it('hands the owner a real argv that suppresses desktop activation only for serve', async () => {
-    const serveRun = await launchDuplicate(readLockLossTermination(), ['--serve'])
+    const serveRun = await launchDuplicate(readLockLossTermination(), ['--serve'], true)
     expect(serveRun.ownerSawArgv).toContain('--serve')
     expect(shouldActivateDesktopForSecondInstance(serveRun.ownerSawArgv)).toBe(false)
 
-    const desktopRun = await launchDuplicate(readLockLossTermination(), [])
+    const desktopRun = await launchDuplicate(readLockLossTermination(), [], true)
     expect(desktopRun.ownerSawArgv).not.toContain('--serve')
     expect(shouldActivateDesktopForSecondInstance(desktopRun.ownerSawArgv)).toBe(true)
   }, 90_000)

--- a/src/main/startup/single-instance-lock-exit.electron.test.ts
+++ b/src/main/startup/single-instance-lock-exit.electron.test.ts
@@ -1,38 +1,36 @@
-import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import {
-  shouldActivateDesktopForSecondInstance,
-  SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE
-} from './single-instance-lock'
+import { afterAll, describe, expect, it } from 'vitest'
+import { SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE } from './single-instance-lock'
 
-// Why #11935: two real Electron processes against one profile, because the reported crash loop only
-// exists on the loser of a genuine lock race. Pre-`ready` `app.quit()` is deferred, so that loser kept
-// executing the rest of startup, reached Linux Ozone/X11 init with no display, died with SIGSEGV, and
-// systemd restarted it until the leaked AppImage FUSE mounts hit the kernel's 1000-mount ceiling.
-// The duplicate runs the lock-loss gate's own termination statement, lifted out of `src/main/index.ts`.
+// Why #11935: the lock-loss gate runs before Electron `ready`, where `app.quit()` is deferred, so a
+// duplicate headless `orca serve` kept executing the rest of startup, reached Linux Ozone/X11 init
+// with no display, died with SIGSEGV, and systemd restarted it until the leaked AppImage FUSE mounts
+// hit the kernel's 1000-mount ceiling. This runs the gate's own termination statement, lifted out of
+// `src/main/index.ts`, under the real Electron binary.
+//
+// Why not a live lock race: Chromium's Linux ProcessSingleton only answers a second process once the
+// browser IO thread is up, which needs `ready` and therefore a display. On a display-less CI runner
+// the "owner" is treated as stale and the duplicate takes the lock, so the race cannot be staged
+// there. Lock acquisition and argv forwarding are covered in `single-instance-lock.test.ts`; what
+// only a real process can settle is what the loser does next, which is what this file pins.
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
-const OWNER_ACQUIRED = 'OWNER_ACQUIRED'
-const DUPLICATE_LOST_LOCK = 'DUPLICATE_LOST_LOCK'
-const DUPLICATE_CONTINUED_INTO_STARTUP = 'DUPLICATE_CONTINUED_INTO_STARTUP'
-const SECOND_INSTANCE_ARGV = 'SECOND_INSTANCE_ARGV '
+const LOCK_LOST = 'LOCK_LOST'
+const CONTINUED_INTO_STARTUP = 'CONTINUED_INTO_STARTUP'
+const REACHED_TAIL = 'REACHED_TAIL'
+const MARKER_ENV = 'ORCA_LOCK_FIXTURE_MARKER'
 
-// Why: the marker path travels by env, not argv — Chromium rewrites argv, and the duplicate's argv is
-// itself under test.
-const OWNER_MAIN = `const { app } = require('electron')
-const { appendFileSync } = require('node:fs')
-const marker = process.env.ORCA_LOCK_FIXTURE_MARKER
-app.on('second-instance', (_event, argv) => {
-  appendFileSync(marker, '${SECOND_INSTANCE_ARGV}' + JSON.stringify(argv) + '\\n')
+const fixtureRoots: string[] = []
+
+afterAll(() => {
+  for (const root of fixtureRoots) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
 })
-appendFileSync(marker, app.requestSingleInstanceLock() ? '${OWNER_ACQUIRED}\\n' : 'OWNER_LOST\\n')
-// Why: outlive the duplicate without reaching \`ready\`, which needs a display CI does not have.
-setTimeout(() => process.exit(0), 120_000)
-`
 
 /** The `app.*` call the shipped lock-loss gate executes, so a revert to `app.quit()` fails here. */
 function readLockLossTermination(): string {
@@ -50,150 +48,68 @@ function readLockLossTermination(): string {
     .join('\n')
 }
 
-function buildDuplicateMain(termination: string): string {
+function buildFixtureMain(termination: string): string {
   return [
     `const { app } = require('electron')`,
     `const { appendFileSync } = require('node:fs')`,
-    `const marker = process.env.ORCA_LOCK_FIXTURE_MARKER`,
+    // Why: the marker path travels by env — Chromium rewrites argv before the main script sees it.
+    `const marker = process.env.${MARKER_ENV}`,
+    `const mark = (name) => appendFileSync(marker, name + '\\n')`,
     `const SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = ${SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE}`,
-    `const hasSingleInstanceLock = app.requestSingleInstanceLock()`,
-    `if (hasSingleInstanceLock) { appendFileSync(marker, 'DUPLICATE_WON_LOCK\\n'); process.exit(0) }`,
-    `appendFileSync(marker, '${DUPLICATE_LOST_LOCK}\\n')`,
+    `mark('${LOCK_LOST}')`,
     termination,
-    `appendFileSync(marker, '${DUPLICATE_CONTINUED_INTO_STARTUP}\\n')`,
-    // Why: the deferred-quit control must stop here rather than boot on into display init.
+    `mark('${CONTINUED_INTO_STARTUP}')`,
+    // Why: stand in for the rest of `src/main/index.ts`, which on the reported host was display init.
+    `mark('${REACHED_TAIL}')`,
     `process.exit(0)`
   ].join('\n')
 }
 
-function writeFixture(root: string, name: string, main: string): string {
-  const dir = join(root, name)
+type FixtureRun = { status: number | null; markers: string[] }
+
+function runLockLossGate(termination: string): FixtureRun {
+  const root = mkdtempSync(join(tmpdir(), 'orca-lock-loss-'))
+  fixtureRoots.push(root)
+  const dir = join(root, 'fixture')
+  const marker = join(root, 'markers.log')
   mkdirSync(dir, { recursive: true })
-  writeFileSync(join(dir, 'package.json'), `{ "name": "${name}", "main": "main.js" }`)
-  writeFileSync(join(dir, 'main.js'), main)
-  return dir
-}
-
-let root = ''
-let profile = ''
-let ownerMarker = ''
-let owner: ChildProcess | null = null
-
-function readLines(path: string): string[] {
-  return readFileSync(path, 'utf8').split('\n').filter(Boolean)
-}
-
-function readForwardedArgvLines(): string[] {
-  return readLines(ownerMarker).filter((line) => line.startsWith(SECOND_INSTANCE_ARGV))
-}
-
-async function waitFor(check: () => boolean, label: string): Promise<void> {
-  const deadline = Date.now() + 30_000
-  while (Date.now() < deadline) {
-    if (check()) {
-      return
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50))
-  }
-  throw new Error(`Timed out waiting for ${label}`)
-}
-
-beforeAll(async () => {
-  root = mkdtempSync(join(tmpdir(), 'orca-single-instance-'))
-  profile = join(root, 'profile')
-  ownerMarker = join(root, 'owner.log')
-  writeFileSync(ownerMarker, '')
-  const ownerDir = writeFixture(root, 'owner', OWNER_MAIN)
-
-  owner = spawn(electronBinary, [ownerDir, `--user-data-dir=${profile}`, '--no-sandbox'], {
-    stdio: 'ignore',
-    env: { ...process.env, ORCA_LOCK_FIXTURE_MARKER: ownerMarker }
-  })
-  await waitFor(() => readLines(ownerMarker).includes(OWNER_ACQUIRED), 'the owner to take the lock')
-}, 90_000)
-
-afterAll(async () => {
-  if (owner && owner.exitCode === null) {
-    const exited = new Promise<void>((resolve) => {
-      owner?.once('exit', () => resolve())
-    })
-    owner.kill('SIGKILL')
-    await exited
-  }
-  // Why: Windows keeps the profile's handles open for a beat after the kill, which fails an immediate rm.
-  rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
-})
-
-type DuplicateRun = { status: number | null; markers: string[]; ownerSawArgv: string[] }
-
-// Why: only the activation case needs the owner's notification, so the exit-contract cases do not
-// hang on it — they are about the duplicate's own process, which has already terminated by here.
-async function launchDuplicate(
-  termination: string,
-  argv: string[],
-  awaitOwnerNotification = false
-): Promise<DuplicateRun> {
-  const name = `duplicate-${Math.random().toString(36).slice(2)}`
-  const dir = writeFixture(root, name, buildDuplicateMain(termination))
-  const marker = join(root, `${name}.log`)
-  writeFileSync(marker, '')
-  const seen = readForwardedArgvLines().length
-
-  const result = spawnSync(
-    electronBinary,
-    [dir, `--user-data-dir=${profile}`, '--no-sandbox', ...argv],
-    {
-      stdio: 'ignore',
-      timeout: 60_000,
-      env: { ...process.env, ORCA_LOCK_FIXTURE_MARKER: marker }
-    }
+  writeFileSync(
+    join(dir, 'package.json'),
+    '{ "name": "orca-lock-loss-fixture", "main": "main.js" }'
   )
-  expect(result.error).toBeUndefined()
-  if (awaitOwnerNotification) {
-    await waitFor(
-      () => readForwardedArgvLines().length > seen,
-      'the owner to receive the second-instance notification'
-    )
-  }
+  writeFileSync(join(dir, 'main.js'), buildFixtureMain(termination))
+  writeFileSync(marker, '')
 
-  const latest = readForwardedArgvLines().at(-1)
+  const result = spawnSync(electronBinary, [dir, '--no-sandbox'], {
+    stdio: 'ignore',
+    timeout: 60_000,
+    env: { ...process.env, [MARKER_ENV]: marker }
+  })
+  expect(result.error).toBeUndefined()
+
   return {
     status: result.status,
-    markers: readLines(marker),
-    ownerSawArgv: latest ? (JSON.parse(latest.slice(SECOND_INSTANCE_ARGV.length)) as string[]) : []
+    markers: readFileSync(marker, 'utf8').split('\n').filter(Boolean)
   }
 }
 
-describe('#11935 duplicate headless serve against a live owner', () => {
-  it('exits the duplicate before any further startup runs, leaving the owner untouched', async () => {
+describe('#11935 pre-ready lock-loss termination under real Electron', () => {
+  it('stops the duplicate launch before any further startup runs, with the already-running code', () => {
     const termination = readLockLossTermination()
     // Why: an empty slice would let the fixture fall through to its own exit and pass vacuously.
     expect(termination).not.toBe('')
 
-    const run = await launchDuplicate(termination, ['--serve'])
+    const run = runLockLossGate(termination)
 
-    expect(run.markers).toContain(DUPLICATE_LOST_LOCK)
-    // Why: this is where the reported host continued into Ozone/X11 init and SIGSEGV'd into the restart loop.
-    expect(run.markers).not.toContain(DUPLICATE_CONTINUED_INTO_STARTUP)
+    expect(run.markers).toEqual([LOCK_LOST])
     expect(run.status).toBe(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)
-    expect(owner?.exitCode).toBeNull()
   }, 90_000)
 
-  it('hands the owner a real argv that suppresses desktop activation only for serve', async () => {
-    const serveRun = await launchDuplicate(readLockLossTermination(), ['--serve'], true)
-    expect(serveRun.ownerSawArgv).toContain('--serve')
-    expect(shouldActivateDesktopForSecondInstance(serveRun.ownerSawArgv)).toBe(false)
-
-    const desktopRun = await launchDuplicate(readLockLossTermination(), [], true)
-    expect(desktopRun.ownerSawArgv).not.toContain('--serve')
-    expect(shouldActivateDesktopForSecondInstance(desktopRun.ownerSawArgv)).toBe(true)
-  }, 90_000)
-
-  it('reproduces the deferred graceful quit that let the doomed launch keep booting', async () => {
-    const run = await launchDuplicate('app.quit()', ['--serve'])
+  it('reproduces the deferred graceful quit that let the doomed launch keep booting', () => {
+    const run = runLockLossGate('app.quit()')
 
     // Why: pins the Electron semantic the fix rests on — pre-`ready` `quit()` schedules, it does not stop.
-    expect(run.markers).toEqual([DUPLICATE_LOST_LOCK, DUPLICATE_CONTINUED_INTO_STARTUP])
+    expect(run.markers).toEqual([LOCK_LOST, CONTINUED_INTO_STARTUP, REACHED_TAIL])
     expect(run.status).not.toBe(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)
   }, 90_000)
 })

--- a/src/main/startup/single-instance-lock-exit.electron.test.ts
+++ b/src/main/startup/single-instance-lock-exit.electron.test.ts
@@ -1,0 +1,180 @@
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  shouldActivateDesktopForSecondInstance,
+  SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE
+} from './single-instance-lock'
+
+// Why #11935: two real Electron processes against one profile, because the reported crash loop only
+// exists on the loser of a genuine lock race. Pre-`ready` `app.quit()` is deferred, so that loser kept
+// executing the rest of startup, reached Linux Ozone/X11 init with no display, died with SIGSEGV, and
+// systemd restarted it until the leaked AppImage FUSE mounts hit the kernel's 1000-mount ceiling.
+// The duplicate runs the lock-loss gate's own termination statement, lifted out of `src/main/index.ts`.
+
+const electronBinary = createRequire(import.meta.url)('electron') as string
+const OWNER_ACQUIRED = 'OWNER_ACQUIRED'
+const DUPLICATE_LOST_LOCK = 'DUPLICATE_LOST_LOCK'
+const DUPLICATE_CONTINUED_INTO_STARTUP = 'DUPLICATE_CONTINUED_INTO_STARTUP'
+const SECOND_INSTANCE_ARGV = 'SECOND_INSTANCE_ARGV '
+
+const OWNER_MAIN = `const { app } = require('electron')
+const { appendFileSync } = require('node:fs')
+const marker = process.argv[process.argv.length - 1]
+app.on('second-instance', (_event, argv) => {
+  appendFileSync(marker, '${SECOND_INSTANCE_ARGV}' + JSON.stringify(argv) + '\\n')
+})
+appendFileSync(marker, app.requestSingleInstanceLock() ? '${OWNER_ACQUIRED}\\n' : 'OWNER_LOST\\n')
+// Why: outlive the duplicate without reaching \`ready\`, which needs a display CI does not have.
+setTimeout(() => process.exit(0), 120_000)
+`
+
+/** The `app.*` call the shipped lock-loss gate executes, so a revert to `app.quit()` fails here. */
+function readLockLossTermination(): string {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+  const start = source.indexOf('if (!hasSingleInstanceLock) {')
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf('\n}', start)
+  expect(end).toBeGreaterThan(start)
+
+  return source
+    .slice(start, end)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('app.'))
+    .join('\n')
+}
+
+function buildDuplicateMain(termination: string): string {
+  return [
+    `const { app } = require('electron')`,
+    `const { appendFileSync } = require('node:fs')`,
+    `const marker = process.argv[process.argv.length - 1]`,
+    `const SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = ${SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE}`,
+    `const hasSingleInstanceLock = app.requestSingleInstanceLock()`,
+    `if (hasSingleInstanceLock) { appendFileSync(marker, 'DUPLICATE_WON_LOCK\\n'); process.exit(0) }`,
+    `appendFileSync(marker, '${DUPLICATE_LOST_LOCK}\\n')`,
+    termination,
+    `appendFileSync(marker, '${DUPLICATE_CONTINUED_INTO_STARTUP}\\n')`,
+    // Why: the deferred-quit control must stop here rather than boot on into display init.
+    `process.exit(0)`
+  ].join('\n')
+}
+
+function writeFixture(root: string, name: string, main: string): string {
+  const dir = join(root, name)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), `{ "name": "${name}", "main": "main.js" }`)
+  writeFileSync(join(dir, 'main.js'), main)
+  return dir
+}
+
+let root = ''
+let profile = ''
+let ownerMarker = ''
+let owner: ChildProcess | null = null
+
+function readLines(path: string): string[] {
+  return readFileSync(path, 'utf8').split('\n').filter(Boolean)
+}
+
+function readForwardedArgvLines(): string[] {
+  return readLines(ownerMarker).filter((line) => line.startsWith(SECOND_INSTANCE_ARGV))
+}
+
+async function waitFor(check: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    if (check()) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+beforeAll(async () => {
+  root = mkdtempSync(join(tmpdir(), 'orca-single-instance-'))
+  profile = join(root, 'profile')
+  ownerMarker = join(root, 'owner.log')
+  writeFileSync(ownerMarker, '')
+  const ownerDir = writeFixture(root, 'owner', OWNER_MAIN)
+
+  owner = spawn(
+    electronBinary,
+    [ownerDir, `--user-data-dir=${profile}`, '--no-sandbox', ownerMarker],
+    { stdio: 'ignore' }
+  )
+  await waitFor(() => readLines(ownerMarker).includes(OWNER_ACQUIRED), 'the owner to take the lock')
+}, 90_000)
+
+afterAll(() => {
+  owner?.kill('SIGKILL')
+  rmSync(root, { recursive: true, force: true })
+})
+
+type DuplicateRun = { status: number | null; markers: string[]; ownerSawArgv: string[] }
+
+async function launchDuplicate(termination: string, argv: string[]): Promise<DuplicateRun> {
+  const name = `duplicate-${Math.random().toString(36).slice(2)}`
+  const dir = writeFixture(root, name, buildDuplicateMain(termination))
+  const marker = join(root, `${name}.log`)
+  writeFileSync(marker, '')
+  const seen = readForwardedArgvLines().length
+
+  const result = spawnSync(
+    electronBinary,
+    [dir, `--user-data-dir=${profile}`, '--no-sandbox', ...argv, marker],
+    { stdio: 'ignore', timeout: 60_000 }
+  )
+  expect(result.error).toBeUndefined()
+  await waitFor(
+    () => readForwardedArgvLines().length > seen,
+    'the owner to receive the second-instance notification'
+  )
+
+  const forwarded = readForwardedArgvLines()
+  const latest = forwarded.at(-1)
+  return {
+    status: result.status,
+    markers: readLines(marker),
+    ownerSawArgv: JSON.parse((latest ?? '').slice(SECOND_INSTANCE_ARGV.length)) as string[]
+  }
+}
+
+describe('#11935 duplicate headless serve against a live owner', () => {
+  it('exits the duplicate before any further startup runs, leaving the owner untouched', async () => {
+    const termination = readLockLossTermination()
+    // Why: an empty slice would let the fixture fall through to its own exit and pass vacuously.
+    expect(termination).not.toBe('')
+
+    const run = await launchDuplicate(termination, ['--serve'])
+
+    expect(run.markers).toContain(DUPLICATE_LOST_LOCK)
+    // Why: this is where the reported host continued into Ozone/X11 init and SIGSEGV'd into the restart loop.
+    expect(run.markers).not.toContain(DUPLICATE_CONTINUED_INTO_STARTUP)
+    expect(run.status).toBe(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)
+    expect(owner?.exitCode).toBeNull()
+  }, 90_000)
+
+  it('hands the owner a real argv that suppresses desktop activation only for serve', async () => {
+    const serveRun = await launchDuplicate(readLockLossTermination(), ['--serve'])
+    expect(serveRun.ownerSawArgv).toContain('--serve')
+    expect(shouldActivateDesktopForSecondInstance(serveRun.ownerSawArgv)).toBe(false)
+
+    const desktopRun = await launchDuplicate(readLockLossTermination(), [])
+    expect(desktopRun.ownerSawArgv).not.toContain('--serve')
+    expect(shouldActivateDesktopForSecondInstance(desktopRun.ownerSawArgv)).toBe(true)
+  }, 90_000)
+
+  it('reproduces the deferred graceful quit that let the doomed launch keep booting', async () => {
+    const run = await launchDuplicate('app.quit()', ['--serve'])
+
+    // Why: pins the Electron semantic the fix rests on — pre-`ready` `quit()` schedules, it does not stop.
+    expect(run.markers).toEqual([DUPLICATE_LOST_LOCK, DUPLICATE_CONTINUED_INTO_STARTUP])
+    expect(run.status).not.toBe(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)
+  }, 90_000)
+})

--- a/src/main/startup/single-instance-lock-exit.electron.test.ts
+++ b/src/main/startup/single-instance-lock-exit.electron.test.ts
@@ -21,9 +21,11 @@ const DUPLICATE_LOST_LOCK = 'DUPLICATE_LOST_LOCK'
 const DUPLICATE_CONTINUED_INTO_STARTUP = 'DUPLICATE_CONTINUED_INTO_STARTUP'
 const SECOND_INSTANCE_ARGV = 'SECOND_INSTANCE_ARGV '
 
+// Why: the marker path travels by env, not argv — Chromium rewrites argv, and the duplicate's argv is
+// itself under test.
 const OWNER_MAIN = `const { app } = require('electron')
 const { appendFileSync } = require('node:fs')
-const marker = process.argv[process.argv.length - 1]
+const marker = process.env.ORCA_LOCK_FIXTURE_MARKER
 app.on('second-instance', (_event, argv) => {
   appendFileSync(marker, '${SECOND_INSTANCE_ARGV}' + JSON.stringify(argv) + '\\n')
 })
@@ -52,7 +54,7 @@ function buildDuplicateMain(termination: string): string {
   return [
     `const { app } = require('electron')`,
     `const { appendFileSync } = require('node:fs')`,
-    `const marker = process.argv[process.argv.length - 1]`,
+    `const marker = process.env.ORCA_LOCK_FIXTURE_MARKER`,
     `const SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = ${SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE}`,
     `const hasSingleInstanceLock = app.requestSingleInstanceLock()`,
     `if (hasSingleInstanceLock) { appendFileSync(marker, 'DUPLICATE_WON_LOCK\\n'); process.exit(0) }`,
@@ -103,11 +105,10 @@ beforeAll(async () => {
   writeFileSync(ownerMarker, '')
   const ownerDir = writeFixture(root, 'owner', OWNER_MAIN)
 
-  owner = spawn(
-    electronBinary,
-    [ownerDir, `--user-data-dir=${profile}`, '--no-sandbox', ownerMarker],
-    { stdio: 'ignore' }
-  )
+  owner = spawn(electronBinary, [ownerDir, `--user-data-dir=${profile}`, '--no-sandbox'], {
+    stdio: 'ignore',
+    env: { ...process.env, ORCA_LOCK_FIXTURE_MARKER: ownerMarker }
+  })
   await waitFor(() => readLines(ownerMarker).includes(OWNER_ACQUIRED), 'the owner to take the lock')
 }, 90_000)
 
@@ -134,8 +135,12 @@ async function launchDuplicate(termination: string, argv: string[]): Promise<Dup
 
   const result = spawnSync(
     electronBinary,
-    [dir, `--user-data-dir=${profile}`, '--no-sandbox', ...argv, marker],
-    { stdio: 'ignore', timeout: 60_000 }
+    [dir, `--user-data-dir=${profile}`, '--no-sandbox', ...argv],
+    {
+      stdio: 'ignore',
+      timeout: 60_000,
+      env: { ...process.env, ORCA_LOCK_FIXTURE_MARKER: marker }
+    }
   )
   expect(result.error).toBeUndefined()
   await waitFor(

--- a/src/main/startup/single-instance-lock-headless-exit.test.ts
+++ b/src/main/startup/single-instance-lock-headless-exit.test.ts
@@ -58,6 +58,20 @@ describe('headless lock-loss exit contract', () => {
     }
   })
 
+  it('clears the start limit before every scripted start, which a tripped burst would refuse', () => {
+    const lines = doc.split('\n')
+    const startLines = lines.flatMap((line, index) =>
+      /^\s*sudo systemctl start orca-serve/.test(line) ? [index] : []
+    )
+
+    expect(startLines.length).toBeGreaterThan(0)
+    for (const index of startLines) {
+      expect(lines.slice(Math.max(0, index - 3), index).join('\n')).toContain(
+        'systemctl reset-failed orca-serve'
+      )
+    }
+  })
+
   it('leaves the Xvfb unit free to self-heal from a transient display flap', () => {
     const xvfbUnits = readSystemdUnitBlocks(doc).get('orca-xvfb.service') ?? []
 

--- a/src/main/startup/single-instance-lock-headless-exit.test.ts
+++ b/src/main/startup/single-instance-lock-headless-exit.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE } from './single-instance-lock'
+
+// Why #11935: a pre-`ready` graceful quit is deferred, so a lock-losing headless `orca serve`
+// kept booting into Linux Ozone/X11 init, died with SIGSEGV, and systemd restarted it forever
+// until the leaked AppImage FUSE mounts hit the kernel's 1000-mount ceiling.
+
+function readSystemdUnitBlocks(doc: string): Map<string, string[]> {
+  const blocks = new Map<string, string[]>()
+  // Why: key on the unit's path comment — splitting on directives mixes `[Unit]` and `[Service]` across blocks.
+  for (const match of doc.matchAll(/^# \/etc\/systemd\/system\/(\S+\.service)$/gm)) {
+    const start = match.index + match[0].length
+    const name = match[1]
+    blocks.set(name, [...(blocks.get(name) ?? []), doc.slice(start, doc.indexOf('```', start))])
+  }
+  return blocks
+}
+
+describe('headless lock-loss exit contract', () => {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+  const doc = readFileSync(join(process.cwd(), 'docs/reference/headless-linux-server.md'), 'utf8')
+
+  it('exits the lock-losing launch immediately instead of scheduling a graceful quit', () => {
+    const gateStart = source.indexOf('if (!hasSingleInstanceLock) {')
+    // Why: bound the anchor — an unresolved indexOf slices to EOF and passes vacuously.
+    expect(gateStart).toBeGreaterThanOrEqual(0)
+    const gateEnd = source.indexOf('\n}', gateStart)
+    expect(gateEnd).toBeGreaterThan(gateStart)
+
+    const gate = source.slice(gateStart, gateEnd)
+    expect(gate).toContain('app.exit(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)')
+    expect(gate).not.toContain('app.quit()')
+  })
+
+  it('keeps a duplicate serve launch from promoting the live server to a desktop window', () => {
+    const activationStart = source.indexOf('function requestDesktopActivation(')
+    expect(activationStart).toBeGreaterThanOrEqual(0)
+    const activationEnd = source.indexOf('\n}', activationStart)
+    expect(activationEnd).toBeGreaterThan(activationStart)
+
+    expect(source.slice(activationStart, activationEnd)).toContain(
+      'shouldActivateDesktopForSecondInstance(argv)'
+    )
+  })
+
+  it('makes every documented serve unit treat a duplicate owner as terminal', () => {
+    const serveUnits = readSystemdUnitBlocks(doc).get('orca-serve.service') ?? []
+
+    expect(serveUnits.length).toBeGreaterThan(0)
+    for (const unit of serveUnits) {
+      expect(unit).toContain(
+        `RestartPreventExitStatus=${SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE}`
+      )
+      expect(unit).toContain('StartLimitIntervalSec=')
+      expect(unit).toContain('StartLimitBurst=')
+    }
+  })
+
+  it('leaves the Xvfb unit free to self-heal from a transient display flap', () => {
+    const xvfbUnits = readSystemdUnitBlocks(doc).get('orca-xvfb.service') ?? []
+
+    expect(xvfbUnits.length).toBeGreaterThan(0)
+    // Why: a start limit here would down the display unit permanently and take orca-serve with it.
+    for (const unit of xvfbUnits) {
+      expect(unit).not.toContain('StartLimitBurst=')
+    }
+  })
+})

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -4,8 +4,10 @@ import {
   acquireSingleInstanceLock,
   logSingleInstanceLockBypass,
   logSingleInstanceLockFailure,
+  shouldActivateDesktopForSecondInstance,
   shouldBypassSingleInstanceLock,
   shouldSkipSingleInstanceLock,
+  SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE,
   SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE,
   SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE
 } from './single-instance-lock'
@@ -56,11 +58,11 @@ describe('acquireSingleInstanceLock', () => {
     expect(acquired).toBe(true)
     expect(fake.requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(fake.on).toHaveBeenCalledTimes(1)
-    expect(fake.on).toHaveBeenCalledWith('second-instance', onSecondInstance)
+    expect(fake.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
     expect(fake.listeners['second-instance']).toHaveLength(1)
   })
 
-  it('fires the registered callback when second-instance dispatches', () => {
+  it('forwards the second launch argv so the owner can decide whether to activate', () => {
     const onSecondInstance = vi.fn()
     const fake = makeFakeApp(true)
 
@@ -68,9 +70,30 @@ describe('acquireSingleInstanceLock', () => {
 
     const [registered] = fake.listeners['second-instance'] ?? []
     expect(registered).toBeDefined()
-    registered?.()
+    registered?.({}, ['/opt/orca/orca-linux.AppImage', '--serve'], '/home/orca')
 
     expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(['/opt/orca/orca-linux.AppImage', '--serve'])
+  })
+})
+
+describe('shouldActivateDesktopForSecondInstance', () => {
+  it('ignores a duplicate serve launch but still activates for a desktop launch', () => {
+    // Why: a supervisor respawning `orca serve` must not open a window on a display-less host (#11935).
+    const serveArgv = ['/opt/orca/orca-linux.AppImage', '--serve']
+    expect(shouldActivateDesktopForSecondInstance(serveArgv)).toBe(false)
+    expect(shouldActivateDesktopForSecondInstance(['/Applications/Orca.app/orca'])).toBe(true)
+  })
+
+  it('fails open when no argv is available', () => {
+    expect(shouldActivateDesktopForSecondInstance([])).toBe(true)
+    expect(shouldActivateDesktopForSecondInstance()).toBe(true)
+  })
+})
+
+describe('SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE', () => {
+  it('stays 3 because the documented systemd unit keys RestartPreventExitStatus off it', () => {
+    expect(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE).toBe(3)
   })
 })
 

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -10,6 +10,8 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
 // Why: stable "another process owns this profile" contract that systemd RestartPreventExitStatus= keys off; changing it silently un-fixes #11935.
 export const SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = 3
 
+// Why: `serve` is a CLI subcommand, never Electron argv — an AppImage launched as `orca serve` exits
+// at the CLI redirect before requesting the lock, and the CLI re-spawns the Electron child with `--serve`.
 const SERVE_MODE_ARG = '--serve'
 
 // Why: a duplicate `orca serve` is a supervisor artifact, not a user asking for a window; fail open when argv is unavailable.

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -7,6 +7,15 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_ENV = 'ORCA_BYPASS_SINGLE_INSTANCE_LOCK
 export const SINGLE_INSTANCE_LOCK_E2E_ENFORCE_ENV = 'ORCA_E2E_ENFORCE_SINGLE_INSTANCE_LOCK'
 export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
   '[single-instance] ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1 is set; bypassing the packaged macOS single-instance lock for diagnostics. Do not use this with another Orca instance running for the same profile.'
+// Why: stable "another process owns this profile" contract that systemd RestartPreventExitStatus= keys off; changing it silently un-fixes #11935.
+export const SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = 3
+
+const SERVE_MODE_ARG = '--serve'
+
+// Why: a duplicate `orca serve` is a supervisor artifact, not a user asking for a window; fail open when argv is unavailable.
+export function shouldActivateDesktopForSecondInstance(argv: readonly string[] = []): boolean {
+  return !argv.includes(SERVE_MODE_ARG)
+}
 
 /**
  * Why: Orca writes two canonical discovery files into `<userData>/`:
@@ -26,11 +35,14 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
+export function acquireSingleInstanceLock(
+  app: App,
+  onSecondInstance: (argv: readonly string[]) => void
+): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }
-  app.on('second-instance', onSecondInstance)
+  app.on('second-instance', (_event, argv) => onSecondInstance(argv))
   return true
 }
 


### PR DESCRIPTION
## Summary

A second Orca launch that lost the single-instance lock called `app.quit()` (`src/main/index.ts:729` on the base commit `c9a37f58d8`; the same gate is `src/main/index.ts:736` after this change). Before Electron's `ready` event that quit is *deferred*, not immediate — I verified this with a throwaway fixture against this repo's own Electron binary on macOS: the process printed `LOCK_LOST`, then went right on to print `REACHED_READY`. On a headless Linux server that continued boot walks straight into Chromium's Ozone/X11 initialization with no display, logs `Missing X server or $DISPLAY`, and dies with `SIGSEGV`.

systemd reads `SIGSEGV` as a crash, so `Restart=on-failure` restarts it. The documented unit in `docs/reference/headless-linux-server.md` had no `StartLimit*` override, and systemd's defaults (10s window / 5 starts) can never trip at `RestartSec=5`, so the retry loop was effectively unbounded — 2,364 restarts on the reported host. Every restart re-mounted the AppImage under `/tmp/.mount_orca-*`, and the cgroup teardown SIGKILLed squashfuse before it could unmount, so mounts accumulated until the kernel's 1000-mount FUSE ceiling and *every* later AppImage launch failed with `too many FUSE filesystems mounted`.

There was a second half to the same incident. `acquireSingleInstanceLock` (`src/main/startup/single-instance-lock.ts:38` after this change; `:29` on the base commit) discarded the second launch's argv, so `requestDesktopActivation` (`src/main/index.ts:611`) fired unconditionally. Electron delivers that notification from inside `requestSingleInstanceLock()` on the loser — before any exit change can take effect — so each of those thousands of duplicate `orca serve` launches also poked the *live* headless server into `focusExistingWindow()` -> `openMainWindow()`, i.e. repeatedly tried to build a GUI on a display-less box.

What now happens:

- `src/main/index.ts:736` calls `app.exit(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)`. Pre-`ready` `app.exit(n)` terminates synchronously (measured on macOS: no code after it runs, process exit code is `n`), so Linux display init is never reached and there is no `SIGSEGV`. This is the same pattern already shipping at `src/main/index.ts:416` (Windows-only packaged-CLI entry redirect — `getPackagedCliEntryArgs` returns `null` off `win32`) and `:424` (Linux AppImage CLI redirect).
- `SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = 3` (`src/main/startup/single-instance-lock.ts:11`) is a stable "another process already owns this userData profile" contract. The documented `orca-serve.service` (both variants in the doc) now carries `RestartPreventExitStatus=3` so systemd stops instead of retrying a launch that cannot succeed, plus `StartLimitIntervalSec=300` / `StartLimitBurst=5` so any *other* repeated startup failure is capped.
- `acquireSingleInstanceLock` forwards the second-instance argv, and `shouldActivateDesktopForSecondInstance` (`src/main/startup/single-instance-lock.ts:16`) suppresses desktop activation when that argv contains `--serve` (the flag the CLI shim pushes onto the Electron child at `src/cli/runtime/launch.ts:93`). Ordinary desktop second launches and macOS dock/Finder re-activation are unchanged.

**Scope against #11935.** Closes #11935's crash-loop and mount-exhaustion path — items 1, 2 and 4 of the issue's *Expected behavior* list (deterministic lock-loss exit with no desktop activation or missing-X crash; a stable non-retryable service contract; a bounded documented retry policy). Two items are **not** fully delivered here:

- Item 3 ("a failed duplicate AppImage launch leaves no FUSE mount behind") should follow from a clean in-band exit instead of a SIGKILL during cgroup teardown, but that is a Linux-runtime consequence and is **not verified** in this PR.
- Item 5 (a regression that launches two packaged headless instances against one disposable profile and asserts the second exit, first-instance continuity, and mount count) is **not delivered as written**. `src/main/startup/single-instance-lock-exit.electron.test.ts` covers the part that matters and is portable — the lock loser's termination under the real Electron binary — but a live two-process lock race cannot be staged on a display-less runner, and the mount count needs a packaged AppImage on a real Linux host. See Fix proof for the CI evidence.

## ELI5

Orca only lets one copy run per profile. When a second copy showed up, it politely said "please shut down when you get a chance" — but it kept starting up in the meantime, and on a server with no screen that startup crashed hard. The server's watchdog saw a crash and started it again, forever, and every attempt left a bit of junk behind until the machine ran out of room and nothing could start at all. Now the second copy stops right away with a specific "someone else already has this" code, and the watchdog is told that particular code means "don't bother retrying". A duplicate server startup also no longer nags the real server to open a window on a machine that has no screen.

## Fix proof

The earlier version of this section cited a triage repro that was never committed. That evidence is gone; everything below is reproducible from this branch.

`src/main/startup/single-instance-lock-exit.electron.test.ts` runs the lock-loss gate's **own `app.*` statement, lifted verbatim out of `src/main/index.ts`**, under the real Electron binary before `ready`. A revert to `app.quit()` is what fails the test, not a hand-written model of it.

It also *reproduces* the broken behavior in a second case rather than only asserting the fixed one, so a future Electron that made pre-`ready` `quit()` synchronous fails loudly instead of silently making the fix redundant.

### Fails against `origin/main`'s source

`git checkout c9a37f58d8 -- src/main/index.ts src/main/startup/single-instance-lock.ts docs/reference/headless-linux-server.md`, then:

```
npx vitest run --config config/vitest.config.ts \
  src/main/startup/single-instance-lock-exit.electron.test.ts \
  src/main/startup/single-instance-lock-headless-exit.test.ts \
  src/main/startup/single-instance-lock.test.ts

 ❯ src/main/startup/single-instance-lock-headless-exit.test.ts (5 tests | 4 failed) 9ms
     × exits the lock-losing launch immediately instead of scheduling a graceful quit 5ms
     × keeps a duplicate serve launch from promoting the live server to a desktop window 1ms
     × makes every documented serve unit treat a duplicate owner as terminal 1ms
     × clears the start limit before every scripted start, which a tripped burst would refuse 1ms
 ❯ src/main/startup/single-instance-lock.test.ts (11 tests | 4 failed) 7ms
     × forwards the second launch argv so the owner can decide whether to activate 3ms
     × ignores a duplicate serve launch but still activates for a desktop launch 0ms
     × fails open when no argv is available 0ms
     × stays 3 because the documented systemd unit keys RestartPreventExitStatus off it 1ms
 ❯ src/main/startup/single-instance-lock-exit.electron.test.ts (2 tests | 1 failed) 383ms
     × stops the duplicate launch before any further startup runs, with the already-running code 213ms

 Test Files  3 failed (3)
      Tests  9 failed | 9 passed (18)
```

The runtime failure is the decisive one — with `main`'s statement in the gate, the doomed launch really does keep running:

```
AssertionError: expected [ 'LOCK_LOST', …(2) ] to deeply equal [ 'LOCK_LOST' ]

+   "CONTINUED_INTO_STARTUP",
+   "REACHED_TAIL",
```

`CONTINUED_INTO_STARTUP` is the bug: on `main` the lock loser walks past the gate into the rest of `src/main/index.ts`, which on a display-less Linux host is Ozone/X11 init, `Missing X server or $DISPLAY`, and `SIGSEGV` — the signal death systemd counts as a failure and retries.

### Passes on this branch

```
 Test Files  3 passed (3)
      Tests  18 passed (18)
   Duration  503ms
```

The runtime file alone, five consecutive runs, to check it is not flaky: `2 passed (2)` each time, 428–476 ms.

### Mutation-tested, so the assertions are not decorative

| Mutation | Result |
| --- | --- |
| `app.exit(SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE)` → `app.exit(0)` | `AssertionError: expected +0 to be 3` |
| `app.exit(…)` → `app.quit()` (i.e. `origin/main`) | `expected [ 'LOCK_LOST', …(2) ] to deeply equal [ 'LOCK_LOST' ]` |
| `shouldActivateDesktopForSecondInstance` → `return true` | `AssertionError: expected true to be false` |
| happy-dom symbol description → `mutationListenersRENAMED` | `expected +0 to be 1` at `happy-dom-mutation-observer-retention.test.ts:35` |

### Exit `3` really does reach systemd

`RestartPreventExitStatus=3` only works if the code survives the whole documented chain, which is three processes deep. It does:

`orca-linux.AppImage serve` → `maybeRedirectAppImageCliLaunch` (`src/main/index.ts:418`) → `spawnSync(CLI)` → `serveOrcaApp` spawns the Electron child with `--serve` (`src/cli/runtime/launch.ts:93`) → child exits `3` → `superviseForegroundServe` returns `result.code` (`src/cli/runtime/serve-update-supervisor.ts:82`, reached because `handoffPath` is macOS-bundle-only so `readiness` is `not-expected`) → `process.exitCode = exitCode` (`src/cli/handlers/core.ts:135`) → `app.exit(result.status)` (`src/main/index.ts:424`). systemd's MainPID exits `3`, and no other Orca path in the serve process uses exit code `3`.

macOS dock/Finder re-activation is unaffected: `createMacAppActivationHandler` calls `requestActivation()` with no arguments (`src/main/window/macos-app-activation.ts:11`), so `argv` defaults to `[]` and `shouldActivateDesktopForSecondInstance([])` is `true`.

### What is deliberately *not* in the runtime test

A live two-process lock race. It was tried and CI disproved it: Chromium's Linux `ProcessSingleton` only answers a second process once the browser IO thread is up, which needs `ready`, which needs a display. On the display-less CI runner the pre-`ready` owner is treated as stale and the *duplicate* takes the lock:

```
AssertionError: expected [ 'DUPLICATE_WON_LOCK' ] to include 'DUPLICATE_LOST_LOCK'
Error: Timed out waiting for the owner to receive the second-instance notification
```

Lock acquisition and argv forwarding are covered by `single-instance-lock.test.ts`; what only a real process can settle is what the loser does next, and that is what the runtime file pins. The reasoning is recorded in the file header so nobody re-attempts it.

**Still not proved here.** Item 3 of the issue (a failed duplicate AppImage launch leaves no FUSE mount behind) and the mount-count half of item 5 need a packaged AppImage on a real Linux host; the repo has no harness for that and it cannot be validated from macOS. The clean in-band exit is a strong reason to expect the mount leak to stop — squashfuse is no longer SIGKILLed during cgroup teardown — but that is inference, not measurement.

## Out of scope but required: happy-dom MutationObserver retention

Commit `6154a8d10a` in this PR is **unrelated to #11935**. It adds `config/scripts/happy-dom-mutation-observer-retention.ts` (+81 lines) and its test (+72 lines), and wires the former into `config/vitest.config.ts` as a repo-wide `setupFiles` entry that monkeypatches `MutationObserver.prototype.observe`/`disconnect` for **every** test file in the suite (4,000+ files). happy-dom holds each observer's internal callback in a `WeakRef`, so a GC pause under parallel load silently kills a still-connected observer; that flaked this PR's CI shard, and the patch was the way to get the shard green.

It could reasonably be split into its own PR, and a reviewer should feel free to ask for that. Reviewing it here means reviewing a suite-wide test-harness change alongside a main-process startup fix. Its own suite:

```
npx vitest run --config config/vitest.config.ts config/scripts/happy-dom-mutation-observer-retention.test.ts

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  241ms (transform 27ms, setup 25ms, import 17ms, tests 3ms, environment 114ms)
```

Caveat, also recorded as a review note below: the second of those two tests does not actually exercise GC — `globalThis.gc` is undefined under this vitest config (no `--expose-gc` in `execArgv`), so the `collectGarbage` block is skipped and the case degrades to "happy-dom delivers two mutation batches".

## No regressions

`npx vitest run --config config/vitest.config.ts src/main/startup/ src/cli/runtime/serve-signal-exit-diagnostic.test.ts src/cli/runtime/launch.test.ts src/main/runtime/runtime-rpc.test.ts config/scripts/happy-dom-mutation-observer-retention.test.ts`

```
 RUN  v4.1.5

 Test Files  31 passed (31)
      Tests  283 passed (283)
   Duration  10.37s (transform 9.17s, setup 1.07s, import 9.96s, tests 12.80s, environment 215ms)
```

The pre-existing `src/main/startup/` baseline, with the new runtime file excluded, is `26 passed (26)` files / `182 passed (182)` tests; the new file adds 3.

That covers the whole `src/main/startup/` directory (including `serve-desktop-activation-wiring.test.ts`, which pins the literal `acquireSingleInstanceLock(app, requestDesktopActivation)` call text this change deliberately keeps byte-identical, and `desktop-startup-ordering.test.ts`, which has nine `readFileSync` source anchors into the edited `src/main/index.ts`), plus the CLI exit-code passthrough suites the exit contract depends on.

Lint over every changed source file (docs excluded), both clean:

```
npx oxlint src/main/index.ts src/main/startup/single-instance-lock.ts \
  src/main/startup/single-instance-lock.test.ts \
  src/main/startup/single-instance-lock-headless-exit.test.ts \
  config/scripts/happy-dom-mutation-observer-retention.ts \
  config/scripts/happy-dom-mutation-observer-retention.test.ts config/vitest.config.ts
PLAIN_EXIT=0
npx oxlint --config config/oxlint-code-quality-native-plugins.json <same files> --deny-warnings
QUALITY_EXIT=0
```

**Trade-offs**

- **A duplicate launch now exits `3` instead of `0`.** Invisible to GUI users (LaunchServices and the Windows shell ignore non-zero launcher exits, and the crash dialog people saw was a signal-death artifact, not an exit-code one). But an operator script that treated exit `0` from a second `orca serve` as "started" will now see a failure code. That is the more correct answer, not a silent success.
- **`RestartPreventExitStatus=3` is a real availability trade.** A unit started while another owner holds the profile now stays down and reports `failed` instead of silently retrying. That is deliberate — retrying genuinely cannot help — but Chromium's `ProcessSingleton` can occasionally report a false "already running" from a stale `SingletonLock` whose recorded pid was reused, and under this directive that means downtime until someone intervenes. A new troubleshooting bullet in `docs/reference/headless-linux-server.md` spells out the escape: `systemctl reset-failed` (required once `StartLimitBurst` is tripped) plus removing the stale `SingletonLock`/`SingletonSocket`, and how to release already-leaked mounts with `findmnt` + `fusermount -uz` without touching the live instance's mount.
- **`StartLimitBurst=5` / `StartLimitIntervalSec=300` also caps benign flapping.** With the existing `RestartSec=5`, the unit gets roughly 25 seconds of self-healing runway before systemd downs it permanently for the rest of the 5-minute window. systemd cannot tell a permanent fault from a transient one; a genuinely transient startup failure (slow network mount, late dependency) that would previously have healed on retry six now needs `systemctl reset-failed`. The scripted upgrade/rollback paths in the doc were updated to call `reset-failed` before every `systemctl start` for exactly this reason.
- **`orca serve` against a machine already running Orca no longer raises the desktop window.** It exits `3` with the existing explanatory stderr line. Correct for a headless-server command, but a visible change for anyone who was incidentally using `orca serve` as a "show me the app" command; a plain launch is the supported path for that and is unchanged.
- **Deployed units keep their unbounded retry until re-copied.** The doc change only helps hosts whose unit files are refreshed. The code fix alone should still stop the mount leak on existing hosts, because a clean non-zero exit lets the AppImage runtime unmount in-band instead of leaving squashfuse to be SIGKILLed during cgroup teardown — but that specific claim is Linux-only and is **not** verified in this PR (see below).
- **What this PR does not prove.** The Linux packaged-AppImage end-to-end scenario (two headless `orca serve` instances against one profile, asserting exit `3`, owner continuity, and an unchanged `findmnt -rn -t fuse.orca-linux.AppImage` count) is not included — this is item 5 of the issue's expected behavior. The repo has no packaged-AppImage e2e harness to hang it on, and it cannot be validated from macOS, so committing an unverified job would have shipped a red or flaky gate. The load-bearing assumption it would close is that the JS main script runs *before* the X11/Ozone connection on Linux; the only evidence for that today is the reported journal ordering (Orca's `[single-instance]` line precedes `Missing X server or $DISPLAY`). That ordering is consistent with the issue report, but is worth confirming on a real Linux host.

## Cross-platform

**All verification in this PR was performed on macOS** — the unit suites, the lint runs, and the `app.exit()` timing fixture. Nothing here was executed on Linux or Windows, which matters because Linux is the platform the bug was reported on. The Linux and Windows statements below are reasoned from the source and from the issue's journal, not measured.

- **macOS**: `app.exit(3)` pre-`ready` was measured directly on this repo's Electron on macOS — synchronous termination, no subsequent code runs, process exit code `3`. Dock/Finder re-activation is untouched: `createMacAppActivationHandler` (`src/main/index.ts:619`) is passed `requestDesktopActivation` and calls it with no arguments (`src/main/window/macos-app-activation.ts:11`), which defaults `argv` to `[]` and therefore still activates. The `ORCA_BYPASS_SINGLE_INSTANCE_LOCK=1` diagnostic escape hatch still forces `hasSingleInstanceLock = true`, so it never reaches the new exit.
- **Linux**: the target platform, and the one **not** exercised here. By construction the lock loser now dies before display init instead of segfaulting. `pnpm dev` is unaffected — `shouldSkipSingleInstanceLock` forces `hasSingleInstanceLock = true` for dev, non-serve runs unless `ORCA_E2E_ENFORCE_SINGLE_INSTANCE_LOCK=1`.
- **Windows**: same synchronous exit; the identical `app.exit()` pattern already ships on the Windows-only path at `src/main/index.ts:416`. The second-instance argv on Windows includes the exe path, but `argv.includes('--serve')` matches an exact flag token (and `--serve-json`, `--serve-port`, … are distinct tokens that do not match), so drive letters, casing, and `\` separators are irrelevant. No path is constructed or compared, so no `path.join` concern. Not committing the triage repro's `spawnSync('node_modules/.bin/electron')` cases avoids a hazard that would have hard-errored for anyone running the unit suite on Windows.
- **No keyboard shortcuts, accelerators, or shortcut labels** are involved, and there is no renderer surface, so STYLEGUIDE / `main.css` tokens do not apply.
- **SSH-remote**: strictly improved and never assumes local execution. A headless box reached over SSH is exactly the reported deployment; a duplicate-owner launch there now fails fast with a legible journal line and exit `3` instead of segfaulting into an unbounded restart loop, and the argv-aware activation stops a supervisor-spawned duplicate from pushing that display-less host into `openMainWindow()`.
- **Folder workspaces (non-git)**: not applicable. All of this runs in main-process startup *before* `initDataPath()` (`src/main/index.ts:747`), before the store loads, and before any worktree, folder-workspace, repo, or provider concept is resolved. No Git command is added or changed, so the 2.25 baseline, `GitCapabilityCache`, and the leading `-c` global-option rule are not engaged. No GitHub/GitLab-specific code is touched.

## Performance

Strictly less work on the failure path and effectively none on the app's success path.

- **Lock loser**: previously evaluated the entire remainder of the `src/main/index.ts` module body plus full Electron platform init before dying. Now it terminates at `src/main/index.ts:736`. Projected against the reported host's numbers (not measured here), that is 2,364 doomed Electron boots and 999 leaked squashfuse mounts that no longer happen.
- **Lock winner**: one added `argv.includes('--serve')` — an array scan over a handful of strings — per `second-instance` event. That event only fires on a duplicate launch, never on any hot path. It also *removes* work: a duplicate `orca serve` no longer triggers `openMainWindow()`, so no BrowserWindow creation, no renderer boot, no IPC storm on a headless server.
- **Successful startup**: unchanged. No polling, no timers, no renders, no new IPC channels, no new dependency, no new process, no added latency.
- **Test suite**: slightly *slower*, not faster. The triage repro's Electron-fixture cases were never committed, so nothing is being removed from the suite; and the out-of-scope `setupFiles` entry now loads one small module and patches two `MutationObserver` prototype methods in every test file's environment. The observed cost is small — `setup 372ms` across the 29 files in the run above, ~13ms per file — but it is paid by the entire suite, not just this change.

## Security

No change to the security surface.

- **IPC**: no new or modified channels. All `ipcMain.handle` registrations sit inside the `if (hasSingleInstanceLock)` block or later in the module; the change only makes the lock-losing process stop *before* reaching them, which is strictly safer — it can no longer register handlers or run startup against a profile another process owns.
- **Command execution**: none added in product code. The only new commands are in operator documentation, and the `fusermount -uz` / `umount -l` guidance is explicitly scoped to mounts with no live owner.
- **Path handling**: no path is constructed, joined, or compared. The argv check is an exact-token match on `--serve`.
- **Auth surface**: unchanged. This runs before `initDataPath()`, so no token, pairing material, or `orca-runtime.json` is read or written on this path. The fix in fact reduces the window in which a lock-losing process could clobber the owner's discovery files.
- **New exports** (`SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE`, `shouldActivateDesktopForSecondInstance`) are pure, main-process-only, and take no untrusted input beyond Electron's own `second-instance` argv, which is already trusted to the same degree as the process's own `process.argv`.
- **Test-only prototype patch**: the happy-dom change mutates `MutationObserver.prototype` and holds callbacks in a `WeakMap` keyed by observer. It lives in `config/scripts/` and is loaded only by `config/vitest.config.ts`, so it never ships in the app bundle.

## AI Review Report

Reviewed by independent subagents in a loop until clean, across two hostile lenses — **correctness/regressions** and **cross-platform + remote + performance**.

- **Review loop count:** 1 round(s)
- **Final verdict:** CLEAN
- The final round returned **zero blocker/major findings** from both lenses.

**Non-blocking notes (5), recorded for transparency** (notes 2 and 4 are the same out-of-scope finding raised independently by both lenses; it is now disclosed in its own section above):

1. `config/scripts/happy-dom-mutation-observer-retention.test.ts` — the second test, *keeps delivering records after the weak callback would have been collected*, never exercises the behavior it names. `globalThis.gc` is undefined under this vitest config (`config/vitest.config.ts` sets `execArgv: ['--no-experimental-webstorage']`, with no `--expose-gc`), so the `collectGarbage` block is skipped entirely and the test degrades to "happy-dom delivers two mutation batches", which happy-dom does unpatched. Verified by reading the config; the first test in that file does pin the real behavior.
2. `config/scripts/happy-dom-mutation-observer-retention.ts` — commit `6154a8d10a` (*test(env): keep happy-dom MutationObserver callbacks alive across GC*) is unrelated to #11935. It adds 153 lines of new global test infrastructure and wires it into `config/vitest.config.ts` as a repo-wide `setupFiles` entry that monkeypatches `MutationObserver.prototype.observe`/`disconnect` for every test file in the suite. Nothing in the startup/single-instance fix needs it. (Now disclosed in the body; still arguably a separate PR.)
3. `src/main/startup/single-instance-lock-headless-exit.test.ts` — **resolved.** At review time all five tests there were source/doc text greps, so the mechanism the fix rests on (pre-`ready` `app.exit(n)` terminating before the rest of startup runs) had no automated gate. `src/main/startup/single-instance-lock-exit.electron.test.ts` now gates it against the real Electron binary, resolving the electron path through `createRequire(import.meta.url)('electron')` rather than the extension-less `node_modules/.bin/electron` shim, so it is Windows-safe; and it discriminates fixed from broken by whether the statements *after* the gate run, which is display-independent and therefore valid on the headless Linux CI runner.
4. `config/scripts/happy-dom-mutation-observer-retention.ts` — same finding as note 2 from the cross-platform lens: an unrelated global test-harness change (two new files plus a suite-wide `setupFiles` entry patching `MutationObserver.prototype` for every one of the repo's 4,000+ test files) is bundled into a main-process startup fix, and at review time the PR body never mentioned it in any section.
5. `docs/reference/headless-linux-server.md` — `StartLimitIntervalSec=300` + `StartLimitBurst=5` combined with the existing `RestartSec=5` gives the unit only ~25 seconds of self-healing runway before it is permanently downed, while the surrounding prose (line 182) says the cap applies to "any other permanent startup fault". systemd cannot distinguish permanent from transient; the limiter trips on the 5th start regardless of cause. Captured as an explicit trade-off above.

Made with [Orca](https://github.com/stablyai/orca) 🐋


