### PR TITLE
fix(gitlab): expire project-ref negatives instead of caching them forever

### DIFF
--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -1,4 +1,5 @@
 import { runCoalescedProbe, type CoalescedProbes } from '../git/coalesced-probe'
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 import { glabExecFileAsync } from '../git/runner'
 import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
 import { DEFAULT_GITLAB_HOSTS, normalizeGitLabHost } from './project-ref-parser'
@@ -8,8 +9,10 @@ export type LocalGitExecOptions = {
 }
 
 const GLAB_KNOWN_HOSTS_TIMEOUT_MS = 10_000
+const UNAUTHENTICATED_HOSTS_MAX_ENTRIES = 128
 const knownHostsCacheByExecutionContext = new Map<string, readonly string[]>()
 const knownHostsInFlightByExecutionContext: CoalescedProbes<readonly string[]> = new Map()
+const unauthenticatedHostExpiries = new Map<string, number>()
 
 function knownHostsExecutionKey(
   connectionId?: string | null,
@@ -26,6 +29,63 @@ function knownHostsExecutionKey(
 export function _resetKnownHostsCache(): void {
   knownHostsCacheByExecutionContext.clear()
   knownHostsInFlightByExecutionContext.clear()
+  unauthenticatedHostExpiries.clear()
+}
+
+/** @internal - exposed for tests only */
+export function _resetGlabUnauthenticatedHosts(): void {
+  unauthenticatedHostExpiries.clear()
+}
+
+function unauthenticatedHostKey(
+  host: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): string {
+  return `${knownHostsExecutionKey(connectionId, localGitOptions)}\0${normalizeGitLabHost(host)}`
+}
+
+/**
+ * Why: `glab auth status --hostname` is how a self-hosted instance that plain
+ * `glab auth status` did not list gets discovered, so a remote that is not
+ * GitLab at all runs it too. Project-ref negatives expire now, and without this
+ * that becomes one `glab` spawn per repo per interval on the hosted-review poll.
+ * The answer is per host, not per repo, and expires on the same clock so a
+ * login still lands within an interval.
+ */
+export function isGlabHostKnownUnauthenticated(
+  host: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): boolean {
+  const key = unauthenticatedHostKey(host, connectionId, localGitOptions)
+  const expiresAt = unauthenticatedHostExpiries.get(key)
+  if (expiresAt === undefined) {
+    return false
+  }
+  if (expiresAt > Date.now()) {
+    return true
+  }
+  unauthenticatedHostExpiries.delete(key)
+  return false
+}
+
+export function rememberGlabHostUnauthenticated(
+  host: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): void {
+  unauthenticatedHostExpiries.set(
+    unauthenticatedHostKey(host, connectionId, localGitOptions),
+    Date.now() + NEGATIVE_ENTRY_TTL_MS
+  )
+  while (unauthenticatedHostExpiries.size > UNAUTHENTICATED_HOSTS_MAX_ENTRIES) {
+    const oldestKey = unauthenticatedHostExpiries.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    unauthenticatedHostExpiries.delete(oldestKey)
+  }
 }
 
 export function rememberGlabKnownHost(
@@ -52,6 +112,9 @@ export function rememberGlabKnownHosts(
     }
     seen.add(normalizedHost)
     additions.push(normalizedHost)
+    unauthenticatedHostExpiries.delete(
+      unauthenticatedHostKey(normalizedHost, connectionId, localGitOptions)
+    )
   }
   if (additions.length === 0) {
     return

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,9 +1,14 @@
 import { glabExecFileAsync } from '../git/runner'
 import { isTransientGitProbeError, readRemoteUrl } from '../git/remote-url-probe'
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
+import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
 import type { IssueSourcePreference } from '../../shared/types'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 import {
+  _resetGlabUnauthenticatedHosts,
+  isGlabHostKnownUnauthenticated,
   parseGlabAuthStatusHosts,
+  rememberGlabHostUnauthenticated,
   rememberGlabKnownHost,
   type LocalGitExecOptions
 } from './gitlab-known-host-probe'
@@ -25,12 +30,16 @@ export {
 export type { LocalGitExecOptions } from './gitlab-known-host-probe'
 
 const PROJECT_REF_CACHE_MAX_ENTRIES = 512
-const projectRefCache = new Map<string, ProjectRef | null>()
+
+type CachedProjectRef = { value: ProjectRef | null; expiresAt: number }
+
+const projectRefCache = new Map<string, CachedProjectRef>()
 
 /** @internal - exposed for tests only */
 export function _resetProjectRefCache(): void {
   projectRefCache.clear()
   clearProjectRefInFlight()
+  _resetGlabUnauthenticatedHosts()
 }
 
 /** @internal - exposed for tests only */
@@ -39,7 +48,14 @@ export function _getProjectRefCacheSize(): number {
 }
 
 function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
-  projectRefCache.set(cacheKey, value)
+  // Why: "not GitLab" only holds until someone configures `origin` or logs into
+  // `glab` — a repo probed before either kept hosted-review detection stale for
+  // the life of the process. Negatives expire the way every other forge's do;
+  // positives still stay (see `createRemoteRefProbeCache`).
+  projectRefCache.set(cacheKey, {
+    value,
+    expiresAt: value === null ? Date.now() + NEGATIVE_ENTRY_TTL_MS : Number.POSITIVE_INFINITY
+  })
   while (projectRefCache.size > PROJECT_REF_CACHE_MAX_ENTRIES) {
     const oldestKey = projectRefCache.keys().next().value
     if (oldestKey === undefined) {
@@ -56,19 +72,30 @@ export async function getProjectRefForRemote(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
-  const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
+  // Why: a reconnect replaces the host an answer came from under the same id, so
+  // the generation is part of the signature; `knownHosts` carries the glab auth
+  // state, so logging into a self-hosted instance re-asks rather than reusing a
+  // ref resolved while that host was unknown.
+  const runtimeKey = connectionId
+    ? `${connectionId}:${getSshGitProviderGeneration(connectionId)}`
+    : `local:${localGitOptions.wslDistro ?? 'host'}`
   const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}\0${knownHosts.join(',')}`
-  if (projectRefCache.has(cacheKey)) {
-    return projectRefCache.get(cacheKey)!
+  const cached = projectRefCache.get(cacheKey)
+  if (cached) {
+    if (cached.expiresAt > Date.now()) {
+      return cached.value
+    }
+    projectRefCache.delete(cacheKey)
   }
 
-  return runProjectRefProbeOnce(cacheKey, () =>
+  return runProjectRefProbeOnce(cacheKey, (ownsKey) =>
     resolveProjectRefForRemote(
       repoPath,
       remoteName,
       knownHosts,
       connectionId,
       cacheKey,
+      ownsKey,
       localGitOptions
     )
   )
@@ -80,8 +107,17 @@ async function resolveProjectRefForRemote(
   knownHosts: readonly string[],
   connectionId: string | null | undefined,
   cacheKey: string,
+  ownsKey: () => boolean,
   localGitOptions: LocalGitExecOptions
 ): Promise<ProjectRef | null> {
+  // Why: a probe abandoned as stale still runs, and the repo state it read is
+  // older than whatever its successor already published. It may answer its own
+  // callers; it may not overwrite the cache.
+  const publish = (value: ProjectRef | null): void => {
+    if (ownsKey()) {
+      rememberProjectRefCacheEntry(cacheKey, value)
+    }
+  }
   try {
     const stdout = await readRemoteUrl(
       {
@@ -96,7 +132,7 @@ async function resolveProjectRefForRemote(
     }
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
-      rememberProjectRefCacheEntry(cacheKey, result)
+      publish(result)
       return result
     }
     const remoteCandidate = parseRemoteProjectRefCandidate(stdout)
@@ -110,17 +146,20 @@ async function resolveProjectRefForRemote(
       ))
     ) {
       rememberGlabKnownHost(remoteCandidate.host, connectionId, localGitOptions)
-      rememberProjectRefCacheEntry(cacheKey, remoteCandidate)
+      publish(remoteCandidate)
       return remoteCandidate
     }
   } catch (error) {
     // Why: a wedged or killed probe is not evidence the remote is not GitLab —
-    // caching it would misdetect the forge for the life of the process (P1-D).
+    // caching it would misdetect the forge until the negative expires (P1-D).
+    // SSH failures stay uncached outright rather than adopting the generic
+    // cache's stable-missing-remote exception: keeping a connected host's
+    // detection fresh is worth the extra probe.
     if (connectionId || isTransientGitProbeError(error)) {
       return null
     }
   }
-  rememberProjectRefCacheEntry(cacheKey, null)
+  publish(null)
   return null
 }
 
@@ -229,12 +268,22 @@ async function isGlabConfiguredForRemoteHost(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<boolean> {
+  // Why: this probe is per host, but the project-ref miss that reaches it is per
+  // repo — without the memo, every non-GitLab repo re-spawns `glab` each time
+  // its negative expires.
+  if (isGlabHostKnownUnauthenticated(projectRef.host, connectionId, localGitOptions)) {
+    return false
+  }
   try {
     const result = await glabExecFileAsync(
       ['auth', 'status', '--hostname', projectRef.host],
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    return result !== undefined
+    if (result === undefined) {
+      rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
+      return false
+    }
+    return true
   } catch (error) {
     const execLike = error as { stdout?: unknown; stderr?: unknown; message?: unknown }
     const output =
@@ -242,6 +291,10 @@ async function isGlabConfiguredForRemoteHost(
         .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
         .join('\n') || String(error)
     const hosts = parseGlabAuthStatusHosts(output).map(normalizeGitLabHost)
-    return hosts.includes(normalizeGitLabHost(projectRef.host))
+    if (hosts.includes(normalizeGitLabHost(projectRef.host))) {
+      return true
+    }
+    rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
+    return false
   }
 }

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -28,16 +28,19 @@ import {
 import { rememberGlabKnownHost, rememberGlabKnownHosts } from './gitlab-known-host-probe'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
+import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 
 describe('gitlab project ref resolution', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    glabExecFileAsyncMock.mockReset()
     sshExecMock.mockReset()
     unregisterSshGitProvider('conn-1')
     _resetProjectRefCache()
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     unregisterSshGitProvider('conn-1')
   })
 
@@ -210,6 +213,110 @@ describe('gitlab project ref resolution', () => {
       host: 'gitlab.com',
       path: 'remote/orca'
     })
+  })
+
+  it('does not cache a local probe killed on its deadline as a definitive miss', async () => {
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('git timed out.'))
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:fork/orca.git\n' })
+
+    await expect(getProjectRef('/repo')).resolves.toBeNull()
+    await expect(getProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'fork/orca'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-probes a repo whose GitLab remote could have been added since the miss', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error("error: No such remote 'origin'"))
+
+    await expect(getProjectRef('/repo')).resolves.toBeNull()
+    await expect(getProjectRef('/repo')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+
+    // Nothing watches `.git/config`, and SSH/WSL repos have no file to watch, so
+    // a remote configured after the miss is only visible once the negative ages out.
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:fork/orca.git\n' })
+    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
+
+    await expect(getProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'fork/orca'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a resolved project ref past the negative interval', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:fork/orca.git\n' })
+
+    await expect(getProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'fork/orca'
+    })
+    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS * 10)
+    await expect(getProjectRef('/repo')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'fork/orca'
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-resolves a self-hosted remote once glab auth knows its host', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.internal:team/orca.git\n' })
+    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
+
+    await expect(getProjectRefForRemote('/repo', 'origin', ['gitlab.com'])).resolves.toBeNull()
+    await expect(
+      getProjectRefForRemote('/repo', 'origin', ['gitlab.com', 'gitlab.internal'])
+    ).resolves.toEqual({ host: 'gitlab.internal', path: 'team/orca' })
+  })
+
+  it('asks glab about an unauthenticated host once per interval, not once per repo', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@github.com:team/orca.git\n' })
+    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
+
+    // Expiring project-ref negatives must not turn the hosted-review poll into a
+    // `glab auth status` spawn per repo per interval — the answer is per host.
+    for (const repoPath of ['/repo-a', '/repo-b', '/repo-c']) {
+      await expect(getProjectRef(repoPath)).resolves.toBeNull()
+    }
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
+    for (const repoPath of ['/repo-a', '/repo-b', '/repo-c']) {
+      await expect(getProjectRef(repoPath)).resolves.toBeNull()
+    }
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not serve a project ref resolved on a retired SSH connection', async () => {
+    sshExecMock
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:before/orca.git\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:after/orca.git\n', stderr: '' })
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'before/orca'
+    })
+
+    // A reconnect can swap the execution host under the same connection id.
+    unregisterSshGitProvider('conn-1')
+    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
+
+    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
+      host: 'gitlab.com',
+      path: 'after/orca'
+    })
+    expect(sshExecMock).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/main/gitlab/project-ref-inflight.ts
+++ b/src/main/gitlab/project-ref-inflight.ts
@@ -9,7 +9,7 @@ export function clearProjectRefInFlight(): void {
 
 export async function runProjectRefProbeOnce(
   cacheKey: string,
-  createProbe: () => Promise<ProjectRef | null>
+  createProbe: (ownsKey: () => boolean) => Promise<ProjectRef | null>
 ): Promise<ProjectRef | null> {
   // Why: joining only a probe that is still young keeps a wedged host's dead
   // promise from pinning every later retry for the process lifetime (P1-D).


### PR DESCRIPTION
## Summary

`src/main/gitlab/gitlab-project-ref-resolution.ts` stored `null` with no expiry and returned any cached value straight from the map. A repo probed before `origin` was configured — or before `glab auth login` ran for its self-hosted host — kept hosted-review provider detection stale **until app restart**. The negative-TTL work that shipped for the other forges (`createRemoteRefProbeCache`: negative TTL, signature keying, 512-entry bound, no caching of transient failures) skipped GitLab.

This mirrors those semantics in the GitLab cache (rather than reusing `createRemoteRefProbeCache`, which takes a *synchronous* URL parser — GitLab's resolution needs an async `glab auth status --hostname` fallback and per-call `knownHosts`):

- Negatives expire on the shared `NEGATIVE_ENTRY_TTL_MS`, imported from `remote-ref-probe-cache` so the interval stays single-sourced. Positives still never expire.
- The SSH provider **generation** joins the cache signature, so a reconnect that swaps the execution host under the same connection id re-asks instead of serving the retired host's answer. (`knownHosts` already carried the glab auth state into the key.)
- A probe abandoned as stale can no longer publish over its successor's answer (`ownsKey` guard, matching the generic cache). `runProjectRefProbeOnce` was dropping the `ownsKey` argument `runCoalescedProbe` already provides.
- Transient git/SSH failures stay uncached, as before. SSH failures deliberately stay uncached *outright* rather than adopting the generic cache's stable-missing-remote exception — keeping a connected host's detection fresh is worth the extra probe. That divergence is commented in the source.

**Cost regression this fix would otherwise have introduced, closed here:** `parseRemoteProjectRefCandidate` accepts *any* host, so a plain GitHub repo reaches `glab auth status --hostname github.com`. With negatives previously cached forever, that spawned `glab` once per repo per process; with negatives expiring it would have become one `glab` spawn per repo per interval on the hosted-review poll (`getProjectSlug`). `gitlab-known-host-probe.ts` now memoizes the "not authenticated" answer **per host** (not per repo) on the same TTL clock, bounded at 128 entries, and a successful `rememberGlabKnownHost` clears it. Three repos on the same unauthenticated host now cost one `glab` spawn per interval instead of three.

Provider-generic: no Azure DevOps / Bitbucket / Gitea path was touched — `remote-ref-probe-cache.ts` is imported from, not modified.

> **Scope note:** this PR originally also carried a deflake for `tests/e2e/workspace-board-lane-virtualization.spec.ts`. That rework did **not** survive CI-runner load (it still failed the changed-e2e-specs job), so it has been removed from this branch and moved to its own PR rather than holding this clean fix hostage. This PR is now GitLab-only.

## Screenshots

`No visual change` — main-process cache behavior only; no renderer or user-facing copy touched.

## Testing

- [x] `pnpm lint` — passed (full run, exit 0), plus `audit:code-quality:native` and `audit:code-quality:type-aware`.
- [x] `pnpm typecheck` — passed (via `pnpm tc`), re-run after rebasing onto current `main` (`194e1a8d4d`).
- [x] `pnpm test` — the targeted suites are green on the current base: `src/main/gitlab/` + `remote-ref-probe-cache` = **237/237**. The full-suite run showed 24 unrelated failures which I verified **base-identical** by re-running them on an unmodified `origin/main` scratch worktree (`agent-exec-handler`, `check-root-directory-entries`, `updater` reproduced there directly; the rest are PTY/daemon/fs-watcher timing on node 26). None of the failing files import anything this PR touches.
- [ ] `pnpm build` — **not run.** No build-surface change in this diff.
- [x] Added or updated high-quality tests that would catch regressions

Tests added to `src/main/gitlab/gl-utils.test.ts` (5 new), each verified **non-vacuous** by reverting the fix and confirming it goes red:

| test | red without fix? |
| --- | --- |
| re-probes a repo whose GitLab remote could have been added since the miss | ✅ fails without TTL |
| does not serve a project ref resolved on a retired SSH connection | ✅ fails without generation keying |
| asks glab about an unauthenticated host once per interval, not once per repo | ✅ fails without the per-host memo |
| keeps a resolved project ref past the negative interval | guard (green before and after — pins that positives don't expire) |
| does not cache a local probe killed on its deadline as a definitive miss | guard (green before and after — pins transient-not-cached) |
| re-resolves a self-hosted remote once glab auth knows its host | guard (auth signature was already keyed via `knownHosts`) |

## AI Review Report

Self-review focused on: cache-poisoning and staleness semantics, probe coalescing races, process-spawn cost, and test vacuity.

Flagged and fixed during review:
- **Spawn-cost regression introduced by my own TTL** — expiring negatives turned `glab auth status --hostname` from once-per-repo-per-process into once-per-repo-per-interval on the hosted-review poll. Found by tracing `getProjectSlug` callers and confirming `parseRemoteProjectRefCandidate` accepts non-GitLab hosts. Fixed with the per-host memo described above, with a test pinning the spawn budget.
- **Stale-probe publish** — `resolveProjectRefForRemote` wrote the cache unconditionally. Now threaded through `ownsKey` and gated.
- Verified no import cycle from `gitlab/` → `git/remote-ref-probe-cache` (that module imports only `ssh-git-dispatch`, `coalesced-probe`, `remote-url-probe`, `stable-missing-git-remote-error`).
- Confirmed `_resetProjectRefCache` also clears the new memo so state cannot leak between tests.

**Cross-platform compatibility explicitly reviewed for macOS, Linux, and Windows.** The change keeps the existing execution-context separation intact and extends it: cache keys distinguish native host, WSL distro (`wslDistro`), and SSH connection *including generation*, so a Windows/WSL host and its native host cannot share a project-ref answer — the existing "keeps local host and local WSL project-ref cache entries separate" test still passes, and the new memo is keyed through the same `knownHostsExecutionKey` (native / `wsl:<distro>` / `connection:<id>:<gen>`). No new path handling, no shell invocation, no new binary arguments; `glab` args are unchanged. Git binary compatibility is unaffected — `git remote get-url` (well below the 2.25 baseline) is the only git command involved and it was not modified. SSH and folder-workspace cases were considered: SSH negatives remain uncached (deliberate, commented), and nothing here assumes a git worktree.

Declining CodeRabbit's **Docstring Coverage (80%)** check per `AGENTS.md` ("Concise/Brief Non-obvious comments ONLY … 1 LINE if possible").

## Security Audit

Low risk; no new attack surface.

- **Command execution:** no new commands. `glab auth status --hostname <host>` was already invoked on this path; this PR only *reduces* how often it runs. Argument construction is unchanged and still array-form (no shell interpolation).
- **Input handling:** the host fed to the new memo comes from `parseRemoteProjectRefCandidate` and is normalized through the existing `normalizeGitLabHost`. Cache keys use `\0` separators consistent with surrounding code, so a host or repo path cannot forge a different context's key.
- **Auth/secrets:** the memo stores only a hostname and an expiry timestamp — no tokens, no `glab` output, no credentials. Auth state is keyed per execution context, so a WSL distro or SSH connection cannot read another's authentication answer. Expiring negatives is a strict improvement for auth correctness: a repo is no longer permanently misclassified based on a pre-login probe.
- **Path handling / IPC / dependencies:** unchanged. No new dependencies. Both caches are bounded (512 project refs, 128 hosts) with FIFO eviction.

## Notes

- Behavior change worth knowing: non-GitLab repos now re-run `git remote get-url` once per 5-minute interval instead of once per process. This is the same cost Azure DevOps / Bitbucket / Gitea already pay, and the `glab` half is amortized per host by the new memo.
- Rebased onto current `main` (`194e1a8d4d`) after #12387/#12388 landed; no file overlap with either.
- `pnpm build` was not run; see Testing.
