### PR TITLE
Allow plugin panels to invoke their own worker commands

### DIFF
--- a/examples/plugins/hello-orca/panel.html
+++ b/examples/plugins/hello-orca/panel.html
@@ -43,6 +43,7 @@
   <body>
     <h1>Hello Orca 👋</h1>
     <p>Panel + worker command + events, gated by consent.</p>
+    <button id="ping">Ping this plugin's worker</button>
     <button id="ctx">Read workspace context</button>
     <select id="terms" hidden></select>
     <button id="send" hidden>Type "echo hi from plugin" into selected terminal</button>
@@ -75,6 +76,17 @@
         if (!resolve) return
         delete pending[data.requestId]
         resolve(data)
+      })
+
+      document.getElementById('ping').addEventListener('click', function () {
+        call('plugin.command.invoke', {
+          commandId: 'hello-ping',
+          args: { source: 'panel' }
+        }).then(function (result) {
+          statusEl.textContent = result.ok
+            ? 'worker pong count=' + result.value.count
+            : 'worker ping failed: ' + (result.error || result.errorCode)
+        })
       })
 
       document.getElementById('ctx').addEventListener('click', function () {

--- a/src/main/plugins/plugin-panel-controller.test.ts
+++ b/src/main/plugins/plugin-panel-controller.test.ts
@@ -5,7 +5,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { pluginManifestSchema } from '../../shared/plugins/plugin-manifest'
 import { createPluginPanelCallAdmission } from '../../shared/plugins/plugin-panel-call-admission'
 import type { ValidDiscoveredPlugin } from './plugin-discovery'
-import { PluginPanelController } from './plugin-panel-controller'
+import {
+  PLUGIN_PANEL_COMMAND_ERROR_MAX_CODE_UNITS,
+  PLUGIN_PANEL_COMMAND_RESULT_MAX_BYTES,
+  PluginPanelController
+} from './plugin-panel-controller'
 
 const roots: string[] = []
 
@@ -42,6 +46,164 @@ async function createPlugin(): Promise<ValidDiscoveredPlugin> {
 }
 
 describe('PluginPanelController identity binding', () => {
+  it('invokes only the command worker bound to the open panel session', async () => {
+    const plugin = await createPlugin()
+    const invokePluginCommand = vi.fn().mockResolvedValue({
+      sessions: [{ id: 'session-one', title: 'First session' }]
+    })
+    const controller = new PluginPanelController({
+      resolveApprovedPlugin: (pluginKey) => (pluginKey === plugin.pluginKey ? plugin : null),
+      contentVerifier: { verify: vi.fn().mockResolvedValue(undefined) },
+      executeHostCall: vi.fn(),
+      invokePluginCommand,
+      log: vi.fn()
+    })
+    const entry = await controller.open('runtime:one', plugin.pluginKey, 'dashboard')
+
+    await expect(
+      controller.execute('runtime:one', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: {
+          commandId: 'history-query',
+          args: { query: 'release' }
+        }
+      })
+    ).resolves.toEqual({
+      ok: true,
+      value: { sessions: [{ id: 'session-one', title: 'First session' }] }
+    })
+    expect(invokePluginCommand).toHaveBeenCalledWith(plugin.pluginKey, 'history-query', {
+      query: 'release'
+    })
+
+    await expect(
+      controller.execute('runtime:one', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: {
+          commandId: 'history-query',
+          pluginKey: 'orca-samples.other'
+        }
+      })
+    ).resolves.toMatchObject({ ok: false, code: 'invalid_params' })
+    expect(invokePluginCommand).toHaveBeenCalledTimes(1)
+
+    await expect(
+      controller.execute('runtime:other', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: { commandId: 'history-query' }
+      })
+    ).resolves.toMatchObject({ ok: false, code: 'invalid_request' })
+    expect(invokePluginCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a bounded action error when the bound plugin command fails', async () => {
+    const plugin = await createPlugin()
+    const controller = new PluginPanelController({
+      resolveApprovedPlugin: () => plugin,
+      contentVerifier: { verify: vi.fn().mockResolvedValue(undefined) },
+      executeHostCall: vi.fn(),
+      invokePluginCommand: vi.fn().mockRejectedValue(new Error('history index unavailable')),
+      log: vi.fn()
+    })
+    const entry = await controller.open('runtime:one', plugin.pluginKey, 'dashboard')
+
+    await expect(
+      controller.execute('runtime:one', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: { commandId: 'history-query' }
+      })
+    ).resolves.toEqual({
+      ok: false,
+      code: 'action_failed',
+      error: 'history index unavailable'
+    })
+  })
+
+  it('truncates oversized worker errors before they reach the renderer', async () => {
+    const plugin = await createPlugin()
+    const controller = new PluginPanelController({
+      resolveApprovedPlugin: () => plugin,
+      contentVerifier: { verify: vi.fn().mockResolvedValue(undefined) },
+      executeHostCall: vi.fn(),
+      invokePluginCommand: vi
+        .fn()
+        .mockRejectedValue(new Error('x'.repeat(PLUGIN_PANEL_COMMAND_ERROR_MAX_CODE_UNITS + 1))),
+      log: vi.fn()
+    })
+    const entry = await controller.open('runtime:one', plugin.pluginKey, 'dashboard')
+
+    await expect(
+      controller.execute('runtime:one', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: { commandId: 'history-query' }
+      })
+    ).resolves.toEqual({
+      ok: false,
+      code: 'action_failed',
+      error: 'x'.repeat(PLUGIN_PANEL_COMMAND_ERROR_MAX_CODE_UNITS)
+    })
+  })
+
+  it('falls back safely when a worker rejection cannot be stringified', async () => {
+    const plugin = await createPlugin()
+    const hostileError = {
+      toString(): string {
+        throw new Error('string coercion failed')
+      }
+    }
+    const controller = new PluginPanelController({
+      resolveApprovedPlugin: () => plugin,
+      contentVerifier: { verify: vi.fn().mockResolvedValue(undefined) },
+      executeHostCall: vi.fn(),
+      invokePluginCommand: vi.fn().mockRejectedValue(hostileError),
+      log: vi.fn()
+    })
+    const entry = await controller.open('runtime:one', plugin.pluginKey, 'dashboard')
+
+    await expect(
+      controller.execute('runtime:one', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: { commandId: 'history-query' }
+      })
+    ).resolves.toEqual({
+      ok: false,
+      code: 'action_failed',
+      error: 'plugin command failed'
+    })
+  })
+
+  it('refuses an oversized worker result before it reaches the renderer', async () => {
+    const plugin = await createPlugin()
+    const controller = new PluginPanelController({
+      resolveApprovedPlugin: () => plugin,
+      contentVerifier: { verify: vi.fn().mockResolvedValue(undefined) },
+      executeHostCall: vi.fn(),
+      invokePluginCommand: vi
+        .fn()
+        .mockResolvedValue('x'.repeat(PLUGIN_PANEL_COMMAND_RESULT_MAX_BYTES + 1)),
+      log: vi.fn()
+    })
+    const entry = await controller.open('runtime:one', plugin.pluginKey, 'dashboard')
+
+    await expect(
+      controller.execute('runtime:one', {
+        sessionToken: entry!.sessionToken,
+        action: 'plugin.command.invoke',
+        params: { commandId: 'history-query' }
+      })
+    ).resolves.toEqual({
+      ok: false,
+      code: 'action_failed',
+      error: 'plugin command result exceeds the size limit'
+    })
+  })
+
   it('uses the session identity and rejects caller-supplied plugin claims', async () => {
     const plugin = await createPlugin()
     const executeHostCall = vi.fn().mockResolvedValue({ ok: true, value: { delivered: true } })

--- a/src/main/plugins/plugin-panel-controller.ts
+++ b/src/main/plugins/plugin-panel-controller.ts
@@ -1,8 +1,13 @@
+import { serialize } from 'node:v8'
 import type {
   PluginPanelActionOutcome,
   PluginPanelEntry
 } from '../../shared/plugins/plugin-panel-bridge'
-import { panelActionCallSchema } from '../../shared/plugins/plugin-panel-bridge'
+import {
+  PLUGIN_PANEL_COMMAND_ACTION,
+  panelActionCallSchema,
+  parsePanelActionParams
+} from '../../shared/plugins/plugin-panel-bridge'
 import {
   admitPluginPanelCall,
   createPluginPanelCallAdmission,
@@ -17,6 +22,20 @@ import {
 } from './plugin-artifact-validation'
 import { PluginPanelSessions, type PluginPanelSessionBinding } from './plugin-panel-sessions'
 
+/** Prevent one worker response from pinning the renderer across clone boundaries. */
+export const PLUGIN_PANEL_COMMAND_RESULT_MAX_BYTES = 1024 * 1024
+/** Keep worker-controlled failures bounded before they cross into the renderer. */
+export const PLUGIN_PANEL_COMMAND_ERROR_MAX_CODE_UNITS = 1024
+
+function getPanelCommandError(error: unknown): string {
+  try {
+    const message = error instanceof Error ? error.message : String(error)
+    return message.slice(0, PLUGIN_PANEL_COMMAND_ERROR_MAX_CODE_UNITS) || 'plugin command failed'
+  } catch {
+    return 'plugin command failed'
+  }
+}
+
 type PluginPanelControllerOptions = {
   resolveApprovedPlugin: (pluginKey: string) => ValidDiscoveredPlugin | null
   contentVerifier: Pick<PluginContentVerifier, 'verify'>
@@ -25,6 +44,7 @@ type PluginPanelControllerOptions = {
     method: string,
     params: unknown
   ) => Promise<PluginPanelActionOutcome>
+  invokePluginCommand?: (pluginKey: string, commandId: string, args?: unknown) => Promise<unknown>
   log: (pluginKey: string, line: string) => void
   panelAdmission?: PluginPanelCallAdmission
 }
@@ -90,6 +110,44 @@ export class PluginPanelController {
       !panelExists
     ) {
       return { ok: false, code: 'unavailable', error: 'panel session is no longer available' }
+    }
+    if (parsed.data.action === PLUGIN_PANEL_COMMAND_ACTION) {
+      const parsedParams = parsePanelActionParams(parsed.data.action, parsed.data.params)
+      if (!parsedParams.ok) {
+        return { ok: false, code: 'invalid_params', error: parsedParams.error }
+      }
+      if (!this.options.invokePluginCommand) {
+        return {
+          ok: false,
+          code: 'unavailable',
+          error: 'plugin command invocation is unavailable'
+        }
+      }
+      const params = parsedParams.params as { commandId: string; args?: unknown }
+      try {
+        const value = await this.options.invokePluginCommand(
+          binding.pluginKey,
+          params.commandId,
+          params.args
+        )
+        if (serialize(value).byteLength > PLUGIN_PANEL_COMMAND_RESULT_MAX_BYTES) {
+          return {
+            ok: false,
+            code: 'action_failed',
+            error: 'plugin command result exceeds the size limit'
+          }
+        }
+        return {
+          ok: true,
+          value
+        }
+      } catch (error) {
+        return {
+          ok: false,
+          code: 'action_failed',
+          error: getPanelCommandError(error)
+        }
+      }
     }
     return this.options.executeHostCall(binding.pluginKey, parsed.data.action, parsed.data.params)
   }

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -76,6 +76,7 @@ export class PluginService {
       contentVerifier: this.contentVerifier,
       executeHostCall: (pluginKey, method, params) =>
         this.executeHostCall(pluginKey, method, params, { viaPanel: true }),
+      invokePluginCommand: this.invokeCommand.bind(this),
       log: (pluginKey, line) => this.logBuffer.append(pluginKey, 'error', line)
     })
     this.workerController = new PluginWorkerController({

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -65,6 +65,42 @@ describe('createPanelBridgeMessageHandler', () => {
     )
   })
 
+  it('relays a same-plugin worker command request without accepting a plugin identity', async () => {
+    const panelWindow = createFakePanelWindow()
+    const { handler, callPanelAction } = createHandler(panelWindow, {
+      ok: true,
+      value: { sessions: [{ id: 'session-one' }] }
+    })
+
+    handler(
+      messageEvent(
+        {
+          type: 'orca-panel-action',
+          requestId: 'req-command',
+          action: 'plugin.command.invoke',
+          params: { commandId: 'history-query', args: { query: 'release' } }
+        },
+        panelWindow
+      )
+    )
+    await flush()
+
+    expect(callPanelAction).toHaveBeenCalledWith({
+      sessionToken: SESSION_TOKEN,
+      action: 'plugin.command.invoke',
+      params: { commandId: 'history-query', args: { query: 'release' } }
+    })
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'orca-panel-action-result',
+        requestId: 'req-command',
+        ok: true,
+        value: { sessions: [{ id: 'session-one' }] }
+      },
+      '*'
+    )
+  })
+
   it('ignores messages whose source is not the panel iframe window', async () => {
     const panelWindow = createFakePanelWindow()
     const { handler, callPanelAction } = createHandler(panelWindow)

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
-import { isPluginPanelAction } from './plugin-host-api'
+import { getPluginHostMethodSpec, isPluginPanelAction } from './plugin-host-api'
+import { pluginCommandIdSchema } from './plugin-manifest'
 
 /**
  * postMessage protocol between a sandboxed plugin panel iframe and the host
@@ -17,6 +18,8 @@ export const PANEL_ACTION_RESULT_TYPE = 'orca-panel-action-result'
 export const PANEL_PING_TYPE = 'orca-panel-ping'
 export const PANEL_PONG_TYPE = 'orca-panel-pong'
 export const PLUGIN_PANEL_FRAME_NAME_PREFIX = 'orca-plugin-panel:'
+/** Main binds command dispatch to the plugin that owns the opaque panel session. */
+export const PLUGIN_PANEL_COMMAND_ACTION = 'plugin.command.invoke'
 
 /** Per-plugin bridge budgets, enforced host-side. */
 export const PANEL_MESSAGE_MAX_BYTES = 64 * 1024
@@ -39,7 +42,13 @@ export const panelActionRequestSchema = z.object({
   type: z.literal(PANEL_ACTION_REQUEST_TYPE),
   /** Plugin-chosen correlation id echoed back on the result message. */
   requestId: z.string().min(1).max(128),
-  action: z.string().min(1).refine(isPluginPanelAction, 'not a panel-callable action'),
+  action: z
+    .string()
+    .min(1)
+    .refine(
+      (action) => action === PLUGIN_PANEL_COMMAND_ACTION || isPluginPanelAction(action),
+      'not a panel-callable action'
+    ),
   params: z.unknown().optional()
 })
 
@@ -149,4 +158,36 @@ export function readPanelPongId(data: unknown): number | null {
   // isSafeInteger, not isInteger: zod's .int() rejects 2**53 and above, and a
   // wider reader would admit ids the watchdog can never have issued.
   return Number.isSafeInteger(frame.pingId) && frame.pingId >= 0 ? frame.pingId : null
+}
+/** Validates action params against the host API spec (shared with workers). */
+export function parsePanelActionParams(
+  action: string,
+  params: unknown
+): { ok: true; params: unknown } | { ok: false; error: string } {
+  if (action === PLUGIN_PANEL_COMMAND_ACTION) {
+    const parsed = z
+      .object({
+        commandId: pluginCommandIdSchema,
+        args: z.unknown().optional()
+      })
+      .strict()
+      .safeParse(params)
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0]
+      const path = issue?.path.join('.') || '(root)'
+      return { ok: false, error: `${path}: ${issue?.message ?? 'invalid action params'}` }
+    }
+    return { ok: true, params: parsed.data }
+  }
+  const spec = getPluginHostMethodSpec(action)
+  if (!spec) {
+    return { ok: false, error: `unknown action: ${action}` }
+  }
+  const parsed = spec.params.safeParse(params)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const path = issue?.path.join('.') || '(root)'
+    return { ok: false, error: `${path}: ${issue?.message ?? 'invalid action params'}` }
+  }
+  return { ok: true, params: parsed.data }
 }

