### PR TITLE
fix(terminal): stop cancelled IME compositions replaying stale preedit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ patchedDependencies:
     hash: 6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258
     path: config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch
   '@xterm/xterm@6.1.0-beta.287':
-    hash: 082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6
+    hash: 595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
     hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
@@ -46,7 +46,7 @@ importers:
         version: 2.5.6
       '@xterm/addon-serialize':
         specifier: 0.15.0-beta.287
-        version: 0.15.0-beta.287(patch_hash=81575700d58b62f9262d302aa4ae43b445a6273d579cd75dd6729c8883011ab9)(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.15.0-beta.287(patch_hash=81575700d58b62f9262d302aa4ae43b445a6273d579cd75dd6729c8883011ab9)(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/headless':
         specifier: 6.1.0-beta.287
         version: 6.1.0-beta.287
@@ -206,25 +206,25 @@ importers:
         version: 5.2.0(rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.8.4))
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.287
-        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/addon-ligatures':
         specifier: 0.11.0-beta.287
-        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/addon-search':
         specifier: 0.17.0-beta.287
-        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/addon-unicode11':
         specifier: 0.10.0-beta.287
-        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.287
-        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.286
-        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))
+        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))
       '@xterm/xterm':
         specifier: 6.1.0-beta.287
-        version: 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+        version: 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -9582,39 +9582,39 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
 
-  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
       lru-cache: 11.5.1
       opentype.js: 2.0.0
 
-  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
 
-  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=81575700d58b62f9262d302aa4ae43b445a6273d579cd75dd6729c8883011ab9)(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=81575700d58b62f9262d302aa4ae43b445a6273d579cd75dd6729c8883011ab9)(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
 
-  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
 
-  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
 
-  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6))':
+  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)
 
   '@xterm/headless@6.1.0-beta.287': {}
 
-  '@xterm/xterm@6.1.0-beta.287(patch_hash=082a4e714662e81b21d386f2c1de4c9dfd13e195c2497e9162b7e87f86b6a9b6)': {}
+  '@xterm/xterm@6.1.0-beta.287(patch_hash=595d23676ffcec9a99a09e9fa2b8f12b9ae2934cf1ff376bcc68f4cf1ec8766e)': {}
 
   abbrev@4.0.0: {}
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-composition-cancel.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-composition-cancel.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function openTerminal(): {
+  emitted: string[]
+  terminal: Terminal
+  textarea: HTMLTextAreaElement
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea
+  if (!textarea) {
+    throw new Error('xterm helper textarea was not created')
+  }
+  const emitted: string[] = []
+  terminal.onData((data) => emitted.push(data))
+  return { emitted, terminal, textarea }
+}
+
+function dispatchCompositionEvent(
+  textarea: HTMLTextAreaElement,
+  type: 'compositionstart' | 'compositionupdate' | 'compositionend',
+  data: string = ''
+): void {
+  const event = new CompositionEvent(type, { bubbles: true })
+  // happy-dom ignores CompositionEventInit.data, but Chromium supplies it.
+  Object.defineProperty(event, 'data', { value: data })
+  textarea.dispatchEvent(event)
+}
+
+function dispatchProcessKeydown(textarea: HTMLTextAreaElement): void {
+  const keydown = new KeyboardEvent('keydown', {
+    key: 'Process',
+    code: 'KeyC',
+    isComposing: true,
+    bubbles: true
+  })
+  Object.defineProperty(keydown, 'keyCode', { value: 229 })
+  textarea.dispatchEvent(keydown)
+}
+
+function dispatchComposedInput(textarea: HTMLTextAreaElement, init: InputEventInit): void {
+  const input = new InputEvent('input', { ...init, bubbles: true })
+  Object.defineProperty(input, 'composed', { value: true })
+  textarea.dispatchEvent(input)
+}
+
+function updatePreedit(textarea: HTMLTextAreaElement, text: string): void {
+  dispatchProcessKeydown(textarea)
+  dispatchCompositionEvent(textarea, 'compositionupdate', text)
+  textarea.value = text
+  dispatchComposedInput(textarea, { data: text, inputType: 'insertCompositionText' })
+}
+
+describe('xterm IME composition cancellation', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('emits nothing when Backspace deletes the whole Pinyin preedit', async () => {
+    const { emitted, terminal, textarea } = openTerminal()
+
+    dispatchCompositionEvent(textarea, 'compositionstart')
+    for (const preedit of ['c', 'ce', 'ces', 'cesh', 'ceshi']) {
+      updatePreedit(textarea, preedit)
+      await nextEventLoop()
+    }
+    for (const preedit of ['cesh', 'ces', 'ce', 'c']) {
+      updatePreedit(textarea, preedit)
+      await nextEventLoop()
+    }
+    // Final Backspace: Chromium clears the preedit and ends the composition
+    // with empty data; the last non-empty compositionupdate was 'c'.
+    dispatchProcessKeydown(textarea)
+    dispatchCompositionEvent(textarea, 'compositionupdate')
+    textarea.value = ''
+    dispatchComposedInput(textarea, { inputType: 'deleteContentBackward' })
+    dispatchCompositionEvent(textarea, 'compositionend')
+    await nextEventLoop()
+
+    expect(emitted).toEqual([])
+    terminal.dispose()
+  })
+
+  it('emits nothing when the preedit is cancelled without observed input events', async () => {
+    const { emitted, terminal, textarea } = openTerminal()
+
+    dispatchCompositionEvent(textarea, 'compositionstart')
+    dispatchCompositionEvent(textarea, 'compositionupdate', 'ce')
+    textarea.value = 'ce'
+    await nextEventLoop()
+    dispatchCompositionEvent(textarea, 'compositionupdate', 'c')
+    textarea.value = 'c'
+    await nextEventLoop()
+    textarea.value = ''
+    dispatchCompositionEvent(textarea, 'compositionend')
+    await nextEventLoop()
+
+    expect(emitted).toEqual([])
+    terminal.dispose()
+  })
+
+  it('still emits an empty-end commit that delivers text via a following input event', async () => {
+    const { emitted, terminal, textarea } = openTerminal()
+
+    dispatchCompositionEvent(textarea, 'compositionstart')
+    dispatchCompositionEvent(textarea, 'compositionupdate', '한')
+    textarea.value = '한'
+    await nextEventLoop()
+    // IBus clears the textarea at compositionend, then restores the commit
+    // through a bare insertText — evidence that this end was not a cancel.
+    textarea.value = ''
+    dispatchCompositionEvent(textarea, 'compositionend')
+    textarea.value = '한'
+    dispatchComposedInput(textarea, { data: '한', inputType: 'insertText' })
+    await nextEventLoop()
+
+    expect(emitted.join('')).toBe('한')
+    terminal.dispose()
+  })
+})


