### PR TITLE
fix(ssh): stop remote workspace pulls from resurrecting closed tabs

### DIFF
--- a/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
@@ -115,6 +115,7 @@ function appState(overrides: Record<string, unknown> = {}): AppState {
     sshConnectionStates: new Map(),
     lastVisitedAtByWorktreeId: {},
     defaultTerminalTabsAppliedByWorktreeId: {},
+    lastSyncedRemoteWorkspaceRevisionByTargetId: {},
     hydrateWorkspaceSession: vi.fn(),
     hydrateTabsSession: vi.fn(),
     hydrateEditorSession: vi.fn(),
@@ -214,6 +215,63 @@ describe('createRemoteWorkspaceTargetSync', () => {
     expect(harness.setForConnectedTargets).toHaveBeenCalledWith(
       expect.objectContaining({ hydratedTargetIds: ['target-a'] })
     )
+  })
+
+  it('pushes local session instead of pulling when the remote snapshot did not advance', async () => {
+    const state = appState({
+      tabsByWorktree: {
+        'repo-a::/remote/work': [{ id: 'tab-a', worktreeId: 'repo-a::/remote/work', ptyId: null }]
+      },
+      lastSyncedRemoteWorkspaceRevisionByTargetId: { [owner.targetId]: 5 }
+    })
+    const stale = snapshot(5, {
+      '/remote/work': [
+        {
+          id: 'closed-tab',
+          worktreePath: '/remote/work',
+          ptyId: null
+        } as RemoteWorkspaceSnapshot['session']['tabsByWorktreePath'][string][number]
+      ]
+    })
+    const harness = createHarness(state, async () => stale)
+
+    await harness.sync.syncAfterConnect(token())
+
+    expect(state.hydrateTabsSession).not.toHaveBeenCalled()
+    expect(state.hydrateWorkspaceSession).not.toHaveBeenCalled()
+    expect(state.markRemoteWorkspaceHydrated).toHaveBeenCalledWith(owner.targetId)
+    expect(harness.setForConnectedTargets).toHaveBeenCalledOnce()
+    expect(harness.setForConnectedTargets).toHaveBeenCalledWith(
+      expect.objectContaining({ hydratedTargetIds: [owner.targetId] })
+    )
+  })
+
+  it('pulls when the remote snapshot advanced past the last synced revision', async () => {
+    const state = appState({
+      lastSyncedRemoteWorkspaceRevisionByTargetId: { [owner.targetId]: 5 }
+    })
+    const harness = createHarness(state, async () => snapshot(6))
+
+    await harness.sync.syncAfterConnect(token())
+
+    expect(state.hydrateTabsSession).toHaveBeenCalledOnce()
+    expect(harness.setForConnectedTargets).not.toHaveBeenCalled()
+  })
+
+  it('ignores an unsolicited snapshot at or below the last synced revision', async () => {
+    const state = appState({
+      lastSyncedRemoteWorkspaceRevisionByTargetId: { [owner.targetId]: 5 }
+    })
+    const harness = createHarness(state, async () => null)
+
+    await harness.sync.applyUnsolicitedSnapshot(owner.targetId, snapshot(5))
+    await harness.sync.applyUnsolicitedSnapshot(owner.targetId, snapshot(4))
+
+    expect(harness.capturePreparationInput).not.toHaveBeenCalled()
+    expect(state.hydrateTabsSession).not.toHaveBeenCalled()
+
+    await harness.sync.applyUnsolicitedSnapshot(owner.targetId, snapshot(6))
+    expect(state.hydrateTabsSession).toHaveBeenCalledOnce()
   })
 
   it.each([

--- a/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.test.ts
@@ -246,6 +246,38 @@ describe('createRemoteWorkspaceTargetSync', () => {
     )
   })
 
+  it('discards a superseded upload so a stale push result cannot report over the newer one', async () => {
+    const state = appState({
+      tabsByWorktree: {
+        'repo-a::/remote/work': [{ id: 'tab-a', worktreeId: 'repo-a::/remote/work', ptyId: null }]
+      },
+      lastSyncedRemoteWorkspaceRevisionByTargetId: { [owner.targetId]: 5 }
+    })
+    const harness = createHarness(state, async () => snapshot(5))
+    const uploads: Deferred<{ targetId: string; result: RemoteWorkspacePatchResult }[]>[] = []
+    harness.setForConnectedTargets.mockImplementation(() => {
+      const upload = deferred<{ targetId: string; result: RemoteWorkspacePatchResult }[]>()
+      uploads.push(upload)
+      return upload.promise
+    })
+
+    const first = harness.sync.syncAfterConnect(token())
+    await vi.waitFor(() => expect(uploads).toHaveLength(1))
+    const second = harness.sync.syncAfterConnect(token())
+    await vi.waitFor(() => expect(uploads).toHaveLength(2))
+
+    uploads[1]!.resolve([{ targetId: owner.targetId, result: { ok: true, snapshot: snapshot(7) } }])
+    await second
+    uploads[0]!.resolve([{ targetId: owner.targetId, result: { ok: true, snapshot: snapshot(6) } }])
+    await first
+
+    const syncedCalls = vi
+      .mocked(state.setRemoteWorkspaceSyncStatus)
+      .mock.calls.filter(([, status]) => status.phase === 'synced')
+    expect(syncedCalls).toHaveLength(1)
+    expect(syncedCalls[0]?.[1]).toMatchObject({ revision: 7 })
+  })
+
   it('pulls when the remote snapshot advanced past the last synced revision', async () => {
     const state = appState({
       lastSyncedRemoteWorkspaceRevisionByTargetId: { [owner.targetId]: 5 }

--- a/src/renderer/src/hooks/remote-workspace-target-sync.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.ts
@@ -169,15 +169,24 @@ export function createRemoteWorkspaceTargetSync(
       })
       return
     }
+    // Why: a superseded sync attempt must not report its upload — arrival
+    // fencing keeps an older push from overwriting the newer attempt's
+    // status/last-synced revision when results resolve out of order.
     const pushLocalSession = async (): Promise<void> => {
-      if (!deps.isPreparationTokenCurrent(token)) {
+      if (
+        !isArrivalCurrent(authority.targetId, arrival) ||
+        !deps.isPreparationTokenCurrent(token)
+      ) {
         return
       }
       const results = await deps.remoteWorkspace.setForConnectedTargets({
         session: buildWorkspaceSessionPayload(deps.store.getState()),
         hydratedTargetIds: [authority.targetId]
       })
-      if (!deps.isPreparationTokenCurrent(token)) {
+      if (
+        !isArrivalCurrent(authority.targetId, arrival) ||
+        !deps.isPreparationTokenCurrent(token)
+      ) {
         return
       }
       const result = results.find((entry) => entry.targetId === authority.targetId)?.result

--- a/src/renderer/src/hooks/remote-workspace-target-sync.ts
+++ b/src/renderer/src/hooks/remote-workspace-target-sync.ts
@@ -169,7 +169,32 @@ export function createRemoteWorkspaceTargetSync(
       })
       return
     }
+    const pushLocalSession = async (): Promise<void> => {
+      if (!deps.isPreparationTokenCurrent(token)) {
+        return
+      }
+      const results = await deps.remoteWorkspace.setForConnectedTargets({
+        session: buildWorkspaceSessionPayload(deps.store.getState()),
+        hydratedTargetIds: [authority.targetId]
+      })
+      if (!deps.isPreparationTokenCurrent(token)) {
+        return
+      }
+      const result = results.find((entry) => entry.targetId === authority.targetId)?.result
+      applyPatchStatus(deps.store.getState(), authority.targetId, result)
+    }
     if (snapshot.revision > 0) {
+      const lastSyncedRevision =
+        deps.store.getState().lastSyncedRemoteWorkspaceRevisionByTargetId[authority.targetId]
+      if (lastSyncedRevision !== undefined && snapshot.revision <= lastSyncedRevision) {
+        // Why: the remote snapshot did not advance since this client last
+        // synced it, so the local session (which may hold newer offline edits,
+        // e.g. tabs closed while disconnected) is authoritative. Applying the
+        // snapshot would resurrect those closed tabs; upload local instead.
+        deps.store.getState().markRemoteWorkspaceHydrated(authority.targetId)
+        await pushLocalSession()
+        return
+      }
       const applyToken = buildDirectSshSnapshotApplyToken(token, snapshot.revision)
       if (applyToken) {
         await applyDirectSshRemoteWorkspaceSnapshot({
@@ -195,24 +220,21 @@ export function createRemoteWorkspaceTargetSync(
       })
       return
     }
-    if (!deps.isPreparationTokenCurrent(token)) {
-      return
-    }
-    const results = await deps.remoteWorkspace.setForConnectedTargets({
-      session: buildWorkspaceSessionPayload(deps.store.getState()),
-      hydratedTargetIds: [authority.targetId]
-    })
-    if (!deps.isPreparationTokenCurrent(token)) {
-      return
-    }
-    const result = results.find((entry) => entry.targetId === authority.targetId)?.result
-    applyPatchStatus(deps.store.getState(), authority.targetId, result)
+    await pushLocalSession()
   }
 
   const applyUnsolicitedSnapshot = async (
     targetId: string,
     snapshot: RemoteWorkspaceSnapshot
   ): Promise<void> => {
+    const lastSyncedRevision =
+      deps.store.getState().lastSyncedRemoteWorkspaceRevisionByTargetId[targetId]
+    if (lastSyncedRevision !== undefined && snapshot.revision <= lastSyncedRevision) {
+      // Why: a late or out-of-order change notification at (or below) the
+      // revision this client already synced carries nothing new — applying it
+      // would stomp newer local state (e.g. re-open a just-closed tab).
+      return
+    }
     const arrival = beginArrival(targetId)
     const authority = deps.getCurrentAuthority(targetId)
     if (!authority) {

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -521,7 +521,7 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
-  it('updates its baseline without scheduling when shouldSchedulePersist returns false', () => {
+  it('coalesces changes made while shouldSchedulePersist is false into the next flush', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = false
     const cleanup = createSessionWriteSubscriber({
@@ -541,7 +541,38 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
-  it('cancels a pending debounce when shouldSchedulePersist returns false', () => {
+  it('defers a blocked flush and persists it once shouldSchedulePersist reopens', () => {
+    const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
+    let shouldSchedule = true
+    const cleanup = createSessionWriteSubscriber({
+      store: useAppStore,
+      persist,
+      shouldSchedulePersist: () => shouldSchedule
+    })
+
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      hydrationSucceeded: true,
+      ...makeTerminalSessionState('shell')
+    })
+    vi.advanceTimersByTime(200)
+    persist.mockClear()
+
+    // Why: a tab closed while a remote snapshot apply is in flight must still
+    // persist after the apply ends, or the next pull resurrects the tab.
+    shouldSchedule = false
+    useAppStore.setState({ tabsByWorktree: { 'wt-1': [] } })
+    vi.advanceTimersByTime(1_000)
+    expect(persist).not.toHaveBeenCalled()
+
+    shouldSchedule = true
+    vi.advanceTimersByTime(200)
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist.mock.calls[0][0].patch.tabsByWorktree?.['wt-1']).toEqual([])
+    cleanup()
+  })
+
+  it('holds a pending debounce while shouldSchedulePersist returns false', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     let shouldSchedule = true
     const cleanup = createSessionWriteSubscriber({

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -173,6 +173,43 @@ export function createSessionWriteSubscriber({
   let prev: Record<string, unknown> | null = null
   const pendingChangedFields = new Set<SessionRelevantField>()
 
+  const scheduleFlush = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer)
+    }
+    timer = setTimeout(() => {
+      timer = null
+      // Why: rebuild from the freshest store state rather than the snapshot
+      // captured when this timer was scheduled. Today this is equivalent
+      // because buildWorkspaceSessionPayload reads only SESSION_RELEVANT_FIELDS
+      // (the same fields gating the timer reset), so the captured `state` is
+      // already current for those fields. Calling getState() guards against a
+      // future refactor that adds a non-relevant field read to the payload
+      // builder — without this, such a change would silently start emitting
+      // stale values for that field.
+      const fresh = store.getState()
+      if (!shouldPersistWorkspaceSession(fresh)) {
+        pendingChangedFields.clear()
+        return
+      }
+      if (shouldSchedulePersist && !shouldSchedulePersist()) {
+        // Why: a remote workspace snapshot apply is in flight. Dropping the
+        // pending fields here would lose edits made during the apply window
+        // (e.g. a tab close) from both the local session file and the remote
+        // mirror — the next pull would resurrect them. Defer until it ends.
+        scheduleFlush()
+        return
+      }
+      const changed = new Set(pendingChangedFields)
+      pendingChangedFields.clear()
+      const patch = buildWorkspaceSessionPatch(fresh, changed)
+      if (Object.keys(patch).length === 0) {
+        return
+      }
+      persist({ patch })
+    }, debounceMs)
+  }
+
   const unsub = store.subscribe((state) => {
     if (!shouldPersistWorkspaceSession(state)) {
       return
@@ -198,44 +235,7 @@ export function createSessionWriteSubscriber({
     for (const field of changedFields) {
       pendingChangedFields.add(field)
     }
-    if (shouldSchedulePersist && !shouldSchedulePersist()) {
-      if (timer !== null) {
-        clearTimeout(timer)
-        timer = null
-      }
-      pendingChangedFields.clear()
-      return
-    }
-    if (timer !== null) {
-      clearTimeout(timer)
-    }
-    timer = setTimeout(() => {
-      timer = null
-      // Why: rebuild from the freshest store state rather than the snapshot
-      // captured when this timer was scheduled. Today this is equivalent
-      // because buildWorkspaceSessionPayload reads only SESSION_RELEVANT_FIELDS
-      // (the same fields gating the timer reset), so the captured `state` is
-      // already current for those fields. Calling getState() guards against a
-      // future refactor that adds a non-relevant field read to the payload
-      // builder — without this, such a change would silently start emitting
-      // stale values for that field.
-      const fresh = store.getState()
-      if (!shouldPersistWorkspaceSession(fresh)) {
-        pendingChangedFields.clear()
-        return
-      }
-      if (shouldSchedulePersist && !shouldSchedulePersist()) {
-        pendingChangedFields.clear()
-        return
-      }
-      const changed = new Set(pendingChangedFields)
-      pendingChangedFields.clear()
-      const patch = buildWorkspaceSessionPatch(fresh, changed)
-      if (Object.keys(patch).length === 0) {
-        return
-      }
-      persist({ patch })
-    }, debounceMs)
+    scheduleFlush()
   })
 
   return () => {

--- a/src/renderer/src/store/slices/ssh-target-cleanup.ts
+++ b/src/renderer/src/store/slices/ssh-target-cleanup.ts
@@ -215,6 +215,10 @@ export function buildRemovedSshTargetCleanupPatch(
     state.remoteWorkspaceSyncStatusByTargetId,
     targetId
   )
+  const removedLastSyncedRevision = Object.prototype.hasOwnProperty.call(
+    state.lastSyncedRemoteWorkspaceRevisionByTargetId,
+    targetId
+  )
   const removedPortForwards = Object.prototype.hasOwnProperty.call(
     state.portForwardsByConnection,
     targetId
@@ -225,6 +229,8 @@ export function buildRemovedSshTargetCleanupPatch(
   )
   const nextSyncStatus = { ...state.remoteWorkspaceSyncStatusByTargetId }
   delete nextSyncStatus[targetId]
+  const nextLastSyncedRevision = { ...state.lastSyncedRemoteWorkspaceRevisionByTargetId }
+  delete nextLastSyncedRevision[targetId]
   const nextPortForwards = { ...state.portForwardsByConnection }
   delete nextPortForwards[targetId]
   const nextDetectedPorts = { ...state.detectedPortsByConnection }
@@ -239,6 +245,7 @@ export function buildRemovedSshTargetCleanupPatch(
     removedLabel ||
     removedHydrated ||
     removedSyncStatus ||
+    removedLastSyncedRevision ||
     removedPortForwards ||
     removedDetectedPorts ||
     tabPtyState.changed ||
@@ -261,6 +268,9 @@ export function buildRemovedSshTargetCleanupPatch(
     ...(removedLabel ? { sshTargetLabels: nextLabels } : {}),
     ...(removedHydrated ? { remoteWorkspaceHydratedTargetIds: nextHydrated } : {}),
     ...(removedSyncStatus ? { remoteWorkspaceSyncStatusByTargetId: nextSyncStatus } : {}),
+    ...(removedLastSyncedRevision
+      ? { lastSyncedRemoteWorkspaceRevisionByTargetId: nextLastSyncedRevision }
+      : {}),
     ...(removedPortForwards ? { portForwardsByConnection: nextPortForwards } : {}),
     ...(removedDetectedPorts ? { detectedPortsByConnection: nextDetectedPorts } : {}),
     ...(tabPtyState.changed

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -80,6 +80,10 @@ describe('createSshSlice', () => {
         [targetId]: { phase: 'offline' },
         [otherTargetId]: { phase: 'synced' }
       },
+      lastSyncedRemoteWorkspaceRevisionByTargetId: {
+        [targetId]: 7,
+        [otherTargetId]: 9
+      },
       portForwardsByConnection: {
         [targetId]: [
           {
@@ -172,6 +176,7 @@ describe('createSshSlice', () => {
     expect(state.sshTargetLabels.has(targetId)).toBe(false)
     expect(state.remoteWorkspaceHydratedTargetIds.has(targetId)).toBe(false)
     expect(state.remoteWorkspaceSyncStatusByTargetId[targetId]).toBeUndefined()
+    expect(state.lastSyncedRemoteWorkspaceRevisionByTargetId[targetId]).toBeUndefined()
     expect(state.portForwardsByConnection[targetId]).toBeUndefined()
     expect(state.detectedPortsByConnection[targetId]).toBeUndefined()
     expect(state.sshCredentialQueue.map((req) => req.targetId)).toEqual([otherTargetId])
@@ -205,6 +210,7 @@ describe('createSshSlice', () => {
     expect(state.sshTargetLabels.get(otherTargetId)).toBe('Other target')
     expect(state.remoteWorkspaceHydratedTargetIds.has(otherTargetId)).toBe(true)
     expect(state.remoteWorkspaceSyncStatusByTargetId[otherTargetId]).toEqual({ phase: 'synced' })
+    expect(state.lastSyncedRemoteWorkspaceRevisionByTargetId[otherTargetId]).toBe(9)
     expect(state.portForwardsByConnection[otherTargetId]).toHaveLength(1)
     expect(state.detectedPortsByConnection[otherTargetId]).toHaveLength(1)
     expect(state.tabsByWorktree[otherWorktreeId][0]?.ptyId).toBe(otherPtyId)
@@ -453,6 +459,31 @@ describe('createSshSlice', () => {
     store.getState().clearRemovedSshTargetState('ssh-1')
 
     expect(store.getState().transientClearedAgentStatusConnectionIds).toEqual({})
+  })
+
+  it('records the last synced remote workspace revision only on synced statuses', () => {
+    const store = createTestStore()
+
+    store.getState().setRemoteWorkspaceSyncStatus('ssh-1', {
+      phase: 'synced',
+      direction: 'push',
+      revision: 4
+    })
+    expect(store.getState().lastSyncedRemoteWorkspaceRevisionByTargetId['ssh-1']).toBe(4)
+
+    store.getState().setRemoteWorkspaceSyncStatus('ssh-1', {
+      phase: 'conflict',
+      direction: 'push',
+      revision: 9
+    })
+    expect(store.getState().lastSyncedRemoteWorkspaceRevisionByTargetId['ssh-1']).toBe(4)
+
+    store.getState().setRemoteWorkspaceSyncStatus('ssh-1', {
+      phase: 'synced',
+      direction: 'pull',
+      revision: 9
+    })
+    expect(store.getState().lastSyncedRemoteWorkspaceRevisionByTargetId['ssh-1']).toBe(9)
   })
 
   it('preserves untouched cleanup slice references while removing deferred target metadata', () => {

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -44,6 +44,12 @@ export type SshSlice = {
   sshTargetsHydrated: boolean
   remoteWorkspaceHydratedTargetIds: Set<string>
   remoteWorkspaceSyncStatusByTargetId: Record<string, RemoteWorkspaceSyncStatus>
+  /** Remote workspace snapshot revision this client last fully synced (push or
+   * pull) per target. Reconnect arbitration compares it against the remote's
+   * current revision to tell "remote unchanged while we were away" (local
+   * session is authoritative, e.g. tabs closed offline) from "another client
+   * wrote" (pull and merge). */
+  lastSyncedRemoteWorkspaceRevisionByTargetId: Record<string, number>
   sshCredentialQueue: SshCredentialRequest[]
   /** Incremented when an SSH target transitions to 'connected'. Allows
    * components like the file explorer to re-trigger data loads that failed
@@ -89,6 +95,7 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
   sshTargetsHydrated: false,
   remoteWorkspaceHydratedTargetIds: new Set(),
   remoteWorkspaceSyncStatusByTargetId: {},
+  lastSyncedRemoteWorkspaceRevisionByTargetId: {},
   sshCredentialQueue: [],
   sshConnectedGeneration: 0,
   portForwardsByConnection: {},
@@ -152,7 +159,17 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
       remoteWorkspaceSyncStatusByTargetId: {
         ...s.remoteWorkspaceSyncStatusByTargetId,
         [targetId]: status
-      }
+      },
+      // Why: a 'synced' status is the receipt that local and remote agree at
+      // this revision; every push/pull success path reports through here.
+      ...(status.phase === 'synced' && typeof status.revision === 'number'
+        ? {
+            lastSyncedRemoteWorkspaceRevisionByTargetId: {
+              ...s.lastSyncedRemoteWorkspaceRevisionByTargetId,
+              [targetId]: status.revision
+            }
+          }
+        : {})
     })),
   enqueueSshCredentialRequest: (req) =>
     set((s) => ({ sshCredentialQueue: [...s.sshCredentialQueue, req] })),

--- a/tests/e2e/ssh-remote-workspace-close-resurrection.spec.ts
+++ b/tests/e2e/ssh-remote-workspace-close-resurrection.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * E2E repro for #10342 / PR #12339: terminal tabs closed while an SSH target
+ * is disconnected must stay closed after the target reconnects.
+ *
+ * The failing path on main: `syncAfterConnect` pulls the relay workspace
+ * snapshot on every reconnect and replaces local tab state whenever the
+ * snapshot revision is > 0 — even when the snapshot did not change since this
+ * client last synced. Tabs closed while offline never reached the relay
+ * mirror, so the pull resurrects them in the tab bar.
+ */
+import { test, expect } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePanePtyId, waitForActiveTerminalManager } from './helpers/terminal'
+import {
+  cleanupDockerSshRelayTarget,
+  DOCKER_SSH_RELAY_REMOTE_REPO_PATH,
+  execDockerSshRelayTargetCommand,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import {
+  connectDockerSshRelayTarget,
+  disconnectDockerSshRelayTarget,
+  reconnectDisconnectedDockerSshRelayTarget
+} from './helpers/docker-ssh-relay-connection'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+const TAB_COUNT = 3
+const SORTABLE_TAB = '[data-testid="sortable-tab"]'
+
+test.use({ seedTestRepo: false })
+
+async function createRemoteTerminalTab(page: Page, worktreeId: string): Promise<void> {
+  const tabId = await page.evaluate((id) => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('Store unavailable')
+    }
+    const tab = state.createTab(id, undefined, undefined, { activate: true })
+    state.setActiveTab(tab.id)
+    state.setActiveTabType('terminal')
+    return tab.id
+  }, worktreeId)
+  await expect
+    .poll(() => page.evaluate(() => window.__store?.getState().activeTabId ?? null), {
+      timeout: 10_000
+    })
+    .toBe(tabId)
+  await waitForActiveTerminalManager(page, 60_000)
+  await waitForActivePanePtyId(page, 60_000)
+}
+
+async function readWorktreeTabIds(page: Page, worktreeId: string): Promise<string[]> {
+  return page.evaluate(
+    (id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id),
+    worktreeId
+  )
+}
+
+async function readRenderedTabIds(page: Page): Promise<string[]> {
+  return page.evaluate(
+    (selector) =>
+      Array.from(document.querySelectorAll(selector))
+        .map((tab) => tab.getAttribute('data-tab-id') ?? '')
+        .filter(Boolean),
+    SORTABLE_TAB
+  )
+}
+
+test.describe('SSH remote workspace close resurrection', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run Docker-backed SSH tests.')
+  test.skip(process.platform === 'win32', 'Docker SSH tests use POSIX SSH tooling.')
+
+  test('tabs closed while disconnected stay closed after reconnect', async ({
+    orcaPage
+  }, testInfo) => {
+    test.setTimeout(240_000)
+    let target: DockerSshRelayTarget | null = null
+    try {
+      target = startDockerSshRelayTarget(testInfo)
+      await waitForSessionReady(orcaPage)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      await expect
+        .poll(() => waitForActiveWorktree(orcaPage), { timeout: 30_000 })
+        .toBe(remote.worktreeId)
+      await waitForActiveTerminalManager(orcaPage, 60_000)
+      await waitForActivePanePtyId(orcaPage, 60_000)
+
+      while ((await readWorktreeTabIds(orcaPage, remote.worktreeId)).length < TAB_COUNT) {
+        await createRemoteTerminalTab(orcaPage, remote.worktreeId)
+      }
+      const allTabIds = await readWorktreeTabIds(orcaPage, remote.worktreeId)
+      expect(allTabIds).toHaveLength(TAB_COUNT)
+
+      // Wait until the relay snapshot mirrors every open tab — this both
+      // commits the pre-close state remotely and records the last synced
+      // revision the reconnect arbitration reads.
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(
+              async ({ targetId, worktreePath }) => {
+                const snapshot = await window.api.remoteWorkspace.get({ targetId })
+                return (
+                  snapshot?.session.tabsByWorktreePath[worktreePath]?.map((tab) => tab.id) ?? []
+                )
+              },
+              { targetId: remote.targetId, worktreePath: DOCKER_SSH_RELAY_REMOTE_REPO_PATH }
+            ),
+          { timeout: 30_000, message: 'SSH tabs were not committed to the relay workspace' }
+        )
+        .toEqual(allTabIds)
+
+      await disconnectDockerSshRelayTarget(orcaPage, remote.targetId)
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(
+              (targetId) => window.__store?.getState().sshConnectionStates.get(targetId)?.status,
+              remote.targetId
+            ),
+          { timeout: 30_000, message: 'SSH target did not disconnect' }
+        )
+        .not.toBe('connected')
+
+      // Latch the push path exactly like a real stale-revision conflict does
+      // (#2323 C2): App.tsx skips pushes for targets in 'conflict', so the tab
+      // closes below never reach the relay mirror and the snapshot goes stale.
+      await orcaPage.evaluate((targetId) => {
+        window.__store?.getState().setRemoteWorkspaceSyncStatus(targetId, {
+          phase: 'conflict',
+          direction: 'push',
+          message: 'Workspace changed on another device'
+        })
+      }, remote.targetId)
+
+      // Close every tab except the first while the target is offline —
+      // through the real tab-bar close buttons, like a user would.
+      const survivingTabId = allTabIds[0]!
+      for (const tabId of allTabIds.slice(1)) {
+        const tab = orcaPage.locator(`${SORTABLE_TAB}[data-tab-id="${tabId}"]`).first()
+        await tab.hover()
+        await tab.getByRole('button', { name: /^Close tab /i }).click()
+        await expect(tab).toHaveCount(0, { timeout: 10_000 })
+      }
+      expect(await readWorktreeTabIds(orcaPage, remote.worktreeId)).toEqual([survivingTabId])
+
+      // Staleness precondition: the relay-side snapshot still holds all three
+      // tabs, so the reconnect pull has stale state to (wrongly) restore.
+      const staleSnapshot = execDockerSshRelayTargetCommand(
+        target,
+        'cat /root/.orca/sessions/*.json'
+      )
+      const staleTabIds = (
+        JSON.parse(staleSnapshot) as {
+          session: { tabsByWorktreePath: Record<string, { id: string }[]> }
+        }
+      ).session.tabsByWorktreePath[DOCKER_SSH_RELAY_REMOTE_REPO_PATH]?.map((tab) => tab.id)
+      expect(staleTabIds).toEqual(allTabIds)
+
+      await reconnectDisconnectedDockerSshRelayTarget(orcaPage, remote.targetId)
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(
+              (targetId) => window.__store?.getState().sshConnectionStates.get(targetId)?.status,
+              remote.targetId
+            ),
+          { timeout: 60_000, message: 'SSH target did not reconnect' }
+        )
+        .toBe('connected')
+
+      // Wait for the post-reconnect workspace sync to settle. The arbitration
+      // must upload local state (remote revision did not advance since the
+      // last sync), not pull the stale snapshot — a pull here is the bug.
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(
+              (targetId) =>
+                window.__store?.getState().remoteWorkspaceSyncStatusByTargetId[targetId] ?? null,
+              remote.targetId
+            ),
+          { timeout: 60_000, message: 'remote workspace sync did not settle after reconnect' }
+        )
+        .toMatchObject({ phase: 'synced', direction: 'push' })
+
+      // The bug: the reconnect pull resurrects the two closed tabs. Give the
+      // sync ample time to misbehave, then assert the DOM tab bar still shows
+      // only the surviving tab.
+      await orcaPage.waitForTimeout(5_000)
+      expect(await readRenderedTabIds(orcaPage)).toEqual([survivingTabId])
+      expect(await readWorktreeTabIds(orcaPage, remote.worktreeId)).toEqual([survivingTabId])
+
+      // And the relay mirror converges to the surviving tab instead of
+      // re-serving the stale three-tab session on the next reconnect.
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(
+              async ({ targetId, worktreePath }) => {
+                const snapshot = await window.api.remoteWorkspace.get({ targetId })
+                return (
+                  snapshot?.session.tabsByWorktreePath[worktreePath]?.map((tab) => tab.id) ?? []
+                )
+              },
+              { targetId: remote.targetId, worktreePath: DOCKER_SSH_RELAY_REMOTE_REPO_PATH }
+            ),
+          { timeout: 30_000, message: 'relay workspace still holds the closed tabs' }
+        )
+        .toEqual([survivingTabId])
+    } finally {
+      cleanupDockerSshRelayTarget(target)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #10342. Related: #2323 (item C2), #9352 (paired-viewer sibling), #11729 / #12264 (complementary main-process lease path — no file overlap).

## Summary

On a direct-SSH workspace, closing terminal tabs doesn't stick: closed tabs re-materialize the next time a terminal is opened (e.g. launching a quick command), on reconnect, or on system wake.

**Mechanism.** Orca mirrors the tab session to the SSH host as a revisioned snapshot (`workspace.get`/`workspace.patch`), and every connect/reconnect/wake runs `syncAfterConnect`, which pulled the snapshot and **replaced local tab state whenever `revision > 0`** — with no check for whether the remote had actually changed since this client last synced (`src/renderer/src/hooks/remote-workspace-target-sync.ts`). Any close that never reached the remote mirror (target offline, push conflict latch per #2323-C2, or the write-drop below) was resurrected by the next pull. Opening a quick-command terminal triggers the SSH connect, hence "open new terminal → all my closed tabs come back" (#10342).

Compounding it, the session-write subscriber **dropped** (not deferred) pending changes while a snapshot apply was in flight — a window up to ~30s after each reconnect (`createSessionWriteSubscriber` + the `shouldSchedulePersist` gate in `App.tsx`). A tab closed in that window never persisted to the local session file or the remote mirror at all.

## Fixes

- **Reconnect arbitration**: track `lastSyncedRemoteWorkspaceRevisionByTargetId` (recorded on every `'synced'` push/pull status; cleared on target removal). In `syncAfterConnect`, if the remote revision did not advance past it, skip the pull and push local state instead — local offline edits win over an unchanged remote snapshot. A genuinely newer revision (another device wrote) still pulls and merges as before.
- **Echo/ordering guard**: ignore unsolicited `workspace.changed` snapshots at or below the last synced revision, so late or out-of-order notifications can't stomp newer local state.
- **Defer, don't drop**: session writes blocked by an in-flight snapshot apply are retried after the debounce interval instead of being discarded, so closes made during the apply window persist once it ends.

#### Test plan

- [x] New regression tests (each fails without the fix): reconnect skip-pull + push-local when revision unchanged; pull still happens when revision advanced; unsolicited snapshots at/below last synced revision ignored; blocked session flush deferred and persisted once the gate reopens (`remote-workspace-target-sync.test.ts`, `session-write-subscriber.test.ts`, `ssh.test.ts`)
- [x] Existing suites green: remote-workspace-target-sync, session-write-subscriber, ssh slice, ssh-target-cleanup, useIpcEvents (96), store-cascades/tabs/tabs-hydration/terminals-hydration (248), direct-ssh recovery/scope, remote-workspace-snapshot-duplicate-tab-repair
- [x] `oxlint`, `typecheck:web`, `check:max-lines-ratchet` clean
- [ ] Manual: on an SSH workspace, close tabs while disconnected, reconnect via quick command — closed tabs stay closed

Generated with [Devin](https://devin.ai)