### PR TITLE
fix(remote): distinguish hosts that need a workspace window

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.runtime-window.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.runtime-window.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { RUNTIME_PROTOCOL_VERSION } from '../../../../shared/protocol-version'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
+import { useAppStore } from '../../store'
+import { RepositoryHostSetupsSection } from './RepositoryHostSetupsSection'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState(), true)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  useAppStore.setState(useAppStore.getInitialState(), true)
+})
+
+describe('RepositoryHostSetupsSection runtime window availability', () => {
+  it('asks users to open Orca when a reachable host has no workspace window', () => {
+    const repo: Repo = {
+      id: 'remote-repo',
+      displayName: 'Orca',
+      path: '/srv/orca',
+      badgeColor: '#737373',
+      addedAt: 100,
+      kind: 'git',
+      executionHostId: 'runtime:hub'
+    }
+    const project: Project = {
+      id: 'github:stablyai/orca',
+      displayName: 'Orca',
+      badgeColor: '#737373',
+      sourceRepoIds: [repo.id],
+      createdAt: 100,
+      updatedAt: 100
+    }
+    const setup: ProjectHostSetup = {
+      id: 'hub-local-setup',
+      projectId: project.id,
+      repoId: repo.id,
+      hostId: 'runtime:hub',
+      executionHostId: 'local',
+      runtimeOwnerEnvironmentId: 'hub',
+      path: repo.path,
+      displayName: repo.displayName,
+      kind: 'git',
+      setupState: 'ready',
+      setupMethod: 'legacy-repo',
+      createdAt: 100,
+      updatedAt: 100
+    }
+    useAppStore.setState({
+      repos: [repo],
+      projects: [project],
+      projectHostSetups: [setup],
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          'hub',
+          {
+            checkedAt: 1,
+            status: {
+              runtimeId: 'runtime-hub',
+              rendererGraphEpoch: 1,
+              graphStatus: 'unavailable',
+              authoritativeWindowId: null,
+              desktopWindowStatus: 'openable',
+              liveTabCount: 0,
+              liveLeafCount: 0,
+              runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+              minCompatibleRuntimeClientVersion: 1,
+              capabilities: []
+            }
+          }
+        ]
+      ])
+    })
+
+    act(() => {
+      root.render(
+        <RepositoryHostSetupsSection repo={repo} forceVisible searchQuery="" searchEntries={[]} />
+      )
+    })
+
+    expect(container.textContent).toContain('Open Orca')
+    expect(container.textContent).toContain(
+      'Orca is connected, but its workspace window is closed. Open Orca on this host to use terminals.'
+    )
+    expect(container.textContent).not.toContain('Ready')
+  })
+})

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.runtime-window.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.runtime-window.test.tsx
@@ -4,12 +4,78 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { RUNTIME_PROTOCOL_VERSION } from '../../../../shared/protocol-version'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { RepositoryHostSetupsSection } from './RepositoryHostSetupsSection'
 
+const repo: Repo = {
+  id: 'remote-repo',
+  displayName: 'Orca',
+  path: '/srv/orca',
+  badgeColor: '#737373',
+  addedAt: 100,
+  kind: 'git',
+  executionHostId: 'runtime:hub'
+}
+const project: Project = {
+  id: 'github:stablyai/orca',
+  displayName: 'Orca',
+  badgeColor: '#737373',
+  sourceRepoIds: [repo.id],
+  createdAt: 100,
+  updatedAt: 100
+}
+const setup: ProjectHostSetup = {
+  id: 'hub-local-setup',
+  projectId: project.id,
+  repoId: repo.id,
+  hostId: 'runtime:hub',
+  executionHostId: 'local',
+  runtimeOwnerEnvironmentId: 'hub',
+  path: repo.path,
+  displayName: repo.displayName,
+  kind: 'git',
+  setupState: 'ready',
+  setupMethod: 'legacy-repo',
+  createdAt: 100,
+  updatedAt: 100
+}
+
 let container: HTMLDivElement
 let root: Root
