### PR TITLE
feat(agents): add reasonix TUI agent provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ src/renderer/src/i18n/locales/.es-catalog-cache.json
 
 # Bench result JSONs are working artifacts
 tests/tools/benchmarks/results/terminal-pipeline-*.json
+
+# Local contribution logs (working notes; not part of the upstream contribution)
+/logs/

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -370,7 +370,8 @@
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "reasonix": "Reasonix"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -338,7 +338,8 @@
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "reasonix": "Reasonix"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -338,7 +338,8 @@
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "reasonix": "Reasonix"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -338,7 +338,8 @@
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "reasonix": "Reasonix"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -338,7 +338,8 @@
           "fc80296033": "Devin",
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "reasonix": "Reasonix"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -114,6 +114,12 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://docs.trae.cn/cli_get-started-with-trae-cli'
   },
   {
+    id: 'reasonix',
+    label: translate('auto.lib.agent.catalog.reasonix', 'Reasonix'),
+    cmd: 'reasonix',
+    homepageUrl: 'https://github.com/esengine/DeepSeek-Reasonix'
+  },
+  {
     id: 'pi',
     label: translate('auto.lib.agent.catalog.302934c5d9', 'Pi'),
     cmd: 'pi',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -130,7 +130,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   grok: true,
   devin: true,
   ante: true,
-  trae: true
+  trae: true,
+  reasonix: true
 }
 
 // Why: return null (not a 'claude' fallback) for unknown so Codex panes don't flash the Claude icon before the hook fires.

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -48,7 +48,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   grok: 'grok',
   devin: 'devin',
   ante: 'ante',
-  trae: 'trae'
+  trae: 'trae',
+  reasonix: 'reasonix'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -38,6 +38,7 @@ export type WellKnownAgentType =
   | 'devin'
   | 'ante'
   | 'trae'
+  | 'reasonix'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -23,6 +23,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   devin: 'Devin',
   ante: 'Ante',
   trae: 'Trae',
+  reasonix: 'Reasonix',
   kimi: 'Kimi'
 }
 

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -48,7 +48,9 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   devin: 'devin',
   ante: null,
   // Why: Orca detects trae by `traecli`, an alias only TRAE CN ships.
