### PR TITLE
chore(mobile): bump to 0.0.37 (versionCode 10)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.36",
+    "version": "0.0.37",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 9
+      "versionCode": 10
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
Completes the 0.0.37 Android release attempted this morning (run 30791649691 failed: `MOBILE_ANDROID_RELEASE_VERSION must match the committed mobile app version` — the bump was never committed).

0.0.37 ships the post-0.0.36 transport fixes verified live tonight on a physical device: released 0.0.36 pins the runtime session to the pairing-time LAN endpoint (e.g. a Tailscale address) and its relay recovery never engages, yielding the "Connected · Orca Relay" + flapping + silent "0 worktrees" cluster (orca#11714 reporters, Neil's report). Fixes on main since the 0.0.36 cut: #12344 resume-mid-dial redial, #11368 half-open socket recovery, #11465 handshake-gated reconnect accounting, #11690 pairing self-heal, #12235 catalog-failure surfacing.

Verification in progress: CI-built APK from main installing on a Samsung SM-S921W, relay-only (LAN endpoint unreachable, no Tailscale), against a production desktop via the production relay fleet. Merge after that passes; then dispatch mobile-android-release with publish enabled.