### PR TITLE
fix(worktree-watcher): refresh status after external pushes

### DIFF
--- a/src/main/git/status-upstream-ref.test.ts
+++ b/src/main/git/status-upstream-ref.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveGitStatusUpstreamRef } from './status-upstream-ref'
+
+const signal = (): AbortSignal => new AbortController().signal
+
+describe('resolveGitStatusUpstreamRef', () => {
+  it('preserves the exact namespace for a slash-containing remote name', async () => {
+    const execGit = vi.fn().mockResolvedValue({
+      stdout:
+        'refs/heads/feature/main\0refs/remotes/team/fork/feature/main\0team/fork/feature/main\n'
+    })
+
+    await expect(
+      resolveGitStatusUpstreamRef(
+        execGit,
+        '/repo',
+        'refs/heads/feature/main',
+        'team/fork/feature/main',
+        signal()
+      )
+    ).resolves.toBe('refs/remotes/team/fork/feature/main')
+    expect(execGit).toHaveBeenCalledWith(
+      [
+        'for-each-ref',
+        '--format=%(refname)%00%(upstream)%00%(upstream:short)',
+        '--count=1',
+        'refs/heads/feature/main'
+      ],
+      '/repo',
+      expect.any(AbortSignal)
+    )
+  })
+
+  it('returns a slash-named local upstream for the binding validator to reject', async () => {
+    const execGit = vi.fn().mockResolvedValue({
+      stdout: 'refs/heads/feature/topic\0refs/heads/feature/base\0feature/base\n'
+    })
+
+    await expect(
+      resolveGitStatusUpstreamRef(
+        execGit,
+        '/repo',
+        'refs/heads/feature/topic',
+        'feature/base',
+        signal()
+      )
+    ).resolves.toBe('refs/heads/feature/base')
+  })
+
+  it('returns a missing custom refspec destination from branch configuration', async () => {
+    const execGit = vi.fn().mockResolvedValue({
+      stdout: 'refs/heads/feature/main\0refs/custom/origin/main\0custom/origin/main\n'
+    })
+
+    await expect(
+      resolveGitStatusUpstreamRef(
+        execGit,
+        '/repo',
+        'refs/heads/feature/main',
+        'custom/origin/main',
+        signal()
+      )
+    ).resolves.toBe('refs/custom/origin/main')
+    expect(execGit).toHaveBeenCalledOnce()
+  })
+
+  it('resolves an accepted effective upstream override explicitly', async () => {
+    const execGit = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: 'refs/heads/feature/prompts\0refs/remotes/origin/main\0origin/main\n'
+      })
+      .mockResolvedValueOnce({
+        stdout: '--end-of-options\nrefs/remotes/origin/feature/prompts\n'
+      })
+
+    await expect(
+      resolveGitStatusUpstreamRef(
+        execGit,
+        '/repo',
+        'refs/heads/feature/prompts',
+        'origin/feature/prompts',
+        signal()
+      )
+    ).resolves.toBe('refs/remotes/origin/feature/prompts')
+    expect(execGit).toHaveBeenNthCalledWith(
+      2,
+      ['rev-parse', '--symbolic-full-name', '--end-of-options', 'origin/feature/prompts'],
+      '/repo',
+      expect.any(AbortSignal)
+    )
+  })
+
+  it('fails safe when an effective override is ambiguous', async () => {
+    const execGit = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: 'refs/heads/feature/main\0refs/remotes/origin/main\0origin/main\n'
+      })
+      .mockResolvedValueOnce({
+        stdout: 'refs/heads/origin/feature/main\nrefs/remotes/origin/feature/main\n'
+      })
+
+    await expect(
+      resolveGitStatusUpstreamRef(
+        execGit,
+        '/repo',
+        'refs/heads/feature/main',
+        'origin/feature/main',
+        signal()
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects a stale status whose accepted branch no longer exists', async () => {
+    const execGit = vi.fn().mockResolvedValue({ stdout: '' })
+
+    await expect(
+      resolveGitStatusUpstreamRef(execGit, '/repo', 'refs/heads/old', 'origin/old', signal())
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/main/git/status-upstream-ref.ts
+++ b/src/main/git/status-upstream-ref.ts
@@ -1,0 +1,52 @@
+import { isSafeGitRefName } from '../../shared/git-status-upstream-ref'
+
+type GitStatusUpstreamRefExec = (
+  args: string[],
+  cwd: string,
+  signal: AbortSignal
+) => Promise<{ stdout: string }>
+
+function exactRefFromOutput(stdout: string): string | undefined {
+  const refs = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(isSafeGitRefName)
+  return refs.length === 1 ? refs[0] : undefined
+}
+
+export async function resolveGitStatusUpstreamRef(
+  execGit: GitStatusUpstreamRefExec,
+  worktreePath: string,
+  branch: string,
+  upstreamName: string,
+  signal: AbortSignal
+): Promise<string | undefined> {
+  if (!branch.startsWith('refs/heads/') || !isSafeGitRefName(branch)) {
+    return undefined
+  }
+  const result = await execGit(
+    ['for-each-ref', '--format=%(refname)%00%(upstream)%00%(upstream:short)', '--count=1', branch],
+    worktreePath,
+    signal
+  )
+  const fields = result.stdout.replace(/\r?\n$/, '').split('\0')
+  if (fields.length !== 3 || fields[0] !== branch) {
+    return undefined
+  }
+  if (fields[2] === upstreamName) {
+    return exactRefFromOutput(fields[1])
+  }
+  try {
+    const effective = await execGit(
+      ['rev-parse', '--symbolic-full-name', '--end-of-options', upstreamName],
+      worktreePath,
+      signal
+    )
+    return exactRefFromOutput(effective.stdout)
+  } catch {
+    if (signal.aborted) {
+      throw signal.reason
+    }
+    return undefined
+  }
+}

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -134,6 +134,10 @@ import { sanitizeLocalDownloadFilename } from '../local-download-filename'
 import { registerFilesystemDownloadFolderHandlers } from './filesystem-download-folder'
 import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
+import {
+  applyGitStatusUpstreamRefWatchRequest,
+  type GitStatusUpstreamRefWatchRequest
+} from './git-status-upstream-ref-watch-request'
 
 // Why: Monaco degrades features on large files like VS Code, so a 5MB block would needlessly lock out ordinary JSON/log files.
 const MAX_TEXT_FILE_SIZE = 50 * 1024 * 1024 // 50MB
@@ -1140,6 +1144,12 @@ export function registerFilesystemHandlers(
   ipcMain.handle('git:cancelStatus', (event, args: { requestToken: string }): void => {
     gitStatusCancellations.cancel(event, args.requestToken)
   })
+
+  ipcMain.handle(
+    'git:setStatusUpstreamRefWatch',
+    (_event, args: GitStatusUpstreamRefWatchRequest): Promise<void> =>
+      applyGitStatusUpstreamRefWatchRequest(store, args)
+  )
 
   // Why: parent status reports only one gitlink row per submodule; fetch inner per-file changes from the submodule's own worktree.
   ipcMain.handle(

--- a/src/main/ipc/git-status-upstream-ref-watch-request.test.ts
+++ b/src/main/ipc/git-status-upstream-ref-watch-request.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+
+const mocks = vi.hoisted(() => ({
+  gitExec: vi.fn(),
+  getProvider: vi.fn(),
+  getProviderGeneration: vi.fn(),
+  resolveRegisteredPath: vi.fn(),
+  getLocalRepo: vi.fn(),
+  getLocalOptions: vi.fn(),
+  setWatch: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({ gitExecFileAsync: mocks.gitExec }))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: mocks.getProvider,
+  getSshGitProviderGeneration: mocks.getProviderGeneration,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'unavailable'
+}))
+vi.mock('./filesystem-auth', () => ({
+  resolveRegisteredWorktreePath: mocks.resolveRegisteredPath
+}))
+vi.mock('./local-worktree-runtime-options', () => ({
+  getLocalRepoForRegisteredWorktree: mocks.getLocalRepo,
+  getLocalGitOptionsForRepo: mocks.getLocalOptions
+}))
+vi.mock('./worktree-base-directory-watcher', () => ({
+  setWorktreeGitStatusRefWatch: mocks.setWatch
+}))
+
+import { applyGitStatusUpstreamRefWatchRequest } from './git-status-upstream-ref-watch-request'
+
+describe('applyGitStatusUpstreamRefWatchRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getProviderGeneration.mockReturnValue(0)
+    mocks.resolveRegisteredPath.mockResolvedValue('/resolved/repo')
+    mocks.getLocalOptions.mockReturnValue({})
+    mocks.setWatch.mockImplementation(
+      async (_args: unknown, resolve: (signal: AbortSignal) => Promise<string | undefined>) =>
+        resolve(new AbortController().signal)
+    )
+  })
+
+  it('routes local exact resolution through the registered worktree runtime', async () => {
+    mocks.getLocalOptions.mockReturnValue({ wslDistro: 'Ubuntu' })
+    mocks.gitExec.mockResolvedValue({
+      stdout: 'refs/heads/feature/main\0refs/remotes/origin/feature/main\0origin/feature/main\n'
+    })
+
+    await applyGitStatusUpstreamRefWatchRequest({} as Store, {
+      worktreeId: 'repo-1::/repo',
+      worktreePath: '/repo',
+      executionHostId: 'wsl:Ubuntu',
+      branch: 'refs/heads/feature/main',
+      upstreamName: 'origin/feature/main'
+    })
+
+    expect(mocks.gitExec).toHaveBeenCalledWith(
+      [
+        'for-each-ref',
+        '--format=%(refname)%00%(upstream)%00%(upstream:short)',
+        '--count=1',
+        'refs/heads/feature/main'
+      ],
+      expect.objectContaining({ cwd: '/resolved/repo', wslDistro: 'Ubuntu', timeout: 15_000 })
+    )
+  })
+
+  it('routes SSH resolution through the current provider generation', async () => {
+    const exec = vi.fn().mockResolvedValue({
+      stdout:
+        'refs/heads/feature/main\0refs/remotes/team/fork/feature/main\0team/fork/feature/main\n'
+    })
+    mocks.getProvider.mockReturnValue({ exec })
+    mocks.getProviderGeneration.mockReturnValue(7)
+
+    await applyGitStatusUpstreamRefWatchRequest({} as Store, {
+      worktreeId: 'repo-1::/repo',
+      worktreePath: '/repo',
+      executionHostId: 'ssh:ssh-1',
+      connectionId: 'ssh-1',
+      branch: 'refs/heads/feature/main',
+      upstreamName: 'team/fork/feature/main'
+    })
+
+    expect(mocks.setWatch).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'ssh-1', providerGeneration: 7 }),
+      expect.any(Function)
+    )
+    expect(exec).toHaveBeenCalledWith(
+      [
+        'for-each-ref',
+        '--format=%(refname)%00%(upstream)%00%(upstream:short)',
+        '--count=1',
+        'refs/heads/feature/main'
+      ],
+      '/repo',
+      expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: 15_000 })
+    )
+  })
+})

--- a/src/main/ipc/git-status-upstream-ref-watch-request.ts
+++ b/src/main/ipc/git-status-upstream-ref-watch-request.ts
@@ -1,0 +1,78 @@
+import type { Store } from '../persistence'
+import { resolveGitStatusUpstreamRef } from '../git/status-upstream-ref'
+import { gitExecFileAsync } from '../git/runner'
+import {
+  getSshGitProvider,
+  getSshGitProviderGeneration,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+} from '../providers/ssh-git-dispatch'
+import { resolveRegisteredWorktreePath } from './filesystem-auth'
+import {
+  getLocalGitOptionsForRepo,
+  getLocalRepoForRegisteredWorktree
+} from './local-worktree-runtime-options'
+import { setWorktreeGitStatusRefWatch } from './worktree-base-directory-watcher'
+import type { GitStatusRefBindingRequest } from './worktree-git-status-ref-watch'
+
+export type GitStatusUpstreamRefWatchRequest = Omit<
+  GitStatusRefBindingRequest,
+  'providerGeneration'
+>
+
+const UPSTREAM_REF_RESOLUTION_TIMEOUT_MS = 15_000
+
+function boundedSignal(signal: AbortSignal): AbortSignal {
+  return AbortSignal.any([signal, AbortSignal.timeout(UPSTREAM_REF_RESOLUTION_TIMEOUT_MS)])
+}
+
+export function applyGitStatusUpstreamRefWatchRequest(
+  store: Store,
+  args: GitStatusUpstreamRefWatchRequest
+): Promise<void> {
+  const providerGeneration = args.connectionId
+    ? getSshGitProviderGeneration(args.connectionId)
+    : undefined
+  return setWorktreeGitStatusRefWatch(
+    { ...args, ...(providerGeneration !== undefined ? { providerGeneration } : {}) },
+    async (bindingSignal) => {
+      if (!args.branch || !args.upstreamName) {
+        return undefined
+      }
+      const signal = boundedSignal(bindingSignal)
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return resolveGitStatusUpstreamRef(
+          (gitArgs, cwd, requestSignal) =>
+            provider.exec(gitArgs, cwd, {
+              signal: requestSignal,
+              timeoutMs: UPSTREAM_REF_RESOLUTION_TIMEOUT_MS
+            }),
+          args.worktreePath,
+          args.branch,
+          args.upstreamName,
+          signal
+        )
+      }
+
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const repo = getLocalRepoForRegisteredWorktree(store, args.worktreePath, worktreePath)
+      const gitOptions = getLocalGitOptionsForRepo(store, repo)
+      return resolveGitStatusUpstreamRef(
+        (gitArgs, cwd, requestSignal) =>
+          gitExecFileAsync(gitArgs, {
+            cwd,
+            signal: requestSignal,
+            timeout: UPSTREAM_REF_RESOLUTION_TIMEOUT_MS,
+            ...(gitOptions.wslDistro ? { wslDistro: gitOptions.wslDistro } : {})
+          }),
+        worktreePath,
+        args.branch,
+        args.upstreamName,
+        signal
+      )
+    }
+  )
+}

