### PR TITLE
feat(sidebar): show live Codex subagent progress

### DIFF
--- a/src/main/agent-hooks/codex-subagent-poll-policy.test.ts
+++ b/src/main/agent-hooks/codex-subagent-poll-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  advanceCodexSubagentPollPlan,
+  CODEX_SUBAGENT_POLL_ACTIVE_MS,
+  CODEX_SUBAGENT_POLL_QUIET_MAX_MS,
+  INITIAL_CODEX_SUBAGENT_POLL_PLAN
+} from './codex-subagent-poll-policy'
+
+describe('Codex subagent poll policy', () => {
+  it('backs off quiet polls to a bounded cadence', () => {
+    const first = advanceCodexSubagentPollPlan(INITIAL_CODEX_SUBAGENT_POLL_PLAN, true)
+    expect(first).toEqual({ delayMs: 2_000 })
+
+    const second = advanceCodexSubagentPollPlan(first, true)
+    expect(second).toEqual({ delayMs: 4_000 })
+
+    const capped = advanceCodexSubagentPollPlan(second, true)
+    expect(capped).toEqual({ delayMs: CODEX_SUBAGENT_POLL_QUIET_MAX_MS })
+    expect(advanceCodexSubagentPollPlan(capped, true)).toEqual({
+      delayMs: CODEX_SUBAGENT_POLL_QUIET_MAX_MS
+    })
+  })
+
+  it('restores the active cadence when activity returns', () => {
+    const quiet = advanceCodexSubagentPollPlan(INITIAL_CODEX_SUBAGENT_POLL_PLAN, true)
+
+    expect(advanceCodexSubagentPollPlan(quiet, false)).toEqual({
+      delayMs: CODEX_SUBAGENT_POLL_ACTIVE_MS
+    })
+  })
+})

--- a/src/main/agent-hooks/codex-subagent-poll-policy.ts
+++ b/src/main/agent-hooks/codex-subagent-poll-policy.ts
@@ -1,0 +1,23 @@
+export const CODEX_SUBAGENT_POLL_ACTIVE_MS = 1_000
+// Why: cap delayed-child discovery lag while cutting steady quiet polling by 80%.
+export const CODEX_SUBAGENT_POLL_QUIET_MAX_MS = 5_000
+
+export type CodexSubagentPollPlan = Readonly<{
+  delayMs: number
+}>
+
+export const INITIAL_CODEX_SUBAGENT_POLL_PLAN: CodexSubagentPollPlan = Object.freeze({
+  delayMs: CODEX_SUBAGENT_POLL_ACTIVE_MS
+})
+
+export function advanceCodexSubagentPollPlan(
+  current: CodexSubagentPollPlan,
+  quiet: boolean
+): CodexSubagentPollPlan {
+  if (!quiet) {
+    return INITIAL_CODEX_SUBAGENT_POLL_PLAN
+  }
+  return {
+    delayMs: Math.min(current.delayMs * 2, CODEX_SUBAGENT_POLL_QUIET_MAX_MS)
+  }
+}

--- a/src/main/agent-hooks/server-codex-subagent-dynamic-lifecycle.test.ts
+++ b/src/main/agent-hooks/server-codex-subagent-dynamic-lifecycle.test.ts
@@ -4,11 +4,19 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { AgentHookServer } from './server'
+import {
+  CODEX_SUBAGENT_POLL_ACTIVE_MS,
+  CODEX_SUBAGENT_POLL_QUIET_MAX_MS
+} from './codex-subagent-poll-policy'
 import { makePaneKey } from '../../shared/stable-pane-id'
 
 const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
 const CHILD_ID = '019fa65f-3144-7151-9c02-cff7a28f316f'
 const SECOND_CHILD_ID = '019fa65f-3144-7151-9c02-cff7a28f3170'
+
+type AgentHookServerPollInternals = {
+  codexSubagentPollTimers: Map<string, ReturnType<typeof setTimeout>>
+}
 
 function line(record: unknown): string {
   return `${JSON.stringify(record)}\n`
@@ -54,6 +62,7 @@ describe('AgentHookServer Codex dynamic subagent lifecycle', () => {
   const dirs: string[] = []
 
   afterEach(() => {
+    vi.useRealTimers()
     for (const dir of dirs) {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -132,6 +141,60 @@ describe('AgentHookServer Codex dynamic subagent lifecycle', () => {
       )
     } finally {
       server.stop()
+    }
+  })
+
+  it('keeps a quiet poll bounded and rearms it on the next Codex turn', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-hook-codex-subagent-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+    const secondChildPath = join(dir, `rollout-child-${SECOND_CHILD_ID}.jsonl`)
+    const started = line({ type: 'event_msg', payload: { type: 'task_started' } })
+    writeFileSync(parentPath, started)
+    writeFileSync(childPath, started)
+    writeFileSync(secondChildPath, started)
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const internals = server as unknown as AgentHookServerPollInternals
+    try {
+      await postCodexHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'root-session',
+        transcript_path: parentPath
+      })
+      expect(internals.codexSubagentPollTimers.has(PANE_KEY)).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(60_000 + CODEX_SUBAGENT_POLL_QUIET_MAX_MS)
+      expect(internals.codexSubagentPollTimers.has(PANE_KEY)).toBe(true)
+
+      appendFileSync(parentPath, spawnLine(CHILD_ID, '/root/long_quiet'))
+      await vi.advanceTimersByTimeAsync(CODEX_SUBAGENT_POLL_QUIET_MAX_MS)
+      expect(server.getStatusSnapshot()[0]?.subagents).toEqual([
+        expect.objectContaining({ id: CHILD_ID, description: '/root/long_quiet' })
+      ])
+
+      appendFileSync(childPath, line({ type: 'event_msg', payload: { type: 'task_complete' } }))
+      await vi.advanceTimersByTimeAsync(CODEX_SUBAGENT_POLL_ACTIVE_MS)
+      expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+
+      await postCodexHook(server, {
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'root-session',
+        prompt: 'continue'
+      })
+      expect(internals.codexSubagentPollTimers.has(PANE_KEY)).toBe(true)
+
+      appendFileSync(parentPath, spawnLine(SECOND_CHILD_ID, '/root/rearmed'))
+      await vi.advanceTimersByTimeAsync(CODEX_SUBAGENT_POLL_ACTIVE_MS)
+      expect(server.getStatusSnapshot()[0]?.subagents).toEqual([
+        expect.objectContaining({ id: SECOND_CHILD_ID, description: '/root/rearmed' })
+      ])
+    } finally {
+      server.stop()
+      vi.useRealTimers()
     }
   })
 

--- a/src/main/agent-hooks/server-codex-subagent-dynamic-lifecycle.test.ts
+++ b/src/main/agent-hooks/server-codex-subagent-dynamic-lifecycle.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { AgentHookServer } from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+const CHILD_ID = '019fa65f-3144-7151-9c02-cff7a28f316f'
+const SECOND_CHILD_ID = '019fa65f-3144-7151-9c02-cff7a28f3170'
+
+function line(record: unknown): string {
+  return `${JSON.stringify(record)}\n`
+}
+
+function activityLine(
+  threadId: string,
+  agentPath: string,
+  kind: 'started' | 'interrupted'
+): string {
+  return line({
+    type: 'event_msg',
+    payload: {
+      type: 'sub_agent_activity',
+      occurred_at_ms: 1234,
+      agent_thread_id: threadId,
+      agent_path: agentPath,
+      kind
+    }
+  })
+}
+
+function spawnLine(threadId: string, agentPath: string): string {
+  return activityLine(threadId, agentPath, 'started')
+}
+
+async function postCodexHook(
+  server: AgentHookServer,
+  payload: Record<string, unknown>
+): Promise<Response> {
+  const env = server.buildPtyEnv()
+  return fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+    },
+    body: JSON.stringify({ paneKey: PANE_KEY, tabId: 'tab-1', worktreeId: 'wt-1', payload })
+  })
+}
+
+describe('AgentHookServer Codex dynamic subagent lifecycle', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    dirs.length = 0
+  })
+
+  it('keeps watching when the roster empties before another child starts', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-hook-codex-subagent-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+    const secondChildPath = join(dir, `rollout-child-${SECOND_CHILD_ID}.jsonl`)
+    const started = line({ type: 'event_msg', payload: { type: 'task_started' } })
+    writeFileSync(parentPath, spawnLine(CHILD_ID, '/root/pr_review'))
+    writeFileSync(childPath, started)
+    writeFileSync(secondChildPath, started)
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCodexHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'root-session',
+        transcript_path: parentPath
+      })
+      expect(server.getStatusSnapshot()[0]?.subagents).toEqual([
+        expect.objectContaining({ id: CHILD_ID })
+      ])
+
+      appendFileSync(parentPath, activityLine(CHILD_ID, '/root/pr_review', 'interrupted'))
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+
+      appendFileSync(parentPath, spawnLine(SECOND_CHILD_ID, '/root/perf_audit'))
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]?.subagents).toEqual([
+            expect.objectContaining({ id: SECOND_CHILD_ID, description: '/root/perf_audit' })
+          ])
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('discovers the first child after binding an initially empty parent transcript', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-hook-codex-subagent-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+    writeFileSync(parentPath, line({ type: 'event_msg', payload: { type: 'task_started' } }))
+    writeFileSync(childPath, line({ type: 'event_msg', payload: { type: 'task_started' } }))
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCodexHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'root-session',
+        transcript_path: parentPath
+      })
+      expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+
+      appendFileSync(parentPath, spawnLine(CHILD_ID, '/root/late_spawn'))
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]?.subagents).toEqual([
+            expect.objectContaining({ id: CHILD_ID, description: '/root/late_spawn' })
+          ])
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('keeps parent discovery active across child hook lifecycle events', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-hook-codex-subagent-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+    const secondChildPath = join(dir, `rollout-child-${SECOND_CHILD_ID}.jsonl`)
+    const started = line({ type: 'event_msg', payload: { type: 'task_started' } })
+    writeFileSync(parentPath, spawnLine(CHILD_ID, '/root/pr_review'))
+    writeFileSync(childPath, started)
+    writeFileSync(secondChildPath, started)
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCodexHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'root-session',
+        transcript_path: parentPath
+      })
+      await postCodexHook(server, {
+        hook_event_name: 'PreToolUse',
+        agent_id: CHILD_ID,
+        agent_type: 'reviewer',
+        tool_name: 'exec_command'
+      })
+
+      appendFileSync(parentPath, spawnLine(SECOND_CHILD_ID, '/root/perf_audit'))
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]?.subagents?.map(({ id }) => id)).toEqual([
+            CHILD_ID,
+            SECOND_CHILD_ID
+          ])
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+
+      await postCodexHook(server, { hook_event_name: 'SubagentStop', agent_id: CHILD_ID })
+      await new Promise((resolve) => setTimeout(resolve, 1_200))
+      expect(server.getStatusSnapshot()[0]?.subagents?.map(({ id }) => id)).toEqual([
+        SECOND_CHILD_ID
+      ])
+
+      appendFileSync(
+        secondChildPath,
+        line({ type: 'event_msg', payload: { type: 'task_complete' } })
+      )
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('switches the watcher when the pane starts a new Codex session', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-hook-codex-subagent-'))
+    dirs.push(dir)
+    const firstParentPath = join(dir, 'rollout-first-parent.jsonl')
+    const nextParentPath = join(dir, 'rollout-next-parent.jsonl')
+    const firstChildPath = join(dir, `rollout-first-child-${CHILD_ID}.jsonl`)
+    const nextChildPath = join(dir, `rollout-next-child-${SECOND_CHILD_ID}.jsonl`)
+    const started = line({ type: 'event_msg', payload: { type: 'task_started' } })
+    writeFileSync(firstParentPath, started)
+    writeFileSync(nextParentPath, started)
+    writeFileSync(firstChildPath, started)
+    writeFileSync(nextChildPath, started)
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      await postCodexHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'first-root-session',
+        transcript_path: firstParentPath
+      })
+      await postCodexHook(server, {
+        hook_event_name: 'SessionStart',
+        session_id: 'next-root-session',
+        transcript_path: nextParentPath
+      })
+
+      appendFileSync(firstParentPath, spawnLine(CHILD_ID, '/root/stale_child'))
+      await new Promise((resolve) => setTimeout(resolve, 1_200))
+      expect(server.getStatusSnapshot()[0]?.subagents).toBeUndefined()
+
+      appendFileSync(nextParentPath, spawnLine(SECOND_CHILD_ID, '/root/current_child'))
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]?.subagents).toEqual([
+            expect.objectContaining({ id: SECOND_CHILD_ID, description: '/root/current_child' })
+          ])
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+    } finally {
+      server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server-codex-subagent-transcript.test.ts
+++ b/src/main/agent-hooks/server-codex-subagent-transcript.test.ts
@@ -204,4 +204,83 @@ describe('AgentHookServer Codex subagent transcript polling', () => {
       server.stop()
     }
   })
