### PR TITLE
fix(terminal): drop IME preedits abandoned by Backspace

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -5697,10 +5697,12 @@
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.test.ts src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts src/renderer/src/components/terminal-pane/terminal-paste-runtime.test.ts src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts src/renderer/src/components/terminal-pane/terminal-ime-candidate-key-release-guard.test.ts src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-ime-linux-candidate-state.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.test.ts",
         "pnpm run test:e2e -- tests/e2e/chinese-ime-chat-input-repro.spec.ts"
       ],
       "testFiles": [
         "src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.test.ts",
+        "src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.test.ts",
         "src/renderer/src/components/terminal-pane/terminal-ime-input-source.test.ts",
         "src/renderer/src/components/terminal-pane/terminal-paste-runtime.test.ts",
         "src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts",
@@ -5716,6 +5718,15 @@
           "assertions": [
             "native text commits route once to the intended PTY",
             "composition/preedit bookkeeping does not leak premature text"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.test.ts",
+          "assertions": [
+            "a Backspace that empties the preedit sends nothing to the PTY instead of replaying the abandoned preedit, whether or not the IME blanks the preedit with its own compositionupdate first",
+            "shrinking a multi-character preedit keeps composing and stays out of the PTY",
+            "real commits still route once, including a Sogou-style commit announced by an empty compositionupdate and an fcitx-style commit whose text only lands on the input event after an empty compositionend",
+            "the routeless dashboard-popout preview terminal drops the abandoned preedit too"
           ]
         },
         {
@@ -5776,6 +5787,15 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-08-03",
+          "runner": "local",
+          "platform": "linux",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.461,
+          "summary": "7 tests passed against real xterm instances: a Backspace that empties the preedit stays out of the PTY in both IME dialects (with and without a blanking compositionupdate), a shrinking multi-character preedit keeps composing, Sogou-style and fcitx-style commits still route exactly once, and the routeless dashboard-popout preview terminal drops the abandoned preedit. Forcing the guard off turns the four suppression assertions red while the three commit assertions stay green."
+        },
         {
           "date": "2026-07-11",
           "runner": "local",
@@ -5845,7 +5865,7 @@
       ],
       "knownGaps": [
         "Current commands include renderer-unit coverage and a CDP-driven Electron repro; real OS IME automation may need manual or soak evidence.",
-        "Backspace/Enter during composition, JIS yen, Arabic/RTL, paste edge cases, and Windows ConPTY post-agent key reset still need representative gate coverage."
+        "Backspace that empties a preedit is covered on both xterm surfaces by renderer-unit tests, not by real OS IME automation; Enter during composition, JIS yen, Arabic/RTL, paste edge cases, and Windows ConPTY post-agent key reset still need representative gate coverage."
       ],
       "demotionRule": "Cannot promote if success is based only on DOM text without PTY byte/cell evidence."
     },

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-ime-bridge.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-ime-bridge.ts
@@ -3,6 +3,8 @@ import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { installTerminalImeCompositionTracker } from '@/components/terminal-pane/terminal-ime-composition-tracker'
 import { installTerminalImeNativeTextForwarder } from '@/components/terminal-pane/terminal-ime-native-text-forwarder'
 import { getMacNativeTextInputSourceTracker } from '@/components/terminal-pane/terminal-ime-input-source'
