### PR TITLE
Let a timed-out remote terminal pane reconnect when the host session is still alive

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
@@ -368,9 +368,11 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       await vi.advanceTimersByTimeAsync(66_000)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
 
+      const callsBeforeRetry = runtimeCall.mock.calls.length
       // The attach wait is single-shot and the cutoff already settled it; replaying it would spin the banner with no RPC in flight.
       expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
       expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      expect(runtimeCall.mock.calls.length).toBe(callsBeforeRetry)
       transport.destroy?.()
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
@@ -7,6 +7,7 @@ import {
   encodeTerminalStreamJson,
   encodeTerminalStreamText
 } from '../../../../shared/terminal-stream-protocol'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
 
 describe('remote runtime pty reattach after the bounded recovery window', () => {
   const runtimeCall = vi.fn()
@@ -78,7 +79,11 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
     )
   }
 
-  function hostSnapshot(terminal: string, snapshotVersion: number, publicationEpoch: string) {
+  function hostSnapshot(
+    terminal: string,
+    snapshotVersion: number,
+    publicationEpoch: string
+  ): RuntimeMobileSessionTabsResult {
     return {
       worktree: 'wt-1',
       publicationEpoch,
@@ -291,9 +296,8 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
     vi.useFakeTimers()
     try {
       const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
-      const { retryAllRemoteRuntimePtyRecoveriesNow } = await import(
-        './remote-runtime-pty-recovery-state'
-      )
+      const { retryAllRemoteRuntimePtyRecoveriesNow } =
+        await import('./remote-runtime-pty-recovery-state')
       runtimeCall.mockImplementation(async (request: { method: string }) => {
         if (request.method === 'session.tabs.activate') {
           return {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamJson,
+  encodeTerminalStreamFrame,
+  encodeTerminalStreamJson,
+  encodeTerminalStreamText
+} from '../../../../shared/terminal-stream-protocol'
+
+describe('remote runtime pty reattach after the bounded recovery window', () => {
+  const runtimeCall = vi.fn()
+  const runtimeSubscribe = vi.fn()
+  const refreshSessionTabsSnapshot = vi.fn(async () => {})
+  const subscriptionSendBinary = vi.fn()
+  let subscriptionCallbacks: {
+    onResponse: (response: unknown) => void
+    onBinary?: (bytes: Uint8Array<ArrayBufferLike>) => void
+    onError?: (error: { code: string; message: string }) => void
+    onClose?: () => void
+  } | null = null
+  let hostListCalls = 0
+
+  function emitMultiplexReady(): void {
+    subscriptionCallbacks?.onResponse({ ok: true, result: { type: 'ready' } })
+  }
+
+  function latestSubscribePayload(): { streamId: number; terminal: string } {
+    const frame = subscriptionSendBinary.mock.calls
+      .map((call) => decodeTerminalStreamFrame(call[0]))
+      .findLast((candidate) => candidate?.opcode === TerminalStreamOpcode.Subscribe)
+    if (!frame) {
+      throw new Error('missing terminal subscribe frame')
+    }
+    const payload = decodeTerminalStreamJson<{ streamId: number; terminal: string }>(frame.payload)
+    if (!payload) {
+      throw new Error('invalid terminal subscribe payload')
+    }
+    return payload
+  }
+
+  function subscribedTerminalHandles(): string[] {
+    return subscriptionSendBinary.mock.calls
+      .map((call) => decodeTerminalStreamFrame(call[0]))
+      .flatMap((frame) => {
+        if (frame?.opcode !== TerminalStreamOpcode.Subscribe) {
+          return []
+        }
+        const payload = decodeTerminalStreamJson<{ terminal: string }>(frame.payload)
+        return payload ? [payload.terminal] : []
+      })
+  }
+
+  function emitSnapshot(streamId: number, data: string): void {
+    subscriptionCallbacks?.onBinary?.(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.SnapshotStart,
+        streamId,
+        seq: 1,
+        payload: encodeTerminalStreamJson({ kind: 'scrollback' })
+      })
+    )
+    subscriptionCallbacks?.onBinary?.(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.SnapshotChunk,
+        streamId,
+        seq: 2,
+        payload: encodeTerminalStreamText(data)
+      })
+    )
+    subscriptionCallbacks?.onBinary?.(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.SnapshotEnd,
+        streamId,
+        seq: 3,
+        payload: new Uint8Array()
+      })
+    )
+  }
+
+  function hostSnapshot(terminal: string, snapshotVersion: number, publicationEpoch: string) {
+    return {
+      worktree: 'wt-1',
+      publicationEpoch,
+      snapshotVersion,
+      activeGroupId: null,
+      activeTabId: 'tab-1::pane:1',
+      activeTabType: 'terminal' as const,
+      tabs: [
+        {
+          type: 'terminal' as const,
+          id: 'tab-1::pane:1',
+          parentTabId: 'tab-1',
+          leafId: 'pane:1',
+          title: 'Claude Code',
+          isActive: true,
+          status: 'ready',
+          terminal
+        }
+      ]
+    }
+  }
+
+  async function attachStalePane() {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const onPtyExit = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-tab-1',
+      leafId: 'pane:1',
+      onPtyExit,
+      onPtyRebind: vi.fn()
+    })
+    transport.attach({
+      existingPtyId: 'remote:env-1@@terminal-stale',
+      cols: 80,
+      rows: 24,
+      callbacks: { onError }
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+
+    // The host keeps publishing the same live handle, so bounded replacement polling finds
+    // no replacement and stops quietly without retiring the pane.
+    runtimeCall.mockImplementation(async (args: { method: string }) => {
+      if (args.method !== 'session.tabs.list') {
+        return { ok: true, result: {} }
+      }
+      hostListCalls += 1
+      return { ok: true, result: hostSnapshot('terminal-stale', hostListCalls + 1, 'epoch-1') }
+    })
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'error',
+        streamId: latestSubscribePayload().streamId,
+        message: 'terminal_handle_stale'
+      }
+    })
+    return { transport, onError, onPtyExit }
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doUnmock('../../runtime/remote-runtime-terminal-multiplexer')
+    vi.doMock('@/runtime/web-runtime-session', () => ({
+      refreshWebRuntimeSessionTabsSnapshot: refreshSessionTabsSnapshot
+    }))
+    vi.clearAllMocks()
+    subscriptionCallbacks = null
+    hostListCalls = 0
+    subscriptionSendBinary.mockReset()
+    runtimeCall.mockImplementation(async (request: { method: string; params?: unknown }) => {
+      if (request.method === 'session.tabs.activate') {
+        return { ok: true, result: hostSnapshot('terminal-stale', 1, 'epoch-1') }
+      }
+      if (request.method === 'terminal.resolvePane') {
+        const params = request.params as { paneKey: string; worktreeId: string }
+        const separator = params.paneKey.indexOf(':')
+        return {
+          ok: true,
+          result: {
+            terminal: {
+              handle: 'terminal-stale',
+              tabId: params.paneKey.slice(0, separator),
+              leafId: params.paneKey.slice(separator + 1),
+              worktreeId: params.worktreeId
+            }
+          }
+        }
+      }
+      return { ok: true, result: { terminal: { handle: 'terminal-stale' } } }
+    })
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: typeof subscriptionCallbacks) => {
+        subscriptionCallbacks = callbacks
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall, subscribe: runtimeSubscribe } }
+    })
+  })
+
+  it('reattaches from a rotated host handle published after the recovery cutoff', async () => {
+    vi.useFakeTimers()
+    try {
+      const { transport, onPtyExit } = await attachStalePane()
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+
+      await vi.advanceTimersByTimeAsync(16_000)
+      expect(handleEvents.getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
+      expect(transport.getRecoveryState?.().phase).not.toBe('disconnected')
+
+      await vi.advanceTimersByTimeAsync(50_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      // The cutoff must not tear down the accepted-snapshot listener; it is the only path back.
+      expect(handleEvents.getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
+
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        hostSnapshot('terminal-after-timeout', 3, 'epoch-2'),
+        'env-1'
+      )
+      await vi.waitFor(() =>
+        expect(latestSubscribePayload()).toMatchObject({ terminal: 'terminal-after-timeout' })
+      )
+
+      emitSnapshot(latestSubscribePayload().streamId, 'reattached')
+      expect(transport.isConnected()).toBe(true)
+      expect(transport.getPtyId()).toBe('remote:env-1@@terminal-after-timeout')
+      expect(onPtyExit).not.toHaveBeenCalled()
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reattaches when the post-cutoff snapshot republishes the same live handle', async () => {
+    vi.useFakeTimers()
+    try {
+      const { transport, onError } = await attachStalePane()
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      const listCallsAtCutoff = hostListCalls
+
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        hostSnapshot('terminal-stale', 3, 'epoch-2'),
+        'env-1'
+      )
+      await vi.waitFor(() => expect(subscribedTerminalHandles()).toHaveLength(2))
+
+      expect(subscribedTerminalHandles()).toEqual(['terminal-stale', 'terminal-stale'])
+      // The snapshot is already-received host evidence; reattaching must cost no inventory RPC.
+      expect(hostListCalls).toBe(listCallsAtCutoff)
+      emitSnapshot(latestSubscribePayload().streamId, 'reattached')
+      expect(transport.isConnected()).toBe(true)
+      expect(onError).not.toHaveBeenCalled()
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a same-handle snapshot while automatic recovery is still running', async () => {
+    vi.useFakeTimers()
+    try {
+      const { transport } = await attachStalePane()
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+
+      await vi.advanceTimersByTimeAsync(16_000)
+      expect(transport.getRecoveryState?.().phase).not.toBe('disconnected')
+
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        hostSnapshot('terminal-stale', 3, 'epoch-2'),
+        'env-1'
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      expect(subscribedTerminalHandles()).toEqual(['terminal-stale'])
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('lets Reconnect poll again once a require-replacement wait outlives its own epoch', async () => {
+    vi.useFakeTimers()
+    try {
+      const { transport } = await attachStalePane()
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      expect(handleEvents.getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
+      const listCallsAtCutoff = hostListCalls
+
+      expect(transport.retryRecovery?.()).toBe(true)
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      expect(hostListCalls).toBeGreaterThan(listCallsAtCutoff)
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
@@ -286,4 +286,49 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
       vi.useRealTimers()
     }
   })
+
+  it('leaves Reconnect available when online fires on a pane latched during the attach wait', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const { retryAllRemoteRuntimePtyRecoveriesNow } = await import(
+        './remote-runtime-pty-recovery-state'
+      )
+      runtimeCall.mockImplementation(async (request: { method: string }) => {
+        if (request.method === 'session.tabs.activate') {
+          return {
+            ok: false,
+            error: {
+              code: 'remote_runtime_unavailable',
+              message: 'Remote Orca runtime connection closed'
+            }
+          }
+        }
+        return { ok: true, result: {} }
+      })
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-tab-1',
+        leafId: 'pane:1',
+        onPtyExit: vi.fn(),
+        onPtyRebind: vi.fn()
+      })
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-stale',
+        cols: 80,
+        rows: 24,
+        callbacks: { onError: vi.fn() }
+      })
+
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+
+      // The attach wait is single-shot and the cutoff already settled it; replaying it would spin the banner with no RPC in flight.
+      expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts
@@ -271,10 +271,10 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
     }
   })
 
-  it('lets Reconnect poll again once a require-replacement wait outlives its own epoch', async () => {
+  it('reattaches from a same-handle snapshot delivered inside the Reconnect window', async () => {
     vi.useFakeTimers()
     try {
-      const { transport } = await attachStalePane()
+      const { transport, onError } = await attachStalePane()
       const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
 
       await vi.advanceTimersByTimeAsync(66_000)
@@ -284,8 +284,49 @@ describe('remote runtime pty reattach after the bounded recovery window', () => 
 
       expect(transport.retryRecovery?.()).toBe(true)
       await vi.advanceTimersByTimeAsync(1_000)
-
       expect(hostListCalls).toBeGreaterThan(listCallsAtCutoff)
+
+      // Reconnect must not disarm the only path back: the click opens a window, it does not spend one.
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        hostSnapshot('terminal-stale', 4, 'epoch-3'),
+        'env-1'
+      )
+      await vi.waitFor(() => expect(subscribedTerminalHandles()).toHaveLength(2))
+
+      emitSnapshot(latestSubscribePayload().streamId, 'reattached')
+      expect(transport.isConnected()).toBe(true)
+      expect(onError).not.toHaveBeenCalled()
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('revives a latched require-replacement pane when online or system resume fires', async () => {
+    vi.useFakeTimers()
+    try {
+      const { transport, onError } = await attachStalePane()
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+      const { retryAllRemoteRuntimePtyRecoveriesNow } =
+        await import('./remote-runtime-pty-recovery-state')
+
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      const listCallsAtCutoff = hostListCalls
+
+      expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(1)
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(hostListCalls).toBeGreaterThan(listCallsAtCutoff)
+
+      handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+        hostSnapshot('terminal-stale', 4, 'epoch-3'),
+        'env-1'
+      )
+      await vi.waitFor(() => expect(subscribedTerminalHandles()).toHaveLength(2))
+
+      emitSnapshot(latestSubscribePayload().streamId, 'reattached')
+      expect(transport.isConnected()).toBe(true)
+      expect(onError).not.toHaveBeenCalled()
       transport.destroy?.()
     } finally {
       vi.useRealTimers()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-latched-pane-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-latched-pane-retention.test.ts
@@ -1,0 +1,358 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamJson
+} from '../../../../shared/terminal-stream-protocol'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+
+// Why: the recovery cutoff no longer tears down the retry registry entry or the accepted-snapshot
+// listener, so those two module-global collections are the only places a latched pane can accumulate.
+describe('remote runtime pty latched-pane retention', () => {
+  const runtimeCall = vi.fn()
+  const runtimeSubscribe = vi.fn()
+  const refreshSessionTabsSnapshot = vi.fn(async () => {})
+  const subscriptionSendBinary = vi.fn()
+  let subscriptionCallbacks: {
+    onResponse: (response: unknown) => void
+    onBinary?: (bytes: Uint8Array<ArrayBufferLike>) => void
+    onError?: (error: { code: string; message: string }) => void
+    onClose?: () => void
+  } | null = null
+  let hostListCalls = 0
+
+  function emitMultiplexReady(): void {
+    subscriptionCallbacks?.onResponse({ ok: true, result: { type: 'ready' } })
+  }
+
+  function latestSubscribePayload(): { streamId: number; terminal: string } {
+    const frame = subscriptionSendBinary.mock.calls
+      .map((call) => decodeTerminalStreamFrame(call[0]))
+      .findLast((candidate) => candidate?.opcode === TerminalStreamOpcode.Subscribe)
+    if (!frame) {
+      throw new Error('missing terminal subscribe frame')
+    }
+    const payload = decodeTerminalStreamJson<{ streamId: number; terminal: string }>(frame.payload)
+    if (!payload) {
+      throw new Error('invalid terminal subscribe payload')
+    }
+    return payload
+  }
+
+  function subscribeFrameCount(): number {
+    return subscriptionSendBinary.mock.calls
+      .map((call) => decodeTerminalStreamFrame(call[0]))
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.Subscribe).length
+  }
+
+  // Why: every pane needs its own host surface, otherwise a later pane reuses the earlier pane's
+  // multiplexed stream and never enters recovery at all.
+  const paneIdentity = (pane: number) => ({
+    hostTabId: `tab-${pane}`,
+    tabId: `web-terminal-tab-${pane}`,
+    leafId: `pane:${pane}`,
+    handle: `terminal-stale-${pane}`
+  })
+
+  const PANE_COUNT = 24
+
+  // Why: one payload carries every pane's surface, matching the real per-worktree session.tabs
+  // response that any polling pane receives.
+  function hostSnapshot(
+    snapshotVersion: number,
+    publicationEpoch: string
+  ): RuntimeMobileSessionTabsResult {
+    return {
+      worktree: 'wt-1',
+      publicationEpoch,
+      snapshotVersion,
+      activeGroupId: null,
+      activeTabId: `${paneIdentity(0).hostTabId}::${paneIdentity(0).leafId}`,
+      activeTabType: 'terminal' as const,
+      tabs: Array.from({ length: PANE_COUNT }, (_unused, pane) => {
+        const identity = paneIdentity(pane)
+        return {
+          type: 'terminal' as const,
+          id: `${identity.hostTabId}::${identity.leafId}`,
+          parentTabId: identity.hostTabId,
+          leafId: identity.leafId,
+          title: 'Claude Code',
+          isActive: pane === 0,
+          status: 'ready' as const,
+          terminal: identity.handle
+        }
+      })
+    }
+  }
+
+  async function attachStalePane(pane: number) {
+    const identity = paneIdentity(pane)
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: identity.tabId,
+      leafId: identity.leafId,
+      onPtyExit: vi.fn(),
+      onPtyRebind: vi.fn()
+    })
+    const subscribesBefore = subscribeFrameCount()
+    transport.attach({
+      existingPtyId: `remote:env-1@@${identity.handle}`,
+      cols: 80,
+      rows: 24,
+      callbacks: { onError: vi.fn() }
+    })
+    await vi.waitFor(() => expect(subscribeFrameCount()).toBeGreaterThan(subscribesBefore))
+
+    // The host keeps publishing the same live handle, so bounded replacement polling finds no
+    // replacement and stops quietly: the exact shape that leaves the pane latched but revivable.
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'error',
+        streamId: latestSubscribePayload().streamId,
+        message: 'terminal_handle_stale'
+      }
+    })
+    return transport
+  }
+
+  async function registries() {
+    const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+    const recoveryState = await import('./remote-runtime-pty-recovery-state')
+    return {
+      subscribers: handleEvents.getWebSessionTerminalHandleSubscriberCountForTests(),
+      scheduled: recoveryState.getScheduledRemoteRuntimePtyRecoveryCountForTests()
+    }
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doUnmock('../../runtime/remote-runtime-terminal-multiplexer')
+    vi.doMock('@/runtime/web-runtime-session', () => ({
+      refreshWebRuntimeSessionTabsSnapshot: refreshSessionTabsSnapshot
+    }))
+    vi.clearAllMocks()
+    subscriptionCallbacks = null
+    hostListCalls = 0
+    subscriptionSendBinary.mockReset()
+    runtimeCall.mockImplementation(async (request: { method: string; params?: unknown }) => {
+      if (request.method === 'session.tabs.list') {
+        hostListCalls += 1
+        return { ok: true, result: hostSnapshot(hostListCalls + 1, 'epoch-1') }
+      }
+      if (request.method === 'session.tabs.activate') {
+        return { ok: true, result: hostSnapshot(1, 'epoch-1') }
+      }
+      if (request.method === 'terminal.resolvePane') {
+        const params = request.params as { paneKey: string; worktreeId: string }
+        const separator = params.paneKey.indexOf(':')
+        const paneTabId = params.paneKey.slice(0, separator)
+        const pane = Number(paneTabId.slice(paneTabId.lastIndexOf('-') + 1))
+        return {
+          ok: true,
+          result: {
+            terminal: {
+              handle: paneIdentity(pane).handle,
+              tabId: paneTabId,
+              leafId: params.paneKey.slice(separator + 1),
+              worktreeId: params.worktreeId
+            }
+          }
+        }
+      }
+      return { ok: true, result: {} }
+    })
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: typeof subscriptionCallbacks) => {
+        subscriptionCallbacks = callbacks
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall, subscribe: runtimeSubscribe } }
+    })
+  })
+
+  it('returns listener and retry-registry counts to baseline across destroy cycles', async () => {
+    vi.useFakeTimers()
+    try {
+      expect(await registries()).toEqual({ subscribers: 0, scheduled: 0 })
+      const latched: { subscribers: number; scheduled: number }[] = []
+      const settled: { subscribers: number; scheduled: number }[] = []
+
+      for (let cycle = 0; cycle < 20; cycle += 1) {
+        const transport = await attachStalePane(cycle)
+        await vi.advanceTimersByTimeAsync(66_000)
+        expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+        latched.push(await registries())
+        transport.destroy?.()
+        await vi.advanceTimersByTimeAsync(1_000)
+        settled.push(await registries())
+      }
+
+      // A latched pane deliberately holds exactly one listener and one registry entry...
+      expect(latched).toEqual(Array.from({ length: 20 }, () => ({ subscribers: 1, scheduled: 1 })))
+      // ...and destroy releases both, so twenty cycles do not accumulate anything.
+      expect(settled).toEqual(Array.from({ length: 20 }, () => ({ subscribers: 0, scheduled: 0 })))
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns to baseline when a latched pane is detached rather than destroyed', async () => {
+    vi.useFakeTimers()
+    try {
+      const settled: { subscribers: number; scheduled: number }[] = []
+      for (let cycle = 0; cycle < 20; cycle += 1) {
+        const transport = await attachStalePane(cycle)
+        await vi.advanceTimersByTimeAsync(66_000)
+        expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+        transport.detach?.()
+        await vi.advanceTimersByTimeAsync(1_000)
+        settled.push(await registries())
+      }
+      expect(settled).toEqual(Array.from({ length: 20 }, () => ({ subscribers: 0, scheduled: 0 })))
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('holds one listener and one registry entry per concurrently latched pane', async () => {
+    vi.useFakeTimers()
+    try {
+      const transports: Awaited<ReturnType<typeof attachStalePane>>[] = []
+      for (let pane = 0; pane < 8; pane += 1) {
+        transports.push(await attachStalePane(pane))
+        await vi.advanceTimersByTimeAsync(66_000)
+      }
+      // Retention is per live pane, not per timeout: eight latched panes hold eight of each.
+      expect(await registries()).toEqual({ subscribers: 8, scheduled: 8 })
+
+      for (const transport of transports) {
+        transport.destroy?.()
+      }
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(await registries()).toEqual({ subscribers: 0, scheduled: 0 })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('leaves a latched pane fully quiescent — no timers, no RPCs, no growth', async () => {
+    vi.useFakeTimers()
+    try {
+      const transport = await attachStalePane(0)
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+
+      const baseline = await registries()
+      const callsAtLatch = runtimeCall.mock.calls.length
+      const timersAtLatch = vi.getTimerCount()
+      // Nothing is armed once the window is spent: the pane costs one listener and one registry
+      // entry, and nothing else, no matter how long it stays latched.
+      expect(timersAtLatch).toBe(0)
+
+      await vi.advanceTimersByTimeAsync(10 * 60_000)
+
+      expect(runtimeCall.mock.calls.length).toBe(callsAtLatch)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(await registries()).toEqual(baseline)
+
+      transport.destroy?.()
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(await registries()).toEqual({ subscribers: 0, scheduled: 0 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not stack listeners, registry entries or timers across repeated revive cycles', async () => {
+    vi.useFakeTimers()
+    try {
+      const { retryAllRemoteRuntimePtyRecoveriesNow } = await import(
+        './remote-runtime-pty-recovery-state'
+      )
+      const transport = await attachStalePane(0)
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+
+      const baseline = await registries()
+      const timersAtFirstLatch = vi.getTimerCount()
+      const subscribesAtFirstLatch = subscribeFrameCount()
+      const observed: {
+        subscribers: number
+        scheduled: number
+        timers: number
+        revived: number
+      }[] = []
+
+      for (let cycle = 0; cycle < 25; cycle += 1) {
+        const revived = retryAllRemoteRuntimePtyRecoveriesNow()
+        // A second trigger in the same window must find nothing to advance, so an online/resume
+        // storm cannot stack fresh recovery epochs on one pane.
+        expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
+        await vi.advanceTimersByTimeAsync(66_000)
+        expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+        observed.push({ ...(await registries()), timers: vi.getTimerCount(), revived })
+      }
+
+      expect(observed).toEqual(
+        Array.from({ length: 25 }, () => ({
+          subscribers: baseline.subscribers,
+          scheduled: baseline.scheduled,
+          timers: timersAtFirstLatch,
+          revived: 1
+        }))
+      )
+      // Each revive re-derives the handle; it must not leave extra live stream subscriptions behind.
+      expect(subscribeFrameCount()).toBe(subscribesAtFirstLatch)
+
+      transport.destroy?.()
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(await registries()).toEqual({ subscribers: 0, scheduled: 0 })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not stack anything when host snapshots arrive repeatedly at a latched pane', async () => {
+    vi.useFakeTimers()
+    try {
+      const handleEvents = await import('../../runtime/web-session-terminal-handle-events')
+      const transport = await attachStalePane(0)
+      await vi.advanceTimersByTimeAsync(66_000)
+      expect(transport.getRecoveryState?.().phase).toBe('disconnected')
+      const baseline = await registries()
+
+      const subscribesAtLatch = subscribeFrameCount()
+
+      for (let cycle = 0; cycle < 50; cycle += 1) {
+        handleEvents.queueAcceptedWebSessionTerminalSnapshot(
+          hostSnapshot(10 + cycle, `epoch-${cycle}`),
+          'env-1'
+        )
+        await vi.advanceTimersByTimeAsync(100)
+      }
+
+      const after = await registries()
+      expect(after.subscribers).toBeLessThanOrEqual(baseline.subscribers)
+      expect(after.scheduled).toBeLessThanOrEqual(baseline.scheduled)
+      // At most one same-handle resubscribe per spent window: 50 snapshots inside one window
+      // must not become 50 subscribes.
+      expect(subscribeFrameCount() - subscribesAtLatch).toBeLessThanOrEqual(1)
+
+      transport.destroy?.()
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(await registries()).toEqual({ subscribers: 0, scheduled: 0 })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -69,6 +69,7 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     expect(state.isActive).toBe(false)
     expect(state.isCurrent(epoch)).toBe(false)
     expect(onChange).toHaveBeenCalled()
+    state.dispose()
   })
 
   it('advances a pending backoff immediately via retryNow and the active registry', async () => {
@@ -154,16 +155,24 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     expect(retryNow).not.toHaveBeenCalled()
   })
 
-  it('removes timed-out panes from the scheduled recovery registry', async () => {
+  it('keeps a timed-out pane revivable through the scheduled recovery registry', async () => {
     vi.useFakeTimers()
     const state = new RemoteRuntimePtyRecoveryState()
-    const epoch = state.begin()
-    state.schedule(epoch, vi.fn())
-    const retryNow = vi.spyOn(state, 'retryNow')
+    const retry = vi.fn()
+    const firstEpoch = state.begin()
+    // Why: the backoff ladder outlasts the recovery window, so a retry is still armed when the cutoff lands.
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS - 100)
+    state.schedule(firstEpoch, retry)
 
-    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
-    retryAllRemoteRuntimePtyRecoveriesNow()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(state.currentPhase).toBe('disconnected')
 
-    expect(retryNow).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(retry).not.toHaveBeenCalled()
+
+    expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(1)
+    expect(retry).toHaveBeenCalledWith(firstEpoch + 1)
+    expect(state.currentPhase).toBe('recovering')
+    state.dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -175,4 +175,36 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     expect(state.currentPhase).toBe('recovering')
     state.dispose()
   })
+
+  it('revives a parked retry that never armed a backoff timer', async () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    const retry = vi.fn()
+    const firstEpoch = state.begin()
+    expect(state.parkRetryForExternalTrigger(firstEpoch, retry)).toBe(true)
+
+    // Why: parking must not fire on its own, so the pane still latches at the cutoff.
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS + 300_000)
+    expect(state.currentPhase).toBe('disconnected')
+    expect(retry).not.toHaveBeenCalled()
+
+    expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(1)
+    expect(retry).toHaveBeenCalledWith(firstEpoch + 1)
+    expect(state.currentPhase).toBe('recovering')
+    state.dispose()
+  })
+
+  it('refuses to park over an armed backoff or a stale epoch', () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    const epoch = state.begin()
+    state.schedule(epoch, vi.fn())
+
+    expect(state.parkRetryForExternalTrigger(epoch, vi.fn())).toBe(false)
+
+    state.cancel()
+    expect(state.parkRetryForExternalTrigger(epoch, vi.fn())).toBe(false)
+    expect(retryAllRemoteRuntimePtyRecoveriesNow()).toBe(0)
+    state.dispose()
+  })
 })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -11,6 +11,10 @@ export type RemoteRuntimePtyRecoveryPhase =
 // Why: system resume / network online need to advance pending pane backoffs without a second coordinator.
 const scheduledRecoveries = new Set<RemoteRuntimePtyRecoveryState>()
 
+export function getScheduledRemoteRuntimePtyRecoveryCountForTests(): number {
+  return scheduledRecoveries.size
+}
+
 export function retryAllRemoteRuntimePtyRecoveriesNow(): number {
   let advanced = 0
   // Why: a synchronous retry failure can schedule the same state again.

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -101,6 +101,14 @@ export class RemoteRuntimePtyRecoveryState {
     return true
   }
 
+  // Why: a one-shot retry whose owner already resolved elsewhere would otherwise survive the cutoff as fake revivable work.
+  discardPendingRetry(retry: (epoch: number) => void): void {
+    if (this.pendingRetry !== retry) {
+      return
+    }
+    this.clearRetryTimer()
+  }
+
   // Why: resume/online should fire an already-scheduled backoff immediately, not start a new epoch.
   retryNow(): boolean {
     if (this.pendingRetry === null || this.pendingEpoch === null) {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -103,12 +103,22 @@ export class RemoteRuntimePtyRecoveryState {
 
   // Why: resume/online should fire an already-scheduled backoff immediately, not start a new epoch.
   retryNow(): boolean {
-    if (this.phase !== 'backoff' || this.pendingRetry === null || this.pendingEpoch === null) {
+    if (this.pendingRetry === null || this.pendingEpoch === null) {
+      return false
+    }
+    if (this.phase !== 'backoff' && this.phase !== 'disconnected') {
       return false
     }
     const retry = this.pendingRetry
-    const epoch = this.pendingEpoch
+    const latched = this.phase === 'disconnected'
     this.clearRetryTimer()
+    if (latched) {
+      // Why: the deadline only stops auto-retry; an explicit trigger opens a fresh recovery window.
+      this.epoch += 1
+      this.attempt = 0
+      this.armDeadline(this.epoch)
+    }
+    const epoch = this.epoch
     this.phase = 'recovering'
     this.onChange?.()
     retry(epoch)
@@ -159,7 +169,8 @@ export class RemoteRuntimePtyRecoveryState {
         return
       }
       this.deadlineTimer = null
-      this.clearRetryTimer()
+      // Why: the cutoff stops self-initiated retries but must keep the pane revivable by online/resume/reconnect.
+      this.stopRetryTimer()
       this.phase = 'disconnected'
       this.onChange?.()
     }, REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
@@ -172,11 +183,15 @@ export class RemoteRuntimePtyRecoveryState {
     this.clearDeadlineTimer()
   }
 
-  private clearRetryTimer(): void {
+  private stopRetryTimer(): void {
     if (this.retryTimer) {
       clearTimeout(this.retryTimer)
       this.retryTimer = null
     }
+  }
+
+  private clearRetryTimer(): void {
+    this.stopRetryTimer()
     this.pendingRetry = null
     this.pendingEpoch = null
     scheduledRecoveries.delete(this)

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -101,6 +101,17 @@ export class RemoteRuntimePtyRecoveryState {
     return true
   }
 
+  // Why: a wait that ends with no liveness evidence arms no timer, so park a retry or online/resume/reconnect find nothing to revive.
+  parkRetryForExternalTrigger(epoch: number, retry: (epoch: number) => void): boolean {
+    if (!this.isCurrent(epoch) || this.pendingRetry !== null) {
+      return false
+    }
+    this.pendingRetry = retry
+    this.pendingEpoch = epoch
+    scheduledRecoveries.add(this)
+    return true
+  }
+
   // Why: a one-shot retry whose owner already resolved elsewhere would otherwise survive the cutoff as fake revivable work.
   discardPendingRetry(retry: (epoch: number) => void): void {
     if (this.pendingRetry !== retry) {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -1354,10 +1354,10 @@ export function createRemoteRuntimePtyTransport(
           }
           // Why: one reattach per spent window, so a handle that really is dead is not retried on every host snapshot.
           autoRecoveryWindowSpent = false
-          recovery.begin()
+          const reattachEpoch = recovery.begin()
           clearPublishedHandleWait()
           const reusedPtyId = remotePtyId
-          void subscribeToHandle(recovery.currentEpoch, true).catch((error) => {
+          void subscribeToHandle(reattachEpoch, true).catch((error) => {
             if (!recoverAfterSubscribeFailure(error, previousHandle, reusedPtyId)) {
               handleRemoteTerminalError(error)
             }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -188,6 +188,8 @@ export function createRemoteRuntimePtyTransport(
   let recoveryReplacementPolicyHandle: string | null = null
   let stopWaitingForPublishedHandle: (() => void) | null = null
   let publishedHandleWaitEpoch: number | null = null
+  // Why: a spent auto-recovery window is the evidence that licenses reattaching the fenced handle; explicit retries must not erase it.
+  let autoRecoveryWindowSpent = false
   let settleHostSessionAttachRetry: ((retry: boolean) => void) | null = null
   let resubscribeInventoryEpoch: number | null = null
   let resubscribeInventoryWindows = 0
@@ -241,9 +243,13 @@ export function createRemoteRuntimePtyTransport(
       clearPublishedHandleWait()
     }
     if (recovery.currentPhase === 'disconnected') {
+      autoRecoveryWindowSpent = true
       // Why: cached pixels may remain, but no stream from the exhausted epoch may keep delivering or accepting terminal traffic.
       subscriptionGeneration += 1
       closeMultiplexedStream()
+    }
+    if (recovery.currentPhase === 'idle') {
+      autoRecoveryWindowSpent = false
     }
     if (
       recovery.currentPhase === 'disconnected' ||
@@ -1343,12 +1349,11 @@ export function createRemoteRuntimePtyTransport(
         }
         if (update.terminalHandle === previousHandle) {
           // Why: once the auto-recovery window is spent, a host still publishing this surface is evidence the fenced handle outlived the stale error.
-          if (
-            recovery.currentPhase !== 'disconnected' ||
-            getCurrentMultiplexedStream(previousHandle)
-          ) {
+          if (!autoRecoveryWindowSpent || getCurrentMultiplexedStream(previousHandle)) {
             return
           }
+          // Why: one reattach per spent window, so a handle that really is dead is not retried on every host snapshot.
+          autoRecoveryWindowSpent = false
           recovery.begin()
           clearPublishedHandleWait()
           const reusedPtyId = remotePtyId
@@ -1471,6 +1476,13 @@ export function createRemoteRuntimePtyTransport(
             code: 'remote_runtime_unavailable'
           })
         }
+        // Why: liveness is unknown, so auto-retry stops here; keep an unarmed retry parked for online/resume/reconnect to fire.
+        recovery.parkRetryForExternalTrigger(recoveryEpoch, (nextEpoch) => {
+          scheduleResubscribeAfterTransportClose(
+            handle ? getRecoveryReplacementPolicy(handle) : 'reuse',
+            nextEpoch
+          )
+        })
         return
       }
       if (!nextHandle) {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -187,6 +187,7 @@ export function createRemoteRuntimePtyTransport(
   let recoveryReplacementPolicy: HostHandleReplacementPolicy = 'reuse'
   let recoveryReplacementPolicyHandle: string | null = null
   let stopWaitingForPublishedHandle: (() => void) | null = null
+  let publishedHandleWaitEpoch: number | null = null
   let settleHostSessionAttachRetry: ((retry: boolean) => void) | null = null
   let resubscribeInventoryEpoch: number | null = null
   let resubscribeInventoryWindows = 0
@@ -236,8 +237,10 @@ export function createRemoteRuntimePtyTransport(
   }
 
   const recovery = new RemoteRuntimePtyRecoveryState(() => {
-    if (recovery.currentPhase === 'disconnected') {
+    if (recovery.currentPhase === 'disposed') {
       clearPublishedHandleWait()
+    }
+    if (recovery.currentPhase === 'disconnected') {
       // Why: cached pixels may remain, but no stream from the exhausted epoch may keep delivering or accepting terminal traffic.
       subscriptionGeneration += 1
       closeMultiplexedStream()
@@ -1257,6 +1260,7 @@ export function createRemoteRuntimePtyTransport(
   function clearPublishedHandleWait(): void {
     stopWaitingForPublishedHandle?.()
     stopWaitingForPublishedHandle = null
+    publishedHandleWaitEpoch = null
   }
 
   function isCurrentRemoteTerminal(targetHandle: string, targetPtyId: string | null): boolean {
@@ -1329,8 +1333,30 @@ export function createRemoteRuntimePtyTransport(
           retireRemoteTerminalId()
           return
         }
-        if (!update.terminalHandle || update.terminalHandle === previousHandle) {
+        if (!update.terminalHandle) {
           return
+        }
+        if (update.terminalHandle === previousHandle) {
+          // Why: once the auto-recovery window is spent, a host still publishing this surface is evidence the fenced handle outlived the stale error.
+          if (
+            recovery.currentPhase !== 'disconnected' ||
+            getCurrentMultiplexedStream(previousHandle)
+          ) {
+            return
+          }
+          recovery.begin()
+          clearPublishedHandleWait()
+          const reusedPtyId = remotePtyId
+          void subscribeToHandle(recovery.currentEpoch, true).catch((error) => {
+            if (!recoverAfterSubscribeFailure(error, previousHandle, reusedPtyId)) {
+              handleRemoteTerminalError(error)
+            }
+          })
+          return
+        }
+        if (recovery.currentPhase === 'disconnected') {
+          // Why: without a live epoch a failed resubscribe is swallowed as already-latched, leaving a pane with no handle and no way back.
+          recovery.begin()
         }
         rebindRemoteTerminalHandle(update.terminalHandle)
         const reboundHandle = handle
@@ -1507,8 +1533,12 @@ export function createRemoteRuntimePtyTransport(
       clearPendingViewportClaim()
     }
     strengthenRecoveryReplacementPolicy(handle, replacementPolicy)
-    if (replacementPolicy === 'require-replacement' && stopWaitingForPublishedHandle) {
-      // Why: once recovery is handed to accepted snapshots, repeated sends to the stale handle must not re-arm inventory RPCs.
+    if (
+      replacementPolicy === 'require-replacement' &&
+      stopWaitingForPublishedHandle &&
+      // Why: only the epoch that handed recovery to accepted snapshots is blocked; a newer epoch is a fresh attempt, not a repeated stale send.
+      publishedHandleWaitEpoch === recoveryEpoch
+    ) {
       return
     }
     if (resubscribeEpoch === recoveryEpoch) {
@@ -1529,6 +1559,7 @@ export function createRemoteRuntimePtyTransport(
     if (tabId && isWebTerminalSurfaceTabId(tabId)) {
       // Why: subscribe before polling so a fresh host snapshot can't land in the gap between the inventory loop and its event-driven fallback.
       waitForPublishedHostSessionHandle(toHostSessionTabId(tabId), resubscribeHandle)
+      publishedHandleWaitEpoch = recoveryEpoch
     }
     resubscribeEpoch = recoveryEpoch
     resubscribeRequestedHandle = null

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -565,11 +565,16 @@ export function createRemoteRuntimePtyTransport(
         if (settleHostSessionAttachRetry === settle) {
           settleHostSessionAttachRetry = null
         }
+        // Why: this wait is single-shot, so replaying it after the cutoff would strand the pane in 'recovering' with no RPC in flight.
+        recovery.discardPendingRetry(scheduledRetry)
         resolve(retry)
+      }
+      const scheduledRetry = (): void => {
+        settle(true)
       }
       settleHostSessionAttachRetry?.(false)
       settleHostSessionAttachRetry = settle
-      if (!recovery.schedule(recoveryEpoch, () => settle(true))) {
+      if (!recovery.schedule(recoveryEpoch, scheduledRetry)) {
         settle(false)
       }
     })


### PR DESCRIPTION
## Summary

A remote-runtime terminal pane that missed the 60-second auto-recovery window latched to `disconnected` forever, even though the host session was alive and streaming (`terminal.list` reporting `connected=true, orphaned=false`). The cutoff severed every path back at the same instant:

- `armDeadline`'s expiry called `clearRetryTimer()` (`remote-runtime-pty-recovery-state.ts:162` on `main`), which dropped `pendingRetry` **and** did `scheduledRecoveries.delete(this)`. Window `online` and `powerMonitor 'resume'` — the only two automatic triggers (`src/renderer/src/runtime/use-remote-runtime-recovery-triggers.ts:11-15`) — became permanent no-ops for that pane.
- The recovery `onChange` handler called `clearPublishedHandleWait()` on `disconnected` (`remote-runtime-pty-transport.ts:238-240` on `main`), unsubscribing the accepted-host-snapshot listener, which after bounded inventory polling stops is the pane's only event-driven path back.
- That listener was already inert for the reported case anyway: `waitForPublishedHostSessionHandle` ignored any snapshot whose `terminalHandle === previousHandle` (`remote-runtime-pty-transport.ts:1332` on `main`), and a host that keeps a live surface only ever republishes the same handle.

Renderer-only changes (line numbers are on this branch):

1. `remote-runtime-pty-recovery-state.ts:205-217` — split `clearRetryTimer()` into a private `stopRetryTimer()` (timer handle only) and the existing full teardown. The deadline now calls `stopRetryTimer()` (`armDeadline`, `:184-198`, call at `:191-192`), so a latched pane keeps its pending retry and stays in `scheduledRecoveries` while arming no timer of its own.
2. `remote-runtime-pty-recovery-state.ts:123-145` — `retryNow()` also fires for `disconnected`, opening a fresh epoch (`epoch += 1`, `attempt = 0`, new deadline) so the transport's `requestedRecoveryEpoch` satisfies `isCurrent()`.
3. `remote-runtime-pty-recovery-state.ts:104-113` — new `parkRetryForExternalTrigger()`: a wait that ends with no liveness evidence (bounded inventory exhausted, or a `require-replacement` policy with no replacement published) arms no backoff timer at all, so before this change there was nothing for `online`/resume to advance. The transport parks an unarmed retry there (`remote-runtime-pty-transport.ts:1479-1485`). Because `retryNow()` still requires `backoff` or `disconnected`, a parked retry cannot fire while recovery is still running — it only becomes reachable after the cutoff.
4. `remote-runtime-pty-recovery-state.ts:115-121` — new `discardPendingRetry()`: `waitForHostSessionAttachRetry` is single-shot, so it drops its own scheduled retry when it settles (`remote-runtime-pty-transport.ts:563-587`). Without this, replaying that wait after the cutoff would strand the pane in `recovering` with no RPC in flight.
5. `remote-runtime-pty-transport.ts:242-253` — `clearPublishedHandleWait()` moves to a `disposed`-only branch; the stream close and `subscriptionGeneration` bump stay on `disconnected`, so the listener survives the latch. The same block sets a new `autoRecoveryWindowSpent` flag on `disconnected` and clears it on `idle`.
6. `remote-runtime-pty-transport.ts:1350-1370` — a post-cutoff snapshot republishing the **same** handle is now accepted as reattach evidence. It is gated on `autoRecoveryWindowSpent` (set only when a full 60 s window expired, cleared on a healthy `idle` and consumed by each accepted reattach), on there being no live multiplexed stream for that handle, and on `surfacePresent` host evidence (`:1343-1346` retires the pane otherwise). The resubscribe is issued as `subscribeToHandle(epoch, /* sameHandleEndRecovery */ true)`, so a successful reattach is recorded by `recordSameHandleEndReuse` and feeds the existing `HOST_SESSION_SAME_HANDLE_END_REUSE_LIMIT` escalation. A post-cutoff **rotated** handle re-opens a recovery epoch before rebinding (`:1367-1370`), so a failed resubscribe isn't swallowed as already-latched.
7. `remote-runtime-pty-transport.ts:1553-1559,1579` — the `require-replacement` published-wait early return is scoped to its own recovery epoch via `publishedHandleWaitEpoch`. Because the wait now survives the latch (change 5), the unscoped guard would otherwise silently swallow the Reconnect button and every `online`/resume revive.

Net: `disconnected` still means "automatic retrying stopped" — no timer, no self-initiated RPC — but a host snapshot (rotated or same handle), `online`/system-resume, and the Reconnect button all reach a fresh subscribe again.

Closes #12097 — the reported failure mode (a pane latched at `auto-retry stopped` while the host session is alive and streaming, with Reconnect not restoring it). Two of the issue's *suggested* fixes are deliberately **not** implemented: there is no new tab-visibility/focus trigger, and no low-frequency background retry loop while latched. The pane is revived by host evidence the client already receives, by `online`/system-resume, or by Reconnect — see Limitations.

## ELI5

Your terminal window connects to a machine somewhere else. If the connection drops, the app spends a minute quietly trying to get it back. Before this change, once that minute ran out the app threw away all its notes — so even when the other machine said "I'm right here, still running," nothing was listening, and clicking Reconnect went nowhere. Now the app stops *trying on its own* after a minute, but keeps its notes. The moment the other machine says it's alive, or your laptop wakes up, or your network comes back, the window quietly reconnects.

## Fix proof

The throwaway repro used while diagnosing (`remote-runtime-pty-transport.bug-12097.test.ts`) is **not** part of this diff — it was reworked into permanent, correctly-named suites: `remote-runtime-pty-deadline-reattach.test.ts` (new, transport-level, following the `remote-runtime-pty-snapshot-escape-tail.test.ts` / `remote-runtime-pty-query-reply-immediate.test.ts` focused-file idiom in the same directory) and rewritten/added cases in the existing `remote-runtime-pty-recovery-state.test.ts`. Coverage corrections and additions made while reworking:

- The repro's unit case scheduled a retry with `RECOVERY_DELAYS_MS[0]` (250 ms), so it fired long before the 60 s cutoff and left nothing pending to preserve. The real backoff ladder (`250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000`) sums to 60,750 ms, i.e. the 8th attempt is armed at t=30.75 s and is still pending when the cutoff lands. The permanent test models that.
- The repro covered two cases (post-cutoff rotated-handle reattach, and re-arming on `online`/resume). The permanent transport suite has six, adding: the actual reported case (host republishes the **same** handle after the cutoff), a negative case proving the same-handle fence is untouched *before* the cutoff, the Reconnect window, and a pane latched during the attach wait (where replaying the single-shot wait must be refused).
- `remote-runtime-pty-recovery-state.test.ts` gains two new cases beyond the rewritten registry test: reviving a parked retry that never armed a backoff timer, and refusing to park over an armed backoff or a stale epoch.

Permanent suites against unfixed source (both changed source files reverted to `main`, tests kept) — 7 failures:

```
 ❯ src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts (15 tests | 3 failed) 10ms
 ❯ src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts (6 tests | 4 failed) 3070ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  ...deadline-reattach.test.ts > reattaches from a rotated host handle published after the recovery cutoff
 FAIL  ...deadline-reattach.test.ts > reattaches when the post-cutoff snapshot republishes the same live handle
 FAIL  ...deadline-reattach.test.ts > reattaches from a same-handle snapshot delivered inside the Reconnect window
 FAIL  ...deadline-reattach.test.ts > revives a latched require-replacement pane when online or system resume fires
 FAIL  ...recovery-state.test.ts > keeps a timed-out pane revivable through the scheduled recovery registry
 FAIL  ...recovery-state.test.ts > revives a parked retry that never armed a backoff timer
 FAIL  ...recovery-state.test.ts > refuses to park over an armed backoff or a stale epoch
 Test Files  2 failed (2)
      Tests  7 failed | 14 passed (21)
```

The two cases that pass without the fix are the intended negatives: `ignores a same-handle snapshot while automatic recovery is still running` (the `#7718` fence must stay intact pre-cutoff) and `leaves Reconnect available when online fires on a pane latched during the attach wait`.

Same suites with the fix — all green:

```
 RUN  v4.1.5

 Test Files  2 passed (2)
      Tests  21 passed (21)
   Duration  2.94s (transform 1.68s, setup 0ms, import 86ms, tests 2.81s, environment 0ms)
```

## No regressions

All neighbouring `terminal-pane` suites plus every suite importing the two changed modules.

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/remote-runtime-pty-deadline-reattach.test.ts \
    src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts \
    src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts \
    src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts \
    src/renderer/src/components/terminal-pane/remote-runtime-pty-query-reply-immediate.test.ts \
    src/renderer/src/components/terminal-pane/remote-runtime-pty-snapshot-escape-tail.test.ts \
    src/renderer/src/components/terminal-pane/terminal-remote-runtime-recovery-ui-state.test.ts

 Test Files  7 passed (7)
      Tests  140 passed (140)
   Duration  18.77s (transform 16.49s, setup 0ms, import 3.21s, tests 32.13s, environment 0ms)
```

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/runtime/use-remote-runtime-recovery-triggers.test.ts \
    src/renderer/src/runtime/web-session-terminal-handle-events.test.ts \
    src/renderer/src/components/terminal-pane/terminal-pane-recovery.test.ts \
    src/renderer/src/hooks/direct-ssh-runtime-wake-isolation.test.tsx

 Test Files  4 passed (4)
      Tests  31 passed (31)
   Duration  6.17s (transform 4.62s, setup 0ms, import 6.07s, tests 63ms, environment 805ms)
```

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/pty-connection.test.ts \
    src/renderer/src/components/terminal-pane/pty-transport.test.ts

 Test Files  2 passed (2)
      Tests  631 passed (631)
   Duration  21.13s (transform 2.49s, setup 0ms, import 1.00s, tests 22.27s, environment 0ms)
```

Specifically preserved: `remote-runtime-pty-transport.test.ts` "reattaches from a later host snapshot after bounded replacement polling stops" (including its subscriber-count 1 → 1 → 0 sequence and its "user input must not turn a bounded reconnect into recurring host-inventory polling" assertion), the post-cutoff quiescence assertions elsewhere in that file (`runtimeCall`/`runtimeSubscribe` call counts unchanged across 5 minutes after the cutoff), and the `it.each` registry test asserting `markHealthy`/`markDisconnected`/`cancel`/`dispose` still evict a pane from `scheduledRecoveries`.

### Trade-offs

These are real user-visible changes, not zero-cost:

- **A pane can now silently self-heal out of the "auto-retry stopped" banner.** That is the intended win, but the banner is no longer a terminal state. The copy stays literally true — the deadline itself re-arms nothing; only host evidence or an explicit trigger does.
- **A latched pane can now close itself.** The accepted-snapshot listener now lives while a pane is latched, so if the host stops publishing the surface the pane is retired (`retireRemoteTerminalId` → `onPtyExit`) instead of sitting there with a Reconnect button. This is the correct pre-deadline behavior, but it is new for latched panes.
- **More banner churn on a flapping link.** After a revive the pane shows `recovering`; if the reattach fails it re-latches after a fresh 60 s window rather than staying latched.
- **The `#7718` same-handle fence is deliberately narrowed.** A post-cutoff same-handle snapshot now re-subscribes a handle a stale error previously fenced off. It is gated on a full 60 s window having been spent (`autoRecoveryWindowSpent`), on there being no live multiplexed stream, and on fresh `surfacePresent` host evidence. The reattach is *counted* by `recordSameHandleEndReuse` — it is not blocked by `HOST_SESSION_SAME_HANDLE_END_REUSE_LIMIT`; the counter's effect is to escalate the replacement policy on the following stream-end cycles. Same-handle behavior before the deadline is unchanged, and a dedicated negative test pins it.
- **Per-revive inventory budget resets.** Each revive bumps the recovery epoch, and `beginResubscribeInventoryWindow` is keyed on epoch, so `HOST_SESSION_INVENTORY_MAX_WINDOWS_PER_RECOVERY` becomes a per-`online`/resume-event cap rather than a lifetime cap. Bounded per event, unbounded in aggregate across many events on a flapping link.

## Cross-platform

Pure renderer TypeScript over `setTimeout`/`clearTimeout` and in-memory `Set`/`Map`. No platform-conditional code, no keyboard shortcuts (no `metaKey`/`ctrlKey`), no Electron accelerators, no shortcut labels, no filesystem paths (so no `path.join` need). Identical on **macOS, Linux and Windows**.

`window.api.ui.onSystemResumed` (main-process `powerMonitor 'resume'`) and the `online` event are pre-existing triggers whose plumbing is untouched; this change only makes them effective for latched panes, on every OS.

**SSH / remote:** this *is* the remote path. The bug only exists for remote-runtime PTY panes reached over a runtime environment (the report is a VPN'd `ws://host:6768`), and the fix is specifically about tolerating a slow reconnect instead of giving up permanently. Nothing assumes local execution, and the same-handle reattach consumes an event the client already receives rather than issuing a new round trip — the right shape for a high-latency link.

**Folder workspaces (non-git):** unaffected. `worktreeId` is used purely as a runtime session selector via `toRuntimeWorktreeSelector`; no Git is run, no `.git` is inspected, and nothing assumes the workspace is a worktree. No Git subcommand, option, capability probe, or `GitCapabilityCache` entry is added or changed, so the Git 2.25 baseline and GitHub/GitLab provider compatibility are untouched.

## Performance

- **No new timers, no new polling, no new IPC.** The cutoff still stops the retry timer, and a parked retry arms none, so a latched pane continues to issue zero self-initiated RPCs; the post-cutoff "no further calls for 5 minutes" assertions remain green.
- **Steady-state cost of a latched pane:** one `Set` entry and one accepted-snapshot subscriber that previously would have been released. `queueAcceptedWebSessionTerminalSnapshot` early-returns when there are no subscribers for the session key, and otherwise only iterates subscribers for snapshots the client is already receiving; `resolveSubscriberUpdate` is a filter over one snapshot's tab list.
- **Same-handle reattach costs zero requests.** It consumes the same `RuntimeMobileSessionTabsResult` an inventory poll would have fetched, so it is strictly better evidence than a `session.tabs.list` at no request cost. The regression test asserts the `session.tabs.list` count is unchanged across the reattach.
- **Bounded firing rate.** The same-handle path clears `autoRecoveryWindowSpent` before resubscribing and calls `recovery.begin()`, so further snapshots are ignored until another full 60 s window has been spent — at most one same-handle resubscribe per 60 s per latched pane.
- **No added React renders on any hot path:** `emitRecoveryState` is already de-duplicated by `lastRecoveryStateKey`.

## Security

No change. No IPC surface added or modified, no command execution, no path handling, no auth or credential surface touched. The change is confined to renderer-side recovery scheduling and to which already-received host snapshot events are acted on. The `#7718` stale-handle fence is narrowed (see Trade-offs), but it still requires fresh host evidence that the surface is present — it cannot attach to an arbitrary or attacker-chosen handle, only to the handle the host itself is currently publishing for this pane.

## Limitations

- **Verified by automated unit tests only, run on macOS.** There is no manual end-to-end verification against a real remote runtime over a high-latency/VPN link, and no CI coverage on Linux or Windows for this specific path. The reasoning that behavior is OS-identical is the argument in *Cross-platform* above, not an observation.
- **Revival still needs an external event.** A latched pane recovers when the host publishes an accepted `session.tabs` snapshot for its surface, when `online`/system-resume fires, or when the user clicks Reconnect. If a client somehow stops receiving session-tabs snapshots for that worktree *and* neither trigger fires, the pane stays latched until Reconnect is clicked. The issue's suggested "re-arm on tab visible/focused" and "low-frequency retry while latched" were not implemented.
- **The banner text was not changed.** A pane can now self-heal out of "auto-retry stopped" without the user doing anything, which may read as inconsistent even though the wording remains literally accurate.

## AI Review Report

Reviewed by independent subagents in a loop until clean, across two hostile lenses — **correctness/regressions** and **cross-platform + remote + performance**.

- **Review loop count:** 2 round(s)
- **Final verdict:** CLEAN
- **Outstanding findings:** none. The final round returned zero blocker/major findings from both lenses.

**Remediation applied between rounds:** 1 pass(es). Findings judged false-positive were rejected with evidence rather than coded around.

Made with [Orca](https://github.com/stablyai/orca) 🐋
