### PR TITLE
fix(terminal): clear stale Windows IME modifiers

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
@@ -274,4 +274,39 @@ describe('Windows IME keyboard ownership', () => {
     hook.unmount()
     harness.dispose()
   })
+
+  it('clears held Shift when an IME-consumed keyup reports Process', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Shift',
+        code: 'ShiftLeft',
+        keyCode: 16,
+        timeStamp: 1,
+        shiftKey: true
+      })
+    )
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Process',
+        code: 'ShiftLeft',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true
+      })
+    )
+    const enter = keyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+      timeStamp: 20
+    })
+
+    harness.terminalInput.dispatchEvent(enter)
+
+    expect(enter.defaultPrevented).toBe(false)
+    hook.unmount()
+    harness.dispose()
+  })
 })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -280,6 +280,25 @@ export function useTerminalKeyboardShortcuts({
     const nativeOnlyShortcutTracker = createTerminalNativeOnlyShortcutTracker()
     const deferredNewlineSender = createTerminalImeDeferredNewlineSender()
     const modifiedEnterChordOwner = createTerminalImeModifiedEnterChordOwner()
+    const reconcileHeldImeEnterModifiers = (
+      event: KeyboardEvent,
+      preserveModifierLostRedispatch = false
+    ): void => {
+      if (heldImeEnterModifiers.size === 0) {
+        return
+      }
+      for (const [kind, pressed] of [
+        ['shift', event.getModifierState('Shift')],
+        ['ctrl', event.getModifierState('Control')]
+      ] as const) {
+        const belongsToActiveChord =
+          preserveModifierLostRedispatch &&
+          modifiedEnterChordOwner.absorb({ kind, code: event.code, timeStamp: event.timeStamp })
+        if (!pressed && !belongsToActiveChord && heldImeEnterModifiers.delete(kind)) {
+          modifiedEnterChordOwner.release({ kind, code: event.code, timeStamp: event.timeStamp })
+        }
+      }
+    }
     const getHeldImeEnterModifier = () =>
       heldImeEnterModifiers.size === 1
         ? (heldImeEnterModifiers.values().next().value ?? null)
@@ -296,6 +315,7 @@ export function useTerminalKeyboardShortcuts({
       return kind ? { kind, code: event.code, timeStamp: event.timeStamp } : null
     }
     const onModifierDown = (e: KeyboardEvent): void => {
+      reconcileHeldImeEnterModifiers(e, e.key === 'Enter' && e.keyCode === 13)
       if (e.key === 'Alt') {
         optionKeyLocation = e.location
       }
@@ -451,6 +471,7 @@ export function useTerminalKeyboardShortcuts({
           deferredNewlineSender.absorbRedispatchedEnter(e))
       ) {
         // Chromium can drop the modifier when re-dispatching the committing Enter.
+        reconcileHeldImeEnterModifiers(e)
         e.preventDefault()
         e.stopImmediatePropagation()
         return
@@ -736,6 +757,9 @@ export function useTerminalKeyboardShortcuts({
     }
 
     const onKeyUp = (e: KeyboardEvent): void => {
+      if (!isTerminalImeEnterKeyUp(e)) {
+        reconcileHeldImeEnterModifiers(e)
+      }
       if (e.key === 'Alt') {
         optionKeyLocation = 0
       }


### PR DESCRIPTION
## Summary

- Reconcile remembered Windows IME Shift/Ctrl ownership from `KeyboardEvent.getModifierState()` on keyboard events.
- Clear modifiers released as Chromium IME `Process` keyups while preserving the modifier-lost Enter redispatch used by active composition chords.
- Add regression coverage for a Korean IME-consumed Shift keyup followed by bare Enter.

Fixes #12256

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck:web`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx` (38 tests)
- [x] Formatting, direct Oxlint quality/type-aware/React Doctor scans, diff check, and max-lines ratchet

`check:code-quality:changed` encountered a Windows Node 24 `spawnSync pnpm.cmd EINVAL`; each of its three Oxlint scans was run directly and passed.

## AI Review Report

Reviewed modifier lifecycle, Chromium's modifier-lost composition Enter redispatch, editable-target scoping, and the existing Shift/Ctrl rollover behavior. The initial unconditional synchronization approach would have broken legitimate composition redispatches, so reconciliation preserves only an Enter owned by the active chord and clears it immediately after absorption.

Cross-platform review confirmed the new behavior remains gated by the existing Windows-only modifier state: macOS/Linux shortcut handling, labels, paths, shells, SSH/folder workspaces, and Electron host behavior are unchanged.

## Security Audit

No new input sources, command execution, path handling, authentication, secrets, dependencies, or IPC are introduced. The change only reconciles renderer-local keyboard state from browser-provided modifier flags.

## Notes

Regression introduced by #11293 (`fe6f929c6e`), which added `heldImeEnterModifiers` and released entries by matching `event.key`; Windows IME `Process` keyups bypass that match.

The reported composition-overlay offset is visually separate and remains out of scope because no shared root cause was identified.