### PR TITLE
test(terminal): cover live macOS Korean syllable flush

### DIFF
--- a/tests/e2e/terminal-macos-2set-korean-native.spec.ts
+++ b/tests/e2e/terminal-macos-2set-korean-native.spec.ts
@@ -32,13 +32,47 @@ function typeNativeTwoSetKorean(processId: number, keyCodes: readonly number[]):
   ])
 }
 
+function typeNativeTwoSetKoreanPreedit(processId: number, keyCodes: readonly number[]): void {
+  execFileSync('osascript', [
+    '-e',
+    `tell application "System Events" to set frontmost of first application process whose unix id is ${processId} to true`,
+    '-e',
+    'tell application "System Events"',
+    '-e',
+    `repeat with currentKeyCode in {${keyCodes.join(', ')}}`,
+    '-e',
+    'key code (currentKeyCode as integer)',
+    '-e',
+    'delay 0.1',
+    '-e',
+    'end repeat',
+    '-e',
+    'end tell'
+  ])
+}
+
+function commitNativeComposition(): void {
+  execFileSync('osascript', ['-e', 'tell application "System Events" to key code 36'])
+}
+
+async function readActiveComposition(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const textarea = document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea:focus')
+    const composition = textarea?.parentElement?.querySelector<HTMLElement>(
+      '.composition-view.active'
+    )
+    return composition?.textContent?.replaceAll('\u200e', '') ?? null
+  })
+}
+
 async function runNativeScenario(
   page: Page,
   testInfo: TestInfo,
   testRepoPath: string,
   processId: number,
   keyCodes: readonly number[],
-  expectedText: string
+  expectedText: string,
+  preCommit?: { committedText: string; preeditText: string }
 ): Promise<void> {
   await waitForSessionReady(page)
   await waitForActiveWorktree(page)
@@ -55,7 +89,16 @@ async function runNativeScenario(
     await startTerminalImeByteReader(page, ptyId, reader)
     await focusActiveTerminalInput(page)
     await installTerminalImeBoundaryProbe(page)
-    typeNativeTwoSetKorean(processId, keyCodes)
+    if (preCommit) {
+      typeNativeTwoSetKoreanPreedit(processId, keyCodes)
+      await expect.poll(() => readActiveComposition(page)).toBe(preCommit.preeditText)
+      await expect
+        .poll(async () => (await readTerminalImeBoundaryTrace(page)).onData.join(''))
+        .toBe(preCommit.committedText)
+      commitNativeComposition()
+    } else {
+      typeNativeTwoSetKorean(processId, keyCodes)
+    }
 
     const receivedBytes = await waitForTerminalImeBytes(page, reader)
     expect(receivedBytes).toEqual([Buffer.from(`${expectedText}\n`).toString('hex')])
@@ -107,6 +150,22 @@ test.describe('Native macOS 2-Set Korean terminal input @headful', () => {
       electronApp.process().pid!,
       [31, 40, 0, 16, 36],
       'ㅐㅏ묘'
+    )
+  })
+
+  test('flushes each syllable while the next remains in preedit', async ({
+    electronApp,
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await runNativeScenario(
+      orcaPage,
+      testInfo,
+      testRepoPath,
+      electronApp.process().pid!,
+      [15, 40, 1, 40, 14, 40],
+      '가나다',
+      { committedText: '가나', preeditText: '다' }
     )
   })
 })


### PR DESCRIPTION
## Summary

- Extend the native macOS 2-Set Korean terminal test with the reported physical `rkskek` sequence.
- Before Enter, assert that `가나` has reached xterm while the active native preedit visibly contains `다`.
- After committing, assert exact `가나다\n` PTY bytes and `가나다\r` xterm data.
- Preserve the existing `한글` and leading-vowel native scenarios from current main.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Ran:

- Native macOS 2-Set Korean headful E2E: 3 passed, including the live `가나` plus `다` preedit boundary and exact final PTY bytes.
- 269 focused terminal IME tests across 17 files.
- Node and web TypeScript checks.
- Focused Oxlint, React Doctor, Oxfmt, and `git diff --check`.
- The native E2E setup rebuilt the Electron app and bundled CLI successfully.

## AI Review Report

Reviewed the native event boundary before and after Enter, including the failure mode where an immediate Enter masks a one-syllable display lag. The test now separates physical typing from composition commit and verifies both the user-visible preedit and the exact committed bytes.

Cross-platform compatibility was checked. This PR changes only a macOS-gated native E2E test; Linux/IBus, Windows IME, SSH and folder-workspace routing, shortcuts, labels, paths, shell behavior, production Electron code, and runtime behavior are unchanged. The broader terminal IME suite passed 269 tests covering Windows, Linux/IBus, Chinese, Japanese, Vietnamese, Sogou/fcitx, cancellation, and deduplication event shapes.

## Security Audit

No production command execution, dependency, IPC, authentication, secret, or path-handling changes. The macOS-only test invokes fixed AppleScript commands with the Electron numeric process ID and fixed physical key codes, and runs only behind `ORCA_E2E_NATIVE_MACOS_KOREAN=1`.

## Notes

PR #12280 typed `gksrmf` and pressed Enter in the same native batch, which could not observe the reported live `rkskek` state. The runtime composition fixes are already on main via #12278 and #12280; this PR closes the native regression-test gap.