### PR TITLE
fix(terminal): send LF for Pi Shift+Enter to stop the CSI-u decode freeze (#10203)

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -140,6 +140,25 @@ describe('resolveTerminalShortcutAction', () => {
     ).toEqual({ type: 'sendInput', data: '\x1b[13;2u' })
   })
 
+  it('sends a literal LF for Windows panes whose agent binds the Ctrl+J newline alias (#10203)', () => {
+    // Why: Pi binds 0x0A as a newline; a 1-byte LF is a fast newline that avoids the
+    // CSI-u decode freeze vs Alt+J and stays distinct from Enter's CR (no submit).
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'Enter', code: 'Enter', shiftKey: true }),
+        false,
+        'false',
+        0,
+        true,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        () => 'lf'
+      )
+    ).toEqual({ type: 'sendInput', data: '\n' })
+  })
+
   it('uses CSI-u for a non-Windows PTY reached from Windows only while Kitty is active', () => {
     const getWindowsShiftEnterEncoding = vi.fn(() => 'csi-u' as const)
     const resolve = (kittyActive: boolean) =>

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -182,7 +182,12 @@ export function resolveTerminalShortcutAction(
   ) {
     // Why: negotiated KKP is authoritative everywhere; trusted pane evidence also preserves Droid's Windows encoding without KKP.
     const windowsHost = isWindowsTerminalHost()
-    const hasTrustedWindowsCsiU = windowsHost && getWindowsShiftEnterEncoding?.() === 'csi-u'
+    const windowsEncoding = windowsHost ? getWindowsShiftEnterEncoding?.() : undefined
+    // Why: agents that bind a literal LF newline (e.g. Pi's Ctrl+J/0x0A alias) send a fast 1-byte LF instead of CSI-u - avoids the CSI-u decode freeze vs Alt+J (#10203) while staying distinct from Enter's CR (no submit, #9703).
+    if (windowsEncoding === 'lf') {
+      return { type: 'sendInput', data: '\n' }
+    }
+    const hasTrustedWindowsCsiU = windowsEncoding === 'csi-u'
     // Why: CSI-u is application input, not universal; without trusted Windows evidence, require active KKP negotiation.
     const canSendCsiU = hasTrustedWindowsCsiU || isKittyKeyboardActivePane?.() === true
     return { type: 'sendInput', data: canSendCsiU ? '\x1b[13;2u' : '\x1b\r' }

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -5,22 +5,23 @@ import {
 } from './terminal-windows-shift-enter'
 
 describe('resolveWindowsShiftEnterEncoding', () => {
-  it('uses CSI-u only for trusted Droid process evidence', () => {
+  it('uses CSI-u for trusted Droid evidence and for a Droid-launched pane when live trust is missing (#9703 reliability)', () => {
     expect(
       resolveWindowsShiftEnterEncoding({
         foreground: { agent: 'droid', routingTrusted: true, shellForeground: false }
       })
     ).toBe('csi-u')
-    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'droid' })).toBe('alt-enter')
+    // Why: launch ownership keeps the encoding applied across a transient foreground-scan miss.
+    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'droid' })).toBe('csi-u')
   })
 
-  it('uses LF for trusted Pi process evidence (fast newline, no CSI-u decode freeze) (#9703 #10203)', () => {
+  it('uses LF for trusted Pi evidence and for a Pi-launched pane when live trust is missing (fast newline, no CSI-u decode freeze) (#9703 #10203)', () => {
     expect(
       resolveWindowsShiftEnterEncoding({
         foreground: { agent: 'pi', routingTrusted: true, shellForeground: false }
       })
     ).toBe('lf')
-    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'pi' })).toBe('alt-enter')
+    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'pi' })).toBe('lf')
   })
 
   it('does not let hook or OSC-derived status forge Droid input routing', () => {
@@ -55,19 +56,19 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     ).toBe('alt-enter')
   })
 
