### PR TITLE
fix(relay): tolerate cell clock skew in pairing invite expiry validation

### DIFF
--- a/src/shared/mobile-relay-pairing-fixtures.ts
+++ b/src/shared/mobile-relay-pairing-fixtures.ts
@@ -107,8 +107,22 @@ export function createMobileRelayPairingFixtures(now: number): PairingFixture[] 
       expected: null
     },
     {
-      name: 'invite beyond ten minutes is invalid',
-      payload: { ...directOffer, relay: { ...relay, inviteExpiresAt: now + 10 * 60 * 1000 + 1 } },
+      name: 'full-TTL invite from a cell clock up to 30s ahead is valid',
+      payload: {
+        ...directOffer,
+        relay: { ...relay, inviteExpiresAt: now + 10 * 60 * 1000 + 30 * 1000 }
+      },
+      expected: {
+        ...directOffer,
+        relay: { ...relay, inviteExpiresAt: now + 10 * 60 * 1000 + 30 * 1000 }
+      }
+    },
+    {
+      name: 'invite beyond ten minutes plus skew leeway is invalid',
+      payload: {
+        ...directOffer,
+        relay: { ...relay, inviteExpiresAt: now + 10 * 60 * 1000 + 30 * 1000 + 1 }
+      },
       expected: null
     },
     {

--- a/src/shared/mobile-relay-pairing-offer.ts
+++ b/src/shared/mobile-relay-pairing-offer.ts
@@ -11,6 +11,10 @@ const PairingScopeSchema = z.enum(['mobile', 'runtime'])
 const BASE64URL_16_PATTERN = /^[A-Za-z0-9_-]{16}$/
 const BASE64URL_43_PATTERN = /^[A-Za-z0-9_-]{43}$/
 const MAX_INVITE_TTL_MS = 10 * 60 * 1000
+// The cell stamps expiry from its own clock; without leeway, a cell clock
+// even slightly ahead of this machine makes every invite fail validation
+// (same class as the host-proof freshness incident).
+const INVITE_EXPIRY_CLOCK_SKEW_MS = 30 * 1000
 
 function isCanonicalHttpsOrigin(value: string): boolean {
   if (
@@ -55,7 +59,10 @@ export function createPairingOfferSchema(now: () => number = () => Date.now()) {
       .int()
       .refine((value) => {
         const currentTime = now()
-        return value > currentTime && value <= currentTime + MAX_INVITE_TTL_MS
+        return (
+          value > currentTime &&
+          value <= currentTime + MAX_INVITE_TTL_MS + INVITE_EXPIRY_CLOCK_SKEW_MS
+        )
       }, 'Expected a future invite expiry no more than 10 minutes away'),
     e2eeFraming: z.literal(2)
   })


### PR DESCRIPTION
## Why

`createPairingRelay` invites are stamped by the cell to expire at exactly `now_cell + 10min` (relay-contract `inviteTtlMs`), while the desktop's `PairingOfferSchema` rejected any expiry past `now_desktop + 10min` with zero tolerance. Any cell clock ahead of the local machine by more than network transit (tens of ms) therefore fails every Relay pairing code with the opaque "Failed to generate pairing code" toast — reproduced live today on a machine ~140ms behind NTP, against healthy production cells. This is the same defect class as the host-proof zero-tolerance freshness check fixed after the 2026-08-01 incident (#10474/#12076), in a validator that fix didn't cover.

## What

- 30s upper-bound leeway (`INVITE_EXPIRY_CLOCK_SKEW_MS`), mirroring `RELAY_HOST_PROOF_CLOCK_SKEW_MS`. Lower bound unchanged; invites remain single-use and attempt-limited server-side.
- Fixtures: full-TTL invite from a cell up to 30s ahead is valid; beyond the leeway stays invalid.

## Server-side counterpart

orca-cloud will additionally issue invites with a margin under the max so *already-released* zero-tolerance desktops stop failing (separate PR + cell roll).