### PR TITLE
fix(terminal): stop Windows IME keys from triggering shortcuts

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
@@ -223,6 +223,113 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     harness.dispose()
   })
 
+  it('guards every keyup of a rapid double Enter press', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    // Two committing Enter presses land before either release is processed.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'Enter',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true
+      })
+    )
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'Enter',
+        keyCode: 229,
+        timeStamp: 20,
+        isComposing: true
+      })
+    )
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Shift',
+        code: 'ShiftLeft',
+        keyCode: 16,
+        timeStamp: 25,
+        shiftKey: true
+      })
+    )
+    for (const timeStamp of [30, 40]) {
+      harness.terminalInput.dispatchEvent(
+        keyboardEvent('keyup', {
+          key: 'Enter',
+          code: 'Enter',
+          keyCode: 13,
+          timeStamp,
+          shiftKey: true
+        })
+      )
+    }
+    vi.runAllTimers()
+
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('drains one press worth of evidence per release, so a later swallowed keydown still synthesizes', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    // Auto-repeat re-fires keydown with no release in between; the whole run
+    // must cost exactly one release to drain.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'Enter',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true
+      })
+    )
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'Enter',
+        keyCode: 229,
+        timeStamp: 20,
+        isComposing: true,
+        repeat: true
+      })
+    )
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 30,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+    expect(harness.sendInput).not.toHaveBeenCalled()
+
+    // Evidence is now drained: a genuinely swallowed keydown still synthesizes.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 50,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+
+    expect(harness.sendInput).toHaveBeenCalledTimes(1)
+    expect(harness.sendInput).toHaveBeenCalledWith('\x1b\r')
+    hook.unmount()
+    harness.dispose()
+  })
+
   it('still synthesizes a newline when the IME swallowed the Enter keydown entirely', () => {
     const harness = createHarness()
     const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
@@ -1,11 +1,4 @@
 // @vitest-environment happy-dom
-// Windows IME Enter-keyup synthesis must require press-time evidence.
-//
-// The keyup branch exists for presses whose keydown the IME swallowed entirely.
-// When the keydown WAS observed, release-time modifier state is rollover noise:
-// a plain committing Enter followed by a rolled-over Shift for the next doubled
-// consonant (했다 → commit-Enter, then Shift for ㄸ) must not become Shift+Enter,
-// and a directly-sent Shift+Enter must not send a second newline from its keyup.
 import { cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
@@ -136,7 +129,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
     harness.startComposition()
 
-    // Plain committing Enter, consumed by the IME: Process/229, no modifiers.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keydown', {
         key: 'Process',
@@ -146,7 +138,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
         isComposing: true
       })
     )
-    // Rollover: Shift pressed for the next doubled consonant before the Enter keyup.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keydown', {
         key: 'Shift',
@@ -156,8 +147,7 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
         shiftKey: true
       })
     )
-    // The Enter keyup reports release-time shiftKey=true while the session is
-    // still pending (the session-end finalizer is delayed under renderer lag).
+    // Release-time Shift belongs to the next doubled consonant.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keyup', {
         key: 'Enter',
@@ -188,7 +178,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
         isComposing: true
       })
     )
-    // Balancing keyup copied from the same native event (same timeStamp).
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keyup', {
         key: 'Enter',
@@ -206,7 +195,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
         shiftKey: true
       })
     )
-    // The physical release arrives later with the rolled-over Shift held.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keyup', {
         key: 'Enter',
@@ -228,7 +216,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
     harness.startComposition()
 
-    // Two committing Enter presses land before either release is processed.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keydown', {
         key: 'Process',
@@ -279,8 +266,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
     harness.startComposition()
 
-    // Auto-repeat re-fires keydown with no release in between; the whole run
-    // must cost exactly one release to drain.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keydown', {
         key: 'Process',
@@ -312,7 +297,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     vi.runAllTimers()
     expect(harness.sendInput).not.toHaveBeenCalled()
 
-    // Evidence is now drained: a genuinely swallowed keydown still synthesizes.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keyup', {
         key: 'Enter',
@@ -335,8 +319,7 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
     harness.startComposition()
 