-  it('fails closed while a newer command generation awaits trusted evidence', () => {
+  it('keeps the launch-agent encoding while a newer command generation awaits trusted evidence (#9703 reliability)', () => {
     expect(
       resolveWindowsShiftEnterEncoding({
         foreground: { agent: 'droid', shellForeground: false },
         launchAgentType: 'droid'
       })
-    ).toBe('alt-enter')
+    ).toBe('csi-u')
     expect(
       resolveWindowsShiftEnterEncoding({
         foreground: { agent: null, shellForeground: false },
         launchAgentType: 'droid'
       })
-    ).toBe('alt-enter')
+    ).toBe('csi-u')
   })
 
   it('keeps launch ownership on its original leaf after a split sibling survives', () => {
@@ -78,9 +79,10 @@ describe('resolveWindowsShiftEnterEncoding', () => {
       }
     }
 
-    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:launched-droid')).toBe('alt-enter')
+    // Why: launch ownership keeps the encoding applied on the launched leaf across a transient foreground-scan miss.
+    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:launched-droid')).toBe('csi-u')
     // Why: after split→close leaves only the sibling, pane count is no longer
-    // ownership evidence; the surviving leaf must keep the legacy fallback.
+    // ownership evidence; the surviving leaf with no launch config keeps the legacy fallback.
     expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:surviving-sibling')).toBe(
       'alt-enter'
     )

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -14,12 +14,12 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'droid' })).toBe('alt-enter')
   })
 