+import { installTerminalImeAbandonedPreeditGuard } from '@/components/terminal-pane/terminal-ime-abandoned-preedit'
+import { XTERM_COMPOSITION_SESSION_END_EVENT } from '@/components/terminal-pane/terminal-ime-composition-route'
 
 export type PreviewImeBridge = {
   /** True when the forwarder owns this keydown, so xterm must not encode it. */
@@ -17,15 +19,31 @@ export type PreviewImeBridge = {
  * Chromium commits IME/native text, silently dropping the glyph. Mirrors
  * TerminalPane's forwarder, macOS-only like the pane's install.
  */
-export function installPreviewImeBridge(terminal: Terminal): PreviewImeBridge | null {
+export function installPreviewImeBridge(terminal: Terminal): PreviewImeBridge {
+  const terminalElement = terminal.element
+  // Why: the preview terminal has no composition route to arbitrate the session payload, so
+  // xterm's own data event would replay an abandoned preedit into the PTY. Cancel the session
+  // end instead. Not macOS-specific — any IME that empties its preedit hits this.
+  const abandonedPreedit = installTerminalImeAbandonedPreeditGuard(terminalElement)
+  const onSessionEnd = (event: Event): void => {
+    if (abandonedPreedit.consume()) {
+      event.preventDefault()
+    }
+  }
+  terminalElement?.addEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onSessionEnd)
+  const disposeAbandonedPreeditGuard = (): void => {
+    terminalElement?.removeEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onSessionEnd)
+    abandonedPreedit.dispose()
+  }
+
   if (getShortcutPlatform() !== 'darwin') {
-    return null
+    return { claimKeyEvent: () => false, dispose: disposeAbandonedPreeditGuard }
   }
   // Why: prewarm the async input-source lookup before the first native-text key needs classification.
   const inputSourceTracker = getMacNativeTextInputSourceTracker()
-  const compositionTracker = installTerminalImeCompositionTracker(terminal.element)
+  const compositionTracker = installTerminalImeCompositionTracker(terminalElement)
   const forwarder = installTerminalImeNativeTextForwarder({
-    terminalElement: terminal.element,
+    terminalElement,
     isComposing: () => compositionTracker?.isActive() ?? false,
     sendInput: (data) => terminal.input(data),
     getInputSourceFeatures: () => inputSourceTracker.getFeatures()
@@ -33,6 +51,7 @@ export function installPreviewImeBridge(terminal: Terminal): PreviewImeBridge | 
   return {
     claimKeyEvent: (event) => forwarder?.claimKeyEvent(event) ?? false,
     dispose: () => {
+      disposeAbandonedPreeditGuard()
       forwarder?.dispose()
       compositionTracker?.dispose()
     }

--- a/src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment happy-dom
+import { Terminal } from '@xterm/xterm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installTerminalImeCompositionRoute } from './terminal-ime-composition-route'
+import type { PtyTransport } from './pty-transport'
+import { installPreviewImeBridge } from '../dashboard-popout/preview-terminal-ime-bridge'
+
+const PTY_ID = 'pty-1'
+
+function nextEventLoop(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  window.setTimeout(resolve, 0)
+  return promise
+}
+
+function openRoutedTerminal(): {
+  routed: string[]
+  emitted: string[]
+  textarea: HTMLTextAreaElement
+} {
+  const container = document.createElement('div')
+  document.body.replaceChildren(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea
+  const element = terminal.element
+  if (!textarea || !element) {
+    throw new Error('xterm helper textarea was not created')
+  }
+  const routed: string[] = []
+  const emitted: string[] = []
+  terminal.onData((data) => emitted.push(data))
+  const transport = { getPtyId: () => PTY_ID } as unknown as PtyTransport
+  installTerminalImeCompositionRoute({
+    terminalElement: element,
+    terminal: { input: (data) => routed.push(data) },
+    capturedTransport: transport,
+    getCurrentTransport: () => transport
+  })
+  return { routed, emitted, textarea }
+}
+
+function composition(
+  textarea: HTMLTextAreaElement,
+  type: 'compositionstart' | 'compositionupdate' | 'compositionend',
+  data = ''
+): void {
+  const event = new CompositionEvent(type, { bubbles: true })
+  // happy-dom ignores CompositionEventInit.data, but Chromium supplies it.
+  Object.defineProperty(event, 'data', { value: data })
+  textarea.dispatchEvent(event)
+}
+
+function setPreedit(textarea: HTMLTextAreaElement, text: string): void {
+  textarea.value = text
+  textarea.setSelectionRange(text.length, text.length)
+  const event = new InputEvent('input', {
+    data: text,
+    inputType: 'insertCompositionText',
+    bubbles: true
+  })
+  Object.defineProperty(event, 'composed', { value: true })
+  textarea.dispatchEvent(event)
+}
+
+function imeKeydown(textarea: HTMLTextAreaElement, key: string, keyCode: number): void {
+  const event = new KeyboardEvent('keydown', { key, code: key, isComposing: true, bubbles: true })
+  Object.defineProperty(event, 'keyCode', { value: keyCode })
+  textarea.dispatchEvent(event)
+}
+
+describe('IME preedit abandoned by Backspace', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  // Backspace during composition is IME-owned: shouldSuppressTerminalImeKeyboardEvent keeps it
+  // away from xterm's key handler, so only the composition lifecycle can reach the PTY.
+  // The two dialects differ in whether the emptied preedit gets its own compositionupdate.
+  for (const blanksPreeditFirst of [true, false]) {
+    it(`sends nothing to the PTY when Backspace empties the last preedit symbol (blank update: ${blanksPreeditFirst})`, async () => {
+      const { routed, emitted, textarea } = openRoutedTerminal()
+
+      composition(textarea, 'compositionstart')
+      composition(textarea, 'compositionupdate', 'ㄑ')
+      setPreedit(textarea, 'ㄑ')
+      await nextEventLoop()
+
+      // macOS reports the IME-consumed Backspace as keyCode 229.
+      imeKeydown(textarea, 'Backspace', 229)
+      if (blanksPreeditFirst) {
+        composition(textarea, 'compositionupdate', '')
+        setPreedit(textarea, '')
+      }
+      composition(textarea, 'compositionend', '')
+      textarea.value = ''
+      await nextEventLoop()
+      await nextEventLoop()
+
+      expect(routed).toEqual([])
+      expect(emitted).toEqual([])
+    })
+  }
+
+  it('keeps composing when Backspace only shrinks a multi-character preedit', async () => {
+    const { routed, emitted, textarea } = openRoutedTerminal()
+
+    composition(textarea, 'compositionstart')
+    composition(textarea, 'compositionupdate', '你好')
+    setPreedit(textarea, '你好')
+    await nextEventLoop()
+
+    imeKeydown(textarea, 'Backspace', 229)
+    composition(textarea, 'compositionupdate', '你')
+    setPreedit(textarea, '你')
+    await nextEventLoop()
+    await nextEventLoop()
+
+    expect(routed).toEqual([])
+    expect(emitted).toEqual([])
+  })
+
+  it('still routes a real commit that follows an emptied preedit', async () => {
+    const { routed, textarea } = openRoutedTerminal()
+
+    composition(textarea, 'compositionstart')
+    composition(textarea, 'compositionupdate', 'ㄅ')
+    setPreedit(textarea, 'ㄅ')
+    await nextEventLoop()
+
+    imeKeydown(textarea, 'Backspace', 229)
+    composition(textarea, 'compositionupdate', '')
+    setPreedit(textarea, '')
+    composition(textarea, 'compositionend', '')
+    await nextEventLoop()
+    await nextEventLoop()
+
+    composition(textarea, 'compositionstart')
+    composition(textarea, 'compositionupdate', '好')
+    setPreedit(textarea, '好')
+    composition(textarea, 'compositionend', '好')
+    await nextEventLoop()
+    await nextEventLoop()
+
+    expect(routed).toEqual(['好'])
+  })
+
+  it('routes a Sogou-style commit announced by an empty compositionupdate', async () => {
+    const { routed, textarea } = openRoutedTerminal()
+
+    composition(textarea, 'compositionstart')
+    composition(textarea, 'compositionupdate', 'ni')
+    setPreedit(textarea, 'ni')
+    await nextEventLoop()
+
+    // Candidate window open: Sogou/fcitx blank the preedit before committing.
+    composition(textarea, 'compositionupdate', '')
+    composition(textarea, 'compositionend', '你')
+    setPreedit(textarea, '你')
+    await nextEventLoop()
+    await nextEventLoop()
+
+    expect(routed).toEqual(['你'])
+  })
+
+  it('routes a commit whose text only lands on the input event after an empty compositionend', async () => {
+    const { routed, textarea } = openRoutedTerminal()
+
+    composition(textarea, 'compositionstart')
+    composition(textarea, 'compositionupdate', 'ni')
+    setPreedit(textarea, 'ni')
+    await nextEventLoop()
+
+    // fcitx/IBus dialect: compositionend carries nothing, the commit arrives as the next input.
+    composition(textarea, 'compositionend', '')
+    setPreedit(textarea, '你')
+    await nextEventLoop()
+    await nextEventLoop()
+
+    expect(routed).toEqual(['你'])
+  })
+
+  it('keeps the abandoned preedit out of the routeless popout preview terminal', async () => {
+    const container = document.createElement('div')
+    document.body.replaceChildren(container)
+    const terminal = new Terminal()
+    terminal.open(container)
+    const textarea = terminal.textarea
+    if (!textarea) {
+      throw new Error('xterm helper textarea was not created')
+    }
+    const emitted: string[] = []
+    terminal.onData((data) => emitted.push(data))
+    installPreviewImeBridge(terminal)
+
+    composition(textarea, 'compositionstart')
+    composition(textarea, 'compositionupdate', 'ㄅ')
+    setPreedit(textarea, 'ㄅ')
+    await nextEventLoop()
+
+    imeKeydown(textarea, 'Backspace', 229)
+    composition(textarea, 'compositionupdate', '')
+    setPreedit(textarea, '')
+    composition(textarea, 'compositionend', '')
+    await nextEventLoop()
+    await nextEventLoop()
+
+    expect(emitted).toEqual([])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-abandoned-preedit.ts
@@ -1,0 +1,64 @@
+import type { IDisposable } from '@xterm/xterm'
+
+// Why: Orca's xterm patch falls back to the last non-empty compositionupdate when a session ends
+// with no committed text (`textareaInput || endData || compositionData`). An IME that empties its
+// preedit instead of committing — macOS Zhuyin Backspace on the last symbol — then replays the
+// abandoned preedit into the PTY rather than deleting. Pristine upstream xterm sends nothing here.
+//
+// The discriminator deliberately avoids the compositionupdate sequence, which differs per IME
+// dialect: some blank the preedit first, macOS can jump straight to compositionend. A commit
+// always surfaces its text either on compositionend or on the input event that follows it.
+
+export type TerminalImeAbandonedPreeditGuard = IDisposable & {
+  /** True once per composition that ended with no committed text, so its payload is stale. */
+  consume: () => boolean
+}
+
+export function installTerminalImeAbandonedPreeditGuard(
+  terminalElement: HTMLElement | null | undefined
+): TerminalImeAbandonedPreeditGuard {
+  let endedEmpty = false
+  let committedAfterEnd = false
+
+  const consume = (): boolean => {
+    const abandoned = endedEmpty && !committedAfterEnd
+    endedEmpty = false
+    committedAfterEnd = false
+    return abandoned
+  }
+
+  if (!terminalElement || typeof terminalElement.addEventListener !== 'function') {
+    return { consume, dispose: () => undefined }
+  }
+
+  const onCompositionStart = (): void => {
+    endedEmpty = false
+    committedAfterEnd = false
+  }
+  const onCompositionEnd = (event: Event): void => {
+    if (event instanceof CompositionEvent) {
+      endedEmpty = event.data === ''
+      committedAfterEnd = false
+    }
+  }
+  const onInput = (event: Event): void => {
+    // Why: Chromium fires the commit's input event right after compositionend and before xterm's
+    // deferred finalizer, so text landing here proves the session committed rather than aborted.
+    if (endedEmpty && event instanceof InputEvent && (event.data?.length ?? 0) > 0) {
+      committedAfterEnd = true
+    }
+  }
+
+  terminalElement.addEventListener('compositionstart', onCompositionStart, true)
+  terminalElement.addEventListener('compositionend', onCompositionEnd, true)
+  terminalElement.addEventListener('input', onInput, true)
+
+  return {
+    consume,
+    dispose: () => {
+      terminalElement.removeEventListener('compositionstart', onCompositionStart, true)
+      terminalElement.removeEventListener('compositionend', onCompositionEnd, true)
+      terminalElement.removeEventListener('input', onInput, true)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-route.ts
@@ -1,5 +1,6 @@
 import type { IDisposable, Terminal } from '@xterm/xterm'
 import type { PtyTransport } from './pty-transport'
+import { installTerminalImeAbandonedPreeditGuard } from './terminal-ime-abandoned-preedit'
 
 export const XTERM_COMPOSITION_SESSION_START_EVENT = 'xterm-composition-session-start'
 export const XTERM_COMPOSITION_SESSION_END_EVENT = 'xterm-composition-session-end'
@@ -64,6 +65,8 @@ export function installTerminalImeCompositionRoute(args: {
     return { dispose: () => undefined }
   }
 
+  const abandonedPreedit = installTerminalImeAbandonedPreeditGuard(terminalElement)
+
   const onSessionStart = (event: Event): void => {
     const detail = getCompositionDetail(event)
     if (!detail || disposed) {
@@ -87,10 +90,12 @@ export function installTerminalImeCompositionRoute(args: {
     if (!captured) {
       return
     }
+    const abandoned = abandonedPreedit.consume()
     sessions.delete(detail.id)
     adjustPendingCompositionCount(terminalElement, -1)
     if (
       disposed ||
+      abandoned ||
       detail.dataPendingReconciliation ||
       !detail.data ||
       captured.ptyId === null ||
@@ -110,6 +115,7 @@ export function installTerminalImeCompositionRoute(args: {
       disposed = true
       adjustPendingCompositionCount(terminalElement, -sessions.size)
       sessions.clear()
+      abandonedPreedit.dispose()
       terminalElement.removeEventListener(XTERM_COMPOSITION_SESSION_START_EVENT, onSessionStart)
       terminalElement.removeEventListener(XTERM_COMPOSITION_SESSION_END_EVENT, onSessionEnd)
     }


### PR DESCRIPTION
## Summary

Backspace that empties an IME preedit no longer replays the abandoned preedit into the PTY.

On macOS Zhuyin, pressing Backspace on the last symbol of a preedit deleted nothing and instead typed that symbol into the terminal, so the user had to press Backspace a second time to actually remove it. Reproduced on a real macOS Zhuyin session with `stty -icanon -echo; cat -v`, which returned the raw bytes `E3 84 91` / `E3 84 98` (`ㄑ` U+3111, `ㄘ` U+3118) — no CR and no DEL.

Root cause is in our own xterm patch, not upstream. `CompositionHelper._sendPendingComposition` resolves the session payload as:

```ts
textareaInput || pending.endData || pending.compositionData
```

and `_lastCompositionData` is deliberately not cleared by an empty `compositionupdate`. When an IME empties its preedit instead of committing, all observable channels are empty, so the chain falls back to `compositionData` — the preedit the user just deleted — and sends it. Pristine `@xterm/xterm@6.1.0-beta.287` emits nothing for the same event sequence, verified by running the identical sequence against an unpatched build.

The fix adds `installTerminalImeAbandonedPreeditGuard`, which treats a composition as abandoned when `compositionend` carries no data **and** no following `input` event carries text. A real commit always surfaces on one of those two channels, so the discriminator does not depend on the `compositionupdate` sequence, which differs per IME dialect (Sogou/fcitx blank the preedit first; macOS can go straight to `compositionend`).

It is wired into both xterm surfaces:

- `terminal-ime-composition-route.ts` (terminal pane) skips the payload instead of calling `terminal.input`.
- `preview-terminal-ime-bridge.ts` (dashboard popout preview terminal) has no composition route and would otherwise emit through xterm's own data event, so it cancels the session-end instead.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — exit 0; oxlint, native and type-aware code-quality audits all report 0 warnings / 0 errors; reliability gate manifest check passed for 62 gates
- [x] `pnpm typecheck` — exit 0
- [x] `pnpm test` — 4111 files passed, 16 skipped; 44115 tests passed, 135 skipped, 0 failed
- [x] `pnpm build` — exit 0 (desktop, CLI, web projection, native)
- [x] Added or updated high-quality tests that would catch regressions

New file `terminal-ime-abandoned-preedit.test.ts` drives real `Terminal` instances with the real composition route, not mocks:

| Case | Expectation |
| --- | --- |
| Backspace empties preedit, IME blanks it with its own `compositionupdate` first | nothing reaches the PTY |
| Backspace empties preedit, IME goes straight to `compositionend` | nothing reaches the PTY |
| Backspace only shrinks a multi-character preedit | still composing, nothing reaches the PTY |
| Sogou-style commit announced by an empty `compositionupdate` | `你` routes exactly once |
| fcitx-style commit whose text only lands on the `input` event after an empty `compositionend` | `你` routes exactly once |
| Routeless dashboard-popout preview terminal, abandoned preedit | nothing reaches the PTY |

The last three are the important ones: they fail if the guard over-suppresses. Forcing the guard off turns the four suppression assertions red while the three commit assertions stay green, so the suite discriminates rather than passing vacuously.

Registered under the existing `terminal-input.ime-and-synthetic-forwarding` reliability gate (commands, testFiles, assertionRefs, evidenceRuns), and narrowed its `knownGaps` entry accordingly.

## AI Review Report

Review focused on the risk that a payload guard drops text the user actually committed.

**Cross-platform.** The guard contains no platform branch — it reads only `CompositionEvent.data` and `InputEvent.data`. No paths, no shell, no keyboard-accelerator or shortcut-label changes, so the `metaKey`/`CmdOrCtrl` and `⌘`/`Ctrl+` rules are not touched. One behavioral note: `installPreviewImeBridge` previously returned `null` on non-darwin and now always returns a bridge, because the abandoned-preedit path is not macOS-specific. Both call sites use `imeBridge?.claimKeyEvent(event) ?? false` and `imeBridge?.dispose()`; the non-darwin bridge returns `claimKeyEvent: () => false`, so observable behavior on Linux and Windows is unchanged and cleanup is now actually performed. Windows MS-IME and Linux fcitx/IBus commits always carry text on `compositionend` or the following `input` event, which the two "must route" tests pin — but that reasoning is covered by unit tests only, not by real-OS IME automation on those platforms.

**SSH / remote / local.** No change to transport, PTY ownership, or process assumptions. The composition route's existing captured-transport and pty-id checks are untouched; the guard only adds one more reason to skip `terminal.input`, evaluated before those checks change any state.

**Agents / integrations / git providers.** Nothing provider- or agent-specific. The change sits below every CLI agent in the renderer input path.

**Performance.** Three passive listeners per terminal element and two booleans. No allocation in the keystroke path, no polling, no IPC. Listeners are removed in `dispose()`, which both surfaces call on teardown.

**UI quality.** No UI surface touched.

**What was flagged and changed.** The first implementation keyed on `compositionupdate('')` preceding `compositionend('')`. That sequence was assumed, not observed, and would have silently failed on IMEs that skip the blanking update — the fix would have looked correct while doing nothing. It was replaced with the dialect-independent discriminator described above, and a second test case was added for the skipped-update dialect. The first implementation also only covered the terminal pane; the dashboard popout preview terminal was found to be independently affected and was fixed in the same change.

## Security Audit

No input validation, command execution, path handling, authentication, secrets, IPC, or dependency surface is touched. The change is a renderer-local DOM event state machine that can only ever *suppress* one already-computed string; it cannot construct, widen, or redirect a payload, and it does not alter which PTY a payload reaches. The residual risk is functional rather than security-related: an over-broad guard would drop legitimate committed text, which the three "must route" test cases exist to catch. No follow-up needed.

## Notes

- The bug is triggered by IMEs that empty a preedit instead of committing (macOS Zhuyin Backspace is the reported case), but the fix is platform-neutral and applies wherever xterm runs.
- This is a regression from our own `config/patches/@xterm__xterm@6.1.0-beta.287.patch`, not an upstream xterm bug, so no upstream PR is needed. The `|| pending.compositionData` fallback is intentionally kept for IMEs that clear the textarea before committing; only the abandoned case is filtered out.
- Real-OS IME automation remains a registered gap for this gate on every platform. Verification here is renderer-unit plus a manual macOS Zhuyin reproduction.
