### PR TITLE
feat(native-chat): support Pi mobile chat

### DIFF
--- a/mobile/src/session/mobile-native-chat-eligibility.test.ts
+++ b/mobile/src/session/mobile-native-chat-eligibility.test.ts
@@ -80,6 +80,19 @@ describe('resolveMobileNativeChat', () => {
     })
   })
 
+  it('resolves Pi from its hook-reported session file', () => {
+    expect(
+      resolveMobileNativeChat({
+        type: 'terminal',
+        launchAgent: 'pi',
+        agentStatus: status({
+          agentType: 'pi',
+          providerSession: { key: 'session_id', id: 'pi-session', transcriptPath: '/tmp/pi.jsonl' }
+        })
+      })
+    ).toEqual({ agent: 'pi', sessionId: 'pi-session', transcriptPath: '/tmp/pi.jsonl' })
+  })
+
   it('returns null for unsupported agents', () => {
     expect(resolveMobileNativeChat({ type: 'terminal', launchAgent: 'gemini' })).toBeNull()
   })

--- a/src/main/native-chat/transcript-line-decoders-pi.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-pi.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { decodePiTranscriptLine } from './transcript-line-decoders-pi'
+
+describe('decodePiTranscriptLine', () => {
+  it('maps Pi user, assistant, tool call, and tool result messages', () => {
+    const user = decodePiTranscriptLine(
+      JSON.stringify({
+        type: 'message',
+        id: 'user-1',
+        timestamp: '2026-08-03T14:00:00.000Z',
+        message: { role: 'user', content: 'Inspect this file', timestamp: 1 }
+      }),
+      'fallback'
+    )
+    expect(user).toMatchObject({
+      id: 'user-1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'Inspect this file' }],
+      source: 'transcript'
+    })
+
+    const assistant = decodePiTranscriptLine(
+      JSON.stringify({
+        type: 'message',
+        id: 'assistant-1',
+        timestamp: '2026-08-03T14:00:01.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'Checking the file' },
+            { type: 'toolCall', id: 'call-1', name: 'read', arguments: { path: 'a.ts' } }
+          ]
+        }
+      }),
+      'fallback'
+    )
+    expect(assistant).toMatchObject({
+      id: 'assistant-1',
+      role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'Checking the file' },
+        { type: 'tool-call', name: 'read', input: { path: 'a.ts' } }
+      ]
+    })
+
+    const toolResult = decodePiTranscriptLine(
+      JSON.stringify({
+        type: 'message',
+        id: 'tool-1',
+        timestamp: '2026-08-03T14:00:02.000Z',
+        message: {
+          role: 'toolResult',
+          toolCallId: 'call-1',
+          toolName: 'read',
+          content: [{ type: 'text', text: 'file contents' }],
+          isError: false
+        }
+      }),
+      'fallback'
+    )
+    expect(toolResult).toMatchObject({
+      id: 'tool-1',
+      role: 'tool',
+      blocks: [{ type: 'tool-result', output: 'file contents' }]
+    })
+  })
+
+  it('skips non-message records and unknown roles', () => {
+    expect(decodePiTranscriptLine('{"type":"session","id":"session-1"}', 'fallback')).toBeNull()
+    expect(
+      decodePiTranscriptLine(
+        JSON.stringify({
+          type: 'message',
+          id: 'system-1',
+          message: { role: 'system', content: 'x' }
+        }),
+        'fallback'
+      )
+    ).toBeNull()
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders-pi.ts
+++ b/src/main/native-chat/transcript-line-decoders-pi.ts
@@ -1,0 +1,88 @@
+// Pi session JSONL line -> NativeChatMessage decoder.
+
+import type { NativeChatBlock, NativeChatMessage } from '../../shared/native-chat-types'
+import {
+  asRecord,
+  extractString,
+  parseJsonObject,
+  timestampMs
+} from '../ai-vault/session-scanner-values'
+import { toolResultOutput } from './transcript-record-blocks'
+
+type PiMessageRole = 'user' | 'assistant' | 'toolResult'
+
+export function decodePiTranscriptLine(line: string, fallbackId: string): NativeChatMessage | null {
+  const record = parseJsonObject(line)
+  if (record?.type !== 'message') {
+    return null
+  }
+  const message = asRecord(record.message)
+  const role = extractString(message?.role) as PiMessageRole | null
+  if (!message || !isPiMessageRole(role)) {
+    return null
+  }
+  const blocks = piMessageBlocks(message, role)
+  if (blocks.length === 0) {
+    return null
+  }
+  return {
+    id: extractString(record.id) ?? fallbackId,
+    role: role === 'toolResult' ? 'tool' : role,
+    blocks,
+    timestamp: parseTimestamp(record.timestamp ?? message.timestamp),
+    source: 'transcript'
+  }
+}
+
+function isPiMessageRole(value: string | null): value is PiMessageRole {
+  return value === 'user' || value === 'assistant' || value === 'toolResult'
+}
+
+function piMessageBlocks(message: Record<string, unknown>, role: PiMessageRole): NativeChatBlock[] {
+  if (role === 'toolResult') {
+    return [
+      {
+        type: 'tool-result',
+        output: toolResultOutput(message.content),
+        ...(message.isError === true ? { isError: true } : {})
+      }
+    ]
+  }
+  const content = typeof message.content === 'string' ? [message.content] : message.content
+  if (!Array.isArray(content)) {
+    return []
+  }
+  const blocks: NativeChatBlock[] = []
+  for (const item of content) {
+    if (typeof item === 'string') {
+      if (item.trim()) {
+        blocks.push({ type: 'text', text: item })
+      }
+      continue
+    }
+    const block = asRecord(item)
+    if (!block) {
+      continue
+    }
+    if (block.type === 'text' || block.type === 'thinking') {
+      const text = extractString(block.text) ?? extractString(block.thinking)
+      if (text) {
+        blocks.push({ type: 'text', text })
+      }
+      continue
+    }
+    if (block.type === 'toolCall') {
+      blocks.push({
+        type: 'tool-call',
+        name: extractString(block.name) ?? 'tool',
+        input: block.arguments ?? {}
+      })
+    }
+  }
+  return blocks
+}
+
+function parseTimestamp(value: unknown): number | null {
+  const parsed = timestampMs(value)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/main/native-chat/transcript-line-decoders.ts
+++ b/src/main/native-chat/transcript-line-decoders.ts
@@ -12,3 +12,4 @@
 export { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
 export { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
 export { decodeGrokTranscriptLine } from './transcript-line-decoders-grok'
+export { decodePiTranscriptLine } from './transcript-line-decoders-pi'

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -10,7 +10,8 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from './sessio
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
-  decodeGrokTranscriptLine
+  decodeGrokTranscriptLine,
+  decodePiTranscriptLine
 } from './transcript-line-decoders'
 import { decodeTranscriptStream } from './transcript-stream-lines'
 
@@ -54,6 +55,9 @@ export async function readNativeChatTranscript(
     }
     if (transcriptAgent === 'grok') {
       return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }
+    }
+    if (transcriptAgent === 'pi') {
+      return { messages: await readTranscript(filePath, decodePiTranscriptLine) }
     }
     return { error: `Unsupported agent for Chat UI transcript: ${agent}` }
   } catch (err) {

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -9,7 +9,8 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from './sessio
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
-  decodeGrokTranscriptLine
+  decodeGrokTranscriptLine,
+  decodePiTranscriptLine
 } from './transcript-line-decoders'
 import { transcriptFallbackId } from './transcript-fallback-id'
 import {
@@ -32,6 +33,9 @@ export function nativeChatLineDecoderForAgent(agent: AgentType): NativeChatLineD
   }
   if (transcriptAgent === 'grok') {
     return decodeGrokTranscriptLine
+  }
+  if (transcriptAgent === 'pi') {
+    return decodePiTranscriptLine
   }
   return null
 }

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -11,9 +11,10 @@ describe('resolveNativeChatTranscriptAgent', () => {
     expect(resolveNativeChatTranscriptAgent('claude')).toBe('claude')
   })
 
-  it('passes codex and grok through and rejects everything else', () => {
+  it('passes codex, grok, and pi through and rejects everything else', () => {
     expect(resolveNativeChatTranscriptAgent('codex')).toBe('codex')
     expect(resolveNativeChatTranscriptAgent('grok')).toBe('grok')
+    expect(resolveNativeChatTranscriptAgent('pi')).toBe('pi')
     expect(resolveNativeChatTranscriptAgent('cursor')).toBeNull()
     expect(resolveNativeChatTranscriptAgent(null)).toBeNull()
     expect(resolveNativeChatTranscriptAgent(undefined)).toBeNull()
@@ -24,6 +25,7 @@ describe('isNativeChatSupportedAgent', () => {
   it('recognizes the parseable agents and rejects unknown / nullish input', () => {
     expect(isNativeChatSupportedAgent('claude')).toBe(true)
     expect(isNativeChatSupportedAgent('openclaude')).toBe(true)
+    expect(isNativeChatSupportedAgent('pi')).toBe(true)
     expect(isNativeChatSupportedAgent('cursor')).toBe(false)
     expect(isNativeChatSupportedAgent(null)).toBe(false)
     expect(isNativeChatSupportedAgent(undefined)).toBe(false)

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,11 +1,12 @@
-export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok'
+export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'pi'
 
 /** Agents whose transcripts the native chat view can parse and render. */
 export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
   'claude',
   'openclaude',
   'codex',
-  'grok'
+  'grok',
+  'pi'
 ])
 
 export function isNativeChatSupportedAgent(agent: string | null | undefined): boolean {
@@ -30,7 +31,7 @@ export function resolveNativeChatTranscriptAgent(
   if (agent === 'claude' || agent === 'openclaude') {
     return 'claude'
   }
-  if (agent === 'codex' || agent === 'grok') {
+  if (agent === 'codex' || agent === 'grok' || agent === 'pi') {
     return agent
   }
   return null


### PR DESCRIPTION
## Summary

Enable the existing mobile native chat surface for Pi agents.

- Add Pi to the shared native-chat support and transcript-agent resolution.
- Decode Pi JSONL `message` records for user, assistant, thinking, tool calls, and tool results.
- Reuse Pi's hook-reported `session_file` for full transcript reads and live tailing.
- Add regression coverage for Pi transcript decoding and mobile eligibility.

## Screenshots

No visual change. This reuses the existing Codex/Claude mobile native-chat UI.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added regression tests for Pi transcript decoding and mobile eligibility

Additional checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/transcript-reader.test.ts src/main/native-chat/transcript-line-decoders.grok.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/transcript-line-decoders-pi.test.ts src/shared/native-chat-agent-support.test.ts`
- Oxlint, Oxfmt, and LSP diagnostics passed on changed files.

## AI Review Report

The review checked the end-to-end path: mobile eligibility, provider session identity, shared agent support, transcript path resolution, full transcript reads, live tail decoding, malformed/unknown Pi records, and tool-call/result rendering. It found no blocking issues.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and Electron-specific platform differences touched by this PR. No platform-specific code, shortcut, shell command, or Electron menu behavior is changed; Pi's existing hook-reported transcript path is passed through unchanged and the decoder is platform-neutral.
