### PR TITLE
fix(gitlab): route self-hosted hosts through GITLAB_HOST for mr/issue commands

### DIFF
--- a/src/main/gitlab/client-mr-review-actions.test.ts
+++ b/src/main/gitlab/client-mr-review-actions.test.ts
@@ -382,4 +382,69 @@ describe('gitlab client — MR operations', () => {
       )
     })
   })
+  // Why: only `api`/`auth` define --hostname, so the `mr` subcommands must take
+  // the self-hosted host through GITLAB_HOST or glab exits on an unknown flag.
+  describe('mr subcommands against a self-hosted SSH host', () => {
+    const projectRef = { host: 'gitlab.example.internal', path: 'g/p' }
+
+    it('merges without --hostname and passes the host through GITLAB_HOST', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+      await expect(mergeMR('/repo', 6, 'merge', undefined, 'conn-1', projectRef)).resolves.toEqual({
+        ok: true
+      })
+
+      const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+      expect(args).toEqual(['mr', 'merge', '6', '-R', 'g/p', '--yes'])
+      expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
+    })
+
+    it('keeps the squash flag while routing the host through the environment', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+      await expect(mergeMR('/repo', 6, 'squash', undefined, 'conn-1', projectRef)).resolves.toEqual(
+        { ok: true }
+      )
+
+      const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+      expect(args).toEqual(['mr', 'merge', '6', '-R', 'g/p', '--yes', '--squash'])
+      expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
+    })
+
+    it('closes without --hostname and passes the host through GITLAB_HOST', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+      await expect(closeMR('/repo', 6, undefined, 'conn-1', projectRef)).resolves.toEqual({
+        ok: true
+      })
+
+      const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+      expect(args).toEqual(['mr', 'close', '6', '-R', 'g/p'])
+      expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
+    })
+
+    it('reopens without --hostname and passes the host through GITLAB_HOST', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+      await expect(reopenMR('/repo', 6, undefined, 'conn-1', projectRef)).resolves.toEqual({
+        ok: true
+      })
+
+      const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+      expect(args).toEqual(['mr', 'reopen', '6', '-R', 'g/p'])
+      expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
+    })
+
+    it('leaves the environment untouched for a local workspace', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+      await expect(mergeMR('/repo', 6, 'merge', undefined, null, projectRef)).resolves.toEqual({
+        ok: true
+      })
+
+      const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+      expect(args).toEqual(['mr', 'merge', '6', '-R', 'g/p', '--yes'])
+      expect(options.env).toBeUndefined()
+    })
+  })
 })

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,4 +1,5 @@
 import { glabExecFileAsync } from '../git/runner'
+import { addWslEnvKeys } from '../wsl-env'
 import { isTransientGitProbeError, readRemoteUrl } from '../git/remote-url-probe'
 import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
