### PR TITLE
test(terminal): pin IME chord survival across mid-composition re-renders

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
+import { useExpandCollapseActions } from './expand-collapse'
 import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
 import {
   installTerminalImeCompositionRoute,
@@ -362,6 +363,76 @@ describe('Windows IME keyboard ownership', () => {
 
     expect(harness.deps.onSearchSelectedText).not.toHaveBeenCalled()
     expect(harness.sendInput).not.toHaveBeenCalled()
+    hook.unmount()
+    harness.dispose()
+  })
+
+  // Why: STA-3291 — busy panes render mid-composition (title updates), and the
+  // chord owner must survive those renders or held-modifier CJK input leaks
+  // newlines. Wiring mirrors TerminalPane: dep objects rebuilt every render.
+  it('absorbs the bare Enter redispatch when re-renders land mid-composition', () => {
+    const harness = createHarness()
+    const factoryFields = {
+      expandedPaneIdRef: { current: null },
+      expandedStyleSnapshotRef: { current: new Map() },
+      containerRef: { current: null },
+      managerRef: { current: null },
+      setExpandedPaneId: vi.fn(),
+      setTabPaneExpanded: vi.fn(),
+      pendingPaneSizeRefreshFrameIdsRef: { current: [] },
+      persistLayoutSnapshot: vi.fn()
+    }
+    const hook = renderHook(() => {
+      const actions = useExpandCollapseActions({ ...factoryFields, tabId: 'tab-1' })
+      useTerminalKeyboardShortcuts({
+        ...harness.deps,
+        setExpandedPane: actions.setExpandedPane,
+        restoreExpandedLayout: actions.restoreExpandedLayout,
+        refreshPaneSizes: actions.refreshPaneSizes,
+        toggleExpandPane: actions.toggleExpandPane
+      })
+    })
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Shift',
+        code: 'ShiftLeft',
+        keyCode: 16,
+        timeStamp: 1,
+        shiftKey: true
+      })
+    )
+    hook.rerender()
+    harness.startComposition()
+    hook.rerender()
+    for (let repeat = 0; repeat < 5; repeat++) {
+      harness.terminalInput.dispatchEvent(
+        keyboardEvent('keydown', {
+          key: 'Process',
+          code: 'Enter',
+          keyCode: 229,
+          timeStamp: 10 + repeat,
+          isComposing: true,
+          shiftKey: true,
+          repeat: repeat > 0
+        })
+      )
+      hook.rerender()
+    }
+
+    const redispatch = keyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+      timeStamp: 40
+    })
+    harness.terminalInput.dispatchEvent(redispatch)
+
+    expect(redispatch.defaultPrevented).toBe(true)
+    const newlineSends = harness.sendInput.mock.calls.filter(
+      ([data]) => typeof data === 'string' && data.includes('\r')
+    )
+    expect(newlineSends).toHaveLength(0)
     hook.unmount()
     harness.dispose()
   })


### PR DESCRIPTION
## Summary

Adds an IME regression test pinning the STA-3291 failure mode behaviorally. The terminal keyboard effect owns the tab's IME chord state; before #12348 it tore down and re-registered on every `TerminalPane` render, so any render landing mid-composition silently reset that state. #12348 fixed the cause and pinned listener-registration stability; this test pins the *user-visible consequence*, so a future regression fails on behavior rather than on an internal counter.

The test wires the hook TerminalPane-shaped (dependency objects rebuilt every render) and interleaves re-renders through modifier hold, composition start, and five auto-repeat `Process`/229 keydowns. It asserts the bare Enter redispatch is still absorbed and that no newline is sent.

Verified non-vacuous: wired through the pre-fix (unmemoized) factory, the redispatch is not absorbed and the test fails.

Also verified on real Windows hardware with the genuine MS Korean 2-Set IME — see the comment below for the raw per-keystroke PTY capture. Five Shift-held double consonants (ㅃㅉㄸㄲㅆ) plus a composed syllable produced exactly one `0d`, from the deliberate Enter, with zero listener churn.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` — web project, clean `tsbuildinfo`, exit 0
- [x] `pnpm test` — targeted: the IME suites, `keyboard-handlers`, and both expand-collapse suites — 43/43 pass on current `main`
- [x] `pnpm lint` — oxlint + react-doctor + oxfmt via pre-commit, clean
- [ ] `pnpm build` — not run (test-only change; no production code touched)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed for vacuity (confirmed the test fails against pre-fix wiring), for whether the assertion is behavioral rather than structural (it asserts absorbed redispatch and zero newline sends, not listener counts), and for platform assumptions. Cross-platform: the test forces the Windows IME code path via a `userAgent` stub, which is how the neighboring IME suites already work; no production code, shortcuts, labels, paths, or shell behavior are touched, so macOS/Linux/Windows behavior is unchanged.

## Security Audit

Test-only change. No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is touched. No new attack surface.

## Notes

- Test-only; production behavior is unchanged. The fix itself shipped in #12348.
- This PR previously also added a dev-only "churn canary" that warned when the effect re-registered rapidly. It has been dropped: its payout depended on a human noticing a console warning, which is not a realistic detection path. The CI regression test in #12348 plus this behavioral test cover the same ground without adding a runtime concept to the codebase.
- The branch name (`sta-3291-churn-canary`) is a leftover from that earlier scope.
