### PR TITLE
perf(agent-status): coalesce live status bursts into one render pass (STA-3328)

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -6236,17 +6236,34 @@ describe('useIpcEvents agent status snapshot integration', () => {
     }
   })
 
-  it('drops queued burst events for a pane its clear removed, preventing resurrection', async () => {
+  it('preserves queued set-clear order for working removal and done retention', async () => {
     vi.useFakeTimers()
-    const setAgentStatus = vi.fn()
-    const removeAgentStatus = vi.fn()
+    let storeState: StoreLike
+    const setAgentStatus = vi.fn(
+      (
+        paneKey: string,
+        payload: { state: string },
+        _title: unknown,
+        timing: { updatedAt: number }
+      ) => {
+        storeState.agentStatusByPaneKey = {
+          ...(storeState.agentStatusByPaneKey as Record<string, unknown>),
+          [paneKey]: { ...payload, updatedAt: timing.updatedAt }
+        }
+      }
+    )
+    const removeAgentStatus = vi.fn((paneKey: string) => {
+      const next = { ...(storeState.agentStatusByPaneKey as Record<string, unknown>) }
+      delete next[paneKey]
+      storeState.agentStatusByPaneKey = next
+    })
     const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
       current: null
     }
     const onClearListenerRef: { current: ((data: { paneKey: string }) => void) | null } = {
       current: null
     }
-    const storeState: StoreLike = buildStoreState({
+    storeState = buildStoreState({
       setAgentStatus,
       removeAgentStatus,
       workspaceSessionReady: true,
@@ -6293,10 +6310,14 @@ describe('useIpcEvents agent status snapshot integration', () => {
       ) {
         throw new Error('Expected agentStatus listeners to be registered')
       }
-      const emit = (receivedAt: number, prompt: string): void => {
+      const emit = (
+        receivedAt: number,
+        prompt: string,
+        state: AgentStatusSetData['state'] = 'working'
+      ): void => {
         onSetListenerRef.current!({
           paneKey: FUTURE_PANE_KEY,
-          state: 'working',
+          state,
           prompt,
           agentType: 'claude',
           receivedAt,
@@ -6308,13 +6329,28 @@ describe('useIpcEvents agent status snapshot integration', () => {
       emit(1_700_000_000_001, 'queued')
       expect(setAgentStatus).toHaveBeenCalledTimes(1)
 
-      // Why: without the purge, the queued 'working' flushes AFTER this clear
-      // and resurrects a status the main process just removed.
       onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY })
       expect(removeAgentStatus).toHaveBeenCalledWith(FUTURE_PANE_KEY)
+      expect(storeState.agentStatusByPaneKey).toEqual({})
 
       vi.advanceTimersByTime(40)
-      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+      expect(setAgentStatus).toHaveBeenCalledTimes(2)
+      expect(storeState.agentStatusByPaneKey).toEqual({})
+
+      emit(1_700_000_000_002, 'task')
+      emit(1_700_000_000_003, 'task', 'done')
+      expect(setAgentStatus).toHaveBeenCalledTimes(3)
+
+      onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY })
+
+      expect(setAgentStatus).toHaveBeenCalledTimes(4)
+      expect(setAgentStatus.mock.calls[3][1]).toEqual(expect.objectContaining({ state: 'done' }))
+      expect(removeAgentStatus).toHaveBeenCalledTimes(1)
+      expect(storeState.agentStatusByPaneKey).toEqual({
+        [FUTURE_PANE_KEY]: expect.objectContaining({ state: 'done' })
+      })
+      vi.advanceTimersByTime(40)
+      expect(setAgentStatus).toHaveBeenCalledTimes(4)
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -6160,6 +6160,166 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
   })
 
+  it('applies a burst leading-edge first, then coalesces the rest into one deferred batch', async () => {
+    // Why: each live status event is its own IPC task, so N events used to pay
+    // N full render passes (STA-3328 mechanism 2). The leading event must stay
+    // synchronous (zero added latency); followers within the burst window must
+    // apply together on one later task, in arrival order.
+    vi.useFakeTimers()
+    const setAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    try {
+      const { useIpcEvents } = await import('./useIpcEvents')
+      useIpcEvents()
+      if (typeof onSetListenerRef.current !== 'function') {
+        throw new Error('Expected agentStatus.onSet listener to be registered')
+      }
+      const emit = (receivedAt: number, prompt: string): void => {
+        onSetListenerRef.current!({
+          paneKey: FUTURE_PANE_KEY,
+          state: 'working',
+          prompt,
+          agentType: 'claude',
+          receivedAt,
+          stateStartedAt: receivedAt
+        })
+      }
+
+      emit(1_700_000_000_000, 'first')
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+
+      emit(1_700_000_000_001, 'second')
+      emit(1_700_000_000_002, 'third')
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(40)
+      expect(setAgentStatus).toHaveBeenCalledTimes(3)
+      expect(setAgentStatus.mock.calls[1][1]).toEqual(expect.objectContaining({ prompt: 'second' }))
+      expect(setAgentStatus.mock.calls[2][1]).toEqual(expect.objectContaining({ prompt: 'third' }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops queued burst events for a pane its clear removed, preventing resurrection', async () => {
+    vi.useFakeTimers()
+    const setAgentStatus = vi.fn()
+    const removeAgentStatus = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const onClearListenerRef: { current: ((data: { paneKey: string }) => void) | null } = {
+      current: null
+    }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      removeAgentStatus,
+      workspaceSessionReady: true,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        },
+        onClear: (cb) => {
+          onClearListenerRef.current = cb as (data: { paneKey: string }) => void
+          return () => {}
+        }
+      })
+    )
+
+    try {
+      const { useIpcEvents } = await import('./useIpcEvents')
+      useIpcEvents()
+      if (
+        typeof onSetListenerRef.current !== 'function' ||
+        typeof onClearListenerRef.current !== 'function'
+      ) {
+        throw new Error('Expected agentStatus listeners to be registered')
+      }
+      const emit = (receivedAt: number, prompt: string): void => {
+        onSetListenerRef.current!({
+          paneKey: FUTURE_PANE_KEY,
+          state: 'working',
+          prompt,
+          agentType: 'claude',
+          receivedAt,
+          stateStartedAt: receivedAt
+        })
+      }
+
+      emit(1_700_000_000_000, 'leading')
+      emit(1_700_000_000_001, 'queued')
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+
+      // Why: without the purge, the queued 'working' flushes AFTER this clear
+      // and resurrects a status the main process just removed.
+      onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY })
+      expect(removeAgentStatus).toHaveBeenCalledWith(FUTURE_PANE_KEY)
+
+      vi.advanceTimersByTime(40)
+      expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not recurse when flushing a pending status re-enters via the store subscriber', async () => {
     // Repro for crash 9fc89529 (RangeError: Maximum call stack size exceeded):
     // the store subscriber calls flushPendingAgentStatuses() on every update.

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -288,6 +288,11 @@ export { resolveZoomTarget } from './resolve-zoom-target'
 const PENDING_AGENT_STATUS_RETRY_MS = 100
 const PENDING_AGENT_STATUS_TTL_MS = 15_000
 const MAX_PENDING_AGENT_STATUS_EVENTS = 100
+// Why: each live status event is its own IPC task, so a multi-agent burst pays
+// one full render pass per event; same-task commits batch to ONE pass (React
+// flushes external-store updates at the microtask boundary). One frame of
+// buffering collapses a burst; the leading event still applies immediately.
+const LIVE_AGENT_STATUS_BURST_WINDOW_MS = 33
 // Why: mobile driver hydration is async; cap replay so a stuck IPC snapshot can't retain an unbounded startup buffer.
 const MAX_PENDING_MOBILE_STATE_EVENTS = 300
 // Why: a rename's event burst lags the on-disk move; shield both ids from the deletion diff for a grace window.
@@ -758,6 +763,9 @@ export function useIpcEvents(): void {
     let pendingAgentStatusRetryTimer: ReturnType<typeof setTimeout> | null = null
     // Why: setAgentStatus notifies synchronously and re-enters this flush mid-drain; guard re-entrancy (crash 9fc89529).
     let isFlushingAgentStatuses = false
+    const liveAgentStatusBurstQueue: AgentStatusIpcPayload[] = []
+    let liveAgentStatusBurstTimer: ReturnType<typeof setTimeout> | null = null
+    let lastLiveAgentStatusApplyAt = 0
 
     unsubs.push(attachMobileMarkdownBridge())
 
@@ -3337,9 +3345,50 @@ export function useIpcEvents(): void {
         })
     }
 
+    function flushLiveAgentStatusBurst(): void {
+      liveAgentStatusBurstTimer = null
+      lastLiveAgentStatusApplyAt = Date.now()
+      // Why: splice before applying — applyAgentStatus can synchronously
+      // re-enter the queue via subscribers, and it must not see this batch.
+      const batch = liveAgentStatusBurstQueue.splice(0)
+      let anyApplied = false
+      for (const data of batch) {
+        if (applyAgentStatus(data) === 'applied') {
+          anyApplied = true
+        }
+      }
+      if (!anyApplied) {
+        lastLiveAgentStatusApplyAt = 0
+      }
+    }
+
+    function enqueueLiveAgentStatus(data: AgentStatusIpcPayload): void {
+      const now = Date.now()
+      if (
+        liveAgentStatusBurstTimer === null &&
+        now - lastLiveAgentStatusApplyAt >= LIVE_AGENT_STATUS_BURST_WINDOW_MS
+      ) {
+        lastLiveAgentStatusApplyAt = now
+        // Why: only an applied event commits state and costs a render pass —
+        // a dropped/pending leading edge must not make its successor pay
+        // burst latency (startup replay and unmounted panes stay immediate).
+        if (applyAgentStatus(data) !== 'applied') {
+          lastLiveAgentStatusApplyAt = 0
+        }
+        return
+      }
+      liveAgentStatusBurstQueue.push(data)
+      if (liveAgentStatusBurstTimer === null) {
+        liveAgentStatusBurstTimer = globalThis.setTimeout(
+          flushLiveAgentStatusBurst,
+          LIVE_AGENT_STATUS_BURST_WINDOW_MS
+        )
+      }
+    }
+
     unsubs.push(
       window.api.agentStatus.onSet((data) => {
-        applyAgentStatus(data)
+        enqueueLiveAgentStatus(data)
       })
     )
     const unsubscribeAgentStatusClear = window.api.agentStatus.onClear?.(
@@ -3368,11 +3417,27 @@ export function useIpcEvents(): void {
               pendingAgentStatusEvents.splice(index, 1)
             }
           }
+          for (let index = liveAgentStatusBurstQueue.length - 1; index >= 0; index -= 1) {
+            const queued = liveAgentStatusBurstQueue[index]
+            if (
+              queued.connectionId === data.connectionId &&
+              queued.receivedAt <= effectiveWatermark
+            ) {
+              liveAgentStatusBurstQueue.splice(index, 1)
+            }
+          }
           useAppStore.getState().clearTransientAgentStatuses(data.connectionId, effectiveWatermark)
           return
         }
         if (!('paneKey' in data) || typeof data.paneKey !== 'string') {
           return
+        }
+        // Why: a queued burst event flushing after this clear would resurrect
+        // the removed status — drop the pane's unflushed sets first.
+        for (let index = liveAgentStatusBurstQueue.length - 1; index >= 0; index -= 1) {
+          if (liveAgentStatusBurstQueue[index].paneKey === data.paneKey) {
+            liveAgentStatusBurstQueue.splice(index, 1)
+          }
         }
         const store = useAppStore.getState()
         if (store.agentStatusByPaneKey[data.paneKey]?.state === 'done') {
@@ -3565,6 +3630,11 @@ export function useIpcEvents(): void {
         globalThis.clearTimeout(pendingAgentStatusRetryTimer)
       }
       pendingAgentStatusEvents.length = 0
+      if (liveAgentStatusBurstTimer !== null) {
+        globalThis.clearTimeout(liveAgentStatusBurstTimer)
+        liveAgentStatusBurstTimer = null
+      }
+      liveAgentStatusBurstQueue.length = 0
       mobileStateHydrationDisposed = true
       pendingMobileStateEvents.length = 0
       unsubscribeRuntimeEnvironmentStore()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3362,6 +3362,23 @@ export function useIpcEvents(): void {
       }
     }
 
+    function drainQueuedLiveAgentStatusesForPane(paneKey: string): void {
+      const queuedForPane: AgentStatusIpcPayload[] = []
+      const remaining: AgentStatusIpcPayload[] = []
+      for (const queued of liveAgentStatusBurstQueue) {
+        if (queued.paneKey === paneKey) {
+          queuedForPane.push(queued)
+        } else {
+          remaining.push(queued)
+        }
+      }
+      liveAgentStatusBurstQueue.length = 0
+      liveAgentStatusBurstQueue.push(...remaining)
+      for (const queued of queuedForPane) {
+        applyAgentStatus(queued)
+      }
+    }
+
     function enqueueLiveAgentStatus(data: AgentStatusIpcPayload): void {
       const now = Date.now()
       if (
@@ -3432,11 +3449,13 @@ export function useIpcEvents(): void {
         if (!('paneKey' in data) || typeof data.paneKey !== 'string') {
           return
         }
-        // Why: a queued burst event flushing after this clear would resurrect
-        // the removed status — drop the pane's unflushed sets first.
-        for (let index = liveAgentStatusBurstQueue.length - 1; index >= 0; index -= 1) {
-          if (liveAgentStatusBurstQueue[index].paneKey === data.paneKey) {
-            liveAgentStatusBurstQueue.splice(index, 1)
+        // Why: preserve set→clear FIFO so a queued completion still survives pane teardown.
+        if (liveAgentStatusBurstQueue.some((queued) => queued.paneKey === data.paneKey)) {
+          drainQueuedLiveAgentStatusesForPane(data.paneKey)
+        }
+        for (let index = pendingAgentStatusEvents.length - 1; index >= 0; index -= 1) {
+          if (pendingAgentStatusEvents[index].data.paneKey === data.paneKey) {
+            pendingAgentStatusEvents.splice(index, 1)
           }
         }
         const store = useAppStore.getState()


### PR DESCRIPTION
## Summary

Third installment of the STA-3328 typing-lag work (after #12359 spinner, #12371 tab-group amplifiers). This addresses the burst **source**: every live agent-status event arrives as its own IPC task, and each one committed the store and paid a full React render pass — profiled live as 200–488ms main-thread tasks (`Receive mojo message → applyAgentStatus → setAgentStatus → renderRootSync`) under heavy orchestration, exactly matching Neil's "happens when using orchestration heavily" report.

The design-defining fact (verified empirically with a real-store/real-React probe before writing any code): **N zustand commits in the same macrotask produce exactly 1 React render pass** — React 19 flushes external-store sync work at the microtask boundary. So no `setAgentStatus` refactor is needed; the fix is dispatch-level in `useIpcEvents`:

- The **leading** event of a burst applies synchronously — single events pay **zero** added latency.
- Followers within a 33ms window buffer and apply together **in one task** — one render pass instead of N. Ordering is unchanged (FIFO; every guard, fold, and side-effect runs per event exactly as before, each seeing the previous event's state).
- Only an **applied** event arms the window: dropped/pending events (startup replay, not-yet-mounted panes) commit nothing and cost no render, so their successors stay immediate — this also preserves the existing buffered-until-mount retry semantics byte-for-byte.
- Both clear paths purge the pane's/connection's queued sets first — without this, a coalesced `working` flushing 33ms after a `clear` would resurrect a removed status (pinned by a dedicated test).
- Effect teardown clears the timer and queue.

Worst-case added status-visibility latency is 33ms — under half the spinner's own 83ms tick.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — oxlint, react-doctor changed-lines gate, oxfmt clean (pre-commit hook re-verified all three)
- [x] `pnpm typecheck` — all three configs pass, 0 errors
- [x] `pnpm test` — full `useIpcEvents.test.ts` suite: 98/98 pass (96 existing + 2 new); full suite left to CI
- [ ] `pnpm build` — left to CI
- [x] New tests verified **non-vacuous** (each fails against the pre-fix source): (1) burst of 3 → leading applies synchronously, followers coalesce into one deferred batch in arrival order; (2) a clear purges queued burst events so a coalesced set cannot resurrect the removed status. One pre-existing test ("buffers ready push events until a mounted tab contains the pane leaf") drove the applied-only-arms-the-window refinement and passes unchanged.

## AI Review Report

Reviewed for: ordering preservation (FIFO queue; leading precedes queued; per-event guards like the `receivedAt` out-of-order rejection see the store state left by the previous event, identical to today's sequential arrival); clear-vs-set races (both the transient watermark path and the direct paneKey clear purge the burst queue using the same raw-paneKey/connectionId comparisons as the existing pending-retry purges); re-entrancy (queue is spliced before applying, mirroring the crash-9fc89529 guard pattern; the existing `isFlushingAgentStatuses` guard is untouched); timer lifecycle (cleared on effect teardown alongside the retry timer; queue emptied); occluded-window behavior (Chromium clamps the 33ms timer to 1s when hidden — status still applies, and a hidden window renders nothing anyway). Cross-platform: renderer-only dispatch change; the SSH/WSL connection-watermark semantics are exercised by the existing suite (98/98). The startup snapshot replay loop was already a single task (batches naturally) and is untouched.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or IPC surface changes. Same events, same validation pipeline, same store actions — only dispatch timing is batched, with a bounded in-memory queue (drained every 33ms, purged on clears and teardown).

## Notes

- Combined effect with #12371: this PR reduces render-pass *count* per burst; #12371 reduces the *cost* of each pass. After both land, re-running the live keystroke-latency rig under agent load will show what's left of the 200–488ms tasks.
- Remaining STA-3328 queue: split-divider drag off the store (drag-only jank), `setTabLayout` structural bailout, audit medium tier.