-    // No Enter keydown was ever observed: only the keyup arrives, with the
-    // chord modifier still held. This is the case the keyup path exists for.
+    // No keydown evidence: preserve the swallowed-keydown fallback.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keyup', {
         key: 'Enter',
@@ -358,7 +341,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     const harness = createHarness()
     const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
 
-    // No composition yet: Shift+Enter keydown is sent directly.
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keydown', {
         key: 'Enter',
@@ -370,7 +352,6 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     )
     expect(harness.sendInput).toHaveBeenCalledTimes(1)
 
-    // The user starts the next Hangul syllable before releasing Enter/Shift.
     harness.startComposition()
     harness.terminalInput.dispatchEvent(
       keyboardEvent('keyup', {

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment happy-dom
+// Windows IME Enter-keyup synthesis must require press-time evidence.
+//
+// The keyup branch exists for presses whose keydown the IME swallowed entirely.
+// When the keydown WAS observed, release-time modifier state is rollover noise:
+// a plain committing Enter followed by a rolled-over Shift for the next doubled
+// consonant (했다 → commit-Enter, then Shift for ㄸ) must not become Shift+Enter,
+// and a directly-sent Shift+Enter must not send a second newline from its keyup.
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
+import {
+  installTerminalImeCompositionRoute,
+  XTERM_COMPOSITION_SESSION_START_EVENT
+} from './terminal-ime-composition-route'
+
+type KeyboardHandlersDeps = Parameters<typeof useTerminalKeyboardShortcuts>[0]
+
+function keyboardEvent(
+  type: 'keydown' | 'keyup',
+  overrides: KeyboardEventInit & { keyCode: number; timeStamp: number; isComposing?: boolean }
+): KeyboardEvent {
+  const event = new KeyboardEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    ...overrides
+  })
+  Object.defineProperties(event, {
+    isComposing: { value: overrides.isComposing ?? false },
+    keyCode: { value: overrides.keyCode },
+    timeStamp: { value: overrides.timeStamp }
+  })
+  return event
+}
+
+function createHarness(): {
+  deps: KeyboardHandlersDeps
+  sendInput: ReturnType<typeof vi.fn>
+  startComposition: () => void
+  terminalInput: HTMLTextAreaElement
+  dispose: () => void
+} {
+  const scope = document.createElement('div')
+  const terminalElement = document.createElement('div')
+  const terminalInput = document.createElement('textarea')
+  terminalInput.className = 'xterm-helper-textarea'
+  terminalElement.append(terminalInput)
+  scope.append(terminalElement)
+  document.body.append(scope)
+
+  const sendInput = vi.fn(() => true)
+  const transport = {
+    getPtyId: () => 'pty-1',
+    sendInput
+  } as unknown as PtyTransport
+  const pane = {
+    id: 1,
+    leafId: '00000000-0000-4000-8000-000000000001',
+    terminal: {
+      element: terminalElement,
+      focus: vi.fn(),
+      getSelection: vi.fn(() => '')
+    }
+  }
+  const manager = {
+    getActivePane: () => pane,
+    getPanes: () => [pane]
+  } as unknown as PaneManager
+  const route = installTerminalImeCompositionRoute({
+    terminalElement,
+    terminal: { input: vi.fn() },
+    capturedTransport: transport,
+    getCurrentTransport: () => transport
+  })
+  const deps: KeyboardHandlersDeps = {
+    tabId: 'tab-1',
+    worktreeId: 'worktree-1',
+    isActive: true,
+    keyboardScopeRef: { current: scope },
+    managerRef: { current: manager },
+    paneTransportsRef: { current: new Map([[pane.id, transport]]) },
+    panePtyBindingsRef: { current: new Map() },
+    paneCwdRef: { current: new Map() },
+    fallbackCwd: '',
+    expandedPaneIdRef: { current: null },
+    setExpandedPane: vi.fn(),
+    restoreExpandedLayout: vi.fn(),
+    refreshPaneSizes: vi.fn(),
+    persistLayoutSnapshot: vi.fn(),
+    toggleExpandPane: vi.fn(),
+    setSearchOpen: vi.fn(),
+    onSearchSelectedText: vi.fn(),
+    onRequestClosePane: vi.fn(),
+    onClearPaneScrollback: vi.fn(),
+    onSetTitle: vi.fn(),
+    onClearPaneTitle: vi.fn(),
+    searchOpenRef: { current: false },
+    searchStateRef: { current: { query: '', caseSensitive: false, regex: false } },
+    macOptionAsAltRef: { current: 'false' }
+  }
+  return {
+    deps,
+    sendInput,
+    terminalInput,
+    startComposition: () => {
+      terminalElement.dispatchEvent(
+        new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, {
+          detail: { id: 1 }
+        })
+      )
+    },
+    dispose: () => {
+      route.dispose()
+      scope.remove()
+    }
+  }
+}
+
+describe('Windows IME Enter-keyup press-time evidence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Windows')
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('does not synthesize a newline from a plain committing Enter with a rolled-over Shift', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    // Plain committing Enter, consumed by the IME: Process/229, no modifiers.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'Enter',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true
+      })
+    )
+    // Rollover: Shift pressed for the next doubled consonant before the Enter keyup.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Shift',
+        code: 'ShiftLeft',
+        keyCode: 16,
+        timeStamp: 20,
+        shiftKey: true
+      })
+    )
+    // The Enter keyup reports release-time shiftKey=true while the session is
+    // still pending (the session-end finalizer is delayed under renderer lag).
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 30,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('keeps suppression across a balancing keyup that copies the keydown timeStamp', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'Enter',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true
+      })
+    )
+    // Balancing keyup copied from the same native event (same timeStamp).
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 10
+      })
+    )
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Shift',
+        code: 'ShiftLeft',
+        keyCode: 16,
+        timeStamp: 20,
+        shiftKey: true
+      })
+    )
+    // The physical release arrives later with the rolled-over Shift held.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 30,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('still synthesizes a newline when the IME swallowed the Enter keydown entirely', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    // No Enter keydown was ever observed: only the keyup arrives, with the
+    // chord modifier still held. This is the case the keyup path exists for.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 30,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+
+    expect(harness.sendInput).toHaveBeenCalledTimes(1)
+    expect(harness.sendInput).toHaveBeenCalledWith('\x1b\r')
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('does not send a second newline from the keyup of a directly-sent Shift+Enter', () => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+
+    // No composition yet: Shift+Enter keydown is sent directly.
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 10,
+        shiftKey: true
+      })
+    )
+    expect(harness.sendInput).toHaveBeenCalledTimes(1)
+
+    // The user starts the next Hangul syllable before releasing Enter/Shift.
+    harness.startComposition()
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 30,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+
+    expect(harness.sendInput).toHaveBeenCalledTimes(1)
+    hook.unmount()
+    harness.dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
@@ -31,6 +31,7 @@ function keyboardEvent(
 function createHarness(): {
   deps: KeyboardHandlersDeps
   editable: HTMLInputElement
+  sendInput: ReturnType<typeof vi.fn>
   startComposition: () => void
   terminalInput: HTMLTextAreaElement
   dispose: () => void
@@ -97,6 +98,7 @@ function createHarness(): {
   return {
     deps,
     editable,
+    sendInput,
     terminalInput,
     startComposition: () => {
       terminalElement.dispatchEvent(
@@ -306,6 +308,59 @@ describe('Windows IME keyboard ownership', () => {
     harness.terminalInput.dispatchEvent(enter)
 
     expect(enter.defaultPrevented).toBe(false)
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it.each([
+    { code: 'KeyQ', shiftKey: true },
+    { code: 'KeyW', ctrlKey: true }
+  ])('keeps an IME-consumed $code out of terminal shortcuts', (modifier) => {
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    const laterWindowHandler = vi.fn()
+    window.addEventListener('keydown', laterWindowHandler)
+    harness.startComposition()
+    const consumed = keyboardEvent('keydown', {
+      key: 'Process',
+      keyCode: 229,
+      timeStamp: 10,
+      isComposing: true,
+      ...modifier
+    })
+
+    harness.terminalInput.dispatchEvent(consumed)
+
+    expect(consumed.defaultPrevented).toBe(false)
+    expect(harness.sendInput).not.toHaveBeenCalled()
+    expect(harness.deps.onRequestClosePane).not.toHaveBeenCalled()
+    expect(laterWindowHandler).not.toHaveBeenCalled()
+    window.removeEventListener('keydown', laterWindowHandler)
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('keeps an IME-consumed Ctrl+Shift+F out of file search', () => {
+    const harness = createHarness()
+    const pane = harness.deps.managerRef.current?.getActivePane()
+    vi.mocked(pane!.terminal.getSelection).mockReturnValue('needle')
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Process',
+        code: 'KeyF',
+        keyCode: 229,
+        timeStamp: 10,
+        isComposing: true,
+        ctrlKey: true,
+        shiftKey: true
+      })
+    )
+
+    expect(harness.deps.onSearchSelectedText).not.toHaveBeenCalled()
+    expect(harness.sendInput).not.toHaveBeenCalled()
     hook.unmount()
     harness.dispose()
   })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
@@ -313,6 +313,7 @@ describe('Windows IME keyboard ownership', () => {
   })
 
   it.each([
+    { code: 'ShiftLeft', shiftKey: true },
     { code: 'KeyQ', shiftKey: true },
     { code: 'KeyW', ctrlKey: true }
   ])('keeps an IME-consumed $code out of terminal shortcuts', (modifier) => {

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -95,6 +95,11 @@ export function recordKeyboardCreatedTerminalPaneSplit(
   return recordCreatedTerminalPaneSplit(createdPane, args)
 }
 
+// Why: bounds the per-code press evidence below so a keydown whose keyup never
+// arrives cannot grow the list without end. Real typing never stacks this many
+// Enter presses before a release.
+const MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE = 8
+
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
     return false
@@ -304,10 +309,12 @@ export function useTerminalKeyboardShortcuts({
     // keydown the IME swallowed entirely. When a keydown for the same physical
     // key was observed, release-time modifier state is rollover noise, not a
     // chord: a plain committing Enter followed by a rolled-over Shift for the
-    // next doubled consonant must not become Shift+Enter. The keydown's
-    // timeStamp is kept so a balancing keyup (copied from the same native
-    // event) does not consume the evidence ahead of the physical release.
-    const observedEnterKeydownTimeStamps = new Map<string, number>()
+    // next doubled consonant must not become Shift+Enter. One entry is kept per
+    // press so a rapid second press cannot be left unguarded by the first
+    // release, and each entry keeps its keydown timeStamp so a balancing keyup
+    // (copied from the same native event) does not consume it ahead of the
+    // physical release.
+    const observedEnterKeydownTimeStamps = new Map<string, number[]>()
     const getHeldImeEnterModifier = () =>
       heldImeEnterModifiers.size === 1
         ? (heldImeEnterModifiers.values().next().value ?? null)
@@ -470,7 +477,15 @@ export function useTerminalKeyboardShortcuts({
         ((e.key === 'Enter' && e.keyCode === 13) ||
           (e.keyCode === 229 && (e.code === 'Enter' || e.code === 'NumpadEnter')))
       ) {
-        observedEnterKeydownTimeStamps.set(e.code, e.timeStamp)
+        const observed = observedEnterKeydownTimeStamps.get(e.code)
+        if (!observed) {
+          observedEnterKeydownTimeStamps.set(e.code, [e.timeStamp])
+        } else if (!e.repeat && observed.length < MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE) {
+          // Why: auto-repeat re-fires keydown with no keyup in between and the
+          // whole run ends in a single release, so a repeat must not stack an
+          // entry that release cannot drain.
+          observed.push(e.timeStamp)
+        }
       }
       const manager = managerRef.current
       if (!manager) {
@@ -804,11 +819,16 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
-      const enterKeydownWasObserved = observedEnterKeydownTimeStamps.has(e.code)
-      if (enterKeydownWasObserved && observedEnterKeydownTimeStamps.get(e.code) !== e.timeStamp) {
-        // Why: a balancing keyup copies the keydown's native timeStamp; only
-        // the physical release (a different timeStamp) consumes the evidence.
-        observedEnterKeydownTimeStamps.delete(e.code)
+      const observedEnterKeydowns = observedEnterKeydownTimeStamps.get(e.code)
+      const enterKeydownWasObserved = observedEnterKeydowns !== undefined
+      if (enterKeydownWasObserved && !observedEnterKeydowns.includes(e.timeStamp)) {
+        // Why: a balancing keyup copies the keydown's native timeStamp; only a
+        // physical release (a different timeStamp) consumes one press worth of
+        // evidence, so a second press stays guarded until its own release.
+        observedEnterKeydowns.shift()
+        if (observedEnterKeydowns.length === 0) {
+          observedEnterKeydownTimeStamps.delete(e.code)
+        }
       }
       const modifiedEnterKind = getImeEnterModifier(e)
       if (isWindows && modifiedEnterKind && isTerminalImeEnterKeyUp(e)) {

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -95,9 +95,7 @@ export function recordKeyboardCreatedTerminalPaneSplit(
   return recordCreatedTerminalPaneSplit(createdPane, args)
 }
 
-// Why: bounds the per-code press evidence below so a keydown whose keyup never
-// arrives cannot grow the list without end. Real typing never stacks this many
-// Enter presses before a release.
+// Bounds evidence when Chromium drops a matching keyup.
 const MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE = 8
 
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -305,15 +303,7 @@ export function useTerminalKeyboardShortcuts({
         }
       }
     }
-    // Why: the Enter-keyup synthesis below must only service presses whose
-    // keydown the IME swallowed entirely. When a keydown for the same physical
-    // key was observed, release-time modifier state is rollover noise, not a
-    // chord: a plain committing Enter followed by a rolled-over Shift for the
-    // next doubled consonant must not become Shift+Enter. One entry is kept per
-    // press so a rapid second press cannot be left unguarded by the first
-    // release, and each entry keeps its keydown timeStamp so a balancing keyup
-    // (copied from the same native event) does not consume it ahead of the
-    // physical release.
+    // Press evidence distinguishes swallowed keydowns from modifier rollover on keyup.
     const observedEnterKeydownTimeStamps = new Map<string, number[]>()
     const getHeldImeEnterModifier = () =>
       heldImeEnterModifiers.size === 1
@@ -469,9 +459,7 @@ export function useTerminalKeyboardShortcuts({
       // Why: replace stale state only for this physical key so rollover cannot
       // disarm a still-held native-only chord before its Kitty keyup arrives.
       nativeOnlyShortcutTracker.prepareKeyDown(e)
-      // Why: recorded ahead of every early return so any observed Enter
-      // keydown (editable targets and re-dispatches included) disqualifies
-      // its keyup from the swallowed-keydown synthesis below.
+      // Record before early returns so every observed Enter disqualifies keyup synthesis.
       if (
         isWindows &&
         ((e.key === 'Enter' && e.keyCode === 13) ||
@@ -481,9 +469,7 @@ export function useTerminalKeyboardShortcuts({
         if (!observed) {
           observedEnterKeydownTimeStamps.set(e.code, [e.timeStamp])
         } else if (!e.repeat && observed.length < MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE) {
-          // Why: auto-repeat re-fires keydown with no keyup in between and the
-          // whole run ends in a single release, so a repeat must not stack an
-          // entry that release cannot drain.
+          // Auto-repeat shares one physical release.
           observed.push(e.timeStamp)
         }
       }
@@ -822,9 +808,7 @@ export function useTerminalKeyboardShortcuts({
       const observedEnterKeydowns = observedEnterKeydownTimeStamps.get(e.code)
       const enterKeydownWasObserved = observedEnterKeydowns !== undefined
       if (enterKeydownWasObserved && !observedEnterKeydowns.includes(e.timeStamp)) {
-        // Why: a balancing keyup copies the keydown's native timeStamp; only a
-        // physical release (a different timeStamp) consumes one press worth of
-        // evidence, so a second press stays guarded until its own release.
+        // A balancing keyup copies its keydown timestamp; only the physical release drains it.
         observedEnterKeydowns.shift()
         if (observedEnterKeydowns.length === 0) {
           observedEnterKeydownTimeStamps.delete(e.code)
@@ -844,10 +828,7 @@ export function useTerminalKeyboardShortcuts({
         const manager = managerRef.current
         const keyboardScope = keyboardScopeRef.current
         if (
-          // Why: synthesize only when the IME swallowed the keydown entirely.
-          // An observed keydown already chose its own path (plain commit,
-          // chord defer, or direct send); a modifier flag on this keyup is
-          // then rollover state from the next keystroke, not a chord.
+          // An observed keydown makes this modifier state rollover, not a swallowed chord.
           !enterKeydownWasObserved &&
           manager &&
           !isEditableTarget(e.target) &&

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -300,6 +300,14 @@ export function useTerminalKeyboardShortcuts({
         }
       }
     }
+    // Why: the Enter-keyup synthesis below must only service presses whose
+    // keydown the IME swallowed entirely. When a keydown for the same physical
+    // key was observed, release-time modifier state is rollover noise, not a
+    // chord: a plain committing Enter followed by a rolled-over Shift for the
+    // next doubled consonant must not become Shift+Enter. The keydown's
+    // timeStamp is kept so a balancing keyup (copied from the same native
+    // event) does not consume the evidence ahead of the physical release.
+    const observedEnterKeydownTimeStamps = new Map<string, number>()
     const getHeldImeEnterModifier = () =>
       heldImeEnterModifiers.size === 1
         ? (heldImeEnterModifiers.values().next().value ?? null)
@@ -454,6 +462,16 @@ export function useTerminalKeyboardShortcuts({
       // Why: replace stale state only for this physical key so rollover cannot
       // disarm a still-held native-only chord before its Kitty keyup arrives.
       nativeOnlyShortcutTracker.prepareKeyDown(e)
+      // Why: recorded ahead of every early return so any observed Enter
+      // keydown (editable targets and re-dispatches included) disqualifies
+      // its keyup from the swallowed-keydown synthesis below.
+      if (
+        isWindows &&
+        ((e.key === 'Enter' && e.keyCode === 13) ||
+          (e.keyCode === 229 && (e.code === 'Enter' || e.code === 'NumpadEnter')))
+      ) {
+        observedEnterKeydownTimeStamps.set(e.code, e.timeStamp)
+      }
       const manager = managerRef.current
       if (!manager) {
         return
@@ -786,6 +804,12 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
+      const enterKeydownWasObserved = observedEnterKeydownTimeStamps.has(e.code)
+      if (enterKeydownWasObserved && observedEnterKeydownTimeStamps.get(e.code) !== e.timeStamp) {
+        // Why: a balancing keyup copies the keydown's native timeStamp; only
+        // the physical release (a different timeStamp) consumes the evidence.
+        observedEnterKeydownTimeStamps.delete(e.code)
+      }
       const modifiedEnterKind = getImeEnterModifier(e)
       if (isWindows && modifiedEnterKind && isTerminalImeEnterKeyUp(e)) {
         const chord = { kind: modifiedEnterKind, code: e.code, timeStamp: e.timeStamp }
@@ -800,6 +824,11 @@ export function useTerminalKeyboardShortcuts({
         const manager = managerRef.current
         const keyboardScope = keyboardScopeRef.current
         if (
+          // Why: synthesize only when the IME swallowed the keydown entirely.
+          // An observed keydown already chose its own path (plain commit,
+          // chord defer, or direct send); a modifier flag on this keyup is
+          // then rollover state from the next keystroke, not a chord.
+          !enterKeydownWasObserved &&
           manager &&
           !isEditableTarget(e.target) &&
           (!keyboardScope || keyboardEventBelongsToScope(e, keyboardScope))
@@ -865,6 +894,7 @@ export function useTerminalKeyboardShortcuts({
       heldImeEnterModifiers.clear()
       modifiedEnterChordOwner.clear()
       deferredNewlineSender.clearRedispatchedEnters()
+      observedEnterKeydownTimeStamps.clear()
     }
 
     window.addEventListener('keydown', onModifierDown, { capture: true })
@@ -877,6 +907,7 @@ export function useTerminalKeyboardShortcuts({
     return () => {
       modifiedEnterChordOwner.clear()
       deferredNewlineSender.clearRedispatchedEnters()
+      observedEnterKeydownTimeStamps.clear()
       window.removeEventListener('keydown', onModifierDown, { capture: true })
       window.removeEventListener('keyup', onKeyUp, { capture: true })
       window.removeEventListener('keydown', onKeyDown, { capture: true })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -13,6 +13,7 @@ import {
   createTerminalImeDeferredNewlineSender,
   createTerminalImeModifiedEnterChordOwner,
   getTerminalImeModifiedEnterKind,
+  isTerminalImeConsumedKey,
   isTerminalImeEnterKeyUp,
   isTerminalImeProcessEnter
 } from './terminal-ime-deferred-newline'
@@ -477,6 +478,22 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
+      const terminalPaneForImeShortcut = manager.getActivePane() ?? manager.getPanes()[0]
+      const hasPendingImeComposition = hasPendingTerminalImeComposition(
+        terminalPaneForImeShortcut?.terminal.element
+      )
+      const imeProcessEnter = isWindows && hasPendingImeComposition && isTerminalImeProcessEnter(e)
+      if (
+        isWindows &&
+        hasPendingImeComposition &&
+        !imeProcessEnter &&
+        isTerminalImeConsumedKey(e)
+      ) {
+        // Process has no logical key, so shortcut matching would fall back to its physical code.
+        e.stopImmediatePropagation()
+        return
+      }
+
       if (matchFileSearchShortcut(e, shortcutPlatform, keybindings, terminalShortcutPolicy)) {
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         const selectedText = normalizeSelectedTextForFileSearch(pane?.terminal.getSelection())
@@ -516,11 +533,6 @@ export function useTerminalKeyboardShortcuts({
         return
       }
 
-      const terminalPaneForImeShortcut = manager.getActivePane() ?? manager.getPanes()[0]
-      const hasPendingImeComposition = hasPendingTerminalImeComposition(
-        terminalPaneForImeShortcut?.terminal.element
-      )
-      const imeProcessEnter = isWindows && hasPendingImeComposition && isTerminalImeProcessEnter(e)
       const shortcutEvent = imeProcessEnter
         ? {
             key: 'Enter',

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -325,6 +325,7 @@ describe('isTerminalImeProcessEnter', () => {
   const event = (overrides: Partial<KeyboardEvent> = {}) =>
     ({
       key: 'Process',
+      code: 'Enter',
       keyCode: 229,
       metaKey: false,
       ctrlKey: false,
@@ -333,19 +334,24 @@ describe('isTerminalImeProcessEnter', () => {
       ...overrides
     }) as KeyboardEvent
 
-  it.each([{ shiftKey: true }, { shiftKey: false, ctrlKey: true }])(
-    'recognizes a Windows IME modifier Enter reported as Process',
-    (modifiers) => {
-      expect(isTerminalImeProcessEnter(event(modifiers))).toBe(true)
-    }
-  )
+  it.each([
+    { shiftKey: true },
+    { shiftKey: false, ctrlKey: true },
+    { code: 'NumpadEnter' },
+    { code: '' },
+    { code: 'Unidentified' }
+  ])('recognizes a Windows IME modifier Enter reported as Process', (modifiers) => {
+    expect(isTerminalImeProcessEnter(event(modifiers))).toBe(true)
+  })
 
   it.each([
     { key: 'Enter' },
     { keyCode: 13 },
     { shiftKey: false },
     { ctrlKey: true },
-    { altKey: true }
+    { altKey: true },
+    { code: 'KeyQ' },
+    { code: 'ArrowLeft' }
   ])('rejects a non-IME or ambiguous Process key', (override) => {
     expect(isTerminalImeProcessEnter(event(override))).toBe(false)
   })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -350,6 +350,7 @@ describe('isTerminalImeProcessEnter', () => {
     { shiftKey: false },
     { ctrlKey: true },
     { altKey: true },
+    { code: 'ShiftLeft' },
     { code: 'KeyQ' },
     { code: 'ArrowLeft' }
   ])('rejects a non-IME or ambiguous Process key', (override) => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -107,11 +107,16 @@ export function getTerminalImeModifiedEnterKind(
 }
 
 export function isTerminalImeProcessEnter(
-  event: Pick<KeyboardEvent, 'key' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+  event: Pick<
+    KeyboardEvent,
+    'key' | 'code' | 'keyCode' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'
+  >
 ): boolean {
+  const { code } = event
   return (
     event.key === 'Process' &&
     event.keyCode === 229 &&
+    (!code || code === 'Unidentified' || code === 'Enter' || code === 'NumpadEnter') &&
     getTerminalImeModifiedEnterKind(event) !== null
   )
 }

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -106,6 +106,10 @@ export function getTerminalImeModifiedEnterKind(
   return null
 }
 
+export function isTerminalImeConsumedKey(event: Pick<KeyboardEvent, 'key' | 'keyCode'>): boolean {
+  return event.key === 'Process' && event.keyCode === 229
+}
+
 export function isTerminalImeProcessEnter(
   event: Pick<
     KeyboardEvent,
@@ -114,8 +118,7 @@ export function isTerminalImeProcessEnter(
 ): boolean {
   const { code } = event
   return (
-    event.key === 'Process' &&
-    event.keyCode === 229 &&
+    isTerminalImeConsumedKey(event) &&
     (!code || code === 'Unidentified' || code === 'Enter' || code === 'NumpadEnter') &&
     getTerminalImeModifiedEnterKind(event) !== null
   )


### PR DESCRIPTION
## Summary

- Stop Windows IME `Process/229` events for Shift, shifted jamo, Japanese conversion keys, and Ctrl chords from being rewritten as modified Enter.
- Block IME-owned non-Enter events before terminal, file-search, and later window shortcut handlers can fall back to the physical key code.
- Require press-time evidence before synthesizing modified Enter on keyup, preventing rollover Shift/Ctrl from creating a newline or duplicating a directly sent chord.
- Preserve modified Enter when Chromium reports `Enter`, `NumpadEnter`, blank, or `Unidentified` code.

Fixes #11878.
Refs #12256.
Follow-up to #11293 and #12259: #12259 clears stale modifier state, while this PR closes the no-Enter `Process/229` misclassification path.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck:web`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions
- [x] 54 focused Windows IME keyboard/deferred-input tests
- [x] Formatting, default Oxlint, type-aware quality scan, React Doctor scan, diff check, and max-lines ratchet

The regression matrix covers the native `Process/ShiftLeft/229` trace, shifted Korean jamo, Japanese Shift+Arrow conversion, Ctrl shortcut fallback, file search, blank/`Unidentified` Enter codes, modifier rollover, balancing keyups, rapid Enter presses, auto-repeat, swallowed keydowns, and directly sent Shift+Enter.

## AI Review Report

Reviewed the full #11293 cross-reference cluster before choosing a targeted fix over a revert. A wholesale revert would restore the duplicate/drop and ordering bugs that #11293 fixed and invalidate several contributor fixes built on its transaction model.

The implementation combines separable community fixes while preserving authorship:

- #11273 by @kunsanglee: nuanced Process/Enter classification, including blank-code compatibility.
- #11616 by @nwparker and #12120 by @holdn2: keep IME-owned physical-code fallback out of terminal shortcuts and place the guard before file search.
- #11937 and the physical Windows trace on #11878 by @KimYoungHwan8750: bounded per-press Enter keydown evidence and rollover protection.

Cross-platform review confirmed the production guard remains Windows-only. macOS/Linux IME routing, shortcut labels, paths, shells, Electron menus, SSH transports, and folder workspaces are unchanged. The blank/`Unidentified` compatibility path avoids regressing remote desktop, on-screen keyboard, or synthetic event sources that cannot report a physical code.

## Security Audit

This reduces unintended PTY writes and shortcut execution from renderer keyboard events. It introduces no command execution, parsing, paths, auth, secrets, dependencies, IPC, or transport changes. Per-press evidence is bounded to eight entries per Enter code and cleared on blur/unmount, preventing dropped keyups from growing renderer state indefinitely.

## Notes

This intentionally does not bundle the separate composition-restart, cancelled-preedit, delayed-syllable, or deferred-timeout fixes tracked by #11855, #11936, #12132, and their associated PRs. Those modify the patched xterm composition lifecycle and should remain independently reviewable.