### PR TITLE
fix(ci): seed the adhoc release repo so releases can be tagged

### DIFF
--- a/config/scripts/setup-adhoc-release-repo.sh
+++ b/config/scripts/setup-adhoc-release-repo.sh
@@ -39,12 +39,21 @@ else
   # Why the features are off: this repo holds releases and nothing else. Leaving
   # issues open invites bug reports against a branch build in a repo nobody
   # watches, where they are simply lost.
+  #
+  # Why --add-readme in a repo with no source: publishing a release creates a tag,
+  # and a tag needs a commit. Empty repo = "Repository is empty" 25 minutes in.
   gh repo create "$ADHOC_REPO" \
     --public \
     --description "Adhoc macOS dev builds of Orca, cut from unlanded branches. Not a source repo." \
+    --add-readme \
     --disable-issues \
     --disable-wiki ||
     fail "Could not create $ADHOC_REPO."
+fi
+
+# Also checked outside the create branch: a repo made before --add-readme is here.
+if ! gh api "repos/$ADHOC_REPO/commits" --jq 'length' >/dev/null 2>&1; then
+  fail "$ADHOC_REPO has no commits — releases cannot be tagged. Add any file to it first."
 fi
 
 echo


### PR DESCRIPTION
## What

`config/scripts/setup-adhoc-release-repo.sh` created `stablyai/orca-adhoc` with `gh repo create` and no initial commit. Adds `--add-readme`, plus a precheck that fails immediately if the repo has no commits.

## Why

Publishing a GitHub release creates a git tag, and a tag needs a commit to point at. An empty repo accepts the *draft* — drafts carry no tag — so the adhoc pipeline built, signed, notarized, uploaded all nine artifacts, verified the update manifest, and only then failed:

```
HTTP 422: Validation Failed (repos/stablyai/orca-adhoc/releases/363749390)
Repository is empty.
```

~25 minutes in, after the notary round trip. The draft-discard step cleaned up correctly, so nothing was stranded, but the whole run was wasted.

The live repo has since been seeded by hand (`ff9ca5b`), so this is about the next time someone runs the setup script — a re-provision, or a fourth channel modelled on this one. The precheck exists because a repo created *before* this change is still empty and the failure only surfaces at the very end.

## Verification

- `bash -n` clean.
- The adhoc pipeline now completes end to end: run 30742467603, all steps green, `v1.4.164-adhoc.20260802094839` published with both architectures and `latest-mac.yml`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