@@ -260,6 +261,22 @@ export function glabHostnameArgs(
   connectionId?: string | null
 ): string[] {
   return connectionId && projectRef?.host ? ['--hostname', projectRef.host] : []
+}
+
+/** Why: only `api`/`auth` define `--hostname`; `mr` and `issue` subcommands reject it (#12193). */
+export function glabHostEnvOptions(
+  projectRef: Pick<ProjectRef, 'host'> | null | undefined,
+  connectionId?: string | null
+): { env?: NodeJS.ProcessEnv } {
+  if (!connectionId || !projectRef?.host) {
+    return {}
+  }
+  const env: NodeJS.ProcessEnv = { ...process.env, GITLAB_HOST: projectRef.host }
+  if (process.platform === 'win32') {
+    // Why: spawn env stops at the wsl.exe boundary unless WSLENV names the var.
+    addWslEnvKeys(env, ['GITLAB_HOST'])
+  }
+  return { env }
 }
 
 async function isGlabConfiguredForRemoteHost(

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -26,6 +26,7 @@ import {
   getProjectRef,
   getProjectRefForRemote,
   parseGlabApiResponse,
+  glabHostEnvOptions,
   parseGlabAuthStatusHosts,
   resolveIssueSource
 } from './gl-utils'
@@ -877,5 +878,49 @@ describe('getGlabKnownHosts', () => {
     ])
     expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
     unregisterSshGitProvider(connectionId)
+  })
+})
+
+describe('glabHostEnvOptions', () => {
+  const projectRef = { host: 'gitlab.example.internal' }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('carries the host in GITLAB_HOST for a connection-backed workspace', () => {
+    const { env } = glabHostEnvOptions(projectRef, 'conn-1')
+
+    expect(env?.GITLAB_HOST).toBe('gitlab.example.internal')
+  })
+
+  it('returns nothing for a local workspace', () => {
+    expect(glabHostEnvOptions(projectRef, null)).toEqual({})
+    expect(glabHostEnvOptions(projectRef, undefined)).toEqual({})
+  })
+
+  it('returns nothing when the project ref carries no host', () => {
+    expect(glabHostEnvOptions(null, 'conn-1')).toEqual({})
+    expect(glabHostEnvOptions({ host: '' }, 'conn-1')).toEqual({})
+  })
+
+  // Why: spawn env stops at the wsl.exe boundary, so Windows has to name the
+  // variable in WSLENV or glab in the distro never sees the host.
+  it('forwards GITLAB_HOST through WSLENV on Windows', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    const { env } = glabHostEnvOptions(projectRef, 'conn-1')
+
+    expect(env?.GITLAB_HOST).toBe('gitlab.example.internal')
+    expect(env?.WSLENV?.split(':')).toContain('GITLAB_HOST')
+  })
+
+  it('leaves WSLENV alone off Windows', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    const { env } = glabHostEnvOptions(projectRef, 'conn-1')
+
+    expect(env?.WSLENV).toBe(process.env.WSLENV)
   })
 })

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -18,6 +18,7 @@ export {
   getIssueProjectRef,
   getProjectRef,
   getProjectRefForRemote,
+  glabHostEnvOptions,
   glabHostnameArgs,
   glabRepoExecOptions,
   parseGlabAuthStatusHosts,

--- a/src/main/gitlab/issue-update.ts
+++ b/src/main/gitlab/issue-update.ts
@@ -5,6 +5,7 @@ import {
   classifyGlabError,
   getGlabKnownHosts,
   glabExecFileAsync,
+  glabHostEnvOptions,
   glabHostnameArgs,
   glabRepoExecOptions,
   release,
@@ -56,17 +57,10 @@ export async function updateIssue(
     await acquire()
     try {
       const cmd = updates.state === 'closed' ? 'close' : 'reopen'
-      await glabExecFileAsync(
-        [
-          'issue',
-          cmd,
-          String(issueNumber),
-          '-R',
-          repoFlag,
-          ...glabHostnameArgs(projectRef, connectionId)
-        ],
-        glabRepoExecOptions(repoPath, connectionId, localGitOptions)
-      )
+      await glabExecFileAsync(['issue', cmd, String(issueNumber), '-R', repoFlag], {
+        ...glabRepoExecOptions(repoPath, connectionId, localGitOptions),
+        ...glabHostEnvOptions(projectRef, connectionId)
+      })
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err)
       // Treat "already closed/reopened" as a no-op (matches gh path).
@@ -102,14 +96,7 @@ export async function updateIssue(
   }
 
   // Field edits via `glab issue update`.
-  const editArgs: string[] = [
-    'issue',
-    'update',
-    String(issueNumber),
-    '-R',
-    repoFlag,
-    ...glabHostnameArgs(projectRef, connectionId)
-  ]
+  const editArgs: string[] = ['issue', 'update', String(issueNumber), '-R', repoFlag]
   let hasEditArgs = false
 
   if (updates.title) {
@@ -136,10 +123,10 @@ export async function updateIssue(
   if (hasEditArgs) {
     await acquire()
     try {
-      await glabExecFileAsync(
-        editArgs,
-        glabRepoExecOptions(repoPath, connectionId, localGitOptions)
-      )
+      await glabExecFileAsync(editArgs, {
+        ...glabRepoExecOptions(repoPath, connectionId, localGitOptions),
+        ...glabHostEnvOptions(projectRef, connectionId)
+      })
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err)
       errors.push(classifyGlabError(stderr).message)

--- a/src/main/gitlab/issues.test.ts
+++ b/src/main/gitlab/issues.test.ts
@@ -285,6 +285,21 @@ describe('gitlab issue operations', () => {
     )
   })
 
+  // Why: `glab issue close` has no --hostname flag; a self-hosted instance is
+  // only reachable through GITLAB_HOST (#12193).
+  it('updateIssue closes through GITLAB_HOST on an SSH workspace', async () => {
+    const projectRef = { host: 'gitlab.example.internal', path: 'stablyai/orca' }
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+
+    await expect(
+      updateIssue('/repo-root', 5, { state: 'closed' }, undefined, 'conn-1', projectRef)
+    ).resolves.toEqual({ ok: true })
+
+    const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+    expect(args).toEqual(['issue', 'close', '5', '-R', 'stablyai/orca'])
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
+  })
+
   it("updateIssue treats 'already closed' as a no-op", async () => {
     getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
     glabExecFileAsyncMock.mockRejectedValueOnce(new Error('Issue is already closed'))

--- a/src/main/gitlab/issues.test.ts
+++ b/src/main/gitlab/issues.test.ts
@@ -285,6 +285,22 @@ describe('gitlab issue operations', () => {
     )
   })
 
+  // Why: `glab issue update` has no --hostname flag either, so field edits on an
+  // SSH workspace must carry the host in GITLAB_HOST (#12193).
+  it('updateIssue edits fields through GITLAB_HOST on an SSH workspace', async () => {
+    const projectRef = { host: 'gitlab.example.internal', path: 'stablyai/orca' }
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+
+    await expect(
+      updateIssue('/repo-root', 5, { title: 'Renamed' }, undefined, 'conn-1', projectRef)
+    ).resolves.toEqual({ ok: true })
+
+    const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+    expect(args.slice(0, 2)).toEqual(['issue', 'update'])
+    expect(args).not.toContain('--hostname')
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
+  })
+
   // Why: `glab issue close` has no --hostname flag; a self-hosted instance is
   // only reachable through GITLAB_HOST (#12193).
   it('updateIssue closes through GITLAB_HOST on an SSH workspace', async () => {

--- a/src/main/gitlab/merge-request-creation-lookup.ts
+++ b/src/main/gitlab/merge-request-creation-lookup.ts
@@ -4,7 +4,7 @@ import {
 } from '../source-control/hosted-review-git-options'
 import {
   glabExecFileAsync,
-  glabHostnameArgs,
+  glabHostEnvOptions,
   glabRepoExecOptions,
   type ProjectRef
 } from './gl-utils'
@@ -65,12 +65,12 @@ export async function findOpenMRByHeadBase(args: {
       '--per-page',
       '2',
       '--output',
-      'json',
-      ...glabHostnameArgs(args.projectRef, args.connectionId)
+      'json'
     ],
     {
       ...glabRepoExecOptions(args.repoPath, args.connectionId),
-      ...(args.connectionId ? {} : getHostedReviewLocalGitOptions(args.options))
+      ...(args.connectionId ? {} : getHostedReviewLocalGitOptions(args.options)),
+      ...glabHostEnvOptions(args.projectRef, args.connectionId)
     }
   )
   const list = JSON.parse(stdout) as {

--- a/src/main/gitlab/merge-request-creation.test.ts
+++ b/src/main/gitlab/merge-request-creation.test.ts
@@ -96,12 +96,15 @@ describe('createGitLabMergeRequest', () => {
         '--draft'
       ])
     )
-    expect(args).toEqual(expect.arrayContaining(['--hostname', 'gitlab.com']))
+    // Why: a local workspace resolves the host from cwd, so neither the flag
+    // nor the env override belongs on the command.
+    expect(args).not.toContain('--hostname')
     expect(options).toMatchObject({
       cwd: '/repo-root',
       timeout: 60_000,
       idempotent: false
     })
+    expect(options.env).toBeUndefined()
     expect(acquireMock).toHaveBeenCalledOnce()
     expect(releaseMock).toHaveBeenCalledOnce()
   })
@@ -265,6 +268,37 @@ describe('createGitLabMergeRequest', () => {
         'main'
       ])
     )
+  })
+
+  // Why: `glab mr create` has no --hostname flag either, so an SSH workspace
+  // has to reach its instance through GITLAB_HOST (#12193).
+  it('creates a merge request through GITLAB_HOST on an SSH workspace', async () => {
+    getProjectSlugMock.mockResolvedValue({ host: 'gitlab.example.internal', path: 'acme/widgets' })
+    glabExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        iid: 51,
+        web_url: 'https://gitlab.example.internal/acme/widgets/-/merge_requests/51'
+      }),
+      stderr: ''
+    })
+
+    await expect(
+      createGitLabMergeRequest(
+        '/remote/repo-root',
+        {
+          provider: 'gitlab',
+          base: 'main',
+          head: 'feature/ssh-host',
+          title: 'SSH host MR'
+        },
+        'ssh-1'
+      )
+    ).resolves.toMatchObject({ ok: true, number: 51 })
+
+    const [args, options] = glabExecFileAsyncMock.mock.calls[0]
+    expect(args.slice(0, 2)).toEqual(['mr', 'create'])
+    expect(args).not.toContain('--hostname')
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
   })
 
   // Why: `glab mr list` has no --hostname flag, so the duplicate lookup has to

