### PR TITLE
fix(sidebar): keep each project's entry-point workspace visible under "Hide sleeping" (#8873)

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -243,12 +243,14 @@ export function HostScreen({
       if (!client) {
         return
       }
+      // alwaysShowDefaultBranchWorkspace is deliberately absent: mobile reads it
+      // but has no toggle, so echoing its local default would silently revert a
+      // desktop opt-out on the first filter tap before ui.get lands (#8873).
       const payload: WorkspaceViewSettings = {
         groupBy: groupModeToDesktop(next.groupMode),
         sortBy: next.sortMode,
         hideSleepingWorkspaces: next.hideSleeping,
         hideDefaultBranchWorkspace: next.hideDefaultBranch,
-        alwaysShowDefaultBranchWorkspace: next.alwaysShowDefaultBranch,
         filterRepoIds: next.filterRepoIds,
         collapsedGroups: next.collapsedGroups
       }

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -169,7 +169,8 @@ export function HostScreen({
   const [filters, setFilters] = useState<FilterState>({
     filterRepoIds: new Set(),
     hideSleeping: false,
-    hideDefaultBranch: false
+    hideDefaultBranch: false,
+    alwaysShowDefaultBranch: true
   })
   const [groupMode, setGroupMode] = useState<MobileGroupMode>('repo')
   const [workspaceStatuses, setWorkspaceStatuses] = useState<readonly WorkspaceStatusDefinition[]>(
@@ -200,6 +201,7 @@ export function HostScreen({
     sortMode: 'recent',
     hideSleeping: false,
     hideDefaultBranch: false,
+    alwaysShowDefaultBranch: true,
     filterRepoIds: [],
     collapsedGroups: [],
     workspaceStatuses: DEFAULT_MOBILE_WORKSPACE_STATUSES
@@ -211,6 +213,7 @@ export function HostScreen({
       sortMode,
       hideSleeping: filters.hideSleeping,
       hideDefaultBranch: filters.hideDefaultBranch,
+      alwaysShowDefaultBranch: filters.alwaysShowDefaultBranch !== false,
       filterRepoIds: [...filters.filterRepoIds],
       collapsedGroups: [...collapsedGroups],
       workspaceStatuses
@@ -227,7 +230,8 @@ export function HostScreen({
     setFilters({
       filterRepoIds: new Set(next.filterRepoIds),
       hideSleeping: next.hideSleeping,
-      hideDefaultBranch: next.hideDefaultBranch
+      hideDefaultBranch: next.hideDefaultBranch,
+      alwaysShowDefaultBranch: next.alwaysShowDefaultBranch
     })
   }, [])
 
@@ -244,6 +248,7 @@ export function HostScreen({
         sortBy: next.sortMode,
         hideSleepingWorkspaces: next.hideSleeping,
         hideDefaultBranchWorkspace: next.hideDefaultBranch,
+        alwaysShowDefaultBranchWorkspace: next.alwaysShowDefaultBranch,
         filterRepoIds: next.filterRepoIds,
         collapsedGroups: next.collapsedGroups
       }

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -106,6 +106,77 @@ describe('filterWorktrees', () => {
     ).toEqual([featureNamedMain])
   })
 
+  it('keeps a sleeping main worktree visible under hide-sleeping by default (#8873)', () => {
+    const main = worktree({ worktreeId: 'main', branch: 'main', isMainWorktree: true })
+    const feature = worktree({ worktreeId: 'feature', isMainWorktree: false })
+
+    expect(
+      filterWorktrees(
+        [main, feature],
+        { filterRepoIds: new Set(), hideSleeping: true, hideDefaultBranch: false },
+        ''
+      )
+    ).toEqual([main])
+  })
+
+  it('keeps a sleeping folder workspace visible under hide-sleeping', () => {
+    const folder = worktree({
+      workspaceKind: 'folder-workspace',
+      worktreeId: 'folder:workspace-1',
+      branch: '',
+      isMainWorktree: true
+    })
+
+    expect(
+      filterWorktrees(
+        [folder],
+        { filterRepoIds: new Set(), hideSleeping: true, hideDefaultBranch: false },
+        ''
+      )
+    ).toEqual([folder])
+  })
+
+  it('re-hides the sleeping main worktree when the desktop setting is off', () => {
+    const main = worktree({ worktreeId: 'main', branch: 'main', isMainWorktree: true })
+
+    expect(
+      filterWorktrees(
+        [main],
+        {
+          filterRepoIds: new Set(),
+          hideSleeping: true,
+          hideDefaultBranch: false,
+          alwaysShowDefaultBranch: false
+        },
+        ''
+      )
+    ).toEqual([])
+  })
+
+  it('falls back to the branch heuristic for hosts that omit isMainWorktree', () => {
+    const legacyMain = worktree({ worktreeId: 'legacy-main', branch: 'refs/heads/master' })
+
+    expect(
+      filterWorktrees(
+        [legacyMain],
+        { filterRepoIds: new Set(), hideSleeping: true, hideDefaultBranch: false },
+        ''
+      )
+    ).toEqual([legacyMain])
+  })
+
+  it('lets hide-default-branch still win over the sleeping exemption', () => {
+    const main = worktree({ worktreeId: 'main', branch: 'main', isMainWorktree: true })
+
+    expect(
+      filterWorktrees(
+        [main],
+        { filterRepoIds: new Set(), hideSleeping: true, hideDefaultBranch: true },
+        ''
+      )
+    ).toEqual([])
+  })
+
   it('keeps folder workspaces when default branch hiding is enabled', () => {
     const folder = worktree({
       workspaceKind: 'folder-workspace',

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -165,6 +165,24 @@ describe('filterWorktrees', () => {
     ).toEqual([legacyMain])
   })
 
+  it('keeps a sleeping folder workspace on hosts that omit isMainWorktree', () => {
+    // A folder workspace has no branch, so the legacy branch heuristic can never
+    // recognise it — without its own arm, #8873 still reproduces on old desktops.
+    const legacyFolder = worktree({
+      workspaceKind: 'folder-workspace',
+      worktreeId: 'folder:legacy-1',
+      branch: ''
+    })
+
+    expect(
+      filterWorktrees(
+        [legacyFolder],
+        { filterRepoIds: new Set(), hideSleeping: true, hideDefaultBranch: false },
+        ''
+      )
+    ).toEqual([legacyFolder])
+  })
+
   it('lets hide-default-branch still win over the sleeping exemption', () => {
     const main = worktree({ worktreeId: 'main', branch: 'main', isMainWorktree: true })
 

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -67,13 +67,15 @@ function isDefaultBranchWorkspace(w: Worktree): boolean {
 
 /**
  * Whether "Hide sleeping" must keep this row — the project's entry point (#8873).
- * Falls back to the branch heuristic for hosts that predate isMainWorktree.
+ * Falls back to the branch heuristic for hosts that predate isMainWorktree; a
+ * folder workspace is always its project's entry point, and isDefaultBranchWorkspace
+ * rejects it by design, so it needs its own legacy arm or #8873 still reproduces.
  */
 function isSleepingSweepExempt(w: Worktree, alwaysShowDefaultBranch: boolean | undefined): boolean {
   if (alwaysShowDefaultBranch === false) {
     return false
   }
-  return w.isMainWorktree ?? isDefaultBranchWorkspace(w)
+  return w.isMainWorktree ?? (w.workspaceKind === 'folder-workspace' || isDefaultBranchWorkspace(w))
 }
 
 function orderMainWorktreeFirst(worktrees: Worktree[]): Worktree[] {

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -65,6 +65,17 @@ function isDefaultBranchWorkspace(w: Worktree): boolean {
   return branch === 'main' || branch === 'master'
 }
 
+/**
+ * Whether "Hide sleeping" must keep this row — the project's entry point (#8873).
+ * Falls back to the branch heuristic for hosts that predate isMainWorktree.
+ */
+function isSleepingSweepExempt(w: Worktree, alwaysShowDefaultBranch: boolean | undefined): boolean {
+  if (alwaysShowDefaultBranch === false) {
+    return false
+  }
+  return w.isMainWorktree ?? isDefaultBranchWorkspace(w)
+}
+
 function orderMainWorktreeFirst(worktrees: Worktree[]): Worktree[] {
   const mainWorktrees = worktrees.filter((worktree) => worktree.isMainWorktree)
   if (mainWorktrees.length === 0) {
@@ -80,7 +91,9 @@ export function filterWorktrees(
 ): Worktree[] {
   let result = worktrees.filter((w) => !w.isArchived)
   if (filters.hideSleeping) {
-    result = result.filter(isWorktreeActive)
+    result = result.filter(
+      (w) => isSleepingSweepExempt(w, filters.alwaysShowDefaultBranch) || isWorktreeActive(w)
+    )
   }
   if (filters.hideDefaultBranch) {
     result = result.filter((w) => !isDefaultBranchWorkspace(w))

--- a/mobile/src/worktree/workspace-list-types.ts
+++ b/mobile/src/worktree/workspace-list-types.ts
@@ -52,6 +52,8 @@ export type FilterState = {
   filterRepoIds: Set<string>
   hideSleeping: boolean
   hideDefaultBranch: boolean
+  /** Absent means on: #8873's exemption must fail open on older host payloads. */
+  alwaysShowDefaultBranch?: boolean
 }
 
 export type Section = { key: string; title: string; icon?: 'pin'; data: Worktree[] }

--- a/mobile/src/worktree/workspace-view-settings.ts
+++ b/mobile/src/worktree/workspace-view-settings.ts
@@ -16,6 +16,7 @@ export type WorkspaceViewSettings = {
   sortBy?: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   hideSleepingWorkspaces?: boolean
   hideDefaultBranchWorkspace?: boolean
+  alwaysShowDefaultBranchWorkspace?: boolean
   filterRepoIds?: string[]
   collapsedGroups?: string[]
   workspaceStatuses?: WorkspaceStatusDefinition[]
@@ -60,6 +61,7 @@ export type MobileViewState = {
   sortMode: MobileSortMode
   hideSleeping: boolean
   hideDefaultBranch: boolean
+  alwaysShowDefaultBranch: boolean
   filterRepoIds: string[]
   collapsedGroups: string[]
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
@@ -83,6 +85,8 @@ export function applyDesktopViewSettings(
     sortMode: sortMode ?? current.sortMode,
     hideSleeping: settings.hideSleepingWorkspaces ?? current.hideSleeping,
     hideDefaultBranch: settings.hideDefaultBranchWorkspace ?? current.hideDefaultBranch,
+    alwaysShowDefaultBranch:
+      settings.alwaysShowDefaultBranchWorkspace ?? current.alwaysShowDefaultBranch,
     filterRepoIds: settings.filterRepoIds ?? current.filterRepoIds,
     collapsedGroups: settings.collapsedGroups ?? current.collapsedGroups,
     workspaceStatuses

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -223,6 +223,7 @@ const UiUpdateFields = z
     showDotfilesByWorktree: z.record(z.string(), z.boolean()).optional(),
     hideCliCreatedWorkspaces: z.boolean().optional(),
     hideDetachedHeadWorkspaces: z.boolean().optional(),
+    alwaysShowDefaultBranchWorkspace: z.boolean().optional(),
     filterRepoIds: StringArray.optional(),
     collapsedGroups: StringArray.optional(),
     uiZoomLevel: z.number().finite().optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -555,7 +555,8 @@ describe('client UI RPC methods', () => {
     ],
     ['browserImportHintHidden', { browserImportHintHidden: true }],
     ['mobileEmulatorTabIntroDismissed', { mobileEmulatorTabIntroDismissed: true }],
-    ['mobileEmulatorAgentSetupDismissed', { mobileEmulatorAgentSetupDismissed: true }]
+    ['mobileEmulatorAgentSetupDismissed', { mobileEmulatorAgentSetupDismissed: true }],
+    ['alwaysShowDefaultBranchWorkspace', { alwaysShowDefaultBranchWorkspace: false }]
   ])('accepts %s, which the renderer persists through ui.set', async (_label, payload) => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
@@ -592,6 +593,7 @@ describe('client UI RPC methods', () => {
       showSleepingWorkspaces: true,
       hideDefaultBranchWorkspace: false,
       hideAutomationGeneratedWorkspaces: false,
+      alwaysShowDefaultBranchWorkspace: true,
       showDotfilesByWorktree: { 'repo::/worktree': true },
       filterRepoIds: ['repo-1'],
       acknowledgedAgentsByPaneKey: { 'pane-1': 123 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -660,6 +660,7 @@ function App(): React.JSX.Element {
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const showDotfilesByWorktree = useAppStore((s) => s.showDotfilesByWorktree)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
@@ -1387,6 +1388,7 @@ function App(): React.JSX.Element {
         hideAutomationGeneratedWorkspaces,
         hideCliCreatedWorkspaces,
         hideDetachedHeadWorkspaces,
+        alwaysShowDefaultBranchWorkspace,
         showDotfilesByWorktree,
         filterRepoIds,
         // Why (#9002): activeView is deliberately NOT included here. It used to
@@ -1420,6 +1422,7 @@ function App(): React.JSX.Element {
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,
     hideDetachedHeadWorkspaces,
+    alwaysShowDefaultBranchWorkspace,
     showDotfilesByWorktree,
     filterRepoIds,
     acknowledgedAgentsByPaneKey

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -1,0 +1,338 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactI18Next from 'react-i18next'
+import type { Repo, Worktree } from '../../../shared/types'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import WorktreeJumpPalette from './WorktreeJumpPalette'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18Next>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key })
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn()
+  }
+}))
+
+vi.mock('@/hooks/useSettingsNavigationMetadata', () => ({
+  useSettingsNavigationMetadata: () => []
+}))
+
+vi.mock('@/components/sidebar/StatusIndicator', () => ({
+  default: () => <span data-status-indicator="true" />
+}))
+
+vi.mock('@/components/repo/RepoBadgeLabel', () => ({
+  RepoBadgeMark: () => <span data-repo-badge-mark="true" />
+}))
+
+vi.mock('@/components/cmd-j/palette-host-badge', () => ({
+  getPaletteHostBadge: () => null
+}))
+
+vi.mock('@/components/ui/command', async () => {
+  const React = await import('react')
+  return {
+    CommandDialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+      open ? <div data-command-dialog="true">{children}</div> : null,
+    CommandInput: ({
+      value,
+      onValueChange,
+      placeholder
+    }: {
+      value?: string
+      onValueChange?: (next: string) => void
+      placeholder?: string
+    }) => {
+      setCommandQuery = onValueChange ?? null
+      return (
+        <input
+          data-command-input="true"
+          placeholder={placeholder}
+          value={value}
+          onChange={(event) => onValueChange?.(event.currentTarget.value)}
+        />
+      )
+    },
+    CommandList: React.forwardRef(function CommandList(
+      { children }: { children: React.ReactNode },
+      ref: React.ForwardedRef<HTMLDivElement>
+    ) {
+      return (
+        <div ref={ref} data-command-list="true">
+          {children}
+        </div>
+      )
+    }),
+    CommandEmpty: ({ children }: { children: React.ReactNode }) => (
+      <div data-command-empty="true">{children}</div>
+    ),
+    CommandItem: ({
+      children,
+      onSelect,
+      value
+    }: {
+      children: React.ReactNode
+      onSelect?: (value: string) => void
+      value?: string
+    }) => (
+      <button data-command-item={value ?? ''} onClick={() => onSelect?.(value ?? '')} type="button">
+        {children}
+      </button>
+    )
+  }
+})
+
+const initialAppState = useAppStore.getInitialState()
+let testRoot: Root
+let testContainer: HTMLDivElement
+let setCommandQuery: ((next: string) => void) | null = null
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repos/repo-1',
+    displayName: 'Repo 1',
+    badgeColor: '#000000',
+    addedAt: 0
+  }
+}
+
+function makeWorktree(
+  id: string,
+  displayName: string,
+  overrides: Partial<Worktree> = {}
+): Worktree {
+  return {
+    id,
+    repoId: 'repo-1',
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderPalette(overrides: Partial<AppState>): Promise<void> {
+  useAppStore.setState({
+    activeModal: 'worktree-palette',
+    activeWorktreeId: null,
+    repos: [makeRepo()],
+    tabsByWorktree: {},
+    browserTabsByWorktree: {},
+    browserPagesByWorkspace: {},
+    unifiedTabsByWorktree: {},
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    // Why explicit: the sweep exemption is what these cases probe, so it must
+    // not ride on whatever the store default happens to be.
+    alwaysShowDefaultBranchWorkspace: true,
+    lastVisitedAtByWorktreeId: {},
+    ...overrides
+  } as Partial<AppState>)
+
+  await act(async () => {
+    testRoot.render(<WorktreeJumpPalette />)
+  })
+  await flushEffects()
+}
+
+function getWorktreeRows(): string[] {
+  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="worktree:"]')].map(
+    (node) => node.textContent ?? ''
+  )
+}
+
+describe('WorktreeJumpPalette', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    setCommandQuery = null
+    useAppStore.setState(initialAppState, true)
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      testRoot.unmount()
+    })
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('keeps every inactive main workspace visible when sleeping workspaces are hidden', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+    const folderMain = makeWorktree('folder-main', 'Folder workspace', {
+      isMainWorktree: true,
+      branch: ''
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
+      showSleepingWorkspaces: false
+    })
+
+    expect(testContainer.textContent).toContain('Default branch workspace')
+    expect(testContainer.textContent).not.toContain('Feature workspace')
+    // Why kept: the exemption keys on isMainWorktree, not the branch name, so a
+    // branchless folder workspace is the project's entry point too.
+    expect(testContainer.textContent).toContain('Folder workspace')
+  })
+
+  it('keeps the explicit default-branch filter authoritative', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch] },
+      showSleepingWorkspaces: false,
+      hideDefaultBranchWorkspace: true
+    })
+
+    expect(testContainer.textContent).not.toContain('Default branch workspace')
+  })
+
+  it('keeps an active non-default workspace visible when sleeping workspaces are hidden', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+    const folderMain = makeWorktree('folder-main', 'Folder workspace', {
+      isMainWorktree: true,
+      branch: ''
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
+      showSleepingWorkspaces: false,
+      browserTabsByWorktree: {
+        feature: [{ id: 'browser-tab-1' }]
+      }
+    })
+
+    expect(testContainer.textContent).toContain('Feature workspace')
+    expect(testContainer.textContent).toContain('Default branch workspace')
+    // Why kept: same isMainWorktree exemption — folder workspaces are covered.
+    expect(testContainer.textContent).toContain('Folder workspace')
+  })
+
+  it('sweeps the sleeping main workspace once the exemption is opted out', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature] },
+      showSleepingWorkspaces: false,
+      alwaysShowDefaultBranchWorkspace: false
+    })
+
+    expect(getWorktreeRows()).toEqual([])
+    expect(testContainer.textContent).not.toContain('Default branch workspace')
+    expect(testContainer.textContent).not.toContain('Feature workspace')
+  })
+
+  it('keeps the show-sleeping baseline and empty-query ordering intact', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+    const folderMain = makeWorktree('folder-main', 'Folder workspace', {
+      isMainWorktree: true,
+      branch: ''
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
+      showSleepingWorkspaces: true,
+      lastVisitedAtByWorktreeId: {
+        feature: 300,
+        'default-branch': 200,
+        'folder-main': 100
+      }
+    })
+
+    expect(getWorktreeRows()).toEqual([
+      expect.stringContaining('Feature workspace'),
+      expect.stringContaining('Default branch workspace'),
+      expect.stringContaining('Folder workspace')
+    ])
+  })
+
+  it('keeps typed-query results on the full non-archived scope', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature] },
+      showSleepingWorkspaces: false
+    })
+
+    expect(testContainer.textContent).not.toContain('Feature workspace')
+
+    expect(setCommandQuery).not.toBeNull()
+
+    await act(async () => {
+      setCommandQuery?.('Feature')
+    })
+    await flushEffects()
+
+    expect(testContainer.textContent).toContain('Feature workspace')
+  })
+})

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -250,7 +250,20 @@ describe('WorktreeJumpPalette', () => {
       worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
       showSleepingWorkspaces: false,
       browserTabsByWorktree: {
-        feature: [{ id: 'browser-tab-1' }]
+        feature: [
+          {
+            id: 'browser-tab-1',
+            worktreeId: 'feature',
+            url: 'https://example.com',
+            title: 'example.com',
+            loading: false,
+            faviconUrl: null,
+            canGoBack: false,
+            canGoForward: false,
+            loadError: null,
+            createdAt: 0
+          }
+        ]
       }
     })
 

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -31,7 +31,8 @@ import {
   isAutomationGeneratedWorkspace,
   isCliCreatedWorkspace,
   isDetachedHeadWorkspace,
-  isDefaultBranchWorkspace
+  isDefaultBranchWorkspace,
+  isSleepingSweepExemptWorkspace
 } from '@/components/sidebar/visible-worktrees'
 import { getLiveAgentStatusByWorktreeId, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { orderEmptyQueryWorktrees } from '@/lib/order-empty-query-worktrees'
@@ -404,6 +405,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
   const workspacePortScan = useAppStore((s) => s.workspacePortScan?.result ?? null)
   const openNewBrowserTabInActiveWorkspace = useAppStore(
@@ -501,6 +503,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         }
         if (
           !showSleepingWorkspaces &&
+          // Why the exemption here too: Cmd+J re-implements the sidebar's
+          // filter pass, so the shared predicate is what keeps them in step.
+          !isSleepingSweepExemptWorkspace(worktree, alwaysShowDefaultBranchWorkspace) &&
           isInactiveWorkspace(
             worktree.id,
             tabsByWorktree,
@@ -515,6 +520,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       }),
     [
       allWorktrees,
+      alwaysShowDefaultBranchWorkspace,
       browserTabsByWorktree,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/FilterToggleRow.tsx
+++ b/src/renderer/src/components/sidebar/FilterToggleRow.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { DropdownMenuShortcut } from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+
+/**
+ * Switch row shared by the two workspace-filter surfaces (the sidebar filter
+ * dropdown and the workspace options menu). Extracted so the two copies cannot
+ * drift as rows are added.
+ */
+export function FilterToggleRow({
+  icon,
+  label,
+  ariaLabel,
+  checked,
+  onChange,
+  shortcutLabel,
+  indented = false
+}: {
+  icon: React.ReactNode
+  label: string
+  /** Full sentence for assistive tech when `label` only reads in visual context. */
+  ariaLabel?: string
+  checked: boolean
+  onChange: (next: boolean) => void
+  shortcutLabel?: string
+  /** Renders the row as a sub-option of the row above it. */
+  indented?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        indented && 'pl-6'
+      )}
+    >
+      <span
+        className={cn(
+          'inline-flex items-center gap-2',
+          indented ? 'text-muted-foreground' : 'text-foreground'
+        )}
+      >
+        <span className="text-muted-foreground">{icon}</span>
+        {label}
+      </span>
+      <span className="inline-flex items-center gap-2">
+        {shortcutLabel ? <DropdownMenuShortcut>{shortcutLabel}</DropdownMenuShortcut> : null}
+        <span
+          aria-hidden
+          className={cn(
+            'relative h-3.5 w-6 shrink-0 rounded-full transition-colors',
+            checked ? 'bg-primary' : 'bg-muted-foreground/30'
+          )}
+        >
+          <span
+            className={cn(
+              'absolute top-0.5 left-0.5 size-2.5 rounded-full bg-background shadow-sm transition-transform',
+              checked && 'translate-x-2.5'
+            )}
+          />
+        </span>
+      </span>
+    </button>
+  )
+}
+
+export default FilterToggleRow

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -23,14 +23,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuSeparator,
-  DropdownMenuShortcut,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
+import { FilterToggleRow } from './FilterToggleRow'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { searchRepos } from '@/lib/repo-search'
-import { cn } from '@/lib/utils'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
 import { translate } from '@/i18n/i18n'
 
