### PR TITLE
perf(runtime): memoize mobile snapshots for mounted terminal worktrees

### DIFF
--- a/src/renderer/src/runtime/sync-runtime-graph-publication-cost.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-publication-cost.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildMobileSessionTabSnapshots } from './sync-runtime-graph'
+import { buildMobileSessionTabSnapshots, registerRuntimeTerminalTab } from './sync-runtime-graph'
 import type { AppState } from '../store/types'
 
 // Why: getBrowserTabsByWorktree reads this slice once per worktree inside the build loop,
@@ -205,5 +205,177 @@ describe('mobile session publication cost', () => {
     expect(titleReads()).toBeGreaterThan(0)
     expect(titleReads()).toBeLessThan(fullBuildReads / WORKTREES + 1)
     expect(rebuiltWorktrees).toEqual(['repo::/title-wt-7'])
+  })
+})
+
+// Distinct ids per test: the snapshot memo is module state shared in this file.
+const MOUNTED_WT = 'repo::/mounted-wt-0'
+const CONTROL_WT = 'repo::/mounted-wt-1'
+const MOUNTED_LEAF_ID = 'aaaaaaaa-1111-4111-8111-111111111111'
+const SPLIT_LEAF_ID = 'bbbbbbbb-1111-4111-8111-111111111111'
+
+function makeMountedState(tabIdPrefix: string): {
+  state: AppState
+  mountedTabId: string
+  titleReads: () => number
+  resetTitleReads: () => void
+} {
+  let titleReads = 0
+  const mountedTabId = `${tabIdPrefix}-term-0`
+  const state = {
+    tabsByWorktree: {
+      [MOUNTED_WT]: [
+        {
+          id: mountedTabId,
+          customTitle: null,
+          ptyId: null,
+          get title() {
+            titleReads++
+            return 'Agent mounted'
+          }
+        }
+      ],
+      [CONTROL_WT]: [
+        { id: `${tabIdPrefix}-term-1`, title: 'Agent control', customTitle: null, ptyId: null }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [mountedTabId]: {
+        root: { type: 'leaf', leafId: MOUNTED_LEAF_ID },
+        activeLeafId: MOUNTED_LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [MOUNTED_LEAF_ID]: 'pty-saved-1' }
+      }
+    },
+    runtimePaneTitlesByTabId: {},
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    unifiedTabsByWorktree: {},
+    tabBarOrderByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    openFiles: [],
+    editorDrafts: {},
+    activeTabId: null,
+    agentStatusByPaneKey: {},
+    browserTabsByWorktree: {}
+  } as unknown as AppState
+  return {
+    state,
+    mountedTabId,
+    titleReads: () => titleReads,
+    resetTitleReads: () => {
+      titleReads = 0
+    }
+  }
+}
+
+function makeLiveSurface(tabId: string): {
+  registration: Parameters<typeof registerRuntimeTerminalTab>[0]
+  setPtyId: (paneId: number, ptyId: string) => void
+  addPane: (paneId: number, leafId: string) => void
+} {
+  const panes = [{ id: 1, leafId: MOUNTED_LEAF_ID }]
+  const ptyIdByPaneId = new Map<number, string | null>([[1, 'pty-live-1']])
+  const manager = {
+    getPanes: () => panes.map((pane) => ({ ...pane })),
+    getActivePane: () => panes[0] ?? null,
+    getLeafId: (paneId: number) => panes.find((pane) => pane.id === paneId)?.leafId ?? null,
+    getNumericIdForLeaf: (leafId: string) =>
+      panes.find((pane) => pane.leafId === leafId)?.id ?? null
+  }
+  const registration = {
+    tabId,
+    worktreeId: MOUNTED_WT,
+    getManager: () => manager,
+    getContainer: () => null,
+    getPtyIdForPane: (paneId: number) => ptyIdByPaneId.get(paneId) ?? null
+  } as unknown as Parameters<typeof registerRuntimeTerminalTab>[0]
+  return {
+    registration,
+    setPtyId: (paneId, ptyId) => {
+      ptyIdByPaneId.set(paneId, ptyId)
+    },
+    addPane: (paneId, leafId) => {
+      panes.push({ id: paneId, leafId })
+      ptyIdByPaneId.set(paneId, `pty-live-${paneId}`)
+    }
+  }
+}
+
+function snapshotsByWorktree(
+  state: AppState
+): Map<string, ReturnType<typeof buildMobileSessionTabSnapshots>[number]> {
+  return new Map(
+    buildMobileSessionTabSnapshots(state).map((snapshot) => [snapshot.worktree, snapshot])
+  )
+}
+
+describe('mounted terminal surface memoization', () => {
+  it('reuses a mounted worktree snapshot when its live pane state is unchanged', () => {
+    const { state, mountedTabId, titleReads, resetTitleReads } = makeMountedState('mounted-a')
+    const unregister = registerRuntimeTerminalTab(makeLiveSurface(mountedTabId).registration)
+    try {
+      const before = snapshotsByWorktree(state)
+      resetTitleReads()
+
+      const after = snapshotsByWorktree(state)
+
+      expect(titleReads()).toBe(0)
+      expect(after.get(MOUNTED_WT)).toBe(before.get(MOUNTED_WT))
+    } finally {
+      unregister()
+    }
+  })
+
+  it('publishes a live pty rebinding on a mounted worktree', () => {
+    const { state, mountedTabId } = makeMountedState('mounted-b')
+    const surface = makeLiveSurface(mountedTabId)
+    const unregister = registerRuntimeTerminalTab(surface.registration)
+    try {
+      const before = snapshotsByWorktree(state)
+
+      surface.setPtyId(1, 'pty-live-2')
+      const after = snapshotsByWorktree(state)
+
+      expect(after.get(MOUNTED_WT)).not.toBe(before.get(MOUNTED_WT))
+      expect(after.get(MOUNTED_WT)?.tabs).toEqual([
+        expect.objectContaining({ ptyId: 'pty-live-2' })
+      ])
+      expect(after.get(CONTROL_WT)).toBe(before.get(CONTROL_WT))
+    } finally {
+      unregister()
+    }
+  })
+
+  it('publishes a live pane split on a mounted worktree', () => {
+    const { state, mountedTabId } = makeMountedState('mounted-c')
+    const surface = makeLiveSurface(mountedTabId)
+    const unregister = registerRuntimeTerminalTab(surface.registration)
+    try {
+      snapshotsByWorktree(state)
+
+      surface.addPane(2, SPLIT_LEAF_ID)
+      const after = snapshotsByWorktree(state)
+
+      expect(
+        after.get(MOUNTED_WT)?.tabs.map((tab) => (tab.type === 'terminal' ? tab.leafId : null))
+      ).toEqual([MOUNTED_LEAF_ID, SPLIT_LEAF_ID])
+    } finally {
+      unregister()
+    }
+  })
+
+  it('falls back to the persisted pty binding after the surface unmounts', () => {
+    const { state, mountedTabId, titleReads, resetTitleReads } = makeMountedState('mounted-d')
+    const unregister = registerRuntimeTerminalTab(makeLiveSurface(mountedTabId).registration)
+    snapshotsByWorktree(state)
+
+    unregister()
+    resetTitleReads()
+    const after = snapshotsByWorktree(state)
+
+    expect(titleReads()).toBeGreaterThan(0)
+    expect(after.get(MOUNTED_WT)?.tabs).toEqual([expect.objectContaining({ ptyId: 'pty-saved-1' })])
   })
 })

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -31,6 +31,7 @@ import type {
   TabGroup,
   TabGroupLayoutNode,
   TerminalLayoutSnapshot,
+  TerminalPaneLayoutNode,
   TerminalTab
 } from '../../../shared/types'
 import { resolveTerminalTabTitle } from '../../../shared/tab-title-resolution'
