### PR TITLE
fix(browser): guest-retention polish — LRU across kill-switch, release veto on interrupted downloads

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1176,7 +1176,7 @@ function Terminal(): React.JSX.Element | null {
   // and terminal panes/watchers/capture contracts are untouched. A revisit
   // rebuilds guests from store state.
   useEffect(() => {
-    if (!renderedActiveWorktreeId || !browserGuestRetentionBudgetEnabled) {
+    if (!renderedActiveWorktreeId) {
       return
     }
     const recency = browserGuestWorktreeRecencyRef.current
@@ -1186,6 +1186,11 @@ function Terminal(): React.JSX.Element | null {
       if (!surfaceIds.has(recency[index])) {
         recency.splice(index, 1)
       }
+    }
+    // Why after the bookkeeping: recency must track activation order even while
+    // the kill switch is off, or re-enabling would evict by worktree-list order.
+    if (!browserGuestRetentionBudgetEnabled) {
+      return
     }
     const state = useAppStore.getState()
     // Why appended: a mounted worktree missing from recency (background mount) ranks oldest.

--- a/src/renderer/src/components/browser-pane/browser-page-download-activity.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-download-activity.test.ts
@@ -1,34 +1,41 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type DownloadRequestedCallback = (event: { downloadId: string; browserPageId: string }) => void
+type DownloadProgressCallback = (event: {
+  downloadId: string
+  state: 'progressing' | 'interrupted' | null
+}) => void
 type DownloadFinishedCallback = (event: { downloadId: string }) => void
 
 describe('browser page download activity', () => {
   let requestedCallbacks: DownloadRequestedCallback[]
+  let progressCallbacks: DownloadProgressCallback[]
   let finishedCallbacks: DownloadFinishedCallback[]
-  let removedRequested: boolean
-  let removedFinished: boolean
+  let removedListenerCount: number
 
   beforeEach(() => {
     vi.resetModules()
     requestedCallbacks = []
+    progressCallbacks = []
     finishedCallbacks = []
-    removedRequested = false
-    removedFinished = false
+    removedListenerCount = 0
+    const removeListener = (): void => {
+      removedListenerCount += 1
+    }
     vi.stubGlobal('window', {
       api: {
         browser: {
           onDownloadRequested: (callback: DownloadRequestedCallback) => {
             requestedCallbacks.push(callback)
-            return () => {
-              removedRequested = true
-            }
+            return removeListener
+          },
+          onDownloadProgress: (callback: DownloadProgressCallback) => {
+            progressCallbacks.push(callback)
+            return removeListener
           },
           onDownloadFinished: (callback: DownloadFinishedCallback) => {
             finishedCallbacks.push(callback)
-            return () => {
-              removedFinished = true
-            }
+            return removeListener
           }
         }
       }
@@ -64,16 +71,51 @@ describe('browser page download activity', () => {
     expect(hasActiveBrowserPageDownload('page-2')).toBe(false)
   })
 
-  it('ignores duplicate start events and unknown finish events', async () => {
+  it('deactivates an interrupted download (no finished event ever fires) and reactivates on resume', async () => {
+    const { hasActiveBrowserPageDownload, installBrowserPageDownloadActivityTracking } =
+      await import('./browser-page-download-activity')
+    installBrowserPageDownloadActivityTracking()
+
+    requestedCallbacks[0]({ downloadId: 'dl-1', browserPageId: 'page-1' })
+    progressCallbacks[0]({ downloadId: 'dl-1', state: 'interrupted' })
+    expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
+
+    progressCallbacks[0]({ downloadId: 'dl-1', state: 'progressing' })
+    expect(hasActiveBrowserPageDownload('page-1')).toBe(true)
+
+    // A null state is transport noise, not a transition.
+    progressCallbacks[0]({ downloadId: 'dl-1', state: null })
+    expect(hasActiveBrowserPageDownload('page-1')).toBe(true)
+
+    finishedCallbacks[0]({ downloadId: 'dl-1' })
+    expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
+  })
+
+  it('ignores duplicate start events, unknown progress and unknown finish events', async () => {
     const { hasActiveBrowserPageDownload, installBrowserPageDownloadActivityTracking } =
       await import('./browser-page-download-activity')
     installBrowserPageDownloadActivityTracking()
 
     requestedCallbacks[0]({ downloadId: 'dl-1', browserPageId: 'page-1' })
     requestedCallbacks[0]({ downloadId: 'dl-1', browserPageId: 'page-1' })
+    progressCallbacks[0]({ downloadId: 'dl-unknown', state: 'interrupted' })
     finishedCallbacks[0]({ downloadId: 'dl-unknown' })
     expect(hasActiveBrowserPageDownload('page-1')).toBe(true)
     finishedCallbacks[0]({ downloadId: 'dl-1' })
+    expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
+  })
+
+  it('finishing an already-interrupted download stays balanced', async () => {
+    const { hasActiveBrowserPageDownload, installBrowserPageDownloadActivityTracking } =
+      await import('./browser-page-download-activity')
+    installBrowserPageDownloadActivityTracking()
+
+    requestedCallbacks[0]({ downloadId: 'dl-1', browserPageId: 'page-1' })
+    requestedCallbacks[0]({ downloadId: 'dl-2', browserPageId: 'page-1' })
+    progressCallbacks[0]({ downloadId: 'dl-1', state: 'interrupted' })
+    finishedCallbacks[0]({ downloadId: 'dl-1' })
+    expect(hasActiveBrowserPageDownload('page-1')).toBe(true)
+    finishedCallbacks[0]({ downloadId: 'dl-2' })
     expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
   })
 
@@ -85,8 +127,7 @@ describe('browser page download activity', () => {
     requestedCallbacks[0]({ downloadId: 'dl-1', browserPageId: 'page-1' })
     cleanup()
 
-    expect(removedRequested).toBe(true)
-    expect(removedFinished).toBe(true)
+    expect(removedListenerCount).toBe(3)
     // A host remount tears down every guest; stale entries must not veto eviction.
     expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
   })

--- a/src/renderer/src/components/browser-pane/browser-page-download-activity.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-download-activity.ts
@@ -3,36 +3,56 @@
 // hidden pages are still writing downloads — main treats a guest unregister as
 // a tab close and cancels their active downloads (browser-manager
 // unregisterGuest), so eviction has to skip those pages until they finish.
-const pageIdByActiveDownloadId = new Map<string, string>()
+type TrackedDownload = { browserPageId: string; active: boolean }
+
+const trackedDownloadsById = new Map<string, TrackedDownload>()
 const activeDownloadCountByPageId = new Map<string, number>()
 
 export function hasActiveBrowserPageDownload(browserPageId: string): boolean {
   return (activeDownloadCountByPageId.get(browserPageId) ?? 0) > 0
 }
 
-function trackDownloadStarted(downloadId: string, browserPageId: string): void {
-  if (pageIdByActiveDownloadId.has(downloadId)) {
+function setDownloadActive(download: TrackedDownload, active: boolean): void {
+  if (download.active === active) {
     return
   }
-  pageIdByActiveDownloadId.set(downloadId, browserPageId)
-  activeDownloadCountByPageId.set(
-    browserPageId,
-    (activeDownloadCountByPageId.get(browserPageId) ?? 0) + 1
-  )
+  download.active = active
+  const count = (activeDownloadCountByPageId.get(download.browserPageId) ?? 0) + (active ? 1 : -1)
+  if (count <= 0) {
+    activeDownloadCountByPageId.delete(download.browserPageId)
+  } else {
+    activeDownloadCountByPageId.set(download.browserPageId, count)
+  }
+}
+
+function trackDownloadStarted(downloadId: string, browserPageId: string): void {
+  if (trackedDownloadsById.has(downloadId)) {
+    return
+  }
+  const download: TrackedDownload = { browserPageId, active: false }
+  trackedDownloadsById.set(downloadId, download)
+  setDownloadActive(download, true)
+}
+
+// Why: an interrupted-resumable download never fires Chromium's 'done' (no
+// finished event), and Orca has no resume path — without this transition the
+// veto would outlive the download for the whole session. A resumed download
+// re-actives on its next 'progressing' tick, restoring the veto.
+function trackDownloadProgress(downloadId: string, state: 'progressing' | 'interrupted' | null): void {
+  const download = trackedDownloadsById.get(downloadId)
+  if (!download || state === null) {
+    return
+  }
+  setDownloadActive(download, state === 'progressing')
 }
 
 function trackDownloadFinished(downloadId: string): void {
-  const browserPageId = pageIdByActiveDownloadId.get(downloadId)
-  if (browserPageId === undefined) {
+  const download = trackedDownloadsById.get(downloadId)
+  if (!download) {
     return
   }
-  pageIdByActiveDownloadId.delete(downloadId)
-  const remaining = (activeDownloadCountByPageId.get(browserPageId) ?? 1) - 1
-  if (remaining <= 0) {
-    activeDownloadCountByPageId.delete(browserPageId)
-  } else {
-    activeDownloadCountByPageId.set(browserPageId, remaining)
-  }
+  setDownloadActive(download, false)
+  trackedDownloadsById.delete(downloadId)
 }
 
 /** App-lifetime tracking; install once from the surface host (Terminal). The
@@ -42,13 +62,17 @@ export function installBrowserPageDownloadActivityTracking(): () => void {
   const removeRequested = window.api.browser.onDownloadRequested((event) => {
     trackDownloadStarted(event.downloadId, event.browserPageId)
   })
+  const removeProgress = window.api.browser.onDownloadProgress((event) => {
+    trackDownloadProgress(event.downloadId, event.state)
+  })
   const removeFinished = window.api.browser.onDownloadFinished((event) => {
     trackDownloadFinished(event.downloadId)
   })
   return () => {
     removeRequested()
+    removeProgress()
     removeFinished()
-    pageIdByActiveDownloadId.clear()
+    trackedDownloadsById.clear()
     activeDownloadCountByPageId.clear()
   }
 }


### PR DESCRIPTION
## Summary

Two robustness follow-ups to #12194's browser-guest retention budget, staged by the safety-review loop's third pass before its session ended (I committed its staged work verbatim; provenance noted in the commit body). Neither is release-gating: both edge cases fail toward retaining extra memory — the pre-#12194 status quo — never toward destroying something in use.

1. Recency bookkeeping now runs even while the retention kill switch is off, so re-enabling the switch evicts in true least-recently-activated order instead of worktree-list order.
2. An interrupted download now releases the eviction veto (new `onDownloadProgress` handling for `interrupted`/null states), so a stuck download entry can't pin a worktree as never-evictable forever.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`browser-page-download-activity.test.ts` extended for the progress/interrupted listener lifecycle (listener add/remove accounting included). PR CI runs the full suite; the delta is 6 files / ~74 lines originally reviewed inside the #12194 until-clean loop.

## AI Review Report

These changes ARE the output of the #12194 adversarial review loop (pass 3), which had already produced two merged fixes (surface-stays-mounted eviction; download veto + kill switch) in that PR. Risks checked there: eviction must never destroy an in-use guest (this PR widens the protection to interrupted downloads) and kill-switch toggling must not corrupt LRU order. Cross-platform: renderer-only logic, no paths/shortcuts/shell/Electron-main surface.

## Security Audit

No new inputs, IPC, command execution, or secrets. The new listener consumes the existing preload `onDownloadProgress` bridge events only.

## Notes

Not needed for the v1.4.165 cherry-picks; rides the next release train. If the rc.1 bake shows any retention oddity, this PR plus the in-code kill switch are the levers.
