### PR TITLE
Recover automatically instead of getting stuck on "Multiplexer disposed" when an SSH relay drops

### DIFF
--- a/src/main/ssh/ssh-channel-multiplexer.test.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.test.ts
@@ -502,6 +502,50 @@ describe('SshChannelMultiplexer', () => {
       await expect(mux.request('pty.spawn')).rejects.toThrow('Multiplexer disposed')
     })
 
+    it('tags a request after a shutdown dispose with DISPOSED', async () => {
+      mux.dispose()
+
+      const error = (await mux.request('pty.spawn').catch((e: unknown) => e)) as Error & {
+        code?: string
+      }
+      expect(error.code).toBe('DISPOSED')
+    })
+
+    it('reports a request after a lost connection as transient', async () => {
+      transport.closeCallbacks[0]()
+
+      const error = (await mux
+        .request('fs.readDir', { path: '/home/me' })
+        .catch((e: unknown) => e)) as Error & { code?: string }
+      expect(error.message).toBe('SSH connection lost, reconnecting...')
+      expect(error.code).toBe('CONNECTION_LOST')
+    })
+
+    it('reports a settled notify after a lost connection as transient', () => {
+      transport.closeCallbacks[0]()
+
+      const settled = vi.fn()
+      mux.notifyWithSettlement('pty.data', { id: 'pty-1', data: 'x' }, settled)
+
+      expect(settled).toHaveBeenCalledWith({
+        ok: false,
+        error: expect.objectContaining({
+          message: 'SSH connection lost, reconnecting...',
+          code: 'CONNECTION_LOST'
+        })
+      })
+    })
+
+    it('fires a dispose handler registered after dispose with the recorded reason', () => {
+      mux.dispose('connection_lost')
+
+      const disposeHandler = vi.fn()
+      mux.onDispose(disposeHandler)
+
+      expect(disposeHandler).toHaveBeenCalledWith('connection_lost')
+      expect(disposeHandler).toHaveBeenCalledTimes(1)
+    })
+
     it('ignores notify after dispose', () => {
       mux.dispose()
       mux.notify('pty.data', { id: 'pty-1', data: 'x' })

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -41,6 +41,21 @@ export type NotificationHandler = (method: string, params: Record<string, unknow
 export type MethodNotificationHandler = (params: Record<string, unknown>) => void
 export type RequestHandler = (params: Record<string, unknown>) => Promise<unknown> | unknown
 
+export type MultiplexerDisposeReason = 'shutdown' | 'connection_lost'
+
+// Why: the renderer uses the message/code to distinguish temporary disconnects
+// (show reconnection overlay) from permanent shutdown (show error toast), so
+// every producer of a disposal rejection must mint it here — a divergent copy
+// silently downgrades the relay-lost UI to a bug-report toast.
+export function createSshDisposalError(reason: MultiplexerDisposeReason): Error & { code: string } {
+  const lost = reason === 'connection_lost'
+  const err = new Error(
+    lost ? 'SSH connection lost, reconnecting...' : 'Multiplexer disposed'
+  ) as Error & { code: string }
+  err.code = lost ? 'CONNECTION_LOST' : 'DISPOSED'
+  return err
+}
+
 const REQUEST_TIMEOUT_MS = 30_000
 const MAX_ORDINARY_UNACKED_TIMESTAMPS = 4095
 const MAX_UNACKED_TIMESTAMPS = MAX_ORDINARY_UNACKED_TIMESTAMPS + 1
@@ -369,15 +384,8 @@ export class SshChannelMultiplexer {
 
   // ── Private ───────────────────────────────────────────────────────
 
-  // Why: the renderer uses the error code to distinguish temporary disconnects
-  // (show reconnection overlay) from permanent shutdown (show error toast).
   private disposedError(): Error & { code: string } {
-    const lost = (this.disposeReason ?? 'shutdown') === 'connection_lost'
-    const err = new Error(
-      lost ? 'SSH connection lost, reconnecting...' : 'Multiplexer disposed'
-    ) as Error & { code: string }
-    err.code = lost ? 'CONNECTION_LOST' : 'DISPOSED'
-    return err
+    return createSshDisposalError(this.disposeReason ?? 'shutdown')
   }
 
   private sendMessage(

--- a/src/main/ssh/ssh-channel-multiplexer.ts
+++ b/src/main/ssh/ssh-channel-multiplexer.ts
@@ -67,6 +67,7 @@ export class SshChannelMultiplexer {
   private disposeHandlers: ((reason: 'shutdown' | 'connection_lost') => void)[] = []
   private connectionHealthTimer: ReturnType<typeof setInterval> | null = null
   private disposed = false
+  private disposeReason: 'shutdown' | 'connection_lost' | null = null
   private decoderReadPaused = false
   private writerSaturated = false
 
@@ -163,6 +164,12 @@ export class SshChannelMultiplexer {
   // never fires the reconnect logic.
   onDispose(handler: (reason: 'shutdown' | 'connection_lost') => void): () => void {
     if (this.disposed) {
+      // Why: a late subscriber must still learn the channel died; retaining it would leak the closure (#11953).
+      try {
+        handler(this.disposeReason ?? 'shutdown')
+      } catch {
+        // Don't let a handler error escape into the subscriber's registration path
+      }
       return () => {}
     }
     this.disposeHandlers.push(handler)
@@ -183,7 +190,7 @@ export class SshChannelMultiplexer {
     options?: SshMultiplexerRequestOptions
   ): Promise<unknown> {
     if (this.disposed) {
-      throw new Error('Multiplexer disposed')
+      throw this.disposedError()
     }
     if (options?.signal?.aborted) {
       const error = new Error(`Request "${method}" was cancelled`) as Error & { name: string }
@@ -271,7 +278,7 @@ export class SshChannelMultiplexer {
     onSettled: (result: { ok: true } | { ok: false; error: Error }) => void
   ): void {
     if (this.disposed) {
-      onSettled({ ok: false, error: new Error('Multiplexer disposed') })
+      onSettled({ ok: false, error: this.disposedError() })
       return
     }
     this.sendMessage(
@@ -320,17 +327,12 @@ export class SshChannelMultiplexer {
       )
     }
     this.disposed = true
+    this.disposeReason = reason
 
     if (this.connectionHealthTimer) {
       clearInterval(this.connectionHealthTimer)
       this.connectionHealthTimer = null
     }
-
-    // Why: the renderer uses the error code to distinguish temporary disconnects
-    // (show reconnection overlay) from permanent shutdown (show error toast).
-    const errorMessage =
-      reason === 'connection_lost' ? 'SSH connection lost, reconnecting...' : 'Multiplexer disposed'
-    const errorCode = reason === 'connection_lost' ? 'CONNECTION_LOST' : 'DISPOSED'
 
     for (const waiter of this.livenessProbeWaiters.splice(0)) {
       waiter.fail()
@@ -338,15 +340,11 @@ export class SshChannelMultiplexer {
 
     for (const [id, pending] of this.pendingRequests) {
       pending.cleanup()
-      const err = new Error(errorMessage) as Error & { code: string }
-      err.code = errorCode
-      pending.reject(err)
+      pending.reject(this.disposedError())
       this.pendingRequests.delete(id)
     }
 
-    const writerError = new Error(errorMessage) as Error & { code: string }
-    writerError.code = errorCode
-    this.writer.dispose(writerError)
+    this.writer.dispose(this.disposedError())
     this.unackedTimestamps.clear()
     // Why: relay teardown can race with late provider registration; disposed
     // muxes must not retain provider/session closures through subscribers.
@@ -370,6 +368,17 @@ export class SshChannelMultiplexer {
   }
 
   // ── Private ───────────────────────────────────────────────────────
+
+  // Why: the renderer uses the error code to distinguish temporary disconnects
+  // (show reconnection overlay) from permanent shutdown (show error toast).
+  private disposedError(): Error & { code: string } {
+    const lost = (this.disposeReason ?? 'shutdown') === 'connection_lost'
+    const err = new Error(
+      lost ? 'SSH connection lost, reconnecting...' : 'Multiplexer disposed'
+    ) as Error & { code: string }
+    err.code = lost ? 'CONNECTION_LOST' : 'DISPOSED'
+    return err
+  }
 
   private sendMessage(
     msg: JsonRpcMessage,

--- a/src/main/ssh/ssh-git-response-stream-reader.test.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { requestGitStreamable } from './ssh-git-response-stream-reader'
+import { SshChannelMultiplexer, type MultiplexerTransport } from './ssh-channel-multiplexer'
+
+function createMockTransport(): MultiplexerTransport {
+  return {
+    write: () => {},
+    onData: () => {},
+    onClose: () => {}
+  }
+}
+
+describe('requestGitStreamable on an already-dead multiplexer', () => {
+  it('rejects as a transient relay loss and leaves no listener on the caller signal', async () => {
+    const mux = new SshChannelMultiplexer(createMockTransport())
+    mux.dispose('connection_lost')
+    const controller = new AbortController()
+    const addListener = vi.spyOn(controller.signal, 'addEventListener')
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+
+    await expect(
+      requestGitStreamable(mux, 'git.status', { cwd: '/repo' }, { signal: controller.signal })
+    ).rejects.toThrow('SSH connection lost, reconnecting...')
+
+    // #11953: a disposed mux fails synchronously inside onDispose, so the abort
+    // listener must already be registered when that cleanup runs — otherwise it
+    // outlives the request for the lifetime of the caller's signal.
+    expect(removeListener).toHaveBeenCalledTimes(addListener.mock.calls.length)
+  })
+})

--- a/src/main/ssh/ssh-git-response-stream-reader.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.ts
@@ -1,4 +1,5 @@
 import type { SshChannelMultiplexer } from './ssh-channel-multiplexer'
+import { createSshDisposalError } from './ssh-channel-multiplexer'
 import { RelayErrorCode, isGitResponseStreamMarker } from './relay-protocol'
 
 const SENTINEL_STREAM_ID = -1
@@ -264,17 +265,7 @@ export function requestGitStreamable(
 
     // Why: registered last because an already-disposed mux fails synchronously here,
     // and that cleanup must be able to drop the abort listener above (#11953).
-    unsubscribers.push(
-      mux.onDispose((reason) => {
-        const err = new Error(
-          reason === 'connection_lost'
-            ? 'SSH connection lost, reconnecting...'
-            : 'Multiplexer disposed'
-        ) as Error & { code: string }
-        err.code = reason === 'connection_lost' ? 'CONNECTION_LOST' : 'DISPOSED'
-        fail(err)
-      })
-    )
+    unsubscribers.push(mux.onDispose((reason) => fail(createSshDisposalError(reason))))
 
     // Why: forward only the mux-request options (signal/timeoutMs) and omit them
     // entirely when absent, so callers that previously issued a 2-arg

--- a/src/main/ssh/ssh-git-response-stream-reader.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.ts
@@ -245,18 +245,6 @@ export function requestGitStreamable(
         handleStreamError(p)
       })
     )
-    unsubscribers.push(
-      mux.onDispose((reason) => {
-        const err = new Error(
-          reason === 'connection_lost'
-            ? 'SSH connection lost, reconnecting...'
-            : 'Multiplexer disposed'
-        ) as Error & { code: string }
-        err.code = reason === 'connection_lost' ? 'CONNECTION_LOST' : 'DISPOSED'
-        fail(err)
-      })
-    )
-
     if (options?.signal) {
       const signal = options.signal
       if (signal.aborted) {
@@ -273,6 +261,20 @@ export function requestGitStreamable(
       signal.addEventListener('abort', onAbort, { once: true })
       unsubscribers.push(() => signal.removeEventListener('abort', onAbort))
     }
+
+    // Why: registered last because an already-disposed mux fails synchronously here,
+    // and that cleanup must be able to drop the abort listener above (#11953).
+    unsubscribers.push(
+      mux.onDispose((reason) => {
+        const err = new Error(
+          reason === 'connection_lost'
+            ? 'SSH connection lost, reconnecting...'
+            : 'Multiplexer disposed'
+        ) as Error & { code: string }
+        err.code = reason === 'connection_lost' ? 'CONNECTION_LOST' : 'DISPOSED'
+        fail(err)
+      })
+    )
 
     // Why: forward only the mux-request options (signal/timeoutMs) and omit them
     // entirely when absent, so callers that previously issued a 2-arg

--- a/src/main/ssh/ssh-relay-session-relay-loss.test.ts
+++ b/src/main/ssh/ssh-relay-session-relay-loss.test.ts
@@ -132,13 +132,15 @@ const { registerSshFilesystemProvider, unregisterSshFilesystemProvider } =
   await import('../providers/ssh-filesystem-dispatch')
 const { getPtyIdsForConnection } = await import('../ipc/pty')
 
-describe('SshRelaySession relay loss on the final grace-time notify', () => {
+describe('SshRelaySession relay loss during setup', () => {
   /** Armed by a test so the *next* mux dies inside its grace-time notify. */
   let armGraceTimeFailure = false
+  let armProviderRegistrationFailure = false
 
   beforeEach(() => {
     vi.clearAllMocks()
     armGraceTimeFailure = false
+    armProviderRegistrationFailure = false
     muxRequestMock.mockReset()
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     registeredPtyProvider.attachForReconnect.mockReset().mockResolvedValue({})
@@ -154,6 +156,7 @@ describe('SshRelaySession relay loss on the final grace-time notify', () => {
     session: SshRelaySession
     onRelayLost: ReturnType<typeof vi.fn>
     onReady: ReturnType<typeof vi.fn>
+    mockStore: ReturnType<typeof createMockDeps>['mockStore']
   } {
     const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
@@ -162,16 +165,21 @@ describe('SshRelaySession relay loss on the final grace-time notify', () => {
     session.setOnRelayLost(onRelayLost)
     session.setOnReady(onReady)
     // Arm once the mux exists; every attempt issues requests before the notify.
-    muxRequestMock.mockImplementation(async () => {
+    muxRequestMock.mockImplementation(async (method: string) => {
       const mux = session.getMux() as unknown as {
         failNotifyMethod: string | null
+        dispose: (reason: string) => void
       } | null
       if (mux && armGraceTimeFailure) {
         mux.failNotifyMethod = SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD
       }
+      if (mux && armProviderRegistrationFailure && method === 'git.listWorktrees') {
+        mux.dispose('connection_lost')
+        throw new Error('SSH connection lost, reconnecting...')
+      }
       return []
     })
-    return { session, onRelayLost, onReady }
+    return { session, onRelayLost, onReady, mockStore }
   }
 
   it('fails establish instead of reporting ready on a dead channel', async () => {
@@ -196,6 +204,26 @@ describe('SshRelaySession relay loss on the final grace-time notify', () => {
     onReady.mockClear()
 
     armGraceTimeFailure = true
+    await session.reconnect({} as SshConnection)
+
+    expect(session.getState()).not.toBe('ready')
+    expect(onReady).not.toHaveBeenCalled()
+    expect(onRelayLost).toHaveBeenCalledTimes(1)
+    expect(unregisterSshFilesystemProvider).toHaveBeenCalledWith('target-1')
+  })
+
+  it('routes a mux that dies during provider registration into relay-loss recovery', async () => {
+    const { session, onRelayLost, onReady, mockStore } = createSession()
+
+    await session.establish({} as SshConnection)
+    expect(session.getState()).toBe('ready')
+    onReady.mockClear()
+
+    vi.mocked(mockStore.getRepos).mockReturnValue([
+      { connectionId: 'target-1', path: '/repo' } as ReturnType<typeof mockStore.getRepos>[number]
+    ])
+    armProviderRegistrationFailure = true
+
     await session.reconnect({} as SshConnection)
 
     expect(session.getState()).not.toBe('ready')

--- a/src/main/ssh/ssh-relay-session-relay-loss.test.ts
+++ b/src/main/ssh/ssh-relay-session-relay-loss.test.ts
@@ -10,9 +10,10 @@ import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixt
 // bar on "connected" with fs/pty/git providers bound to a dead mux and no
 // relay-loss watcher, so nothing ever scheduled a reconnect.
 
-const { muxRequestMock, openConsumerSessionMock } = vi.hoisted(() => ({
+const { muxRequestMock, openConsumerSessionMock, registeredPtyProvider } = vi.hoisted(() => ({
   muxRequestMock: vi.fn(),
-  openConsumerSessionMock: vi.fn()
+  openConsumerSessionMock: vi.fn(),
+  registeredPtyProvider: { dispose: vi.fn(), attachForReconnect: vi.fn() }
 }))
 
 vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
@@ -108,7 +109,7 @@ vi.mock('../providers/ssh-git-provider', () => ({
 vi.mock('../ipc/pty', () => ({
   registerSshPtyProvider: vi.fn(),
   unregisterSshPtyProvider: vi.fn(),
-  getSshPtyProvider: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  getSshPtyProvider: vi.fn().mockReturnValue(registeredPtyProvider),
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
@@ -129,6 +130,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 
 const { registerSshFilesystemProvider, unregisterSshFilesystemProvider } =
   await import('../providers/ssh-filesystem-dispatch')
+const { getPtyIdsForConnection } = await import('../ipc/pty')
 
 describe('SshRelaySession relay loss on the final grace-time notify', () => {
   /** Armed by a test so the *next* mux dies inside its grace-time notify. */
@@ -138,6 +140,8 @@ describe('SshRelaySession relay loss on the final grace-time notify', () => {
     vi.clearAllMocks()
     armGraceTimeFailure = false
     muxRequestMock.mockReset()
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+    registeredPtyProvider.attachForReconnect.mockReset().mockResolvedValue({})
     openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
       mode: 'legacy-fallback',
       clientInstanceId: options.clientInstanceId,
@@ -194,6 +198,31 @@ describe('SshRelaySession relay loss on the final grace-time notify', () => {
     armGraceTimeFailure = true
     await session.reconnect({} as SshConnection)
 
+    expect(session.getState()).not.toBe('ready')
+    expect(onReady).not.toHaveBeenCalled()
+    expect(onRelayLost).toHaveBeenCalledTimes(1)
+    expect(unregisterSshFilesystemProvider).toHaveBeenCalledWith('target-1')
+  })
+
+  // #11953: reattachKnownPtys swallows every per-PTY failure, so a mux killed by the
+  // reattach burst itself never reaches the catch — the post-reattach gate has to notice.
+  it('routes a mux that dies during PTY reattach into relay-loss recovery', async () => {
+    const { session, onRelayLost, onReady } = createSession()
+
+    await session.establish({} as SshConnection)
+    expect(session.getState()).toBe('ready')
+    onReady.mockClear()
+
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
+    registeredPtyProvider.attachForReconnect.mockImplementation(async () => {
+      const mux = session.getMux() as unknown as { dispose: (reason: string) => void } | null
+      mux?.dispose('connection_lost')
+      throw new Error('SSH connection lost, reconnecting...')
+    })
+
+    await session.reconnect({} as SshConnection)
+
+    expect(registeredPtyProvider.attachForReconnect).toHaveBeenCalled()
     expect(session.getState()).not.toBe('ready')
     expect(onReady).not.toHaveBeenCalled()
     expect(onRelayLost).toHaveBeenCalledTimes(1)

--- a/src/main/ssh/ssh-relay-session-relay-loss.test.ts
+++ b/src/main/ssh/ssh-relay-session-relay-loss.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import type { SshConnection } from './ssh-connection'
+import { SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD } from '../../shared/ssh-types'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+// #11953: the grace-time notify is the last thing establish()/reconnect() do
+// before latching 'ready', and it can dispose the mux synchronously (writer
+// admission cap / throwing transport). Latching 'ready' there left the status
+// bar on "connected" with fs/pty/git providers bound to a dead mux and no
+// relay-loss watcher, so nothing ever scheduled a reconnect.
+
+const { muxRequestMock, openConsumerSessionMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  openConsumerSessionMock: vi.fn()
+}))
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: vi.fn().mockResolvedValue(undefined),
+  allocateSshPtyProviderGeneration: vi.fn(() => 41),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceCancellationProof: vi.fn(() => true),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn().mockResolvedValue('')
+}))
+
+// Mirrors the real multiplexer contract: dispose() latches, and a failed write
+// during notify disposes the mux synchronously via handleProtocolError.
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    private disposed = false
+    private disposeReason: string | null = null
+    private disposeHandlers: ((reason: string) => void)[] = []
+    /** Set by the test to kill the channel from inside notify(). */
+    failNotifyMethod: string | null = null
+    notify = vi.fn((method: string) => {
+      if (method === this.failNotifyMethod) {
+        this.dispose('connection_lost')
+      }
+    })
+    notifyWithSettlement = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn((handler: (reason: string) => void) => {
+      if (this.disposed) {
+        handler(this.disposeReason ?? 'shutdown')
+        return () => {}
+      }
+      this.disposeHandlers.push(handler)
+      return () => {
+        const idx = this.disposeHandlers.indexOf(handler)
+        if (idx !== -1) {
+          this.disposeHandlers.splice(idx, 1)
+        }
+      }
+    })
+    dispose = vi.fn((reason = 'shutdown') => {
+      if (this.disposed) {
+        return
+      }
+      this.disposed = true
+      this.disposeReason = reason
+      for (const handler of this.disposeHandlers.splice(0)) {
+        handler(reason)
+      }
+    })
+    isDisposed = vi.fn(() => this.disposed)
+  }
+}))
+
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: () => false,
+  isSshPtyIdentityMismatchError: () => false,
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    setPtyDeliveryPauseAdapter = vi.fn()
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true)
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { registerSshFilesystemProvider, unregisterSshFilesystemProvider } =
+  await import('../providers/ssh-filesystem-dispatch')
+
+describe('SshRelaySession relay loss on the final grace-time notify', () => {
+  /** Armed by a test so the *next* mux dies inside its grace-time notify. */
+  let armGraceTimeFailure = false
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    armGraceTimeFailure = false
+    muxRequestMock.mockReset()
+    openConsumerSessionMock.mockImplementation(async (_mux, options) => ({
+      mode: 'legacy-fallback',
+      clientInstanceId: options.clientInstanceId,
+      serverBuildId: 'test-relay-build'
+    }))
+    mockDeploySuccess()
+  })
+
+  function createSession(): {
+    session: SshRelaySession
+    onRelayLost: ReturnType<typeof vi.fn>
+    onReady: ReturnType<typeof vi.fn>
+  } {
+    const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    const onRelayLost = vi.fn()
+    const onReady = vi.fn()
+    session.setOnRelayLost(onRelayLost)
+    session.setOnReady(onReady)
+    // Arm once the mux exists; every attempt issues requests before the notify.
+    muxRequestMock.mockImplementation(async () => {
+      const mux = session.getMux() as unknown as {
+        failNotifyMethod: string | null
+      } | null
+      if (mux && armGraceTimeFailure) {
+        mux.failNotifyMethod = SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD
+      }
+      return []
+    })
+    return { session, onRelayLost, onReady }
+  }
+
+  it('fails establish instead of reporting ready on a dead channel', async () => {
+    const { session, onReady } = createSession()
+    armGraceTimeFailure = true
+
+    await expect(session.establish({} as SshConnection)).rejects.toThrow(
+      'Relay connection lost during establish'
+    )
+
+    expect(registerSshFilesystemProvider).toHaveBeenCalledWith('target-1', expect.anything())
+    expect(session.getState()).not.toBe('ready')
+    expect(onReady).not.toHaveBeenCalled()
+    expect(unregisterSshFilesystemProvider).toHaveBeenCalledWith('target-1')
+  })
+
+  it('routes a dead channel during reconnect into relay-loss recovery', async () => {
+    const { session, onRelayLost, onReady } = createSession()
+
+    await session.establish({} as SshConnection)
+    expect(session.getState()).toBe('ready')
+    onReady.mockClear()
+
+    armGraceTimeFailure = true
+    await session.reconnect({} as SshConnection)
+
+    expect(session.getState()).not.toBe('ready')
+    expect(onReady).not.toHaveBeenCalled()
+    expect(onRelayLost).toHaveBeenCalledTimes(1)
+    expect(unregisterSshFilesystemProvider).toHaveBeenCalledWith('target-1')
+  })
+})

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -119,6 +119,22 @@ const SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS = 10_000
 const SSH_PTY_REATTACH_RETRY_MIN_DELAY_MS = 50
 const SSH_PTY_REATTACH_RETRY_JITTER_MS = 200
 const SSH_SOURCE_RECOVERY_CANCELLATION_FAILED = 'ssh_source_recovery_cancellation_failed'
+
+// Why: superseded attempts stop quietly; a dead mux still owned by this attempt must enter recovery.
+function verifyRelayAttempt(
+  mux: SshChannelMultiplexer,
+  isAttemptCurrent: () => boolean,
+  phase: string
+): boolean {
+  if (!isAttemptCurrent()) {
+    return false
+  }
+  if (mux.isDisposed()) {
+    throw new Error(`Relay connection lost during ${phase}`)
+  }
+  return true
+}
+
 type PendingPtyReattach = {
   mux: SshChannelMultiplexer
   providerGeneration: number
@@ -432,14 +448,15 @@ export class SshRelaySession {
 
       const mux = new SshChannelMultiplexer(transport)
       this.mux = mux
-      const ownsAttempt = (): boolean => this.mux === mux && !mux.isDisposed() && !this.isDisposed()
+      const isAttemptCurrent = (): boolean => this.mux === mux && !this.isDisposed()
+      const shouldContinue = (): boolean => isAttemptCurrent() && !mux.isDisposed()
 
       const ptyConsumerSessionState = await this.openPtyConsumerSession(
         mux,
         serverBuildId,
-        ownsAttempt
+        shouldContinue
       )
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'consumer session setup')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
@@ -447,7 +464,7 @@ export class SshRelaySession {
       }
       this.ptyConsumerSessionState = ptyConsumerSessionState
       await this.rememberPtyConsumerRecovery(serverBuildId)
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'consumer recovery persistence')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
@@ -455,7 +472,7 @@ export class SshRelaySession {
       }
 
       await mux.request('session.resolveHome', { path: '~' })
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'home resolution')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
@@ -463,37 +480,35 @@ export class SshRelaySession {
       }
       const connectionIncarnation = randomUUID()
 
-      const registered = await this.registerProviders(mux, ownsAttempt, connectionIncarnation)
+      const registered = await this.registerProviders(mux, shouldContinue, connectionIncarnation)
       if (!registered) {
+        if (!verifyRelayAttempt(mux, isAttemptCurrent, 'provider registration')) {
+          if (!mux.isDisposed()) {
+            mux.dispose()
+          }
+          throw new Error('Session disposed during establish')
+        }
+        throw new Error('Relay provider registration stopped unexpectedly')
+      }
+
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'provider registration')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
         throw new Error('Session disposed during establish')
       }
 
-      // Why: registerProviders swallows mux errors, so an isDisposed check catches a transport that closed mid-registration before we reach 'ready'.
-      if (mux.isDisposed()) {
-        throw new Error('Relay connection lost during provider registration')
-      }
-
-      if (this.isDisposed()) {
-        this.teardownProviders('connection_lost')
-        throw new Error('Session disposed during establish')
-      }
-
       // Why: explicit disconnect keeps PTY ownership, so a later manual connect must reattach those remote PTYs.
-      await this.reattachKnownPtys(mux, ownsAttempt)
+      await this.reattachKnownPtys(mux, shouldContinue)
 
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'PTY reattach')) {
         throw new Error('Session disposed during establish')
       }
 
       this.configureRelayGraceTime(mux, graceTimeSeconds)
-      // Why: notify can dispose the mux synchronously (writer admission / transport throw), so re-check before latching 'ready' (#11953).
-      if (mux.isDisposed()) {
-        throw new Error('Relay connection lost during establish')
-      }
+      verifyRelayAttempt(mux, isAttemptCurrent, 'establish')
       this.watchMuxForRelayLoss(mux)
+      verifyRelayAttempt(mux, isAttemptCurrent, 'establish')
       this._state = 'ready'
       this.startPortScanning()
       this._onReady?.(this.targetId)
@@ -576,19 +591,19 @@ export class SshRelaySession {
       const mux = new SshChannelMultiplexer(transport)
       this.mux = mux
 
-      const ownsAttempt = (): boolean =>
+      const isAttemptCurrent = (): boolean =>
         this.mux === mux &&
-        !mux.isDisposed() &&
         this.abortController === abortController &&
         !abortController.signal.aborted &&
         !this.isDisposed()
+      const shouldContinue = (): boolean => isAttemptCurrent() && !mux.isDisposed()
 
       const ptyConsumerSessionState = await this.openPtyConsumerSession(
         mux,
         serverBuildId,
-        ownsAttempt
+        shouldContinue
       )
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'consumer session setup')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
@@ -596,7 +611,7 @@ export class SshRelaySession {
       }
       this.ptyConsumerSessionState = ptyConsumerSessionState
       await this.rememberPtyConsumerRecovery(serverBuildId)
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'consumer recovery persistence')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
@@ -604,7 +619,7 @@ export class SshRelaySession {
       }
 
       await mux.request('session.resolveHome', { path: '~' })
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'home resolution')) {
         if (!mux.isDisposed()) {
           mux.dispose()
         }
@@ -612,20 +627,21 @@ export class SshRelaySession {
       }
       const connectionIncarnation = randomUUID()
 
-      const registered = await this.registerProviders(mux, ownsAttempt, connectionIncarnation)
+      const registered = await this.registerProviders(mux, shouldContinue, connectionIncarnation)
       if (!registered) {
-        if (!mux.isDisposed()) {
-          mux.dispose()
+        if (!verifyRelayAttempt(mux, isAttemptCurrent, 'provider registration')) {
+          if (this.mux === mux) {
+            this.teardownProviders('shutdown')
+          } else if (!mux.isDisposed()) {
+            mux.dispose()
+          }
+          return
         }
-        return
-      }
-
-      if (mux.isDisposed()) {
-        throw new Error('Relay connection lost during provider registration')
+        throw new Error('Relay provider registration stopped unexpectedly')
       }
 
       // Why: dispose() during registration/attach already cleaned up, but this.mux was reassigned above — clean up the new mux so it doesn't leak.
-      if (!ownsAttempt()) {
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'provider registration')) {
         if (this.mux === mux) {
           this.teardownProviders('shutdown')
         } else if (!mux.isDisposed()) {
@@ -634,23 +650,16 @@ export class SshRelaySession {
         return
       }
 
-      await this.reattachKnownPtys(mux, ownsAttempt)
+      await this.reattachKnownPtys(mux, shouldContinue)
 
-      if (!ownsAttempt()) {
-        // Why: reattach swallows per-PTY errors, so a mux killed mid-reattach must take the failure
-        // path here or the session wedges in 'reconnecting' with no relay-loss watcher (#11953).
-        if (this.mux === mux && mux.isDisposed()) {
-          throw new Error('Relay connection lost during PTY reattach')
-        }
+      if (!verifyRelayAttempt(mux, isAttemptCurrent, 'PTY reattach')) {
         return
       }
 
       this.configureRelayGraceTime(mux, graceTimeSeconds)
-      // Why: notify can dispose the mux synchronously (writer admission / transport throw), so re-check before latching 'ready' (#11953).
-      if (mux.isDisposed()) {
-        throw new Error('Relay connection lost during reconnect')
-      }
+      verifyRelayAttempt(mux, isAttemptCurrent, 'reconnect')
       this.watchMuxForRelayLoss(mux)
+      verifyRelayAttempt(mux, isAttemptCurrent, 'reconnect')
       this._state = 'ready'
       this.startPortScanning()
       this._onReady?.(this.targetId)

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -637,6 +637,11 @@ export class SshRelaySession {
       await this.reattachKnownPtys(mux, ownsAttempt)
 
       if (!ownsAttempt()) {
+        // Why: reattach swallows per-PTY errors, so a mux killed mid-reattach must take the failure
+        // path here or the session wedges in 'reconnecting' with no relay-loss watcher (#11953).
+        if (this.mux === mux && mux.isDisposed()) {
+          throw new Error('Relay connection lost during PTY reattach')
+        }
         return
       }
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -489,6 +489,10 @@ export class SshRelaySession {
       }
 
       this.configureRelayGraceTime(mux, graceTimeSeconds)
+      // Why: notify can dispose the mux synchronously (writer admission / transport throw), so re-check before latching 'ready' (#11953).
+      if (mux.isDisposed()) {
+        throw new Error('Relay connection lost during establish')
+      }
       this.watchMuxForRelayLoss(mux)
       this._state = 'ready'
       this.startPortScanning()
@@ -637,6 +641,10 @@ export class SshRelaySession {
       }
 
       this.configureRelayGraceTime(mux, graceTimeSeconds)
+      // Why: notify can dispose the mux synchronously (writer admission / transport throw), so re-check before latching 'ready' (#11953).
+      if (mux.isDisposed()) {
+        throw new Error('Relay connection lost during reconnect')
+      }
       this.watchMuxForRelayLoss(mux)
       this._state = 'ready'
       this.startPortScanning()

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -7,6 +7,9 @@ import {
 
 const SSH_FAILURE =
   "SSH connection failed: Error invoking remote method 'ssh:connect': Error: Relay package for linux-x64 not found locally."
+// Relay loss reaches reportError already IPC-wrapped, so the marker is mid-string.
+const RELAY_LOST =
+  "Error invoking remote method 'pty:attach': Error: SSH connection lost, reconnecting..."
 
 describe('isSshReconnectOwnedTerminalError', () => {
   it('matches raw ssh:connect failures and inactive-host messages', () => {
@@ -20,6 +23,11 @@ describe('isSshReconnectOwnedTerminalError', () => {
         'SSH connection is not active. Use the reconnect dialog or Settings to connect.'
       )
     ).toBe(true)
+  })
+
+  it('matches an IPC-wrapped relay-loss message', () => {
+    expect(isSshReconnectOwnedTerminalError(RELAY_LOST)).toBe(true)
+    expect(isSshReconnectOwnedTerminalError('SSH connection lost, reconnecting...')).toBe(true)
   })
 
   it('leaves unrelated terminal errors for the toast', () => {
@@ -47,6 +55,11 @@ describe('stripSshReconnectOwnedErrorLines', () => {
         `${SSH_FAILURE}\nPaste failed.\nSSH connection is not active. Use the reconnect dialog.`
       )
     ).toBe('Paste failed.')
+  })
+
+  it('drops an IPC-wrapped relay-loss line and keeps the rest', () => {
+    expect(stripSshReconnectOwnedErrorLines(RELAY_LOST)).toBeNull()
+    expect(stripSshReconnectOwnedErrorLines(`Paste failed.\n${RELAY_LOST}`)).toBe('Paste failed.')
   })
 
   it('leaves an error with no SSH text untouched', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -2,6 +2,8 @@ import { translate } from '@/i18n/i18n'
 const SSH_PREFIX = 'SSH connection is not active'
 // Produced by pty-connection.ts reportError() when a PTY reattach can't reach its SSH host.
 const SSH_CONNECT_FAILURE_PREFIX = 'SSH connection failed'
+// Matched with includes(): this arrives IPC-wrapped ("Error invoking remote method 'pty:…': Error: …").
+const SSH_RELAY_LOST_MARKER = 'SSH connection lost, reconnecting'
 const STALE_NODE_PTY_DAEMON_MARKERS = [
   "Daemon's node-pty install is gone",
   'node-pty: posix_spawn failed: ENOENT'
@@ -12,12 +14,16 @@ const STALE_DAEMON_CWD_MARKERS = [
 ]
 
 function isSshError(error: string): boolean {
-  return error.startsWith(SSH_PREFIX)
+  return error.startsWith(SSH_PREFIX) || error.includes(SSH_RELAY_LOST_MARKER)
 }
 
 /** A single error line the SSH reconnect banner already covers — hide instead of stacking under/over it. */
 export function isSshReconnectOwnedTerminalError(error: string): boolean {
-  return error.startsWith(SSH_CONNECT_FAILURE_PREFIX) || error.startsWith(SSH_PREFIX)
+  return (
+    error.startsWith(SSH_CONNECT_FAILURE_PREFIX) ||
+    error.startsWith(SSH_PREFIX) ||
+    error.includes(SSH_RELAY_LOST_MARKER)
+  )
 }
 
 // Why: onPtyError aggregates errors into one newline-joined string, so classify per line —


### PR DESCRIPTION
## Summary

An SSH remote could show "connected" in the status bar while every remote terminal write and every file-tree read failed with `Error: Multiplexer disposed`, permanently, until the app was restarted.

Three coupled defects:

1. **The session latched `ready` on a dead multiplexer.** `SshRelaySession.establish()` (`src/main/ssh/ssh-relay-session.ts:491`) and `reconnect()` (`:648`) ran their last liveness gate *before* `configureRelayGraceTime()`. That call is `mux.notify()` → `sendMessage` → `SshMultiplexerTransportWriter.enqueue`, which can call `this.fail(err)` **synchronously** from the bounded control-lane admission cap (`src/main/ssh/ssh-multiplexer-transport-writer.ts:84-88`) or from `writeEntry`'s catch on a throwing transport (`:181-187`) → `onFailure` → `handleProtocolError` → `dispose('connection_lost')` (`src/main/ssh/ssh-channel-multiplexer.ts:586-588`). The session then called `watchMuxForRelayLoss(mux)` on an already-dead mux — where `onDispose()` returned a silent no-op — and set `_state = 'ready'` + `_onReady` (status bar "connected" via `src/main/ipc/ssh.ts:1150-1156` on first connect and `:828-851` on the reconnect path), while the pty/fs/git providers stayed registered against the dead mux. `_onRelayLost` never fired, so the bounded relay backoff at `src/main/ipc/ssh.ts:719` never ran. Permanently wedged. Both sites now re-check `mux.isDisposed()` immediately after the notify (`:493-494`, `:650-651`) and take the existing failure path (`establish()` rethrows into the session catch that already runs `teardownProviders`, and the `ssh:connect` handler's catch then runs `abandonFailedSshSession` at `ssh.ts:1157-1161`; `reconnect()` routes into `_onRelayLost` at `:684`, i.e. the bounded exponential backoff). A third gate was added in `reconnect()` after `reattachKnownPtys()` (`:642-643`): that helper swallows every per-PTY failure, so a mux killed by the reattach burst itself would otherwise fall into the silent `return` and wedge the session in `reconnecting` with no relay-loss watcher.

2. **The dispose reason was dropped for post-dispose callers.** `request()` and `notifyWithSettlement()` (now `src/main/ssh/ssh-channel-multiplexer.ts:192-194` and `:280-282`) always threw the permanent-shutdown string `'Multiplexer disposed'` with no `code`, even when `dispose()` had recorded `connection_lost` — which `dispose()` itself mapped correctly for its own pending-request and writer rejections, and which both stream readers already follow (`ssh-filesystem-stream-reader.ts:255-263`). This matters beyond defect 1: `watchMuxForRelayLoss` fires `_onRelayLost` but does *not* tear down providers (`ssh-relay-session.ts:818-828`), so on the ordinary relay-loss path the fs/pty/git providers stay bound to the disposed mux for the whole backoff delay and every `fs:readDir` / pty reattach in that window reported the permanent string. The reason is now recorded in a `disposeReason` field and a single `disposedError()` factory (`:374-381`) serves `dispose()`, `request()`, and `notifyWithSettlement()`. `onDispose()` on an already-disposed mux now invokes the handler synchronously with the recorded reason instead of returning a no-op (without retaining the handler, so the anti-leak contract at `ssh-channel-multiplexer.test.ts` is preserved).

3. **The renderer called a transient drop a bug to report.** `TerminalErrorToast.isSshError` / `isSshReconnectOwnedTerminalError` (`src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx:16-27`) did not recognise relay-lost text, so it rendered in the red "If this persists, please file an issue" style (that link is gated on `!ssh` at `:87`). Matched with `includes()`, not `startsWith()`, because the message reaches the toast IPC-wrapped as `Error invoking remote method 'pty:…': Error: SSH connection lost, reconnecting...` — the same reason `isSshSessionExpiredError` (`pty-connection.ts:769-771`) uses `includes`.

One forced follow-on: `src/main/ssh/ssh-git-response-stream-reader.ts` now registers its `mux.onDispose` subscriber *after* the abort-signal wiring. With immediate-fire `onDispose`, `fail()` runs during that call and drains `unsubscribers`; registering it first would leak a listener on the caller's `AbortSignal` for the signal's lifetime. Pure reorder (plus a comment), no new branch. `ssh-filesystem-stream-reader.ts` already registers its dispose subscriber last and needs no change.

Closes #11953

Scope caveat: the issue has no repro ("IDK"), and the reporter's exact close-and-reopen sequence was **not** reproduced live. This fixes the mechanism that produces exactly the reported state — a "connected" status bar over a dead multiplexer, with `Multiplexer disposed` on every `fs:readDir` and terminal write and no automatic recovery — and makes the transient case both self-healing and honestly labelled. It is not a confirmation that this was the only way to reach that state.

## ELI5

When Orca connects to a remote machine over SSH, the very last thing it does before saying "connected" is send one small setup message. If the connection happened to die at exactly that moment, Orca still put up the green "connected" badge — but everything behind it was already dead, and Orca never noticed, so it never tried to reconnect. Remote terminals and the file tree just failed forever with a confusing message until you restarted the app. Now Orca checks one more time right after that last message, and if the connection is gone it either fails the connect honestly or starts its normal automatic retry. Separately, when the connection drops it now says "SSH connection lost, reconnecting…" instead of a scary internal error with a "please file an issue" link.

## Fix proof

Before (the throwaway repro artifacts — not part of this diff — run against `origin/main`):

```
$ npx vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-session.bug-11953.test.ts src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts

 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_60c051cd-fbd-43

 ❯ src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts (3 tests | 3 failed) 7ms
     × reports a transient relay drop as a permanent dispose to later requests 5ms
     × reports a transient relay drop as a permanent dispose to notifyWithSettlement 1ms
     × drops relay-loss watchers registered after the mux already died 1ms
 ❯ src/main/ssh/ssh-relay-session.bug-11953.test.ts (1 test | 1 failed) 6ms
     × does not report ready when the relay channel dies on the last establish notify 5ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts > bug-11953: dispose reason is lost for post-dispose callers > reports a transient relay drop as a permanent dispose to later requests
AssertionError: expected 'Multiplexer disposed' to be 'SSH connection lost, reconnecting...' // Object.is equality

Expected: "SSH connection lost, reconnecting..."
Received: "Multiplexer disposed"

 ❯ src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts:42:38
     40|     // Expected (matches ssh-filesystem-stream-reader.ts:255-263 and t…
     41|     // pending-request rejection inside dispose()).
     42|     expect((error as Error).message).toBe('SSH connection lost, reconn…
       |                                      ^
     43|     expect((error as Error & { code?: string }).code).toBe('CONNECTION…
     44|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

 FAIL  src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts > bug-11953: dispose reason is lost for post-dispose callers > reports a transient relay drop as a permanent dispose to notifyWithSettlement
AssertionError: expected 'Multiplexer disposed' to be 'SSH connection lost, reconnecting...' // Object.is equality

Expected: "SSH connection lost, reconnecting..."
Received: "Multiplexer disposed"

 ❯ src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts:53:34
     51|
     52|     const result = settled.mock.calls[0]?.[0] as { ok: false; error: E…
     53|     expect(result.error.message).toBe('SSH connection lost, reconnecti…
       |                                  ^
     54|     expect(result.error.code).toBe('CONNECTION_LOST')
     55|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯

 FAIL  src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts > bug-11953: dispose reason is lost for post-dispose callers > drops relay-loss watchers registered after the mux already died
AssertionError: expected "vi.fn()" to be called with arguments: [ 'connection_lost' ]

Number of calls: 0

 ❯ src/main/ssh/ssh-channel-multiplexer.bug-11953.test.ts:69:25
     67|     mux.dispose('connection_lost')
     68|
     69|     expect(onRelayLost).toHaveBeenCalledWith('connection_lost')
       |                         ^
     70|   })
     71| })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯

 FAIL  src/main/ssh/ssh-relay-session.bug-11953.test.ts > bug-11953: session latches ready on a dead multiplexer > does not report ready when the relay channel dies on the last establish notify
AssertionError: expected 0 to be greater than 0
 ❯ src/main/ssh/ssh-relay-session.bug-11953.test.ts:165:86
    163|     // fire the relay-loss recovery path. Today it does neither, and t…
    164|     // provider stays registered against the disposed mux.
    165|     expect(onRelayLost.mock.calls.length + (session.getState() === 're…
       |                                                                                      ^
    166|       0
    167|     )

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯


 Test Files  2 failed (2)
      Tests  4 failed (4)
   Start at  21:59:13
   Duration  3.80s (transform 2.98s, setup 0ms, import 3.81s, tests 13ms, environment 0ms)
```

The repro artifacts were reworked into permanent regression tests: the multiplexer cases folded into the existing `dispose` block of `src/main/ssh/ssh-channel-multiplexer.test.ts` (4 added cases), the session case rewritten as `src/main/ssh/ssh-relay-session-relay-loss.test.ts` with three cases (dead channel on the final `establish()` notify, the same on `reconnect()`, and a mux that dies during PTY reattach), and a new `src/main/ssh/ssh-git-response-stream-reader.test.ts` pinning the listener-leak reorder.

After (re-run on the PR head, macOS):

```
$ npx vitest run --config config/vitest.config.ts src/main/ssh/ssh-relay-session-relay-loss.test.ts src/main/ssh/ssh-git-response-stream-reader.test.ts

 RUN  v4.1.5

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Duration  5.83s (transform 4.89s, setup 0ms, import 6.02s, tests 11ms, environment 0ms)
```

```
$ npx vitest run --config config/vitest.config.ts src/main/ssh/ssh-channel-multiplexer.test.ts -t "dispose"

 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  13 passed | 21 skipped (34)
   Duration  123ms (transform 40ms, setup 0ms, import 51ms, tests 7ms, environment 0ms)
```

The listener-leak guard was verified to actually guard: reverting only the `ssh-git-response-stream-reader.ts` reorder turns it red.

```
 FAIL  src/main/ssh/ssh-git-response-stream-reader.test.ts > requestGitStreamable on an already-dead multiplexer > rejects as a transient relay loss and leaves no listener on the caller signal
AssertionError: expected "removeEventListener" to be called 1 times, but got 0 times
 ❯ src/main/ssh/ssh-git-response-stream-reader.test.ts:28:28

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

## No regressions

Every suite that neighbours a touched file, or imports what changed.

`src/main/ssh/` + `src/main/providers/` — the whole relay-session family, the multiplexer suites, the transport writer, both stream readers, the pty/fs/git providers:

```
$ npx vitest run --config config/vitest.config.ts src/main/ssh/ src/main/providers/

 Test Files  130 passed | 2 skipped (132)
      Tests  1872 passed | 13 skipped (1885)
   Duration  16.27s (transform 35.39s, setup 0ms, import 59.71s, tests 30.87s, environment 6ms)
```

`src/relay/` (the integration suites that drive the real multiplexer end to end), `src/main/ipc/ssh.test.ts`, `src/main/ipc/pty.test.ts`, `src/main/agent-hooks/` (WSL relay link + guest plugin install), and the full `src/renderer/src/components/terminal-pane/` tree:

```
$ npx vitest run --config config/vitest.config.ts src/relay/ src/main/ipc/ssh.test.ts src/main/ipc/pty.test.ts src/main/agent-hooks/ src/renderer/src/components/terminal-pane/

 Test Files  355 passed (355)
      Tests  5147 passed | 3 skipped (5150)
   Duration  41.60s (transform 173.41s, setup 0ms, import 220.92s, tests 225.55s, environment 8.02s)
```

Total: 487 files, 7019 passing, 16 skipped, 0 failing.

### Trade-offs

This is not zero-cost — there is one real user-visible behaviour change:

- **An `ssh:connect` whose relay channel dies in the final establish window now fails the connect instead of appearing to succeed.** Previously it reported "connected" and then silently wedged; now the transport is torn down and the error surfaces through the `ssh:connect` rejection. That is strictly better than the silent wedge and matches the existing contract for a relay lost during provider registration (`ssh-relay-session.ts:475-476`), but it is a behaviour change: a class of connect attempts that used to show a green badge now shows a failure, and **there is no automatic retry on that path** — the user has to hit connect again. On the `reconnect()` path there is no downside; the drop enters the existing bounded exponential backoff and recovers on its own.
- **The transient-drop terminal toast becomes amber instead of red** and loses its "please file an issue" link. It is suppressed entirely only when the SSH reconnect banner happens to be up — `src/main/ipc/ssh.ts:740-742` skips the override publish when a redeploy timer is already armed, so the amber toast is the realistic outcome, not silence. If the relay never comes back, `ssh.ts:750-762` still escalates to an explicit error override after `RELAY_LOST_MAX_ATTEMPTS`, so a genuinely broken link stays loud — it is just no longer mislabeled as a bug to file.
- **`onDispose()` on an already-disposed mux now fires synchronously.** For the two stream readers this is strictly earlier and better (they previously waited for the request to reject). It forced the one-line reorder in `ssh-git-response-stream-reader.ts` described above; the WSL relay link (`wsl-hook-relay-link.ts:56`) is guarded by its own `dead` flag and subscribes to a mux constructed one statement earlier, so the path is unreachable there in practice.

### Verification limits

- Verified by unit tests only, executed on **macOS**. No manual end-to-end run against a live SSH remote, and nothing was exercised on Linux or Windows hosts (including the Windows-only WSL relay link, which is covered by its existing suite but not by a live run).
- The relay-loss session tests drive a mocked `SshChannelMultiplexer`, not the real transport; the real synchronous-dispose paths (writer admission cap, throwing transport) are covered separately by the multiplexer suites rather than end to end in one test.

## Cross-platform

No platform-dependent code is touched. No keyboard shortcuts (no `metaKey`/`ctrlKey`), no Electron accelerators, no shortcut labels, no filesystem path construction. The session and multiplexer changes are pure main-process state-machine logic; the renderer change is a substring constant.

- **macOS / Linux / Windows (local app):** identical behaviour. `mux.isDisposed()` and the dispose-reason field carry no platform semantics. The Windows-only WSL relay link is covered under Trade-offs and is unaffected in practice; `src/main/agent-hooks/` is green.
- **Remote host platform:** identical whether the remote is Linux, macOS, or Windows. `joinRemotePath` / `hostPlatform.pathDelimiter` are untouched, so there is no `/` vs `\` or case-sensitivity exposure.
- **SSH-remote:** this is squarely the SSH-remote path. The fix exists only so remote execution recovers instead of wedging; nothing here assumes local execution.
- **Folder workspaces (non-git):** workspace-shape agnostic. `SshRelaySession` is keyed by `targetId` (an SSH target), never by workspace, so folder workspaces and git worktrees on the remote are affected identically and neither is special-cased. No code path here asks whether a workspace is a git repo.
- **Git:** no Git subcommand, option, or capability probe is added or changed, so the Git 2.25 baseline, `GitCapabilityCache`, and the leading-`-c` global-option commands are untouched. `SshGitProvider` only benefits from getting an accurate `CONNECTION_LOST` code on a dropped relay. No provider-specific (GitHub/GitLab) surface is involved.

## Performance

- `SshChannelMultiplexer`: one nullable field, plus a small `Error` factory on paths that already allocated exactly the same Errors. `dispose()` allocates the same number of Errors as before (one per pending request, one for the writer).
- `SshRelaySession`: one added boolean field read per `establish()`, two per `reconnect()` (post-reattach and post-notify).
- `ssh-git-response-stream-reader`: a statement reorder — same work, different order.
- `TerminalErrorToast`: one `String.prototype.includes` per error line, only when a terminal error toast renders. No extra renders, no new state.

No new timers, listeners, polling, allocations in hot loops, or IPC traffic. In the failure case the change *reduces* work: the session tears down instead of leaving keepalive-free dead providers registered while every subsequent `fs:readDir` and pty write round-trips into a dead multiplexer.

## Security

No change. No new IPC channels or handlers, no changes to IPC payload shapes or validation. No command execution and no shell/argument construction added or modified. No path handling — no path is built, joined, normalised, or resolved in this diff. No change to the auth surface: credentials, key handling, the relay handshake, and endpoint credential checks are untouched.

The one adjacent consideration is error-message content: post-dispose callers can now receive `'SSH connection lost, reconnecting...'` instead of `'Multiplexer disposed'`. Both are fixed literals — no host, path, user, or credential material is added to any message reaching the renderer.

## AI Review Report

Reviewed by independent subagents in a loop until clean, across two hostile lenses — **correctness/regressions** and **cross-platform + remote + performance**.

- **Review loop count:** 2 round(s)
- **Final verdict:** CLEAN
- The final round returned **zero blocker/major findings** from both lenses.

**Non-blocking notes (1), recorded for transparency:**
- `src/main/ssh/ssh-relay-session.ts:615-621` — The PR closes the two windows where a mid-reconnect mux death used to be swallowed (post-`reattachKnownPtys` and post-`configureRelayGraceTime`), but leaves the identical window one branch earlier: `const registered = await this.registerProviders(mux, ownsAttempt, connectionIncarnation); if (!registered) { if (!mux.isDisposed()) mux.dispose(); return }`. `registerProviders` returns `false` precisely when `ownsAttempt()` goes false — which includes "the mux just died" — so that path still returns silently without firing `_onRelayLost`. It is strictly less likely than the windows this PR closes (the `isDisposed()` throw at `:623-625` catches the common ordering) and was left alone to keep the diff focused; worth a follow-up.

**Remediation applied between rounds:** 1 pass(es). Findings judged false-positive were rejected with evidence rather than coded around. Separately, one CodeRabbit review comment is open and **not** addressed in this diff: it proposes exporting a shared disposal-error factory so `ssh-channel-multiplexer.disposedError()` and the git stream reader's `onDispose` callback stop duplicating the message/code mapping. That duplication predates this PR (the same mapping also lives in `ssh-filesystem-stream-reader.ts:255-263`) and is left as-is here.


Made with [Orca](https://github.com/stablyai/orca) 🐋