--- a/tests/e2e/plugin-demo.spec.ts
+++ b/tests/e2e/plugin-demo.spec.ts
@@ -78,7 +78,10 @@ test('runs hello-orca panel, command, and event behind visible consent', async (
 
   try {
     const installed = await orcaPage.evaluate(async (sourcePath) => {
-      const settings = await window.api.settings.set({ pluginSystemEnabled: true })
+      const settings = await window.api.settings.set({
+        pluginSystemEnabled: true,
+        uiLanguage: 'en'
+      })
       window.__store?.setState({ settings })
       const result = await window.api.plugins.install({ kind: 'local-path', path: sourcePath })
       if (!result.ok) {
@@ -143,6 +146,10 @@ test('runs hello-orca panel, command, and event behind visible consent', async (
     }, pluginRoot)
 
     await openDemoPanel(orcaPage)
+
+    const panel = orcaPage.frameLocator('iframe[title="Hello Orca"]')
+    await panel.getByRole('button', { name: "Ping this plugin's worker" }).click()
+    await expect(panel.locator('#status')).toHaveText('worker pong count=3')
 
     const panelPath = join(pluginRoot, 'panel.html')
     const panelHtml = await readFile(panelPath, 'utf8')


### PR DESCRIPTION
## Summary

- add a session-bound `plugin.command.invoke` panel action so a plugin panel can call commands registered by its own worker
- preserve the existing plugin consent, manifest contribution, registered-handler, message-size, and rate-limit checks
- reject caller-supplied plugin identity and cap serialized worker results at 1 MiB
- extend the `hello-orca` example and Electron E2E coverage to exercise the complete panel-to-worker path

## Why

Plugin panels can currently call a small set of host actions, but they cannot consume data or logic owned by their plugin worker. That prevents sandboxed panels from presenting dynamic plugin data such as local indexes, databases, or computed history unless Orca adds a dedicated host API for every use case.

This change keeps the iframe sandbox intact. Main derives the plugin identity from the opaque panel session and routes only to a command contributed and registered by that same enabled plugin.

## Security boundaries

- panel requests contain only `commandId` and optional `args`; extra fields such as `pluginKey` fail validation
- command dispatch uses the plugin key bound to the verified panel session
- the existing worker command validation and consent model remains authoritative
- worker errors are converted to bounded panel errors, and successful results are limited to 1 MiB before crossing renderer clone boundaries

## Testing

- 24 focused Vitest tests
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `oxfmt --check` on all changed files
- `oxlint --deny-warnings` on changed TypeScript files
- `pnpm run build:electron-vite`
- `pnpm run test:e2e -- tests/e2e/plugin-demo.spec.ts --workers=1`