### PR TITLE
fix(skills): run WSL setup commands in WSL

### DIFF
--- a/src/renderer/src/lib/project-skill-runtime.test.ts
+++ b/src/renderer/src/lib/project-skill-runtime.test.ts
@@ -68,7 +68,7 @@ describe('project skill runtime helpers', () => {
     expect(getProjectSkillInstallDisabledReason(repairRuntime)).toContain('unavailable')
   })
 
-  it('forces PowerShell for WSL setup and for host setup when the terminal shell is WSL', () => {
+  it('uses the runtime shell for WSL setup and PowerShell for host setup', () => {
     expect(
       getProjectAgentSkillTerminalShellOverride(
         'win32',
@@ -82,7 +82,7 @@ describe('project skill runtime helpers', () => {
         { terminalWindowsShell: 'pwsh.exe' },
         getProjectAgentSkillRuntime(wslRuntime, 'win32')
       )
-    ).toBe('powershell.exe')
+    ).toBeUndefined()
   })
 
   it('forces PowerShell for host setup when the terminal shell is Git Bash', () => {

--- a/src/renderer/src/lib/project-skill-runtime.ts
+++ b/src/renderer/src/lib/project-skill-runtime.ts
@@ -47,7 +47,7 @@ export function getProjectAgentSkillTerminalShellOverride(
     return undefined
   }
   if (runtime?.runtime === 'wsl') {
-    return 'powershell.exe'
+    return undefined
   }
   // Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
   // Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.


### PR DESCRIPTION
## Summary

- Open the setup terminal in the selected WSL runtime for WSL skill install and update actions.
- Show and copy the native `npx skills ...` command that the WSL terminal can execute directly.
- Remove the PowerShell `wsl.exe` wrapper from this WSL-only path.
- Keep native Windows host setup behavior, including PowerShell/cmd `npx` preflight handling, unchanged.

Previously Orca displayed a PowerShell command but opened a WSL shell below it, so pressing Enter in the provided terminal produced a Zsh parse error near `&`. The command and terminal environment now agree.

## Screenshots

No visual layout change. The setup terminal behavior changes from PowerShell syntax inside a WSL shell to a native WSL command.

## Testing

- [ ] `pnpm lint` — code-quality, reliability, max-lines, and guide checks passed; the command stops on pre-existing stale generated skill manifests: `current-manifest.json`, `snapshot-registry.json`, and `release-mapping.json`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full Windows suite was attempted during investigation and has unrelated baseline failures involving symlink privileges, POSIX-only paths and `/bin/sh`, and relay PTY fake timers.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused and manual validation:

- 39 setup/runtime/PowerShell quoting tests passed; one POSIX-only platform test was skipped on Windows.
- Agent Orchestration install and update completed from Orca's WSL setup terminal.
- Computer Use install and update completed from Orca's WSL setup terminal.
- The resulting skills were discovered by Orca Re-check.
- Before choosing the runtime-native UI behavior, the generated compatibility wrapper was also executed successfully in Windows PowerShell 5.1 and PowerShell 7 without `quote>`, `expecting "in"`, or detached `printf` failures.

## AI Review Report

The AI review traced command construction, prerequisite wrapping, setup-terminal shell selection, project runtime resolution, and the settings panel call sites. It specifically checked:

- that WSL commands stay native and are paired with a WSL terminal;
- that native Windows host commands retain PowerShell/cmd preflight behavior;
- that Git Bash and configured `wsl.exe` host shells still receive the existing host fallback where required;
- that update-to-install normalization remains native-Windows-only;
- default and explicitly selected WSL distributions;
- folder workspaces and project-runtime repair states;
- remote/SSH runtime behavior so a Windows client does not inject Windows shell syntax into a remote terminal.

Cross-platform compatibility was reviewed for macOS, Linux, Windows PowerShell 5.1/7, WSL Bash/Zsh, Git Bash, Electron terminal startup, and SSH/remote runtimes. No keyboard shortcuts, labels, paths, or visual styling are changed.

## Security Audit

- This change removes a nested PowerShell → `wsl.exe` → POSIX shell → Base64/eval boundary from WSL setup, reducing quoting and command-injection surface.
- The native WSL command still comes from Orca's fixed agent-feature install/update command builders; this change does not introduce user-controlled shell fragments.
- WSL distribution selection remains handled by the runtime/terminal launcher rather than interpolated into the displayed command.
- No authentication, secrets, dependencies, IPC schemas, filesystem permissions, or network destinations are added or changed.
- Native Windows prerequisite checks and remote runtime safeguards remain unchanged.

No security follow-up is required.

## Notes

- A copied WSL command is intentionally valid in WSL, not in an arbitrary Windows shell. The UI now opens the matching runtime terminal so the primary install action works without translation.
- This does not add `--yes`/`-y`; interactive `npx skills` confirmation remains supported.
- #11631 and #6580 overlap adjacent setup-terminal/install behavior and were reviewed before porting this change to current `main`.