### PR TITLE
fix(browser): re-apply the chrome inset after a webview guest is replaced

### DIFF
--- a/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
@@ -121,6 +121,27 @@ describe('syncBrowserPageChromeInset', () => {
     const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
     expect(viewport.chromeInset.style.height).toBe('48px')
   })
+
+  it('restores the inset when guest recovery rebuilds the shell', () => {
+    mountSlotViewport('workspace-1')
+    ensureBrowserPageViewport('page-1', 'workspace-1')
+    syncBrowserPageChromeInset('page-1', 48)
+    // Guest replacement tears the shell down; the recovery re-render rebuilds it without re-measuring the chrome.
+    removeBrowserPageViewport('page-1')
+
+    const rebuilt = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    expect(rebuilt.chromeInset.style.height).toBe('48px')
+  })
+
+  it('applies an inset measured before the shell existed', () => {
+    syncBrowserPageChromeInset('page-2', 40)
+    mountSlotViewport('workspace-1')
+
+    const viewport = ensureBrowserPageViewport('page-2', 'workspace-1')!
+
+    expect(viewport.chromeInset.style.height).toBe('40px')
+  })
 })
 
 describe('applyBrowserPageViewportLayout', () => {

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.ts
@@ -14,6 +14,11 @@ type BrowserPageViewport = {
 
 const browserPageViewports = new Map<string, BrowserPageViewport>()
 
+// Why: React measures the chrome only on mount, but shells are rebuilt without a
+// re-measure (guest recovery/replacement, profile switch, slot remount). Remembering
+// the inset keeps geometry a property of attaching a guest, not of the first mount.
+const browserPageChromeInsetHeights = new Map<string, number>()
+
 const slotRootListeners = new Map<string, Set<() => void>>()
 
 function notifySlotRootListeners(workspaceTabId: string): void {
@@ -88,6 +93,10 @@ export function ensureBrowserPageViewport(
   const chromeInset = document.createElement('div')
   chromeInset.dataset.browserPageChromeInset = ''
   chromeInset.className = 'shrink-0'
+  const rememberedInsetHeight = browserPageChromeInsetHeights.get(browserPageId)
+  if (rememberedInsetHeight !== undefined) {
+    chromeInset.style.height = `${rememberedInsetHeight}px`
+  }
 
   const container = document.createElement('div')
   container.dataset.browserPageContainer = ''
@@ -141,11 +150,13 @@ export function applyBrowserPageViewportLayout(
 }
 
 export function syncBrowserPageChromeInset(browserPageId: string, heightPx: number): void {
+  const insetHeight = Math.max(0, heightPx)
+  browserPageChromeInsetHeights.set(browserPageId, insetHeight)
   const viewport = browserPageViewports.get(browserPageId)
   if (!viewport) {
     return
   }
-  viewport.chromeInset.style.height = `${Math.max(0, heightPx)}px`
+  viewport.chromeInset.style.height = `${insetHeight}px`
 }
 
 export function parkBrowserPageViewport(browserPageId: string): void {


### PR DESCRIPTION
## Defect

The chrome inset that pushes a browser guest below the toolbar is applied only from `BrowserPane`'s layout effect, whose deps are `[browserTab.id, isActive, isPaintable, slotViewportReady]` — i.e. the first mount. Every path that rebuilds the page viewport shell **without** re-running that effect ends up with a zero-height `chromeInset`, so the guest fills the whole overlay slot and paints under the browser chrome.

`ensureBrowserPageViewport` (called during render) is the only place a shell is built, and it always built one with an unset inset height.

## Failure scenario

1. The user is on an active browser tab whose guest suffers lifecycle loss — main-side registration is dropped, or `webview.reload()` throws on a detached guest so `recoverRenderer()` falls through to `replaceGuest()`.
2. `replaceGuest` → `replacePersistentWebview(pageId)` (default `preserveViewport: false`) → `removeBrowserPageViewport` destroys the shell.
3. `onReplacementReady` bumps `guestRecoveryGeneration`, the page re-renders, `ensureBrowserPageViewport` builds a **fresh** shell, and the guest effect attaches a new `<webview>` and un-parks it.
4. The layout effect that measures the chrome header never re-runs (none of its deps changed), so the new shell keeps a 0px inset: the recovered page renders shifted up, underlapping the toolbar, until an unrelated resize or tab switch forces a recompute.

The same hole exists on two other rebuild paths that reuse the render-time `ensureBrowserPageViewport`: a session-profile switch (`destroyPersistentWebview` on partition mismatch, then an immediate rebuild) and an overlay slot-root remount (the STA-3228 rebuild branch).

## Fix

Make the geometry a property of the viewport rather than of the first mount: `browser-page-viewport.ts` now remembers the last synced inset height per page and applies it whenever it builds a shell. Any path that produces a live guest — first mount, recovery, replacement, profile switch, slot remount, system resume — attaches into a correctly offset container, with no synthetic resize involved. It also fixes the ordering case where the chrome is measured before the shell exists (that height used to be dropped).

The height stays remembered across guest teardown on purpose: destroy/replace are guest-lifecycle churn for a page that still exists, and the `ResizeObserver` on the chrome header keeps correcting the value if the chrome height changes.

## Verification

- `src/renderer/src/components/browser-pane/browser-page-viewport.test.ts` gains two cases: the inset survives a shell rebuild after guest replacement, and an inset measured before the shell existed is applied when it is built.
- Confirmed both fail on `origin/main` (`expected '' to be '48px'` / `'40px'`) and pass with the change, by reverting `browser-page-viewport.ts` to `origin/main` and restoring it.
- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane` → 36 files / 251 tests passing.
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` clean; oxlint + oxfmt clean on the changed files.