### PR TITLE
fix(native-chat): preserve IME deletions at composition end

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   fieldProps: null as {
     onSend?: () => void
     onStop?: () => void
+    onCompositionStart?: () => void
+    onCompositionEnd?: (event: { currentTarget: HTMLTextAreaElement }) => void
     sessionOptionsSurface?: SessionOptionsSurface | null
     sessionOptionsSnapshot?: SessionOptionDescriptor[]
   } | null,
@@ -249,6 +251,46 @@ describe('NativeChatComposer', () => {
     )
 
     expect(new Set(mocks.draftScopeKeys)).toEqual(new Set(['tab-1:leaf-1']))
+  })
+
+  it('adopts an IME deletion delivered only by compositionend', () => {
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+    const textarea = document.createElement('textarea')
+    textarea.value = ''
+    mocks.setDraft.mockClear()
+
+    act(() => {
+      mocks.fieldProps?.onCompositionStart?.()
+      mocks.fieldProps?.onCompositionEnd?.({ currentTarget: textarea })
+    })
+
+    expect(mocks.setDraft).toHaveBeenCalledOnce()
+    expect(mocks.setDraft).toHaveBeenCalledWith('')
+  })
+
+  it('does not duplicate a composition value already adopted by onChange', () => {
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    )
+    const textarea = document.createElement('textarea')
+    textarea.value = 'hello'
+    mocks.setDraft.mockClear()
+
+    act(() => mocks.fieldProps?.onCompositionEnd?.({ currentTarget: textarea }))
+
+    expect(mocks.setDraft).not.toHaveBeenCalled()
   })
 
   it('shows the model already selected in the Claude TUI when chat opens', async () => {

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -375,6 +375,17 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       setHistory
     })
 
