### PR TITLE
fix(chat): preserve browser-owned IME composition

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -14,7 +14,6 @@ const mocks = vi.hoisted(() => ({
   fieldProps: null as {
     onSend?: () => void
     onStop?: () => void
-    onCompositionStart?: () => void
     onCompositionEnd?: (event: { currentTarget: HTMLTextAreaElement }) => void
     sessionOptionsSurface?: SessionOptionsSurface | null
     sessionOptionsSnapshot?: SessionOptionDescriptor[]
@@ -267,7 +266,6 @@ describe('NativeChatComposer', () => {
     mocks.setDraft.mockClear()
 
     act(() => {
-      mocks.fieldProps?.onCompositionStart?.()
       mocks.fieldProps?.onCompositionEnd?.({ currentTarget: textarea })
     })
 

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -102,7 +102,6 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     const [notice, setNotice] = useState<string | null>(null)
     const [dictationPressed, setDictationPressed] = useState(false)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
-    const isComposingRef = useRef(false)
     const { cancelPendingSends, trackPendingSend } = useNativeChatSendLifecycle(
       terminalTabId,
       targetPtyId,
@@ -363,7 +362,6 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       activeSuggestion,
       draft,
       history,
-      isComposing: () => isComposingRef.current,
       completePickerItem: completeItem,
       dispatchPickerCommand,
       dismissPicker: dismiss,
@@ -410,11 +408,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
           setActiveSuggestion(0)
         }}
         onKeyDown={handleKeyDown}
-        onCompositionStart={() => {
-          isComposingRef.current = true
-        }}
         onCompositionEnd={(event) => {
-          isComposingRef.current = false
           if (event.currentTarget.value !== draft) {
             handleDraftChange(event.currentTarget.value, event.currentTarget)
           }

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -4,6 +4,7 @@ import type {
   KeyboardEventHandler,
   RefObject
 } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import { Image as ImageIcon, ImageOff, X } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -38,7 +39,6 @@ export type NativeChatComposerFieldProps = {
   onDraftChange: (value: string, element: HTMLTextAreaElement) => void
   onTextareaSelect: (element: HTMLTextAreaElement) => void
   onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>
-  onCompositionStart: CompositionEventHandler<HTMLTextAreaElement>
   onCompositionEnd: CompositionEventHandler<HTMLTextAreaElement>
   onPaste: ClipboardEventHandler<HTMLTextAreaElement>
   pickerListboxId: string
@@ -80,7 +80,6 @@ export function NativeChatComposerField({
   onDraftChange,
   onTextareaSelect,
   onKeyDown,
-  onCompositionStart,
   onCompositionEnd,
   onPaste,
   pickerListboxId,
@@ -97,6 +96,16 @@ export function NativeChatComposerField({
   sessionOptionsSurface,
   sessionOptionsSnapshot
 }: NativeChatComposerFieldProps): React.JSX.Element {
+  const compositionActiveRef = useRef(false)
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea || compositionActiveRef.current || textarea.value === draft) {
+      return
+    }
+    textarea.value = draft
+  }, [draft, textareaRef])
+
   return (
     <div className="shrink-0 bg-background">
       {/* Extra bottom padding keeps the input box off the window rim. */}
@@ -164,13 +173,18 @@ export function NativeChatComposerField({
             ) : null}
             <textarea
               ref={textareaRef}
-              value={draft}
+              defaultValue={draft}
               disabled={disabled}
               rows={2}
               onChange={(e) => onDraftChange(e.target.value, e.currentTarget)}
               onKeyDown={onKeyDown}
-              onCompositionStart={onCompositionStart}
-              onCompositionEnd={onCompositionEnd}
+              onCompositionStart={() => {
+                compositionActiveRef.current = true
+              }}
+              onCompositionEnd={(event) => {
+                compositionActiveRef.current = false
+                onCompositionEnd(event)
+              }}
               onPaste={onPaste}
               onSelect={(e) => onTextareaSelect(e.currentTarget)}
               aria-expanded={autocomplete.mode === 'slash' || autocomplete.mode === 'skill'}

--- a/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autogrow.test.tsx
@@ -6,7 +6,7 @@
  *  has no layout engine, so real pixel growth is covered by app validation. */
 
 import { createRef } from 'react'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -47,7 +47,6 @@ function renderField(draft: string): HTMLTextAreaElement {
       onDraftChange={vi.fn()}
       onTextareaSelect={vi.fn()}
       onKeyDown={vi.fn()}
-      onCompositionStart={vi.fn()}
       onCompositionEnd={vi.fn()}
       onPaste={vi.fn()}
       pickerListboxId="picker"
@@ -65,6 +64,45 @@ function renderField(draft: string): HTMLTextAreaElement {
     />
   )
   return screen.getByRole('textbox') as HTMLTextAreaElement
+}
+
+function composerField(draft: string, onDraftChange = vi.fn(), onCompositionEnd = vi.fn()) {
+  return (
+    <NativeChatComposerField
+      textareaRef={createRef<HTMLTextAreaElement>()}
+      draft={draft}
+      disabled={false}
+      hasPty
+      canSend
+      autocomplete={{ mode: 'none' }}
+      activeSuggestion={0}
+      notice={null}
+      imageAttachments={[]}
+      sendButtonDisabled={false}
+      isWorking={false}
+      attachDisabled={false}
+      dictationDisabled={false}
+      isDictating={false}
+      isDictationHoldMode={false}
+      onDraftChange={onDraftChange}
+      onTextareaSelect={vi.fn()}
+      onKeyDown={vi.fn()}
+      onCompositionEnd={onCompositionEnd}
+      onPaste={vi.fn()}
+      pickerListboxId="picker"
+      onChoosePickerItem={vi.fn()}
+      onRetrySkills={vi.fn()}
+      onAcceptMention={vi.fn()}
+      onRemoveImageAttachment={vi.fn()}
+      onAttach={vi.fn()}
+      onDictationToggle={vi.fn()}
+      onDictationHoldStart={vi.fn()}
+      onDictationHoldEnd={vi.fn()}
+      onSend={vi.fn()}
+      sessionOptionsSurface={null}
+      sessionOptionsSnapshot={[]}
+    />
+  )
 }
 
 describe('native chat composer autogrow', () => {
@@ -94,5 +132,34 @@ describe('native chat composer autogrow', () => {
     // A JS measure pass writes style.height and only re-measures on the next
     // value change, so a re-wrap from a window/pane resize would strand it.
     expect(renderField('a\n'.repeat(6)).style.height).toBe('')
+  })
+})
+
+describe('native chat composer composition ownership', () => {
+  it('keeps a streaming rerender from overwriting the active browser composition', () => {
+    const onDraftChange = vi.fn()
+    const onCompositionEnd = vi.fn()
+    const view = render(composerField('', onDraftChange, onCompositionEnd))
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.compositionStart(textarea)
+    textarea.value = '한'
+
+    view.rerender(composerField('stale streaming draft', onDraftChange, onCompositionEnd))
+
+    expect(screen.getByRole('textbox')).toBe(textarea)
+    expect(textarea.value).toBe('한')
+    fireEvent.compositionEnd(textarea, { data: '한' })
+    expect(onCompositionEnd).toHaveBeenCalledOnce()
+    expect(onDraftChange).not.toHaveBeenCalled()
+  })
+
+  it('applies an external draft update while the composer is idle', () => {
+    const view = render(composerField('before'))
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    view.rerender(composerField('after'))
+
+    expect(screen.getByRole('textbox')).toBe(textarea)
+    expect(textarea.value).toBe('after')
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-typing-redirect.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-redirect.test.ts
@@ -39,6 +39,7 @@ describe('shouldRedirectNativeChatTyping', () => {
 
   it('does not redirect IME composition or already-handled events', () => {
     expect(shouldRedirectNativeChatTyping(keyEvent({ isComposing: true }))).toBe(false)
+    expect(shouldRedirectNativeChatTyping(keyEvent({ keyCode: 229 }))).toBe(false)
     expect(shouldRedirectNativeChatTyping(keyEvent({ defaultPrevented: true }))).toBe(false)
   })
 

--- a/src/renderer/src/components/native-chat/native-chat-typing-redirect.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-redirect.ts
@@ -1,3 +1,5 @@
+import { isImeOwnedKeyboardEvent } from '@/lib/ime-composition-keyboard-event'
+
 type KeyboardRedirectEvent = {
   key: string
   ctrlKey: boolean
@@ -6,6 +8,7 @@ type KeyboardRedirectEvent = {
   altKey?: boolean
   defaultPrevented: boolean
   isComposing?: boolean
+  keyCode?: number
   target: EventTarget | null
 }
 
@@ -31,7 +34,7 @@ const INTERACTIVE_TARGET_SELECTOR = [
 export function shouldRedirectNativeChatTyping(event: KeyboardRedirectEvent): boolean {
   if (
     event.defaultPrevented ||
-    event.isComposing ||
+    isImeOwnedKeyboardEvent(event) ||
     event.ctrlKey ||
     event.metaKey ||
     event.key.length !== 1
@@ -53,7 +56,7 @@ export function shouldFocusNativeChatPaneFromPointerTarget(target: EventTarget |
 export function shouldFocusNativeChatComposerFromEditingKey(event: KeyboardRedirectEvent): boolean {
   if (
     event.defaultPrevented ||
-    event.isComposing ||
+    isImeOwnedKeyboardEvent(event) ||
     event.ctrlKey ||
     event.metaKey ||
     event.shiftKey ||

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-keydown.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-keydown.test.tsx
@@ -27,7 +27,7 @@ function picker(items = [COMMAND]): Extract<ComposerAutocomplete, { mode: 'slash
   }
 }
 
-function setup(autocomplete: ComposerAutocomplete = picker(), composing = false) {
+function setup(autocomplete: ComposerAutocomplete = picker()) {
   const callbacks = {
     completePickerItem: vi.fn(),
     dispatchPickerCommand: vi.fn(),
@@ -45,19 +45,21 @@ function setup(autocomplete: ComposerAutocomplete = picker(), composing = false)
       activeSuggestion: 0,
       draft: '/',
       history: EMPTY_HISTORY,
-      isComposing: () => composing,
       ...callbacks
     })
   )
   return { handler: hook.result.current, callbacks }
 }
 
-function keyEvent(key: string, isComposing = false) {
+function keyEvent(
+  key: string,
+  { isComposing = false, keyCode = 0 }: { isComposing?: boolean; keyCode?: number } = {}
+) {
   return {
     key,
     shiftKey: false,
-    keyCode: isComposing ? 229 : 0,
-    nativeEvent: { isComposing },
+    keyCode,
+    nativeEvent: { isComposing, keyCode },
     preventDefault: vi.fn()
   }
 }
@@ -89,11 +91,24 @@ describe('useNativeChatComposerKeyDown', () => {
   })
 
   it('does not accept or submit while IME composition is active', () => {
-    const { handler, callbacks } = setup(picker(), true)
-    const event = keyEvent('Enter', true)
+    const { handler, callbacks } = setup()
+    const event = keyEvent('Enter', { isComposing: true, keyCode: 13 })
     handler(event as never)
-    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(event.preventDefault).not.toHaveBeenCalled()
     expect(callbacks.dispatchPickerCommand).not.toHaveBeenCalled()
     expect(callbacks.send).not.toHaveBeenCalled()
+  })
+
+  it('ignores the recorded macOS IME Enter before handling its ordinary redispatch', () => {
+    const { handler, callbacks } = setup()
+    const compositionEnter = keyEvent('Enter', { isComposing: true, keyCode: 229 })
+    handler(compositionEnter as never)
+    expect(compositionEnter.preventDefault).not.toHaveBeenCalled()
+    expect(callbacks.dispatchPickerCommand).not.toHaveBeenCalled()
+    expect(callbacks.send).not.toHaveBeenCalled()
+
+    const ordinaryRedispatch = keyEvent('Enter', { keyCode: 13 })
+    handler(ordinaryRedispatch as never)
+    expect(callbacks.dispatchPickerCommand).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-keydown.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-keydown.ts
@@ -1,4 +1,5 @@
 import { useCallback, type Dispatch, type KeyboardEventHandler, type SetStateAction } from 'react'
+import { isImeOwnedKeyboardEvent } from '@/lib/ime-composition-keyboard-event'
 import {
   recallNext,
   recallPrevious,
@@ -12,7 +13,6 @@ export type UseNativeChatComposerKeyDownArgs = {
   activeSuggestion: number
   draft: string
   history: HistoryState
-  isComposing: () => boolean
   completePickerItem: (item: NativeChatPickerItem) => void
   dispatchPickerCommand: (item: Extract<NativeChatPickerItem, { kind: 'command' }>) => void
   dismissPicker: (triggerKey: string) => void
@@ -29,7 +29,6 @@ export function useNativeChatComposerKeyDown({
   activeSuggestion,
   draft,
   history,
-  isComposing,
   completePickerItem,
   dispatchPickerCommand,
   dismissPicker,
@@ -42,12 +41,7 @@ export function useNativeChatComposerKeyDown({
 }: UseNativeChatComposerKeyDownArgs): KeyboardEventHandler<HTMLTextAreaElement> {
   return useCallback(
     (event) => {
-      if (isComposing() || event.nativeEvent.isComposing || event.keyCode === 229) {
-        // Why: IME Enter confirms composition; allowing it to fall through
-        // would accept a picker row or submit a partial draft.
-        if (event.key === 'Enter') {
-          event.preventDefault()
-        }
+      if (isImeOwnedKeyboardEvent(event)) {
         return
       }
 
@@ -119,7 +113,6 @@ export function useNativeChatComposerKeyDown({
       draft,
       history,
       interrupt,
-      isComposing,
       send,
       setActiveSuggestion,
       setCaret,

--- a/src/renderer/src/components/native-chat/use-native-chat-font-scale.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-font-scale.ts
@@ -6,6 +6,7 @@ import {
   increaseChatFontScale
 } from './native-chat-font-scale'
 import { isMacPlatform } from './native-chat-shortcut'
+import { isImeOwnedKeyboardEvent } from '@/lib/ime-composition-keyboard-event'
 
 export type ChatFontScaleControls = {
   /** Current chat text scale (1 = default). Apply as a font-size multiplier. */
@@ -35,6 +36,9 @@ export function useNativeChatFontScale(enabled: boolean): ChatFontScaleControls 
     }
     const isMac = isMacPlatform()
     const onKeyDown = (e: KeyboardEvent): void => {
+      if (isImeOwnedKeyboardEvent(e)) {
+        return
+      }
       const action = chatFontScaleActionForEvent(e, isMac)
       if (!action) {
         return

--- a/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
@@ -11,6 +11,7 @@ import {
   isNativeChatTabWideFallbackSafe,
   resolveNativeChatActiveLayoutLeafId
 } from './native-chat-leaf-routing'
+import { isImeOwnedKeyboardEvent } from '@/lib/ime-composition-keyboard-event'
 
 export function resolveNativeChatToggleShortcutDetectedAgent({
   terminalTabId,
@@ -46,7 +47,7 @@ export function useNativeChatToggleShortcut(worktreeId: string, isWorktreeActive
     }
     const isMac = isMacPlatform()
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.repeat || !matchesNativeChatToggleShortcut(e, isMac)) {
+      if (isImeOwnedKeyboardEvent(e) || e.repeat || !matchesNativeChatToggleShortcut(e, isMac)) {
         return
       }
       const state = useAppStore.getState()

--- a/tests/e2e/native-chat-first-flush-race.spec.ts
+++ b/tests/e2e/native-chat-first-flush-race.spec.ts
@@ -1,15 +1,96 @@
 import { randomUUID } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
-import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
+import {
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
 import type { GlobalSettings } from '../../src/shared/types'
 
 const LOADING_TITLE = 'Loading conversation…'
 const ERROR_TITLE = 'Could not load conversation'
+const TWO_SET_KOREAN_ID = 'com.apple.inputmethod.Korean.2SetKorean'
+
+function typeNativeKeys(processId: number, keyCodes: readonly number[]): void {
+  execFileSync('osascript', [
+    '-e',
+    `tell application "System Events" to set frontmost of first application process whose unix id is ${processId} to true`,
+    '-e',
+    'tell application "System Events"',
+    '-e',
+    `repeat with currentKeyCode in {${keyCodes.join(', ')}}`,
+    '-e',
+    'key code (currentKeyCode as integer)',
+    '-e',
+    'delay 0.08',
+    '-e',
+    'end repeat',
+    '-e',
+    'end tell'
+  ])
+}
+
+async function installNativeChatImeTrace(page: Page): Promise<void> {
+  await page.locator('[data-native-chat-root="true"] textarea').evaluate((element) => {
+    const textarea = element as HTMLTextAreaElement
+    textarea.dataset.imeTrace = '[]'
+    const record = (event: Event): void => {
+      const trace = JSON.parse(textarea.dataset.imeTrace ?? '[]') as Record<string, unknown>[]
+      const entry: Record<string, unknown> = {
+        type: event.type,
+        value: textarea.value,
+        selectionStart: textarea.selectionStart,
+        selectionEnd: textarea.selectionEnd
+      }
+      if (event instanceof KeyboardEvent) {
+        Object.assign(entry, {
+          key: event.key,
+          keyCode: event.keyCode,
+          isComposing: event.isComposing
+        })
+      } else if (event instanceof InputEvent) {
+        Object.assign(entry, {
+          data: event.data,
+          inputType: event.inputType,
+          isComposing: event.isComposing
+        })
+      } else if (event instanceof CompositionEvent) {
+        entry.data = event.data
+      }
+      trace.push(entry)
+      textarea.dataset.imeTrace = JSON.stringify(trace)
+    }
+    for (const type of [
+      'keydown',
+      'beforeinput',
+      'compositionstart',
+      'compositionupdate',
+      'input',
+      'compositionend',
+      'keyup'
+    ]) {
+      textarea.addEventListener(type, record, true)
+    }
+  })
+}
+
+async function readNativeChatImeTrace(page: Page): Promise<Record<string, unknown>[]> {
+  return page
+    .locator('[data-native-chat-root="true"] textarea')
+    .evaluate((element) => JSON.parse((element as HTMLTextAreaElement).dataset.imeTrace ?? '[]'))
+}
 
 async function enableNativeChatSetting(page: Page): Promise<void> {
   await page.evaluate(async () => {
@@ -159,6 +240,99 @@ test.describe('Native chat first-flush transcript race (#8401)', () => {
         path: path.join(screenshotDir, '02-hydrated.png')
       })
     } finally {
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+})
+
+test.describe('Native macOS Korean session chat @headful', () => {
+  test.skip(
+    process.platform !== 'darwin' || process.env.ORCA_E2E_NATIVE_MACOS_KOREAN !== '1',
+    'Requires macOS with 2-Set Korean selected and Accessibility access'
+  )
+
+  test('keeps browser composition stable through streaming rerenders and owns only ordinary Enter', async ({
+    electronApp,
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await expect(orcaPage.evaluate(() => window.api.app.getKeyboardInputSourceId())).resolves.toBe(
+      TWO_SET_KOREAN_ID
+    )
+
+    const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const byteReader = createTerminalImeByteReader(testRepoPath, 2)
+    const [tabId] = descriptor.paneKey.split(':')
+    const sessionId = `e2e-native-chat-ime-${randomUUID()}`
+    const scratchDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-native-chat-ime-'))
+    const transcriptPath = path.join(scratchDir, `${sessionId}.jsonl`)
+    writeFileSync(
+      transcriptPath,
+      claudeTranscriptLines({
+        sessionId,
+        userText: 'Keep this session streaming',
+        assistantText: 'Streaming response placeholder'
+      })
+    )
+
+    try {
+      await startTerminalImeByteReader(orcaPage, ptyId, byteReader)
+      await enableNativeChatSetting(orcaPage)
+      await seedClaudeProviderSession(orcaPage, {
+        paneKey: descriptor.paneKey,
+        worktreeId: descriptor.worktreeId,
+        sessionId,
+        transcriptPath
+      })
+      await toggleTerminalTabToChatView(orcaPage, { tabId, worktreeId: descriptor.worktreeId })
+
+      const composer = orcaPage.locator('[data-native-chat-root="true"] textarea')
+      await expect(composer).toBeVisible({ timeout: 15_000 })
+      await composer.focus()
+      await installNativeChatImeTrace(orcaPage)
+      typeNativeKeys(electronApp.process().pid!, [7, 35, 17, 46, 7, 46])
+      await expect.poll(() => composer.inputValue()).toBe('테스트')
+
+      await orcaPage.waitForTimeout(1_500)
+      await expect(composer).toHaveValue('테스트')
+      typeNativeKeys(electronApp.process().pid!, [36])
+      await expect(composer).toHaveValue('')
+
+      await composer.fill('ordinary')
+      await composer.press('Enter')
+      const receivedBytes = await waitForTerminalImeBytes(orcaPage, byteReader)
+      expect(receivedBytes).toEqual([
+        Buffer.from('테스트\n').toString('hex'),
+        Buffer.from('ordinary\n').toString('hex')
+      ])
+      const trace = await readNativeChatImeTrace(orcaPage)
+      expect(trace.some((entry) => entry.type === 'compositionstart')).toBe(true)
+      expect(trace.some((entry) => entry.type === 'compositionend')).toBe(true)
+      expect(
+        trace.some(
+          (entry) =>
+            entry.type === 'keydown' &&
+            entry.key === 'Enter' &&
+            entry.keyCode === 229 &&
+            entry.isComposing === true
+        )
+      ).toBe(true)
+      const evidencePath = testInfo.outputPath('native-macos-2set-session-chat.json')
+      writeFileSync(
+        evidencePath,
+        JSON.stringify({ expectedText: '테스트', events: trace }, null, 2)
+      )
+      await testInfo.attach('native-macos-2set-session-chat.json', {
+        path: evidencePath,
+        contentType: 'application/json'
+      })
+    } finally {
+      removeTerminalImeByteReader(byteReader)
       rmSync(scratchDir, { recursive: true, force: true })
     }
   })


### PR DESCRIPTION
## Summary

- leave active textarea composition owned by Chromium instead of driving it with a controlled React value
- synchronize external drafts only while the browser is idle and reconcile the live DOM value at composition end
- stop IME-owned events at the existing application-action boundary for submit, picker, typing redirect, font scale, and chat toggle
- remove the duplicate parent composition ref and callback plumbing

NativeChatComposerField already existed. This adds no class, component abstraction, tracker module, registry, or production file.

## Native evidence

A physical macOS 2-Set Korean Electron journey types 테스트 into session chat while the agent is working:

- the same textarea retains 테스트 through 1.5 seconds of streaming rerenders
- the recorded Enter shape is key Enter, keyCode 229, isComposing true
- compositionstart and compositionend are both present in the attached Playwright trace
- exact PTY input is 테스트 followed by newline, once
- the paired ordinary path is ordinary followed by newline

## Mutation checks

- deleting the single IME action guard duplicates the composed send in the physical journey while the ordinary path remains ordinary
- changing the textarea back to controlled value draft fails only the active-composition positive; all six idle and ordinary field tests pass
- restoring preventDefault on IME Enter does not change the native macOS result; its removal is a native-ownership simplification, not the trace-proven mechanism

## Verification

- physical macOS Korean headful Electron E2E: 1 passed
- focused native-chat tests: 24 passed
- changed-file Oxlint and formatting
- node and web typechecks
- max-lines ratchet and diff check

## Remaining certification

This remains draft. Windows native Korean evidence, reporter confirmation, and issue-specific classification are still required by the goalpost. Terminal and CLI/TUI reports remain owned by the stacked terminal PR rather than this native-chat path.