### PR TITLE
fix(orchestration): keep completed tasks closed when a superseded dispatch's terminal exits

### DIFF
--- a/src/main/runtime/orchestration/db-superseded-dispatch-guard.test.ts
+++ b/src/main/runtime/orchestration/db-superseded-dispatch-guard.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from './db'
+
+// #11499: failDispatch used to move the TASK unconditionally, so a superseded
+// dispatch's terminal exiting reopened work another dispatch already completed.
+// These tests pin the guard: only the task's current dispatch, while the task
+// is still on an active attempt, may transition the task.
+describe('failDispatch superseded-dispatch guard', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+  // Supersede A → dispatch B → B completes → A's terminal exits.
+  it('does not reopen a completed task when a superseded dispatch fails', () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'supersede-sensitive work' })
+    const superseded = d.createDispatchContext(task.id, 'term_a')
+    d.updateTaskStatus(task.id, 'ready')
+    const current = d.createDispatchContext(task.id, 'term_b')
+    const settlement = d.settleWorkerReport({
+      taskId: task.id,
+      dispatchId: current.id,
+      outcome: 'succeeded',
+      result: 'done by B'
+    })
+    expect(settlement.action).toBe('settled')
+    expect(d.getTask(task.id)?.status).toBe('completed')
+
+    const failed = d.failDispatch(superseded.id, 'Agent exited with code 0')
+
+    expect(failed?.status).toBe('failed')
+    expect(d.getTask(task.id)?.status).toBe('completed')
+    expect(d.getDispatchContextById(current.id)?.status).toBe('completed')
+  })
+
+  it('leaves a concurrently re-dispatched task untouched when the superseded dispatch fails', () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'supersede window' })
+    const superseded = d.createDispatchContext(task.id, 'term_a')
+    d.updateTaskStatus(task.id, 'ready')
+    const current = d.createDispatchContext(task.id, 'term_b')
+
+    const failed = d.failDispatch(superseded.id, 'Agent exited with code 0')
+
+    expect(failed?.status).toBe('failed')
+    expect(d.getTask(task.id)?.status).toBe('dispatched')
+    expect(d.getDispatchContextById(current.id)?.status).toBe('dispatched')
+  })
+
+  it('leaves an already-settled dispatch and its task untouched', () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'settled work' })
+    const ctx = d.createDispatchContext(task.id, 'term_a')
+    const settlement = d.settleWorkerReport({
+      taskId: task.id,
+      dispatchId: ctx.id,
+      outcome: 'succeeded',
+      result: 'done'
+    })
+    expect(settlement.action).toBe('settled')
+
+    const result = d.failDispatch(ctx.id, 'Agent exited with code 0')
+
+    expect(result?.status).toBe('completed')
+    expect(result?.failure_count).toBe(0)
+    expect(d.getTask(task.id)?.status).toBe('completed')
+  })
+
+  it('still reopens the task when its current dispatch fails', () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'normal crash' })
+    const ctx = d.createDispatchContext(task.id, 'term_a')
+
+    const failed = d.failDispatch(ctx.id, 'Agent exited with code -1')
+
+    expect(failed?.status).toBe('failed')
+    expect(d.getTask(task.id)?.status).toBe('ready')
+  })
+
+  it('still fails the task when the circuit breaker trips on the current dispatch', () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'flaky' })
+    let ctx = d.createDispatchContext(task.id, 'term_a')
+    d.failDispatch(ctx.id, 'timeout')
+    ctx = d.createDispatchContext(task.id, 'term_a')
+    d.failDispatch(ctx.id, 'timeout')
+    ctx = d.createDispatchContext(task.id, 'term_a')
+
+    const after3 = d.failDispatch(ctx.id, 'timeout')
+
+    expect(after3?.status).toBe('circuit_broken')
+    expect(d.getTask(task.id)?.status).toBe('failed')
+  })
+})

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -5818,6 +5818,11 @@ export class OrchestrationDb {
     if (!ctx) {
       return undefined
     }
+    // Why: settled contexts are immutable — a late exit of an already-completed
+    // or already-failed dispatch must not re-fail it (#11499).
+    if (ctx.status !== 'pending' && ctx.status !== 'dispatched') {
+      return ctx
+    }
 
     const newFailureCount = ctx.failure_count + 1
     const newStatus: DispatchStatus = newFailureCount >= 3 ? 'circuit_broken' : 'failed'
@@ -5832,9 +5837,17 @@ export class OrchestrationDb {
       )
       .run(newStatus, newFailureCount, error, ctxId)
 
-    // Why: back to 'ready' not 'pending' — 'pending' would strand it since promoteReadyTasks only runs when a dep completes.
-    const taskStatus: TaskStatus = newStatus === 'circuit_broken' ? 'failed' : 'ready'
-    this.db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run(taskStatus, ctx.task_id)
+    // Why: only the task's CURRENT dispatch may move the task, and only while the
+    // task is still on an active attempt — mirrors settleWorkerReport's
+    // inactive/stale-dispatch guards. A superseded dispatch's terminal exiting
+    // must not reopen a task another dispatch already completed (#11499).
+    const task = this.getTask(ctx.task_id)
+    const currentDispatch = this.getDispatchContext(ctx.task_id)
+    if (task?.status === 'dispatched' && currentDispatch?.id === ctx.id) {
+      // Why: back to 'ready' not 'pending' — 'pending' would strand it since promoteReadyTasks only runs when a dep completes.
+      const taskStatus: TaskStatus = newStatus === 'circuit_broken' ? 'failed' : 'ready'
+      this.db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run(taskStatus, ctx.task_id)
+    }
 
     return this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as
       | DispatchContextRow

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -5827,26 +5827,36 @@ export class OrchestrationDb {
     const newFailureCount = ctx.failure_count + 1
     const newStatus: DispatchStatus = newFailureCount >= 3 ? 'circuit_broken' : 'failed'
 
-    this.db
-      .prepare(
-        `UPDATE dispatch_contexts
-         SET status = ?, failure_count = ?, last_failure = ?,
-             completed_at = COALESCE(completed_at, datetime('now')),
-             capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
-         WHERE id = ?`
-      )
-      .run(newStatus, newFailureCount, error, ctxId)
+    // Why: the dispatch and task updates must land atomically — a crash between
+    // them would strand a settled dispatch under a task stuck 'dispatched',
+    // which no sweeper repairs (same pattern as settleWorkerReport).
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      this.db
+        .prepare(
+          `UPDATE dispatch_contexts
+           SET status = ?, failure_count = ?, last_failure = ?,
+               completed_at = COALESCE(completed_at, datetime('now')),
+               capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
+           WHERE id = ?`
+        )
+        .run(newStatus, newFailureCount, error, ctxId)
 
-    // Why: only the task's CURRENT dispatch may move the task, and only while the
-    // task is still on an active attempt — mirrors settleWorkerReport's
-    // inactive/stale-dispatch guards. A superseded dispatch's terminal exiting
-    // must not reopen a task another dispatch already completed (#11499).
-    const task = this.getTask(ctx.task_id)
-    const currentDispatch = this.getDispatchContext(ctx.task_id)
-    if (task?.status === 'dispatched' && currentDispatch?.id === ctx.id) {
-      // Why: back to 'ready' not 'pending' — 'pending' would strand it since promoteReadyTasks only runs when a dep completes.
-      const taskStatus: TaskStatus = newStatus === 'circuit_broken' ? 'failed' : 'ready'
-      this.db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run(taskStatus, ctx.task_id)
+      // Why: only the task's CURRENT dispatch may move the task, and only while the
+      // task is still on an active attempt — mirrors settleWorkerReport's
+      // inactive/stale-dispatch guards. A superseded dispatch's terminal exiting
+      // must not reopen a task another dispatch already completed (#11499).
+      const task = this.getTask(ctx.task_id)
+      const currentDispatch = this.getDispatchContext(ctx.task_id)
+      if (task?.status === 'dispatched' && currentDispatch?.id === ctx.id) {
+        // Why: back to 'ready' not 'pending' — 'pending' would strand it since promoteReadyTasks only runs when a dep completes.
+        const taskStatus: TaskStatus = newStatus === 'circuit_broken' ? 'failed' : 'ready'
+        this.db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run(taskStatus, ctx.task_id)
+      }
+      this.db.exec('COMMIT')
+    } catch (transactionError) {
+      this.db.exec('ROLLBACK')
+      throw transactionError
     }
 
     return this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as


### PR DESCRIPTION
## Summary

A completed orchestration task silently flipped back to `ready` when a superseded dispatch's terminal exited (#11499, Linear STA-2978). `OrchestrationDb.failDispatch` applied its task transition unconditionally, so `failActiveDispatchOnExit` firing for a still-`dispatched` superseded context reopened work another dispatch had already completed — and a coordinator polling `task-list --ready` could re-dispatch finished tasks.

This PR guards the task transition in `failDispatch` with the same invariants `settleWorkerReport` already enforces:

- a settled dispatch context (completed/failed/circuit_broken/stopped) is immutable — a late exit no longer re-fails it;
- only the task's **current** dispatch may move the task, and only while the task is still on an active (`dispatched`) attempt.

The dispatch row itself still records the failure (`Agent exited with code N`), so superseded-worker cleanup remains fully attributed. Normal crash handling (current dispatch fails → task back to `ready`) and the 3-strike circuit breaker (task → `failed`) are unchanged, pinned by tests.

Reproduced live before the fix and re-verified gone after, on a dev build with an isolated profile: dispatch task → supersede to a second terminal → complete via `worker_done` → close the superseded terminal's tab in the UI. Before: task `completed → ready`, superseded ctx `failed`. After: task stays `completed`, superseded ctx still `failed`. The preserved path was also verified live: closing the *current* dispatch's terminal still returns its task to `ready`.

## Screenshots

No visual change (runtime state fix; no UI surface touched). Live-rig evidence screenshot is attached in the validation comment below.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (orchestration scope locally: 30 files / 446 tests green ×3 rounds; full suite green in CI — 41/41 checks SUCCESS at 5beb3031e1)
- [ ] `pnpm build`
- [x] Added `db-superseded-dispatch-guard.test.ts` (5 tests). Revert-proof: with the `db.ts` hunk reverted, the 3 guard tests go RED (task flips `ready`), the 2 preserved-behavior tests stay green.

## AI Review Report

Two-lane adversarial review loop via Orca orchestration, fresh reviewers per round, until a clean same-round pair: round 1 — Codex gpt-5.6-sol xhigh (reproduction lane) CLEAN after independently reproducing the pre-fix flip and revert-proofing the tests; Claude Fable 5 xhigh (thinking lane) found one P3: the dispatch/task updates were two autocommit statements, so a crash between them could strand a settled dispatch under a task stuck 'dispatched'. Fixed in 5beb3031e1 (BEGIN IMMEDIATE/COMMIT/ROLLBACK, same pattern as settleWorkerReport). Round 2 — both fresh lanes CLEAN at 5beb3031e1: nested-transaction audit (all four callers are top-level; no production caller inside a transaction), forced mid-transaction error rolls both rows back, every task state enumerated with no legitimate reopen skipped, circuit breaker preserved (and an accidental exit+escalation double-count removed). An independent perf lane audited first: no findings (all four call sites are cold event paths; EXPLAIN QUERY PLAN shows indexed point reads). Cross-platform: this change is platform-neutral main-process SQLite state logic — no shortcuts, labels, paths, shell, or Electron platform differences are touched; the triggering exit path exists on macOS (reproduced), Windows+WSL (original report), and Linux, and the guard applies identically to all of them.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The change only tightens internal SQLite state transitions with two additional read queries (`getTask`, `getDispatchContext`) inside the existing synchronous writer; no new data crosses any boundary.

## Notes

- The reporter's environment (Windows+WSL 1.4.161) hit this through the same `failActiveDispatchOnExit` path; on macOS the flip reproduces with renderer-created terminals closed via the tab X (CLI-created terminals tear down through a path that never reaches `failDispatch` — pre-existing asymmetry, unchanged here).
- A superseded context that outlives its terminal still sits `dispatched` forever on hosts where the exit path doesn't fire; that phantom-row cleanup is intentionally out of scope.

Fixes #11499