--- a/src/main/gitlab/merge-request-creation.test.ts
+++ b/src/main/gitlab/merge-request-creation.test.ts
@@ -4,6 +4,7 @@ const {
   getProjectSlugMock,
   glabExecFileAsyncMock,
   glabHostnameArgsMock,
+  glabHostEnvOptionsMock,
   glabRepoExecOptionsMock,
   acquireMock,
   releaseMock,
@@ -12,6 +13,9 @@ const {
   getProjectSlugMock: vi.fn(),
   glabExecFileAsyncMock: vi.fn(),
   glabHostnameArgsMock: vi.fn((projectRef: { host: string }) => ['--hostname', projectRef.host]),
+  glabHostEnvOptionsMock: vi.fn((projectRef: { host: string }, connectionId?: string | null) =>
+    connectionId ? { env: { GITLAB_HOST: projectRef.host } } : {}
+  ),
   glabRepoExecOptionsMock: vi.fn((repoPath: string, connectionId?: string | null) =>
     connectionId ? {} : { cwd: repoPath }
   ),
@@ -29,6 +33,7 @@ vi.mock('./gl-utils', () => ({
   release: releaseMock,
   glabExecFileAsync: glabExecFileAsyncMock,
   glabHostnameArgs: glabHostnameArgsMock,
+  glabHostEnvOptions: glabHostEnvOptionsMock,
   glabRepoExecOptions: glabRepoExecOptionsMock
 }))
 
@@ -43,6 +48,7 @@ describe('createGitLabMergeRequest', () => {
     getProjectSlugMock.mockReset()
     glabExecFileAsyncMock.mockReset()
     glabHostnameArgsMock.mockClear()
+    glabHostEnvOptionsMock.mockClear()
     glabRepoExecOptionsMock.mockClear()
     acquireMock.mockReset()
     releaseMock.mockReset()
@@ -259,5 +265,39 @@ describe('createGitLabMergeRequest', () => {
         'main'
       ])
     )
+  })
+
+  // Why: `glab mr list` has no --hostname flag, so the duplicate lookup has to
+  // reach a self-hosted instance through GITLAB_HOST instead (#12193).
+  it('looks up an existing merge request through GITLAB_HOST on an SSH workspace', async () => {
+    glabExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('merge request already exists'))
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 77,
+            web_url: 'https://gitlab.example.internal/acme/widgets/-/merge_requests/77'
+          }
+        ]),
+        stderr: ''
+      })
+    getProjectSlugMock.mockResolvedValue({ host: 'gitlab.example.internal', path: 'acme/widgets' })
+
+    await expect(
+      createGitLabMergeRequest(
+        '/repo-root',
+        {
+          provider: 'gitlab',
+          base: 'main',
+          head: 'feature/existing',
+          title: 'Existing MR'
+        },
+        'ssh-1'
+      )
+    ).resolves.toMatchObject({ ok: false, code: 'already_exists' })
+
+    const [args, options] = glabExecFileAsyncMock.mock.calls[1]
+    expect(args).not.toContain('--hostname')
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.example.internal')
   })
 })

