### PR TITLE
fix(windows): avoid grok-hook exit 255 when GROK_HOME is unset

### DIFF
--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -89,11 +89,10 @@ describe('GrokHookService', () => {
     expect(script).toContain('/hook/grok')
     if (process.platform === 'win32') {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
-      expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
+      expect(script).toContain('setlocal EnableDelayedExpansion')
+      expect(script).toContain('if defined GROK_HOME set "ORCA_GROK_HOME=%GROK_HOME%"')
       expect(script).toContain('%GROK_HOME:~4096,1%')
-      expect(script).toContain(
-        'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
-      )
+      expect(script).toContain('!ORCA_GROK_HOME:~-1!')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -118,14 +118,14 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
       '@echo off',
-      'setlocal',
+      // Why: delayed expansion so trailing-`\` guard never percent-expands an empty
+      // GROK_HOME into invalid `\"` syntax (exit 255 → orca-status:stop red X).
+      'setlocal EnableDelayedExpansion',
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
-      'set "ORCA_GROK_HOME=%GROK_HOME%"',
-      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
-      // Why: a trailing backslash escapes curl's closing argv quote on Windows,
-      // merging the payload option into grokHome and dropping the hook body.
-      'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
+      'set "ORCA_GROK_HOME="',
+      `if defined GROK_HOME set "ORCA_GROK_HOME=%GROK_HOME%" & if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
+      'if defined ORCA_GROK_HOME if not "!ORCA_GROK_HOME!"=="" if "!ORCA_GROK_HOME:~-1!"=="\\" set "ORCA_GROK_HOME=!ORCA_GROK_HOME!."',
       WINDOWS_GROK_HOOK_POST_COMMAND,
       'exit /b 0',
       ...buildWindowsHookStdinDrainEpilogue(),


### PR DESCRIPTION
## Summary
- Grok TUI shows `global/orca-status:stop[0].hooks[0] failed with exit code 255` on Windows when `GROK_HOME` is unset (common for Orca-launched agent sessions).
- Root cause: managed `grok-hook.cmd` percent-expanded `%GROK_HOME:~N%` / `%ORCA_GROK_HOME:~-1%` on an empty home. Unset vars become bare `~N` tokens; combined with the trailing-`\` guard's `\"` comparison, cmd rewrites the line into invalid syntax and exits **255**.
- Fix: `setlocal EnableDelayedExpansion` and only apply envelope/trailing-slash handling when `GROK_HOME` is defined, using `!ORCA_GROK_HOME:~-1!` for the slash check.

## Test plan
- [x] Reproduced exit 255 with empty `GROK_HOME` before fix; exit 0 after
- [x] Empty / trailing-slash / normal `GROK_HOME` → hook + runner exit 0
- [x] `vitest run src/main/grok/hook-service.test.ts` (4 pass)
- [ ] In Orca on Windows: run a Grok turn, confirm stop hook no longer shows red exit 255

Related: #12320 (resume quoting is separate); user-visible orca-status failure.