@@ -93,6 +94,22 @@ type MobileSessionPublicationInputs = {
   terminalTheme: RuntimeMobileTerminalTheme | undefined
 }
 /**
+ * Live PaneManager/DOM reads for one mounted terminal tab, captured once per
+ * publication.
+ *
+ * Why: builders read this instead of the registry, so live state the memo
+ * cannot witness is unrepresentable — mounted worktrees memoize like the rest
+ * instead of rebuilding on every publication.
+ */
+type MountedTerminalSurfaceCapture = {
+  paneLeafIds: readonly string[]
+  hasLiveActivePane: boolean
+  liveActiveLeafId: string | null
+  liveLayoutRoot: TerminalPaneLayoutNode | null
+  numericPaneIdByLeafId: ReadonlyMap<string, number | null>
+  ptyIdByNumericPaneId: ReadonlyMap<number, string | null>
+}
+/**
  * One worktree's complete mobile-snapshot input set.
  *
  * Why: every builder below takes this instead of `AppState`, so the compiler —
@@ -131,8 +148,7 @@ type MobileSessionWorktreeInputs = {
   activeBrowserWorkspaceId: string | null
   generatedTitlesEnabled: boolean
   terminalTheme: RuntimeMobileTerminalTheme | undefined
-  // Why: a mounted TerminalPane feeds live DOM/PaneManager state that no store reference can witness.
-  hasMountedTerminalSurface: boolean
+  mountedSurfaceCaptureByTabId: ReadonlyMap<string, MountedTerminalSurfaceCapture>
 }
 
 const registeredTabs = new Map<string, RegisteredTerminalTab>()
@@ -1026,11 +1042,99 @@ function buildMobileSessionWorktreeInputs(
     activeBrowserWorkspaceId: state.activeBrowserTabIdByWorktree?.[worktreeId] ?? null,
     generatedTitlesEnabled: publication.generatedTitlesEnabled,
     terminalTheme: publication.terminalTheme,
-    hasMountedTerminalSurface: terminalTabs.some((tab) => registeredTabs.has(tab.id))
+    mountedSurfaceCaptureByTabId: captureMountedTerminalSurfaces(
+      terminalTabs,
+      state.terminalLayoutsByTabId
+    )
   }
 }
 
-function narrowedEntriesEqual<T>(a: ReadonlyMap<string, T>, b: ReadonlyMap<string, T>): boolean {
+function captureMountedTerminalSurfaces(
+  terminalTabs: AppState['tabsByWorktree'][string],
+  terminalLayoutsByTabId: AppState['terminalLayoutsByTabId']
+): ReadonlyMap<string, MountedTerminalSurfaceCapture> {
+  let captures: Map<string, MountedTerminalSurfaceCapture> | null = null
+  for (const tab of terminalTabs) {
+    const registered = registeredTabs.get(tab.id)
+    if (!registered) {
+      continue
+    }
+    captures ??= new Map()
+    captures.set(tab.id, captureMountedTerminalSurface(registered, terminalLayoutsByTabId[tab.id]))
+  }
+  return captures ?? EMPTY_NARROWED_BY_KEY
+}
+
+function captureMountedTerminalSurface(
+  registered: RegisteredTerminalTab,
+  savedLayout: AppState['terminalLayoutsByTabId'][string] | undefined
+): MountedTerminalSurfaceCapture {
+  const manager = registered.getManager()
+  const paneLeafIds = manager?.getPanes().map((pane) => pane.leafId) ?? []
+  const activePane = manager?.getActivePane() ?? null
+  const firstChild = registered.getContainer()?.firstElementChild
+  // Why: mirrors getRuntimeLeafIdsForTerminal so every leaf the builder resolves has a captured pane id.
+  const effectiveLeafIds =
+    paneLeafIds.length > 0
+      ? paneLeafIds
+      : collectLeafIdsInOrder(savedLayout?.root).filter(isTerminalLeafId)
+  const numericPaneIdByLeafId = new Map<string, number | null>()
+  const ptyIdByNumericPaneId = new Map<number, string | null>()
+  for (const leafId of effectiveLeafIds) {
+    const numericPaneId = manager?.getNumericIdForLeaf(leafId) ?? null
+    numericPaneIdByLeafId.set(leafId, numericPaneId)
+    if (numericPaneId !== null) {
+      ptyIdByNumericPaneId.set(numericPaneId, registered.getPtyIdForPane(numericPaneId))
+    }
+  }
+  return {
+    paneLeafIds,
+    hasLiveActivePane: activePane !== null,
+    liveActiveLeafId: activePane !== null ? (manager?.getLeafId(activePane.id) ?? null) : null,
+    liveLayoutRoot: serializePaneTree(
+      typeof HTMLElement !== 'undefined' && firstChild instanceof HTMLElement ? firstChild : null
+    ),
+    numericPaneIdByLeafId,
+    ptyIdByNumericPaneId
+  }
+}
+
+function mountedTerminalSurfaceCaptureEquals(
+  a: MountedTerminalSurfaceCapture,
+  b: MountedTerminalSurfaceCapture
+): boolean {
+  return (
+    a.hasLiveActivePane === b.hasLiveActivePane &&
+    a.liveActiveLeafId === b.liveActiveLeafId &&
+    a.paneLeafIds.length === b.paneLeafIds.length &&
+    a.paneLeafIds.every((leafId, index) => b.paneLeafIds[index] === leafId) &&
+    narrowedEntriesEqual(a.numericPaneIdByLeafId, b.numericPaneIdByLeafId) &&
+    narrowedEntriesEqual(a.ptyIdByNumericPaneId, b.ptyIdByNumericPaneId) &&
+    // Why: serialization allocates a fresh tree per capture, so it compares by content.
+    jsonContentEquals(a.liveLayoutRoot, b.liveLayoutRoot)
+  )
+}
+
+function mountedSurfaceCapturesEqual(
+  a: ReadonlyMap<string, MountedTerminalSurfaceCapture>,
+  b: ReadonlyMap<string, MountedTerminalSurfaceCapture>
+): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const [tabId, capture] of a) {
+    const other = b.get(tabId)
+    if (!other || !mountedTerminalSurfaceCaptureEquals(capture, other)) {
+      return false
+    }
+  }
+  return true
+}
+
+function narrowedEntriesEqual<K, T>(a: ReadonlyMap<K, T>, b: ReadonlyMap<K, T>): boolean {
   if (a === b) {
     return true
   }
@@ -1056,9 +1160,6 @@ function canReuseMobileSessionSnapshot(
   next: MobileSessionWorktreeInputs
 ): boolean {
   return (
-    // Why: live DOM/PaneManager state is invisible to store references, so a mounted surface always rebuilds.
-    !previous.hasMountedTerminalSurface &&
-    !next.hasMountedTerminalSurface &&
     previous.worktreeId === next.worktreeId &&
     previous.terminalTabs === next.terminalTabs &&
     previous.browserWorkspaces === next.browserWorkspaces &&
@@ -1084,6 +1185,12 @@ function canReuseMobileSessionSnapshot(
     narrowedEntriesEqual(
       previous.certificateFailureByBrowserPageId,
       next.certificateFailureByBrowserPageId
+    ) &&
+    // Why: live DOM/PaneManager state is invisible to store references; the
+    // capture makes it comparable instead of forcing mounted worktrees to rebuild.
+    mountedSurfaceCapturesEqual(
+      previous.mountedSurfaceCaptureByTabId,
+      next.mountedSurfaceCaptureByTabId
     )
   )
 }
@@ -1683,12 +1790,10 @@ function resolveMobileTerminalTheme(
 }
 
 function getRuntimeLeafIdsForTerminal(
-  tabId: string,
+  capture: MountedTerminalSurfaceCapture | undefined,
   savedLayout: AppState['terminalLayoutsByTabId'][string] | undefined
-): string[] {
-  const registered = registeredTabs.get(tabId)
-  const manager = registered?.getManager()
-  const liveLeafIds = manager?.getPanes().map((pane) => pane.leafId) ?? []
+): readonly string[] {
+  const liveLeafIds = capture?.paneLeafIds ?? []
   if (liveLeafIds.length > 0) {
     return liveLeafIds
   }
@@ -1707,18 +1812,15 @@ function buildMobileTerminalSurfaceTabs(
   terminal: NonNullable<AppState['tabsByWorktree'][string]>[number],
   unifiedTabId?: string
 ): RuntimeMobileSessionSnapshotTab[] {
-  const registered = registeredTabs.get(terminal.id)
+  const capture = inputs.mountedSurfaceCaptureByTabId.get(terminal.id)
   const isDesktopTabActive = unifiedTabId
     ? isUnifiedTabActiveInActiveGroup(inputs, unifiedTabId)
     : inputs.activeTerminalTabId === terminal.id
-  const manager = registered?.getManager()
-  const liveActivePaneId = manager?.getActivePane()?.id ?? null
   const savedLayout = inputs.terminalLayoutByTabId.get(terminal.id)
-  const leafIds = getRuntimeLeafIdsForTerminal(terminal.id, savedLayout)
-  const activeLeafId =
-    liveActivePaneId !== null
-      ? (manager?.getLeafId(liveActivePaneId) ?? null)
-      : (savedLayout?.activeLeafId ?? leafIds[0] ?? null)
+  const leafIds = getRuntimeLeafIdsForTerminal(capture, savedLayout)
+  const activeLeafId = capture?.hasLiveActivePane
+    ? capture.liveActiveLeafId
+    : (savedLayout?.activeLeafId ?? leafIds[0] ?? null)
   const paneTitles = inputs.paneTitlesByTabId.get(terminal.id) ?? {}
   const generatedTitlesEnabled = inputs.generatedTitlesEnabled
   const sanitizedSavedLayout = savedLayout
@@ -1736,11 +1838,7 @@ function buildMobileTerminalSurfaceTabs(
       ? seededLaunchDraft
       : null
   const publishedLaunchDraft = launchDraftEntry?.text.trim() ? launchDraftEntry : null
-  const container = registered?.getContainer()
-  const firstChild = container?.firstElementChild
-  const liveLayoutRoot = serializePaneTree(
-    typeof HTMLElement !== 'undefined' && firstChild instanceof HTMLElement ? firstChild : null
-  )
+  const liveLayoutRoot = capture?.liveLayoutRoot ?? null
   const parentLayout = normalizeTerminalLayoutSnapshot({
     // Why: live DOM tree is authoritative when mounted, else the saved tree; synthesize only as a last resort, never re-guess.
     root: resolveTerminalLayoutRoot({
@@ -1760,11 +1858,11 @@ function buildMobileTerminalSurfaceTabs(
       : {})
   } satisfies TerminalLayoutSnapshot).snapshot
   return leafIds.map((leafId) => {
-    const numericPaneId = manager?.getNumericIdForLeaf(leafId) ?? null
+    const numericPaneId = capture?.numericPaneIdByLeafId.get(leafId) ?? null
     const ptyId =
       numericPaneId === null
         ? (savedPtyIdsByLeafId[leafId] ?? (leafIds.length === 1 ? terminal.ptyId : null))
-        : (registered?.getPtyIdForPane(numericPaneId) ?? savedPtyIdsByLeafId[leafId] ?? null)
+        : (capture?.ptyIdByNumericPaneId.get(numericPaneId) ?? savedPtyIdsByLeafId[leafId] ?? null)
     const legacyPaneId = numericPaneId === null ? /^pane:(\d+)$/.exec(leafId)?.[1] : null
     const paneTitle =
       numericPaneId !== null


### PR DESCRIPTION
## Summary

Follow-up to #12207, found during a release scan of #12207 + #12245: the per-worktree mobile-snapshot rebuild memo refused to skip any worktree with a mounted TerminalPane, because the builders read live PaneManager/DOM state the memo could not witness. Hidden worktrees stay mounted (8 hot-parked + 12 retained by default; unbounded with `terminalHiddenViewParking` off), so on the always-on hosts the memo targeted, ~20 worktrees still paid a full content build on every publication — plus the new inputs build and deep compare #12207 added.

This PR captures the live reads instead of bypassing the memo. `MountedTerminalSurfaceCapture` snapshots, once per publication per mounted tab: the live pane leaf ids, the live active leaf, the serialized pane DOM tree, and each pane's numeric-id/pty bindings. The builders now read only the capture — `registeredTabs` is no longer reachable from the build path — so live state outside the capture is unrepresentable, preserving the compiler-proof input-set property #12207 established. The memo compares captures by value, so a mounted worktree whose panes did not change reuses its snapshot like any other, and any live change (split, pty rebinding, active-pane move, unmount) still forces a rebuild.

No behavior change to snapshot content: the capture holds exactly the values the builders previously read live, resolved at the same point in the same synchronous build pass.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec oxlint` on both changed files (plus pre-commit oxlint + React Doctor + oxfmt)
- [x] `pnpm run typecheck:web`
- [ ] `pnpm test` — the wrapper does not run in this environment (`windows-native-registry` rebuild); vitest was invoked directly:
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/` — 58 files / 569 tests pass
- [x] All out-of-directory importers of `sync-runtime-graph` (`terminal-pane/`, `hooks/`, `store/slices/`, `workspace-activation-terminal-focus`) — 370 files / 5317 tests pass
- [ ] `pnpm build`
- [x] Added 4 tests in `sync-runtime-graph-publication-cost.test.ts`; the skip test (`reuses a mounted worktree snapshot when its live pane state is unchanged`) fails against the pre-fix source (verified via stash), and the three live-change tests pin the safety direction

### New tests

- reuses a mounted worktree snapshot when its live pane state is unchanged (zero content-build reads + object identity)
- publishes a live pty rebinding on a mounted worktree (new ptyId reaches the snapshot; unmounted sibling untouched)
- publishes a live pane split on a mounted worktree (second leaf appears)
- falls back to the persisted pty binding after the surface unmounts (rebuild fires, saved `ptyIdsByLeafId` takes over)

These also close a review gap: `hasMountedTerminalSurface` — the guard this PR replaces — previously had no test that would fail if it were dropped.

## AI Review Report

Reviewed as part of a 4-reviewer release scan of #12207 + #12245 (skip-safety, contract, perf, security), which produced this finding: the mounted-set assumption ("mounted ≈ active worktree") was wrong, making #12207 a small net regression for the mounted tail. Risks checked for this fix:

- **Capture completeness**: the build path's only live-state reads were `registeredTabs.get()` in `getRuntimeLeafIdsForTerminal` and `buildMobileTerminalSurfaceTabs` (`getPanes`, `getActivePane`/`getLeafId`, `getContainer` → `serializePaneTree`, `getNumericIdForLeaf`, `getPtyIdForPane`). All six reads are in the capture; after this change neither builder references the registry, so a future live read must be added to the capture type to compile.
- **Staleness (the P0-shaped risk post-#12245)**: a false "unchanged" would be withheld from main permanently. The capture is rebuilt from live sources on every publication and compared by value, so any live change is witnessed; verified by the pty-rebinding and pane-split tests.
- **Semantics preservation**: the active-leaf fallback chain (`hasLiveActivePane` distinguishes live-null from no-live-pane), the pty resolution chain (live → saved → single-tab fallback), and the persisted-leaf path when `getPanes()` is empty all mirror the pre-change expressions one-for-one.
- **Cost**: capture is O(panes) per mounted tab (a DOM walk the build already did every publication) and is only allocated for worktrees with registered tabs; the 200+ unmounted tail shares the empty-map singleton and compares by reference.
- **Cross-platform (macOS/Linux/Windows)**: renderer-only TypeScript; no paths, shortcuts, shell, or Electron platform APIs touched. The `typeof HTMLElement !== 'undefined'` guard moved intact, so node-side test environments are unaffected. SSH/remote and folder-workspace paths flow through the same store slices and are unaffected.

## Security Audit

No new IPC surface, command execution, path handling, or input parsing. The change is renderer-local memoization: it reads existing in-process PaneManager/DOM state and compares it by value. The IPC payload shape (`RuntimeSyncWindowGraph`) is untouched; main-process code is untouched. No dependencies added. Captured pty ids were already published in snapshots pre-change; the capture holds them at most one publication generation.

## Notes

- The capture also removes the mounted-tail deep-compare/backstop churn flagged in the scan; the remaining P2s from that scan (comparator exhaustiveness enforcement, unmemoized agent-status index, two-generation retention in the backstop) are intentionally not bundled here.
- If `serializePaneTree` output ever jitters (e.g. float pane sizes on window resize), the capture compares unequal and rebuilds — identical behavior to before this PR, never a suppressed publication.
