### PR TITLE
fix(worktrees): fence SSH worktree deletion PTY teardown to the owning host

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -8350,6 +8350,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(worktreeId, {
       runtime: runtimeStub,
+      resolvedWorktreeId: worktreeId,
       localProvider: ptyProvider,
       onPtyStopped: clearProviderPtyStateMock
     })
@@ -8361,6 +8362,36 @@ describe('registerWorktreeHandlers', () => {
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(worktreeId)
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
       repoId: 'repo-folder'
+    })
+  })
+
+  // Folder projects can be SSH-backed, and folder workspace ids are `repoId::path::workspace:<uuid>`
+  // — reusable across hosts — so the sweep must name the owning connection.
+  it('fences an SSH folder workspace PTY sweep to the owning connection', async () => {
+    const sshPtyProvider = { id: 'ssh-pty-provider' } as never
+    const worktreeId = 'repo-folder::/remote/folder::workspace:child-1'
+    store.getRepo.mockReturnValue({
+      id: 'repo-folder',
+      path: '/remote/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder',
+      connectionId: 'conn-1'
+    })
+    getSshPtyProviderMock.mockReturnValue(sshPtyProvider)
+
+    await handlers['worktrees:remove'](null, { worktreeId })
+
+    expect(getSshPtyProviderMock).toHaveBeenCalledWith('conn-1')
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(worktreeId, {
+      runtime: runtimeStub,
+      resolvedWorktreeId: worktreeId,
+      resolvedConnectionId: 'conn-1',
+      localProvider: sshPtyProvider,
+      onPtyStopped: clearProviderPtyStateMock,
+      includeProviderInventory: true,
+      includeLocalRegistry: false
     })
   })
 
@@ -9948,6 +9979,70 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(removeWorktreeMock).toHaveBeenCalled()
     expect(callOrder).toEqual(['preflight', 'kill', 'git'])
