### PR TITLE
fix(search): blur the file search input on Escape

### DIFF
--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFileSearchPanel } from './useFileSearchPanel'
+import { SearchQueryRow } from './SearchQueryRow'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const mocks = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>,
+  executeSearch: vi.fn(),
+  cancelPendingSearch: vi.fn(),
+  clearFileSearch: vi.fn()
+}))
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector(mocks.state),
+    { getState: () => mocks.state }
+  )
+  return { useAppStore }
+})
+
+vi.mock('@/store/selectors', () => ({
+  useActiveWorktree: () => ({ path: '/repo' })
+}))
+
+vi.mock('./useFileSearchRunner', () => ({
+  useFileSearchRunner: () => ({
+    executeSearch: mocks.executeSearch,
+    cancelPendingSearch: mocks.cancelPendingSearch
+  })
+}))
+
+function Harness(): React.JSX.Element {
+  const model = useFileSearchPanel('search')
+  return <SearchQueryRow {...model.queryRowProps} />
+}
+
+let container: HTMLDivElement
+let root: Root
+
+function renderPanel(query: string): void {
+  mocks.state = {
+    activeWorktreeId: 'wt-1',
+    openFile: vi.fn(),
+    setPendingEditorReveal: vi.fn(),
+    fileSearchStateByWorktree: { 'wt-1': { query } },
+    updateFileSearchState: vi.fn(),
+    consumeFileSearchSeedRequest: vi.fn(),
+    toggleFileSearchCollapsedFile: vi.fn(),
+    clearFileSearch: mocks.clearFileSearch
+  }
+  act(() => {
+    root.render(<Harness />)
+  })
+}
+
+function input(): HTMLInputElement {
+  const element = container.querySelector<HTMLInputElement>('input')
+  if (!element) {
+    throw new Error('query input not rendered')
+  }
+  return element
+}
+
+function pressEscape(isComposing = false): void {
+  act(() => {
+    input().dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', isComposing, bubbles: true, cancelable: true })
+    )
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  vi.clearAllMocks()
+})
+
+describe('useFileSearchPanel Escape handling', () => {
+  it('clears the search and blurs the input when a query is present', () => {
+    renderPanel('owner')
+    act(() => {
+      input().focus()
+    })
+
+    pressEscape()
+
+    expect(mocks.clearFileSearch).toHaveBeenCalledWith('wt-1')
+    expect(document.activeElement).not.toBe(input())
+  })
+
+  it('blurs the input even when the query is empty', () => {
+    renderPanel('')
+    act(() => {
+      input().focus()
+    })
+
+    pressEscape()
+
+    expect(mocks.clearFileSearch).not.toHaveBeenCalled()
+    expect(document.activeElement).not.toBe(input())
+  })
+
+  it('keeps focus and query while IME composition is active', () => {
+    renderPanel('가나')
+    act(() => {
+      input().focus()
+    })
+
+    pressEscape(true)
+
+    expect(mocks.clearFileSearch).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(input())
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
@@ -213,6 +213,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
         if (fileSearchQuery) {
           handleClearSearch()
         }
+        ;(e.target as HTMLInputElement).blur()
       }
       if (e.key === 'Enter') {
         executeSearch(fileSearchQuery)


### PR DESCRIPTION
## Summary

Pressing `Escape` in the sidebar file search cleared the query but left keyboard focus stuck in the input — and with an empty query it did nothing at all. The input now blurs on `Escape`, so the keyboard gets back to the rest of the app either way. `Escape` during IME composition is still ignored, so in-progress Hangul/CJK input isn't dropped.

The fix is one line in `useFileSearchPanel.ts`, using the same blur idiom the project board cells already use. This also brings the panel in line with `TerminalSearch` and `RichMarkdownSearchBar`, which both back out on `Escape`.

Closes stablyai/orca#12292

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added `useFileSearchPanel.test.tsx`, following the existing `WorkspaceKanbanSearchField.test.tsx` pattern: real `KeyboardEvent`s dispatched through the rendered `SearchQueryRow`. Three cases: `Escape` with a query clears and blurs, `Escape` with an empty query blurs (previously a no-op), and `Escape` mid-composition leaves query and focus alone.

On `pnpm test`: the full suite shows 12 failures on my machine, but they reproduce identically on a clean upstream `main` checkout (updater, relay, ai-vault scale tests, etc. — likely my local Node 22 vs the required Node 24), so they're unrelated to this change. The new tests and everything else in the touched area pass.

## AI Review Report

Reviewed with Claude Code. Most of the cross-platform checklist is unaffected by construction: no shortcuts, labels, paths, or shell behavior are touched, and `blur()` is plain DOM that behaves the same on macOS, Linux, and Windows. Everything stays inside the renderer, so SSH/remote workspaces behave identically. The one real risk we looked at was IME — blurring during composition would drop in-progress input — but the existing `isComposing` guard returns before the blur runs, and a test now pins that.

## Security Audit

The handler consumes an existing keyboard event and calls `blur()` on its own input. No new input handling, command execution, path handling, IPC, or dependencies.

## Notes

No platform-specific behavior. No follow-up planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)