### PR TITLE
fix: wrap unbroken auto-rename failure output

### DIFF
--- a/src/renderer/src/components/sidebar/AutoRenameFailedDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/AutoRenameFailedDialog.test.tsx
@@ -83,3 +83,28 @@ describe('AutoRenameFailedDialog full output', () => {
     expect(document.body.textContent).not.toContain('first run full output')
   })
 })
+
+// Why: happy-dom does no intrinsic sizing, so assert the two declarations that
+// keep an unbroken token from widening DialogContent's grid column instead.
+describe('AutoRenameFailedDialog unbroken output containment', () => {
+  it('keeps the output surface shrinkable and breakable mid-token', async () => {
+    getBranchRenameFailureOutput.mockResolvedValueOnce(`{"error":"${'A'.repeat(1000)}"}`)
+    await renderDialog()
+
+    const dialog = document.querySelector('[role="dialog"]')
+    const output = dialog?.querySelector('pre')
+    expect(output).toBeTruthy()
+    expect(output?.textContent).toContain('A'.repeat(1000))
+
+    // `break-words` (overflow-wrap: break-word) wraps painted text but leaves
+    // min-content at the full token width; only `anywhere` shrinks it.
+    expect(output?.className).toContain('[overflow-wrap:anywhere]')
+    expect(output?.className).not.toContain('break-words')
+
+    // DialogContent is a grid, so its child needs min-w-0 to shrink below min-content.
+    const gridChild = Array.from(dialog?.children ?? []).find((child) =>
+      child.contains(output ?? null)
+    )
+    expect(gridChild?.className).toContain('min-w-0')
+  })
+})

