### PR TITLE
fix(terminal): require a physical Enter key for the Windows IME Process-Enter path

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -326,6 +326,7 @@ describe('isTerminalImeProcessEnter', () => {
     ({
       key: 'Process',
       keyCode: 229,
+      code: 'Enter',
       metaKey: false,
       ctrlKey: false,
       altKey: false,
@@ -340,6 +341,10 @@ describe('isTerminalImeProcessEnter', () => {
     }
   )
 
+  it('recognizes the numeric keypad Enter', () => {
+    expect(isTerminalImeProcessEnter(event({ code: 'NumpadEnter' }))).toBe(true)
+  })
+
   it.each([
     { key: 'Enter' },
     { keyCode: 13 },
@@ -347,6 +352,19 @@ describe('isTerminalImeProcessEnter', () => {
     { ctrlKey: true },
     { altKey: true }
   ])('rejects a non-IME or ambiguous Process key', (override) => {
+    expect(isTerminalImeProcessEnter(event(override))).toBe(false)
+  })
+
+  // Why: the Windows Korean IME claims both the jamo keydown and the bare Shift
+  // keydown while composing, and Chromium reports each as Process/229 with the
+  // modifier held. Only `code` distinguishes them from a real Shift+Enter.
+  it.each([
+    { code: 'KeyR' },
+    { code: 'KeyE' },
+    { code: 'KeyT' },
+    { code: 'ShiftLeft' },
+    { code: 'ShiftRight' }
+  ])('rejects an IME-claimed non-Enter physical key', (override) => {
     expect(isTerminalImeProcessEnter(event(override))).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -107,11 +107,18 @@ export function getTerminalImeModifiedEnterKind(
 }
 
 export function isTerminalImeProcessEnter(
-  event: Pick<KeyboardEvent, 'key' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+  event: Pick<
+    KeyboardEvent,
+    'key' | 'keyCode' | 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'
+  >
 ): boolean {
   return (
     event.key === 'Process' &&
     event.keyCode === 229 &&
+    // Why: Windows masks every IME-consumed keydown as Process/229, so the held
+    // modifier alone cannot tell Shift+Enter from Shift+<jamo> (ㄲㄸㅃㅆㅉ, ㅒㅖ) or
+    // even the IME-claimed bare Shift. `code` is the physical key and is not masked.
+    (event.code === 'Enter' || event.code === 'NumpadEnter') &&
     getTerminalImeModifiedEnterKind(event) !== null
   )
 }


### PR DESCRIPTION
Closes #12151
Closes #12152

## Summary

On Windows with a Korean IME, typing a double consonant (ㄲㄸㅃㅆㅉ) or ㅒ/ㅖ inserts a spurious newline into the running agent's prompt. `isTerminalImeProcessEnter()` accepted **any** IME-consumed keydown that carried a Shift or Ctrl modifier:

```ts
return (
  event.key === 'Process' &&
  event.keyCode === 229 &&
  getTerminalImeModifiedEnterKind(event) !== null   // only checks shiftKey / ctrlKey
)
```

Windows Chromium masks *every* key the IME consumes as `key: 'Process', keyCode: 229`, so the predicate cannot tell Shift+Enter from Shift+R (ㄲ) — it never looks at which physical key was pressed. `keyboard-handlers.ts` then synthesises `{ key: 'Enter', ... }` from it, `resolveTerminalShortcutAction()` returns `\x1b[13;2u`, and the agent inserts a newline mid-word.

The fix gates on `event.code`, which carries the physical key and is not masked by the IME. This can only *narrow* the predicate, so it cannot introduce new false positives.

Because the send is deferred to `compositionend`, the newline lands one syllable early — typing `줄바꿈` produces `줄\n바꿈`.

<details>
<summary>Measured keydown stream (Chrome 151 / Windows 11 / 2-set layout, typing <code>ㄲㄲ</code>)</summary>

```
#  type     key      code        keyCode  shift  isComposing  predicate
1  keydown  Shift    ShiftRight  16       true   false        false
2  keydown  Process  KeyR        229      true   false        false
   compositionstart / compositionupdate "ㄲ"
3  keydown  Process  ShiftRight  229      true   true         TRUE   <-- misread
4  keydown  Shift    ShiftRight  16       true   true         false
5  keydown  Process  KeyR        229      true   true         TRUE   <-- misread
   compositionupdate "ㄲ" / compositionend "ㄲ"
```

Event 3 shows the trigger is broader than the "double consonants" described in #12152 — while composing, the IME also claims the **bare Shift keydown** and Chromium delivers it as `Process`/229. `code` is populated and correct on every one of these.

Running the two functions cut verbatim out of a shipped 1.4.164 bundle against synthetic events for the full layout gives **7 false positives** (ㄲㄸㅃㅆㅉ + ㅒㅖ), with genuine Shift+Enter and Ctrl+Enter still correct.

</details>

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

I did not run the repo-wide scripts — I don't have the monorepo toolchain installed locally. Rather than leave that as a blank, here is exactly what I did run, and the gaps:

| What I ran | Result |
|---|---|
| `terminal-ime-deferred-newline.test.ts` under real vitest | **38 passed (38)** — all pre-existing cases plus the new ones |
| Same test file against the **unpatched** source (negative control) | `5 failed \| 33 passed` — exactly the five new cases, nothing else |
| `tsc --noEmit --strict` on the changed module + `terminal-ime-composition-route.ts` | clean; the unpatched source produces the identical result, so the `Pick<>` change introduces no type error |
| `oxfmt --check` with the repo's `.oxfmtrc.json` | `All matched files use the correct format.` |
| End-to-end on a locally patched 1.4.164 install | Spurious newlines gone; **Shift+Enter pressed mid-composition still inserts a newline** |

The test file's only imports outside the module under test are `import type`, so it has no runtime dependencies and runs standalone. **Not covered:** repo-wide `pnpm test`, `oxlint` and the custom gates (`check:reliability-gates`, `check:max-lines-ratchet`, …), and `pnpm build`. CI should confirm those.

New tests:
- `recognizes the numeric keypad Enter` — `code: 'NumpadEnter'`
- `rejects an IME-claimed non-Enter physical key` — `KeyR`, `KeyE`, `KeyT`, `ShiftLeft`, `ShiftRight`

The existing fixture omitted `code` entirely, so `code: 'Enter'` is added to it. That matches reality — `keyboard-handlers-ime.test.tsx` already models the IME-claimed Enter as `{ key: 'Process', code: 'Enter' }`.

## AI Review Report

Risks checked and how they were resolved:

- **Does narrowing break a genuine Shift+Enter?** This is the main risk, since the whole code path exists to serve it. Checked three ways: `code` is spec'd as the physical key and is not masked by the IME; the repo's own integration tests already assume `code: 'Enter'` for this event; and I verified on a locally patched build that Shift+Enter pressed *mid-composition* still inserts a newline. Remaining uncertainty is flagged under Notes.
- **Hidden dependants.** A code search shows exactly three files reference `isTerminalImeProcessEnter` — the definition, `keyboard-handlers.ts`, and its test. All three reviewed.
- **Regression in existing tests.** Confirmed by running the whole file, not just the new cases: 38/38, and the negative control isolates the five new failures to the unpatched predicate.
- **Formatting/type drift.** `oxfmt --check` and `tsc --noEmit --strict` both clean.

**Cross-platform compatibility (macOS / Linux / Windows).** The only caller gates this predicate behind `isWindows`:

```ts
const imeProcessEnter = isWindows && hasPendingImeComposition && isTerminalImeProcessEnter(e)
```

so macOS and Linux behaviour is unchanged — the branch never executes there. `KeyboardEvent.code` is a physical-key identifier defined independently of keyboard layout, IME, and OS, so the new condition carries no platform-specific assumption. No shortcut definitions, labels, paths, shell invocations, or Electron platform branches are touched.

On the other side, this likely fixes the same defect for **other IMEs on Windows**: Chinese Pinyin (Shift commonly toggles to English mid-composition), Japanese (uppercase romaji), and Vietnamese Telex/VNI (uppercase) all hold Shift during composition and would hit the identical false positive today.

## Security Audit

- **Input handling** — the change strictly reduces the set of keyboard events that cause bytes to be written to the pty. It removes an unintended `\x1b[13;2u` injection triggered by ordinary text entry; it does not widen any input path.
- **Command execution / path handling / auth / secrets / IPC** — untouched. No new syscalls, no filesystem access, no serialization boundary changes.
- **Dependencies** — none added or upgraded.
- **Untrusted input** — `event.code` is a fixed-vocabulary DOM-supplied identifier compared against two literals; it is not interpolated into anything.

No follow-up items identified.

## Notes

- **Windows-only code path.** The defect and the fix are both behind `isWindows`.
- **Open question for reviewers.** The check treats a blank or absent `code` as "not Enter". On my hardware `code` is always populated (see the dump above) and the existing integration tests assume `code: 'Enter'`. If you know of an environment where a genuine Shift+Enter arrives with an empty `code` — remote desktop, virtual keyboards, remapping tools — the condition should be relaxed to `!event.code || event.code === 'Enter' || event.code === 'NumpadEnter'`. Happy to switch to the lenient form if you prefer.
- **The newline offset** (one syllable early) comes from `sendTerminalInputAfterComposition` deferring the send to `compositionend`. That behaviour is unchanged here and may share a root with #12132.
- **Why CI did not catch this.** `terminal-ime-e2e.yml` runs only on `ubuntu-22.04` with ibus-hangul, and the faulty branch is gated on `isWindows`, so it never executes in CI. `korean-ime-terminal-shift-enter-commit.spec.ts` dispatches jamo Process keys only *without* Shift, and the committing chord only with `code: 'Enter'` — no case combines `shiftKey: true` with a non-Enter `code`.
- **Not related to #9703.** "trust Pi CSI-u Shift+Enter on Windows" (shipped in 1.4.164) is a different bug — Pi + Git Bash, Shift+Enter submitting instead of inserting a newline. It landed after the 1.4.161 → 1.4.162 regression window and does not touch this predicate. Flagging it so nobody re-investigates that path.
- **On the docstring-coverage warning.** `AGENTS.md` asks for concise non-obvious "WHY not HOW" comments and explicitly warns against verbosity; neither function in this file carries a docstring today. I followed the file's existing style with a short `// Why:` comment rather than adding JSDoc. Happy to add docstrings if maintainers prefer.