--- a/src/main/ipc/worktree-base-directory-event-filter.test.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.test.ts
@@ -168,7 +168,7 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     })
   })
 
-  it('classifies common config and remote-tracking refs as status-only external push/fetch signals', () => {
+  it('classifies config and the exact upstream ref as status-only external push signals', () => {
     const target = makeGitCommonTarget()
     // External `git push -u` writes only branch.<name>.remote/merge into the
     // common config; without this signal the upstream stays invisible until a
@@ -183,11 +183,14 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
       gitStatusRepoIds: ['repo-1'],
       headIdentityRepoIds: []
     })
-    for (const path of [
+    const boundPaths = [
       join(COMMON_DIR, 'refs', 'remotes', 'origin', 'main'),
       // Branch names with slashes nest arbitrarily deep.
-      join(COMMON_DIR, 'refs', 'remotes', 'origin', 'feature', 'nested')
-    ]) {
+      join(COMMON_DIR, 'refs', 'remotes', 'team', 'fork', 'feature', 'nested'),
+      join(COMMON_DIR, 'refs', 'custom', 'origin', 'main')
+    ]
+    for (const path of boundPaths) {
+      target.gitStatusRefPaths = new Set([path])
       for (const type of ['create', 'update'] as const) {
         expect(classifyWorktreeBaseChange(target, { type, path })).toEqual({
           structureRepoIds: [],
@@ -207,6 +210,16 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
       gitStatusRepoIds: [],
       headIdentityRepoIds: []
     })
+    expect(
+      classifyWorktreeBaseChange(target, {
+        type: 'update',
+        path: join(COMMON_DIR, 'refs', 'remotes', 'origin', 'unrelated')
+      })
+    ).toEqual({
+      structureRepoIds: [],
+      gitStatusRepoIds: [],
+      headIdentityRepoIds: []
+    })
   })
 
   it('classifies Windows-shaped linked metadata paths', () => {
@@ -214,7 +227,8 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     const target: WorktreeBaseWatchTarget = {
       ...makeGitCommonTarget(),
       key: `git-common:local:${commonDir}`,
-      path: commonDir
+      path: commonDir,
+      gitStatusRefPaths: new Set([win32.join(commonDir, 'refs', 'remotes', 'origin', 'main')])
     }
     expect(
       classifyWorktreeBaseChange(target, {

--- a/src/main/ipc/worktree-base-directory-event-filter.test.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.test.ts
@@ -168,6 +168,47 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
     })
   })
 
+  it('classifies common config and remote-tracking refs as status-only external push/fetch signals', () => {
+    const target = makeGitCommonTarget()
+    // External `git push -u` writes only branch.<name>.remote/merge into the
+    // common config; without this signal the upstream stays invisible until a
+    // safety poll.
+    expect(
+      classifyWorktreeBaseChange(target, {
+        type: 'update',
+        path: join(COMMON_DIR, 'config')
+      })
+    ).toEqual({
+      structureRepoIds: [],
+      gitStatusRepoIds: ['repo-1'],
+      headIdentityRepoIds: []
+    })
+    for (const path of [
+      join(COMMON_DIR, 'refs', 'remotes', 'origin', 'main'),
+      // Branch names with slashes nest arbitrarily deep.
+      join(COMMON_DIR, 'refs', 'remotes', 'origin', 'feature', 'nested')
+    ]) {
+      for (const type of ['create', 'update'] as const) {
+        expect(classifyWorktreeBaseChange(target, { type, path })).toEqual({
+          structureRepoIds: [],
+          gitStatusRepoIds: ['repo-1'],
+          headIdentityRepoIds: []
+        })
+      }
+    }
+    // Ref-lock churn from an in-flight or aborted ref update stays invisible.
+    expect(
+      classifyWorktreeBaseChange(target, {
+        type: 'create',
+        path: join(COMMON_DIR, 'refs', 'remotes', 'origin', 'main.lock')
+      })
+    ).toEqual({
+      structureRepoIds: [],
+      gitStatusRepoIds: [],
+      headIdentityRepoIds: []
+    })
+  })
+
   it('classifies Windows-shaped linked metadata paths', () => {
     const commonDir = win32.join('C:\\', 'repos', 'project', '.git')
     const target: WorktreeBaseWatchTarget = {
@@ -195,21 +236,36 @@ describe('matchingWorktreeBaseRepoIds (git-common)', () => {
       gitStatusRepoIds: ['repo-1'],
       headIdentityRepoIds: []
     })
+    expect(
+      classifyWorktreeBaseChange(target, {
+        type: 'update',
+        path: win32.join(commonDir, 'refs', 'remotes', 'origin', 'main')
+      })
+    ).toEqual({
+      structureRepoIds: [],
+      gitStatusRepoIds: ['repo-1'],
+      headIdentityRepoIds: []
+    })
   })
 
   it('ignores non-status common-dir churn', () => {
     const target = makeGitCommonTarget()
     for (const path of [
-      join(COMMON_DIR, 'config'),
       join(COMMON_DIR, 'FETCH_HEAD'),
       join(COMMON_DIR, 'COMMIT_EDITMSG'),
       join(COMMON_DIR, 'objects', 'ab', 'cdef'),
+      // Local branch tips churn on every commit; head moves surface via logs/HEAD.
       join(COMMON_DIR, 'refs', 'heads', 'main'),
-      join(COMMON_DIR, 'logs', 'HEAD'),
+      // Remote-tracking reflogs churn alongside every push/fetch ref update.
+      join(COMMON_DIR, 'logs', 'refs', 'remotes', 'origin', 'main'),
       // Nested HEAD outside worktrees/ must not be mistaken for the primary's.
       join(COMMON_DIR, 'modules', 'sub', 'HEAD')
     ]) {
-      expect(matchingWorktreeBaseRepoIds(target, { type: 'update', path })).toEqual([])
+      expect(classifyWorktreeBaseChange(target, { type: 'update', path })).toEqual({
+        structureRepoIds: [],
+        gitStatusRepoIds: [],
+        headIdentityRepoIds: []
+      })
     }
   })
 

--- a/src/main/ipc/worktree-base-directory-event-filter.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.ts
@@ -93,12 +93,16 @@ function matchingBaseRepoIds(
 
 // Why: branch switches and commits in the primary checkout rewrite these
 // top-level common-dir files; matching them keeps root-checkout branch/status
-// as fresh as linked worktrees. Deeper churn (objects, refs, logs) is ignored.
+// as fresh as linked worktrees. Deeper churn (objects, refs/heads, logs) is
+// ignored.
 // `config.worktree` is structural because it is the only file whose write
 // flips `git worktree list`'s sparse flag, and no status/commit path touches
 // it — so it cannot re-open the index-churn fanout this classifier closes.
 const GIT_COMMON_PRIMARY_STRUCTURAL_FILES = new Set(['HEAD', 'packed-refs', 'config.worktree'])
-const GIT_COMMON_PRIMARY_STATUS_FILES = new Set(['index'])
+// `config` is status-tier: an external `git push -u` writes only
+// branch.<name>.remote/merge there, and a config write can move neither HEAD
+// nor the worktree listing.
+const GIT_COMMON_PRIMARY_STATUS_FILES = new Set(['index', 'config'])
 const GIT_COMMON_LINKED_STRUCTURAL_FILES = new Set(['HEAD', 'gitdir', 'locked', 'config.worktree'])
 const GIT_COMMON_LINKED_STATUS_FILES = new Set(['index'])
 
@@ -108,6 +112,19 @@ const GIT_COMMON_LINKED_STATUS_FILES = new Set(['index'])
 // kept separate from index churn so only these events re-read head identities.
 function isHeadLogParts(parts: string[], offset: number): boolean {
   return parts.length === offset + 2 && parts[offset] === 'logs' && parts[offset + 1] === 'HEAD'
+}
+
+// Remote-tracking refs are the only refs/** carve-out from the depth cutoff:
+// external push/fetch rewrites them, and git status derives upstream plus
+// ahead/behind from them. Ref locks and reflogs stay ignored so fetch/prune
+// churn cannot fan out beyond one debounced refresh.
+function isRemoteTrackingRefParts(parts: string[]): boolean {
+  return (
+    parts.length >= 3 &&
+    parts[0] === 'refs' &&
+    parts[1] === 'remotes' &&
+    !parts.at(-1)?.endsWith('.lock')
+  )
 }
 
 function allRepoIds(target: WorktreeBaseWatchTarget): string[] {
@@ -170,6 +187,9 @@ function classifyGitCommonEvent(
   if (parts[0] !== 'worktrees') {
     if (isHeadLogParts(parts, 0)) {
       return headIdentityChange(repoIds)
+    }
+    if (isRemoteTrackingRefParts(parts)) {
+      return gitStatusChange(repoIds)
     }
     return NO_CHANGE
   }

--- a/src/main/ipc/worktree-base-directory-event-filter.ts
+++ b/src/main/ipc/worktree-base-directory-event-filter.ts
@@ -31,6 +31,8 @@ export type WorktreeBaseWatchTarget = {
   path: string
   connectionId?: string
   repos: Map<string, WorktreeBaseRepoWatchConfig>
+  /** Exact upstream leaf selected by accepted active-worktree status. */
+  gitStatusRefPaths?: ReadonlySet<string>
 }
 
 export function pathRelativeToWorktreeWatchRoot(
@@ -114,16 +116,18 @@ function isHeadLogParts(parts: string[], offset: number): boolean {
   return parts.length === offset + 2 && parts[offset] === 'logs' && parts[offset + 1] === 'HEAD'
 }
 
-// Remote-tracking refs are the only refs/** carve-out from the depth cutoff:
-// external push/fetch rewrites them, and git status derives upstream plus
-// ahead/behind from them. Ref locks and reflogs stay ignored so fetch/prune
-// churn cannot fan out beyond one debounced refresh.
-function isRemoteTrackingRefParts(parts: string[]): boolean {
-  return (
-    parts.length >= 3 &&
-    parts[0] === 'refs' &&
-    parts[1] === 'remotes' &&
-    !parts.at(-1)?.endsWith('.lock')
+// Only the active status result's exact upstream ref crosses the refs/** cutoff.
+function isBoundUpstreamRef(
+  target: WorktreeBaseWatchTarget,
+  eventPath: string,
+  parts: string[]
+): boolean {
+  if (parts.length < 2 || parts[0] !== 'refs' || parts.at(-1)?.endsWith('.lock')) {
+    return false
+  }
+  const eventKey = normalizeRuntimePathForComparison(eventPath)
+  return [...(target.gitStatusRefPaths ?? [])].some(
+    (path) => normalizeRuntimePathForComparison(path) === eventKey
   )
 }
 
@@ -188,7 +192,7 @@ function classifyGitCommonEvent(
     if (isHeadLogParts(parts, 0)) {
       return headIdentityChange(repoIds)
     }
-    if (isRemoteTrackingRefParts(parts)) {
+    if (isBoundUpstreamRef(target, event.path, parts)) {
       return gitStatusChange(repoIds)
     }
     return NO_CHANGE

--- a/src/main/ipc/worktree-base-directory-notifications.ts
+++ b/src/main/ipc/worktree-base-directory-notifications.ts
@@ -1,0 +1,78 @@
+import type { BrowserWindow } from 'electron'
+import type { WorktreeBaseCollectedChanges } from './worktree-base-directory-change-collector'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import {
+  refreshWorktreeHeadIdentities,
+  type WorktreeHeadIdentityRefreshState
+} from './worktree-head-identity-refresh'
+import { notifyWorktreeGitStatusMetadataChanged, notifyWorktreesChanged } from './worktree-remote'
+
+export type WorktreeBaseNotificationWatch = WorktreeBaseWatchTarget & {
+  mainWindow: BrowserWindow
+  notifyTimer: ReturnType<typeof setTimeout> | null
+  pendingStructureRepoIds: Set<string>
+  pendingGitStatusRepoIds: Set<string>
+  pendingHeadIdentityRepoIds: Set<string>
+  headIdentityRefresh: WorktreeHeadIdentityRefreshState
+  disposed: boolean
+}
+
+const WATCH_DEBOUNCE_MS = 250
+
+export function clearPendingWorktreeBaseNotifications(watch: WorktreeBaseNotificationWatch): void {
+  watch.pendingStructureRepoIds.clear()
+  watch.pendingGitStatusRepoIds.clear()
+  watch.pendingHeadIdentityRepoIds.clear()
+}
+
+export function supportsWorktreeHeadIdentityRefresh(watch: WorktreeBaseNotificationWatch): boolean {
+  return watch.kind === 'git-common' && !watch.connectionId
+}
+
+export function scheduleWorktreeBaseNotification(
+  watch: WorktreeBaseNotificationWatch,
+  changes: Partial<Omit<WorktreeBaseCollectedChanges, 'overflow'>>
+): void {
+  if (watch.disposed || watch.mainWindow.isDestroyed()) {
+    clearPendingWorktreeBaseNotifications(watch)
+    return
+  }
+  for (const repoId of changes.structureRepoIds ?? []) {
+    watch.pendingStructureRepoIds.add(repoId)
+  }
+  for (const repoId of changes.gitStatusRepoIds ?? []) {
+    watch.pendingGitStatusRepoIds.add(repoId)
+  }
+  for (const repoId of changes.headIdentityRepoIds ?? []) {
+    watch.pendingHeadIdentityRepoIds.add(repoId)
+  }
+  clearTimeout(watch.notifyTimer ?? undefined)
+  watch.notifyTimer = setTimeout(() => {
+    watch.notifyTimer = null
+    if (watch.disposed || watch.mainWindow.isDestroyed()) {
+      clearPendingWorktreeBaseNotifications(watch)
+      return
+    }
+    const pendingStructure = [...watch.pendingStructureRepoIds]
+    const hasHeadIdentity = watch.pendingHeadIdentityRepoIds.size > 0
+    const sourceControlRepoIds = new Set(
+      [...watch.pendingGitStatusRepoIds, ...watch.pendingHeadIdentityRepoIds].filter(
+        (repoId) => !watch.pendingStructureRepoIds.has(repoId)
+      )
+    )
+    const emitHeadIdentities = pendingStructure.length === 0
+    clearPendingWorktreeBaseNotifications(watch)
+    for (const repoId of pendingStructure) {
+      notifyWorktreesChanged(watch.mainWindow, repoId)
+    }
+    for (const repoId of sourceControlRepoIds) {
+      notifyWorktreeGitStatusMetadataChanged(watch.mainWindow, repoId)
+    }
+    if (
+      supportsWorktreeHeadIdentityRefresh(watch) &&
+      (pendingStructure.length > 0 || hasHeadIdentity)
+    ) {
+      void refreshWorktreeHeadIdentities(watch, watch.headIdentityRefresh, emitHeadIdentities)
+    }
+  }, WATCH_DEBOUNCE_MS)
+}

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -59,6 +59,8 @@ export type WorktreeBasePollerOptions = {
   pollIntervalMs?: number
   platform?: NodeJS.Platform
   visibility?: WorktreePollerWindowVisibility
+  getGitStatusRefPaths?: () => readonly string[]
+  onWatchError?: (error: Error) => void
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
   onFullScan?: () => void
 }
@@ -349,7 +351,9 @@ export async function startWorktreeBaseDirectoryPoller(
       pollIntervalMs,
       platform,
       visibility,
-      options.onFullScan
+      options.onFullScan,
+      options.getGitStatusRefPaths,
+      options.onWatchError
     )
   }
   return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options.onFullScan)

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { join, sep } from 'node:path'
 import type { GlobalSettings, Repo } from '../../shared/types'
-import type { WorktreeBasePollEvent } from './worktree-base-directory-poller'
+import type {
+  WorktreeBasePollEvent,
+  WorktreeBasePollerOptions
+} from './worktree-base-directory-poller'
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(async () => ''),
@@ -41,6 +44,7 @@ import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
 import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
 import {
   disposeWorktreeBaseDirectoryWatchers,
+  setWorktreeGitStatusRefWatch,
   syncWorktreeBaseDirectoryWatchers
 } from './worktree-base-directory-watcher'
 import { matchingWorktreeBaseRepoIds } from './worktree-base-directory-event-filter'
@@ -49,6 +53,7 @@ type PollerCallback = (events: WorktreeBasePollEvent[]) => void
 
 const watcherCallbacks = new Map<string, PollerCallback>()
 const unsubscribeMocks = new Map<string, ReturnType<typeof vi.fn>>()
+const pollerOptions = new Map<string, WorktreeBasePollerOptions>()
 const absolutePath = (...parts: string[]): string => join(sep, ...parts)
 const WORKTREE_ROOT = absolutePath('workspace', 'worktrees')
 const PROJECT_ROOT = absolutePath('workspace', 'projects', 'project')
@@ -97,13 +102,15 @@ describe('worktree base directory watcher', () => {
     vi.useFakeTimers()
     watcherCallbacks.clear()
     unsubscribeMocks.clear()
+    pollerOptions.clear()
     vi.mocked(getSshFilesystemProvider).mockReturnValue(undefined)
     vi.mocked(readGitCommonHeadIdentities).mockResolvedValue([])
     vi.mocked(startWorktreeBaseDirectoryPoller).mockImplementation(
-      async (target, _getRepos, onEvents) => {
+      async (target, _getRepos, onEvents, options) => {
         const unsubscribe = vi.fn(async () => {})
         watcherCallbacks.set(target.path, onEvents)
         unsubscribeMocks.set(target.path, unsubscribe)
+        pollerOptions.set(target.path, options ?? {})
         return { unsubscribe }
       }
     )
@@ -201,6 +208,149 @@ describe('worktree base directory watcher', () => {
     expect(notifyWorktreesChanged).not.toHaveBeenCalled()
     expect(notifyWorktreeGitStatusMetadataChanged).toHaveBeenCalledTimes(1)
     expect(notifyWorktreeGitStatusMetadataChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
+  })
+
+  it('keeps one active-worktree upstream ref binding and ignores stale cleanup', async () => {
+    const firstWorktreeId = `repo-1::${PROJECT_ROOT}`
+    const nextWorktreeId = `repo-1::${absolutePath('workspace', 'worktrees', 'next')}`
+    await setWorktreeGitStatusRefWatch(
+      {
+        worktreeId: firstWorktreeId,
+        worktreePath: PROJECT_ROOT,
+        executionHostId: 'local',
+        branch: 'refs/heads/first',
+        upstreamName: 'origin/first'
+      },
+      async () => 'refs/remotes/origin/first'
+    )
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    const getPaths = pollerOptions.get(PROJECT_GIT_COMMON_DIR)?.getGitStatusRefPaths
+    expect(getPaths?.()).toEqual([join(PROJECT_GIT_COMMON_DIR, 'refs/remotes/origin/first')])
+
+    await setWorktreeGitStatusRefWatch(
+      {
+        worktreeId: nextWorktreeId,
+        worktreePath: absolutePath('workspace', 'worktrees', 'next'),
+        executionHostId: 'local',
+        branch: 'refs/heads/next',
+        upstreamName: 'origin/next'
+      },
+      async () => 'refs/remotes/origin/next'
+    )
+    await setWorktreeGitStatusRefWatch(
+      {
+        worktreeId: firstWorktreeId,
+        worktreePath: PROJECT_ROOT,
+        executionHostId: 'local'
+      },
+      async () => undefined
+    )
+    expect(getPaths?.()).toEqual([join(PROJECT_GIT_COMMON_DIR, 'refs/remotes/origin/next')])
+
+    await setWorktreeGitStatusRefWatch(
+      {
+        worktreeId: nextWorktreeId,
+        worktreePath: absolutePath('workspace', 'worktrees', 'next'),
+        executionHostId: 'local',
+        branch: 'refs/heads/next',
+        upstreamName: 'origin/next-invalid'
+      },
+      async () => 'refs/remotes/origin/../escape'
+    )
+    expect(getPaths?.()).toEqual([])
+  })
+
+  it('filters SSH common-dir events to the active worktree upstream ref', async () => {
+    const remoteCallbacks = new Map<string, (events: never[]) => void>()
+    const remoteWatch = vi.fn(async (root: string, callback: (events: never[]) => void) => {
+      remoteCallbacks.set(root, callback)
+      return vi.fn()
+    })
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({
+      stat: vi.fn(async () => ({ type: 'directory', size: 0, mtime: 0 })),
+      realpath: vi.fn(async (path: string) => path),
+      readFile: vi.fn(async () => ({ content: '', isBinary: false })),
+      watch: remoteWatch
+    } as never)
+
+    await syncWorktreeBaseDirectoryWatchers(
+      makeStore([makeRepo({ connectionId: 'ssh-1', path: '/home/alice/project' })]) as never,
+      makeWindow() as never
+    )
+    await setWorktreeGitStatusRefWatch(
+      {
+        worktreeId: 'repo-1::/home/alice/project',
+        worktreePath: '/home/alice/project',
+        executionHostId: 'ssh:ssh-1',
+        connectionId: 'ssh-1',
+        branch: 'refs/heads/feature',
+        upstreamName: 'origin/feature'
+      },
+      async () => 'refs/remotes/origin/feature'
+    )
+    remoteCallbacks.get('/home/alice/project/.git')?.([
+      {
+        kind: 'update',
+        absolutePath: '/home/alice/project/.git/refs/remotes/origin/unrelated'
+      }
+    ] as never[])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(notifyWorktreeGitStatusMetadataChanged).not.toHaveBeenCalled()
+
+    remoteCallbacks.get('/home/alice/project/.git')?.([
+      {
+        kind: 'update',
+        absolutePath: '/home/alice/project/.git/refs/remotes/origin/feature'
+      }
+    ] as never[])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(notifyWorktreeGitStatusMetadataChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
+  })
+
+  it('invalidates exact resolution only when common config changes', async () => {
+    const worktreeId = `repo-1::${PROJECT_ROOT}`
+    const request = {
+      worktreeId,
+      worktreePath: PROJECT_ROOT,
+      executionHostId: 'local',
+      branch: 'refs/heads/feature',
+      upstreamName: 'origin/feature'
+    }
+    const resolve = vi.fn(async () => 'refs/remotes/origin/feature')
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    emit(PROJECT_GIT_COMMON_DIR, [
+      { type: 'update', path: join(PROJECT_GIT_COMMON_DIR, 'refs/remotes/origin/feature') }
+    ])
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    expect(resolve).toHaveBeenCalledOnce()
+
+    emit(PROJECT_GIT_COMMON_DIR, [{ type: 'update', path: join(PROJECT_GIT_COMMON_DIR, 'config') }])
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    expect(resolve).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates exact resolution before a local watcher error refresh', async () => {
+    const request = {
+      worktreeId: `repo-1::${PROJECT_ROOT}`,
+      worktreePath: PROJECT_ROOT,
+      executionHostId: 'local',
+      branch: 'refs/heads/feature',
+      upstreamName: 'origin/feature'
+    }
+    const resolve = vi.fn(async () => 'refs/remotes/origin/feature')
+    await syncWorktreeBaseDirectoryWatchers(makeStore([makeRepo()]) as never, makeWindow() as never)
+    await setWorktreeGitStatusRefWatch(request, resolve)
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    pollerOptions.get(PROJECT_GIT_COMMON_DIR)?.onWatchError?.(new Error('watch interrupted'))
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    warn.mockRestore()
+
+    expect(resolve).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(300)
+    expect(notifyWorktreesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
   })
 
   it('keeps linked HEAD and lock metadata structural', async () => {
@@ -530,6 +680,16 @@ describe('worktree base directory watcher', () => {
       makeStore([makeRepo({ connectionId: 'ssh-1', path: '/home/alice/project' })]) as never,
       makeWindow() as never
     )
+    const request = {
+      worktreeId: 'repo-1::/home/alice/project',
+      worktreePath: '/home/alice/project',
+      executionHostId: 'ssh:ssh-1',
+      connectionId: 'ssh-1',
+      branch: 'refs/heads/feature',
+      upstreamName: 'origin/feature'
+    }
+    const resolve = vi.fn(async () => 'refs/remotes/origin/feature')
+    await setWorktreeGitStatusRefWatch(request, resolve)
 
     remoteCallbacks.get('/home/alice/project/.git')?.([
       {
@@ -541,12 +701,16 @@ describe('worktree base directory watcher', () => {
     await vi.advanceTimersByTimeAsync(300)
     expect(notifyWorktreesChanged).not.toHaveBeenCalled()
     expect(notifyWorktreeGitStatusMetadataChanged).toHaveBeenCalledTimes(1)
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    expect(resolve).toHaveBeenCalledOnce()
 
     vi.mocked(notifyWorktreeGitStatusMetadataChanged).mockClear()
     remoteCallbacks.get('/home/alice/project/.git')?.([{ kind: 'overflow' }] as never[])
     await vi.advanceTimersByTimeAsync(300)
     expect(notifyWorktreesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
     expect(notifyWorktreeGitStatusMetadataChanged).not.toHaveBeenCalled()
+    await setWorktreeGitStatusRefWatch(request, resolve)
+    expect(resolve).toHaveBeenCalledTimes(2)
   })
 
   it('unsubscribes roots that disappear after repo settings change', async () => {

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -1,6 +1,5 @@
 import type { BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
-import { notifyWorktreeGitStatusMetadataChanged, notifyWorktreesChanged } from './worktree-remote'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   createWorktreeHeadIdentityRefreshState,
@@ -12,6 +11,11 @@ import {
   collectRemoteWorktreeBaseChanges,
   type WorktreeBaseCollectedChanges
 } from './worktree-base-directory-change-collector'
+import {
+  clearPendingWorktreeBaseNotifications,
+  scheduleWorktreeBaseNotification,
+  supportsWorktreeHeadIdentityRefresh
+} from './worktree-base-directory-notifications'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import {
   buildWorktreeBaseDirectoryWatchTargets,
@@ -21,6 +25,14 @@ import {
   createWorktreePollerWindowVisibility,
   startWorktreeBaseDirectoryPoller
 } from './worktree-base-directory-poller'
+import {
+  applyActiveGitStatusRefBinding,
+  clearActiveGitStatusRefBinding,
+  invalidateActiveGitStatusRefResolution,
+  invalidateGitStatusRefResolutionForPaths,
+  updateActiveGitStatusRefBinding,
+  type GitStatusRefBindingRequest
+} from './worktree-git-status-ref-watch'
 
 type ActiveWatch = WorktreeBaseWatchTarget & {
   mainWindow: BrowserWindow
@@ -30,76 +42,19 @@ type ActiveWatch = WorktreeBaseWatchTarget & {
   pendingGitStatusRepoIds: Set<string>
   pendingHeadIdentityRepoIds: Set<string>
   headIdentityRefresh: WorktreeHeadIdentityRefreshState
+  gitStatusRefPaths: Set<string>
   disposed: boolean
 }
 
-const WATCH_DEBOUNCE_MS = 250
 const activeWatches = new Map<string, ActiveWatch>()
 let syncGeneration = 0
 let scheduledSync: ReturnType<typeof setTimeout> | null = null
 let latestSyncContext: { mainWindow: BrowserWindow; store: Store } | null = null
-
-function clearPendingRepoIds(watch: ActiveWatch): void {
-  watch.pendingStructureRepoIds.clear()
-  watch.pendingGitStatusRepoIds.clear()
-  watch.pendingHeadIdentityRepoIds.clear()
-}
-
-type PendingNotificationInput = Partial<Omit<WorktreeBaseCollectedChanges, 'overflow'>>
-
-function scheduleNotification(watch: ActiveWatch, changes: PendingNotificationInput): void {
-  if (watch.disposed || watch.mainWindow.isDestroyed()) {
-    clearPendingRepoIds(watch)
-    return
-  }
-  for (const repoId of changes.structureRepoIds ?? []) {
-    watch.pendingStructureRepoIds.add(repoId)
-  }
-  for (const repoId of changes.gitStatusRepoIds ?? []) {
-    watch.pendingGitStatusRepoIds.add(repoId)
-  }
-  for (const repoId of changes.headIdentityRepoIds ?? []) {
-    watch.pendingHeadIdentityRepoIds.add(repoId)
-  }
-  // clearTimeout tolerates null (no-op), so no guard needed before rescheduling.
-  clearTimeout(watch.notifyTimer ?? undefined)
-  watch.notifyTimer = setTimeout(() => {
-    watch.notifyTimer = null
-    if (watch.disposed || watch.mainWindow.isDestroyed()) {
-      clearPendingRepoIds(watch)
-      return
-    }
-    const pendingStructure = [...watch.pendingStructureRepoIds]
-    const hasHeadIdentity = watch.pendingHeadIdentityRepoIds.size > 0
-    // Source Control refreshes on both index churn and head moves; structural
-    // repos already refresh via the authoritative listing, so drop them here.
-    const sourceControlRepoIds = new Set(
-      [...watch.pendingGitStatusRepoIds, ...watch.pendingHeadIdentityRepoIds].filter(
-        (repoId) => !watch.pendingStructureRepoIds.has(repoId)
-      )
-    )
-    // Structural ticks refresh silently (emit=false): the authoritative listing
-    // already reported them, so this only re-baselines ahead of later head diffs.
-    const emitHeadIdentities = pendingStructure.length === 0
-    clearPendingRepoIds(watch)
-    for (const repoId of pendingStructure) {
-      notifyWorktreesChanged(watch.mainWindow, repoId)
-    }
-    for (const repoId of sourceControlRepoIds) {
-      notifyWorktreeGitStatusMetadataChanged(watch.mainWindow, repoId)
-    }
-    // Only re-read head identities for true head triggers: an index rewrite
-    // cannot move HEAD, so status-only bursts skip the linked-worktree scan.
-    if (supportsHeadIdentityRefresh(watch) && (pendingStructure.length > 0 || hasHeadIdentity)) {
-      void refreshWorktreeHeadIdentities(watch, watch.headIdentityRefresh, emitHeadIdentities)
-    }
-  }, WATCH_DEBOUNCE_MS)
-}
-
-// Why: SSH common dirs would need per-signal network reads to diff heads;
-// remote background freshness stays on the structural path for now.
-function supportsHeadIdentityRefresh(watch: ActiveWatch): boolean {
-  return watch.kind === 'git-common' && !watch.connectionId
+export function setWorktreeGitStatusRefWatch(
+  args: GitStatusRefBindingRequest,
+  resolveUpstreamRef: (signal: AbortSignal) => Promise<string | undefined>
+): Promise<void> {
+  return updateActiveGitStatusRefBinding(args, () => activeWatches.values(), resolveUpstreamRef)
 }
 
 function hasCollectedChanges(changes: WorktreeBaseCollectedChanges): boolean {
@@ -118,12 +73,18 @@ function handleLocalWatchEvents(
   }
   if (error) {
     console.warn(`[worktree-base-watcher] watcher failed for ${watch.path}:`, error)
-    scheduleNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
+    invalidateActiveGitStatusRefResolution(watch, () => activeWatches.values())
+    scheduleWorktreeBaseNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
     return
   }
+  invalidateGitStatusRefResolutionForPaths(
+    watch,
+    events.map((event) => event.path),
+    () => activeWatches.values()
+  )
   const changes = collectLocalWorktreeBaseChanges(watch, events)
   if (hasCollectedChanges(changes)) {
-    scheduleNotification(watch, changes)
+    scheduleWorktreeBaseNotification(watch, changes)
   }
 }
 
@@ -134,20 +95,29 @@ function handleRemoteWatchEvents(
   if (watch.disposed || watch.mainWindow.isDestroyed()) {
     return
   }
+  invalidateGitStatusRefResolutionForPaths(
+    watch,
+    events.flatMap((event) =>
+      event.kind === 'overflow' ? [] : [event.absolutePath, event.oldAbsolutePath]
+    ),
+    () => activeWatches.values()
+  )
   const changes = collectRemoteWorktreeBaseChanges(watch, events)
   if (changes.overflow) {
-    scheduleNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
+    invalidateActiveGitStatusRefResolution(watch, () => activeWatches.values())
+    scheduleWorktreeBaseNotification(watch, { structureRepoIds: [...watch.repos.keys()] })
     return
   }
   if (hasCollectedChanges(changes)) {
-    scheduleNotification(watch, changes)
+    scheduleWorktreeBaseNotification(watch, changes)
   }
 }
 
 function createActiveWatch(
   target: WorktreeBaseWatchTarget,
   mainWindow: BrowserWindow,
-  subscription: ActiveWatch['subscription']
+  subscription: ActiveWatch['subscription'],
+  gitStatusRefPaths: Set<string>
 ): ActiveWatch {
   return {
     ...target,
@@ -158,6 +128,7 @@ function createActiveWatch(
     pendingGitStatusRepoIds: new Set(),
     pendingHeadIdentityRepoIds: new Set(),
     headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
+    gitStatusRefPaths,
     disposed: false
   }
 }
@@ -167,6 +138,8 @@ async function subscribeTarget(
   mainWindow: BrowserWindow
 ): Promise<ActiveWatch> {
   let activeWatch: ActiveWatch | null = null
+  const gitStatusRefPaths = new Set<string>()
+  applyActiveGitStatusRefBinding({ ...target, gitStatusRefPaths })
   if (target.connectionId) {
     const provider = getSshFilesystemProvider(target.connectionId)
     if (!provider) {
@@ -179,9 +152,12 @@ async function subscribeTarget(
       }
       handleRemoteWatchEvents(currentWatch, events)
     })
-    activeWatch = createActiveWatch(target, mainWindow, {
-      unsubscribe: async () => unwatch()
-    })
+    activeWatch = createActiveWatch(
+      target,
+      mainWindow,
+      { unsubscribe: async () => unwatch() },
+      gitStatusRefPaths
+    )
     return activeWatch
   }
 
@@ -201,11 +177,18 @@ async function subscribeTarget(
     {
       visibility: createWorktreePollerWindowVisibility(
         () => (activeWatches.get(target.key) ?? activeWatch)?.mainWindow ?? null
-      )
+      ),
+      getGitStatusRefPaths: () => [...gitStatusRefPaths],
+      onWatchError: (error) => {
+        const currentWatch = activeWatches.get(target.key) ?? activeWatch
+        if (currentWatch && !currentWatch.disposed) {
+          handleLocalWatchEvents(currentWatch, error, [])
+        }
+      }
     }
   )
-  activeWatch = createActiveWatch(target, mainWindow, subscription)
-  if (supportsHeadIdentityRefresh(activeWatch)) {
+  activeWatch = createActiveWatch(target, mainWindow, subscription, gitStatusRefPaths)
+  if (supportsWorktreeHeadIdentityRefresh(activeWatch)) {
     // Baseline eagerly so the first status-only signal — possibly hours after
     // subscribe — diffs against subscribe-time heads instead of silently
     // re-baselining past an external commit.
@@ -223,6 +206,7 @@ async function replaceWatch(
   if (previous) {
     previous.repos = target.repos
     previous.mainWindow = mainWindow
+    applyActiveGitStatusRefBinding(previous)
     return
   }
   try {
@@ -234,6 +218,7 @@ async function replaceWatch(
       })
       return
     }
+    applyActiveGitStatusRefBinding(activeWatch)
     activeWatches.set(target.key, activeWatch)
   } catch (error) {
     console.warn(`[worktree-base-watcher] failed to watch ${target.path}:`, error)
@@ -248,7 +233,7 @@ async function removeWatch(key: string): Promise<void> {
   activeWatches.delete(key)
   watch.disposed = true
   clearTimeout(watch.notifyTimer ?? undefined)
-  clearPendingRepoIds(watch)
+  clearPendingWorktreeBaseNotifications(watch)
   await watch.subscription.unsubscribe().catch((error) => {
     console.warn(`[worktree-base-watcher] failed to unwatch ${watch.path}:`, error)
   })
@@ -327,6 +312,7 @@ export function scheduleCurrentWorktreeBaseDirectoryWatcherSync(): void {
 export async function disposeWorktreeBaseDirectoryWatchers(): Promise<void> {
   syncGeneration++
   latestSyncContext = null
+  clearActiveGitStatusRefBinding()
   if (scheduledSync) {
     clearTimeout(scheduledSync)
     scheduledSync = null

--- a/src/main/ipc/worktree-git-common-entry-snapshot.ts
+++ b/src/main/ipc/worktree-git-common-entry-snapshot.ts
@@ -1,0 +1,76 @@
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
+const INDEX_FILE = 'index'
+const HEAD_LOG_FILE = join('logs', 'HEAD')
+
+function statSignature(value: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${value.mtimeMs}:${value.ctimeMs}:${value.ino}`
+}
+
+export async function gitCommonDirectorySignature(path: string): Promise<string> {
+  try {
+    const value = await stat(path)
+    return `${statSignature(value)}:${value.size}`
+  } catch {
+    return 'missing'
+  }
+}
+
+export async function gitCommonFileSignature(path: string): Promise<string | null> {
+  try {
+    const value = await stat(path)
+    return value.isFile() ? `${statSignature(value)}:${value.size}` : null
+  } catch {
+    return null
+  }
+}
+
+export type GitCommonEntrySnapshot = {
+  dirSignature: string
+  structuralSignatures: Map<string, string>
+  indexSignature: string | null
+  headLogSignature: string | null
+}
+
+export async function snapshotGitCommonEntry(
+  entryPath: string,
+  previous: GitCommonEntrySnapshot | undefined,
+  forceFullScan: boolean
+): Promise<GitCommonEntrySnapshot> {
+  // Structural leaves change in place every tick; only index uses the entry-dir gate.
+  const structuralSignatures = new Map<string, string>()
+  const [nextDirSignature, headLogSignature] = await Promise.all([
+    gitCommonDirectorySignature(entryPath),
+    gitCommonFileSignature(join(entryPath, HEAD_LOG_FILE)),
+    Promise.all(
+      STRUCTURAL_METADATA_FILES.map(async (name) => {
+        const signature = await gitCommonFileSignature(join(entryPath, name))
+        if (signature !== null) {
+          structuralSignatures.set(name, signature)
+        }
+      })
+    )
+  ])
+  if (nextDirSignature === 'missing') {
+    return (
+      previous ?? {
+        dirSignature: nextDirSignature,
+        structuralSignatures,
+        indexSignature: null,
+        headLogSignature
+      }
+    )
+  }
+  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
+  const indexSignature = shouldReadIndex
+    ? await gitCommonFileSignature(join(entryPath, INDEX_FILE))
+    : previous.indexSignature
+  return {
+    dirSignature: nextDirSignature,
+    structuralSignatures,
+    indexSignature,
+    headLogSignature
+  }
+}

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -7,11 +7,13 @@ import type {
 } from './worktree-base-directory-poller'
 
 // Shared with the darwin primary-metadata poll so platforms cannot drift.
-// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag.
+// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag;
+// `config` gains branch.<name>.remote/merge on an external `git push -u`.
 export const PRIMARY_CHECKOUT_METADATA_FILES = [
   'HEAD',
   'packed-refs',
   'index',
+  'config',
   'config.worktree',
   'logs/HEAD'
 ]

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -1,10 +1,16 @@
-import { readdir, stat } from 'node:fs/promises'
+import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   WorktreeBasePollEvent,
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import {
+  gitCommonDirectorySignature,
+  gitCommonFileSignature,
+  snapshotGitCommonEntry,
+  type GitCommonEntrySnapshot
+} from './worktree-git-common-entry-snapshot'
 
 // Shared with the darwin primary-metadata poll so platforms cannot drift.
 // `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag;
@@ -17,7 +23,6 @@ export const PRIMARY_CHECKOUT_METADATA_FILES = [
   'config.worktree',
   'logs/HEAD'
 ]
-const LINKED_WORKTREE_STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
 const LINKED_WORKTREE_INDEX_FILE = 'index'
 const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
 // Why: the entry-dir signature gate can miss same-granule index rewrites on
@@ -25,87 +30,28 @@ const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
 // same way the base poller's backstop rescan does.
 const INDEX_BACKSTOP_TICKS = 15
 
-function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
-  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
-}
-
-async function dirSignature(path: string): Promise<string> {
-  try {
-    // Why: keep `size` — on a coarse-timestamp filesystem a same-granule directory
-    // allocation change would otherwise slip the readdir gate to the backstop.
-    const s = await stat(path)
-    return `${statSignature(s)}:${s.size}`
-  } catch {
-    return 'missing'
-  }
-}
-
-async function fileSignature(path: string): Promise<string | null> {
-  try {
-    const s = await stat(path)
-    return s.isFile() ? `${statSignature(s)}:${s.size}` : null
-  } catch {
-    return null
-  }
-}
-
-type GitCommonEntrySnapshot = {
-  dirSignature: string
-  structuralSignatures: Map<string, string>
-  indexSignature: string | null
-  headLogSignature: string | null
-}
-
 type GitCommonSnapshot = {
   worktreesDirSignature: string
   entries: Map<string, GitCommonEntrySnapshot>
   primarySignatures: Map<string, string>
+  statusRefPaths: Set<string>
+  statusRefSignatures: Map<string, string>
   didFullScan: boolean
 }
 
-async function snapshotGitCommonEntry(
-  entryPath: string,
-  previous: GitCommonEntrySnapshot | undefined,
-  forceFullScan: boolean
-): Promise<GitCommonEntrySnapshot> {
-  // Why: HEAD, gitdir, locked, config.worktree and logs/HEAD are rewritten in place without bumping
-  // the entry-dir mtime, so — like the pre-idle-gate poller — they are re-stat'd EVERY tick, never
-  // gated behind the dir signature (else a raw HEAD/structural rewrite would slip to the ~30s
-  // backstop). Only `index` rides the entry-dir signature (its same-dir rewrites are index-backstop-bounded).
-  const structuralSignatures = new Map<string, string>()
-  const [nextDirSignature, headLogSignature] = await Promise.all([
-    dirSignature(entryPath),
-    fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE)),
-    Promise.all(
-      LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
-        const signature = await fileSignature(join(entryPath, name))
-        if (signature !== null) {
-          structuralSignatures.set(name, signature)
-        }
-      })
-    )
-  ])
-  if (nextDirSignature === 'missing') {
-    // A transient stat failure must not masquerade as a removal; the parent listing is authoritative.
-    return (
-      previous ?? {
-        dirSignature: nextDirSignature,
-        structuralSignatures,
-        indexSignature: null,
-        headLogSignature
+async function snapshotStatusRefSignatures(
+  paths: ReadonlySet<string>
+): Promise<Map<string, string>> {
+  const signatures = new Map<string, string>()
+  await Promise.all(
+    [...paths].map(async (path) => {
+      const signature = await gitCommonFileSignature(path)
+      if (signature !== null) {
+        signatures.set(path, signature)
       }
-    )
-  }
-  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
-  const indexSignature = shouldReadIndex
-    ? await fileSignature(join(entryPath, LINKED_WORKTREE_INDEX_FILE))
-    : previous.indexSignature
-  return {
-    dirSignature: nextDirSignature,
-    structuralSignatures,
-    indexSignature,
-    headLogSignature
-  }
+    })
+  )
+  return signatures
 }
 
 async function snapshotPrimaryCheckoutSignatures(
@@ -114,7 +60,7 @@ async function snapshotPrimaryCheckoutSignatures(
   const signatures = new Map<string, string>()
   await Promise.all(
     PRIMARY_CHECKOUT_METADATA_FILES.map(async (name) => {
-      const signature = await fileSignature(join(commonDirPath, name))
+      const signature = await gitCommonFileSignature(join(commonDirPath, name))
       if (signature !== null) {
         signatures.set(name, signature)
       }
@@ -127,12 +73,14 @@ async function snapshotGitCommon(
   commonDirPath: string,
   previous?: GitCommonSnapshot,
   includePrimary = true,
-  forceFullScan = false
+  forceFullScan = false,
+  statusRefPaths: Set<string> = new Set()
 ): Promise<GitCommonSnapshot> {
   const worktreesDir = join(commonDirPath, 'worktrees')
-  const [worktreesDirSignature, primarySignatures] = await Promise.all([
-    dirSignature(worktreesDir),
-    includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>()
+  const [worktreesDirSignature, primarySignatures, statusRefSignatures] = await Promise.all([
+    gitCommonDirectorySignature(worktreesDir),
+    includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>(),
+    snapshotStatusRefSignatures(statusRefPaths)
   ])
   // Why: enumerate the worktrees dir EVERY tick rather than gating the readdir on its stat signature.
   // A single readdir of a small dir is negligible next to the per-entry structural stats that already
@@ -172,6 +120,8 @@ async function snapshotGitCommon(
     worktreesDirSignature,
     entries,
     primarySignatures,
+    statusRefPaths,
+    statusRefSignatures,
     didFullScan: forceFullScan
   }
 }
@@ -252,6 +202,19 @@ function diffGitCommon(
       join(commonDirPath, name)
     )
   )
+  for (const path of next.statusRefPaths) {
+    // A newly selected ref is a baseline change, not a filesystem event.
+    if (!prev.statusRefPaths.has(path)) {
+      continue
+    }
+    const type = classifySignatureDiff(
+      prev.statusRefSignatures.get(path),
+      next.statusRefSignatures.get(path)
+    )
+    if (type) {
+      events.push({ type, path })
+    }
+  }
   return events
 }
 
@@ -261,12 +224,19 @@ export async function startGitCommonPolling(
   pollIntervalMs: number,
   visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
-  includePrimary = true
+  includePrimary = true,
+  getStatusRefPaths: () => readonly string[] = () => []
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
   let tickCount = 0
-  let snapshot = await snapshotGitCommon(commonDirPath, undefined, includePrimary)
+  let snapshot = await snapshotGitCommon(
+    commonDirPath,
+    undefined,
+    includePrimary,
+    false,
+    new Set(getStatusRefPaths())
+  )
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
 
@@ -293,7 +263,8 @@ export async function startGitCommonPolling(
         commonDirPath,
         snapshot,
         includePrimary,
-        shouldForceFullScan
+        shouldForceFullScan,
+        new Set(getStatusRefPaths())
       )
       if (disposed) {
         return

--- a/src/main/ipc/worktree-git-common-primary-polling.ts
+++ b/src/main/ipc/worktree-git-common-primary-polling.ts
@@ -1,0 +1,148 @@
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type {
+  WorktreeBasePollEvent,
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-polling'
+
+type PrimaryMetadataSnapshot = {
+  signatures: Map<string, string>
+  statusRefPaths: Set<string>
+}
+
+async function snapshotPrimaryCheckoutMetadata(
+  commonDirPath: string,
+  getStatusRefPaths: () => readonly string[]
+): Promise<PrimaryMetadataSnapshot> {
+  const signatures = new Map<string, string>()
+  const statusRefPaths = new Set(getStatusRefPaths())
+  const paths = [
+    ...PRIMARY_CHECKOUT_METADATA_FILES.map((name) => join(commonDirPath, name)),
+    ...statusRefPaths
+  ]
+  await Promise.all(
+    paths.map(async (filePath) => {
+      try {
+        const value = await stat(filePath)
+        if (value.isFile()) {
+          signatures.set(filePath, `${value.mtimeMs}:${value.ctimeMs}:${value.ino}:${value.size}`)
+        }
+      } catch {
+        // Missing dynamic leaves remain selected so later creation is visible.
+      }
+    })
+  )
+  return { signatures, statusRefPaths }
+}
+
+function classifyMetadataSignatureDiff(
+  prevSignature: string | undefined,
+  nextSignature: string | undefined
+): WorktreeBasePollEvent['type'] | null {
+  if (prevSignature === undefined && nextSignature === undefined) {
+    return null
+  }
+  if (prevSignature === undefined) {
+    return 'create'
+  }
+  if (nextSignature === undefined) {
+    return 'delete'
+  }
+  return prevSignature === nextSignature ? null : 'update'
+}
+
+function diffPrimaryMetadata(
+  prev: PrimaryMetadataSnapshot,
+  next: PrimaryMetadataSnapshot
+): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  const paths = new Set([...prev.signatures.keys(), ...next.signatures.keys()])
+  for (const path of paths) {
+    const isStatusRef = prev.statusRefPaths.has(path) || next.statusRefPaths.has(path)
+    if (isStatusRef && (!prev.statusRefPaths.has(path) || !next.statusRefPaths.has(path))) {
+      continue
+    }
+    const type = classifyMetadataSignatureDiff(prev.signatures.get(path), next.signatures.get(path))
+    if (type) {
+      events.push({ type, path })
+    }
+  }
+  return events
+}
+
+export async function startGitCommonPrimaryPolling(
+  commonDirPath: string,
+  getStatusRefPaths: () => readonly string[],
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility,
+  onFullScan?: () => void
+): Promise<WorktreeBaseSubscription> {
+  let disposed = false
+  let ticking = false
+  let snapshot = await snapshotPrimaryCheckoutMetadata(commonDirPath, getStatusRefPaths)
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let parkedWhileHidden = false
+
+  const tick = async (): Promise<void> => {
+    timer = null
+    if (disposed) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
+      return
+    }
+    if (ticking) {
+      return
+    }
+    ticking = true
+    const startedAt = Date.now()
+    onFullScan?.()
+    try {
+      const next = await snapshotPrimaryCheckoutMetadata(commonDirPath, getStatusRefPaths)
+      if (disposed) {
+        return
+      }
+      const events = diffPrimaryMetadata(snapshot, next)
+      snapshot = next
+      if (events.length > 0) {
+        onEvents(events)
+      }
+    } catch {
+      // Transient fs error: keep the previous snapshot and retry next tick.
+    } finally {
+      ticking = false
+    }
+    if (!disposed) {
+      const nextDelay = Math.max(
+        0,
+        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
+      )
+      timer = setTimeout(() => void tick(), nextDelay)
+      timer.unref?.()
+    }
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed || !parkedWhileHidden) {
+      return
+    }
+    parkedWhileHidden = false
+    void tick()
+  })
+  timer = setTimeout(() => void tick(), pollIntervalMs)
+  timer.unref?.()
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribeVisibility()
+    }
+  }
+}

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -146,6 +146,23 @@ describe('worktree git-common narrow watch (darwin)', () => {
     expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
   })
 
+  it('detects a common config write via the primary-metadata poll', async () => {
+    // Why: an external `git push -u` rewrites only the common config (plus
+    // remote-tracking refs) — outside the narrow worktrees/ stream, so the
+    // primary-metadata poll must carry it.
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const configPath = join(commonDir, 'config')
+    await writeFile(configPath, '[core]\n\tbare = false\n')
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    await appendFile(configPath, '[branch "main"]\n\tremote = origin\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
+    })
+  })
+
   it('tears down and re-arms when the watched root is deleted', async () => {
     installSubscribeMock()
     const commonDir = await makeCommonDir(true)
@@ -537,6 +554,24 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     await appendFile(headLogPath, 'next\n')
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'update', path: headLogPath })
+    })
+    expect(fullScans).not.toHaveBeenCalled()
+  })
+
+  it('polls the common config so an external push -u surfaces its new upstream', async () => {
+    // Why: `git push -u` from an external shell rewrites only the common
+    // config (plus remote-tracking refs); the primary-metadata list must
+    // surface it or the upstream stays invisible until a safety poll.
+    const commonDir = await makePollingCommonDir()
+    const configPath = join(commonDir, 'config')
+    await writeFile(configPath, '[core]\n\tbare = false\n')
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+    await startPollingWatch(commonDir, received, fullScans)
+
+    await appendFile(configPath, '[branch "main"]\n\tremote = origin\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
     })
     expect(fullScans).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -119,13 +119,21 @@ describe('worktree git-common narrow watch (darwin)', () => {
     }
   }
 
-  async function startWatch(commonDir: string, received: WorktreeBasePollEvent[][]): Promise<void> {
+  async function startWatch(
+    commonDir: string,
+    received: WorktreeBasePollEvent[][],
+    getStatusRefPaths: () => readonly string[] = () => [],
+    onWatchError?: (error: Error) => void
+  ): Promise<void> {
     const watch = await startGitCommonWatch(
       makeTarget(commonDir),
       (events) => received.push(events),
       POLL_MS,
       'darwin',
-      alwaysVisible
+      alwaysVisible,
+      undefined,
+      getStatusRefPaths,
+      onWatchError
     )
     cleanups.push(() => watch.unsubscribe())
   }
@@ -161,6 +169,41 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
     })
+  })
+
+  it('polls only the accepted upstream ref and rebinds without synthetic events', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const firstRef = join(commonDir, 'refs', 'remotes', 'origin', 'first')
+    const nextRef = join(commonDir, 'refs', 'remotes', 'origin', 'next')
+    const unrelatedRef = join(commonDir, 'refs', 'remotes', 'origin', 'unrelated')
+    await mkdir(join(commonDir, 'refs', 'remotes', 'origin'), { recursive: true })
+    await Promise.all([
+      writeFile(firstRef, 'aaa\n'),
+      writeFile(nextRef, 'bbb\n'),
+      writeFile(unrelatedRef, 'ccc\n')
+    ])
+    let selected = [firstRef]
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received, () => selected)
+
+    statCalls.length = 0
+    await appendFile(firstRef, 'updated\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: firstRef })
+    })
+    expect(statCalls).not.toContain(unrelatedRef)
+
+    received.length = 0
+    selected = [nextRef]
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    expect(received.flat()).toEqual([])
+    await appendFile(firstRef, 'ignored\n')
+    await appendFile(nextRef, 'watched\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: nextRef })
+    })
+    expect(received.flat()).not.toContainEqual({ type: 'update', path: firstRef })
   })
 
   it('tears down and re-arms when the watched root is deleted', async () => {
@@ -214,6 +257,20 @@ describe('worktree git-common narrow watch (darwin)', () => {
     // A replaced watch cannot tear down its successor or report stale events.
     expect(received).toHaveLength(receivedAfterRearm)
     expect(childSubscriptions[1].unsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('routes watcher failures through the unknown-metadata callback', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const received: WorktreeBasePollEvent[][] = []
+    const onWatchError = vi.fn()
+    await startWatch(commonDir, received, () => [], onWatchError)
+
+    const error = new Error('watcher child reported failure')
+    childSubscriptions[0].callback(error, [])
+
+    expect(onWatchError).toHaveBeenCalledWith(error)
+    expect(received).toEqual([])
   })
 
   it('reports a structural change after a watcher-child interruption', async () => {
@@ -432,7 +489,8 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     commonDir: string,
     received: WorktreeBasePollEvent[][],
     onFullScan?: () => void,
-    visibility: WorktreePollerWindowVisibility = alwaysVisible
+    visibility: WorktreePollerWindowVisibility = alwaysVisible,
+    getStatusRefPaths: () => readonly string[] = () => []
   ): Promise<void> {
     const watch = await startGitCommonWatch(
       makePollingTarget(commonDir),
@@ -440,7 +498,8 @@ describe('worktree git-common polling gate (non-darwin)', () => {
       POLL_MS,
       'linux',
       visibility,
-      onFullScan
+      onFullScan,
+      getStatusRefPaths
     )
     cleanups.push(() => watch.unsubscribe())
   }
@@ -574,6 +633,29 @@ describe('worktree git-common polling gate (non-darwin)', () => {
       expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
     })
     expect(fullScans).not.toHaveBeenCalled()
+  })
+
+  it('detects create, update, and delete for one transient upstream ref', async () => {
+    const commonDir = await makePollingCommonDir()
+    const refPath = join(commonDir, 'refs', 'remotes', 'origin', 'feature', 'nested')
+    await mkdir(join(commonDir, 'refs', 'remotes', 'origin', 'feature'), { recursive: true })
+    const received: WorktreeBasePollEvent[][] = []
+    await startPollingWatch(commonDir, received, undefined, alwaysVisible, () => [refPath])
+
+    await writeFile(refPath, 'aaa\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'create', path: refPath })
+    })
+    received.length = 0
+    await appendFile(refPath, 'bbb\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: refPath })
+    })
+    received.length = 0
+    await rm(refPath)
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'delete', path: refPath })
+    })
   })
 
   it('forces a full scan on the 15-tick backstop', async () => {

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -7,10 +7,8 @@ import type {
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
-import {
-  PRIMARY_CHECKOUT_METADATA_FILES,
-  startGitCommonPolling
-} from './worktree-git-common-polling'
+import { startGitCommonPolling } from './worktree-git-common-polling'
+import { startGitCommonPrimaryPolling } from './worktree-git-common-primary-polling'
 
 // Watches a repo's `<common>/.git/worktrees` metadata plus the primary
 // checkout's shallow branch/index files — the only paths the git-common event
@@ -27,130 +25,12 @@ import {
 // process when unsubscribe overlaps in-flight callbacks (issue #8732), and
 // root deletion via `git worktree prune` makes that overlap routine here.
 
-// Why: branch switches and commits made in the primary checkout rewrite these
-// top-level files (linked-worktree equivalents live under `worktrees/`).
-// Deliberately excludes FETCH_HEAD-style churn that carries no status change.
-async function snapshotPrimaryCheckoutMetadata(
-  commonDirPath: string
-): Promise<Map<string, number>> {
-  const mtimes = new Map<string, number>()
-  for (const name of PRIMARY_CHECKOUT_METADATA_FILES) {
-    const filePath = join(commonDirPath, name)
-    try {
-      mtimes.set(filePath, (await stat(filePath)).mtimeMs)
-    } catch {
-      // Missing file (e.g. no packed-refs yet) diffs into a create later.
-    }
-  }
-  return mtimes
-}
-
-function diffMtimeMap(
-  prev: Map<string, number>,
-  next: Map<string, number>
-): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  for (const [path, mtime] of next) {
-    const prevMtime = prev.get(path)
-    if (prevMtime === undefined) {
-      events.push({ type: 'create', path })
-    } else if (prevMtime !== mtime) {
-      events.push({ type: 'update', path })
-    }
-  }
-  for (const path of prev.keys()) {
-    if (!next.has(path)) {
-      events.push({ type: 'delete', path })
-    }
-  }
-  return events
-}
-
-async function startSnapshotDiffPoller(
-  takeSnapshot: () => Promise<Map<string, number>>,
-  onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number,
-  visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
-): Promise<WorktreeBaseSubscription> {
-  let disposed = false
-  let ticking = false
-  let snapshot = await takeSnapshot()
-  let timer: ReturnType<typeof setTimeout> | null = null
-  let parkedWhileHidden = false
-
-  const tick = async (): Promise<void> => {
-    timer = null
-    if (disposed) {
-      return
-    }
-    if (!visibility.isWindowVisible()) {
-      parkedWhileHidden = true
-      return
-    }
-    if (ticking) {
-      return
-    }
-    ticking = true
-    // Why: measure from tick start so cadence is start-to-start, not gap-after-completion (which would
-    // land each visible refresh a full scan-duration late every tick).
-    const startedAt = Date.now()
-    onFullScan?.()
-    try {
-      const next = await takeSnapshot()
-      if (disposed) {
-        return
-      }
-      const events = diffMtimeMap(snapshot, next)
-      snapshot = next
-      if (events.length > 0) {
-        onEvents(events)
-      }
-    } catch {
-      // Transient fs error: keep the previous snapshot and retry next tick.
-    } finally {
-      ticking = false
-    }
-    if (!disposed) {
-      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
-      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
-      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      const nextDelay = Math.max(
-        0,
-        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
-      )
-      timer = setTimeout(() => void tick(), nextDelay)
-      timer.unref?.()
-    }
-  }
-
-  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
-    if (disposed || !parkedWhileHidden) {
-      return
-    }
-    parkedWhileHidden = false
-    void tick()
-  })
-
-  timer = setTimeout(() => void tick(), pollIntervalMs)
-  timer.unref?.()
-
-  return {
-    unsubscribe: async () => {
-      disposed = true
-      if (timer) {
-        clearTimeout(timer)
-      }
-      unsubscribeVisibility()
-    }
-  }
-}
-
 async function startGitCommonNarrowWatch(
   target: WorktreeBaseWatchTarget,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
-  visibility: WorktreePollerWindowVisibility
+  visibility: WorktreePollerWindowVisibility,
+  onWatchError?: (error: Error) => void
 ): Promise<WorktreeBaseSubscription> {
   const worktreesDir = join(target.path, 'worktrees')
   let disposed = false
@@ -254,7 +134,11 @@ async function startGitCommonNarrowWatch(
             return
           }
           if (error) {
-            onEvents([{ type: 'update', path: worktreesDir }])
+            if (onWatchError) {
+              onWatchError(error)
+            } else {
+              onEvents([{ type: 'update', path: worktreesDir }])
+            }
             teardownAndRearm()
             return
           }
@@ -274,7 +158,11 @@ async function startGitCommonNarrowWatch(
           // resubscribe gap; report a structural change so worktrees re-sync.
           onInterruption: () => {
             if (!disposed && active) {
-              onEvents([{ type: 'update', path: worktreesDir }])
+              if (onWatchError) {
+                onWatchError(new Error('Git common watcher interrupted'))
+              } else {
+                onEvents([{ type: 'update', path: worktreesDir }])
+              }
             }
           }
         }
@@ -316,13 +204,16 @@ export async function startGitCommonWatch(
   pollIntervalMs: number,
   platform: NodeJS.Platform,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  getStatusRefPaths: () => readonly string[] = () => [],
+  onWatchError?: (error: Error) => void
 ): Promise<WorktreeBaseSubscription> {
   if (platform === 'darwin') {
     const [narrowWatch, primaryMetadataPoll] = await Promise.all([
-      startGitCommonNarrowWatch(target, onEvents, pollIntervalMs, visibility),
-      startSnapshotDiffPoller(
-        () => snapshotPrimaryCheckoutMetadata(target.path),
+      startGitCommonNarrowWatch(target, onEvents, pollIntervalMs, visibility, onWatchError),
+      startGitCommonPrimaryPolling(
+        target.path,
+        getStatusRefPaths,
         onEvents,
         pollIntervalMs,
         visibility,
@@ -335,5 +226,13 @@ export async function startGitCommonWatch(
       }
     }
   }
-  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, visibility, onFullScan)
+  return startGitCommonPolling(
+    target.path,
+    onEvents,
+    pollIntervalMs,
+    visibility,
+    onFullScan,
+    true,
+    getStatusRefPaths
+  )
 }

--- a/src/main/ipc/worktree-git-status-ref-watch.test.ts
+++ b/src/main/ipc/worktree-git-status-ref-watch.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearActiveGitStatusRefBinding,
+  updateActiveGitStatusRefBinding,
+  type GitStatusRefBindingRequest,
+  type GitStatusRefWatchTarget
+} from './worktree-git-status-ref-watch'
+
+function makeTarget(): GitStatusRefWatchTarget {
+  return {
+    kind: 'git-common',
+    path: 'C:\\repo\\.git',
+    repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'repo', nestWorkspaces: false }]]),
+    gitStatusRefPaths: new Set()
+  }
+}
+
+describe('worktree git status ref watch binding', () => {
+  afterEach(() => clearActiveGitStatusRefBinding())
+
+  function request(overrides: Partial<GitStatusRefBindingRequest> = {}) {
+    return {
+      worktreeId: 'repo-1::C:\\repo',
+      worktreePath: 'C:\\repo',
+      executionHostId: 'local',
+      branch: 'refs/heads/feature/main',
+      upstreamName: 'origin/feature/main',
+      ...overrides
+    }
+  }
+
+  it('binds a custom refspec destination exactly', async () => {
+    const target = makeTarget()
+    await updateActiveGitStatusRefBinding(
+      request(),
+      () => [target],
+      async () => 'refs/custom/origin/main'
+    )
+
+    expect([...target.gitStatusRefPaths]).toEqual(['C:/repo/.git/refs/custom/origin/main'])
+  })
+
+  it('does not spend the dynamic ref stat on a slash-named local upstream', async () => {
+    const target = makeTarget()
+    await updateActiveGitStatusRefBinding(
+      request(),
+      () => [target],
+      async () => 'refs/heads/feature/base'
+    )
+
+    expect(target.gitStatusRefPaths).toEqual(new Set())
+  })
+
+  it('keeps a slash-containing remote name exact', async () => {
+    const target = makeTarget()
+    await updateActiveGitStatusRefBinding(
+      request(),
+      () => [target],
+      async () => 'refs/remotes/team/fork/feature/main'
+    )
+
+    expect([...target.gitStatusRefPaths]).toEqual([
+      'C:/repo/.git/refs/remotes/team/fork/feature/main'
+    ])
+  })
+
+  it('does not resolve the exact ref again on unchanged status ticks', async () => {
+    const target = makeTarget()
+    const resolve = vi.fn(async () => 'refs/remotes/origin/feature/main')
+
+    await updateActiveGitStatusRefBinding(request(), () => [target], resolve)
+    await updateActiveGitStatusRefBinding(request(), () => [target], resolve)
+
+    expect(resolve).toHaveBeenCalledOnce()
+  })
+
+  it('applies an in-flight resolution to a replacement watch', async () => {
+    const first = makeTarget()
+    const replacement = makeTarget()
+    let current = [first]
+    let finish: (ref: string) => void = () => {}
+    const pending = new Promise<string>((resolve) => {
+      finish = resolve
+    })
+
+    const update = updateActiveGitStatusRefBinding(
+      request(),
+      () => current,
+      () => pending
+    )
+    current = [replacement]
+    finish('refs/remotes/origin/feature/main')
+    await update
+
+    expect(first.gitStatusRefPaths).toEqual(new Set())
+    expect([...replacement.gitStatusRefPaths]).toEqual([
+      'C:/repo/.git/refs/remotes/origin/feature/main'
+    ])
+
+    const latest = makeTarget()
+    current = [latest]
+    const resolve = vi.fn(async () => 'refs/remotes/origin/feature/main')
+    await updateActiveGitStatusRefBinding(request(), () => current, resolve)
+    expect(resolve).not.toHaveBeenCalled()
+    expect([...latest.gitStatusRefPaths]).toEqual(['C:/repo/.git/refs/remotes/origin/feature/main'])
+  })
+})

--- a/src/main/ipc/worktree-git-status-ref-watch.ts
+++ b/src/main/ipc/worktree-git-status-ref-watch.ts
@@ -1,0 +1,198 @@
+import { resolveRuntimePath } from '../../shared/cross-platform-path'
+import { isSafeGitStatusUpstreamRef } from '../../shared/git-status-upstream-ref'
+import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import {
+  pathRelativeToWorktreeWatchRoot,
+  type WorktreeBaseWatchTarget
+} from './worktree-base-directory-event-filter'
+
+export type GitStatusRefWatchTarget = Pick<
+  WorktreeBaseWatchTarget,
+  'kind' | 'connectionId' | 'repos' | 'path'
+> & {
+  gitStatusRefPaths: Set<string>
+}
+
+type ActiveGitStatusRefBinding = {
+  worktreeId: string
+  repoId: string
+  connectionId?: string
+  upstreamRef: string
+}
+
+type GitStatusRefResolution = {
+  key: string
+  worktreeId: string
+  repoId: string
+  connectionId?: string
+  controller: AbortController
+  promise: Promise<void>
+  retryAt: number
+}
+
+export type GitStatusRefBindingRequest = {
+  worktreeId: string
+  worktreePath: string
+  executionHostId: string
+  connectionId?: string
+  providerGeneration?: number
+  branch?: string
+  upstreamName?: string
+}
+
+const FAILED_RESOLUTION_RETRY_MS = 5 * 60_000
+
+let activeBinding: ActiveGitStatusRefBinding | null = null
+let activeResolution: GitStatusRefResolution | null = null
+
+function watchMatchesBinding(
+  watch: GitStatusRefWatchTarget,
+  binding: ActiveGitStatusRefBinding
+): boolean {
+  return (
+    watch.kind === 'git-common' &&
+    watch.connectionId === binding.connectionId &&
+    watch.repos.has(binding.repoId)
+  )
+}
+
+function watchMatchesResolution(
+  watch: GitStatusRefWatchTarget,
+  resolution: GitStatusRefResolution
+): boolean {
+  return (
+    watch.kind === 'git-common' &&
+    watch.connectionId === resolution.connectionId &&
+    watch.repos.has(resolution.repoId)
+  )
+}
+
+export function applyActiveGitStatusRefBinding(watch: GitStatusRefWatchTarget): void {
+  watch.gitStatusRefPaths.clear()
+  if (activeBinding && watchMatchesBinding(watch, activeBinding)) {
+    watch.gitStatusRefPaths.add(resolveRuntimePath(watch.path, activeBinding.upstreamRef))
+  }
+}
+
+function applyBindingToWatches(watches: Iterable<GitStatusRefWatchTarget>): void {
+  for (const watch of watches) {
+    applyActiveGitStatusRefBinding(watch)
+  }
+}
+
+function clearResolutionForWorktree(
+  worktreeId: string,
+  getWatches: () => Iterable<GitStatusRefWatchTarget>
+): void {
+  if (activeResolution?.worktreeId !== worktreeId) {
+    return
+  }
+  activeResolution.controller.abort()
+  activeResolution = null
+  activeBinding = null
+  applyBindingToWatches(getWatches())
+}
+
+function resolutionKey(args: GitStatusRefBindingRequest): string {
+  return [
+    args.executionHostId,
+    args.connectionId ?? '',
+    args.providerGeneration ?? 0,
+    args.worktreeId,
+    args.worktreePath,
+    args.branch,
+    args.upstreamName
+  ].join('\0')
+}
+
+export function updateActiveGitStatusRefBinding(
+  args: GitStatusRefBindingRequest,
+  getWatches: () => Iterable<GitStatusRefWatchTarget>,
+  resolveUpstreamRef: (signal: AbortSignal) => Promise<string | undefined>
+): Promise<void> {
+  if (!args.branch || !args.upstreamName) {
+    clearResolutionForWorktree(args.worktreeId, getWatches)
+    return Promise.resolve()
+  }
+
+  const key = resolutionKey(args)
+  if (activeResolution?.key === key && activeResolution.retryAt > Date.now()) {
+    applyBindingToWatches(getWatches())
+    return activeResolution.promise
+  }
+
+  activeResolution?.controller.abort()
+  activeBinding = null
+  applyBindingToWatches(getWatches())
+
+  const controller = new AbortController()
+  const resolution = {
+    key,
+    worktreeId: args.worktreeId,
+    repoId: getRepoIdFromWorktreeId(args.worktreeId),
+    ...(args.connectionId ? { connectionId: args.connectionId } : {}),
+    controller,
+    promise: Promise.resolve(),
+    retryAt: Number.POSITIVE_INFINITY
+  }
+  resolution.promise = Promise.resolve()
+    .then(() => resolveUpstreamRef(controller.signal))
+    .then((upstreamRef) => {
+      if (activeResolution !== resolution) {
+        return
+      }
+      activeBinding =
+        upstreamRef && isSafeGitStatusUpstreamRef(upstreamRef)
+          ? {
+              worktreeId: args.worktreeId,
+              repoId: getRepoIdFromWorktreeId(args.worktreeId),
+              ...(args.connectionId ? { connectionId: args.connectionId } : {}),
+              upstreamRef
+            }
+          : null
+      applyBindingToWatches(getWatches())
+    })
+    .catch(() => {
+      if (activeResolution === resolution && !controller.signal.aborted) {
+        resolution.retryAt = Date.now() + FAILED_RESOLUTION_RETRY_MS
+      }
+    })
+  activeResolution = resolution
+  return resolution.promise
+}
+
+export function invalidateActiveGitStatusRefResolution(
+  changedWatch: GitStatusRefWatchTarget,
+  getWatches: () => Iterable<GitStatusRefWatchTarget>
+): void {
+  if (!activeResolution || !watchMatchesResolution(changedWatch, activeResolution)) {
+    return
+  }
+  activeResolution.controller.abort()
+  activeResolution = null
+  activeBinding = null
+  applyBindingToWatches(getWatches())
+}
+
+export function invalidateGitStatusRefResolutionForPaths(
+  changedWatch: GitStatusRefWatchTarget,
+  paths: (string | undefined)[],
+  getWatches: () => Iterable<GitStatusRefWatchTarget>
+): void {
+  const configChanged = paths.some((path) => {
+    if (!path || changedWatch.kind !== 'git-common') {
+      return false
+    }
+    const parts = pathRelativeToWorktreeWatchRoot(changedWatch.path, path)
+    return parts?.length === 1 && parts[0] === 'config'
+  })
+  if (configChanged) {
+    invalidateActiveGitStatusRefResolution(changedWatch, getWatches)
+  }
+}
+
+export function clearActiveGitStatusRefBinding(): void {
+  activeResolution?.controller.abort()
+  activeResolution = null
+  activeBinding = null
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2885,6 +2885,14 @@ export type PreloadApi = {
       requestToken?: string
     }) => Promise<GitStatusResult>
     cancelStatus: (args: { requestToken: string }) => Promise<void>
+    setStatusUpstreamRefWatch: (args: {
+      worktreeId: string
+      worktreePath: string
+      executionHostId: string
+      connectionId?: string
+      branch?: string
+      upstreamName?: string
+    }) => Promise<void>
     submoduleStatus: (args: {
       worktreePath: string
       submodulePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3215,6 +3215,14 @@ const api = {
     }): Promise<unknown> => ipcRenderer.invoke('git:status', args),
     cancelStatus: (args: { requestToken: string }): Promise<void> =>
       ipcRenderer.invoke('git:cancelStatus', args),
+    setStatusUpstreamRefWatch: (args: {
+      worktreeId: string
+      worktreePath: string
+      executionHostId: string
+      connectionId?: string
+      branch?: string
+      upstreamName?: string
+    }): Promise<void> => ipcRenderer.invoke('git:setStatusUpstreamRefWatch', args),
     submoduleStatus: (args: {
       worktreePath: string
       submodulePath: string

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.test.ts
@@ -311,17 +311,40 @@ describe('refreshGitStatusForWorktree', () => {
     }
     vi.stubGlobal('window', { api: { git: { status: vi.fn().mockResolvedValue(status) } } })
     const deps = makeDeps()
+    const onStatusAccepted = vi.fn()
 
     await refreshGitStatusForWorktree({
       worktreeId: 'wt-stale',
       worktreePath: '/repo',
       deps,
-      request: { shouldApply: () => false }
+      request: { shouldApply: () => false, onStatusAccepted }
     })
 
     expect(deps.setGitStatus).not.toHaveBeenCalled()
     expect(deps.updateWorktreeGitIdentity).not.toHaveBeenCalled()
     expect(deps.fetchUpstreamStatus).not.toHaveBeenCalled()
+    expect(onStatusAccepted).not.toHaveBeenCalled()
+  })
+
+  it('publishes upstream watch identity only after accepting the status result', async () => {
+    const status: GitStatusResult = {
+      entries: [],
+      conflictOperation: 'unknown',
+      upstreamStatus: { hasUpstream: true, upstreamName: 'origin/feature', ahead: 0, behind: 0 }
+    }
+    vi.stubGlobal('window', { api: { git: { status: vi.fn().mockResolvedValue(status) } } })
+    const deps = makeDeps()
+    const onStatusAccepted = vi.fn()
+
+    await refreshGitStatusForWorktree({
+      worktreeId: 'wt-current',
+      worktreePath: '/repo',
+      deps,
+      request: { shouldApply: () => true, onStatusAccepted }
+    })
+
+    expect(onStatusAccepted).toHaveBeenCalledOnce()
+    expect(onStatusAccepted).toHaveBeenCalledWith(status)
   })
 
   it('does not let an older automatic explicit upstream fetch overwrite a strict result', async () => {

--- a/src/renderer/src/components/right-sidebar/git-status-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/git-status-refresh.ts
@@ -117,6 +117,7 @@ export async function refreshGitStatusForWorktree({
     reuseLineStats?: boolean
     signal?: AbortSignal
     shouldApply?: () => boolean
+    onStatusAccepted?: (status: GitStatusResult) => void
   }
 }): Promise<void> {
   const refreshOrder = beginAutomaticUpstreamRefresh(worktreeId)
@@ -149,6 +150,7 @@ export async function refreshGitStatusForWorktree({
       // explicit clear signal so stale branch names don't linger in the UI.
       branch: status.branch ?? (status.head ? null : undefined)
     })
+    request?.onStatusAccepted?.(status)
     if (pushTarget) {
       // Why: porcelain status reports Git's configured upstream. Source Control
       // actions for PR-created worktrees must instead reconcile with Orca's

--- a/src/renderer/src/components/right-sidebar/use-git-status-upstream-ref-watch.test.ts
+++ b/src/renderer/src/components/right-sidebar/use-git-status-upstream-ref-watch.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as React from 'react'
+
+const { runtimeState, setWatch } = vi.hoisted(() => ({
+  runtimeState: { environmentId: null as string | null },
+  setWatch: vi.fn(async () => {})
+}))
+let cleanup: (() => void) | undefined
+
+vi.mock('@/runtime/runtime-git-client', () => ({
+  setRuntimeGitStatusUpstreamRefWatch: setWatch
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: () => null
+}))
+
+vi.mock('./file-explorer-runtime-owner', () => ({
+  getRightSidebarWorktreeRuntimeSettings: () => ({
+    activeRuntimeEnvironmentId: runtimeState.environmentId
+  })
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof React>('react')
+  return {
+    ...actual,
+    useCallback: (callback: unknown) => callback,
+    useEffect: (effect: () => void | (() => void)) => {
+      cleanup = effect() ?? undefined
+    }
+  }
+})
+
+import { useGitStatusUpstreamRefWatch } from './use-git-status-upstream-ref-watch'
+
+describe('useGitStatusUpstreamRefWatch', () => {
+  beforeEach(() => {
+    setWatch.mockClear()
+    runtimeState.environmentId = null
+    cleanup = undefined
+  })
+
+  it('clears a local binding with the runtime scope that created it', () => {
+    useGitStatusUpstreamRefWatch({
+      enabled: true,
+      executionHostId: 'local',
+      worktreeId: 'repo-1::/repo',
+      worktreePath: '/repo'
+    })
+
+    runtimeState.environmentId = 'runtime-1'
+    cleanup?.()
+
+    expect(setWatch).toHaveBeenCalledWith(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'repo-1::/repo',
+        worktreePath: '/repo',
+        connectionId: undefined
+      },
+      { executionHostId: 'local' }
+    )
+  })
+
+  it('publishes the accepted branch and upstream display identity', () => {
+    const publish = useGitStatusUpstreamRefWatch({
+      enabled: true,
+      executionHostId: 'ssh:ssh-1',
+      worktreeId: 'repo-1::/repo',
+      worktreePath: '/repo'
+    })
+
+    publish({
+      entries: [],
+      conflictOperation: 'unknown',
+      branch: 'refs/heads/feature/local',
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'team/fork/feature/local',
+        ahead: 0,
+        behind: 0
+      }
+    })
+
+    expect(setWatch).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'repo-1::/repo', worktreePath: '/repo' }),
+      {
+        executionHostId: 'ssh:ssh-1',
+        branch: 'refs/heads/feature/local',
+        upstreamName: 'team/fork/feature/local'
+      }
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-git-status-upstream-ref-watch.ts
+++ b/src/renderer/src/components/right-sidebar/use-git-status-upstream-ref-watch.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect } from 'react'
+import { getConnectionId } from '@/lib/connection-context'
+import { setRuntimeGitStatusUpstreamRefWatch } from '@/runtime/runtime-git-client'
+import type { GitStatusResult } from '../../../../shared/types'
+import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-owner'
+
+export function useGitStatusUpstreamRefWatch(args: {
+  enabled: boolean
+  executionHostId: string | null | undefined
+  worktreeId: string | null
+  worktreePath: string | null
+}): (status: GitStatusResult) => void {
+  const runtimeEnvironmentId = args.worktreeId
+    ? getRightSidebarWorktreeRuntimeSettings(args.worktreeId).activeRuntimeEnvironmentId
+    : null
+  const connectionId = args.worktreeId ? (getConnectionId(args.worktreeId) ?? undefined) : undefined
+  const scope =
+    args.enabled && args.executionHostId
+      ? `${args.executionHostId}\0${runtimeEnvironmentId}\0${args.worktreeId}\0${args.worktreePath}`
+      : null
+
+  const publish = useCallback(
+    (status: GitStatusResult): void => {
+      if (!scope || !args.executionHostId || !args.worktreeId || !args.worktreePath) {
+        return
+      }
+      const upstreamName = status.upstreamStatus?.hasUpstream
+        ? status.upstreamStatus.upstreamName
+        : undefined
+      void setRuntimeGitStatusUpstreamRefWatch(
+        {
+          settings: { activeRuntimeEnvironmentId: runtimeEnvironmentId },
+          worktreeId: args.worktreeId,
+          worktreePath: args.worktreePath,
+          connectionId
+        },
+        {
+          executionHostId: args.executionHostId,
+          ...(status.branch ? { branch: status.branch } : {}),
+          ...(upstreamName ? { upstreamName } : {})
+        }
+      ).catch(() => {})
+    },
+    [
+      args.executionHostId,
+      args.worktreeId,
+      args.worktreePath,
+      connectionId,
+      runtimeEnvironmentId,
+      scope
+    ]
+  )
+
+  useEffect(() => {
+    if (!scope || !args.executionHostId || !args.worktreeId || !args.worktreePath) {
+      return
+    }
+    const executionHostId = args.executionHostId
+    const worktreeId = args.worktreeId
+    const worktreePath = args.worktreePath
+    return () => {
+      void setRuntimeGitStatusUpstreamRefWatch(
+        {
+          settings: { activeRuntimeEnvironmentId: runtimeEnvironmentId },
+          worktreeId,
+          worktreePath,
+          connectionId
+        },
+        { executionHostId }
+      ).catch(() => {})
+    }
+  }, [
+    args.executionHostId,
+    args.worktreeId,
+    args.worktreePath,
+    connectionId,
+    runtimeEnvironmentId,
+    scope
+  ])
+
+  return publish
+}

--- a/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
+++ b/src/renderer/src/components/right-sidebar/useGitStatusPolling.ts
@@ -14,6 +14,7 @@ import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-
 import { useGitStatusFileWatchRefresh } from './git-status-file-watch-refresh'
 import { useGitStatusPushSignalRefresh } from './git-status-push-signal-refresh'
 import { useStaleConflictOperationPolling } from './stale-conflict-operation-poll'
+import { useGitStatusUpstreamRefWatch } from './use-git-status-upstream-ref-watch'
 import {
   createGitStatusRefreshPacing,
   createGitStatusRefreshScheduler,
@@ -102,6 +103,13 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
     activeGitStatusPollingArgs
   )
 
+  const publishUpstreamRefWatch = useGitStatusUpstreamRefWatch({
+    enabled: canFetchActiveWorktreeGitStatus,
+    executionHostId: activeExecutionHostId,
+    worktreeId: activeWorktreeId,
+    worktreePath
+  })
+
   const runFetchStatus = useCallback(
     async (request: {
       reason: GitStatusRefreshReason
@@ -121,8 +129,9 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
       }
       try {
         const connectionId = getConnectionId(activeWorktreeId) ?? undefined
+        const runtimeSettings = getRightSidebarWorktreeRuntimeSettings(activeWorktreeId)
         await refreshGitStatusForWorktree({
-          settings: getRightSidebarWorktreeRuntimeSettings(activeWorktreeId),
+          settings: runtimeSettings,
           worktreeId: activeWorktreeId,
           worktreePath,
           connectionId,
@@ -136,7 +145,8 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
           request: {
             ...(request.reason === 'safety' ? { reuseLineStats: true } : {}),
             signal: request.signal,
-            shouldApply: request.shouldApply
+            shouldApply: request.shouldApply,
+            onStatusAccepted: publishUpstreamRefWatch
           }
         })
       } catch {
@@ -148,6 +158,7 @@ export function useGitStatusPolling(options: { enabled?: boolean } = {}): void {
       activeWorktreeId,
       fetchUpstreamStatus,
       canFetchActiveWorktreeGitStatus,
+      publishUpstreamRefWatch,
       worktreePath,
       setGitStatus,
       setUpstreamStatus,

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -180,6 +180,24 @@ export async function getRuntimeGitStatus(
   )
 }
 
+export async function setRuntimeGitStatusUpstreamRefWatch(
+  context: RuntimeGitContext,
+  args: { executionHostId: string; branch?: string; upstreamName?: string }
+): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind !== 'local' || !context.worktreeId) {
+    return
+  }
+  await window.api.git.setStatusUpstreamRefWatch({
+    worktreeId: context.worktreeId,
+    worktreePath: resolveLocalWorktreePath(context),
+    executionHostId: args.executionHostId,
+    ...(context.connectionId ? { connectionId: context.connectionId } : {}),
+    ...(args.branch ? { branch: args.branch } : {}),
+    ...(args.upstreamName ? { upstreamName: args.upstreamName } : {})
+  })
+}
+
 let nextGitStatusRequestToken = 0
 
 function createGitStatusAbortError(): Error {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1991,6 +1991,7 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
     cancelStatus: async ({ requestToken }) => {
       webGitStatusAbortControllers.get(requestToken)?.abort()
     },
+    setStatusUpstreamRefWatch: async () => {},
     submoduleStatus: async ({ worktreePath, submodulePath, area }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       return callRuntimeResult('git.submoduleStatus', {

--- a/src/shared/git-status-upstream-ref.test.ts
+++ b/src/shared/git-status-upstream-ref.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isSafeGitRefName, isSafeGitStatusUpstreamRef } from './git-status-upstream-ref'
+
+describe('git status upstream refs', () => {
+  it('accepts exact remote and custom upstream namespaces', () => {
+    expect(isSafeGitStatusUpstreamRef('refs/remotes/team/fork/feature/nested')).toBe(true)
+    expect(isSafeGitStatusUpstreamRef('refs/custom/origin/main')).toBe(true)
+    expect(isSafeGitStatusUpstreamRef('refs/tracking/main')).toBe(true)
+    expect(isSafeGitStatusUpstreamRef('refs/tracked-main')).toBe(true)
+  })
+
+  it('recognizes local branch refs without accepting them for dynamic status polling', () => {
+    expect(isSafeGitRefName('refs/heads/feature/base')).toBe(true)
+    expect(isSafeGitStatusUpstreamRef('refs/heads/feature/base')).toBe(false)
+    expect(isSafeGitStatusUpstreamRef('refs/worktree/feature/base')).toBe(false)
+  })
+
+  it.each([
+    'refs/heads/main',
+    '/refs/remotes/origin/main',
+    'refs/remotes/origin/../main',
+    'refs/remotes/origin/main.lock',
+    'refs/remotes/origin/feature\\escape',
+    'refs/remotes/origin/@{upstream}'
+  ])('rejects unsafe or non-remote ref %s', (ref) => {
+    expect(isSafeGitStatusUpstreamRef(ref)).toBe(false)
+  })
+})

--- a/src/shared/git-status-upstream-ref.ts
+++ b/src/shared/git-status-upstream-ref.ts
@@ -1,0 +1,45 @@
+const REF_PREFIX = 'refs/'
+const LOCAL_BRANCH_REF_PREFIX = 'refs/heads/'
+const WORKTREE_REF_PREFIXES = ['refs/bisect/', 'refs/rewritten/', 'refs/worktree/']
+const FORBIDDEN_REF_CHARS = '~^:?*[\\'
+
+function hasForbiddenRefChar(ref: string): boolean {
+  for (const char of ref) {
+    const code = char.charCodeAt(0)
+    if (code <= 0x20 || code === 0x7f || FORBIDDEN_REF_CHARS.includes(char)) {
+      return true
+    }
+  }
+  return false
+}
+
+export function isSafeGitRefName(ref: string): boolean {
+  if (!ref.startsWith(REF_PREFIX) || ref.endsWith('/')) {
+    return false
+  }
+  if (ref.includes('..') || ref.includes('@{') || hasForbiddenRefChar(ref)) {
+    return false
+  }
+  const parts = ref.split('/')
+  return (
+    parts.length >= 2 &&
+    parts.every(
+      (part) =>
+        part.length > 0 &&
+        part !== '.' &&
+        part !== '..' &&
+        !part.startsWith('.') &&
+        !part.endsWith('.') &&
+        !part.endsWith('.lock')
+    )
+  )
+}
+
+export function isSafeGitStatusUpstreamRef(ref: string): boolean {
+  return (
+    isSafeGitRefName(ref) &&
+    ref !== 'refs/heads' &&
+    !ref.startsWith(LOCAL_BRANCH_REF_PREFIX) &&
+    !WORKTREE_REF_PREFIXES.some((prefix) => ref === prefix.slice(0, -1) || ref.startsWith(prefix))
+  )
+}


### PR DESCRIPTION
## Summary

Git pushes can update only common-Git-dir metadata, leaving the worktree itself untouched. Orca therefore missed two important cases when no interactive OSC-133 command boundary was available: an external or agent-driven first `git push -u`, and later plain `git push` operations on an already-tracked branch.

This change closes both gaps:

- Poll the common `.git/config` as fixed metadata so a first `push -u` refreshes status when Git writes `branch.<name>.remote` and `.merge`.
- After an accepted status result for the active worktree, pass the full branch/upstream identity to main and resolve the exact remote-tracking ref through Git's configured refspec mapping.
- Bind that one exact ref as a transient stat leaf on the existing common-dir watcher. Create, update, and delete all produce the existing debounced status signal; rebinding establishes a silent baseline.
- On SSH, filter the existing recursive event stream to the same exact ref path instead of adding polling or protocol fan-out.

This handles agent tool-subprocess pushes, external shells, custom fetch refspecs, slash-containing remote names, worktree/config/HEAD changes, and watcher replacement. Ambiguous overrides, local-only upstreams, stale provider generations, cleanup races, and folder/runtime contexts fail closed.

## Performance and scope

- No recursive local `refs/remotes` watch.
- No reftable or packed-ref scanning.
- One fixed `config` stat per common-dir poll plus at most one dynamic upstream-ref stat for the active worktree.
- Only the active worktree owns a binding; unrelated remote refs remain silent.
- Existing per-target debounce and overflow invalidation behavior remains intact.

The Git commands and options used remain compatible with the Git 2.25 baseline. Paths are normalized through Node path handling for macOS, Linux, Windows/WSL, and SSH hosts.

## Electron QA

Validated in the development Electron app against this PR branch. Before an external shell push, Source Control showed `↑1` against the configured upstream and `↑2` against `origin/main`:

![Before external push: upstream ahead by one](https://github.com/user-attachments/assets/9c9a0956-c27e-4f0c-a0ba-f68eb254aa29)

After a raw external `git push`, the upstream `↑1` and Push action cleared automatically within five seconds, while the unrelated `origin/main` comparison correctly remained `↑2`:

![After external push: upstream synchronized automatically](https://github.com/user-attachments/assets/df7f44ae-5c89-4bfd-8115-ad188e768348)

## Testing

- [x] 83 focused status/upstream/watcher tests
- [x] Full Node, CLI, and web typecheck
- [x] Full lint, reliability, max-lines, and localization checks
- [x] `git diff --check`
- [x] Same-model senior review loop completed with a final `CLEAN` pass
- [x] Electron before/after validation of an external plain push

The expanded native watcher run passed 199/202 tests. The remaining three macOS narrow-watcher timing tests (`delivers instant add/update/remove without polling`, `arms via existence polling when the worktrees dir appears later`, and `keeps watching across worktrees dir delete and recreate`) reproduce independently in this environment; the mocked and newly added watcher paths pass.

## Security

The new IPC request is scoped to the active worktree and validated against accepted status identity and the currently executing Git host. Ref paths are resolved from Git/config data, contained within the expected common Git directory, and never treated as commands. No dependencies or provider-specific assumptions were added.
