### PR TITLE
fix(native-chat): classify diff lines whose content begins with -- or ++

### DIFF
--- a/mobile/src/session/mobile-native-chat-diff.test.ts
+++ b/mobile/src/session/mobile-native-chat-diff.test.ts
@@ -36,6 +36,18 @@ describe('diffFromText', () => {
     expect(diffFromText('Here is a list:\n- one bullet\nthat is all')).toBeNull()
   })
 
+  it('counts a removed -- comment line despite the --- prefix collision', () => {
+    // Parity with the renderer test: a deleted `-- comment` (SQL/Lua/Haskell) is emitted
+    // by git as `---<content>` and must read as a deletion, not a file header.
+    const diff = diffFromText('@@ -1,2 +1,2 @@\n ctx\n---sql comment\n+new')
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: '--sql comment' },
+      { kind: 'add', text: 'new' }
+    ])
+  })
+
   it('caps large diffs before creating render rows', () => {
     const text = Array.from(
       { length: 1_000 },

--- a/src/renderer/src/components/native-chat/native-chat-diff.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-diff.test.ts
@@ -60,4 +60,49 @@ describe('diffFromText', () => {
     expect(diff?.filter((l) => l.kind === 'add').map((l) => l.text)).toEqual(['new'])
     expect(diff?.filter((l) => l.kind === 'del').map((l) => l.text)).toEqual(['old'])
   })
+
+  it('counts a removed line whose content begins with -- (--- prefix collision)', () => {
+    // A deleted SQL/Lua/Haskell `-- comment` is emitted by git as `---<content>`,
+    // which must be classified as a deletion, not mistaken for the `--- a/file` header.
+    const diff = diffFromText('@@ -1,2 +1,2 @@\n ctx\n---sql comment\n+new')
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: '--sql comment' },
+      { kind: 'add', text: 'new' }
+    ])
+  })
+
+  it('counts an added line whose content begins with ++ (+++ prefix collision)', () => {
+    const diff = diffFromText('@@ -1,2 +1,2 @@\n ctx\n-old\n+++flag')
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: 'old' },
+      { kind: 'add', text: '++flag' }
+    ])
+  })
+
+  it('counts a --- content deletion in a header-less agent-tool diff (no @@)', () => {
+    // Agent-tool output may carry no `@@` hunk header; the pair rule (unlike countDiffLines'
+    // hunk-state fix) must still classify `---<content>` as a deletion here.
+    const diff = diffFromText('---sql comment\n+new\n-more context')
+    expect(diff).toEqual([
+      { kind: 'del', text: '--sql comment' },
+      { kind: 'add', text: 'new' },
+      { kind: 'del', text: 'more context' }
+    ])
+  })
+
+  it('does not swallow a --x / ++y content pair as a file header', () => {
+    // A deletion of `--note` immediately followed by an addition of `++flag` must both
+    // count — they are NOT the canonical `--- <old>` / `+++ <new>` header pair (no space).
+    const diff = diffFromText('@@ -1,2 +1,2 @@\n ctx\n---note\n+++flag')
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: '--note' },
+      { kind: 'add', text: '++flag' }
+    ])
+  })
 })

--- a/src/shared/native-chat-diff.ts
+++ b/src/shared/native-chat-diff.ts
@@ -62,17 +62,28 @@ export function diffFromText(
     return null
   }
   const bounded = toLines(text, maxLines)
+  const raw = bounded.lines
   let added = 0
   let removed = 0