+
+  it('parks a waiting child without keeping a completed lead working', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agent-hook-codex-subagent-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+    writeFileSync(parentPath, spawnLine(CHILD_ID, '/root/test_agent'))
+    writeFileSync(
+      childPath,
+      line({ type: 'event_msg', payload: { type: 'task_started' } }) +
+        line({
+          type: 'response_item',
+          payload: { type: 'function_call', name: 'wait_agent', call_id: 'call-wait-1' }
+        })
+    )
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/codex`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify({
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: {
+            hook_event_name: 'Stop',
+            session_id: 'root-session',
+            transcript_path: parentPath
+          }
+        })
+      })
+
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'done',
+        subagents: [expect.objectContaining({ id: CHILD_ID, state: 'idle' })]
+      })
+
+      appendFileSync(
+        childPath,
+        line({
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call-wait-1', output: '' }
+        })
+      )
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]).toMatchObject({
+            state: 'working',
+            subagents: [expect.objectContaining({ id: CHILD_ID, state: 'working' })]
+          })
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+
+      appendFileSync(
+        childPath,
+        line({
+          type: 'response_item',
+          payload: { type: 'function_call', name: 'wait_agent', call_id: 'call-wait-2' }
+        })
+      )
+      await vi.waitFor(
+        () => {
+          expect(server.getStatusSnapshot()[0]).toMatchObject({
+            state: 'done',
+            subagents: [expect.objectContaining({ id: CHILD_ID, state: 'idle' })]
+          })
+        },
+        { timeout: 3_000, interval: 50 }
+      )
+    } finally {
+      server.stop()
+    }
+  })
 })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -16,6 +16,7 @@ import {
   createHookListenerState,
   getEndpointFileName,
   hasCodexParentTranscript,
+  hasCodexTranscriptSubagents,
   hasPendingAgentResultText,
   HOOK_REQUEST_SLOWLORIS_MS,
   isNewTurnEvent,
@@ -99,6 +100,11 @@ import {
   type AgentProviderSessionMetadata
 } from '../../shared/agent-session-resume'
 import { isCommandCodeNewTurnWhileWorking } from '../../shared/command-code-turn-boundary'
+import {
+  advanceCodexSubagentPollPlan,
+  INITIAL_CODEX_SUBAGENT_POLL_PLAN,
+  type CodexSubagentPollPlan
+} from './codex-subagent-poll-policy'
 
 export type { AgentHookSource }
 
@@ -191,7 +197,6 @@ type RetiredPaneFence = {
 const LAST_STATUS_FILE_NAME = 'last-status.json'
 const ASSISTANT_MESSAGE_RETRY_ATTEMPTS = 5
 const ASSISTANT_MESSAGE_RETRY_MS = 50
-const CODEX_SUBAGENT_POLL_MS = 1_000
 const INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS = 15_000
 
 // Why: starts at 2 — pre-merge v1 lacked receivedAt/stateStartedAt (never shipped); a mismatched version hydrates empty (treated as corrupt).
@@ -1535,7 +1540,8 @@ export class AgentHookServer {
 
   private scheduleCodexSubagentPoll(
     source: AgentHookSource,
-    original: EnrichedAgentHookEventPayload
+    original: EnrichedAgentHookEventPayload,
+    plan: CodexSubagentPollPlan = INITIAL_CODEX_SUBAGENT_POLL_PLAN
   ): void {
     // Why: a nested non-codex CLI inherits ORCA_PANE_KEY, so clearing here would silently end a live codex poll.
     if (source !== 'codex') {
@@ -1568,8 +1574,12 @@ export class AgentHookServer {
             payload
           })
         : original
-      this.scheduleCodexSubagentPoll(source, next)
-    }, CODEX_SUBAGENT_POLL_MS)
+      // Why: inactive empty rosters only need late-rollout grace; the next Codex hook restores active polling.
+      const quiet =
+        !hasCodexTranscriptSubagents(this.state, original.paneKey) &&
+        (payload.state !== 'working' || original.hookEventName === 'SessionStart')
+      this.scheduleCodexSubagentPoll(source, next, advanceCodexSubagentPollPlan(plan, quiet))
+    }, plan.delayMs)
     this.codexSubagentPollTimers.set(original.paneKey, timer)
     if (typeof timer.unref === 'function') {
       timer.unref()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -15,7 +15,7 @@ import {
   clearClaudeAnsweredQuestionWait,
   createHookListenerState,
   getEndpointFileName,
-  hasCodexTranscriptSubagents,
+  hasCodexParentTranscript,
   hasPendingAgentResultText,
   HOOK_REQUEST_SLOWLORIS_MS,
   isNewTurnEvent,
@@ -28,6 +28,7 @@ import {
   normalizeHookPayload,
   parseFormEncodedBody,
   readRequestBody,
+  refreshCodexSubagentTranscriptStatus,
   reapRestoredClaudeSubagentsForDeadPane,
   reconcileRemoteCodexState,
   resolveCachedClaudeCompactOwnership,
@@ -1534,7 +1535,6 @@ export class AgentHookServer {
 
   private scheduleCodexSubagentPoll(
     source: AgentHookSource,
-    body: unknown,
     original: EnrichedAgentHookEventPayload
   ): void {
     // Why: a nested non-codex CLI inherits ORCA_PANE_KEY, so clearing here would silently end a live codex poll.
@@ -1542,7 +1542,7 @@ export class AgentHookServer {
       return
     }
     this.clearCodexSubagentPoll(original.paneKey)
-    if (!hasCodexTranscriptSubagents(this.state, original.paneKey)) {
+    if (!hasCodexParentTranscript(this.state, original.paneKey)) {
       return
     }
     const timer = setTimeout(() => {
@@ -1551,14 +1551,24 @@ export class AgentHookServer {
       if (!this.server || current !== original) {
         return
       }
-      const normalized = normalizeHookPayload(this.state, source, body, this.env)
-      if (!normalized) {
+      const payload = refreshCodexSubagentTranscriptStatus(this.state, original.paneKey)
+      if (!payload) {
         return
       }
       const subagentsChanged =
-        JSON.stringify(normalized.payload.subagents) !== JSON.stringify(original.payload.subagents)
-      const next = subagentsChanged ? this.applyNormalizedStatus(normalized) : original
-      this.scheduleCodexSubagentPoll(source, body, next)
+        JSON.stringify(payload.subagents) !== JSON.stringify(original.payload.subagents)
+      const next = subagentsChanged
+        ? this.applyNormalizedStatus({
+            paneKey: original.paneKey,
+            launchToken: original.launchToken,
+            tabId: original.tabId,
+            worktreeId: original.worktreeId,
+            connectionId: original.connectionId,
+            providerSession: original.providerSession,
+            payload
+          })
+        : original
+      this.scheduleCodexSubagentPoll(source, next)
     }, CODEX_SUBAGENT_POLL_MS)
     this.codexSubagentPollTimers.set(original.paneKey, timer)
     if (typeof timer.unref === 'function') {
@@ -2484,7 +2494,7 @@ export class AgentHookServer {
           this.recordCurrentAuthorityObservation(event)
           const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
           this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
-          this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
+          this.scheduleCodexSubagentPoll(source, enriched)
         }
 
         res.writeHead(204)

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -258,6 +258,47 @@ describe('readNativeChatTranscript (codex)', () => {
     const reasoning = result.messages.find((m) => m.role === 'reasoning')
     expect(reasoning?.blocks[0]).toEqual({ type: 'text', text: 'I will run it' })
   })
+
+  it('maps custom tool activity emitted by Codex subagents', async () => {
+    const filePath = await writeFixture('orca-native-chat-codex-custom-tool-', [
+      {
+        type: 'response_item',
+        timestamp: '2026-06-01T10:00:00.000Z',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          input: 'const result = await tools.exec_command({ cmd: "git status" })'
+        }
+      },
+      {
+        type: 'response_item',
+        timestamp: '2026-06-01T10:00:01.000Z',
+        payload: {
+          type: 'custom_tool_call_output',
+          output: [
+            { type: 'input_text', text: 'Script completed\n' },
+            { type: 'input_text', text: '## main...origin/main\n' }
+          ]
+        }
+      }
+    ])
+
+    const result = await readNativeChatTranscript('codex', 'codex-sess', { filePath })
+    if (!('messages' in result)) {
+      throw new Error('expected messages')
+    }
+
+    expect(result.messages.map((message) => message.role)).toEqual(['assistant', 'tool'])
+    expect(result.messages[0]?.blocks[0]).toEqual({
+      type: 'tool-call',
+      name: 'exec',
+      input: 'const result = await tools.exec_command({ cmd: "git status" })'
+    })
+    expect(result.messages[1]?.blocks[0]).toEqual({
+      type: 'tool-result',
+      output: 'Script completed\n## main...origin/main'
+    })
+  })
 })
 
 describe('readNativeChatTranscript (errors)', () => {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1244,7 +1244,8 @@ html.native-shell .app-layout {
   background: color-mix(in srgb, var(--sidebar-foreground) 1.25%, transparent);
 }
 
-.worktree-agent-row-hover[data-focused-agent-pane='true'] {
+.worktree-agent-row-hover[data-focused-agent-pane='true'],
+.worktree-agent-row-hover[data-current='true'] {
   /* Why: a borderless fill. --sidebar-accent ≈ --sidebar in light mode, so the
      selection wash mixes sidebar-foreground into the accent to stay legible
      without going so dark that muted text (timestamp) drops out. */
@@ -1255,7 +1256,8 @@ html.native-shell .app-layout {
   background: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
-.dark .worktree-agent-row-hover[data-focused-agent-pane='true'] {
+.dark .worktree-agent-row-hover[data-focused-agent-pane='true'],
+.dark .worktree-agent-row-hover[data-current='true'] {
   background: color-mix(in srgb, var(--accent) 70%, transparent);
 }
 
@@ -1584,13 +1586,17 @@ html.native-shell .app-layout {
 }
 
 [data-compact-agent-list='true']
-  .compact-agent-row.worktree-agent-row-hover[data-focused-agent-pane='true'] {
+  .compact-agent-row.worktree-agent-row-hover[data-focused-agent-pane='true'],
+[data-compact-agent-list='true'] .compact-agent-row.worktree-agent-row-hover[data-current='true'] {
   background: color-mix(in srgb, var(--sidebar-foreground) 12%, var(--sidebar-accent));
 }
 
 .dark
   [data-compact-agent-list='true']
-  .compact-agent-row.worktree-agent-row-hover[data-focused-agent-pane='true'] {
+  .compact-agent-row.worktree-agent-row-hover[data-focused-agent-pane='true'],
+.dark
+  [data-compact-agent-list='true']
+  .compact-agent-row.worktree-agent-row-hover[data-current='true'] {
   background: color-mix(in srgb, var(--accent) 70%, transparent);
 }
 

--- a/src/renderer/src/components/agent-child-disclosure-label.ts
+++ b/src/renderer/src/components/agent-child-disclosure-label.ts
@@ -1,0 +1,16 @@
+import { translate } from '@/i18n/i18n'
+
+export function agentChildDisclosureLabel(expanded: boolean, count: number): string {
+  if (expanded) {
+    return count === 1
+      ? translate('components.agent-child-disclosure.hide-one', 'Hide 1 child agent')
+      : translate('components.agent-child-disclosure.hide-other', 'Hide {{count}} child agents', {
+          count
+        })
+  }
+  return count === 1
+    ? translate('components.agent-child-disclosure.show-one', 'Show 1 child agent')
+    : translate('components.agent-child-disclosure.show-other', 'Show {{count}} child agents', {
+        count
+      })
+}

--- a/src/renderer/src/components/codex-subagent-display-label.ts
+++ b/src/renderer/src/components/codex-subagent-display-label.ts
@@ -1,0 +1,10 @@
+const CODEX_ROOT_AGENT_PATH = '/root/'
+
+export function formatCodexSubagentDisplayLabel(value: string): string {
+  const label = value.trim()
+  if (!label.startsWith(CODEX_ROOT_AGENT_PATH)) {
+    return label
+  }
+  const pathSegments = label.slice(CODEX_ROOT_AGENT_PATH.length).split('/').filter(Boolean)
+  return pathSegments.at(-1) ?? label
+}

--- a/src/renderer/src/components/dashboard/DashboardAgentChildDisclosure.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentChildDisclosure.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { translate } from '@/i18n/i18n'
+import { agentChildDisclosureLabel } from '@/components/agent-child-disclosure-label'
 
 type Props = {
   childAgentCount?: number
@@ -52,15 +52,7 @@ export function DashboardAgentChildDisclosure({
       onMouseDown={stopMouseDown}
       onKeyDown={stopKeyDown}
       className="-ml-0.5 inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-sidebar-border/80 bg-sidebar text-foreground/80 shadow-xs hover:bg-sidebar-accent hover:text-foreground"
-      aria-label={translate(
-        'auto.components.dashboard.DashboardAgentChildDisclosure.1b57ce9fa4',
-        '{{value0}} {{value1}} child {{value2}}',
-        {
-          value0: childAgentsExpanded ? 'Hide' : 'Show',
-          value1: childAgentCount,
-          value2: childAgentCount === 1 ? 'agent' : 'agents'
-        }
-      )}
+      aria-label={agentChildDisclosureLabel(childAgentsExpanded, childAgentCount)}
       aria-expanded={childAgentsExpanded}
     >
       <ChevronRight

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -390,6 +390,8 @@ describe('DashboardAgentRow', () => {
   it('renders orchestration child rows with a connector and tree level', () => {
     const markup = renderRow(
       makeAgent({
+        rowSource: 'subagent',
+        subagentSession: { id: 'child-1', provider: 'codex', parentPaneKey: 'tab-1:leaf-1' },
         lineage: {
           depth: 1,
           isFirstSibling: true,
@@ -400,6 +402,7 @@ describe('DashboardAgentRow', () => {
     )
 
     expect(markup).toContain('data-agent-lineage-connector="last"')
+    expect(markup).toContain('data-subagent-id="child-1"')
     expect(markup).toContain('role="treeitem"')
     expect(markup).toContain('aria-level="2"')
     expect(classTokens(markup)).toContain('pl-5')

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react'
 import { cn } from '@/lib/utils'
 import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
 import { AgentIcon } from '@/lib/agent-catalog'
+import { formatCodexSubagentDisplayLabel } from '@/components/codex-subagent-display-label'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DashboardAgentChildDisclosure } from './DashboardAgentChildDisclosure'
@@ -68,6 +69,8 @@ type Props = {
   hideExpand?: boolean
   /** Reuse the row's hover tint to show the focused terminal pane's agent. */
   isFocusedPane?: boolean
+  /** Mark a synthetic child row whose inspector is currently open. */
+  isCurrentAgent?: boolean
   // Why: inline-card orchestration rows fold children under a leading chevron.
   childAgentCount?: number
   childAgentsExpanded?: boolean
@@ -92,6 +95,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   hideIdentityIcon = false,
   hideExpand = false,
   isFocusedPane = false,
+  isCurrentAgent = false,
   childAgentCount,
   childAgentsExpanded = false,
   onToggleChildAgents,
@@ -105,6 +109,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
     typeof childAgentCount === 'number' &&
     childAgentCount > 0 &&
     typeof onToggleChildAgents === 'function'
+  const isHighlighted = isFocusedPane || isCurrentAgent
   const [expanded, setExpanded] = useState(false)
   const handleToggleExpanded = useCallback(() => {
     setExpanded((prev) => !prev)
@@ -143,7 +148,9 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const conversationName = useAgentRowConversationName(agent)
   const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
   // Why: prompt is '' when unknown, so fall back to the state label to keep the row labeled.
-  const displayLabel = prompt || agentStateLabel(asDotState(agent.state))
+  const sourceLabel = prompt || agentStateLabel(asDotState(agent.state))
+  const isCodexSubagent = agent.subagentSession?.provider === 'codex'
+  const displayLabel = isCodexSubagent ? formatCodexSubagentDisplayLabel(sourceLabel) : sourceLabel
   const model = agent.entry.model?.trim() ?? ''
   const isWorking = agent.state === 'working'
   // Why: 'working' names the running tool and 'waiting' names what an approval is blocked on;
@@ -199,10 +206,12 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
         sendTargetStatus === 'disabled' && 'cursor-default opacity-60'
       )}
       data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
+      data-current={isCurrentAgent ? 'true' : undefined}
       data-agent-send-target={sendTargetStatus}
       title={titleParts.length > 0 ? titleParts.join(' • ') : undefined}
       role={participatesInLineage ? 'treeitem' : undefined}
       aria-level={participatesInLineage ? (lineage?.depth ?? 0) + 1 : undefined}
+      aria-selected={participatesInLineage ? isCurrentAgent : undefined}
     >
       {lineageChildCount > 0 && !hideLineageConnectors ? (
         <span
@@ -266,9 +275,9 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
             expanded ? 'h-auto whitespace-pre-wrap break-words' : 'h-[1lh] truncate',
             isUnvisited ? 'font-semibold text-foreground' : 'font-normal text-muted-foreground',
             // Why: the selected-row fill washes out muted text — keep it readable.
-            isFocusedPane && !isUnvisited && 'text-foreground/90'
+            isHighlighted && !isUnvisited && 'text-foreground/90'
           )}
-          title={displayLabel}
+          title={sourceLabel}
         >
           {displayLabel}
         </span>

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -208,6 +208,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
       data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
       data-current={isCurrentAgent ? 'true' : undefined}
       data-agent-send-target={sendTargetStatus}
+      data-subagent-id={agent.subagentSession?.id}
       title={titleParts.length > 0 ? titleParts.join(' • ') : undefined}
       role={participatesInLineage ? 'treeitem' : undefined}
       aria-level={participatesInLineage ? (lineage?.depth ?? 0) + 1 : undefined}

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -113,7 +113,7 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const handleActivate = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      // Why: subagent rows have no pane of their own, so focus the spawning parent's pane.
+      // Why: subagents have no pane, so the caller receives their explicit parent fallback.
       onActivate(agent.tab.id, agent.activationPaneKey ?? agent.paneKey)
     },
     [onActivate, agent.tab.id, agent.activationPaneKey, agent.paneKey]

--- a/src/renderer/src/components/dashboard/useDashboardData.ts
+++ b/src/renderer/src/components/dashboard/useDashboardData.ts
@@ -15,8 +15,15 @@ export type DashboardAgentRow = {
   rowSource?: 'live' | 'retained' | 'subagent'
   state: AgentStatusState | 'idle'
   /** Pane to focus when the row is activated, when it differs from paneKey.
-   *  Subagent rows have no pane of their own and activate their parent's. */
+   *  Subagent rows use this as the parent-terminal fallback. */
   activationPaneKey?: string
+  /** Explicit provider session identity for an in-process child. The child has
+   *  no PTY, so consumers must not derive this from the synthetic pane key. */
+  subagentSession?: {
+    id: string
+    provider: AgentType
+    parentPaneKey: string
+  }
   /** When this agent first began reporting status. Derived from the oldest
    *  stateHistory entry, falling back to updatedAt when no history exists yet.
    *  Used to sort agents by when they started. */

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
@@ -1,13 +1,15 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 
 const mocks = vi.hoisted(() => ({
   state: {
     activeModal: 'codex-subagent-progress',
     modalData: {} as Record<string, unknown>,
     closeModal: vi.fn(),
-    agentStatusByPaneKey: {} as Record<string, unknown>
+    agentStatusByPaneKey: {} as Record<string, unknown>,
+    agentStatusEpoch: 0
   },
   liveSession: vi.fn()
 }))
@@ -68,6 +70,7 @@ describe('CodexSubagentProgressSheet', () => {
     mocks.state.activeModal = 'codex-subagent-progress'
     mocks.state.modalData = target()
     mocks.state.agentStatusByPaneKey = {}
+    mocks.state.agentStatusEpoch = 0
     mocks.liveSession.mockReturnValue(liveSession())
   })
 
@@ -114,6 +117,43 @@ describe('CodexSubagentProgressSheet', () => {
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
     const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(markup).toContain('data-working="false"')
+  })
+
+  it('uses a fresh working roster while the transcript is between updates', async () => {
+    const now = Date.parse('2026-08-03T12:00:00.000Z')
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
+    mocks.state.agentStatusByPaneKey = {
+      'parent-pane': {
+        updatedAt: now,
+        subagents: [{ id: 'child-1', state: 'working' }]
+      }
+    }
+    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+    dateNow.mockRestore()
+
+    expect(markup).toContain('data-working="true"')
+  })
+
+  it('stops trusting an expired working roster after the freshness epoch advances', async () => {
+    const now = Date.parse('2026-08-03T12:00:00.000Z')
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
+    mocks.state.agentStatusEpoch = 1
+    mocks.state.agentStatusByPaneKey = {
+      'parent-pane': {
+        updatedAt: now - AGENT_STATUS_STALE_AFTER_MS - 1,
+        subagents: [{ id: 'child-1', state: 'working' }]
+      }
+    }
+    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+    dateNow.mockRestore()
 
     expect(markup).toContain('data-working="false"')
   })

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
@@ -1,0 +1,134 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    activeModal: 'codex-subagent-progress',
+    modalData: {} as Record<string, unknown>,
+    closeModal: vi.fn(),
+    agentStatusByPaneKey: {} as Record<string, unknown>
+  },
+  inferredConnectionId: null as string | null | undefined,
+  runtimeEnvironmentId: null as string | null,
+  liveSession: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state)
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionIdFromState: () => mocks.inferredConnectionId
+}))
+
+vi.mock('@/components/native-chat/native-chat-runtime-owner', () => ({
+  selectNativeChatRuntimeEnvironmentId: () => mocks.runtimeEnvironmentId
+}))
+
+vi.mock('@/components/native-chat/use-native-chat-live-session', () => ({
+  useNativeChatLiveSession: mocks.liveSession
+}))
+
+vi.mock('@/components/native-chat/NativeChatMessageList', () => ({
+  NativeChatMessageList: ({ isWorking }: { isWorking: boolean }) => (
+    <div data-testid="message-list" data-working={isWorking ? 'true' : 'false'} />
+  )
+}))
+
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SheetContent: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  SheetDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>
+}))
+
+function target(connectionId: string | null | undefined): Record<string, unknown> {
+  return {
+    sessionId: 'child-1',
+    paneKey: 'parent\u0000subagent:child-1',
+    parentPaneKey: 'parent-pane',
+    terminalTabId: 'tab-1',
+    worktreeId: 'wt-1',
+    label: 'Review files',
+    model: 'gpt-5.4-mini',
+    state: 'working',
+    ...(connectionId === undefined ? {} : { connectionId })
+  }
+}
+
+function liveSession(): Record<string, unknown> {
+  return {
+    sessionId: 'child-1',
+    agent: 'codex',
+    status: 'working',
+    messages: [{ id: 'message-1' }],
+    hasMore: false,
+    loadingEarlier: false,
+    loadEarlier: vi.fn(),
+    readPhase: 'ready'
+  }
+}
+
+describe('CodexSubagentProgressSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.state.activeModal = 'codex-subagent-progress'
+    mocks.state.modalData = target(null)
+    mocks.state.agentStatusByPaneKey = {}
+    mocks.inferredConnectionId = null
+    mocks.runtimeEnvironmentId = null
+    mocks.liveSession.mockReturnValue(liveSession())
+  })
+
+  it('renders a read-only live child transcript on the local transport', async () => {
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(mocks.liveSession).toHaveBeenCalledWith({
+      paneKey: 'parent\u0000subagent:child-1',
+      agent: 'codex',
+      sessionId: 'child-1',
+      runtimeEnvironmentId: null
+    })
+    expect(markup).toContain('Read only')
+    expect(markup).toContain('data-testid="message-list"')
+    expect(markup).not.toContain('Send a message')
+  })
+
+  it('routes runtime-owned child transcripts to the resolved remote runtime', async () => {
+    mocks.state.modalData = target('runtime-ssh-target-1')
+    mocks.runtimeEnvironmentId = 'runtime-env-1'
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(mocks.liveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeEnvironmentId: 'runtime-env-1' })
+    )
+  })
+
+  it('stops showing a stale working state after the child leaves the live roster', async () => {
+    mocks.state.agentStatusByPaneKey = { 'parent-pane': { subagents: [] } }
+    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(markup).toContain('data-working="false"')
+  })
+
+  it('blocks legacy SSH without attempting a local transcript read', async () => {
+    mocks.state.modalData = target('ssh-target-1')
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(mocks.liveSession).not.toHaveBeenCalled()
+    expect(markup).toContain(
+      'Live subagent transcripts are not available for legacy SSH workspaces.'
+    )
+  })
+})

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
@@ -99,7 +99,7 @@ describe('CodexSubagentProgressSheet', () => {
   })
 
   it('routes runtime-owned child transcripts to the resolved remote runtime', async () => {
-    mocks.state.modalData = target('runtime-ssh-target-1')
+    mocks.state.modalData = target(null)
     mocks.runtimeEnvironmentId = 'runtime-env-1'
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
@@ -112,6 +112,16 @@ describe('CodexSubagentProgressSheet', () => {
 
   it('stops showing a stale working state after the child leaves the live roster', async () => {
     mocks.state.agentStatusByPaneKey = { 'parent-pane': { subagents: [] } }
+    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(markup).toContain('data-working="false"')
+  })
+
+  it('stops showing a captured working state after the parent entry disappears', async () => {
+    mocks.state.agentStatusByPaneKey = {}
     mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
@@ -23,14 +23,29 @@ vi.mock('@/components/native-chat/use-native-chat-live-session', () => ({
 }))
 
 vi.mock('@/components/native-chat/NativeChatMessageList', () => ({
-  NativeChatMessageList: ({ isWorking }: { isWorking: boolean }) => (
-    <div data-testid="message-list" data-working={isWorking ? 'true' : 'false'} />
+  NativeChatMessageList: ({
+    session,
+    isWorking
+  }: {
+    session: { messages: { id: string }[]; hasMore: boolean }
+    isWorking: boolean
+  }) => (
+    <div
+      data-testid="message-list"
+      data-working={isWorking ? 'true' : 'false'}
+      data-message-ids={session.messages.map((message) => message.id).join(',')}
+      data-has-more={String(session.hasMore)}
+    />
   )
 }))
 
 vi.mock('@/components/ui/sheet', () => ({
-  Sheet: ({ children }: { children: ReactNode }) => <>{children}</>,
-  SheetContent: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  Sheet: ({ children, modal }: { children: ReactNode; modal?: boolean }) => (
+    <div data-modal={String(modal)}>{children}</div>
+  ),
+  SheetContent: ({ children, showOverlay }: { children: ReactNode; showOverlay?: boolean }) => (
+    <section data-show-overlay={String(showOverlay)}>{children}</section>
+  ),
   SheetHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
   SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
   SheetDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>
@@ -41,6 +56,7 @@ function target(
 ): Record<string, unknown> {
   return {
     sessionId: 'child-1',
+    startedAt: 1_000,
     paneKey: 'parent\u0000subagent:child-1',
     parentPaneKey: 'parent-pane',
     terminalTabId: 'tab-1',
@@ -56,7 +72,15 @@ function liveSession(): Record<string, unknown> {
     sessionId: 'child-1',
     agent: 'codex',
     status: 'working',
-    messages: [{ id: 'message-1' }],
+    messages: [
+      {
+        id: 'message-1',
+        role: 'assistant',
+        timestamp: 1_000,
+        source: 'transcript',
+        blocks: [{ type: 'text', text: 'Child progress' }]
+      }
+    ],
     hasMore: false,
     loadingEarlier: false,
     loadEarlier: vi.fn(),
@@ -87,7 +111,39 @@ describe('CodexSubagentProgressSheet', () => {
     })
     expect(markup).toContain('Read only')
     expect(markup).toContain('data-testid="message-list"')
+    expect(markup).toContain('data-modal="false"')
+    expect(markup).toContain('data-show-overlay="false"')
     expect(markup).not.toContain('Send a message')
+  })
+
+  it('removes parent turns copied into a full-history child rollout', async () => {
+    mocks.liveSession.mockReturnValue({
+      ...liveSession(),
+      messages: [
+        {
+          id: 'inherited-parent-message',
+          role: 'assistant',
+          timestamp: 900,
+          source: 'transcript',
+          blocks: [{ type: 'text', text: 'Parent history' }]
+        },
+        {
+          id: 'child-message',
+          role: 'assistant',
+          timestamp: 1_100,
+          source: 'transcript',
+          blocks: [{ type: 'text', text: 'Child progress' }]
+        }
+      ],
+      hasMore: true
+    })
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(markup).toContain('data-message-ids="child-message"')
+    expect(markup).toContain('data-has-more="false"')
+    expect(markup).not.toContain('inherited-parent-message')
   })
 
   it('routes runtime-owned child transcripts to the resolved remote runtime', async () => {
@@ -103,7 +159,6 @@ describe('CodexSubagentProgressSheet', () => {
 
   it('stops showing a stale working state after the child leaves the live roster', async () => {
     mocks.state.agentStatusByPaneKey = { 'parent-pane': { subagents: [] } }
-    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
     const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
@@ -113,7 +168,6 @@ describe('CodexSubagentProgressSheet', () => {
 
   it('stops showing a captured working state after the parent entry disappears', async () => {
     mocks.state.agentStatusByPaneKey = {}
-    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
     const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
@@ -139,6 +193,24 @@ describe('CodexSubagentProgressSheet', () => {
     expect(markup).toContain('data-working="true"')
   })
 
+  it('uses a fresh idle roster over an unfinished long-lived transcript', async () => {
+    const now = Date.parse('2026-08-03T12:00:00.000Z')
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
+    mocks.state.agentStatusByPaneKey = {
+      'parent-pane': {
+        updatedAt: now,
+        subagents: [{ id: 'child-1', state: 'idle' }]
+      }
+    }
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
+    dateNow.mockRestore()
+
+    expect(markup).toContain('Idle')
+    expect(markup).toContain('data-working="false"')
+  })
+
   it('stops trusting an expired working roster after the freshness epoch advances', async () => {
     const now = Date.parse('2026-08-03T12:00:00.000Z')
     const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
@@ -149,7 +221,6 @@ describe('CodexSubagentProgressSheet', () => {
         subagents: [{ id: 'child-1', state: 'working' }]
       }
     }
-    mocks.liveSession.mockReturnValue({ ...liveSession(), status: 'done' })
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
     const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.test.tsx
@@ -9,21 +9,11 @@ const mocks = vi.hoisted(() => ({
     closeModal: vi.fn(),
     agentStatusByPaneKey: {} as Record<string, unknown>
   },
-  inferredConnectionId: null as string | null | undefined,
-  runtimeEnvironmentId: null as string | null,
   liveSession: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state)
-}))
-
-vi.mock('@/lib/connection-context', () => ({
-  getConnectionIdFromState: () => mocks.inferredConnectionId
-}))
-
-vi.mock('@/components/native-chat/native-chat-runtime-owner', () => ({
-  selectNativeChatRuntimeEnvironmentId: () => mocks.runtimeEnvironmentId
 }))
 
 vi.mock('@/components/native-chat/use-native-chat-live-session', () => ({
@@ -44,7 +34,9 @@ vi.mock('@/components/ui/sheet', () => ({
   SheetDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>
 }))
 
-function target(connectionId: string | null | undefined): Record<string, unknown> {
+function target(
+  hostAuthority: Record<string, unknown> = { kind: 'local' }
+): Record<string, unknown> {
   return {
     sessionId: 'child-1',
     paneKey: 'parent\u0000subagent:child-1',
@@ -53,8 +45,7 @@ function target(connectionId: string | null | undefined): Record<string, unknown
     worktreeId: 'wt-1',
     label: 'Review files',
     model: 'gpt-5.4-mini',
-    state: 'working',
-    ...(connectionId === undefined ? {} : { connectionId })
+    hostAuthority
   }
 }
 
@@ -75,10 +66,8 @@ describe('CodexSubagentProgressSheet', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.state.activeModal = 'codex-subagent-progress'
-    mocks.state.modalData = target(null)
+    mocks.state.modalData = target()
     mocks.state.agentStatusByPaneKey = {}
-    mocks.inferredConnectionId = null
-    mocks.runtimeEnvironmentId = null
     mocks.liveSession.mockReturnValue(liveSession())
   })
 
@@ -99,8 +88,7 @@ describe('CodexSubagentProgressSheet', () => {
   })
 
   it('routes runtime-owned child transcripts to the resolved remote runtime', async () => {
-    mocks.state.modalData = target(null)
-    mocks.runtimeEnvironmentId = 'runtime-env-1'
+    mocks.state.modalData = target({ kind: 'runtime', environmentId: 'runtime-env-1' })
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
     renderToStaticMarkup(<CodexSubagentProgressSheet />)
@@ -131,7 +119,7 @@ describe('CodexSubagentProgressSheet', () => {
   })
 
   it('blocks legacy SSH without attempting a local transcript read', async () => {
-    mocks.state.modalData = target('ssh-target-1')
+    mocks.state.modalData = target({ kind: 'legacy-ssh' })
     const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
 
     const markup = renderToStaticMarkup(<CodexSubagentProgressSheet />)
@@ -139,6 +127,18 @@ describe('CodexSubagentProgressSheet', () => {
     expect(mocks.liveSession).not.toHaveBeenCalled()
     expect(markup).toContain(
       'Live subagent transcripts are not available for legacy SSH workspaces.'
+    )
+  })
+
+  it('keeps captured runtime routing after the parent and workspace owner disappear', async () => {
+    mocks.state.modalData = target({ kind: 'runtime', environmentId: 'runtime-env-1' })
+    mocks.state.agentStatusByPaneKey = {}
+    const { default: CodexSubagentProgressSheet } = await import('./CodexSubagentProgressSheet')
+
+    renderToStaticMarkup(<CodexSubagentProgressSheet />)
+
+    expect(mocks.liveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeEnvironmentId: 'runtime-env-1' })
     )
   })
 })

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
@@ -12,8 +12,12 @@ import {
   SheetTitle
 } from '@/components/ui/sheet'
 import { translate } from '@/i18n/i18n'
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { useAppStore } from '@/store'
-import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusState
+} from '../../../../shared/agent-status-types'
 import { resolveCodexSubagentProgressRoute } from './codex-subagent-progress-route'
 import {
   parseCodexSubagentProgressTarget,
@@ -166,7 +170,16 @@ function CodexSubagentProgressBody({
   target: CodexSubagentProgressTarget
 }): React.JSX.Element {
   const parentEntry = useAppStore((state) => state.agentStatusByPaneKey[target.parentPaneKey])
-  const liveSubagent = parentEntry?.subagents?.find((subagent) => subagent.id === target.sessionId)
+  // Freshness expiry retains the entry and advances only this epoch.
+  const agentStatusEpoch = useAppStore((state) => state.agentStatusEpoch)
+  void agentStatusEpoch
+  const freshParentEntry =
+    parentEntry && isExplicitAgentStatusFresh(parentEntry, Date.now(), AGENT_STATUS_STALE_AFTER_MS)
+      ? parentEntry
+      : undefined
+  const liveSubagent = freshParentEntry?.subagents?.find(
+    (subagent) => subagent.id === target.sessionId
+  )
   const route = resolveCodexSubagentProgressRoute(target.hostAuthority)
   const state = liveSubagent?.state ?? 'idle'
   const dotState = asDotState(state)

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
@@ -1,0 +1,260 @@
+import { Loader2, MessageSquare, TriangleAlert } from 'lucide-react'
+import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import { NativeChatMessageList } from '@/components/native-chat/NativeChatMessageList'
+import { selectNativeChatRuntimeEnvironmentId } from '@/components/native-chat/native-chat-runtime-owner'
+import { selectNativeChatViewState } from '@/components/native-chat/native-chat-view-state'
+import { useNativeChatLiveSession } from '@/components/native-chat/use-native-chat-live-session'
+import { Badge } from '@/components/ui/badge'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from '@/components/ui/sheet'
+import { translate } from '@/i18n/i18n'
+import { getConnectionIdFromState } from '@/lib/connection-context'
+import { useAppStore } from '@/store'
+import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import { resolveCodexSubagentProgressRoute } from './codex-subagent-progress-route'
+import {
+  parseCodexSubagentProgressTarget,
+  type CodexSubagentProgressTarget
+} from './codex-subagent-progress-target'
+
+type ProgressPlaceholderKind = 'loading' | 'empty' | 'error'
+
+function asDotState(state: AgentStatusState | 'idle'): AgentDotState {
+  switch (state) {
+    case 'working':
+    case 'blocked':
+    case 'waiting':
+    case 'done':
+    case 'idle':
+      return state
+  }
+}
+
+function ProgressPlaceholder({
+  kind,
+  message
+}: {
+  kind: ProgressPlaceholderKind
+  message?: string
+}): React.JSX.Element {
+  const copy =
+    kind === 'loading'
+      ? {
+          title: translate(
+            'components.codex-subagent-progress.loading.title',
+            'Waiting for subagent output…'
+          ),
+          subtitle: translate(
+            'components.codex-subagent-progress.loading.subtitle',
+            'New messages, reasoning, and tool activity will appear here as Codex writes them.'
+          )
+        }
+      : kind === 'empty'
+        ? {
+            title: translate(
+              'components.codex-subagent-progress.empty.title',
+              'No transcript entries'
+            ),
+            subtitle: translate(
+              'components.codex-subagent-progress.empty.subtitle',
+              'This subagent did not write any visible messages or tool activity.'
+            )
+          }
+        : {
+            title: translate(
+              'components.codex-subagent-progress.error.title',
+              'Subagent progress unavailable'
+            ),
+            subtitle:
+              message ??
+              translate(
+                'components.codex-subagent-progress.error.subtitle',
+                'The subagent transcript could not be read.'
+              )
+          }
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center"
+      aria-live="polite"
+    >
+      <div
+        className={
+          kind === 'error'
+            ? 'flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive'
+            : 'flex size-12 items-center justify-center rounded-full bg-accent text-accent-foreground'
+        }
+      >
+        {kind === 'loading' ? (
+          <Loader2 className="size-6 animate-spin" />
+        ) : kind === 'error' ? (
+          <TriangleAlert className="size-6" />
+        ) : (
+          <MessageSquare className="size-6" />
+        )}
+      </div>
+      <p className="text-sm font-medium text-foreground">{copy.title}</p>
+      <p className="max-w-sm text-balance text-xs text-muted-foreground">{copy.subtitle}</p>
+    </div>
+  )
+}
+
+function unavailableMessage(
+  reason: 'unknown-owner' | 'legacy-ssh' | 'runtime-owner-missing'
+): string {
+  switch (reason) {
+    case 'legacy-ssh':
+      return translate(
+        'components.codex-subagent-progress.unavailable.legacy-ssh',
+        'Live subagent transcripts are not available for legacy SSH workspaces.'
+      )
+    case 'runtime-owner-missing':
+      return translate(
+        'components.codex-subagent-progress.unavailable.runtime-owner-missing',
+        'The remote runtime owner is not available yet. Reopen this view after the workspace reconnects.'
+      )
+    case 'unknown-owner':
+      return translate(
+        'components.codex-subagent-progress.unavailable.unknown-owner',
+        'Orca could not determine which host owns this subagent transcript.'
+      )
+  }
+}
+
+function CodexSubagentTranscript({
+  target,
+  state,
+  runtimeEnvironmentId
+}: {
+  target: CodexSubagentProgressTarget
+  state: AgentStatusState | 'idle'
+  runtimeEnvironmentId: string | null
+}): React.JSX.Element {
+  const session = useNativeChatLiveSession({
+    paneKey: target.paneKey,
+    agent: 'codex',
+    sessionId: target.sessionId,
+    runtimeEnvironmentId
+  })
+  const viewState = selectNativeChatViewState(session)
+  const working = state === 'working' || session.status === 'working'
+
+  if (viewState.kind === 'error') {
+    return <ProgressPlaceholder kind="error" message={viewState.message} />
+  }
+  if (viewState.kind === 'loading' || (working && session.messages.length === 0)) {
+    return <ProgressPlaceholder kind="loading" />
+  }
+  if (viewState.kind === 'empty') {
+    return <ProgressPlaceholder kind="empty" />
+  }
+  return (
+    <NativeChatMessageList
+      session={session}
+      isWorking={working}
+      expandSignal={false}
+      fontScale={1}
+    />
+  )
+}
+
+function CodexSubagentProgressBody({
+  target
+}: {
+  target: CodexSubagentProgressTarget
+}): React.JSX.Element {
+  const parentEntry = useAppStore((state) => state.agentStatusByPaneKey[target.parentPaneKey])
+  const liveSubagent = parentEntry?.subagents?.find((subagent) => subagent.id === target.sessionId)
+  const inferredConnectionId = useAppStore((state) =>
+    getConnectionIdFromState(state, target.worktreeId)
+  )
+  const runtimeEnvironmentId = useAppStore((state) =>
+    selectNativeChatRuntimeEnvironmentId(state, target.terminalTabId)
+  )
+  const connectionId =
+    target.connectionId === undefined ? inferredConnectionId : target.connectionId
+  const route = resolveCodexSubagentProgressRoute(connectionId, runtimeEnvironmentId)
+  const state = liveSubagent?.state ?? (parentEntry ? 'idle' : target.state)
+  const dotState = asDotState(state)
+  const label = liveSubagent?.description?.trim() || target.label
+  const model = liveSubagent?.model?.trim() || target.model
+
+  return (
+    <>
+      <SheetHeader className="border-b border-border pr-12">
+        <div className="flex min-w-0 items-center gap-2">
+          <AgentStateDot state={dotState} size="md" />
+          <SheetTitle className="min-w-0 truncate" title={label}>
+            {label}
+          </SheetTitle>
+          <Badge variant="secondary">
+            {translate('components.codex-subagent-progress.read-only', 'Read only')}
+          </Badge>
+        </div>
+        <SheetDescription className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span>
+            {translate(
+              'components.codex-subagent-progress.description',
+              'Codex subagent transcript'
+            )}
+          </span>
+          <span aria-hidden>·</span>
+          <span>{agentStateLabel(dotState)}</span>
+          {model ? (
+            <>
+              <span aria-hidden>·</span>
+              <span className="font-mono text-xs">{model}</span>
+            </>
+          ) : null}
+        </SheetDescription>
+      </SheetHeader>
+      <div className="flex min-h-0 flex-1 flex-col bg-background">
+        {route.kind === 'readable' ? (
+          <CodexSubagentTranscript
+            target={target}
+            state={state}
+            runtimeEnvironmentId={route.runtimeEnvironmentId}
+          />
+        ) : (
+          <ProgressPlaceholder kind="error" message={unavailableMessage(route.reason)} />
+        )}
+      </div>
+    </>
+  )
+}
+
+export default function CodexSubagentProgressSheet(): React.JSX.Element {
+  const activeModal = useAppStore((state) => state.activeModal)
+  const modalData = useAppStore((state) => state.modalData)
+  const closeModal = useAppStore((state) => state.closeModal)
+  const target = parseCodexSubagentProgressTarget(modalData)
+  const open = activeModal === 'codex-subagent-progress'
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          closeModal()
+        }
+      }}
+    >
+      <SheetContent className="w-full p-0 sm:max-w-2xl" data-codex-subagent-progress="">
+        {target ? (
+          <CodexSubagentProgressBody target={target} />
+        ) : (
+          <>
+            <SheetTitle className="sr-only">
+              {translate('components.codex-subagent-progress.title', 'Codex subagent progress')}
+            </SheetTitle>
+            <ProgressPlaceholder kind="error" />
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
@@ -178,7 +178,7 @@ function CodexSubagentProgressBody({
   const connectionId =
     target.connectionId === undefined ? inferredConnectionId : target.connectionId
   const route = resolveCodexSubagentProgressRoute(connectionId, runtimeEnvironmentId)
-  const state = liveSubagent?.state ?? (parentEntry ? 'idle' : target.state)
+  const state = liveSubagent?.state ?? 'idle'
   const dotState = asDotState(state)
   const label = liveSubagent?.description?.trim() || target.label
   const model = liveSubagent?.model?.trim() || target.model

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
@@ -23,6 +23,7 @@ import {
   parseCodexSubagentProgressTarget,
   type CodexSubagentProgressTarget
 } from './codex-subagent-progress-target'
+import { scopeCodexSubagentTranscript } from './codex-subagent-transcript-scope'
 
 type ProgressPlaceholderKind = 'loading' | 'empty' | 'error'
 
@@ -142,13 +143,19 @@ function CodexSubagentTranscript({
     sessionId: target.sessionId,
     runtimeEnvironmentId
   })
-  const viewState = selectNativeChatViewState(session)
-  const working = state === 'working' || session.status === 'working'
+  const transcriptScope = scopeCodexSubagentTranscript(
+    session.messages,
+    session.hasMore,
+    target.startedAt
+  )
+  const scopedSession = { ...session, ...transcriptScope }
+  const viewState = selectNativeChatViewState(scopedSession)
+  const working = state === 'working'
 
   if (viewState.kind === 'error') {
     return <ProgressPlaceholder kind="error" message={viewState.message} />
   }
-  if (viewState.kind === 'loading' || (working && session.messages.length === 0)) {
+  if (viewState.kind === 'loading' || (working && scopedSession.messages.length === 0)) {
     return <ProgressPlaceholder kind="loading" />
   }
   if (viewState.kind === 'empty') {
@@ -156,7 +163,7 @@ function CodexSubagentTranscript({
   }
   return (
     <NativeChatMessageList
-      session={session}
+      session={scopedSession}
       isWorking={working}
       expandSignal={false}
       fontScale={1}
@@ -240,13 +247,19 @@ export default function CodexSubagentProgressSheet(): React.JSX.Element {
   return (
     <Sheet
       open={open}
+      modal={false}
       onOpenChange={(nextOpen) => {
         if (!nextOpen) {
           closeModal()
         }
       }}
     >
-      <SheetContent className="w-full p-0 sm:max-w-2xl" data-codex-subagent-progress="">
+      <SheetContent
+        className="w-full p-0 sm:max-w-2xl"
+        data-codex-subagent-progress=""
+        showOverlay={false}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
         {target ? (
           <CodexSubagentProgressBody target={target} />
         ) : (

--- a/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
+++ b/src/renderer/src/components/sidebar/CodexSubagentProgressSheet.tsx
@@ -1,7 +1,6 @@
 import { Loader2, MessageSquare, TriangleAlert } from 'lucide-react'
 import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
 import { NativeChatMessageList } from '@/components/native-chat/NativeChatMessageList'
-import { selectNativeChatRuntimeEnvironmentId } from '@/components/native-chat/native-chat-runtime-owner'
 import { selectNativeChatViewState } from '@/components/native-chat/native-chat-view-state'
 import { useNativeChatLiveSession } from '@/components/native-chat/use-native-chat-live-session'
 import { Badge } from '@/components/ui/badge'
@@ -13,7 +12,6 @@ import {
   SheetTitle
 } from '@/components/ui/sheet'
 import { translate } from '@/i18n/i18n'
-import { getConnectionIdFromState } from '@/lib/connection-context'
 import { useAppStore } from '@/store'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import { resolveCodexSubagentProgressRoute } from './codex-subagent-progress-route'
@@ -169,15 +167,7 @@ function CodexSubagentProgressBody({
 }): React.JSX.Element {
   const parentEntry = useAppStore((state) => state.agentStatusByPaneKey[target.parentPaneKey])
   const liveSubagent = parentEntry?.subagents?.find((subagent) => subagent.id === target.sessionId)
-  const inferredConnectionId = useAppStore((state) =>
-    getConnectionIdFromState(state, target.worktreeId)
-  )
-  const runtimeEnvironmentId = useAppStore((state) =>
-    selectNativeChatRuntimeEnvironmentId(state, target.terminalTabId)
-  )
-  const connectionId =
-    target.connectionId === undefined ? inferredConnectionId : target.connectionId
-  const route = resolveCodexSubagentProgressRoute(connectionId, runtimeEnvironmentId)
+  const route = resolveCodexSubagentProgressRoute(target.hostAuthority)
   const state = liveSubagent?.state ?? 'idle'
   const dotState = asDotState(state)
   const label = liveSubagent?.description?.trim() || target.label

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -18,6 +18,10 @@ type MockAgentOptions = {
   prompt: string
   worktreeId: string
   startedAt?: number
+  rowSource?: DashboardAgentRowData['rowSource']
+  model?: string
+  connectionId?: string | null
+  subagentSession?: DashboardAgentRowData['subagentSession']
 }
 
 function mockAgent({
@@ -26,13 +30,17 @@ function mockAgent({
   agentType,
   prompt,
   worktreeId,
-  startedAt = 1000
+  startedAt = 1000,
+  rowSource = 'live',
+  model,
+  connectionId,
+  subagentSession
 }: MockAgentOptions): DashboardAgentRowData {
   return {
     paneKey,
     tab: { id: tabId },
     agentType,
-    rowSource: 'live',
+    rowSource,
     state: 'working',
     startedAt,
     entry: {
@@ -42,8 +50,11 @@ function mockAgent({
       updatedAt: startedAt,
       stateStartedAt: startedAt,
       stateHistory: [],
-      worktreeId
-    }
+      worktreeId,
+      model,
+      connectionId
+    },
+    subagentSession
   } as unknown as DashboardAgentRowData
 }
 
@@ -84,6 +95,7 @@ function buildMockStoreState(): Record<string, unknown> {
     ptyIdsByTabId: {},
     runtimePaneTitlesByTabId: {},
     sendPromptToSidebarAgentTarget: vi.fn(),
+    openModal: activationMocks.openModal,
     settings: {
       promptCacheTimerEnabled: true,
       promptCacheTtlMs: 60_000
@@ -93,7 +105,8 @@ function buildMockStoreState(): Record<string, unknown> {
 
 const activationMocks = vi.hoisted(() => ({
   activateAndRevealWorktree: vi.fn(),
-  activateTabAndFocusPane: vi.fn()
+  activateTabAndFocusPane: vi.fn(),
+  openModal: vi.fn()
 }))
 
 const staleAgentRowMocks = vi.hoisted(() => ({
@@ -368,6 +381,81 @@ describe('WorktreeCardAgents activation', () => {
     expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
     expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('opens Codex subagent progress instead of activating the parent pane', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const parentPaneKey = makePaneKey('tab-1', LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey: `${parentPaneKey}\u0000subagent:child-1`,
+        tabId: 'tab-1',
+        agentType: 'reviewer',
+        prompt: 'Review files',
+        worktreeId: 'wt-1',
+        rowSource: 'subagent',
+        model: 'gpt-5.4-mini',
+        connectionId: null,
+        subagentSession: { id: 'child-1', provider: 'codex', parentPaneKey }
+      })
+    ]
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    capturedRowActivations[0].onActivate('tab-1', parentPaneKey)
+
+    expect(activationMocks.openModal).toHaveBeenCalledWith(
+      'codex-subagent-progress',
+      expect.objectContaining({
+        sessionId: 'child-1',
+        parentPaneKey,
+        terminalTabId: 'tab-1',
+        worktreeId: 'wt-1',
+        label: 'Review files',
+        connectionId: null
+      })
+    )
+    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+  })
+
+  it('opens Codex subagent progress from compact rows', async () => {
+    mockAgentActivityDisplayMode = 'compact'
+    const parentPaneKey = makePaneKey('tab-1', LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey: `${parentPaneKey}\u0000subagent:child-compact`,
+        tabId: 'tab-1',
+        agentType: 'reviewer',
+        prompt: 'Inspect compact progress',
+        worktreeId: 'wt-1',
+        rowSource: 'subagent',
+        connectionId: null,
+        subagentSession: { id: 'child-compact', provider: 'codex', parentPaneKey }
+      })
+    ]
+    const host = document.createElement('div')
+    document.body.append(host)
+    const root: Root = createRoot(host)
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    await act(async () => {
+      root.render(<WorktreeCardAgents worktreeId="wt-1" />)
+    })
+    const row = host.querySelector('.compact-agent-row')
+    expect(row).toBeInstanceOf(HTMLElement)
+
+    await act(async () => {
+      row?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(activationMocks.openModal).toHaveBeenCalledWith(
+      'codex-subagent-progress',
+      expect.objectContaining({ sessionId: 'child-compact', parentPaneKey })
+    )
+    expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    act(() => root.unmount())
+    host.remove()
   })
 
   it('reveals the worktree and focuses a compact automation worker row hydrated during reveal', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -411,6 +411,7 @@ describe('WorktreeCardAgents activation', () => {
       'codex-subagent-progress',
       expect.objectContaining({
         sessionId: 'child-1',
+        startedAt: 1000,
         parentPaneKey,
         terminalTabId: 'tab-1',
         worktreeId: 'wt-1',

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -21,6 +21,7 @@ type MockAgentOptions = {
   rowSource?: DashboardAgentRowData['rowSource']
   model?: string
   connectionId?: string | null
+  ptyId?: string | null
   subagentSession?: DashboardAgentRowData['subagentSession']
 }
 
@@ -34,11 +35,12 @@ function mockAgent({
   rowSource = 'live',
   model,
   connectionId,
+  ptyId,
   subagentSession
 }: MockAgentOptions): DashboardAgentRowData {
   return {
     paneKey,
-    tab: { id: tabId },
+    tab: { id: tabId, ptyId },
     agentType,
     rowSource,
     state: 'working',
@@ -396,6 +398,7 @@ describe('WorktreeCardAgents activation', () => {
         rowSource: 'subagent',
         model: 'gpt-5.4-mini',
         connectionId: null,
+        ptyId: 'local-pty-1',
         subagentSession: { id: 'child-1', provider: 'codex', parentPaneKey }
       })
     ]
@@ -412,7 +415,7 @@ describe('WorktreeCardAgents activation', () => {
         terminalTabId: 'tab-1',
         worktreeId: 'wt-1',
         label: 'Review files',
-        connectionId: null
+        hostAuthority: { kind: 'local' }
       })
     )
     expect(activationMocks.activateAndRevealWorktree).not.toHaveBeenCalled()
@@ -431,6 +434,7 @@ describe('WorktreeCardAgents activation', () => {
         worktreeId: 'wt-1',
         rowSource: 'subagent',
         connectionId: null,
+        ptyId: 'local-pty-1',
         subagentSession: { id: 'child-compact', provider: 'codex', parentPaneKey }
       })
     ]

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -26,6 +26,7 @@ import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constant
 import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
 import { useWorktreeAgentExpansionState } from './worktree-card-agents-expansion-state'
 import { translate } from '@/i18n/i18n'
+import { createCodexSubagentProgressTarget } from './codex-subagent-progress-target'
 
 export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
   'orca-suppress-worktree-list-scroll-adjustment'
@@ -80,6 +81,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     useAppStore((s) => s.agentActivityDisplayMode) ?? DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
   const dropAgentStatus = useAppStore((s) => s.dropAgentStatus)
   const dismissRetainedAgent = useAppStore((s) => s.dismissRetainedAgent)
+  const openModal = useAppStore((s) => s.openModal)
   const { targetMode: agentSendPopoverTargetMode, agentStatusEpoch } = useAppStore(
     useShallow((s) => selectSendTargetControlInputs(s, worktreeId))
   )
@@ -187,6 +189,17 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   const handleActivateRetainedAgent = useCallback(() => {
     // Why: hibernation-retained rows are passive completion evidence; activating would resume sleeping sessions, so the row is inert.
   }, [])
+  const handleOpenCodexSubagentProgress = useCallback(
+    (agent: DashboardAgentRowData) => {
+      const target = createCodexSubagentProgressTarget(agent, worktreeId)
+      if (!target) {
+        handleActivateAgentTab(agent.tab.id, agent.activationPaneKey ?? agent.paneKey)
+        return
+      }
+      openModal('codex-subagent-progress', target)
+    },
+    [handleActivateAgentTab, openModal, worktreeId]
+  )
 
   // Why: one 30s tick per non-empty inline list; zero-agent cards never mount this (see WorktreeCardAgents), so idle worktrees pay no timer cost.
   const now = useNow(30_000)
@@ -262,7 +275,11 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           agent={agent}
           onDismiss={handleDismissAgent}
           onActivate={
-            agent.rowSource === 'retained' ? handleActivateRetainedAgent : handleActivateAgentTab
+            agent.rowSource === 'retained'
+              ? handleActivateRetainedAgent
+              : agent.subagentSession?.provider === 'codex'
+                ? () => handleOpenCodexSubagentProgress(agent)
+                : handleActivateAgentTab
           }
           now={now}
           // Why: bold the row until the user visits its tab (useAutoAckViewedAgent auto-acks on focus, muting it).
@@ -323,7 +340,11 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           agent={agent}
           now={now}
           onActivate={
-            agent.rowSource === 'retained' ? handleActivateRetainedAgent : handleActivateAgentTab
+            agent.rowSource === 'retained'
+              ? handleActivateRetainedAgent
+              : agent.subagentSession?.provider === 'codex'
+                ? () => handleOpenCodexSubagentProgress(agent)
+                : handleActivateAgentTab
           }
           sendTargetStatus={sendTarget?.status}
           sendTargetDisabledReason={sendTarget?.disabledReason}

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -27,6 +27,7 @@ import { revealElementInScrollContainer } from './worktree-sidebar-reveal'
 import { useWorktreeAgentExpansionState } from './worktree-card-agents-expansion-state'
 import { translate } from '@/i18n/i18n'
 import { createCodexSubagentProgressTarget } from './codex-subagent-progress-target'
+import { selectCodexSubagentProgressHostAuthority } from './codex-subagent-progress-host-authority'
 
 export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
   'orca-suppress-worktree-list-scroll-adjustment'
@@ -191,7 +192,13 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   }, [])
   const handleOpenCodexSubagentProgress = useCallback(
     (agent: DashboardAgentRowData) => {
-      const target = createCodexSubagentProgressTarget(agent, worktreeId)
+      const hostAuthority = selectCodexSubagentProgressHostAuthority(useAppStore.getState(), {
+        worktreeId,
+        parentPaneKey: agent.subagentSession?.parentPaneKey ?? agent.paneKey,
+        tabPtyId: agent.tab.ptyId,
+        connectionId: agent.entry.connectionId
+      })
+      const target = createCodexSubagentProgressTarget(agent, worktreeId, hostAuthority)
       if (!target) {
         handleActivateAgentTab(agent.tab.id, agent.activationPaneKey ?? agent.paneKey)
         return

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -28,6 +28,7 @@ import { useWorktreeAgentExpansionState } from './worktree-card-agents-expansion
 import { translate } from '@/i18n/i18n'
 import { createCodexSubagentProgressTarget } from './codex-subagent-progress-target'
 import { selectCodexSubagentProgressHostAuthority } from './codex-subagent-progress-host-authority'
+import { useCodexSubagentProgressPaneKey } from './codex-subagent-progress-selection'
 
 export const SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT =
   'orca-suppress-worktree-list-scroll-adjustment'
@@ -90,6 +91,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
   const sendTargetInputs = useAppStore(useShallow((s) => selectSendTargetInputs(s, worktreeId)))
   const sendPromptToSidebarAgentTarget = useAppStore((s) => s.sendPromptToSidebarAgentTarget)
   const focusedAgentPaneKey = useFocusedAgentPaneKey(worktreeId)
+  const selectedSubagentPaneKey = useCodexSubagentProgressPaneKey(worktreeId)
   const compactAgentListRootRef = useRef<HTMLDivElement | null>(null)
 
   // Why: derive per-agent unvisited flags from the ack map so rows bold on first appearance and mute once the tab is visited.
@@ -187,9 +189,8 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     },
     [worktreeId]
   )
-  const handleActivateRetainedAgent = useCallback(() => {
-    // Why: hibernation-retained rows are passive completion evidence; activating would resume sleeping sessions, so the row is inert.
-  }, [])
+  // Why: hibernation-retained rows are passive completion evidence; activating would resume sleeping sessions, so the row is inert.
+  const handleActivateRetainedAgent = useCallback(() => undefined, [])
   const handleOpenCodexSubagentProgress = useCallback(
     (agent: DashboardAgentRowData) => {
       const hostAuthority = selectCodexSubagentProgressHostAuthority(useAppStore.getState(), {
@@ -246,9 +247,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
     [toggleLineageParentState]
   )
 
-  const stopBubble = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-  }, [])
+  const stopBubble = useCallback((e: React.MouseEvent) => e.stopPropagation(), [])
 
   // Why: root leaf siblings reserve a leading spacer when any root has a chevron, keeping the state-dot column aligned (descendants already indent).
   const anyRootHasChildren = rootAgents.some(
@@ -303,7 +302,8 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           }
           // Why: keep leaf rows aligned with parent rows — see anyRootHasChildren above.
           reserveDisclosureGutter={isRootAgent && anyRootHasChildren && !hasChildAgents}
-          isFocusedPane={agent.paneKey === focusedAgentPaneKey}
+          isFocusedPane={selectedSubagentPaneKey === null && agent.paneKey === focusedAgentPaneKey}
+          isCurrentAgent={agent.paneKey === selectedSubagentPaneKey}
           sendTargetStatus={sendTarget?.status}
           sendTargetDisabledReason={sendTarget?.disabledReason}
           onSendTargetClick={isAgentSendTargetModeActive ? handleSendTargetClick : undefined}
@@ -362,7 +362,8 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
             hasChildAgents ? () => toggleLineageParent(agent.paneKey) : undefined
           }
           reserveDisclosureGutter={isRootAgent && anyRootHasChildren && !hasChildAgents}
-          isFocusedPane={agent.paneKey === focusedAgentPaneKey}
+          isFocusedPane={selectedSubagentPaneKey === null && agent.paneKey === focusedAgentPaneKey}
+          isCurrentAgent={agent.paneKey === selectedSubagentPaneKey}
           cacheTimerActive={cacheTimerActive}
         />
         {hasChildAgents ? (

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-host-authority.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-host-authority.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveCodexSubagentProgressHostAuthority,
+  selectCodexSubagentProgressHostAuthority,
+  type CodexSubagentProgressHostAuthorityState
+} from './codex-subagent-progress-host-authority'
+
+const PARENT_PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+
+function state(
+  overrides: Partial<CodexSubagentProgressHostAuthorityState> = {}
+): CodexSubagentProgressHostAuthorityState {
+  return {
+    repos: [],
+    settings: { activeRuntimeEnvironmentId: null },
+    worktreesByRepo: {},
+    detectedWorktreesByRepo: {},
+    folderWorkspaces: [],
+    projectGroups: [],
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+function select(
+  overrides: Partial<CodexSubagentProgressHostAuthorityState>,
+  worktreeId: string,
+  tabPtyId: string
+) {
+  return selectCodexSubagentProgressHostAuthority(state(overrides), {
+    worktreeId,
+    parentPaneKey: PARENT_PANE_KEY,
+    tabPtyId,
+    connectionId: null
+  })
+}
+
+describe('Codex subagent progress host authority', () => {
+  it('keeps a legacy-local worktree on its concrete local PTY despite a focused runtime', () => {
+    expect(
+      select(
+        {
+          repos: [{ id: 'repo', connectionId: null, executionHostId: null }],
+          settings: { activeRuntimeEnvironmentId: 'focused-env' },
+          worktreesByRepo: { repo: [{ id: 'repo::wt-local', repoId: 'repo' }] }
+        },
+        'repo::wt-local',
+        'local-pty-1'
+      )
+    ).toEqual({ kind: 'local' })
+  })
+
+  it('captures a null-stamped Model-B owner from explicit worktree authority', () => {
+    expect(
+      select(
+        {
+          repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:env-1' }],
+          worktreesByRepo: { repo: [{ id: 'repo::wt-runtime', repoId: 'repo' }] }
+        },
+        'repo::wt-runtime',
+        'remote:env-1@@terminal-1'
+      )
+    ).toEqual({ kind: 'runtime', environmentId: 'env-1' })
+  })
+
+  it('uses the pane PTY instead of a stale tab-level fallback', () => {
+    expect(
+      selectCodexSubagentProgressHostAuthority(
+        state({
+          repos: [{ id: 'repo', connectionId: null, executionHostId: 'runtime:env-1' }],
+          worktreesByRepo: { repo: [{ id: 'repo::wt-runtime', repoId: 'repo' }] },
+          terminalLayoutsByTabId: {
+            'tab-1': {
+              root: { type: 'leaf', leafId: '11111111-1111-4111-8111-111111111111' },
+              activeLeafId: '11111111-1111-4111-8111-111111111111',
+              expandedLeafId: null,
+              ptyIdsByLeafId: {
+                '11111111-1111-4111-8111-111111111111': 'remote:env-1@@terminal-1'
+              }
+            }
+          }
+        }),
+        {
+          worktreeId: 'repo::wt-runtime',
+          parentPaneKey: PARENT_PANE_KEY,
+          tabPtyId: 'local-stale-pty',
+          connectionId: null
+        }
+      )
+    ).toEqual({ kind: 'runtime', environmentId: 'env-1' })
+  })
+
+  it('preserves local and runtime folder workspace ownership', () => {
+    const folderState = {
+      folderWorkspaces: [
+        {
+          id: 'local-folder',
+          projectGroupId: 'local-group',
+          connectionId: null,
+          executionHostId: 'local' as const
+        },
+        {
+          id: 'runtime-folder',
+          projectGroupId: 'runtime-group',
+          connectionId: null,
+          executionHostId: 'runtime:env-2' as const
+        }
+      ],
+      projectGroups: [
+        { id: 'local-group', connectionId: null, executionHostId: 'local' as const },
+        {
+          id: 'runtime-group',
+          connectionId: null,
+          executionHostId: 'runtime:env-2' as const
+        }
+      ]
+    }
+    expect(select(folderState, 'folder:local-folder', 'local-folder-pty')).toEqual({
+      kind: 'local'
+    })
+    expect(select(folderState, 'folder:runtime-folder', 'remote:env-2@@folder-terminal')).toEqual({
+      kind: 'runtime',
+      environmentId: 'env-2'
+    })
+  })
+
+  it('fails closed for legacy SSH, unknown status ownership, and conflicting runtime evidence', () => {
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: 'ssh-target-1',
+        explicitRuntimeEnvironmentId: 'unrelated-runtime',
+        ptyId: 'remote:unrelated-runtime@@terminal-1'
+      })
+    ).toEqual({ kind: 'legacy-ssh' })
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: undefined,
+        explicitRuntimeEnvironmentId: 'unrelated-runtime',
+        ptyId: 'local-pty-1'
+      })
+    ).toEqual({ kind: 'unknown', reason: 'unknown-owner' })
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: null,
+        explicitRuntimeEnvironmentId: 'env-1',
+        ptyId: 'remote:env-2@@terminal-1'
+      })
+    ).toEqual({ kind: 'unknown', reason: 'unknown-owner' })
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: null,
+        explicitRuntimeEnvironmentId: 'env-1',
+        ptyId: 'stale-local-pty'
+      })
+    ).toEqual({ kind: 'unknown', reason: 'unknown-owner' })
+  })
+
+  it('accepts a runtime-owned SSH PTY only with its matching explicit runtime owner', () => {
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: 'runtime-ssh-target-1',
+        explicitRuntimeEnvironmentId: 'env-1',
+        ptyId: 'ssh:runtime-ssh-target-1@@relay-pty-1'
+      })
+    ).toEqual({ kind: 'runtime', environmentId: 'env-1' })
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: 'runtime-ssh-target-1',
+        explicitRuntimeEnvironmentId: null,
+        ptyId: 'ssh:runtime-ssh-target-1@@relay-pty-1'
+      })
+    ).toEqual({ kind: 'unknown', reason: 'runtime-owner-missing' })
+  })
+
+  it('does not infer local ownership after runtime evidence disappears', () => {
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: 'runtime-ssh-target-1',
+        explicitRuntimeEnvironmentId: null,
+        ptyId: null
+      })
+    ).toEqual({ kind: 'unknown', reason: 'runtime-owner-missing' })
+    expect(
+      resolveCodexSubagentProgressHostAuthority({
+        connectionId: null,
+        explicitRuntimeEnvironmentId: null,
+        ptyId: null
+      })
+    ).toEqual({ kind: 'unknown', reason: 'unknown-owner' })
+  })
+})

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-host-authority.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-host-authority.ts
@@ -1,0 +1,102 @@
+import type { AppState } from '@/store/types'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from '@/lib/worktree-runtime-owner'
+import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
+
+export type CodexSubagentProgressHostAuthority =
+  | { kind: 'local' }
+  | { kind: 'runtime'; environmentId: string }
+  | { kind: 'legacy-ssh' }
+  | { kind: 'unknown'; reason: 'unknown-owner' | 'runtime-owner-missing' }
+
+export type CodexSubagentProgressHostAuthorityState = WorktreeRuntimeOwnerState &
+  Pick<AppState, 'terminalLayoutsByTabId'>
+
+export function resolveCodexSubagentProgressHostAuthority(args: {
+  connectionId: string | null | undefined
+  explicitRuntimeEnvironmentId: string | null
+  ptyId: string | null | undefined
+}): CodexSubagentProgressHostAuthority {
+  if (args.connectionId === undefined) {
+    return { kind: 'unknown', reason: 'unknown-owner' }
+  }
+  const runtimeOwnedConnection = isRuntimeOwnedSshTargetId(args.connectionId)
+  if (typeof args.connectionId === 'string' && !runtimeOwnedConnection) {
+    return { kind: 'legacy-ssh' }
+  }
+
+  const explicitRuntimeEnvironmentId = args.explicitRuntimeEnvironmentId?.trim() || null
+  const ptyId = args.ptyId?.trim() || null
+  if (ptyId?.startsWith('remote:')) {
+    const remotePty = parseRemoteRuntimePtyId(ptyId)
+    if (!remotePty) {
+      return { kind: 'unknown', reason: 'unknown-owner' }
+    }
+    if (
+      remotePty.environmentId &&
+      explicitRuntimeEnvironmentId &&
+      remotePty.environmentId !== explicitRuntimeEnvironmentId
+    ) {
+      return { kind: 'unknown', reason: 'unknown-owner' }
+    }
+    const environmentId = remotePty.environmentId ?? explicitRuntimeEnvironmentId
+    return environmentId
+      ? { kind: 'runtime', environmentId }
+      : { kind: 'unknown', reason: 'runtime-owner-missing' }
+  }
+  const sshPty = ptyId ? parseAppSshPtyId(ptyId) : null
+  if (sshPty) {
+    return runtimeOwnedConnection &&
+      sshPty.connectionId === args.connectionId &&
+      explicitRuntimeEnvironmentId
+      ? { kind: 'runtime', environmentId: explicitRuntimeEnvironmentId }
+      : {
+          kind: 'unknown',
+          reason: runtimeOwnedConnection ? 'runtime-owner-missing' : 'unknown-owner'
+        }
+  }
+  if (ptyId?.startsWith('ssh:')) {
+    return { kind: 'unknown', reason: 'unknown-owner' }
+  }
+  if (ptyId) {
+    if (explicitRuntimeEnvironmentId || runtimeOwnedConnection) {
+      return { kind: 'unknown', reason: 'unknown-owner' }
+    }
+    return { kind: 'local' }
+  }
+  if (explicitRuntimeEnvironmentId) {
+    return { kind: 'runtime', environmentId: explicitRuntimeEnvironmentId }
+  }
+  return {
+    kind: 'unknown',
+    reason: runtimeOwnedConnection ? 'runtime-owner-missing' : 'unknown-owner'
+  }
+}
+
+export function selectCodexSubagentProgressHostAuthority(
+  state: CodexSubagentProgressHostAuthorityState,
+  args: {
+    worktreeId: string
+    parentPaneKey: string
+    tabPtyId: string | null | undefined
+    connectionId: string | null | undefined
+  }
+): CodexSubagentProgressHostAuthority {
+  const pane = parsePaneKey(args.parentPaneKey)
+  const panePtyId = pane
+    ? state.terminalLayoutsByTabId[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId]
+    : undefined
+  return resolveCodexSubagentProgressHostAuthority({
+    connectionId: args.connectionId,
+    explicitRuntimeEnvironmentId: getExplicitRuntimeEnvironmentIdForWorktree(
+      state,
+      args.worktreeId
+    ),
+    ptyId: panePtyId ?? args.tabPtyId
+  })
+}

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-route.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-route.test.ts
@@ -3,41 +3,43 @@ import { resolveCodexSubagentProgressRoute } from './codex-subagent-progress-rou
 
 describe('resolveCodexSubagentProgressRoute', () => {
   it('keeps local transcripts on the local transport', () => {
-    expect(resolveCodexSubagentProgressRoute(null, null)).toEqual({
+    expect(resolveCodexSubagentProgressRoute({ kind: 'local' })).toEqual({
       kind: 'readable',
       runtimeEnvironmentId: null
     })
   })
 
   it('routes runtime-owned transcripts to their remote runtime', () => {
-    expect(resolveCodexSubagentProgressRoute('runtime-ssh-target-1', 'runtime-env-1')).toEqual({
-      kind: 'readable',
-      runtimeEnvironmentId: 'runtime-env-1'
-    })
-  })
-
-  it('prefers a resolved Model-B runtime owner over a local PTY stamp', () => {
-    expect(resolveCodexSubagentProgressRoute(null, 'runtime-env-1')).toEqual({
+    expect(
+      resolveCodexSubagentProgressRoute({ kind: 'runtime', environmentId: 'runtime-env-1' })
+    ).toEqual({
       kind: 'readable',
       runtimeEnvironmentId: 'runtime-env-1'
     })
   })
 
   it('blocks runtime-owned transcripts until the runtime owner resolves', () => {
-    expect(resolveCodexSubagentProgressRoute('runtime-ssh-target-1', null)).toEqual({
+    expect(
+      resolveCodexSubagentProgressRoute({
+        kind: 'unknown',
+        reason: 'runtime-owner-missing'
+      })
+    ).toEqual({
       kind: 'unavailable',
       reason: 'runtime-owner-missing'
     })
   })
 
   it('does not fall back to local reads for legacy SSH or unknown owners', () => {
-    expect(resolveCodexSubagentProgressRoute('ssh-target-1', 'unrelated-runtime')).toEqual({
+    expect(resolveCodexSubagentProgressRoute({ kind: 'legacy-ssh' })).toEqual({
       kind: 'unavailable',
       reason: 'legacy-ssh'
     })
-    expect(resolveCodexSubagentProgressRoute(undefined, 'unrelated-runtime')).toEqual({
-      kind: 'unavailable',
-      reason: 'unknown-owner'
-    })
+    expect(resolveCodexSubagentProgressRoute({ kind: 'unknown', reason: 'unknown-owner' })).toEqual(
+      {
+        kind: 'unavailable',
+        reason: 'unknown-owner'
+      }
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-route.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-route.test.ts
@@ -3,7 +3,7 @@ import { resolveCodexSubagentProgressRoute } from './codex-subagent-progress-rou
 
 describe('resolveCodexSubagentProgressRoute', () => {
   it('keeps local transcripts on the local transport', () => {
-    expect(resolveCodexSubagentProgressRoute(null, 'unrelated-runtime')).toEqual({
+    expect(resolveCodexSubagentProgressRoute(null, null)).toEqual({
       kind: 'readable',
       runtimeEnvironmentId: null
     })
@@ -11,6 +11,13 @@ describe('resolveCodexSubagentProgressRoute', () => {
 
   it('routes runtime-owned transcripts to their remote runtime', () => {
     expect(resolveCodexSubagentProgressRoute('runtime-ssh-target-1', 'runtime-env-1')).toEqual({
+      kind: 'readable',
+      runtimeEnvironmentId: 'runtime-env-1'
+    })
+  })
+
+  it('prefers a resolved Model-B runtime owner over a local PTY stamp', () => {
+    expect(resolveCodexSubagentProgressRoute(null, 'runtime-env-1')).toEqual({
       kind: 'readable',
       runtimeEnvironmentId: 'runtime-env-1'
     })
@@ -24,11 +31,11 @@ describe('resolveCodexSubagentProgressRoute', () => {
   })
 
   it('does not fall back to local reads for legacy SSH or unknown owners', () => {
-    expect(resolveCodexSubagentProgressRoute('ssh-target-1', null)).toEqual({
+    expect(resolveCodexSubagentProgressRoute('ssh-target-1', 'unrelated-runtime')).toEqual({
       kind: 'unavailable',
       reason: 'legacy-ssh'
     })
-    expect(resolveCodexSubagentProgressRoute(undefined, null)).toEqual({
+    expect(resolveCodexSubagentProgressRoute(undefined, 'unrelated-runtime')).toEqual({
       kind: 'unavailable',
       reason: 'unknown-owner'
     })

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-route.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCodexSubagentProgressRoute } from './codex-subagent-progress-route'
+
+describe('resolveCodexSubagentProgressRoute', () => {
+  it('keeps local transcripts on the local transport', () => {
+    expect(resolveCodexSubagentProgressRoute(null, 'unrelated-runtime')).toEqual({
+      kind: 'readable',
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('routes runtime-owned transcripts to their remote runtime', () => {
+    expect(resolveCodexSubagentProgressRoute('runtime-ssh-target-1', 'runtime-env-1')).toEqual({
+      kind: 'readable',
+      runtimeEnvironmentId: 'runtime-env-1'
+    })
+  })
+
+  it('blocks runtime-owned transcripts until the runtime owner resolves', () => {
+    expect(resolveCodexSubagentProgressRoute('runtime-ssh-target-1', null)).toEqual({
+      kind: 'unavailable',
+      reason: 'runtime-owner-missing'
+    })
+  })
+
+  it('does not fall back to local reads for legacy SSH or unknown owners', () => {
+    expect(resolveCodexSubagentProgressRoute('ssh-target-1', null)).toEqual({
+      kind: 'unavailable',
+      reason: 'legacy-ssh'
+    })
+    expect(resolveCodexSubagentProgressRoute(undefined, null)).toEqual({
+      kind: 'unavailable',
+      reason: 'unknown-owner'
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-route.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-route.ts
@@ -1,25 +1,20 @@
-import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
-import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+import type { CodexSubagentProgressHostAuthority } from './codex-subagent-progress-host-authority'
 
 export type CodexSubagentProgressRoute =
   | { kind: 'readable'; runtimeEnvironmentId: string | null }
   | { kind: 'unavailable'; reason: 'unknown-owner' | 'legacy-ssh' | 'runtime-owner-missing' }
 
 export function resolveCodexSubagentProgressRoute(
-  connectionId: string | null | undefined,
-  runtimeEnvironmentId: string | null
+  authority: CodexSubagentProgressHostAuthority
 ): CodexSubagentProgressRoute {
-  if (connectionId === undefined) {
-    return { kind: 'unavailable', reason: 'unknown-owner' }
+  switch (authority.kind) {
+    case 'local':
+      return { kind: 'readable', runtimeEnvironmentId: null }
+    case 'runtime':
+      return { kind: 'readable', runtimeEnvironmentId: authority.environmentId }
+    case 'legacy-ssh':
+      return { kind: 'unavailable', reason: 'legacy-ssh' }
+    case 'unknown':
+      return { kind: 'unavailable', reason: authority.reason }
   }
-  if (!isNativeChatTranscriptLocalReadable(connectionId)) {
-    return { kind: 'unavailable', reason: 'legacy-ssh' }
-  }
-  if (runtimeEnvironmentId) {
-    return { kind: 'readable', runtimeEnvironmentId }
-  }
-  if (isRuntimeOwnedSshTargetId(connectionId)) {
-    return { kind: 'unavailable', reason: 'runtime-owner-missing' }
-  }
-  return { kind: 'readable', runtimeEnvironmentId: null }
 }

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-route.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-route.ts
@@ -15,10 +15,11 @@ export function resolveCodexSubagentProgressRoute(
   if (!isNativeChatTranscriptLocalReadable(connectionId)) {
     return { kind: 'unavailable', reason: 'legacy-ssh' }
   }
+  if (runtimeEnvironmentId) {
+    return { kind: 'readable', runtimeEnvironmentId }
+  }
   if (isRuntimeOwnedSshTargetId(connectionId)) {
-    return runtimeEnvironmentId
-      ? { kind: 'readable', runtimeEnvironmentId }
-      : { kind: 'unavailable', reason: 'runtime-owner-missing' }
+    return { kind: 'unavailable', reason: 'runtime-owner-missing' }
   }
   return { kind: 'readable', runtimeEnvironmentId: null }
 }

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-route.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-route.ts
@@ -1,0 +1,24 @@
+import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+
+export type CodexSubagentProgressRoute =
+  | { kind: 'readable'; runtimeEnvironmentId: string | null }
+  | { kind: 'unavailable'; reason: 'unknown-owner' | 'legacy-ssh' | 'runtime-owner-missing' }
+
+export function resolveCodexSubagentProgressRoute(
+  connectionId: string | null | undefined,
+  runtimeEnvironmentId: string | null
+): CodexSubagentProgressRoute {
+  if (connectionId === undefined) {
+    return { kind: 'unavailable', reason: 'unknown-owner' }
+  }
+  if (!isNativeChatTranscriptLocalReadable(connectionId)) {
+    return { kind: 'unavailable', reason: 'legacy-ssh' }
+  }
+  if (isRuntimeOwnedSshTargetId(connectionId)) {
+    return runtimeEnvironmentId
+      ? { kind: 'readable', runtimeEnvironmentId }
+      : { kind: 'unavailable', reason: 'runtime-owner-missing' }
+  }
+  return { kind: 'readable', runtimeEnvironmentId: null }
+}

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-selection.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-selection.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCodexSubagentProgressPaneKey } from './codex-subagent-progress-selection'
+
+const target = {
+  sessionId: 'child-1',
+  startedAt: 10,
+  paneKey: 'parent\u0000subagent:child-1',
+  parentPaneKey: 'parent',
+  terminalTabId: 'tab-1',
+  worktreeId: 'wt-1',
+  label: '/root/test_agent',
+  hostAuthority: { kind: 'local' }
+}
+
+describe('resolveCodexSubagentProgressPaneKey', () => {
+  it('selects only the inspected child in its worktree', () => {
+    expect(resolveCodexSubagentProgressPaneKey('codex-subagent-progress', target, 'wt-1')).toBe(
+      'parent\u0000subagent:child-1'
+    )
+    expect(
+      resolveCodexSubagentProgressPaneKey('codex-subagent-progress', target, 'wt-2')
+    ).toBeNull()
+    expect(resolveCodexSubagentProgressPaneKey('none', target, 'wt-1')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-selection.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-selection.ts
@@ -1,0 +1,20 @@
+import { useAppStore } from '@/store'
+import { parseCodexSubagentProgressTarget } from './codex-subagent-progress-target'
+
+export function resolveCodexSubagentProgressPaneKey(
+  activeModal: string,
+  modalData: Record<string, unknown>,
+  worktreeId: string
+): string | null {
+  if (activeModal !== 'codex-subagent-progress') {
+    return null
+  }
+  const target = parseCodexSubagentProgressTarget(modalData)
+  return target?.worktreeId === worktreeId ? target.paneKey : null
+}
+
+export function useCodexSubagentProgressPaneKey(worktreeId: string): string | null {
+  const activeModal = useAppStore((state) => state.activeModal)
+  const modalData = useAppStore((state) => state.modalData)
+  return resolveCodexSubagentProgressPaneKey(activeModal, modalData, worktreeId)
+}

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-target.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-target.test.ts
@@ -29,6 +29,7 @@ describe('Codex subagent progress target', () => {
       createCodexSubagentProgressTarget(childRow(), 'folder:workspace-1', { kind: 'local' })
     ).toEqual({
       sessionId: 'child-1',
+      startedAt: 10,
       paneKey: 'parent\u0000subagent:child-1',
       parentPaneKey: 'parent-pane',
       terminalTabId: 'tab-1',
@@ -47,6 +48,12 @@ describe('Codex subagent progress target', () => {
 
   it('rejects malformed modal data', () => {
     expect(parseCodexSubagentProgressTarget({ sessionId: 'child-1' })).toBeNull()
+    expect(
+      parseCodexSubagentProgressTarget({
+        ...createCodexSubagentProgressTarget(childRow(), 'wt-1', { kind: 'local' }),
+        startedAt: 0
+      } as Record<string, unknown>)
+    ).toBeNull()
   })
 
   it('retains captured runtime authority without consulting live workspace state', () => {

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-target.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-target.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import {
+  createCodexSubagentProgressTarget,
+  parseCodexSubagentProgressTarget
+} from './codex-subagent-progress-target'
+
+function childRow(provider = 'codex'): DashboardAgentRow {
+  return {
+    paneKey: 'parent\u0000subagent:child-1',
+    tab: { id: 'tab-1' },
+    agentType: 'reviewer',
+    rowSource: 'subagent',
+    state: 'working',
+    startedAt: 10,
+    entry: {
+      prompt: 'Review files',
+      model: 'gpt-5.4-mini',
+      connectionId: null,
+      orchestration: { taskId: 'child', dispatchId: 'child' }
+    },
+    subagentSession: { id: 'child-1', provider, parentPaneKey: 'parent-pane' }
+  } as DashboardAgentRow
+}
+
+describe('Codex subagent progress target', () => {
+  it('preserves explicit child identity and local host authority', () => {
+    expect(createCodexSubagentProgressTarget(childRow(), 'folder:workspace-1')).toEqual({
+      sessionId: 'child-1',
+      paneKey: 'parent\u0000subagent:child-1',
+      parentPaneKey: 'parent-pane',
+      terminalTabId: 'tab-1',
+      worktreeId: 'folder:workspace-1',
+      label: 'Review files',
+      model: 'gpt-5.4-mini',
+      state: 'working',
+      connectionId: null
+    })
+  })
+
+  it('does not create a Codex target for another provider', () => {
+    expect(createCodexSubagentProgressTarget(childRow('claude'), 'wt-1')).toBeNull()
+  })
+
+  it('rejects malformed modal data', () => {
+    expect(parseCodexSubagentProgressTarget({ sessionId: 'child-1' })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-target.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-target.test.ts
@@ -25,7 +25,9 @@ function childRow(provider = 'codex'): DashboardAgentRow {
 
 describe('Codex subagent progress target', () => {
   it('preserves explicit child identity and local host authority', () => {
-    expect(createCodexSubagentProgressTarget(childRow(), 'folder:workspace-1')).toEqual({
+    expect(
+      createCodexSubagentProgressTarget(childRow(), 'folder:workspace-1', { kind: 'local' })
+    ).toEqual({
       sessionId: 'child-1',
       paneKey: 'parent\u0000subagent:child-1',
       parentPaneKey: 'parent-pane',
@@ -33,16 +35,28 @@ describe('Codex subagent progress target', () => {
       worktreeId: 'folder:workspace-1',
       label: 'Review files',
       model: 'gpt-5.4-mini',
-      state: 'working',
-      connectionId: null
+      hostAuthority: { kind: 'local' }
     })
   })
 
   it('does not create a Codex target for another provider', () => {
-    expect(createCodexSubagentProgressTarget(childRow('claude'), 'wt-1')).toBeNull()
+    expect(
+      createCodexSubagentProgressTarget(childRow('claude'), 'wt-1', { kind: 'local' })
+    ).toBeNull()
   })
 
   it('rejects malformed modal data', () => {
     expect(parseCodexSubagentProgressTarget({ sessionId: 'child-1' })).toBeNull()
+  })
+
+  it('retains captured runtime authority without consulting live workspace state', () => {
+    const target = createCodexSubagentProgressTarget(childRow(), 'wt-1', {
+      kind: 'runtime',
+      environmentId: 'env-1'
+    })
+
+    expect(parseCodexSubagentProgressTarget(target as Record<string, unknown>)).toMatchObject({
+      hostAuthority: { kind: 'runtime', environmentId: 'env-1' }
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-target.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-target.ts
@@ -1,5 +1,5 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
-import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import type { CodexSubagentProgressHostAuthority } from './codex-subagent-progress-host-authority'
 
 export type CodexSubagentProgressTarget = {
   sessionId: string
@@ -9,17 +9,8 @@ export type CodexSubagentProgressTarget = {
   worktreeId: string
   label: string
   model?: string
-  state: AgentStatusState | 'idle'
-  connectionId?: string | null
+  hostAuthority: CodexSubagentProgressHostAuthority
 }
-
-const TARGET_STATES = new Set<AgentStatusState | 'idle'>([
-  'working',
-  'blocked',
-  'waiting',
-  'done',
-  'idle'
-])
 
 function nonEmptyString(value: unknown): string | null {
   if (typeof value !== 'string') {
@@ -31,7 +22,8 @@ function nonEmptyString(value: unknown): string | null {
 
 export function createCodexSubagentProgressTarget(
   agent: DashboardAgentRow,
-  worktreeId: string
+  worktreeId: string,
+  hostAuthority: CodexSubagentProgressHostAuthority
 ): CodexSubagentProgressTarget | null {
   const session = agent.subagentSession
   if (agent.rowSource !== 'subagent' || session?.provider !== 'codex') {
@@ -51,8 +43,29 @@ export function createCodexSubagentProgressTarget(
     worktreeId,
     label,
     ...(model ? { model } : {}),
-    state: agent.state,
-    connectionId: agent.entry.connectionId
+    hostAuthority
+  }
+}
+
+function parseHostAuthority(value: unknown): CodexSubagentProgressHostAuthority | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const authority = value as Record<string, unknown>
+  switch (authority.kind) {
+    case 'local':
+    case 'legacy-ssh':
+      return { kind: authority.kind }
+    case 'runtime': {
+      const environmentId = nonEmptyString(authority.environmentId)
+      return environmentId ? { kind: 'runtime', environmentId } : null
+    }
+    case 'unknown':
+      return authority.reason === 'unknown-owner' || authority.reason === 'runtime-owner-missing'
+        ? { kind: 'unknown', reason: authority.reason }
+        : null
+    default:
+      return null
   }
 }
 
@@ -65,7 +78,7 @@ export function parseCodexSubagentProgressTarget(
   const terminalTabId = nonEmptyString(value.terminalTabId)
   const worktreeId = nonEmptyString(value.worktreeId)
   const label = nonEmptyString(value.label)
-  const state = value.state
+  const hostAuthority = parseHostAuthority(value.hostAuthority)
   if (
     !sessionId ||
     !paneKey ||
@@ -73,16 +86,11 @@ export function parseCodexSubagentProgressTarget(
     !terminalTabId ||
     !worktreeId ||
     !label ||
-    typeof state !== 'string' ||
-    !TARGET_STATES.has(state as AgentStatusState | 'idle')
+    !hostAuthority
   ) {
     return null
   }
   const model = nonEmptyString(value.model)
-  const connectionId = value.connectionId
-  if (connectionId !== undefined && connectionId !== null && typeof connectionId !== 'string') {
-    return null
-  }
   return {
     sessionId,
     paneKey,
@@ -91,7 +99,6 @@ export function parseCodexSubagentProgressTarget(
     worktreeId,
     label,
     ...(model ? { model } : {}),
-    state: state as AgentStatusState | 'idle',
-    ...(connectionId === undefined ? {} : { connectionId })
+    hostAuthority
   }
 }

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-target.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-target.ts
@@ -1,0 +1,97 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import type { AgentStatusState } from '../../../../shared/agent-status-types'
+
+export type CodexSubagentProgressTarget = {
+  sessionId: string
+  paneKey: string
+  parentPaneKey: string
+  terminalTabId: string
+  worktreeId: string
+  label: string
+  model?: string
+  state: AgentStatusState | 'idle'
+  connectionId?: string | null
+}
+
+const TARGET_STATES = new Set<AgentStatusState | 'idle'>([
+  'working',
+  'blocked',
+  'waiting',
+  'done',
+  'idle'
+])
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+export function createCodexSubagentProgressTarget(
+  agent: DashboardAgentRow,
+  worktreeId: string
+): CodexSubagentProgressTarget | null {
+  const session = agent.subagentSession
+  if (agent.rowSource !== 'subagent' || session?.provider !== 'codex') {
+    return null
+  }
+  const label =
+    agent.entry.orchestration?.displayName?.trim() ||
+    agent.entry.prompt.trim() ||
+    agent.agentType.trim() ||
+    'Codex subagent'
+  const model = agent.entry.model?.trim() || undefined
+  return {
+    sessionId: session.id,
+    paneKey: agent.paneKey,
+    parentPaneKey: session.parentPaneKey,
+    terminalTabId: agent.tab.id,
+    worktreeId,
+    label,
+    ...(model ? { model } : {}),
+    state: agent.state,
+    connectionId: agent.entry.connectionId
+  }
+}
+
+export function parseCodexSubagentProgressTarget(
+  value: Record<string, unknown>
+): CodexSubagentProgressTarget | null {
+  const sessionId = nonEmptyString(value.sessionId)
+  const paneKey = nonEmptyString(value.paneKey)
+  const parentPaneKey = nonEmptyString(value.parentPaneKey)
+  const terminalTabId = nonEmptyString(value.terminalTabId)
+  const worktreeId = nonEmptyString(value.worktreeId)
+  const label = nonEmptyString(value.label)
+  const state = value.state
+  if (
+    !sessionId ||
+    !paneKey ||
+    !parentPaneKey ||
+    !terminalTabId ||
+    !worktreeId ||
+    !label ||
+    typeof state !== 'string' ||
+    !TARGET_STATES.has(state as AgentStatusState | 'idle')
+  ) {
+    return null
+  }
+  const model = nonEmptyString(value.model)
+  const connectionId = value.connectionId
+  if (connectionId !== undefined && connectionId !== null && typeof connectionId !== 'string') {
+    return null
+  }
+  return {
+    sessionId,
+    paneKey,
+    parentPaneKey,
+    terminalTabId,
+    worktreeId,
+    label,
+    ...(model ? { model } : {}),
+    state: state as AgentStatusState | 'idle',
+    ...(connectionId === undefined ? {} : { connectionId })
+  }
+}

--- a/src/renderer/src/components/sidebar/codex-subagent-progress-target.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-progress-target.ts
@@ -3,6 +3,7 @@ import type { CodexSubagentProgressHostAuthority } from './codex-subagent-progre
 
 export type CodexSubagentProgressTarget = {
   sessionId: string
+  startedAt: number
   paneKey: string
   parentPaneKey: string
   terminalTabId: string
@@ -37,6 +38,7 @@ export function createCodexSubagentProgressTarget(
   const model = agent.entry.model?.trim() || undefined
   return {
     sessionId: session.id,
+    startedAt: agent.startedAt,
     paneKey: agent.paneKey,
     parentPaneKey: session.parentPaneKey,
     terminalTabId: agent.tab.id,
@@ -73,6 +75,10 @@ export function parseCodexSubagentProgressTarget(
   value: Record<string, unknown>
 ): CodexSubagentProgressTarget | null {
   const sessionId = nonEmptyString(value.sessionId)
+  const startedAt =
+    typeof value.startedAt === 'number' && Number.isFinite(value.startedAt) && value.startedAt > 0
+      ? value.startedAt
+      : null
   const paneKey = nonEmptyString(value.paneKey)
   const parentPaneKey = nonEmptyString(value.parentPaneKey)
   const terminalTabId = nonEmptyString(value.terminalTabId)
@@ -81,6 +87,7 @@ export function parseCodexSubagentProgressTarget(
   const hostAuthority = parseHostAuthority(value.hostAuthority)
   if (
     !sessionId ||
+    !startedAt ||
     !paneKey ||
     !parentPaneKey ||
     !terminalTabId ||
@@ -93,6 +100,7 @@ export function parseCodexSubagentProgressTarget(
   const model = nonEmptyString(value.model)
   return {
     sessionId,
+    startedAt,
     paneKey,
     parentPaneKey,
     terminalTabId,

--- a/src/renderer/src/components/sidebar/codex-subagent-transcript-scope.test.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-transcript-scope.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage, NativeChatRole } from '../../../../shared/native-chat-types'
+import { scopeCodexSubagentTranscript } from './codex-subagent-transcript-scope'
+
+function message(id: string, role: NativeChatRole, timestamp: number | null): NativeChatMessage {
+  return {
+    id,
+    role,
+    timestamp,
+    source: 'transcript',
+    blocks: [{ type: 'text', text: id }]
+  }
+}
+
+describe('scopeCodexSubagentTranscript', () => {
+  it('removes the parent prefix copied into a full-history child rollout', () => {
+    const scoped = scopeCodexSubagentTranscript(
+      [
+        message('parent-user', 'user', 1_000),
+        message('parent-assistant', 'assistant', 1_100),
+        message('child-progress', 'assistant', 2_100),
+        message('child-tool-result', 'tool', null)
+      ],
+      true,
+      2_000
+    )
+
+    expect(scoped.messages.map((entry) => entry.id)).toEqual([
+      'child-progress',
+      'child-tool-result'
+    ])
+    expect(scoped.hasMore).toBe(false)
+  })
+
+  it('keeps older-history pagination until the child start boundary is reached', () => {
+    expect(
+      scopeCodexSubagentTranscript([message('child-later', 'assistant', 2_200)], true, 2_000)
+        .hasMore
+    ).toBe(true)
+    expect(
+      scopeCodexSubagentTranscript(
+        [message('parent', 'user', 1_900), message('child-first', 'assistant', 2_100)],
+        true,
+        2_000
+      ).hasMore
+    ).toBe(false)
+  })
+
+  it('does not expose transcript messages without a trusted child boundary', () => {
+    expect(scopeCodexSubagentTranscript([message('parent', 'user', 1_000)], true, 0)).toEqual({
+      messages: [],
+      hasMore: false
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/codex-subagent-transcript-scope.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-transcript-scope.ts
@@ -16,7 +16,7 @@ export function scopeCodexSubagentTranscript(
   const firstOwnedMessage = messages.findIndex(
     (message) => message.timestamp !== null && message.timestamp >= startedAt
   )
-  if (firstOwnedMessage < 0) {
+  if (firstOwnedMessage === -1) {
     return { messages: [], hasMore: false }
   }
   // Why: Codex full-history forks copy parent turns before the provider-authored child start boundary.

--- a/src/renderer/src/components/sidebar/codex-subagent-transcript-scope.ts
+++ b/src/renderer/src/components/sidebar/codex-subagent-transcript-scope.ts
@@ -1,0 +1,27 @@
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+
+export type CodexSubagentTranscriptScope = {
+  messages: NativeChatMessage[]
+  hasMore: boolean
+}
+
+export function scopeCodexSubagentTranscript(
+  messages: readonly NativeChatMessage[],
+  hasMore: boolean,
+  startedAt: number
+): CodexSubagentTranscriptScope {
+  if (!Number.isFinite(startedAt) || startedAt <= 0) {
+    return { messages: [], hasMore: false }
+  }
+  const firstOwnedMessage = messages.findIndex(
+    (message) => message.timestamp !== null && message.timestamp >= startedAt
+  )
+  if (firstOwnedMessage < 0) {
+    return { messages: [], hasMore: false }
+  }
+  // Why: Codex full-history forks copy parent turns before the provider-authored child start boundary.
+  return {
+    messages: messages.slice(firstOwnedMessage),
+    hasMore: hasMore && firstOwnedMessage === 0
+  }
+}

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -23,6 +23,7 @@ const WorktreeVisibilityDialog = lazyWithRetry(() => import('./WorktreeVisibilit
 const OrcaYamlTrustDialog = lazyWithRetry(() => import('./OrcaYamlTrustDialog'))
 const ForgetSshWorkspaceDialog = lazyWithRetry(() => import('./ForgetSshWorkspaceDialog'))
 const AgentDashboardSidebarHost = lazyWithRetry(() => import('./AgentDashboardSidebarHost'))
+const CodexSubagentProgressSheet = lazyWithRetry(() => import('./CodexSubagentProgressSheet'))
 
 const MIN_WIDTH = 220
 const MAX_WIDTH = 500
@@ -183,6 +184,7 @@ function Sidebar({
         {activeModal === 'worktree-visibility' ? <WorktreeVisibilityDialog /> : null}
         {activeModal === 'confirm-orca-yaml-hooks' ? <OrcaYamlTrustDialog /> : null}
         {activeModal === 'forget-ssh-workspace' ? <ForgetSshWorkspaceDialog /> : null}
+        {activeModal === 'codex-subagent-progress' ? <CodexSubagentProgressSheet /> : null}
       </React.Suspense>
       {sidebarOpen ? (
         <WorkspaceKanbanDrawer

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -727,6 +727,7 @@ describe('applyAgentRowLineage', () => {
     const entry = makeEntry(PANE_KEY_1, 1000, {
       state: 'working',
       prompt: 'review the PR',
+      connectionId: 'runtime-ssh-env-1',
       subagents: [
         {
           id: 'a1',
@@ -751,8 +752,9 @@ describe('applyAgentRowLineage', () => {
     expect(children[0]).toMatchObject({
       state: 'working',
       agentType: 'general-purpose',
-      entry: { model: 'gpt-5.4-mini' },
+      entry: { model: 'gpt-5.4-mini', connectionId: 'runtime-ssh-env-1' },
       activationPaneKey: PANE_KEY_1,
+      subagentSession: { id: 'a1', provider: 'claude', parentPaneKey: PANE_KEY_1 },
       startedAt: 1500
     })
     expect(children[0].entry.prompt).toBe('Review loop')
@@ -764,6 +766,27 @@ describe('applyAgentRowLineage', () => {
     expect(ordered[0].lineage).toMatchObject({ depth: 0, childCount: 2 })
     expect(ordered[1].lineage).toMatchObject({ depth: 1, isFirstSibling: true })
     expect(ordered[2].lineage).toMatchObject({ depth: 1, isLastSibling: true })
+  })
+
+  it('binds a Codex child row to the resolved parent provider session', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex', title: 'Codex' })],
+      entries: [
+        makeEntry(PANE_KEY_1, 1000, {
+          agentType: undefined,
+          terminalTitle: 'Codex',
+          subagents: [{ id: 'child-codex', state: 'working', startedAt: 1500 }]
+        })
+      ],
+      retained: [],
+      now: 2000
+    })
+
+    expect(rows.find((row) => row.rowSource === 'subagent')?.subagentSession).toEqual({
+      id: 'child-codex',
+      provider: 'codex',
+      parentPaneKey: PANE_KEY_1
+    })
   })
 
   it('decays working subagent child rows to idle when the parent status is stale', () => {

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.subagent.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.subagent.test.tsx
@@ -55,6 +55,7 @@ describe('CompactAgentRow subagent display', () => {
     expect(row.textContent).not.toContain('Default')
     expect(row.textContent).not.toContain('gpt-5.6-sol')
     expect(row.getAttribute('title')).toBe('/root/test_agent')
+    expect(row.getAttribute('data-subagent-id')).toBe('child-1')
     expect(row.getAttribute('data-current')).toBe('true')
     expect(row.getAttribute('aria-selected')).toBe('true')
   })

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.subagent.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.subagent.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { CompactAgentRow } from './worktree-card-compact-agent-row'
+
+vi.mock('@/components/dashboard/use-agent-row-conversation-name', () => ({
+  useAgentRowConversationName: () => null
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownForPane: () => null
+}))
+
+afterEach(cleanup)
+
+type AgentRowOverrides = Omit<Partial<DashboardAgentRow>, 'entry'> & {
+  entry?: Partial<DashboardAgentRow['entry']>
+}
+
+function agentRow(overrides: AgentRowOverrides = {}): DashboardAgentRow {
+  const row = {
+    paneKey: 'parent\u0000subagent:child-1',
+    tab: { id: 'tab-1' },
+    agentType: 'default',
+    rowSource: 'subagent',
+    state: 'working',
+    startedAt: 1_000,
+    entry: {
+      prompt: '/root/test_agent',
+      state: 'working',
+      stateStartedAt: 1_000,
+      stateHistory: [],
+      model: 'gpt-5.6-sol'
+    },
+    subagentSession: { id: 'child-1', provider: 'codex', parentPaneKey: 'parent' },
+    lineage: { depth: 1, isFirstSibling: true, isLastSibling: true, childCount: 0 }
+  } as unknown as DashboardAgentRow
+  return {
+    ...row,
+    ...overrides,
+    entry: { ...row.entry, ...overrides.entry }
+  } as DashboardAgentRow
+}
+
+describe('CompactAgentRow subagent display', () => {
+  it('uses a concise child label and keeps canonical metadata in the tooltip', () => {
+    render(<CompactAgentRow agent={agentRow()} now={2_000} onActivate={vi.fn()} isCurrentAgent />)
+
+    const row = screen.getByRole('treeitem')
+    expect(row.textContent).toContain('test_agent')
+    expect(row.textContent).not.toContain('/root/')
+    expect(row.textContent).not.toContain('Default')
+    expect(row.textContent).not.toContain('gpt-5.6-sol')
+    expect(row.getAttribute('title')).toBe('/root/test_agent')
+    expect(row.getAttribute('data-current')).toBe('true')
+    expect(row.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('keeps an aggregate parent row free of stale child-launch tool text', () => {
+    render(
+      <CompactAgentRow
+        agent={agentRow({
+          paneKey: 'parent',
+          agentType: 'codex',
+          rowSource: 'live',
+          entry: {
+            prompt: 'Agnes_Core | main',
+            state: 'working',
+            stateStartedAt: 1_000,
+            stateHistory: [],
+            toolName: 'collaborationlist_agents'
+          },
+          lineage: { depth: 0, isFirstSibling: true, isLastSibling: true, childCount: 1 }
+        })}
+        now={2_000}
+        onActivate={vi.fn()}
+        childAgentCount={1}
+        childAgentsExpanded
+        onToggleChildAgents={vi.fn()}
+        hideIdentityIcon
+      />
+    )
+
+    const row = screen.getByRole('treeitem')
+    expect(row.textContent).toContain('Agnes_Core | main')
+    expect(row.textContent).not.toContain('collaborationlist_agents')
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('Hide 1 child agent')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.subagent.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.subagent.test.tsx
@@ -53,7 +53,7 @@ describe('CompactAgentRow subagent display', () => {
     expect(row.textContent).toContain('test_agent')
     expect(row.textContent).not.toContain('/root/')
     expect(row.textContent).not.toContain('Default')
-    expect(row.textContent).not.toContain('gpt-5.6-sol')
+    expect(row.textContent).toContain('gpt-5.6-sol')
     expect(row.getAttribute('title')).toBe('/root/test_agent')
     expect(row.getAttribute('data-subagent-id')).toBe('child-1')
     expect(row.getAttribute('data-current')).toBe('true')

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -126,8 +126,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   const handleActivate = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
-      // Why: subagent child rows have no pane of their own; they focus the
-      // parent pane whose session spawned them.
+      // Why: subagents have no pane, so the caller receives their explicit parent fallback.
       onActivate(agent.tab.id, agent.activationPaneKey ?? agent.paneKey)
     },
     [agent.activationPaneKey, agent.paneKey, agent.tab.id, onActivate]

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -267,6 +267,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
       data-current={isCurrentAgent ? 'true' : undefined}
       data-agent-send-target={sendTargetStatus}
+      data-subagent-id={agent.subagentSession?.id}
       role={agent.lineage ? 'treeitem' : undefined}
       aria-level={agent.lineage ? agent.lineage.depth + 1 : undefined}
       aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -6,12 +6,13 @@ import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { cn } from '@/lib/utils'
 import { getAgentDotState } from './worktree-card-agent-summary'
-import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { formatAgentToolPreview } from '@/lib/agent-row-tool-preview'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
+import { agentChildDisclosureLabel } from '@/components/agent-child-disclosure-label'
+import { formatCodexSubagentDisplayLabel } from '@/components/codex-subagent-display-label'
 
 function formatShortTimeAgo(ts: number, now: number): string {
   const delta = now - ts
@@ -29,17 +30,19 @@ function formatShortTimeAgo(ts: number, now: number): string {
   return `${Math.floor(hours / 24)}d`
 }
 
-function getCompactAgentPrimary(
-  agent: DashboardAgentRowData,
-  conversationName: string | null
-): string {
-  const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
-  return prompt || agentStateLabel(getAgentDotState(agent))
+function getCompactAgentPrimary(agent: DashboardAgentRowData, primarySource: string): string {
+  const label = primarySource || agentStateLabel(getAgentDotState(agent))
+  return agent.subagentSession?.provider === 'codex'
+    ? formatCodexSubagentDisplayLabel(label)
+    : label
 }
 
-function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
+function getCompactAgentSecondary(agent: DashboardAgentRowData, hasChildAgents: boolean): string {
   if (agent.entry.interrupted === true) {
     return 'Interrupted by user'
+  }
+  if (hasChildAgents) {
+    return ''
   }
   const toolPreview = formatAgentToolPreview(agent.entry, agent.state)
   if (toolPreview) {
@@ -50,8 +53,11 @@ function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
     return lastAssistantMessage
   }
   // Why: child rows without descriptions use their role as primary text; repeating its formatted label adds no information.
-  if (agent.rowSource === 'subagent' && agent.entry.prompt?.trim() === agent.agentType.trim()) {
-    return ''
+  if (agent.rowSource === 'subagent') {
+    const agentType = agent.agentType.trim()
+    if (agentType === 'default' || agent.entry.prompt?.trim() === agentType) {
+      return ''
+    }
   }
   return formatAgentTypeLabel(agent.agentType)
 }
@@ -87,6 +93,7 @@ type CompactAgentRowProps = {
   onToggleChildAgents?: () => void
   reserveDisclosureGutter?: boolean
   isFocusedPane?: boolean
+  isCurrentAgent?: boolean
   hideIdentityIcon?: boolean
   cacheTimerActive?: boolean
 }
@@ -103,6 +110,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   onToggleChildAgents,
   reserveDisclosureGutter = false,
   isFocusedPane = false,
+  isCurrentAgent = false,
   hideIdentityIcon = false,
   cacheTimerActive = true
 }: CompactAgentRowProps) {
@@ -116,10 +124,12 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
   const hideIcon = hideIdentityIcon || agent.rowSource === 'subagent'
   const dotState = getAgentDotState(agent)
   const conversationName = useAgentRowConversationName(agent)
-  const primary = getCompactAgentPrimary(agent, conversationName)
+  const primarySource = conversationName ?? getAgentRowPrimaryText(agent.entry)
+  const primary = getCompactAgentPrimary(agent, primarySource)
   const isLineageChild = agent.lineage?.depth === 1
-  const secondary = getCompactAgentSecondary(agent)
+  const secondary = getCompactAgentSecondary(agent, hasChildDisclosure)
   const model = agent.entry.model?.trim() ?? ''
+  const isHighlighted = isFocusedPane || isCurrentAgent
   const shortTime = getCompactAgentTime(agent, now)
   const cacheTimer = usePromptCacheCountdownForPane(agent.paneKey, cacheTimerActive)
 
@@ -166,15 +176,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         <button
           type="button"
           className="compact-agent-child-disclosure-button flex size-4 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-worktree-sidebar-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-worktree-sidebar-ring"
-          aria-label={translate(
-            'auto.components.sidebar.worktree.card.compact.agents.a128d7006b',
-            '{{value0}} {{value1}} child {{value2}}',
-            {
-              value0: childAgentsExpanded ? 'Hide' : 'Show',
-              value1: childAgentCount,
-              value2: childAgentCount === 1 ? 'agent' : 'agents'
-            }
-          )}
+          aria-label={agentChildDisclosureLabel(childAgentsExpanded, childAgentCount)}
           aria-expanded={childAgentsExpanded}
           onClick={handleToggleChildren}
           onKeyDown={stopActivationKeyPropagation}
@@ -197,13 +199,12 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         </span>
       )}
       <span className="min-w-0 flex-1 truncate">
-        {/* Why: the selected-row fill is strong enough to wash out the dimmed
-            prompt/secondary text, so lift both toward full foreground when focused. */}
-        <span className={isFocusedPane ? 'text-foreground' : 'text-muted-foreground/90'}>
+        {/* Why: the selected-row fill washes out dimmed prompt and secondary text. */}
+        <span className={isHighlighted ? 'text-foreground' : 'text-muted-foreground/90'}>
           {primary}
         </span>
         {secondary && (
-          <span className={isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/65'}>
+          <span className={isHighlighted ? 'text-foreground/70' : 'text-muted-foreground/65'}>
             {' '}
             - {secondary}
           </span>
@@ -213,7 +214,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         <span
           className={cn(
             'min-w-0 max-w-24 truncate font-mono text-[10px]',
-            isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/70'
+            isHighlighted ? 'text-foreground/70' : 'text-muted-foreground/70'
           )}
           title={model}
         >
@@ -224,7 +225,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         <span
           className={cn(
             'shrink-0 text-[10px] tabular-nums',
-            isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/70'
+            isHighlighted ? 'text-foreground/70' : 'text-muted-foreground/70'
           )}
         >
           +{childAgentCount}
@@ -236,7 +237,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
           className={cn(
             'shrink-0 text-[10px] tabular-nums',
             // Why: the muted timestamp drops out against the selected-row fill.
-            isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/60'
+            isHighlighted ? 'text-foreground/70' : 'text-muted-foreground/60'
           )}
         >
           {shortTime}
@@ -254,7 +255,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
         hasChildDisclosure && 'worktree-agent-lineage-parent-row',
         isLineageChild && 'worktree-agent-lineage-child-row',
         'flex h-6 items-center gap-1',
-        isFocusedPane && 'bg-worktree-sidebar-accent',
+        isHighlighted && 'bg-worktree-sidebar-accent',
         sendTargetStatus === 'sending' && 'cursor-progress opacity-75',
         sendTargetStatus === 'disabled' && 'cursor-default opacity-60'
       )}
@@ -264,11 +265,16 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       onPointerDown={(e) => e.stopPropagation()}
       onDragStart={(e) => e.stopPropagation()}
       data-focused-agent-pane={isFocusedPane ? 'true' : undefined}
+      data-current={isCurrentAgent ? 'true' : undefined}
       data-agent-send-target={sendTargetStatus}
       role={agent.lineage ? 'treeitem' : undefined}
       aria-level={agent.lineage ? agent.lineage.depth + 1 : undefined}
       aria-expanded={hasChildDisclosure ? childAgentsExpanded : undefined}
-      title={sendTargetDisabledReason ?? `${primary}${secondary ? ` - ${secondary}` : ''}`}
+      aria-selected={agent.lineage ? isCurrentAgent : undefined}
+      title={
+        sendTargetDisabledReason ??
+        `${primarySource || primary}${secondary ? ` - ${secondary}` : ''}`
+      }
     >
       {rowBody}
     </div>

--- a/src/renderer/src/components/sidebar/worktree-subagent-child-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-subagent-child-rows.ts
@@ -1,5 +1,6 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
-import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
+import { resolveCompatibleAgentTypeForOwner } from '../../../../shared/agent-title-owner'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 
 /** Row-identity key for an in-process subagent child row. The NUL separator
@@ -8,6 +9,13 @@ import type { TerminalTab } from '../../../../shared/terminal-tab-types'
  *  `orchestration.parentPaneKey` instead. */
 function subagentRowKey(parentPaneKey: string, subagentId: string): string {
   return `${parentPaneKey}\u0000subagent:${subagentId}`
+}
+
+function resolveSubagentProvider(parentEntry: AgentStatusEntry, tab: TerminalTab): AgentType {
+  const entryAgentType = resolveCompatibleAgentTypeForOwner(parentEntry.agentType, tab.launchAgent)
+  return entryAgentType && entryAgentType !== 'unknown'
+    ? entryAgentType
+    : (tab.launchAgent ?? entryAgentType ?? 'unknown')
 }
 
 /**
@@ -28,6 +36,7 @@ export function buildSubagentChildRows(args: {
   if (!subagents || subagents.length === 0) {
     return []
   }
+  const provider = resolveSubagentProvider(args.parentEntry, args.tab)
   return subagents.map((subagent) => {
     const activeState = args.parentIsFresh && subagent.state !== 'idle' ? subagent.state : undefined
     const state = activeState ?? 'idle'
@@ -42,6 +51,7 @@ export function buildSubagentChildRows(args: {
       model: subagent.model,
       paneKey,
       worktreeId: args.parentEntry.worktreeId,
+      connectionId: args.parentEntry.connectionId,
       tabId: args.parentEntry.tabId,
       stateHistory: [],
       orchestration: {
@@ -59,6 +69,11 @@ export function buildSubagentChildRows(args: {
       rowSource: 'subagent' as const,
       state,
       activationPaneKey: args.parentEntry.paneKey,
+      subagentSession: {
+        id: subagent.id,
+        provider,
+        parentPaneKey: args.parentEntry.paneKey
+      },
       startedAt
     }
   })

--- a/src/renderer/src/components/ui/sheet.test.tsx
+++ b/src/renderer/src/components/ui/sheet.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from './sheet'
+
+afterEach(cleanup)
+
+describe('SheetContent', () => {
+  it('can render a non-modal inspector without an overlay', () => {
+    render(
+      <Sheet open modal={false}>
+        <SheetContent showOverlay={false}>
+          <SheetTitle>Progress</SheetTitle>
+          <SheetDescription>Live transcript</SheetDescription>
+        </SheetContent>
+      </Sheet>
+    )
+
+    expect(document.querySelector('[data-slot="sheet-content"]')).not.toBeNull()
+    expect(document.querySelector('[data-slot="sheet-overlay"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/ui/sheet.tsx
+++ b/src/renderer/src/components/ui/sheet.tsx
@@ -72,6 +72,7 @@ function SheetContent({
   children,
   side = 'right',
   showCloseButton = true,
+  showOverlay = true,
   overlayClassName,
   overlayStyle,
   style,
@@ -79,12 +80,13 @@ function SheetContent({
 }: React.ComponentProps<typeof SheetPrimitive.Content> &
   VariantProps<typeof sheetContentVariants> & {
     showCloseButton?: boolean
+    showOverlay?: boolean
     overlayClassName?: string
     overlayStyle?: React.CSSProperties
   }) {
   return (
     <SheetPortal>
-      <SheetOverlay className={overlayClassName} style={overlayStyle} />
+      {showOverlay ? <SheetOverlay className={overlayClassName} style={overlayStyle} /> : null}
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(sheetContentVariants({ side }), className)}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16238,6 +16238,28 @@
       "deliveryFailed": "The new {{agent}} session started, but its context could not be sent.",
       "launchFailed": "Could not start a new {{agent}} session."
     },
+    "codex-subagent-progress": {
+      "loading": {
+        "title": "Waiting for subagent output…",
+        "subtitle": "New messages, reasoning, and tool activity will appear here as Codex writes them."
+      },
+      "empty": {
+        "title": "No transcript entries",
+        "subtitle": "This subagent did not write any visible messages or tool activity."
+      },
+      "error": {
+        "title": "Subagent progress unavailable",
+        "subtitle": "The subagent transcript could not be read."
+      },
+      "unavailable": {
+        "legacy-ssh": "Live subagent transcripts are not available for legacy SSH workspaces.",
+        "runtime-owner-missing": "The remote runtime owner is not available yet. Reopen this view after the workspace reconnects.",
+        "unknown-owner": "Orca could not determine which host owns this subagent transcript."
+      },
+      "read-only": "Read only",
+      "description": "Codex subagent transcript",
+      "title": "Codex subagent progress"
+    },
     "status": {
       "bar": {
         "workspaceSpace": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15897,6 +15897,12 @@
     }
   },
   "components": {
+    "agent-child-disclosure": {
+      "hide-one": "Hide 1 child agent",
+      "hide-other": "Hide {{count}} child agents",
+      "show-one": "Show 1 child agent",
+      "show-other": "Show {{count}} child agents"
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "Image paste is not supported for this agent.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14347,6 +14347,12 @@
     }
   },
   "components": {
+    "agent-child-disclosure": {
+      "hide-one": "Ocultar 1 subagente",
+      "hide-other": "Ocultar {{count}} subagentes",
+      "show-one": "Mostrar 1 subagente",
+      "show-other": "Mostrar {{count}} subagentes"
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "Este agente no admite pegar imágenes.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14348,10 +14348,10 @@
   },
   "components": {
     "agent-child-disclosure": {
-      "hide-one": "1 個のサブエージェントを非表示",
-      "hide-other": "{{count}} 個のサブエージェントを非表示",
-      "show-one": "1 個のサブエージェントを表示",
-      "show-other": "{{count}} 個のサブエージェントを表示"
+      "hide-one": "1 個のサブ Agent を非表示",
+      "hide-other": "{{count}} 個のサブ Agent を非表示",
+      "show-one": "1 個のサブ Agent を表示",
+      "show-other": "{{count}} 個のサブ Agent を表示"
     },
     "native-chat": {
       "composer": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14347,6 +14347,12 @@
     }
   },
   "components": {
+    "agent-child-disclosure": {
+      "hide-one": "1 個のサブエージェントを非表示",
+      "hide-other": "{{count}} 個のサブエージェントを非表示",
+      "show-one": "1 個のサブエージェントを表示",
+      "show-other": "{{count}} 個のサブエージェントを表示"
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "この Agent では画像の貼り付けはサポートされていません。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14376,6 +14376,12 @@
     }
   },
   "components": {
+    "agent-child-disclosure": {
+      "hide-one": "하위 에이전트 1개 숨기기",
+      "hide-other": "하위 에이전트 {{count}}개 숨기기",
+      "show-one": "하위 에이전트 1개 표시",
+      "show-other": "하위 에이전트 {{count}}개 표시"
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "이 에이전트는 이미지 붙여넣기를 지원하지 않습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14367,6 +14367,12 @@
     }
   },
   "components": {
+    "agent-child-disclosure": {
+      "hide-one": "隐藏 1 个子智能体",
+      "hide-other": "隐藏 {{count}} 个子智能体",
+      "show-one": "显示 1 个子智能体",
+      "show-other": "显示 {{count}} 个子智能体"
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "此智能体不支持粘贴图片。",

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -815,6 +815,7 @@ export type UISlice = {
     | 'feature-wall'
     | 'feature-tips'
     | 'new-workspace-composer'
+    | 'codex-subagent-progress'
     | 'confirm-orca-yaml-hooks'
   modalData: Record<string, unknown>
   openModal: (modal: UISlice['activeModal'], data?: Record<string, unknown>) => void

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -50,6 +50,8 @@ import {
 } from './codex-subagent-roster'
 import {
   createCodexSubagentTranscriptState,
+  finishTrackedCodexTranscriptSubagent,
+  hasTrackedCodexParentTranscript,
   hasTrackedCodexTranscriptSubagents,
   reconcileCodexSubagentTranscript,
   type CodexSubagentTranscriptState
@@ -3633,6 +3635,10 @@ export function hasCodexTranscriptSubagents(state: HookListenerState, paneKey: s
   return hasTrackedCodexTranscriptSubagents(state.codexSubagentTranscriptByPaneKey.get(paneKey))
 }
 
+export function hasCodexParentTranscript(state: HookListenerState, paneKey: string): boolean {
+  return hasTrackedCodexParentTranscript(state.codexSubagentTranscriptByPaneKey.get(paneKey))
+}
+
 export function seedCodexStateFromSnapshot(
   state: HookListenerState,
   paneKey: string,
@@ -3784,6 +3790,23 @@ function buildCodexChildDrivenStatusPayload(
   })
 }
 
+export function refreshCodexSubagentTranscriptStatus(
+  state: HookListenerState,
+  paneKey: string
+): ParsedAgentStatusPayload | null {
+  const transcriptState = state.codexSubagentTranscriptByPaneKey.get(paneKey)
+  const transcriptPath = transcriptState?.parent.filePath
+  if (!transcriptState || !transcriptPath) {
+    return null
+  }
+  reconcileCodexSubagentTranscript(
+    transcriptState,
+    getOrCreateCodexSubagentRoster(state, paneKey),
+    transcriptPath
+  )
+  return buildCodexChildDrivenStatusPayload(state, undefined, paneKey, {})
+}
+
 function normalizeCodexSubagentLifecycleEvent(
   state: HookListenerState,
   eventName: 'SubagentStart' | 'SubagentStop',
@@ -3808,6 +3831,10 @@ function normalizeCodexSubagentLifecycleEvent(
     )
   } else {
     finishCodexSubagent(roster, agentId)
+    finishTrackedCodexTranscriptSubagent(
+      state.codexSubagentTranscriptByPaneKey.get(paneKey),
+      agentId
+    )
   }
   return buildCodexChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
 }

--- a/src/shared/codex-subagent-roster.test.ts
+++ b/src/shared/codex-subagent-roster.test.ts
@@ -5,6 +5,7 @@ import {
   AGENT_TYPE_MAX_LENGTH
 } from './agent-status-types'
 import {
+  codexRosterEffectiveState,
   codexRosterToSnapshots,
   finishCodexSubagent,
   setCodexSubagentModel,
@@ -111,5 +112,18 @@ describe('Codex subagent roster', () => {
 
       expect(roster.get('child-1')?.model).toHaveLength(AGENT_MODEL_MAX_LENGTH)
     })
+  })
+
+  it('does not keep a completed lead working for a parked child', () => {
+    const roster: CodexSubagentRoster = new Map()
+
+    upsertCodexSubagent(roster, 'child-1', { state: 'idle' }, 10)
+    expect(codexRosterEffectiveState(roster, 'done')).toBe('done')
+
+    upsertCodexSubagent(roster, 'child-1', { state: 'working' }, 10)
+    expect(codexRosterEffectiveState(roster, 'done')).toBe('working')
+
+    upsertCodexSubagent(roster, 'child-1', { state: 'waiting' }, 10)
+    expect(codexRosterEffectiveState(roster, 'done')).toBe('waiting')
   })
 })

--- a/src/shared/codex-subagent-roster.ts
+++ b/src/shared/codex-subagent-roster.ts
@@ -15,7 +15,7 @@ type TrackedCodexSubagent = {
   agentType?: string
   description?: string
   model?: string
-  state: 'working' | 'waiting'
+  state: 'working' | 'waiting' | 'idle'
   startedAt: number
 }
 
@@ -26,7 +26,7 @@ export function upsertCodexSubagent(
     agentType?: string
     description?: string
     model?: string
-    state: 'working' | 'waiting'
+    state: 'working' | 'waiting' | 'idle'
   },
   now: number
 ): void {
@@ -88,7 +88,7 @@ export function seedCodexSubagentRoster(
   snapshots: readonly AgentSubagentSnapshot[]
 ): void {
   for (const snapshot of snapshots) {
-    if (snapshot.state !== 'working' && snapshot.state !== 'waiting') {
+    if (snapshot.state !== 'working' && snapshot.state !== 'waiting' && snapshot.state !== 'idle') {
       continue
     }
     upsertCodexSubagent(
@@ -130,10 +130,12 @@ export function codexRosterEffectiveState(
   if (!roster || roster.size === 0) {
     return leadState
   }
+  let hasWorkingChild = false
   for (const tracked of roster.values()) {
     if (tracked.state === 'waiting') {
       return 'waiting'
     }
+    hasWorkingChild ||= tracked.state === 'working'
   }
-  return leadState === 'done' ? 'working' : leadState
+  return leadState === 'done' && hasWorkingChild ? 'working' : leadState
 }

--- a/src/shared/codex-subagent-transcript-lifecycle.ts
+++ b/src/shared/codex-subagent-transcript-lifecycle.ts
@@ -24,6 +24,8 @@ export function reconcileCodexSubagentTranscriptLifecycle(
       state = 'working'
     } else if (recordValue.type === 'event_msg' && payload.type === 'task_complete') {
       complete = true
+    } else if (recordValue.type === 'event_msg' && payload.type === 'agent_message') {
+      state = 'working'
     } else if (recordValue.type === 'response_item' && payload.type === 'function_call') {
       const toolName = typeof payload.name === 'string' ? payload.name : undefined
       state =
@@ -33,7 +35,6 @@ export function reconcileCodexSubagentTranscriptLifecycle(
       (payload.type === 'function_call_output' ||
         payload.type === 'custom_tool_call' ||
         payload.type === 'custom_tool_call_output' ||
-        payload.type === 'agent_message' ||
         payload.type === 'message')
     ) {
       state = 'working'

--- a/src/shared/codex-subagent-transcript-lifecycle.ts
+++ b/src/shared/codex-subagent-transcript-lifecycle.ts
@@ -1,0 +1,43 @@
+import { isAskUserQuestionTool } from './agent-question-answered-intent'
+
+type JsonRecord = Record<string, unknown>
+
+export type CodexSubagentTranscriptLifecycleState = 'working' | 'waiting' | 'idle'
+
+function record(value: unknown): JsonRecord | undefined {
+  return typeof value === 'object' && value !== null ? (value as JsonRecord) : undefined
+}
+
+export function reconcileCodexSubagentTranscriptLifecycle(
+  records: readonly JsonRecord[],
+  initialState: CodexSubagentTranscriptLifecycleState
+): { complete: boolean; state: CodexSubagentTranscriptLifecycleState } {
+  let complete = false
+  let state = initialState
+  for (const recordValue of records) {
+    const payload = record(recordValue.payload)
+    if (!payload) {
+      continue
+    }
+    if (recordValue.type === 'event_msg' && payload.type === 'task_started') {
+      complete = false
+      state = 'working'
+    } else if (recordValue.type === 'event_msg' && payload.type === 'task_complete') {
+      complete = true
+    } else if (recordValue.type === 'response_item' && payload.type === 'function_call') {
+      const toolName = typeof payload.name === 'string' ? payload.name : undefined
+      state =
+        toolName === 'wait_agent' ? 'idle' : isAskUserQuestionTool(toolName) ? 'waiting' : 'working'
+    } else if (
+      recordValue.type === 'response_item' &&
+      (payload.type === 'function_call_output' ||
+        payload.type === 'custom_tool_call' ||
+        payload.type === 'custom_tool_call_output' ||
+        payload.type === 'agent_message' ||
+        payload.type === 'message')
+    ) {
+      state = 'working'
+    }
+  }
+  return { complete, state }
+}

--- a/src/shared/codex-subagent-transcript-model.ts
+++ b/src/shared/codex-subagent-transcript-model.ts
@@ -1,0 +1,22 @@
+type JsonRecord = Record<string, unknown>
+
+function record(value: unknown): JsonRecord | undefined {
+  return typeof value === 'object' && value !== null ? (value as JsonRecord) : undefined
+}
+
+export function readCodexSubagentTranscriptModel(
+  records: readonly JsonRecord[]
+): string | undefined {
+  let model: string | undefined
+  for (const recordValue of records) {
+    if (recordValue.type !== 'turn_context') {
+      continue
+    }
+    const payload = record(recordValue.payload)
+    const value = typeof payload?.model === 'string' ? payload.model.trim() : ''
+    if (value) {
+      model = value
+    }
+  }
+  return model
+}

--- a/src/shared/codex-subagent-transcript.test.ts
+++ b/src/shared/codex-subagent-transcript.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import type * as NodeFs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -287,5 +287,77 @@ describe('Codex subagent transcript reconciliation', () => {
       expect(openSyncCalls).toHaveBeenCalledTimes(2)
       expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
     })
+  })
+
+  it('marks a child idle while wait_agent is pending and working when it resumes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'codex-subagent-transcript-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const childPath = join(dir, `rollout-child-${CHILD_ID}.jsonl`)
+    writeFileSync(parentPath, jsonl([activity('started')]))
+    writeFileSync(
+      childPath,
+      jsonl([
+        { type: 'event_msg', payload: { type: 'task_started' } },
+        {
+          type: 'response_item',
+          payload: { type: 'function_call', name: 'wait_agent', call_id: 'call-wait-1' }
+        }
+      ])
+    )
+    const state = createCodexSubagentTranscriptState()
+    const roster: CodexSubagentRoster = new Map()
+
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+    expect(codexRosterToSnapshots(roster)?.[0]?.state).toBe('idle')
+
+    appendFileSync(
+      childPath,
+      jsonl([
+        {
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call-wait-1', output: '' }
+        },
+        {
+          type: 'response_item',
+          payload: { type: 'agent_message', author: '/root', recipient: '/root/test_agent' }
+        }
+      ])
+    )
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+    expect(codexRosterToSnapshots(roster)?.[0]?.state).toBe('working')
+
+    appendFileSync(
+      childPath,
+      jsonl([
+        {
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'request_user_input',
+            call_id: 'call-question'
+          }
+        }
+      ])
+    )
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+    expect(codexRosterToSnapshots(roster)?.[0]?.state).toBe('waiting')
+
+    appendFileSync(
+      childPath,
+      jsonl([
+        {
+          type: 'response_item',
+          payload: { type: 'function_call_output', call_id: 'call-question', output: '' }
+        },
+        {
+          type: 'response_item',
+          payload: { type: 'function_call', name: 'wait_agent', call_id: 'call-wait-2' }
+        }
+      ])
+    )
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+    expect(codexRosterToSnapshots(roster)?.[0]?.state).toBe('idle')
+    expect(hasTrackedCodexTranscriptSubagents(state)).toBe(true)
   })
 })

--- a/src/shared/codex-subagent-transcript.test.ts
+++ b/src/shared/codex-subagent-transcript.test.ts
@@ -315,12 +315,8 @@ describe('Codex subagent transcript reconciliation', () => {
       childPath,
       jsonl([
         {
-          type: 'response_item',
-          payload: { type: 'function_call_output', call_id: 'call-wait-1', output: '' }
-        },
-        {
-          type: 'response_item',
-          payload: { type: 'agent_message', author: '/root', recipient: '/root/test_agent' }
+          type: 'event_msg',
+          payload: { type: 'agent_message', message: 'Resumed work' }
         }
       ])
     )

--- a/src/shared/codex-subagent-transcript.ts
+++ b/src/shared/codex-subagent-transcript.ts
@@ -7,6 +7,10 @@ import {
   upsertCodexSubagent,
   type CodexSubagentRoster
 } from './codex-subagent-roster'
+import {
+  reconcileCodexSubagentTranscriptLifecycle,
+  type CodexSubagentTranscriptLifecycleState
+} from './codex-subagent-transcript-lifecycle'
 
 const TRANSCRIPT_READ_MAX_BYTES = 1024 * 1024
 const TRANSCRIPT_LINE_MAX_BYTES = 256 * 1024
@@ -27,6 +31,7 @@ type TrackedTranscriptSubagent = JsonlCursor & {
    *  because the cursor is incremental: `turn_context` is emitted once per
    *  turn, so a later read usually carries no model at all. */
   model?: string
+  state: CodexSubagentTranscriptLifecycleState
   startedAt: number
   unresolvedSince?: number
 }
@@ -222,22 +227,6 @@ function readChildModel(records: JsonRecord[]): string | undefined {
   return model
 }
 
-function childIsComplete(records: JsonRecord[]): boolean {
-  let complete = false
-  for (const recordValue of records) {
-    if (recordValue.type !== 'event_msg') {
-      continue
-    }
-    const payload = record(recordValue.payload)
-    if (payload?.type === 'task_started') {
-      complete = false
-    } else if (payload?.type === 'task_complete') {
-      complete = true
-    }
-  }
-  return complete
-}
-
 export function createCodexSubagentTranscriptState(): CodexSubagentTranscriptState {
   return {
     parent: { offset: 0, carry: '' },
@@ -249,6 +238,19 @@ export function hasTrackedCodexTranscriptSubagents(
   state: CodexSubagentTranscriptState | undefined
 ): boolean {
   return Boolean(state && state.subagents.size > 0)
+}
+
+export function hasTrackedCodexParentTranscript(
+  state: CodexSubagentTranscriptState | undefined
+): boolean {
+  return Boolean(state?.parent.filePath)
+}
+
+export function finishTrackedCodexTranscriptSubagent(
+  state: CodexSubagentTranscriptState | undefined,
+  id: string
+): void {
+  state?.subagents.delete(id.trim())
 }
 
 export function reconcileCodexSubagentTranscript(
@@ -280,9 +282,11 @@ export function reconcileCodexSubagentTranscript(
     const tracked = state.subagents.get(activity.id) ?? {
       offset: 0,
       carry: '',
+      state: 'working',
       startedAt: activity.startedAt
     }
     tracked.description = activity.description ?? tracked.description
+    tracked.state = 'working'
     state.subagents.set(activity.id, tracked)
     upsertCodexSubagent(
       roster,
@@ -313,11 +317,16 @@ export function reconcileCodexSubagentTranscript(
     } else {
       tracked.unresolvedSince = undefined
       tracked.model = readChildModel(records) ?? tracked.model
-      // Why: re-applied every reconcile, not just on discovery — the parent's
-      // own activity upsert can rebuild this child's roster entry, which would
-      // otherwise drop a model found on an earlier poll.
-      setCodexSubagentModel(roster, id, tracked.model)
-      if (!childIsComplete(records)) {
+      const lifecycle = reconcileCodexSubagentTranscriptLifecycle(records, tracked.state)
+      tracked.state = lifecycle.state
+      if (!lifecycle.complete) {
+        upsertCodexSubagent(
+          roster,
+          id,
+          { description: tracked.description, state: tracked.state },
+          tracked.startedAt
+        )
+        setCodexSubagentModel(roster, id, tracked.model)
         continue
       }
     }

--- a/src/shared/codex-subagent-transcript.ts
+++ b/src/shared/codex-subagent-transcript.ts
@@ -11,6 +11,7 @@ import {
   reconcileCodexSubagentTranscriptLifecycle,
   type CodexSubagentTranscriptLifecycleState
 } from './codex-subagent-transcript-lifecycle'
+import { readCodexSubagentTranscriptModel } from './codex-subagent-transcript-model'
 
 const TRANSCRIPT_READ_MAX_BYTES = 1024 * 1024
 const TRANSCRIPT_LINE_MAX_BYTES = 256 * 1024
@@ -209,24 +210,6 @@ function readActivity(recordValue: JsonRecord):
   }
 }
 
-/** Latest model from the child's own `turn_context` records. A child can be
- *  launched on a different model than its parent, so this is read from the
- *  child rollout rather than inherited. */
-function readChildModel(records: JsonRecord[]): string | undefined {
-  let model: string | undefined
-  for (const recordValue of records) {
-    if (recordValue.type !== 'turn_context') {
-      continue
-    }
-    const payload = record(recordValue.payload)
-    const value = typeof payload?.model === 'string' ? payload.model.trim() : ''
-    if (value) {
-      model = value
-    }
-  }
-  return model
-}
-
 export function createCodexSubagentTranscriptState(): CodexSubagentTranscriptState {
   return {
     parent: { offset: 0, carry: '' },
@@ -316,7 +299,7 @@ export function reconcileCodexSubagentTranscript(
       }
     } else {
       tracked.unresolvedSince = undefined
-      tracked.model = readChildModel(records) ?? tracked.model
+      tracked.model = readCodexSubagentTranscriptModel(records) ?? tracked.model
       const lifecycle = reconcileCodexSubagentTranscriptLifecycle(records, tracked.state)
       tracked.state = lifecycle.state
       if (!lifecycle.complete) {

--- a/tests/e2e/codex-subagent-concurrent-progress.spec.ts
+++ b/tests/e2e/codex-subagent-concurrent-progress.spec.ts
@@ -70,8 +70,8 @@ test.describe('Codex concurrent subagent progress', () => {
     appendSubagentActivity(context, secondChildId, secondPath, 'started', secondStartedAt)
 
     await expandParentChildren(orcaPage, context.prompt)
-    const firstRow = childAgentRow(orcaPage, 'concurrent_first')
-    const secondRow = childAgentRow(orcaPage, 'concurrent_second')
+    const firstRow = childAgentRow(orcaPage, firstChildId)
+    const secondRow = childAgentRow(orcaPage, secondChildId)
     await expect(firstRow).toBeVisible({ timeout: 15_000 })
     await expect(secondRow).toBeVisible({ timeout: 15_000 })
     await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Working')).toBeVisible()
@@ -127,7 +127,7 @@ test.describe('Codex concurrent subagent progress', () => {
     await expect(secondRow).toHaveAttribute('aria-selected', 'true')
 
     appendCodexRecords(firstChildPath, [codexEvent(firstStartedAt + 6, { type: 'task_complete' })])
-    await expect(childAgentRow(orcaPage, 'concurrent_first')).toHaveCount(0, {
+    await expect(childAgentRow(orcaPage, firstChildId)).toHaveCount(0, {
       timeout: 15_000
     })
     await expect(secondRow).toBeVisible()
@@ -136,7 +136,7 @@ test.describe('Codex concurrent subagent progress', () => {
     appendCodexRecords(secondChildPath, [
       codexEvent(secondStartedAt + 2, { type: 'task_complete' })
     ])
-    await expect(childAgentRow(orcaPage, 'concurrent_second')).toHaveCount(0, {
+    await expect(childAgentRow(orcaPage, secondChildId)).toHaveCount(0, {
       timeout: 15_000
     })
     await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Done')).toBeVisible()

--- a/tests/e2e/codex-subagent-concurrent-progress.spec.ts
+++ b/tests/e2e/codex-subagent-concurrent-progress.spec.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from 'node:crypto'
+
+import { test, expect } from './helpers/orca-app'
+import {
+  appendCodexRecords,
+  appendSubagentActivity,
+  childAgentRow,
+  codexEvent,
+  codexProgressSheet,
+  codexResponse,
+  expandParentChildren,
+  parentAgentRow,
+  startCodexSubagentScenario,
+  writeChildRollout
+} from './helpers/codex-subagent-rollout-fixture'
+
+test.describe('Codex concurrent subagent progress', () => {
+  test('switches isolated live transcripts and removes concurrent children independently', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    const context = await startCodexSubagentScenario({
+      page: orcaPage,
+      electronApp,
+      promptPrefix: 'CODEX_CONCURRENT_PARENT'
+    })
+    const firstChildId = randomUUID()
+    const secondChildId = randomUUID()
+    const firstStartedAt = context.startedAt + 10
+    const secondStartedAt = context.startedAt + 20
+    const firstPath = '/root/concurrent_first'
+    const secondPath = '/root/concurrent_second'
+    const firstInitial = `FIRST_INITIAL_${context.startedAt}`
+    const firstReasoning = `FIRST_REASONING_${context.startedAt}`
+    const firstToolOutput = `FIRST_TOOL_OUTPUT_${context.startedAt}`
+    const firstFinal = `FIRST_FINAL_${context.startedAt}`
+    const secondInitial = `SECOND_INITIAL_${context.startedAt}`
+    const firstInherited = `FIRST_INHERITED_PARENT_${context.startedAt}`
+    const secondInherited = `SECOND_INHERITED_PARENT_${context.startedAt}`
+
+    const firstChildPath = writeChildRollout({
+      context,
+      sessionId: firstChildId,
+      agentPath: firstPath,
+      startedAt: firstStartedAt,
+      inheritedUserMarker: firstInherited,
+      records: [
+        codexResponse(firstStartedAt + 1, {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: firstInitial }]
+        })
+      ]
+    })
+    const secondChildPath = writeChildRollout({
+      context,
+      sessionId: secondChildId,
+      agentPath: secondPath,
+      startedAt: secondStartedAt,
+      inheritedAssistantMarker: secondInherited,
+      records: [
+        codexResponse(secondStartedAt + 1, {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: secondInitial }]
+        })
+      ]
+    })
+    appendSubagentActivity(context, firstChildId, firstPath, 'started', firstStartedAt)
+    appendSubagentActivity(context, secondChildId, secondPath, 'started', secondStartedAt)
+
+    await expandParentChildren(orcaPage, context.prompt)
+    const firstRow = childAgentRow(orcaPage, 'concurrent_first')
+    const secondRow = childAgentRow(orcaPage, 'concurrent_second')
+    await expect(firstRow).toBeVisible({ timeout: 15_000 })
+    await expect(secondRow).toBeVisible({ timeout: 15_000 })
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Working')).toBeVisible()
+
+    await firstRow.click()
+    const progressSheet = codexProgressSheet(orcaPage)
+    await expect(progressSheet).toBeVisible({ timeout: 15_000 })
+    await expect(progressSheet.getByRole('heading', { name: firstPath, exact: true })).toBeVisible()
+    await expect(progressSheet.getByText(firstInitial, { exact: true })).toBeVisible()
+    await expect(progressSheet.getByText(firstInherited, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(secondInitial, { exact: true })).toHaveCount(0)
+    await expect(firstRow).toHaveAttribute('aria-selected', 'true')
+    await expect(secondRow).toHaveAttribute('aria-selected', 'false')
+
+    appendCodexRecords(firstChildPath, [
+      codexResponse(firstStartedAt + 2, {
+        type: 'reasoning',
+        summary: [{ type: 'summary_text', text: firstReasoning }]
+      }),
+      codexResponse(firstStartedAt + 3, {
+        type: 'custom_tool_call',
+        name: 'exec',
+        input: 'git status --short'
+      }),
+      codexResponse(firstStartedAt + 4, {
+        type: 'custom_tool_call_output',
+        output: [{ type: 'input_text', text: firstToolOutput }]
+      }),
+      codexEvent(firstStartedAt + 5, { type: 'agent_message', message: firstFinal })
+    ])
+    await expect(progressSheet.getByText(firstReasoning, { exact: true })).toBeVisible({
+      timeout: 15_000
+    })
+    await expect(progressSheet.getByText(firstFinal, { exact: true })).toBeVisible({
+      timeout: 15_000
+    })
+    const toolRun = progressSheet.getByRole('button').filter({ hasText: '1×' }).first()
+    await expect(toolRun).toBeVisible()
+    await toolRun.click()
+    await expect(progressSheet.locator('pre').filter({ hasText: firstToolOutput })).toBeVisible()
+
+    await secondRow.click()
+    await expect(
+      progressSheet.getByRole('heading', { name: secondPath, exact: true })
+    ).toBeVisible()
+    await expect(progressSheet.getByText(secondInitial, { exact: true })).toBeVisible()
+    await expect(progressSheet.getByText(secondInherited, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(firstInitial, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(firstReasoning, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(firstToolOutput, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(firstFinal, { exact: true })).toHaveCount(0)
+    await expect(firstRow).toHaveAttribute('aria-selected', 'false')
+    await expect(secondRow).toHaveAttribute('aria-selected', 'true')
+
+    appendCodexRecords(firstChildPath, [codexEvent(firstStartedAt + 6, { type: 'task_complete' })])
+    await expect(childAgentRow(orcaPage, 'concurrent_first')).toHaveCount(0, {
+      timeout: 15_000
+    })
+    await expect(secondRow).toBeVisible()
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Working')).toBeVisible()
+
+    appendCodexRecords(secondChildPath, [
+      codexEvent(secondStartedAt + 2, { type: 'task_complete' })
+    ])
+    await expect(childAgentRow(orcaPage, 'concurrent_second')).toHaveCount(0, {
+      timeout: 15_000
+    })
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Done')).toBeVisible()
+    await expect(progressSheet).toBeVisible()
+    await expect(progressSheet.getByText('Idle', { exact: true })).toBeVisible()
+    await expect(progressSheet.getByText(secondInitial, { exact: true })).toBeVisible()
+  })
+})

--- a/tests/e2e/codex-subagent-sidebar-lifecycle.spec.ts
+++ b/tests/e2e/codex-subagent-sidebar-lifecycle.spec.ts
@@ -1,0 +1,344 @@
+import { randomUUID } from 'node:crypto'
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+
+import type { AgentHookEndpoint } from '../../src/shared/agent-hook-endpoint-file'
+import { test, expect } from './helpers/orca-app'
+import { readHookEndpoint } from './helpers/agent-hook-endpoint'
+import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+function jsonl(records: unknown[]): string {
+  return `${records.map((record) => JSON.stringify(record)).join('\n')}\n`
+}
+
+function subagentActivity(
+  sessionId: string,
+  agentPath: string,
+  kind: 'started' | 'interrupted',
+  occurredAtMs: number
+): string {
+  return jsonl([
+    {
+      type: 'event_msg',
+      payload: {
+        type: 'sub_agent_activity',
+        occurred_at_ms: occurredAtMs,
+        agent_thread_id: sessionId,
+        agent_path: agentPath,
+        kind
+      }
+    }
+  ])
+}
+
+function childTranscript({
+  sessionId,
+  parentSessionId,
+  cwd,
+  progressMarker,
+  inheritedUserMarker,
+  inheritedAssistantMarker,
+  activityStartedAt
+}: {
+  sessionId: string
+  parentSessionId: string
+  cwd: string
+  progressMarker: string
+  inheritedUserMarker: string
+  inheritedAssistantMarker: string
+  activityStartedAt: number
+}): string {
+  const inheritedTimestamp = new Date(activityStartedAt - 1).toISOString()
+  const childTimestamp = new Date(activityStartedAt + 1).toISOString()
+  return jsonl([
+    {
+      type: 'session_meta',
+      timestamp: inheritedTimestamp,
+      payload: {
+        id: sessionId,
+        cwd,
+        thread_source: 'subagent',
+        forked_from_id: parentSessionId,
+        source: {
+          subagent: {
+            thread_spawn: {
+              parent_thread_id: parentSessionId,
+              depth: 1,
+              agent_path: '/root/e2e_child'
+            }
+          }
+        }
+      }
+    },
+    {
+      type: 'response_item',
+      timestamp: inheritedTimestamp,
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'text', text: inheritedUserMarker }]
+      }
+    },
+    {
+      type: 'response_item',
+      timestamp: inheritedTimestamp,
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: inheritedAssistantMarker }]
+      }
+    },
+    {
+      type: 'event_msg',
+      timestamp: childTimestamp,
+      payload: { type: 'task_started' }
+    },
+    {
+      type: 'response_item',
+      timestamp: childTimestamp,
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: progressMarker }]
+      }
+    }
+  ])
+}
+
+async function postCodexHook(
+  endpoint: AgentHookEndpoint,
+  event: {
+    paneKey: string
+    worktreeId: string
+    payload: Record<string, unknown>
+  }
+): Promise<void> {
+  const [tabId] = event.paneKey.split(':')
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/codex`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': endpoint.token
+    },
+    body: JSON.stringify({
+      paneKey: event.paneKey,
+      tabId,
+      worktreeId: event.worktreeId,
+      env: endpoint.env,
+      version: endpoint.version,
+      payload: event.payload
+    })
+  })
+  if (response.status !== 204) {
+    throw new Error(`Codex hook POST returned ${response.status}`)
+  }
+}
+
+async function enableInlineAgentCards(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    if (!state.worktreeCardProperties.includes('inline-agents')) {
+      state.toggleWorktreeCardProperty('inline-agents')
+    }
+    state.closeActivityPage()
+  })
+}
+
+function parentAgentRow(page: Page, prompt: string) {
+  return page.getByRole('treeitem').filter({ hasText: prompt }).first()
+}
+
+async function expandSingleChild(page: Page, prompt: string): Promise<void> {
+  const disclosure = parentAgentRow(page, prompt).locator('button[aria-expanded]')
+  await expect(disclosure).toBeVisible({ timeout: 15_000 })
+  if ((await disclosure.getAttribute('aria-expanded')) === 'false') {
+    await disclosure.click()
+  }
+}
+
+test.describe('Codex subagent sidebar lifecycle', () => {
+  test('discovers, opens, removes, and rediscovers dynamically spawned children', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage)
+    await enableInlineAgentCards(orcaPage)
+
+    const endpoint = await readHookEndpoint(electronApp)
+    const { paneKey, worktreeId } = await waitForActivePaneHookDescriptor(orcaPage)
+    const isolatedHome = await electronApp.evaluate(({ app }) => app.getPath('home'))
+    const cwd = await orcaPage.evaluate((targetWorktreeId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const worktree = Object.values(store.getState().worktreesByRepo)
+        .flat()
+        .find((candidate) => candidate.id === targetWorktreeId)
+      if (!worktree) {
+        throw new Error(`Worktree ${targetWorktreeId} was not found`)
+      }
+      return worktree.path
+    }, worktreeId)
+
+    const startedAt = Date.now()
+    const date = new Date(startedAt)
+    const dayDirectory = path.join(
+      isolatedHome,
+      '.codex',
+      'sessions',
+      String(date.getFullYear()),
+      String(date.getMonth() + 1).padStart(2, '0'),
+      String(date.getDate()).padStart(2, '0')
+    )
+    mkdirSync(dayDirectory, { recursive: true })
+
+    const parentSessionId = randomUUID()
+    const firstChildId = randomUUID()
+    const secondChildId = randomUUID()
+    const parentPath = path.join(dayDirectory, `rollout-e2e-parent-${parentSessionId}.jsonl`)
+    const firstChildPath = path.join(dayDirectory, `rollout-e2e-child-${firstChildId}.jsonl`)
+    const secondChildPath = path.join(dayDirectory, `rollout-e2e-child-${secondChildId}.jsonl`)
+    const prompt = `CODEX_DYNAMIC_PARENT_${startedAt}`
+    const firstProgress = `FIRST_CHILD_PROGRESS_${startedAt}`
+    const secondProgress = `SECOND_CHILD_PROGRESS_${startedAt}`
+    const firstInheritedUser = `FIRST_PARENT_HISTORY_USER_${startedAt}`
+    const firstInheritedAssistant = `FIRST_PARENT_HISTORY_ASSISTANT_${startedAt}`
+    const secondInheritedUser = `SECOND_PARENT_HISTORY_USER_${startedAt}`
+    const secondInheritedAssistant = `SECOND_PARENT_HISTORY_ASSISTANT_${startedAt}`
+
+    writeFileSync(
+      parentPath,
+      jsonl([
+        {
+          type: 'session_meta',
+          timestamp: new Date(startedAt).toISOString(),
+          payload: { id: parentSessionId, cwd }
+        },
+        {
+          type: 'event_msg',
+          timestamp: new Date(startedAt).toISOString(),
+          payload: { type: 'task_started' }
+        }
+      ])
+    )
+    writeFileSync(
+      firstChildPath,
+      childTranscript({
+        sessionId: firstChildId,
+        parentSessionId,
+        cwd,
+        progressMarker: firstProgress,
+        inheritedUserMarker: firstInheritedUser,
+        inheritedAssistantMarker: firstInheritedAssistant,
+        activityStartedAt: startedAt + 1
+      })
+    )
+    writeFileSync(
+      secondChildPath,
+      childTranscript({
+        sessionId: secondChildId,
+        parentSessionId,
+        cwd,
+        progressMarker: secondProgress,
+        inheritedUserMarker: secondInheritedUser,
+        inheritedAssistantMarker: secondInheritedAssistant,
+        activityStartedAt: startedAt + 3
+      })
+    )
+
+    await postCodexHook(endpoint, {
+      paneKey,
+      worktreeId,
+      payload: {
+        hook_event_name: 'UserPromptSubmit',
+        session_id: parentSessionId,
+        transcript_path: parentPath,
+        prompt
+      }
+    })
+    await postCodexHook(endpoint, {
+      paneKey,
+      worktreeId,
+      payload: {
+        hook_event_name: 'Stop',
+        session_id: parentSessionId,
+        transcript_path: parentPath
+      }
+    })
+
+    await expect(orcaPage.getByText(prompt, { exact: true })).toBeVisible({ timeout: 15_000 })
+
+    appendFileSync(
+      parentPath,
+      subagentActivity(firstChildId, '/root/first_live_child', 'started', startedAt + 1)
+    )
+    await expandSingleChild(orcaPage, prompt)
+    const firstChild = orcaPage
+      .getByRole('treeitem')
+      .filter({ hasText: 'first_live_child' })
+      .first()
+    await expect(firstChild).toBeVisible({ timeout: 15_000 })
+    await firstChild.click()
+
+    const progressSheet = orcaPage.locator('[data-codex-subagent-progress]')
+    await expect(progressSheet).toBeVisible({ timeout: 15_000 })
+    await expect(
+      progressSheet.getByRole('heading', { name: '/root/first_live_child', exact: true })
+    ).toBeVisible()
+    await expect(progressSheet.getByText(firstProgress, { exact: true })).toBeVisible({
+      timeout: 15_000
+    })
+    await expect(progressSheet.getByText(firstInheritedUser, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(firstInheritedAssistant, { exact: true })).toHaveCount(0)
+    await orcaPage.keyboard.press('Escape')
+    await expect(progressSheet).toBeHidden()
+
+    appendFileSync(
+      parentPath,
+      subagentActivity(firstChildId, '/root/first_live_child', 'interrupted', startedAt + 2)
+    )
+    await expect(orcaPage.getByText('first_live_child', { exact: true })).toHaveCount(0, {
+      timeout: 15_000
+    })
+    await expect(parentAgentRow(orcaPage, prompt).locator('button[aria-expanded]')).toHaveCount(0)
+
+    appendFileSync(
+      parentPath,
+      subagentActivity(secondChildId, '/root/second_live_child', 'started', startedAt + 3)
+    )
+    await expandSingleChild(orcaPage, prompt)
+    const secondChild = orcaPage
+      .getByRole('treeitem')
+      .filter({ hasText: 'second_live_child' })
+      .first()
+    await expect(secondChild).toBeVisible({ timeout: 15_000 })
+    await secondChild.click()
+    await expect(progressSheet.getByText(secondProgress, { exact: true })).toBeVisible({
+      timeout: 15_000
+    })
+    await expect(progressSheet.getByText(secondInheritedUser, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(secondInheritedAssistant, { exact: true })).toHaveCount(0)
+    await orcaPage.keyboard.press('Escape')
+    await expect(progressSheet).toBeHidden()
+
+    appendFileSync(
+      secondChildPath,
+      jsonl([{ type: 'event_msg', payload: { type: 'task_complete' } }])
+    )
+    await expect(orcaPage.getByText('second_live_child', { exact: true })).toHaveCount(0, {
+      timeout: 15_000
+    })
+    await expect(parentAgentRow(orcaPage, prompt).locator('button[aria-expanded]')).toHaveCount(0)
+    await expect(parentAgentRow(orcaPage, prompt).getByLabel('Done', { exact: true })).toBeVisible()
+  })
+})

