### PR TITLE
fix(wsl-cli): stop the WSL bridge swallowing every command that contains --for

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -73,6 +73,7 @@
     "../src/main/rolling-file-backup.ts",
     "../src/main/startup/hydrate-shell-path.ts",
     "../src/main/runtime/runtime-metadata.ts",
+    "../src/main/cli/wsl-cli-scripts.ts",
     "../src/main/win32-utils.ts"
   ],
   "compilerOptions": {

--- a/src/cli/wsl-bridge-flag-collision.test.ts
+++ b/src/cli/wsl-bridge-flag-collision.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildWslBridgeScript, buildWslLauncher } from '../main/cli/wsl-cli-scripts'
+import { BOOLEAN_FLAGS, GLOBAL_FLAGS } from './args'
+import { COMMAND_SPECS } from './specs'
+
+// Why: PowerShell binds parameters by unique name prefix, so a bridge parameter whose name
+// starts with a CLI flag swallows that flag and every argument after it.
+const POWERSHELL_COMMON_PARAMETERS = [
+  'Debug',
+  'ErrorAction',
+  'ErrorVariable',
+  'InformationAction',
+  'InformationVariable',
+  'OutBuffer',
+  'OutVariable',
+  'PipelineVariable',
+  'ProgressAction',
+  'Verbose',
+  'WarningAction',
+  'WarningVariable'
+]
+
+const WINDOWS_LAUNCHER_PATH =
+  'C:\\Users\\dev\\AppData\\Local\\Programs\\orca\\resources\\bin\\orca.exe'
+
+function bridgeParameterNames(): string[] {
+  return [...buildWslBridgeScript().matchAll(/^\s*\[string(?:\[\])?\]\$(\w+),?$/gm)].map(
+    (match) => match[1]
+  )
+}
+
+describe('WSL bridge parameters', () => {
+  it('cannot prefix-capture a CLI flag', () => {
+    const flags = new Set([
+      ...GLOBAL_FLAGS,
+      ...BOOLEAN_FLAGS,
+      ...COMMAND_SPECS.flatMap((spec) => spec.allowedFlags)
+    ])
+    const parameters = [...bridgeParameterNames(), ...POWERSHELL_COMMON_PARAMETERS]
+
+    const collisions = parameters.flatMap((parameter) =>
+      [...flags]
+        .filter((flag) => parameter.toLowerCase().startsWith(flag.toLowerCase()))
+        .map((flag) => `--${flag} binds to -${parameter}`)
+    )
+
+    expect(collisions).toEqual([])
+  })
+
+  it('declares every parameter the launcher passes it', () => {
+    const forwarded =
+      buildWslLauncher(WINDOWS_LAUNCHER_PATH).split('$ORCA_BRIDGE_PS1_WIN"')[1] ?? ''
+    const passed = [...forwarded.matchAll(/-([A-Za-z]\w*)/g)].map((match) => match[1])
+
+    expect(passed).not.toHaveLength(0)
+    expect(bridgeParameterNames()).toEqual(expect.arrayContaining(passed))
+  })
+})

