### PR TITLE
fix(mobile): surface worktree catalog failures instead of silent 0 worktrees (STA-3123)

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -1,14 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import {
-  View,
-  Text,
-  StyleSheet,
-  SectionList,
-  Pressable,
-  ActivityIndicator,
-  Alert,
-  RefreshControl
-} from 'react-native'
+import { View, Text, StyleSheet, SectionList, Pressable, Alert, RefreshControl } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useFocusEffect, useLocalSearchParams, usePathname, useRouter } from 'expo-router'
 import {
@@ -95,6 +86,7 @@ import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sectio
 import { getMobileWorkspaceLineageGroupKey } from '../../../src/worktree/mobile-workspace-lineage'
 import { areWorktreeListsEqual } from '../../../src/worktree/worktree-list-snapshot'
 import { WorktreeCatalogSnapshotClient } from '../../../src/worktree/worktree-catalog-snapshot-client'
+import { HostWorkspaceListStates } from '../../../src/worktree/host-workspace-list-states'
 import { repoColor } from '../../../src/worktree/repo-color'
 import {
   WORKSPACE_GROUP_OPTIONS as GROUP_OPTIONS,
@@ -154,6 +146,9 @@ export function HostScreen({
   const forceReconnectHost = useForceReconnect()
   const [worktrees, setWorktrees] = useState<Worktree[]>(initialCache ?? [])
   const [worktreesLoaded, setWorktreesLoaded] = useState(initialCache != null)
+  // Why (STA-3123): error code of the last failed worktree.ps, so a broken catalog
+  // path renders as a failure instead of an empty host. Cleared on the next success.
+  const [catalogError, setCatalogError] = useState<string | null>(null)
   // Why: track the locally-opened worktree so the active-row highlight moves instantly instead of waiting for the next poll.
   const [optimisticActiveWorktreeId, setOptimisticActiveWorktreeId] = useState<string | null>(null)
   // One tick drives every visible agent row's relative timestamp.
@@ -326,6 +321,7 @@ export function HostScreen({
     repoMetadataFetchedAtRef.current = 0
     // Why: useState initializer runs only on first mount, so re-seed the cache when Expo Router reuses this screen for a new hostId.
     const freshCache = hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
+    setCatalogError(null)
     if (freshCache) {
       setWorktrees(freshCache)
       setLastKnownWorktrees(freshCache)
@@ -427,17 +423,27 @@ export function HostScreen({
       const requestHostId = hostId
 
       try {
-        const pendingCatalog = await worktreeCatalogRef.current.fetch(requestClient, requestHostId)
+        const fetched = await worktreeCatalogRef.current.fetch(requestClient, requestHostId)
         if (clientRef.current !== requestClient || hostId !== requestHostId) {
           return
         }
         if (!options.allowDuringModal && newWorktreeModalVisibleRef.current) {
           return
         }
+        // Why (STA-3123): a failed catalog request must not pass for "0 worktrees";
+        // surface it so a broken remote host is diagnosable instead of looking empty.
+        if (fetched.kind === 'request_failed') {
+          setCatalogError(fetched.code)
+          return
+        }
+        if (fetched.pending.admission.kind === 'invalid') {
+          setCatalogError('invalid_response')
+        }
         // Why: unchanged responses still yield the confirmed rows, so every poll reasserts
         // host truth over optimistic local edits regardless of payload size.
-        const confirmed = worktreeCatalogRef.current.admit(pendingCatalog)
+        const confirmed = worktreeCatalogRef.current.admit(fetched.pending)
         if (confirmed) {
+          setCatalogError(null)
           // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
           setWorktrees((current) =>
             areWorktreeListsEqual(current, confirmed) ? current : confirmed
@@ -486,6 +492,9 @@ export function HostScreen({
         }
       } catch {
         // Will retry on reconnect
+        if (clientRef.current === requestClient && hostId === requestHostId) {
+          setCatalogError('network_error')
+        }
       } finally {
         fetchWorktreesInFlightRef.current = false
       }
@@ -1099,27 +1108,15 @@ export function HostScreen({
         </View>
       )}
 
-      {/* Loading state */}
-      {((connState === 'connecting' || connState === 'reconnecting') &&
-        displayWorktrees.length === 0) ||
-      (connState === 'connected' && !worktreesLoaded && displayWorktrees.length === 0) ? (
-        <View style={styles.centered}>
-          <ActivityIndicator size="small" color={colors.textSecondary} />
-        </View>
-      ) : null}
-
-      {/* Empty state */}
-      {connState === 'connected' && worktreesLoaded && sections.length === 0 && (
-        <View style={styles.centered}>
-          <Text style={styles.emptyText}>
-            {search
-              ? 'No matching worktrees'
-              : activeFilterCount > 0
-                ? 'No worktrees match filters'
-                : 'No worktrees'}
-          </Text>
-        </View>
-      )}
+      <HostWorkspaceListStates
+        connState={connState}
+        worktreesLoaded={worktreesLoaded}
+        displayCount={displayWorktrees.length}
+        sectionCount={sections.length}
+        catalogError={catalogError}
+        search={search}
+        activeFilterCount={activeFilterCount}
+      />
 
       {sections.length > 0 && (
         <SectionList

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -20,6 +20,11 @@ import { navigateToMobileHostEdit } from '../src/transport/host-edit-navigation'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
 import { pickResumeWorktree } from '../src/worktree/resume-worktree'
 import { WORKTREE_PS_FULL_LIMIT } from '../src/worktree/worktree-catalog-snapshot-client'
+import {
+  markHomeWorktreeCatalogUnavailable,
+  type HomeWorktreeSummary,
+  type HostWorktreeInfo
+} from '../src/worktree/home-worktree-info'
 import type { RpcClient } from '../src/transport/rpc-client'
 import { sendSingleFlightRequest } from '../src/transport/request-single-flight'
 import {
@@ -68,28 +73,6 @@ type StatsSummary = {
   totalPRsCreated: number
   totalAgentTimeMs: number
   firstEventAt: number | null
-}
-
-type WorktreeSummary = {
-  worktreeId: string
-  repo: string
-  branch: string
-  displayName: string
-  liveTerminalCount: number
-  status?: 'working' | 'active' | 'permission' | 'done' | 'inactive'
-  // The worktree the desktop currently has focused (exactly one is true).
-  isActive?: boolean
-  // Last terminal-output time (ms); breaks ties when nothing is focused.
-  lastOutputAt?: number
-}
-
-type HostWorktreeInfo = {
-  hostId: string
-  totalWorktrees: number
-  activeCount: number
-  lastActiveWorktree: WorktreeSummary | null
-  // Why (STA-3123): a failed worktree.ps with no cached counts must not render as "0 worktrees".
-  catalogUnavailable?: boolean
 }
 
 type HomeTaskSettings = {
@@ -163,22 +146,11 @@ function fetchWorktreeInfo(
   ) => void,
   disposed: () => boolean
 ) {
-  // Why: only seed a zeroed entry when the host has no prior info; keep cached data on transient failure so counts don't flip to 0 during reconnects.
-  const markLoadedIfMissing = () => {
+  const markUnavailable = () => {
     setInfo((prev) => {
-      if (prev[hostId]) {
-        return prev
-      }
-      return {
-        ...prev,
-        [hostId]: {
-          hostId,
-          totalWorktrees: 0,
-          activeCount: 0,
-          lastActiveWorktree: null,
-          catalogUnavailable: true
-        }
-      }
+      const current = prev[hostId]
+      const next = markHomeWorktreeCatalogUnavailable(current, hostId)
+      return next === current ? prev : { ...prev, [hostId]: next }
     })
   }
 
@@ -188,7 +160,7 @@ function fetchWorktreeInfo(
         return
       }
       if (response.ok) {
-        const result = response.result as { worktrees: WorktreeSummary[] }
+        const result = response.result as { worktrees: HomeWorktreeSummary[] }
         const worktrees = result.worktrees ?? []
         setCachedWorktrees(hostId, worktrees)
         const activeStatuses = new Set(['working', 'active', 'permission'])
@@ -205,12 +177,12 @@ function fetchWorktreeInfo(
           }
         }))
       } else {
-        markLoadedIfMissing()
+        markUnavailable()
       }
     })
     .catch(() => {
       if (!disposed()) {
-        markLoadedIfMissing()
+        markUnavailable()
       }
     })
 }
@@ -557,7 +529,7 @@ export default function HomeScreen() {
   const resumeWorktree = useMemo(() => {
     // Why: only surface Resume for connected hosts; a stale worktree taps into a route that can't load.
     if (lastVisited && hostStates[lastVisited.hostId] === 'connected') {
-      const cached = getCachedWorktrees(lastVisited.hostId) as WorktreeSummary[] | null
+      const cached = getCachedWorktrees(lastVisited.hostId) as HomeWorktreeSummary[] | null
       const match = cached?.find((w) => w.worktreeId === lastVisited.worktreeId)
       if (match) {
         return { hostId: lastVisited.hostId, worktree: match }

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -88,6 +88,8 @@ type HostWorktreeInfo = {
   totalWorktrees: number
   activeCount: number
   lastActiveWorktree: WorktreeSummary | null
+  // Why (STA-3123): a failed worktree.ps with no cached counts must not render as "0 worktrees".
+  catalogUnavailable?: boolean
 }
 
 type HomeTaskSettings = {
@@ -173,7 +175,8 @@ function fetchWorktreeInfo(
           hostId,
           totalWorktrees: 0,
           activeCount: 0,
-          lastActiveWorktree: null
+          lastActiveWorktree: null,
+          catalogUnavailable: true
         }
       }
     })
@@ -789,8 +792,11 @@ export default function HomeScreen() {
                 verdict={verdict}
                 path={hostPaths[item.id] ?? 'lan'}
                 worktreeCounts={
-                  info ? { total: info.totalWorktrees, active: info.activeCount } : undefined
+                  info && !info.catalogUnavailable
+                    ? { total: info.totalWorktrees, active: info.activeCount }
+                    : undefined
                 }
+                worktreeCountsUnavailable={info?.catalogUnavailable === true}
                 onPress={() => router.push(`/h/${item.id}`)}
                 onLongPress={() => {
                   triggerMediumImpact()

--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -14,6 +14,9 @@ export function MobileHostCard(props: {
   verdict: ConnectionVerdict
   path: MobileConnectionPath
   worktreeCounts?: { total: number; active: number }
+  // Why (STA-3123): the host is connected but its worktree catalog request failed,
+  // so the card must say "unavailable" instead of asserting a count of zero.
+  worktreeCountsUnavailable?: boolean
   onPress: () => void
   onLongPress: () => void
 }) {
@@ -21,7 +24,9 @@ export function MobileHostCard(props: {
   const isError = ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
   const worktreeSummary = props.worktreeCounts
     ? `${props.worktreeCounts.total} worktree${props.worktreeCounts.total === 1 ? '' : 's'}${props.worktreeCounts.active > 0 ? ` · ${props.worktreeCounts.active} active` : ''}`
-    : null
+    : props.worktreeCountsUnavailable
+      ? 'Worktree list unavailable'
+      : null
   return (
     <Pressable
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}

--- a/mobile/src/worktree/home-worktree-info.test.ts
+++ b/mobile/src/worktree/home-worktree-info.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { markHomeWorktreeCatalogUnavailable, type HostWorktreeInfo } from './home-worktree-info'
+
+describe('markHomeWorktreeCatalogUnavailable', () => {
+  it('marks a host unavailable when no catalog has loaded', () => {
+    expect(markHomeWorktreeCatalogUnavailable(undefined, 'host-1')).toEqual({
+      hostId: 'host-1',
+      totalWorktrees: 0,
+      activeCount: 0,
+      lastActiveWorktree: null,
+      catalogUnavailable: true
+    })
+  })
+
+  it('marks cached counts unavailable without discarding the cached snapshot', () => {
+    const current: HostWorktreeInfo = {
+      hostId: 'host-1',
+      totalWorktrees: 3,
+      activeCount: 1,
+      lastActiveWorktree: {
+        worktreeId: 'worktree-1',
+        repo: 'orca',
+        branch: 'feature',
+        displayName: 'Feature',
+        liveTerminalCount: 1
+      }
+    }
+
+    expect(markHomeWorktreeCatalogUnavailable(current, 'host-1')).toEqual({
+      ...current,
+      catalogUnavailable: true
+    })
+  })
+
+  it('reuses an already unavailable snapshot to avoid repeated render churn', () => {
+    const current: HostWorktreeInfo = {
+      hostId: 'host-1',
+      totalWorktrees: 0,
+      activeCount: 0,
+      lastActiveWorktree: null,
+      catalogUnavailable: true
+    }
+
+    expect(markHomeWorktreeCatalogUnavailable(current, 'host-1')).toBe(current)
+  })
+})

--- a/mobile/src/worktree/home-worktree-info.ts
+++ b/mobile/src/worktree/home-worktree-info.ts
@@ -1,0 +1,37 @@
+export type HomeWorktreeSummary = {
+  worktreeId: string
+  repo: string
+  branch: string
+  displayName: string
+  liveTerminalCount: number
+  status?: 'working' | 'active' | 'permission' | 'done' | 'inactive'
+  isActive?: boolean
+  lastOutputAt?: number
+}
+
+export type HostWorktreeInfo = {
+  hostId: string
+  totalWorktrees: number
+  activeCount: number
+  lastActiveWorktree: HomeWorktreeSummary | null
+  catalogUnavailable?: boolean
+}
+
+export function markHomeWorktreeCatalogUnavailable(
+  current: HostWorktreeInfo | undefined,
+  hostId: string
+): HostWorktreeInfo {
+  if (current?.catalogUnavailable) {
+    return current
+  }
+  if (current) {
+    return { ...current, catalogUnavailable: true }
+  }
+  return {
+    hostId,
+    totalWorktrees: 0,
+    activeCount: 0,
+    lastActiveWorktree: null,
+    catalogUnavailable: true
+  }
+}

--- a/mobile/src/worktree/host-workspace-list-state.test.ts
+++ b/mobile/src/worktree/host-workspace-list-state.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  selectHostWorkspaceListState,
+  type HostWorkspaceListStateInput
+} from './host-workspace-list-state'
+
+function input(overrides: Partial<HostWorkspaceListStateInput>): HostWorkspaceListStateInput {
+  return {
+    connState: 'connected',
+    worktreesLoaded: true,
+    displayCount: 0,
+    sectionCount: 0,
+    catalogError: null,
+    ...overrides
+  }
+}
+
+// Regression guard for STA-3123: a remote host whose worktree.ps fails must render
+// as a catalog failure, never as a healthy host with zero workspaces.
+describe('selectHostWorkspaceListState', () => {
+  it('reports catalog-error instead of empty when the fetch failed with no rows', () => {
+    expect(selectHostWorkspaceListState(input({ catalogError: 'forbidden' }))).toBe('catalog-error')
+    expect(
+      selectHostWorkspaceListState(input({ catalogError: 'forbidden', worktreesLoaded: false }))
+    ).toBe('catalog-error')
+  })
+
+  it('keeps showing cached rows (no overlay) when a later fetch fails', () => {
+    expect(
+      selectHostWorkspaceListState(
+        input({ catalogError: 'network_error', displayCount: 3, sectionCount: 2 })
+      )
+    ).toBeNull()
+  })
+
+  it('still reports empty for a filtered-out cached list during a failure', () => {
+    expect(
+      selectHostWorkspaceListState(
+        input({ catalogError: 'network_error', displayCount: 3, sectionCount: 0 })
+      )
+    ).toBe('empty')
+  })
+
+  it('reports empty only after a successful load confirmed zero workspaces', () => {
+    expect(selectHostWorkspaceListState(input({}))).toBe('empty')
+    expect(selectHostWorkspaceListState(input({ worktreesLoaded: false }))).toBe('loading')
+  })
+
+  it('shows the spinner while connecting regardless of error state', () => {
+    expect(
+      selectHostWorkspaceListState(input({ connState: 'reconnecting', catalogError: 'x' }))
+    ).toBe('loading')
+    expect(
+      selectHostWorkspaceListState(
+        input({ connState: 'connecting', worktreesLoaded: false, catalogError: null })
+      )
+    ).toBe('loading')
+  })
+
+  it('renders nothing while disconnected with cached rows', () => {
+    expect(
+      selectHostWorkspaceListState(
+        input({ connState: 'disconnected', displayCount: 2, sectionCount: 1 })
+      )
+    ).toBeNull()
+  })
+})

--- a/mobile/src/worktree/host-workspace-list-state.ts
+++ b/mobile/src/worktree/host-workspace-list-state.ts
@@ -1,0 +1,34 @@
+import type { ConnectionState } from '../transport/types'
+
+export type HostWorkspaceListStateInput = {
+  connState: ConnectionState
+  worktreesLoaded: boolean
+  displayCount: number
+  sectionCount: number
+  catalogError: string | null
+}
+
+// Why (STA-3123): one owner for the list's loading/failed/empty precedence, so a
+// failed worktree.ps can never render as a healthy host with zero workspaces.
+export function selectHostWorkspaceListState(
+  input: HostWorkspaceListStateInput
+): 'loading' | 'catalog-error' | 'empty' | null {
+  const { connState, worktreesLoaded, displayCount, sectionCount, catalogError } = input
+  const connecting = connState === 'connecting' || connState === 'reconnecting'
+  if (
+    (connecting && displayCount === 0) ||
+    (connState === 'connected' && !worktreesLoaded && displayCount === 0 && !catalogError)
+  ) {
+    return 'loading'
+  }
+  if (connState !== 'connected') {
+    return null
+  }
+  if (catalogError && displayCount === 0) {
+    return 'catalog-error'
+  }
+  if (worktreesLoaded && sectionCount === 0) {
+    return 'empty'
+  }
+  return null
+}

--- a/mobile/src/worktree/host-workspace-list-states.tsx
+++ b/mobile/src/worktree/host-workspace-list-states.tsx
@@ -1,0 +1,65 @@
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import { colors, spacing, typography } from '../theme/mobile-theme'
+import {
+  selectHostWorkspaceListState,
+  type HostWorkspaceListStateInput
+} from './host-workspace-list-state'
+
+export function HostWorkspaceListStates(
+  props: HostWorkspaceListStateInput & {
+    search: string
+    activeFilterCount: number
+  }
+) {
+  const state = selectHostWorkspaceListState(props)
+  if (state === 'loading') {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="small" color={colors.textSecondary} />
+      </View>
+    )
+  }
+  if (state === 'catalog-error') {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>Could not load workspaces from this host</Text>
+        <Text style={styles.catalogErrorDetail}>
+          {`worktree.ps failed (${props.catalogError}) — retrying automatically`}
+        </Text>
+      </View>
+    )
+  }
+  if (state === 'empty') {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>
+          {props.search
+            ? 'No matching worktrees'
+            : props.activeFilterCount > 0
+              ? 'No worktrees match filters'
+              : 'No worktrees'}
+        </Text>
+      </View>
+    )
+  }
+  return null
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  emptyText: {
+    color: colors.textSecondary,
+    fontSize: typography.bodySize
+  },
+  catalogErrorDetail: {
+    marginTop: spacing.xs,
+    paddingHorizontal: spacing.lg,
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    textAlign: 'center'
+  }
+})

--- a/mobile/src/worktree/worktree-catalog-snapshot-client.test.ts
+++ b/mobile/src/worktree/worktree-catalog-snapshot-client.test.ts
@@ -3,8 +3,16 @@ import type { RpcClient } from '../transport/rpc-client'
 import {
   admitWorktreeCatalogResponse,
   WORKTREE_PS_FULL_LIMIT,
-  WorktreeCatalogSnapshotClient
+  WorktreeCatalogSnapshotClient,
+  type WorktreeCatalogFetchResult
 } from './worktree-catalog-snapshot-client'
+
+function admitFetched(
+  snapshots: WorktreeCatalogSnapshotClient,
+  fetched: WorktreeCatalogFetchResult
+) {
+  return snapshots.admit(fetched.kind === 'response' ? fetched.pending : null)
+}
 
 describe('admitWorktreeCatalogResponse', () => {
   it('accepts new-host full and unchanged responses', () => {
@@ -94,8 +102,8 @@ describe('WorktreeCatalogSnapshotClient', () => {
     )
     const snapshots = new WorktreeCatalogSnapshotClient()
 
-    const first = snapshots.admit(await snapshots.fetch(client, 'host-1'))
-    const second = snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    const first = admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
+    const second = admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
 
     expect(first).toEqual(rows)
     expect(second).toEqual(rows)
@@ -109,7 +117,7 @@ describe('WorktreeCatalogSnapshotClient', () => {
     const snapshots = new WorktreeCatalogSnapshotClient()
 
     await snapshots.fetch(client, 'host-1')
-    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
 
     expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
       limit: WORKTREE_PS_FULL_LIMIT,
@@ -121,7 +129,7 @@ describe('WorktreeCatalogSnapshotClient', () => {
     const client = clientWithResults({ worktrees: [], snapshotId: 'snapshot-1' })
     const snapshots = new WorktreeCatalogSnapshotClient()
 
-    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
     snapshots.admit(null)
     await snapshots.fetch(client, 'host-1')
 
@@ -139,8 +147,8 @@ describe('WorktreeCatalogSnapshotClient', () => {
     )
     const snapshots = new WorktreeCatalogSnapshotClient()
 
-    snapshots.admit(await snapshots.fetch(client, 'host-1'))
-    snapshots.admit(await snapshots.fetch(client, 'host-1'))
+    admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
+    admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
     await snapshots.fetch(client, 'host-1')
 
     expect(client.sendRequest).toHaveBeenNthCalledWith(3, 'worktree.ps', {
@@ -154,7 +162,7 @@ describe('WorktreeCatalogSnapshotClient', () => {
     const secondClient = clientWithResults({ worktrees: [], snapshotId: 'snapshot-2' })
     const snapshots = new WorktreeCatalogSnapshotClient()
 
-    snapshots.admit(await snapshots.fetch(firstClient, 'host-1'))
+    admitFetched(snapshots, await snapshots.fetch(firstClient, 'host-1'))
     await snapshots.fetch(secondClient, 'host-2')
 
     expect(secondClient.sendRequest).toHaveBeenCalledWith('worktree.ps', {
@@ -170,13 +178,49 @@ describe('WorktreeCatalogSnapshotClient', () => {
 
     // Host A's response is still in flight when the screen switches to host B.
     const stale = await snapshots.fetch(firstClient, 'host-1')
-    snapshots.admit(await snapshots.fetch(secondClient, 'host-2'))
-    expect(snapshots.admit(stale)).toBeNull()
+    admitFetched(snapshots, await snapshots.fetch(secondClient, 'host-2'))
+    expect(admitFetched(snapshots, stale)).toBeNull()
 
     await snapshots.fetch(secondClient, 'host-2')
     expect(secondClient.sendRequest).toHaveBeenNthCalledWith(2, 'worktree.ps', {
       limit: WORKTREE_PS_FULL_LIMIT,
       afterSnapshotId: 'snapshot-2'
+    })
+  })
+
+  // Why (STA-3123): a failed worktree.ps rendered as "0 worktrees"; callers need the
+  // failure code to show an error state instead of an empty host.
+  it('surfaces the RPC error code on failure and keeps the admitted token', async () => {
+    const responses: unknown[] = [
+      { id: 'request', ok: true, result: { worktrees: [], snapshotId: 'snapshot-1' } },
+      { id: 'request', ok: false, error: { code: 'forbidden', message: 'nope' } },
+      { id: 'request', ok: true, result: { unchanged: true, snapshotId: 'snapshot-1' } }
+    ]
+    const client = {
+      sendRequest: vi.fn(async () => responses.shift())
+    } as unknown as RpcClient
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    admitFetched(snapshots, await snapshots.fetch(client, 'host-1'))
+    const failed = await snapshots.fetch(client, 'host-1')
+    expect(failed).toEqual({ kind: 'request_failed', code: 'forbidden' })
+
+    await snapshots.fetch(client, 'host-1')
+    expect(client.sendRequest).toHaveBeenNthCalledWith(3, 'worktree.ps', {
+      limit: WORKTREE_PS_FULL_LIMIT,
+      afterSnapshotId: 'snapshot-1'
+    })
+  })
+
+  it('falls back to a generic failure code when the error carries none', async () => {
+    const client = {
+      sendRequest: vi.fn(async () => ({ id: 'request', ok: false, error: { message: 'x' } }))
+    } as unknown as RpcClient
+    const snapshots = new WorktreeCatalogSnapshotClient()
+
+    expect(await snapshots.fetch(client, 'host-1')).toEqual({
+      kind: 'request_failed',
+      code: 'request_failed'
     })
   })
 })

--- a/mobile/src/worktree/worktree-catalog-snapshot-client.ts
+++ b/mobile/src/worktree/worktree-catalog-snapshot-client.ts
@@ -1,5 +1,5 @@
 import type { RpcClient } from '../transport/rpc-client'
-import type { RpcSuccess } from '../transport/types'
+import type { RpcFailure, RpcSuccess } from '../transport/types'
 import type { Worktree } from './workspace-list-sections'
 
 // Why: worktree.ps silently truncates at 200; use a high cap so large hosts don't drop workspaces.
@@ -10,11 +10,18 @@ export type WorktreeCatalogAdmission<T> =
   | { kind: 'unchanged'; snapshotId: string }
   | { kind: 'invalid' }
 
-type PendingWorktreeCatalog = {
+export type PendingWorktreeCatalog = {
   admission: WorktreeCatalogAdmission<Worktree>
   client: RpcClient
   hostId: string
 }
+
+// Why (STA-3123): a failed worktree.ps must stay distinguishable from an empty
+// catalog — collapsing both to "no rows" made unreachable remote-server catalogs
+// render as a healthy host with 0 worktrees.
+export type WorktreeCatalogFetchResult =
+  | { kind: 'response'; pending: PendingWorktreeCatalog }
+  | { kind: 'request_failed'; code: string }
 
 function validSnapshotId(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 && value.length <= 128 ? value : null
@@ -56,7 +63,7 @@ export class WorktreeCatalogSnapshotClient {
   private snapshotId: string | null = null
   private confirmedWorktrees: Worktree[] | null = null
 
-  async fetch(client: RpcClient, hostId: string): Promise<PendingWorktreeCatalog | null> {
+  async fetch(client: RpcClient, hostId: string): Promise<WorktreeCatalogFetchResult> {
     if (this.client !== client || this.hostId !== hostId) {
       this.client = client
       this.hostId = hostId
@@ -69,15 +76,22 @@ export class WorktreeCatalogSnapshotClient {
       afterSnapshotId: requestedSnapshotId
     })
     if (!response.ok) {
-      return null
+      const code = (response as RpcFailure).error?.code
+      return {
+        kind: 'request_failed',
+        code: typeof code === 'string' && code.length > 0 ? code : 'request_failed'
+      }
     }
     return {
-      admission: admitWorktreeCatalogResponse<Worktree>(
-        (response as RpcSuccess).result,
-        requestedSnapshotId
-      ),
-      client,
-      hostId
+      kind: 'response',
+      pending: {
+        admission: admitWorktreeCatalogResponse<Worktree>(
+          (response as RpcSuccess).result,
+          requestedSnapshotId
+        ),
+        client,
+        hostId
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the "remote Orca server shows 0 worktrees" presentation from STA-3123 (synced GitHub issue #11869): a connected host whose `worktree.ps` request fails is no longer indistinguishable from a genuinely empty host.

- **Host page** (`/h/[hostId]`): when the catalog RPC fails (RPC error, invalid payload, or transport throw) and there are no cached rows, the screen now shows "Could not load workspaces from this host — `worktree.ps failed (<code>) — retrying automatically`" instead of an eternal spinner or a "No worktrees" empty state. The existing 3s poll / reconnect / pull-to-refresh paths clear the state on the next success; cached rows still win when present.
- **Home screen host card**: a failed `worktree.ps` no longer seeds a fabricated `0 worktrees` count. With no prior data the card now says "Worktree list unavailable"; cached counts are still kept through transient failures.
- `WorktreeCatalogSnapshotClient.fetch` now returns a discriminated result (`response` vs `request_failed` with the server error code) instead of collapsing failures to `null`, and preserves the snapshot token across failures.

Investigation notes: on current code the direct-pair catalog path is healthy end-to-end — verified via a fake mobile E2EE client (exact app params: `{limit: 10000, afterSnapshotId: null}`) against an isolated branch-built `orca serve` and against the installed production serve, plus a live iOS-sim pairing (screenshots below). The field "0 worktrees while CLI shows dozens" therefore reaches users through this silent-failure masking, which also made the original report undiagnosable — after this PR the failing host displays the actual RPC error code.

## Screenshots

Host page, paired to a connected mock host whose `worktree.ps` returns an RPC error (previously rendered as an empty host):

![host page failure state](https://github.com/user-attachments/assets/a92f61eb-5140-407f-ab6e-256d9fecf63e)

Home screen: failing host (Host 4) says "Worktree list unavailable"; healthy host (Host 3) keeps real counts:

![home card unavailable](https://github.com/user-attachments/assets/56ca14c9-6d92-4e62-a83f-2fd6b9838063)

Healthy path unchanged — iOS sim paired directly to an isolated `orca serve` built from this branch lists its catalog:

![healthy direct pairing](https://github.com/user-attachments/assets/cc066ccf-91f9-4765-b44d-a658c32e9416)

## Testing

- [x] `pnpm lint` (root, plus mobile `oxlint` — clean)
- [x] `pnpm typecheck` (root, plus mobile `tsc --noEmit` — clean)
- [x] `pnpm test` — targeted: mobile vitest `src/worktree/` (113 tests passing, includes new failure-path and state-precedence tests); changed-code quality gate (`check-changed-code-quality.mjs`): 0 new findings incl. React Doctor
- [ ] `pnpm build` — not run in full; `build:cli` + `build:electron-vite` were built and exercised for the QA serve rig (change is mobile-only)
- [x] Added or updated high-quality tests that would catch regressions: `worktree-catalog-snapshot-client.test.ts` (error-code surfacing, token preservation across failures) and new `host-workspace-list-state.test.ts` (loading/failure/empty precedence — a failed fetch can never render as "No worktrees")

## AI Review Report

Reviewed for: (1) failure-state vs cached-rows interplay — cached rows always win; the failure state only replaces the *empty* presentation; (2) snapshot-token semantics — a `request_failed` fetch does not clear the admitted token (server never answered), while an invalid success payload still resets it, covered by tests; (3) staleness — error state is guarded by the same client/host staleness checks as row application and is reset when the route re-seeds for a new hostId; (4) live QA on the iOS simulator confirmed both the failure state and the untouched healthy path. Cross-platform: the change is React Native (iOS/Android) only — no desktop/Electron, shortcut, path, or shell behavior touched; no `metaKey`/path separators involved; text-only UI additions render identically on both mobile platforms.

## Security Audit

The only new input surface is the RPC error `code` string rendered into the failure caption. It is rendered via React Native `Text` (no HTML/markup interpretation) and is only ever produced by an already-authenticated paired host; non-string/empty codes are normalized to `request_failed`. No command execution, path handling, secret handling, IPC, or dependency changes. Device tokens and pairing payloads are never logged by the new code.

## Notes

- STA-3123 also reports that the Mac host list does not aggregate remote Runtime Environment worktrees (parity with the desktop sidebar). That is a separate feature-sized data path (`worktree.ps` never merges environment runtimes; sessions for such rows would also need proxying) and is intentionally not attempted here — this PR makes the failing-catalog case visible and diagnosable, which is the P0 observable, and gives field users the actual error code to report.
- Server-side follow-up worth a look (matches STA-1730): `computeResolvedWorktrees` caches a scan-timeout-degraded (possibly empty) snapshot for the TTL without distinguishing it from an authoritative result.

References: STA-3123, #11869