@@ -62,6 +61,10 @@ const SidebarFilter = React.memo(function SidebarFilter({
   const setHideCliCreatedWorkspaces = useAppStore((s) => s.setHideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
   const setHideDetachedHeadWorkspaces = useAppStore((s) => s.setHideDetachedHeadWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
+  const setAlwaysShowDefaultBranchWorkspace = useAppStore(
+    (s) => s.setAlwaysShowDefaultBranchWorkspace
+  )
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const repos = useAppStore((s) => s.repos)
@@ -114,6 +117,9 @@ const SidebarFilter = React.memo(function SidebarFilter({
     hideAutomationGeneratedWorkspaces ||
     hideCliCreatedWorkspaces ||
     hideDetachedHeadWorkspaces ||
+    // Why counted: turning the exemption off is the only way this row narrows
+    // the list, so the badge and Reset filters must both notice it.
+    !alwaysShowDefaultBranchWorkspace ||
     hasRepoFilter
   const activeFilterCount =
     (hasSleepingFilter ? 1 : 0) +
@@ -121,6 +127,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     (hideAutomationGeneratedWorkspaces ? 1 : 0) +
     (hideCliCreatedWorkspaces ? 1 : 0) +
     (hideDetachedHeadWorkspaces ? 1 : 0) +
+    (alwaysShowDefaultBranchWorkspace ? 0 : 1) +
     selectedCount
 
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
@@ -136,6 +143,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     setHideAutomationGeneratedWorkspaces(false)
     setHideCliCreatedWorkspaces(false)
     setHideDetachedHeadWorkspaces(false)
+    setAlwaysShowDefaultBranchWorkspace(true)
     setFilterRepoIds([])
   }, [
     setShowSleepingWorkspaces,
@@ -143,6 +151,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     setHideAutomationGeneratedWorkspaces,
     setHideCliCreatedWorkspaces,
     setHideDetachedHeadWorkspaces,
+    setAlwaysShowDefaultBranchWorkspace,
     setFilterRepoIds
   ])
 
@@ -211,6 +220,20 @@ const SidebarFilter = React.memo(function SidebarFilter({
           checked={!showSleepingWorkspaces}
           onChange={(hideSleeping) => setShowSleepingWorkspaces(!hideSleeping)}
           shortcutLabel={sleepingShortcut === 'Unassigned' ? undefined : sleepingShortcut}
+        />
+        <FilterToggleRow
+          indented
+          icon={<GitBranch className="size-3.5" />}
+          label={translate(
+            'auto.components.sidebar.SidebarFilter.keepDefaultBranch',
+            'Except default branch'
+          )}
+          ariaLabel={translate(
+            'auto.components.sidebar.SidebarFilter.keepDefaultBranchAria',
+            'Keep the default branch visible while hiding sleeping workspaces'
+          )}
+          checked={alwaysShowDefaultBranchWorkspace}
+          onChange={setAlwaysShowDefaultBranchWorkspace}
         />
         <FilterToggleRow
           icon={<GitBranch className="size-3.5" />}
@@ -371,51 +394,5 @@ const SidebarFilter = React.memo(function SidebarFilter({
     </DropdownMenu>
   )
 })
-
-function FilterToggleRow({
-  icon,
-  label,
-  checked,
-  onChange,
-  shortcutLabel
-}: {
-  icon: React.ReactNode
-  label: string
-  checked: boolean
-  onChange: (next: boolean) => void
-  shortcutLabel?: string
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      onClick={() => onChange(!checked)}
-      className="flex w-full items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-    >
-      <span className="inline-flex items-center gap-2 text-foreground">
-        <span className="text-muted-foreground">{icon}</span>
-        {label}
-      </span>
-      <span className="inline-flex items-center gap-2">
-        {shortcutLabel ? <DropdownMenuShortcut>{shortcutLabel}</DropdownMenuShortcut> : null}
-        <span
-          aria-hidden
-          className={cn(
-            'relative h-3.5 w-6 shrink-0 rounded-full transition-colors',
-            checked ? 'bg-primary' : 'bg-muted-foreground/30'
-          )}
-        >
-          <span
-            className={cn(
-              'absolute top-0.5 left-0.5 size-2.5 rounded-full bg-background shadow-sm transition-transform',
-              checked && 'translate-x-2.5'
-            )}
-          />
-        </span>
-      </span>
-    </button>
-  )
-}
 
 export default SidebarFilter

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { CalendarClock, GitBranch, GitCommitHorizontal, Moon, SquareTerminal } from 'lucide-react'
 import { useAppStore } from '@/store'
-import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { FilterToggleRow } from './FilterToggleRow'
 
 const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilterSection() {
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
@@ -17,6 +17,10 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
   const setHideCliCreatedWorkspaces = useAppStore((s) => s.setHideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
   const setHideDetachedHeadWorkspaces = useAppStore((s) => s.setHideDetachedHeadWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
+  const setAlwaysShowDefaultBranchWorkspace = useAppStore(
+    (s) => s.setAlwaysShowDefaultBranchWorkspace
+  )
 
   return (
     <>
@@ -33,6 +37,20 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
         )}
         checked={!showSleepingWorkspaces}
         onChange={(hideSleeping) => setShowSleepingWorkspaces(!hideSleeping)}
+      />
+      <FilterToggleRow
+        indented
+        icon={<GitBranch className="size-3.5" />}
+        label={translate(
+          'auto.components.sidebar.SidebarWorkspaceFilterSection.keepDefaultBranch',
+          'Except default branch'
+        )}
+        ariaLabel={translate(
+          'auto.components.sidebar.SidebarWorkspaceFilterSection.keepDefaultBranchAria',
+          'Keep the default branch visible while hiding sleeping workspaces'
+        )}
+        checked={alwaysShowDefaultBranchWorkspace}
+        onChange={setAlwaysShowDefaultBranchWorkspace}
       />
       <FilterToggleRow
         icon={<GitBranch className="size-3.5" />}
@@ -73,46 +91,5 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
     </>
   )
 })
-
-function FilterToggleRow({
-  icon,
-  label,
-  checked,
-  onChange
-}: {
-  icon: React.ReactNode
-  label: string
-  checked: boolean
-  onChange: (next: boolean) => void
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      onClick={() => onChange(!checked)}
-      className="flex w-full items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-    >
-      <span className="inline-flex items-center gap-2 text-foreground">
-        <span className="text-muted-foreground">{icon}</span>
-        {label}
-      </span>
-      <span
-        aria-hidden
-        className={cn(
-          'relative h-3.5 w-6 shrink-0 rounded-full transition-colors',
-          checked ? 'bg-primary' : 'bg-muted-foreground/30'
-        )}
-      >
-        <span
-          className={cn(
-            'absolute top-0.5 left-0.5 size-2.5 rounded-full bg-background shadow-sm transition-transform',
-            checked && 'translate-x-2.5'
-          )}
-        />
-      </span>
-    </button>
-  )
-}
 
 export default SidebarWorkspaceFilterSection

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -40,6 +40,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const repos = useAppStore((s) => s.repos)
   const setWorkspaceHostScope = useAppStore((s) => s.setWorkspaceHostScope)
@@ -84,6 +85,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     hideAutomationGeneratedWorkspaces ||
     hideCliCreatedWorkspaces ||
     hideDetachedHeadWorkspaces ||
+    !alwaysShowDefaultBranchWorkspace ||
     hasRepoFilter ||
     hasHostVisibilityFilter
   const activeFilterCount =
@@ -92,6 +94,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     (hideAutomationGeneratedWorkspaces ? 1 : 0) +
     (hideCliCreatedWorkspaces ? 1 : 0) +
     (hideDetachedHeadWorkspaces ? 1 : 0) +
+    (alwaysShowDefaultBranchWorkspace ? 0 : 1) +
     (hasHostVisibilityFilter ? 1 : 0) +
     selectedCount
   const activeFilterLabel = `${activeFilterCount} ${activeFilterCount === 1 ? 'filter' : 'filters'}`

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5222,6 +5222,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const openModal = useAppStore((s) => s.openModal)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
@@ -5509,6 +5510,7 @@ const WorktreeList = React.memo(function WorktreeList({
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
       hideDetachedHeadWorkspaces,
+      alwaysShowDefaultBranchWorkspace,
       repoMap,
       workspaceHostScope,
       visibleWorkspaceHostIds,
@@ -5526,6 +5528,7 @@ const WorktreeList = React.memo(function WorktreeList({
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,
     hideDetachedHeadWorkspaces,
+    alwaysShowDefaultBranchWorkspace,
     workspaceHostScope,
     visibleWorkspaceHostIds,
     settings,
@@ -6487,6 +6490,7 @@ const WorktreeList = React.memo(function WorktreeList({
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
       hideDetachedHeadWorkspaces,
+      alwaysShowDefaultBranchWorkspace,
       visibleWorkspaceHostIds,
       workspaceHostScope
     }),
@@ -6497,6 +6501,7 @@ const WorktreeList = React.memo(function WorktreeList({
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
       hideDetachedHeadWorkspaces,
+      alwaysShowDefaultBranchWorkspace,
       visibleWorkspaceHostIds,
       workspaceHostScope
     ]
@@ -6509,6 +6514,9 @@ const WorktreeList = React.memo(function WorktreeList({
   )
   const setHideCliCreatedWorkspaces = useAppStore((s) => s.setHideCliCreatedWorkspaces)
   const setHideDetachedHeadWorkspaces = useAppStore((s) => s.setHideDetachedHeadWorkspaces)
+  const setAlwaysShowDefaultBranchWorkspace = useAppStore(
+    (s) => s.setAlwaysShowDefaultBranchWorkspace
+  )
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
 
@@ -6532,6 +6540,9 @@ const WorktreeList = React.memo(function WorktreeList({
     if (actions.resetHideDetachedHeadWorkspaces) {
       setHideDetachedHeadWorkspaces(false)
     }
+    if (actions.resetAlwaysShowDefaultBranchWorkspace) {
+      setAlwaysShowDefaultBranchWorkspace(true)
+    }
     if (actions.resetVisibleWorkspaceHostIds) {
       setVisibleWorkspaceHostIds(null)
     }
@@ -6542,6 +6553,7 @@ const WorktreeList = React.memo(function WorktreeList({
     setHideAutomationGeneratedWorkspaces,
     setHideCliCreatedWorkspaces,
     setHideDetachedHeadWorkspaces,
+    setAlwaysShowDefaultBranchWorkspace,
     setVisibleWorkspaceHostIds,
     filterState
   ])

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
@@ -34,11 +34,14 @@ function makeState(overrides: Partial<AddRepoSkipFinalizationState>): AddRepoSki
     filterRepoIds: [],
     showActiveOnly: false,
     hideDefaultBranchWorkspace: false,
+    showSleepingWorkspaces: true,
+    alwaysShowDefaultBranchWorkspace: true,
     worktreesByRepo: {},
     setActiveRepo: vi.fn(),
     setFilterRepoIds: vi.fn(),
     setShowActiveOnly: vi.fn(),
     setHideDefaultBranchWorkspace: vi.fn(),
+    setAlwaysShowDefaultBranchWorkspace: vi.fn(),
     ...overrides
   }
 }
@@ -81,6 +84,48 @@ describe('finalizeImportedRepoAfterSkip', () => {
     finalizeImportedRepoAfterSkip(state, 'repo-new')
 
     expect(state.setHideDefaultBranchWorkspace).toHaveBeenCalledWith(false)
+  })
+
+  it('re-enables the default-branch exemption when the import would land asleep and hidden', () => {
+    const state = makeState({
+      showSleepingWorkspaces: false,
+      alwaysShowDefaultBranchWorkspace: false,
+      worktreesByRepo: {
+        'repo-new': [
+          makeWorktree({
+            id: 'repo-new::/repo/main',
+            repoId: 'repo-new',
+            isMainWorktree: true,
+            branch: 'refs/heads/main'
+          })
+        ]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setAlwaysShowDefaultBranchWorkspace).toHaveBeenCalledWith(true)
+  })
+
+  it('leaves the default-branch exemption alone when sleeping workspaces are shown', () => {
+    const state = makeState({
+      showSleepingWorkspaces: true,
+      alwaysShowDefaultBranchWorkspace: false,
+      worktreesByRepo: {
+        'repo-new': [
+          makeWorktree({
+            id: 'repo-new::/repo/main',
+            repoId: 'repo-new',
+            isMainWorktree: true,
+            branch: 'refs/heads/main'
+          })
+        ]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setAlwaysShowDefaultBranchWorkspace).not.toHaveBeenCalled()
   })
 
   it('still reveals the imported repo when it has no discovered worktrees yet', () => {

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -6,11 +6,14 @@ export type AddRepoSkipFinalizationState = {
   filterRepoIds: string[]
   showActiveOnly: boolean
   hideDefaultBranchWorkspace: boolean
+  showSleepingWorkspaces: boolean
+  alwaysShowDefaultBranchWorkspace: boolean
   worktreesByRepo: Record<string, Worktree[]>
   setActiveRepo: (repoId: string | null) => void
   setFilterRepoIds: (repoIds: string[]) => void
   setShowActiveOnly: (value: boolean) => void
   setHideDefaultBranchWorkspace: (value: boolean) => void
+  setAlwaysShowDefaultBranchWorkspace: (value: boolean) => void
 }
 
 export function finalizeImportedRepoAfterSkip(
@@ -36,5 +39,15 @@ export function finalizeImportedRepoAfterSkip(
     importedWorktrees.every((worktree) => isDefaultBranchWorkspace(worktree))
   ) {
     state.setHideDefaultBranchWorkspace(false)
+  }
+  // Why: with "Hide sleeping" on, a freshly imported project has no live PTY
+  // yet, so the opted-out exemption would leave it invisible on arrival.
+  if (
+    importedWorktrees.length > 0 &&
+    state.alwaysShowDefaultBranchWorkspace === false &&
+    !state.showSleepingWorkspaces &&
+    importedWorktrees.every((worktree) => worktree.isMainWorktree)
+  ) {
+    state.setAlwaysShowDefaultBranchWorkspace(true)
   }
 }

--- a/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
@@ -95,6 +95,7 @@ describe('#8873 default-branch workspace under "Hide sleeping"', () => {
       'hideAutomationGeneratedWorkspaces',
       'hideCliCreatedWorkspaces',
       'hideDetachedHeadWorkspaces',
+      'alwaysShowDefaultBranchWorkspace',
       'visibleWorkspaceHostIds',
       'workspaceHostScope'
     ]
@@ -105,5 +106,89 @@ describe('#8873 default-branch workspace under "Hide sleeping"', () => {
     )
 
     expect(alwaysShowKnob).toBeDefined()
+  })
+})
+
+describe('the "Hide sleeping" exemption for project entry-point rows', () => {
+  function visible(worktrees: Worktree[], overrides: Partial<VisibleOptions>): string[] {
+    return computeVisibleWorktreeIds(
+      { repo1: worktrees },
+      worktrees.map((w) => w.id),
+      visibleOptions({ showSleepingWorkspaces: false, ...overrides })
+    )
+  }
+
+  it('re-hides the sleeping default branch when the user opts out', () => {
+    const worktree = makeDefaultBranchWorktree()
+
+    expect(visible([worktree], { alwaysShowDefaultBranchWorkspace: false })).toEqual([])
+  })
+
+  it('keeps the sleeping default branch when the option is explicitly on', () => {
+    const worktree = makeDefaultBranchWorktree()
+
+    expect(visible([worktree], { alwaysShowDefaultBranchWorkspace: true })).toEqual([worktree.id])
+  })
+
+  it('lets an explicit "Hide default branch" still win over the exemption', () => {
+    const worktree = makeDefaultBranchWorktree()
+
+    expect(
+      visible([worktree], {
+        hideDefaultBranchWorkspace: true,
+        alwaysShowDefaultBranchWorkspace: true
+      })
+    ).toEqual([])
+  })
+
+  it('still sweeps sleeping non-main workspaces', () => {
+    const feature: Worktree = {
+      ...makeDefaultBranchWorktree(),
+      id: 'wt-feature',
+      branch: 'refs/heads/feature',
+      isMainWorktree: false
+    }
+
+    expect(visible([feature], { alwaysShowDefaultBranchWorkspace: true })).toEqual([])
+  })
+
+  it('keeps a sleeping folder workspace, which has no sibling row to fall back to', () => {
+    // Folder-mode projects are main worktrees with an empty branch/head, so the
+    // default-branch predicate rejects them; sweeping them drops the whole project.
+    const folder: Worktree = {
+      ...makeDefaultBranchWorktree(),
+      id: 'wt-folder',
+      branch: '',
+      head: ''
+    }
+    expect(isDefaultBranchWorkspace(folder)).toBe(false)
+
+    expect(visible([folder], { alwaysShowDefaultBranchWorkspace: true })).toEqual([folder.id])
+  })
+
+  it('keeps a sleeping detached-HEAD main worktree', () => {
+    const detachedMain: Worktree = { ...makeDefaultBranchWorktree(), id: 'wt-detached', branch: '' }
+
+    expect(visible([detachedMain], { alwaysShowDefaultBranchWorkspace: true })).toEqual([
+      detachedMain.id
+    ])
+  })
+
+  it('lets "Hide detached HEAD" still win over the exemption', () => {
+    const detachedMain: Worktree = { ...makeDefaultBranchWorktree(), id: 'wt-detached', branch: '' }
+
+    expect(
+      visible([detachedMain], {
+        hideDetachedHeadWorkspaces: true,
+        alwaysShowDefaultBranchWorkspace: true
+      })
+    ).toEqual([])
+  })
+
+  it('keeps every project’s entry point, not just the first', () => {
+    const mainA = makeDefaultBranchWorktree()
+    const mainB: Worktree = { ...makeDefaultBranchWorktree(), id: 'wt-main-b' }
+
+    expect(visible([mainA, mainB], {})).toEqual([mainA.id, mainB.id])
   })
 })

--- a/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
@@ -191,4 +191,15 @@ describe('the "Hide sleeping" exemption for project entry-point rows', () => {
 
     expect(visible([mainA, mainB], {})).toEqual([mainA.id, mainB.id])
   })
+
+  it('does not flicker out while an SSH host is offline', () => {
+    // A disconnected SSH provider re-synthesizes persisted worktrees with empty
+    // head/branch (orca-runtime.ts) while isMainWorktree stays a path compare —
+    // and the dead PTYs make the row read as sleeping at exactly that moment.
+    const awake = makeDefaultBranchWorktree()
+    const offline: Worktree = { ...awake, head: '', branch: '' }
+
+    expect(visible([offline], {})).toEqual([offline.id])
+    expect(visible([awake], {})).toEqual([awake.id])
+  })
 })

--- a/src/renderer/src/components/sidebar/repro-8873-default-branch-hidden-by-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/repro-8873-default-branch-hidden-by-hide-sleeping.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeVisibleWorktreeIds,
+  isDefaultBranchWorkspace,
+  type SidebarFilterState
+} from './visible-worktrees'
+import type { Repo, Worktree } from '../../../../shared/types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+
+/**
+ * Repro for #8873 — "[Feature]: Display default branch".
+ *
+ * Reporter: turning "Hide default branch" OFF does not keep the repo's
+ * default-branch workspace in the sidebar; once it has no live PTY/browser/agent
+ * it counts as sleeping and "Hide sleeping" sweeps it away. There is no
+ * "Always display default branch" escape hatch.
+ */
+
+function makeRepo(id: string): Repo {
+  return { id, path: `/${id}`, displayName: id, badgeColor: '#000', addedAt: 0 }
+}
+
+function makeDefaultBranchWorktree(): Worktree {
+  return {
+    id: 'wt-main',
+    repoId: 'repo1',
+    path: '/tmp/repo1',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true,
+    displayName: 'main',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+const repoMap = new Map<string, Repo>([['repo1', makeRepo('repo1')]])
+
+type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
+
+function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
+  return {
+    filterRepoIds: [],
+    showSleepingWorkspaces: true,
+    tabsByWorktree: {},
+    ptyIdsByTabId: {},
+    browserTabsByWorktree: {},
+    worktreeIdsWithLiveAgent: new Set(),
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    repoMap,
+    workspaceHostScope: 'all',
+    defaultHostId: LOCAL_EXECUTION_HOST_ID,
+    worktreeLineageById: {},
+    ...overrides
+  }
+}
+
+describe('#8873 default-branch workspace under "Hide sleeping"', () => {
+  it('is genuinely the default-branch row the "Hide default branch" toggle targets', () => {
+    expect(isDefaultBranchWorkspace(makeDefaultBranchWorktree())).toBe(true)
+  })
+
+  it('stays in the sidebar when it is sleeping and "Hide sleeping" is on', () => {
+    const worktree = makeDefaultBranchWorktree()
+
+    const visible = computeVisibleWorktreeIds({ repo1: [worktree] }, [worktree.id], {
+      ...visibleOptions({
+        // "Hide sleeping" ON, "Hide default branch" OFF — exactly the reporter's setup.
+        showSleepingWorkspaces: false,
+        hideDefaultBranchWorkspace: false
+      })
+    })
+
+    expect(visible).toEqual([worktree.id])
+  })
+
+  it('exposes an opt-in that keeps the default branch visible under "Hide sleeping"', () => {
+    // The issue asks for an "Always display default branch" flag. Prove the
+    // sidebar filter contract has no such knob today.
+    const filterKeys: readonly (keyof SidebarFilterState)[] = [
+      'showSleepingWorkspaces',
+      'filterRepoIds',
+      'hideDefaultBranchWorkspace',
+      'hideAutomationGeneratedWorkspaces',
+      'hideCliCreatedWorkspaces',
+      'hideDetachedHeadWorkspaces',
+      'visibleWorkspaceHostIds',
+      'workspaceHostScope'
+    ]
+    const optionKeys = Object.keys(visibleOptions())
+
+    const alwaysShowKnob = [...filterKeys, ...optionKeys].find((key) =>
+      /always.*default|default.*always|pinDefaultBranch/i.test(key)
+    )
+
+    expect(alwaysShowKnob).toBeDefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
@@ -38,6 +38,7 @@ function filterState(overrides: Partial<FilterState> = {}): FilterState {
     hideAutomationGeneratedWorkspaces: false,
     hideCliCreatedWorkspaces: false,
     hideDetachedHeadWorkspaces: false,
+    alwaysShowDefaultBranchWorkspace: true,
     workspaceHostScope: 'all',
     ...overrides
   }
@@ -97,6 +98,17 @@ describe('sidebarHasActiveFilters', () => {
     expect(sidebarHasActiveFilters(filterState({ filterRepoIds: ['repo1'] }))).toBe(true)
   })
 
+  it('counts an opted-out default-branch exemption as an active filter', () => {
+    expect(sidebarHasActiveFilters(filterState({ alwaysShowDefaultBranchWorkspace: false }))).toBe(
+      true
+    )
+  })
+
+  it('treats a missing default-branch exemption as the default, not a filter', () => {
+    const { alwaysShowDefaultBranchWorkspace: _omitted, ...withoutFlag } = filterState()
+    expect(sidebarHasActiveFilters(withoutFlag)).toBe(false)
+  })
+
   it('returns true when only host visibility is narrowed', () => {
     expect(sidebarHasActiveFilters(filterState({ visibleWorkspaceHostIds: ['local'] }))).toBe(true)
   })
@@ -111,6 +123,7 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: false
     })
   })
@@ -126,6 +139,7 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: false
     })
   })
@@ -140,6 +154,7 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: true,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: false
     })
   })
@@ -152,6 +167,7 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: true,
       resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: false
     })
   })
@@ -164,6 +180,7 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: true,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: false
     })
   })
@@ -189,7 +206,23 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: false,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: true
+    })
+  })
+
+  it('flags only the default-branch exemption for reset when it is the sole filter', () => {
+    expect(
+      computeClearFilterActions(filterState({ alwaysShowDefaultBranchWorkspace: false }))
+    ).toEqual({
+      resetShowSleepingWorkspaces: false,
+      resetFilterRepoIds: false,
+      resetHideDefaultBranchWorkspace: false,
+      resetHideAutomationGeneratedWorkspaces: false,
+      resetHideCliCreatedWorkspaces: false,
+      resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: true,
+      resetVisibleWorkspaceHostIds: false
     })
   })
 
@@ -211,6 +244,7 @@ describe('computeClearFilterActions', () => {
       resetHideAutomationGeneratedWorkspaces: true,
       resetHideCliCreatedWorkspaces: false,
       resetHideDetachedHeadWorkspaces: false,
+      resetAlwaysShowDefaultBranchWorkspace: false,
       resetVisibleWorkspaceHostIds: true
     })
   })

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -22,6 +22,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
   const hideAutomationGeneratedWorkspaces = useAppStore((s) => s.hideAutomationGeneratedWorkspaces)
   const hideCliCreatedWorkspaces = useAppStore((s) => s.hideCliCreatedWorkspaces)
   const hideDetachedHeadWorkspaces = useAppStore((s) => s.hideDetachedHeadWorkspaces)
+  const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
   const workspaceHostScope = useAppStore((s) => s.workspaceHostScope)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
   const settings = useAppStore((s) => s.settings)
@@ -61,6 +62,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         hideAutomationGeneratedWorkspaces,
         hideCliCreatedWorkspaces,
         hideDetachedHeadWorkspaces,
+        alwaysShowDefaultBranchWorkspace,
         repoMap,
         workspaceHostScope,
         visibleWorkspaceHostIds,
@@ -79,6 +81,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces,
     hideDetachedHeadWorkspaces,
+    alwaysShowDefaultBranchWorkspace,
     workspaceHostScope,
     visibleWorkspaceHostIds,
     settings,

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -553,6 +553,69 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([parent.id, child.id])
   })
 
