### PR TITLE
Fix Codex launch draft delivery after delayed setup

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6597,6 +6597,7 @@ describe('connectPanePty', () => {
     capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
     await flushAsyncTicks()
 
+    expect(transport.sendInputAccepted).toHaveBeenCalledTimes(1)
     expect(transport.sendInputAccepted).toHaveBeenCalledWith(
       '\x1b[200~Linked Linear issue: STA-905\x1b[201~'
     )

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6603,7 +6603,7 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('does not consume startup draft delivery before deferred connect starts', async () => {
+  it('releases startup draft delivery when disposed before deferred connect starts', async () => {
     const { connectPanePty } = await import('./pty-connection')
     globalThis.requestAnimationFrame = vi.fn(() => 1)
     const transport = createMockTransport('pty-codex')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6536,6 +6536,72 @@ describe('connectPanePty', () => {
     expect(mockStoreState.recordTerminalInput).toHaveBeenCalledWith(makePaneKey('tab-1', LEAF_1))
   })
 
+  it('keeps startup draft ownership while deferred connect waits through setup', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { beginAgentStartupDeliveryAttempt: claimStartupDelivery } =
+      await import('@/lib/agent-startup-delayed-delivery')
+
+    const deferredFrames: FrameRequestCallback[] = []
+    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      deferredFrames.push(callback)
+      return 1
+    })
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    const transport = createMockTransport('pty-codex')
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-codex'
+    })
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: null }]
+    }
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({
+      startup: {
+        command: 'wait-for-setup-then-codex',
+        launchAgent: 'codex',
+        launchConfig: { agentArgs: '', agentEnv: {} },
+        launchToken: 'launch-token-setup',
+        draftPrompt: 'Linked Linear issue: STA-905'
+      }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    const sidecarClaimed = claimStartupDelivery({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      launchToken: 'launch-token-setup'
+    })
+    expect(sidecarClaimed).toBe(false)
+
+    let frameCount = 0
+    while (deferredFrames.length > 0 && transport.connect.mock.calls.length === 0) {
+      if (frameCount >= 20) {
+        throw new Error('startup did not connect after the deferred setup handoff')
+      }
+      frameCount += 1
+      deferredFrames.shift()?.(frameCount * 16)
+    }
+    await flushAsyncTicks()
+    expect(capturedDataCallback.current).not.toBeNull()
+    capturedDataCallback.current?.('\x1b[?2004hWaiting for setup to finish...')
+    expect(transport.sendInputAccepted).not.toHaveBeenCalled()
+
+    capturedDataCallback.current?.('\x1b[?2004h\x1b[2K› ')
+    await flushAsyncTicks()
+
+    expect(transport.sendInputAccepted).toHaveBeenCalledWith(
+      '\x1b[200~Linked Linear issue: STA-905\x1b[201~'
+    )
+  })
+
   it('does not consume startup draft delivery before deferred connect starts', async () => {
     const { connectPanePty } = await import('./pty-connection')
     globalThis.requestAnimationFrame = vi.fn(() => 1)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1267,6 +1267,8 @@ export function connectPanePty(
     })
     startupDraftDeliveryClaimed = false
   }
+  // Why: reserve before deferred connect so the creation sidecar cannot time out during setup and strand this pane's live scanner.
+  const ownsStartupDraftPaste = claimStartupDraftPasteDelivery()
   if (paneStartup?.launchConfig) {
     useAppStore.getState().registerAgentLaunchConfig(cacheKey, paneStartup.launchConfig, {
       agentType: paneStartup.launchAgent ?? paneStartup.initialAgentStatus?.agent,
@@ -4700,7 +4702,6 @@ export function connectPanePty(
       }
       schedulePendingStartupCommandDelivery()
     }
-    const ownsStartupDraftPaste = claimStartupDraftPasteDelivery()
     const startupDraftReadyScanner = ownsStartupDraftPaste
       ? createDraftPasteReadyScanner(
           startupDraftAgentConfig?.draftPasteReadySignal ?? 'render-quiet-after-bracketed-paste'


### PR DESCRIPTION
## Summary

- Reserve startup-draft delivery for the mounted terminal pane before its deferred PTY connection begins.
- Prevent the creation sidecar's eight-second readiness budget from consuming a launch while setup still owns the PTY.
- Add a regression covering sidecar contention followed by the delayed Codex composer-ready frame.

## Screenshots

The Linear pointer is visibly present as an unsent Codex draft after a 12-second setup delay:

![codex-linear-draft-after-fix.png](https://github.com/user-attachments/assets/878e8f52-70e0-4709-9154-2b260446203b)

## Testing

- [ ] pnpm lint
- [ ] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Completed focused verification:

- 540 tests in pty-connection.test.ts
- 71 tests across new-workspace.test.ts and worktree-activation.test.ts
- pnpm run typecheck:web
- pnpm run check:max-lines-ratchet
- oxfmt check on both changed files
- All three Oxlint configurations on both changed files
- Isolated Electron validation with real Codex after a 12-second setup delay; foreground PTY inspection confirmed Codex owned the terminal

## AI Review Report

Reviewed the delivery-claim lifecycle for duplicate writes, abandoned mounts, deferred PTY connection, and setup-to-agent ownership changes. The main risk was claiming too early and leaving the launch token consumed; the existing dispose path still releases any unattempted claim, and the regression verifies that the competing sidecar cannot steal the active pane's launch. Cross-platform compatibility was checked for macOS, Linux, and Windows: this changes no shortcuts, labels, paths, shell commands, process recognition, or platform-specific Electron behavior, and the ownership logic is shared by local, SSH, and folder-workspace terminal paths.

## Security Audit

No new command execution, prompt parsing, IPC, authentication, dependency, or filesystem behavior is introduced. The change only advances when an existing launch-token claim occurs, retaining its worktree/tab/token scoping and existing cleanup. The regression uses inert test strings, and no credentials or private data were added to the diff.

## Notes

The complete changed-file quality wrapper could not parse pnpm's Node-engine warning under local Node 26; its three underlying Oxlint scans were run directly and returned zero diagnostics. The repository requires Node 24. Production Orca was not touched during Electron validation.
