### PR TITLE
test(terminal): harden daemon upgrade adoption

### DIFF
--- a/src/main/daemon/daemon-pty-upgrade-adoption.test.ts
+++ b/src/main/daemon/daemon-pty-upgrade-adoption.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonPtyRouter } from './daemon-pty-router'
+import { DaemonServer } from './daemon-server'
+import { STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION } from './daemon-protocol-version'
+import { getDaemonSocketPath } from './daemon-spawner'
+import type { DaemonFileLog } from './daemon-file-log'
+import type { SubprocessHandle } from './session'
+
+type FixtureSubprocess = SubprocessHandle & { emitData: (data: string) => void }
+
+function createFixtureSubprocess(pid: number): FixtureSubprocess {
+  let onData: ((data: string) => void) | undefined
+  let onExit: ((code: number) => void) | undefined
+  return {
+    pid,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    kill: vi.fn(() => onExit?.(0)),
+    forceKill: vi.fn(() => onExit?.(137)),
+    signal: vi.fn(),
+    onData: vi.fn((callback) => {
+      onData = callback
+    }),
+    onExit: vi.fn((callback) => {
+      onExit = callback
+    }),
+    dispose: vi.fn(),
+    emitData: (data) => onData?.(data)
+  }
+}
+
+describe('daemon PTY upgrade adoption', () => {
+  const servers: DaemonServer[] = []
+  const adapters: DaemonPtyAdapter[] = []
+  const directories: string[] = []
+  let router: DaemonPtyRouter | null = null
+
+  afterEach(async () => {
+    router?.dispose()
+    router = null
+    for (const adapter of adapters.splice(0)) {
+      adapter.dispose()
+    }
+    await Promise.all(servers.splice(0).map((server) => server.shutdown()))
+    for (const directory of directories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('reattaches a live v30 pane through a v31 router without spawning a replacement', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'daemon-pty-upgrade-adoption-'))
+    directories.push(directory)
+    const legacyProtocol = STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION - 1
+    const currentProtocol = STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION
+    const legacySocketPath = getDaemonSocketPath(directory, legacyProtocol)
+    const currentSocketPath = getDaemonSocketPath(directory, currentProtocol)
+    const legacyTokenPath = join(directory, 'legacy.token')
+    const currentTokenPath = join(directory, 'current.token')
+    const log: DaemonFileLog = { log: () => {}, close: () => {} }
+    const legacySubprocesses: FixtureSubprocess[] = []
+    const currentSubprocesses: FixtureSubprocess[] = []
+    const legacyServer = new DaemonServer({
+      socketPath: legacySocketPath,
+      tokenPath: legacyTokenPath,
+      protocolVersion: legacyProtocol,
+      log,
+      spawnSubprocess: () => {
+        const subprocess = createFixtureSubprocess(30_030)
+        legacySubprocesses.push(subprocess)
+        return subprocess
+      }
+    })
+    const currentServer = new DaemonServer({
+      socketPath: currentSocketPath,
+      tokenPath: currentTokenPath,
+      protocolVersion: currentProtocol,
+      log,
+      spawnSubprocess: () => {
+        const subprocess = createFixtureSubprocess(31_031)
+        currentSubprocesses.push(subprocess)
+        return subprocess
+      }
+    })
+    servers.push(legacyServer, currentServer)
+    await Promise.all([legacyServer.start(), currentServer.start()])
+
+    const oldAppAdapter = new DaemonPtyAdapter({
+      socketPath: legacySocketPath,
+      tokenPath: legacyTokenPath,
+      protocolVersion: legacyProtocol
+    })
+    adapters.push(oldAppAdapter)
+    const original = await oldAppAdapter.spawn({
+      sessionId: 'v30-stable-pane',
+      cols: 80,
+      rows: 24
+    })
+    legacySubprocesses[0]?.emitData('output-before-v31-upgrade')
+    oldAppAdapter.dispose()
+
+    const legacyAdapter = new DaemonPtyAdapter({
+      socketPath: legacySocketPath,
+      tokenPath: legacyTokenPath,
+      protocolVersion: legacyProtocol
+    })
+    const currentAdapter = new DaemonPtyAdapter({
+      socketPath: currentSocketPath,
+      tokenPath: currentTokenPath,
+      protocolVersion: currentProtocol
+    })
+    adapters.push(legacyAdapter, currentAdapter)
+    router = new DaemonPtyRouter({ current: currentAdapter, legacy: [legacyAdapter] })
+    await router.discoverLegacySessions()
+
+    const adopted = await router.spawn({
+      sessionId: original.id,
+      cols: 120,
+      rows: 40,
+      attachOnly: true,
+      command: 'must-not-run'
+    })
+
+    expect(adopted).toMatchObject({
+      id: original.id,
+      incarnationId: original.incarnationId,
+      isReattach: true,
+      snapshot: expect.stringContaining('output-before-v31-upgrade')
+    })
+    expect(legacySubprocesses).toHaveLength(1)
+    expect(currentSubprocesses).toHaveLength(0)
+    router.write(original.id, 'input-after-v31-upgrade')
+    await vi.waitFor(() =>
+      expect(legacySubprocesses[0]?.write).toHaveBeenCalledWith('input-after-v31-upgrade')
+    )
+  })
+})