+  })
+
+  // Regression: `repoId::path` ids repeat across hosts, so an SSH delete used to reach the
+  // runtime's same-id local (or other-connection) terminals and stop them.
+  it('fences an SSH worktree delete PTY sweep to the owning connection', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: null
+    }
+    const sshPtyProvider = { id: 'ssh-pty-provider' } as never
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue({
+      listWorktrees: vi.fn().mockResolvedValue([
+        { path: '/remote/repo', head: 'main', branch: 'main', isBare: false, isMainWorktree: true },
+        {
+          path: '/remote/feature-wt',
+          head: 'feature',
+          branch: 'feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue({}),
+      worktreeIsClean: vi.fn().mockResolvedValue({ clean: true })
+    })
+    getSshPtyProviderMock.mockReturnValue(sshPtyProvider)
+    getEffectiveHooksFromConfigMock.mockReturnValue(null)
+
+    await handlers['worktrees:remove'](null, { worktreeId: 'repo-ssh::/remote/feature-wt' })
+
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith('repo-ssh::/remote/feature-wt', {
+      runtime: runtimeStub,
+      resolvedWorktreeId: 'repo-ssh::/remote/feature-wt',
+      resolvedConnectionId: 'conn-1',
+      localProvider: sshPtyProvider,
+      onPtyStopped: clearProviderPtyStateMock,
+      requirePhysicalStop: true,
+      includeLocalRegistry: false
+    })
+  })
+
+  // The local counterpart still identifies itself by exact id so a selector that resolves
+  // two hosts can no longer decide which workspace loses its terminals.
+  it('pins a local worktree delete PTY sweep to the exact worktree id', async () => {
+    mockKnownFeatureWorktree()
+    getEffectiveHooksMock.mockReturnValue(null)
+    removeWorktreeMock.mockResolvedValue({})
+
+    await handlers['worktrees:remove'](null, { worktreeId: 'repo-1::/workspace/feature-wt' })
+
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(
+      'repo-1::/workspace/feature-wt',
+      expect.objectContaining({ resolvedWorktreeId: 'repo-1::/workspace/feature-wt' })
+    )
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(
+      'repo-1::/workspace/feature-wt',
+      expect.not.objectContaining({ resolvedConnectionId: expect.anything() })
+    )
   })
 
   // Why (#11960): the PTY gate previously had no escape hatch at all, so a

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -169,6 +169,11 @@ async function stopPtysForDestructiveWorktreeRemoval(
   }
   const teardownResult = await killAllProcessesForWorktree(worktreeId, {
     runtime,
+    // Why: `repoId::path` ids repeat across hosts, so an unfenced sweep stops a same-id
+    // workspace's terminals on another connection — and the selector lookup this replaces
+    // throws `selector_ambiguous` the moment two hosts own the id.
+    resolvedWorktreeId: worktreeId,
+    ...(connectionId ? { resolvedConnectionId: connectionId } : {}),
     localProvider: provider,
     onPtyStopped: clearProviderPtyState,
     requirePhysicalStop: true,
@@ -2290,10 +2295,30 @@ export function registerWorktreeHandlers(
             }
             // Why: folder workspaces share one root, so there's no Git remove step to close shells; sweep PTYs before dropping metadata.
             await withWorktreeRemoveStageSpan('pty_sweep', 'folder', async () => {
+              // Folder projects can be SSH-backed, so fence the sweep to the owning host exactly
+              // like the git paths — the local inventory must never reach a remote workspace's id.
+              const ownerHost = parseExecutionHostId(
+                resolveWorktreeRemovalOwnerHostId(store, args.worktreeId, repo, args.hostId)
+              )
+              const sshPtyProvider =
+                ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
+              const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'
               await killAllProcessesForWorktree(args.worktreeId, {
                 runtime,
-                localProvider: getLocalPtyProvider(),
-                onPtyStopped: clearProviderPtyState
+                resolvedWorktreeId: args.worktreeId,
+                ...(ownerHost?.kind === 'ssh' ? { resolvedConnectionId: ownerHost.targetId } : {}),
+                ...(ownerHost?.kind === 'runtime'
+                  ? { resolvedRuntimeEnvironmentId: ownerHost.environmentId }
+                  : {}),
+                localProvider: sshPtyProvider ?? getLocalPtyProvider(),
+                onPtyStopped: clearProviderPtyState,
+                ...(externalHost
+                  ? {
+                      includeProviderInventory:
+                        ownerHost?.kind === 'ssh' && Boolean(sshPtyProvider),
+                      includeLocalRegistry: false
+                    }
+                  : {})
               }).catch((err) => {
                 console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
               })

--- a/src/main/runtime/missing-worktree-terminal-reconciliation.test.ts
+++ b/src/main/runtime/missing-worktree-terminal-reconciliation.test.ts
@@ -64,14 +64,23 @@ describe('stopMissingWorktreeTerminals', () => {
     const localProvider = createProvider([`${deletedId}@@local-session`])
     const sshProvider = createProvider([`${deletedId}@@ssh-session`])
     const getSshProvider = vi.fn(() => sshProvider)
+    const runtime = createRuntime()
 
     await stopMissingWorktreeTerminals({ ...localRepo, connectionId: 'ssh-1' }, [deletedId], [], {
-      runtime: createRuntime(),
+      runtime,
       getLocalProvider: () => localProvider,
       getSshProvider
     })
 
     expect(getSshProvider).toHaveBeenCalledWith('ssh-1')
+    // The runtime graph holds both hosts' terminals under one id, so the sweep must fence to this one.
+    expect(runtime.stopTerminalsForWorktree).toHaveBeenCalledWith(
+      deletedId,
+      expect.objectContaining({
+        resolvedWorktreeId: deletedId,
+        resolvedConnectionId: 'ssh-1'
+      })
+    )
     expect(sshProvider.shutdown).toHaveBeenCalledWith(
       `${deletedId}@@ssh-session`,
       expect.objectContaining({ immediate: true })
@@ -95,7 +104,12 @@ describe('stopMissingWorktreeTerminals', () => {
     )
 
     expect(result).toEqual({ stoppedWorktreeIds: [deletedId] })
-    expect(runtime.stopTerminalsForWorktree).toHaveBeenCalledWith(deletedId)
+    // The graph fallback still names the owning connection: this repo's inventory must not
+    // stop a same-id workspace's terminals on another host.
+    expect(runtime.stopTerminalsForWorktree).toHaveBeenCalledWith(deletedId, {
+      resolvedWorktreeId: deletedId,
+      resolvedConnectionId: 'ssh-1'
+    })
   })
 
   // Why: an agent cleaning up workspaces deletes many at once. Enumerating the

--- a/src/main/runtime/missing-worktree-terminal-reconciliation.ts
+++ b/src/main/runtime/missing-worktree-terminal-reconciliation.ts
@@ -46,6 +46,18 @@ function withSharedProcessSnapshot(provider: IPtyProvider): IPtyProvider {
   })
 }
 
+// Why: `repoId::path` ids repeat across hosts, so a sweep driven by one repo's inventory
+// must name its owner or it stops a same-id workspace's terminals on another host.
+function hostFence(
+  repo: Repo,
+  worktreeId: string
+): { resolvedWorktreeId: string; resolvedConnectionId?: string } {
+  return {
+    resolvedWorktreeId: worktreeId,
+    ...(repo.connectionId ? { resolvedConnectionId: repo.connectionId } : {})
+  }
+}
+
 type MissingWorktreeTerminalReconciliationDeps = {
   runtime: OrcaRuntimeService
   getLocalProvider: () => IPtyProvider | null
@@ -83,7 +95,7 @@ export async function stopMissingWorktreeTerminals(
         MISSING_WORKTREE_TEARDOWN_CONCURRENCY,
         async (worktreeId) => {
           try {
-            await deps.runtime.stopTerminalsForWorktree(worktreeId)
+            await deps.runtime.stopTerminalsForWorktree(worktreeId, hostFence(repo, worktreeId))
             return worktreeId
           } catch {
             return null
@@ -102,6 +114,7 @@ export async function stopMissingWorktreeTerminals(
         try {
           await killAllProcessesForWorktree(worktreeId, {
             runtime: deps.runtime,
+            ...hostFence(repo, worktreeId),
             localProvider: provider,
             onPtyStopped: deps.onPtyStopped,
             // Why: the shared process snapshot is only valid while nothing needs a

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5923,6 +5923,66 @@ describe('OrcaRuntimeService', () => {
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(`${TEST_REPO_ID}::/remote/feature`)
   })
 
+  // Regression: `repoId::path` ids repeat across hosts, so the SSH delete's runtime sweep used to
+  // stop the same-id local workspace's terminals too.
+  it('leaves a same-id local terminal running when the SSH copy is removed', async () => {
+    const remoteRepo = {
+      id: TEST_REPO_ID,
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const remoteStore = { ...store, getRepos: () => [remoteRepo], getRepo: () => remoteRepo }
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo',
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/remote/feature',
+          head: 'abc',
+          branch: 'feature/foo',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue(undefined)
+    }
+    registerSshGitProvider('ssh-1', gitProvider as never)
+    const ptyProvider = {
+      listProcesses: vi.fn().mockResolvedValue([]),
+      shutdown: vi.fn().mockResolvedValue(undefined)
+    }
+    const runtime = new OrcaRuntimeService(remoteStore as never, undefined, {
+      getSshProvider: () => ptyProvider as never
+    })
+    const stopAndWait = vi.fn(async () => true)
+    runtime.setPtyController({
+      write: () => true,
+      kill: vi.fn(() => true),
+      stopAndWait,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime, null)
+    runtime.registerPty('pty-remote', `${TEST_REPO_ID}::/remote/feature`, 'ssh-1')
+    runtime.registerPty('pty-local-same-id', `${TEST_REPO_ID}::/remote/feature`, null)
+
+    try {
+      await runtime.removeManagedWorktree('path:/remote/feature', true, false)
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+
+    expect(stopAndWait).toHaveBeenCalledWith('pty-remote', expect.anything())
+    expect(stopAndWait).not.toHaveBeenCalledWith('pty-local-same-id', expect.anything())
+  })
+
   it('rejects SSH-backed runtime removal of the main worktree before provider deletion', async () => {
     const remoteStore = {
       ...store,
@@ -34493,6 +34553,31 @@ describe('OrcaRuntimeService', () => {
       })
     ).resolves.toEqual({ stopped: 0 })
     expect(kill).not.toHaveBeenCalled()
+  })
+
+  it('stops only the owning connection when one worktree id lives on two hosts', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const kill = vi.fn(() => true)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      stopAndWait: vi.fn(async () => true),
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime, null)
+    // The store keeps one `repoId::path` per host, so deleting the SSH copy must leave the
+    // local copy's terminals running — the fence the destructive removal paths now supply.
+    runtime.registerPty('pty-ssh', TEST_WORKTREE_ID, 'ssh-1')
+    runtime.registerPty('pty-local', TEST_WORKTREE_ID, null)
+
+    await expect(
+      runtime.stopTerminalsForWorktree(TEST_WORKTREE_ID, {
+        resolvedWorktreeId: TEST_WORKTREE_ID,
+        resolvedConnectionId: 'ssh-1'
+      })
+    ).resolves.toEqual({ stopped: 1 })
+    expect(kill).toHaveBeenCalledWith('pty-ssh')
+    expect(kill).not.toHaveBeenCalledWith('pty-local')
   })
 
   it('awaits physical PTY stop when destructive teardown supplies shared dedupe', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3387,6 +3387,10 @@ export class OrcaRuntimeService {
     }
     const teardownResult = await killAllProcessesForWorktree(worktreeId, {
       runtime: this,
+      // Why: `repoId::path` ids repeat across hosts, so an unfenced sweep stops a same-id
+      // workspace's terminals on another connection (mirrors the IPC removal path).
+      resolvedWorktreeId: worktreeId,
+      ...(connectionId ? { resolvedConnectionId: connectionId } : {}),
       localProvider: provider,
       onPtyStopped: this.onPtyStopped ?? undefined,
       requirePhysicalStop: true,
@@ -23438,14 +23442,34 @@ export class OrcaRuntimeService {
               'Cannot delete the project root workspace. Remove the folder project instead.'
             )
           }
-          const localProvider = this.getLocalProvider()
-          if (localProvider) {
+          // Folder projects can be SSH-backed, so resolve the owner before sweeping.
+          const folderHost = parseExecutionHostId(
+            store.getWorktreeMeta(removalTarget.id)?.hostId ?? getRepoExecutionHostId(repo)
+          )
+          const folderSshPtyProvider =
+            folderHost?.kind === 'ssh' ? this.getSshProviderFn?.(folderHost.targetId) : undefined
+          const externalFolderHost = folderHost?.kind === 'ssh' || folderHost?.kind === 'runtime'
+          const folderPtyProvider = folderSshPtyProvider ?? this.getLocalProvider()
+          if (folderPtyProvider) {
             // Why: folder workspace deletion has no Git removal phase where PTYs
             // would otherwise be swept; tear them down before hiding the workspace.
             await killAllProcessesForWorktree(removalTarget.id, {
               runtime: this,
-              localProvider,
-              onPtyStopped: this.onPtyStopped ?? undefined
+              // External host inventories must never sweep a same-id local workspace.
+              resolvedWorktreeId: removalTarget.id,
+              ...(folderHost?.kind === 'ssh' ? { resolvedConnectionId: folderHost.targetId } : {}),
+              ...(folderHost?.kind === 'runtime'
+                ? { resolvedRuntimeEnvironmentId: folderHost.environmentId }
+                : {}),
+              localProvider: folderPtyProvider,
+              onPtyStopped: this.onPtyStopped ?? undefined,
+              ...(externalFolderHost
+                ? {
+                    includeProviderInventory:
+                      folderHost?.kind === 'ssh' && Boolean(folderSshPtyProvider),
+                    includeLocalRegistry: false
+                  }
+                : {})
             }).catch((err) => {
               console.warn(`[worktree-teardown] failed for ${removalTarget.id}:`, err)
             })


### PR DESCRIPTION
## Summary

Deleting a workspace stopped terminals by worktree id alone. Worktree ids are `repoId::path` and the store deliberately keeps the same id under more than one host, so an SSH delete could kill a same-id **local** workspace's live terminals — or fail the delete outright with `selector_ambiguous` once two hosts owned the id.

Every destructive PTY sweep now names its owner (`resolvedWorktreeId` + `resolvedConnectionId` / `resolvedRuntimeEnvironmentId`), the same fence the forget-local path already had:

- `stopPtysForDestructiveWorktreeRemoval` in `src/main/ipc/worktrees.ts` — covers all five destructive callers (SSH git delete, SSH orphan-directory cleanup, local git delete, local orphan/leftover-directory cleanup).
- The IPC folder-workspace branch of `worktrees:remove` — folder projects can be SSH-backed, and it was sweeping the *local* inventory unfenced. Now resolves the owner host (worktree meta > repo) exactly like forget-local, and uses the SSH PTY provider with `includeLocalRegistry: false` when the owner is external.
- `OrcaRuntimeService.stopPtysForDestructiveWorktreeRemoval` and the runtime folder branch of `removeManagedWorktree` — the CLI/mobile `worktree.rm` surface, a line-for-line duplicate of the IPC bug.
- `stopMissingWorktreeTerminals` — a repo-scoped reconciliation sweep that could stop another host's same-id terminals; both the provider path and the no-provider graph fallback are fenced.

The #11960 `allowUnverifiedStop` force-delete gate is untouched (still set only by an explicit Force Delete, never inferred from `force`); its two regression tests still pass.

**Audit of every teardown call site** (requirement: fence or justify):

| Call site | Before | Now |
| --- | --- | --- |
| `ipc/worktrees.ts` `stopPtysForDestructiveWorktreeRemoval` (5 callers) | unfenced | fenced |
| `ipc/worktrees.ts` folder-workspace remove | unfenced, local provider | fenced + owner provider |
| `ipc/worktrees.ts` forget-local | already fenced (#12153-era hardening) | unchanged |
| `orca-runtime.ts` `stopPtysForDestructiveWorktreeRemoval` | unfenced | fenced |
| `orca-runtime.ts` folder-workspace `removeManagedWorktree` | unfenced, local provider | fenced + owner provider |
| `orca-runtime.ts` orphan (`!repo`) removal | already fenced | unchanged |
| `missing-worktree-terminal-reconciliation.ts` (both paths) | unfenced | fenced |

Known residual, **not** fixed here: a *local* delete still passes no host fence, so it can in principle reach an SSH/runtime same-id workspace (the mirror direction). `stopTerminalsForWorktree` has no "local-only" predicate — `resolvedConnectionId === undefined` means "any host" — and adding one would change that method's contract and the already-shipped forget-local path's behavior. It also can't simply exclude `remote:`-prefixed PTYs, because local repos can be runtime-environment-backed and those PTYs *must* die before deletion. Left as a separate follow-up; the reported P1 (SSH delete reaching other hosts) is closed.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — full run, green
- [x] `pnpm typecheck` — full run, green
- [ ] `pnpm test` — ran the affected suites only (`ipc/worktrees`, `ipc/worktrees-windows`, `runtime/worktree-teardown`, `runtime/worktree-teardown-unstopped-pty`, `runtime/missing-worktree-terminal-reconciliation`, `rpc/methods/worktree*`: 316 passed) plus targeted `orca-runtime.test.ts` filters (`SSH` 76, `folder` 23, `remove` 12, `terminal` 223, `same-id` 3 — all passed). The full suite was not run locally; CI covers it.
- [ ] `pnpm build` — not run locally; no build-surface change (main-process logic only). CI covers it.
- [x] Added or updated high-quality tests that would catch regressions
  - `orca-runtime.test.ts`: an SSH `removeManagedWorktree` end-to-end test asserting a same-id **local** PTY is never stopped while the remote one is; plus a `stopTerminalsForWorktree` unit test that two hosts sharing one id stop only the fenced one. Both were **verified to fail** with the fence reverted (the e2e one killed 2 PTYs instead of 1).
  - `ipc/worktrees.test.ts`: exact-deps assertions for the SSH git delete, the SSH folder workspace delete, and the local delete (fence present, no `resolvedConnectionId` leaked into the local path).
  - `missing-worktree-terminal-reconciliation.test.ts`: fence assertions on both the provider and no-provider paths.

## AI Review Report

Self-review with Claude, focused on: (1) does adding `resolvedWorktreeId` change matching semantics — yes, it swaps exact-string id equality for repoId + `runtimePathsEqual` path comparison and skips selector resolution; that is the same trade the forget-local path already makes, and the #10252 regression test proves folder-instance suffixes are still not collapsed into their sibling checkouts; (2) does it weaken the #11960 gate — no, `requirePhysicalStop`/`allowUnverifiedStop` are untouched and both waiver tests still pass; (3) do the `includeProviderInventory` / `includeLocalRegistry` toggles match the proven forget-local shape — yes, copied field-for-field; (4) folder workspaces vs git worktrees and local vs SSH vs runtime hosts are each covered by an explicit branch, with the runtime-environment case routed through `resolvedRuntimeEnvironmentId`.

Cross-platform: explicitly checked. No shortcuts, labels, shell invocations, or path string-building were added — path comparison is delegated to the existing `runtimePathsEqual` / `splitWorktreeId` helpers that already normalize Windows vs POSIX spelling, and no Electron-specific API is touched. Behavior is identical on macOS, Linux, and Windows; the WSL/runtime-environment host is handled by the same `resolvedRuntimeEnvironmentId` branch as before.

Declining CodeRabbit's Docstring Coverage check per `AGENTS.md` ("Concise/Brief Non-obvious comments ONLY … 1 LINE if possible") — the added comments state *why* the fence exists, which is the non-obvious part.

## Security Audit

This is a privilege-scoping fix: it *narrows* which processes a delete may kill, so a workspace on host A can no longer have its terminals terminated by a deletion on host B (an availability/data-loss class issue — killing a live agent's shell). No new input handling, no command execution, no new path construction, no auth or secrets, and no IPC surface change (`RemoveWorktreeArgs` is unchanged). The one behavioral widening to note: for external hosts the local PTY registry is no longer swept (`includeLocalRegistry: false`) — intentional, since that registry only ever holds local rows, and it matches the existing forget-local path. No dependency changes. Follow-up: the local→remote mirror direction described in the Summary.

## Notes

- Scope note: the task named `ipc/worktrees.ts`, but the identical function is duplicated in `orca-runtime.ts` (the CLI/mobile `worktree.rm` path) and the same defect class sits in the reconciliation sweep. Fixing only the IPC copy would have left the CLI and mobile delete paths broken, so all three are in this PR — called out here rather than landed silently.
- No migration or persisted-state change; the fence is computed per-call from the store's existing host ownership.