--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -340,7 +340,7 @@ describe('WslCliInstaller', () => {
     expect(bridge).toContain('if ([string]::IsNullOrEmpty($WslCwd))')
     expect(bridge).toContain('$env:ORCA_CLI_CWD = $WslCwd')
     expect(bridge).toContain('Push-Location -LiteralPath (Split-Path -Parent $OrcaLauncher)')
-    expect(bridge).toContain('& $OrcaLauncher @ForwardArgs')
+    expect(bridge).toContain('& $OrcaLauncher @OrcaForwardArgs')
     const nullExitCodeBranch = bridge.indexOf('if ($null -eq $LASTEXITCODE)')
     const invocationFailureBranch = bridge.indexOf('if (-not $?)')
     expect(nullExitCodeBranch).toBeGreaterThan(-1)

--- a/src/main/cli/wsl-cli-scripts.ts
+++ b/src/main/cli/wsl-cli-scripts.ts
@@ -33,6 +33,8 @@ exec "$ORCA_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$ORCA_BRIDGE_P
 }
 
 export function buildWslBridgeScript(): string {
+  // Why: PowerShell binds parameters by name prefix, so a parameter named for a CLI flag
+  // eats it — -ForwardArgs swallowed `--for` and everything after it.
   return `${BRIDGE_MANAGED_MARKER}
 [CmdletBinding(PositionalBinding=$false)]
 param(
@@ -42,7 +44,7 @@ param(
   [string]$WslCwd,
 
   [Parameter(ValueFromRemainingArguments=$true)]
-  [string[]]$ForwardArgs
+  [string[]]$OrcaForwardArgs
 )
 
 $exitCode = 0
@@ -53,7 +55,7 @@ try {
     $env:ORCA_CLI_CWD = $WslCwd
   }
   Push-Location -LiteralPath (Split-Path -Parent $OrcaLauncher)
-  & $OrcaLauncher @ForwardArgs
+  & $OrcaLauncher @OrcaForwardArgs
   if ($null -eq $LASTEXITCODE) {
     if (-not $?) {
       $exitCode = 1


### PR DESCRIPTION
Fixes #12196.

## Summary

On WSL, every Orca CLI command containing `--for` died before reaching `orca.exe`:

```
orca-wsl-bridge.ps1 : A positional parameter cannot be found that accepts argument 'terminal'.
```

The bridge declares `[Parameter(ValueFromRemainingArguments=$true)] [string[]]$ForwardArgs`. PowerShell binds parameters by unique **name prefix**, so `--for` bound to `-ForwardArgs`, consumed `tui-idle` as its value, and stopped remainder collection — leaving the real subcommand with no positional slot. `--for=tui-idle` slipped through only because `=` is not PowerShell parameter syntax.

The user-visible effect: `orca terminal wait --terminal <handle> --for tui-idle` — the exact form printed by `orca skills get orchestration` — never worked on WSL. An agent following the shipped guide hit this on its first wait.

Renaming the parameter to `$OrcaForwardArgs` takes it out of the CLI's flag namespace. `--for` is the only collision in the current 213-flag surface (`--format`, `--from`, `--files-modified`, `--worktree` were all verified unaffected), so this is a two-token change to the generated script.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New test `src/cli/wsl-bridge-flag-collision.test.ts` enforces the invariant rather than the instance: no flag in `COMMAND_SPECS` / `GLOBAL_FLAGS` / `BOOLEAN_FLAGS`, and no PowerShell common parameter, may be a prefix of any bridge parameter name. It **fails on the pre-fix script** with exactly

```
AssertionError: expected [ '--for binds to -ForwardArgs' ] to deeply equal []
```

and passes after. A second case asserts the launcher and the bridge still agree on the parameters they exchange, so a half-rename cannot pass. `config/tsconfig.cli.json` gains `src/main/cli/wsl-cli-scripts.ts` so the CLI project typechecks the import, following the existing pattern for main-process files reached from `src/cli`.

`pnpm test` on this branch: **44037 passed, 11 failed**. All 11 are unrelated to this change and were confirmed on a pristine checkout of the same commit — 9 pre-existing environment failures on Linux/WSL (`pty-subprocess`, `local-pty-provider`, `configure-process` GPU flags, `agent-exec-handler`, `managed-hook-timeout`), plus `orca-runtime-files.test.ts > rejects stale absolute terminal artifact previews`, which is **flaky**: run alone on this branch three times it passed, failed, passed.

### Verified against the real binary, not only the generated string

Rendered the patched builder's output and diffed it against the bridge shipped in 1.4.164 — byte-identical apart from the two renamed tokens. Then ran both scripts against the real `orca.exe` from WSL, same argument vector:

| bridge | `terminal wait --terminal bogus --for tui-idle --timeout-ms 1` |
|---|---|
| shipped 1.4.164 | `A positional parameter cannot be found that accepts argument 'terminal'` |
| patched | `terminal_handle_stale` — Orca's own error, so the argv arrived intact |

No regression on the rest of the bridge's contract: `terminal list --json` and `worktree list --json` return normally (cwd still resolves through `ORCA_CLI_CWD`), and an unknown subcommand still exits 1.

## AI Review Report

Reviewed with Claude (Opus 5). Risks checked and findings:

- **Cross-platform.** The change is confined to `buildWslBridgeScript()`, which only ever runs on Windows + WSL; macOS and Linux paths do not read it. No path handling, shortcut, or label is touched.
- **Upgrade / version skew.** Flagged as the main risk: could a user end up with a new bridge and an old launcher? No — `WslCliInstaller.install()` writes launcher and bridge in the same operation, and `status` reports `stale` when either file's content differs from the expected output, which triggers a reinstall of both. The renamed parameter is also never named by the launcher (it is the remainder-args parameter), so even a skewed pair would keep binding `-WslCwd` correctly.
- **Scope.** `-WslCwd` and `-OrcaLauncher` were deliberately left alone: neither collides with any current flag, and renaming `-WslCwd` would require changing the launcher's call site for no present defect. The new test now guards them too, so a future flag that would collide fails CI instead of shipping.
- **SSH / remote / local.** No change — the WSL bridge is a local-interop path only.
- **Agent / integration compatibility.** Provider-neutral; this is transport plumbing beneath every agent and integration. It restores the documented `--for` form for all of them.
- **Performance.** None; identical work, one different identifier.
- **UI.** Not applicable.

## Security Audit

- **Command execution / input handling.** The patch does not change how arguments are parsed, quoted, or forwarded — it renames the parameter that collects them. No new interpolation, no new shell invocation, no change to `Push-Location`/`& $OrcaLauncher` semantics or to exit-code propagation.
- **Path handling.** Untouched (`$OrcaLauncher`, `$WslCwd` unchanged).
- **Secrets / auth / IPC / dependencies.** Not touched; no new dependency.
- **Follow-up, separate defect.** While isolating this one I found and filed #12231: the same bridge destroys every ASCII `"` in CLI arguments, because Windows PowerShell 5.1 does not escape embedded quotes when building a native command line. It is silent when the quoted span has no whitespace and splits the argument when it does. That is a distinct root cause at a later stage and is deliberately **not** in this PR.

## Notes

- Windows/WSL-specific. Reproduced and verified on Windows 11 + WSL2 (Ubuntu), Windows PowerShell 5.1.26100.8875, Orca 1.4.164.
- Users pick up the fix when the installer rewrites the managed scripts; existing installs are detected as `stale` and reinstalled.
- The `--for=tui-idle` equals-form workaround stays valid, so nothing that adopted it breaks.
