### PR TITLE
fix(terminal): stop Ctrl+Enter leaking CSI-u without kitty keyboard

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
@@ -270,27 +270,32 @@ describe('resolveTerminalShortcutAction', () => {
     expect(getWindowsShiftEnterEncoding).toHaveBeenCalledTimes(2)
   })
 
-  it('forwards Ctrl+Enter as the kitty CSI-u chord so TUIs can cue instead of send', () => {
-    // Why: xterm.js collapses Ctrl+Enter to a bare CR; intercept upstream and
-    // emit the kitty sequence (modifier code 5 = Ctrl) so probing TUIs receive
-    // the distinct chord on every platform.
-    expect(
-      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), true)
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
-    expect(
-      resolveTerminalShortcutAction(event({ key: 'Enter', code: 'Enter', ctrlKey: true }), false)
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
-    // Windows uses the same kitty sequence for now: no TUI is known to treat the
-    // CSI-u Ctrl+Enter form as inert (cf. the Shift+Enter Codex-on-PowerShell case).
-    expect(
-      resolveTerminalShortcutAction(
-        event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
-        false,
-        'false',
-        0,
-        true
-      )
-    ).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
+  const ctrlEnter = (isWindows: boolean, kittyActive?: boolean) =>
+    resolveTerminalShortcutAction(
+      event({ key: 'Enter', code: 'Enter', ctrlKey: true }),
+      false,
+      'false',
+      0,
+      isWindows,
+      undefined,
+      undefined,
+      kittyActive === undefined ? undefined : () => kittyActive
+    )
+
+  it('forwards Ctrl+Enter as the kitty CSI-u chord while kitty keyboard is negotiated', () => {
+    // Why: xterm.js collapses Ctrl+Enter to a bare CR; intercept upstream and emit
+    // the kitty sequence (modifier code 5 = Ctrl) so probing TUIs receive the chord.
+    expect(ctrlEnter(false, true)).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
+    expect(ctrlEnter(true, true)).toEqual({ type: 'sendInput', data: '\x1b[13;5u' })
+  })
+
+  it('sends a bare CR for Ctrl+Enter when kitty keyboard is not active', () => {
+    // Regression: CSI-u is application input. On a local Windows ConPTY pane with no
+    // negotiated KKP the TUI printed the escape literally, leaking `[13;5u` into the
+    // prompt. Fall back to the CR xterm.js would otherwise have sent.
+    expect(ctrlEnter(true, false)).toEqual({ type: 'sendInput', data: '\r' })
+    expect(ctrlEnter(false, false)).toEqual({ type: 'sendInput', data: '\r' })
+    expect(ctrlEnter(true)).toEqual({ type: 'sendInput', data: '\r' })
 
     // Modifier combos that are NOT plain Ctrl+Enter must keep falling through.
     expect(

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -195,8 +195,13 @@ export function resolveTerminalShortcutAction(
     !event.shiftKey &&
     event.key === 'Enter'
   ) {
-    // Why: xterm.js collapses Ctrl+Enter to a bare CR, so forward kitty CSI-u (modifier 5 = Ctrl) so the chord reaches TUIs; no Windows fallback yet (#2418).
-    return { type: 'sendInput', data: '\x1b[13;5u' }
+    // Why: CSI-u only reaches a TUI as a chord while kitty keyboard is negotiated.
+    // Without it (local Windows ConPTY) the TUI prints the escape literally, so fall
+    // back to the bare CR xterm.js would have sent rather than leaking `[13;5u`.
+    return {
+      type: 'sendInput',
+      data: isKittyKeyboardActivePane?.() === true ? '\x1b[13;5u' : '\r'
+    }
   }
 
   if (


### PR DESCRIPTION
## Summary

Fixes #12329.

Pressing Ctrl+Enter in a local Windows ConPTY pane inserted the literal text `[13;5u` into the prompt instead of delivering the chord.

Ctrl+Enter emitted the kitty CSI-u sequence unconditionally:

```ts
return { type: 'sendInput', data: '\x1b[13;5u' }
```

CSI-u is application input. It only reads as a chord while the kitty keyboard protocol is negotiated for that pane, and on a local Windows ConPTY pane it is not, so the TUI printed the escape verbatim.

Shift+Enter, three lines above, already guards exactly this and falls back to `\x1b\r`:

```ts
const canSendCsiU = hasTrustedWindowsCsiU || isKittyKeyboardActivePane?.() === true
return { type: 'sendInput', data: canSendCsiU ? '\x1b[13;2u' : '\x1b\r' }
```

Ctrl+Enter had no such guard, and its own comment acknowledged the gap: *"no Windows fallback yet (#2418)"*.

This gates the sequence on active kitty keyboard and otherwise sends the bare CR that xterm.js would have collapsed Ctrl+Enter to. That restores the pre-existing default rather than inventing an encoding, and matches the fallback the reporter validated locally.

### Behavior change worth reviewing

The rewritten test replaces an assertion that documented the opposite assumption:

> Windows uses the same kitty sequence for now: no TUI is known to treat the CSI-u Ctrl+Enter form as inert (cf. the Shift+Enter Codex-on-PowerShell case).

#12329 is the counter-example, with Codex 0.146.0 on ConPTY. So this is a deliberate reversal, not an oversight being patched. It narrows Ctrl+Enter only where the chord was never being delivered anyway: with kitty keyboard active the CSI-u path is unchanged.

I used `isKittyKeyboardActivePane` alone rather than also reusing Shift+Enter's `getWindowsShiftEnterEncoding` signal. That setting is specifically about the Shift+Enter encoding, and borrowing it to authorize a different chord would couple two unrelated decisions.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (one pre-existing unrelated failure, see Notes)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full suite does not pass on this machine before or after, see Notes)
- [ ] `pnpm build` (not run locally)
- [x] Added regression tests

- `src/renderer/src/components/terminal-pane/`: **2887 passed, 218 files, 0 failed**
- New `sends a bare CR for Ctrl+Enter when kitty keyboard is not active` covers Windows, non-Windows, and the unset-callback case.
- The existing CSI-u expectation is kept for the kitty-active path on both platforms, so the chord is still pinned where it works.
- **Confirmed to fail against the previous implementation**: reverting the source fails exactly the new case and nothing else.

### Verification caveat

I do not have Codex on a Korean IME Windows setup and did not reproduce the literal `[13;5u` first-hand. The diagnosis in #12329 is unusually precise (the reporter located the branch in the shipped renderer bundle and validated a fallback locally), and it matches the source exactly. Verified here by tests rather than by observation.

## AI Review Report

Reviewed with Claude. Risks checked:

- **Cross-platform.** No platform branch added. The guard is the kitty-keyboard capability, not an OS check, so macOS and Linux panes with negotiated KKP keep the CSI-u chord and those without get the CR they would have had from xterm.js anyway.
- **Does not disturb Shift+Enter.** That branch is untouched, including its `getWindowsShiftEnterEncoding` trusted-Windows path.
- **Fallback choice.** `\r` rather than Shift+Enter's `\x1b\r`: alt-enter means newline, whereas Ctrl+Enter collapsing to CR is the documented pre-interception xterm.js behavior, so CR is the conservative restore.
- **Flagged and addressed.** The review flagged that the existing test called `resolveTerminalShortcutAction` positionally with 5 args and could not reach the 8th parameter. The test now uses a small helper so the kitty callback is actually exercised instead of left `undefined` in every case.

## Security Audit

- **Input handling.** This strictly reduces what is written to the PTY: an escape sequence is replaced by a single carriage return on the path where the escape was being printed as text. No new input is trusted or forwarded.
- **Command execution, path handling, auth, secrets, IPC, dependencies.** Untouched. No dependency changes.
- Worth noting the pre-fix behavior injected attacker-irrelevant but user-visible escape text into a prompt; narrowing it removes a small correctness hazard where a TUI could receive unintended literal characters.

## Notes

- **Pre-existing lint failure.** `pnpm lint` fails at `verify:skill-bundle-manifest` with stale `resources/skills/*.json`. Reproduces on a clean `main`, so it is not introduced here, and those are generated artifacts I did not want to churn.
- **`pnpm test` and `pnpm build` not completed locally.** A clean `main` on this Windows machine fails 167 tests across 57 files, so a green local suite is not achievable either way. The affected area is fully green.
- **Related but not addressed.** #12329 also mentions subsequent Korean input showing repeated newlines. That symptom belongs to the IME composition path and is handled separately in #12187; this PR deliberately only fixes the literal `[13;5u` leak.
- **#2418** is referenced by the comment this PR replaces and may be closeable as a result. I have not verified its current state.
