### PR TITLE
Cover the mobile approval card dropping on a live state transition

### DIFF
--- a/mobile/src/session/use-mobile-native-chat-prompts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.test.ts
@@ -24,6 +24,32 @@ function permissionFor(status: Partial<AgentStatusEntry> | null): unknown {
   return captured
 }
 
+// Keeps one probe mounted across a status change, so the assertion covers a live
+// pane whose agent resumed rather than a pane first rendered in the later state.
+function permissionAcross(
+  before: Partial<AgentStatusEntry>,
+  after: Partial<AgentStatusEntry>
+): { before: unknown; after: unknown } {
+  let captured: unknown
+  function Probe({ status }: { status: Partial<AgentStatusEntry> }): null {
+    captured = useMobileNativeChatPrompts({
+      enabled: true,
+      status: status as AgentStatusEntry,
+      messages: []
+    }).permission
+    return null
+  }
+  let renderer: ReturnType<typeof TestRenderer.create> | undefined
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(createElement(Probe, { status: before }))
+  })
+  const capturedBefore = captured
+  TestRenderer.act(() => {
+    renderer?.update(createElement(Probe, { status: after }))
+  })
+  return { before: capturedBefore, after: captured }
+}
+
 describe('useMobileNativeChatPrompts approval-envelope state gate', () => {
   it('renders no approval card while the agent is working', () => {
     expect(permissionFor({ state: 'working', interactivePrompt: APPROVAL })).toBeNull()
@@ -48,6 +74,16 @@ describe('useMobileNativeChatPrompts approval-envelope state gate', () => {
     expect(permissionFor({ state: 'blocked', interactivePrompt: APPROVAL })).toMatchObject({
       title: 'Allow Bash?'
     })
+  })
+
+  it('drops the approval card when a waiting agent resumes on the same pane', () => {
+    const permission = permissionAcross(
+      { state: 'waiting', interactivePrompt: APPROVAL },
+      { state: 'working', interactivePrompt: APPROVAL }
+    )
+
+    expect(permission.before).toMatchObject({ title: 'Allow Bash?' })
+    expect(permission.after).toBeNull()
   })
 
   it('prefers the heuristic numbered menu over the envelope while paused', () => {


### PR DESCRIPTION
## Summary

Follow-up to #12206, which landed the paused-state gate for the mobile native chat approval card.

The six cases that shipped with it each mount a fresh probe and assert the card for one status. That pins the mapping from a status to a card, but not the transition between statuses on a live pane — a `permission` value computed once and reused would satisfy all six. The transition is the shape a phone actually observes: the pane stays mounted while the agent it is watching moves from `waiting` to `working`, and that is exactly when the stale card had to disappear.

Adds one case that keeps a single probe mounted across the status change, plus a small helper for it. Test-only; no production change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Confirmed the case is not redundant with the six already on `main`: memoizing `permission` on first render (`useMemo(..., [])` around the gated expression) fails **only** this test and leaves the other six green. Removing the gate entirely fails this one alongside the existing `working` / `done` cases, so it also still guards the original defect.

- `mobile` workspace: 387 files / 2,874 tests pass, `tsc --noEmit` and `oxlint` clean.
- Repo root: `pnpm lint` passes. `pnpm typecheck` and `pnpm build` pass; this branch touches no production code and no root-suite file (`mobile/**` is not in the root vitest include).
- Pre-existing on macOS, unrelated to this branch: `config/scripts/check-root-directory-entries.test.mjs` fails because `.github/scripts/check-root-directory-entries.sh` uses `declare -A`, which needs bash 4+ while macOS ships bash 3.2, so the guard script exits 2 before any assertion.

## AI Review Report

Reviewed for whether the new case earns its place rather than restating coverage that already exists, since a duplicate test is worse than none. The mutation above is the evidence: it isolates a defect class — a permission value that is correct on first render and never recomputed — that no existing case detects.

Also reviewed the helper for test-suite hygiene: it keeps the existing `permissionFor` untouched, captures both the before and after values so the assertion proves the card was actually present first (a test that only asserted `null` after would pass even if the card never rendered), and follows the file's existing `react-test-renderer` + `TestRenderer.act` style rather than introducing a second harness.

Cross-platform: checked for macOS, Linux and Windows. Test-only change in the React Native workspace with no platform branch, no path handling, no shell invocation, and no shortcut or label; it runs identically on all three hosts. Nothing Electron-specific is touched.

## Security Audit

No production code, no new dependency, no filesystem, process, network or IPC surface. The change adds one test case and one test-local helper. No input handling, command execution, path handling, auth or secret is involved. No follow-up needed.

## Notes

- Context: I reported #11928 and had #11933 open with the same gate change; #12206 landed first and I have closed mine as superseded. This PR is the piece of that branch that is not on `main`, split out on current `main` as suggested on similar duplicates.
- The gate's remaining blind spot is unchanged and out of scope here: `TeammateIdle` clears a wait by name match, and `claudeTeammateIdMatchesName` matches any id shaped `a<name>-<hex>`, so a name/id prefix collision can falsely clear a wait to `working` while a genuine approval envelope is still cached. Flagging rather than widening this PR to the roster matcher.