+  it('gives a sleeping-exempt main its cached-sort slot, not a position at the end', () => {
+    // #8873: the exempted main enters `all` and is sorted with everyone else,
+    // so Cmd+1-9 numbers it where the sidebar actually renders it.
+    const awakeA = makeWorktree('awake-a')
+    const main = { ...makeWorktree('main'), isMainWorktree: true }
+    const awakeB = makeWorktree('awake-b')
+
+    const options = {
+      showSleepingWorkspaces: false,
+      tabsByWorktree: {
+        [awakeA.id]: [makeTab('t-a', awakeA.id, 'p-a')],
+        [awakeB.id]: [makeTab('t-b', awakeB.id, 'p-b')]
+      },
+      ptyIdsByTabId: { 't-a': ['p-a'], 't-b': ['p-b'] }
+    }
+    const byRepo = { repo1: [awakeA, main, awakeB] }
+    const sortedIds = [awakeA.id, main.id, awakeB.id]
+
+    expect(
+      computeVisibleWorktreeIds(
+        byRepo,
+        sortedIds,
+        visibleOptions({ ...options, alwaysShowDefaultBranchWorkspace: true })
+      )
+    ).toEqual([awakeA.id, main.id, awakeB.id])
+
+    expect(
+      computeVisibleWorktreeIds(
+        byRepo,
+        sortedIds,
+        visibleOptions({ ...options, alwaysShowDefaultBranchWorkspace: false })
+      )
+    ).toEqual([awakeA.id, awakeB.id])
+  })
+
+  it('leaves lineage ordering untouched when the exempted main is also a parent', () => {
+    // The parent used to arrive via addVisibleLineageAncestors and now arrives
+    // on its own; either way it must render immediately above its child.
+    const parent = { ...makeWorktree('parent'), isMainWorktree: true }
+    const child = makeWorktree('child')
+    const sibling = makeWorktree('sibling')
+    const lineage = makeWorktreeLineage(child, parent)
+
+    const run = (alwaysShowDefaultBranchWorkspace: boolean): string[] =>
+      computeVisibleWorktreeIds(
+        { repo1: [parent, child, sibling] },
+        [sibling.id, child.id, parent.id],
+        visibleOptions({
+          showSleepingWorkspaces: false,
+          alwaysShowDefaultBranchWorkspace,
+          tabsByWorktree: {
+            [child.id]: [makeTab('t-child', child.id, 'p-child')],
+            [sibling.id]: [makeTab('t-sib', sibling.id, 'p-sib')]
+          },
+          ptyIdsByTabId: { 't-child': ['p-child'], 't-sib': ['p-sib'] },
+          worktreeLineageById: { [child.id]: lineage }
+        })
+      )
+
+    expect(run(true)).toEqual([sibling.id, parent.id, child.id])
+    expect(run(false)).toEqual(run(true))
+  })
+
   it('includes a filtered parent from resolved inline lineage when hydration has no side-map entry', () => {
     const parent = makeWorktree('parent')
     const child = makeWorktree('child')

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -35,6 +35,25 @@ export function isDefaultBranchWorkspace(worktree: Worktree): boolean {
   return worktree.isMainWorktree && worktree.branch.trim() !== ''
 }
 
+/**
+ * Whether the "Hide sleeping" sweep must keep this row (#8873).
+ *
+ * Why isMainWorktree and not isDefaultBranchWorkspace: the project's primary
+ * checkout is the repo's only guaranteed entry point. Folder workspaces and
+ * detached-HEAD mains fail the default-branch predicate yet often have no
+ * sibling row at all, so sweeping them drops the entire project out of the
+ * sidebar, Cmd+J and the board with no way back except changing a filter.
+ *
+ * Why shared: the sidebar pipeline and the jump palette both apply this, and a
+ * second copy is how the two surfaces drift.
+ */
+export function isSleepingSweepExemptWorkspace(
+  worktree: Worktree,
+  alwaysShowDefaultBranchWorkspace: boolean | undefined
+): boolean {
+  return alwaysShowDefaultBranchWorkspace !== false && worktree.isMainWorktree
+}
+
 export function isAutomationGeneratedWorkspace(worktree: Worktree): boolean {
   return worktree.automationProvenance?.kind === 'created-by-automation'
 }
@@ -63,6 +82,8 @@ export type SidebarFilterState = {
   hideAutomationGeneratedWorkspaces: boolean
   hideCliCreatedWorkspaces: boolean
   hideDetachedHeadWorkspaces: boolean
+  /** Keeps each project's main workspace out of the "Hide sleeping" sweep; absent means on. */
+  alwaysShowDefaultBranchWorkspace?: boolean
   visibleWorkspaceHostIds?: readonly ExecutionHostId[] | null
   workspaceHostScope?: ExecutionHostScope
 }
@@ -84,6 +105,9 @@ export function sidebarHasActiveFilters(state: SidebarFilterState): boolean {
     state.hideAutomationGeneratedWorkspaces ||
     state.hideCliCreatedWorkspaces ||
     state.hideDetachedHeadWorkspaces ||
+    // Why: turning this off is the only way to narrow the list below the
+    // default, so Clear Filters must be able to undo it like any other filter.
+    state.alwaysShowDefaultBranchWorkspace === false ||
     state.visibleWorkspaceHostIds != null ||
     (state.workspaceHostScope != null && state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE)
   )
@@ -98,6 +122,7 @@ export type ClearFilterActions = {
   resetHideAutomationGeneratedWorkspaces: boolean
   resetHideCliCreatedWorkspaces: boolean
   resetHideDetachedHeadWorkspaces: boolean
+  resetAlwaysShowDefaultBranchWorkspace: boolean
   resetVisibleWorkspaceHostIds: boolean
 }
 
@@ -119,6 +144,7 @@ export function computeClearFilterActions(state: SidebarFilterState): ClearFilte
     resetHideAutomationGeneratedWorkspaces: state.hideAutomationGeneratedWorkspaces,
     resetHideCliCreatedWorkspaces: state.hideCliCreatedWorkspaces,
     resetHideDetachedHeadWorkspaces: state.hideDetachedHeadWorkspaces,
+    resetAlwaysShowDefaultBranchWorkspace: state.alwaysShowDefaultBranchWorkspace === false,
     resetVisibleWorkspaceHostIds:
       state.visibleWorkspaceHostIds != null ||
       (state.workspaceHostScope != null && state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE)
@@ -155,6 +181,11 @@ export function computeVisibleWorktreeIds(
     hideAutomationGeneratedWorkspaces: boolean
     hideCliCreatedWorkspaces: boolean
     hideDetachedHeadWorkspaces: boolean
+    // Why optional here, against the "why required" rule above: omitting it
+    // must fail *open*. A caller that forgets the flag then shows an extra row
+    // instead of silently re-hiding the project's entry point, which is the
+    // exact regression #8873 reports.
+    alwaysShowDefaultBranchWorkspace?: boolean
     repoMap: Map<string, Repo>
     workspaceHostScope: ExecutionHostScope
     visibleWorkspaceHostIds?: readonly ExecutionHostId[] | null
@@ -211,8 +242,11 @@ export function computeVisibleWorktreeIds(
   }
 
   if (!opts.showSleepingWorkspaces) {
+    // Why no !hideDefaultBranchWorkspace term: that filter already ran above, so
+    // an explicit hide still wins over the exemption.
     all = all.filter(
       (w) =>
+        isSleepingSweepExemptWorkspace(w, opts.alwaysShowDefaultBranchWorkspace) ||
         !isInactiveWorkspace(
           w.id,
           opts.tabsByWorktree,
@@ -370,6 +404,7 @@ export function getVisibleWorktreeIds(): string[] {
     hideAutomationGeneratedWorkspaces: state.hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces: state.hideCliCreatedWorkspaces,
     hideDetachedHeadWorkspaces: state.hideDetachedHeadWorkspaces,
+    alwaysShowDefaultBranchWorkspace: state.alwaysShowDefaultBranchWorkspace,
     repoMap,
     workspaceHostScope: state.workspaceHostScope,
     visibleWorkspaceHostIds: state.visibleWorkspaceHostIds,

--- a/src/renderer/src/components/worktree-jump-palette-sleeping-filter.test.ts
+++ b/src/renderer/src/components/worktree-jump-palette-sleeping-filter.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isSleepingSweepExemptWorkspace } from './sidebar/visible-worktrees'
+import type { Worktree } from '../../../shared/types'
+
+const source = readFileSync(join(__dirname, 'WorktreeJumpPalette.tsx'), 'utf8')
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-main',
+    repoId: 'repo1',
+    path: '/tmp/repo1',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true,
+    displayName: 'main',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('Cmd+J empty-query "Hide sleeping" pass (#8873)', () => {
+  // Why source-level: the palette re-implements the sidebar's filter pass
+  // inline, so the only structural guarantee that the two agree is that both
+  // call the shared predicate. A behavioral copy here would not catch a
+  // hand-rolled duplicate creeping back in.
+  it('routes the sleeping sweep through the shared exemption predicate', () => {
+    const start = source.indexOf('const emptyQueryVisibleWorktrees = useMemo(')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const end = source.indexOf('const { visibleWorktreesForState', start)
+    const filterPass = source.slice(start, end)
+
+    expect(filterPass).toContain(
+      '!isSleepingSweepExemptWorkspace(worktree, alwaysShowDefaultBranchWorkspace)'
+    )
+    expect(filterPass).toContain('alwaysShowDefaultBranchWorkspace,')
+  })
+
+  it('reads the flag from the same store field the sidebar uses', () => {
+    expect(source).toContain(
+      'const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)'
+    )
+  })
+
+  it('exempts a project entry point by default and honours an explicit opt-out', () => {
+    const main = makeWorktree()
+
+    expect(isSleepingSweepExemptWorkspace(main, undefined)).toBe(true)
+    expect(isSleepingSweepExemptWorkspace(main, true)).toBe(true)
+    expect(isSleepingSweepExemptWorkspace(main, false)).toBe(false)
+  })
+
+  it('never exempts a non-main workspace', () => {
+    const feature = makeWorktree({ id: 'wt-feature', isMainWorktree: false })
+
+    expect(isSleepingSweepExemptWorkspace(feature, true)).toBe(false)
+    expect(isSleepingSweepExemptWorkspace(feature, undefined)).toBe(false)
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4305,7 +4305,9 @@
           "ee240a39eb": "Edit filters",
           "automationCreated": "Hide automation-created",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "Hide detached HEAD"
+          "detachedHead": "Hide detached HEAD",
+          "keepDefaultBranch": "Except default branch",
+          "keepDefaultBranchAria": "Keep the default branch visible while hiding sleeping workspaces"
         },
         "SidebarHeader": {
           "25a95899c9": "Add Project",
@@ -4370,7 +4372,9 @@
           "82594419ba": "Filters",
           "automationCreated": "Hide automation-created",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "Hide detached HEAD"
+          "detachedHead": "Hide detached HEAD",
+          "keepDefaultBranch": "Except default branch",
+          "keepDefaultBranchAria": "Keep the default branch visible while hiding sleeping workspaces"
         },
         "sidebarHostOptions": {
           "3e102f111c": "All hosts",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4227,7 +4227,9 @@
           "ee240a39eb": "Editar filtros",
           "automationCreated": "Ocultar creados por automatizaciones",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "Ocultar HEAD desacoplado"
+          "detachedHead": "Ocultar HEAD desacoplado",
+          "keepDefaultBranch": "Excepto la rama predeterminada",
+          "keepDefaultBranchAria": "Mantener visible la rama predeterminada al ocultar los espacios de trabajo en reposo"
         },
         "SidebarHeader": {
           "92154beb7e": "Nuevo espacio de trabajo",
@@ -4292,7 +4294,9 @@
           "82594419ba": "Filtros",
           "automationCreated": "Ocultar creados por automatizaciones",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "Ocultar HEAD desacoplado"
+          "detachedHead": "Ocultar HEAD desacoplado",
+          "keepDefaultBranch": "Excepto la rama predeterminada",
+          "keepDefaultBranchAria": "Mantener visible la rama predeterminada al ocultar los espacios de trabajo en reposo"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Diseño de actividad del Agent",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4208,7 +4208,9 @@
           "ee240a39eb": "フィルターの編集",
           "automationCreated": "自動化で作成されたワークスペースを非表示",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "分離HEADを非表示"
+          "detachedHead": "分離HEADを非表示",
+          "keepDefaultBranch": "デフォルトのブランチを除く",
+          "keepDefaultBranchAria": "スリープ中のワークスペースを非表示にしてもデフォルトのブランチは表示したままにする"
         },
         "SidebarHeader": {
           "92154beb7e": "新規ワークスペース",
@@ -4273,7 +4275,9 @@
           "82594419ba": "フィルター",
           "automationCreated": "自動化で作成されたワークスペースを非表示",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "分離HEADを非表示"
+          "detachedHead": "分離HEADを非表示",
+          "keepDefaultBranch": "デフォルトのブランチを除く",
+          "keepDefaultBranchAria": "スリープ中のワークスペースを非表示にしてもデフォルトのブランチは表示したままにする"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Agent アクティビティのレイアウト",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4208,7 +4208,9 @@
           "ee240a39eb": "필터 편집",
           "automationCreated": "자동화로 생성된 워크스페이스 숨기기",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "분리된 HEAD 숨기기"
+          "detachedHead": "분리된 HEAD 숨기기",
+          "keepDefaultBranch": "기본 브랜치는 제외",
+          "keepDefaultBranchAria": "슬립 중인 워크스페이스를 숨겨도 기본 브랜치는 계속 표시"
         },
         "SidebarHeader": {
           "92154beb7e": "새로운 워크스페이스",
@@ -4273,7 +4275,9 @@
           "82594419ba": "필터",
           "automationCreated": "자동화로 생성된 워크스페이스 숨기기",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "분리된 HEAD 숨기기"
+          "detachedHead": "분리된 HEAD 숨기기",
+          "keepDefaultBranch": "기본 브랜치는 제외",
+          "keepDefaultBranchAria": "슬립 중인 워크스페이스를 숨겨도 기본 브랜치는 계속 표시"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Agent 활동 레이아웃",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4220,7 +4220,9 @@
           "ee240a39eb": "编辑筛选条件",
           "automationCreated": "隐藏自动化创建的工作区",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "隐藏分离 HEAD"
+          "detachedHead": "隐藏分离 HEAD",
+          "keepDefaultBranch": "默认分支除外",
+          "keepDefaultBranchAria": "隐藏休眠工作区时仍显示默认分支"
         },
         "SidebarHeader": {
           "92154beb7e": "新工作区",
@@ -4285,7 +4287,9 @@
           "82594419ba": "筛选条件",
           "automationCreated": "隐藏自动化创建的工作区",
           "cliCreated": "Hide CLI-created",
-          "detachedHead": "隐藏分离 HEAD"
+          "detachedHead": "隐藏分离 HEAD",
+          "keepDefaultBranch": "默认分支除外",
+          "keepDefaultBranchAria": "隐藏休眠工作区时仍显示默认分支"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "智能体活动布局",

--- a/src/renderer/src/lib/startup-ui-hydration.ts
+++ b/src/renderer/src/lib/startup-ui-hydration.ts
@@ -51,6 +51,7 @@ export function getStartupErrorFallbackUI(uiHydrated: boolean): PersistedUIState
     hideDefaultBranchWorkspace: false,
     hideCliCreatedWorkspaces: false,
     hideDetachedHeadWorkspaces: false,
+    alwaysShowDefaultBranchWorkspace: true,
     hideAutomationGeneratedWorkspaces: false,
     filterRepoIds: [],
     collapsedGroups: [],

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -721,6 +721,33 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().showSleepingWorkspaces).toBe(true)
   })
 
+  it('defaults the default-branch sleeping exemption to on', () => {
+    expect(getDefaultUIState().alwaysShowDefaultBranchWorkspace).toBe(true)
+    expect(createUIStore().getState().alwaysShowDefaultBranchWorkspace).toBe(true)
+  })
+
+  it('treats a legacy profile with no default-branch exemption key as opted in', () => {
+    // Why: profiles written before #8873 are exactly the ones showing the bug,
+    // so an absent key must hydrate to on rather than silently re-hiding main.
+    const store = createUIStore()
+    const legacy = makePersistedUI()
+    delete (legacy as Partial<PersistedUIState>).alwaysShowDefaultBranchWorkspace
+
+    store.getState().hydratePersistedUI(legacy, 'startup')
+
+    expect(store.getState().alwaysShowDefaultBranchWorkspace).toBe(true)
+  })
+
+  it('preserves an explicit default-branch exemption opt-out on hydration', () => {
+    const store = createUIStore()
+
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ alwaysShowDefaultBranchWorkspace: false }), 'startup')
+
+    expect(store.getState().alwaysShowDefaultBranchWorkspace).toBe(false)
+  })
+
   it('defaults workspace host scope to all hosts', () => {
     expect(getDefaultUIState().workspaceHostScope).toBe('all')
     expect(createUIStore().getState().workspaceHostScope).toBe('all')

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -875,6 +875,8 @@ export type UISlice = {
   setHideCliCreatedWorkspaces: (v: boolean) => void
   hideDetachedHeadWorkspaces: boolean
   setHideDetachedHeadWorkspaces: (v: boolean) => void
+  alwaysShowDefaultBranchWorkspace: boolean
+  setAlwaysShowDefaultBranchWorkspace: (v: boolean) => void
   showDotfilesByWorktree: Record<string, boolean>
   setShowDotfilesForWorktree: (worktreeId: string, showDotfiles: boolean) => void
   toggleShowDotfilesForWorktree: (worktreeId: string) => void
@@ -2053,6 +2055,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   setHideCliCreatedWorkspaces: (v) => set({ hideCliCreatedWorkspaces: v }),
   hideDetachedHeadWorkspaces: false,
   setHideDetachedHeadWorkspaces: (v) => set({ hideDetachedHeadWorkspaces: v }),
+  alwaysShowDefaultBranchWorkspace: true,
+  setAlwaysShowDefaultBranchWorkspace: (v) => set({ alwaysShowDefaultBranchWorkspace: v }),
 
   showDotfilesByWorktree: {},
   setShowDotfilesForWorktree: (worktreeId, showDotfiles) =>
@@ -2459,6 +2463,9 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         hideAutomationGeneratedWorkspaces: ui.hideAutomationGeneratedWorkspaces === true,
         hideCliCreatedWorkspaces: ui.hideCliCreatedWorkspaces === true,
         hideDetachedHeadWorkspaces: ui.hideDetachedHeadWorkspaces === true,
+        // Why !== false: profiles written before #8873 have no key, and they are
+        // precisely the ones showing the bug, so absence must mean "exempt".
+        alwaysShowDefaultBranchWorkspace: ui.alwaysShowDefaultBranchWorkspace !== false,
         showDotfilesByWorktree: sanitizeShowDotfilesByWorktree(ui.showDotfilesByWorktree),
         // Why: startup hydrates UI before repo catalogs, so defer repo-filter validation to the all-host refresh.
         filterRepoIds:

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -478,6 +478,7 @@ export function getDefaultUIState(): PersistedUIState {
     hideAutomationGeneratedWorkspaces: false,
     hideCliCreatedWorkspaces: false,
     hideDetachedHeadWorkspaces: false,
+    alwaysShowDefaultBranchWorkspace: true,
     showDotfilesByWorktree: {},
     filterRepoIds: [],
     collapsedGroups: [],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3391,6 +3391,8 @@ export type PersistedUIState = {
   hideCliCreatedWorkspaces?: boolean
   /** Hide workspaces sitting on a detached HEAD; folder workspaces (no head at all) are unaffected. */
   hideDetachedHeadWorkspaces?: boolean
+  /** Keep each project's main workspace out of the "Hide sleeping" sweep. Absent means on (#8873). */
+  alwaysShowDefaultBranchWorkspace?: boolean
   /** Per-worktree Explorer dotfile visibility. Missing entries inherit the default: show. */
   showDotfilesByWorktree?: Record<string, boolean>
   filterRepoIds: string[]

--- a/tests/e2e/default-branch-visibility.spec.ts
+++ b/tests/e2e/default-branch-visibility.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression #8873: with "Hide sleeping" on, the project's main workspace must
+ * stay in the sidebar — it is the only guaranteed way back into the project —
+ * while a sleeping feature workspace is still swept.
+ */
+
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
+
+type SidebarVisibilityScenario = {
+  defaultBranchId: string
+  featureId: string
+}
+
+async function seedSidebarVisibilityScenario(page: Page): Promise<SidebarVisibilityScenario> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    const repo = state.repos[0]
+    if (!repo) {
+      throw new Error('Sidebar visibility E2E needs a seeded repo')
+    }
+
+    const currentWorktree = (state.worktreesByRepo[repo.id] ?? [])[0]
+    if (!currentWorktree) {
+      throw new Error('Sidebar visibility E2E needs a seeded worktree')
+    }
+
+    const defaultBranchId = 'e2e-default-branch-visibility-main'
+    const featureId = 'e2e-default-branch-visibility-feature'
+    const currentId = currentWorktree.id
+
+    store.setState((current) => ({
+      worktreesByRepo: {
+        ...current.worktreesByRepo,
+        [repo.id]: [
+          {
+            ...currentWorktree,
+            id: currentId,
+            displayName: 'Current workspace',
+            isMainWorktree: false,
+            branch: 'refs/heads/current',
+            lastActivityAt: 3
+          },
+          {
+            ...currentWorktree,
+            id: defaultBranchId,
+            displayName: 'Default branch workspace',
+            isMainWorktree: true,
+            branch: 'refs/heads/main',
+            lastActivityAt: 2
+          },
+          {
+            ...currentWorktree,
+            id: featureId,
+            displayName: 'Feature workspace',
+            isMainWorktree: false,
+            branch: 'refs/heads/feature',
+            lastActivityAt: 1
+          }
+        ]
+      },
+      tabsByWorktree: {
+        ...current.tabsByWorktree,
+        [defaultBranchId]: [],
+        [featureId]: []
+      },
+      browserTabsByWorktree: {
+        ...current.browserTabsByWorktree,
+        [defaultBranchId]: [],
+        [featureId]: []
+      }
+    }))
+
+    const nextState = store.getState()
+    nextState.setActiveView('terminal')
+    nextState.setSidebarOpen(true)
+    nextState.setGroupBy('none')
+    nextState.setSortBy('recent')
+    nextState.setShowActiveOnly(false)
+    nextState.setFilterRepoIds([])
+
+    return { defaultBranchId, featureId }
+  })
+}
+
+test.describe('Default branch visibility', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('keeps the default branch visible when sleeping workspaces are hidden', async ({
+    orcaPage
+  }) => {
+    const { defaultBranchId, featureId } = await seedSidebarVisibilityScenario(orcaPage)
+    const defaultBranchRow = worktreeRow(orcaPage, defaultBranchId)
+    const featureRow = worktreeRow(orcaPage, featureId)
+
+    // Poll rather than set once: hydration can land after the seed and reset the filters.
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          ({ defaultBranchId, featureId }) => {
+            const state = window.__store?.getState()
+            state?.setShowSleepingWorkspaces(false)
+            state?.setHideDefaultBranchWorkspace(false)
+            state?.setAlwaysShowDefaultBranchWorkspace(true)
+            const featureTabs = state?.tabsByWorktree[featureId] ?? []
+            return {
+              alwaysShowDefaultBranchWorkspace: state?.alwaysShowDefaultBranchWorkspace ?? null,
+              defaultBranchTabs: state?.tabsByWorktree[defaultBranchId]?.length ?? 0,
+              featureBrowserTabs: state?.browserTabsByWorktree[featureId]?.length ?? 0,
+              featureHasLivePty: featureTabs.some(
+                (tab) => (state?.ptyIdsByTabId[tab.id] ?? []).length > 0
+              ),
+              featureTabs: featureTabs.length,
+              hideDefaultBranchWorkspace: state?.hideDefaultBranchWorkspace ?? null,
+              showSleepingWorkspaces: state?.showSleepingWorkspaces ?? null
+            }
+          },
+          { defaultBranchId, featureId }
+        )
+      )
+      .toEqual({
+        alwaysShowDefaultBranchWorkspace: true,
+        defaultBranchTabs: 0,
+        featureBrowserTabs: 0,
+        featureHasLivePty: false,
+        featureTabs: 0,
+        hideDefaultBranchWorkspace: false,
+        showSleepingWorkspaces: false
+      })
+
+    await expect(defaultBranchRow).toBeVisible()
+    await expect(defaultBranchRow).toContainText('Default branch workspace')
+    await expect(featureRow).toHaveCount(0)
+
+    // Opting out of the exemption is the only way back to the pre-#8873 sweep.
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().setAlwaysShowDefaultBranchWorkspace(false)
+    })
+
+    await expect(defaultBranchRow).toHaveCount(0)
+
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().setAlwaysShowDefaultBranchWorkspace(true)
+    })
+
+    await expect(defaultBranchRow).toBeVisible()
+
+    // The explicit hide filter still outranks the exemption.
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().setHideDefaultBranchWorkspace(true)
+    })
+
+    await expect(defaultBranchRow).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Description

Fixes #8873

"Hide sleeping" swept **each project's main workspace** out of the sidebar as soon as it had no live PTY, browser tab or agent — even with "Hide default branch" **off**. For a project whose only row *is* that workspace (a folder workspace, a fresh clone, a detached-HEAD main), the entire project vanished from the sidebar with no in-place way back.

Root cause: `computeVisibleWorktreeIds` in `src/renderer/src/components/sidebar/visible-worktrees.ts` ran the sleeping sweep over every row with no exemption, and `WorktreeJumpPalette.tsx` re-implemented the same pass inline for its empty-query list. The workspace board and Cmd+1–9 both consume `computeVisibleWorktreeIds`, so all four surfaces dropped the row.

What changed:

- New shared predicate **`isSleepingSweepExemptWorkspace`** (`visible-worktrees.ts`), keyed on **`isMainWorktree`** rather than on the branch name. This is deliberate: a disconnected SSH provider re-synthesizes persisted worktrees with empty `head`/`branch` while their PTYs are dead — exactly the moment a branch-keyed exemption would evaporate and the row would flicker out. Keying on `isMainWorktree` also covers folder workspaces (no branch at all) and detached-HEAD mains.
- Wired into `computeVisibleWorktreeIds` (sidebar, Cmd+1–9, workspace board) **and** into the jump palette's duplicate filter pass, so the two implementations can no longer drift.
- Explicit **"Hide default branch"** and **"Hide detached HEAD"** still win — they filter *before* the sleeping sweep, so an explicit hide is always authoritative.
- Ships **default-on with an escape hatch**: a persisted `alwaysShowDefaultBranchWorkspace` setting, surfaced as an indented sub-option **"Except default branch"** directly under "Hide sleeping" in both filter menus, counted by the active-filter badges and restored by Reset / Clear Filters. Absent means **on**, so profiles written before this change — precisely the ones hitting the bug — hydrate opted in.
- Mobile gets the same exemption (`mobile/src/worktree/workspace-list-sections.ts` had the identical ordering defect) and reads the setting through the existing `PersistedUIState` bridge. The phone has no toggle UI of its own yet — see trade-offs.
- Extracts the byte-identical toggle row duplicated across `SidebarFilter.tsx` and `SidebarWorkspaceFilterSection.tsx` into `FilterToggleRow.tsx`. Not optional polish: `SidebarFilter.tsx` sat at 395/400 effective lines, and bumping or disabling `max-lines` is forbidden by AGENTS.md.
- Re-enables the exemption when an imported project would otherwise land asleep and invisible (`add-repo-skip-finalization.ts`), mirroring the existing `hideDefaultBranchWorkspace` reset next to it.

## ELI5

Orca's sidebar has a switch called **"Hide sleeping"** that tidies up by hiding workspaces you aren't actively using.

The problem: it also hid the *front door*. Every project has one main workspace — the one you land on when you open the repo. If you weren't running anything in it, "Hide sleeping" made it disappear. And if that was the project's only workspace, the whole project vanished from your sidebar. You couldn't click it, because there was nothing left to click.

Now the front door always stays put. Everything else still hides exactly as before. If you genuinely want the front door hidden too, there's a new little switch tucked right under "Hide sleeping" called **"Except default branch"** — turn it off and you get the old behavior back. It starts on, so nobody has to go find it to get the bug fixed.

## Fix proof

Test file: **`src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts`** (committed as an independently-adjudicated repro in `5b6e15314c`, *before* the fix).

**BEFORE** — production fix reverted in place (`git checkout f3e087ec06 -- src/renderer/src/components/sidebar/visible-worktrees.ts`), everything else at HEAD:

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts

 × stays in the sidebar when it is sleeping and "Hide sleeping" is on          5ms
 × keeps the sleeping default branch when the option is explicitly on          2ms
 × keeps a sleeping folder workspace, which has no sibling row to fall back to 0ms
 × keeps a sleeping detached-HEAD main worktree                                0ms
 × keeps every project's entry point, not just the first                       2ms
 × does not flicker out while an SSH host is offline                           0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 6 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected [] to deeply equal [ 'wt-main' ]
AssertionError: expected [] to deeply equal [ 'wt-main' ]
AssertionError: expected [] to deeply equal [ 'wt-folder' ]
AssertionError: expected [] to deeply equal [ 'wt-detached' ]
AssertionError: expected [] to deeply equal [ 'wt-main', 'wt-main-b' ]
AssertionError: expected [] to deeply equal [ 'wt-main' ]

 Test Files  1 failed (1)
      Tests  6 failed | 6 passed (12)
```

**AFTER** — at HEAD:

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Duration  2.35s
```

The repro's behavioral assertions are untouched and flip green from production code alone — they pass **no** opt-in flag, which is why the exemption had to ship default-on. The only edit to the repro file was adding the new key to its own hand-written filter-key enumeration, which is that test's stated contract (it enumerates the API surface with literals, so no production change could ever satisfy it).

## Visual proof

Captured with a real Electron run (a scratch capture harness, not committed — the durable e2e is `tests/e2e/default-branch-visibility.spec.ts`, ported from #8966; 1280×800, same seeded repo, same screenshot clip measured before the filter flip so both frames are pixel-comparable). BEFORE was produced by checking `src/renderer src/main src/shared` back to base `f3e087ec06` and rebuilding `--mode e2e`; AFTER is the same spec against HEAD, passing 3/3 under `--repeat-each=3`.

**Sidebar with "Hide sleeping" ON — before:** the project's sleeping `master` primary workspace is gone and the project collapses to "No workspaces found / Clear Filters".

![before-sidebar-hide-sleeping.png](https://github.com/user-attachments/assets/93519493-f808-4108-9228-f7b3fc8f7676)

**After:** the project and its sleeping `master` `primary` row remain visible (grey/inactive dot — it really is sleeping), and the filter badge still reads `1`.

![after-sidebar-hide-sleeping.png](https://github.com/user-attachments/assets/241c5f1d-ea4b-4965-9ebc-ad66748ca8f7)

**Filter menu — before:** no escape hatch; the only lever is "Hide default branch", which hides main even when it's awake.

![before-filter-menu.png](https://github.com/user-attachments/assets/336f65c6-cb0c-4060-b3ee-83b2630eaff2)

**After:** new indented sub-toggle **"Except default branch"** directly under "Hide sleeping", on by default.

![after-filter-menu.png](https://github.com/user-attachments/assets/d89406ca-d813-4194-8025-2c6db4bbf38c)

Full-window context shots, before and after:

![before-window-hide-sleeping.png](https://github.com/user-attachments/assets/1bbfa24c-2c0c-4767-974b-641950893d3e)

![after-window-hide-sleeping.png](https://github.com/user-attachments/assets/85eef03d-21d9-4ca0-a86c-a20efb7d9a52)

The BEFORE run is not a staged screenshot — the spec **failed** at `expect(row).toBeVisible()` with `element(s) not found`, and its DOM dump read `"No workspaces found\nClear Filters"`. AFTER, the same dump reads `"orca-e2e-repo-BqLq3j\nInactive\nmaster\nprimary\nmaster"`. No video: this is static state, not motion, so screenshots are the honest medium.

## Regressions & trade-offs

**No test regressions found.** Evidence, all run in the worktree:

| Command | Result |
|---|---|
| `vitest src/renderer/src/components/sidebar/` | 211 files / **1849 tests passed** |
| 10 directly-affected files (repro, `visible-worktrees`, `sidebar-filter-state`, `add-repo-skip-finalization`, both jump-palette specs, `store/slices/ui`, `startup-ui-hydration`, `client-ui`, `locale-english-regression`) | 10 files / **295 passed** |
| 11 second-tier importers (`rendered-sidebar-worktree-order`, `smart-sort`, `useIpcEvents`, 2× `WorkspaceKanbanDrawer`, `cmd-j/palette-activation-focus-routing`, …) | 11 files / **243 passed** |
| `vitest src/shared/ src/renderer/src/store/slices/ src/renderer/src/lib/` | 901 files / **9400 passed** |
| `vitest src/renderer/src/hooks/ src/renderer/src/i18n/` | 75 files / **691 passed** |
| `vitest src/main/runtime/` | 219 files / **3423 passed** |
| `vitest mobile/src/worktree/` | 15 files / **110 passed** |
| Playwright `worktree*.spec.ts` (6 specs, `electron-headless`) | **19/19 passed (1.9m)** |
| `tsc --noEmit` on web / node / cli configs (`--composite false`) | exit 0 |
| `oxlint` + `oxlint --config config/oxlint-code-quality-native-plugins.json … --deny-warnings` | exit 0 |
| `check-max-lines-ratchet.mjs` | "352 grandfathered suppression(s), **no new bypasses**" |
| `check-reliability-gates.mjs` | 62 gates pass |
| `verify:localization-catalog` / `:extraction` / `:coverage` | all exit 0 |

Two tests failed only during a full 1417-file parallel run of `src/renderer/src/components/`: `ai-vault-session-worktree-map.test.tsx` (a perf-budget assertion whose own comment calls the bound "loose to stay quiet on a slow CI box") and `project-view-wrapper-source-context-boundary.test.ts` (a dynamic `await import` timing out). Neither file nor anything they import is in this diff — `git diff --stat f3e087ec06...HEAD -- src/renderer/src/components/github-project/ src/renderer/src/components/right-sidebar/` is **empty** — and re-running both in isolation gives 2 files / 7 tests passed. A second full run reproduced only one of the two, confirming nondeterminism.

**Mobile now runs (the previous caveat is cleared).** `mobile/node_modules` was empty in this environment; installing it made both mobile gates runnable, and they are green:

| Command | Result |
|---|---|
| `mobile/` vitest, full suite | **2751 passed / 3 skipped**, 374 files |
| `mobile/` vitest `src/worktree/` | 15 files / **111 passed** |
| `mobile/` `tsc --noEmit -p tsconfig.json` | 1 error, unrelated (below) |

The only mobile failures are 12 files under `mobile/src/terminal/` that cannot resolve `./terminal-webview-engine.generated`, plus the identical single `TS2307` in typecheck. That file is a build artifact never generated in this checkout; nothing in this diff touches `mobile/src/terminal/`. The earlier `TS5102: baseUrl has been removed` blocker was also an artifact of the missing install and no longer reproduces.

### User-visible behavior changes and trade-offs — disclosed

1. **Default-on changes behavior on upgrade.** Anyone running "Hide sleeping" today with a sleeping main gets that row back after updating. This is the deliberate choice: default-off would leave the reported symptom present until the user hunts for a toggle, and would fail the committed repro's behavioral case. The escape hatch is the toggle, not "hide main forever".
2. **Row-count noise scales with project count.** With 30 projects, "Hide sleeping" now leaves 30 always-present main rows in the sidebar *and* on the workspace board. This is the single strongest argument for shipping a toggle rather than an unconditional rule. Worth a release note.
3. **Two toggles that can contradict.** "Hide default branch" ON + "Except default branch" ON is a legal, confusing combination; hide wins because it filters earlier. The sub-row renders unconditionally rather than vanishing based on a sibling toggle, because rows that disappear are worse UX than a no-op — but it also renders (and increments the active-filter badge) when "Hide sleeping" is **off**, where it does nothing. A reviewer may reasonably ask for `!showSleepingWorkspaces` gating on render and count; I'd take that patch.
4. **Naming vs. semantics.** The label and persisted key say "default branch"; the predicate means `isMainWorktree`, so it deliberately also covers folder workspaces and detached-HEAD mains. This is the last cheap moment to rename — after ship, `alwaysShowDefaultBranchWorkspace` is a persisted `PersistedUIState` key, a strict zod field and 10 locale entries across 5 languages, and renaming needs a migration.
5. **Mobile has no toggle UI — write-back clobber now FIXED.** Mobile reads and honors the setting but still can't change it. The dangerous half is fixed here: `mobile/app/h/[hostId]/index.tsx` no longer sends `alwaysShowDefaultBranchWorkspace` in its `ui.set` payload, so a desktop opt-out can no longer be silently reverted by tapping a mobile filter before the `ui.get` roundtrip lands. Mobile is a reader only. This also answers CodeRabbit's note on mobile's `activeFilterCount`/`clearFilters`: mobile deliberately neither counts nor resets a setting it cannot own. Threading a real mobile toggle still needs headroom in that file, which sits at 1594 against a 1603 cap I'm not allowed to bump.
6. **Mobile legacy fallback gap — FIXED.** The fallback is now `w.isMainWorktree ?? (w.workspaceKind === 'folder-workspace' || isDefaultBranchWorkspace(w))`. A folder workspace has no branch, so the legacy branch heuristic could never recognise it and #8873 still reproduced for folder workspaces paired with a host that predates `isMainWorktree`. Covered by a new case in `mobile/src/worktree/workspace-list-sections.test.ts`.
7. **Importing a project flips a global preference.** `add-repo-skip-finalization.ts` calls `setAlwaysShowDefaultBranchWorkspace(true)` so an import can't land invisible — but that un-hides every project's main row, not just the imported one. It mirrors the pre-existing `setHideDefaultBranchWorkspace(false)` next to it.
8. **One more persisted UI field.** `PersistedUIState`, the strict `ui.set` schema, the debounced App writer, hydration and defaults — five files of plumbing for one boolean. The payoff is the escape hatch plus riding the existing desktop/mobile sync.
9. **Lineage ordering shifted, intentionally.** An exempted main that is also a lineage parent now enters the sorted list in its cached-sort slot instead of arriving via `addVisibleLineageAncestors`, so Cmd+1–9 numbers it where the sidebar actually renders it. Pinned by a test in `f8a03a48c8`.
10. **Diff is wider than the bug.** `FilterToggleRow.tsx` touches two components not strictly implicated, forced by the 400-line cap on `SidebarFilter.tsx` and the no-bump rule. It removes a real copy-paste duplicate; every class string (`bg-primary`, `bg-muted-foreground/30`, `ring-ring`, `text-[12px]`) is carried over unchanged, so no new tokens, sizes or shadow tiers were invented.

### Backward compatibility

`store.updateUI(updates)` is a merge, so an **older** mobile/relay client omitting the key does **not** clear a desktop opt-out, and old builds ignore the extra key on downgrade. `UiUpdate` is `.strict()`, so a **newer** mobile paired to a **pre-#8873 desktop** has its whole `ui.set` batch rejected — that's this repo's accepted design for every added UI key, not something introduced here, but it belongs in the mobile-backcompat ledger.

## Perf

**Verdict: NO REGRESSION.** Zero new IPC calls, zero new git/fs work, zero new timers or polling.

- **Filter cost.** Micro-benchmarked `computeVisibleWorktreeIds` at 50 repos × 20 worktrees = 1000 rows, `showSleepingWorkspaces: false`, 7 alternating rounds × 500 calls, median: exemption OFF **0.1130 ms/call**, exemption ON **0.1185 ms/call** → **+5.5 µs (+4.9%)**, and that already includes carrying 50 extra rows through the sort, the lineage pass and the map lookup. The `||` short-circuits *past* the more expensive `isInactiveWorkspace` for main worktrees.
- **Store subscriptions.** 7 new selectors, all `useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)` — a primitive boolean, referentially stable, identical in shape to the 4 sibling `hide*Workspaces` selectors already at each site. No object literals, no broken `useShallow` gates. `pnpm check:zustand-selector-fanout`: 2500 subscribers × 2000 unrelated writes = 5M selector runs, median **94.09 ms**, **0 render invalidations** — ~19 ns/run, so 5 extra always-mounted selectors cost ~0.1 µs per store write.
- **Extra visible rows don't fan out.** The list is virtualized (`@tanstack/react-virtual`, overscan 10), so mounted `WorktreeCard`s are capped by viewport, not repo count. Main-side pacing already tiers the review poll (`NO_REVIEW_REFRESH_INTERVAL_MS = 15 * 60_000`, `MAX_ACTIVE_BRANCHES = 8`) and default branches are the canonical no-review case. And `DEFAULT_SHOW_SLEEPING_WORKSPACES = true`, so in the default configuration these cards were already mounted — no new steady-state cost for the default user.
- **Persistence.** One boolean added to the *already existing* 150 ms-debounced `ui.set` payload (~30 bytes); it only changes on an explicit toggle, so no new write frequency. Mobile routes it entirely through `viewStateRef`, adding no renders or RPCs.
- **Latency.** No probe, await or resolve inserted into any interaction path (tab close, tab switch, terminal render/scroll, startup).

The one thing to watch: if a future change removes virtualization from `WorktreeList`, the extra row per project is where it would first be felt.

## Release scan

**PASS-WITH-NOTES.** Span `f3e087ec06` → `95d61411d9`, 5 commits, 34 files, +1302/−105. The two commits added since the scan below are tests plus a mobile-only fix; neither introduces a dependency, binary, network sink or process spawn, so the P0/P1 verdict is unchanged.

- **P0 (release blocking): none.** No dependency or lockfile movement (`package.json`, `pnpm-lock.yaml`, `mobile/package.json` all untouched), no install hooks, no binaries, no `eval`/`child_process`/download-execute, no secrets, no new logging or network sink. No file, git, PTY or tab operation touched — nothing in this span can close, archive or delete anything. No new casts, non-null assertions or `JSON.parse`; `startup-ui-hydration.ts` includes the key so a hydration failure still yields a well-formed `PersistedUIState`. No startup risk.
- **P1: none.**
- **P2:** the mobile write-back clobber (trade-off #5), the mobile folder-workspace legacy fallback (#6), the sub-toggle rendering/counting when its parent is off (#3), the label-vs-`isMainWorktree` naming (#4), the import-flips-a-global-preference behavior (#7), and the default-on upgrade change needing a release note (#1). All enumerated above with suggested fixes.
- **Drift check:** `grep isInactiveWorkspace` finds exactly two production sweep sites (`visible-worktrees.ts`, `WorktreeJumpPalette.tsx`); both now use the shared predicate. Key-coverage parity against the sibling `hideDetachedHeadWorkspaces` is exact.
- **Platform/remoting:** no path handling, no `metaKey`, no shell, no native modules. SSH is explicitly covered by a test proving the exemption survives a disconnected provider re-synthesizing worktrees with empty `head`/`branch`. Folder workspaces covered by design and by test. No GitHub/GitLab-specific code touched.

**Before release:** add a release note that heavy multi-repo users will see one extra always-visible row per project under "Hide sleeping", with the opt-out at Hide sleeping → "Except default branch". The mobile typecheck/vitest item is done — both ran here and are green.

## Review loop

Reviewed 1 time until clean — verdict: *"Merge-ready. The fix addresses the real root cause at a single shared predicate (`isSleepingSweepExemptWorkspace`) and wires all three surfaces that implement the sleeping sweep — `computeVisibleWorktreeIds` (sidebar, Cmd+1–9, workspace board), `WorktreeJumpPalette`'s inline empty-query pass, and mobile's `filterWorktrees`. Keying on `isMainWorktree` instead of the branch is verifiably correct: `orca-runtime.ts`'s disconnected-SSH synthesis emits empty head/branch but preserves `isMainWorktree` via path compare, so a branch-keyed exemption would have vanished precisely when the PTYs are dead. Persistence, hydration (absent means on), the `ui.set` zod schema, `PersistedUIState` parity, i18n across all five catalogs, Clear Filters, and the mobile bridge are all covered. The committed repro's behavioural assertions are untouched — only the test's own hand-written filter-key enumeration gained the new key, which is that test's stated contract. All checks I ran are green; remaining items are polish (badge/enabled-state semantics of the sub-toggle when Hide sleeping is off, a dead default export, and two brittle source-text assertions)."*

No unresolved blocking findings.

## Credits

Co-authored with **@rodboev**, whose **#8966** ("feat(sidebar): keep the default branch visible when sleeping workspaces are hidden") independently diagnosed #8873. The two PRs are now combined here.

**What was cross-referenced.** #8966's exempt set is `{isMainWorktree ∧ branch ≠ ''}`; this PR's is `{isMainWorktree}`. The first is a strict subset of the second — every row #8966 rescues, this also rescues, plus folder workspaces, detached-HEAD mains and SSH-offline rows whose branch is blanked. So #8966's production diff is fully subsumed and was not ported. Its `visible-worktrees.test.ts` additions were also skipped: two duplicate cases already here, and one asserting the inverse of this PR's deliberate folder-workspace behavior.

**What was ported** (commit `95d61411d9`, `Co-authored-by: Rod Boev`):

- `src/renderer/src/components/WorktreeJumpPalette.test.tsx` — a real happy-dom render harness. This PR's only palette coverage was a source-string assertion that proved the call site existed without ever rendering a row. Two of its cases asserted a folder-mode main stays hidden; flipped, because this PR's `isMainWorktree` keying exempts folder workspaces on purpose, so they now document that choice.
- `tests/e2e/default-branch-visibility.spec.ts` — this PR shipped no e2e at all. Ported minus its render-lint scaffolding, and extended with a leg that toggles `alwaysShowDefaultBranchWorkspace` off and back on. Passes: `1 passed (10.1s)`, `electron-headless`.
- Two cases #8966 predates are new: the opt-out swept through the DOM, and the same end-to-end.

**#8966 is superseded by this PR and will be closed on merge**, with the credit above.

Made with [Orca](https://github.com/stablyai/orca) 🐋

