### PR TITLE
perf(runtime): withhold unchanged mobile snapshots from the graph payload

### DIFF
--- a/src/main/runtime/graph-sync-payload-partition.test.ts
+++ b/src/main/runtime/graph-sync-payload-partition.test.ts
@@ -40,13 +40,27 @@ const storeBase = {
   })
 }
 
-function makeSession(): WorkspaceSessionState {
+function makeSession(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
   return {
     activeRepoId: 'repo-1',
     activeWorktreeId: WT_A,
     activeTabId: null,
     tabsByWorktree: {},
-    terminalLayoutsByTabId: {}
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+function makeTerminalTab(id: string, ptyId: string) {
+  return {
+    id,
+    ptyId,
+    worktreeId: WT_A,
+    title: `Terminal ${id}`,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
   }
 }
 
@@ -65,6 +79,9 @@ function createRuntime() {
   })
   const events: RuntimeMobileSessionTabsResult[] = []
   runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+  const setSession = (next: WorkspaceSessionState): void => {
+    session = next
+  }
   const sync = (
     mobileSessionTabs: RuntimeMobileSessionTabsSnapshot[],
     unchangedMobileSessionWorktrees?: string[]
@@ -75,7 +92,7 @@ function createRuntime() {
       mobileSessionTabs,
       ...(unchangedMobileSessionWorktrees ? { unchangedMobileSessionWorktrees } : {})
     })
-  return { runtime, events, sync, internals: runtime as unknown as RuntimeInternals }
+  return { runtime, events, sync, setSession, internals: runtime as unknown as RuntimeInternals }
 }
 
 function makeSnapshot(worktree: string, version: number): RuntimeMobileSessionTabsSnapshot {
@@ -161,6 +178,57 @@ describe('graph-sync mobile payload partition', () => {
     expect(internals.mobileSessionTabsByWorktree.get(WT_B)?.tabs).toEqual([
       expect.objectContaining({ parentTabId: 'tab-1' })
     ])
+  })
+
+  it('asks for a republish when headless hydration masks a dropped renderer snapshot', () => {
+    const { sync, setSession, internals } = createRuntime()
+    setSession(
+      makeSession({
+        tabsByWorktree: { [WT_A]: [makeTerminalTab('serve-tab', 'serve-pty-1')] }
+      })
+    )
+    sync([makeSnapshot(WT_A, 1)])
+    internals.mobileSessionTabsByWorktree.delete(WT_A)
+
+    const result = sync([], [WT_A])
+    expect(result.mobileSessionResyncWorktrees).toEqual([WT_A])
+    expect(internals.mobileSessionTabsByWorktree.get(WT_A)?.publicationEpoch).toMatch(
+      /^headless-hydrated:/
+    )
+
+    const resend = sync([makeSnapshot(WT_A, 1)], [])
+    expect(resend.mobileSessionResyncWorktrees).toBeUndefined()
+    expect(
+      internals.mobileSessionTabsByWorktree
+        .get(WT_A)
+        ?.tabs.map((tab) => (tab.type === 'terminal' ? tab.parentTabId : tab.id))
+    ).toEqual(['tab-1', 'serve-tab'])
+  })
+
+  it('requests the accepted revision again to prune a stale preserved tab', () => {
+    const { sync, setSession, internals } = createRuntime()
+    setSession(
+      makeSession({
+        tabsByWorktree: { [WT_A]: [makeTerminalTab('serve-tab', 'serve-pty-1')] }
+      })
+    )
+    sync([makeSnapshot(WT_A, 1)])
+    expect(
+      internals.mobileSessionTabsByWorktree
+        .get(WT_A)
+        ?.tabs.some((tab) => tab.type === 'terminal' && tab.parentTabId === 'serve-tab')
+    ).toBe(true)
+
+    setSession(makeSession())
+    const result = sync([], [WT_A])
+    expect(result.mobileSessionResyncWorktrees).toEqual([WT_A])
+
+    sync([makeSnapshot(WT_A, 1)], [])
+    expect(
+      internals.mobileSessionTabsByWorktree
+        .get(WT_A)
+        ?.tabs.some((tab) => tab.type === 'terminal' && tab.parentTabId === 'serve-tab')
+    ).toBe(false)
   })
 
   it('leaves the legacy full-payload contract untouched when no list is sent', () => {

--- a/src/main/runtime/graph-sync-payload-partition.test.ts
+++ b/src/main/runtime/graph-sync-payload-partition.test.ts
@@ -231,6 +231,21 @@ describe('graph-sync mobile payload partition', () => {
     ).toBe(false)
   })
 
+  it('does not request a renderer tab rejected by the retirement fence', () => {
+    const { sync, setSession, internals } = createRuntime()
+    setSession(
+      makeSession({
+        terminalTopologyRevisionByRepoId: { 'repo-1': 1 }
+      })
+    )
+
+    sync([makeSnapshot(WT_A, 1)])
+    expect(internals.mobileSessionTabsByWorktree.get(WT_A)?.tabs).toEqual([])
+
+    expect(sync([], [WT_A]).mobileSessionResyncWorktrees).toBeUndefined()
+    expect(sync([], [WT_A]).mobileSessionResyncWorktrees).toBeUndefined()
+  })
+
   it('leaves the legacy full-payload contract untouched when no list is sent', () => {
     const { events, sync, internals } = createRuntime()
     sync([makeSnapshot(WT_A, 1), makeSnapshot(WT_B, 2)])

--- a/src/main/runtime/graph-sync-payload-partition.test.ts
+++ b/src/main/runtime/graph-sync-payload-partition.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The renderer withholds unchanged mobile-session snapshots from the graph
+ * payload. Main must treat those worktrees as live rather than pruning them as
+ * removed, and must ask for a republish of any it no longer holds.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  RuntimeMobileSessionTabsResult,
+  RuntimeMobileSessionTabsSnapshot,
+  RuntimeSyncWindowGraphResult
+} from '../../shared/runtime-types'
+import type { WorkspaceSessionState } from '../../shared/types'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const WT_A = 'repo-1::/tmp/worktree-a'
+const WT_B = 'repo-1::/tmp/worktree-b'
+
+const storeBase = {
+  getRepo: () => ({
+    id: 'repo-1',
+    path: '/tmp/repo',
+    displayName: 'repo',
+    badgeColor: 'blue',
+    addedAt: 1
+  }),
+  getRepos: () => [storeBase.getRepo()],
+  addRepo: () => {},
+  updateRepo: () => undefined as never,
+  getAllWorktreeMeta: () => ({}),
+  getWorktreeMeta: () => undefined,
+  getGitHubCache: () => ({ pr: {}, issue: {} }),
+  setWorktreeMeta: () => undefined as never,
+  removeWorktreeMeta: () => {},
+  getSettings: () => ({
+    workspaceDir: '/tmp/workspaces',
+    nestWorkspaces: false,
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: ''
+  })
+}
+
+function makeSession(): WorkspaceSessionState {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: WT_A,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {}
+  }
+}
+
+type RuntimeInternals = {
+  mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+}
+
+function createRuntime() {
+  let session = makeSession()
+  const runtime = new OrcaRuntimeService({
+    ...storeBase,
+    getWorkspaceSession: () => session,
+    setWorkspaceSession: (next: WorkspaceSessionState) => {
+      session = next
+    }
+  })
+  const events: RuntimeMobileSessionTabsResult[] = []
+  runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+  const sync = (
+    mobileSessionTabs: RuntimeMobileSessionTabsSnapshot[],
+    unchangedMobileSessionWorktrees?: string[]
+  ): RuntimeSyncWindowGraphResult =>
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs,
+      ...(unchangedMobileSessionWorktrees ? { unchangedMobileSessionWorktrees } : {})
+    })
+  return { runtime, events, sync, internals: runtime as unknown as RuntimeInternals }
+}
+
+function makeSnapshot(worktree: string, version: number): RuntimeMobileSessionTabsSnapshot {
+  return {
+    worktree,
+    publicationEpoch: 'renderer:test-epoch',
+    snapshotVersion: version,
+    activeGroupId: 'group-1',
+    activeTabId: 'tab-1::leaf-1',
+    activeTabType: 'terminal',
+    tabs: [
+      {
+        type: 'terminal',
+        id: 'tab-1::leaf-1',
+        parentTabId: 'tab-1',
+        leafId: 'leaf-1',
+        title: `Terminal ${worktree}`,
+        isActive: true
+      }
+    ]
+  }
+}
+
+describe('graph-sync mobile payload partition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a withheld worktree alive instead of pruning it as removed', () => {
+    const { events, sync, internals } = createRuntime()
+    sync([makeSnapshot(WT_A, 1), makeSnapshot(WT_B, 2)])
+    vi.advanceTimersByTime(300)
+    const storedB = internals.mobileSessionTabsByWorktree.get(WT_B)
+    expect(storedB).toBeDefined()
+    events.length = 0
+
+    // A publishes a change; B is withheld as unchanged rather than omitted.
+    sync([makeSnapshot(WT_A, 3)], [WT_B])
+    vi.advanceTimersByTime(300)
+
+    expect(internals.mobileSessionTabsByWorktree.get(WT_B)).toBe(storedB)
+    expect(events.filter((event) => 'removed' in event && event.removed === true)).toEqual([])
+    expect(events.map((event) => event.worktree)).toEqual([WT_A])
+  })
+
+  it('still prunes a worktree the renderer omits from both lists', () => {
+    const { events, sync, internals } = createRuntime()
+    sync([makeSnapshot(WT_A, 1), makeSnapshot(WT_B, 2)])
+    vi.advanceTimersByTime(300)
+    events.length = 0
+
+    sync([makeSnapshot(WT_A, 3)], [])
+    vi.advanceTimersByTime(300)
+
+    expect(internals.mobileSessionTabsByWorktree.has(WT_B)).toBe(false)
+    const removed = events.filter((event) => 'removed' in event && event.removed === true)
+    expect(removed.map((event) => event.worktree)).toEqual([WT_B])
+  })
+
+  it('asks for a republish of a withheld worktree it dropped, and accepts the resend', () => {
+    const { sync, internals } = createRuntime()
+    sync([makeSnapshot(WT_A, 1), makeSnapshot(WT_B, 2)])
+    vi.advanceTimersByTime(300)
+
+    // Main drops B on its own (worktree metadata removal) while the renderer
+    // still believes B is delivered.
+    internals.mobileSessionTabsByWorktree.delete(WT_B)
+
+    const result = sync([], [WT_A, WT_B])
+    vi.advanceTimersByTime(300)
+    expect(result.mobileSessionResyncWorktrees).toEqual([WT_B])
+    expect(internals.mobileSessionTabsByWorktree.has(WT_A)).toBe(true)
+
+    // The renderer republishes B at the SAME (epoch, version) it last sent. The
+    // accept gate must no longer treat that as an already-accepted no-op.
+    const resend = sync([makeSnapshot(WT_B, 2)], [WT_A])
+    vi.advanceTimersByTime(300)
+    expect(resend.mobileSessionResyncWorktrees).toBeUndefined()
+    expect(internals.mobileSessionTabsByWorktree.get(WT_B)?.tabs).toEqual([
+      expect.objectContaining({ parentTabId: 'tab-1' })
+    ])
+  })
+
+  it('leaves the legacy full-payload contract untouched when no list is sent', () => {
+    const { events, sync, internals } = createRuntime()
+    sync([makeSnapshot(WT_A, 1), makeSnapshot(WT_B, 2)])
+    vi.advanceTimersByTime(300)
+    events.length = 0
+
+    // No unchangedMobileSessionWorktrees field at all: omission still prunes.
+    sync([makeSnapshot(WT_A, 3)])
+    vi.advanceTimersByTime(300)
+
+    expect(internals.mobileSessionTabsByWorktree.has(WT_B)).toBe(false)
+    expect(
+      events.filter((event) => 'removed' in event && event.removed === true).map((e) => e.worktree)
+    ).toEqual([WT_B])
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -28966,9 +28966,9 @@ export class OrcaRuntimeService {
       this.acceptedRendererMobileSnapshotByWorktree.set(snapshot.worktree, {
         publicationEpoch: snapshot.publicationEpoch,
         rendererVersion: snapshot.snapshotVersion,
-        rendererTabCount: snapshot.tabs.length,
+        rendererTabCount: fencedSnapshot.tabs.length,
         rendererTabIdentityKeys: new Set(
-          snapshot.tabs.flatMap((tab) => this.getMobileSessionSnapshotTabIdentityKeys(tab))
+          fencedSnapshot.tabs.flatMap((tab) => this.getMobileSessionSnapshotTabIdentityKeys(tab))
         )
       })
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5373,7 +5373,12 @@ export class OrcaRuntimeService {
     const previousLeaves = this.leaves
     this.tabs = new Map(graph.tabs.map((tab) => [tab.tabId, tab]))
     const lifecycleLeaves = this.reconcileMobileSessionRetirementFences(graph.leaves)
-    const changedMobileWorktrees = this.syncMobileSessionTabs(graph.mobileSessionTabs)
+    const mobileSessionResyncWorktrees = new Set<string>()
+    const changedMobileWorktrees = this.syncMobileSessionTabs(
+      graph.mobileSessionTabs,
+      graph.unchangedMobileSessionWorktrees,
+      mobileSessionResyncWorktrees
+    )
     const nextLeaves = new Map<string, RuntimeLeafRecord>()
     const graphSyncedAt = this.nextTitleObservationSequence()
 
@@ -5549,7 +5554,10 @@ export class OrcaRuntimeService {
     return {
       ...this.getStatus(),
       ...(agentOrchestrationByPaneKey ? { agentOrchestrationByPaneKey } : {}),
-      ...(nativeChatLaunchDraftResolutions.length > 0 ? { nativeChatLaunchDraftResolutions } : {})
+      ...(nativeChatLaunchDraftResolutions.length > 0 ? { nativeChatLaunchDraftResolutions } : {}),
+      ...(mobileSessionResyncWorktrees.size > 0
+        ? { mobileSessionResyncWorktrees: [...mobileSessionResyncWorktrees] }
+        : {})
     }
   }
 
@@ -28834,7 +28842,9 @@ export class OrcaRuntimeService {
   // Returns the worktrees whose stored snapshot object changed during this
   // sync, so the caller can fan out only actually-changed worktrees.
   private syncMobileSessionTabs(
-    snapshots: RuntimeMobileSessionTabsSnapshot[] | undefined
+    snapshots: RuntimeMobileSessionTabsSnapshot[] | undefined,
+    unchangedWorktreeIds?: string[],
+    resyncWorktreeIds: Set<string> = new Set()
   ): Set<string> {
     const changedWorktreeIds = new Set<string>()
     if (snapshots === undefined) {
@@ -28869,6 +28879,20 @@ export class OrcaRuntimeService {
       })
     }
     const nextWorktrees = new Set<string>()
+    // Why: the renderer withholds unchanged snapshots to keep the graph payload
+    // small, so these worktrees are still live and must not fall into the prune
+    // below. One main holds nothing for was dropped main-side after the renderer
+    // last published it; ask for a republish or its tabs stay gone until it changes.
+    for (const worktreeId of unchangedWorktreeIds ?? []) {
+      if (this.mobileSessionTabsByWorktree.has(worktreeId)) {
+        nextWorktrees.add(worktreeId)
+        continue
+      }
+      resyncWorktreeIds.add(worktreeId)
+      // Why: the accept gate compares against the renderer's last accepted pair,
+      // which outlives the dropped snapshot and would reject the republish.
+      this.acceptedRendererMobileSnapshotByWorktree.delete(worktreeId)
+    }
     for (const snapshot of snapshots) {
       nextWorktrees.add(snapshot.worktree)
       const existing = this.mobileSessionTabsByWorktree.get(snapshot.worktree)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2721,7 +2721,12 @@ export class OrcaRuntimeService {
   // resend (or stale) and is skipped without touching the stored entry.
   private acceptedRendererMobileSnapshotByWorktree = new Map<
     string,
-    { publicationEpoch: string; rendererVersion: number }
+    {
+      publicationEpoch: string
+      rendererVersion: number
+      rendererTabCount: number
+      rendererTabIdentityKeys: ReadonlySet<string>
+    }
   >()
   private clientSessionTabSelections = new ClientSessionTabSelectionStore()
   // Why: idempotency map for mobile terminal creation — a retried create with the
@@ -23203,6 +23208,7 @@ export class OrcaRuntimeService {
       store.removeWorktreeMeta(worktreeId)
     }
     this.mobileSessionTabsByWorktree.delete(worktreeId)
+    this.acceptedRendererMobileSnapshotByWorktree.delete(worktreeId)
     advertisedUrlWatcher.forgetWorktree(worktreeId)
     deleteWorktreeHistoryDir(worktreeId)
     this.closeHeadlessBrowserPagesForWorktree(worktreeId)
@@ -28879,16 +28885,34 @@ export class OrcaRuntimeService {
       })
     }
     const nextWorktrees = new Set<string>()
+    const incomingWorktreeIds = new Set(snapshots.map((snapshot) => snapshot.worktree))
     // Why: the renderer withholds unchanged snapshots to keep the graph payload
     // small, so these worktrees are still live and must not fall into the prune
-    // below. One main holds nothing for was dropped main-side after the renderer
-    // last published it; ask for a republish or its tabs stay gone until it changes.
+    // below. Ask for a republish when main no longer holds that accepted renderer
+    // publication or a formerly-preserved runtime tab has gone stale.
     for (const worktreeId of unchangedWorktreeIds ?? []) {
-      if (this.mobileSessionTabsByWorktree.has(worktreeId)) {
+      const existing = this.mobileSessionTabsByWorktree.get(worktreeId)
+      const accepted = this.acceptedRendererMobileSnapshotByWorktree.get(worktreeId)
+      if (existing) {
         nextWorktrees.add(worktreeId)
+      }
+      if (
+        existing &&
+        accepted &&
+        (existing.publicationEpoch === accepted.publicationEpoch ||
+          existing.publicationEpoch.startsWith(`${accepted.publicationEpoch}:headless-merge:`)) &&
+        existing.tabs.length >= accepted.rendererTabCount &&
+        (existing.tabs.length === accepted.rendererTabCount ||
+          !this.storedMobileSnapshotHasStalePreservedTab(
+            existing,
+            accepted.rendererTabIdentityKeys
+          ))
+      ) {
         continue
       }
-      resyncWorktreeIds.add(worktreeId)
+      if (!incomingWorktreeIds.has(worktreeId)) {
+        resyncWorktreeIds.add(worktreeId)
+      }
       // Why: the accept gate compares against the renderer's last accepted pair,
       // which outlives the dropped snapshot and would reject the republish.
       this.acceptedRendererMobileSnapshotByWorktree.delete(worktreeId)
@@ -28917,7 +28941,7 @@ export class OrcaRuntimeService {
         !(
           existing &&
           snapshot.snapshotVersion === accepted.rendererVersion &&
-          this.storedMobileSnapshotHasStalePreservedTab(existing, snapshot)
+          this.storedMobileSnapshotHasStalePreservedTab(existing, accepted.rendererTabIdentityKeys)
         )
       ) {
         continue
@@ -28941,7 +28965,11 @@ export class OrcaRuntimeService {
       )
       this.acceptedRendererMobileSnapshotByWorktree.set(snapshot.worktree, {
         publicationEpoch: snapshot.publicationEpoch,
-        rendererVersion: snapshot.snapshotVersion
+        rendererVersion: snapshot.snapshotVersion,
+        rendererTabCount: snapshot.tabs.length,
+        rendererTabIdentityKeys: new Set(
+          snapshot.tabs.flatMap((tab) => this.getMobileSessionSnapshotTabIdentityKeys(tab))
+        )
       })
     }
     for (const [worktreeId, existing] of [...this.mobileSessionTabsByWorktree.entries()]) {
@@ -29063,22 +29091,19 @@ export class OrcaRuntimeService {
   }
 
   // Why: the accepted-revision no-op gate must not fossilize preserved runtime
-  // tabs. A stored merged snapshot's tabs that are absent from the incoming
-  // renderer publication exist only via preservation; if any such tab no longer
+  // tabs. A stored merged snapshot's tabs absent from the accepted renderer
+  // publication exist only via preservation; if any such tab no longer
   // passes the preservation predicate (binding removed from the live PTY table
-  // and persisted session, or browser page closed), the stored snapshot is
-  // stale even though the renderer revision is unchanged.
+  // and persisted session, or browser page closed), the stored snapshot is stale.
   private storedMobileSnapshotHasStalePreservedTab(
     existing: RuntimeMobileSessionTabsSnapshot,
-    incoming: RuntimeMobileSessionTabsSnapshot
+    rendererTabIdentityKeys: ReadonlySet<string>
   ): boolean {
-    const incomingIds = new Set(
-      incoming.tabs.flatMap((tab) => this.getMobileSessionSnapshotTabIdentityKeys(tab))
-    )
     return existing.tabs.some(
       (tab) =>
-        !this.getMobileSessionSnapshotTabIdentityKeys(tab).some((id) => incomingIds.has(id)) &&
-        !this.shouldPreserveHeadlessMobileSessionTab(existing, tab)
+        !this.getMobileSessionSnapshotTabIdentityKeys(tab).some((id) =>
+          rendererTabIdentityKeys.has(id)
+        ) && !this.shouldPreserveHeadlessMobileSessionTab(existing, tab)
     )
   }
 

--- a/src/renderer/src/runtime/sync-runtime-graph-payload-partition.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-payload-partition.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  scheduleRuntimeGraphSync,
+  setRuntimeGraphStoreStateGetter,
+  setRuntimeGraphSyncEnabled
+} from './sync-runtime-graph'
+import type { AppState } from '../store/types'
+import type { RuntimeSyncWindowGraph } from '../../../shared/runtime-types'
+
+function leafIdFor(index: number): string {
+  return `${String(index).padStart(8, '0')}-1111-4111-8111-111111111111`
+}
+
+/** Distinct ids per test: the publication memo is module state shared in this file. */
+function makeState(prefix: string, worktreeCount: number, titles: string[] = []): AppState {
+  const tabsByWorktree: Record<string, unknown[]> = {}
+  const terminalLayoutsByTabId: Record<string, unknown> = {}
+  for (let i = 0; i < worktreeCount; i++) {
+    const tabId = `${prefix}-term-${i}`
+    tabsByWorktree[`repo::/${prefix}-wt-${i}`] = [
+      { id: tabId, title: titles[i] ?? `Agent ${i}`, customTitle: null, ptyId: null }
+    ]
+    terminalLayoutsByTabId[tabId] = {
+      root: { type: 'leaf', leafId: leafIdFor(i) },
+      activeLeafId: leafIdFor(i),
+      expandedLeafId: null
+    }
+  }
+  return {
+    tabsByWorktree,
+    terminalLayoutsByTabId,
+    runtimePaneTitlesByTabId: {},
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    layoutByWorktree: {},
+    unifiedTabsByWorktree: {},
+    tabBarOrderByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    openFiles: [],
+    editorDrafts: {},
+    activeTabId: null,
+    agentStatusByPaneKey: {},
+    browserTabsByWorktree: {}
+  } as unknown as AppState
+}
+
+function graphOf(call: unknown[] | undefined): RuntimeSyncWindowGraph {
+  return call?.[0] as RuntimeSyncWindowGraph
+}
+
+function publishedWorktrees(call: unknown[] | undefined): string[] {
+  return (graphOf(call).mobileSessionTabs ?? []).map((snapshot) => snapshot.worktree).sort()
+}
+
+function withheldWorktrees(call: unknown[] | undefined): string[] {
+  return [...(graphOf(call).unchangedMobileSessionWorktrees ?? [])].sort()
+}
+
+async function flushSync(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(20)
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+afterEach(() => {
+  setRuntimeGraphSyncEnabled(false)
+  setRuntimeGraphStoreStateGetter(null)
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+function startSync(
+  state: AppState,
+  syncWindowGraph: ReturnType<typeof vi.fn>
+): { setState: (next: AppState) => void } {
+  let current = state
+  vi.useFakeTimers()
+  vi.stubGlobal('window', { api: { runtime: { syncWindowGraph } } })
+  vi.stubGlobal('HTMLElement', class HTMLElement {})
+  setRuntimeGraphStoreStateGetter(() => current)
+  setRuntimeGraphSyncEnabled(true)
+  return {
+    setState: (next: AppState) => {
+      current = next
+    }
+  }
+}
+
+describe('mobile session graph payload partition', () => {
+  it('withholds every unchanged worktree from the republished payload', async () => {
+    const syncWindowGraph = vi.fn().mockResolvedValue({})
+    startSync(makeState('a', 3), syncWindowGraph)
+
+    await flushSync()
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[0])).toEqual([
+      'repo::/a-wt-0',
+      'repo::/a-wt-1',
+      'repo::/a-wt-2'
+    ])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[0])).toEqual([])
+
+    scheduleRuntimeGraphSync()
+    await flushSync()
+
+    expect(syncWindowGraph).toHaveBeenCalledTimes(2)
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[1])).toEqual([])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[1])).toEqual([
+      'repo::/a-wt-0',
+      'repo::/a-wt-1',
+      'repo::/a-wt-2'
+    ])
+  })
+
+  it('publishes only the worktree whose snapshot changed', async () => {
+    const syncWindowGraph = vi.fn().mockResolvedValue({})
+    const { setState } = startSync(makeState('b', 3), syncWindowGraph)
+    await flushSync()
+
+    setState(makeState('b', 3, ['Agent 0', 'Agent 1 (done)', 'Agent 2']))
+    scheduleRuntimeGraphSync()
+    await flushSync()
+
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[1])).toEqual(['repo::/b-wt-1'])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[1])).toEqual([
+      'repo::/b-wt-0',
+      'repo::/b-wt-2'
+    ])
+  })
+
+  it('republishes a changed worktree whose publication threw before it was acknowledged', async () => {
+    const syncWindowGraph = vi.fn().mockResolvedValue({})
+    const { setState } = startSync(makeState('c', 3), syncWindowGraph)
+    await flushSync()
+
+    // The publication carrying c-wt-1's new snapshot fails in flight.
+    setState(makeState('c', 3, ['Agent 0', 'Agent 1 (done)', 'Agent 2']))
+    syncWindowGraph.mockRejectedValueOnce(new Error('ipc closed'))
+    scheduleRuntimeGraphSync()
+    await flushSync()
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[1])).toEqual(['repo::/c-wt-1'])
+
+    // Nothing changed since, but main never acknowledged it: resend, don't withhold.
+    scheduleRuntimeGraphSync()
+    await flushSync()
+
+    expect(syncWindowGraph).toHaveBeenCalledTimes(3)
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[2])).toEqual(['repo::/c-wt-1'])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[2])).toEqual([
+      'repo::/c-wt-0',
+      'repo::/c-wt-2'
+    ])
+  })
+
+  it('resends everything when the first publication throws', async () => {
+    const syncWindowGraph = vi.fn().mockRejectedValueOnce(new Error('ipc closed'))
+    syncWindowGraph.mockResolvedValue({})
+    startSync(makeState('d', 3), syncWindowGraph)
+    await flushSync()
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[0])).toHaveLength(3)
+
+    scheduleRuntimeGraphSync()
+    await flushSync()
+
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[1])).toEqual([
+      'repo::/d-wt-0',
+      'repo::/d-wt-1',
+      'repo::/d-wt-2'
+    ])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[1])).toEqual([])
+  })
+
+  it('republishes worktrees main reports it dropped after acknowledging them', async () => {
+    const syncWindowGraph = vi.fn().mockResolvedValue({})
+    startSync(makeState('e', 3), syncWindowGraph)
+    await flushSync()
+
+    syncWindowGraph.mockResolvedValueOnce({ mobileSessionResyncWorktrees: ['repo::/e-wt-2'] })
+    scheduleRuntimeGraphSync()
+    await flushSync()
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[1])).toHaveLength(3)
+
+    // The resync reply schedules its own republish; no store change is needed.
+    await flushSync()
+
+    expect(syncWindowGraph).toHaveBeenCalledTimes(3)
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[2])).toEqual(['repo::/e-wt-2'])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[2])).toEqual([
+      'repo::/e-wt-0',
+      'repo::/e-wt-1'
+    ])
+  })
+
+  it('drops a removed worktree from both the payload and the withheld list', async () => {
+    const syncWindowGraph = vi.fn().mockResolvedValue({})
+    const { setState } = startSync(makeState('f', 3), syncWindowGraph)
+    await flushSync()
+
+    setState(makeState('f', 2))
+    scheduleRuntimeGraphSync()
+    await flushSync()
+
+    expect(publishedWorktrees(syncWindowGraph.mock.calls[1])).toEqual([])
+    expect(withheldWorktrees(syncWindowGraph.mock.calls[1])).toEqual([
+      'repo::/f-wt-0',
+      'repo::/f-wt-1'
+    ])
+  })
+})

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -217,6 +217,9 @@ const EMPTY_WORKTREE_UNIFIED_TABS: AppState['unifiedTabsByWorktree'][string] = [
 const EMPTY_WORKTREE_TAB_GROUPS: AppState['groupsByWorktree'][string] = []
 const EMPTY_WORKTREE_OPEN_FILE_IDS: readonly string[] = []
 const mobileSessionPublicationEpoch = `renderer:${createBrowserUuid()}`
+// Why: the snapshot object main last acknowledged per worktree; anything still
+// identical is withheld from the graph payload instead of re-cloned across IPC.
+const publishedMobileSessionSnapshotByWorktree = new Map<string, RuntimeMobileSessionTabsSnapshot>()
 
 export function setRuntimeGraphStoreStateGetter(getter: (() => AppState) | null): void {
   getStoreState = getter
@@ -698,10 +701,13 @@ async function syncRuntimeGraph(): Promise<void> {
       .map((tab) => [tab.id, tab])
   )
   const generatedTitlesEnabled = state.settings?.tabAutoGenerateTitle === true
+  const mobileSessionTabs = buildMobileSessionTabSnapshots(state, systemPrefersDark)
+  const publication = partitionMobileSessionPublication(mobileSessionTabs)
   const graph: RuntimeSyncWindowGraph = {
     tabs: [],
     leaves: [],
-    mobileSessionTabs: buildMobileSessionTabSnapshots(state, systemPrefersDark)
+    mobileSessionTabs: publication.changed,
+    unchangedMobileSessionWorktrees: publication.unchangedWorktrees
   }
 
   for (const [tabId, registeredTab] of registeredTabs) {
@@ -811,6 +817,9 @@ async function syncRuntimeGraph(): Promise<void> {
 
   try {
     const result = await window.api.runtime.syncWindowGraph(graph)
+    // Why: only an acknowledged publication may be treated as delivered. A throw
+    // leaves the memo behind, so the retry resends every worktree in full.
+    commitMobileSessionPublication(mobileSessionTabs, result?.mobileSessionResyncWorktrees)
     const currentState = getStoreState()
     currentState?.setRuntimeAgentOrchestrationByPaneKey?.(result?.agentOrchestrationByPaneKey ?? {})
     for (const resolution of result?.nativeChatLaunchDraftResolutions ?? []) {
@@ -821,8 +830,50 @@ async function syncRuntimeGraph(): Promise<void> {
         })
       }
     }
+    if (result?.mobileSessionResyncWorktrees?.length) {
+      scheduleRuntimeGraphSync()
+    }
   } catch (error) {
     console.error('[runtime] Failed to sync renderer graph:', error)
+  }
+}
+
+function partitionMobileSessionPublication(snapshots: RuntimeMobileSessionTabsSnapshot[]): {
+  changed: RuntimeMobileSessionTabsSnapshot[]
+  unchangedWorktrees: string[]
+} {
+  const changed: RuntimeMobileSessionTabsSnapshot[] = []
+  const unchangedWorktrees: string[] = []
+  for (const snapshot of snapshots) {
+    // Why: buildMobileSessionTabSnapshots returns the cached object for a worktree
+    // it did not rebuild, so identity — not a deep compare — settles this.
+    if (publishedMobileSessionSnapshotByWorktree.get(snapshot.worktree) === snapshot) {
+      unchangedWorktrees.push(snapshot.worktree)
+    } else {
+      changed.push(snapshot)
+    }
+  }
+  return { changed, unchangedWorktrees }
+}
+
+function commitMobileSessionPublication(
+  snapshots: RuntimeMobileSessionTabsSnapshot[],
+  resyncWorktrees: string[] | undefined
+): void {
+  const published = new Set<string>()
+  for (const snapshot of snapshots) {
+    published.add(snapshot.worktree)
+    publishedMobileSessionSnapshotByWorktree.set(snapshot.worktree, snapshot)
+  }
+  for (const worktreeId of publishedMobileSessionSnapshotByWorktree.keys()) {
+    if (!published.has(worktreeId)) {
+      publishedMobileSessionSnapshotByWorktree.delete(worktreeId)
+    }
+  }
+  // Why: main dropped these after acknowledging them, so forget the delivery and
+  // let the scheduled resync republish them in full.
+  for (const worktreeId of resyncWorktrees ?? []) {
+    publishedMobileSessionSnapshotByWorktree.delete(worktreeId)
   }
 }
 

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -143,7 +143,11 @@ export type RuntimeSyncedLeaf = {
 export type RuntimeSyncWindowGraph = {
   tabs: RuntimeSyncedTab[]
   leaves: RuntimeSyncedLeaf[]
+  /** Only worktrees whose snapshot changed since the last acknowledged publication. */
   mobileSessionTabs?: RuntimeMobileSessionTabsSnapshot[]
+  /** Worktrees the renderer is still publishing unchanged; main must keep their
+   *  stored snapshots alive instead of pruning them as removed. */
+  unchangedMobileSessionWorktrees?: string[]
 }
 
 export type RuntimeNativeChatLaunchDraftResolution = {
@@ -157,6 +161,9 @@ export type RuntimeSyncWindowGraphResult = RuntimeStatus & {
    *  parent metadata needed by title-derived agent rows without name guessing. */
   agentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
   nativeChatLaunchDraftResolutions?: RuntimeNativeChatLaunchDraftResolution[]
+  /** Worktrees the renderer withheld as unchanged that main holds no snapshot
+   *  for — it dropped them independently, so the renderer must republish them. */
+  mobileSessionResyncWorktrees?: string[]
 }
 
 export type RuntimeMobileSessionTerminalTab = {


### PR DESCRIPTION
> **Builds on merged #12207.** This PR now targets `main`; the partition below relies on the reference-identical unchanged snapshots introduced there.

## Summary

Every renderer graph sync structured-cloned all of the user's worktree mobile-session snapshots to the main process, whether or not any had changed.

Measured on a synthetic profile matching the reported crash telemetry (222 worktrees, 787 tabs, 787 terminal layouts):

| | Payload | `structuredClone` |
| --- | ---: | ---: |
| Before, every sync | 374 KB | 5.08 ms |
| After, unchanged republish | 3.4 KB | 0.02 ms |
| After, one worktree changed | 5.3 KB | 0.04 ms |

Electron clones on serialize and again on deserialize, so the real cost is roughly double the figure above. This transport cost — not the renderer-side rebuild, which is ~1 ms after #12207 — is the bulk of a publication.

The renderer now sends only snapshots main has not acknowledged, and names the rest in a new `unchangedMobileSessionWorktrees` list. Main seeds `nextWorktrees` from that list so its prune treats withheld worktrees as live rather than removed.

**The IPC call itself stays unconditional.** `syncWindowGraph` is not a one-way publish: its return value is the only channel carrying `agentOrchestrationByPaneKey` to the renderer (`sync-runtime-graph.ts` holds the sole caller of `setRuntimeAgentOrchestrationByPaneKey`, and no event channel exists), and the handler adopts pre-allocated handles, merges detached leaves, refreshes writable flags, and drains graph-sync callbacks on every sync. Skipping the call when the graph looks unchanged would starve all of that — the renderer cannot know what main has to deliver. Only the payload shrinks.

### Two failure modes this design creates, both closed explicitly

1. **A publication that throws must not count as delivered.** The last-sent memo advances only after main acknowledges, so a failed publication is resent in full instead of being withheld forever as "already sent".
2. **A worktree main drops on its own** (`removeWorktreeMetadataAndHistory`) would otherwise never come back, because the renderer believes it is already delivered. Main now returns those in `mobileSessionResyncWorktrees`, which also clears the accepted-revision record so the republish is not rejected by the accept gate as a no-op.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec oxlint` on every changed file
- [x] `pnpm run typecheck:web`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/` — 58 files / 564 tests pass
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/` — 213 files pass; 6 failures in `orca-runtime-files.test.ts` and `rpc/methods/ai-vault.test.ts` are pre-existing Windows path-separator assertions (`expected [ '\ctor\codex\home\sessions' ] to include '/ctor/codex/home/sessions'`), reproduced identically on the base commit with this change stashed
- [x] All out-of-directory importers of `sync-runtime-graph` — 9 files / 780 tests pass
- [x] Added tests, and verified each fails without the change

`pnpm test` (the wrapper) cannot run in this environment — `windows-native-registry` fails to rebuild — so vitest was invoked directly.

### New tests

`src/renderer/src/runtime/sync-runtime-graph-payload-partition.test.ts`
- withholds every unchanged worktree from a republish
- publishes only the worktree whose snapshot changed
- republishes a changed worktree whose publication threw before it was acknowledged
- resends everything when the first publication throws
- republishes worktrees main reports it dropped after acknowledging them
- drops a removed worktree from both the payload and the withheld list

`src/main/runtime/graph-sync-payload-partition.test.ts`
- keeps a withheld worktree alive instead of pruning it as removed
- still prunes a worktree the renderer omits from both lists
- asks for a republish of a withheld worktree it dropped, and accepts the resend
- leaves the legacy full-payload contract untouched when no list is sent

Negative controls: reverting the ack gate fails 3 of the renderer tests; reverting the `nextWorktrees` seed fails 2 of the main tests.

## AI Review Report

Reviewed the renderer/main contract for staleness risk, since a false "unchanged" silently publishes stale tabs to paired clients.

Checked and resolved:
- **Return-value starvation** — audited every field of `RuntimeSyncWindowGraphResult` and every side effect in the main handler before concluding the call must stay unconditional. This is why the PR shrinks the payload rather than skipping the sync.
- **Prune correctness** — the withheld list is folded into `nextWorktrees` before the prune loop, and a test asserts a worktree omitted from *both* lists is still pruned and still emits its removed frame.
- **Ack ordering** — the memo commit sits after `await`, inside `try`, so a rejection leaves it untouched.
- **Accept-gate interaction** — a resync clears `acceptedRendererMobileSnapshotByWorktree`, otherwise a republish at the same `(epoch, version)` is discarded and the worktree never recovers.
- **Version-skew** — renderer and main ship in one build, so there is no mixed-version path; a renderer reload resets the module memo and forces a full resend. The new fields are optional, and a caller that sends neither (`src/main/index.ts` headless sync) keeps its exact previous behavior, covered by a test.

Cross-platform: no platform-dependent behavior added — no paths, shell invocation, shortcuts, or labels. The change is plain data structures over existing IPC, identical on macOS, Linux, and Windows.

## Security Audit

No new IPC surface: two optional fields on an existing authenticated channel. `unchangedMobileSessionWorktrees` carries worktree ids that main already holds, and it can only ever *retain* an existing entry — it cannot inject, mutate, or resurrect snapshot content, so a malformed list cannot forge tabs. Unknown ids fall through to the resync path rather than creating state. `mobileSessionResyncWorktrees` only deletes renderer-local memo entries, whose worst case is a redundant full republish. No input parsing, command execution, path handling, auth, secrets, or dependency changes.

## Notes

- #12207 is merged into `main`; this follow-up now targets `main` directly and relies on its reference-identical unchanged snapshots.
- The renderer-side rebuild is not addressed here and does not need to be: it measures ~1 ms at this scale after #12207. A separately-proposed micro-optimization of the per-sync tab flatten was dropped as not worth a review cycle at 0.18 ms.



## Final merge-readiness review — 2026-08-03

Reviewed exact stacked range `27d470c2ac645cbcd4cf75c087ce6b3dc771a49d...5081a12ac2f044725939fa7eb63f22a461611658`. The final independent review returned **CLEAN**. GitHub reports a clean merge state and 42 completed checks with zero failures, including Windows packaging. The final focused run covered 18 files and passed 1,158 tests with one skip; typecheck, lint, format, max-lines, diff/reference cleanliness, and negative controls also passed.

### Meaningful fixes found during review

- `6e369e6c37`: withheld publications skipped same-revision preservation reconciliation. Removed serve/SSH tabs could remain stale, while headless hydration could mask a renderer snapshot dropped by main. The fix tracks accepted renderer membership and requests targeted resyncs; regressions cover both paths.
- `5081a12ac2`: accepted membership metadata used raw `snapshot.tabs` even when retirement fencing removed tabs before storage. Every later withheld publication could therefore request another full resync. Metadata now uses `fencedSnapshot.tabs`; a negative control proves two consecutive withheld publications no longer resync.

### Statistical benchmark

Identical SHA-256-verified uncommitted harness at baseline `3658165119`, #12207 at `27d470c2ac`, and the combined stack at `5081a12ac2`. Each target used three independently started, rotated rounds with 50 warmups and 150 measured samples per round: **450 measured samples per target per metric**. Values are `median / p95 [bootstrap 95% CI for median]`.

| Metric | Baseline | #12207 | Combined through #12245 |
| --- | ---: | ---: | ---: |
| Direct snapshot build | 1.382 / 2.053 ms [1.341, 1.421] | **0.135 / 0.189 ms [0.1348, 0.1360]** | 0.138 / 0.218 ms [0.1373, 0.1399] |
| Scheduled publication, excluding the deliberate 16 ms coalescing delay | 2.913 / 3.929 ms [2.860, 2.967] | 1.581 / 1.851 ms [1.575, 1.588] | **0.277 / 0.379 ms [0.2758, 0.2792]** |
| `structuredClone` | 1.369 / 1.873 ms [1.363, 1.381] | 1.329 / 1.436 ms [1.327, 1.332] | **0.0466 / 0.0529 ms [0.0465, 0.0468]** |
| Payload bytes | 933,388 | 933,386 | **49,631** |

The combined stack reduces median scheduled-publication time **90.5%** and payload size **94.7%** versus baseline. Compared with #12207 alone, this PR reduces scheduled time **82.5%**, clone time **96.5%**, and payload **94.7%**. Its 0.003 ms direct-build bookkeeping overhead is dwarfed by the transport reduction.

Every measured iteration changed exactly one status. Baseline and #12207 published all 222 snapshots; the combined stack published the changed worktree and withheld the other 221. Payload content preserved the changed status, and there were zero measured publication failures.

Raw local artifacts remain uncommitted in the dedicated benchmark worktree under `.benchmarks/mobile-session-publication/` (`report.md`, `summary.json`, `execution.json`, and `raw/*.json`). Absolute wall times should be treated cautiously because an unrelated two-day-old Node/Vite repro remained at approximately one logical CPU throughout; rotated commit order, independent processes, warmups, and confidence intervals reduce but cannot eliminate that host-load noise. The relative effects are large and consistent.

### Validation gaps and merge order

- #12207 merged first; #12245 now targets `main`.
- The saved `low spec windows` environment was unavailable: `remote_runtime_unavailable: Could not connect to the remote Orca runtime.` Windows packaging CI passed.
- `$electron`, `$perf`, and `$orca-mobile-emulator-qa` were unavailable. This is not a visual change, so no screenshots were fabricated and no prohibited OS-level UI automation was substituted.
- This PR remains a draft and was not merged.

