### PR TITLE
fix(orchestration): retain update settlement authority

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -6511,10 +6511,10 @@
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "daemon", "ssh"],
-      "coverageNotes": "A deterministic service-state-machine oracle now models a current-contract worker and coordinator whose renderer graph identities disappear across an app/runtime update. It proves hook-attested authority can settle once or explicitly take over while retaining exact Task, Dispatch, terminal identity, and filesystem bytes, and rejects foreign pane evidence. Other deterministic units cover authority-aware legacy formatting, exact legacy worker identity planning, local worker presentation, retained-output reads after adoption, reveal-failure warnings, stable-pane Run/Dispatch routing, the SSH in-process CLI fallback, and federated non-reveal. Two isolated macOS Electron journeys launch fake Codex workers through the real RPC path and record append-only spawn/interruption ledgers. They assert immediate inactive presentation, one live agent PID, stable PTY/incarnation/tab/leaf/worktree/Task/Dispatch identity, and no interruption after workspace re-entry; the restart journey additionally removes renderer ownership, marks the Dispatch legacy, retains the daemon process across an app restart, and proves exact background adoption with readable ACK output and no resume replay. Distinct A/B artifacts plus live SSH, WSL, folder, remote-runtime, Linux, and Windows cutover journeys remain explicit gaps.",
+      "coverageNotes": "A deterministic service-state-machine oracle now models a current-contract worker and coordinator whose renderer graph identities disappear across an app/runtime update. It exercises the production verifier with restored PTY and hydrated hook commitments, proves authenticated completion replay across a fresh runtime, explicit takeover, ordinary mail routing, remote-attachment process fencing, retained Task/Dispatch/terminal identity, and unchanged fixture marker bytes, and rejects foreign pane evidence. Other deterministic units cover authority-aware legacy formatting, exact legacy worker identity planning, local worker presentation, retained-output reads after adoption, reveal-failure warnings, stable-pane Run/Dispatch routing, the SSH in-process CLI fallback, and federated non-reveal. Two isolated macOS Electron journeys launch fake Codex workers through the real RPC path and record append-only spawn/interruption ledgers. They assert immediate inactive presentation, one live agent PID, stable PTY/incarnation/tab/leaf/worktree/Task/Dispatch identity, and no interruption after workspace re-entry; the restart journey additionally removes renderer ownership, marks the Dispatch legacy, retains the daemon process across an app restart, and proves exact background adoption with readable ACK output and no resume replay. Distinct A/B artifacts plus live SSH, WSL, folder, remote-runtime, Linux, and Windows cutover journeys remain explicit gaps.",
       "motivatingLinks": ["https://github.com/stablyai/orca/pull/11107#discussion_r3663321387"],
       "invariant": "Starting a worker in the coordinator's current workspace must materialize one inactive terminal tab before worker-start returns, preserve coordinator focus, and remain exactly once after workspace re-entry. After an app update or restart, an exact live legacy worker must fence automatic provider resume, adopt its original PTY into its original background pane, retain readable output, and clear the resume record without spawning, writing, signalling, interrupting, replacing, or focusing the worker. A current-contract worker whose renderer graph identity is temporarily absent must retain its Dispatch capability and settle exactly once from exact hook-attested handle, pane, and process evidence; otherwise only an exact attested coordinator may take over. An exact existing target workspace must receive a discoverable tab without stealing coordinator focus; if renderer reveal fails, worker-start must expose that the live worker remains background-only. Run and Dispatch checks must resolve through the caller's stable pane identity when a terminal handle is reminted, while a live handle outranks mismatched pane metadata, explicit legacy terminal inspection remains handle-scoped, and remote or headless worker presentation remains background-only.",
-      "oracle": "Drive Run create, Task create, and worker-start through production Electron runtimes with a deterministic Codex fixture. Require append-only ledgers with one still-live PID and no interruption, a visible inactive worker tab while the coordinator stays active, Run delivery through stable pane identity, and stable PTY/incarnation, tab, leaf, worktree, Task, and Dispatch across workspace re-entry. In a restart journey, retain the original daemon PTY and PID, remove renderer ownership, retain sleeping-session evidence, mark the Dispatch legacy, relaunch, and require exact inactive tab adoption, readable ACK output, cleared resume state, one spawn, and no resume argv or Conversation interrupted text after another workspace round trip. The service oracle removes renderer identity from a current-contract worker, replays one authenticated completion and one explicit takeover, and requires one Task, Dispatch, terminal authority, message, mutation, and byte-identical filesystem marker while foreign pane evidence remains rejected. Unit tests separately assert authority-specific legacy affordances, exact identity and owner matching, retained-output fallback, pane-stable routing, federated non-activation, and SSH fallback parity.",
+      "oracle": "Drive Run create, Task create, and worker-start through production Electron runtimes with a deterministic Codex fixture. Require append-only ledgers with one still-live PID and no interruption, a visible inactive worker tab while the coordinator stays active, Run delivery through stable pane identity, and stable PTY/incarnation, tab, leaf, worktree, Task, and Dispatch across workspace re-entry. In a restart journey, retain the original daemon PTY and PID, remove renderer ownership, retain sleeping-session evidence, mark the Dispatch legacy, relaunch, and require exact inactive tab adoption, readable ACK output, cleared resume state, one spawn, and no resume argv or Conversation interrupted text after another workspace round trip. The service oracle removes renderer lookup identity from current-contract callers while retaining real restored-PTY and hook commitments, replays authenticated completion and takeover across fresh runtimes, and requires one Task, Dispatch, terminal authority, message, mutation, ordinary-mail delivery, remote process fencing, and unchanged fixture marker bytes while foreign pane evidence remains rejected. Unit tests separately assert authority-specific legacy affordances, exact identity and owner matching, retained-output fallback, pane-stable routing, federated non-activation, and SSH fallback parity.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/orchestration.test.ts src/cli/handlers/orchestration-check-identity.test.ts src/cli/handlers/orchestration-worker-cli.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/ssh/ssh-remote-orca-cli.test.ts",
@@ -6545,7 +6545,8 @@
             "an exact current worker settles once through an app/runtime update even when renderer graph identity is absent",
             "only an attested current coordinator may explicitly take over retained live work",
             "Task, Dispatch, terminal authority, completion, and filesystem bytes are neither lost nor duplicated",