--- a/src/renderer/src/components/sidebar/AutoRenameFailedDialog.tsx
+++ b/src/renderer/src/components/sidebar/AutoRenameFailedDialog.tsx
@@ -115,7 +115,8 @@ export function AutoRenameFailedDialog({
           )}
         </p>
         {/* Why: agent-CLI output is literal and often multi-line, so render it
-            verbatim (mono, wrapped) inside a height-capped scroll region. */}
+            verbatim (mono, wrapped) inside a height-capped scroll region.
+            min-w-0 keeps an unbroken token from widening this grid column. */}
         <div className="min-w-0 space-y-1.5">
           <p className="text-xs font-medium text-foreground">
             {translate(

--- a/src/renderer/src/components/sidebar/AutoRenameFailedDialog.tsx
+++ b/src/renderer/src/components/sidebar/AutoRenameFailedDialog.tsx
@@ -116,7 +116,7 @@ export function AutoRenameFailedDialog({
         </p>
         {/* Why: agent-CLI output is literal and often multi-line, so render it
             verbatim (mono, wrapped) inside a height-capped scroll region. */}
-        <div className="space-y-1.5">
+        <div className="min-w-0 space-y-1.5">
           <p className="text-xs font-medium text-foreground">
             {translate(
               'auto.components.sidebar.AutoRenameFailedDialog.74fc00776f',
@@ -143,7 +143,7 @@ export function AutoRenameFailedDialog({
             >
               {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
             </Button>
-            <pre className="scrollbar-sleek max-h-[40vh] overflow-auto rounded-md border border-border/60 bg-muted/40 py-3 pl-3 pr-9 font-mono text-[11px] leading-4 whitespace-pre-wrap break-words text-foreground">
+            <pre className="scrollbar-sleek max-h-[40vh] overflow-auto rounded-md border border-border/60 bg-muted/40 py-3 pl-3 pr-9 font-mono text-[11px] leading-4 whitespace-pre-wrap [overflow-wrap:anywhere] text-foreground">
               {detailText}
             </pre>
           </div>


### PR DESCRIPTION
## Summary

Fix `AutoRenameFailedDialog` so long failure output without whitespace wraps inside the dialog instead of expanding the grid item beyond the modal and viewport.

## Root cause

The error block is a `<pre>` inside a direct child of the dialog's grid layout. `break-words` maps to `overflow-wrap: break-word`, which wraps painted text but does not reduce the element's min-content contribution. A long unbroken token therefore widened the grid item and pushed the error surface and actions outside the dialog.

The fix:

- allows the direct grid child to shrink with `min-w-0`
- uses `overflow-wrap: anywhere` so unbroken output contributes usable wrap opportunities during intrinsic sizing
- removes the conflicting `break-words` declaration

## Reproduction

1. Run Orca in development mode and add a project with at least one worktree.
2. Open DevTools and inject an unbroken auto-rename failure:

```js
const worktrees = await window.api.worktrees.listAll()
await window.api.worktrees.updateMeta({
  worktreeId: worktrees[1].id,
  updates: {
    firstAgentMessageRenameError: `{"error":"${"A".repeat(1000)}"}`
  }
})
window.location.reload()
```

3. Click the worktree's **rename failed** badge.
4. Before this fix, the unbroken value expands past the dialog boundary. After this fix, it wraps within the error details surface.

## Screenshots

The image URLs are pinned to an immutable commit in the contributor fork rather than a movable asset branch.

### Original incident

A real model error containing an unbroken JSON segment pushed the details surface outside the modal.

![Original incident](https://raw.githubusercontent.com/doyoonear/orca/c610c270b264e64daf39e3835cbc880c79807714/docs/assets/pr/auto-rename-dialog/incident.png)

### Reproduction entry point

The injected failure appears through the normal worktree **rename failed** badge.

![Reproduction entry point](https://raw.githubusercontent.com/doyoonear/orca/c610c270b264e64daf39e3835cbc880c79807714/docs/assets/pr/auto-rename-dialog/reproduction-entry.png)

### Before

The development reproduction overflows horizontally and escapes the dialog.

![Before: unbroken error output overflows the dialog](https://raw.githubusercontent.com/doyoonear/orca/c610c270b264e64daf39e3835cbc880c79807714/docs/assets/pr/auto-rename-dialog/as-is.png)

### After

The same unbroken value wraps within the existing width and height constraints.

![After: unbroken error output wraps inside the dialog](https://raw.githubusercontent.com/doyoonear/orca/c610c270b264e64daf39e3835cbc880c79807714/docs/assets/pr/auto-rename-dialog/to-be.png)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full suite reports 13 failures in unrelated updater and terminal IME tests; the focused dialog suite passes 4/4
- [x] `pnpm build`
- [x] Manual Electron verification with a 1,000-character unbroken JSON value
- [x] Explained regression coverage: `happy-dom` does not calculate CSS intrinsic layout, so the existing component test cannot detect this overflow. A one-off Playwright-driven Electron check verified `scrollWidth === clientWidth`, but no browser-layout test was added to recurring CI.

Manual layout inspection also confirmed `overflow-wrap: anywhere` and `white-space: pre-wrap`.

## AI Review Report

The review checked intrinsic grid sizing, wrapping behavior, conflicting Tailwind utilities, dialog containment, vertical scrolling, and light/dark UI quality.

- **Cross-platform:** reviewed for macOS, Linux, and Windows. The change is platform-neutral CSS and touches no shortcuts, labels, filesystem paths, shell behavior, or Electron platform branches. Runtime verification was performed on macOS; Windows and Linux were reviewed but not run locally.
- **Local/remote/SSH:** the renderer-only layout behavior is identical for local, remote, and SSH worktrees and adds no latency-sensitive behavior.
- **Agents, integrations, and Git providers:** the dialog continues to render generic failure text and does not branch on agent, integration, GitHub, GitLab, or other provider behavior.
- **Performance:** the change adds no JavaScript work, subscriptions, or hot-path processing.
- **UI quality:** verified containment and wrapping with the original incident and a 1,000-character unbroken payload in both light and dark presentation evidence.

## Security Audit

No IPC, command execution, filesystem, authentication, dependency, or secret-handling behavior changed. Failure output continues to render as React text content inside `<pre>` rather than HTML, so untrusted CLI output is not executed or interpreted as markup.

## Notes

- No localization changes are required.
- X handle: [@pear_dev_](https://x.com/pear_dev_)
