### PR TITLE
perf(tabs): take split-divider drag off the store (STA-3328)

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
@@ -209,14 +209,15 @@ describe('TabGroupSplitLayout divider drag', () => {
   it('ignores events from pointers that do not own the drag', async () => {
     await act(async () => {
       handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 350 }))
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 2 }))
       handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 2, clientX: 300 }))
       handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 2 }))
     })
-    expect(firstPane.style.flex).toBe('0.5 1 0%')
+    expect(firstPane.style.flex).toBe('0.35 1 0%')
     expect(setTabGroupSplitRatioMock).not.toHaveBeenCalled()
 
     await act(async () => {
-      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 350 }))
       handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
     })
     expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.35)

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
@@ -54,19 +54,49 @@ function pointerEvent(type: string, init: { pointerId?: number; clientX?: number
 
 describe('TabGroupSplitLayout divider drag', () => {
   let container: HTMLDivElement
-  let root: Root
+  let root: Root | null
   let handle: HTMLElement
   let firstPane: HTMLElement
   let secondPane: HTMLElement
+  let containerRect: DOMRect
+  let resizeObserverCallback: ResizeObserverCallback | null
+  const resizeObserverDisconnectMock = vi.fn()
 
   beforeEach(async () => {
     setTabGroupSplitRatioMock.mockClear()
     recordFeatureInteractionMock.mockClear()
+    resizeObserverDisconnectMock.mockClear()
+    resizeObserverCallback = null
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        private readonly callback: ResizeObserverCallback
+        private tracksSplitContainer = false
+
+        constructor(callback: ResizeObserverCallback) {
+          this.callback = callback
+        }
+
+        observe(target: Element): void {
+          if (target === handle?.parentElement) {
+            this.tracksSplitContainer = true
+            resizeObserverCallback = this.callback
+          }
+        }
+        unobserve(): void {}
+        disconnect(): void {
+          if (this.tracksSplitContainer) {
+            resizeObserverDisconnectMock()
+          }
+        }
+      }
+    )
     container = document.createElement('div')
     document.body.appendChild(container)
-    root = createRoot(container)
+    const mountedRoot = createRoot(container)
+    root = mountedRoot
     await act(async () => {
-      root.render(
+      mountedRoot.render(
         <TabGroupSplitLayout
           layout={{
             type: 'split',
@@ -85,24 +115,32 @@ describe('TabGroupSplitLayout divider drag', () => {
     expect(handle).not.toBeNull()
     firstPane = handle.previousElementSibling as HTMLElement
     secondPane = handle.nextElementSibling as HTMLElement
-    let captured = false
+    const capturedPointers = new Set<number>()
     Object.assign(handle, {
-      setPointerCapture: () => {
-        captured = true
+      setPointerCapture: (pointerId: number) => {
+        capturedPointers.add(pointerId)
       },
-      releasePointerCapture: () => {
-        captured = false
+      releasePointerCapture: (pointerId: number) => {
+        capturedPointers.delete(pointerId)
       },
-      hasPointerCapture: () => captured
+      hasPointerCapture: (pointerId: number) => capturedPointers.has(pointerId)
     })
     const splitContainer = handle.parentElement as HTMLElement
-    splitContainer.getBoundingClientRect = () =>
-      ({ left: 0, top: 0, width: 1000, height: 500, right: 1000, bottom: 500 }) as DOMRect
+    containerRect = {
+      left: 0,
+      top: 0,
+      width: 1000,
+      height: 500,
+      right: 1000,
+      bottom: 500
+    } as DOMRect
+    splitContainer.getBoundingClientRect = vi.fn(() => containerRect)
   })
 
   afterEach(() => {
-    act(() => root.unmount())
+    act(() => root?.unmount())
     container.remove()
+    vi.unstubAllGlobals()
   })
 
   it('writes pane styles per move and commits the store once on release', async () => {
@@ -144,5 +182,65 @@ describe('TabGroupSplitLayout divider drag', () => {
     })
     expect(setTabGroupSplitRatioMock).toHaveBeenCalledTimes(1)
     expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.15)
+  })
+
+  it('refreshes drag geometry only when the split container resizes', async () => {
+    const getRectMock = handle.parentElement?.getBoundingClientRect as ReturnType<typeof vi.fn>
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 250 }))
+    })
+    expect(firstPane.style.flex).toBe('0.25 1 0%')
+    expect(getRectMock).toHaveBeenCalledOnce()
+
+    containerRect = { ...containerRect, width: 500, right: 500 } as DOMRect
+    resizeObserverCallback?.([], {} as ResizeObserver)
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 250 }))
+      handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
+    })
+
+    expect(firstPane.style.flex).toBe('0.5 1 0%')
+    expect(getRectMock).toHaveBeenCalledTimes(2)
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.5)
+    expect(resizeObserverDisconnectMock).toHaveBeenCalledOnce()
+  })
+
+  it('ignores events from pointers that do not own the drag', async () => {
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 2, clientX: 300 }))
+      handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 2 }))
+    })
+    expect(firstPane.style.flex).toBe('0.5 1 0%')
+    expect(setTabGroupSplitRatioMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 350 }))
+      handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
+    })
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.35)
+  })
+
+  it.each(['pointercancel', 'lostpointercapture'])('commits on %s', async (eventType) => {
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 400 }))
+      handle.dispatchEvent(pointerEvent(eventType, { pointerId: 1 }))
+    })
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.4)
+    expect(resizeObserverDisconnectMock).toHaveBeenCalledOnce()
+  })
+
+  it('commits and releases drag resources on unmount', async () => {
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 450 }))
+    })
+    act(() => root?.unmount())
+    root = null
+
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.45)
+    expect(resizeObserverDisconnectMock).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+
+// Why: the sibling TabGroupSplitLayout.test.ts calls components as plain
+// functions and cannot exercise the drag gesture; these tests real-render the
+// handle to pin the STA-3328 contract — pointermove writes pane styles
+// directly and the store is committed exactly once, on release.
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const setTabGroupSplitRatioMock = vi.fn()
+const recordFeatureInteractionMock = vi.fn()
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      recordFeatureInteraction: recordFeatureInteractionMock,
+      setTabGroupSplitRatio: setTabGroupSplitRatioMock
+    })
+}))
+
+vi.mock('./TabGroupPanel', () => ({
+  default: ({ groupId }: { groupId: string }) => <div data-testid={`panel-${groupId}`} />
+}))
+
+vi.mock('./useTabDragSplit', () => ({
+  useTabDragSplit: () => ({
+    activeDrag: null,
+    collisionDetection: vi.fn(),
+    hoveredDropTarget: null,
+    hoveredTabInsertion: null,
+    isTabDragActiveRef: { current: false },
+    onDragCancel: vi.fn(),
+    onDragEnd: vi.fn(),
+    onDragMove: vi.fn(),
+    onDragOver: vi.fn(),
+    onDragStart: vi.fn(),
+    sensors: [],
+    setDragRootNode: vi.fn()
+  })
+}))
+
+import TabGroupSplitLayout from './TabGroupSplitLayout'
+
+function pointerEvent(type: string, init: { pointerId?: number; clientX?: number }): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'pointerId', { value: init.pointerId ?? 1 })
+  Object.defineProperty(event, 'clientX', { value: init.clientX ?? 0 })
+  Object.defineProperty(event, 'clientY', { value: 0 })
+  return event
+}
+
+describe('TabGroupSplitLayout divider drag', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let handle: HTMLElement
+  let firstPane: HTMLElement
+  let secondPane: HTMLElement
+
+  beforeEach(async () => {
+    setTabGroupSplitRatioMock.mockClear()
+    recordFeatureInteractionMock.mockClear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <TabGroupSplitLayout
+          layout={{
+            type: 'split',
+            direction: 'horizontal',
+            ratio: 0.5,
+            first: { type: 'leaf', groupId: 'left-group' },
+            second: { type: 'leaf', groupId: 'right-group' }
+          }}
+          worktreeId="wt-1"
+          focusedGroupId="right-group"
+          isWorktreeActive={true}
+        />
+      )
+    })
+    handle = container.querySelector('.tab-group-split-resize-handle') as HTMLElement
+    expect(handle).not.toBeNull()
+    firstPane = handle.previousElementSibling as HTMLElement
+    secondPane = handle.nextElementSibling as HTMLElement
+    let captured = false
+    Object.assign(handle, {
+      setPointerCapture: () => {
+        captured = true
+      },
+      releasePointerCapture: () => {
+        captured = false
+      },
+      hasPointerCapture: () => captured
+    })
+    const splitContainer = handle.parentElement as HTMLElement
+    splitContainer.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 1000, height: 500, right: 1000, bottom: 500 }) as DOMRect
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('writes pane styles per move and commits the store once on release', async () => {
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+    })
+    expect(recordFeatureInteractionMock).toHaveBeenCalledWith('terminal-panes')
+
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 300 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 320 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 340 }))
+    })
+
+    // Why: the drag must never publish store updates per move (STA-3328) —
+    // the panes track the pointer via direct style writes instead.
+    expect(setTabGroupSplitRatioMock).not.toHaveBeenCalled()
+    expect(firstPane.style.flex).toBe('0.34 1 0%')
+    expect(secondPane.style.flex).toBe('0.66 1 0%')
+
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
+    })
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledTimes(1)
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.34)
+  })
+
+  it('clamps the committed ratio and skips the commit when nothing moved', async () => {
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
+    })
+    expect(setTabGroupSplitRatioMock).not.toHaveBeenCalled()
+
+    await act(async () => {
+      handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1 }))
+      handle.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 20 }))
+      handle.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }))
+    })
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledTimes(1)
+    expect(setTabGroupSplitRatioMock).toHaveBeenCalledWith('wt-1', '', 0.15)
+  })
+})

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -34,6 +34,10 @@ function ResizeHandle({
   const onPointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       event.preventDefault()
+      // Why: a second pointer must not steal or finalize the active gesture.
+      if (activeResizeCleanupRef.current) {
+        return
+      }
       const handle = event.currentTarget
       const container = handle.parentElement
       if (!container) {
@@ -44,7 +48,6 @@ function ResizeHandle({
       if (!firstPane || !secondPane) {
         return
       }
-      activeResizeCleanupRef.current?.()
       onResizeStart()
       setDragging(true)
       handle.setPointerCapture(event.pointerId)

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -39,20 +39,34 @@ function ResizeHandle({
       if (!container) {
         return
       }
+      const firstPane = handle.previousElementSibling as HTMLElement | null
+      const secondPane = handle.nextElementSibling as HTMLElement | null
+      if (!firstPane || !secondPane) {
+        return
+      }
       activeResizeCleanupRef.current?.()
       onResizeStart()
       setDragging(true)
       handle.setPointerCapture(event.pointerId)
+      // Why: measure once — the container can't resize mid-drag, and per-move
+      // getBoundingClientRect forces a reflow against freshly written styles.
+      const rect = container.getBoundingClientRect()
+      let draggedRatio: number | null = null
 
       const onPointerMove = (moveEvent: PointerEvent): void => {
         if (!handle.hasPointerCapture(event.pointerId)) {
           return
         }
-        const rect = container.getBoundingClientRect()
         const ratio = isHorizontal
           ? (moveEvent.clientX - rect.left) / rect.width
           : (moveEvent.clientY - rect.top) / rect.height
-        onRatioChange(Math.min(MAX_RATIO, Math.max(MIN_RATIO, ratio)))
+        const clamped = Math.min(MAX_RATIO, Math.max(MIN_RATIO, ratio))
+        draggedRatio = clamped
+        // Why: direct style writes keep the drag off the store — a commit per
+        // pointermove published 60-120 global store updates/s against every
+        // subscriber (STA-3328). React re-applies identical flex on commit.
+        firstPane.style.flex = `${clamped} 1 0%`
+        secondPane.style.flex = `${1 - clamped} 1 0%`
       }
 
       let cleaned = false
@@ -61,6 +75,9 @@ function ResizeHandle({
           return
         }
         cleaned = true
+        if (draggedRatio !== null) {
+          onRatioChange(draggedRatio)
+        }
         if (updateDragging) {
           setDragging(false)
         }

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -48,13 +48,16 @@ function ResizeHandle({
       onResizeStart()
       setDragging(true)
       handle.setPointerCapture(event.pointerId)
-      // Why: measure once — the container can't resize mid-drag, and per-move
-      // getBoundingClientRect forces a reflow against freshly written styles.
-      const rect = container.getBoundingClientRect()
+      // Why: measure outside pointermove so pane writes never force a readback.
+      let rect = container.getBoundingClientRect()
+      const resizeObserver = new ResizeObserver(() => {
+        rect = container.getBoundingClientRect()
+      })
+      resizeObserver.observe(container)
       let draggedRatio: number | null = null
 
       const onPointerMove = (moveEvent: PointerEvent): void => {
-        if (!handle.hasPointerCapture(event.pointerId)) {
+        if (moveEvent.pointerId !== event.pointerId || !handle.hasPointerCapture(event.pointerId)) {
           return
         }
         const ratio = isHorizontal
@@ -75,6 +78,7 @@ function ResizeHandle({
           return
         }
         cleaned = true
+        resizeObserver.disconnect()
         if (draggedRatio !== null) {
           onRatioChange(draggedRatio)
         }
@@ -97,16 +101,22 @@ function ResizeHandle({
         }
       }
 
-      const onPointerUp = (): void => {
-        cleanup()
+      const onPointerUp = (upEvent: PointerEvent): void => {
+        if (upEvent.pointerId === event.pointerId) {
+          cleanup()
+        }
       }
 
-      const onPointerCancel = (): void => {
-        cleanup()
+      const onPointerCancel = (cancelEvent: PointerEvent): void => {
+        if (cancelEvent.pointerId === event.pointerId) {
+          cleanup()
+        }
       }
 
-      const onLostPointerCapture = (): void => {
-        cleanup()
+      const onLostPointerCapture = (lostEvent: PointerEvent): void => {
+        if (lostEvent.pointerId === event.pointerId) {
+          cleanup()
+        }
       }
 
       handle.addEventListener('pointermove', onPointerMove)

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -949,6 +949,32 @@ describe('TabsSlice', () => {
       expect(layout.ratio).toBe(0.5)
       expect(layout.second.ratio).toBe(0.7)
     })
+
+    it('keeps state identity when the ratio is unchanged', () => {
+      store.setState({
+        layoutByWorktree: {
+          [WT]: {
+            type: 'split',
+            direction: 'horizontal',
+            ratio: 0.5,
+            first: { type: 'leaf', groupId: 'g-1' },
+            second: { type: 'leaf', groupId: 'g-2' }
+          }
+        }
+      })
+      const before = store.getState().layoutByWorktree
+
+      // Why: an unchanged commit must not mint fresh root state — every store
+      // subscriber wakes on the new reference (STA-3328).
+      store.getState().setTabGroupSplitRatio(WT, '', 0.5)
+      expect(store.getState().layoutByWorktree).toBe(before)
+
+      store.getState().setTabGroupSplitRatio(WT, '', 0.5004)
+      expect(store.getState().layoutByWorktree).toBe(before)
+
+      store.getState().setTabGroupSplitRatio(WT, '', 0.7)
+      expect(store.getState().layoutByWorktree).not.toBe(before)
+    })
   })
 
   describe('move/copy/merge group operations', () => {

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -962,18 +962,23 @@ describe('TabsSlice', () => {
           }
         }
       })
-      const before = store.getState().layoutByWorktree
+      const beforeState = store.getState()
+      const beforeLayout = beforeState.layoutByWorktree
+      const subscriber = vi.fn()
+      const unsubscribe = store.subscribe(subscriber)
 
       // Why: an unchanged commit must not mint fresh root state — every store
       // subscriber wakes on the new reference (STA-3328).
       store.getState().setTabGroupSplitRatio(WT, '', 0.5)
-      expect(store.getState().layoutByWorktree).toBe(before)
+      expect(store.getState()).toBe(beforeState)
+      expect(store.getState().layoutByWorktree).toBe(beforeLayout)
+      expect(subscriber).not.toHaveBeenCalled()
 
       store.getState().setTabGroupSplitRatio(WT, '', 0.5004)
-      expect(store.getState().layoutByWorktree).toBe(before)
-
-      store.getState().setTabGroupSplitRatio(WT, '', 0.7)
-      expect(store.getState().layoutByWorktree).not.toBe(before)
+      expect(store.getState().layoutByWorktree).not.toBe(beforeLayout)
+      expect(subscriber).toHaveBeenCalledOnce()
+      expect((store.getState().layoutByWorktree[WT] as { ratio: number }).ratio).toBe(0.5004)
+      unsubscribe()
     })
   })
 

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1790,7 +1790,7 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     set((state) => {
       const currentLayout = state.layoutByWorktree[worktreeId]
       if (!currentLayout) {
-        return {}
+        return state
       }
       // Why: an unchanged ratio must not mint fresh root state — every store
       // subscriber wakes on the new reference (STA-3328).
@@ -1801,12 +1801,8 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
             ? targetNode[segment]
             : undefined
       }
-      if (
-        targetNode &&
-        targetNode.type === 'split' &&
-        Math.abs((targetNode.ratio ?? 0.5) - ratio) < 0.0005
-      ) {
-        return {}
+      if (!targetNode || targetNode.type !== 'split' || (targetNode.ratio ?? 0.5) === ratio) {
+        return state
       }
       return {
         layoutByWorktree: {

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1792,6 +1792,22 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       if (!currentLayout) {
         return {}
       }
+      // Why: an unchanged ratio must not mint fresh root state — every store
+      // subscriber wakes on the new reference (STA-3328).
+      let targetNode: TabGroupLayoutNode | undefined = currentLayout
+      for (const segment of nodePath.length > 0 ? nodePath.split('.') : []) {
+        targetNode =
+          targetNode && targetNode.type === 'split' && (segment === 'first' || segment === 'second')
+            ? targetNode[segment]
+            : undefined
+      }
+      if (
+        targetNode &&
+        targetNode.type === 'split' &&
+        Math.abs((targetNode.ratio ?? 0.5) - ratio) < 0.0005
+      ) {
+        return {}
+      }
       return {
         layoutByWorktree: {
           ...state.layoutByWorktree,


### PR DESCRIPTION
## Summary

Fourth installment of the STA-3328 perf work (#12359 spinner, #12371 tab-group amplifiers, #12377 status coalescing). This fixes the split-divider drag, confirmed HIGH in the terminal-pane React audit: every `pointermove` committed a global store write (60–120 publications/s against every subscriber during a drag) and performed a layout read after pane style changes.

Changes:

- **Drag runs off the store.** Pointer movement writes the two pane `flex` styles directly. The container is measured at drag start and only refreshed by a drag-scoped `ResizeObserver`, so the pointer hot path performs no layout read. Terminal pane observers still drive fits from the element size changes.
- **The model commits once.** The final ratio is persisted on the owning pointer's `pointerup`, `pointercancel`, `lostpointercapture`, or component unmount, and only after movement. Foreign pointer events cannot change or end the gesture.
- **Unchanged ratios are true Zustand no-ops.** Exact duplicates return the existing root state, preserving root and `layoutByWorktree` identity without notifying subscribers. Near-but-distinct ratios persist exactly, keeping direct DOM styles and restored state coherent.

## Screenshots

Equal split before the gesture:

![Equal split before the gesture](https://github.com/user-attachments/assets/d95088a0-f6ae-4d83-b44b-5337f241fbb1)

Persisted 66/34 split after the gesture, with terminal input still working:

![Persisted split after the gesture](https://github.com/user-attachments/assets/62dd02e1-1c19-40f8-9d30-8540b953a9ae)

## Testing

- [x] Same-model review round fixed three in-scope issues; the follow-up round returned `CLEAN`
- [x] Tab-group + tabs slice: 13 files / 163 tests
- [x] `terminal-geometry.visible-convergence` gate: 8 files / 1,676 passed / 1 skipped
- [x] `pnpm typecheck`
- [x] Changed-code quality: 0 findings; oxfmt and max-lines ratchet pass
- [x] Electron on macOS, intended worktree identity verified:
  - four pointer moves changed the visible split from 50/50 to 66/34 with **0 `layoutByWorktree` publications** and the persisted ratio still at 0.5
  - release produced exactly **1** layout publication and persisted `0.6627505183137526`
  - typed terminal input echoed after release
  - resizing the Electron window while capture remained active refreshed geometry against the new container, again with 0 mid-drag layout publications and 1 release commit
- [ ] Packaged Linux/Windows and live SSH UI gestures were not run; the renderer path is shared and provider/session ownership is unchanged

The prior Node 24 CI failure was an unrelated native-chat watcher flake outside this diff; it passed under Node 26 and in three local reruns. The pushed review commit started a fresh CI run.

## Reliability Contract

- **Invariant — `terminal-geometry.visible-convergence`:** visible panes track the owning pointer without publishing tab-layout state per move; the final visible ratio is persisted once on every gesture termination path; container resize during capture uses current geometry; terminal resize/fit ownership remains unchanged.
- **Failure source:** STA-3328's measured input lag and the terminal-pane React audit's split-divider HIGH finding.
- **Oracle:** real-render gesture tests assert zero store calls during movement, one final commit, clamping, pointer ownership, cancel/lost-capture/unmount cleanup, and resize-observer cleanup; the Electron run proves visible pane movement, publication counts, persisted ratio, post-drag terminal input, and live window-resize behavior.
- **Gate:** existing experimental `terminal-geometry.visible-convergence` gate, passed locally.
- **Providers/platforms:** local macOS covered live. Linux, Windows, daemon, SSH, and remote-runtime are unaffected at provider/session layers; their live UI gesture is an accepted gap.
- **Performance budget:** two pane style writes per `pointermove`; zero store/layout publications and zero layout reads in that hot path; one drag-scoped observer; exactly one final model commit; observer/listeners disconnect on release, cancel, lost capture, and unmount.
- **Diagnostics:** deterministic store-subscriber assertions and Electron publication counts distinguish future hot-path or persistence regressions.

## AI Review Report

The first same-model review found and fixed three material issues without widening STA-3328: stale geometry after a container resize, epsilon/direct-DOM divergence plus a false Zustand no-op, and foreign-pointer interference. The second review re-audited the full diff and nearby lifecycle/store behavior and returned clean. Cross-platform pointer events are renderer-only; SSH and folder workspaces use the same component without local filesystem, process, or provider assumptions.

## Security Audit

No command execution, path handling, auth, secrets, IPC, or provider changes. The change is limited to pointer-event ownership, render-layer sizing, and final store timing.

## Notes

This PR remains limited to the split-divider HIGH finding. Other STA-3328 medium-tier candidates remain for re-measurement rather than expansion here.