--- a/src/main/daemon/daemon-server-attach-only.test.ts
+++ b/src/main/daemon/daemon-server-attach-only.test.ts
@@ -73,4 +73,33 @@ describe('DaemonServer attach-only preparation', () => {
     ).resolves.toMatchObject({ isNew: false })
     expect(preparePtySpawn).toHaveBeenCalledOnce()
   })
+
+  it('prepares a fresh spawn when attachOnly is not the boolean true', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'daemon-attach-only-shape-test-'))
+    directories.push(directory)
+    const socketPath = getDaemonSocketPath(directory)
+    const tokenPath = join(directory, 'test.token')
+    const preparePtySpawn = vi.fn(async () => {})
+    const server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      preparePtySpawn,
+      spawnSubprocess: () => createMockSubprocess()
+    })
+    servers.push(server)
+    await server.start()
+    const client = new DaemonClient({ socketPath, tokenPath })
+    clients.push(client)
+    await client.ensureConnected()
+
+    await expect(
+      client.request('createOrAttach', {
+        sessionId: 'malformed-attach-only-session',
+        cols: 80,
+        rows: 24,
+        attachOnly: 'false' as never
+      })
+    ).resolves.toMatchObject({ isNew: true })
+    expect(preparePtySpawn).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -723,6 +723,7 @@ export class DaemonServer {
         }
         this.createOrAttachInFlight++
         const p = request.payload
+        const attachOnly = p.attachOnly === true
         let routedSessionId = p.sessionId
         let result: Awaited<ReturnType<TerminalHost['createOrAttach']>>
         try {
@@ -733,7 +734,7 @@ export class DaemonServer {
           ) {
             throw new Error('agent_session_identity_required')
           }
-          if (!p.attachOnly) {
+          if (!attachOnly) {
             await this.preparePtySpawnUnlessCanceled(p.sessionId, clientId)
           }
           if (p.historySeed !== undefined && p.historySeedTransferId !== undefined) {
@@ -754,7 +755,7 @@ export class DaemonServer {
             envToDelete: p.envToDelete,
             command: p.command,
             startupCommandDelivery: p.startupCommandDelivery,
-            ...(p.attachOnly === true ? { attachOnly: true } : {}),
+            ...(attachOnly ? { attachOnly: true } : {}),
             // Why: RPC payloads are untrusted JSON; persist only the allowlisted routing enum, never arbitrary identity.
             ...(isTuiAgent(p.launchAgent) ? { launchAgent: p.launchAgent } : {}),
             shellOverride: p.shellOverride,

--- a/src/renderer/src/lib/pane-manager/pane-fit-continuation-retry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-continuation-retry.ts
@@ -26,6 +26,9 @@ function scheduleRetryTick(run: () => void): RetrySchedule {
         return
       }
       settled = true
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(rafId)
+      }
       run()
     }
     const rafId = requestAnimationFrame(() => {

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -106,6 +106,22 @@ describe('safeFitAndThen unmeasurable-pane retry', () => {
     await expect(handle.completion).resolves.toBe(true)
   })
 
+  it('cancels a throttled animation frame when the timer wins', async () => {
+    const pane = createPane({ rect: { width: 0, height: 0 } })
+    const continuation = vi.fn()
+
+    const handle = safeFitAndThen(pane, 'reattach-pty-resize', continuation, {
+      retryIfUnmeasurable: true
+    })
+    pane.setRect({ width: 800, height: 600 })
+    vi.advanceTimersByTime(32)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(1)
+    expect(pendingRafs.size).toBe(0)
+    expect(continuation).toHaveBeenCalledOnce()
+    await expect(handle.completion).resolves.toBe(true)
+  })
+
   it('cancels its scheduled frame with the continuation', async () => {
     const pane = createPane({ rect: { width: 0, height: 0 } })
     const continuation = vi.fn()


### PR DESCRIPTION
## Summary

- normalize daemon `attachOnly` exactly once before spawn preparation and host dispatch
- cancel a throttled animation-frame callback when the hidden-window timer wins
- add a deterministic two-daemon v30-to-v31 adoption test using real daemon sockets

## Upgrade contract

The new harness creates a live PTY in a protocol-v30 daemon, disconnects the old app adapter, starts a protocol-v31 daemon and router, discovers the preserved v30 session, and mounts it with `attachOnly`. It verifies the exact PTY/incarnation/output survive, no v30 or v31 replacement process is spawned, and input remains writable through the v30 owner.

## Validation

- 231 focused tests across daemon server/adapter/router/upgrade adoption and pane fit
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- changed-file oxlint and oxfmt
