### PR TITLE
fix(mobile): native chat QA sweep — reconnect history, stale status, prompt-card and paging fixes (STA-3333)

### DIFF
--- a/mobile/src/session/MobileAgentWorkingIndicator.tsx
+++ b/mobile/src/session/MobileAgentWorkingIndicator.tsx
@@ -11,10 +11,13 @@ export function MobileAgentWorkingIndicator({
 }: {
   stale?: boolean
 }): React.JSX.Element {
+  const firstDot = useRef(new Animated.Value(0.3)).current
+  const secondDot = useRef(new Animated.Value(0.3)).current
+  const thirdDot = useRef(new Animated.Value(0.3)).current
   const dots = [
-    useRef(new Animated.Value(0.3)).current,
-    useRef(new Animated.Value(0.3)).current,
-    useRef(new Animated.Value(0.3)).current
+    { id: 'first', opacity: firstDot },
+    { id: 'second', opacity: secondDot },
+    { id: 'third', opacity: thirdDot }
   ]
 
   useEffect(() => {
@@ -25,8 +28,8 @@ export function MobileAgentWorkingIndicator({
       Animated.loop(
         Animated.sequence([
           Animated.delay(i * 160),
-          Animated.timing(dot, { toValue: 1, duration: 320, useNativeDriver: true }),
-          Animated.timing(dot, { toValue: 0.3, duration: 320, useNativeDriver: true })
+          Animated.timing(dot.opacity, { toValue: 1, duration: 320, useNativeDriver: true }),
+          Animated.timing(dot.opacity, { toValue: 0.3, duration: 320, useNativeDriver: true })
         ])
       )
     )
@@ -40,8 +43,8 @@ export function MobileAgentWorkingIndicator({
       <Text style={styles.label}>{stale ? 'Agent status stale' : 'Agent is working'}</Text>
       {stale ? null : (
         <View style={styles.dots}>
-          {dots.map((dot, i) => (
-            <Animated.View key={i} style={[styles.dot, { opacity: dot }]} />
+          {dots.map((dot) => (
+            <Animated.View key={dot.id} style={[styles.dot, { opacity: dot.opacity }]} />
           ))}
         </View>
       )}

--- a/mobile/src/session/MobileAgentWorkingIndicator.tsx
+++ b/mobile/src/session/MobileAgentWorkingIndicator.tsx
@@ -3,8 +3,14 @@ import { Animated, StyleSheet, Text, View } from 'react-native'
 import { colors, spacing, typography } from '../theme/mobile-theme'
 
 /** Animated three-dot "agent is working" row, shown while the active agent is
- *  still producing a reply. Pure presentation — visibility is the caller's call. */
-export function MobileAgentWorkingIndicator(): React.JSX.Element {
+ *  still producing a reply. Pure presentation — visibility is the caller's call.
+ *  `stale` mutes it while the transport is down: the state came from
+ *  pre-disconnect data and must not read as live activity. */
+export function MobileAgentWorkingIndicator({
+  stale = false
+}: {
+  stale?: boolean
+}): React.JSX.Element {
   const dots = [
     useRef(new Animated.Value(0.3)).current,
     useRef(new Animated.Value(0.3)).current,
@@ -12,6 +18,9 @@ export function MobileAgentWorkingIndicator(): React.JSX.Element {
   ]
 
   useEffect(() => {
+    if (stale) {
+      return
+    }
     const animations = dots.map((dot, i) =>
       Animated.loop(
         Animated.sequence([
@@ -24,16 +33,18 @@ export function MobileAgentWorkingIndicator(): React.JSX.Element {
     animations.forEach((a) => a.start())
     return () => animations.forEach((a) => a.stop())
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [stale])
 
   return (
-    <View style={styles.row}>
-      <Text style={styles.label}>Agent is working</Text>
-      <View style={styles.dots}>
-        {dots.map((dot, i) => (
-          <Animated.View key={i} style={[styles.dot, { opacity: dot }]} />
-        ))}
-      </View>
+    <View style={[styles.row, stale && styles.rowStale]}>
+      <Text style={styles.label}>{stale ? 'Agent status stale' : 'Agent is working'}</Text>
+      {stale ? null : (
+        <View style={styles.dots}>
+          {dots.map((dot, i) => (
+            <Animated.View key={i} style={[styles.dot, { opacity: dot }]} />
+          ))}
+        </View>
+      )}
     </View>
   )
 }
@@ -45,6 +56,9 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm
+  },
+  rowStale: {
+    opacity: 0.55
   },
   label: {
     color: colors.textMuted,

--- a/mobile/src/session/MobileNativeChatLoadEarlierHeader.tsx
+++ b/mobile/src/session/MobileNativeChatLoadEarlierHeader.tsx
@@ -1,0 +1,30 @@
+import { ActivityIndicator, Pressable, Text } from 'react-native'
+import { colors } from '../theme/mobile-theme'
+import { styles } from './mobile-native-chat-view-styles'
+
+/** "Load earlier messages" list header: spinner while a page is in flight, an
+ *  error + tap-to-retry affordance when the last page failed. */
+export function MobileNativeChatLoadEarlierHeader({
+  loadingEarlier,
+  loadEarlierError,
+  onLoadEarlier
+}: {
+  loadingEarlier?: boolean
+  loadEarlierError?: string | null
+  onLoadEarlier?: () => void
+}): React.JSX.Element {
+  return (
+    <Pressable style={styles.loadEarlier} onPress={onLoadEarlier} disabled={loadingEarlier}>
+      {loadingEarlier ? (
+        <ActivityIndicator size="small" color={colors.textMuted} />
+      ) : loadEarlierError ? (
+        <>
+          <Text style={styles.loadEarlierErrorText}>{loadEarlierError}</Text>
+          <Text style={styles.loadEarlierRetryText}>Tap to retry</Text>
+        </>
+      ) : (
+        <Text style={styles.loadEarlierText}>Load earlier messages</Text>
+      )}
+    </Pressable>
+  )
+}

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -2,6 +2,7 @@ import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { MAX_TOOL_RESULT_CHARS } from './mobile-native-chat-message-styles'
 
 vi.mock('react-native', async () => {
   const React = await import('react')
@@ -30,7 +31,7 @@ function userMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
   return { id: 'u1', role: 'user', blocks, timestamp: null, source: 'transcript' }
 }
 
-describe('MobileNativeChatMessage image-ref rendering', () => {
+describe('MobileNativeChatMessage', () => {
   let renderer: ReactTestRenderer | null = null
 
   beforeEach(() => {
@@ -41,7 +42,10 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     renderer = null
   })
 
-  function render(message: NativeChatMessage): ReactTestRenderer {
+  function render(
+    message: NativeChatMessage,
+    props: { toolsExpanded?: boolean } = {}
+  ): ReactTestRenderer {
     const original = console.error
     const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
       if (typeof a[0] === 'string' && a[0].includes('react-test-renderer is deprecated')) {
@@ -51,7 +55,7 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     })
     try {
       act(() => {
-        renderer = create(createElement(MobileNativeChatMessage, { message }))
+        renderer = create(createElement(MobileNativeChatMessage, { message, ...props }))
       })
     } finally {
       spy.mockRestore()
@@ -83,5 +87,27 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       .findAllByType('Text' as never)
       .map((node) => String(node.children.join('')))
     expect(texts.some((text) => text.includes('/tmp/host.png'))).toBe(true)
+  })
+
+  it('bounds expanded diff-less tool input before native text layout', () => {
+    const tree = render(
+      {
+        id: 'a1',
+        role: 'assistant',
+        blocks: [
+          { type: 'tool-call', name: 'CustomTool', input: { payload: 'x'.repeat(100_000) } }
+        ],
+        timestamp: null,
+        source: 'transcript'
+      },
+      { toolsExpanded: true }
+    )
+
+    const detail = tree.root
+      .findAllByType('Text' as never)
+      .map((node) => String(node.children.join('')))
+      .find((text) => text.startsWith('{\n'))
+    expect(detail).toHaveLength(MAX_TOOL_RESULT_CHARS + 1)
+    expect(detail?.endsWith('…')).toBe(true)
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MAX_TOOL_RESULT_CHARS } from './mobile-native-chat-message-styles'
@@ -109,5 +109,33 @@ describe('MobileNativeChatMessage', () => {
       .find((text) => text.startsWith('{\n'))
     expect(detail).toHaveLength(MAX_TOOL_RESULT_CHARS + 1)
     expect(detail?.endsWith('…')).toBe(true)
+  })
+
+  it('expands formatted detail for a pending JSON-string tool input', () => {
+    const tree = render({
+      id: 'a1',
+      role: 'assistant',
+      blocks: [
+        {
+          type: 'tool-call',
+          name: 'CustomTool',
+          input: '{"cmd":"git status","description":"Inspect changes"}'
+        }
+      ],
+      timestamp: null,
+      source: 'transcript'
+    })
+    const textIn = (node: ReactTestInstance): string[] =>
+      node.findAllByType('Text' as never).map((text) => String(text.children.join('')))
+    const pressableWith = (label: string) =>
+      tree.root.findAllByType('Pressable' as never).find((node) => textIn(node).includes(label))!
+
+    act(() => pressableWith('1×').props.onPress())
+    expect(textIn(tree.root).some((text) => text.startsWith('{\n'))).toBe(false)
+
+    act(() => pressableWith('CustomTool').props.onPress())
+    expect(textIn(tree.root)).toContain(
+      '{\n  "cmd": "git status",\n  "description": "Inspect changes"\n}'
+    )
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -17,7 +17,8 @@ import { isRenderableImageUri } from './mobile-native-chat-image-preview'
 import { MAX_TOOL_RESULT_CHARS, styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
 import {
-  summarizeToolInput,
+  describeToolInput,
+  formatToolInput,
   summarizeToolRun,
   toolFilePath
 } from './mobile-native-chat-tool-summary'
@@ -88,14 +89,20 @@ function ToolLine({
   const [expanded, setExpanded] = useState(defaultExpanded)
   const { call, result } = pair
   const name = call ? call.name : 'Result'
+  // The row label is a human summary (path / primary arg), never raw JSON;
+  // the expanded detail below shows the full formatted input.
   const preview = call
-    ? summarizeToolInput(call.input)
+    ? describeToolInput(call.input)
     : (result?.output.split('\n')[0]?.slice(0, 80) ?? '')
   // Why: collapsed tool rows are the common path; defer bounded diff parsing
   // until the user asks to reveal the detail.
   const callDiff = expanded && call ? diffFromToolCall(call.name, call.input, diffLineLimit) : null
   const resultDiff = expanded && result ? diffFromText(result.output, diffLineLimit) : null
-  const hasDetail = callDiff !== null || result !== undefined || preview.length > 40
+  const hasDetail =
+    callDiff !== null ||
+    result !== undefined ||
+    preview.length > 40 ||
+    (call !== undefined && call.input !== null && typeof call.input === 'object')
   // A tool that targets a file (Read/Edit/Write…) renders its preview as a
   // tappable link that opens the file, independent of the line's expand tap.
   const filePath = call ? toolFilePath(call.input) : null
@@ -127,7 +134,11 @@ function ToolLine({
       {expanded ? (
         <View style={styles.toolDetail}>
           {callDiff ? <DiffView lines={callDiff} /> : null}
-          {!callDiff && call && preview ? <Text style={styles.mono}>{preview}</Text> : null}
+          {/* Diff-less calls show the full formatted input (pretty JSON), not
+              the one-line label repeated (desktop parity). */}
+          {!callDiff && call ? (
+            <Text style={styles.mono}>{formatToolInput(call.input)}</Text>
+          ) : null}
           {result ? (
             <ResultBody output={result.output} isError={result.isError} diff={resultDiff} />
           ) : null}

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -73,6 +73,13 @@ function ResultBody({
   )
 }
 
+function formatBoundedToolInput(input: unknown): string {
+  const detail = formatToolInput(input)
+  return detail.length > MAX_TOOL_RESULT_CHARS
+    ? `${detail.slice(0, MAX_TOOL_RESULT_CHARS)}…`
+    : detail
+}
+
 /** One request: a tool call and its result rendered together as a single
  *  expandable line. `defaultExpanded` lets the group toggle open every line. */
 function ToolLine({
@@ -135,9 +142,9 @@ function ToolLine({
         <View style={styles.toolDetail}>
           {callDiff ? <DiffView lines={callDiff} /> : null}
           {/* Diff-less calls show the full formatted input (pretty JSON), not
-              the one-line label repeated (desktop parity). */}
+              the one-line label repeated, bounded like desktop tool detail. */}
           {!callDiff && call ? (
-            <Text style={styles.mono}>{formatToolInput(call.input)}</Text>
+            <Text style={styles.mono}>{formatBoundedToolInput(call.input)}</Text>
           ) : null}
           {result ? (
             <ResultBody output={result.output} isError={result.isError} diff={resultDiff} />

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -19,6 +19,7 @@ import { nativeChatMessageText } from './mobile-native-chat-message-text'
 import {
   describeToolInput,
   formatToolInput,
+  isStructuredToolInput,
   summarizeToolRun,
   toolFilePath
 } from './mobile-native-chat-tool-summary'
@@ -109,7 +110,7 @@ function ToolLine({
     callDiff !== null ||
     result !== undefined ||
     preview.length > 40 ||
-    (call !== undefined && call.input !== null && typeof call.input === 'object')
+    (call !== undefined && isStructuredToolInput(call.input))
   // A tool that targets a file (Read/Edit/Write…) renders its preview as a
   // tappable link that opens the file, independent of the line's expand tap.
   const filePath = call ? toolFilePath(call.input) : null

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -49,6 +49,7 @@ export function MobileNativeChatOverlay({
         agent={controller.nativeChatAgent}
         agentWorking={controller.nativeChatAgentWorking}
         streamingText={controller.nativeChatStreamingText}
+        streamIdentity={controller.nativeChatStreamIdentity}
         onStop={controller.handleNativeChatStop}
         ask={controller.nativeChatAsk}
         askKey={controller.nativeChatAskKey}

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -51,6 +51,8 @@ export function MobileNativeChatOverlay({
         streamingText={controller.nativeChatStreamingText}
         onStop={controller.handleNativeChatStop}
         ask={controller.nativeChatAsk}
+        askKey={controller.nativeChatAskKey}
+        onDismissAsk={controller.dismissNativeChatAsk}
         onAnswerAsk={controller.handleNativeChatAnswerAsk}
         onCancelAsk={controller.handleNativeChatCancelAsk}
         question={controller.nativeChatQuestion}
@@ -60,6 +62,7 @@ export function MobileNativeChatOverlay({
         onOpenFile={controller.handleNativeChatOpenFile}
         hasMore={session.hasMore}
         loadingEarlier={session.loadingEarlier}
+        loadEarlierError={session.loadEarlierError}
         onLoadEarlier={session.loadEarlier}
         onSend={images.sendNativeChat}
         pending={controller.chatPending}

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -61,6 +61,10 @@ type Overrides = {
   sendErrorMessage?: string | null
   onClearSendError?: () => void
   inputLockReason?: 'disconnected' | 'waiting' | null
+  hasMore?: boolean
+  loadingEarlier?: boolean
+  loadEarlierError?: string | null
+  onLoadEarlier?: () => void
   onSend?: (text: string) => Promise<boolean>
 }
 
@@ -75,7 +79,7 @@ function suppressRendererWarning(): () => void {
   return () => spy.mockRestore()
 }
 
-describe('MobileNativeChatView send-error banner', () => {
+describe('MobileNativeChatView', () => {
   let renderer: ReactTestRenderer | null = null
 
   beforeEach(() => {
@@ -161,5 +165,29 @@ describe('MobileNativeChatView send-error banner', () => {
     await pressSend()
 
     expect(onClearSendError).toHaveBeenCalledOnce()
+  })
+
+  it('blocks automatic paging but keeps explicit retry after loading earlier fails', async () => {
+    const onLoadEarlier = vi.fn()
+    await render({
+      hasMore: true,
+      loadEarlierError: 'Couldn’t load earlier messages',
+      onLoadEarlier
+    })
+    const list = renderer!.root.find((node) => node.type === 'FlatList')
+
+    act(() => {
+      list.props.onScroll({
+        nativeEvent: {
+          contentOffset: { y: 0 },
+          contentSize: { height: 1000 },
+          layoutMeasurement: { height: 400 }
+        }
+      })
+    })
+
+    expect(onLoadEarlier).not.toHaveBeenCalled()
+    await act(async () => list.props.ListHeaderComponent.props.onLoadEarlier())
+    expect(onLoadEarlier).toHaveBeenCalledOnce()
   })
 })

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -95,6 +95,7 @@ describe('MobileNativeChatView send-error banner', () => {
           createElement(MobileNativeChatView, {
             messages: [],
             status: 'ready',
+            streamIdentity: 'test-stream',
             onSend: overrides.onSend ?? vi.fn().mockResolvedValue(true),
             pending: [],
             composerText: '',

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -3,14 +3,22 @@ import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'rea
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MobileNativeChatView } from './MobileNativeChatView'
 
-vi.mock('react-native', () => ({
-  ActivityIndicator: 'ActivityIndicator',
-  FlatList: 'FlatList',
-  Pressable: 'Pressable',
-  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
-  Text: 'Text',
-  View: 'View'
-}))
+const { scrollToEnd } = vi.hoisted(() => ({ scrollToEnd: vi.fn() }))
+
+vi.mock('react-native', async () => {
+  const React = await import('react')
+  return {
+    ActivityIndicator: 'ActivityIndicator',
+    FlatList: React.forwardRef((props: object, ref) => {
+      React.useImperativeHandle(ref, () => ({ scrollToEnd }))
+      return React.createElement('FlatList', props)
+    }),
+    Pressable: 'Pressable',
+    StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+    Text: 'Text',
+    View: 'View'
+  }
+})
 
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
@@ -58,6 +66,7 @@ vi.mock('./MobileNativeChatComposer', async () => {
 })
 
 type Overrides = {
+  messages?: Parameters<typeof MobileNativeChatView>[0]['messages']
   sendErrorMessage?: string | null
   onClearSendError?: () => void
   inputLockReason?: 'disconnected' | 'waiting' | null
@@ -84,6 +93,7 @@ describe('MobileNativeChatView', () => {
 
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    scrollToEnd.mockClear()
   })
 
   afterEach(() => {
@@ -111,6 +121,23 @@ describe('MobileNativeChatView', () => {
     } finally {
       restore()
     }
+  }
+
+  async function update(overrides: Overrides = {}): Promise<void> {
+    await act(async () => {
+      renderer?.update(
+        createElement(MobileNativeChatView, {
+          messages: [],
+          status: 'ready',
+          streamIdentity: 'test-stream',
+          onSend: vi.fn().mockResolvedValue(true),
+          pending: [],
+          composerText: '',
+          onComposerTextChange: vi.fn(),
+          ...overrides
+        })
+      )
+    })
   }
 
   function banners(): ReactTestInstance[] {
@@ -189,5 +216,32 @@ describe('MobileNativeChatView', () => {
     expect(onLoadEarlier).not.toHaveBeenCalled()
     await act(async () => list.props.ListHeaderComponent.props.onLoadEarlier())
     expect(onLoadEarlier).toHaveBeenCalledOnce()
+  })
+
+  it('does not defeat prepend anchoring when a short list was also at bottom', async () => {
+    vi.useFakeTimers()
+    const current = {
+      id: 'current',
+      role: 'assistant' as const,
+      blocks: [{ type: 'text' as const, text: 'current' }],
+      timestamp: 0,
+      source: 'transcript' as const
+    }
+    const older = { ...current, id: 'older', blocks: [{ type: 'text' as const, text: 'older' }] }
+    try {
+      await render({ messages: [current], hasMore: true })
+      await act(async () => vi.runAllTimersAsync())
+      scrollToEnd.mockClear()
+
+      await update({ messages: [current], hasMore: true, loadingEarlier: true })
+      await update({ messages: [older, current], hasMore: false, loadingEarlier: false })
+      const list = renderer!.root.find((node) => node.type === 'FlatList')
+      act(() => list.props.onContentSizeChange())
+      await act(async () => vi.runAllTimersAsync())
+
+      expect(scrollToEnd).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -236,6 +236,7 @@ describe('MobileNativeChatView', () => {
       await update({ messages: [current], hasMore: true, loadingEarlier: true })
       await update({ messages: [older, current], hasMore: false, loadingEarlier: false })
       const list = renderer!.root.find((node) => node.type === 'FlatList')
+      expect(list.props.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 1 })
       act(() => list.props.onContentSizeChange())
       await act(async () => vi.runAllTimersAsync())
 

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -236,7 +236,7 @@ describe('MobileNativeChatView', () => {
       await update({ messages: [current], hasMore: true, loadingEarlier: true })
       await update({ messages: [older, current], hasMore: false, loadingEarlier: false })
       const list = renderer!.root.find((node) => node.type === 'FlatList')
-      expect(list.props.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 1 })
+      expect(list.props.maintainVisibleContentPosition).toEqual({ minIndexForVisible: 0 })
       act(() => list.props.onContentSizeChange())
       await act(async () => vi.runAllTimersAsync())
 

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -162,9 +162,6 @@ export function MobileNativeChatView({
   const [atBottom, setAtBottom] = useState(true)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const keepHistoryPositionRef = useRef(Boolean(loadingEarlier))
-  if (loadingEarlier) {
-    keepHistoryPositionRef.current = true
-  }
   const keepHistoryPosition = keepHistoryPositionRef.current
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
   useEffect(
@@ -203,9 +200,7 @@ export function MobileNativeChatView({
     return () => clearTimeout(t)
   }, [data.length, atBottom, keyboardInset])
   useEffect(() => {
-    if (!loadingEarlier) {
-      keepHistoryPositionRef.current = false
-    }
+    keepHistoryPositionRef.current = Boolean(loadingEarlier)
   }, [loadingEarlier])
 
   const handleSend = useCallback(

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -298,8 +298,8 @@ export function MobileNativeChatView({
               contentContainerStyle={styles.listContent}
               onScroll={onScroll}
               scrollEventThrottle={32}
-              // Skip the load-earlier header so the first visible message stays anchored.
-              maintainVisibleContentPosition={{ minIndexForVisible: 1 }}
+              // FlatList adds its header offset internally; anchor the first message.
+              maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
               onContentSizeChange={() => {
                 if (data.length > 0 && atBottom && !keepHistoryPosition) {
                   listRef.current?.scrollToEnd({ animated: false })

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -227,11 +227,11 @@ export function MobileNativeChatView({
       const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
       setAtBottom(distanceFromBottom < 80)
       // Near the top — page in older history.
-      if (contentOffset.y < 60 && hasMore && !loadingEarlier) {
+      if (contentOffset.y < 60 && hasMore && !loadingEarlier && !loadEarlierError) {
         onLoadEarlier?.()
       }
     },
-    [hasMore, loadingEarlier, onLoadEarlier]
+    [hasMore, loadingEarlier, loadEarlierError, onLoadEarlier]
   )
 
   // Align a single message's top to the top of the viewport.

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -20,7 +20,8 @@ import {
   mobileNativeChatEmptyState,
   type MobileNativeChatPendingItem
 } from './mobile-native-chat-render-data'
-import { useMobileNativeChatAskDismiss } from './use-mobile-native-chat-ask-dismiss'
+import { useMobileNativeChatStreamingBubble } from './use-mobile-native-chat-streaming-bubble'
+import { MobileNativeChatLoadEarlierHeader } from './MobileNativeChatLoadEarlierHeader'
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
@@ -52,6 +53,8 @@ type Props = {
   streamingText?: string
   hasMore?: boolean
   loadingEarlier?: boolean
+  /** Last older-history page failed; shows an inline retry in the header row. */
+  loadEarlierError?: string | null
   onLoadEarlier?: () => void
   onSend: (text: string) => Promise<boolean>
   /** Optimistic queued sends (owned by the route so they survive view switches). */
@@ -85,6 +88,11 @@ type Props = {
   /** Structured AskUserQuestion prompt parsed from the transcript (preferred over
    *  the heuristic question card). */
   ask?: AskPrompt | null
+  /** Stable key for the ask card. Dismissal state lives in the controller (it
+   *  must survive this subtree unmounting on a chat↔terminal toggle). */
+  askKey?: string | null
+  /** Hide the answered/dismissed ask until a different question arrives. */
+  onDismissAsk?: () => void
   /** Deliver the ask answer as per-question selections; the send hook turns them
    *  into selector keystrokes (Claude) or pasted label text (other agents). */
   onAnswerAsk?: (prompt: AskPrompt, selections: AskAnswerSelection[]) => Promise<boolean>
@@ -110,6 +118,7 @@ export function MobileNativeChatView({
   streamingText,
   hasMore,
   loadingEarlier,
+  loadEarlierError,
   onLoadEarlier,
   onSend,
   pending,
@@ -130,6 +139,8 @@ export function MobileNativeChatView({
   filePaths,
   onNeedFiles,
   ask,
+  askKey,
+  onDismissAsk,
   onAnswerAsk,
   onCancelAsk,
   question,
@@ -142,10 +153,6 @@ export function MobileNativeChatView({
   const insets = useSafeAreaInsets()
   const listRef = useRef<FlatList<NativeChatMessage>>(null)
   const [toolsExpanded, setToolsExpanded] = useState(false)
-  // Dismiss the question card as soon as it's answered; the live status lingers
-  // briefly (the agent emits a post-tool event with the same prompt), so hide it
-  // until a genuinely different question arrives.
-  const { askKey, showAsk, dismissAsk } = useMobileNativeChatAskDismiss(ask)
   // Lift the composer clear of the keyboard, plus the bottom safe-area so it
   // never sits under the home indicator / nav bar (mirrors the terminal dock).
   const bottomPad = keyboardInset > 0 ? keyboardInset + insets.bottom : insets.bottom
@@ -166,9 +173,10 @@ export function MobileNativeChatView({
   // route-owned optimistic queued messages. Memoize on the same deps so the
   // downstream autoscroll effects/`renderItem` keep referential stability.
   const foldedMessages = useMemo(() => foldMobileNativeChatMessages(messages), [messages])
+  const streaming = useMobileNativeChatStreamingBubble(foldedMessages, streamingText)
   const { data } = useMemo(
-    () => buildMobileNativeChatTransientData({ folded: foldedMessages, streamingText, pending }),
-    [foldedMessages, streamingText, pending]
+    () => buildMobileNativeChatTransientData({ folded: foldedMessages, streaming, pending }),
+    [foldedMessages, streaming, pending]
   )
 
   // Follow the tail as the conversation grows and keep the newest message above
@@ -256,6 +264,10 @@ export function MobileNativeChatView({
     return () => clearTimeout(timer)
   }, [rawLockReason])
   const lockReason = lockHeld ? rawLockReason : null
+  // Everything derived from agent status is pre-disconnect data while the
+  // transport is down: mute the working row and disable Stop (a tap could not
+  // reach the PTY anyway). Shares the lock's debounce so blips don't flicker it.
+  const statusStale = lockReason === 'disconnected'
 
   return (
     <View style={[styles.root, { paddingBottom: bottomPad }]}>
@@ -274,6 +286,9 @@ export function MobileNativeChatView({
               contentContainerStyle={styles.listContent}
               onScroll={onScroll}
               scrollEventThrottle={32}
+              // Anchor the viewport to the first visible row so a loadEarlier
+              // prepend grows the list upward instead of jumping the reader.
+              maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
               onContentSizeChange={() => {
                 if (data.length > 0 && atBottom) {
                   listRef.current?.scrollToEnd({ animated: false })
@@ -296,17 +311,11 @@ export function MobileNativeChatView({
               }}
               ListHeaderComponent={
                 hasMore ? (
-                  <Pressable
-                    style={styles.loadEarlier}
-                    onPress={onLoadEarlier}
-                    disabled={loadingEarlier}
-                  >
-                    {loadingEarlier ? (
-                      <ActivityIndicator size="small" color={colors.textMuted} />
-                    ) : (
-                      <Text style={styles.loadEarlierText}>Load earlier messages</Text>
-                    )}
-                  </Pressable>
+                  <MobileNativeChatLoadEarlierHeader
+                    loadingEarlier={loadingEarlier}
+                    loadEarlierError={loadEarlierError}
+                    onLoadEarlier={onLoadEarlier}
+                  />
                 ) : null
               }
               ListEmptyComponent={
@@ -333,22 +342,24 @@ export function MobileNativeChatView({
         </GestureHandlerRootView>
       )}
       {/* Pending agent prompt: a structured AskUserQuestion wins, then a
-          heuristic permission, then a heuristic question. */}
-      {showAsk && ask ? (
+          heuristic permission, then a heuristic question. The controller owns
+          dismissal (it must survive this subtree unmounting on a view toggle);
+          `ask` arrives already nulled while dismissed. */}
+      {ask ? (
         <MobileNativeChatAsk
           key={askKey ?? 'ask'}
           prompt={ask}
           onAnswer={async (selections) => {
             const accepted = (await onAnswerAsk?.(ask, selections)) ?? false
             if (accepted) {
-              dismissAsk()
+              onDismissAsk?.()
             }
             return accepted
           }}
           onCancel={async () => {
             const accepted = (await onCancelAsk?.()) ?? false
             if (accepted) {
-              dismissAsk()
+              onDismissAsk?.()
             }
             return accepted
           }}
@@ -370,7 +381,7 @@ export function MobileNativeChatView({
           tool-calls expand/collapse toggle on the left, Stop in the far corner. */}
       <View style={styles.chromeRow}>
         <View style={styles.chromeLeft}>
-          {agentWorking ? <MobileAgentWorkingIndicator /> : null}
+          {agentWorking ? <MobileAgentWorkingIndicator stale={statusStale} /> : null}
           <Pressable
             style={({ pressed }) => [styles.chromeToggle, pressed && styles.pressed]}
             onPress={() => setToolsExpanded((v) => !v)}
@@ -386,8 +397,13 @@ export function MobileNativeChatView({
         </View>
         {agentWorking ? (
           <Pressable
-            style={({ pressed }) => [styles.stopButton, pressed && styles.pressed]}
+            style={({ pressed }) => [
+              styles.stopButton,
+              pressed && !statusStale && styles.pressed,
+              statusStale && styles.stopDisabled
+            ]}
             onPress={onStop}
+            disabled={statusStale}
             hitSlop={8}
             accessibilityLabel="Stop the agent"
           >

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -51,6 +51,8 @@ type Props = {
   /** Live partial assistant text while a turn is still streaming (from the agent
    *  status hook). Shown as an in-progress bubble until the transcript catches up. */
   streamingText?: string
+  /** Scopes streaming catch-up state to the active host/workspace/tab/session. */
+  streamIdentity: string
   hasMore?: boolean
   loadingEarlier?: boolean
   /** Last older-history page failed; shows an inline retry in the header row. */
@@ -116,6 +118,7 @@ export function MobileNativeChatView({
   agentWorking,
   onStop,
   streamingText,
+  streamIdentity,
   hasMore,
   loadingEarlier,
   loadEarlierError,
@@ -173,7 +176,11 @@ export function MobileNativeChatView({
   // route-owned optimistic queued messages. Memoize on the same deps so the
   // downstream autoscroll effects/`renderItem` keep referential stability.
   const foldedMessages = useMemo(() => foldMobileNativeChatMessages(messages), [messages])
-  const streaming = useMobileNativeChatStreamingBubble(foldedMessages, streamingText)
+  const streaming = useMobileNativeChatStreamingBubble(
+    foldedMessages,
+    streamingText,
+    streamIdentity
+  )
   const { data } = useMemo(
     () => buildMobileNativeChatTransientData({ folded: foldedMessages, streaming, pending }),
     [foldedMessages, streaming, pending]

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -161,6 +161,11 @@ export function MobileNativeChatView({
   const bottomPad = keyboardInset > 0 ? keyboardInset + insets.bottom : insets.bottom
   const [atBottom, setAtBottom] = useState(true)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const keepHistoryPositionRef = useRef(Boolean(loadingEarlier))
+  if (loadingEarlier) {
+    keepHistoryPositionRef.current = true
+  }
+  const keepHistoryPosition = keepHistoryPositionRef.current
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
   useEffect(
     () => () => {
@@ -191,12 +196,17 @@ export function MobileNativeChatView({
   // we don't yank the user away while they read history. (Also fires on keyboard
   // close, which is harmless while atBottom.)
   useEffect(() => {
-    if (data.length === 0 || !atBottom) {
+    if (data.length === 0 || !atBottom || keepHistoryPositionRef.current) {
       return
     }
     const t = setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 60)
     return () => clearTimeout(t)
   }, [data.length, atBottom, keyboardInset])
+  useEffect(() => {
+    if (!loadingEarlier) {
+      keepHistoryPositionRef.current = false
+    }
+  }, [loadingEarlier])
 
   const handleSend = useCallback(
     async (text: string): Promise<boolean> => {
@@ -297,7 +307,7 @@ export function MobileNativeChatView({
               // prepend grows the list upward instead of jumping the reader.
               maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
               onContentSizeChange={() => {
-                if (data.length > 0 && atBottom) {
+                if (data.length > 0 && atBottom && !keepHistoryPosition) {
                   listRef.current?.scrollToEnd({ animated: false })
                 }
               }}

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -303,9 +303,8 @@ export function MobileNativeChatView({
               contentContainerStyle={styles.listContent}
               onScroll={onScroll}
               scrollEventThrottle={32}
-              // Anchor the viewport to the first visible row so a loadEarlier
-              // prepend grows the list upward instead of jumping the reader.
-              maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
+              // Skip the load-earlier header so the first visible message stays anchored.
+              maintainVisibleContentPosition={{ minIndexForVisible: 1 }}
               onContentSizeChange={() => {
                 if (data.length > 0 && atBottom && !keepHistoryPosition) {
                   listRef.current?.scrollToEnd({ animated: false })

--- a/mobile/src/session/mobile-native-chat-permission-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-permission-send.test.ts
@@ -13,6 +13,11 @@ import {
   markMobileNativeChatInputStale,
   resetMobileNativeChatStaleInputForTests
 } from './mobile-native-chat-stale-input'
+import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite,
+  resetMobileNativeChatTerminalWritesForTests
+} from './mobile-native-chat-terminal-write-lock'
 
 describe('sendMobileNativeChatPermissionResponse', () => {
   it('writes an approval as raw bytes without appending Return', async () => {
@@ -64,6 +69,7 @@ describe('useMobileNativeChatPermissionSend', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     resetMobileNativeChatStaleInputForTests()
+    resetMobileNativeChatTerminalWritesForTests()
   })
 
   afterEach(() => {
@@ -101,5 +107,43 @@ describe('useMobileNativeChatPermissionSend', () => {
     expect(sendRequest).toHaveBeenCalledTimes(1)
     expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '1', enter: false })
     expect(isMobileNativeChatInputStale('terminal')).toBe(true)
+  })
+
+  it('rejects a choice while another composed write holds the terminal, then recovers', async () => {
+    const onSendError = vi.fn()
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { send: { handle: 'terminal', accepted: true, bytesWritten: 1 } }
+    })
+    function Harness(): null {
+      respond = useMobileNativeChatPermissionSend({
+        client: { sendRequest } as unknown as RpcClient,
+        enabled: true,
+        handleRef: { current: 'terminal' },
+        deviceTokenRef: { current: null },
+        onSendError
+      })
+      return null
+    }
+    act(() => {
+      renderer = create(createElement(Harness))
+    })
+
+    // An image paste sequence is mid-flight into the same PTY: the choice
+    // keystroke must not interleave into it.
+    expect(acquireMobileNativeChatTerminalWrite('terminal')).toBe(true)
+    await act(async () => {
+      await expect(respond?.('1')).resolves.toBe(false)
+    })
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(onSendError).toHaveBeenCalledWith('Response not sent')
+
+    releaseMobileNativeChatTerminalWrite('terminal')
+    await act(async () => {
+      await expect(respond?.('1')).resolves.toBe(true)
+    })
+    // The choice released its own hold on the way out.
+    expect(acquireMobileNativeChatTerminalWrite('terminal')).toBe(true)
+    releaseMobileNativeChatTerminalWrite('terminal')
   })
 })

--- a/mobile/src/session/mobile-native-chat-permission-send.ts
+++ b/mobile/src/session/mobile-native-chat-permission-send.ts
@@ -4,6 +4,10 @@ import {
   sendMobileNativeChatMessageWithOutcome,
   type MobileNativeChatSendOutcome
 } from './mobile-native-chat-send'
+import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite
+} from './mobile-native-chat-terminal-write-lock'
 
 export function sendMobileNativeChatPermissionResponse(args: {
   client: RpcClient
@@ -36,15 +40,26 @@ export function useMobileNativeChatPermissionSend(args: {
         args.onSendError('Response not sent (disconnected)')
         return false
       }
+      // A choice keystroke must not interleave into a mid-flight composed write
+      // (image paste, paced answer) on the same PTY.
+      if (!acquireMobileNativeChatTerminalWrite(terminal)) {
+        args.onSendError('Response not sent')
+        return false
+      }
       // No stale-input heal here (unlike the text/ask sends): a choice is an
       // `enter: false` key for an active overlay that swallows the clear, so it
       // would consume the marker still protecting the next real message.
-      const outcome = await sendMobileNativeChatPermissionResponse({
-        client: args.client,
-        terminal,
-        deviceToken: args.deviceTokenRef.current,
-        text
-      })
+      let outcome: MobileNativeChatSendOutcome
+      try {
+        outcome = await sendMobileNativeChatPermissionResponse({
+          client: args.client,
+          terminal,
+          deviceToken: args.deviceTokenRef.current,
+          text
+        })
+      } finally {
+        releaseMobileNativeChatTerminalWrite(terminal)
+      }
       if (outcome === 'unknown') {
         // Why: the response may have been delivered (ack lost / path cutover) —
         // a definite "not sent" would invite a double answer.

--- a/mobile/src/session/mobile-native-chat-render-data.ts
+++ b/mobile/src/session/mobile-native-chat-render-data.ts
@@ -7,6 +7,10 @@ import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { foldToolMessages } from './mobile-native-chat-blocks'
 import { normalizeImageTranscriptMessages } from './mobile-native-chat-image-transcript-markers'
 import { stripNoiseMessages } from './mobile-native-chat-noise'
+import {
+  createMobileNativeChatStreamingGate,
+  deriveMobileNativeChatStreaming
+} from './mobile-native-chat-streaming-gate'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 
 /** The centered empty-state copy for a chat with no messages, mirroring the
@@ -46,7 +50,9 @@ export type MobileNativeChatPendingItem = {
 /** Derive the list data from the raw transcript: fold tool turns into the
  *  assistant turn, optionally append a synthetic streaming bubble, then the
  *  route-owned optimistic "queued" messages at the tail. Returns the
- *  intermediate `folded`/`streaming` so the caller can memoize on them. */
+ *  intermediate `folded`/`streaming` so the caller can memoize on them.
+ *  One-shot form: derives the streaming bubble through a fresh gate (no
+ *  cross-tick memory); the live view threads its own gate instead. */
 export function buildMobileNativeChatData({
   messages,
   streamingText,
@@ -57,7 +63,12 @@ export function buildMobileNativeChatData({
   pending: MobileNativeChatPendingItem[]
 }): { folded: NativeChatMessage[]; streaming: string | null; data: NativeChatMessage[] } {
   const folded = foldMobileNativeChatMessages(messages)
-  return buildMobileNativeChatTransientData({ folded, streamingText, pending })
+  const { streaming } = deriveMobileNativeChatStreaming(
+    createMobileNativeChatStreamingGate(),
+    folded,
+    streamingText
+  )
+  return buildMobileNativeChatTransientData({ folded, streaming, pending })
 }
 
 export function foldMobileNativeChatMessages(messages: NativeChatMessage[]): NativeChatMessage[] {
@@ -68,16 +79,14 @@ export function foldMobileNativeChatMessages(messages: NativeChatMessage[]): Nat
 
 export function buildMobileNativeChatTransientData({
   folded,
-  streamingText,
+  streaming,
   pending
 }: {
   folded: NativeChatMessage[]
-  streamingText?: string
+  /** Streaming bubble text, already gated by `deriveMobileNativeChatStreaming`. */
+  streaming: string | null
   pending: MobileNativeChatPendingItem[]
 }): { folded: NativeChatMessage[]; streaming: string | null; data: NativeChatMessage[] } {
-  // Only show the streaming bubble while its text leads the transcript — once the
-  // real assistant turn lands with the same text, drop the synthetic one.
-  const streaming = deriveStreaming(folded, streamingText)
   const data: NativeChatMessage[] = [
     ...folded,
     ...(streaming
@@ -105,27 +114,4 @@ export function buildMobileNativeChatTransientData({
     }))
   ]
   return { folded, streaming, data }
-}
-
-function deriveStreaming(folded: NativeChatMessage[], streamingText?: string): string | null {
-  const text = streamingText?.trim()
-  if (!text) {
-    return null
-  }
-  const last = folded[folded.length - 1]
-  const lastText =
-    last?.role === 'assistant'
-      ? last.blocks
-          .filter((b) => b.type === 'text')
-          .map((b) => (b.type === 'text' ? b.text : ''))
-          .join('')
-          .trim()
-      : ''
-  // Hide the synthetic bubble only once the real turn has landed leading with the
-  // streamed text. A bare length compare would suppress a short new reply behind a
-  // longer previous turn; a completed prior turn won't start with the new prefix.
-  if (lastText.startsWith(text)) {
-    return null
-  }
-  return text
 }

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -99,6 +99,27 @@ describe('applyMobileNativeChatStreamFrame', () => {
     })
   })
 
+  it('replaces a partially overlapping replay that no longer extends the retained tail', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['old-1', 'shared', 'old-tail'].map(message))
+
+    const replay = [message('shared'), message('compacted-summary'), message('old-tail')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: false, beforeOffset: 0 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: false,
+      beforeOffset: 0,
+      windowReplaced: true
+    })
+  })
+
   it('keeps the pagination cursor when an append does not trim history', () => {
     const merger = createNativeChatMerger()
     replaceList(merger, [message('a')])

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -120,6 +120,27 @@ describe('applyMobileNativeChatStreamFrame', () => {
     })
   })
 
+  it('replaces retained history when replay metadata says no earlier rows remain', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['removed-1', 'removed-2', 'a', 'b'].map(message))
+
+    const replay = [message('a'), message('b')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: false, beforeOffset: 0 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: false,
+      beforeOffset: 0,
+      windowReplaced: true
+    })
+  })
+
   it('keeps the pagination cursor when an append does not trim history', () => {
     const merger = createNativeChatMerger()
     replaceList(merger, [message('a')])

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -32,7 +32,8 @@ describe('applyMobileNativeChatStreamFrame', () => {
       kind: 'messages',
       messages: [message('a'), message('b')],
       hasMore: true,
-      beforeOffset: 123
+      beforeOffset: 123,
+      windowReplaced: true
     })
   })
 
@@ -51,6 +52,50 @@ describe('applyMobileNativeChatStreamFrame', () => {
       kind: 'messages',
       messages: [message('b'), message('c'), message('d')],
       cursorInvalidated: true
+    })
+  })
+
+  it('keeps paged-in history when a reconnect replay overlaps it', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['p1', 'p2', 'a', 'b'].map(message))
+
+    const result = applyMobileNativeChatStreamFrame({
+      merger,
+      // Replayed window: the retained tail plus what arrived while disconnected.
+      frame: { type: 'snapshot', messages: [message('a'), message('b'), message('c')] },
+      limit: 100,
+      replaceSnapshot: false
+    })
+
+    expect(result).toEqual({
+      kind: 'messages',
+      messages: ['p1', 'p2', 'a', 'b', 'c'].map(message)
+    })
+  })
+
+  it('replaces the window when a reconnect replay is disjoint from history', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, [message('old-1'), message('old-2')])
+
+    // A long outage (or compaction while away) cannot be stitched without a gap.
+    const result = applyMobileNativeChatStreamFrame({
+      merger,
+      frame: {
+        type: 'snapshot',
+        messages: [message('fresh-1'), message('fresh-2')],
+        hasMore: true,
+        beforeOffset: 900
+      },
+      limit: 100,
+      replaceSnapshot: false
+    })
+
+    expect(result).toEqual({
+      kind: 'messages',
+      messages: [message('fresh-1'), message('fresh-2')],
+      hasMore: true,
+      beforeOffset: 900,
+      windowReplaced: true
     })
   })
 
@@ -79,7 +124,12 @@ describe('applyMobileNativeChatStreamFrame', () => {
         limit: 40,
         replaceSnapshot: false
       })
-    ).toEqual({ kind: 'messages', messages: [message('new')], hasMore: false })
+    ).toEqual({
+      kind: 'messages',
+      messages: [message('new')],
+      hasMore: false,
+      windowReplaced: true
+    })
   })
 
   it('surfaces snapshot errors and ignores unrelated frames', () => {

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -43,7 +43,12 @@ describe('applyMobileNativeChatStreamFrame', () => {
 
     const result = applyMobileNativeChatStreamFrame({
       merger,
-      frame: { type: 'snapshot', messages: [message('b'), message('c'), message('d')] },
+      frame: {
+        type: 'snapshot',
+        messages: [message('b'), message('c'), message('d')],
+        hasMore: true,
+        beforeOffset: 20
+      },
       limit: 3,
       replaceSnapshot: false
     })
@@ -51,7 +56,32 @@ describe('applyMobileNativeChatStreamFrame', () => {
     expect(result).toMatchObject({
       kind: 'messages',
       messages: [message('b'), message('c'), message('d')],
-      cursorInvalidated: true
+      cursorInvalidated: true,
+      hasMore: true
+    })
+  })
+
+  it('refreshes paging metadata when a replay still starts at the retained oldest row', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, [message('a'), message('b')])
+
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: {
+          type: 'snapshot',
+          messages: [message('a'), message('b')],
+          hasMore: false,
+          beforeOffset: 0
+        },
+        limit: 40,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: [message('a'), message('b')],
+      hasMore: false,
+      beforeOffset: 0
     })
   })
 

--- a/mobile/src/session/mobile-native-chat-stream-frame.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.ts
@@ -25,12 +25,35 @@ export type AppliedMobileNativeChatFrame =
       windowReplaced?: boolean
     }
 
+function replayExtendsRetainedTail(
+  merger: NativeChatMerger,
+  messages: readonly NativeChatMessage[]
+): boolean {
+  const firstIndex = messages[0] ? merger.indexById.get(messages[0].id) : undefined
+  if (firstIndex === undefined) {
+    return false
+  }
+  let expectedIndex = firstIndex
+  let sawNewMessage = false
+  for (const message of messages) {
+    const existingIndex = merger.indexById.get(message.id)
+    if (existingIndex === undefined) {
+      sawNewMessage = true
+    } else if (sawNewMessage || existingIndex !== expectedIndex) {
+      return false
+    } else {
+      expectedIndex += 1
+    }
+  }
+  return expectedIndex === merger.list.length
+}
+
 /** Applies runtime stream frames while preserving the initial-snapshot versus
  *  reconnect-replay distinction owned by the session hook. A replay snapshot
- *  that overlaps the retained list merges in by id — paged-in history survives
- *  a socket blip instead of collapsing to the replayed window. A disjoint
- *  replay (long outage, compaction while away) can't be stitched without a
- *  gap, so it falls back to replacing with the fresh authoritative window. */
+ *  that extends a contiguous retained tail merges in by id — paged-in history
+ *  survives a socket blip instead of collapsing to the replayed window. A
+ *  discontinuous replay (long outage, compaction while away) can't be stitched
+ *  without a gap, so it falls back to the fresh authoritative window. */
 export function applyMobileNativeChatStreamFrame(args: {
   merger: NativeChatMerger
   frame: MobileNativeChatStreamFrame
@@ -50,12 +73,12 @@ export function applyMobileNativeChatStreamFrame(args: {
   if (!Array.isArray(frame.messages)) {
     return { kind: 'ignored' }
   }
-  const replayOverlapsHistory =
+  const replayExtendsHistory =
     frame.type === 'snapshot' &&
     !replaceSnapshot &&
     merger.list.length > 0 &&
-    frame.messages.some((message) => merger.indexById.has(message.id))
-  if (frame.type === 'replacement' || (frame.type === 'snapshot' && !replayOverlapsHistory)) {
+    replayExtendsRetainedTail(merger, frame.messages)
+  if (frame.type === 'replacement' || (frame.type === 'snapshot' && !replayExtendsHistory)) {
     replaceList(merger, frame.messages)
     return {
       kind: 'messages',

--- a/mobile/src/session/mobile-native-chat-stream-frame.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.ts
@@ -19,10 +19,18 @@ export type AppliedMobileNativeChatFrame =
       hasMore?: boolean
       beforeOffset?: number
       cursorInvalidated?: boolean
+      /** The frame replaced the whole retained window (replacement, first
+       *  snapshot, or a replay snapshot disjoint from local history) — the
+       *  caller must reset its paging window/cursor to the frame's. */
+      windowReplaced?: boolean
     }
 
 /** Applies runtime stream frames while preserving the initial-snapshot versus
- *  reconnect-replay distinction owned by the session hook. */
+ *  reconnect-replay distinction owned by the session hook. A replay snapshot
+ *  that overlaps the retained list merges in by id — paged-in history survives
+ *  a socket blip instead of collapsing to the replayed window. A disjoint
+ *  replay (long outage, compaction while away) can't be stitched without a
+ *  gap, so it falls back to replacing with the fresh authoritative window. */
 export function applyMobileNativeChatStreamFrame(args: {
   merger: NativeChatMerger
   frame: MobileNativeChatStreamFrame
@@ -42,12 +50,18 @@ export function applyMobileNativeChatStreamFrame(args: {
   if (!Array.isArray(frame.messages)) {
     return { kind: 'ignored' }
   }
-  if (frame.type === 'replacement' || (frame.type === 'snapshot' && replaceSnapshot)) {
+  const replayOverlapsHistory =
+    frame.type === 'snapshot' &&
+    !replaceSnapshot &&
+    merger.list.length > 0 &&
+    frame.messages.some((message) => merger.indexById.has(message.id))
+  if (frame.type === 'replacement' || (frame.type === 'snapshot' && !replayOverlapsHistory)) {
     replaceList(merger, frame.messages)
     return {
       kind: 'messages',
       messages: merger.list,
       hasMore: frame.hasMore,
+      windowReplaced: true,
       ...(frame.beforeOffset == null ? {} : { beforeOffset: frame.beforeOffset })
     }
   }

--- a/mobile/src/session/mobile-native-chat-stream-frame.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.ts
@@ -25,19 +25,19 @@ export type AppliedMobileNativeChatFrame =
       windowReplaced?: boolean
     }
 
-function replayExtendsRetainedTail(
+function replayRetainedTailStart(
   merger: NativeChatMerger,
   messages: readonly NativeChatMessage[],
   hasMore: boolean | undefined
-): boolean {
+): number | null {
   const firstIndex = messages[0] ? merger.indexById.get(messages[0].id) : undefined
   if (firstIndex === undefined) {
-    return false
+    return null
   }
   // `hasMore: false` is authoritative: retained rows before the replay window
   // were removed while disconnected, even when the newest IDs still match.
   if (hasMore === false && firstIndex > 0) {
-    return false
+    return null
   }
   let expectedIndex = firstIndex
   let sawNewMessage = false
@@ -46,12 +46,12 @@ function replayExtendsRetainedTail(
     if (existingIndex === undefined) {
       sawNewMessage = true
     } else if (sawNewMessage || existingIndex !== expectedIndex) {
-      return false
+      return null
     } else {
       expectedIndex += 1
     }
   }
-  return expectedIndex === merger.list.length
+  return expectedIndex === merger.list.length ? firstIndex : null
 }
 
 /** Applies runtime stream frames while preserving the initial-snapshot versus
@@ -79,12 +79,11 @@ export function applyMobileNativeChatStreamFrame(args: {
   if (!Array.isArray(frame.messages)) {
     return { kind: 'ignored' }
   }
-  const replayExtendsHistory =
-    frame.type === 'snapshot' &&
-    !replaceSnapshot &&
-    merger.list.length > 0 &&
-    replayExtendsRetainedTail(merger, frame.messages, frame.hasMore)
-  if (frame.type === 'replacement' || (frame.type === 'snapshot' && !replayExtendsHistory)) {
+  const replayStartIndex =
+    frame.type === 'snapshot' && !replaceSnapshot && merger.list.length > 0
+      ? replayRetainedTailStart(merger, frame.messages, frame.hasMore)
+      : null
+  if (frame.type === 'replacement' || (frame.type === 'snapshot' && replayStartIndex === null)) {
     replaceList(merger, frame.messages)
     return {
       kind: 'messages',
@@ -96,11 +95,23 @@ export function applyMobileNativeChatStreamFrame(args: {
   }
   const previousFirstId = merger.list[0]?.id
   const messages = applyAppend(merger, frame.messages, limit)
+  const cursorInvalidated = Boolean(previousFirstId && messages[0]?.id !== previousFirstId)
+  const replayStillStartsAtOldest = frame.type === 'snapshot' && replayStartIndex === 0
   return {
     kind: 'messages',
     messages,
     // Why: once the bounded live window drops its oldest row, the snapshot's
     // byte cursor no longer describes the oldest retained message.
-    ...(previousFirstId && messages[0]?.id !== previousFirstId ? { cursorInvalidated: true } : {})
+    ...(cursorInvalidated ? { cursorInvalidated: true } : {}),
+    // A trimmed replay creates page-able history even if the prior window had
+    // none; otherwise only a replay sharing our oldest row owns its metadata.
+    ...(frame.type === 'snapshot' && cursorInvalidated
+      ? { hasMore: true }
+      : replayStillStartsAtOldest
+        ? {
+            ...(frame.hasMore == null ? {} : { hasMore: frame.hasMore }),
+            ...(frame.beforeOffset == null ? {} : { beforeOffset: frame.beforeOffset })
+          }
+        : {})
   }
 }

--- a/mobile/src/session/mobile-native-chat-stream-frame.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.ts
@@ -27,10 +27,16 @@ export type AppliedMobileNativeChatFrame =
 
 function replayExtendsRetainedTail(
   merger: NativeChatMerger,
-  messages: readonly NativeChatMessage[]
+  messages: readonly NativeChatMessage[],
+  hasMore: boolean | undefined
 ): boolean {
   const firstIndex = messages[0] ? merger.indexById.get(messages[0].id) : undefined
   if (firstIndex === undefined) {
+    return false
+  }
+  // `hasMore: false` is authoritative: retained rows before the replay window
+  // were removed while disconnected, even when the newest IDs still match.
+  if (hasMore === false && firstIndex > 0) {
     return false
   }
   let expectedIndex = firstIndex
@@ -77,7 +83,7 @@ export function applyMobileNativeChatStreamFrame(args: {
     frame.type === 'snapshot' &&
     !replaceSnapshot &&
     merger.list.length > 0 &&
-    replayExtendsRetainedTail(merger, frame.messages)
+    replayExtendsRetainedTail(merger, frame.messages, frame.hasMore)
   if (frame.type === 'replacement' || (frame.type === 'snapshot' && !replayExtendsHistory)) {
     replaceList(merger, frame.messages)
     return {

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -94,6 +94,17 @@ describe('deriveMobileNativeChatStreaming', () => {
     expect(again.gate).toEqual(first.gate)
   })
 
+  it('drops a prior chat baseline when the stream identity changes', () => {
+    const repeatedId = [assistant('a1', 'new answer landed')]
+    let gate = createMobileNativeChatStreamingGate('tab-a')
+    gate = deriveMobileNativeChatStreaming(gate, repeatedId, undefined, 'tab-a').gate
+
+    const switched = deriveMobileNativeChatStreaming(gate, repeatedId, 'new answer', 'tab-b')
+
+    expect(switched.streaming).toBeNull()
+    expect(switched.gate.scopeKey).toBe('tab-b')
+  })
+
   it('returns null for empty or whitespace streaming text', () => {
     const prior = [assistant('a1', 'x')]
     expect(run([{ folded: prior, text: '   ' }]).results).toEqual([null])

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  createMobileNativeChatStreamingGate,
+  deriveMobileNativeChatStreaming,
+  type MobileNativeChatStreamingGate
+} from './mobile-native-chat-streaming-gate'
+
+function assistant(id: string, text: string): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp: 0,
+    source: 'transcript'
+  }
+}
+
+/** Run a sequence of (folded, streamingText) ticks through one gate. */
+function run(ticks: { folded: NativeChatMessage[]; text?: string }[]): {
+  gate: MobileNativeChatStreamingGate
+  results: (string | null)[]
+} {
+  let gate = createMobileNativeChatStreamingGate()
+  const results: (string | null)[] = []
+  for (const tick of ticks) {
+    const step = deriveMobileNativeChatStreaming(gate, tick.folded, tick.text)
+    gate = step.gate
+    results.push(step.streaming)
+  }
+  return { gate, results }
+}
+
+describe('deriveMobileNativeChatStreaming', () => {
+  it('shows a genuine reply that repeats the previous turn as a prefix', () => {
+    const prior = [assistant('a1', 'The tests pass.')]
+    const { results } = run([
+      { folded: prior }, // idle tick anchors the pre-stream tail
+      { folded: prior, text: 'The' },
+      { folded: prior, text: 'The tests' },
+      { folded: prior, text: 'The tests pass.' }
+    ])
+    expect(results).toEqual([null, 'The', 'The tests', 'The tests pass.'])
+  })
+
+  it('hides the bubble once the real turn lands leading with the streamed text', () => {
+    const prior = [assistant('a1', 'earlier turn')]
+    const landed = [...prior, assistant('a2', 'fresh answer with a tail')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'fresh answer' },
+      { folded: landed, text: 'fresh answer' }
+    ])
+    expect(results).toEqual([null, 'fresh answer', null])
+  })
+
+  it('suppresses an identical repeated reply once its own turn lands', () => {
+    const prior = [assistant('a1', 'Done.')]
+    const landed = [...prior, assistant('a2', 'Done.')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'Done.' }, // repeated-prefix reply stays visible
+      { folded: landed, text: 'Done.' } // its own turn landed — hide
+    ])
+    expect(results).toEqual([null, 'Done.', null])
+  })
+
+  it('re-anchors when a new reply part replaces the stream mid-turn', () => {
+    const prior = [assistant('a1', 'context')]
+    const partOneLanded = [...prior, assistant('a2', 'part one full text')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'part one' },
+      { folded: partOneLanded, text: 'part one' }, // caught up — hide
+      // Part two is not an extension of part one: new segment, new baseline.
+      { folded: partOneLanded, text: 'part' }
+    ])
+    expect(results).toEqual([null, 'part one', null, 'part'])
+  })
+
+  it('falls back to suppress-on-prefix when mounted mid-stream', () => {
+    // No idle tick ever observed: a duplicate bubble is worse than briefly
+    // hiding a mount-coincident repeated reply.
+    const landed = [assistant('a1', 'flushed part still streaming in status')]
+    const { results } = run([{ folded: landed, text: 'flushed part' }])
+    expect(results).toEqual([null])
+  })
+
+  it('is idempotent for a repeated tick', () => {
+    const prior = [assistant('a1', 'The tests pass.')]
+    const first = run([{ folded: prior }, { folded: prior, text: 'The tests' }])
+    const again = deriveMobileNativeChatStreaming(first.gate, prior, 'The tests')
+    expect(again.streaming).toBe('The tests')
+    expect(again.gate).toEqual(first.gate)
+  })
+
+  it('returns null for empty or whitespace streaming text', () => {
+    const prior = [assistant('a1', 'x')]
+    expect(run([{ folded: prior, text: '   ' }]).results).toEqual([null])
+    expect(run([{ folded: prior }]).results).toEqual([null])
+  })
+})

--- a/mobile/src/session/mobile-native-chat-streaming-gate.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.ts
@@ -8,6 +8,8 @@ import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
  *  hides only when the tail MOVED during the segment and leads with the
  *  streamed text (the real turn landed), never for an older identical turn. */
 export type MobileNativeChatStreamingGate = {
+  /** Chat/session identity this baseline belongs to. */
+  scopeKey: string | null
   /** Streamed text seen on the previous tick ('' while idle). */
   prevText: string
   /** Folded tail message id when the current segment began; null while the
@@ -16,8 +18,10 @@ export type MobileNativeChatStreamingGate = {
   baselineTailId: string | null
 }
 
-export function createMobileNativeChatStreamingGate(): MobileNativeChatStreamingGate {
-  return { prevText: '', baselineTailId: null }
+export function createMobileNativeChatStreamingGate(
+  scopeKey: string | null = null
+): MobileNativeChatStreamingGate {
+  return { scopeKey, prevText: '', baselineTailId: null }
 }
 
 function assistantTailText(tail: NativeChatMessage | undefined): string {
@@ -40,7 +44,7 @@ function advanceGate(
 ): MobileNativeChatStreamingGate {
   return gate.prevText === prevText && gate.baselineTailId === baselineTailId
     ? gate
-    : { prevText, baselineTailId }
+    : { ...gate, prevText, baselineTailId }
 }
 
 /** Advance the gate one tick and derive the visible streaming text (null hides
@@ -49,20 +53,23 @@ function advanceGate(
 export function deriveMobileNativeChatStreaming(
   gate: MobileNativeChatStreamingGate,
   folded: readonly NativeChatMessage[],
-  streamingText: string | undefined
+  streamingText: string | undefined,
+  scopeKey: string | null = gate.scopeKey
 ): { gate: MobileNativeChatStreamingGate; streaming: string | null } {
+  const scopedGate =
+    gate.scopeKey === scopeKey ? gate : createMobileNativeChatStreamingGate(scopeKey)
   const text = streamingText?.trim() ?? ''
   const tail = folded.at(-1)
   const tailId = tail?.id ?? null
   if (!text) {
     // Idle: keep anchoring the baseline to the live tail so the next segment
     // knows which tail predates it.
-    return { gate: advanceGate(gate, '', tailId), streaming: null }
+    return { gate: advanceGate(scopedGate, '', tailId), streaming: null }
   }
   // A stream that is not an extension of the previous tick is a new segment
   // (next reply part); re-anchor to the tail that predates it.
-  const segmentStart = gate.prevText !== '' && !text.startsWith(gate.prevText)
-  const baselineTailId = segmentStart ? tailId : gate.baselineTailId
+  const segmentStart = scopedGate.prevText !== '' && !text.startsWith(scopedGate.prevText)
+  const baselineTailId = segmentStart ? tailId : scopedGate.baselineTailId
   const tailText = assistantTailText(tail)
   const tailLeadsWithStream = tailText.startsWith(text)
   // baselineTailId === null: mounted mid-stream with no pre-stream observation —
@@ -70,7 +77,7 @@ export function deriveMobileNativeChatStreaming(
   // hiding an improbable mount-coincident repeated reply).
   const caughtUp = tailLeadsWithStream && (baselineTailId === null || tailId !== baselineTailId)
   return {
-    gate: advanceGate(gate, text, baselineTailId),
+    gate: advanceGate(scopedGate, text, baselineTailId),
     streaming: caughtUp ? null : text
   }
 }

--- a/mobile/src/session/mobile-native-chat-streaming-gate.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.ts
@@ -1,0 +1,76 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+/** Decides whether the live streaming preview should render as a synthetic
+ *  bubble. Text alone can't tell "the transcript caught up with this stream"
+ *  from "a new reply happens to repeat the previous turn's prefix" — the old
+ *  prefix test swallowed genuine repeated-prefix replies. The gate keeps the
+ *  transcript tail observed when the current stream segment began: the bubble
+ *  hides only when the tail MOVED during the segment and leads with the
+ *  streamed text (the real turn landed), never for an older identical turn. */
+export type MobileNativeChatStreamingGate = {
+  /** Streamed text seen on the previous tick ('' while idle). */
+  prevText: string
+  /** Folded tail message id when the current segment began; null while the
+   *  gate has never observed an idle tick (mounted mid-stream), where the
+   *  legacy suppress-on-prefix rule applies. */
+  baselineTailId: string | null
+}
+
+export function createMobileNativeChatStreamingGate(): MobileNativeChatStreamingGate {
+  return { prevText: '', baselineTailId: null }
+}
+
+function assistantTailText(tail: NativeChatMessage | undefined): string {
+  if (!tail || tail.role !== 'assistant') {
+    return ''
+  }
+  return tail.blocks
+    .filter((block) => block.type === 'text')
+    .map((block) => (block.type === 'text' ? block.text : ''))
+    .join('')
+    .trim()
+}
+
+// Reuses the incoming gate object when nothing moved, so a caller can detect
+// "no change" by reference (and a render-time state adjustment can settle).
+function advanceGate(
+  gate: MobileNativeChatStreamingGate,
+  prevText: string,
+  baselineTailId: string | null
+): MobileNativeChatStreamingGate {
+  return gate.prevText === prevText && gate.baselineTailId === baselineTailId
+    ? gate
+    : { prevText, baselineTailId }
+}
+
+/** Advance the gate one tick and derive the visible streaming text (null hides
+ *  the bubble). Pure and idempotent for a repeated (text, tail) pair, so a
+ *  re-render without new data cannot flip the decision. */
+export function deriveMobileNativeChatStreaming(
+  gate: MobileNativeChatStreamingGate,
+  folded: readonly NativeChatMessage[],
+  streamingText: string | undefined
+): { gate: MobileNativeChatStreamingGate; streaming: string | null } {
+  const text = streamingText?.trim() ?? ''
+  const tail = folded.at(-1)
+  const tailId = tail?.id ?? null
+  if (!text) {
+    // Idle: keep anchoring the baseline to the live tail so the next segment
+    // knows which tail predates it.
+    return { gate: advanceGate(gate, '', tailId), streaming: null }
+  }
+  // A stream that is not an extension of the previous tick is a new segment
+  // (next reply part); re-anchor to the tail that predates it.
+  const segmentStart = gate.prevText !== '' && !text.startsWith(gate.prevText)
+  const baselineTailId = segmentStart ? tailId : gate.baselineTailId
+  const tailText = assistantTailText(tail)
+  const tailLeadsWithStream = tailText.startsWith(text)
+  // baselineTailId === null: mounted mid-stream with no pre-stream observation —
+  // fall back to suppress-on-prefix (a duplicate bubble is worse than briefly
+  // hiding an improbable mount-coincident repeated reply).
+  const caughtUp = tailLeadsWithStream && (baselineTailId === null || tailId !== baselineTailId)
+  return {
+    gate: advanceGate(gate, text, baselineTailId),
+    streaming: caughtUp ? null : text
+  }
+}

--- a/mobile/src/session/mobile-native-chat-terminal-write-lock.ts
+++ b/mobile/src/session/mobile-native-chat-terminal-write-lock.ts
@@ -1,0 +1,25 @@
+// Serializes composed native-chat write sequences (clear/paste/settle/submit,
+// paced answer keystrokes) per HOST terminal. Two concurrent sequences into one
+// PTY interleave their bytes; a second sender must be rejected up front, not
+// woven in. Module scope for the same reason as the stale-input marker: the
+// terminal outlives any one screen, and independent hooks share the same PTY.
+const writeInFlightTerminals = new Set<string>()
+
+/** Claim the terminal for one composed write sequence. False = another
+ *  sequence is mid-flight; the caller must reject its send. */
+export function acquireMobileNativeChatTerminalWrite(terminal: string): boolean {
+  if (writeInFlightTerminals.has(terminal)) {
+    return false
+  }
+  writeInFlightTerminals.add(terminal)
+  return true
+}
+
+export function releaseMobileNativeChatTerminalWrite(terminal: string): void {
+  writeInFlightTerminals.delete(terminal)
+}
+
+/** Test-only: module scope outlives a single test's hooks. */
+export function resetMobileNativeChatTerminalWritesForTests(): void {
+  writeInFlightTerminals.clear()
+}

--- a/mobile/src/session/mobile-native-chat-tool-summary.ts
+++ b/mobile/src/session/mobile-native-chat-tool-summary.ts
@@ -3,6 +3,7 @@ export {
   countToolCalls,
   describeToolInput,
   formatToolInput,
+  isStructuredToolInput,
   summarizeToolInput,
   summarizeToolRun,
   toolFilePath

--- a/mobile/src/session/mobile-native-chat-tool-summary.ts
+++ b/mobile/src/session/mobile-native-chat-tool-summary.ts
@@ -1,6 +1,8 @@
 export {
   briefToolArg,
   countToolCalls,
+  describeToolInput,
+  formatToolInput,
   summarizeToolInput,
   summarizeToolRun,
   toolFilePath

--- a/mobile/src/session/mobile-native-chat-view-styles.ts
+++ b/mobile/src/session/mobile-native-chat-view-styles.ts
@@ -24,6 +24,9 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.xs
   },
+  stopDisabled: {
+    opacity: 0.4
+  },
   stopLabel: {
     color: colors.statusRed,
     fontSize: typography.metaSize,
@@ -105,5 +108,16 @@ export const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: typography.metaSize,
     fontWeight: '600'
+  },
+  loadEarlierErrorText: {
+    color: colors.statusRed,
+    fontSize: typography.metaSize,
+    fontWeight: '600'
+  },
+  loadEarlierRetryText: {
+    color: colors.textSecondary,
+    fontSize: typography.metaSize,
+    fontWeight: '700',
+    marginTop: spacing.xs
   }
 })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -423,9 +423,10 @@ describe('useMobileNativeChatAnswerSend', () => {
     await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
   })
 
-  it('lets a superseding answer inherit the cancelled chain’s lock and releases it last', async () => {
+  it('fences a superseding answer after the cancelled chain moved the selector', async () => {
+    const onSendError = vi.fn()
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
-    await mount({ sendRequest } as unknown as RpcClient, vi.fn())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
 
     const prompt: AskPrompt = {
       questions: [
@@ -438,22 +439,24 @@ describe('useMobileNativeChatAnswerSend', () => {
     await act(async () => {
       first = answerSend?.answerAsk(prompt, [{ indices: [0] }, { indices: [0] }])
     })
-    // The user changes their mind mid-pacing: the new answer must not be
-    // rejected by the lock its own predecessor still holds.
+    // The first digit already advanced Claude to q2. Replaying a from-q1 key
+    // plan now would answer the wrong question.
     await act(async () => {
       second = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
     })
     await act(async () => vi.runAllTimersAsync())
 
     await expect(first).resolves.toBe(false)
-    await expect(second).resolves.toBe(true)
+    await expect(second).resolves.toBe(false)
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(onSendError).toHaveBeenCalledWith('Answer partly sent — check chat before retrying')
     // Both chains unwound: the terminal is free for the next composed write.
     expect(acquireMobileNativeChatTerminalWrite('terminal')).toBe(true)
     releaseMobileNativeChatTerminalWrite('terminal')
   })
 
-  it('queues a superseding answer behind an in-flight terminal write', async () => {
-    let resolveFirst: (response: ReturnType<typeof acceptedResponse>) => void = () => undefined
+  it('does not write a successor after the prior in-flight key is accepted', async () => {
+    let resolveFirst: (response: unknown) => void = () => undefined
     const sendRequest = vi
       .fn()
       .mockImplementationOnce(
@@ -487,6 +490,42 @@ describe('useMobileNativeChatAnswerSend', () => {
       resolveFirst(acceptedResponse())
       await Promise.resolve()
     })
+    await expect(first).resolves.toBe(false)
+    await expect(second).resolves.toBe(false)
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets a queued successor continue after the prior key is definitely rejected', async () => {
+    let resolveFirst: (response: unknown) => void = () => undefined
+    const sendRequest = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, vi.fn())
+
+    let first: Promise<boolean> | undefined
+    let second: Promise<boolean> | undefined
+    await act(async () => {
+      first = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [0] }])
+      await Promise.resolve()
+    })
+    await act(async () => {
+      second = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+      await Promise.resolve()
+    })
+    await act(async () => {
+      resolveFirst({
+        ...acceptedResponse(),
+        result: { send: { accepted: false } }
+      })
+      await Promise.resolve()
+    })
+
     await expect(first).resolves.toBe(false)
     await expect(second).resolves.toBe(true)
     expect(sendRequest).toHaveBeenCalledTimes(2)

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -11,6 +11,11 @@ import {
   markMobileNativeChatInputStale,
   resetMobileNativeChatStaleInputForTests
 } from './mobile-native-chat-stale-input'
+import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite,
+  resetMobileNativeChatTerminalWritesForTests
+} from './mobile-native-chat-terminal-write-lock'
 import { useMobileNativeChatAnswerSend } from './use-mobile-native-chat-answer-send'
 
 type AnswerSend = ReturnType<typeof useMobileNativeChatAnswerSend>
@@ -45,6 +50,7 @@ describe('useMobileNativeChatAnswerSend', () => {
     vi.useFakeTimers()
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     resetMobileNativeChatStaleInputForTests()
+    resetMobileNativeChatTerminalWritesForTests()
   })
 
   afterEach(() => {
@@ -375,8 +381,9 @@ describe('useMobileNativeChatAnswerSend', () => {
   })
 
   it('cancels delayed keystrokes when the acknowledged input lease is lost', async () => {
+    const onSendError = vi.fn()
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
-    await mount({ sendRequest } as unknown as RpcClient, vi.fn())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
 
     const prompt: AskPrompt = {
       questions: [
@@ -395,5 +402,53 @@ describe('useMobileNativeChatAnswerSend', () => {
 
     await expect(result).resolves.toBe(false)
     expect(sendRequest).toHaveBeenCalledTimes(1)
+    // The first group DID land before the swap aborted the chain — the card
+    // must not end looking cleanly sent (STA-3333: abort paths misreported).
+    expect(onSendError).toHaveBeenCalledWith('Answer partly sent — check chat before retrying')
+  })
+
+  it('rejects an answer while another composed write holds the terminal', async () => {
+    const onSendError = vi.fn()
+    const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
+
+    // An image paste sequence is mid-flight into the same PTY.
+    expect(acquireMobileNativeChatTerminalWrite('terminal')).toBe(true)
+    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(false)
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(onSendError).toHaveBeenCalledWith('Answer not sent')
+
+    // Once that sequence releases, answers flow again.
+    releaseMobileNativeChatTerminalWrite('terminal')
+    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
+  })
+
+  it('lets a superseding answer inherit the cancelled chain’s lock and releases it last', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, vi.fn())
+
+    const prompt: AskPrompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'q2', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] }
+      ]
+    }
+    let first: Promise<boolean> | undefined
+    let second: Promise<boolean> | undefined
+    await act(async () => {
+      first = answerSend?.answerAsk(prompt, [{ indices: [0] }, { indices: [0] }])
+    })
+    // The user changes their mind mid-pacing: the new answer must not be
+    // rejected by the lock its own predecessor still holds.
+    await act(async () => {
+      second = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+    })
+    await act(async () => vi.runAllTimersAsync())
+
+    await expect(first).resolves.toBe(false)
+    await expect(second).resolves.toBe(true)
+    // Both chains unwound: the terminal is free for the next composed write.
+    expect(acquireMobileNativeChatTerminalWrite('terminal')).toBe(true)
+    releaseMobileNativeChatTerminalWrite('terminal')
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -491,4 +491,39 @@ describe('useMobileNativeChatAnswerSend', () => {
     await expect(second).resolves.toBe(true)
     expect(sendRequest).toHaveBeenCalledTimes(2)
   })
+
+  it('does not write a successor after the prior delivery becomes ambiguous', async () => {
+    let rejectFirst: (error: Error) => void = () => undefined
+    const onSendError = vi.fn()
+    const sendRequest = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirst = reject
+          })
+      )
+      .mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
+
+    let first: Promise<boolean> | undefined
+    let second: Promise<boolean> | undefined
+    await act(async () => {
+      first = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [0] }])
+      await Promise.resolve()
+    })
+    await act(async () => {
+      second = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+      await Promise.resolve()
+    })
+    await act(async () => {
+      rejectFirst(markRpcDeliveryUnknown(new Error('Connection closed')))
+      await Promise.resolve()
+    })
+
+    await expect(first).resolves.toBe(false)
+    await expect(second).resolves.toBe(false)
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(onSendError).toHaveBeenCalledWith('Answer unconfirmed — check chat before retrying')
+  })
 })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -451,4 +451,44 @@ describe('useMobileNativeChatAnswerSend', () => {
     expect(acquireMobileNativeChatTerminalWrite('terminal')).toBe(true)
     releaseMobileNativeChatTerminalWrite('terminal')
   })
+
+  it('queues a superseding answer behind an in-flight terminal write', async () => {
+    let resolveFirst: (response: ReturnType<typeof acceptedResponse>) => void = () => undefined
+    const sendRequest = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, vi.fn())
+
+    const prompt: AskPrompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'q2', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] }
+      ]
+    }
+    let first: Promise<boolean> | undefined
+    let second: Promise<boolean> | undefined
+    await act(async () => {
+      first = answerSend?.answerAsk(prompt, [{ indices: [0] }, { indices: [0] }])
+      await Promise.resolve()
+    })
+    await act(async () => {
+      second = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+      await Promise.resolve()
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      resolveFirst(acceptedResponse())
+      await Promise.resolve()
+    })
+    await expect(first).resolves.toBe(false)
+    await expect(second).resolves.toBe(true)
+    expect(sendRequest).toHaveBeenCalledTimes(2)
+  })
 })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -80,6 +80,8 @@ export function useMobileNativeChatAnswerSend(args: {
   // superseding answer inherits the cancelled chain's hold (it re-enters before
   // the old chain unwinds), and only the last chain out releases the lock.
   const writeHoldsRef = useRef(new Map<string, number>())
+  // Successors wait for the prior chain's active RPC before sharing its hold.
+  const writeTurnsRef = useRef(new Map<string, Promise<void>>())
   const delaysRef = useRef<
     Set<{ timer: ReturnType<typeof setTimeout>; resolve: (completed: boolean) => void }>
   >(new Set())
@@ -122,12 +124,22 @@ export function useMobileNativeChatAnswerSend(args: {
         return false
       }
       holds.set(handle, heldCount + 1)
+      const previousTurn = writeTurnsRef.current.get(handle) ?? Promise.resolve()
+      let finishTurn: () => void = () => undefined
+      const turn = new Promise<void>((resolve) => {
+        finishTurn = resolve
+      })
+      writeTurnsRef.current.set(handle, turn)
       // A new answer supersedes any still-pending keystroke writes.
       cancelPending()
       const generation = generationRef.current
       let sawUnknownOutcome = false
       let sawAcceptedGroup = false
       try {
+        await previousTurn
+        if (generationRef.current !== generation) {
+          return false
+        }
         // One budget for the whole answer instead of a fresh timeout per keystroke
         // group, which let an N-group selector hold the card for N × the send timeout.
         // It bounds transport time only: each deliberate pacing wait is credited back
@@ -162,8 +174,11 @@ export function useMobileNativeChatAnswerSend(args: {
           }
           return outcome === 'accepted'
         }
-        const wait = (ms: number): Promise<boolean> =>
-          new Promise((resolve) => {
+        const wait = (ms: number): Promise<boolean> => {
+          if (generationRef.current !== generation) {
+            return Promise.resolve(false)
+          }
+          return new Promise((resolve) => {
             const delay = {
               timer: setTimeout(() => {
                 delaysRef.current.delete(delay)
@@ -173,6 +188,7 @@ export function useMobileNativeChatAnswerSend(args: {
             }
             delaysRef.current.add(delay)
           })
+        }
         const fail = (): false => {
           // Why: keystrokes that may have landed (ack lost / path cutover) must
           // not read as a definite failure — a blind resend could double-step
@@ -246,6 +262,10 @@ export function useMobileNativeChatAnswerSend(args: {
         }
         return groups.length > 0
       } finally {
+        finishTurn()
+        if (writeTurnsRef.current.get(handle) === turn) {
+          writeTurnsRef.current.delete(handle)
+        }
         // Last chain out releases; a superseded chain unwinding late must not
         // free the lock out from under the successor sharing its hold.
         const remaining = (holds.get(handle) ?? 1) - 1

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -263,7 +263,9 @@ export function useMobileNativeChatAnswerSend(args: {
         }
         return groups.length > 0
       } finally {
-        finishTurn(predecessorSafe && !sawUnknownOutcome)
+        // Any accepted key changed the live selector, so a queued replacement
+        // cannot safely apply its from-scratch key plan to that new position.
+        finishTurn(predecessorSafe && !sawUnknownOutcome && !sawAcceptedGroup)
         if (writeTurnsRef.current.get(handle) === turn) {
           writeTurnsRef.current.delete(handle)
         }

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -15,6 +15,10 @@ import {
 } from './mobile-native-chat-send'
 import { healMobileNativeChatStaleInput } from './mobile-native-chat-stale-input'
 import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite
+} from './mobile-native-chat-terminal-write-lock'
+import {
   resolveNativeChatTranscriptAgent,
   shouldStepNativeChatAskAnswer
 } from '../../../src/shared/native-chat-agent-support'
@@ -72,6 +76,10 @@ export function useMobileNativeChatAnswerSend(args: {
   const generationRef = useRef(0)
   const activeRouteRef = useRef({ client, enabled, sessionId, streamIdentity })
   activeRouteRef.current = { client, enabled, sessionId, streamIdentity }
+  // Per-terminal count of this hook's chains sharing one write-lock hold: a
+  // superseding answer inherits the cancelled chain's hold (it re-enters before
+  // the old chain unwinds), and only the last chain out releases the lock.
+  const writeHoldsRef = useRef(new Map<string, number>())
   const delaysRef = useRef<
     Set<{ timer: ReturnType<typeof setTimeout>; resolve: (completed: boolean) => void }>
   >(new Set())
@@ -103,125 +111,151 @@ export function useMobileNativeChatAnswerSend(args: {
       if (!hasAskAnswer(prompt, selections)) {
         return false
       }
+      // One composed write sequence per terminal: an answer landing mid-flight
+      // in an image paste (or vice versa) would interleave bytes into the PTY.
+      // A superseding answer shares the cancelled chain's hold on this terminal
+      // (that chain has not unwound to its release yet).
+      const holds = writeHoldsRef.current
+      const heldCount = holds.get(handle) ?? 0
+      if (heldCount === 0 && !acquireMobileNativeChatTerminalWrite(handle)) {
+        onSendError('Answer not sent')
+        return false
+      }
+      holds.set(handle, heldCount + 1)
       // A new answer supersedes any still-pending keystroke writes.
       cancelPending()
       const generation = generationRef.current
       let sawUnknownOutcome = false
       let sawAcceptedGroup = false
-      // One budget for the whole answer instead of a fresh timeout per keystroke
-      // group, which let an N-group selector hold the card for N × the send timeout.
-      // It bounds transport time only: each deliberate pacing wait is credited back
-      // below, so a long multi-question answer still gets a full budget to write in.
-      let deadline = openMobileNativeChatSendBudget()
-      const sendTerminal = async (body: string, enter: boolean): Promise<boolean> => {
-        const activeRoute = activeRouteRef.current
-        if (
-          !activeRoute.enabled ||
-          activeRoute.client !== client ||
-          activeRoute.sessionId !== sessionId ||
-          activeRoute.streamIdentity !== streamIdentity ||
-          handleRef.current !== handle
-        ) {
-          return false
-        }
-        const outcome = await sendMobileNativeChatMessageWithOutcome({
-          client,
-          terminal: handle,
-          text: body,
-          enter,
-          deadline,
-          ...(deviceTokenRef.current
-            ? { mobileClient: { id: deviceTokenRef.current, type: 'mobile' } }
-            : {})
-        })
-        if (outcome === 'unknown') {
-          sawUnknownOutcome = true
-        }
-        if (outcome === 'accepted') {
-          sawAcceptedGroup = true
-        }
-        return outcome === 'accepted'
-      }
-      const wait = (ms: number): Promise<boolean> =>
-        new Promise((resolve) => {
-          const delay = {
-            timer: setTimeout(() => {
-              delaysRef.current.delete(delay)
-              resolve(generationRef.current === generation)
-            }, ms),
-            resolve
+      try {
+        // One budget for the whole answer instead of a fresh timeout per keystroke
+        // group, which let an N-group selector hold the card for N × the send timeout.
+        // It bounds transport time only: each deliberate pacing wait is credited back
+        // below, so a long multi-question answer still gets a full budget to write in.
+        let deadline = openMobileNativeChatSendBudget()
+        const sendTerminal = async (body: string, enter: boolean): Promise<boolean> => {
+          const activeRoute = activeRouteRef.current
+          if (
+            !activeRoute.enabled ||
+            activeRoute.client !== client ||
+            activeRoute.sessionId !== sessionId ||
+            activeRoute.streamIdentity !== streamIdentity ||
+            handleRef.current !== handle
+          ) {
+            return false
           }
-          delaysRef.current.add(delay)
-        })
-      const fail = (): false => {
-        if (generationRef.current === generation) {
+          const outcome = await sendMobileNativeChatMessageWithOutcome({
+            client,
+            terminal: handle,
+            text: body,
+            enter,
+            deadline,
+            ...(deviceTokenRef.current
+              ? { mobileClient: { id: deviceTokenRef.current, type: 'mobile' } }
+              : {})
+          })
+          if (outcome === 'unknown') {
+            sawUnknownOutcome = true
+          }
+          if (outcome === 'accepted') {
+            sawAcceptedGroup = true
+          }
+          return outcome === 'accepted'
+        }
+        const wait = (ms: number): Promise<boolean> =>
+          new Promise((resolve) => {
+            const delay = {
+              timer: setTimeout(() => {
+                delaysRef.current.delete(delay)
+                resolve(generationRef.current === generation)
+              }, ms),
+              resolve
+            }
+            delaysRef.current.add(delay)
+          })
+        const fail = (): false => {
           // Why: keystrokes that may have landed (ack lost / path cutover) must
           // not read as a definite failure — a blind resend could double-step
           // the selector. An earlier group that WAS accepted is the same hazard
           // in definite form: a multi-question answer whose shared budget ran out
           // mid-sequence left the remote selector half-stepped, and telling the
           // user nothing was sent invites a retry on top of the advanced state.
-          onSendError(
-            sawAcceptedGroup
-              ? 'Answer partly sent — check chat before retrying'
-              : sawUnknownOutcome
-                ? 'Answer unconfirmed — check chat before retrying'
-                : 'Answer not sent'
-          )
-        }
-        return false
-      }
-      // Grok commits pasted labels; Claude and Codex need their selector-specific
-      // keystrokes paced so each step renders before the next lands.
-      if (!shouldStepNativeChatAskAnswer(agentRef.current)) {
-        // This shape pastes the label into the composer and commits it, so an
-        // orphaned image paste would be submitted along with the answer (#10228).
-        // The selector shapes below deliberately skip the heal: their keys are
-        // `enter: false` for an active overlay, and a single-select answer is a
-        // bare option digit that cannot submit the line at all, so clearing there
-        // would consume the marker still protecting the next real message.
-        // Desktop splits it identically — use-native-chat-interactive-send.ts
-        // routes only the pasted-label shape through the clearing sender.
-        if (
-          !(await healMobileNativeChatStaleInput({
-            client,
-            terminal: handle,
-            deviceToken: deviceTokenRef.current,
-            deadline
-          }))
-        ) {
-          if (generationRef.current === generation) {
-            onSendError('Answer not sent')
+          // A superseded/aborted chain (session swap, Stop, newer answer) stays
+          // silent only while nothing was written yet: once a group landed,
+          // ending silently leaves the card looking cleanly sent.
+          if (generationRef.current === generation || sawAcceptedGroup || sawUnknownOutcome) {
+            onSendError(
+              sawAcceptedGroup
+                ? 'Answer partly sent — check chat before retrying'
+                : sawUnknownOutcome
+                  ? 'Answer unconfirmed — check chat before retrying'
+                  : 'Answer not sent'
+            )
           }
           return false
         }
-        if (generationRef.current !== generation) {
-          return false
-        }
-        return (await sendTerminal(formatAskAnswer(prompt, selections), true)) || fail()
-      }
-      const groups =
-        resolveNativeChatTranscriptAgent(agentRef.current) === 'codex'
-          ? buildCodexAskAnswerKeys(prompt, selections)
-          : buildAskAnswerKeys(prompt, selections)
-      for (let index = 0; index < groups.length; index += 1) {
-        if (generationRef.current !== generation) {
-          return false
-        }
-        const group = groups[index]!
-        const body = 'raw' in group ? group.raw : sanitizeAskFreeText(group.text)
-        if (!(await sendTerminal(body, false))) {
-          return fail()
-        }
-        if (index < groups.length - 1) {
-          if (!(await wait(MOBILE_NATIVE_CHAT_QUESTION_STEP_MS))) {
+        // Grok commits pasted labels; Claude and Codex need their selector-specific
+        // keystrokes paced so each step renders before the next lands.
+        if (!shouldStepNativeChatAskAnswer(agentRef.current)) {
+          // This shape pastes the label into the composer and commits it, so an
+          // orphaned image paste would be submitted along with the answer (#10228).
+          // The selector shapes below deliberately skip the heal: their keys are
+          // `enter: false` for an active overlay, and a single-select answer is a
+          // bare option digit that cannot submit the line at all, so clearing there
+          // would consume the marker still protecting the next real message.
+          // Desktop splits it identically — use-native-chat-interactive-send.ts
+          // routes only the pasted-label shape through the clearing sender.
+          if (
+            !(await healMobileNativeChatStaleInput({
+              client,
+              terminal: handle,
+              deviceToken: deviceTokenRef.current,
+              deadline
+            }))
+          ) {
+            if (generationRef.current === generation) {
+              onSendError('Answer not sent')
+            }
             return false
           }
-          // Pacing is deliberate, not transport latency — don't charge it to the budget.
-          deadline += MOBILE_NATIVE_CHAT_QUESTION_STEP_MS
+          if (generationRef.current !== generation) {
+            return fail()
+          }
+          return (await sendTerminal(formatAskAnswer(prompt, selections), true)) || fail()
+        }
+        const groups =
+          resolveNativeChatTranscriptAgent(agentRef.current) === 'codex'
+            ? buildCodexAskAnswerKeys(prompt, selections)
+            : buildAskAnswerKeys(prompt, selections)
+        for (let index = 0; index < groups.length; index += 1) {
+          if (generationRef.current !== generation) {
+            return fail()
+          }
+          const group = groups[index]!
+          const body = 'raw' in group ? group.raw : sanitizeAskFreeText(group.text)
+          if (!(await sendTerminal(body, false))) {
+            return fail()
+          }
+          if (index < groups.length - 1) {
+            if (!(await wait(MOBILE_NATIVE_CHAT_QUESTION_STEP_MS))) {
+              return fail()
+            }
+            // Pacing is deliberate, not transport latency — don't charge it to the budget.
+            deadline += MOBILE_NATIVE_CHAT_QUESTION_STEP_MS
+          }
+        }
+        return groups.length > 0
+      } finally {
+        // Last chain out releases; a superseded chain unwinding late must not
+        // free the lock out from under the successor sharing its hold.
+        const remaining = (holds.get(handle) ?? 1) - 1
+        if (remaining <= 0) {
+          holds.delete(handle)
+          releaseMobileNativeChatTerminalWrite(handle)
+        } else {
+          holds.set(handle, remaining)
         }
       }
-      return groups.length > 0
     },
     [
       agentRef,

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -80,8 +80,8 @@ export function useMobileNativeChatAnswerSend(args: {
   // superseding answer inherits the cancelled chain's hold (it re-enters before
   // the old chain unwinds), and only the last chain out releases the lock.
   const writeHoldsRef = useRef(new Map<string, number>())
-  // Successors wait for the prior chain's active RPC before sharing its hold.
-  const writeTurnsRef = useRef(new Map<string, Promise<void>>())
+  // Successors wait for the prior RPC and inherit any delivery ambiguity.
+  const writeTurnsRef = useRef(new Map<string, Promise<boolean>>())
   const delaysRef = useRef<
     Set<{ timer: ReturnType<typeof setTimeout>; resolve: (completed: boolean) => void }>
   >(new Set())
@@ -124,9 +124,9 @@ export function useMobileNativeChatAnswerSend(args: {
         return false
       }
       holds.set(handle, heldCount + 1)
-      const previousTurn = writeTurnsRef.current.get(handle) ?? Promise.resolve()
-      let finishTurn: () => void = () => undefined
-      const turn = new Promise<void>((resolve) => {
+      const previousTurn = writeTurnsRef.current.get(handle) ?? Promise.resolve(true)
+      let finishTurn: (safeToContinue: boolean) => void = () => undefined
+      const turn = new Promise<boolean>((resolve) => {
         finishTurn = resolve
       })
       writeTurnsRef.current.set(handle, turn)
@@ -135,9 +135,10 @@ export function useMobileNativeChatAnswerSend(args: {
       const generation = generationRef.current
       let sawUnknownOutcome = false
       let sawAcceptedGroup = false
+      let predecessorSafe = true
       try {
-        await previousTurn
-        if (generationRef.current !== generation) {
+        predecessorSafe = await previousTurn
+        if (!predecessorSafe || generationRef.current !== generation) {
           return false
         }
         // One budget for the whole answer instead of a fresh timeout per keystroke
@@ -262,7 +263,7 @@ export function useMobileNativeChatAnswerSend(args: {
         }
         return groups.length > 0
       } finally {
-        finishTurn()
+        finishTurn(predecessorSafe && !sawUnknownOutcome)
         if (writeTurnsRef.current.get(handle) === turn) {
           writeTurnsRef.current.delete(handle)
         }

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
@@ -18,9 +18,38 @@ describe('useMobileNativeChatAskDismiss', () => {
     state = null
   })
 
-  function Harness({ prompt }: { prompt: AskPrompt }): null {
-    state = useMobileNativeChatAskDismiss(prompt)
+  function Harness({
+    prompt,
+    scopeKey = 'tab-1',
+    observing = true
+  }: {
+    prompt: AskPrompt | null
+    scopeKey?: string | null
+    observing?: boolean
+  }): null {
+    state = useMobileNativeChatAskDismiss({ ask: prompt, scopeKey, observing })
     return null
+  }
+
+  async function mount(props: Parameters<typeof Harness>[0]): Promise<void> {
+    const original = console.error
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      original(...args)
+    })
+    try {
+      await act(async () => {
+        renderer = create(createElement(Harness, props))
+      })
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  }
+
+  async function update(props: Parameters<typeof Harness>[0]): Promise<void> {
+    await act(async () => renderer?.update(createElement(Harness, props)))
   }
 
   const first: AskPrompt = {
@@ -37,24 +66,47 @@ describe('useMobileNativeChatAskDismiss', () => {
   }
 
   it('shows a structurally different replacement without an intervening null', async () => {
-    const original = console.error
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
-      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
-        return
-      }
-      original(...args)
-    })
-    try {
-      await act(async () => {
-        renderer = create(createElement(Harness, { prompt: first }))
-      })
-    } finally {
-      consoleSpy.mockRestore()
-    }
+    await mount({ prompt: first })
     act(() => state?.dismissAsk())
     expect(state?.showAsk).toBe(false)
 
-    await act(async () => renderer?.update(createElement(Harness, { prompt: replacement })))
+    await update({ prompt: replacement })
     expect(state?.showAsk).toBe(true)
+  })
+
+  it('keeps a dismissal across a chat→terminal→chat toggle', async () => {
+    // While the chat surface is hidden the prompt derives to null; that null
+    // proves nothing about the agent and must not reset the dismissal.
+    await mount({ prompt: first })
+    act(() => state?.dismissAsk())
+
+    await update({ prompt: null, observing: false })
+    await update({ prompt: first, observing: true })
+
+    expect(state?.showAsk).toBe(false)
+  })
+
+  it('forgets the dismissal once the prompt clears while observable', async () => {
+    await mount({ prompt: first })
+    act(() => state?.dismissAsk())
+
+    // Agent moved on: the prompt cleared with chat visible.
+    await update({ prompt: null, observing: true })
+    await update({ prompt: first, observing: true })
+
+    expect(state?.showAsk).toBe(true)
+  })
+
+  it('scopes the dismissal to the tab that showed the card', async () => {
+    await mount({ prompt: first, scopeKey: 'tab-1' })
+    act(() => state?.dismissAsk())
+
+    // The same question on another tab is a different pending prompt.
+    await update({ prompt: first, scopeKey: 'tab-2' })
+    expect(state?.showAsk).toBe(true)
+
+    // Returning to the dismissing tab keeps it hidden.
+    await update({ prompt: first, scopeKey: 'tab-1' })
+    expect(state?.showAsk).toBe(false)
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
@@ -104,9 +104,14 @@ describe('useMobileNativeChatAskDismiss', () => {
     // The same question on another tab is a different pending prompt.
     await update({ prompt: first, scopeKey: 'tab-2' })
     expect(state?.showAsk).toBe(true)
+    act(() => state?.dismissAsk())
+    expect(state?.showAsk).toBe(false)
 
-    // Returning to the dismissing tab keeps it hidden.
+    // Dismissing tab 2 must not overwrite tab 1's dismissal.
     await update({ prompt: first, scopeKey: 'tab-1' })
+    expect(state?.showAsk).toBe(false)
+
+    await update({ prompt: first, scopeKey: 'tab-2' })
     expect(state?.showAsk).toBe(false)
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
@@ -20,14 +20,21 @@ describe('useMobileNativeChatAskDismiss', () => {
 
   function Harness({
     prompt,
+    detectedPrompt = prompt,
     scopeKey = 'tab-1',
     observing = true
   }: {
     prompt: AskPrompt | null
+    detectedPrompt?: AskPrompt | null
     scopeKey?: string | null
     observing?: boolean
   }): null {
-    state = useMobileNativeChatAskDismiss({ ask: prompt, scopeKey, observing })
+    state = useMobileNativeChatAskDismiss({
+      ask: prompt,
+      detectedAsk: detectedPrompt,
+      scopeKey,
+      observing
+    })
     return null
   }
 
@@ -72,15 +79,41 @@ describe('useMobileNativeChatAskDismiss', () => {
 
     await update({ prompt: replacement })
     expect(state?.showAsk).toBe(true)
+
+    await update({ prompt: first })
+    expect(state?.showAsk).toBe(true)
+  })
+
+  it('keeps a dismissal while status gating hides a still-detected prompt', async () => {
+    await mount({ prompt: first })
+    const acceptedDismiss = state!.dismissAsk
+
+    await update({ prompt: null, detectedPrompt: first })
+    act(() => acceptedDismiss())
+    await update({ prompt: first })
+
+    expect(state?.showAsk).toBe(false)
+  })
+
+  it('ignores an answer that settles after its prompt cleared', async () => {
+    await mount({ prompt: first })
+    const lateDismiss = state!.dismissAsk
+
+    await update({ prompt: null })
+    act(() => lateDismiss())
+    await update({ prompt: first })
+
+    expect(state?.showAsk).toBe(true)
   })
 
   it('keeps a dismissal across a chat→terminal→chat toggle', async () => {
     // While the chat surface is hidden the prompt derives to null; that null
     // proves nothing about the agent and must not reset the dismissal.
     await mount({ prompt: first })
-    act(() => state?.dismissAsk())
+    const acceptedDismiss = state!.dismissAsk
 
     await update({ prompt: null, observing: false })
+    act(() => acceptedDismiss())
     await update({ prompt: first, observing: true })
 
     expect(state?.showAsk).toBe(false)
@@ -112,6 +145,17 @@ describe('useMobileNativeChatAskDismiss', () => {
     expect(state?.showAsk).toBe(false)
 
     await update({ prompt: first, scopeKey: 'tab-2' })
+    expect(state?.showAsk).toBe(false)
+  })
+
+  it('records a settled answer against its originating tab', async () => {
+    await mount({ prompt: first, scopeKey: 'tab-1' })
+    const tabOneDismiss = state!.dismissAsk
+
+    await update({ prompt: replacement, scopeKey: 'tab-2' })
+    act(() => tabOneDismiss())
+    await update({ prompt: first, scopeKey: 'tab-1' })
+
     expect(state?.showAsk).toBe(false)
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { AskPrompt } from './mobile-native-chat-ask'
 
 /** Track the answered-ask key so the lingering live status doesn't re-show the
@@ -9,6 +9,9 @@ import type { AskPrompt } from './mobile-native-chat-ask'
  *  chat↔terminal view toggle, and a dismissal must survive that round-trip. */
 export function useMobileNativeChatAskDismiss(args: {
   ask?: AskPrompt | null
+  /** Ungated prompt payload. A working/done status hides the card but does not
+   *  prove the sticky prompt itself cleared. */
+  detectedAsk?: AskPrompt | null
   /** Dismissals are scoped to the tab that showed the card, so one tab's
    *  dismissal can't hide an identical question on another tab. */
   scopeKey: string | null
@@ -21,18 +24,22 @@ export function useMobileNativeChatAskDismiss(args: {
   showAsk: boolean
   dismissAsk: () => void
 } {
-  const { ask, scopeKey, observing } = args
+  const { ask, detectedAsk = ask, scopeKey, observing } = args
   const askKey = ask ? JSON.stringify(ask.questions) : null
+  const detectedAskKey = detectedAsk ? JSON.stringify(detectedAsk.questions) : null
+  const detectedAskKeysRef = useRef(new Map<string | null, string | null>())
+  if (observing) {
+    detectedAskKeysRef.current.set(scopeKey, detectedAskKey)
+  }
   const [dismissedByScope, setDismissedByScope] = useState<Map<string | null, string>>(
     () => new Map()
   )
-  // Once the prompt clears while observable (agent moved on), forget the
-  // dismissal so a later question — even an identical one — shows again.
-  const askPresent = ask != null
+  // A cleared or genuinely different detected prompt retires the old dismissal.
   useEffect(() => {
-    if (observing && !askPresent) {
+    if (observing) {
       setDismissedByScope((previous) => {
-        if (!previous.has(scopeKey)) {
+        const dismissedKey = previous.get(scopeKey)
+        if (dismissedKey === undefined || dismissedKey === detectedAskKey) {
           return previous
         }
         const next = new Map(previous)
@@ -40,10 +47,12 @@ export function useMobileNativeChatAskDismiss(args: {
         return next
       })
     }
-  }, [observing, askPresent, scopeKey])
-  const showAsk = askPresent && dismissedByScope.get(scopeKey) !== askKey
+  }, [observing, detectedAskKey, scopeKey])
+  const showAsk = askKey !== null && dismissedByScope.get(scopeKey) !== askKey
   const dismissAsk = (): void => {
-    if (askKey !== null) {
+    // An answer may settle after the prompt cleared or was replaced. Only the
+    // still-current prompt may install a lasting dismissal.
+    if (askKey !== null && detectedAskKeysRef.current.get(scopeKey) === askKey) {
       setDismissedByScope((previous) => new Map(previous).set(scopeKey, askKey))
     }
   }

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
@@ -3,24 +3,42 @@ import type { AskPrompt } from './mobile-native-chat-ask'
 
 /** Track the answered-ask key so the lingering live status doesn't re-show the
  *  same card. The agent emits a post-tool event with the same prompt right after
- *  an answer, so the card is hidden until a genuinely different question arrives. */
-export function useMobileNativeChatAskDismiss(ask?: AskPrompt | null): {
+ *  an answer, so the card is hidden until a genuinely different question arrives.
+ *
+ *  Owned by the controller, not the chat subtree: the overlay unmounts on a
+ *  chat↔terminal view toggle, and a dismissal must survive that round-trip. */
+export function useMobileNativeChatAskDismiss(args: {
+  ask?: AskPrompt | null
+  /** Dismissals are scoped to the tab that showed the card, so one tab's
+   *  dismissal can't hide an identical question on another tab. */
+  scopeKey: string | null
+  /** True while the chat surface can actually observe the prompt. A null ask
+   *  while hidden proves nothing (prompts aren't derived off-chat) and must not
+   *  reset the dismissal — that reset is what resurfaced dismissed cards. */
+  observing: boolean
+}): {
   askKey: string | null
   showAsk: boolean
   dismissAsk: () => void
 } {
+  const { ask, scopeKey, observing } = args
   const askKey = ask ? JSON.stringify(ask.questions) : null
-  const [dismissedAskKey, setDismissedAskKey] = useState<string | null>(null)
-  // Once the prompt clears (agent moved on), forget the dismissal so a later
-  // question — even an identical one — shows again instead of staying hidden.
+  const [dismissed, setDismissed] = useState<{ scope: string | null; key: string } | null>(null)
+  // Once the prompt clears while observable (agent moved on), forget the
+  // dismissal so a later question — even an identical one — shows again.
   const askPresent = ask != null
   useEffect(() => {
-    if (!askPresent) {
-      setDismissedAskKey(null)
+    if (observing && !askPresent) {
+      setDismissed((prev) => (prev !== null && prev.scope === scopeKey ? null : prev))
     }
-  }, [askPresent])
-  const showAsk = askPresent && askKey !== dismissedAskKey
-  const dismissAsk = (): void => setDismissedAskKey(askKey)
+  }, [observing, askPresent, scopeKey])
+  const showAsk =
+    askPresent && !(dismissed !== null && dismissed.scope === scopeKey && dismissed.key === askKey)
+  const dismissAsk = (): void => {
+    if (askKey !== null) {
+      setDismissed({ scope: scopeKey, key: askKey })
+    }
+  }
 
   return { askKey, showAsk, dismissAsk }
 }

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
@@ -28,12 +28,14 @@ export function useMobileNativeChatAskDismiss(args: {
   const askKey = ask ? JSON.stringify(ask.questions) : null
   const detectedAskKey = detectedAsk ? JSON.stringify(detectedAsk.questions) : null
   const detectedAskKeysRef = useRef(new Map<string | null, string | null>())
-  if (observing) {
-    detectedAskKeysRef.current.set(scopeKey, detectedAskKey)
-  }
   const [dismissedByScope, setDismissedByScope] = useState<Map<string | null, string>>(
     () => new Map()
   )
+  useEffect(() => {
+    if (observing) {
+      detectedAskKeysRef.current.set(scopeKey, detectedAskKey)
+    }
+  }, [observing, detectedAskKey, scopeKey])
   // A cleared or genuinely different detected prompt retires the old dismissal.
   useEffect(() => {
     if (observing) {

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
@@ -23,20 +23,28 @@ export function useMobileNativeChatAskDismiss(args: {
 } {
   const { ask, scopeKey, observing } = args
   const askKey = ask ? JSON.stringify(ask.questions) : null
-  const [dismissed, setDismissed] = useState<{ scope: string | null; key: string } | null>(null)
+  const [dismissedByScope, setDismissedByScope] = useState<Map<string | null, string>>(
+    () => new Map()
+  )
   // Once the prompt clears while observable (agent moved on), forget the
   // dismissal so a later question — even an identical one — shows again.
   const askPresent = ask != null
   useEffect(() => {
     if (observing && !askPresent) {
-      setDismissed((prev) => (prev !== null && prev.scope === scopeKey ? null : prev))
+      setDismissedByScope((previous) => {
+        if (!previous.has(scopeKey)) {
+          return previous
+        }
+        const next = new Map(previous)
+        next.delete(scopeKey)
+        return next
+      })
     }
   }, [observing, askPresent, scopeKey])
-  const showAsk =
-    askPresent && !(dismissed !== null && dismissed.scope === scopeKey && dismissed.key === askKey)
+  const showAsk = askPresent && dismissedByScope.get(scopeKey) !== askKey
   const dismissAsk = (): void => {
     if (askKey !== null) {
-      setDismissed({ scope: scopeKey, key: askKey })
+      setDismissedByScope((previous) => new Map(previous).set(scopeKey, askKey))
     }
   }
 

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -50,6 +50,8 @@ export type MobileNativeChatController = {
   nativeChatSession: ReturnType<typeof useMobileNativeChatSession>
   nativeChatAgentWorking: boolean
   nativeChatStreamingText?: string
+  /** Host/workspace/tab/session identity for stateful streaming suppression. */
+  nativeChatStreamIdentity: string
   nativeChatPermission: ReturnType<typeof detectAgentPermission>
   nativeChatQuestion: ReturnType<typeof parseAgentQuestion>
   /** The pending ask, already null while dismissed (dismissal lives here so it
@@ -131,10 +133,12 @@ export function useMobileNativeChatController(args: {
   activeChatAgentRef.current = activeChatResolution?.agent ?? null
 
   const activeChatSessionId = activeChatResolution?.sessionId ?? null
-  const streamIdentity = `${hostId}\0${worktreeId}\0${activeSessionTabId ?? ''}\0${activeChatSessionId ?? ''}\0${activeHandleRef.current ?? ''}`
+  const sourceIdentity = `${hostId}\0${worktreeId}`
+  const streamIdentity = `${sourceIdentity}\0${activeSessionTabId ?? ''}\0${activeChatSessionId ?? ''}\0${activeHandleRef.current ?? ''}`
 
   const nativeChatSession = useMobileNativeChatSession({
     client,
+    sourceIdentity,
     agent: activeChatResolution?.agent ?? null,
     sessionId: activeChatSessionId,
     transcriptPath: activeChatResolution?.transcriptPath ?? null
@@ -289,6 +293,7 @@ export function useMobileNativeChatController(args: {
     nativeChatSession,
     nativeChatAgentWorking,
     nativeChatStreamingText,
+    nativeChatStreamIdentity: streamIdentity,
     nativeChatPermission,
     nativeChatQuestion,
     nativeChatAsk: showNativeChatAsk ? nativeChatAskPrompt : null,

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -20,6 +20,7 @@ import { openMobileNativeChatFile } from './mobile-native-chat-open-file'
 import { useMobileNativeChatPermissionSend } from './mobile-native-chat-permission-send'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 import { useMobileNativeChatAnswerSend } from './use-mobile-native-chat-answer-send'
+import { useMobileNativeChatAskDismiss } from './use-mobile-native-chat-ask-dismiss'
 import { useMobileNativeChatCancelAsk } from './use-mobile-native-chat-cancel-ask'
 import {
   useMobileNativeChatDrafts,
@@ -51,7 +52,13 @@ export type MobileNativeChatController = {
   nativeChatStreamingText?: string
   nativeChatPermission: ReturnType<typeof detectAgentPermission>
   nativeChatQuestion: ReturnType<typeof parseAgentQuestion>
+  /** The pending ask, already null while dismissed (dismissal lives here so it
+   *  survives the chat-view subtree unmounting on a view toggle). */
   nativeChatAsk: ReturnType<typeof parseAskFromStatus>
+  /** Stable key for the current ask card (keys the card component). */
+  nativeChatAskKey: string | null
+  /** Hide the current ask until a genuinely different question arrives. */
+  dismissNativeChatAsk: () => void
   handleNativeChatOpenFile: (relativePath: string) => void
   handleNativeChatAnswerAsk: (
     prompt: AskPrompt,
@@ -169,11 +176,20 @@ export function useMobileNativeChatController(args: {
   const {
     permission: nativeChatPermission,
     question: nativeChatQuestion,
-    ask: nativeChatAsk
+    ask: nativeChatAskPrompt
   } = useMobileNativeChatPrompts({
     enabled: activeChatResolution != null,
     status: nativeChatStatus,
     messages: nativeChatSession.messages
+  })
+  const {
+    askKey: nativeChatAskKey,
+    showAsk: showNativeChatAsk,
+    dismissAsk: dismissNativeChatAsk
+  } = useMobileNativeChatAskDismiss({
+    ask: nativeChatAskPrompt,
+    scopeKey: activeSessionTabId,
+    observing: showNativeChat
   })
 
   const handleNativeChatOpenFile = useCallback(
@@ -275,7 +291,9 @@ export function useMobileNativeChatController(args: {
     nativeChatStreamingText,
     nativeChatPermission,
     nativeChatQuestion,
-    nativeChatAsk,
+    nativeChatAsk: showNativeChatAsk ? nativeChatAskPrompt : null,
+    nativeChatAskKey,
+    dismissNativeChatAsk,
     handleNativeChatOpenFile,
     handleNativeChatAnswerAsk: answerAsk,
     handleNativeChatCancelAsk: cancelAsk,

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -180,6 +180,7 @@ export function useMobileNativeChatController(args: {
   const {
     permission: nativeChatPermission,
     question: nativeChatQuestion,
+    detectedAsk: nativeChatDetectedAsk,
     ask: nativeChatAskPrompt
   } = useMobileNativeChatPrompts({
     enabled: activeChatResolution != null,
@@ -192,6 +193,7 @@ export function useMobileNativeChatController(args: {
     dismissAsk: dismissNativeChatAsk
   } = useMobileNativeChatAskDismiss({
     ask: nativeChatAskPrompt,
+    detectedAsk: nativeChatDetectedAsk,
     scopeKey: activeSessionTabId,
     observing: showNativeChat
   })

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse, RpcSuccess } from '../transport/types'
 import { resetMobileNativeChatStaleInputForTests } from './mobile-native-chat-stale-input'
+import { resetMobileNativeChatTerminalWritesForTests } from './mobile-native-chat-terminal-write-lock'
 import { useMobileNativeChatImageAttachments } from './use-mobile-native-chat-image-attachments'
 
 // Fully stub the picker so the real expo/react-native chain never loads under
@@ -88,9 +89,10 @@ describe('useMobileNativeChatImageAttachments', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     pick.mockReset()
-    // Stale markers live at module scope now (they outlive the screen), so they
-    // also outlive a test.
+    // Stale markers and write locks live at module scope (they outlive the
+    // screen), so they also outlive a test.
     resetMobileNativeChatStaleInputForTests()
+    resetMobileNativeChatTerminalWritesForTests()
   })
   afterEach(() => {
     act(() => renderer?.unmount())

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.ts
@@ -26,6 +26,10 @@ import {
   isMobileNativeChatInputStale,
   markMobileNativeChatInputStale
 } from './mobile-native-chat-stale-input'
+import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite
+} from './mobile-native-chat-terminal-write-lock'
 
 type CurrentRef<T> = { readonly current: T }
 type ShowToast = (message: string, durationMs?: number) => void
@@ -127,8 +131,6 @@ export function useMobileNativeChatImageAttachments({
   // checked 'connected' at entry, so only a ref can see a mid-upload disconnect.
   const connStateRef = useRef(connState)
   connStateRef.current = connState
-  // Serialize clear/paste/submit ownership per terminal while allowing other tabs to send.
-  const sendInFlightTerminalsRef = useRef(new Set<string>())
 
   const attachments = (scopeKey ? attachmentsByScope[scopeKey] : undefined) ?? NO_ATTACHMENTS
 
@@ -219,14 +221,14 @@ export function useMobileNativeChatImageAttachments({
 
   const sendNativeChat = useCallback(
     async (text: string): Promise<boolean> => {
+      // Serialize clear/paste/submit ownership per terminal while allowing other
+      // tabs to send. Shared with the prompt-card writes (answer/permission), so
+      // a card tap can't interleave into a mid-flight paste sequence either.
       const operationTerminal = activeHandleRef.current
-      if (operationTerminal && sendInFlightTerminalsRef.current.has(operationTerminal)) {
+      if (operationTerminal && !acquireMobileNativeChatTerminalWrite(operationTerminal)) {
         onError?.()
         onSendError('Message not sent')
         return false
-      }
-      if (operationTerminal) {
-        sendInFlightTerminalsRef.current.add(operationTerminal)
       }
       // One budget for the whole user action. The paste loop, the settle, and the
       // text body that follows are a single send from the composer's point of view;
@@ -347,7 +349,7 @@ export function useMobileNativeChatImageAttachments({
         }
       } finally {
         if (operationTerminal) {
-          sendInFlightTerminalsRef.current.delete(operationTerminal)
+          releaseMobileNativeChatTerminalWrite(operationTerminal)
         }
       }
     },

--- a/mobile/src/session/use-mobile-native-chat-message-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.test.ts
@@ -19,6 +19,11 @@ vi.mock('./mobile-native-chat-stale-input', () => ({
 }))
 
 import { useMobileNativeChatMessageSend } from './use-mobile-native-chat-message-send'
+import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite,
+  resetMobileNativeChatTerminalWritesForTests
+} from './mobile-native-chat-terminal-write-lock'
 import { buildAgentTuiClearInputForText } from '../../../src/shared/agent-tui-input-clear'
 
 type Send = ReturnType<typeof useMobileNativeChatMessageSend>
@@ -28,6 +33,7 @@ const DRAFT = 'Linked Linear issue: ABC-123\nhttps://linear.app/x/issue/ABC-123'
 describe('useMobileNativeChatMessageSend', () => {
   let renderer: ReactTestRenderer | null = null
   let api: Send | null = null
+  let onSendError = vi.fn()
 
   const mount = (
     readSeededLaunchDraftSeed: () => { text: string; createdAt: number | null } | null
@@ -44,7 +50,7 @@ describe('useMobileNativeChatMessageSend', () => {
         restoreRejectedDraft: () => {},
         acceptSend: () => {},
         holdUnconfirmedSend: () => {},
-        onSendError: () => {}
+        onSendError
       })
       return null
     }
@@ -70,6 +76,8 @@ describe('useMobileNativeChatMessageSend', () => {
     sendWithOutcome.mockResolvedValue('accepted')
     clearInputWrite.mockReset()
     clearInputWrite.mockResolvedValue(true)
+    onSendError = vi.fn()
+    resetMobileNativeChatTerminalWritesForTests()
   })
   afterEach(() => {
     act(() => {
@@ -172,5 +180,28 @@ describe('useMobileNativeChatMessageSend', () => {
       await api!.answerQuestion('1')
     })
     expect(sentArgs().resolvedLaunchDraft).toBeUndefined()
+  })
+
+  it('rejects a question answer while another composed write holds the terminal', async () => {
+    mount(() => null)
+    // An image paste sequence is mid-flight into the same PTY.
+    expect(acquireMobileNativeChatTerminalWrite('term')).toBe(true)
+
+    let result: boolean | undefined
+    await act(async () => {
+      result = await api!.answerQuestion('1')
+    })
+    expect(result).toBe(false)
+    expect(sendWithOutcome).not.toHaveBeenCalled()
+    expect(onSendError).toHaveBeenCalledWith('Answer not sent')
+
+    releaseMobileNativeChatTerminalWrite('term')
+    await act(async () => {
+      result = await api!.answerQuestion('1')
+    })
+    expect(result).toBe(true)
+    // The answer released its own hold on the way out.
+    expect(acquireMobileNativeChatTerminalWrite('term')).toBe(true)
+    releaseMobileNativeChatTerminalWrite('term')
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-message-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-message-send.ts
@@ -7,6 +7,10 @@ import {
   type MobileNativeChatSendOutcome
 } from './mobile-native-chat-send'
 import { healMobileNativeChatStaleInput } from './mobile-native-chat-stale-input'
+import {
+  acquireMobileNativeChatTerminalWrite,
+  releaseMobileNativeChatTerminalWrite
+} from './mobile-native-chat-terminal-write-lock'
 import type { MobileNativeChatSendOrigin } from './use-mobile-native-chat-drafts'
 import type { MobileNativeChatLaunchDraftSeed } from './use-mobile-native-chat-launch-draft-seed'
 import { buildAgentTuiClearInputForText } from '../../../src/shared/agent-tui-input-clear'
@@ -210,11 +214,26 @@ export function useMobileNativeChatMessageSend(args: {
     [sendWithOutcome]
   )
 
-  // A question answer is not composer text, so it never syncs the draft.
+  // A question answer is not composer text, so it never syncs the draft. It
+  // reaches this send directly (not through the image hook's locked path), so
+  // it takes the per-terminal write lock itself: an answer landing mid-flight
+  // in an image paste sequence would interleave bytes into the PTY.
   const answerQuestion = useCallback(
-    async (text: string): Promise<boolean> =>
-      (await sendMessage(text, undefined, false)) !== 'rejected',
-    [sendMessage]
+    async (text: string): Promise<boolean> => {
+      const terminal = handleRef.current
+      if (terminal && !acquireMobileNativeChatTerminalWrite(terminal)) {
+        onSendError('Answer not sent')
+        return false
+      }
+      try {
+        return (await sendMessage(text, undefined, false)) !== 'rejected'
+      } finally {
+        if (terminal) {
+          releaseMobileNativeChatTerminalWrite(terminal)
+        }
+      }
+    },
+    [handleRef, onSendError, sendMessage]
   )
 
   return { send, sendWithOutcome, answerQuestion }

--- a/mobile/src/session/use-mobile-native-chat-prompts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.test.ts
@@ -2,26 +2,38 @@ import { createElement } from 'react'
 import TestRenderer from 'react-test-renderer'
 import { describe, expect, it } from 'vitest'
 import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { useMobileNativeChatPrompts } from './use-mobile-native-chat-prompts'
 
 const APPROVAL = JSON.stringify({
   approval: { tool: 'Bash', summary: 'pnpm build > build.log 2>&1' }
 })
 
-function permissionFor(status: Partial<AgentStatusEntry> | null): unknown {
-  let captured: unknown
+const ASK = JSON.stringify({
+  questions: [{ question: 'Which path?', options: ['fast', 'safe'] }]
+})
+
+function promptsFor(
+  status: Partial<AgentStatusEntry> | null,
+  messages: NativeChatMessage[] = []
+): ReturnType<typeof useMobileNativeChatPrompts> {
+  let captured: ReturnType<typeof useMobileNativeChatPrompts> | undefined
   function Probe(): null {
     captured = useMobileNativeChatPrompts({
       enabled: true,
       status: status as AgentStatusEntry | null,
-      messages: []
-    }).permission
+      messages
+    })
     return null
   }
   TestRenderer.act(() => {
     TestRenderer.create(createElement(Probe))
   })
-  return captured
+  return captured!
+}
+
+function permissionFor(status: Partial<AgentStatusEntry> | null): unknown {
+  return promptsFor(status).permission
 }
 
 describe('useMobileNativeChatPrompts approval-envelope state gate', () => {
@@ -58,5 +70,42 @@ describe('useMobileNativeChatPrompts approval-envelope state gate', () => {
     }) as { options: Array<{ label: string }> } | null
     expect(permission).toMatchObject({ title: 'Permission requested' })
     expect(permission?.options.map((o) => o.label)).toEqual(['Yes', 'No'])
+  })
+})
+
+describe('useMobileNativeChatPrompts ask state gate', () => {
+  const askMessages: NativeChatMessage[] = [
+    {
+      id: 'm1',
+      role: 'assistant',
+      blocks: [
+        {
+          type: 'tool-call',
+          name: 'AskUserQuestion',
+          input: { questions: [{ question: 'Which path?', options: ['fast', 'safe'] }] }
+        }
+      ],
+      timestamp: 0,
+      source: 'transcript'
+    }
+  ]
+
+  it('renders the ask card only while the agent is waiting or blocked', () => {
+    expect(promptsFor({ state: 'waiting', interactivePrompt: ASK }).ask).toMatchObject({
+      questions: [{ question: 'Which path?' }]
+    })
+    expect(promptsFor({ state: 'blocked', interactivePrompt: ASK }).ask).not.toBeNull()
+  })
+
+  it('renders no ask card from a sticky prompt while the agent is working or done', () => {
+    // The prompt payload outlives its answer — same paused gate as permission.
+    expect(promptsFor({ state: 'working', interactivePrompt: ASK }).ask).toBeNull()
+    expect(promptsFor({ state: 'done', interactivePrompt: ASK }).ask).toBeNull()
+  })
+
+  it('gates the transcript-derived pending ask the same way', () => {
+    expect(promptsFor({ state: 'waiting' }, askMessages).ask).not.toBeNull()
+    expect(promptsFor({ state: 'working' }, askMessages).ask).toBeNull()
+    expect(promptsFor(null, askMessages).ask).toBeNull()
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-prompts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.test.ts
@@ -99,8 +99,13 @@ describe('useMobileNativeChatPrompts ask state gate', () => {
 
   it('renders no ask card from a sticky prompt while the agent is working or done', () => {
     // The prompt payload outlives its answer — same paused gate as permission.
-    expect(promptsFor({ state: 'working', interactivePrompt: ASK }).ask).toBeNull()
-    expect(promptsFor({ state: 'done', interactivePrompt: ASK }).ask).toBeNull()
+    const working = promptsFor({ state: 'working', interactivePrompt: ASK })
+    expect(working.ask).toBeNull()
+    expect(working.detectedAsk).not.toBeNull()
+
+    const done = promptsFor({ state: 'done', interactivePrompt: ASK })
+    expect(done.ask).toBeNull()
+    expect(done.detectedAsk).not.toBeNull()
   })
 
   it('gates the transcript-derived pending ask the same way', () => {

--- a/mobile/src/session/use-mobile-native-chat-prompts.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.ts
@@ -45,6 +45,9 @@ export function useMobileNativeChatPrompts(args: {
   return {
     permission,
     question,
-    ask: enabled ? (askFromStatus ?? askFromMessages) : null
+    // Ask cards sit inside the same paused gate as the approval envelope above:
+    // the prompt payload outlives its answer, so only a waiting/blocked agent
+    // may surface one — never a working or done one.
+    ask: enabled && blocked ? (askFromStatus ?? askFromMessages) : null
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-prompts.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.ts
@@ -8,6 +8,7 @@ import { parseAgentQuestion } from './mobile-native-chat-question'
 export type MobileNativeChatPrompts = {
   permission: ReturnType<typeof detectAgentPermission>
   question: ReturnType<typeof parseAgentQuestion>
+  detectedAsk: ReturnType<typeof parseAskFromStatus>
   ask: ReturnType<typeof parseAskFromStatus>
 }
 
@@ -41,13 +42,15 @@ export function useMobileNativeChatPrompts(args: {
     () => (askFromStatus ? null : extractPendingAsk(messages)),
     [askFromStatus, messages]
   )
+  const detectedAsk = askFromStatus ?? askFromMessages
 
   return {
     permission,
     question,
+    detectedAsk: enabled ? detectedAsk : null,
     // Ask cards sit inside the same paused gate as the approval envelope above:
     // the prompt payload outlives its answer, so only a waiting/blocked agent
     // may surface one — never a working or done one.
-    ask: enabled && blocked ? (askFromStatus ?? askFromMessages) : null
+    ask: enabled && blocked ? detectedAsk : null
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -36,6 +36,7 @@ describe('useMobileNativeChatSession', () => {
   function Harness({ client }: { client: RpcClient | null }): null {
     state = useMobileNativeChatSession({
       client,
+      sourceIdentity: 'host-a\0workspace-a',
       agent: 'claude',
       sessionId: 'session',
       transcriptPath: null
@@ -348,14 +349,17 @@ describe('useMobileNativeChatSession transcriptLoading', () => {
   function Harness({
     client,
     sessionId,
-    agent = 'claude'
+    agent = 'claude',
+    sourceIdentity = 'host-a\0workspace-a'
   }: {
     client: RpcClient | null
     sessionId: string | null
     agent?: string | null
+    sourceIdentity?: string
   }): null {
     const session = useMobileNativeChatSession({
       client,
+      sourceIdentity,
       agent,
       sessionId,
       transcriptPath: null
@@ -463,6 +467,30 @@ describe('useMobileNativeChatSession transcriptLoading', () => {
       transcriptLoading: false,
       ids: ['a-1', 'a-2']
     })
+  })
+
+  it('never holds a cached list across a host/workspace source change', async () => {
+    const firstClient = {
+      subscribe: vi.fn((_method: string, _params: unknown, onData: (frame: unknown) => void) => {
+        onData({ type: 'snapshot', messages: [message('source-a')], hasMore: false })
+        return () => {}
+      })
+    } as unknown as RpcClient
+    await mountAt(firstClient, 'session-a')
+
+    const secondClient = { subscribe: vi.fn(() => () => {}) } as unknown as RpcClient
+    renders.length = 0
+    await act(async () =>
+      renderer?.update(
+        createElement(Harness, {
+          client: secondClient,
+          sessionId: 'session-a',
+          sourceIdentity: 'host-b\0workspace-b'
+        })
+      )
+    )
+
+    expect(renders[0]).toMatchObject({ status: 'loading', ids: [] })
   })
 
   it('never hands out the previous session’s messages under the new session id', async () => {

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -281,6 +281,35 @@ describe('useMobileNativeChatSession', () => {
     expect(state?.hasMore).toBe(false)
   })
 
+  it('clears a stale cursor when a replacement omits paging metadata', async () => {
+    const sendRequest = vi.fn()
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({
+        type: 'snapshot',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`)),
+        hasMore: true,
+        beforeOffset: 100
+      })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    await act(async () =>
+      emit({
+        type: 'replacement',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`new-${index}`))
+      })
+    )
+    act(() => state?.loadEarlier())
+
+    expect(sendRequest).toHaveBeenCalledWith('nativeChat.readSession', {
+      agent: 'claude',
+      sessionId: 'session',
+      limit: 100
+    })
+  })
+
   it('surfaces a failed older-history page and clears it on a retry', async () => {
     const sendRequest = vi
       .fn()

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -222,6 +222,36 @@ describe('useMobileNativeChatSession', () => {
     expect(state?.messages.at(-1)?.id).toBe('live-1')
   })
 
+  it('drops paged rows that an authoritative replay says were removed', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        messages: Array.from({ length: 60 }, (_unused, index) => message(`paged-${index}`)),
+        hasMore: false,
+        beforeOffset: 40
+      }
+    })
+    const window = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: window, hasMore: true, beforeOffset: 100 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+    expect(state?.messages).toHaveLength(100)
+
+    await act(async () =>
+      emit({ type: 'snapshot', messages: window, hasMore: false, beforeOffset: 0 })
+    )
+
+    expect(state?.messages).toEqual(window)
+    expect(state?.hasMore).toBe(false)
+  })
+
   it('surfaces a failed older-history page and clears it on a retry', async () => {
     const sendRequest = vi
       .fn()

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -174,6 +174,113 @@ describe('useMobileNativeChatSession', () => {
     }
   )
 
+  it('keeps paged-in history across an auto-reconnect replay snapshot', async () => {
+    // The transport replays the subscription with its original params after an
+    // in-place reconnect, so the replayed snapshot is the newest initial window
+    // again. It must merge into the grown history, not truncate it back to 40.
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        messages: Array.from({ length: 60 }, (_unused, index) => message(`paged-${index}`)),
+        hasMore: false,
+        beforeOffset: 40
+      }
+    })
+    const window = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: window, hasMore: true, beforeOffset: 100 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+    expect(state?.messages).toHaveLength(100)
+
+    // Reconnect replay: the same newest-40 window. History survives untouched.
+    await act(async () =>
+      emit({ type: 'snapshot', messages: window, hasMore: true, beforeOffset: 100 })
+    )
+    expect(state?.messages).toHaveLength(100)
+    expect(state?.messages[0]?.id).toBe('paged-0')
+
+    // A replay carrying one message that arrived while away merges it in; the
+    // grown window stays bounded, so only the single oldest row trims.
+    await act(async () =>
+      emit({
+        type: 'snapshot',
+        messages: [...window, message('live-1')],
+        hasMore: true,
+        beforeOffset: 100
+      })
+    )
+    expect(state?.messages).toHaveLength(100)
+    expect(state?.messages[0]?.id).toBe('paged-1')
+    expect(state?.messages.at(-1)?.id).toBe('live-1')
+  })
+
+  it('surfaces a failed older-history page and clears it on a retry', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error: { message: 'nope' } })
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { messages: [message('older')], hasMore: false, beforeOffset: 0 }
+      })
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      onData({
+        type: 'snapshot',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`)),
+        hasMore: true,
+        beforeOffset: 100
+      })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+    expect(state?.loadEarlierError).toBeTruthy()
+    expect(state?.loadingEarlier).toBe(false)
+
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+    expect(state?.loadEarlierError).toBeNull()
+    expect(state?.messages[0]?.id).toBe('older')
+  })
+
+  it('surfaces a rejected older-history request instead of leaking it', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('Connection interrupted')
+      ) as unknown as RpcClient['sendRequest']
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      onData({
+        type: 'snapshot',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`)),
+        hasMore: true,
+        beforeOffset: 100
+      })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+
+    expect(state?.loadEarlierError).toBeTruthy()
+    expect(state?.loadingEarlier).toBe(false)
+  })
+
   it('rejects a cursor page invalidated by live trim and retries with a growing tail', async () => {
     let resolveCursorPage: (response: unknown) => void = () => {}
     const sendRequest = vi
@@ -291,7 +398,8 @@ describe('useMobileNativeChatSession transcriptLoading', () => {
   it('re-reads instead of resurfacing a settled read when the same identity returns', async () => {
     // Leaving chat view nulls the agent, then returning restores the identity a
     // settled read already matched — but its list was cleared, so trusting it
-    // would report 'ready' over an empty transcript.
+    // would report 'ready' over an empty transcript. The last settled list for
+    // this identity keeps rendering while the re-read is in flight.
     const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
       onData({ type: 'snapshot', messages: [message('a-1')], hasMore: false })
       return () => {}
@@ -309,12 +417,17 @@ describe('useMobileNativeChatSession transcriptLoading', () => {
       renderer?.update(createElement(Harness, { client, sessionId: 'session-a', agent: 'claude' }))
     )
 
-    expect(renders[0]).toMatchObject({ status: 'loading', transcriptLoading: true, ids: [] })
+    expect(renders[0]).toMatchObject({
+      status: 'loading',
+      transcriptLoading: true,
+      ids: ['a-1']
+    })
   })
 
-  it('re-reads instead of resurfacing a settled read after a reconnect', async () => {
-    // A reconnect swaps the client without moving the identity; the effect
-    // re-subscribes and clears the list, so the old outcome must not stand.
+  it('keeps the last settled list rendered while a swapped client re-reads', async () => {
+    // A manual-retry reconnect swaps the client without moving the identity; the
+    // old outcome must not stand ('loading', not 'ready'), but the cached
+    // transcript keeps rendering instead of collapsing to a full-screen spinner.
     const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
       onData({ type: 'snapshot', messages: [message('a-1')], hasMore: false })
       return () => {}
@@ -323,13 +436,33 @@ describe('useMobileNativeChatSession transcriptLoading', () => {
     await mountAt(client, 'session-a')
     expect(renders.at(-1)).toMatchObject({ status: 'ready' })
 
-    const reconnected = { subscribe: vi.fn(() => () => {}) } as unknown as RpcClient
+    let emitFresh: (frame: unknown) => void = () => {}
+    const reconnected = {
+      subscribe: vi.fn((_method: string, _params: unknown, onData: (frame: unknown) => void) => {
+        emitFresh = onData
+        return () => {}
+      })
+    } as unknown as RpcClient
     renders.length = 0
     await act(async () =>
       renderer?.update(createElement(Harness, { client: reconnected, sessionId: 'session-a' }))
     )
 
-    expect(renders[0]).toMatchObject({ status: 'loading', transcriptLoading: true, ids: [] })
+    expect(renders[0]).toMatchObject({
+      status: 'loading',
+      transcriptLoading: true,
+      ids: ['a-1']
+    })
+
+    // The fresh client's snapshot supersedes the held list.
+    await act(async () =>
+      emitFresh({ type: 'snapshot', messages: [message('a-1'), message('a-2')], hasMore: false })
+    )
+    expect(renders.at(-1)).toMatchObject({
+      status: 'ready',
+      transcriptLoading: false,
+      ids: ['a-1', 'a-2']
+    })
   })
 
   it('never hands out the previous session’s messages under the new session id', async () => {

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -222,6 +222,35 @@ describe('useMobileNativeChatSession', () => {
     expect(state?.messages.at(-1)?.id).toBe('live-1')
   })
 
+  it('enables paging when a replay trims a window that previously had no earlier rows', async () => {
+    const sendRequest = vi.fn()
+    const window = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: window, hasMore: false, beforeOffset: 0 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    await act(async () =>
+      emit({
+        type: 'snapshot',
+        messages: [...window.slice(1), message('live-1')],
+        hasMore: true,
+        beforeOffset: 10
+      })
+    )
+
+    expect(state?.messages[0]?.id).toBe('win-1')
+    expect(state?.hasMore).toBe(true)
+    act(() => state?.loadEarlier())
+    expect(sendRequest).toHaveBeenCalledWith('nativeChat.readSession', {
+      agent: 'claude',
+      sessionId: 'session',
+      limit: 100
+    })
+  })
+
   it('drops paged rows that an authoritative replay says were removed', async () => {
     const sendRequest = vi.fn().mockResolvedValue({
       ok: true,

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -24,6 +24,8 @@ export type MobileNativeChatSession = {
   hasMore: boolean
   /** Whether an older-history page is currently loading. */
   loadingEarlier: boolean
+  /** Set when the last older-history page failed; retry via `loadEarlier`. */
+  loadEarlierError: string | null
   /** Grow the window to page in older history. */
   loadEarlier: () => void
 }
@@ -35,6 +37,8 @@ const EMPTY_MESSAGES: NativeChatMessage[] = []
 const INITIAL_LIMIT = 40
 const PAGE = 60
 const MAX_MESSAGES = 2000
+
+const LOAD_EARLIER_ERROR = 'Couldn’t load earlier messages'
 
 type ReadSessionResult =
   | { messages: NativeChatMessage[]; hasMore?: boolean; beforeOffset?: number }
@@ -81,6 +85,7 @@ export function useMobileNativeChatSession(args: {
   const [error, setError] = useState<string | undefined>(undefined)
   const [hasMore, setHasMore] = useState(false)
   const [loadingEarlier, setLoadingEarlier] = useState(false)
+  const [loadEarlierError, setLoadEarlierError] = useState<string | null>(null)
   const loadingEarlierRef = useRef(false)
   const beforeOffsetRef = useRef<number | null>(null)
   // Stateful id-dedup merger: caches the id→index map so each live append frame
@@ -92,6 +97,22 @@ export function useMobileNativeChatSession(args: {
   const sessionIdRef = useRef<string | null>(sessionId)
   sessionIdRef.current = sessionId
   const streamGenerationRef = useRef(0)
+  // Whether this subscription already delivered its base snapshot; later
+  // snapshots on the same subscription are reconnect replays, not fresh bases.
+  const snapshotSeenRef = useRef(false)
+  // Last list a settled read produced, keyed by the identity it belongs to. A
+  // reconnect swaps the client without moving the identity; keep rendering this
+  // while the swapped client's read is in flight instead of collapsing to a
+  // full-screen spinner (UI stays steady while loading).
+  const lastListRef = useRef<{ identity: string; messages: NativeChatMessage[] } | null>(null)
+  const settledReady = settled?.status === 'ready'
+  useEffect(() => {
+    // Post-commit capture: while a swap is re-reading, `settled` is null and
+    // the previous commit's capture keeps serving this identity.
+    if (settledReady) {
+      lastListRef.current = { identity, messages }
+    }
+  }, [settledReady, identity, messages])
 
   // Replace the base list (read results are an ordered tail). Resets the merger
   // cache so the index is rebuilt once over the new base.
@@ -107,7 +128,9 @@ export function useMobileNativeChatSession(args: {
     streamGenerationRef.current += 1
     limitRef.current = INITIAL_LIMIT
     loadingEarlierRef.current = false
+    snapshotSeenRef.current = false
     setLoadingEarlier(false)
+    setLoadEarlierError(null)
     setList([])
     setError(undefined)
     setHasMore(false)
@@ -133,20 +156,11 @@ export function useMobileNativeChatSession(args: {
           return
         }
         const frame = raw as MobileNativeChatStreamFrame
-        if (frame.type === 'replacement' || frame.type === 'snapshot') {
-          // Why: replacement and reconnect snapshots are authoritative windows;
-          // stale page limits/results must not constrain the fresh generation.
-          streamGenerationRef.current += 1
-          limitRef.current = INITIAL_LIMIT
-          loadingEarlierRef.current = false
-          setLoadingEarlier(false)
-        }
-        const replaceSnapshot = frame.type === 'snapshot'
         const applied = applyMobileNativeChatStreamFrame({
           merger: mergerRef.current,
           frame,
           limit: limitRef.current,
-          replaceSnapshot
+          replaceSnapshot: !snapshotSeenRef.current
         })
         if (applied.kind === 'ignored') {
           return
@@ -155,6 +169,22 @@ export function useMobileNativeChatSession(args: {
           setRead({ client, identity, status: 'error' })
           setError(applied.error)
           return
+        }
+        if (frame.type === 'snapshot') {
+          snapshotSeenRef.current = true
+        }
+        if (applied.windowReplaced || frame.type === 'snapshot') {
+          // Why: any authoritative window (and any replay merge) invalidates an
+          // in-flight older-page request; stale results must not land on it.
+          streamGenerationRef.current += 1
+          loadingEarlierRef.current = false
+          setLoadingEarlier(false)
+          setLoadEarlierError(null)
+        }
+        if (applied.windowReplaced) {
+          // Only a genuinely fresh window resets the grown read window — an
+          // overlapping reconnect replay keeps the paged-in history and limit.
+          limitRef.current = INITIAL_LIMIT
         }
         setMessages(applied.messages)
         if (applied.hasMore != null) {
@@ -198,6 +228,9 @@ export function useMobileNativeChatSession(args: {
     const beforeOffset = beforeOffsetRef.current
     loadingEarlierRef.current = true
     setLoadingEarlier(true)
+    setLoadEarlierError(null)
+    const requestIsCurrent = (): boolean =>
+      sessionIdRef.current === requestSessionId && streamGenerationRef.current === requestGeneration
     void (async () => {
       try {
         const response = await client.sendRequest('nativeChat.readSession', {
@@ -207,18 +240,17 @@ export function useMobileNativeChatSession(args: {
           ...(beforeOffset === null ? {} : { beforeOffset }),
           ...(transcriptPath ? { transcriptPath } : {})
         })
-        if (!response.ok) {
-          return
-        }
-        const result = response.result as ReadSessionResult
-        if ('error' in result) {
+        const result = response.ok ? (response.result as ReadSessionResult) : null
+        if (!result || 'error' in result) {
+          // Surface the failed page (silently doing nothing reads as a dead
+          // scroll); the header row offers a retry through loadEarlier.
+          if (requestIsCurrent()) {
+            setLoadEarlierError(LOAD_EARLIER_ERROR)
+          }
           return
         }
         // Drop a stale resolve from a session that swapped underneath us.
-        if (
-          sessionIdRef.current !== requestSessionId ||
-          streamGenerationRef.current !== requestGeneration
-        ) {
+        if (!requestIsCurrent()) {
           return
         }
         limitRef.current = nextLimit
@@ -233,12 +265,14 @@ export function useMobileNativeChatSession(args: {
           setList(result.messages)
           setHasMore(result.messages.length >= nextLimit)
         }
+      } catch {
+        // A rejected transport request (disconnect mid-page) is a failed page too.
+        if (requestIsCurrent()) {
+          setLoadEarlierError(LOAD_EARLIER_ERROR)
+        }
       } finally {
         // A late page from a prior tab must not unlock the current tab's request.
-        if (
-          sessionIdRef.current === requestSessionId &&
-          streamGenerationRef.current === requestGeneration
-        ) {
+        if (requestIsCurrent()) {
           loadingEarlierRef.current = false
           setLoadingEarlier(false)
         }
@@ -246,15 +280,24 @@ export function useMobileNativeChatSession(args: {
     })()
   }, [client, agent, sessionId, transcriptPath, hasMore, setList])
 
+  // While the swapped-client read is in flight the previous settled list for
+  // this same identity keeps rendering; `transcriptLoading` still tells
+  // consumers not to trust it as settled history.
+  const heldMessages =
+    !settled && status === 'loading' && lastListRef.current?.identity === identity
+      ? lastListRef.current.messages
+      : EMPTY_MESSAGES
+
   return {
     // Withheld until the settled read belongs to this identity: the effect that
     // clears the previous tab's list is passive, so `messages` lags a commit.
-    messages: settled ? messages : EMPTY_MESSAGES,
+    messages: settled ? messages : heldMessages,
     status,
     transcriptLoading: status === 'loading',
     error,
     hasMore,
     loadingEarlier,
+    loadEarlierError,
     loadEarlier
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -49,13 +49,15 @@ type ReadSessionResult =
  *  an ordered tail); live appends merge by id so order stays stable. */
 export function useMobileNativeChatSession(args: {
   client: RpcClient | null
+  /** Stable host/workspace source; unlike `client`, it survives manual reconnect. */
+  sourceIdentity: string
   agent: string | null
   sessionId: string | null
   transcriptPath: string | null
 }): MobileNativeChatSession {
-  const { client, agent, sessionId, transcriptPath } = args
+  const { client, sourceIdentity, agent, sessionId, transcriptPath } = args
   const [messages, setMessages] = useState<NativeChatMessage[]>([])
-  const identity = `${agent ?? ''}\0${sessionId ?? ''}\0${transcriptPath ?? ''}`
+  const identity = `${sourceIdentity}\0${agent ?? ''}\0${sessionId ?? ''}\0${transcriptPath ?? ''}`
   // Pre-read status is a pure function of the props, so derive it rather than
   // letting the effect write it a commit later.
   const initialStatus: MobileNativeChatStatus =

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -187,12 +187,14 @@ export function useMobileNativeChatSession(args: {
           // Only a genuinely fresh window resets the grown read window — an
           // overlapping reconnect replay keeps the paged-in history and limit.
           limitRef.current = INITIAL_LIMIT
+          beforeOffsetRef.current = applied.beforeOffset ?? null
+          setHasMore(applied.hasMore ?? applied.messages.length >= INITIAL_LIMIT)
         }
         setMessages(applied.messages)
-        if (applied.hasMore != null) {
+        if (!applied.windowReplaced && applied.hasMore != null) {
           setHasMore(applied.hasMore)
         }
-        if (applied.beforeOffset != null) {
+        if (!applied.windowReplaced && applied.beforeOffset != null) {
           beforeOffsetRef.current = applied.beforeOffset
         }
         if (applied.cursorInvalidated) {

--- a/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
+++ b/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  createMobileNativeChatStreamingGate,
+  deriveMobileNativeChatStreaming
+} from './mobile-native-chat-streaming-gate'
+
+/** Live streaming-bubble text for the chat list. The gate remembers which
+ *  transcript tail predates the current stream segment, so a reply that repeats
+ *  the previous turn's prefix still shows while streaming. */
+export function useMobileNativeChatStreamingBubble(
+  folded: readonly NativeChatMessage[],
+  streamingText: string | undefined
+): string | null {
+  const [gate, setGate] = useState(createMobileNativeChatStreamingGate)
+  const step = deriveMobileNativeChatStreaming(gate, folded, streamingText)
+  if (step.gate !== gate) {
+    // Render-time state adjustment (derived-state pattern): the advance is
+    // idempotent for a repeated (text, tail) pair, so this settles in one pass.
+    setGate(step.gate)
+  }
+  return step.streaming
+}

--- a/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
+++ b/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
@@ -10,10 +10,11 @@ import {
  *  the previous turn's prefix still shows while streaming. */
 export function useMobileNativeChatStreamingBubble(
   folded: readonly NativeChatMessage[],
-  streamingText: string | undefined
+  streamingText: string | undefined,
+  scopeKey: string
 ): string | null {
   const [gate, setGate] = useState(createMobileNativeChatStreamingGate)
-  const step = deriveMobileNativeChatStreaming(gate, folded, streamingText)
+  const step = deriveMobileNativeChatStreaming(gate, folded, streamingText, scopeKey)
   if (step.gate !== gate) {
     // Render-time state adjustment (derived-state pattern): the advance is
     // idempotent for a repeated (text, tail) pair, so this settles in one pass.

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -3,8 +3,10 @@ import type { NativeChatBlock } from './native-chat-types'
 import {
   briefToolArg,
   describeToolInput,
+  formatToolInput,
   summarizeToolInput,
-  summarizeToolRun
+  summarizeToolRun,
+  toolFilePath
 } from './native-chat-tool-summary'
 
 describe('describeToolInput', () => {
@@ -18,6 +20,16 @@ describe('describeToolInput', () => {
   it('labels a command-shaped call with the command text', () => {
     expect(describeToolInput({ command: 'pnpm test', description: 'Run tests' })).toBe('pnpm test')
     expect(describeToolInput({ pattern: 'foo.*bar', glob: '*.ts' })).toBe('foo.*bar')
+  })
+
+  it('normalizes Codex JSON-string arguments for labels, details, and file links', () => {
+    expect(describeToolInput('{"cmd":"git status --short"}')).toBe('git status --short')
+    expect(formatToolInput('{"cmd":"git status --short"}')).toBe(
+      '{\n  "cmd": "git status --short"\n}'
+    )
+    expect(toolFilePath('{"file_path":"src/index.ts"}')).toBe('src/index.ts')
+    expect(briefToolArg('{"cmd":"git status --short"}')).toBe('git status --short')
+    expect(describeToolInput('{"command":["bash","-lc","make"]}')).toBe('bash -lc make')
   })
 
   it('falls back to the bounded JSON preview for other shapes', () => {

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, it } from 'vitest'
 import type { NativeChatBlock } from './native-chat-types'
-import { briefToolArg, summarizeToolInput, summarizeToolRun } from './native-chat-tool-summary'
+import {
+  briefToolArg,
+  describeToolInput,
+  summarizeToolInput,
+  summarizeToolRun
+} from './native-chat-tool-summary'
+
+describe('describeToolInput', () => {
+  it('labels a file-target call with its path, not raw JSON', () => {
+    expect(describeToolInput({ file_path: '/repo/src/app/Main.tsx', offset: 10 })).toBe(
+      '/repo/src/app/Main.tsx'
+    )
+    expect(describeToolInput({ path: 'src/index.ts' })).toBe('src/index.ts')
+  })
+
+  it('labels a command-shaped call with the command text', () => {
+    expect(describeToolInput({ command: 'pnpm test', description: 'Run tests' })).toBe('pnpm test')
+    expect(describeToolInput({ pattern: 'foo.*bar', glob: '*.ts' })).toBe('foo.*bar')
+  })
+
+  it('falls back to the bounded JSON preview for other shapes', () => {
+    expect(describeToolInput({ todos: [{ id: 1 }] })).toBe(
+      summarizeToolInput({ todos: [{ id: 1 }] })
+    )
+    expect(describeToolInput('raw string input')).toBe('raw string input')
+    expect(describeToolInput(null)).toBe('')
+  })
+
+  it('truncates an overlong path like any other preview', () => {
+    const path = `/very/${'long/'.repeat(30)}file.ts`
+    expect(describeToolInput({ file_path: path }).length).toBeLessThanOrEqual(80)
+    expect(describeToolInput({ file_path: path })).toContain('…')
+  })
+})
 
 describe('summarizeToolInput bounded preview', () => {
   it('collapses depth beyond the bound instead of serializing the whole tree', () => {

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -57,6 +57,11 @@ export function formatToolInput(input: unknown): string {
   }
 }
 
+export function isStructuredToolInput(input: unknown): boolean {
+  const normalized = normalizeToolInput(input)
+  return normalized !== null && typeof normalized === 'object'
+}
+
 export function toolFilePath(input: unknown): string | null {
   const normalized = normalizeToolInput(input)
   if (!normalized || typeof normalized !== 'object') {

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -20,64 +20,95 @@ function truncatePreview(collapsed: string): string {
  *  argument (command/query/…), else the bounded JSON preview. Keeps raw
  *  `{"file_path":…}` JSON out of the tappable row label. */
 export function describeToolInput(input: unknown): string {
-  const path = toolFilePath(input)
+  const normalized = normalizeToolInput(input)
+  const path = toolFilePath(normalized)
   if (path) {
     return truncatePreview(path)
   }
-  if (input && typeof input === 'object') {
-    const value = input as Record<string, unknown>
+  if (normalized && typeof normalized === 'object') {
+    const value = normalized as Record<string, unknown>
     const primary =
       value.command ?? value.cmd ?? value.query ?? value.pattern ?? value.description ?? value.url
-    if (typeof primary === 'string' && primary.trim()) {
-      return summarizeToolInput(primary)
+    const primarySummary = summarizePrimaryToolArg(primary)
+    if (primarySummary) {
+      return primarySummary
     }
   }
-  return summarizeToolInput(input)
+  return summarizeToolInput(normalized)
 }
 
-/** Full, pretty-printed tool-call input for the expanded detail view. Strings
- *  pass through as-is; objects/arrays print as indented JSON so a diff-less call
- *  (e.g. a question payload) reads cleanly instead of one long minified line. */
+/** Full, pretty-printed tool-call input for the expanded detail view. Structured
+ *  JSON strings and objects print as indented JSON; other strings pass through. */
 export function formatToolInput(input: unknown): string {
-  if (input === null || input === undefined) {
+  const normalized = normalizeToolInput(input)
+  if (normalized === null || normalized === undefined) {
     return ''
   }
-  if (typeof input === 'string') {
-    return input
+  if (typeof normalized === 'string') {
+    return normalized
   }
-  if (typeof input === 'number' || typeof input === 'boolean') {
-    return String(input)
+  if (typeof normalized === 'number' || typeof normalized === 'boolean') {
+    return String(normalized)
   }
   try {
-    return JSON.stringify(input, null, 2) ?? ''
+    return JSON.stringify(normalized, null, 2) ?? ''
   } catch {
     return ''
   }
 }
 
 export function toolFilePath(input: unknown): string | null {
-  if (!input || typeof input !== 'object') {
+  const normalized = normalizeToolInput(input)
+  if (!normalized || typeof normalized !== 'object') {
     return null
   }
-  const value = input as Record<string, unknown>
+  const value = normalized as Record<string, unknown>
   const path = value.file_path ?? value.filePath ?? value.path ?? value.notebook_path
   return typeof path === 'string' && path.length > 0 ? path : null
 }
 
 export function briefToolArg(input: unknown): string {
-  if (input && typeof input === 'object') {
-    const value = input as Record<string, unknown>
+  const normalized = normalizeToolInput(input)
+  if (normalized && typeof normalized === 'object') {
+    const value = normalized as Record<string, unknown>
     const path = value.file_path ?? value.filePath ?? value.path ?? value.notebook_path
     if (typeof path === 'string' && path.length > 0) {
       const parts = path.split(/[\\/]/).filter(Boolean)
       return parts.at(-1) ?? path
     }
     const command = value.command ?? value.cmd ?? value.query ?? value.pattern
-    if (typeof command === 'string') {
-      return summarizeToolInput(command).slice(0, 28)
+    const commandSummary = summarizePrimaryToolArg(command)
+    if (commandSummary) {
+      return commandSummary.slice(0, 28)
     }
   }
-  return summarizeToolInput(input).slice(0, 28)
+  return summarizeToolInput(normalized).slice(0, 28)
+}
+
+function normalizeToolInput(input: unknown): unknown {
+  if (typeof input !== 'string') {
+    return input
+  }
+  const first = input.trimStart()[0]
+  if (first !== '{' && first !== '[') {
+    return input
+  }
+  try {
+    const parsed: unknown = JSON.parse(input)
+    return parsed !== null && typeof parsed === 'object' ? parsed : input
+  } catch {
+    return input
+  }
+}
+
+function summarizePrimaryToolArg(input: unknown): string | null {
+  if (typeof input === 'string' && input.trim()) {
+    return summarizeToolInput(input)
+  }
+  if (Array.isArray(input) && input.length > 0 && input.every((part) => typeof part === 'string')) {
+    return summarizeToolInput(input.join(' '))
+  }
+  return null
 }
 
 export function summarizeToolRun(blocks: readonly NativeChatBlock[]): string {

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -7,10 +7,32 @@ const MAX_PREVIEW_DEPTH = 2
 const MAX_TOOL_RUN_SUMMARY_PARTS = 3
 
 export function summarizeToolInput(input: unknown): string {
-  const collapsed = toRawPreview(input).replace(/\s+/g, ' ').trim()
+  return truncatePreview(toRawPreview(input).replace(/\s+/g, ' ').trim())
+}
+
+function truncatePreview(collapsed: string): string {
   return collapsed.length <= MAX_PREVIEW_LENGTH
     ? collapsed
     : `${collapsed.slice(0, MAX_PREVIEW_LENGTH - 1)}…`
+}
+
+/** Human label for a tool line: the target file path, else the primary string
+ *  argument (command/query/…), else the bounded JSON preview. Keeps raw
+ *  `{"file_path":…}` JSON out of the tappable row label. */
+export function describeToolInput(input: unknown): string {
+  const path = toolFilePath(input)
+  if (path) {
+    return truncatePreview(path)
+  }
+  if (input && typeof input === 'object') {
+    const value = input as Record<string, unknown>
+    const primary =
+      value.command ?? value.cmd ?? value.query ?? value.pattern ?? value.description ?? value.url
+    if (typeof primary === 'string' && primary.trim()) {
+      return summarizeToolInput(primary)
+    }
+  }
+  return summarizeToolInput(input)
 }
 
 /** Full, pretty-printed tool-call input for the expanded detail view. Strings


### PR DESCRIPTION
## Summary

Fixes the confirmed defect list from the STA-3333 mobile native chat QA sweep (live QA + code-audit findings on the ticket):

1. **Auto-reconnect no longer truncates history to 40.** The transport replays `nativeChat.subscribe` with its original params after an in-place reconnect, and the session hook treated every `snapshot` as replace-list. The hook now honors the snapshot-vs-replay distinction: a replay snapshot that overlaps retained history merges in by id (paged-in history survives the blip); a disjoint replay (long outage / compaction while away) falls back to replacing with the fresh authoritative window, since stitching would leave a silent gap.
2. **Manual retry keeps the cached transcript on screen.** `forceReconnect` swaps to a new client identity; the hook now holds the last settled list for the same agent/session identity and keeps rendering it while the swapped client's read is in flight, instead of collapsing to a full-screen spinner. `transcriptLoading` still gates consumers (launch-draft seed) until the fresh read settles.
3. **Stale agent status is muted while disconnected.** The working row renders dimmed as "Agent status stale" with the animation stopped, and Stop is disabled (a tap could not reach the PTY anyway). Shares the composer lock's 600 ms debounce so connection blips don't flicker it.
4. **Dismissed Ask cards stay dismissed across chat→terminal→chat toggles.** Dismissal state moved from the unmounting view subtree into the controller, scoped per tab, and only resets when the prompt clears while the chat surface can actually observe it. Ask prompts also gained the same waiting/blocked gate the permission path already had, so a sticky prompt payload can't render as a live card while the agent is working/done.
5. **loadEarlier failures surface.** RPC failure, error results, and rejected transport requests (previously an unhandled rejection) now set an inline "Couldn’t load earlier messages / Tap to retry" header row instead of silently doing nothing.
6. **No viewport jump on history prepend.** The chat FlatList uses `maintainVisibleContentPosition` so a successful loadEarlier grows the list upward under a stable viewport.
7. **Answer-send abort paths report honestly.** A chain aborted mid-answer (session swap, lease loss, supersede) after keystrokes already landed now reports "Answer partly sent — check chat before retrying" instead of leaving the card looking cleanly sent.
8. **PTY writes can no longer interleave.** The per-terminal send-in-flight guard moved from the image-attachments hook into a shared module-scope write lock, now also taken by ask answers, permission responses, and question answers. A superseding answer inherits the cancelled chain's hold (refcounted) so changing your mind mid-answer still works; Stop/cancel stay unguarded so interrupts can't deadlock against the send they cancel.
9. **Streaming bubble no longer swallows repeated-prefix replies.** A new streaming gate remembers which transcript tail predates the current stream segment: the bubble hides only when the tail *moved* during the segment and leads with the streamed text (genuine catch-up), never because an older turn happens to share the new reply's prefix. Falls back to the old suppress-on-prefix rule only when mounted mid-stream.
10. **Tool rows label with a clean summary.** Expanded tool lines now show the target file path or primary string argument (command/query/pattern/…) instead of raw `{"file_path":…}` JSON; the expanded detail shows the fully formatted input (desktop parity).

`MobileNativeChatView.tsx` crossed the 400-line cap with these changes, so the load-earlier header and the streaming-bubble wiring were extracted into `MobileNativeChatLoadEarlierHeader.tsx` and `use-mobile-native-chat-streaming-bubble.ts` (no `max-lines` disables).

**Coordination:** written to compose with #12364 (STA-3331) and #12366 (STA-3332), which touch `MobileNativeChatView.tsx`, `MobileNativeChatOverlay.tsx`, and the controller and are expected to merge first. Their fixes (keyboardShouldPersistTaps, send classification, open-file flow) are not duplicated here. One small textual conflict is possible in the FlatList prop block of `MobileNativeChatView.tsx` against #12364 (adjacent added props); my side is a single `maintainVisibleContentPosition` line plus comment.

Refs STA-3333.

## Screenshots

No visual change beyond the states described above (muted status row, error/retry header row, tool-row labels); not run on a simulator — see Notes.

## Testing

- [x] `pnpm lint` (oxlint root + mobile, code-quality native/type-aware audits, max-lines ratchet, react-doctor changed-lines gate — all clean)
- [x] `pnpm typecheck` (root three-project tsc + mobile tsc)
- [x] `pnpm test` (mobile suite: 391 files, 2913 passed / 3 skipped; affected shared desktop tests pass)
- [ ] `pnpm build` (not run — no build-affecting changes; CI covers it)
- [x] Added or updated high-quality tests per fix: replay merge/replace at the stream-frame seam and hook level, cached-transcript-across-swap, loadEarlier failure + retry, ask-dismiss toggle/tab-scope survival, ask blocked-gate, abort misreport, write-lock exclusion + supersede inheritance across all three card paths, streaming-gate scenarios (repeated-prefix, catch-up, part switch, mid-stream mount, idempotency), and `describeToolInput` labels.

## AI Review Report

Self-reviewed with focus on: (1) reconnect-replay window semantics — verified the disjoint-replay fallback preserves the existing "authoritative snapshot resets a maxed-out window" behavior via the pre-existing tests; (2) write-lock deadlock/leak risks — a superseding answer inherits the hold via a per-hook refcount, only the last chain out releases, and Stop/cancel deliberately bypass the lock so interrupts can't deadlock; a hung holder is bounded by the send budget; (3) render purity — the streaming gate advances via the sanctioned render-time state-adjustment pattern (idempotent, settles in one pass) and the transcript cache is captured post-commit in an effect, both verified against the react-doctor changed-lines gate; (4) stale-list safety — the held list is keyed by the full agent/session/transcript identity, so it can never serve another tab's messages (locked by test). Cross-platform: no keyboard shortcuts, path handling, or shell behavior touched; changes are React Native UI/transport logic identical across iOS/Android clients and agnostic of the desktop host OS (native/WSL/SSH); the shared tool-summary change is pure string formatting with Windows-path-safe helpers already in place.

## Security Audit

No new input parsing from untrusted sources, no command execution, no auth or secret handling. The write-lock module holds only terminal handles in memory. `describeToolInput` renders agent-provided strings through the existing bounded-preview truncation (length caps, depth caps, circular-safe) — no new injection surface since output is plain `Text`. The loadEarlier error string is a fixed literal, not server-echoed content. IPC/RPC surface unchanged (no new methods; the fix reuses existing subscribe/read RPCs).

## Notes

- The optional simulator smoke pass (MOCK_NATIVE_CHAT rig) was **skipped** — fixes are covered by unit tests at the pure seams; the device re-check of tap handling requested by STA-3331's PR is still outstanding.
- Merge-replays are bounded by the grown window, so a replay carrying new tail messages trims the same number of oldest rows (cursor falls back to the growing-tail read, as with live-append trims).
- The `blocked` gate on ask prompts means hosts that never publish agent status will not surface ask cards — this matches the pre-existing behavior of the permission and question cards.