### PR DESCRIPTION
## Summary

- Treat an IME composition with no textarea, `compositionend`, `input`, or `keypress` commit evidence as cancelled instead of replaying stale preedit text.
- Preserve valid empty-`compositionend` commits that deliver text through a following `insertText` event.
- Add regression coverage against the real patched xterm build for macOS Pinyin Backspace cancellation and the Linux IBus commit shape.

Fixes #11936.

## Regression source

Introduced by #11293, merge commit `fe6f929c6e` (`fix(terminal): reconcile cross-platform IME composition lifecycle`). That commit added the `_sendPendingComposition` fallback to the last non-empty `compositionupdate` value. It is present in `v1.4.163` and absent from the `v1.4.162-rc.0` baseline.

A full revert of #11293 would restore the duplicate/drop and composition-ordering bugs it fixed. This PR changes only the ambiguous empty-evidence fallback.

Adapted from #11938 by @Him188; the contributor remains the commit author.

## Comparison with #11550

#11550 is complementary rather than an alternative to this fix:

- This PR fixes cancellation with no commit evidence, including macOS Pinyin. #11550 leaves `_sendPendingComposition`'s stale `compositionData` fallback unconditional, so its Windows deletion token does not fix the macOS path in #11936.
- #11550 adds useful Windows-specific handling for native `Process/229` Backspace/Delete: allow the deletion keydown into xterm, reconcile preedit state when native progress is absent, and consume the paired ordinary keyup under Kitty reporting.
- Its Shift/Enter changes should not be copied: #12265 already replaced them with physical-code-compatible classification, IME shortcut ownership, and press-evidence rollover handling. #11550's strict `Enter|NumpadEnter` requirement would regress valid blank/`Unidentified` IME Enter events.

The deletion-only portion of #11550 remains a good candidate for a separate follow-up adapted to #12265's current window-capture ownership. Folding it here would mix a Windows keyboard-routing change into the macOS cancellation fix and make both harder to validate.

Before reuse, that extraction also needs an explicit Windows runtime gate and coverage for delayed native progress and complex preedit deletion. #11550 currently lets any platform's composing `keyCode=229` Backspace/Delete bypass suppression and reconciles unchanged preedit on the next zero-delay task.
## Screenshots

No visual change.

## Testing

- [x] 253 terminal IME and keyboard ownership tests
- [x] `pnpm typecheck:web`
- [x] Frozen install/patch integrity
- [x] Formatting, default Oxlint, native/type-aware quality scans, reliability gates, max-lines ratchet, and diff checks
- [x] Added cancellation and valid empty-end commit regression tests against the installed xterm build

`pnpm lint` passes all changed-code and code-quality stages, then stops at `verify:skill-bundle-manifest` because unrelated generated skill artifacts on current `main` are stale. This PR does not touch those artifacts.

## Security audit

This only narrows when renderer composition text may be emitted to the PTY. It adds no command execution, IPC, transport, dependency, path, auth, or secret handling changes.

