### PR TITLE
fix(repo-icon): keep a renamed fork's own owner avatar

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1669,7 +1669,8 @@ export async function getRepoSlug(
 
 /**
  * Resolve a fork's upstream/parent owner/repo, or null when not a fork.
- * Why: a fork's `origin` is the personal copy, so repo identity (avatar) should prefer upstream.
+ * Why: drives the fork indicator, and a same-name fork's avatar prefers the
+ * upstream owner (a renamed fork keeps its own owner).
  * Best-effort: any failure (offline, unauthed, non-GitHub) resolves to null.
  */
 export async function getRepoUpstream(

--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -214,6 +214,36 @@ describe('detectRepoIcon', () => {
     })
   })
 
+  it('keeps the renamed fork own owner avatar while storing the upstream metadata', async () => {
+    const repoPath = await makeTempRepoDir()
+    await gitExecFileAsync(['init'], { cwd: repoPath })
+    await gitExecFileAsync(['remote', 'add', 'origin', 'git@github.com:acme/rocket-pro.git'], {
+      cwd: repoPath
+    })
+    await gitExecFileAsync(
+      ['remote', 'add', 'upstream', 'git@github.com:upstream-org/rocket.git'],
+      {
+        cwd: repoPath
+      }
+    )
+
+    await expect(detectRepoIconAndUpstream({ repoPath, kind: 'git' })).resolves.toEqual({
+      gitRemoteIdentity: {
+        canonicalKey: 'github.com/upstream-org/rocket',
+        remoteName: 'upstream',
+        remoteUrl: 'git@github.com:upstream-org/rocket.git'
+      },
+      // Why: a renamed fork is its own project, so the avatar stays on the origin owner.
+      repoIcon: {
+        type: 'image',
+        src: 'https://github.com/acme.png?size=64',
+        source: 'github',
+        label: 'acme/rocket-pro'
+      },
+      upstream: { owner: 'upstream-org', repo: 'rocket', host: 'github.com' }
+    })
+  })
+
   it('detects a provider-neutral git remote identity for non-GitHub remotes', async () => {
     const repoPath = await makeTempRepoDir()
     await gitExecFileAsync(['init'], { cwd: repoPath })

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -71,14 +71,18 @@ async function detectRemotePackageHomepageIcon(
   }
 }
 
-async function detectGitHubAvatarIcon(
+export async function detectGitHubAvatarIcon(
   repoPath: string,
   connectionId?: string | null,
   upstream?: GitHubRepositoryIdentity | null
 ): Promise<RepoIcon | null> {
   try {
-    // Why: a fork's origin is the personal copy, so prefer the upstream owner.
-    const slug = upstream ?? (await getRepoSlug(repoPath, connectionId))
+    const origin = await getRepoSlug(repoPath, connectionId).catch(() => null)
+    // Why: a same-name fork is a personal copy identified by its upstream owner;
+    // a renamed fork is its own project, so its origin owner wins.
+    const renamedFork =
+      upstream && origin && origin.repo.toLowerCase() !== upstream.repo.toLowerCase()
+    const slug = renamedFork ? origin : (upstream ?? origin)
     return slug ? githubAvatarIcon(slug) : null
   } catch {
     return null

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -1,6 +1,11 @@
 import { readFile, stat } from 'node:fs/promises'
 import type { GitHubRepositoryIdentity, RepoKind } from '../shared/types'
-import { faviconUrlFromWebsite, githubAvatarIcon, type RepoIcon } from '../shared/repo-icon'
+import {
+  faviconUrlFromWebsite,
+  githubAvatarIcon,
+  githubAvatarSlug,
+  type RepoIcon
+} from '../shared/repo-icon'
 import { getRepoSlug, getRepoUpstream } from './github/client'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import type { IFilesystemProvider } from './providers/types'
@@ -77,12 +82,7 @@ export async function detectGitHubAvatarIcon(
   upstream?: GitHubRepositoryIdentity | null
 ): Promise<RepoIcon | null> {
   try {
-    const origin = await getRepoSlug(repoPath, connectionId).catch(() => null)
-    // Why: a same-name fork is a personal copy identified by its upstream owner;
-    // a renamed fork is its own project, so its origin owner wins.
-    const renamedFork =
-      upstream && origin && origin.repo.toLowerCase() !== upstream.repo.toLowerCase()
-    const slug = renamedFork ? origin : (upstream ?? origin)
+    const slug = githubAvatarSlug(await getRepoSlug(repoPath, connectionId), upstream)
     return slug ? githubAvatarIcon(slug) : null
   } catch {
     return null

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1012,9 +1012,8 @@ import {
   getSshGitProviderGeneration,
   requireSshGitProvider
 } from '../providers/ssh-git-dispatch'
-import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
+import { detectGitHubAvatarIcon, detectRepoIconAndUpstream } from '../repo-icon-autodetect'
 import { enrichMissingRepoGitRemoteIdentities } from '../repo-git-remote-identity-enrichment'
-import { githubAvatarIcon } from '../../shared/repo-icon'
 import type { ClaudeAccountService } from '../claude-accounts/service'
 import type {
   CodexAccountService,
@@ -19275,7 +19274,10 @@ export class OrcaRuntimeService {
         const updates: Partial<Repo> = { upstream: upstream ?? null }
         // Only migrate the auto-detected origin avatar; never touch a chosen icon.
         if (upstream && repo.repoIcon?.type === 'image' && repo.repoIcon.source === 'github') {
-          updates.repoIcon = githubAvatarIcon(upstream)
+          const repoIcon = await detectGitHubAvatarIcon(repo.path, null, upstream)
+          if (repoIcon) {
+            updates.repoIcon = repoIcon
+          }
         }
         store.updateRepo(repo.id, updates)
         changed = true

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19271,13 +19271,25 @@ export class OrcaRuntimeService {
         } catch {
           continue
         }
+        const repoIcon =
+          upstream && repo.repoIcon?.type === 'image' && repo.repoIcon.source === 'github'
+            ? await detectGitHubAvatarIcon(repo.path, null, upstream)
+            : null
+        // Why: settings can change the repo while the probes above are pending, so
+        // re-read it — a stale snapshot must not clobber a user-chosen icon or an
+        // upstream another path already resolved.
+        const current = store.getRepos().find((candidate) => candidate.id === repo.id)
+        if (!current || current.upstream !== undefined) {
+          continue
+        }
         const updates: Partial<Repo> = { upstream: upstream ?? null }
         // Only migrate the auto-detected origin avatar; never touch a chosen icon.
-        if (upstream && repo.repoIcon?.type === 'image' && repo.repoIcon.source === 'github') {
-          const repoIcon = await detectGitHubAvatarIcon(repo.path, null, upstream)
-          if (repoIcon) {
-            updates.repoIcon = repoIcon
-          }
+        if (
+          repoIcon &&
+          current.repoIcon?.type === 'image' &&
+          current.repoIcon.source === 'github'
+        ) {
+          updates.repoIcon = repoIcon
         }
         store.updateRepo(repo.id, updates)
         changed = true

--- a/src/main/runtime/repo-icon-fork-backfill.test.ts
+++ b/src/main/runtime/repo-icon-fork-backfill.test.ts
@@ -94,15 +94,30 @@ describe('startup fork-upstream backfill', () => {
     })
   })
 
-  it('never migrates an icon the user chose', async () => {
+  it('keeps an icon chosen while avatar detection is pending', async () => {
     const runtime = new OrcaRuntimeService()
-    const updateRepo = attachStore(runtime, [
-      makeRepo({ repoIcon: { type: 'emoji', emoji: '🚀' } })
-    ])
+    const repo = makeRepo()
+    const repos = [repo]
+    const updateRepo = attachStore(runtime, repos)
     getRepoUpstream.mockResolvedValue({ owner: 'upstream-org', repo: 'rocket' })
-    getRepoSlug.mockResolvedValue({ owner: 'acme', repo: 'rocket-pro' })
+    let resolveSlug!: (value: { owner: string; repo: string }) => void
+    let markSlugStarted!: () => void
+    const slugStarted = new Promise<void>((resolve) => {
+      markSlugStarted = resolve
+    })
+    getRepoSlug.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSlug = resolve
+          markSlugStarted()
+        })
+    )
 
-    await (runtime as unknown as BackfillInternals).backfillForkUpstreams()
+    const backfill = (runtime as unknown as BackfillInternals).backfillForkUpstreams()
+    await slugStarted
+    repos[0] = { ...repo, repoIcon: { type: 'emoji', emoji: '🚀' } }
+    resolveSlug({ owner: 'acme', repo: 'rocket-pro' })
+    await backfill
 
     expect(updateRepo).toHaveBeenCalledExactlyOnceWith('repo-1', {
       upstream: { owner: 'upstream-org', repo: 'rocket' }

--- a/src/main/runtime/repo-icon-fork-backfill.test.ts
+++ b/src/main/runtime/repo-icon-fork-backfill.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../shared/types'
+import * as client from '../github/client'
+import { OrcaRuntimeService } from './orca-runtime'
+
+vi.mock('../github/client', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getRepoUpstream: vi.fn(),
+  getRepoSlug: vi.fn()
+}))
+
+const getRepoUpstream = vi.mocked(client.getRepoUpstream)
+const getRepoSlug = vi.mocked(client.getRepoSlug)
+
+type BackfillInternals = { backfillForkUpstreams(): Promise<void> }
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/workspace/rocket-pro',
+    displayName: 'rocket-pro',
+    badgeColor: '#2563eb',
+    addedAt: 1,
+    kind: 'git',
+    repoIcon: {
+      type: 'image',
+      src: 'https://github.com/acme.png?size=64',
+      source: 'github',
+      label: 'acme/rocket-pro'
+    },
+    ...overrides
+  }
+}
+
+function attachStore(runtime: OrcaRuntimeService, repos: Repo[]) {
+  const updateRepo = vi.fn((repoId: string, updates: Partial<Repo>) => {
+    const index = repos.findIndex((repo) => repo.id === repoId)
+    repos[index] = { ...repos[index], ...updates }
+  })
+  Object.assign(runtime, { store: { getRepos: () => repos, updateRepo } })
+  return updateRepo
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('startup fork-upstream backfill', () => {
+  it('keeps a renamed fork own owner avatar while recording the upstream', async () => {
+    const runtime = new OrcaRuntimeService()
+    const updateRepo = attachStore(runtime, [makeRepo()])
+    getRepoUpstream.mockResolvedValue({ owner: 'upstream-org', repo: 'rocket' })
+    getRepoSlug.mockResolvedValue({ owner: 'acme', repo: 'rocket-pro' })
+
+    await (runtime as unknown as BackfillInternals).backfillForkUpstreams()
+
+    expect(updateRepo).toHaveBeenCalledExactlyOnceWith('repo-1', {
+      upstream: { owner: 'upstream-org', repo: 'rocket' },
+      repoIcon: {
+        type: 'image',
+        src: 'https://github.com/acme.png?size=64',
+        source: 'github',
+        label: 'acme/rocket-pro'
+      }
+    })
+  })
+
+  it('migrates a same-name fork to the upstream owner avatar', async () => {
+    const runtime = new OrcaRuntimeService()
+    const updateRepo = attachStore(runtime, [
+      makeRepo({
+        path: '/workspace/rocket',
+        repoIcon: {
+          type: 'image',
+          src: 'https://github.com/acme.png?size=64',
+          source: 'github',
+          label: 'acme/rocket'
+        }
+      })
+    ])
+    getRepoUpstream.mockResolvedValue({ owner: 'upstream-org', repo: 'rocket' })
+    getRepoSlug.mockResolvedValue({ owner: 'acme', repo: 'rocket' })
+
+    await (runtime as unknown as BackfillInternals).backfillForkUpstreams()
+
+    expect(updateRepo).toHaveBeenCalledExactlyOnceWith('repo-1', {
+      upstream: { owner: 'upstream-org', repo: 'rocket' },
+      repoIcon: {
+        type: 'image',
+        src: 'https://github.com/upstream-org.png?size=64',
+        source: 'github',
+        label: 'upstream-org/rocket'
+      }
+    })
+  })
+
+  it('never migrates an icon the user chose', async () => {
+    const runtime = new OrcaRuntimeService()
+    const updateRepo = attachStore(runtime, [
+      makeRepo({ repoIcon: { type: 'emoji', emoji: '🚀' } })
+    ])
+    getRepoUpstream.mockResolvedValue({ owner: 'upstream-org', repo: 'rocket' })
+    getRepoSlug.mockResolvedValue({ owner: 'acme', repo: 'rocket-pro' })
+
+    await (runtime as unknown as BackfillInternals).backfillForkUpstreams()
+
+    expect(updateRepo).toHaveBeenCalledExactlyOnceWith('repo-1', {
+      upstream: { owner: 'upstream-org', repo: 'rocket' }
+    })
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryIconPicker.github-avatar-refresh.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryIconPicker.github-avatar-refresh.test.tsx
@@ -106,7 +106,7 @@ describe('RepositoryIconPicker GitHub avatar refresh', () => {
         label: 'stablyai/orca'
       }
     })
-    // Offline/unauthed: the parent lookup returns null. The fork's own origin
+    // Offline/unauthed: the parent lookup returns null. The same-name origin
     // owner must NOT be persisted over the parent identity.
     apiMocks.repoUpstream.mockResolvedValueOnce(null)
     apiMocks.repoSlug.mockResolvedValueOnce({ owner: 'parkerrex', repo: 'orca' })
@@ -117,6 +117,5 @@ describe('RepositoryIconPicker GitHub avatar refresh', () => {
     await flushEffects()
 
     expect(updateRepo).not.toHaveBeenCalled()
-    expect(apiMocks.repoSlug).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/settings/repository-icon-github.test.ts
+++ b/src/renderer/src/components/settings/repository-icon-github.test.ts
@@ -36,8 +36,10 @@ describe('repository GitHub avatar resolution', () => {
     apiMocks.repoUpstream.mockReset()
   })
 
-  it('uses stored upstream by default to avoid unnecessary live checks', async () => {
+  it('uses stored upstream by default and keeps the parent avatar for same-name forks', async () => {
     const repo = makeRepo({ upstream: { owner: 'stablyai', repo: 'orca' } })
+    // The fork's own origin owner — same repo name, so the parent avatar wins.
+    apiMocks.repoSlug.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
 
     await expect(resolveRepositoryGitHubAvatar({ kind: 'local' }, repo)).resolves.toEqual({
       repoIcon: {
@@ -50,7 +52,40 @@ describe('repository GitHub avatar resolution', () => {
     })
 
     expect(apiMocks.repoUpstream).not.toHaveBeenCalled()
-    expect(apiMocks.repoSlug).not.toHaveBeenCalled()
+    // Only the origin slug is consulted (for the renamed-fork check).
+    expect(apiMocks.repoSlug).toHaveBeenCalledExactlyOnceWith({
+      repoPath: '/workspace/orca',
+      repoId: 'repo-1'
+    })
+  })
+
+  it('prefers the renamed fork own owner over the stored upstream', async () => {
+    const repo = makeRepo({ upstream: { owner: 'upstream-org', repo: 'rocket' } })
+    apiMocks.repoUpstream.mockResolvedValueOnce({ owner: 'upstream-org', repo: 'rocket' })
+    apiMocks.repoSlug.mockResolvedValueOnce({ owner: 'acme', repo: 'rocket-pro' })
+
+    const resolution = await resolveRepositoryGitHubAvatar({ kind: 'local' }, repo, {
+      forceLive: true
+    })
+
+    expect(resolution).toEqual({
+      repoIcon: {
+        type: 'image',
+        src: 'https://github.com/acme.png?size=64',
+        source: 'github',
+        label: 'acme/rocket-pro'
+      },
+      upstream: { owner: 'upstream-org', repo: 'rocket' }
+    })
+    // The fork metadata is untouched; only the avatar moves to the fork's own owner.
+    expect(buildRepositoryGitHubAvatarUpdate(repo, resolution)).toEqual({
+      repoIcon: {
+        type: 'image',
+        src: 'https://github.com/acme.png?size=64',
+        source: 'github',
+        label: 'acme/rocket-pro'
+      }
+    })
   })
 
   it('force-resolves the live origin owner when a non-fork repo was transferred', async () => {
@@ -140,7 +175,7 @@ describe('repository GitHub avatar resolution', () => {
       }
     })
     apiMocks.repoUpstream.mockResolvedValueOnce(null)
-    // The fork's own origin owner — the value we must NOT persist over the parent.
+    // The fork's own origin owner — same repo name, so it must NOT replace the parent.
     apiMocks.repoSlug.mockResolvedValueOnce({ owner: 'parkerrex', repo: 'orca' })
 
     const resolution = await resolveRepositoryGitHubAvatar({ kind: 'local' }, repo, {
@@ -156,8 +191,6 @@ describe('repository GitHub avatar resolution', () => {
       },
       upstream: { owner: 'stablyai', repo: 'orca' }
     })
-    // The origin slug must never be consulted once we fall back to the known parent.
-    expect(apiMocks.repoSlug).not.toHaveBeenCalled()
     // Nothing changed, so no repo write is produced (no sticky null clobber).
     expect(buildRepositoryGitHubAvatarUpdate(repo, resolution)).toBeNull()
   })

--- a/src/renderer/src/components/settings/repository-icon-github.test.ts
+++ b/src/renderer/src/components/settings/repository-icon-github.test.ts
@@ -195,6 +195,22 @@ describe('repository GitHub avatar resolution', () => {
     expect(buildRepositoryGitHubAvatarUpdate(repo, resolution)).toBeNull()
   })
 
+  it('propagates an ambiguous origin probe failure instead of flipping to the parent avatar', async () => {
+    // A renamed fork already showing its own owner. A rejected origin probe cannot
+    // tell renamed from same-name, so it must surface rather than resolve to the
+    // parent avatar — callers keep the stored icon.
+    const repo = makeRepo({
+      upstream: { owner: 'upstream-org', repo: 'rocket' },
+      repoIcon: githubAvatarIcon({ owner: 'acme', repo: 'rocket-pro' })
+    })
+    apiMocks.repoUpstream.mockResolvedValueOnce({ owner: 'upstream-org', repo: 'rocket' })
+    apiMocks.repoSlug.mockRejectedValueOnce(new Error('runtime rpc timeout'))
+
+    await expect(
+      resolveRepositoryGitHubAvatar({ kind: 'local' }, repo, { forceLive: true })
+    ).rejects.toThrow('runtime rpc timeout')
+  })
+
   it('persists an upstream change when only the GitHub host differs', () => {
     const repo = makeRepo({
       upstream: { owner: 'acme', repo: 'widgets', host: 'github.com' }

--- a/src/renderer/src/components/settings/repository-icon-github.ts
+++ b/src/renderer/src/components/settings/repository-icon-github.ts
@@ -55,20 +55,23 @@ export async function resolveRepositoryGitHubAvatar(
   repo: Repo,
   options: ResolveRepositoryGitHubAvatarOptions = {}
 ): Promise<RepositoryGitHubAvatarResolution> {
-  const upstream =
+  const liveUpstream =
     !options.forceLive && repo.upstream !== undefined
       ? repo.upstream
       : await resolveRepositoryUpstreamLive(runtimeTarget, repo).catch(() => null)
-  if (upstream) {
-    return { repoIcon: githubAvatarIcon(upstream), upstream }
-  }
   // Why: a null live upstream is ambiguous (offline/unauthed vs. not-a-fork). Keep
-  // the last-known parent avatar so a transient failure can't clobber fork identity.
-  if (repo.upstream) {
-    return { repoIcon: githubAvatarIcon(repo.upstream), upstream: repo.upstream }
+  // the last-known parent so a transient failure can't clobber fork identity.
+  const upstream = liveUpstream ?? repo.upstream ?? null
+  if (!upstream) {
+    const slug = await resolveRepositorySlugLive(runtimeTarget, repo)
+    return { repoIcon: slug ? githubAvatarIcon(slug) : null, upstream: null }
   }
-  const slug = await resolveRepositorySlugLive(runtimeTarget, repo)
-  return { repoIcon: slug ? githubAvatarIcon(slug) : null, upstream: null }
+  // Why: a same-name fork is a personal copy identified by its upstream owner; a
+  // renamed fork is its own project, so its origin owner wins. A failed origin
+  // probe degrades to the upstream owner.
+  const origin = await resolveRepositorySlugLive(runtimeTarget, repo).catch(() => null)
+  const renamedFork = origin && origin.repo.toLowerCase() !== upstream.repo.toLowerCase()
+  return { repoIcon: githubAvatarIcon(renamedFork ? origin : upstream), upstream }
 }
 
 function sameRepositoryIdentity(

--- a/src/renderer/src/components/settings/repository-icon-github.ts
+++ b/src/renderer/src/components/settings/repository-icon-github.ts
@@ -1,5 +1,5 @@
 import type { GitHubRepositoryIdentity, Repo } from '../../../../shared/types'
-import { githubAvatarIcon, type RepoIcon } from '../../../../shared/repo-icon'
+import { githubAvatarIcon, githubAvatarSlug, type RepoIcon } from '../../../../shared/repo-icon'
 import { githubRepoIdentityKey } from '../../../../shared/github-repository-identity-key'
 import { callRuntimeRpc, type getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 
@@ -62,16 +62,10 @@ export async function resolveRepositoryGitHubAvatar(
   // Why: a null live upstream is ambiguous (offline/unauthed vs. not-a-fork). Keep
   // the last-known parent so a transient failure can't clobber fork identity.
   const upstream = liveUpstream ?? repo.upstream ?? null
-  if (!upstream) {
-    const slug = await resolveRepositorySlugLive(runtimeTarget, repo)
-    return { repoIcon: slug ? githubAvatarIcon(slug) : null, upstream: null }
-  }
-  // Why: a same-name fork is a personal copy identified by its upstream owner; a
-  // renamed fork is its own project, so its origin owner wins. A failed origin
-  // probe degrades to the upstream owner.
-  const origin = await resolveRepositorySlugLive(runtimeTarget, repo).catch(() => null)
-  const renamedFork = origin && origin.repo.toLowerCase() !== upstream.repo.toLowerCase()
-  return { repoIcon: githubAvatarIcon(renamedFork ? origin : upstream), upstream }
+  // Why: a rejected origin probe is also ambiguous, so it propagates — callers keep
+  // the stored icon rather than flipping a renamed fork back to the parent avatar.
+  const slug = githubAvatarSlug(await resolveRepositorySlugLive(runtimeTarget, repo), upstream)
+  return { repoIcon: slug ? githubAvatarIcon(slug) : null, upstream }
 }
 
 function sameRepositoryIdentity(

--- a/src/shared/repo-icon.test.ts
+++ b/src/shared/repo-icon.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { githubAvatarIcon, sanitizeRepoIcon } from './repo-icon'
+import { githubAvatarIcon, githubAvatarSlug, sanitizeRepoIcon } from './repo-icon'
 
 const PNG_1X1_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
@@ -165,5 +165,26 @@ describe('sanitizeRepoIcon', () => {
     expect(
       githubAvatarIcon({ owner: 'acme', repo: 'widgets', host: 'github.com@evil.example' })
     ).toMatchObject({ src: 'https://github.com/acme.png?size=64' })
+  })
+})
+
+describe('githubAvatarSlug', () => {
+  const upstream = { owner: 'upstream-org', repo: 'rocket' }
+
+  it('keeps the upstream owner for a same-name fork, case-insensitively', () => {
+    expect(githubAvatarSlug({ owner: 'acme', repo: 'rocket' }, upstream)).toEqual(upstream)
+    expect(githubAvatarSlug({ owner: 'acme', repo: 'RocKet' }, upstream)).toEqual(upstream)
+  })
+
+  it('keeps the fork own owner once it has been renamed', () => {
+    const origin = { owner: 'acme', repo: 'rocket-pro' }
+    expect(githubAvatarSlug(origin, upstream)).toEqual(origin)
+  })
+
+  it('falls back to whichever identity is known', () => {
+    const origin = { owner: 'acme', repo: 'rocket-pro' }
+    expect(githubAvatarSlug(origin, null)).toEqual(origin)
+    expect(githubAvatarSlug(null, upstream)).toEqual(upstream)
+    expect(githubAvatarSlug(null, undefined)).toBeNull()
   })
 })

--- a/src/shared/repo-icon.ts
+++ b/src/shared/repo-icon.ts
@@ -31,8 +31,24 @@ export function faviconUrlFromWebsite(rawUrl: string): string | null {
   }
 }
 
+type GitHubAvatarSlug = { owner: string; repo: string; host?: string }
+
+/**
+ * Pick the owner whose avatar represents a repo, given its `origin` and fork parent.
+ * Why: a same-name fork is a personal copy, so it reads as the parent project; a
+ * renamed fork is its own project and keeps its own owner.
+ */
+export function githubAvatarSlug(
+  origin: GitHubAvatarSlug | null | undefined,
+  upstream: GitHubAvatarSlug | null | undefined
+): GitHubAvatarSlug | null {
+  const renamedFork =
+    origin && upstream && origin.repo.toLowerCase() !== upstream.repo.toLowerCase()
+  return renamedFork ? origin : (upstream ?? origin ?? null)
+}
+
 // Why: shared default icon URL/label for main auto-detect and the renderer picker.
-export function githubAvatarIcon(slug: { owner: string; repo: string; host?: string }): RepoIcon {
+export function githubAvatarIcon(slug: GitHubAvatarSlug): RepoIcon {
   // Why: GHES uses the same /<login>.png avatar path as github.com.
   const host = normalizeGitHubAvatarHost(slug.host)
   return {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -253,8 +253,9 @@ export type Repo = {
   badgeColor: string
   repoIcon?: RepoIcon | null
   /** Set when the repo is a fork: the upstream/parent owner/repo. Drives the
-   *  default avatar (upstream owner, not the personal fork) and the fork
-   *  indicator. Absent = not a fork, or fork status not yet resolved. */
+   *  fork indicator and the default avatar of same-name forks (renamed forks
+   *  keep their own owner). Absent = not a fork, or fork status not yet
+   *  resolved. */
   upstream?: GitHubRepositoryIdentity | null
   addedAt: number
   kind?: RepoKind


### PR DESCRIPTION
## Summary

Fork repos always defaulted to the upstream (parent) owner's avatar, so a fork renamed into its own project showed its parent's logo in the left sidebar. Now:

- Same-name forks (personal copies) still prefer the upstream owner's avatar.
- Renamed forks keep their own origin owner's avatar (repo-name comparison is case-insensitive).

The rule is applied at all three decision points — repo-add auto-detection (`detectGitHubAvatarIcon`), the startup backfill for repos added before fork detection existed, and the settings avatar refresh (`resolveRepositoryGitHubAvatar`) — so already-affected repos self-correct when their repo settings open (or via "Use GitHub avatar"). `upstream` metadata semantics (fork badge, issue source, fork-sync offer) are unchanged.

## Screenshots

No screenshots. Visual change: a renamed fork's sidebar icon now shows the fork's own owner avatar instead of the parent project's logo; same-name forks are unchanged.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (one unrelated `run-electron-vite-dev` timeout under full-suite load; passes standalone)
- [x] `pnpm build`
- [x] Added regression tests: renamed-fork cases for main-process auto-detect and renderer avatar resolution; kept same-name fork cases to pin the preserved behavior, including the offline no-clobber protection.

## AI Review Report

- **Cross-platform (macOS/Linux/Windows)**: pure string/URL logic; no paths, shortcuts, shell, or Electron platform APIs touched.
- **SSH/remote/local**: `detectGitHubAvatarIcon` keeps its `connectionId` path (SSH providers); renderer resolution keeps the runtime-RPC path for environment targets. The new origin probe reuses `getRepoSlug`, which already handles SSH hosts and GHES.
- **Agents/integrations**: none touched.
- **Git providers**: confined to the GitHub module; non-GitHub remotes resolve `null` and behave as before. GitLab flow untouched. Folder workspaces skip this path entirely (`kind === 'git'` guard).
- **Performance**: one extra local `git remote` resolution per avatar decision, only at add-time, the sequential startup backfill, and settings-open refresh — no hot paths. Origin probe failure degrades to the previous upstream-avatar behavior.
- **Behavior safety**: verified the two paths that could have silently reintroduced the bug (startup backfill overwrite, settings-open refresh overwrite) — both now share the same rule.

## Security Audit

- No new input parsing: the repo-name comparison uses owner/repo identities from existing resolvers.
- Avatar URLs are still built only by `githubAvatarIcon`, whose host normalization (rejects credentials/path/query/hash) is unchanged.
- No new command execution: reuses existing `getRepoSlug`/`getRepoUpstream` (same git/gh surface, same timeouts); no IPC, auth, secrets, or dependency changes.

## Notes

No platform-specific or provider-specific behavior added. Existing repos that stored the wrong (upstream) avatar self-correct when their repo settings open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
