### PR TITLE
fix(terminal): reattach panes across daemon protocol upgrade

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1452,11 +1452,17 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
-    it('fails closed before dispatching attach-only to a v30 daemon', async () => {
+    it('reattaches a stable pane through a preserved v30 daemon', async () => {
       const ensureConnected = vi
         .spyOn(DaemonClient.prototype, 'ensureConnected')
         .mockResolvedValue()
-      const request = vi.spyOn(DaemonClient.prototype, 'request')
+      const request = vi.spyOn(DaemonClient.prototype, 'request').mockResolvedValue({
+        isNew: false,
+        snapshot: null,
+        pid: 4321,
+        shellState: 'unsupported',
+        incarnationId: 'legacy-stable-pane-incarnation'
+      })
       const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
       try {
         await expect(
@@ -1464,10 +1470,65 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
             cols: 80,
             rows: 24,
             sessionId: 'legacy-stable-pane-session',
-            attachOnly: true
+            attachOnly: true,
+            command: 'must-not-run'
           })
-        ).rejects.toThrow('terminal_pane_owner_unknown')
-        expect(request).not.toHaveBeenCalledWith('createOrAttach', expect.anything())
+        ).resolves.toMatchObject({
+          id: 'legacy-stable-pane-session',
+          incarnationId: 'legacy-stable-pane-incarnation',
+          isReattach: true
+        })
+        expect(request).toHaveBeenCalledWith(
+          'createOrAttach',
+          expect.objectContaining({
+            command: undefined,
+            launchAgent: undefined,
+            startupCommandDelivery: undefined
+          })
+        )
+        expect(request.mock.calls[0]?.[1]).not.toHaveProperty('attachOnly')
+      } finally {
+        legacy.dispose()
+        request.mockRestore()
+        ensureConnected.mockRestore()
+      }
+    })
+
+    it('retires a replacement created by a raced-out v30 stable pane', async () => {
+      const ensureConnected = vi
+        .spyOn(DaemonClient.prototype, 'ensureConnected')
+        .mockResolvedValue()
+      const request = vi
+        .spyOn(DaemonClient.prototype, 'request')
+        .mockResolvedValueOnce({
+          isNew: true,
+          snapshot: null,
+          pid: 4321,
+          shellState: 'unsupported',
+          incarnationId: 'legacy-replacement-incarnation'
+        })
+        .mockResolvedValueOnce({})
+      const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
+      try {
+        await expect(
+          legacy.spawn({
+            cols: 80,
+            rows: 24,
+            sessionId: 'raced-out-legacy-session',
+            attachOnly: true,
+            command: 'must-not-run'
+          })
+        ).rejects.toThrow('Session not found: raced-out-legacy-session')
+        expect(request).toHaveBeenNthCalledWith(
+          1,
+          'createOrAttach',
+          expect.objectContaining({ command: undefined })
+        )
+        expect(request).toHaveBeenNthCalledWith(2, 'kill', {
+          sessionId: 'raced-out-legacy-session',
+          immediate: true
+        })
+        expect(legacy.getActiveSessionIds()).toEqual([])
       } finally {
         legacy.dispose()
         request.mockRestore()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -32,6 +32,7 @@ import {
   type DaemonEvent,
   type GetSnapshotResult,
   type ListSessionsResult,
+  SessionNotFoundError,
   type SessionInfo,
   type TakePendingOutputResult
 } from './types'
@@ -334,9 +335,6 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
-    if (opts.attachOnly && this.protocolVersion < STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION) {
-      throw new Error('terminal_pane_owner_unknown')
-    }
     const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
     const operation = {
       exitsBySessionId: new Map<string, { incarnationId?: string }[]>(),
@@ -382,6 +380,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
       throw new Error('agent_session_claim_unavailable')
     }
     const requestedSessionId = opts.sessionId!
+    // Why: v30 daemons survive upgrades; reject their accidental create result before publication.
+    const attachOnly = opts.attachOnly === true
+    const emulateLegacyAttachOnly =
+      attachOnly && this.protocolVersion < STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION
     let sessionId = requestedSessionId
     let wslDistro = resolveWslSessionContext({
       cwd: opts.cwd,
@@ -498,25 +500,29 @@ export class DaemonPtyAdapter implements IPtyProvider {
         sessionId,
         cols: effectiveCols,
         rows: effectiveRows,
-        cwd: effectiveCwd,
-        env: opts.env,
-        envToDelete: opts.envToDelete,
-        command: opts.command,
-        startupCommandDelivery: opts.startupCommandDelivery,
-        launchAgent: opts.launchAgent,
-        ...(opts.attachOnly ? { attachOnly: true } : {}),
+        cwd: attachOnly ? undefined : effectiveCwd,
+        env: attachOnly ? undefined : opts.env,
+        envToDelete: attachOnly ? undefined : opts.envToDelete,
+        command: attachOnly ? undefined : opts.command,
+        startupCommandDelivery: attachOnly ? undefined : opts.startupCommandDelivery,
+        launchAgent: attachOnly ? undefined : opts.launchAgent,
+        ...(attachOnly && !emulateLegacyAttachOnly ? { attachOnly: true } : {}),
         // Why: without forwarding the override, the daemon falls back to cmd.exe/PowerShell, ignoring the shell the renderer chose; this matches LocalPtyProvider.
-        shellOverride: opts.shellOverride,
-        terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
-        terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation,
-        shellReadySupported,
-        ...(shellReadyTimeoutMs !== undefined ? { shellReadyTimeoutMs } : {}),
+        shellOverride: attachOnly ? undefined : opts.shellOverride,
+        terminalWindowsWslDistro: attachOnly ? undefined : opts.terminalWindowsWslDistro,
+        terminalWindowsPowerShellImplementation: attachOnly
+          ? undefined
+          : opts.terminalWindowsPowerShellImplementation,
+        shellReadySupported: attachOnly ? false : shellReadySupported,
+        ...(!attachOnly && shellReadyTimeoutMs !== undefined ? { shellReadyTimeoutMs } : {}),
         ...(historySeed ? { historySeed } : {}),
         ...(historySeedTransferId ? { historySeedTransferId } : {}),
-        ...(this.supportsStartupIngress && opts.startupIngress
+        ...(this.supportsStartupIngress && !attachOnly && opts.startupIngress
           ? { startupIngress: opts.startupIngress }
           : {}),
-        ...(opts.agentSessionEnsure ? { agentSessionEnsure: opts.agentSessionEnsure } : {})
+        ...(!attachOnly && opts.agentSessionEnsure
+          ? { agentSessionEnsure: opts.agentSessionEnsure }
+          : {})
       })
     }
 
@@ -604,6 +610,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       historySeedSegments = null
     }
     let result = await createOrAttach(historySeedSegments)
+    if (emulateLegacyAttachOnly && result.isNew) {
+      operation.ignoreNextExit = true
+      await this.client.request('kill', { sessionId: requestedSessionId, immediate: true })
+      throw new SessionNotFoundError(requestedSessionId)
+    }
     await adoptSpawnResultSession(result)
     // Both ids: adoptSpawnResultSession may have rewritten sessionId to the claim owner.
     this.clearSessionAwaitingDaemonRecovery(requestedSessionId)


### PR DESCRIPTION
## Summary

- restore terminal panes hosted by the preserved v1.4.167 protocol-v30 daemon
- keep native atomic attach-only behavior for protocol v31+
- reject and immediately retire any replacement session created by a legacy exit race
- strip launch commands and agent metadata from stable-pane adoption requests

## Regression

`cd68a8b00c` introduced protocol-v31 stable-pane `attachOnly`, while the compatibility router intentionally preserved live v30 daemons from v1.4.167. Every restored pane was routed to its valid v30 owner and then rejected locally with `terminal_pane_owner_unknown` before any daemon RPC.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-pty-router.test.ts src/main/daemon/degraded-daemon-pty-provider.test.ts --reporter=dot`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts -t 'persisted owner|stable-pane owner|completed runtime-owned pane' --reporter=dot`
- `pnpm run typecheck:node`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