-  trae: 'trae-cn'
+  trae: 'trae-cn',
+  // Why: the skills CLI has no reasonix key; drop to the universal target.
+  reasonix: null
 } satisfies Record<TuiAgent, string | null>
 
 /**

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -102,6 +102,7 @@ export const AGENT_KIND_VALUES = [
   'devin',
   'ante',
   'trae',
+  'reasonix',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -306,6 +306,13 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'devin',
     // Why: `devin -- <prompt>` auto-submits immediately (docs.devin.ai/cli), so start the REPL with no argv prompt.
     promptInjectionMode: 'stdin-after-start'
+  },
+  reasonix: {
+    detectCmd: 'reasonix',
+    launchCmd: 'reasonix',
+    expectedProcess: 'reasonix',
+    // Why: reasonix's prompt contract is unverified; start bare and inject after startup, like aider/goose.
+    promptInjectionMode: 'stdin-after-start'
   }
 }
 

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -40,7 +40,8 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   hermes: 'Hermes',
   openclaw: 'OpenClaw',
   copilot: 'GitHub Copilot',
-  grok: 'Grok'
+  grok: 'Grok',
+  reasonix: 'Reasonix'
 }
 
 /** Canonical agent id list derived from the exhaustive display-name record,

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -38,7 +38,8 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
-  'openclaw'
+  'openclaw',
+  'reasonix'
 ] as const satisfies readonly TuiAgent[]
 
 // Why: fresh installs should expose Claude Agent Teams in agent pickers; the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2608,6 +2608,7 @@ export type TuiAgent =
   | 'devin' // Devin CLI
   | 'ante' // Ante (Antigma Labs)
   | 'trae' // Trae CLI
+  | 'reasonix' // Reasonix (npm CLI)
 
 export type TaskViewPresetId = 'all' | 'issues' | 'review' | 'my-issues' | 'my-prs' | 'prs'
 


### PR DESCRIPTION
## Summary

Adds **reasonix** (npm-installed terminal coding agent, `reasonix@1.19.4`) as a launchable TUI agent provider in Orca.

reasonix installs via `npm install -g reasonix` and runs as a terminal TUI (`reasonix`), matching the same model as claude-code / codex / opencode. Orca detects the npm-installed binary on PATH and launches it in a pty like any other agent:

- new `TuiAgent` member `'reasonix'` plus a `TUI_AGENT_CONFIG` entry (`detectCmd`/`launchCmd` = `reasonix`, `promptInjectionMode: 'stdin-after-start'`)
- telemetry kind (`AGENT_KIND_VALUES` + `TUI_AGENT_KIND_BY_AGENT`), display name, skills CLI mapping (falls back to universal), auto-pick order, well-known status labels
- agent picker catalog entry plus locale strings in all 5 catalogs (en/es/ja/ko/zh)

User-visible change: the agent picker / new-tab flow gains a "Reasonix" option; when installed it is detected and launchable like any other agent.

## Screenshots

No screenshots available: the authoring environment could not launch Electron (GitHub network timeouts blocked the Electron binary download). The visual change is a single new "Reasonix" entry (letter "R" glyph fallback) in the agent picker; no other UI changes.

## Testing

- [x] `pnpm lint` — oxlint 0 warnings / 0 errors; `audit:code-quality:native` + `type-aware` 0/0; reliability gates (62) pass; max-lines ratchet OK
- [x] `pnpm typecheck` — all 3 tsconfigs (node / cli / web) zero errors; every `Record<TuiAgent, …>` table exhaustive (compiler-driven)
- [x] `pnpm test` (affected suites) — agent-kind / keybindings / agent-detection / agent-type-label / tui-agent-selection: 146 tests pass; localization catalog verified (en synced, es/ja/ko/zh aligned)
- [ ] `pnpm build` — not run locally: requires the Electron binary, which could not be downloaded in this environment (network timeout); CI `package` job covers it
- [x] Tests: existing exhaustive-mapping tests automatically cover the new agent (`agent-kind.test.ts` sync test, `keybindings.test.ts` per-agent actions, `skills-cli-agent-keys.test.ts`); a temp launch-command test verified `launchCmd` = `reasonix` on darwin / linux / win32

## AI Review Report

Reviewed with an AI coding agent; main risks checked:

- **Cross-platform (macOS/Linux/Windows)**: `detectCmd`/`launchCmd` use the single `reasonix` bin on all three platforms (npm installs the platform binary via `@reasonix/cli-*` optionalDependencies); Windows pty spawn goes through the existing shell-fallback chain. No hardcoded paths, shortcuts, or platform-specific shell behavior introduced.
- **SSH / remote / local**: no changes to remote or SSH paths; detection uses the same PATH lookup as every other agent.
- **Agent / integration compatibility**: declarative `TUI_AGENT_CONFIG` pattern only; zero behavior change to existing providers; `SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT['reasonix'] = null` safely drops to the universal target since the skills CLI has no reasonix key.
- **Performance**: config-only change; no hot-path or runtime loops.
- **UI quality**: single catalog entry; icon falls back to the letter glyph (reasonix publishes no SVG); locale strings added to all 5 catalogs.
- Review flagged 3 follow-ups, all fixed: missing `es.json` entry, missing auto-pick order entry, missing well-known status labels (`agent-status-types.ts` / `agent-type-label.ts`).

## Security Audit

- **Input handling**: none — no new user-input paths; the launch command is a static string.
- **Command execution**: `launchCmd: 'reasonix'` runs the user-installed binary, same trust model as every existing agent; no flag-injection surface added.
- **Path handling**: no new path logic.
- **Auth / secrets**: none.
- **Dependencies**: no dependency changes (reasonix is installed by the user, not bundled).
- **IPC**: no IPC surface changes.

## Notes

- `promptInjectionMode` is `'stdin-after-start'` (bare launch + paste) because reasonix's prompt contract is not yet verified; if `reasonix <prompt>` or a `--prefill`-style flag is confirmed, it can be upgraded to `'argv'` / `draftPromptFlag` in a follow-up.
- Not verified locally: the full `pnpm test` suite and an interactive reasonix launch inside a hosted pty (Electron binary unavailable in the authoring environment); CI covers both.
- No release or version changes.