+    const handleDraftChange = useCallback(
+      (value: string, element: HTMLTextAreaElement) => {
+        setDraft(value)
+        setHistory((prev) => ({ entries: prev.entries, index: null }))
+        syncCaret(element)
+        handleDraftOrCaretChange(value, element.selectionStart ?? value.length)
+        setActiveSuggestion(0)
+      },
+      [handleDraftOrCaretChange, setDraft, syncCaret]
+    )
+
     return (
       <NativeChatComposerField
         textareaRef={textareaRef}
@@ -392,13 +403,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         dictationDisabled={dictationDisabled}
         isDictating={isDictating}
         isDictationHoldMode={isDictationHoldMode}
-        onDraftChange={(value, element) => {
-          setDraft(value)
-          setHistory((prev) => ({ entries: prev.entries, index: null }))
-          syncCaret(element)
-          handleDraftOrCaretChange(value, element.selectionStart ?? value.length)
-          setActiveSuggestion(0)
-        }}
+        onDraftChange={handleDraftChange}
         onTextareaSelect={(element) => {
           syncCaret(element)
           handleDraftOrCaretChange(element.value, element.selectionStart ?? element.value.length)
@@ -408,8 +413,11 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         onCompositionStart={() => {
           isComposingRef.current = true
         }}
-        onCompositionEnd={() => {
+        onCompositionEnd={(event) => {
           isComposingRef.current = false
+          if (event.currentTarget.value !== draft) {
+            handleDraftChange(event.currentTarget.value, event.currentTarget)
+          }
         }}
         onPaste={handlePaste}
         pickerListboxId={picker.listboxId}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-hangul-syllable-flush.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-hangul-syllable-flush.test.ts
@@ -14,6 +14,7 @@ function nextEventLoop(): Promise<void> {
 }
 
 function openTerminal(TerminalType: typeof EsmTerminal): {
+  compositionView: HTMLElement
   emitted: string[]
   textarea: HTMLTextAreaElement
 } {
@@ -25,9 +26,13 @@ function openTerminal(TerminalType: typeof EsmTerminal): {
   if (!terminal.textarea) {
     throw new Error('xterm textarea was not created')
   }
+  const compositionView = container.querySelector<HTMLElement>('.composition-view')
+  if (!compositionView) {
+    throw new Error('xterm composition view was not created')
+  }
   const emitted: string[] = []
   terminal.onData((data) => emitted.push(data))
-  return { emitted, textarea: terminal.textarea }
+  return { compositionView, emitted, textarea: terminal.textarea }
 }
 
 function composition(
@@ -122,6 +127,21 @@ describe.each([
     await nextEventLoop()
 
     expect(emitted.join('')).toBe('한글')
+  })
+
+  it('shows 가나다 before the final macOS composition commits', async () => {
+    const { compositionView, emitted, textarea } = openTerminal(TerminalType)
+    composeSyllable(textarea, '', ['ㄱ', '가'])
+    composition(textarea, 'compositionend', '가')
+    composeSyllable(textarea, '가', ['ㄴ', '나'])
+    await nextEventLoop()
+    composition(textarea, 'compositionend', '나')
+    composeSyllable(textarea, '가나', ['ㄷ', '다'])
+    await nextEventLoop()
+
+    expect(emitted.join('')).toBe('가나')
+    expect(compositionView.classList.contains('active')).toBe(true)
+    expect(compositionView.textContent).toContain('다')
   })
 
   it('does not double-send after an IBus insertText commit', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-composition-cancel.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-composition-cancel.test.ts
@@ -96,16 +96,15 @@ describe('xterm IME composition cancellation', () => {
     terminal.dispose()
   })
 
-  it('emits nothing when the preedit is cancelled without observed input events', async () => {
+  it('drops a Sogou preedit cancelled without a trailing input event', async () => {
     const { emitted, terminal, textarea } = openTerminal()
 
     dispatchCompositionEvent(textarea, 'compositionstart')
-    dispatchCompositionEvent(textarea, 'compositionupdate', 'ce')
-    textarea.value = 'ce'
-    await nextEventLoop()
-    dispatchCompositionEvent(textarea, 'compositionupdate', 'c')
-    textarea.value = 'c'
-    await nextEventLoop()
+    for (const preedit of ['nihao', 'niha', 'nih', 'ni', 'n']) {
+      dispatchCompositionEvent(textarea, 'compositionupdate', preedit)
+      textarea.value = preedit
+      await nextEventLoop()
+    }
     textarea.value = ''
     dispatchCompositionEvent(textarea, 'compositionend')
     await nextEventLoop()


### PR DESCRIPTION
## Summary

- resynchronize the native chat draft from the live textarea on `compositionend` when Sogou/WeChat deletes a preedit without firing a final `input` event
- reuse the normal draft-change path so caret, history, picker state, and the persisted draft remain consistent
- pin the exact macOS 2-Set `r k s k e k` (`가나다`) terminal contract: two committed syllables plus the visible active third syllable before blur
- pin the Sogou terminal cancellation shape `nihao → niha → nih → ni → n → empty` with no trailing input event

Current `main` already fixes the terminal-layer behavior through #12278 and the cancelled-preedit reconciliation, and #12276 directly exercises the native Microsoft Pinyin Shift-toggle trace on Windows. This PR closes the remaining adjacent native-chat gap from #12230 and makes all three reported reproductions explicit regression contracts.

The native-chat fix follows the diagnosis contributed by @fengxinzi1814 in #12230, credited as co-author. #12274 by @kcfang independently provides real-macOS Zhuyin evidence for the same empty-preedit terminal shape; current xterm reconciliation already resolves it without adding another terminal listener state machine. #12043 independently identified the Hangul finalizer cause later landed through #12278.

Fixes #12230
Fixes #11914
Fixes #12063

## Screenshots

No visual design change. The visible changes are restored IME text: `가나다` remains present during the active final composition, and a deleted Sogou `n` stays deleted.

## Testing

- 126 focused native-chat and terminal IME unit tests across 9 files
- Electron E2E: Microsoft Pinyin Shift commits its active preedit exactly once
- Electron E2E: Sogou-style candidate selection commits Chinese text without leaking selector keys
- `oxfmt` and `oxlint`
- Node typecheck
- max-lines ratchet
- `git diff --check`

## AI Review Report

The change was checked against the three native event contracts separately rather than treating CJK IMEs as one path.

- **macOS Hangul:** no production timing is changed here; the test proves #12278 leaves `가나` emitted while xterm's active composition view contains `다`, matching the pre-click state of the physical-key repro.
- **Windows Pinyin:** the existing native Electron trace remains green and proves Shift commits `nihao` without clearing it or sending a newline.
- **macOS Sogou:** terminal cancellation remains data-free even without a trailing input event. Native chat now adopts the DOM's authoritative empty value at composition end; ordinary compositions already adopted through `onChange` do not cause a second write.
- **Cross-platform/SSH/folder workspaces:** the only production change is renderer-local controlled-textarea state reconciliation. Terminal transport, PTY routing, paths, worktree assumptions, and platform shortcut behavior are unchanged.

## Security Audit

No IPC, transport, command execution, authentication, secrets, path handling, or dependency behavior changes. The native chat handler only copies the current textarea value into its existing draft state through the same path used by `onChange`.

## Notes

Synthetic macOS event coverage is based on the repository's recorded 2-Set and empty-composition shapes. A final physical IME pass on macOS is still worthwhile because CI cannot install and drive Sogou itself; the code no longer depends on a Sogou-specific event ordering beyond `compositionend` exposing the live DOM value.