-  const lines = bounded.lines.map((line): NativeChatDiffLine => {
+  const lines = raw.map((line, i): NativeChatDiffLine => {
     if (line.startsWith('@@') || line.startsWith('diff ') || line.startsWith('index ')) {
       return { kind: 'meta', text: line }
     }
-    if (line.startsWith('+') && !line.startsWith('+++')) {
+    // Why: `--- <old>`/`+++ <new>` file headers always carry a trailing space + path and
+    // travel as a consecutive pair. A deletion of `-- comment` (SQL/Lua/Haskell) is emitted
+    // by git as `---<content>` (no space) — match the canonical separator pair, not a lone
+    // prefix, so it counts as a deletion (agent-tool diffs may lack the `@@` countDiffLines relies on).
+    const isHeaderPair =
+      (line.startsWith('--- ') && raw[i + 1]?.startsWith('+++ ')) ||
+      (line.startsWith('+++ ') && i > 0 && raw[i - 1].startsWith('--- '))
+    if (isHeaderPair) {
+      return { kind: 'context', text: line }
+    }
+    if (line.startsWith('+')) {
       added += 1
       return { kind: 'add', text: line.slice(1) }
     }
-    if (line.startsWith('-') && !line.startsWith('---')) {
+    if (line.startsWith('-')) {
       removed += 1
       return { kind: 'del', text: line.slice(1) }
     }


### PR DESCRIPTION
## Summary

`diffFromText` in `src/shared/native-chat-diff.ts` colourizes the unified-diff text an agent tool returns (wired at `NativeChatToolRun.tsx:44`, which feeds it `block.output`). It classified each line with `line.startsWith('+') && !line.startsWith('+++')` / `line.startsWith('-') && !line.startsWith('---')` to skip the `+++ b/file` / `--- a/file` file headers.

That guard was too broad: a **removed** content line whose original text began with `--` (a SQL/Lua/Haskell `-- comment`, or `--i` in C-family) is emitted by git as the diff line `---<content>`, which the `!startsWith('---')` check treated as a file header — so the deletion was misclassified as gray context and not counted. The symmetric collision affects an **added** line whose content began with `++` (`+++flag`). When such a line was the only add/del signal, the `added + removed < 2` gate then dropped the whole coloured diff.

Concretely, `diffFromText('@@ -1,2 +1,2 @@\n ctx\n---sql comment\n+new')` returned `null` (the `---sql comment` deletion was swallowed as a header, leaving `added=1/removed=0`), instead of rendering the deletion red and the addition green.

This is the **sibling of #12133** (`countDiffLines`, merged today), which fixed the identical collision in the GitLab MR-dialog counter. That PR's docstring even points here: it notes `countDiffLines` "requires hunk headers" and defers "header-less agent-tool diffs" to `diffFromText` — so `diffFromText` must handle this case correctly.

## Fix

A line is treated as a file header only when it matches the **canonical `--- <old>` → `+++ <new>` pair** — i.e. a `--- `/`+++ ` prefix (trailing space + path, the form git headers always carry) AND the adjacent line forms the matching half of the pair. Any other `-`/`+` line — including `---<content>`/`+++<content>` (no space), and a `--x` deletion next to a `++y` addition — is normal del/add content. Matching the canonical separator (not a lone `---`/`+++` prefix) avoids mistaking a content pair for a header, and unlike the `countDiffLines` fix (which keys off the `@@` hunk header) it also covers header-less agent-tool output that may carry no `@@`.

## Screenshots

No visual change beyond corrected diff colouring (and no longer dropping small `--`/`++` diffs entirely).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:
- Regression tests in `native-chat-diff.test.ts` (renderer): removed `--` content, added `++` content, a header-less (no `@@`) deletion, and a `--x`/`++y` content pair that must NOT be read as a header — each asserting the full line structure (kind + stripped text + order).
- Parity test in `mobile/src/session/mobile-native-chat-diff.test.ts` (the mobile module re-exports the shared function, so the fix applies automatically).
- **RED-before-GREEN, isolated:** reverting the predicate makes exactly the new renderer tests fail (the lone-prefix/pair variant fails the content-pair test; reverting to the original guard fails the collision tests); pre-existing tests stay green. Re-applying → 12/12 renderer + 7/7 mobile green.
- `pnpm typecheck` green across all three node tsconfigs + the mobile tsconfig; `pnpm exec oxlint` clean; `pnpm exec oxfmt --check` clean on all three files.

## AI Review Report

- **Cross-platform (macOS/Linux/Windows):** the SUT is pure string parsing of tool-result text; no platform assumptions. Runs identically everywhere.
- **SSH/remote/local + folder-workspace:** N/A — parses a string already in hand; no git binary / SSH / folder-workspace path involved.
- **Provider/agent neutrality:** native-chat tool-result diff rendering (shared by desktop + mobile).
- **Performance / hot path:** none — runs once per tool-result block on render.
- **UI quality:** corrects diff colouring and prevents small `--`/`++` diffs from being dropped entirely.

## Security Audit

Pure string-parsing fix on already-trusted agent-tool output. No new input handling, IPC, auth, path, or dependency surface.

## Notes

- Single desktop call site: `NativeChatToolRun.tsx:44` (`diff = diffFromText(block.output)`); mobile mirrors via re-export.
- Why the canonical-separator pair rule instead of the `@@`-hunk-state fix used in `countDiffLines` (#12133): GitLab API diffs always carry `@@` hunks, but agent-tool `block.output` may be header-less, so a rule that doesn't depend on `@@` covers both. `countDiffLines`'s docstring already defers header-less diffs to this function. Matching the canonical `--- <old>` / `+++ <new>` pair (trailing space + path) ensures a `--x` deletion next to a `++y` addition is NOT mistaken for a header.
- A maintainer may need to approve-and-run the CI workflows for this fork PR; let me know if anything else is needed.