+
+function runtimeStatus(
+  graphStatus: RuntimeStatus['graphStatus'],
+  desktopWindowStatus: RuntimeStatus['desktopWindowStatus']
+): RuntimeStatus {
+  return {
+    runtimeId: 'runtime-hub',
+    rendererGraphEpoch: 1,
+    graphStatus,
+    authoritativeWindowId: graphStatus === 'ready' ? 1 : null,
+    desktopWindowStatus,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+    minCompatibleRuntimeClientVersion: 1,
+    capabilities: []
+  }
+}
+
+function renderSetup(status: RuntimeStatus | null): void {
+  useAppStore.setState({
+    repos: [repo],
+    projects: [project],
+    projectHostSetups: [setup],
+    runtimeStatusByEnvironmentId: new Map([['hub', { checkedAt: 1, status }]])
+  })
+  act(() => {
+    root.render(
+      <RepositoryHostSetupsSection repo={repo} forceVisible searchQuery="" searchEntries={[]} />
+    )
+  })
+}
 
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState(), true)
@@ -26,74 +92,28 @@ afterEach(() => {
 
 describe('RepositoryHostSetupsSection runtime window availability', () => {
   it('asks users to open Orca when a reachable host has no workspace window', () => {
-    const repo: Repo = {
-      id: 'remote-repo',
-      displayName: 'Orca',
-      path: '/srv/orca',
-      badgeColor: '#737373',
-      addedAt: 100,
-      kind: 'git',
-      executionHostId: 'runtime:hub'
-    }
-    const project: Project = {
-      id: 'github:stablyai/orca',
-      displayName: 'Orca',
-      badgeColor: '#737373',
-      sourceRepoIds: [repo.id],
-      createdAt: 100,
-      updatedAt: 100
-    }
-    const setup: ProjectHostSetup = {
-      id: 'hub-local-setup',
-      projectId: project.id,
-      repoId: repo.id,
-      hostId: 'runtime:hub',
-      executionHostId: 'local',
-      runtimeOwnerEnvironmentId: 'hub',
-      path: repo.path,
-      displayName: repo.displayName,
-      kind: 'git',
-      setupState: 'ready',
-      setupMethod: 'legacy-repo',
-      createdAt: 100,
-      updatedAt: 100
-    }
-    useAppStore.setState({
-      repos: [repo],
-      projects: [project],
-      projectHostSetups: [setup],
-      runtimeStatusByEnvironmentId: new Map([
-        [
-          'hub',
-          {
-            checkedAt: 1,
-            status: {
-              runtimeId: 'runtime-hub',
-              rendererGraphEpoch: 1,
-              graphStatus: 'unavailable',
-              authoritativeWindowId: null,
-              desktopWindowStatus: 'openable',
-              liveTabCount: 0,
-              liveLeafCount: 0,
-              runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
-              minCompatibleRuntimeClientVersion: 1,
-              capabilities: []
-            }
-          }
-        ]
-      ])
-    })
-
-    act(() => {
-      root.render(
-        <RepositoryHostSetupsSection repo={repo} forceVisible searchQuery="" searchEntries={[]} />
-      )
-    })
+    renderSetup(runtimeStatus('unavailable', 'openable'))
 
     expect(container.textContent).toContain('Open Orca')
     expect(container.textContent).toContain(
       'Orca is connected, but its workspace window is closed. Open Orca on this host to use terminals.'
     )
     expect(container.textContent).not.toContain('Ready')
+  })
+
+  it('keeps an unreachable runtime setup disconnected', () => {
+    renderSetup(null)
+
+    expect(container.textContent).toContain('Disconnected')
+    expect(container.textContent).not.toContain('Open Orca')
+    expect(container.textContent).not.toContain('Ready')
+  })
+
+  it('keeps a runtime with a ready graph ready', () => {
+    renderSetup(runtimeStatus('ready', 'available'))
+
+    expect(container.textContent).toContain('Ready')
+    expect(container.textContent).not.toContain('Open Orca')
+    expect(container.textContent).not.toContain('Disconnected')
   })
 })

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -24,6 +24,10 @@ import {
   selectRuntimeAwareSshStatus,
   selectRuntimeAwareSshTargetLabel
 } from '@/store/slices/runtime-environment-ssh'
+import {
+  isConnectedRuntimeHostState,
+  runtimeHostConnectionState
+} from '@/runtime/runtime-host-connection-state'
 
 type RepositoryHostSetupsSectionProps = {
   repo: Repo
@@ -214,9 +218,24 @@ export function RepositoryHostSetupsSection({
           const runtimeOwnerEnvironmentId =
             setup.runtimeOwnerEnvironmentId?.trim() ||
             (transportHost?.kind === 'runtime' ? transportHost.environmentId : null)
+          const runtimeOwnerStatusEntry = runtimeOwnerEnvironmentId
+            ? runtimeStatusByEnvironmentId.get(runtimeOwnerEnvironmentId)
+            : undefined
+          const runtimeOwnerStatus = runtimeOwnerStatusEntry?.status
+          const runtimeOwnerConnectionState = runtimeOwnerEnvironmentId
+            ? runtimeHostConnectionState({
+                hasStatus: Boolean(runtimeOwnerStatusEntry),
+                online: Boolean(runtimeOwnerStatus),
+                graphStatus: runtimeOwnerStatus?.graphStatus,
+                desktopWindowStatus: runtimeOwnerStatus?.desktopWindowStatus,
+                remoteControl: runtimeOwnerStatus?.remoteControl
+              })
+            : null
           const runtimeOwnerReachable =
             !runtimeOwnerEnvironmentId ||
-            Boolean(runtimeStatusByEnvironmentId.get(runtimeOwnerEnvironmentId)?.status)
+            (runtimeOwnerConnectionState !== null &&
+              isConnectedRuntimeHostState(runtimeOwnerConnectionState))
+          const runtimeOwnerNeedsWindow = runtimeOwnerConnectionState === 'needs-window'
           const nestedSshStatus =
             runtimeOwnerEnvironmentId && executionHost?.kind === 'ssh'
               ? selectRuntimeAwareSshStatus(
@@ -235,20 +254,23 @@ export function RepositoryHostSetupsSection({
           const setupReady =
             setup.setupState === 'ready' &&
             runtimeOwnerReachable &&
+            !runtimeOwnerNeedsWindow &&
             (nestedSshStatus === undefined || nestedSshStatus === 'connected')
           const setupStateLabel = !runtimeOwnerReachable
             ? translate(
                 'auto.components.settings.RepositoryPane.hostStateDisconnected',
                 'Disconnected'
               )
-            : nestedSshStatus === null
-              ? translate('auto.components.settings.RepositoryPane.hostStateUnknown', 'Unknown')
-              : nestedSshStatus !== undefined && nestedSshStatus !== 'connected'
-                ? translate(
-                    'auto.components.settings.RepositoryPane.hostStateDisconnected',
-                    'Disconnected'
-                  )
-                : getSetupStateLabel(setup.setupState)
+            : runtimeOwnerNeedsWindow
+              ? translate('auto.components.settings.RepositoryPane.hostStateOpenOrca', 'Open Orca')
+              : nestedSshStatus === null
+                ? translate('auto.components.settings.RepositoryPane.hostStateUnknown', 'Unknown')
+                : nestedSshStatus !== undefined && nestedSshStatus !== 'connected'
+                  ? translate(
+                      'auto.components.settings.RepositoryPane.hostStateDisconnected',
+                      'Disconnected'
+                    )
+                  : getSetupStateLabel(setup.setupState)
           const setupHostLabel =
             runtimeOwnerEnvironmentId && executionHost?.kind === 'ssh'
               ? translate(
@@ -298,6 +320,14 @@ export function RepositoryHostSetupsSection({
                       'Path pending'
                     )}
                 </p>
+                {runtimeOwnerNeedsWindow ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {translate(
+                      'auto.components.settings.RepositoryPane.hostStateOpenOrcaHelp',
+                      'Orca is connected, but its workspace window is closed. Open Orca on this host to use terminals.'
+                    )}
+                  </p>
+                ) : null}
               </div>
               {isCurrentSetup ? (
                 <SettingsBadge>

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.test.tsx
@@ -30,6 +30,17 @@ describe('RuntimeHostStatusRow', () => {
     expect(markup).toContain('Connect')
   })
 
+  it('renders reachable hosts that need a workspace window without calling them disconnected', () => {
+    const markup = renderToStaticMarkup(
+      <RuntimeHostStatusRow label="Dev Box" state="needs-window" onDisconnect={async () => {}} />
+    )
+
+    expect(markup).toContain('Dev Box')
+    expect(markup).toContain('Workspace window closed')
+    expect(markup).toContain('Disconnect')
+    expect(markup).not.toContain('Disconnected')
+  })
+
   it('renders connected hosts with a disconnect action', () => {
     const markup = renderToStaticMarkup(
       <RuntimeHostStatusRow label="Dev Box" state="connected" onDisconnect={async () => {}} />

--- a/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
+++ b/src/renderer/src/components/status-bar/RuntimeHostStatusRow.tsx
@@ -2,13 +2,20 @@ import { useCallback, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { useMountedRef } from '@/hooks/useMountedRef'
-
-export type RuntimeHostConnectionState = 'connected' | 'checking' | 'reconnecting' | 'disconnected'
+import {
+  isConnectedRuntimeHostState,
+  type RuntimeHostConnectionState
+} from '@/runtime/runtime-host-connection-state'
 
 function runtimeStatusLabel(state: RuntimeHostConnectionState): string {
   switch (state) {
     case 'connected':
       return translate('auto.components.status.bar.SshStatusSegment.runtime_online', 'Connected')
+    case 'needs-window':
+      return translate(
+        'auto.components.status.bar.SshStatusSegment.runtime_workspace_window_closed',
+        'Workspace window closed'
+      )
     case 'checking':
       return translate('auto.components.status.bar.SshStatusSegment.runtime_checking', 'Checking')
     case 'reconnecting':
@@ -28,6 +35,7 @@ function runtimeDotColor(state: RuntimeHostConnectionState): string {
   switch (state) {
     case 'connected':
       return 'bg-emerald-500'
+    case 'needs-window':
     case 'checking':
     case 'reconnecting':
       return 'bg-yellow-500'
@@ -37,7 +45,7 @@ function runtimeDotColor(state: RuntimeHostConnectionState): string {
 }
 
 function runtimeStatusTone(state: RuntimeHostConnectionState): string {
-  if (state === 'checking' || state === 'reconnecting') {
+  if (state === 'needs-window' || state === 'checking' || state === 'reconnecting') {
     return 'text-yellow-500'
   }
   return 'text-muted-foreground'
@@ -46,6 +54,7 @@ function runtimeStatusTone(state: RuntimeHostConnectionState): string {
 function runtimeActionLabel(state: RuntimeHostConnectionState): string | null {
   switch (state) {
     case 'connected':
+    case 'needs-window':
       return translate('auto.components.status.bar.SshStatusSegment.59b553e2aa', 'Disconnect')
     case 'disconnected':
       return translate('auto.components.status.bar.SshStatusSegment.63f36455cc', 'Connect')
@@ -73,7 +82,7 @@ export function RuntimeHostStatusRow({
   const actionLabel = runtimeActionLabel(state)
 
   const handleAction = useCallback(async () => {
-    const action = state === 'connected' ? onDisconnect : onConnect
+    const action = isConnectedRuntimeHostState(state) ? onDisconnect : onConnect
     if (!action) {
       return
     }
@@ -116,7 +125,7 @@ export function RuntimeHostStatusRow({
       </div>
       {busy ? (
         <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
-      ) : actionLabel && (state === 'connected' ? onDisconnect : onConnect) ? (
+      ) : actionLabel && (isConnectedRuntimeHostState(state) ? onDisconnect : onConnect) ? (
         <button
           type="button"
           onClick={() => void handleAction()}

--- a/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
+import { connectRuntimeHostForNavigation } from './SshStatusSegment'
 import {
-  connectRuntimeHostForNavigation,
   isConnectedRuntimeHostState,
+  runtimeHostConnectionState,
   runtimeStatusForOverall
-} from './SshStatusSegment'
+} from '@/runtime/runtime-host-connection-state'
 
 describe('SshStatusSegment host status helpers', () => {
   it('counts connected remote servers as connected hosts', () => {
@@ -11,6 +12,39 @@ describe('SshStatusSegment host status helpers', () => {
     // There is no separate "available" state — a reachable host is just Connected.
     expect(runtimeStatusForOverall('connected')).toBe('connected')
     expect(isConnectedRuntimeHostState('connected')).toBe(true)
+  })
+
+  it('keeps reachable servers connected while identifying a closed workspace window', () => {
+    const state = runtimeHostConnectionState({
+      hasStatus: true,
+      online: true,
+      graphStatus: 'unavailable',
+      desktopWindowStatus: 'openable'
+    })
+
+    expect(state).toBe('needs-window')
+    expect(runtimeStatusForOverall(state)).toBe('connected')
+    expect(isConnectedRuntimeHostState(state)).toBe(true)
+  })
+
+  it('does not hide a closed connection behind stale workspace-window diagnostics', () => {
+    const state = runtimeHostConnectionState({
+      hasStatus: true,
+      online: true,
+      graphStatus: 'unavailable',
+      desktopWindowStatus: 'openable',
+      remoteControl: {
+        state: 'closed',
+        pendingRequestCount: 0,
+        subscriptionCount: 0,
+        reconnectAttempt: 0,
+        lastConnectedAt: null,
+        lastClose: null,
+        lastError: 'Connection closed'
+      }
+    })
+
+    expect(state).toBe('disconnected')
   })
 
   it('keeps reconnecting and disconnected remote servers out of the connected count', () => {

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -17,10 +17,15 @@ import {
   toRuntimeExecutionHostId
 } from '../../../../shared/execution-host'
 import { isUserManagedRuntimeEnvironment } from '../../../../shared/runtime-environments'
-import { RuntimeHostStatusRow, type RuntimeHostConnectionState } from './RuntimeHostStatusRow'
+import { RuntimeHostStatusRow } from './RuntimeHostStatusRow'
 import { SshTargetStatusRow } from './SshTargetStatusRow'
 import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../../shared/remote-runtime-shared-control-types'
 import { connectRuntimeEnvironmentAndRecordStatus } from './runtime-environment-explicit-connect'
+import {
+  isConnectedRuntimeHostState,
+  runtimeHostConnectionState,
+  runtimeStatusForOverall
+} from '@/runtime/runtime-host-connection-state'
 
 function isConnecting(status: SshConnectionStatus): boolean {
   return ['connecting', 'deploying-relay', 'reconnecting'].includes(status)
@@ -73,35 +78,6 @@ function sshStatusForOverall(status: SshConnectionStatus): HostStatus {
   return isConnecting(status) ? 'connecting' : 'disconnected'
 }
 
-function runtimeHostConnectionState({
-  hasStatus,
-  online,
-  remoteControl
-}: {
-  hasStatus: boolean
-  online: boolean
-  remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
-}): RuntimeHostConnectionState {
-  if (!hasStatus) {
-    return 'checking'
-  }
-  if (remoteControl?.state === 'reconnecting') {
-    return 'reconnecting'
-  }
-  if (!online) {
-    return 'disconnected'
-  }
-  if (remoteControl?.state === 'closed' && remoteControl.lastError) {
-    return 'disconnected'
-  }
-  // Why: "connected" means attached/reachable, NOT "is the active default host".
-  // Both surfaces (this status bar and Settings > Remote Orca Servers) must agree
-  // on that single definition, or a reachable-but-not-active host reads
-  // "Connected" in one place and "Available" in the other. Active/default is a
-  // separate concept (surfaced elsewhere), so it must not change this state.
-  return 'connected'
-}
-
 function runtimeHostConnectionDetail(
   remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
 ): string | undefined {
@@ -130,22 +106,6 @@ function runtimeHostConnectionDetail(
   // status row and make the line truncate — only surface actionable detail
   // (errors, close reasons, reconnect attempts) above.
   return undefined
-}
-
-export function runtimeStatusForOverall(state: RuntimeHostConnectionState): HostStatus {
-  switch (state) {
-    case 'connected':
-      return 'connected'
-    case 'checking':
-    case 'reconnecting':
-      return 'connecting'
-    case 'disconnected':
-      return 'disconnected'
-  }
-}
-
-export function isConnectedRuntimeHostState(state: RuntimeHostConnectionState): boolean {
-  return state === 'connected'
 }
 
 export async function connectRuntimeHostForNavigation(args: {
@@ -210,6 +170,8 @@ export function SshStatusSegment({
         hasStatus: Boolean(statusEntry),
         online: Boolean(statusEntry?.status),
         active: settings?.activeRuntimeEnvironmentId === environment.id,
+        graphStatus: statusEntry?.status?.graphStatus,
+        desktopWindowStatus: statusEntry?.status?.desktopWindowStatus,
         remoteControl: statusEntry?.status?.remoteControl ?? null
       }
     })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3206,7 +3206,8 @@
             "runtime_disconnect_failed": "Disconnect failed",
             "runtime_reconnecting": "Reconnecting",
             "runtime_last_close_reason": "Closed: {{value0}}",
-            "runtime_reconnect_attempt": "Attempt {{value0}}"
+            "runtime_reconnect_attempt": "Attempt {{value0}}",
+            "runtime_workspace_window_closed": "Workspace window closed"
           },
           "StatusBar": {
             "9659e38343": "Ports",
@@ -6685,7 +6686,9 @@
           "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
           "hostStateDisconnected": "Disconnected",
           "hostStateUnknown": "Unknown",
-          "nestedHostLabel": "{{value0}} via {{value1}}"
+          "nestedHostLabel": "{{value0}} via {{value1}}",
+          "hostStateOpenOrca": "Open Orca",
+          "hostStateOpenOrcaHelp": "Orca is connected, but its workspace window is closed. Open Orca on this host to use terminals."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "Command template",

--- a/src/renderer/src/runtime/runtime-host-connection-state.ts
+++ b/src/renderer/src/runtime/runtime-host-connection-state.ts
@@ -1,0 +1,70 @@
+import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../shared/remote-runtime-shared-control-types'
+import type { RuntimeStatus } from '../../../shared/runtime-types'
+
+type HostStatus = 'connected' | 'disconnected' | 'connecting'
+
+export type RuntimeHostConnectionState =
+  | 'connected'
+  | 'needs-window'
+  | 'checking'
+  | 'reconnecting'
+  | 'disconnected'
+
+export function runtimeHostNeedsWorkspaceWindow(
+  status?: {
+    graphStatus?: RuntimeStatus['graphStatus']
+    desktopWindowStatus?: RuntimeStatus['desktopWindowStatus']
+  } | null
+): boolean {
+  // Why: a reachable main process cannot serve interactive workspaces without its renderer graph.
+  return status?.graphStatus !== 'ready' && status?.desktopWindowStatus === 'openable'
+}
+
+export function runtimeHostConnectionState({
+  hasStatus,
+  online,
+  graphStatus,
+  desktopWindowStatus,
+  remoteControl
+}: {
+  hasStatus: boolean
+  online: boolean
+  graphStatus?: RuntimeStatus['graphStatus']
+  desktopWindowStatus?: RuntimeStatus['desktopWindowStatus']
+  remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
+}): RuntimeHostConnectionState {
+  if (!hasStatus) {
+    return 'checking'
+  }
+  if (remoteControl?.state === 'reconnecting') {
+    return 'reconnecting'
+  }
+  if (!online) {
+    return 'disconnected'
+  }
+  if (remoteControl?.state === 'closed' && remoteControl.lastError) {
+    return 'disconnected'
+  }
+  if (runtimeHostNeedsWorkspaceWindow({ graphStatus, desktopWindowStatus })) {
+    return 'needs-window'
+  }
+  // Why: "connected" means attached/reachable, not "is the active default host".
+  return 'connected'
+}
+
+export function runtimeStatusForOverall(state: RuntimeHostConnectionState): HostStatus {
+  switch (state) {
+    case 'connected':
+    case 'needs-window':
+      return 'connected'
+    case 'checking':
+    case 'reconnecting':
+      return 'connecting'
+    case 'disconnected':
+      return 'disconnected'
+  }
+}
+
+export function isConnectedRuntimeHostState(state: RuntimeHostConnectionState): boolean {
+  return state === 'connected' || state === 'needs-window'
+}


### PR DESCRIPTION
## Summary

Reachable Remote Orca Servers no longer look fully ready when their workspace renderer is unavailable. Project host settings now show **Open Orca** with an explanation, while the status-bar host row shows **Workspace window closed** and remains correctly counted as connected with a **Disconnect** action.

This is a status-clarity fix for current, legacy, and degraded headed servers. Graph-ready headless servers are unaffected, so it does not preserve or expand the renderer dependency being removed by #6844.

Fixes #12350.

## Screenshots

Before, the remote setup was presented as **Ready** even though its renderer graph was unavailable (sanitized):

<img width="1565" height="255" alt="Sanitized screenshot showing a remote host incorrectly labeled Ready" src="https://github.com/user-attachments/assets/9451a62c-554f-4415-933b-b8ea36f1cef1" />

After this change, that badge reads **Open Orca** with explanatory copy, and the remote-host menu reads **Workspace window closed**.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 44,356 tests passed and 9 unrelated tests failed in updater, relay, native-watcher, and root-directory fixture suites. Under the required Node 24 runtime, five of those failures passed on rerun; the remaining four reproduced unchanged on clean `upstream/main` (`src/main/updater.test.ts` and `config/scripts/check-root-directory-entries.test.mjs`).
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused verification: 24/24 tests passed across project-host settings, runtime-host classification, status-bar presentation, connected-count semantics, and closed-connection precedence, including disconnected and graph-ready boundary states added from review feedback.

## AI Review Report

An independent final review returned clean after checking the shared state classifier, both UI surfaces, and regression coverage. An earlier simplification pass identified duplicate reachability logic and an inverted UI-to-domain type dependency; the final implementation centralizes classification in a neutral renderer runtime module and reuses it from Settings and the status bar. CodeRabbit requested explicit disconnected and graph-ready Settings boundaries; both were added and revalidated.

Compatibility review explicitly covered macOS, Linux, and Windows. The change adds no shortcuts, platform labels, paths, shell behavior, Git commands, or Electron platform branches. Local hosts remain unchanged; nested SSH setups inherit their Remote Orca Server owner's state; graph-ready remote/headless hosts remain connected; and no agent, integration, or Git-provider-specific behavior changes. The classification is O(1) over already-fetched status and adds no polling, subscriptions, IPC, or hot-path work. UI review confirmed existing badge, color, spacing, and typography tokens are reused.

## Security Audit

The change reads existing validated runtime status fields only. It adds no input handling, command execution, filesystem access, path construction, authentication changes, secrets, dependencies, IPC methods, or network requests. A stale `closed` shared-control connection with an error continues to take precedence as disconnected, so stale window diagnostics cannot make a failed connection appear reachable.

## Notes

- Related: #8300, which can prevent this state by keeping a headed renderer alive when its window closes.
- Related: #6844, the Electron-free headless-server work.
- The separate terminal-surface timeout seen on the older host build was resolved by updating that host and is intentionally outside this PR.