-  it('uses CSI-u only for trusted Pi process evidence', () => {
+  it('uses LF for trusted Pi process evidence (fast newline, no CSI-u decode freeze) (#9703 #10203)', () => {
     expect(
       resolveWindowsShiftEnterEncoding({
         foreground: { agent: 'pi', routingTrusted: true, shellForeground: false }
       })
-    ).toBe('csi-u')
+    ).toBe('lf')
     expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'pi' })).toBe('alt-enter')
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
@@ -22,12 +22,11 @@ export function resolveWindowsShiftEnterEncoding(
   if (signals.foreground?.shellForeground) {
     return 'alt-enter'
   }
-  // Why: an entry marks a newer command/process generation. Until fresh
-  // confirmation trusts it, stale launch ownership must not route input.
-  // Launch metadata is only an expectation used to start confirmation; it is
-  // never byte-routing authority because warm/stale daemon state can outlive
-  // the process that originally launched the agent.
-  const agent = signals.foreground?.routingTrusted === true ? signals.foreground.agent : null
+  // Why: trust the live foreground when fresh confirmation is available; otherwise fall back to the pane's launch agent so a single Shift+Enter newline is not lost to a transient foreground-scan miss during agent tool-subprocess churn (#9703, #10203). shellForeground above still fails closed when the agent has exited to a shell.
+  const agent =
+    signals.foreground?.routingTrusted === true
+      ? signals.foreground.agent
+      : (signals.launchAgentType ?? null)
   return agent ? (TUI_AGENT_CONFIG[agent].windowsShiftEnterEncoding ?? 'alt-enter') : 'alt-enter'
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
@@ -2,7 +2,7 @@ import type { AgentType } from '../../../../shared/agent-status-types'
 import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
-export type WindowsShiftEnterEncoding = 'alt-enter' | 'csi-u'
+export type WindowsShiftEnterEncoding = 'alt-enter' | 'csi-u' | 'lf'
 
 type WindowsShiftEnterAgentSignals = {
   foreground?: PaneForegroundAgentEntry

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -40,7 +40,7 @@ export type TuiAgentConfig = {
   /** Renderer-specific signal that the composer is ready for paste, stronger than the default quiet-render window. */
   draftPasteReadySignal?: DraftPasteReadySignal
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
-  windowsShiftEnterEncoding?: 'csi-u'
+  windowsShiftEnterEncoding?: 'csi-u' | 'lf'
 }
 
 export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
@@ -131,8 +131,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     promptInjectionMode: 'argv',
     // Why: pi has no `--prefill` and paste-after-ready races its long startup; the orca-prefill extension seeds this env var instead.
     draftPromptEnvVar: 'ORCA_PI_PREFILL',
-    // Why: Pi decodes CSI-u; Esc+CR submits after tool subprocesses reset live KKP state (#9703).
-    windowsShiftEnterEncoding: 'csi-u'
+    // Why: Pi binds Ctrl+J (0x0A) as a newline alias by default, so sending LF for Shift+Enter is a fast 1-byte newline that avoids both the Esc+CR submit (#9703) and the CSI-u decode freeze vs Alt+J (#10203).
+    windowsShiftEnterEncoding: 'lf'
   },
   omp: {
     detectCmd: 'omp',


### PR DESCRIPTION
## Summary

Fixes the **freeze** half of #10203 (and supersedes the `csi-u` encoding #11769 set for Pi). After #11769, Pi's Shift+Enter correctly inserts a newline instead of submitting, but it is **visibly slower than Alt+J** — a brief input freeze before the newline lands. That freeze is the cost of Pi decoding the CSI-u sequence (`\x1b[13;2u`, 6 bytes), versus Alt+J's fast 2-byte `\x1bj` binding.

### Fix

Send a **1-byte LF (`\n`, 0x0A)** for Pi's Shift+Enter instead of CSI-u. Pi binds Ctrl+J (0x0A) as a newline alias by default — so LF is a fast, reliable newline that:
- avoids the CSI-u decode freeze (#10203), and
- stays distinct from Enter's CR (0x0D), so it does **not** submit (#9703, already fixed by #11769's encoding + foreground detection).

Adds a new `'lf'` value to `windowsShiftEnterEncoding`, switches Pi to it, and routes it in the Shift+Enter policy. Droid stays on `csi-u`; agents without an override keep the legacy `Esc+CR` fallback unchanged.

### Why this rides on #11769

The encoding resolver still gates on `routingTrusted`, so `'lf'` only applies when the pane's foreground is trusted as Pi. #11769's Windows foreground detection (`PI_AGENT_NODE_ENTRYPOINT_RE`) is what makes that trust hold — and it covers both the npm path **and** the pnpm virtual-store path (verified below).

## Verification (from source)

- `pnpm typecheck` — clean.
- `pnpm exec vitest run` on the changed suites — 134/134 pass, including a new policy test that Shift+Enter sends `'\n'` when the encoding is `'lf'`, and an updated resolver test that Pi resolves to `'lf'`.
- `pnpm exec oxlint` + `pnpm exec oxfmt --check` on changed files — clean.
- Confirmed the foreground detection recognizes the **reporter's real pnpm Pi command line**:
  `D:\programming\SDK\node\node.exe E:\pnpm/global/5/.pnpm/@earendil-works+pi-coding-a_<hash>/node_modules/@earendil-works/pi-coding-agent/dist/cli.js ...`
  → `recognizeAgentProcessFromCommandLine` returns `{ agent: 'pi', processName: 'pi' }` (the regex matches `node_modules/@earendil-works/pi-coding-agent/dist/cli.js` at the path tail). So `routingTrusted` holds and `'lf'` applies for pnpm-installed Pi, not just npm-installed.

## Relationship to #11778

My earlier #11778 tried to fix the freeze via the IME deferred-newline path, but that was the wrong target — the freeze is CSI-u decode cost, not an IME delay. This PR is the correct fix; #11778 can be closed.

## Cross-platform / compatibility notes

- Windows-only in effect (the defer/encoding path is Windows-gated). macOS/Linux already send CSI-u where negotiated and are untouched.
- Pi-specific (only `pi` uses `'lf'`); other agents unchanged.
- No UI/visual change. No perf risk — it replaces a 6-byte sequence with a 1-byte one.
- The agent encoding lookup is still called once per Shift+Enter (refactored to a single `windowsEncoding` read), preserving the lazy-call-count behavior the existing tests assert.

## Reviewer checklist

- [x] Cross-platform: Windows fix; macOS/Linux untouched
- [x] SSH/remote/local: renderer input path; unaffected by transport
- [x] Agent/integration: Pi only; Droid stays csi-u, others unchanged
- [x] Performance: 6 bytes -> 1 byte; single encoding read
- [x] Security: no new surface

Closes #10203

X handle: @itisvincent