### PR TITLE
fix(ports): keep the UI responsive when process creation is delayed (#11161)

### DIFF
--- a/config/knip.json
+++ b/config/knip.json
@@ -10,6 +10,7 @@
     "src/main/speech/stt-worker.ts",
     "src/main/warp-themes/warp-theme-parser-worker.ts",
     "src/main/ai-vault/session-scanner-opencode-sqlite-worker-entry.ts",
+    "src/main/ports/port-scan-command-worker-entry.ts",
     "src/main/ipc/parcel-watcher-process-entry.ts",
     "src/main/hang-watchdog/main-thread-hang-watchdog-entry.ts",
     "src/main/codex/codex-app-server-grant-entry.ts",

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -216,6 +216,11 @@ export const electronViteConfig: UserConfig = {
           'session-scanner-opencode-sqlite-worker-entry': resolve(
             'src/main/ai-vault/session-scanner-opencode-sqlite-worker-entry.ts'
           ),
+          // Why: port-scan spawns run on a worker thread so an endpoint-security
+          // hook on CreateProcessW cannot freeze CrBrowserMain (issue #11161).
+          'port-scan-command-worker-entry': resolve(
+            'src/main/ports/port-scan-command-worker-entry.ts'
+          ),
           // Why: forked with ELECTRON_RUN_AS_NODE so @parcel/watcher faults
           // can't take down the main process (issue #7547).
           'parcel-watcher-process-entry': resolve('src/main/ipc/parcel-watcher-process-entry.ts'),

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -9,12 +9,27 @@ import {
   resetWorkspacePortScanTimeoutBackoffForTests,
   scanWorkspacePorts
 } from './local-workspace-port-scanner'
+import { PortScanCommandTimeout } from './port-scan-command-client'
 
-const execFileMock = vi.hoisted(() => vi.fn())
+const runPortScanCommandMock = vi.hoisted(() => vi.fn())
 
-vi.mock('child_process', () => ({
-  execFile: execFileMock
+vi.mock('./port-scan-command-worker-spawn', () => ({
+  runPortScanCommand: runPortScanCommandMock
 }))
+
+// Healthy hosts return process creation in single-digit ms; the scanner only
+// reads spawnMs to decide whether to skip optional metadata commands.
+const FAST_SPAWN_MS = 2
+
+function commandOutput(
+  stdout: string,
+  spawnMs = FAST_SPAWN_MS
+): Promise<{
+  stdout: string
+  spawnMs: number
+}> {
+  return Promise.resolve({ stdout, spawnMs })
+}
 
 const worktrees = [
   {
@@ -177,46 +192,34 @@ describe('scanWorkspacePorts attribution work', () => {
   afterEach(() => {
     resetWorkspacePortScanTimeoutBackoffForTests()
     vi.restoreAllMocks()
-    execFileMock.mockReset()
+    runPortScanCommandMock.mockReset()
   })
 
   it('normalizes worktree paths once per scan instead of once per port phase', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const win32ResolveSpy = vi.spyOn(path.win32, 'resolve')
     const posixResolveSpy = vi.spyOn(path.posix, 'resolve')
-    const invokeCallback = (callback: unknown, stdout: string): void => {
-      if (typeof callback !== 'function') {
-        throw new Error('missing execFile callback')
+    runPortScanCommandMock.mockImplementation((command: string, args: readonly string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return commandOutput(
+          ['p123', 'cnode', 'n127.0.0.1:3000', 'p124', 'cnode', 'n127.0.0.1:3001'].join('\n')
+        )
       }
-      const execCallback = callback as (error: Error | null, stdout: string) => void
-      execCallback(null, stdout)
-    }
-    execFileMock.mockImplementation(
-      (command: string, args: string[], _options: unknown, callback: unknown) => {
-        if (command === 'lsof' && args.includes('-iTCP')) {
-          invokeCallback(
-            callback,
-            ['p123', 'cnode', 'n127.0.0.1:3000', 'p124', 'cnode', 'n127.0.0.1:3001'].join('\n')
-          )
-        } else if (command === 'lsof') {
-          invokeCallback(
-            callback,
-            ['p123', 'n/repo/service', 'p124', 'n/repo/worktrees/feature/app'].join('\n')
-          )
-        } else if (command === 'ps') {
-          invokeCallback(
-            callback,
-            [
-              '123 node /repo/service/server.js',
-              '124 node /repo/worktrees/feature/app/server.js'
-            ].join('\n')
-          )
-        } else {
-          invokeCallback(callback, '')
-        }
-        return { kill: vi.fn() }
+      if (command === 'lsof') {
+        return commandOutput(
+          ['p123', 'n/repo/service', 'p124', 'n/repo/worktrees/feature/app'].join('\n')
+        )
       }
-    )
+      if (command === 'ps') {
+        return commandOutput(
+          [
+            '123 node /repo/service/server.js',
+            '124 node /repo/worktrees/feature/app/server.js'
+          ].join('\n')
+        )
+      }
+      return commandOutput('')
+    })
 
     const scan = await scanWorkspacePorts(worktrees, {
       lookup: () => undefined,
@@ -240,14 +243,17 @@ describe('scanWorkspacePorts command timeout', () => {
     vi.useRealTimers()
     resetWorkspacePortScanTimeoutBackoffForTests()
     vi.restoreAllMocks()
-    execFileMock.mockReset()
+    runPortScanCommandMock.mockReset()
   })
+
+  // The worker owns the command deadline now, so it is what rejects.
+  const workerTimeout = (): Promise<never> =>
+    Promise.reject(new PortScanCommandTimeout('lsof timed out after 4000ms'))
 
   it('returns an unavailable scan when lsof never reports completion', async () => {
     vi.useFakeTimers()
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
-    const killMock = vi.fn()
-    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    runPortScanCommandMock.mockImplementation(workerTimeout)
 
     let settled = false
     const scanPromise = scanWorkspacePorts([], {
@@ -266,15 +272,13 @@ describe('scanWorkspacePorts command timeout', () => {
       ports: [],
       unavailableReason: 'Port scanning is unavailable on darwin.'
     })
-    expect(killMock).toHaveBeenCalled()
   })
 
   it('backs off after a command timeout instead of launching lsof on every scan tick', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
-    const killMock = vi.fn()
-    execFileMock.mockImplementation(() => ({ kill: killMock }))
+    runPortScanCommandMock.mockImplementation(workerTimeout)
 
     const firstScanPromise = scanWorkspacePorts([], {
       lookup: () => undefined,
@@ -287,7 +291,7 @@ describe('scanWorkspacePorts command timeout', () => {
       ports: [],
       unavailableReason: 'Port scanning is unavailable on darwin.'
     })
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(1)
 
     const cooldownScans = await Promise.all(
       Array.from({ length: 10 }, () =>
@@ -306,17 +310,12 @@ describe('scanWorkspacePorts command timeout', () => {
     expect(
       cooldownScans.every((scan) => scan.unavailableReason?.includes('temporarily paused'))
     ).toBe(true)
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(1)
 
     vi.setSystemTime(65_001)
     await vi.advanceTimersByTimeAsync(0)
-    execFileMock.mockImplementation(
-      (_command: string, args: string[], _options: unknown, callback: unknown) => {
-        const execCallback = callback as (error: Error | null, stdout: string) => void
-        const output = args.includes('-iTCP') ? 'p123\ncnode\nn127.0.0.1:3000' : ''
-        execCallback(null, output)
-        return { kill: vi.fn() }
-      }
+    runPortScanCommandMock.mockImplementation((_command: string, args: readonly string[]) =>
+      commandOutput(args.includes('-iTCP') ? 'p123\ncnode\nn127.0.0.1:3000' : '')
     )
 
     const recoveredScan = await scanWorkspacePorts([], {
@@ -325,6 +324,54 @@ describe('scanWorkspacePorts command timeout', () => {
     })
 
     expect(recoveredScan.unavailableReason).toBeUndefined()
-    expect(execFileMock).toHaveBeenCalledTimes(4)
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('scanWorkspacePorts with delayed process creation', () => {
+  afterEach(() => {
+    resetWorkspacePortScanTimeoutBackoffForTests()
+    vi.restoreAllMocks()
+    runPortScanCommandMock.mockReset()
+  })
+
+  // Regression for #11161: an endpoint-security hook on CreateProcessW delays
+  // the spawn, not the command. That must not read as a command timeout.
+  it('does not report a command timeout when only process creation was delayed', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    runPortScanCommandMock.mockImplementation(() =>
+      commandOutput('p123\ncnode\nn127.0.0.1:3000', 4_200)
+    )
+
+    const scan = await scanWorkspacePorts([], { lookup: () => undefined, reconcileScan: vi.fn() })
+
+    expect(scan.unavailableReason).toBeUndefined()
+    expect(scan.ports).toHaveLength(1)
+  })
+
+  it('skips the optional metadata commands for one cycle after a stalled spawn', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    runPortScanCommandMock.mockImplementation(() =>
+      commandOutput('p123\ncnode\nn127.0.0.1:3000', 4_200)
+    )
+
+    await scanWorkspacePorts([], { lookup: () => undefined, reconcileScan: vi.fn() })
+
+    // Only the primary probe; lsof -d cwd and ps are not issued this cycle.
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('still collects process metadata when process creation was fast', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    runPortScanCommandMock.mockImplementation((command: string, args: readonly string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return commandOutput('p123\ncnode\nn127.0.0.1:3000')
+      }
+      return commandOutput('')
+    })
+
+    await scanWorkspacePorts([], { lookup: () => undefined, reconcileScan: vi.fn() })
+
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/main/ports/local-workspace-port-scanner.ts
+++ b/src/main/ports/local-workspace-port-scanner.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines -- Why: the platform-specific scan paths share parsing,
 attribution, and normalization rules that must stay in lockstep. */
-import { execFile } from 'node:child_process'
 import { readFile, readdir, readlink } from 'node:fs/promises'
 import path from 'node:path'
 import type {
@@ -11,10 +10,20 @@ import type {
 } from '../../shared/workspace-ports'
 import { getProcessOutputFields } from '../../shared/process-output-field-scanner'
 import { advertisedUrlWatcher, type AdvertisedUrlWatcher } from './advertised-url-watcher'
+import { PortScanCommandTimeout } from './port-scan-command-client'
+import { runPortScanCommand } from './port-scan-command-worker-spawn'
 import { WorkspacePortScanTimeoutBackoff } from './workspace-port-scan-timeout-backoff'
 
-const COMMAND_TIMEOUT_MS = 4_000
+// Why (#11161): this module must never import child_process. Every spawn goes
+// through the worker client so a hooked CreateProcessW stalls that thread
+// instead of the main process' event loop. Enforced by
+// port-scan-command-import-boundary.test.ts.
+
 const MAX_PORTS = 200
+// A primary probe whose process creation blocked this long proves the host
+// intercepts spawns; skip the optional metadata commands for this cycle so one
+// scan costs one stall instead of two.
+const STALLED_SPAWN_MS = 2_000
 const HTTP_PORTS = new Set([80, 3000, 3001, 4200, 5000, 5173, 5174, 8000, 8080, 8888])
 const HTTPS_PORTS = new Set([443, 8443])
 
@@ -208,8 +217,17 @@ async function scanPlatformListeningPorts(): Promise<RawListeningPort[]> {
 }
 
 async function scanDarwinLsofPorts(): Promise<RawListeningPort[]> {
-  const { stdout } = await runCommand('lsof', ['-nP', '-iTCP', '-sTCP:LISTEN', '-F', 'pcn'])
+  const { stdout, spawnMs } = await runPortScanCommand('lsof', [
+    '-nP',
+    '-iTCP',
+    '-sTCP:LISTEN',
+    '-F',
+    'pcn'
+  ])
   const ports = parseLsofListeningOutput(stdout)
+  if (spawnMs >= STALLED_SPAWN_MS) {
+    return ports
+  }
   const metadata = await loadDarwinProcessMetadata(
     new Set(ports.flatMap((p) => (p.pid ? [p.pid] : [])))
   )
@@ -217,8 +235,11 @@ async function scanDarwinLsofPorts(): Promise<RawListeningPort[]> {
 }
 
 async function scanWindowsNetstatPorts(): Promise<RawListeningPort[]> {
-  const { stdout } = await runCommand('netstat', ['-ano', '-p', 'tcp'])
+  const { stdout, spawnMs } = await runPortScanCommand('netstat', ['-ano', '-p', 'tcp'])
   const ports = parseNetstatListeningOutput(stdout)
+  if (spawnMs >= STALLED_SPAWN_MS) {
+    return ports
+  }
   const metadata = await loadWindowsProcessMetadata(
     new Set(ports.flatMap((p) => (p.pid ? [p.pid] : [])))
   )
@@ -322,8 +343,8 @@ async function loadDarwinProcessMetadata(pids: Set<number>): Promise<Map<number,
   }
 
   const [cwdOutput, commandOutput] = await Promise.all([
-    runCommand('lsof', ['-a', '-p', pidList, '-d', 'cwd', '-Fn']).catch(() => null),
-    runCommand('ps', ['-p', pidList, '-o', 'pid=', '-o', 'command=']).catch(() => null)
+    runPortScanCommand('lsof', ['-a', '-p', pidList, '-d', 'cwd', '-Fn']).catch(() => null),
+    runPortScanCommand('ps', ['-p', pidList, '-o', 'pid=', '-o', 'command=']).catch(() => null)
   ])
 
   let currentPid: number | null = null
@@ -360,7 +381,7 @@ async function loadWindowsProcessMetadata(
       .filter(Number.isFinite)
       .map((pid) => `ProcessId=${pid}`)
       .join(' OR ')
-    const { stdout } = await runCommand('powershell.exe', [
+    const { stdout } = await runPortScanCommand('powershell.exe', [
       '-NoProfile',
       '-Command',
       `Get-CimInstance Win32_Process -Filter "${pidFilter}" | Select-Object ProcessId,Name,CommandLine | ConvertTo-Json -Compress`
@@ -382,62 +403,8 @@ async function loadWindowsProcessMetadata(
   return result
 }
 
-async function runCommand(command: string, args: string[]): Promise<{ stdout: string }> {
-  return await new Promise((resolve, reject) => {
-    let settled = false
-    let child: ReturnType<typeof execFile> | undefined
-    const timer = setTimeout(() => {
-      if (settled) {
-        return
-      }
-      settled = true
-      child?.kill()
-      reject(new CommandTimeoutError(command, COMMAND_TIMEOUT_MS))
-    }, COMMAND_TIMEOUT_MS)
-
-    const settle = (callback: () => void): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      clearTimeout(timer)
-      callback()
-    }
-
-    // Why: Node's execFile timeout only signals the child; if the callback
-    // never arrives, the workspace port scan would otherwise hang forever.
-    try {
-      child = execFile(
-        command,
-        args,
-        {
-          timeout: COMMAND_TIMEOUT_MS,
-          maxBuffer: 2 * 1024 * 1024,
-          windowsHide: true
-        },
-        (error, stdout) => {
-          if (error) {
-            settle(() => reject(error))
-            return
-          }
-          settle(() => resolve({ stdout: String(stdout) }))
-        }
-      )
-    } catch (error) {
-      settle(() => reject(error))
-    }
-  })
-}
-
-class CommandTimeoutError extends Error {
-  constructor(command: string, timeoutMs: number) {
-    super(`${command} timed out after ${timeoutMs}ms`)
-    this.name = 'CommandTimeoutError'
-  }
-}
-
 function isCommandTimeoutError(error: unknown): boolean {
-  return error instanceof CommandTimeoutError
+  return error instanceof PortScanCommandTimeout
 }
 
 async function readTextIfAvailable(filePath: string): Promise<string | undefined> {

--- a/src/main/ports/port-scan-command-client.test.ts
+++ b/src/main/ports/port-scan-command-client.test.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'node:events'
+import { Worker } from 'node:worker_threads'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_QUEUED_CALLS,
+  PortScanCommandClient,
+  PortScanCommandTimeout,
+  PortScanWorkerUnavailableError
+} from './port-scan-command-client'
+import type { PortScanCommandRequest, PortScanCommandResponse } from './port-scan-command-protocol'
+
+class FakeWorker extends EventEmitter {
+  readonly posted: PortScanCommandRequest[] = []
+  terminated = false
+
+  postMessage(request: PortScanCommandRequest): void {
+    this.posted.push(request)
+  }
+  unref(): void {}
+  terminate(): Promise<number> {
+    this.terminated = true
+    return Promise.resolve(0)
+  }
+  respond(response: PortScanCommandResponse): void {
+    this.emit('message', response)
+  }
+}
+
+function clientWithFakeWorker(callTimeoutMs = 30_000): {
+  client: PortScanCommandClient
+  workers: FakeWorker[]
+} {
+  const workers: FakeWorker[] = []
+  const client = new PortScanCommandClient({
+    workerFactory: () => {
+      const worker = new FakeWorker()
+      workers.push(worker)
+      return worker as unknown as Worker
+    },
+    callTimeoutMs,
+    log: () => {}
+  })
+  return { client, workers }
+}
+
+describe('PortScanCommandClient', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('dispatches one command at a time so a stalled spawn cannot fan out', async () => {
+    const { client, workers } = clientWithFakeWorker()
+
+    const first = client.run('netstat', ['-ano'])
+    const second = client.run('powershell.exe', ['-NoProfile'])
+    await Promise.resolve()
+
+    expect(workers[0].posted).toHaveLength(1)
+    workers[0].respond({ id: workers[0].posted[0].id, ok: true, stdout: 'a', spawnMs: 3 })
+    await expect(first).resolves.toMatchObject({ stdout: 'a' })
+
+    expect(workers[0].posted).toHaveLength(2)
+    workers[0].respond({ id: workers[0].posted[1].id, ok: true, stdout: 'b', spawnMs: 4 })
+    await expect(second).resolves.toMatchObject({ stdout: 'b' })
+  })
+
+  it('ignores responses that do not correlate with the active request', async () => {
+    const { client, workers } = clientWithFakeWorker()
+    const pending = client.run('netstat', [])
+    await Promise.resolve()
+
+    workers[0].respond({ id: 999, ok: true, stdout: 'stale', spawnMs: 1 })
+    workers[0].respond({ id: workers[0].posted[0].id, ok: true, stdout: 'fresh', spawnMs: 1 })
+
+    await expect(pending).resolves.toMatchObject({ stdout: 'fresh' })
+  })
+
+  it('rehydrates a worker-side command timeout so the scan can back off', async () => {
+    const { client, workers } = clientWithFakeWorker()
+    const pending = client.run('lsof', [])
+    await Promise.resolve()
+
+    workers[0].respond({
+      id: workers[0].posted[0].id,
+      ok: false,
+      error: 'lsof timed out after 4000ms',
+      timedOut: true,
+      spawnMs: 2
+    })
+
+    await expect(pending).rejects.toBeInstanceOf(PortScanCommandTimeout)
+  })
+
+  it('reports a worker crash as a non-timeout error and respawns for the next call', async () => {
+    const { client, workers } = clientWithFakeWorker()
+    const first = client.run('lsof', [])
+    await Promise.resolve()
+
+    workers[0].emit('error', new Error('worker died'))
+    await expect(first).rejects.toThrow('worker died')
+    // A crash is not a command timeout: backing off would blame the command.
+    await expect(first.catch((e) => e)).resolves.not.toBeInstanceOf(PortScanCommandTimeout)
+
+    const second = client.run('lsof', [])
+    await Promise.resolve()
+    expect(workers).toHaveLength(2)
+    workers[1].respond({ id: workers[1].posted[0].id, ok: true, stdout: 'ok', spawnMs: 1 })
+    await expect(second).resolves.toMatchObject({ stdout: 'ok' })
+  })
+
+  it('terminates a silent worker at the call deadline without arming the backoff', async () => {
+    vi.useFakeTimers()
+    const { client, workers } = clientWithFakeWorker(1_000)
+    const pending = client.run('lsof', [])
+    const assertion = expect(pending).rejects.not.toBeInstanceOf(PortScanCommandTimeout)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await assertion
+    expect(workers[0].terminated).toBe(true)
+  })
+
+  it('rejects overflow instead of growing the queue without bound', async () => {
+    const { client } = clientWithFakeWorker()
+    // One dispatched call plus a full queue; the worker never responds.
+    const held = Array.from({ length: MAX_QUEUED_CALLS + 1 }, () => client.run('lsof', []))
+    held.forEach((pending) => pending.catch(() => {}))
+
+    await expect(client.run('lsof', [])).rejects.toThrow('queue is full')
+  })
+
+  it('fails closed instead of spawning the command on this thread', async () => {
+    const client = new PortScanCommandClient({
+      workerFactory: () => {
+        throw new Error('worker entry not found')
+      },
+      log: () => {}
+    })
+
+    await expect(client.run('netstat', [])).rejects.toBeInstanceOf(PortScanWorkerUnavailableError)
+  })
+})
+
+describe('PortScanCommandClient on a real worker thread', () => {
+  // The load-bearing assertion for #11161: a worker that blocks its own thread
+  // inside process creation, exactly as a hooked CreateProcessW does, must not
+  // stall the calling event loop. Reverting to an in-process execFile fails it.
+  const WORKER_SOURCE = `
+    const { parentPort } = require('node:worker_threads')
+    const { execFile } = require('node:child_process')
+    parentPort.on('message', (request) => {
+      const startedAt = Date.now()
+      const until = startedAt + 800
+      while (Date.now() < until) {}
+      execFile(process.execPath, ['-e', '0'], () => {
+        parentPort.postMessage({
+          id: request.id,
+          ok: true,
+          stdout: '',
+          spawnMs: Date.now() - startedAt
+        })
+      })
+    })
+  `
+
+  it('keeps the calling event loop responsive while a spawn stalls', async () => {
+    const client = new PortScanCommandClient({
+      workerFactory: () => new Worker(WORKER_SOURCE, { eval: true }),
+      log: () => {}
+    })
+
+    let maxStallMs = 0
+    let last = Date.now()
+    const monitor = setInterval(() => {
+      const now = Date.now()
+      maxStallMs = Math.max(maxStallMs, now - last - 10)
+      last = now
+    }, 10)
+
+    try {
+      const results = await Promise.all([client.run('netstat', []), client.run('lsof', [])])
+      expect(results[0].spawnMs).toBeGreaterThanOrEqual(700)
+      expect(results[1].spawnMs).toBeGreaterThanOrEqual(700)
+      expect(maxStallMs).toBeLessThan(400)
+    } finally {
+      clearInterval(monitor)
+    }
+  }, 20_000)
+})

--- a/src/main/ports/port-scan-command-client.ts
+++ b/src/main/ports/port-scan-command-client.ts
@@ -1,0 +1,293 @@
+import type { Worker } from 'node:worker_threads'
+import {
+  PORT_SCAN_WORKER_CALL_TIMEOUT_MS,
+  type PortScanCommandRequest,
+  type PortScanCommandResponse
+} from './port-scan-command-protocol'
+
+// Why (#11161): a lazily spawned, unref'd worker owns port-scan process
+// creation so a hooked CreateProcessW cannot stall the main process' event
+// loop (CrBrowserMain). Lifecycle — FIFO one-at-a-time dispatch, per-call
+// deadline from dispatch, respawn-on-fault with a consecutive-death cap, idle
+// teardown, bounded queue, fail-closed — mirrors the client added for #8864 in
+// src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts.
+
+export const IDLE_TEARDOWN_MS = 5 * 60_000
+export const MAX_CONSECUTIVE_DEATHS = 3
+// A scan issues at most two commands and the renderer already guards against
+// overlapping ticks; anything beyond this is pile-up, not backlog.
+export const MAX_QUEUED_CALLS = 8
+
+export type PortScanWorkerFactory = () => Worker
+
+export type PortScanCommandOutcome = {
+  stdout: string
+  spawnMs: number
+}
+
+/** The worker could not be started at all — distinct from a command failure. */
+export class PortScanWorkerUnavailableError extends Error {}
+
+/** The command itself overran its budget on the worker; drives scan backoff. */
+export class PortScanCommandTimeout extends Error {}
+
+type PendingCall = {
+  request: PortScanCommandRequest
+  resolve: (value: PortScanCommandOutcome) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout | null
+}
+
+/**
+ * Main-thread bridge that runs port-scan commands on a persistent worker
+ * thread. Never falls back to spawning on this thread: a build that cannot
+ * provide the worker degrades port scanning rather than reintroducing the
+ * main-thread hang this boundary exists to prevent.
+ */
+export class PortScanCommandClient {
+  private worker: Worker | null = null
+  private active: PendingCall | null = null
+  private queue: PendingCall[] = []
+  private idleTimer: NodeJS.Timeout | null = null
+  private consecutiveDeaths = 0
+  private nextId = 1
+  private loggedWorkerUnavailable = false
+  private cleanupWorkerListeners: (() => void) | null = null
+  private readonly workerFactory: PortScanWorkerFactory
+  private readonly callTimeoutMs: number
+  private readonly log: (message: string) => void
+
+  constructor(options: {
+    workerFactory: PortScanWorkerFactory
+    callTimeoutMs?: number
+    log?: (message: string) => void
+  }) {
+    this.workerFactory = options.workerFactory
+    this.callTimeoutMs = options.callTimeoutMs ?? PORT_SCAN_WORKER_CALL_TIMEOUT_MS
+    this.log = options.log ?? ((message) => console.warn(message))
+  }
+
+  /**
+   * Run one command on the worker and capture stdout.
+   * @param command - Binary to execute.
+   * @param args - Argument vector.
+   * @returns stdout plus how long process creation blocked the worker.
+   * @throws PortScanCommandTimeout when the command overran its budget,
+   *   PortScanWorkerUnavailableError when no worker could be started.
+   */
+  run(command: string, args: readonly string[]): Promise<PortScanCommandOutcome> {
+    return new Promise<PortScanCommandOutcome>((resolve, reject) => {
+      // A fresh burst from full idle is a new scan: clear a death count carried
+      // from an earlier one so the respawn cap cannot drain this scan early.
+      if (!this.active && this.queue.length === 0) {
+        this.consecutiveDeaths = 0
+      }
+      if (this.queue.length >= MAX_QUEUED_CALLS) {
+        reject(new Error('Port scan command queue is full.'))
+        return
+      }
+      this.queue.push({
+        request: { id: this.nextId++, command, args },
+        resolve,
+        reject,
+        timer: null
+      })
+      this.pump()
+    })
+  }
+
+  private pump(): void {
+    if (this.active || this.queue.length === 0) {
+      return
+    }
+    const worker = this.ensureWorker()
+    if (!worker) {
+      this.failQueuedAsUnavailable()
+      return
+    }
+    const call = this.queue.shift()
+    if (!call) {
+      return
+    }
+    this.active = call
+    this.clearIdleTimer()
+    // Deadline starts at dispatch, not enqueue: a queued call must not burn its
+    // budget while an earlier stalled spawn holds the worker.
+    call.timer = setTimeout(() => this.onCallDeadline(call), this.callTimeoutMs)
+    call.timer.unref?.()
+    worker.postMessage(call.request)
+  }
+
+  private ensureWorker(): Worker | null {
+    if (this.worker) {
+      return this.worker
+    }
+    try {
+      const worker = this.workerFactory()
+      const onMessage = (response: PortScanCommandResponse): void => this.onMessage(response)
+      const onError = (error: Error): void => this.onWorkerFault(error)
+      const onExit = (code: number): void => this.onWorkerExit(code)
+      worker.on('message', onMessage)
+      worker.on('error', onError)
+      worker.on('exit', onExit)
+      this.cleanupWorkerListeners = () => {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        worker.off('exit', onExit)
+      }
+      // Never keep the app alive for a port scan.
+      worker.unref?.()
+      this.worker = worker
+      return worker
+    } catch (err) {
+      // Why (#11161): never fall back to execFile on this thread. A missing or
+      // mispackaged worker bundle must degrade port scanning, not restore the
+      // UI freeze this boundary prevents.
+      if (!this.loggedWorkerUnavailable) {
+        this.loggedWorkerUnavailable = true
+        this.log(
+          `[workspace-ports] command worker unavailable; port scanning is disabled. ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        )
+      }
+      return null
+    }
+  }
+
+  private onMessage(response: PortScanCommandResponse): void {
+    const call = this.active
+    if (!call || call.request.id !== response.id) {
+      return
+    }
+    this.consecutiveDeaths = 0
+    if (response.ok) {
+      this.settle(call, () => call.resolve({ stdout: response.stdout, spawnMs: response.spawnMs }))
+    } else {
+      const error = response.timedOut
+        ? new PortScanCommandTimeout(response.error)
+        : new Error(response.error)
+      this.settle(call, () => call.reject(error))
+    }
+    this.afterSettle()
+  }
+
+  private onCallDeadline(call: PendingCall): void {
+    if (this.active !== call) {
+      return
+    }
+    // A worker that is this far past its budget is wedged, not slow. Treat it
+    // as a fault (respawn) rather than a command timeout so the scanner does
+    // not back off for something the command did not do.
+    this.onWorkerFault(
+      new Error(`Port scan command worker did not respond within ${this.callTimeoutMs}ms`)
+    )
+  }
+
+  private onWorkerExit(code: number): void {
+    // A clean self-exit is not a death, but the stale handle must be dropped or
+    // the next dispatch would post into a dead worker and stall to its deadline.
+    if (code === 0 && !this.active && this.queue.length === 0) {
+      this.destroyWorker()
+      return
+    }
+    this.onWorkerFault(new Error(`Port scan command worker exited with code ${code}`))
+  }
+
+  private onWorkerFault(error: Error): void {
+    const failed = this.active
+    this.destroyWorker()
+    this.consecutiveDeaths++
+    if (failed) {
+      this.settle(failed, () => failed.reject(error))
+    }
+    if (this.consecutiveDeaths >= MAX_CONSECUTIVE_DEATHS) {
+      this.drainQueueAfterCrashLoop(error)
+      return
+    }
+    if (this.queue.length > 0) {
+      this.pump()
+    }
+  }
+
+  private drainQueueAfterCrashLoop(error: Error): void {
+    const pending = this.queue
+    this.queue = []
+    this.consecutiveDeaths = 0
+    const drainError = new Error(
+      `Port scan command worker crashed repeatedly (${error.message}); skipping remaining commands`
+    )
+    for (const call of pending) {
+      this.settle(call, () => call.reject(drainError))
+    }
+  }
+
+  private failQueuedAsUnavailable(): void {
+    const pending = this.queue
+    this.queue = []
+    for (const call of pending) {
+      this.settle(call, () =>
+        call.reject(new PortScanWorkerUnavailableError('port scan command worker spawn failed'))
+      )
+    }
+  }
+
+  private settle(call: PendingCall, run: () => void): void {
+    if (call.timer) {
+      clearTimeout(call.timer)
+      call.timer = null
+    }
+    if (this.active === call) {
+      this.active = null
+    }
+    run()
+  }
+
+  private afterSettle(): void {
+    if (this.queue.length > 0) {
+      this.pump()
+    } else {
+      this.scheduleIdleTeardown()
+    }
+  }
+
+  private scheduleIdleTeardown(): void {
+    this.clearIdleTimer()
+    if (!this.worker) {
+      return
+    }
+    // Deliberately far longer than the 30s scan cadence so a visible window
+    // reuses one thread instead of recreating it every tick; in practice this
+    // is the hidden-window teardown.
+    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
+    this.idleTimer.unref?.()
+  }
+
+  private teardownIfIdle(): void {
+    this.idleTimer = null
+    if (this.active || this.queue.length > 0) {
+      return
+    }
+    this.destroyWorker()
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer)
+      this.idleTimer = null
+    }
+  }
+
+  private destroyWorker(): void {
+    this.clearIdleTimer()
+    const worker = this.worker
+    this.worker = null
+    if (!worker) {
+      return
+    }
+    this.cleanupWorkerListeners?.()
+    this.cleanupWorkerListeners = null
+    worker.removeAllListeners()
+    void worker.terminate().catch(() => undefined)
+  }
+}

--- a/src/main/ports/port-scan-command-execution.test.ts
+++ b/src/main/ports/port-scan-command-execution.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  PortScanCommandTimeoutError,
+  runPortScanCommandInProcess
+} from './port-scan-command-execution'
+
+type ExecCallback = (
+  error: (Error & { killed?: boolean; code?: string }) | null,
+  stdout: string
+) => void
+
+function blockCallingThread(ms: number): void {
+  const until = Date.now() + ms
+  while (Date.now() < until) {
+    // Busy-wait: a hooked CreateProcessW holds the thread, it does not yield.
+  }
+}
+
+describe('runPortScanCommandInProcess', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // Regression for #11161. The watchdog used to be armed before execFile, so
+  // time libuv spent inside CreateProcessW was charged to the command and a
+  // healthy command was reported as a timeout.
+  it('does not report a timeout when only process creation was delayed', async () => {
+    const execFileMock = vi.fn((_c: string, _a: string[], _o: unknown, callback: unknown) => {
+      blockCallingThread(4_200)
+      setTimeout(() => (callback as ExecCallback)(null, 'ok'), 5)
+      return { kill: vi.fn() }
+    })
+
+    const result = await runPortScanCommandInProcess('lsof', [], execFileMock as never)
+
+    expect(result.stdout).toBe('ok')
+    expect(result.spawnMs).toBeGreaterThanOrEqual(4_000)
+  })
+
+  it('kills the child and times out when the callback never arrives', async () => {
+    vi.useFakeTimers()
+    const kill = vi.fn()
+    const execFileMock = vi.fn(() => ({ kill }))
+
+    const promise = runPortScanCommandInProcess('lsof', [], execFileMock as never)
+    const assertion = expect(promise).rejects.toBeInstanceOf(PortScanCommandTimeoutError)
+    await vi.advanceTimersByTimeAsync(4_000)
+
+    await assertion
+    expect(kill).toHaveBeenCalled()
+  })
+
+  // Without this, moving the manual watchdog after the spawn would leave the
+  // scanner's backoff unreachable: Node's own timeout kill would surface as a
+  // plain error and never be classified as a timeout.
+  it("classifies Node's own execFile timeout kill as a command timeout", async () => {
+    const execFileMock = vi.fn((_c: string, _a: string[], _o: unknown, callback: unknown) => {
+      const error = Object.assign(new Error('killed'), { killed: true })
+      setTimeout(() => (callback as ExecCallback)(error, ''), 1)
+      return { kill: vi.fn() }
+    })
+
+    await expect(
+      runPortScanCommandInProcess('lsof', [], execFileMock as never)
+    ).rejects.toBeInstanceOf(PortScanCommandTimeoutError)
+  })
+
+  it('does not treat a maxBuffer overflow kill as a command timeout', async () => {
+    const execFileMock = vi.fn((_c: string, _a: string[], _o: unknown, callback: unknown) => {
+      const error = Object.assign(new Error('stdout maxBuffer exceeded'), {
+        killed: true,
+        code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+      })
+      setTimeout(() => (callback as ExecCallback)(error, ''), 1)
+      return { kill: vi.fn() }
+    })
+
+    await expect(
+      runPortScanCommandInProcess('netstat', [], execFileMock as never)
+    ).rejects.not.toBeInstanceOf(PortScanCommandTimeoutError)
+  })
+
+  it('leaves a genuine command failure unclassified so the scan does not back off', async () => {
+    const execFileMock = vi.fn((_c: string, _a: string[], _o: unknown, callback: unknown) => {
+      setTimeout(() => (callback as ExecCallback)(new Error('ENOENT'), ''), 1)
+      return { kill: vi.fn() }
+    })
+
+    await expect(
+      runPortScanCommandInProcess('lsof', [], execFileMock as never)
+    ).rejects.not.toBeInstanceOf(PortScanCommandTimeoutError)
+  })
+})

--- a/src/main/ports/port-scan-command-execution.ts
+++ b/src/main/ports/port-scan-command-execution.ts
@@ -1,0 +1,122 @@
+import { execFile, type ExecFileException } from 'node:child_process'
+import {
+  PORT_SCAN_COMMAND_TIMEOUT_MS,
+  PORT_SCAN_MAX_BUFFER_BYTES
+} from './port-scan-command-protocol'
+
+// Why (#11161): this is the only place that spawns a port-scan command, and it
+// is meant to run on a worker thread. libuv performs process creation inline on
+// the calling loop, so hosting it on the main process' loop is what froze the
+// UI when an endpoint-security module hooked CreateProcessW.
+
+export class PortScanCommandTimeoutError extends Error {
+  constructor(command: string, timeoutMs: number) {
+    super(`${command} timed out after ${timeoutMs}ms`)
+    this.name = 'PortScanCommandTimeoutError'
+  }
+}
+
+export type PortScanCommandResult = {
+  stdout: string
+  // How long the execFile call itself held the calling thread. On a healthy
+  // host this is single-digit ms; a hooked CreateProcessW pushes it to seconds.
+  spawnMs: number
+}
+
+type ExecFileImpl = typeof execFile
+
+// Node kills the child itself when `options.timeout` elapses, surfacing as an
+// error carrying the kill. That must still be classified as a command timeout,
+// otherwise moving the manual watchdog after the spawn (below) would leave the
+// scanner's backoff unreachable. maxBuffer overflow also kills the child, so it
+// is excluded — that is a command that produced too much output, not a hang.
+function isTimeoutKill(error: ExecFileException): boolean {
+  if (error.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+    return false
+  }
+  return error.killed === true
+}
+
+/**
+ * Run one port-scan command and capture stdout.
+ * @param command - Binary to execute (never a shell).
+ * @param args - Argument vector, passed through untouched.
+ * @param execFileImpl - Seam for tests.
+ * @returns stdout plus the synchronous cost of creating the process.
+ * @throws PortScanCommandTimeoutError when the command itself overruns its
+ *   budget; other spawn/exec failures reject with the underlying error.
+ */
+export async function runPortScanCommandInProcess(
+  command: string,
+  args: readonly string[],
+  execFileImpl: ExecFileImpl = execFile
+): Promise<PortScanCommandResult> {
+  const spawnStartedAt = Date.now()
+  let spawnReturnedAt: number | null = null
+  // A synchronous callback (only reachable from a test double) has no spawn
+  // return to measure against, so fall back to elapsed time at settle.
+  const spawnMs = (): number => (spawnReturnedAt ?? Date.now()) - spawnStartedAt
+
+  return await new Promise<PortScanCommandResult>((resolve, reject) => {
+    let settled = false
+    let timer: NodeJS.Timeout | null = null
+    let child: ReturnType<ExecFileImpl> | undefined
+
+    const settle = (run: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      run()
+    }
+
+    try {
+      child = execFileImpl(
+        command,
+        args as string[],
+        {
+          timeout: PORT_SCAN_COMMAND_TIMEOUT_MS,
+          maxBuffer: PORT_SCAN_MAX_BUFFER_BYTES,
+          windowsHide: true
+        },
+        (error, stdout) => {
+          if (error) {
+            settle(() =>
+              reject(
+                isTimeoutKill(error)
+                  ? new PortScanCommandTimeoutError(command, PORT_SCAN_COMMAND_TIMEOUT_MS)
+                  : error
+              )
+            )
+            return
+          }
+          settle(() => resolve({ stdout: String(stdout), spawnMs: spawnMs() }))
+        }
+      )
+    } catch (error) {
+      settle(() => reject(error))
+      return
+    }
+
+    spawnReturnedAt = Date.now()
+    // Why (#11161): arm the watchdog only once execFile has returned. Armed
+    // before the call, it also counted the time libuv spent inside
+    // CreateProcessW, so a delayed spawn was misreported as a command timeout
+    // and tripped the scanner's 60s-5min backoff for a command that never ran.
+    // Node's own options.timeout is the primary killer; this covers the case
+    // where the callback never arrives at all.
+    if (!settled) {
+      timer = setTimeout(() => {
+        settle(() => {
+          child?.kill()
+          reject(new PortScanCommandTimeoutError(command, PORT_SCAN_COMMAND_TIMEOUT_MS))
+        })
+      }, PORT_SCAN_COMMAND_TIMEOUT_MS)
+      timer.unref?.()
+    }
+  })
+}

--- a/src/main/ports/port-scan-command-import-boundary.test.ts
+++ b/src/main/ports/port-scan-command-import-boundary.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why (#11161): the whole fix is that no port-scan spawn runs on the main
+// process' event loop. That is a property of the import graph, so assert it
+// directly — a future edit that reaches for execFile here would silently
+// restore the UI freeze without failing any behavioural test.
+
+const CHILD_PROCESS_IMPORT =
+  /from\s+['"](node:)?child_process['"]|require\(\s*['"](node:)?child_process['"]/
+const ELECTRON_IMPORT = /from\s+['"]electron['"]|require\(\s*['"]electron['"]/
+
+// Comments in these files legitimately name the modules they must not import,
+// so strip comments before matching.
+function sourceOf(fileName: string): string {
+  return readFileSync(join(__dirname, fileName), 'utf-8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+}
+
+describe('port scan main-thread spawn boundary', () => {
+  it('keeps local-workspace-port-scanner.ts free of child_process', () => {
+    expect(CHILD_PROCESS_IMPORT.test(sourceOf('local-workspace-port-scanner.ts'))).toBe(false)
+  })
+
+  it('keeps port-scan-command-client.ts free of child_process', () => {
+    expect(CHILD_PROCESS_IMPORT.test(sourceOf('port-scan-command-client.ts'))).toBe(false)
+  })
+
+  it('keeps the worker entry free of electron', () => {
+    expect(ELECTRON_IMPORT.test(sourceOf('port-scan-command-worker-entry.ts'))).toBe(false)
+    expect(ELECTRON_IMPORT.test(sourceOf('port-scan-command-execution.ts'))).toBe(false)
+  })
+})

--- a/src/main/ports/port-scan-command-protocol.ts
+++ b/src/main/ports/port-scan-command-protocol.ts
@@ -1,0 +1,22 @@
+// Why: request/response shapes shared by the port-scan worker entry and its
+// main-thread client. Kept type-only and Electron-free so importing it into the
+// worker bundle cannot drag Electron across the thread boundary.
+
+export const PORT_SCAN_COMMAND_TIMEOUT_MS = 4_000
+export const PORT_SCAN_MAX_BUFFER_BYTES = 2 * 1024 * 1024
+
+// The client's own deadline must outlast the command budget: on a host that
+// hooks process creation the worker is stuck in uv_spawn long before the
+// command itself starts, and killing the worker for that would discard a scan
+// that is about to succeed.
+export const PORT_SCAN_WORKER_CALL_TIMEOUT_MS = 30_000
+
+export type PortScanCommandRequest = {
+  id: number
+  command: string
+  args: readonly string[]
+}
+
+export type PortScanCommandResponse =
+  | { id: number; ok: true; stdout: string; spawnMs: number }
+  | { id: number; ok: false; error: string; timedOut: boolean; spawnMs: number }

--- a/src/main/ports/port-scan-command-worker-entry.ts
+++ b/src/main/ports/port-scan-command-worker-entry.ts
@@ -1,0 +1,34 @@
+import { parentPort } from 'node:worker_threads'
+import {
+  PortScanCommandTimeoutError,
+  runPortScanCommandInProcess
+} from './port-scan-command-execution'
+import type { PortScanCommandRequest, PortScanCommandResponse } from './port-scan-command-protocol'
+
+// Why (#11161): owns every port-scan spawn so the hooked CreateProcessW stalls
+// this thread instead of CrBrowserMain. Must stay Electron-free — a worker
+// thread cannot require('electron').
+
+const port = parentPort
+if (port) {
+  port.on('message', (request: PortScanCommandRequest) => {
+    void handle(request).then((response) => port.postMessage(response))
+  })
+}
+
+async function handle(request: PortScanCommandRequest): Promise<PortScanCommandResponse> {
+  try {
+    const { stdout, spawnMs } = await runPortScanCommandInProcess(request.command, request.args)
+    return { id: request.id, ok: true, stdout, spawnMs }
+  } catch (error) {
+    return {
+      id: request.id,
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      timedOut: error instanceof PortScanCommandTimeoutError,
+      // The stall is the diagnostically interesting part of a failure here, but
+      // it is unknown once the call threw, so report it as unmeasured.
+      spawnMs: 0
+    }
+  }
+}

--- a/src/main/ports/port-scan-command-worker-spawn.ts
+++ b/src/main/ports/port-scan-command-worker-spawn.ts
@@ -1,0 +1,58 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { PortScanCommandClient, type PortScanCommandOutcome } from './port-scan-command-client'
+
+// Why: resolves the built worker entry and owns the process-wide client, so the
+// client class stays Electron-free (electron is require'd lazily here) and the
+// scanner depends only on runPortScanCommand below. Mirrors
+// session-scanner-opencode-sqlite-worker-spawn.ts.
+
+function resolveWorkerEntryPath(): string {
+  let app: { isPackaged: boolean } | null = null
+  try {
+    app = require('electron').app ?? null
+  } catch {
+    app = null
+  }
+  if (app?.isPackaged) {
+    return join(
+      process.resourcesPath,
+      'app.asar',
+      'out',
+      'main',
+      'port-scan-command-worker-entry.js'
+    )
+  }
+  return join(__dirname, 'port-scan-command-worker-entry.js')
+}
+
+function defaultWorkerFactory(): Worker {
+  const workerPath = resolveWorkerEntryPath()
+  // A missing built entry must throw synchronously so the client can fail
+  // closed instead of waiting on a worker that can never post a result.
+  if (!existsSync(workerPath)) {
+    throw new Error(`Port scan command worker entry not found: ${workerPath}`)
+  }
+  return new Worker(workerPath, { name: 'orca-port-scan-command' })
+}
+
+let sharedClient: PortScanCommandClient | null = null
+
+function getSharedClient(): PortScanCommandClient {
+  sharedClient ??= new PortScanCommandClient({ workerFactory: defaultWorkerFactory })
+  return sharedClient
+}
+
+/**
+ * Run one port-scan command off the main thread.
+ * @param command - Binary to execute (never a shell).
+ * @param args - Argument vector.
+ * @returns stdout plus how long process creation blocked the worker thread.
+ */
+export function runPortScanCommand(
+  command: string,
+  args: readonly string[]
+): Promise<PortScanCommandOutcome> {
+  return getSharedClient().run(command, args)
+}


### PR DESCRIPTION
## Summary

Orca ran the workspace port scan's probe commands on the Electron main process. libuv performs process creation **inline on the calling event loop**, and in the main process that loop is the browser UI thread (`CrBrowserMain`) — so an "async" `execFile` is only asynchronous *after* the child exists. On the reporter's machine an endpoint-security module hooks `CreateProcessW`, so every scan tick froze the whole window for the duration of the spawn: `netstat -ano -p tcp` plus `powershell.exe -NoProfile -Command Get-CimInstance ...` on Windows, `lsof`/`ps` on macOS, every 30 s. That is exactly the stack in the reporter's hang dump (`CrBrowserMain` → injected module → `KERNELBASE!CreateProcessInternalW` → `Orca!uv_spawn`).

The same stall also produced a **false diagnosis**. The 4 s command watchdog was armed at `local-workspace-port-scanner.ts:389` *before* `execFile` at `:410`, so by the time control returned from the blocking spawn the deadline had already passed and the timer fired immediately. `child.kill()` ran and a `CommandTimeoutError` was raised for a command that never got to run, which fed `commandTimeoutBackoff.recordTimeout()` and surfaced the reporter's "Port scanning is temporarily paused after a command timeout" banner. Their own out-of-band `netstat` runs averaged 0.446 s — the entire 4 s budget was consumed inside the spawn.

Now:

- Probe commands run on a lazily created, `unref`'d worker thread (`port-scan-command-worker-entry.ts`), so the hooked `CreateProcessW` stalls that thread and the UI keeps painting. The client (`port-scan-command-client.ts`) mirrors the `OpenCodeSqliteWorkerClient` lifecycle introduced for the same class of bug in #8864: FIFO one-at-a-time dispatch, per-call deadline armed at dispatch, respawn-on-fault with a consecutive-death cap, idle teardown, bounded queue, and fail-closed (it never falls back to in-process `execFile`).
- The manual watchdog is armed only *after* `execFile` returns (`port-scan-command-execution.ts`), so it measures the command instead of the spawn. Node's own `options.timeout` stays the primary killer, and its kill shape (`killed: true`) is now classified as a command timeout — without that, moving the watchdog later would have silently made `commandTimeoutBackoff.recordTimeout()` unreachable in production. A `maxBuffer` overflow kill is explicitly excluded, since that is too much output, not a hang.
- A scan whose primary probe reports `spawnMs >= 2000` skips its optional metadata commands for that cycle, capping a hooked host at roughly one stall per scan instead of two.

Closes #11161

## ELI5

Some company laptops run security software that inspects every new program before it is allowed to start. Orca checks which ports your projects are using every 30 seconds by starting a couple of small system programs, and it was doing that on the same thread that draws the window — so while the security software was thinking, the whole app sat frozen. Worse, Orca started its own four-second stopwatch *before* the program had even launched, so it concluded the program had hung and switched port scanning off with a "temporarily paused" message. Now those little programs are started on a separate background thread, and the stopwatch starts when the program actually starts. The window stays responsive, and the pause message only appears when a command genuinely hangs.

## Reproduction

I could reproduce the field condition without any endpoint-security software by putting an unreachable UNC path first on `PATH`. Windows' SMB resolution then blocks *inside* process creation for ~21 s, which is the same shape as a hooked `CreateProcessW` — a delay in the spawn, not in the command.

Baseline, `child_process.spawn` (the async API) called on the loop:

```
┌──────────────────────────────┬─────────────────┬─────────────┬──────────┐
│ label                        │ syncSpawnCallMs │ loopStallMs │ exitCode │
├──────────────────────────────┼─────────────────┼─────────────┼──────────┤
│ 'baseline PATH'              │ 4.3             │ 5           │ 0        │
│ 'slow PATH (dead UNC first)' │ 21039.5         │ 21034.6     │ 0        │
└──────────────────────────────┴─────────────────┴─────────────┴──────────┘
```

21 s of that is a hard event-loop stall — the async API is synchronous through `uv_spawn`.

At the code level, a repro test driving `scanWorkspacePorts` with an `execFile` double that blocks the calling thread for 4200 ms and then completes the command healthily 5 ms later failed on `main` in both of the ways the reporter described:

```
AssertionError: expected 4190 to be less than 500          ← the UI freeze
AssertionError: expected 'Port scanning is unavailable on darwin.' to be undefined   ← the false timeout
```

## Fix proof

The load-bearing check drives the **built, shipped artifact** — `out/main/port-scan-command-worker-entry.js` in a real `Worker` — against that real 21 s `CreateProcessW` delay, and measures the calling loop:

```
poisoned PATH head: \\192.0.2.123\orca-repro;C:\Users\...
{
  "ok": true,
  "workerReportedSpawnMs": 21037,
  "stdoutBytes": 13219,
  "callerMaxLoopStallMs": 22,
  "totalMs": 21081
}
```

All three failure modes are gone at once: process creation really did block for 21 s, the calling loop's worst stall was **22 ms**, and the command **succeeded** (13 KB of real `netstat` output) instead of being killed and reported as a timeout. `spawnMs` of 21037 also trips the metadata-skip guard, so the follow-up `powershell.exe` spawn is not issued that cycle.

The repro was converted into permanent regression tests rather than kept under a bug-numbered name: its blocking-`execFile` mechanism now gates watchdog ordering in `port-scan-command-execution.test.ts`, its event-loop-stall assertion is re-armed against a **real worker thread running a real spawn** in `port-scan-command-client.test.ts`, and its "no false timeout" assertion lives in `local-workspace-port-scanner.test.ts`.

```
$ npx vitest run --config config/vitest.config.ts src/main/ports
 Test Files  7 passed (7)
      Tests  101 passed (101)
```

I verified the real-worker assertion actually discriminates: running the identical workload (2 × 800 ms of blocking + a real spawn) on the calling thread instead measures a stall of `> 400 ms` and fails the same bound, while routing it through the client keeps it under. An import-boundary test additionally fails if `local-workspace-port-scanner.ts` or the client ever reaches for `child_process` again — the fix is a property of the import graph, and a behavioural test alone would not catch its removal.

## No regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/ports                    → 7 files, 101 tests passed
$ npx vitest run ... src/main/ipc/workspace-ports.test.ts \
    src/main/runtime/rpc/methods/workspace-ports.test.ts \
    src/relay/port-scan-handler.test.ts src/relay/windows-port-scan.test.ts          → 4 files,  32 tests passed
$ npx vitest run ... WorkspacePortScanner.test.tsx PortsPanel.test.tsx              → 2 files,  33 tests passed

$ npx tsc --noEmit -p config/tsconfig.node.json                                      → clean
$ npx oxlint src/main/ports/                                                         → clean
$ npx oxlint --config config/oxlint-code-quality-native-plugins.json src/main/ports --deny-warnings   → clean
$ npx oxlint --type-aware --config config/oxlint-code-quality-type-aware.json src/main/ports --deny-warnings → clean
$ npx oxfmt --check src/main/ports/ electron.vite.config.ts                          → all formatted
$ node config/scripts/check-reliability-gates.mjs                                    → 62 gates passed
$ node config/scripts/check-max-lines-ratchet.mjs                                    → OK, no new bypasses
$ npx electron-vite build                                                            → built; worker entry emitted, 0 electron requires
```

**Trade-offs** — this is not free:

1. **On a hooked host a scan now takes as long as the stall instead of failing fast at 4 s.** The Ports panel shows its existing refreshing state for longer rather than going blank with a paused banner. Bounded by the metadata-skip guard and by a 30 s per-command client deadline.
2. **On a hooked host, process name / cwd attribution is dropped for that cycle**, so some workspace ports render as `external` for one scan. This is the same degradation those best-effort calls already produced on error, and it recovers on the next healthy scan.
3. **If the built worker entry cannot be loaded (corrupt or mispackaged build), port scanning reports unavailable AND localhost worktree labels stop registering**, because `src/main/ipc/localhost-worktree-labels.ts:45` uses a scan as its SSRF allowlist and fails closed. This is the deliberate fail-closed policy from #8864 (never silently move spawning back onto the UI thread), guarded by the vite input registration, an `existsSync` fail-fast, and a one-shot log line — but it disables a second feature, so it is stated rather than buried.
4. **A host whose spawn exceeds the 30 s client deadline** loses that scan and respawns the worker. It is reported as a worker fault, not a command timeout, so it does not arm the backoff; the next tick retries.

On a healthy host the added cost is ~1–2 ms per scan.

## Screenshots

No visual change. The renderer contract is byte-identical — `unavailableReason` strings and scan return shapes are unchanged.

## Testing

- [x] `pnpm lint` (oxlint native + type-aware, oxfmt, reliability gates, max-lines ratchet — all run on the changed surface)
- [x] `pnpm typecheck` (`tsconfig.node.json`)
- [x] `pnpm test` (every suite in the touched directory plus every suite importing what changed)
- [x] `pnpm build` (`electron-vite build`; new worker entry emitted and verified electron-free)
- [x] Added regression tests that would catch this specific regression, including one that drives a **real** worker thread with a **real** spawn, and an import-boundary test that fails if spawning moves back to the main thread

## AI Review Report

Reviewed for correctness, lifecycle, and platform risk. What it checked and what changed as a result:

- **The watchdog reorder silently disabling backoff.** Moving the manual timer after `execFile` means Node's own `options.timeout` usually wins the race. Node surfaces that as a plain error with `killed: true`, which the old code did not classify — so `recordTimeout()` would have become unreachable in production while tests still passed. Fixed by classifying the kill shape, and covered by a dedicated test. `maxBuffer` overflow (also a kill) is excluded so a chatty command is not mistaken for a hang.
- **Concurrent dispatch re-creating the same bug one level down.** `uv_spawn` blocks the *worker's* loop too, so a second in-flight request would have its deadline armed while the first spawn is still stalling the thread. The client dispatches strictly FIFO and arms each deadline at dispatch, not at enqueue.
- **Worker lifecycle faults**: crash mid-request, silent worker, clean self-exit leaving a stale handle, crash-loop, and queue overflow are each covered by a test. A crash is deliberately *not* reported as a command timeout — backing off would blame the command for the worker's failure.
- **Cross-platform, explicitly checked for macOS, Linux, and Windows.** **Windows** (the reported platform) changes materially and for the better: `netstat -ano -p tcp` and `powershell.exe -NoProfile -Command Get-CimInstance ...` move to the worker with identical argv and `windowsHide: true`, so `CreateProcessW` PATH/PATHEXT resolution and quoting are unchanged; `powershell.exe` is the single most expensive spawn for an EDR to inspect (AMSI + script-block logging) and it is no longer on the UI thread. **macOS** gets the same for `lsof` and `ps`. **Linux** reads `/proc` directly and spawns nothing, so it only inherits the corrected timeout semantics. Worker path resolution uses `node:path` `join` only — no separator assumptions — and mirrors `session-scanner-opencode-sqlite-worker-spawn.ts`, already validated on all three platforms. No native module, so the Ubuntu 20.04 / glibc 2.31 floor is untouched. No keyboard, accelerator, or shortcut-glyph surface is involved.
- **Env snapshot caveat**, recorded deliberately: `new Worker(path)` snapshots `process.env` at creation rather than sharing it, so a worker created before a later main-process `PATH` mutation resolves binaries against the snapshot. All four binaries live on the base system `PATH` on their platforms (System32 on Windows, `/usr/sbin` and `/bin` on macOS), the worker is created lazily on first scan (well after startup `PATH` hydration), and respawn-on-fault refreshes it. `SHARE_ENV` was deliberately not used — it would make env mutation racy across threads for a benefit we do not need.
- **SSH-remote**: unchanged and unreachable from this path. `getStoreWorkspacePortProbes` drops every worktree whose repo carries a `connectionId`, and the renderer routes non-local targets through the relay RPC, where scanning is implemented independently in `src/relay/port-scan-handler.ts` / `src/relay/windows-port-scan.ts` inside the remote daemon. No relay protocol, daemon, or shared-type change. A remote host with its own EDR hook is **not** fixed by this change — that is the relay's separate implementation and is worth a follow-up.
- **Folder workspaces (non-git)**: this path never invokes git, so the Git 2.25 baseline and `GitCapabilityCache` rules do not apply. Probes come from store worktree meta with an explicit `isFolderRepo` branch, and only the resulting path string is used for attribution. Folder workspaces and git worktrees behave identically before and after. No git provider (GitHub/GitLab) surface is involved.
- **Performance**: main-thread CPU strictly decreases — parsing and attribution stay on main, but the spawn syscall leaves it. Steady state adds one lazily created, `unref`'d worker thread (a few MB of V8 heap), created on the first scan, reused across the 30 s cadence, torn down after 5 minutes idle. That interval is deliberately much longer than the cadence so a visible window does not re-create the thread every tick; because the renderer stops the interval when the window is hidden, it is effectively the hidden-window teardown. Thread creation is ~10–20 ms and is never intercepted by a process-creation hook. Per command we add one structured-clone round trip: the request is two short strings, the response is stdout bounded by the existing `maxBuffer: 2 MB` (typical `netstat`/`lsof` output is tens of KB, sub-millisecond to clone). No new polling, no new renderer IPC, no added renders.

## Security Audit

- **Command execution**: same four commands, same argument vectors, still `execFile` (never a shell), still `windowsHide: true`, still `maxBuffer: 2 MB`. The only change is which thread issues the spawn. Arguments are built from PIDs already filtered through `Number.isFinite` before interpolation, exactly as before.
- **IPC**: no renderer-facing IPC channel, payload, or handler changed. The worker channel is an in-process `MessagePort` between the main process and its own thread; the request is `{ id, command, args }` originating entirely from this module's own constants, never from renderer input.
- **Path handling**: the worker entry path is resolved with `node:path` `join` from `process.resourcesPath`/`__dirname` and validated with `existsSync` before use. No user-controlled path enters it.
- **Auth / secrets / dependencies**: no change. No new dependencies.
- One behavioural note with a security dimension: `src/main/ipc/localhost-worktree-labels.ts:45` uses a scan as its SSRF allowlist. This change makes it *more* conservative, not less — a scan that cannot run yields no ports and every registration is rejected (fail-closed). It never widens the allowlist.
- **Follow-up**: the relay's own port-scan implementation has the same in-loop spawn shape on a remote host. It does not affect the Orca UI, but it is worth the same treatment.

## Notes

- Platform-specific behaviour, env-snapshot semantics, the fail-closed consequence for localhost worktree labels, and the relay follow-up are all called out above.

Made with [Orca](https://github.com/stablyai/orca) 🐋
