### PR TITLE
fix(terminal): stop keyboard effect re-registering on every pane render

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -56,8 +56,8 @@ import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/termin
 import {
   applyExpandedLayoutTo,
   cancelPendingPaneSizeRefreshFrames,
-  createExpandCollapseActions,
-  restoreExpandedLayoutFrom
+  restoreExpandedLayoutFrom,
+  useExpandCollapseActions
 } from './expand-collapse'
 import { useTerminalKeyboardShortcuts, type SearchState } from './keyboard-handlers'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
@@ -1250,7 +1250,7 @@ function TerminalPane(
     refreshPaneSizes,
     syncExpandedLayout,
     toggleExpandPane
-  } = createExpandCollapseActions({
+  } = useExpandCollapseActions({
     expandedPaneIdRef,
     expandedStyleSnapshotRef,
     containerRef,

--- a/src/renderer/src/components/terminal-pane/expand-collapse-render-stability.test.ts
+++ b/src/renderer/src/components/terminal-pane/expand-collapse-render-stability.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { useExpandCollapseActions } from './expand-collapse'
+import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
+
+type ExpandCollapseHookState = Parameters<typeof useExpandCollapseActions>[0]
+type KeyboardHandlersDeps = Parameters<typeof useTerminalKeyboardShortcuts>[0]
+
+// Field identities are stable across renders (refs, setState, store actions,
+// useCallback); TerminalPane rebuilds only the wrapping object literal.
+function createStableFields(): Omit<ExpandCollapseHookState, 'tabId'> {
+  return {
+    expandedPaneIdRef: { current: null },
+    expandedStyleSnapshotRef: { current: new Map() },
+    containerRef: { current: null },
+    managerRef: { current: null },
+    setExpandedPaneId: vi.fn(),
+    setTabPaneExpanded: vi.fn(),
+    pendingPaneSizeRefreshFrameIdsRef: { current: [] },
+    persistLayoutSnapshot: vi.fn()
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('useExpandCollapseActions render stability', () => {
+  it('keeps all five action identities across rerenders that rebuild the state object', () => {
+    const fields = createStableFields()
+    const hook = renderHook(() => useExpandCollapseActions({ ...fields, tabId: 'tab-1' }))
+    const first = hook.result.current
+
+    hook.rerender()
+    hook.rerender()
+
+    const actionNames = Object.keys(first) as (keyof typeof first)[]
+    expect(actionNames).toHaveLength(5)
+    for (const name of actionNames) {
+      expect(Object.is(hook.result.current[name], first[name])).toBe(true)
+    }
+  })
+
+  it('remints actions when tabId changes', () => {
+    const fields = createStableFields()
+    const hook = renderHook(({ tabId }) => useExpandCollapseActions({ ...fields, tabId }), {
+      initialProps: { tabId: 'tab-1' }
+    })
+    const first = hook.result.current
+
+    hook.rerender({ tabId: 'tab-2' })
+
+    expect(Object.is(hook.result.current.setExpandedPane, first.setExpandedPane)).toBe(false)
+  })
+})
+
+describe('terminal keyboard effect registration stability', () => {
+  it('registers window listeners once across rerenders with TerminalPane-shaped wiring', () => {
+    const scope = document.createElement('div')
+    document.body.append(scope)
+    const pane = {
+      id: 1,
+      leafId: '00000000-0000-4000-8000-000000000001',
+      terminal: { element: scope, focus: vi.fn(), getSelection: vi.fn(() => '') }
+    }
+    const manager = {
+      getActivePane: () => pane,
+      getPanes: () => [pane]
+    } as unknown as PaneManager
+    const transport = { getPtyId: () => 'pty-1', sendInput: vi.fn(() => true) }
+    const fields = createStableFields()
+    const stableDeps = {
+      tabId: 'tab-1',
+      worktreeId: 'worktree-1',
+      isActive: true,
+      keyboardScopeRef: { current: scope },
+      managerRef: { current: manager },
+      paneTransportsRef: {
+        current: new Map([[pane.id, transport as unknown as PtyTransport]])
+      },
+      panePtyBindingsRef: { current: new Map() },
+      paneCwdRef: { current: new Map() },
+      fallbackCwd: '',
+      expandedPaneIdRef: { current: null },
+      setSearchOpen: vi.fn(),
+      onSearchSelectedText: vi.fn(),
+      onRequestClosePane: vi.fn(),
+      onClearPaneScrollback: vi.fn(),
+      onSetTitle: vi.fn(),
+      onClearPaneTitle: vi.fn(),
+      searchOpenRef: { current: false },
+      searchStateRef: { current: { query: '', caseSensitive: false, regex: false } },
+      macOptionAsAltRef: { current: 'false' as const }
+    }
+
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const countBeforeinputAdds = (): number =>
+      addSpy.mock.calls.filter(([type]) => type === 'beforeinput').length
+
+    const hook = renderHook(() => {
+      // Same wiring shape as TerminalPane: both dep objects are rebuilt every render.
+      const actions = useExpandCollapseActions({ ...fields, tabId: stableDeps.tabId })
+      useTerminalKeyboardShortcuts({
+        ...stableDeps,
+        setExpandedPane: actions.setExpandedPane,
+        restoreExpandedLayout: actions.restoreExpandedLayout,
+        refreshPaneSizes: actions.refreshPaneSizes,
+        persistLayoutSnapshot: fields.persistLayoutSnapshot,
+        toggleExpandPane: actions.toggleExpandPane
+      } as KeyboardHandlersDeps)
+    })
+    expect(countBeforeinputAdds()).toBe(1)
+
+    for (let render = 0; render < 10; render++) {
+      hook.rerender()
+    }
+
+    expect(countBeforeinputAdds()).toBe(1)
+    hook.unmount()
+    scope.remove()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/expand-collapse.ts
+++ b/src/renderer/src/components/terminal-pane/expand-collapse.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 
@@ -204,4 +205,45 @@ export function createExpandCollapseActions(state: ExpandCollapseState) {
     syncExpandedLayout,
     toggleExpandPane
   }
+}
+
+// Why: four of these actions are deps of the terminal keyboard effect; unstable
+// identities would tear down and re-register its window listeners every render.
+export function useExpandCollapseActions(state: ExpandCollapseState) {
+  const {
+    expandedPaneIdRef,
+    expandedStyleSnapshotRef,
+    containerRef,
+    managerRef,
+    setExpandedPaneId,
+    setTabPaneExpanded,
+    pendingPaneSizeRefreshFrameIdsRef,
+    tabId,
+    persistLayoutSnapshot
+  } = state
+  return useMemo(
+    () =>
+      createExpandCollapseActions({
+        expandedPaneIdRef,
+        expandedStyleSnapshotRef,
+        containerRef,
+        managerRef,
+        setExpandedPaneId,
+        setTabPaneExpanded,
+        pendingPaneSizeRefreshFrameIdsRef,
+        tabId,
+        persistLayoutSnapshot
+      }),
+    [
+      expandedPaneIdRef,
+      expandedStyleSnapshotRef,
+      containerRef,
+      managerRef,
+      setExpandedPaneId,
+      setTabPaneExpanded,
+      pendingPaneSizeRefreshFrameIdsRef,
+      tabId,
+      persistLayoutSnapshot
+    ]
+  )
 }


### PR DESCRIPTION
## Summary

`TerminalPane` called `createExpandCollapseActions()` bare in its render body. The factory mints five fresh closures per call, and four of them (`setExpandedPane`, `restoreExpandedLayout`, `refreshPaneSizes`, `toggleExpandPane`) are dependencies of `useTerminalKeyboardShortcuts` — so the terminal keyboard effect tore down and re-registered its seven `window` listeners on **every** `TerminalPane` render, and every piece of effect-owned IME state (`modifiedEnterChordOwner`, `heldImeEnterModifiers`, `nativeOnlyShortcutTracker`, `deferredNewlineSender`, `observedEnterKeydownTimeStamps`, `optionKeyLocation`) was silently reset each time. Any render landing mid-chord or mid-composition wiped tracker state — the class of bug behind the STA-3128 symptom that #12265 patched downstream.

Fix: `useExpandCollapseActions`, a memoized wrapper in `expand-collapse.ts` keyed on field-level identities (all stable per mounted pane), so the actions — and therefore the keyboard effect registration — are stable across renders. The raw factory is unchanged for non-hook callers/tests.

Live measurement (dev app, CDP-instrumented `window` listener add/remove counts, single pane running 50 OSC title updates — title updates are what drives pane renders in a busy TUI; raw output and echo drive none):

| Scenario | Before | After |
|---|---|---|
| Idle 5s | 0 listener ops | 0 |
| Typing 31 chars | 0 | 0 |
| `seq 1 20000` output burst | 0 | 0 |
| 50 OSC title updates | **700 listener ops** (7 listeners × 50 re-registrations, 1:1 with renders) | **0** (all 50 title updates confirmed processed) |

Fixes #12269 (STA-3291)

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` (all three projects, clean `tsbuildinfo`)
- [x] `pnpm test` — targeted: `expand-collapse-render-stability.test.ts` (new), `expand-collapse.test.ts`, `keyboard-handlers.test.ts`, `keyboard-handlers-ime.test.tsx`, `keyboard-handlers-ime-enter-keyup.test.tsx` — 42/42 pass
- [x] `pnpm lint` — oxlint + react-doctor + oxfmt on changed files via pre-commit; `lint-react-doctor-changed` gate exits 0
- [ ] `pnpm build` — not run (renderer-only memoization; no build-surface change)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New regression test pins registration stability with TerminalPane-shaped wiring (dep objects rebuilt every render): action identities stable 5/5 across rerenders, remint on `tabId` change, and exactly one `window` listener registration across 10 rerenders. Verified non-vacuous: wiring it through the raw factory fails with `expected 11 to be 1`.

## AI Review Report

Reviewed the diff for: dependency-array correctness (hook deps enumerate every field the factory consumes; refs are stable, `setExpandedPaneId` is a `useState` setter, `setTabPaneExpanded` a store action, `persistLayoutSnapshot` a `useCallback` on `[tabId, setTabLayout, worktreeId]` — so the memo remints exactly when it should), rules-of-hooks (unconditional call site), and residual churn sources in the keyboard effect's dep array (`keybindings` is a direct store selector; `terminalShortcutPolicy` is a string; remaining entries are refs/`useCallback`s — the factory was the only churn source, confirmed by the zero post-fix measurement). Cross-platform: no shortcuts, labels, paths, shell behavior, or Electron platform branches touched; the memoization gap was shared renderer code affecting macOS/Linux/Windows identically (visible symptom historically Windows IME). SSH/remote and folder-workspace paths unaffected — pane wiring is common to all transports.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The change memoizes existing renderer-local closures; listener add/remove surface shrinks. No new attack surface; no follow-up needed.

## Notes

- Follow-up hardening in #12357 (this PR merged while the canary commit was in flight, so it landed separately): a dev-only churn canary (`keyboard-effect-churn-canary.ts`) warns when one mounted keyboard hook re-registers more than 4 times in 2s — catching any future identity-unstable dependency loudly in dev instead of silently re-churning. Keyed per mounted hook instance so tab remounts never false-positive; rate-limited; bounded state; compiled out of production builds (`import.meta.env.DEV`). A wiring-level test asserts the warn actually fires when a dep churns.
- Latent since #12265 removed the visible IME symptom; this corrects the underlying invariant ("one claim until release" now actually bounds a chord's lifetime) and stops 14 listener ops per render per mounted pane.
- A pre-existing react-doctor warning at `TerminalPane.tsx:1642` (`no-adjust-state-on-prop-change`) surfaces when this file is scanned; it is outside this change and left untouched.