--- a/src/main/gitlab/merge-request-creation.ts
+++ b/src/main/gitlab/merge-request-creation.ts
@@ -16,7 +16,7 @@ import { getProjectSlug } from './client'
 import {
   acquire,
   glabExecFileAsync,
-  glabHostnameArgs,
+  glabHostEnvOptions,
   glabRepoExecOptions,
   release
 } from './gl-utils'
@@ -183,8 +183,7 @@ export async function createGitLabMergeRequest(
       title,
       '--description',
       body,
-      '--yes',
-      ...glabHostnameArgs(projectRef, connectionId)
+      '--yes'
     ]
     if (head) {
       createArgs.push('--source-branch', head)
@@ -196,6 +195,7 @@ export async function createGitLabMergeRequest(
       const { stdout } = await glabExecFileAsync(createArgs, {
         ...glabRepoExecOptions(repoPath, connectionId),
         ...(connectionId ? {} : getHostedReviewLocalGitOptions(options)),
+        ...glabHostEnvOptions(projectRef, connectionId),
         timeout: 60_000,
         idempotent: false
       })

--- a/src/main/gitlab/merge-request-state-mutations.ts
+++ b/src/main/gitlab/merge-request-state-mutations.ts
@@ -1,7 +1,7 @@
 import type { IssueSourcePreference } from '../../shared/repo-types'
 import {
   acquire,
-  glabHostnameArgs,
+  glabHostEnvOptions,
   glabRepoExecOptions,
   glabExecFileAsync,
   release,
@@ -26,17 +26,10 @@ export async function closeMR(
     async (projectRef, repoFlag) => {
       await acquire()
       try {
-        await glabExecFileAsync(
-          [
-            'mr',
-            'close',
-            String(iid),
-            '-R',
-            repoFlag,
-            ...glabHostnameArgs(projectRef, connectionId)
-          ],
-          glabRepoExecOptions(repoPath, connectionId, localGitOptions)
-        )
+        await glabExecFileAsync(['mr', 'close', String(iid), '-R', repoFlag], {
+          ...glabRepoExecOptions(repoPath, connectionId, localGitOptions),
+          ...glabHostEnvOptions(projectRef, connectionId)
+        })
         return { ok: true }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -70,17 +63,10 @@ export async function reopenMR(
     async (projectRef, repoFlag) => {
       await acquire()
       try {
-        await glabExecFileAsync(
-          [
-            'mr',
-            'reopen',
-            String(iid),
-            '-R',
-            repoFlag,
-            ...glabHostnameArgs(projectRef, connectionId)
-          ],
-          glabRepoExecOptions(repoPath, connectionId, localGitOptions)
-        )
+        await glabExecFileAsync(['mr', 'reopen', String(iid), '-R', repoFlag], {
+          ...glabRepoExecOptions(repoPath, connectionId, localGitOptions),
+          ...glabHostEnvOptions(projectRef, connectionId)
+        })
         return { ok: true }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -118,17 +104,11 @@ export async function mergeMR(
         const methodFlag =
           method === 'squash' ? ['--squash'] : method === 'rebase' ? ['--rebase'] : []
         await glabExecFileAsync(
-          [
-            'mr',
-            'merge',
-            String(iid),
-            '-R',
-            repoFlag,
-            '--yes',
-            ...methodFlag,
-            ...glabHostnameArgs(projectRef, connectionId)
-          ],
-          glabRepoExecOptions(repoPath, connectionId, localGitOptions)
+          ['mr', 'merge', String(iid), '-R', repoFlag, '--yes', ...methodFlag],
+          {
+            ...glabRepoExecOptions(repoPath, connectionId, localGitOptions),
+            ...glabHostEnvOptions(projectRef, connectionId)
+          }
         )
         return { ok: true }
       } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #12193, fixes #12556 — GitLab write actions from a repository opened as an SSH-hosted workspace fail before Orca ever reaches GitLab:

```
glab mr merge 6 -R example-group/example-project --yes --hostname gitlab.example.internal
ERROR Unknown flag: --hostname. Try --help for usage.
```

`--hostname` is **not** a glab global flag. It is defined per command, on `glab api` and the auth commands only — [`glab api`](https://docs.gitlab.com/cli/api/) documents it ("The GitLab hostname for the request"), while [`glab mr merge`](https://docs.gitlab.com/cli/mr/merge/), [`glab mr close`](https://docs.gitlab.com/cli/mr/close/) and [`glab mr list`](https://docs.gitlab.com/cli/mr/list/) list only `-h, --help` and `-R, --repo` under inherited options. `glabHostnameArgs()` was appending it regardless of the subcommand.

**The report covers `mr merge`, but the same helper fed six more subcommands.** All of them break the same way. The trigger is the SSH workspace, not the instance: `glabHostnameArgs` fires on `connectionId && projectRef?.host`, and on an SSH workspace `connectionId` is always set while `projectRef.host` always resolves — it is the same object that supplies `-R`. So these fail against gitlab.com too, not only self-hosted instances:

| Call site | Command |
| --- | --- |
| `client.ts` `mergeMR` | `glab mr merge` |
| `client.ts` `closeMR` | `glab mr close` |
| `client.ts` `reopenMR` | `glab mr reopen` |
| `merge-request-creation-lookup.ts` `findOpenMRByHeadBase` | `glab mr list` (duplicate-MR lookup) |
| `issue-update.ts` `updateIssue` | `glab issue close` / `glab issue reopen` |
| `merge-request-creation.ts` `createGitLabMergeRequest` | `glab mr create` |
| `issue-update.ts` `updateIssue` (field edits) | `glab issue update` |

This explains why the panels still load while merging fails: the other 26 call sites run `glab api`, which does accept `--hostname`. Those are left exactly as they are.

The seven above now carry the host in `GITLAB_HOST`, which glab honours for every command, through a new `glabHostEnvOptions()` helper alongside the existing `glabHostnameArgs()`. This is the same mechanism the issue suggests and the same one `redirectPortedHostnameToEnv()` already uses for ported hosts.

## Rebase note (2026-08-18)

Rebased onto `b2612de1`. Three upstream refactors moved this PR's targets, so the diff no longer lines up with the file names in the original description — corrected above, and recorded here so the move is not mistaken for scope creep:

| Upstream change | Effect here |
| --- | --- |
| #14704 (split issue-tracker clients under the max-lines budget) | `updateIssue` moved out of `issues.ts` into the new `issue-update.ts`. Both `glab issue` fixes were reapplied there; `issues.ts` is back to upstream verbatim and now only builds `glab api` calls. |
| #14728 (split oversized test files) | `client-mr.test.ts` no longer exists. The four `mr` cases moved to `client-mr-review-actions.test.ts`, which mocks `gl-utils` through `vi.importActual` — so they now exercise the **real** `glabHostEnvOptions`, not a stub. That is a strict improvement given a stale stub is what hid the `mr create` regression in the first place. |
| #14447 (drop the `shared/types` barrel) | Import paths only. |

`glabHostnameArgs` is still on every non-`api` path on current `main`, including the newly split `issue-update.ts`, so nothing here has been fixed upstream in the meantime. Re-audited after the rebase: every remaining `glabHostnameArgs` call builds a `glab api` command, and the two `mr create` / `issue update` argument arrays that are assembled in variables (and so escape a naive grep) were checked by hand.

Reverting `issue-update.ts` alone to its upstream state fails the two `issues.test.ts` cases, confirming the fix is still load-bearing after the move:

```
× updateIssue edits fields through GITLAB_HOST on an SSH workspace
  AssertionError: expected [ 'issue', 'update', '5', '-R', ...(5) ] to not include '--hostname'
× updateIssue closes through GITLAB_HOST on an SSH workspace
```

## Screenshots

No visual change — this is main-process CLI argument construction.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added 14 cases across four files. Eight of them fail on an unmodified `main`, one per broken call site: `client-mr-review-actions.test.ts` (merge, merge with `--squash`, close, reopen), `merge-request-creation.test.ts` (MR creation and the duplicate-MR lookup), and `issues.test.ts` (issue close and field edits). Each asserts the command carries no `--hostname` and that `GITLAB_HOST` reaches glab instead. `gl-utils.test.ts` adds five unit cases for the helper itself, including the local-workspace and missing-host paths that must stay untouched.

There was no existing coverage for a non-`api` subcommand on a connection-backed workspace — every `--hostname` assertion in the suite was on an `api` call — which is how this went unnoticed.

Ran the surrounding suites for regressions: `src/main/gitlab/` (271 tests), `src/main/source-control/` (122 tests), `src/main/git/runner.test.ts` (36 tests) all pass.

Pre-existing failures on this machine, reproduced on an unmodified `main` and unrelated to this PR: `release-rc-history` and `publish-complete-draft-releases` (this machine has `tag.gpgsign` enabled globally), `plugin-install`, `updater`, `agent-exec-handler`, `automation-schedules`, and the `terminal-ime-xterm-*` files (flaky under xterm's composition timers — they pass on a rerun).

## AI Review Report

Reviewed with Claude Code. Checks and findings:

- **Verified against glab's documentation, not inferred from the error message.** Each affected subcommand's flag list was checked before changing it, which is also how the four unreported call sites surfaced. `glab api` was confirmed to *keep* `--hostname`, so the 26 API call sites are deliberately untouched.
- **Windows/WSL was a real gap and is handled.** `runner.ts` documents that "spawn env can't cross the `wsl.exe` boundary" and "WSLENV forwards only named vars". Passing `env` alone would have left the fix inert for a WSL-routed glab, so `glabHostEnvOptions()` calls `addWslEnvKeys(env, ['GITLAB_HOST'])` on `win32`, mirroring how `nonInteractiveGitEnv` forwards `GIT_SSH_COMMAND`. Covered by a test that stubs `process.platform`.
- **`redirectPortedHostnameToEnv()` deliberately left alone.** It translates `--hostname` to `GITLAB_HOST` only for `host:port` values, and an existing test ("leaves a port-less `--hostname` untouched") pins that as intended — it exists because glab's `--hostname` rejects ports, which is a different problem from a subcommand not defining the flag at all. Widening it would have silently changed the `api` and `auth status` paths.
- **The flag audit was redone from scratch and found two more call sites.** The first pass enumerated `glabHostnameArgs` usages with a truncated listing and missed `mr create` and `issue update`; re-running it over all 35 usages surfaced both. Every usage is now classified by the subcommand it builds, and only the `glab api` ones keep the flag.
- **A misleading test mock was corrected.** `merge-request-creation.test.ts` stubbed `glabHostnameArgs` with an implementation that ignores `connectionId`, so its local-workspace case asserted `--hostname` on a command that never carries it. That assertion is now the real contract (no flag, no env override on a local workspace), which is what let `mr create` regress unnoticed.
- **Option-merge order checked.** `glabHostEnvOptions()` is spread last, but it returns `{}` for a local workspace, so it can never clobber `getHostedReviewLocalGitOptions()`; and `glabRepoExecOptions()` only ever returns `cwd`/`wslDistro`, so there is no `env` to overwrite.
- **Git provider compatibility:** GitLab-only paths; no GitHub or generic review code touched, and no GitHub-specific naming introduced.
- **SSH / remote / local:** the helper is a no-op without a `connectionId`, so local and local-WSL workspaces keep their current behaviour byte for byte (asserted in tests).
- **Performance:** one object spread per invocation on paths that already spawn a process.

## Security Audit

The change moves a hostname from a command-line argument into the child process environment. It is the repository's own resolved project host, not user free-text, and it is the same value that was already being passed on the command line.

- **No secrets involved.** `GITLAB_HOST` is a hostname; tokens continue to come from glab's own config or `GITLAB_TOKEN`/`GLAB_TOKEN`, which are untouched.
- **Environment inheritance is explicit.** The helper spreads `process.env` before adding the key, matching `redirectPortedHostnameToEnv()`, so no existing variable is dropped.
- **WSLENV is additive.** `addWslEnvKeys()` appends to any existing `WSLENV` and forwards only the named variable, so no unrelated Windows-side value is exposed to the distro.
- Marginally *less* exposure than before: the host no longer appears in the process argument list, which is world-readable on Linux.

No new input parsing, path handling, auth, dependency, or IPC surface.

## Notes

- Reproducing needs a self-hosted GitLab reached through an Orca SSH workspace; the tests are written to stand in for that environment by asserting the exact argv and env handed to glab.
- Windows users running glab inside WSL are covered by the `WSLENV` forwarding described above.


