### PR TITLE
fix(rate-limits): resolve Kimi usage credentials from configured WSL runtime

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -177,6 +177,7 @@ import { RateLimitService } from './rate-limits/service'
 import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
+import { resolveKimiHomePath } from './rate-limits/kimi-home-path'
 import { createAccountRuntimeTargetSettingsSync } from './rate-limits/account-runtime-target-sync'
 import {
   attachMainWindowServices,
@@ -2196,6 +2197,9 @@ void app.whenReady().then(async () => {
   rateLimits.setCodexHomePathResolver((target) =>
     codexRuntimeHome!.prepareForRateLimitFetch(target)
   )
+  // Why: Kimi Code running inside WSL rotates the WSL-side credentials file, so
+  // quota polls must read the configured runtime target's home, not the host's.
+  rateLimits.setKimiHomePathResolver(() => resolveKimiHomePath(store!.getSettings()))
   rateLimits.setCodexFetchTarget(getInitialCodexRateLimitTarget(store.getSettings()))
   rateLimits.setClaudeFetchTarget(getInitialClaudeRateLimitTarget(store.getSettings()))
   const syncAccountRuntimeTargets = createAccountRuntimeTargetSettingsSync(

--- a/src/main/rate-limits/kimi-fetcher.test.ts
+++ b/src/main/rate-limits/kimi-fetcher.test.ts
@@ -1,28 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const netFetchMock = vi.hoisted(() => vi.fn())
-const fsState = vi.hoisted<{ credentials: string | null; readError: Error | null }>(() => ({
+const fsState = vi.hoisted<{
+  credentials: string | null
+  readError: Error | null
+  readPaths: string[]
+}>(() => ({
   credentials: null,
-  readError: null
+  readError: null,
+  readPaths: []
 }))
 
 vi.mock('electron', () => ({
   net: { fetch: netFetchMock }
 }))
 
-vi.mock('node:fs', () => ({
-  existsSync: () => fsState.credentials !== null,
-  readFileSync: () => {
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => {
+    fsState.readPaths.push(String(path))
     if (fsState.readError) {
       throw fsState.readError
     }
     if (fsState.credentials === null) {
-      throw new Error('ENOENT')
+      const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
     }
     return fsState.credentials
-  },
-  writeFileSync: () => {},
-  renameSync: () => {}
+  }
 }))
 
 vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
@@ -60,6 +65,7 @@ describe('fetchKimiRateLimits', () => {
     netFetchMock.mockReset()
     fsState.credentials = null
     fsState.readError = null
+    fsState.readPaths = []
   })
 
   afterEach(() => {
@@ -141,6 +147,71 @@ describe('fetchKimiRateLimits', () => {
     expect(result.status).toBe('error')
     expect(result.error).toMatch(/expired/i)
     expect(result.error).toMatch(/run kimi on the computer running Orca/i)
+    expect(result.usageMetadata).toEqual({
+      failureKind: 'delegated-refresh-required',
+      source: 'oauth'
+    })
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reads host credentials from ~/.kimi-code by default', async () => {
+    fsState.credentials = freshCredentials()
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    const result = await fetchKimiRateLimits()
+
+    expect(result.status).toBe('ok')
+    expect(fsState.readPaths).toEqual(['/home/test/.kimi-code/credentials/kimi-code.json'])
+  })
+
+  it('honors KIMI_CODE_HOME when no home path override is given', async () => {
+    vi.stubEnv('KIMI_CODE_HOME', '/custom/kimi-home')
+    fsState.credentials = freshCredentials()
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    const result = await fetchKimiRateLimits()
+
+    expect(result.status).toBe('ok')
+    expect(fsState.readPaths).toEqual(['/custom/kimi-home/credentials/kimi-code.json'])
+  })
+
+  it('reads credentials over the UNC path when given a WSL home', async () => {
+    fsState.credentials = freshCredentials()
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    const result = await fetchKimiRateLimits({
+      kimiHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\cengiz\\.kimi-code'
+    })
+
+    expect(result.status).toBe('ok')
+    expect(fsState.readPaths).toEqual([
+      '\\\\wsl.localhost\\Ubuntu\\home\\cengiz\\.kimi-code\\credentials\\kimi-code.json'
+    ])
+  })
+
+  it('reports unavailable when the WSL home has no credentials file', async () => {
+    const result = await fetchKimiRateLimits({
+      kimiHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\cengiz\\.kimi-code'
+    })
+
+    expect(result.status).toBe('unavailable')
+    expect(result.error).toMatch(/Not signed in/)
+    expect(fsState.readPaths).toEqual([
+      '\\\\wsl.localhost\\Ubuntu\\home\\cengiz\\.kimi-code\\credentials\\kimi-code.json'
+    ])
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('points at the WSL distro when the WSL-side token is expired', async () => {
+    fsState.credentials = JSON.stringify({ access_token: 'tok-old', expires_at: 1 })
+
+    const result = await fetchKimiRateLimits({
+      kimiHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\cengiz\\.kimi-code'
+    })
+
+    expect(result.status).toBe('error')
+    expect(result.error).toMatch(/expired/i)
+    expect(result.error).toMatch(/WSL distro Ubuntu/)
     expect(result.usageMetadata).toEqual({
       failureKind: 'delegated-refresh-required',
       source: 'oauth'

--- a/src/main/rate-limits/kimi-fetcher.ts
+++ b/src/main/rate-limits/kimi-fetcher.ts
@@ -1,12 +1,17 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 as pathWin32 } from 'node:path'
 import { net } from 'electron'
 import type {
   ProviderRateLimits,
   RateLimitWindow,
   UsageRateLimitMetadata
 } from '../../shared/rate-limit-types'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  createAuthFilesystemOperation,
+  type SharedAuthFilesystemOperation
+} from './auth-filesystem-operation'
 
 // Why: Kimi Code's managed coding plan exposes subscription usage at
 // `${base}/usages` (see packages/oauth/src/managed-usage.ts in the CLI bundle).
@@ -18,14 +23,24 @@ const API_TIMEOUT_MS = 10_000
 const SESSION_WINDOW_MINUTES = 300 // 5h
 const WEEKLY_WINDOW_MINUTES = 10080 // 7d
 
-function getKimiHome(): string {
-  // Why: match the CLI's `KIMI_CODE_HOME ?? ~/.kimi-code` resolution so we read
-  // the same OAuth credentials the running Kimi CLI writes.
-  return process.env.KIMI_CODE_HOME ?? join(homedir(), '.kimi-code')
+export type FetchKimiRateLimitsOptions = {
+  // Why: a WSL runtime target points at the distro's ~/.kimi-code via its UNC
+  // path; null keeps the host KIMI_CODE_HOME / ~/.kimi-code resolution.
+  kimiHomePath?: string | null
 }
 
-function getCredentialsPath(): string {
-  return join(getKimiHome(), 'credentials', 'kimi-code.json')
+function getKimiHome(kimiHomePath?: string | null): string {
+  // Why: match the CLI's `KIMI_CODE_HOME ?? ~/.kimi-code` resolution so we read
+  // the same OAuth credentials the running Kimi CLI writes.
+  return kimiHomePath ?? process.env.KIMI_CODE_HOME ?? join(homedir(), '.kimi-code')
+}
+
+function getCredentialsPath(kimiHomePath?: string | null): string {
+  const home = getKimiHome(kimiHomePath)
+  // Why: UNC paths need win32 joining so the result stays a valid \\wsl$ path.
+  return parseWslUncPath(home)
+    ? pathWin32.join(home, 'credentials', 'kimi-code.json')
+    : join(home, 'credentials', 'kimi-code.json')
 }
 
 type KimiCredentials = {
@@ -52,22 +67,63 @@ function parseCredentials(value: unknown): KimiCredentials | null {
   return credentials
 }
 
-function readCredentials(): CredentialsReadResult {
-  const path = getCredentialsPath()
-  if (!existsSync(path)) {
-    return { status: 'missing' }
+const credentialsReadByPath = new Map<
+  string,
+  SharedAuthFilesystemOperation<CredentialsReadResult>
+>()
+
+function credentialsErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message
   }
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
-    const credentials = parseCredentials(parsed)
-    return credentials
-      ? { status: 'ok', credentials }
-      : { status: 'error', error: 'Kimi credentials file is invalid' }
-  } catch (err) {
-    return {
-      status: 'error',
-      error: err instanceof Error ? err.message : 'Unable to read Kimi credentials'
+  // Why: AbortSignal timeouts reject with a DOMException, not an Error.
+  const message = (err as { message?: unknown } | null)?.message
+  return typeof message === 'string' ? message : 'Unable to read Kimi credentials'
+}
+
+function getCredentialsRead(path: string): SharedAuthFilesystemOperation<CredentialsReadResult> {
+  const existing = credentialsReadByPath.get(path)
+  if (existing) {
+    return existing
+  }
+  // Why: dedupe UNC reads because Node cannot cancel an in-flight read
+  // (mirrors codex-fetcher's backend auth read).
+  const read = createAuthFilesystemOperation(path, async (): Promise<CredentialsReadResult> => {
+    let raw: string
+    try {
+      raw = await readFile(path, 'utf-8')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException | null)?.code === 'ENOENT') {
+        return { status: 'missing' }
+      }
+      return { status: 'error', error: credentialsErrorMessage(err) }
     }
+    try {
+      const credentials = parseCredentials(JSON.parse(raw))
+      return credentials
+        ? { status: 'ok', credentials }
+        : { status: 'error', error: 'Kimi credentials file is invalid' }
+    } catch (err) {
+      return { status: 'error', error: credentialsErrorMessage(err) }
+    }
+  })
+  credentialsReadByPath.set(path, read)
+  const clearRead = (): void => {
+    if (credentialsReadByPath.get(path) === read) {
+      credentialsReadByPath.delete(path)
+    }
+  }
+  void read.result.then(clearRead, clearRead)
+  return read
+}
+
+async function readCredentials(path: string): Promise<CredentialsReadResult> {
+  try {
+    // Why: a disconnected WSL distro can stall a UNC read; bound it so the
+    // poll degrades to an error instead of hanging the fetch cycle.
+    return await getCredentialsRead(path).wait(AbortSignal.timeout(API_TIMEOUT_MS))
+  } catch (err) {
+    return { status: 'error', error: credentialsErrorMessage(err) }
   }
 }
 
@@ -231,16 +287,23 @@ function result(
 /**
  * Read-only subscription usage for Kimi Code.
  *
- * Why read-only: the access token lives in `~/.kimi-code/credentials/kimi-code.json`
+ * Why read-only: the access token lives in `<kimi home>/credentials/kimi-code.json`
  * and is refreshed by the Kimi CLI itself (15-min TTL, refresh-token rotation).
  * Orca must NEVER refresh or rewrite that file — a rotated refresh token would
  * log out a live `kimi` session. We only read the current token and call the
  * same `GET /usages` endpoint, with the same headers, that the CLI's own
  * `/usage` command uses. The completion endpoint (the one Moonshot gates to
  * approved coding agents) is never touched here.
+ *
+ * The Kimi home follows the configured local-account runtime target: host reads
+ * `KIMI_CODE_HOME ?? ~/.kimi-code`; a WSL target reads the distro's home over
+ * its `\\wsl$\<distro>` UNC path (the CLI running inside WSL rotates that copy).
  */
-export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
-  const readResult = readCredentials()
+export async function fetchKimiRateLimits(
+  options?: FetchKimiRateLimitsOptions
+): Promise<ProviderRateLimits> {
+  const credentialsPath = getCredentialsPath(options?.kimiHomePath)
+  const readResult = await readCredentials(credentialsPath)
   if (readResult.status === 'missing') {
     return result('unavailable', 'Not signed in to Kimi Code')
   }
@@ -255,9 +318,12 @@ export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
     // Why: don't refresh — the CLI owns the token lifecycle. Report a transient
     // error so the rate-limit service keeps the last good snapshot (stale
     // policy) until the user next runs Kimi and the CLI refreshes the file.
+    const wslInfo = parseWslUncPath(credentialsPath)
     return result(
       'error',
-      'Kimi session expired — run kimi on the computer running Orca, then retry usage.',
+      wslInfo
+        ? `Kimi session expired — run kimi inside WSL distro ${wslInfo.distro}, then retry usage.`
+        : 'Kimi session expired — run kimi on the computer running Orca, then retry usage.',
       { failureKind: 'delegated-refresh-required', source: 'oauth' }
     )
   }

--- a/src/main/rate-limits/kimi-home-path.test.ts
+++ b/src/main/rate-limits/kimi-home-path.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../shared/constants'
+import type { GlobalSettings } from '../../shared/types'
+
+const wslState = vi.hoisted<{ home: string | null; defaultDistro: string | null }>(() => ({
+  home: null,
+  defaultDistro: null
+}))
+
+vi.mock('../wsl', () => ({
+  getWslHome: vi.fn(() => wslState.home),
+  getDefaultWslDistro: vi.fn(() => wslState.defaultDistro)
+}))
+
+import { resolveKimiHomePath } from './kimi-home-path'
+
+const WSL_HOME_UNC = '\\\\wsl.localhost\\Ubuntu\\home\\cengiz'
+
+function settings(overrides: Partial<GlobalSettings>): GlobalSettings {
+  return { ...getDefaultSettings('/tmp'), ...overrides }
+}
+
+describe('resolveKimiHomePath', () => {
+  beforeEach(() => {
+    wslState.home = WSL_HOME_UNC
+    wslState.defaultDistro = 'Ubuntu'
+  })
+
+  it('resolves to the host default for a host runtime policy', () => {
+    const result = resolveKimiHomePath(settings({ localAccountRuntime: 'host' }), 'win32')
+
+    expect(result).toEqual({ runtime: 'host', wslDistro: null, homePath: null })
+  })
+
+  it('resolves the configured distro home over its UNC path for a WSL policy', () => {
+    const result = resolveKimiHomePath(
+      settings({ localAccountRuntime: 'wsl', localAccountWslDistro: 'Ubuntu' }),
+      'win32'
+    )
+
+    expect(result).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      homePath: `${WSL_HOME_UNC}\\.kimi-code`
+    })
+  })
+
+  it('falls back to the default distro when the WSL policy pins none', () => {
+    const result = resolveKimiHomePath(
+      settings({ localAccountRuntime: 'wsl', localAccountWslDistro: null }),
+      'win32'
+    )
+
+    expect(result).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      homePath: `${WSL_HOME_UNC}\\.kimi-code`
+    })
+  })
+
+  it('follows the global Windows runtime default for the auto policy', () => {
+    const result = resolveKimiHomePath(
+      settings({
+        localAccountRuntime: 'auto',
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+      }),
+      'win32'
+    )
+
+    expect(result.runtime).toBe('wsl')
+    expect(result.homePath).toBe(`${WSL_HOME_UNC}\\.kimi-code`)
+  })
+
+  it('resolves to the host default for the auto policy off Windows', () => {
+    const result = resolveKimiHomePath(
+      settings({
+        localAccountRuntime: 'auto',
+        localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+      }),
+      'darwin'
+    )
+
+    expect(result).toEqual({ runtime: 'host', wslDistro: null, homePath: null })
+  })
+
+  it('resolves to the host default for a WSL policy off Windows', () => {
+    const result = resolveKimiHomePath(
+      settings({ localAccountRuntime: 'wsl', localAccountWslDistro: 'Ubuntu' }),
+      'darwin'
+    )
+
+    expect(result).toEqual({ runtime: 'host', wslDistro: null, homePath: null })
+  })
+
+  it('reports an unresolvable WSL home as a null home path', () => {
+    wslState.home = null
+
+    const result = resolveKimiHomePath(
+      settings({ localAccountRuntime: 'wsl', localAccountWslDistro: 'Ubuntu' }),
+      'win32'
+    )
+
+    expect(result).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu', homePath: null })
+  })
+})

--- a/src/main/rate-limits/kimi-home-path.ts
+++ b/src/main/rate-limits/kimi-home-path.ts
@@ -1,0 +1,43 @@
+import { win32 as pathWin32 } from 'node:path'
+import type { GlobalSettings } from '../../shared/types'
+import { resolveLocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
+import { getDefaultWslDistro, getWslHome } from '../wsl'
+
+export type KimiHomePathResolution = {
+  runtime: 'host' | 'wsl'
+  wslDistro: string | null
+  // Why: null on host (the fetcher keeps its KIMI_CODE_HOME / ~/.kimi-code
+  // default) and when the WSL distro home cannot be resolved.
+  homePath: string | null
+}
+
+type KimiHomePathSettings = Pick<
+  GlobalSettings,
+  'localAccountRuntime' | 'localAccountWslDistro' | 'localWindowsRuntimeDefault'
+>
+
+/**
+ * Resolve the Kimi credentials home for the configured local-account runtime
+ * target, mirroring how Codex resolves its WSL home: the distro comes from the
+ * persisted target (falling back to the default distro) and the Linux home from
+ * the cached `echo $HOME` probe, read over its UNC path — never via wsl.exe.
+ */
+export function resolveKimiHomePath(
+  settings: KimiHomePathSettings,
+  platform: NodeJS.Platform = process.platform
+): KimiHomePathResolution {
+  const target = resolveLocalAccountRuntimeTarget(settings, platform)
+  // Why: an explicit 'wsl' policy only makes sense on Windows hosts; elsewhere
+  // resolveLocalAccountRuntimeTarget still returns it, so pin to host like
+  // getInitialCodexRateLimitTarget does.
+  if (target.runtime !== 'wsl' || platform !== 'win32') {
+    return { runtime: 'host', wslDistro: null, homePath: null }
+  }
+  const distro = target.wslDistro ?? getDefaultWslDistro()
+  const home = distro ? getWslHome(distro) : null
+  return {
+    runtime: 'wsl',
+    wslDistro: distro,
+    homePath: home ? pathWin32.join(home, '.kimi-code') : null
+  }
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1450,6 +1450,49 @@ describe('RateLimitService', () => {
     )
   })
 
+  it('passes the resolved WSL Kimi home into rate-limit fetches', async () => {
+    const service = new RateLimitService()
+    const wslKimiHome = '\\\\wsl.localhost\\Ubuntu\\home\\cengiz\\.kimi-code'
+    service.setKimiHomePathResolver(() => ({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      homePath: wslKimiHome
+    }))
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 0, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 0, Date.now()))
+
+    await serviceInternals(service).fetchAll()
+
+    expect(fetchKimiRateLimits).toHaveBeenCalledWith({ kimiHomePath: wslKimiHome })
+  })
+
+  it('surfaces an error instead of fetching when the WSL Kimi home is unavailable', async () => {
+    const service = new RateLimitService()
+    service.setKimiHomePathResolver(() => ({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      homePath: null
+    }))
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 0, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 0, Date.now()))
+
+    await serviceInternals(service).fetchAll()
+
+    expect(fetchKimiRateLimits).not.toHaveBeenCalled()
+    expect(service.getState().kimi?.status).toBe('error')
+    expect(service.getState().kimi?.error).toMatch(/WSL Kimi home unavailable for Ubuntu/)
+  })
+
+  it('fetches Kimi with the host default when no home path resolver is set', async () => {
+    const service = new RateLimitService()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 0, Date.now()))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 0, Date.now()))
+
+    await serviceInternals(service).fetchAll()
+
+    expect(fetchKimiRateLimits).toHaveBeenCalledWith({ kimiHomePath: null })
+  })
+
   it('reuses a caller-provided idempotency key when consuming a Codex reset credit', async () => {
     const service = new RateLimitService()
     const idempotencyKey = '11111111-1111-4111-8111-111111111111'

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -21,6 +21,7 @@ import {
 } from '../claude-accounts/runtime-selection'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
+import type { KimiHomePathResolution } from './kimi-home-path'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
@@ -38,6 +39,7 @@ export type InactiveCodexAccountInfo = {
 }
 
 type CodexHomePathResolver = (target?: CodexAccountSelectionTarget) => string | null
+type KimiHomePathResolver = () => KimiHomePathResolution
 type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
@@ -218,6 +220,7 @@ export class RateLimitService {
   private lastOpencodeConfigHash = ''
   private lastMiniMaxConfigHash = ''
   private codexHomePathResolver: CodexHomePathResolver | null = null
+  private kimiHomePathResolver: KimiHomePathResolver | null = null
   private codexFetchTarget: NormalizedCodexAccountSelectionTarget = {
     runtime: 'host',
     wslDistro: null
@@ -254,6 +257,10 @@ export class RateLimitService {
 
   setCodexHomePathResolver(resolver: CodexHomePathResolver): void {
     this.codexHomePathResolver = resolver
+  }
+
+  setKimiHomePathResolver(resolver: KimiHomePathResolver): void {
+    this.kimiHomePathResolver = resolver
   }
 
   setCodexFetchTarget(target?: CodexAccountSelectionTarget): void {
@@ -1294,6 +1301,22 @@ export class RateLimitService {
     }
   }
 
+  private getMissingWslKimiHomeResult(
+    resolution: KimiHomePathResolution
+  ): ProviderRateLimits | null {
+    if (resolution.runtime !== 'wsl' || resolution.homePath) {
+      return null
+    }
+    return {
+      provider: 'kimi',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: `WSL Kimi home unavailable for ${resolution.wslDistro ?? 'default distro'}`,
+      status: 'error'
+    }
+  }
+
   private async fetchCodexResetResultState(
     target: NormalizedCodexAccountSelectionTarget,
     codexHomePath: string | null,
@@ -1626,6 +1649,14 @@ export class RateLimitService {
     const missingWslCodexHome = codexHomePath
       ? null
       : this.getMissingWslCodexHomeResult(codexTarget)
+    // Why: Kimi has no account switcher, so its runtime target is re-resolved
+    // from settings on every poll instead of being tracked like codexFetchTarget.
+    const kimiHomePathResolution = this.kimiHomePathResolver?.() ?? {
+      runtime: 'host' as const,
+      wslDistro: null,
+      homePath: null
+    }
+    const missingWslKimiHome = this.getMissingWslKimiHomeResult(kimiHomePathResolution)
     const grokResultPromise = fetchGrokRateLimits({
       signal,
       authReadResult: grokAuthReadResult
@@ -1661,7 +1692,8 @@ export class RateLimitService {
           workspaceIdOverride || undefined,
           this.networkProxySettingsResolver?.()
         ),
-        fetchKimiRateLimits(),
+        missingWslKimiHome ??
+          fetchKimiRateLimits({ kimiHomePath: kimiHomePathResolution.homePath }),
         miniMaxConfigResult.error
           ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
           : fetchMiniMaxRateLimits({


### PR DESCRIPTION
## Summary

Fixes #12370.

On Windows hosts where Kimi Code runs inside WSL, the status bar permanently showed "Run Kimi to refresh": `fetchKimiRateLimits()` read OAuth credentials only from the host's `~/.kimi-code/credentials/kimi-code.json`, while the Kimi CLI inside WSL rotates the WSL-side copy every 15 minutes — so the host copy is always expired (`delegated-refresh-required`).

The Kimi fetcher now resolves its credentials home from the configured local-account runtime target, mirroring the existing Codex pattern:

- `kimi-home-path.ts` (new): `resolveKimiHomePath(settings)` — host policy keeps the fetcher's `KIMI_CODE_HOME ?? ~/.kimi-code` default; a WSL policy resolves the distro's home via the existing cached `getDefaultWslDistro()` / `getWslHome(distro)` probe and reads it over its `\\wsl.localhost\<distro>` UNC path. Off Windows the target pins to host, matching `getInitialCodexRateLimitTarget`.
- `kimi-fetcher.ts`: accepts `{ kimiHomePath? }`; the credentials read goes through `createAuthFilesystemOperation` with per-path in-flight dedup and a 10s bound (same UNC-read pattern as codex-fetcher's backend auth read), so a disconnected distro degrades to an error instead of hanging the poll. UNC paths are joined with `pathWin32`. Expired-token copy now says "run kimi inside WSL distro \<distro\>" for WSL reads.
- `service.ts` / `index.ts`: a `setKimiHomePathResolver` closure re-resolves the target from live settings on every poll (Kimi has no account switcher, so no `kimiFetchTarget` state tracking like Codex). An unresolvable WSL home yields an explicit `WSL Kimi home unavailable for \<distro\>` error instead of silently falling back to the stale host file — mirroring `getMissingWslCodexHomeResult`.

Failure semantics and the read-only guarantee are unchanged: Orca never refreshes or rewrites the credentials file; missing file → "Not signed in to Kimi Code", expired token → `delegated-refresh-required`.

## Screenshots

No visual change. (With the fix, the Kimi status-bar usage populates on WSL-runtime hosts instead of showing "Run Kimi to refresh"; no renderer code was touched.)

## Testing

- [ ] `pnpm lint` — not run in full; `oxlint` on all 7 changed files: 0 warnings/errors, plus `check-changed-code-quality.mjs` (0 new findings) and `check-max-lines-ratchet.mjs` (OK)
- [ ] `pnpm typecheck` — `typecheck:node` clean (change is main-process only)
- [ ] `pnpm test` — scoped run: `vitest run src/main/rate-limits` → 415/415 passed (30 files), including 95 tests in the 3 touched/added test files
- [ ] `pnpm build` — not run locally
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New/updated tests cover: host default unchanged, `KIMI_CODE_HOME` honored, WSL UNC path resolution, missing file in WSL home, expired token in WSL home (asserts WSL-distro copy + `delegated-refresh-required`), all `localAccountRuntime` policies incl. off-Windows pinning, unresolvable WSL home, and service wiring (resolver value passed through, missing-home short-circuit, no-resolver host default).

## AI Review Report

The diff was reviewed by an AI coding agent (Kimi Code) with focus on:

- **Cross-platform compatibility (macOS / Linux / Windows)**: the WSL branch is gated on `platform === 'win32'` (both in `resolveKimiHomePath` and via the pin-to-host guard matching `getInitialCodexRateLimitTarget`); on macOS/Linux the resolution always returns the host default and `getCredentialsPath` uses POSIX `join`. `pathWin32.join` is used only when `parseWslUncPath` confirms a UNC path, so host behavior on every platform is byte-identical to before. No shortcuts, labels, shell behavior, or Electron platform APIs were touched; no new `wsl.exe` invocations (file reads go over UNC, the distro/home probe reuses the existing cached `src/main/wsl.ts` helpers).
- **Regression risk**: host-path resolution order (`kimiHomePath ?? KIMI_CODE_HOME ?? ~/.kimi-code`) verified to preserve the previous default exactly when no resolver option is passed (covered by tests); sync → async credentials read converted all call sites (single exported fetcher, single caller in service).
- It flagged that the expired-token error copy was wrong for WSL ("on the computer running Orca") — fixed with a distro-specific message — and that an un-probed WSL home must not silently fall back to the stale host file — handled with an explicit error result.

## Security Audit

- **Auth/secrets**: the credentials file (contains access + refresh tokens) is still opened read-only; no token refresh, no writes, no logging of file contents. The access token is sent only as a Bearer header to the Kimi `/usages` HTTPS endpoint via electron `net.fetch`, exactly as before.
- **Path handling**: the WSL home path comes from the existing local `wsl.exe -- echo $HOME` probe in `src/main/wsl.ts` (local machine trust boundary, same as Codex usage), not from remote/IPC input. No path traversal surface: segments are fixed (`credentials/kimi-code.json`).
- **Command execution**: none added — no new spawned processes.
- **Input handling/DoS**: UNC reads are deduped per path and bounded by `AbortSignal.timeout(10s)` so a stalled WSL distro cannot exhaust the fs thread pool or hang the fetch cycle; JSON parse of the credentials file is wrapped and reports only generic messages (no content leakage into errors).
- **Dependencies/IPC**: no new dependencies, no IPC surface changes.

No follow-up required.

## Notes

- Windows + WSL only: behavior on macOS/Linux is unchanged by construction (pinned to host).
- The Grok fetcher shares the `delegated-refresh-required` pattern and reads auth host-only — it likely has the same WSL blind spot but was deliberately left out of scope; happy to follow up if maintainers want the same treatment there.
- Validated end-to-end reasoning against a live Win11 + WSL (Ubuntu) setup where the bug reproduced (host credentials expired, WSL credentials fresh); the fix makes the poll read the WSL copy that the running CLI actually rotates.