### PR TITLE
fix(terminal): recover degraded daemon spawn routing

### DIFF
--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -689,6 +689,29 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(adapterInstances[0].listProcesses).toHaveBeenCalled()
   })
 
+  it('rechecks the preserved daemon endpoint before recovering fresh-spawn routing', async () => {
+    const mod = await importFresh()
+    ensureRunningOverrides.push(async () => ({
+      socketPath: '/fake/degraded-socket',
+      tokenPath: '/fake/degraded-token',
+      mode: 'degraded-new-pty-fallback'
+    }))
+    await mod.initDaemonPtyProvider()
+    checkDaemonHealthMock.mockClear()
+
+    const { DegradedDaemonPtyProvider } = await import('./degraded-daemon-pty-provider')
+    const provider = mod.getDaemonProvider()
+    expect(provider).toBeInstanceOf(DegradedDaemonPtyProvider)
+    const degradedProvider = provider as InstanceType<typeof DegradedDaemonPtyProvider>
+
+    await expect(degradedProvider.recoverFreshSpawnRouting()).resolves.toBe(true)
+    expect(checkDaemonHealthMock).toHaveBeenCalledWith(
+      '/fake/degraded-socket',
+      '/fake/degraded-token'
+    )
+    expect(degradedProvider.routesFreshSpawnsToLocalProvider).toBeUndefined()
+  })
+
   it('fans pty:exit for every active session *before* unbinding listeners, and killedCount is captured pre-fanout', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -763,7 +763,9 @@ export async function initDaemonPtyProvider(
         ? new DegradedDaemonPtyProvider({
             current: newAdapter,
             legacy: legacyAdapters,
-            fallback: getLocalPtyProvider()
+            fallback: getLocalPtyProvider(),
+            probeCurrentDaemonSpawn: async () =>
+              (await checkDaemonHealth(info.socketPath, info.tokenPath)) === 'healthy'
           })
         : legacyAdapters.length > 0
           ? new DaemonPtyRouter({

--- a/src/main/daemon/degraded-daemon-fresh-spawn-routing.ts
+++ b/src/main/daemon/degraded-daemon-fresh-spawn-routing.ts
@@ -20,6 +20,18 @@ export class DegradedDaemonFreshSpawnRouter {
     return this.target === this.fallback ? true : undefined
   }
 
+  supportsGitGuardHost(sessionId?: string): boolean {
+    const provider = (sessionId ? this.sessionProviders.get(sessionId) : undefined) ?? this.target
+    return provider.supportsGitCredentialGuardHost?.(sessionId) === true
+  }
+
+  canProvideSnapshot(sessionId: string): boolean {
+    return (
+      this.sessionProviders.get(sessionId)?.canProvideAuthoritativeBufferSnapshot?.(sessionId) ===
+      true
+    )
+  }
+
   async recover(): Promise<boolean> {
     if (this.target === this.current) {
       return true

--- a/src/main/daemon/degraded-daemon-fresh-spawn-routing.ts
+++ b/src/main/daemon/degraded-daemon-fresh-spawn-routing.ts
@@ -1,0 +1,63 @@
+import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+
+export const DEGRADED_DAEMON_RECOVERY_RETRY_MS = 30_000
+
+export class DegradedDaemonFreshSpawnRouter {
+  private target: IPtyProvider
+  private recovery: Promise<boolean> | null = null
+  private retryAfterMs = 0
+
+  constructor(
+    private readonly current: IPtyProvider,
+    private readonly fallback: IPtyProvider,
+    private readonly sessionProviders: Map<string, IPtyProvider>,
+    private readonly probeCurrent: (() => Promise<boolean>) | null
+  ) {
+    this.target = fallback
+  }
+
+  get routesToFallback(): true | undefined {
+    return this.target === this.fallback ? true : undefined
+  }
+
+  async recover(): Promise<boolean> {
+    if (this.target === this.current) {
+      return true
+    }
+    if (!this.probeCurrent) {
+      return false
+    }
+    if (Date.now() < this.retryAfterMs) {
+      return false
+    }
+    if (this.recovery) {
+      return this.recovery
+    }
+    const recovery = this.probeCurrent()
+      .catch(() => false)
+      .then((healthy) => {
+        if (healthy) {
+          this.target = this.current
+          console.info('[daemon] PTY spawn health recovered; fresh terminals are daemon-backed')
+        } else {
+          this.retryAfterMs = Date.now() + DEGRADED_DAEMON_RECOVERY_RETRY_MS
+        }
+        return healthy
+      })
+      .finally(() => {
+        if (this.recovery === recovery) {
+          this.recovery = null
+        }
+      })
+    this.recovery = recovery
+    return recovery
+  }
+
+  async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
+    const mapped = opts.sessionId ? this.sessionProviders.get(opts.sessionId) : undefined
+    const target = mapped ?? this.target
+    const result = await target.spawn(opts)
+    this.sessionProviders.set(result.id, target)
+    return result
+  }
+}

--- a/src/main/daemon/degraded-daemon-fresh-spawn-routing.ts
+++ b/src/main/daemon/degraded-daemon-fresh-spawn-routing.ts
@@ -69,7 +69,9 @@ export class DegradedDaemonFreshSpawnRouter {
     const mapped = opts.sessionId ? this.sessionProviders.get(opts.sessionId) : undefined
     const target = mapped ?? this.target
     const result = await target.spawn(opts)
-    this.sessionProviders.set(result.id, target)
+    if (!result.exitedBeforeSpawnReply) {
+      this.sessionProviders.set(result.id, target)
+    }
     return result
   }
 }

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { DegradedDaemonPtyProvider } from './degraded-daemon-pty-provider'
+import { DEGRADED_DAEMON_RECOVERY_RETRY_MS } from './degraded-daemon-fresh-spawn-routing'
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import type { PtyProcessInspection } from '../providers/pty-process-inspection'
@@ -226,6 +227,64 @@ describe('DegradedDaemonPtyProvider', () => {
     expect(fallback.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
     expect(current.write).toHaveBeenCalledWith('daemon-session', 'old\n')
     expect(fallback.write).toHaveBeenCalledWith(fresh.id, 'new\n')
+  })
+
+  it('routes later fresh PTYs to the daemon after spawn health recovers', async () => {
+    const current = createDaemonAdapter('daemon')
+    const fallback = createProvider('fallback')
+    const probeCurrentDaemonSpawn = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+    const provider = new DegradedDaemonPtyProvider({
+      current,
+      legacy: [],
+      fallback,
+      probeCurrentDaemonSpawn
+    })
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+
+    try {
+      await expect(provider.recoverFreshSpawnRouting()).resolves.toBe(false)
+      await provider.spawn({ cols: 80, rows: 24 })
+      await expect(provider.recoverFreshSpawnRouting()).resolves.toBe(false)
+      expect(probeCurrentDaemonSpawn).toHaveBeenCalledOnce()
+      now.mockReturnValue(1_000 + DEGRADED_DAEMON_RECOVERY_RETRY_MS)
+      await expect(provider.recoverFreshSpawnRouting()).resolves.toBe(true)
+      const recovered = await provider.spawn({ cols: 80, rows: 24, worktreeId: 'wt-1' })
+
+      expect(provider.routesFreshSpawnsToLocalProvider).toBeUndefined()
+      expect(fallback.spawn).toHaveBeenCalledOnce()
+      expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24, worktreeId: 'wt-1' })
+      expect(recovered.id).toBe('daemon-new')
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('coalesces concurrent fresh-spawn recovery probes', async () => {
+    let resolveProbe: ((healthy: boolean) => void) | undefined
+    const probeCurrentDaemonSpawn = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveProbe = resolve
+        })
+    )
+    const provider = new DegradedDaemonPtyProvider({
+      current: createDaemonAdapter('daemon'),
+      legacy: [],
+      fallback: createProvider('fallback'),
+      probeCurrentDaemonSpawn
+    })
+
+    const first = provider.recoverFreshSpawnRouting()
+    const second = provider.recoverFreshSpawnRouting()
+    expect(probeCurrentDaemonSpawn).toHaveBeenCalledOnce()
+    resolveProbe?.(true)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    await expect(provider.recoverFreshSpawnRouting()).resolves.toBe(true)
+    expect(probeCurrentDaemonSpawn).toHaveBeenCalledOnce()
   })
 
   it('routes a previously daemon-backed id to fallback after daemon exit removes the mapping', async () => {

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -292,6 +292,28 @@ describe('DegradedDaemonPtyProvider', () => {
     expect(probeCurrentDaemonSpawn).toHaveBeenCalledOnce()
   })
 
+  it('does not retain recovered daemon ownership after exit beats the spawn reply', async () => {
+    const current = createDaemonAdapter('daemon')
+    const provider = new DegradedDaemonPtyProvider({
+      current,
+      legacy: [],
+      fallback: createProvider('fallback'),
+      probeCurrentDaemonSpawn: vi.fn(async () => true)
+    })
+    vi.mocked(current.spawn).mockImplementation(async () => {
+      current.emitExit('daemon-fast-exit', 0)
+      return { id: 'daemon-fast-exit', exitedBeforeSpawnReply: true }
+    })
+
+    await provider.recoverFreshSpawnRouting()
+    await expect(provider.spawn({ cols: 80, rows: 24 })).resolves.toMatchObject({
+      id: 'daemon-fast-exit',
+      exitedBeforeSpawnReply: true
+    })
+
+    expect(provider.getCurrentDaemonSessionIds()).toEqual([])
+  })
+
   it('routes a previously daemon-backed id to fallback after daemon exit removes the mapping', async () => {
     const current = createDaemonAdapter('daemon', ['daemon-session'])
     const fallback = createProvider('fallback')

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -125,6 +125,8 @@ function createDaemonAdapter(
   return {
     ...createProvider(label, sessions, true),
     protocolVersion: 13,
+    supportsGitCredentialGuardHost: vi.fn(() => true),
+    canProvideAuthoritativeBufferSnapshot: vi.fn(() => true),
     listSessions: vi.fn(async () => []),
     ackColdRestore: vi.fn(),
     clearTombstone: vi.fn(),
@@ -254,9 +256,12 @@ describe('DegradedDaemonPtyProvider', () => {
       const recovered = await provider.spawn({ cols: 80, rows: 24, worktreeId: 'wt-1' })
 
       expect(provider.routesFreshSpawnsToLocalProvider).toBeUndefined()
+      expect(provider.isDegraded).toBe(true)
+      expect(provider.supportsGitCredentialGuardHost()).toBe(true)
       expect(fallback.spawn).toHaveBeenCalledOnce()
       expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24, worktreeId: 'wt-1' })
       expect(recovered.id).toBe('daemon-new')
+      expect(provider.canProvideAuthoritativeBufferSnapshot(recovered.id)).toBe(true)
     } finally {
       now.mockRestore()
     }

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -11,18 +11,20 @@ import type {
   PtySpawnOptions,
   PtySpawnResult
 } from '../providers/types'
-import { findDaemonAdapter, listProviderSessionIds } from './degraded-daemon-session-routing'
+import {
+  discoverDegradedDaemonSessions,
+  findDaemonAdapter,
+  listProviderSessionIds
+} from './degraded-daemon-session-routing'
 import { probePtyOwners } from './daemon-pty-liveness-probe'
+import { DegradedDaemonFreshSpawnRouter } from './degraded-daemon-fresh-spawn-routing'
 
 export class DegradedDaemonPtyProvider implements IPtyProvider {
-  readonly routesFreshSpawnsToLocalProvider = true
-  // Why: surface that fresh PTYs lack daemon persistence until restart.
-  readonly isDegraded = true
-
   private current: DaemonPtyAdapter
   private legacy: DaemonPtyAdapter[]
   private fallback: IPtyProvider
   private sessionProviders = new Map<string, IPtyProvider>()
+  private freshSpawns: DegradedDaemonFreshSpawnRouter
   private unsubscribers: (() => void)[] = []
   private dataListeners: ((payload: PtyDataEvent) => void)[] = []
   private exitListeners: ((payload: { id: string; code: number }) => void)[] = []
@@ -31,10 +33,17 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     current: DaemonPtyAdapter
     legacy: DaemonPtyAdapter[]
     fallback: IPtyProvider
+    probeCurrentDaemonSpawn?: () => Promise<boolean>
   }) {
     this.current = opts.current
     this.legacy = opts.legacy
     this.fallback = opts.fallback
+    this.freshSpawns = new DegradedDaemonFreshSpawnRouter(
+      opts.current,
+      opts.fallback,
+      this.sessionProviders,
+      opts.probeCurrentDaemonSpawn ?? null
+    )
 
     for (const provider of this.allProviders()) {
       this.unsubscribers.push(
@@ -53,25 +62,18 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     }
   }
 
-  async discoverDaemonSessions(): Promise<void> {
-    for (const adapter of this.allDaemonAdapters()) {
-      try {
-        const sessions = await adapter.listProcesses()
-        for (const session of sessions) {
-          this.sessionProviders.set(session.id, adapter)
-        }
-      } catch (error) {
-        console.warn('[daemon] Failed to discover degraded daemon sessions', error)
-      }
-    }
+  discoverDaemonSessions(): Promise<void> {
+    return discoverDegradedDaemonSessions(this.allDaemonAdapters(), this.sessionProviders)
   }
 
+  get routesFreshSpawnsToLocalProvider(): true | undefined {
+    return this.freshSpawns.routesToFallback
+  }
+
+  recoverFreshSpawnRouting = (): Promise<boolean> => this.freshSpawns.recover()
+
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
-    const mapped = opts.sessionId ? this.sessionProviders.get(opts.sessionId) : undefined
-    const target = mapped ?? this.fallback
-    const result = await target.spawn(opts)
-    this.sessionProviders.set(result.id, target)
-    return result
+    return this.freshSpawns.spawn(opts)
   }
 
   async attach(id: string): Promise<void> {

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -20,6 +20,8 @@ import { probePtyOwners } from './daemon-pty-liveness-probe'
 import { DegradedDaemonFreshSpawnRouter } from './degraded-daemon-fresh-spawn-routing'
 
 export class DegradedDaemonPtyProvider implements IPtyProvider {
+  readonly isDegraded = true
+
   private current: DaemonPtyAdapter
   private legacy: DaemonPtyAdapter[]
   private fallback: IPtyProvider
@@ -72,13 +74,15 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
 
   recoverFreshSpawnRouting = (): Promise<boolean> => this.freshSpawns.recover()
 
-  async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
-    return this.freshSpawns.spawn(opts)
-  }
+  supportsGitCredentialGuardHost = (id?: string): boolean =>
+    this.freshSpawns.supportsGitGuardHost(id)
 
-  async attach(id: string): Promise<void> {
-    await this.providerFor(id).attach(id)
-  }
+  canProvideAuthoritativeBufferSnapshot = (id: string): boolean =>
+    this.freshSpawns.canProvideSnapshot(id)
+
+  spawn = (opts: PtySpawnOptions): Promise<PtySpawnResult> => this.freshSpawns.spawn(opts)
+
+  attach = (id: string): Promise<void> => this.providerFor(id).attach(id)
 
   hasPty(id: string): boolean {
     const mapped = this.sessionProviders.get(id)
@@ -149,9 +153,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     return (await this.providerFor(id).getBufferSnapshot?.(id, opts)) ?? null
   }
 
-  async clearBuffer(id: string): Promise<void> {
-    await this.providerFor(id).clearBuffer(id)
-  }
+  clearBuffer = (id: string): Promise<void> => this.providerFor(id).clearBuffer(id)
 
   async closeStartupQueryAuthority(id: string): Promise<number> {
     return (await this.providerFor(id).closeStartupQueryAuthority?.(id)) ?? 0

--- a/src/main/daemon/degraded-daemon-session-routing.ts
+++ b/src/main/daemon/degraded-daemon-session-routing.ts
@@ -1,6 +1,21 @@
 import type { IPtyProvider } from '../providers/types'
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 
+export async function discoverDegradedDaemonSessions(
+  adapters: readonly DaemonPtyAdapter[],
+  sessionProviders: Map<string, IPtyProvider>
+): Promise<void> {
+  for (const adapter of adapters) {
+    try {
+      for (const session of await adapter.listProcesses()) {
+        sessionProviders.set(session.id, adapter)
+      }
+    } catch (error) {
+      console.warn('[daemon] Failed to discover degraded daemon sessions', error)
+    }
+  }
+}
+
 export function listProviderSessionIds(
   sessionProviders: ReadonlyMap<string, IPtyProvider>,
   provider: IPtyProvider

--- a/src/main/ipc/pty-management.test.ts
+++ b/src/main/ipc/pty-management.test.ts
@@ -44,10 +44,17 @@ vi.mock('../daemon/daemon-pty-router', () => {
 // subscribes to adapter events, so keep only the accessors pty-management uses.
 vi.mock('../daemon/degraded-daemon-pty-provider', () => {
   class DegradedDaemonPtyProvider {
-    readonly isDegraded = true
     private allAdapters: unknown[]
+    private routesFreshToFallback = true
     constructor(opts: { current: unknown; legacy: unknown[] }) {
       this.allAdapters = [opts.current, ...opts.legacy]
+    }
+    get routesFreshSpawnsToLocalProvider(): true | undefined {
+      return this.routesFreshToFallback ? true : undefined
+    }
+    async recoverFreshSpawnRouting(): Promise<boolean> {
+      this.routesFreshToFallback = false
+      return true
     }
     getAllAdapters() {
       return this.allAdapters
@@ -175,6 +182,19 @@ describe('pty:management IPC handlers', () => {
 
       expect(result.degraded).toBe(true)
       expect(result.sessions.map((s) => s.sessionId)).toEqual(['preserved-1'])
+    })
+
+    it('clears degraded mode after durable fresh-spawn routing recovers', async () => {
+      const current = makeAdapter(5, [makeSession('preserved-1')])
+      const provider = await makeDegradedProvider(current)
+      const { registerDaemonManagementHandlers } = await importFresh()
+      getDaemonProviderMock.mockReturnValue(provider)
+      registerDaemonManagementHandlers()
+      const handler = buildHandlerMap()['pty:management:listSessions']
+
+      await expect(handler({})).resolves.toMatchObject({ degraded: true })
+      await provider.recoverFreshSpawnRouting()
+      await expect(handler({})).resolves.toMatchObject({ degraded: false })
     })
 
     it('returns empty list when no daemon provider is installed', async () => {

--- a/src/main/ipc/pty-management.ts
+++ b/src/main/ipc/pty-management.ts
@@ -26,7 +26,11 @@ function getDaemonAdapters(): DaemonPtyAdapter[] {
 
 // Why: surface degraded mode (daemon alive but cannot spawn fresh PTYs) so the UI can warn new terminals lack persistence.
 function isDaemonDegraded(): boolean {
-  return getDaemonProvider() instanceof DegradedDaemonPtyProvider
+  const provider = getDaemonProvider()
+  return (
+    provider instanceof DegradedDaemonPtyProvider &&
+    provider.routesFreshSpawnsToLocalProvider === true
+  )
 }
 
 async function collectSessions(adapters: DaemonPtyAdapter[]): Promise<DaemonSessionInfo[]> {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1078,6 +1078,41 @@ describe('registerPtyHandlers', () => {
     }
   )
 
+  it('recovers degraded routing for a fresh runtime session with a stable id', async () => {
+    let degraded = true
+    const daemonSpawn = vi.fn(async (options: { sessionId?: string; isNewSession?: boolean }) => ({
+      id: options.sessionId ?? 'unexpected-fallback-id'
+    }))
+    const provider = createAgentClaimProvider({ spawn: daemonSpawn })
+    const recoverFreshSpawnRouting = vi.fn(async () => {
+      degraded = false
+      return true
+    })
+    Object.defineProperties(provider, {
+      routesFreshSpawnsToLocalProvider: {
+        configurable: true,
+        get: () => (degraded ? true : undefined)
+      },
+      recoverFreshSpawnRouting: { value: recoverFreshSpawnRouting }
+    })
+    setLocalPtyProvider(provider as never)
+    const controller = registerAgentClaimController()
+
+    await controller.spawn({
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp/recovered-stable-session',
+      worktreeId: 'repo::/tmp/recovered-stable-session',
+      sessionId: 'serve-stable-session',
+      isNewSession: true
+    })
+
+    expect(recoverFreshSpawnRouting).toHaveBeenCalledOnce()
+    expect(daemonSpawn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'serve-stable-session', isNewSession: true })
+    )
+  })
+
   it('adopts a daemon owner recovered from provider listing before claimed ensure', async () => {
     const owner: AgentSessionOwnerBinding = {
       claim: recoveredAgentClaim,

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -764,6 +764,7 @@ describe('registerPtyHandlers', () => {
       setPtyController: vi.fn((next) => {
         controller = next
       }),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'term_recovered'),
       registerPreAllocatedHandleForPty: vi.fn(),
       registerPty: vi.fn()
     }
@@ -1032,6 +1033,50 @@ describe('registerPtyHandlers', () => {
     expect(physicalSpawn).toHaveBeenCalledOnce()
     clearProviderPtyState('pty-local-claim')
   })
+
+  it.each(['runtime controller', 'renderer IPC'] as const)(
+    'recovers degraded fresh-spawn routing before %s chooses daemon host semantics',
+    async (entryPoint) => {
+      let degraded = true
+      const daemonSpawn = vi.fn(async (options: { sessionId?: string }) => ({
+        id: options.sessionId ?? 'unexpected-fallback-id'
+      }))
+      const provider = createAgentClaimProvider({ spawn: daemonSpawn })
+      const recoverFreshSpawnRouting = vi.fn(async () => {
+        degraded = false
+        return true
+      })
+      Object.defineProperties(provider, {
+        routesFreshSpawnsToLocalProvider: {
+          configurable: true,
+          get: () => (degraded ? true : undefined)
+        },
+        recoverFreshSpawnRouting: { value: recoverFreshSpawnRouting }
+      })
+      setLocalPtyProvider(provider as never)
+      const controller = registerAgentClaimController()
+      const worktreeId = 'repo::/tmp/recovered-daemon-routing'
+      const spawnArgs = {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp/recovered-daemon-routing',
+        worktreeId
+      }
+
+      await (entryPoint === 'runtime controller'
+        ? controller.spawn(spawnArgs)
+        : handlers.get('pty:spawn')!(null, spawnArgs))
+
+      expect(recoverFreshSpawnRouting).toHaveBeenCalledOnce()
+      expect(daemonSpawn).toHaveBeenCalledOnce()
+      expect(daemonSpawn.mock.calls[0]?.[0].sessionId).toMatch(
+        new RegExp(`^${worktreeId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}@@`)
+      )
+      expect(recoverFreshSpawnRouting.mock.invocationCallOrder[0]).toBeLessThan(
+        daemonSpawn.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+      )
+    }
+  )
 
   it('adopts a daemon owner recovered from provider listing before claimed ensure', async () => {
     const owner: AgentSessionOwnerBinding = {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -227,9 +227,6 @@ import type { PtyListedSession } from '../../shared/pty-listed-session'
 // Routes PTY operations by connectionId (null = local provider).
 
 let localProvider: IPtyProvider = new LocalPtyProvider()
-type FreshLocalFallbackProvider = IPtyProvider & {
-  routesFreshSpawnsToLocalProvider?: true
-}
 const sshProviders = new Map<string, IPtyProvider>()
 const sshProvidersByGeneration = new Map<number, IPtyProvider>()
 
@@ -1448,10 +1445,19 @@ function isClaudeLaunchCommand(command: string | undefined): boolean {
   )
 }
 
-function routesFreshSpawnsToLocalProvider(
-  provider: IPtyProvider
-): provider is FreshLocalFallbackProvider {
-  return (provider as FreshLocalFallbackProvider).routesFreshSpawnsToLocalProvider === true
+function routesFreshSpawnsToLocalProvider(provider: IPtyProvider): boolean {
+  return provider.routesFreshSpawnsToLocalProvider === true
+}
+
+function recoverFreshSpawnProviderRouting(
+  provider: IPtyProvider,
+  connectionId: string | null | undefined,
+  sessionId: string | undefined
+): Promise<boolean> | undefined {
+  if (connectionId || sessionId || !routesFreshSpawnsToLocalProvider(provider)) {
+    return
+  }
+  return provider.recoverFreshSpawnRouting?.()
 }
 
 function beginPtySpawnForWorktree(
@@ -3821,6 +3827,14 @@ export function registerPtyHandlers(
       await assertFolderWorkspacePtyPathUsable(args.worktreeId)
       const cwd = resolvePtySpawnStartupCwd(args.worktreeId, args.cwd)
       const provider = getProvider(args.connectionId)
+      const freshSpawnRecovery = recoverFreshSpawnProviderRouting(
+        provider,
+        args.connectionId,
+        args.sessionId
+      )
+      if (freshSpawnRecovery) {
+        await freshSpawnRecovery
+      }
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
         throw new Error('A Claude account switch is in progress. Try again after it finishes.')
@@ -4950,6 +4964,14 @@ export function registerPtyHandlers(
         didFallbackToWorkspaceRootCwd && cwd ? ({ kind: 'worktree', cwd } as const) : undefined
       spawnTiming.mark('preflight')
       const provider = getProvider(args.connectionId)
+      const freshSpawnRecovery = recoverFreshSpawnProviderRouting(
+        provider,
+        args.connectionId,
+        args.sessionId
+      )
+      if (freshSpawnRecovery) {
+        await freshSpawnRecovery
+      }
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
         throw new Error('A Claude account switch is in progress. Try again after it finishes.')

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1452,9 +1452,10 @@ function routesFreshSpawnsToLocalProvider(provider: IPtyProvider): boolean {
 function recoverFreshSpawnProviderRouting(
   provider: IPtyProvider,
   connectionId: string | null | undefined,
-  sessionId: string | undefined
+  sessionId: string | undefined,
+  isNewSession = sessionId === undefined
 ): Promise<boolean> | undefined {
-  if (connectionId || sessionId || !routesFreshSpawnsToLocalProvider(provider)) {
+  if (connectionId || (!isNewSession && sessionId) || !routesFreshSpawnsToLocalProvider(provider)) {
     return
   }
   return provider.recoverFreshSpawnRouting?.()
@@ -3830,7 +3831,8 @@ export function registerPtyHandlers(
       const freshSpawnRecovery = recoverFreshSpawnProviderRouting(
         provider,
         args.connectionId,
-        args.sessionId
+        args.sessionId,
+        args.isNewSession
       )
       if (freshSpawnRecovery) {
         await freshSpawnRecovery
@@ -3866,7 +3868,8 @@ export function registerPtyHandlers(
         sessionId !== undefined ? getRelayPtyId(args.connectionId, sessionId) : undefined
       const effectiveSessionAppId =
         sessionId !== undefined ? getAppPtyId(args.connectionId, sessionId) : undefined
-      const isMintedSessionId = callerRequestedSessionId === undefined && isDaemonHostSpawn
+      const isNewDaemonSession =
+        isDaemonHostSpawn && (callerRequestedSessionId === undefined || args.isNewSession === true)
       const expectedWslDistro = !args.connectionId
         ? (resolveWslSessionContext({
             cwd,
@@ -4030,7 +4033,7 @@ export function registerPtyHandlers(
         rows: args.rows,
         cwd,
         env,
-        ...(isMintedSessionId ? { isNewSession: true } : {})
+        ...(isNewDaemonSession ? { isNewSession: true } : {})
       }
       if (!args.connectionId && !isDaemonHostSpawn) {
         spawnOptions.codexHomePathOverride = { value: selectedCodexHomePath }
@@ -4186,8 +4189,8 @@ export function registerPtyHandlers(
           if (isDaemonHostSpawn && expectedPtyId) {
             preparedProvisionalExecutionContext =
               runtime?.preparePtyExecutionContext?.(expectedPtyId, expectedWslDistro, {
-                resetIncarnation: isMintedSessionId,
-                preserveExisting: !isMintedSessionId
+                resetIncarnation: isNewDaemonSession,
+                preserveExisting: !isNewDaemonSession
               }) ?? false
           }
           const sequenceBeforeProviderSpawn = expectedPtyId
@@ -4296,7 +4299,10 @@ export function registerPtyHandlers(
                 : result.wslDistro
           )
         } catch (err) {
-          if ((isMintedSessionId || preparedProvisionalExecutionContext) && effectiveSessionAppId) {
+          if (
+            (isNewDaemonSession || preparedProvisionalExecutionContext) &&
+            effectiveSessionAppId
+          ) {
             runtime?.preparePtyExecutionContext?.(effectiveSessionAppId, null, {
               resetIncarnation: true
             })
@@ -4339,7 +4345,7 @@ export function registerPtyHandlers(
               store?.markSshRemotePtyLease(args.connectionId, effectiveSessionRelayId, 'expired')
             }
           }
-          if (isMintedSessionId && sessionId !== undefined) {
+          if (isNewDaemonSession && sessionId !== undefined) {
             clearProviderPtyState(sessionId)
           }
           throw spawnError

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -95,6 +95,10 @@ export type { PtyProcessInfo, PtySpawnResult }
 type PtyProbeOptions = { signal?: AbortSignal }
 
 export type IPtyProvider = {
+  /** Fresh local spawns currently route to an in-process, non-persistent fallback. */
+  readonly routesFreshSpawnsToLocalProvider?: true
+  /** Re-probes a degraded durable host before main commits to fallback spawn semantics. */
+  recoverFreshSpawnRouting?: () => Promise<boolean>
   spawn(opts: PtySpawnOptions): Promise<PtySpawnResult>
   /** Whether this spawn target can append the Git guard after its final env merge. */
   supportsGitCredentialGuardHost?: (sessionId?: string) => boolean

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25031,6 +25031,7 @@ describe('OrcaRuntimeService', () => {
         persistHostSessionBinding: true
       })
     )
+    expect(spawn.mock.calls[0]?.[0]).not.toHaveProperty('isNewSession')
     expect(activated.tabs).toEqual([
       expect.objectContaining({
         id: `host-tab::${HEADLESS_LEAF_ID}`,
@@ -25101,6 +25102,7 @@ describe('OrcaRuntimeService', () => {
         tabId: 'host-tab',
         leafId: HEADLESS_LEAF_ID,
         sessionId: expect.stringMatching(/^serve-/),
+        isNewSession: true,
         persistHostSessionBinding: true
       })
     )

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1295,6 +1295,7 @@ type TerminalCreateOptions = {
   tabId?: string
   leafId?: string
   sessionId?: string
+  isNewSession?: boolean
   preAllocatedHandle?: string
   persistHostSessionBinding?: boolean
   // Why: only the host-derived structured resume path may attach provider
@@ -1549,6 +1550,7 @@ type RuntimePtyController = {
     tabId?: string
     leafId?: string
     sessionId?: string
+    isNewSession?: boolean
     persistHostSessionBinding?: boolean
     terminalColorQueryReplies?: { foreground?: string; background?: string }
     agentSessionEnsure?: {
@@ -24557,6 +24559,7 @@ export class OrcaRuntimeService {
         ...(launchOpts.signal ? { signal: launchOpts.signal } : {}),
         ...(launchOpts.onPtySpawnCommitted ? { onPtySpawnCommitted: reportPtySpawnCommitted } : {}),
         ...(launchOpts.sessionId ? { sessionId: launchOpts.sessionId } : {}),
+        ...(launchOpts.isNewSession ? { isNewSession: true } : {}),
         // Why: a headless-created pane has no renderer session writer. Persist
         // its tab/leaf binding at spawn so a later promoted window reattaches
         // the live daemon or SSH PTY instead of replacing it with a fresh one.
@@ -25313,6 +25316,7 @@ export class OrcaRuntimeService {
     // Why: SshPtyProvider treats sessionId as a relay reattach; only synthesize local serve ids so SSH fresh terminals still call pty.spawn.
     const stableSessionId =
       opts.identity?.sessionId ?? (workspace.connectionId ? undefined : `serve-${randomUUID()}`)
+    const isNewSession = stableSessionId !== undefined && opts.identity?.sessionId === undefined
     const terminal = await this.createTerminal(`id:${worktreeId}`, {
       focus: false,
       command: opts.command,
@@ -25332,6 +25336,7 @@ export class OrcaRuntimeService {
         : stableSessionId
           ? { sessionId: stableSessionId }
           : {}),
+      ...(isNewSession ? { isNewSession: true } : {}),
       persistHostSessionBinding: true,
       // Why: this method publishes the authoritative snapshot below; skip the intermediate publish to avoid a wrong-group flash.
       deferMobileSessionPublish: true,


### PR DESCRIPTION
## Summary

- Recover fresh terminal routing from the non-persistent local fallback when the preserved daemon can spawn PTYs again.
- Revalidate the durable host before deriving session IDs, host environment, hooks, persistence, and terminal-handle semantics.
- Preserve fresh-session intent for runtime-owned terminals with stable pre-minted IDs while keeping restored and stable-pane sessions on the explicit adoption/reattach path.
- Forward owner-sensitive Git-guard and authoritative-buffer-snapshot capabilities after recovery so recovered daemon terminals remain parkable.
- Coalesce concurrent probes and apply a 30-second retry cooldown after failures so degraded-mode terminal creation does not repeatedly pay the health timeout.
- Keep existing fallback and daemon sessions on their original owners; SSH behavior is unchanged.
- Avoid retaining recovered daemon ownership when a PTY exits before its spawn reply.

## Root cause

After a transient PTY spawn-health failure, DegradedDaemonPtyProvider permanently routed every later fresh terminal to the local fallback until restart. Those non-persistent PTYs cannot participate in durable terminal parking, allowing hidden renderer panes and memory pressure to accumulate.

The design follows the existing durable-host ownership model: host readiness is revalidated authoritatively, the provider route changes once, and downstream consumers derive from that route. Renderer observation is not used as runtime truth.

## Reliability contract

- **Invariant — agent-session.provider-ownership:** fresh local spawns may switch back to the durable daemon only after authoritative health recovery; attach/adopt paths and already-owned fallback/daemon sessions keep their exact owner; an exited spawn reply must not recreate stale ownership.
- **Failure source:** a transient daemon health timeout left all later fresh terminals on the non-persistent fallback until app restart, defeating parking and allowing hidden renderer/resource growth.
- **Oracle:** deterministic tests force failed recovery, later recovery, concurrent probes, cooldown, stable-ID fresh creation, restored-session reattach, stable-pane adoption, owner-sensitive capability routing, hidden-at-spawn timing, and exit-before-spawn-reply ordering.
- **Gate:** config/reliability-gates.jsonc → agent-session.provider-ownership.
- **Provider/platform coverage:** local and daemon behavior are covered by provider/controller tests and macOS Electron evidence. SSH/remote recovery remains excluded by connectionId and existing owners remain provider-routed. WSL and folder workspaces use the shared main routing contracts. Linux and Windows are covered by CI unit/type/package and native-smoke jobs; live SSH/WSL recovery is an accepted gap.
- **Performance budget:** recovery adds no polling, inventory scan, subprocess fanout, renderer wake loop, or unbounded cache. Concurrent probes share one promise; failed probes are suppressed for 30 seconds; successful recovery becomes a constant-time fast path. Tests assert one probe for concurrent callers and no repeat during cooldown.
- **Diagnostics:** successful recovery emits one bounded daemon-routing log, and deterministic tests identify provider ownership, probe count, and early-exit cleanup.
- **Residual gaps:** the production UI has no safe switch for forcing daemon degradation/recovery, so Electron evidence proves the real fresh-terminal surface and live PTY state while the transition itself remains a deterministic lower-layer oracle. Live SSH/WSL and Linux/Windows recovery journeys were not run.

## Testing

- 2,403 reliability-gate tests passed, 1 skipped.
- 1,541 directly affected tests passed, 1 skipped.
- Node typecheck passed.
- Changed-file oxlint and oxfmt checks passed.
- Max-lines ratchet and diff checks passed.
- GitHub PR checks are green, including Node 24/26 shards, macOS/Linux/Windows native smoke, typecheck, Git compatibility, and packaging.

Coverage includes failed recovery, later recovery, concurrent probe coalescing, retry cooldown, daemon endpoint wiring, management warning state, runtime-controller ordering, renderer-IPC ordering, stable-ID fresh runtime creation, restored-session reattach, stable-pane adoption, Git-guard/snapshot capability routing, hidden-at-spawn timing, pane materialization deduplication, and exit-before-spawn-reply ownership cleanup.

## Electron QA

Validated current HEAD d779e9d07b in the actual Orca dev app through CDP-only Electron automation on macOS.

- Confirmed the intended amphipod worktree and branch identity.
- Selected the PR workspace and used New tab → New Terminal.
- Typed through the rendered xterm and visibly received the expected branch and HEAD.
- Backing state reported two bound PTYs, two listed sessions, both live at 135×58, with zero renderer console errors.

![PR #12277 Electron fresh-terminal validation](https://github.com/user-attachments/assets/baf9de52-371e-4d49-a7f6-169fc088a1fa)

The degraded-to-recovered transition itself is covered by the deterministic recovery/provider tests because production Electron has no safe UI control for inducing that fault.

## AI review report

The latest main branch was merged and conflicts in PTY spawn routing/runtime creation were reconciled without dropping stable-pane adoption or fresh-session recovery semantics.

A same-model, same-effort independent reviewer audited the full post-merge diff for correctness, ownership/reattach behavior, failure ordering, security, SSH/WSL/folder-workspace/cross-platform behavior, and performance. It found one material issue: a recovered daemon PTY that exited before its spawn reply could be reinserted into the session-provider map after the exit callback removed it, retaining stale ownership and memory. Commit d779e9d07b adds the liveness guard and regression test.

The reviewer reran the full diff after the fix and returned CLEAN with no remaining in-scope correctness, regression, security, cross-platform, SSH/folder-workspace, or performance findings.

## Security audit

- Reuses the existing authenticated local daemon health protocol and socket/token paths; no new IPC channel, network listener, command construction, or credential surface.
- The recovery hook runs only for fresh native degraded spawns. SSH and restored/adopted reattach paths are excluded.
- Owner-sensitive capabilities remain routed to the provider that owns each session.
- No secrets or raw paths are added to logs.
- No dependency changes.

## Notes

- Existing fallback-owned PTYs remain on the fallback because live PTY processes cannot be migrated safely between owners. Only later fresh spawns recover to the daemon.
- This PR has no mobile UI changes, so mobile-emulator QA is not applicable.
