### PR TITLE
fix(ui): always show Onboarding and Restart Orca in Help

### DIFF
--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -42,8 +42,8 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
   const [appVersion, setAppVersion] = useState<string | null>(null)
   const updateCheckHint = getUpdateCheckHint()
   // Why: channel switching is a power-user escape hatch that can downgrade the app
-  // onto an unvetted build. Option/Alt-clicking the header reveals it, matching the
-  // Help menu's hidden admin options rather than shipping it on the default surface.
+  // onto an unvetted build. Option/Alt-clicking the header reveals it rather than
+  // shipping it on the default surface.
   const [channelSwitcherRevealed, setChannelSwitcherRevealed] = useState(false)
 
   useEffect(() => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -227,6 +227,11 @@ describe('SidebarSettingsHelpMenu', () => {
     expect(html).toContain('Onboarding')
   })
 
+  it('renders Restart Orca by default', () => {
+    const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
+    expect(html).toContain('Restart Orca')
+  })
+
   it('renders Docs link', () => {
     const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
     expect(html).toContain('Docs')

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -222,9 +222,9 @@ describe('SidebarSettingsHelpMenu', () => {
     expect(html).not.toContain('Milestones')
   })
 
-  it('hides the Onboarding admin entry by default', () => {
+  it('renders the Onboarding menu item by default', () => {
     const html = renderToStaticMarkup(<SidebarSettingsHelpMenu />)
-    expect(html).not.toContain('Onboarding')
+    expect(html).toContain('Onboarding')
   })
 
   it('renders Docs link', () => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -95,7 +95,6 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const settingsShortcut = useShortcutKeyDetails('app.settings')
   const [menuOpen, setMenuOpen] = useState(false)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
-  const [showAdminOptions, setShowAdminOptions] = useState(false)
   const [isRestartingOrca, setIsRestartingOrca] = useState(false)
   const lastShowOnboardingAtRef = React.useRef(0)
   const updateCheckModifiersRef = React.useRef(NO_UPDATE_CHECK_MODIFIERS)
@@ -108,14 +107,6 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const handleMenuOpenChange = (open: boolean): void => {
     setMenuOpen(open)
     updateCheckModifiersRef.current = NO_UPDATE_CHECK_MODIFIERS
-    if (!open) {
-      setShowAdminOptions(false)
-    }
-  }
-
-  const revealAdminOptions = (altKey: boolean): void => {
-    // Why: Restart stays off the default Help menu; hold Option/Alt when opening.
-    setShowAdminOptions(altKey)
   }
 
   const handleShowOnboarding = (): void => {
@@ -220,8 +211,6 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
                     'Help'
                   )}
                   className="text-muted-foreground"
-                  onPointerDown={(event) => revealAdminOptions(event.altKey)}
-                  onClick={(event) => revealAdminOptions(event.altKey)}
                 >
                   <CircleHelp className="size-3.5" />
                 </Button>
@@ -330,18 +319,14 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
                 'Check for Updates'
               )}
             </DropdownMenuItem>
-            {showAdminOptions ? (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={handleRestartOrca} disabled={isRestartingOrca}>
-                  <RotateCw className="size-3.5" />
-                  {translate(
-                    'auto.components.sidebar.SidebarSettingsHelpMenu.ad3d3ed7f1',
-                    'Restart Orca'
-                  )}
-                </DropdownMenuItem>
-              </>
-            ) : null}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={handleRestartOrca} disabled={isRestartingOrca}>
+              <RotateCw className="size-3.5" />
+              {translate(
+                'auto.components.sidebar.SidebarSettingsHelpMenu.ad3d3ed7f1',
+                'Restart Orca'
+              )}
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -114,8 +114,7 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   }
 
   const revealAdminOptions = (altKey: boolean): void => {
-    // Why: onboarding replay and restart stay off the default Help menu; holding
-    // Option/Alt before opening is an intentional power-user affordance.
+    // Why: Restart stays off the default Help menu; hold Option/Alt when opening.
     setShowAdminOptions(altKey)
   }
 
@@ -268,19 +267,17 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
                 />
               </DropdownMenuItem>
             ) : null}
-            {showAdminOptions ? (
-              <DropdownMenuItem
-                className="whitespace-nowrap"
-                onClick={handleShowOnboarding}
-                onSelect={handleShowOnboarding}
-              >
-                <School className="size-3.5" />
-                {translate(
-                  'auto.components.sidebar.SidebarSettingsHelpMenu.b7e4d2a19c',
-                  'Onboarding'
-                )}
-              </DropdownMenuItem>
-            ) : null}
+            <DropdownMenuItem
+              className="whitespace-nowrap"
+              onClick={handleShowOnboarding}
+              onSelect={handleShowOnboarding}
+            >
+              <School className="size-3.5" />
+              {translate(
+                'auto.components.sidebar.SidebarSettingsHelpMenu.b7e4d2a19c',
+                'Onboarding'
+              )}
+            </DropdownMenuItem>
             <ExternalMenuItem
               label={translate(
                 'auto.components.sidebar.SidebarSettingsHelpMenu.cdc87f897e',


### PR DESCRIPTION
## Summary
- Always show **Onboarding** and **Restart Orca** in the sidebar Help menu instead of hiding them behind Option/Alt.
- Remove the Alt-only admin gate from the Help menu trigger (nothing else used it).
- Update unit tests to expect both items on the default menu.

Users could not find how to replay onboarding because the action required holding Alt while opening Help — some reinstalled Orca instead. Restart had the same non-discoverable affordance.

## Test plan
- [ ] Open the sidebar Help menu without holding Alt — confirm **Onboarding** and **Restart Orca** are listed
- [ ] Click **Onboarding** — confirm the onboarding flow starts again
- [ ] Click **Restart Orca** — confirm the app restarts (or shows the restart toast/error path)
- [ ] Confirm no other Help items still depend on holding Alt
- [ ] Run `SidebarSettingsHelpMenu` unit tests if dependencies are installed