### PR TITLE
fix(editor): stop Cmd/Ctrl+Shift+T reopening a phantom editor tab

### DIFF
--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -1712,6 +1712,49 @@ describe('createEditorSlice recently closed editor tabs', () => {
     expect(store.getState().openFiles[0]?.id).toBe(firstId)
     expect(store.getState().tabBarOrderByWorktree['wt-1']).toEqual([firstId])
   })
+
+  it('reactivates the live tab when a stale reopen id targets an already-open file', () => {
+    const store = createEditorTabsStore()
+    store.setState({
+      worktreesByRepo: {
+        'repo-1': [
+          { id: 'wt-1', repoId: 'repo-1', path: '/repo' },
+          { id: 'wt-2', repoId: 'repo-1', path: '/repo-2' }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+    const sharedPath = '/home/me/.zshrc'
+    const openShared = (worktreeId: string): string =>
+      store.getState().openFile({
+        filePath: sharedPath,
+        relativePath: '.zshrc',
+        worktreeId,
+        language: 'shell',
+        mode: 'edit'
+      })
+
+    // Bare path id: nothing else owns this path yet.
+    const staleWt1Id = openShared('wt-1')
+    expect(staleWt1Id).toBe(sharedPath)
+    store.getState().closeFile(staleWt1Id)
+
+    // wt-2 claims the bare id, so wt-1's reopen gets a namespaced id instead.
+    const wt2Id = openShared('wt-2')
+    expect(wt2Id).toBe(sharedPath)
+    const liveWt1Id = openShared('wt-1')
+    expect(liveWt1Id).toBe(ownedEditorFileId(sharedPath, 'wt-1', null))
+    store.getState().closeFile(wt2Id)
+
+    expect(store.getState().reopenClosedEditorTab('wt-1')).toBe(true)
+
+    expect(store.getState().openFiles.map((file) => file.id)).toEqual([liveWt1Id])
+    expect(store.getState().activeFileId).toBe(liveWt1Id)
+    expect(store.getState().activeFileIdByWorktree['wt-1']).toBe(liveWt1Id)
+    expect(
+      (store.getState().unifiedTabsByWorktree['wt-1'] ?? []).map((tab) => tab.entityId)
+    ).toEqual([liveWt1Id])
+    expect(store.getState().tabBarOrderByWorktree['wt-1']).toEqual([liveWt1Id])
+  })
 })
 
 describe('createEditorSlice markdown view state', () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1677,8 +1677,10 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           matchesEditorMode(f, reusableOpenFileModes) &&
           isSameEditorOwner(f, worktreeId, runtimeEnvironmentId)
       )
-      const id =
-        options?.reopenId && !s.openFiles.some((candidate) => candidate.id === options.reopenId)
+      // Why: a snapshot's reopenId can be a stale shape — the same path is bare in whichever worktree opened it first and namespaced elsewhere — so honoring it while this owner's tab is already open would strand activeFileId and the unified tab on an id no OpenFile has.
+      const id = existing
+        ? existing.id
+        : options?.reopenId && !s.openFiles.some((candidate) => candidate.id === options.reopenId)
           ? options.reopenId
           : resolveEditorFileIdForOwner(
               s,


### PR DESCRIPTION
## Defect

Reopening a closed editor tab (Cmd/Ctrl+Shift+T) could create a tab backed by no `OpenFile` and point `activeFileId` at it.

Editor ids are **not symmetrical across workspaces**. `resolveEditorFileIdForOwner` gives the *first* owner of an absolute path the **bare path** as its id, and every other owner of that same path a **namespaced** id (`editor:<worktreeId>:<runtimeKey>:<encodedPath>`, via `buildOwnedEditorFileId`). Which shape a workspace gets depends on who happened to have the path open at the time.

`closeFile` captures `reopenId: fileId` into the recently-closed snapshot (`src/renderer/src/store/slices/editor.ts`), and `reopenClosedEditorTab` replays it through `openFile({ reopenId })`. `openFile` honored that `reopenId` whenever *no open file currently held that exact id* — it never checked whether the same `(filePath, mode, owner)` was already open under the **other** id shape.

## Concrete failure scenario

Two workspaces, `wt-1` and `wt-2`, both open the same absolute path (e.g. a shared dotfile such as `/home/me/.zshrc` — common with SSH/remote hosts and folder workspaces):

1. `wt-1` opens the path first → id is the bare `/home/me/.zshrc`.
2. `wt-1` closes it → snapshot records `reopenId: '/home/me/.zshrc'`.
3. `wt-2` opens the same path → nothing else owns it now, so `wt-2` also gets the bare id.
4. `wt-1` opens the path again → the bare id is taken, so `wt-1`'s live tab is now `editor:wt-1:local:%2Fhome%2Fme%2F.zshrc`.
5. `wt-2` closes its tab.
6. Cmd/Ctrl+Shift+T in `wt-1` pops the step-2 snapshot with the stale bare `reopenId`.

No open file holds `/home/me/.zshrc`, so `openFile` accepted it as `id` — but `existing` still matched `wt-1`'s live namespaced tab, so control took the `existing` branch and `openFiles.map(f => f.id === id ...)` matched nothing. Nothing was created or updated, yet the same call still wrote the stale id into `activeFileId`, `activeFileIdByWorktree`, `tabBarOrderByWorktree`, and a new unified tab entity via `openWorkspaceEditorItem`.

Observed store state before the fix (captured from the new test):

```
openFiles:    ["editor:wt-1:local:%2Fhome%2Fme%2F.zshrc"]
activeFileId: "/home/me/.zshrc"                              <- dangles, no OpenFile
unified tabs: ["editor:wt-1:local:...", "/home/me/.zshrc"]   <- phantom tab
tabBar:       ["/home/me/.zshrc", "editor:wt-1:local:..."]
```

The user sees a tab that renders nothing and an active editor pointing at a file that isn't open.

## Fix

Make the id used at capture and the id used at restore resolve through the same canonicalization: when an `OpenFile` already exists for this `(filePath, mode, owner)`, always use *its* id and never let a snapshot's stale `reopenId` shape override it.

```ts
const id = existing
  ? existing.id
  : options?.reopenId && !s.openFiles.some((candidate) => candidate.id === options.reopenId)
    ? options.reopenId
    : resolveEditorFileIdForOwner(...)
```

This is a no-op for the normal (non-reopen) path: `resolveEditorFileIdForOwner` already returns `existing.id` using the *identical* `filePath` + `matchesEditorMode` + `isSameEditorOwner` predicate. It only changes the reopen path, where the stale id previously won. The reopen now reactivates the live tab instead of minting an unbacked one, so no id that fails to resolve to a real open file can reach `activeFileId` or the tab bar.

Cross-cutting behavior preserved: the change is owner-aware (`worktreeId` + `runtimeEnvironmentId`), so local, SSH, WSL, relay, and mirrored host-owned tabs all keep their distinct entities; nothing assumes git worktrees over folder workspaces, and no platform-specific behavior was introduced.

## Verification

- New test `reactivates the live tab when a stale reopen id targets an already-open file` in `src/renderer/src/store/slices/editor.test.ts`, built on the existing `createEditorTabsStore` harness. It drives the real store through the six steps above and asserts `openFiles`, `activeFileId`, `activeFileIdByWorktree`, `unifiedTabsByWorktree`, and `tabBarOrderByWorktree` all converge on the one live id.
- Confirmed the test **fails on unmodified `main`** (`expected '/home/me/.zshrc' to be 'editor:wt-1:local:%2Fhome%2Fme%2F.zshrc'`) by stashing the source change, re-running, then restoring it — and passes with the fix.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/store` → 148 files, 2274 tests passed.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/editor` → 153 files, 1039 tests passed.
- Also ran the other `openFile`/reopen call sites: `floating-terminal-panel-inputs`, `editor-restored-tab-conflict-scan`, `editor-autosave-conflict-flow`, `editor-autosave-controller`, `execute-open-editor-path-move`, `remap-open-editor-tabs-for-path-change`, `new-markdown` → all passed.
- `npx tsc --noEmit -p config/tsconfig.web.json` → no new errors (only the pre-existing `TS6307` `src/main/**` project-membership noise, untouched by this change).
- `npx oxlint` clean on both changed files.