-            "foreign pane evidence cannot borrow retained lifecycle authority"
+            "foreign pane evidence cannot borrow retained lifecycle authority",
+            "ordinary mail and remote attachments use the same attested pane and process authority"
           ]
         },
         {
@@ -6633,8 +6634,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
           "result": "failed",
-          "durationSeconds": 3.56,
-          "summary": "The byte-identical dbe15c3303 oracle failed 2 of 3 rows on origin/main@34291f07e9: the attested worker remained dispatched after worker_done and the attested coordinator could not take over without renderer pane identity."
+          "durationSeconds": 3.07,
+          "summary": "The byte-identical 5f45c270f1 oracle, applied as the sole tree overlay in 063340a8ba on origin/main@34291f07e9, failed 3 of 5 rows: completion remained dispatched, takeover lacked a stable pane, and remote attachment authority lost process identity."
         },
         {
           "date": "2026-08-03",
@@ -6642,8 +6643,8 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
           "result": "passed",
-          "durationSeconds": 6.53,
-          "summary": "The same byte-identical oracle passed 3 tests on candidate@cd63bc8843, preserving exact authority and filesystem bytes while rejecting foreign pane evidence."
+          "durationSeconds": 3.13,
+          "summary": "The same byte-identical oracle passed 5 tests on candidate@2748b0b29b, exercising the production verifier and fresh-runtime replay while preserving exact DB identity and unchanged fixture bytes."
         },
         {
           "date": "2026-08-03",
@@ -6651,8 +6652,17 @@
           "platform": "macos",
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
           "result": "failed",
-          "durationSeconds": 10.46,
-          "summary": "With current-authority propagation disabled on candidate@7003954794, the same byte-identical oracle failed settlement and takeover while its foreign-pane rejection stayed green."
+          "durationSeconds": 3.14,
+          "summary": "With current-authority propagation actually disabled in candidate child 08a7db37bf, the same byte-identical oracle failed 2 of 5 rows: completion remained dispatched and remote attachment authority was rejected."
+        },
+        {
+          "date": "2026-08-03",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 3.1,
+          "summary": "After reverting the intentional break in d2a4e2e024, the same byte-identical oracle passed all 5 tests."
         },
         {
           "date": "2026-07-28",
@@ -6701,7 +6711,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The byte-identical dbe15c3303 service oracle is red on origin/main@34291f07e9, green on candidate@cd63bc8843, and red with current-authority propagation disabled on candidate ancestor 7003954794. The focused presentation and stale-handle tests failed against the earlier pre-fix implementation. The restart journey additionally failed first on empty retained output while the original PTY/PID remained live, then passed after the scoped recovered-worker snapshot fallback. The live incident and pre-fix Electron topology showed workspace re-entry replaying provider resume against a worker whose tab binding was missing. Distinct installed A/B and CI artifacts are still needed."
+        "evidence": "The byte-identical 5f45c270f1 service oracle is red as the sole overlay 063340a8ba on origin/main@34291f07e9, green on candidate@2748b0b29b, red with current-authority propagation actually disabled in child 08a7db37bf, and green again after revert d2a4e2e024. The focused presentation and stale-handle tests failed against the earlier pre-fix implementation. The restart journey additionally failed first on empty retained output while the original PTY/PID remained live, then passed after the scoped recovered-worker snapshot fallback. The live incident and pre-fix Electron topology showed workspace re-entry replaying provider resume against a worker whose tab binding was missing. Distinct installed A/B and CI artifacts are still needed."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -6511,11 +6511,12 @@
       "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "daemon", "ssh"],
-      "coverageNotes": "Deterministic units cover authority-aware legacy formatting, exact legacy worker identity planning, local worker presentation, retained-output reads after adoption, reveal-failure warnings, stable-pane Run/Dispatch routing, the SSH in-process CLI fallback, and federated non-reveal. Two isolated macOS Electron journeys launch fake Codex workers through the real RPC path and record append-only spawn/interruption ledgers. They assert immediate inactive presentation, one live agent PID, stable PTY/incarnation/tab/leaf/worktree/Task/Dispatch identity, and no interruption after workspace re-entry; the restart journey additionally removes renderer ownership, marks the Dispatch legacy, retains the daemon process across an app restart, and proves exact background adoption with readable ACK output and no resume replay. Distinct A/B artifacts plus live SSH, WSL, folder, remote-runtime, Linux, and Windows cutover journeys remain explicit gaps.",
+      "coverageNotes": "A deterministic service-state-machine oracle now models a current-contract worker and coordinator whose renderer graph identities disappear across an app/runtime update. It proves hook-attested authority can settle once or explicitly take over while retaining exact Task, Dispatch, terminal identity, and filesystem bytes, and rejects foreign pane evidence. Other deterministic units cover authority-aware legacy formatting, exact legacy worker identity planning, local worker presentation, retained-output reads after adoption, reveal-failure warnings, stable-pane Run/Dispatch routing, the SSH in-process CLI fallback, and federated non-reveal. Two isolated macOS Electron journeys launch fake Codex workers through the real RPC path and record append-only spawn/interruption ledgers. They assert immediate inactive presentation, one live agent PID, stable PTY/incarnation/tab/leaf/worktree/Task/Dispatch identity, and no interruption after workspace re-entry; the restart journey additionally removes renderer ownership, marks the Dispatch legacy, retains the daemon process across an app restart, and proves exact background adoption with readable ACK output and no resume replay. Distinct A/B artifacts plus live SSH, WSL, folder, remote-runtime, Linux, and Windows cutover journeys remain explicit gaps.",
       "motivatingLinks": ["https://github.com/stablyai/orca/pull/11107#discussion_r3663321387"],
-      "invariant": "Starting a worker in the coordinator's current workspace must materialize one inactive terminal tab before worker-start returns, preserve coordinator focus, and remain exactly once after workspace re-entry. After an app update or restart, an exact live legacy worker must fence automatic provider resume, adopt its original PTY into its original background pane, retain readable output, and clear the resume record without spawning, writing, signalling, interrupting, replacing, or focusing the worker. An exact existing target workspace must receive a discoverable tab without stealing coordinator focus; if renderer reveal fails, worker-start must expose that the live worker remains background-only. Run and Dispatch checks must resolve through the caller's stable pane identity when a terminal handle is reminted, while a live handle outranks mismatched pane metadata, explicit legacy terminal inspection remains handle-scoped, and remote or headless worker presentation remains background-only.",
-      "oracle": "Drive Run create, Task create, and worker-start through production Electron runtimes with a deterministic Codex fixture. Require append-only ledgers with one still-live PID and no interruption, a visible inactive worker tab while the coordinator stays active, Run delivery through stable pane identity, and stable PTY/incarnation, tab, leaf, worktree, Task, and Dispatch across workspace re-entry. In a restart journey, retain the original daemon PTY and PID, remove renderer ownership, retain sleeping-session evidence, mark the Dispatch legacy, relaunch, and require exact inactive tab adoption, readable ACK output, cleared resume state, one spawn, and no resume argv or Conversation interrupted text after another workspace round trip. Unit tests separately assert authority-specific legacy affordances, exact identity and owner matching, retained-output fallback, pane-stable routing, federated non-activation, and SSH fallback parity.",
+      "invariant": "Starting a worker in the coordinator's current workspace must materialize one inactive terminal tab before worker-start returns, preserve coordinator focus, and remain exactly once after workspace re-entry. After an app update or restart, an exact live legacy worker must fence automatic provider resume, adopt its original PTY into its original background pane, retain readable output, and clear the resume record without spawning, writing, signalling, interrupting, replacing, or focusing the worker. A current-contract worker whose renderer graph identity is temporarily absent must retain its Dispatch capability and settle exactly once from exact hook-attested handle, pane, and process evidence; otherwise only an exact attested coordinator may take over. An exact existing target workspace must receive a discoverable tab without stealing coordinator focus; if renderer reveal fails, worker-start must expose that the live worker remains background-only. Run and Dispatch checks must resolve through the caller's stable pane identity when a terminal handle is reminted, while a live handle outranks mismatched pane metadata, explicit legacy terminal inspection remains handle-scoped, and remote or headless worker presentation remains background-only.",
+      "oracle": "Drive Run create, Task create, and worker-start through production Electron runtimes with a deterministic Codex fixture. Require append-only ledgers with one still-live PID and no interruption, a visible inactive worker tab while the coordinator stays active, Run delivery through stable pane identity, and stable PTY/incarnation, tab, leaf, worktree, Task, and Dispatch across workspace re-entry. In a restart journey, retain the original daemon PTY and PID, remove renderer ownership, retain sleeping-session evidence, mark the Dispatch legacy, relaunch, and require exact inactive tab adoption, readable ACK output, cleared resume state, one spawn, and no resume argv or Conversation interrupted text after another workspace round trip. The service oracle removes renderer identity from a current-contract worker, replays one authenticated completion and one explicit takeover, and requires one Task, Dispatch, terminal authority, message, mutation, and byte-identical filesystem marker while foreign pane evidence remains rejected. Unit tests separately assert authority-specific legacy affordances, exact identity and owner matching, retained-output fallback, pane-stable routing, federated non-activation, and SSH fallback parity.",
       "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
         "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/orchestration.test.ts src/cli/handlers/orchestration-check-identity.test.ts src/cli/handlers/orchestration-worker-cli.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/ssh/ssh-remote-orca-cli.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/formatter.test.ts src/main/runtime/rpc/methods/orchestration-federation.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.test.ts",
@@ -6524,6 +6525,7 @@
         "pnpm run test:e2e -- tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts --workers=1"
       ],
       "testFiles": [
+        "src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts",
         "src/main/runtime/orchestration/formatter.test.ts",
         "src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.test.ts",
         "src/main/runtime/orca-runtime.test.ts",
@@ -6537,6 +6539,15 @@
         "tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts"
       ],
       "assertionRefs": [
+        {
+          "file": "src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts",
+          "assertions": [
+            "an exact current worker settles once through an app/runtime update even when renderer graph identity is absent",
+            "only an attested current coordinator may explicitly take over retained live work",
+            "Task, Dispatch, terminal authority, completion, and filesystem bytes are neither lost nor duplicated",
+            "foreign pane evidence cannot borrow retained lifecycle authority"
+          ]
+        },
         {
           "file": "src/main/runtime/orchestration/orchestration-legacy-worker-terminal-recovery.test.ts",
           "assertions": [
@@ -6617,6 +6628,33 @@
       ],
       "evidenceRuns": [
         {
+          "date": "2026-08-03",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
+          "result": "failed",
+          "durationSeconds": 3.56,
+          "summary": "The byte-identical dbe15c3303 oracle failed 2 of 3 rows on origin/main@34291f07e9: the attested worker remained dispatched after worker_done and the attested coordinator could not take over without renderer pane identity."
+        },
+        {
+          "date": "2026-08-03",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 6.53,
+          "summary": "The same byte-identical oracle passed 3 tests on candidate@cd63bc8843, preserving exact authority and filesystem bytes while rejecting foreign pane evidence."
+        },
+        {
+          "date": "2026-08-03",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts --reporter=dot",
+          "result": "failed",
+          "durationSeconds": 10.46,
+          "summary": "With current-authority propagation disabled on candidate@7003954794, the same byte-identical oracle failed settlement and takeover while its foreign-pane rejection stayed green."
+        },
+        {
           "date": "2026-07-28",
           "runner": "local",
           "platform": "macos",
@@ -6663,7 +6701,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The focused presentation and stale-handle tests failed against the pre-fix implementation. The restart journey additionally failed first on empty retained output while the original PTY/PID remained live, then passed after the scoped recovered-worker snapshot fallback. The live incident and pre-fix Electron topology showed workspace re-entry replaying provider resume against a worker whose tab binding was missing. Saved intentional-break and CI artifacts are still needed."
+        "evidence": "The byte-identical dbe15c3303 service oracle is red on origin/main@34291f07e9, green on candidate@cd63bc8843, and red with current-authority propagation disabled on candidate ancestor 7003954794. The focused presentation and stale-handle tests failed against the earlier pre-fix implementation. The restart journey additionally failed first on empty retained output while the original PTY/PID remained live, then passed after the scoped recovered-worker snapshot fallback. The live incident and pre-fix Electron topology showed workspace re-entry replaying provider resume against a worker whose tab binding was missing. Distinct installed A/B and CI artifacts are still needed."
       },
       "performanceBudget": {
         "required": true,

--- a/src/main/runtime/rpc/methods/orchestration-runs.ts
+++ b/src/main/runtime/rpc/methods/orchestration-runs.ts
@@ -2,7 +2,10 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalBoolean, OptionalString, requiredString } from '../schemas'
 import { ORCHESTRATION_RUN_PAGE_LIMIT } from '../../../../shared/orchestration-run-pagination'
-import type { OrcaRuntimeService } from '../../orca-runtime'
+import type {
+  OrcaRuntimeService,
+  OrchestrationCompatibilityCallerAuthority
+} from '../../orca-runtime'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { assertCallerHandleMatchesEvidence } from './orchestration-run-scope'
 
@@ -24,8 +27,15 @@ const RunListParams = z.object({
 })
 const RunShowParams = z.object({ id: requiredString('Missing --id'), from: OptionalString })
 
-function requireCallerPane(runtime: OrcaRuntimeService, handle: string): string {
-  const paneKey = runtime.getTerminalPaneKey(handle)
+function requireCallerPane(
+  runtime: OrcaRuntimeService,
+  handle: string,
+  callerAuthority?: OrchestrationCompatibilityCallerAuthority
+): string {
+  const paneKey =
+    callerAuthority?.terminalHandle === handle
+      ? callerAuthority.paneKey
+      : runtime.getTerminalPaneKey(handle)
   if (!paneKey) {
     throw new OrchestrationError(
       'stable_pane_required',
@@ -67,7 +77,7 @@ export const ORCHESTRATION_RUN_METHODS: RpcMethod[] = [
         orchestrationCompatibilityCallerAuthority: callerAuthority
       }
     ) => {
-      const paneKey = requireCallerPane(runtime, params.from)
+      const paneKey = requireCallerPane(runtime, params.from, callerAuthority)
       if (
         params.takeoverLegacy &&
         (callerAuthority?.terminalHandle !== params.from || callerAuthority.paneKey !== paneKey)

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -408,7 +408,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         : undefined
       if (remoteAttachment) {
         rejectFederatedExplicitTarget(params)
-        const processIncarnation = runtime.getTerminalProcessIncarnation(from)
+        const processIncarnation =
+          attestedCaller?.processIncarnation ?? runtime.getTerminalProcessIncarnation(from)
         if (
           !db.verifyRemoteAttachmentAuthority({
             dispatchId: remoteAttachment.dispatch_id,

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -387,12 +387,22 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     params: SendParams,
     handler: async (
       params,
-      { runtime, orchestrationCapability, legacyCoordinatorRunId, revalidateLegacyCoordinator }
+      {
+        runtime,
+        orchestrationCapability,
+        legacyCoordinatorRunId,
+        revalidateLegacyCoordinator,
+        orchestrationCompatibilityCallerAuthority
+      }
     ) => {
       const db = runtime.getOrchestrationDb()
       const from = params.from ?? 'unknown'
-      // Why: caller-supplied pane fields are only compatibility metadata; lifecycle authority uses the runtime-observed pane plus capability.
-      const senderPaneKey = runtime.getTerminalPaneKey(from) ?? undefined
+      const attestedCaller =
+        orchestrationCompatibilityCallerAuthority?.terminalHandle === from
+          ? orchestrationCompatibilityCallerAuthority
+          : undefined
+      // Why: attested hook identity survives graph remount; caller params never supply lifecycle authority.
+      const senderPaneKey = attestedCaller?.paneKey ?? runtime.getTerminalPaneKey(from) ?? undefined
       const remoteAttachment = senderPaneKey
         ? db.findActiveRemoteAttachmentForPane(senderPaneKey)
         : undefined
@@ -582,7 +592,10 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             dispatchId: dispatch.id,
             capability: orchestrationCapability,
             paneKey: senderPaneKey,
-            processIncarnation: runtime.getTerminalProcessIncarnation(from) ?? undefined
+            processIncarnation:
+              attestedCaller?.processIncarnation ??
+              runtime.getTerminalProcessIncarnation(from) ??
+              undefined
           })
           if (!authority.valid) {
             const rejection =

--- a/src/main/runtime/rpc/orchestration-legacy-compatibility.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-compatibility.ts
@@ -65,11 +65,14 @@ export class OrchestrationLegacyCompatibility {
       return { handled: false }
     }
     const values = params as Record<string, unknown>
-    if (
-      CURRENT_AUTHORITY_PREFLIGHT_METHODS.has(request.method) &&
-      this.usesCurrentAuthority(request, values)
-    ) {
-      return { handled: false }
+    if (CURRENT_AUTHORITY_PREFLIGHT_METHODS.has(request.method)) {
+      const callerAuthority = this.resolveCurrentAuthority(request, values)
+      if (callerAuthority) {
+        return {
+          handled: false,
+          orchestrationCompatibilityCallerAuthority: callerAuthority
+        }
+      }
     }
     const result = await this.route(request, params, signal)
     if (result !== undefined) {
@@ -122,45 +125,48 @@ export class OrchestrationLegacyCompatibility {
       : undefined
   }
 
-  private usesCurrentAuthority(request: RpcRequest, params: Record<string, unknown>): boolean {
+  private resolveCurrentAuthority(
+    request: RpcRequest,
+    params: Record<string, unknown>
+  ): OrchestrationCompatibilityCallerAuthority | undefined {
     const db = this.runtime.getOrchestrationDb()
     const adoption = db.getLegacyAdoption()
     if (!adoption || stringValue(params.run) || request.method === 'orchestration.runUse') {
-      return false
+      return undefined
     }
     const evidence = request.orchestrationCompatibilityEvidence
     if (!evidence?.terminalHandle || !evidence.paneKey) {
-      return false
+      return undefined
     }
     const claimedHandle = currentCallerHandle(request.method, params)
     if (claimedHandle && claimedHandle !== evidence.terminalHandle) {
-      return false
+      return undefined
     }
     const dispatch = db.getActiveDispatchForIdentity(evidence.terminalHandle, evidence.paneKey)
     if (dispatch) {
       if (dispatch.contract_version !== CURRENT_CONTRACT_VERSION) {
-        return false
+        return undefined
       }
       const caller = this.runtime.verifyOrchestrationCompatibilityCaller(evidence)
-      return Boolean(
-        caller &&
+      return caller &&
         caller.terminalHandle === evidence.terminalHandle &&
         db.getActiveDispatchForIdentity(caller.terminalHandle, caller.paneKey)?.id === dispatch.id
-      )
+        ? caller
+        : undefined
     }
     const remoteAttachment = db.findActiveRemoteAttachmentForPane(evidence.paneKey)
     if (remoteAttachment) {
       const caller = this.runtime.verifyOrchestrationCompatibilityCaller(evidence)
-      return Boolean(
-        caller &&
+      return caller &&
         caller.terminalHandle === evidence.terminalHandle &&
         db.findActiveRemoteAttachmentForPane(caller.paneKey)?.dispatch_id ===
           remoteAttachment.dispatch_id
-      )
+        ? caller
+        : undefined
     }
     const boundRun = db.getCurrentRunForPane(evidence.paneKey)
     if (!boundRun) {
-      return false
+      return undefined
     }
     const legacyCandidate =
       boundRun.id === adoption.adopted_run_id
@@ -171,7 +177,7 @@ export class OrchestrationLegacyCompatibility {
           })
         : undefined
     if (legacyCandidate) {
-      return false
+      return undefined
     }
     const caller = this.runtime.verifyOrchestrationCompatibilityCaller(evidence)
     if (
@@ -179,16 +185,18 @@ export class OrchestrationLegacyCompatibility {
       caller.terminalHandle !== evidence.terminalHandle ||
       db.getCurrentRunForPane(caller.paneKey)?.id !== boundRun.id
     ) {
-      return false
+      return undefined
     }
     if (boundRun.id !== adoption.adopted_run_id) {
-      return true
+      return caller
     }
     return !db.resolveLegacyCoordinatorCandidate({
       runId: adoption.adopted_run_id,
       terminalHandle: caller.terminalHandle,
       paneKey: caller.paneKey
     })
+      ? caller
+      : undefined
   }
 
   private async route(

--- a/src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts
+++ b/src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts
@@ -1,0 +1,318 @@
+import { createHash } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../shared/protocol-version'
+import Database from '../../sqlite/sync-database'
+import { OrcaRuntimeService } from '../orca-runtime'
+import { OrchestrationDb } from '../orchestration/db'
+import type { RpcRequest, RpcResponse } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { ORCHESTRATION_METHODS } from './methods/orchestration'
+
+const WORKER_HANDLE = 'term_pre_update_worker'
+const WORKER_PANE = 'tab_pre_update:33333333-3333-4333-8333-333333333333'
+const COORDINATOR_HANDLE = 'term_pre_update_coordinator'
+const CURRENT_COORDINATOR_HANDLE = 'term_current_coordinator'
+const CURRENT_COORDINATOR_PANE = 'tab_current:44444444-4444-4444-8444-444444444444'
+const PROCESS_INCARNATION = 'pty-stable:incarnation-stable'
+const WORK_BYTES = Buffer.from('preserved filesystem work\n', 'utf8')
+
+type Harness = {
+  db: OrchestrationDb
+  dispatcher: RpcDispatcher
+  taskId: string
+  dispatchId: string
+  capability: string
+  adoptedRunId: string
+  markerPath: string
+}
+
+type UpdateRpcRequest = RpcRequest & {
+  compatibilityInvocationId?: string
+  orchestrationCompatibilityEvidence?: {
+    terminalHandle?: string
+    paneKey?: string
+    launchToken?: string
+  }
+}
+
+const harnesses: Harness[] = []
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const harness of harnesses.splice(0)) {
+    harness.db.close()
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function createUpdateHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-update-settlement-'))
+  tempDirs.push(dir)
+  const markerPath = join(dir, 'worker-result.txt')
+  const dbPath = join(dir, 'orchestration.db')
+  writeFileSync(markerPath, WORK_BYTES)
+
+  const oldRuntimeDb = new OrchestrationDb(dbPath)
+  const task = oldRuntimeDb.createTask({
+    spec: 'finish work across an app update',
+    createdByTerminalHandle: COORDINATOR_HANDLE
+  })
+  const dispatch = oldRuntimeDb.createDispatchContext(task.id, WORKER_HANDLE, WORKER_PANE)
+  const capability = oldRuntimeDb.mintDispatchCapability({
+    dispatchId: dispatch.id,
+    paneKey: WORKER_PANE,
+    processIncarnation: PROCESS_INCARNATION
+  })
+  oldRuntimeDb.close()
+
+  const raw = new Database(dbPath)
+  raw.exec(`
+    DROP INDEX IF EXISTS idx_messages_delivery_contract;
+    DROP TABLE IF EXISTS legacy_mail_receipts;
+    DROP TABLE IF EXISTS legacy_operation_receipts;
+    DROP TABLE IF EXISTS legacy_compatibility_principals;
+    DROP TABLE IF EXISTS legacy_adoptions;
+  `)
+  raw.pragma('user_version = 18')
+  raw.close()
+
+  const db = new OrchestrationDb(dbPath)
+  const adoptedRunId = db.getTask(task.id)?.run_id
+  expect(adoptedRunId).toBeTruthy()
+  const runtime = new OrcaRuntimeService()
+  runtime.setOrchestrationDb(db)
+  vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(null)
+  vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
+    handle === WORKER_HANDLE ? PROCESS_INCARNATION : null
+  )
+  Object.defineProperty(runtime, 'verifyOrchestrationCompatibilityCaller', {
+    value: vi.fn((evidence: UpdateRpcRequest['orchestrationCompatibilityEvidence']) => {
+      if (
+        !evidence?.launchToken ||
+        !evidence.terminalHandle ||
+        !evidence.paneKey ||
+        ![
+          `${WORKER_HANDLE}:${WORKER_PANE}`,
+          `${CURRENT_COORDINATOR_HANDLE}:${CURRENT_COORDINATOR_PANE}`
+        ].includes(`${evidence.terminalHandle}:${evidence.paneKey}`)
+      ) {
+        return null
+      }
+      return {
+        hostScope: { kind: 'local', hostId: 'local' },
+        terminalHandle: evidence.terminalHandle,
+        paneKey: evidence.paneKey,
+        processIncarnation: PROCESS_INCARNATION,
+        launchTokenHash: createHash('sha256').update(evidence.launchToken).digest('hex')
+      }
+    })
+  })
+  vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+  const harness = {
+    db,
+    dispatcher: new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS }),
+    taskId: task.id,
+    dispatchId: dispatch.id,
+    capability,
+    adoptedRunId: adoptedRunId as string,
+    markerPath
+  }
+  harnesses.push(harness)
+  return harness
+}
+
+function request(
+  method: string,
+  params: Record<string, unknown>,
+  role: 'worker' | 'current-coordinator',
+  invocationId: string
+): UpdateRpcRequest {
+  const worker = role === 'worker'
+  return {
+    id: `rpc_${invocationId}`,
+    authToken: 'caller-token',
+    method,
+    params,
+    orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION,
+    orchestrationRequestId: invocationId,
+    compatibilityInvocationId: invocationId,
+    orchestrationCompatibilityEvidence: {
+      terminalHandle: worker ? WORKER_HANDLE : CURRENT_COORDINATOR_HANDLE,
+      paneKey: worker ? WORKER_PANE : CURRENT_COORDINATOR_PANE,
+      launchToken: `${role}-launch-token`
+    }
+  } as unknown as UpdateRpcRequest
+}
+
+function entityCounts(db: OrchestrationDb): Record<string, number> {
+  const sqlite = (db as unknown as { db: Database.Database }).db
+  return Object.fromEntries(
+    ['tasks', 'dispatch_contexts', 'messages', 'legacy_compatibility_principals'].map((table) => [
+      table,
+      (sqlite.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get() as { count: number }).count
+    ])
+  )
+}
+
+function resultOf(response: RpcResponse): Record<string, unknown> {
+  expect(response.ok).toBe(true)
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  return response.result as Record<string, unknown>
+}
+
+function expectIdentityAndWorkPreserved(harness: Harness): void {
+  expect(harness.db.getDispatchContextById(harness.dispatchId)).toMatchObject({
+    id: harness.dispatchId,
+    task_id: harness.taskId,
+    assignee_handle: WORKER_HANDLE,
+    assignee_pane_key: WORKER_PANE,
+    process_incarnation: PROCESS_INCARNATION
+  })
+  expect(readFileSync(harness.markerPath)).toEqual(WORK_BYTES)
+}
+
+describe('orchestration runtime update settlement', () => {
+  it('settles one retained worker report exactly once after its pane handle is orphaned', async () => {
+    const harness = createUpdateHarness()
+    const completion = request(
+      'orchestration.send',
+      {
+        from: WORKER_HANDLE,
+        to: COORDINATOR_HANDLE,
+        type: 'worker_done',
+        subject: 'Completed',
+        body: 'work survived the update',
+        payload: JSON.stringify({
+          taskId: harness.taskId,
+          dispatchId: harness.dispatchId,
+          outcome: 'succeeded',
+          filesModified: ['worker-result.txt']
+        })
+      },
+      'worker',
+      'retained-worker-done'
+    )
+    completion.orchestrationCapability = harness.capability
+
+    const first = await harness.dispatcher.dispatch(completion)
+    const replay = await harness.dispatcher.dispatch({ ...completion, id: 'rpc_replay' })
+    const firstResult = resultOf(first)
+    const replayResult = resultOf(replay)
+
+    expect(firstResult).toMatchObject({ message: { type: 'worker_done' } })
+    expect(replayResult).toMatchObject({
+      message: firstResult.message,
+      mutation: { requestId: 'retained-worker-done', replayed: true }
+    })
+    expect(harness.db.getTask(harness.taskId)).toMatchObject({ status: 'completed' })
+    expect(harness.db.getDispatchContextById(harness.dispatchId)).toMatchObject({
+      status: 'completed'
+    })
+    expect(entityCounts(harness.db)).toEqual({
+      tasks: 1,
+      dispatch_contexts: 1,
+      messages: 1,
+      legacy_compatibility_principals: 0
+    })
+    expectIdentityAndWorkPreserved(harness)
+  })
+
+  it('allows only the attested current coordinator to take over retained live work', async () => {
+    const harness = createUpdateHarness()
+    const takeover = request(
+      'orchestration.runUse',
+      {
+        id: harness.adoptedRunId,
+        from: CURRENT_COORDINATOR_HANDLE,
+        takeoverLegacy: true
+      },
+      'current-coordinator',
+      'authenticated-takeover'
+    )
+
+    const spoofed = await harness.dispatcher.dispatch({
+      ...takeover,
+      id: 'rpc_spoofed',
+      params: { ...(takeover.params as Record<string, unknown>), from: COORDINATOR_HANDLE }
+    })
+    const first = await harness.dispatcher.dispatch(takeover)
+    const replay = await harness.dispatcher.dispatch({ ...takeover, id: 'rpc_takeover_replay' })
+    const firstResult = resultOf(first)
+    const replayResult = resultOf(replay)
+
+    expect(spoofed).toMatchObject({ ok: false, error: { code: 'stable_pane_required' } })
+    expect(firstResult).toMatchObject({
+      run: {
+        id: harness.adoptedRunId,
+        coordinator_handle: CURRENT_COORDINATOR_HANDLE,
+        coordinator_pane_key: CURRENT_COORDINATOR_PANE
+      }
+    })
+    expect(replayResult).toMatchObject({
+      run: firstResult.run,
+      mutation: { requestId: 'authenticated-takeover', replayed: true }
+    })
+    expect(harness.db.getTask(harness.taskId)).toMatchObject({ status: 'dispatched' })
+    expect(harness.db.getDispatchContextById(harness.dispatchId)).toMatchObject({
+      status: 'dispatched'
+    })
+    expect(entityCounts(harness.db)).toEqual({
+      tasks: 1,
+      dispatch_contexts: 1,
+      messages: 0,
+      legacy_compatibility_principals: 0
+    })
+    expectIdentityAndWorkPreserved(harness)
+  })
+
+  it('rejects a current worker whose claimed pane lacks exact attestation', async () => {
+    const harness = createUpdateHarness()
+    const completion = request(
+      'orchestration.send',
+      {
+        from: WORKER_HANDLE,
+        to: COORDINATOR_HANDLE,
+        type: 'worker_done',
+        subject: 'Completed',
+        body: 'forged completion',
+        payload: JSON.stringify({
+          taskId: harness.taskId,
+          dispatchId: harness.dispatchId,
+          outcome: 'succeeded'
+        })
+      },
+      'worker',
+      'forged-worker-done'
+    )
+    completion.orchestrationCapability = harness.capability
+    completion.orchestrationCompatibilityEvidence = {
+      ...completion.orchestrationCompatibilityEvidence!,
+      paneKey: 'tab_foreign:99999999-9999-4999-8999-999999999999'
+    }
+
+    const response = await harness.dispatcher.dispatch(completion)
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: {
+        lifecycle: {
+          action: 'rejected',
+          code: 'dispatch_capability_invalid',
+          reason: 'The caller is not the Dispatch pane.'
+        }
+      }
+    })
+    expect(harness.db.getTask(harness.taskId)).toMatchObject({ status: 'dispatched' })
+    expect(harness.db.getDispatchContextById(harness.dispatchId)).toMatchObject({
+      status: 'dispatched'
+    })
+    expectIdentityAndWorkPreserved(harness)
+  })
+})

--- a/src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts
+++ b/src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts
@@ -17,11 +17,13 @@ const COORDINATOR_HANDLE = 'term_pre_update_coordinator'
 const CURRENT_COORDINATOR_HANDLE = 'term_current_coordinator'
 const CURRENT_COORDINATOR_PANE = 'tab_current:44444444-4444-4444-8444-444444444444'
 const PROCESS_INCARNATION = 'pty-stable:incarnation-stable'
+const CURRENT_COORDINATOR_PROCESS_INCARNATION =
+  'pty-current-coordinator:incarnation-current-coordinator'
 const WORK_BYTES = Buffer.from('preserved filesystem work\n', 'utf8')
 
 type Harness = {
   db: OrchestrationDb
-  dispatcher: RpcDispatcher
+  createDispatcher: () => RpcDispatcher
   taskId: string
   dispatchId: string
   capability: string
@@ -84,38 +86,68 @@ function createUpdateHarness(): Harness {
   const db = new OrchestrationDb(dbPath)
   const adoptedRunId = db.getTask(task.id)?.run_id
   expect(adoptedRunId).toBeTruthy()
-  const runtime = new OrcaRuntimeService()
-  runtime.setOrchestrationDb(db)
-  vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(null)
-  vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
-    handle === WORKER_HANDLE ? PROCESS_INCARNATION : null
-  )
-  Object.defineProperty(runtime, 'verifyOrchestrationCompatibilityCaller', {
-    value: vi.fn((evidence: UpdateRpcRequest['orchestrationCompatibilityEvidence']) => {
-      if (
-        !evidence?.launchToken ||
-        !evidence.terminalHandle ||
-        !evidence.paneKey ||
-        ![
-          `${WORKER_HANDLE}:${WORKER_PANE}`,
-          `${CURRENT_COORDINATOR_HANDLE}:${CURRENT_COORDINATOR_PANE}`
-        ].includes(`${evidence.terminalHandle}:${evidence.paneKey}`)
-      ) {
-        return null
+  const createDispatcher = (): RpcDispatcher => {
+    const authorities = [
+      {
+        handle: WORKER_HANDLE,
+        paneKey: WORKER_PANE,
+        ptyId: 'pty-stable',
+        incarnationId: 'incarnation-stable',
+        launchToken: 'worker-launch-token'
+      },
+      {
+        handle: CURRENT_COORDINATOR_HANDLE,
+        paneKey: CURRENT_COORDINATOR_PANE,
+        ptyId: 'pty-current-coordinator',
+        incarnationId: 'incarnation-current-coordinator',
+        launchToken: 'current-coordinator-launch-token'
       }
-      return {
-        hostScope: { kind: 'local', hostId: 'local' },
-        terminalHandle: evidence.terminalHandle,
-        paneKey: evidence.paneKey,
-        processIncarnation: PROCESS_INCARNATION,
-        launchTokenHash: createHash('sha256').update(evidence.launchToken).digest('hex')
+    ]
+    const runtime = new OrcaRuntimeService(null, undefined, {
+      attestAgentHookCompatibilityAuthority: ({ paneKey, launchTokenHash }) => {
+        const authority = authorities.find((candidate) => candidate.paneKey === paneKey)
+        return authority &&
+          createHash('sha256').update(authority.launchToken).digest('hex') === launchTokenHash
+          ? { paneKey, source: 'hydrated_commitment' }
+          : null
       }
     })
-  })
-  vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (ptyId: string, worktreeId: string, state: Record<string, unknown>) => void
+      issuePtyHandle: (pty: unknown) => string
+      ptysById: Map<string, unknown>
+      handleByPtyId: Map<string, string>
+      restoredOrchestrationAuthorityByPtyId: Map<string, Record<string, unknown>>
+    }
+    for (const authority of authorities) {
+      internals.recordPtyWorktree(authority.ptyId, 'repo::/retained-worktree', {
+        connected: true,
+        paneKey: authority.paneKey,
+        incarnationId: authority.incarnationId
+      })
+      internals.handleByPtyId.set(authority.ptyId, authority.handle)
+      internals.issuePtyHandle(internals.ptysById.get(authority.ptyId))
+      internals.restoredOrchestrationAuthorityByPtyId.set(authority.ptyId, {
+        ptyId: authority.ptyId,
+        worktreeId: 'repo::/retained-worktree',
+        terminalHandle: authority.handle,
+        paneKey: authority.paneKey,
+        processIncarnation: `${authority.ptyId}:${authority.incarnationId}`,
+        hostScope: { kind: 'local', hostId: 'local' }
+      })
+    }
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(null)
+    const getProcessIncarnation = runtime.getTerminalProcessIncarnation.bind(runtime)
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation')
+      .mockImplementationOnce(getProcessIncarnation)
+      .mockReturnValue(null)
+    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+    return new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS })
+  }
   const harness = {
     db,
-    dispatcher: new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS }),
+    createDispatcher,
     taskId: task.id,
     dispatchId: dispatch.id,
     capability,
@@ -201,8 +233,8 @@ describe('orchestration runtime update settlement', () => {
     )
     completion.orchestrationCapability = harness.capability
 
-    const first = await harness.dispatcher.dispatch(completion)
-    const replay = await harness.dispatcher.dispatch({ ...completion, id: 'rpc_replay' })
+    const first = await harness.createDispatcher().dispatch(completion)
+    const replay = await harness.createDispatcher().dispatch({ ...completion, id: 'rpc_replay' })
     const firstResult = resultOf(first)
     const replayResult = resultOf(replay)
 
@@ -237,13 +269,15 @@ describe('orchestration runtime update settlement', () => {
       'authenticated-takeover'
     )
 
-    const spoofed = await harness.dispatcher.dispatch({
+    const spoofed = await harness.createDispatcher().dispatch({
       ...takeover,
       id: 'rpc_spoofed',
       params: { ...(takeover.params as Record<string, unknown>), from: COORDINATOR_HANDLE }
     })
-    const first = await harness.dispatcher.dispatch(takeover)
-    const replay = await harness.dispatcher.dispatch({ ...takeover, id: 'rpc_takeover_replay' })
+    const first = await harness.createDispatcher().dispatch(takeover)
+    const replay = await harness
+      .createDispatcher()
+      .dispatch({ ...takeover, id: 'rpc_takeover_replay' })
     const firstResult = resultOf(first)
     const replayResult = resultOf(replay)
 
@@ -297,7 +331,7 @@ describe('orchestration runtime update settlement', () => {
       paneKey: 'tab_foreign:99999999-9999-4999-8999-999999999999'
     }
 
-    const response = await harness.dispatcher.dispatch(completion)
+    const response = await harness.createDispatcher().dispatch(completion)
 
     expect(response).toMatchObject({
       ok: true,
@@ -314,5 +348,81 @@ describe('orchestration runtime update settlement', () => {
       status: 'dispatched'
     })
     expectIdentityAndWorkPreserved(harness)
+  })
+
+  it('routes ordinary mail with the same attested authority without settling work', async () => {
+    const harness = createUpdateHarness()
+    const response = await harness.createDispatcher().dispatch(
+      request(
+        'orchestration.send',
+        {
+          from: WORKER_HANDLE,
+          to: COORDINATOR_HANDLE,
+          type: 'status',
+          subject: 'Retained worker checkpoint',
+          body: readFileSync(harness.markerPath, 'utf8')
+        },
+        'worker',
+        'retained-worker-status'
+      )
+    )
+
+    expect(resultOf(response)).toMatchObject({
+      message: { type: 'status', body: WORK_BYTES.toString('utf8') }
+    })
+    expect(harness.db.getTask(harness.taskId)).toMatchObject({ status: 'dispatched' })
+    expect(harness.db.getDispatchContextById(harness.dispatchId)).toMatchObject({
+      status: 'dispatched'
+    })
+    expect(entityCounts(harness.db)).toEqual({
+      tasks: 1,
+      dispatch_contexts: 1,
+      messages: 1,
+      legacy_compatibility_principals: 0
+    })
+    expectIdentityAndWorkPreserved(harness)
+  })
+
+  it('uses attested process authority when a remote attachment loses runtime lookup', async () => {
+    const harness = createUpdateHarness()
+    const attachment = {
+      dispatch_id: 'dispatch-remote-retained',
+      task_id: 'task-remote-retained',
+      process_incarnation: CURRENT_COORDINATOR_PROCESS_INCARNATION
+    }
+    vi.spyOn(harness.db, 'findActiveRemoteAttachmentForPane').mockReturnValue(attachment as never)
+    const verifyAuthority = vi
+      .spyOn(harness.db, 'verifyRemoteAttachmentAuthority')
+      .mockReturnValue(true)
+    vi.spyOn(harness.db, 'enqueueFederationRelay').mockReturnValue({
+      message_id: 'relay-retained-status',
+      sequence: 1,
+      dispatch_id: attachment.dispatch_id
+    } as never)
+
+    const response = await harness.createDispatcher().dispatch({
+      ...request(
+        'orchestration.send',
+        {
+          from: CURRENT_COORDINATOR_HANDLE,
+          type: 'status',
+          subject: 'Retained remote checkpoint',
+          body: 'remote work survived'
+        },
+        'current-coordinator',
+        'retained-remote-status'
+      ),
+      orchestrationCapability: 'dcap_remote_retained'
+    })
+
+    expect(resultOf(response)).toMatchObject({
+      relay: { dispatchId: attachment.dispatch_id, accepted: true }
+    })
+    expect(verifyAuthority).toHaveBeenCalledWith({
+      dispatchId: attachment.dispatch_id,
+      capability: 'dcap_remote_retained',
+      paneKey: CURRENT_COORDINATOR_PANE,
+      processIncarnation: CURRENT_COORDINATOR_PROCESS_INCARNATION
+    })
   })
 })


### PR DESCRIPTION
## Summary

- propagate exact hook-attested current worker authority into lifecycle settlement when renderer graph identity is unavailable after an app/runtime update
- permit explicit legacy Run takeover from the same exact attested current coordinator without requiring a mounted renderer pane
- retain attested process identity for remote attachments, and register a deterministic production-verifier service oracle in the reliability gate

## Reproduction

The concrete task task_20799fc24aa9 / Dispatch ctx_cb7d4031bd88 originally finished work but worker_done was rejected after an update because term_9970c3a6-c425-4582-b20e-9cb9450b8da8 was no longer recognized as the Dispatch pane. App 1.4.167 now shows that Dispatch completed, consistent with PR #11789 restoring its live pane, but current main still rejected the authoritative service path when renderer identity was deliberately absent.

The byte-identical SHA-256 5f45c270f1ea55de24aa4087f9288ac227d2fdb9f3dd68aba5efd02c7e498f35 oracle has a corrected four-point chain: baseline-only overlay 063340a8ba on origin/main@34291f07e9 failed 3/5, candidate@2748b0b29b passed 5/5, actual disabled child 08a7db37bf failed 2/5, and revert d2a4e2e024 passed 5/5. It uses no timing oracle, exercises the production verifier with restored PTY/hook commitments, replays completion and takeover across fresh runtimes, and covers ordinary mail, remote process fencing, exact DB identity/counts, unchanged fixture bytes, and foreign-pane rejection.

The separate term_890e4466-365f-4074-bf3f-0f7957428ef9 observation is not causal here: App 1.4.167 reports it exited, disconnected, and non-writable with paneRuntimeId -1, and terminal send now rejects it with terminal_not_writable. This PR does not duplicate #11789 terminal-mount work.

## Validation

- 7 focused Vitest files, 210 tests passed after the audit changes
- pnpm typecheck:node
- pnpm typecheck:cli
- pnpm check:reliability-gates
- pnpm check:max-lines-ratchet
- git diff origin/main...HEAD --check

## Security audit

Renderer metadata is not trusted as authority. The fallback is admitted only after the production verifier proves the same live/restored PTY handle, stable pane, launch-token/hook commitment, process incarnation, active Dispatch or bound Run, and host-scoped authority; lifecycle settlement independently requires the Dispatch capability, and mismatched handles and foreign pane evidence remain fenced.

## Remaining gaps

Distinct installed A/B artifacts, paired headed/headless runtimes, Docker SSH, folder workspaces, WSL, Linux, and Windows remain live-topology gaps recorded in config/reliability-gates.jsonc. The filesystem marker proves the tested service transition leaves fixture bytes unchanged; it is not a live workspace cleanup/topology test.