### PR TITLE
fix(terminal): reconcile status after escape interrupt

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -422,6 +422,23 @@ describe('agent interrupt inference', () => {
     expect(inferInterrupt).not.toHaveBeenCalled()
   })
 
+  it('does not rearm after disposal', () => {
+    vi.useFakeTimers()
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => makeEntry(),
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.dispose()
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
+  })
+
   it('requires exact plain Escape and Ctrl+C key events', () => {
     expect(isPlainEscapeKeyEvent(keyEvent({ key: 'Escape' }))).toBe(true)
     expect(isCtrlCKeyEvent(keyEvent({ key: 'c', ctrlKey: true }))).toBe(true)

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -204,10 +204,10 @@ describe('agent interrupt inference', () => {
         now: () => 1_100
       })
 
-      tracker.observeInputIntent('plain-escape')
+      tracker.observeInputIntent('plain-escape', entry, 1)
       expect(inferInterrupt).not.toHaveBeenCalled()
 
-      tracker.observeInputIntent('plain-escape')
+      tracker.observeInputIntent('plain-escape', entry, 1)
 
       expect(inferInterrupt).toHaveBeenCalledWith({
         paneKey: PANE_KEY,
@@ -455,35 +455,42 @@ describe('agent interrupt inference', () => {
     expect(inferInterrupt).not.toHaveBeenCalled()
   })
 
-  it('does not let a delayed acknowledgment cancel a newer turn inference', () => {
-    vi.useFakeTimers()
-    const olderEntry = makeEntry()
-    const newerEntry = makeEntry({
-      prompt: 'newer task',
-      updatedAt: 2_000,
-      stateStartedAt: 1_900
-    })
-    const inferInterrupt = vi.fn()
-    const tracker = createAgentInterruptInference({
-      paneKey: PANE_KEY,
-      getStatusEntry: () => newerEntry,
-      inferInterrupt,
-      now: () => 2_100
-    })
+  it.each([
+    ['an older status', makeEntry()],
+    ['an absent status', null]
+  ] as const)(
+    'does not let a delayed acknowledgment for %s cancel a newer turn after cleanup',
+    (_label, olderEntry) => {
+      vi.useFakeTimers()
+      const newerEntry = makeEntry({
+        prompt: 'newer task',
+        updatedAt: 2_000,
+        stateStartedAt: 1_900
+      })
+      let currentEntry: AgentStatusEntry | undefined = newerEntry
+      const inferInterrupt = vi.fn()
+      const tracker = createAgentInterruptInference({
+        paneKey: PANE_KEY,
+        getStatusEntry: () => currentEntry,
+        inferInterrupt,
+        now: () => 2_100
+      })
 
-    tracker.observeInputIntent('plain-escape', newerEntry)
-    tracker.observeInputIntent('plain-escape', olderEntry)
-    vi.advanceTimersByTime(500)
+      tracker.observeInputIntent('plain-escape', newerEntry, 2)
+      currentEntry = undefined
+      tracker.observeInputIntent('plain-escape', olderEntry, 1)
+      vi.advanceTimersByTime(500)
 
-    expect(inferInterrupt).toHaveBeenCalledWith({
-      paneKey: PANE_KEY,
-      baselineUpdatedAt: 2_000,
-      baselineStateStartedAt: 1_900,
-      baselinePrompt: 'newer task',
-      baselineAgentType: 'codex',
-      intent: 'plain-escape'
-    })
-  })
+      expect(inferInterrupt).toHaveBeenCalledWith({
+        paneKey: PANE_KEY,
+        baselineUpdatedAt: 2_000,
+        baselineStateStartedAt: 1_900,
+        baselinePrompt: 'newer task',
+        baselineAgentType: 'codex',
+        intent: 'plain-escape'
+      })
+    }
+  )
 
   it('requires exact plain Escape and Ctrl+C key events', () => {
     expect(isPlainEscapeKeyEvent(keyEvent({ key: 'Escape' }))).toBe(true)

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -439,6 +439,22 @@ describe('agent interrupt inference', () => {
     expect(inferInterrupt).not.toHaveBeenCalled()
   })
 
+  it('does not infer against a status created after the input baseline', () => {
+    vi.useFakeTimers()
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => makeEntry(),
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape', null)
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
+  })
+
   it('requires exact plain Escape and Ctrl+C key events', () => {
     expect(isPlainEscapeKeyEvent(keyEvent({ key: 'Escape' }))).toBe(true)
     expect(isCtrlCKeyEvent(keyEvent({ key: 'c', ctrlKey: true }))).toBe(true)

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -455,6 +455,36 @@ describe('agent interrupt inference', () => {
     expect(inferInterrupt).not.toHaveBeenCalled()
   })
 
+  it('does not let a delayed acknowledgment cancel a newer turn inference', () => {
+    vi.useFakeTimers()
+    const olderEntry = makeEntry()
+    const newerEntry = makeEntry({
+      prompt: 'newer task',
+      updatedAt: 2_000,
+      stateStartedAt: 1_900
+    })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => newerEntry,
+      inferInterrupt,
+      now: () => 2_100
+    })
+
+    tracker.observeInputIntent('plain-escape', newerEntry)
+    tracker.observeInputIntent('plain-escape', olderEntry)
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).toHaveBeenCalledWith({
+      paneKey: PANE_KEY,
+      baselineUpdatedAt: 2_000,
+      baselineStateStartedAt: 1_900,
+      baselinePrompt: 'newer task',
+      baselineAgentType: 'codex',
+      intent: 'plain-escape'
+    })
+  })
+
   it('requires exact plain Escape and Ctrl+C key events', () => {
     expect(isPlainEscapeKeyEvent(keyEvent({ key: 'Escape' }))).toBe(true)
     expect(isCtrlCKeyEvent(keyEvent({ key: 'c', ctrlKey: true }))).toBe(true)

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -11,7 +11,7 @@ import { isAskUserQuestionTool } from '../../../../shared/agent-question-answere
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 
 export type AgentInterruptInference = {
-  observeInputIntent(intent: AgentInterruptInputIntent): void
+  observeInputIntent(intent: AgentInterruptInputIntent, entry?: AgentStatusEntry): void
   flushPending(): boolean | Promise<boolean>
   dispose(): void
 }
@@ -112,6 +112,7 @@ export function createAgentInterruptInference({
   setTimer = (callback, ms) => setTimeout(callback, ms),
   clearTimer = (timer) => clearTimeout(timer)
 }: AgentInterruptInferenceDeps): AgentInterruptInference {
+  let disposed = false
   let pendingTimer: ReturnType<typeof setTimeout> | null = null
   let pendingBaseline: CapturedInterruptBaseline | null = null
   let doubleEscapeBaseline: CapturedInterruptBaseline | null = null
@@ -159,6 +160,9 @@ export function createAgentInterruptInference({
   }
 
   const flushPending = (): boolean | Promise<boolean> => {
+    if (disposed) {
+      return false
+    }
     const baseline = pendingBaseline
     pendingTimer = null
     pendingBaseline = null
@@ -199,8 +203,11 @@ export function createAgentInterruptInference({
   }
 
   return {
-    observeInputIntent(intent) {
-      const entry = getStatusEntry()
+    observeInputIntent(intent, capturedEntry) {
+      if (disposed) {
+        return
+      }
+      const entry = capturedEntry ?? getStatusEntry()
       if (!entry) {
         clearPending()
         return
@@ -247,6 +254,7 @@ export function createAgentInterruptInference({
     },
     flushPending,
     dispose() {
+      disposed = true
       clearPending()
     }
   }

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -207,7 +207,12 @@ export function createAgentInterruptInference({
       if (disposed) {
         return
       }
-      const entry = capturedEntry === undefined ? getStatusEntry() : capturedEntry
+      const currentEntry = getStatusEntry()
+      // Why: an older acknowledged write must not replace a newer turn's pending inference.
+      if (capturedEntry !== undefined && currentEntry && currentEntry !== capturedEntry) {
+        return
+      }
+      const entry = capturedEntry === undefined ? currentEntry : capturedEntry
       if (!entry) {
         clearPending()
         return

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -11,7 +11,7 @@ import { isAskUserQuestionTool } from '../../../../shared/agent-question-answere
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 
 export type AgentInterruptInference = {
-  observeInputIntent(intent: AgentInterruptInputIntent, entry?: AgentStatusEntry): void
+  observeInputIntent(intent: AgentInterruptInputIntent, entry?: AgentStatusEntry | null): void
   flushPending(): boolean | Promise<boolean>
   dispose(): void
 }
@@ -207,7 +207,7 @@ export function createAgentInterruptInference({
       if (disposed) {
         return
       }
-      const entry = capturedEntry ?? getStatusEntry()
+      const entry = capturedEntry === undefined ? getStatusEntry() : capturedEntry
       if (!entry) {
         clearPending()
         return

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -11,7 +11,11 @@ import { isAskUserQuestionTool } from '../../../../shared/agent-question-answere
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 
 export type AgentInterruptInference = {
-  observeInputIntent(intent: AgentInterruptInputIntent, entry?: AgentStatusEntry | null): void
+  observeInputIntent(
+    intent: AgentInterruptInputIntent,
+    entry?: AgentStatusEntry | null,
+    baselineSequence?: number
+  ): void
   flushPending(): boolean | Promise<boolean>
   dispose(): void
 }
@@ -117,6 +121,7 @@ export function createAgentInterruptInference({
   let pendingBaseline: CapturedInterruptBaseline | null = null
   let doubleEscapeBaseline: CapturedInterruptBaseline | null = null
   let doubleEscapeTimer: ReturnType<typeof setTimeout> | null = null
+  let latestBaselineSequence = 0
 
   const clearPendingTimer = (): void => {
     if (pendingTimer !== null) {
@@ -203,9 +208,15 @@ export function createAgentInterruptInference({
   }
 
   return {
-    observeInputIntent(intent, capturedEntry) {
+    observeInputIntent(intent, capturedEntry, baselineSequence) {
       if (disposed) {
         return
+      }
+      if (baselineSequence !== undefined) {
+        if (baselineSequence < latestBaselineSequence) {
+          return
+        }
+        latestBaselineSequence = baselineSequence
       }
       const currentEntry = getStatusEntry()
       // Why: an older acknowledged write must not replace a newer turn's pending inference.

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7564,7 +7564,7 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
   })
 
-  it('flushes pending interrupt inference before dropping an exited foreground agent command', async () => {
+  it('pins interrupt inference before acknowledged input and command exit cleanup', async () => {
     const { connectPanePty } = await import('./pty-connection')
 
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
@@ -7633,18 +7633,14 @@ describe('connectPanePty', () => {
     if (!onDataHandler) {
       throw new Error('expected onData handler to be registered')
     }
-    terminalTarget.dispatch(
-      keyEvent({
-        key: 'c',
-        ctrlKey: true
-      })
-    )
-    ;(onDataHandler as unknown as (data: string) => void)('\x03')
+    terminalTarget.dispatch(keyEvent({ key: 'Escape' }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b')
 
     capturedDataCallback.current?.('\x1b]133;D;130\x07thebr ~/repo $ ')
     expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
     expect(mockStoreState.dropAgentStatus).not.toHaveBeenCalled()
 
+    delete mockStoreState.agentStatusByPaneKey[paneKey]
     writeAccepted.resolve(true)
     await flushAsyncTicks()
 
@@ -7654,7 +7650,7 @@ describe('connectPanePty', () => {
       baselineStateStartedAt: 900,
       baselinePrompt: 'stop quickly',
       baselineAgentType: 'codex',
-      intent: 'ctrl-c'
+      intent: 'plain-escape'
     })
     expect(mockStoreState.dropAgentStatus).toHaveBeenCalledWith(paneKey)
   })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1950,6 +1950,8 @@ export function connectPanePty(
     questionAnsweredInference.observeSentTerminalInput(data)
   }
   let pendingTerminalInputWrite: Promise<void> | null = null
+  let sequencedInterruptStatusBaseline: AgentStatusEntry | null | undefined
+  let interruptStatusBaselineSequence = 0
   const setPendingTerminalInputWrite = (promise: Promise<void>): void => {
     pendingTerminalInputWrite = promise
     void promise.finally(() => {
@@ -4054,6 +4056,12 @@ export function connectPanePty(
     const acknowledgedIntent = intent ?? inferIntentFromExactTerminalInput(data)
     if (acknowledgedIntent && transport.sendInputAccepted) {
       const interruptStatusBaseline = useAppStore.getState().agentStatusByPaneKey[cacheKey] ?? null
+      // Why: equal snapshots retain double-Escape semantics while older snapshots lose ack races.
+      if (sequencedInterruptStatusBaseline !== interruptStatusBaseline) {
+        sequencedInterruptStatusBaseline = interruptStatusBaseline
+        interruptStatusBaselineSequence += 1
+      }
+      const capturedBaselineSequence = interruptStatusBaselineSequence
       claimViewportForUserActivity()
       if (acknowledgedIntent === 'ctrl-c') {
         // Why: the accepted-write callback is async; let the next command be
@@ -4069,7 +4077,11 @@ export function connectPanePty(
             markAcceptedTerminalInputSent()
             observeAcceptedShellCommandInput(data)
             observeAcceptedTerminalInput(data, acknowledgedIntent)
-            interruptInference.observeInputIntent(acknowledgedIntent, interruptStatusBaseline)
+            interruptInference.observeInputIntent(
+              acknowledgedIntent,
+              interruptStatusBaseline,
+              capturedBaselineSequence
+            )
             observeTitleOnlyInterrupt()
           } else {
             // Why: Esc/Ctrl+C are the first keys users press on a frozen pane;

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4053,6 +4053,7 @@ export function connectPanePty(
     // excluded because those transports do not expose sendInputAccepted.
     const acknowledgedIntent = intent ?? inferIntentFromExactTerminalInput(data)
     if (acknowledgedIntent && transport.sendInputAccepted) {
+      const interruptStatusBaseline = useAppStore.getState().agentStatusByPaneKey[cacheKey]
       claimViewportForUserActivity()
       if (acknowledgedIntent === 'ctrl-c') {
         // Why: the accepted-write callback is async; let the next command be
@@ -4068,7 +4069,7 @@ export function connectPanePty(
             markAcceptedTerminalInputSent()
             observeAcceptedShellCommandInput(data)
             observeAcceptedTerminalInput(data, acknowledgedIntent)
-            interruptInference.observeInputIntent(acknowledgedIntent)
+            interruptInference.observeInputIntent(acknowledgedIntent, interruptStatusBaseline)
             observeTitleOnlyInterrupt()
           } else {
             // Why: Esc/Ctrl+C are the first keys users press on a frozen pane;

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4053,7 +4053,7 @@ export function connectPanePty(
     // excluded because those transports do not expose sendInputAccepted.
     const acknowledgedIntent = intent ?? inferIntentFromExactTerminalInput(data)
     if (acknowledgedIntent && transport.sendInputAccepted) {
-      const interruptStatusBaseline = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+      const interruptStatusBaseline = useAppStore.getState().agentStatusByPaneKey[cacheKey] ?? null
       claimViewportForUserActivity()
       if (acknowledgedIntent === 'ctrl-c') {
         // Why: the accepted-write callback is async; let the next command be


### PR DESCRIPTION
## Summary

- capture the exact terminal agent-status generation, including absence, before asynchronous PTY input acknowledgment
- infer interruption only after Escape or Ctrl+C is accepted, while main still strictly revalidates the captured turn
- fence stale and out-of-order acknowledgments so they cannot replace a newer pending inference, including after renderer row cleanup
- prevent late acknowledged input from rearming inference after pane disposal
- preserve OpenCode/Copilot double-Escape semantics and keep native-chat behavior unchanged

## Reliability contract

- **Invariant — `terminal-input.interrupt-turn-identity`:** only an accepted Escape or Ctrl+C may reconcile the exact captured active turn to interrupted Done; delayed input must never affect a newer turn or a disposed pane.
- **Failure source:** PTY acknowledgment may resolve after command-exit cleanup, after another turn starts, or after the newer renderer row disappears.
- **Oracle:** deterministic renderer tests cover captured absence, stale/out-of-order acknowledgments, row cleanup, disposal, command-exit flushing, rejected writes, and same-generation double Escape; main tests prove exact timestamp/prompt/type/state authority; Electron proves the visible Working to interrupted Done transition with a real Codex turn.
- **Gate:** no matching entry currently exists in `config/reliability-gates.jsonc`; this remains an explicit accepted manifest gap, covered in this PR by the targeted deterministic suites and Electron artifact.
- **Provider/platform coverage:** local/daemon PTY is covered by tests and macOS Electron. SSH fire-and-forget, mobile/relay, WSL, and native-chat do not use the changed acknowledged-input branch and are unaffected. Linux and Windows runtime UI were not exercised; the code adds no platform-dependent behavior.
- **Performance budget:** one constant-time status snapshot and generation comparison per accepted interrupt; no polling, broad scans, subprocesses, subscriptions, render fanout, or unbounded retained state.
- **Diagnostics:** existing `[agent-interrupt]` failure logs plus captured baseline fields and status history identify rejected or applied inference.
- **Residual gaps:** no live Linux/Windows UI run and no dedicated reliability-manifest gate; SSH/WSL/mobile transport paths remain unchanged rather than directly exercised.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/agent-hooks/server.test.ts src/main/ipc/agent-hooks.test.ts` — 844 passed
- `pnpm run typecheck:web`
- `pnpm run check:max-lines-ratchet`
- `git diff --check origin/main...HEAD`
- three sequential same-model review passes; first two fixed meaningful acknowledgment races, final fresh pass returned CLEAN

## Electron QA

- exact instance: `jaeger @ brennanb2025/fix-codex-escape-status`, HEAD `43e84daf7d`
- real Codex terminal turn ran `sleep 30`; Escape changed the rendered terminal/sidebar/tab from Working to Done/Interrupted
- backing status changed to `state: done`, `interrupted: true`
- screenshots: https://github.com/stablyai/orca/pull/12345#issuecomment-5172825369

## AI review report

- fixed an absent-baseline ambiguity that could interrupt a turn created after input
- fixed stale acknowledgment replacement of a newer pending inference
- added generation ordering so stale callbacks cannot cancel newer inference after row cleanup while same-turn double Escape remains valid
- final independent pass found no actionable correctness, regression, scope, or performance issue

## Security audit

- no new IPC surface, permissions, shell commands, persisted data, or external input handling
- main-process inference remains authoritative and requires an exact captured turn match

## Notes

No mobile emulator run: the PR changes only the desktop renderer acknowledged terminal-input path.