### PR TITLE
fix(windows): quote agent resume for cmd.exe on cold restore

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -278,6 +278,7 @@ import {
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
 } from '../../../../shared/tui-agent-launch-defaults'
+import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
 import {
   agentProviderSessionsEqual,
   isResumableTuiAgent,
@@ -4894,6 +4895,14 @@ export function connectPanePty(
         (useLiveEntry && entry ? state.getAgentLaunchConfigForStatusEntry(entry) : undefined) ??
         matchingSleepingLaunchConfig
       const resumePlatform = getColdRestoreAgentResumePlatform()
+      // Why: cold restore types the resume line into the restored tab shell.
+      // Omitting `shell` defaults win32 quoting to PowerShell, which breaks
+      // cmd.exe tabs (single-quoted resume ids become literal argv).
+      const resumeShell = resolveLocalWindowsAgentStartupShell({
+        platform: resumePlatform,
+        isRemote: false,
+        terminalWindowsShell: state.settings?.terminalWindowsShell
+      })
       const startupPlan = buildAgentResumeStartupPlan({
         agent,
         providerSession,
@@ -4910,7 +4919,8 @@ export function connectPanePty(
         ...(launchConfig?.ompResumeFilePath
           ? { ompResumeFilePath: launchConfig.ompResumeFilePath }
           : {}),
-        platform: resumePlatform
+        platform: resumePlatform,
+        shell: resumeShell
       })
       if (!startupPlan) {
         return null

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -11,6 +11,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { translate } from '@/i18n/i18n'
 
 export type ResumeSleepingAgentSessionsOptions = {
@@ -68,6 +69,17 @@ export function launchSleepingAgentSession(
 ): boolean {
   const state = useAppStore.getState()
   const launchConfig = record.launchConfig
+  // Why: cold/sleeping resume types the launch line into the live terminal shell.
+  // Win32 defaults to PowerShell quoting when `shell` is omitted, but users may run
+  // cmd.exe: single-quoted tokens then become literal argv (`'--resume'`, `'uuid'`)
+  // and agent CLIs reject the resume. Match the host `terminalWindowsShell` family.
+  const platform = getResumeLaunchPlatform(record.worktreeId)
+  const shell = resolveLocalWindowsAgentStartupShell({
+    platform,
+    // Platform is already forced to linux for remote/WSL worktrees above.
+    isRemote: false,
+    terminalWindowsShell: state.settings?.terminalWindowsShell
+  })
   const startupPlan = buildAgentResumeStartupPlan({
     agent: record.agent,
     providerSession: record.providerSession,
@@ -84,7 +96,8 @@ export function launchSleepingAgentSession(
     ...(launchConfig?.ompResumeFilePath
       ? { ompResumeFilePath: launchConfig.ompResumeFilePath }
       : {}),
-    platform: getResumeLaunchPlatform(record.worktreeId)
+    platform,
+    shell
   })
   if (!startupPlan) {
     toast.error(

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -593,6 +593,40 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe("codex 'resume' 's1'")
   })
 
+  it('quotes Windows resume argv for cmd.exe when shell is cmd', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'grok',
+      providerSession: { key: 'session_id', id: '019fc272-80fa-7a91-80a2-9c461ef1a9da' },
+      cmdOverrides: {},
+      agentArgs: '--permission-mode bypassPermissions',
+      platform: 'win32',
+      shell: 'cmd'
+    })
+
+    // Why: cmd.exe treats single quotes as literal characters. Resume must use
+    // double quotes (or unquoted tokens) so the CLI receives clean argv.
+    expect(plan?.launchCommand).toBe(
+      'grok "--permission-mode" "bypassPermissions" "--resume" "019fc272-80fa-7a91-80a2-9c461ef1a9da"'
+    )
+  })
+
+  it('keeps cmd-quoted agentCommand aligned with cmd resume suffix', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'grok',
+      providerSession: { key: 'session_id', id: '019fc272-80fa-7a91-80a2-9c461ef1a9da' },
+      cmdOverrides: {},
+      agentCommand: 'grok "--permission-mode" "bypassPermissions"',
+      platform: 'win32',
+      shell: 'cmd'
+    })
+
+    // Regression: agentCommand from a prior cmd launch + PowerShell-default resume
+    // suffix produced mixed quoting and broke reboot restore on cmd.exe tabs.
+    expect(plan?.launchCommand).toBe(
+      'grok "--permission-mode" "bypassPermissions" "--resume" "019fc272-80fa-7a91-80a2-9c461ef1a9da"'
+    )
+  })
+
   it('honors command overrides when building POSIX resume plans', () => {
     const plan = buildAgentResumeStartupPlan({
       agent: 'codex',


### PR DESCRIPTION
## Summary
- Cold restore and sleeping-agent resume typed launch lines into the live terminal **without** passing the host `terminalWindowsShell` family, so win32 defaulted to PowerShell single-quote argv.
- On `cmd.exe` tabs those quotes are literal characters, so agent CLIs reject `--resume` / permission flags after reboot (e.g. `unexpected argument ''<uuid>'' found`).
- Pass `resolveLocalWindowsAgentStartupShell` into `buildAgentResumeStartupPlan` from:
  - `pty-connection.ts` cold restore
  - `sleeping-agent-session-launch.ts`
- Matches existing runtime RPC + AI Vault resume paths.
- Add cmd resume quoting regression tests (including mixed `agentCommand` + resume suffix case).

Fixes #12320
Related #11340

## Test plan
- [x] `npx vitest run src/shared/tui-agent-startup.test.ts src/shared/windows-terminal-shell.test.ts` (73 tests pass)
- [ ] Windows: set terminal shell to `cmd.exe`, launch grok/claude with permission args, fully quit Orca, reopen worktree — auto-resume should start agent TUI (no `unexpected argument ''...''`)
- [ ] Windows: same with `powershell.exe` shell — resume still works (single-quote path)
- [ ] AI Vault / runtime RPC resume paths unchanged (already passed shell)