--- a/tests/e2e/codex-subagent-state-and-session.spec.ts
+++ b/tests/e2e/codex-subagent-state-and-session.spec.ts
@@ -38,7 +38,7 @@ test.describe('Codex subagent state and session boundaries', () => {
 
     appendSubagentActivity(context, childId, agentPath, 'started', childStartedAt)
     await expandParentChildren(orcaPage, context.prompt)
-    const childRow = childAgentRow(orcaPage, 'state_transitions')
+    const childRow = childAgentRow(orcaPage, childId)
     await expect(childRow).toBeVisible({ timeout: 15_000 })
     await childRow.click()
 
@@ -119,7 +119,7 @@ test.describe('Codex subagent state and session boundaries', () => {
     await expect(progressSheet.getByText(answeredProgress, { exact: true })).toBeVisible()
 
     appendCodexRecords(childPath, [codexEvent(childStartedAt + 8, { type: 'task_complete' })])
-    await expect(childAgentRow(orcaPage, 'state_transitions')).toHaveCount(0, {
+    await expect(childAgentRow(orcaPage, childId)).toHaveCount(0, {
       timeout: 15_000
     })
     await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Done')).toBeVisible()
@@ -154,7 +154,7 @@ test.describe('Codex subagent state and session boundaries', () => {
       oldStartedAt
     )
     await expandParentChildren(orcaPage, firstContext.prompt)
-    await expect(childAgentRow(orcaPage, 'old_session_child')).toBeVisible({ timeout: 15_000 })
+    await expect(childAgentRow(orcaPage, oldChildId)).toBeVisible({ timeout: 15_000 })
 
     const nextSessionId = randomUUID()
     const nextStartedAt = firstContext.startedAt + 100
@@ -210,7 +210,7 @@ test.describe('Codex subagent state and session boundaries', () => {
       }
     })
     await expect(orcaPage.getByText(nextPrompt, { exact: true })).toBeVisible({ timeout: 15_000 })
-    await expect(childAgentRow(orcaPage, 'old_session_child')).toHaveCount(0)
+    await expect(childAgentRow(orcaPage, oldChildId)).toHaveCount(0)
 
     const staleChildId = randomUUID()
     const currentChildId = randomUUID()
@@ -254,9 +254,9 @@ test.describe('Codex subagent state and session boundaries', () => {
     )
 
     await expandParentChildren(orcaPage, nextPrompt)
-    const currentRow = childAgentRow(orcaPage, 'current_session_child')
+    const currentRow = childAgentRow(orcaPage, currentChildId)
     await expect(currentRow).toBeVisible({ timeout: 15_000 })
-    await expect(childAgentRow(orcaPage, 'stale_watcher_child')).toHaveCount(0)
+    await expect(childAgentRow(orcaPage, staleChildId)).toHaveCount(0)
     await currentRow.click()
     const progressSheet = codexProgressSheet(orcaPage)
     await expect(progressSheet.getByText(currentProgress, { exact: true })).toBeVisible({
@@ -268,7 +268,7 @@ test.describe('Codex subagent state and session boundaries', () => {
     appendCodexRecords(currentChildPath, [
       codexEvent(currentStartedAt + 2, { type: 'task_complete' })
     ])
-    await expect(childAgentRow(orcaPage, 'current_session_child')).toHaveCount(0, {
+    await expect(childAgentRow(orcaPage, currentChildId)).toHaveCount(0, {
       timeout: 15_000
     })
     await expect(parentAgentRow(orcaPage, nextPrompt).getByLabel('Done')).toBeVisible()

--- a/tests/e2e/codex-subagent-state-and-session.spec.ts
+++ b/tests/e2e/codex-subagent-state-and-session.spec.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from 'node:crypto'
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { test, expect } from './helpers/orca-app'
+import {
+  appendCodexRecords,
+  appendSubagentActivity,
+  childAgentRow,
+  codexEvent,
+  codexJsonl,
+  codexProgressSheet,
+  codexResponse,
+  expandParentChildren,
+  parentAgentRow,
+  postCodexHook,
+  startCodexSubagentScenario,
+  writeChildRollout,
+  type CodexSubagentE2EContext
+} from './helpers/codex-subagent-rollout-fixture'
+
+test.describe('Codex subagent state and session boundaries', () => {
+  test('recovers a late rollout and renders idle, resumed, waiting, and completed states', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    const context = await startCodexSubagentScenario({
+      page: orcaPage,
+      electronApp,
+      promptPrefix: 'CODEX_STATE_PARENT'
+    })
+    const childId = randomUUID()
+    const childStartedAt = context.startedAt + 10
+    const agentPath = '/root/state_transitions'
+    const initialProgress = `STATE_INITIAL_${context.startedAt}`
+    const resumedProgress = `STATE_RESUMED_${context.startedAt}`
+    const answeredProgress = `STATE_ANSWERED_${context.startedAt}`
+
+    appendSubagentActivity(context, childId, agentPath, 'started', childStartedAt)
+    await expandParentChildren(orcaPage, context.prompt)
+    const childRow = childAgentRow(orcaPage, 'state_transitions')
+    await expect(childRow).toBeVisible({ timeout: 15_000 })
+    await childRow.click()
+
+    const progressSheet = codexProgressSheet(orcaPage)
+    await expect(progressSheet).toBeVisible({ timeout: 15_000 })
+    await expect(
+      progressSheet.getByText('Waiting for subagent output…', { exact: true })
+    ).toBeVisible()
+
+    const childPath = writeChildRollout({
+      context,
+      sessionId: childId,
+      agentPath,
+      startedAt: childStartedAt,
+      records: [
+        codexResponse(childStartedAt + 1, {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: initialProgress }]
+        })
+      ]
+    })
+    await expect(progressSheet.getByText(initialProgress, { exact: true })).toBeVisible({
+      timeout: 15_000
+    })
+    await expect(childRow.getByLabel('Working')).toBeVisible()
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Working')).toBeVisible()
+
+    appendCodexRecords(childPath, [
+      codexResponse(childStartedAt + 2, {
+        type: 'function_call',
+        name: 'wait_agent',
+        call_id: 'wait-1',
+        arguments: '{}'
+      })
+    ])
+    await expect(childRow.getByLabel('Idle')).toBeVisible({ timeout: 15_000 })
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Done')).toBeVisible()
+    await expect(progressSheet.getByText('Idle', { exact: true })).toBeVisible()
+
+    appendCodexRecords(childPath, [
+      codexResponse(childStartedAt + 3, {
+        type: 'function_call_output',
+        call_id: 'wait-1',
+        output: ''
+      }),
+      codexEvent(childStartedAt + 4, { type: 'agent_message', message: resumedProgress })
+    ])
+    await expect(childRow.getByLabel('Working')).toBeVisible({ timeout: 15_000 })
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Working')).toBeVisible()
+    await expect(progressSheet.getByText('Working', { exact: true })).toBeVisible()
+    await expect(progressSheet.getByText(resumedProgress, { exact: true })).toBeVisible()
+
+    appendCodexRecords(childPath, [
+      codexResponse(childStartedAt + 5, {
+        type: 'function_call',
+        name: 'request_user_input',
+        call_id: 'question-1',
+        arguments: '{"questions":[]}'
+      })
+    ])
+    await expect(childRow.getByLabel('Waiting for input')).toBeVisible({ timeout: 15_000 })
+    await expect(
+      parentAgentRow(orcaPage, context.prompt).getByLabel('Waiting for input')
+    ).toBeVisible()
+    await expect(progressSheet.getByText('Waiting for input', { exact: true })).toBeVisible()
+
+    appendCodexRecords(childPath, [
+      codexResponse(childStartedAt + 6, {
+        type: 'function_call_output',
+        call_id: 'question-1',
+        output: 'confirmed'
+      }),
+      codexEvent(childStartedAt + 7, { type: 'agent_message', message: answeredProgress })
+    ])
+    await expect(childRow.getByLabel('Working')).toBeVisible({ timeout: 15_000 })
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Working')).toBeVisible()
+    await expect(progressSheet.getByText(answeredProgress, { exact: true })).toBeVisible()
+
+    appendCodexRecords(childPath, [codexEvent(childStartedAt + 8, { type: 'task_complete' })])
+    await expect(childAgentRow(orcaPage, 'state_transitions')).toHaveCount(0, {
+      timeout: 15_000
+    })
+    await expect(parentAgentRow(orcaPage, context.prompt).getByLabel('Done')).toBeVisible()
+    await expect(progressSheet.getByText('Idle', { exact: true })).toBeVisible()
+    await expect(progressSheet.getByText(answeredProgress, { exact: true })).toBeVisible()
+  })
+
+  test('drops the prior child roster when the parent pane starts a new Codex session', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    const firstContext = await startCodexSubagentScenario({
+      page: orcaPage,
+      electronApp,
+      promptPrefix: 'CODEX_FIRST_SESSION'
+    })
+    const oldChildId = randomUUID()
+    const oldStartedAt = firstContext.startedAt + 10
+    const oldProgress = `OLD_CHILD_PROGRESS_${firstContext.startedAt}`
+    writeChildRollout({
+      context: firstContext,
+      sessionId: oldChildId,
+      agentPath: '/root/old_session_child',
+      startedAt: oldStartedAt,
+      records: [codexEvent(oldStartedAt + 1, { type: 'agent_message', message: oldProgress })]
+    })
+    appendSubagentActivity(
+      firstContext,
+      oldChildId,
+      '/root/old_session_child',
+      'started',
+      oldStartedAt
+    )
+    await expandParentChildren(orcaPage, firstContext.prompt)
+    await expect(childAgentRow(orcaPage, 'old_session_child')).toBeVisible({ timeout: 15_000 })
+
+    const nextSessionId = randomUUID()
+    const nextStartedAt = firstContext.startedAt + 100
+    const nextPrompt = `CODEX_NEXT_SESSION_${firstContext.startedAt}`
+    const nextParentPath = path.join(
+      firstContext.dayDirectory,
+      `rollout-e2e-parent-${nextSessionId}.jsonl`
+    )
+    writeFileSync(
+      nextParentPath,
+      codexJsonl([
+        {
+          type: 'session_meta',
+          timestamp: new Date(nextStartedAt).toISOString(),
+          payload: { id: nextSessionId, cwd: firstContext.cwd }
+        },
+        codexEvent(nextStartedAt, { type: 'task_started' })
+      ])
+    )
+    const nextContext: CodexSubagentE2EContext = {
+      ...firstContext,
+      parentPath: nextParentPath,
+      parentSessionId: nextSessionId,
+      prompt: nextPrompt,
+      startedAt: nextStartedAt
+    }
+    await postCodexHook(firstContext.endpoint, {
+      paneKey: firstContext.paneKey,
+      worktreeId: firstContext.worktreeId,
+      payload: {
+        hook_event_name: 'SessionStart',
+        session_id: nextSessionId,
+        transcript_path: nextParentPath
+      }
+    })
+    await postCodexHook(firstContext.endpoint, {
+      paneKey: firstContext.paneKey,
+      worktreeId: firstContext.worktreeId,
+      payload: {
+        hook_event_name: 'UserPromptSubmit',
+        session_id: nextSessionId,
+        transcript_path: nextParentPath,
+        prompt: nextPrompt
+      }
+    })
+    await postCodexHook(firstContext.endpoint, {
+      paneKey: firstContext.paneKey,
+      worktreeId: firstContext.worktreeId,
+      payload: {
+        hook_event_name: 'Stop',
+        session_id: nextSessionId,
+        transcript_path: nextParentPath
+      }
+    })
+    await expect(orcaPage.getByText(nextPrompt, { exact: true })).toBeVisible({ timeout: 15_000 })
+    await expect(childAgentRow(orcaPage, 'old_session_child')).toHaveCount(0)
+
+    const staleChildId = randomUUID()
+    const currentChildId = randomUUID()
+    const staleStartedAt = nextStartedAt + 10
+    const currentStartedAt = nextStartedAt + 20
+    writeChildRollout({
+      context: firstContext,
+      sessionId: staleChildId,
+      agentPath: '/root/stale_watcher_child',
+      startedAt: staleStartedAt,
+      records: [codexEvent(staleStartedAt + 1, { type: 'agent_message', message: 'STALE_WATCHER' })]
+    })
+    const currentProgress = `CURRENT_CHILD_PROGRESS_${firstContext.startedAt}`
+    const currentInherited = `CURRENT_PARENT_PREFIX_${firstContext.startedAt}`
+    const currentChildPath = writeChildRollout({
+      context: nextContext,
+      sessionId: currentChildId,
+      agentPath: '/root/current_session_child',
+      startedAt: currentStartedAt,
+      inheritedUserMarker: currentInherited,
+      records: [
+        codexEvent(currentStartedAt + 1, {
+          type: 'agent_message',
+          message: currentProgress
+        })
+      ]
+    })
+    appendSubagentActivity(
+      firstContext,
+      staleChildId,
+      '/root/stale_watcher_child',
+      'started',
+      staleStartedAt
+    )
+    appendSubagentActivity(
+      nextContext,
+      currentChildId,
+      '/root/current_session_child',
+      'started',
+      currentStartedAt
+    )
+
+    await expandParentChildren(orcaPage, nextPrompt)
+    const currentRow = childAgentRow(orcaPage, 'current_session_child')
+    await expect(currentRow).toBeVisible({ timeout: 15_000 })
+    await expect(childAgentRow(orcaPage, 'stale_watcher_child')).toHaveCount(0)
+    await currentRow.click()
+    const progressSheet = codexProgressSheet(orcaPage)
+    await expect(progressSheet.getByText(currentProgress, { exact: true })).toBeVisible({
+      timeout: 15_000
+    })
+    await expect(progressSheet.getByText(oldProgress, { exact: true })).toHaveCount(0)
+    await expect(progressSheet.getByText(currentInherited, { exact: true })).toHaveCount(0)
+
+    appendCodexRecords(currentChildPath, [
+      codexEvent(currentStartedAt + 2, { type: 'task_complete' })
+    ])
+    await expect(childAgentRow(orcaPage, 'current_session_child')).toHaveCount(0, {
+      timeout: 15_000
+    })
+    await expect(parentAgentRow(orcaPage, nextPrompt).getByLabel('Done')).toBeVisible()
+  })
+})

--- a/tests/e2e/helpers/codex-subagent-rollout-fixture.ts
+++ b/tests/e2e/helpers/codex-subagent-rollout-fixture.ts
@@ -147,7 +147,10 @@ export async function postCodexHook(
     })
   })
   if (response.status !== 204) {
-    throw new Error(`Codex hook POST returned ${response.status}`)
+    const body = await response.text().catch(() => '')
+    throw new Error(
+      `Codex hook POST returned ${response.status}${body ? `: ${body.slice(0, 500)}` : ''}`
+    )
   }
 }
 
@@ -257,8 +260,8 @@ export function parentAgentRow(page: Page, prompt: string): Locator {
   return page.getByRole('treeitem').filter({ hasText: prompt }).first()
 }
 
-export function childAgentRow(page: Page, label: string): Locator {
-  return page.getByRole('treeitem').filter({ hasText: label }).first()
+export function childAgentRow(page: Page, sessionId: string): Locator {
+  return page.locator(`[role="treeitem"][data-subagent-id="${sessionId}"]`)
 }
 
 export function codexProgressSheet(page: Page): Locator {

--- a/tests/e2e/helpers/codex-subagent-rollout-fixture.ts
+++ b/tests/e2e/helpers/codex-subagent-rollout-fixture.ts
@@ -1,0 +1,274 @@
+import { randomUUID } from 'node:crypto'
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { ElectronApplication, Locator, Page } from '@stablyai/playwright-test'
+
+import type { AgentHookEndpoint } from '../../../src/shared/agent-hook-endpoint-file'
+import { readHookEndpoint } from './agent-hook-endpoint'
+import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './store'
+
+export type CodexSubagentE2EContext = {
+  cwd: string
+  dayDirectory: string
+  endpoint: AgentHookEndpoint
+  paneKey: string
+  parentPath: string
+  parentSessionId: string
+  prompt: string
+  startedAt: number
+  worktreeId: string
+}
+
+export function codexJsonl(records: readonly unknown[]): string {
+  return `${records.map((record) => JSON.stringify(record)).join('\n')}\n`
+}
+
+export function codexEvent(at: number, payload: Record<string, unknown>): unknown {
+  return {
+    type: 'event_msg',
+    timestamp: new Date(at).toISOString(),
+    payload
+  }
+}
+
+export function codexResponse(at: number, payload: Record<string, unknown>): unknown {
+  return {
+    type: 'response_item',
+    timestamp: new Date(at).toISOString(),
+    payload
+  }
+}
+
+export function childRolloutPath(context: CodexSubagentE2EContext, sessionId: string): string {
+  return path.join(context.dayDirectory, `rollout-e2e-child-${sessionId}.jsonl`)
+}
+
+export function appendCodexRecords(filePath: string, records: readonly unknown[]): void {
+  appendFileSync(filePath, codexJsonl(records))
+}
+
+export function writeChildRollout(args: {
+  context: CodexSubagentE2EContext
+  sessionId: string
+  agentPath: string
+  startedAt: number
+  records?: readonly unknown[]
+  inheritedUserMarker?: string
+  inheritedAssistantMarker?: string
+}): string {
+  const inheritedAt = args.startedAt - 1
+  const records: unknown[] = [
+    {
+      type: 'session_meta',
+      timestamp: new Date(inheritedAt).toISOString(),
+      payload: {
+        id: args.sessionId,
+        cwd: args.context.cwd,
+        thread_source: 'subagent',
+        forked_from_id: args.context.parentSessionId,
+        source: {
+          subagent: {
+            thread_spawn: {
+              parent_thread_id: args.context.parentSessionId,
+              depth: 1,
+              agent_path: args.agentPath
+            }
+          }
+        }
+      }
+    }
+  ]
+  if (args.inheritedUserMarker) {
+    records.push(
+      codexResponse(inheritedAt, {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'text', text: args.inheritedUserMarker }]
+      })
+    )
+  }
+  if (args.inheritedAssistantMarker) {
+    records.push(
+      codexResponse(inheritedAt, {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: args.inheritedAssistantMarker }]
+      })
+    )
+  }
+  records.push(codexEvent(args.startedAt, { type: 'task_started' }), ...(args.records ?? []))
+
+  const filePath = childRolloutPath(args.context, args.sessionId)
+  writeFileSync(filePath, codexJsonl(records))
+  return filePath
+}
+
+export function appendSubagentActivity(
+  context: CodexSubagentE2EContext,
+  sessionId: string,
+  agentPath: string,
+  kind: 'started' | 'interacted' | 'interrupted',
+  occurredAt: number
+): void {
+  appendCodexRecords(context.parentPath, [
+    codexEvent(occurredAt, {
+      type: 'sub_agent_activity',
+      occurred_at_ms: occurredAt,
+      agent_thread_id: sessionId,
+      agent_path: agentPath,
+      kind
+    })
+  ])
+}
+
+export async function postCodexHook(
+  endpoint: AgentHookEndpoint,
+  event: {
+    paneKey: string
+    worktreeId: string
+    payload: Record<string, unknown>
+  }
+): Promise<void> {
+  const [tabId] = event.paneKey.split(':')
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/codex`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': endpoint.token
+    },
+    body: JSON.stringify({
+      paneKey: event.paneKey,
+      tabId,
+      worktreeId: event.worktreeId,
+      env: endpoint.env,
+      version: endpoint.version,
+      payload: event.payload
+    })
+  })
+  if (response.status !== 204) {
+    throw new Error(`Codex hook POST returned ${response.status}`)
+  }
+}
+
+async function enableInlineAgentCards(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    if (!state.worktreeCardProperties.includes('inline-agents')) {
+      state.toggleWorktreeCardProperty('inline-agents')
+    }
+    state.closeActivityPage()
+  })
+}
+
+export async function startCodexSubagentScenario(args: {
+  page: Page
+  electronApp: ElectronApplication
+  promptPrefix: string
+}): Promise<CodexSubagentE2EContext> {
+  await waitForSessionReady(args.page)
+  await waitForActiveWorktree(args.page)
+  await ensureTerminalVisible(args.page)
+  await waitForActiveTerminalManager(args.page)
+  await enableInlineAgentCards(args.page)
+
+  const endpoint = await readHookEndpoint(args.electronApp)
+  const { paneKey, worktreeId } = await waitForActivePaneHookDescriptor(args.page)
+  const isolatedHome = await args.electronApp.evaluate(({ app }) => app.getPath('home'))
+  const cwd = await args.page.evaluate((targetWorktreeId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const worktree = Object.values(store.getState().worktreesByRepo)
+      .flat()
+      .find((candidate) => candidate.id === targetWorktreeId)
+    if (!worktree) {
+      throw new Error(`Worktree ${targetWorktreeId} was not found`)
+    }
+    return worktree.path
+  }, worktreeId)
+
+  const startedAt = Date.now()
+  const date = new Date(startedAt)
+  const dayDirectory = path.join(
+    isolatedHome,
+    '.codex',
+    'sessions',
+    String(date.getFullYear()),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0')
+  )
+  mkdirSync(dayDirectory, { recursive: true })
+
+  const parentSessionId = randomUUID()
+  const parentPath = path.join(dayDirectory, `rollout-e2e-parent-${parentSessionId}.jsonl`)
+  const prompt = `${args.promptPrefix}_${startedAt}`
+  writeFileSync(
+    parentPath,
+    codexJsonl([
+      {
+        type: 'session_meta',
+        timestamp: new Date(startedAt).toISOString(),
+        payload: { id: parentSessionId, cwd }
+      },
+      codexEvent(startedAt, { type: 'task_started' })
+    ])
+  )
+  const context = {
+    cwd,
+    dayDirectory,
+    endpoint,
+    paneKey,
+    parentPath,
+    parentSessionId,
+    prompt,
+    startedAt,
+    worktreeId
+  }
+  await postCodexHook(endpoint, {
+    paneKey,
+    worktreeId,
+    payload: {
+      hook_event_name: 'UserPromptSubmit',
+      session_id: parentSessionId,
+      transcript_path: parentPath,
+      prompt
+    }
+  })
+  await postCodexHook(endpoint, {
+    paneKey,
+    worktreeId,
+    payload: {
+      hook_event_name: 'Stop',
+      session_id: parentSessionId,
+      transcript_path: parentPath
+    }
+  })
+  await args.page.getByText(prompt, { exact: true }).waitFor({ state: 'visible', timeout: 15_000 })
+  return context
+}
+
+export function parentAgentRow(page: Page, prompt: string): Locator {
+  return page.getByRole('treeitem').filter({ hasText: prompt }).first()
+}
+
+export function childAgentRow(page: Page, label: string): Locator {
+  return page.getByRole('treeitem').filter({ hasText: label }).first()
+}
+
+export function codexProgressSheet(page: Page): Locator {
+  return page.locator('[data-codex-subagent-progress]')
+}
+
+export async function expandParentChildren(page: Page, prompt: string): Promise<void> {
+  const disclosure = parentAgentRow(page, prompt).locator('button[aria-expanded]')
+  await disclosure.waitFor({ state: 'visible', timeout: 15_000 })
+  if ((await disclosure.getAttribute('aria-expanded')) === 'false') {
+    await disclosure.click()
+  }
+}


### PR DESCRIPTION
## Summary

- Make live Codex internal subagent rows clickable in both full and compact sidebar views and open the provider-assigned child session in a non-modal, read-only progress sheet.
- Keep child discovery live across empty rosters, completion, interruption, and later dynamic spawns; derive `working`, `waiting`, and `idle` from the child rollout so a parked child does not keep its completed parent marked as running.
- Scope full-history (`fork_turns: "all"`) child rollouts at the provider-authored child start boundary. Parent user/assistant turns copied into the rollout stay hidden while the child's messages, reasoning, custom tool calls, and results remain live.
- Capture transcript host authority at click time so local, managed-runtime, SSH-backed runtime, and folder-workspace routing cannot drift while the sheet is open. Legacy SSH, unknown ownership, and conflicting evidence fail closed.
- Keep the inspected child visibly selected without changing parent terminal focus; shorten `/root/<name>` child labels while retaining canonical metadata in tooltips.

This is a focused follow-up to #9637. It does not close the remaining cross-worktree orchestration and deduplication scope in #8251.

Closes #12621

Refs #8251

## Screenshots

![Codex subagent live progress sheet](https://raw.githubusercontent.com/parkavenue9639/orca/pr-assets-codex-subagent-live-progress/.github/pr-assets/codex-subagent-live-progress.png)

The screenshot was captured from an isolated Electron E2E profile with synthetic Codex rollouts; no user session history is included.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (full typecheck inside `pnpm build`; `typecheck:web` repeated on the final commit)
- [x] `pnpm test` completed after rebasing onto `upstream/main@41c4d8e8`: 56,376 passed, 190 skipped, and 23 failed across nine unrelated files when launched inside an Orca-managed macOS terminal.
  - Controlled reruns cleared two environment/artifact-only failures: `shell-startup-feature-channel` passed 12/12 after clearing inherited Orca shell variables; the WSL separator passed 4/4 with the ignored cross-version checkout cache temporarily moved outside the scan and then restored.
  - The remaining 20 local failures are confined to seven upstream-only files with zero PR diff: three PTY shell-feature assertions receive an absent feature channel on current upstream, four macOS login-Bash assertions inherit local prompt hooks (`git_branch` / `find_git_branch`), and 13 happy-dom/xterm IME assertions do not activate or clear the expected composition overlay in this runtime.
- [x] Current Codex subagent regression: all 12 matching files / 51 tests passed.
- [x] Conflict-surface regression: 7 renderer/transcript files / 83 tests passed; the final model/lifecycle subset passed 3 files / 21 tests after commit hooks.
- [x] Expanded isolated Electron E2E matrix: 4 scenarios cover late rollout recovery, dynamic interruption/removal/rediscovery, concurrent child switching and live reasoning/custom-tool updates, independent completion, `idle → working → waiting → working → complete`, parent-state convergence, parent-session replacement/stale-watcher isolation, and parent/other-child history exclusion. Every scenario passed twice with 2 workers (8/8).
- [x] `pnpm build` passed after the rebase, including full typecheck, relay, CLI, Electron/Vite, built-skills verification, web projection, and macOS native helpers. The optional `/usr/local/bin/orca-dev` symlink refresh was denied without elevation, but the build continued and exited successfully.
- [x] Commit hooks: oxlint, React Doctor rules, and oxfmt.
- [x] `git diff --check`
- [x] Poll-cost follow-up rebased as `fdaba84b6a`: the 3 current poll/dynamic-lifecycle/transcript files / 11 tests passed; all 12 Codex subagent test files / 51 tests passed; full `pnpm typecheck`, full `pnpm lint`, formatting, and `git diff --check` passed. The server integration test covers transcript-only child discovery after more than 60 seconds of quiet polling and restoration of the 1-second cadence on the next Codex turn.

Additional real-session validation used Codex CLI 0.146.0 in an isolated dev profile. A child spawned with `fork_turns: "all"` showed its unique progress marker and live tool activity, did not show the unique parent-history marker, transitioned to Idle with its final result retained, disappeared from the dynamic child row after completion, and returned its result to a Done parent.

A second real-session matrix on the same CLI started three children with distinct long-running, short-running, and `wait_agent` paths. Orca showed the long child as Working and the parked child as Idle after the short child completed; completed rows disappeared independently. Switching the non-modal sheet from the completed long child to the waiting child replaced the transcript instead of merging it. After `send_message` resumed the parked child, its sheet retained only its own progress/wait/resume records, all live child rows cleared, and the parent converged to Done with `REAL_PARENT_DONE_20260804`.

## Review Notes

The implementation was iterated against real dynamic child sessions, including children that start after the initial parent hook, park in `wait_agent`, resume, complete, disappear, and are followed by a new child. The generic Codex transcript view is unchanged by the parent-prefix filter; scoping is applied only in the subagent progress surface using the captured `startedAt` boundary.

The hook server keeps a 1-second incremental parent-rollout poll while the lead is working or a transcript child is tracked. With an empty roster and a non-working or pre-prompt lead, it backs off from 1 to 2 to 4 to 5 seconds, reducing steady quiet filesystem checks by 80%; child activity or any new Codex hook restores the 1-second cadence. The quiet poll stays capped instead of stopping because transcript-only late child creation can arrive without another hook. Reads reuse the existing cursor and byte/line bounds rather than rescanning whole files or all sessions.

The change considers macOS, Linux, Windows, local worktrees, folder workspaces, managed runtimes, runtime-owned SSH panes, and legacy SSH fail-closed behavior. It adds no Git commands or native dependencies.

## Security Audit

- The progress surface remains read-only and omits composer, send, interrupt, prompt-card, and PTY control paths.
- No new IPC channel, credential access, shell execution, or transcript mutation is introduced.
- Modal input is parsed into a narrow target shape. Runtime routing is pinned to captured authority; unknown, legacy SSH, malformed, or conflicting ownership becomes unavailable instead of falling back across hosts.
- Full-history parent turns are excluded before rendering using the provider-authored child start boundary. If that trusted boundary is absent or invalid, the progress view exposes no transcript messages.
- Transcript polling uses the hook-provided parent path, validated child session IDs, existing bounded JSONL readers, and existing Native Chat rendering.

## Notes

- Managed-runtime transcripts, including runtime-owned SSH panes, are supported when exact ownership resolves.
- Legacy SSH workspaces intentionally show an unavailable state rather than risking a local transcript read.
- Folder workspaces are covered for both local and managed-runtime ownership.
- X handle: Not provided.

