### PR TITLE
fix(worktrees): stop silently switching existing Windows setup scripts to Git Bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ docs/**
 !docs/reference/headless-linux-server.md
 !docs/reference/linux-glibc-compatibility.md
 !docs/reference/relay-grace-time-reconfiguration.md
+!docs/reference/windows-setup-shell.md
 
 # Stably CLI (only docs/ are tracked)
 .stably/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Orca targets macOS, Linux, and Windows. Keep all platform-dependent behavior beh
 - **Keyboard shortcuts**: Never hardcode `e.metaKey`. Use a platform check (`navigator.userAgent.includes('Mac')`) to pick `metaKey` on Mac and `ctrlKey` on Linux/Windows. Electron menu accelerators should use `CmdOrCtrl`.
 - **Shortcut labels in UI**: Display `⌘` / `⇧` on Mac and `Ctrl+` / `Shift+` on other platforms.
 - **File paths**: Use `path.join` or Electron/Node path utilities — never assume `/` or `\`.
+- **Windows setup scripts**: the setup/issue-command runner is a `.cmd` batch file unless the script starts with a `#!` line. Never derive it from the user's terminal-shell preference. See [`docs/reference/windows-setup-shell.md`](./docs/reference/windows-setup-shell.md).
 - **Linux native modules**: keep the glibc floor at Ubuntu 20.04 / glibc 2.31. A module compiled from source on a newer runner can reference symbol versions absent on the floor and crash the app on startup. See [`docs/reference/linux-glibc-compatibility.md`](./docs/reference/linux-glibc-compatibility.md); packaging fails if a bundled native binary needs newer glibc.
 
 ## SSH Use Case

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Orca targets macOS, Linux, and Windows. Keep all platform-dependent behavior beh
 - **Keyboard shortcuts**: Never hardcode `e.metaKey`. Use a platform check (`navigator.userAgent.includes('Mac')`) to pick `metaKey` on Mac and `ctrlKey` on Linux/Windows. Electron menu accelerators should use `CmdOrCtrl`.
 - **Shortcut labels in UI**: Display `⌘` / `⇧` on Mac and `Ctrl+` / `Shift+` on other platforms.
 - **File paths**: Use `path.join` or Electron/Node path utilities — never assume `/` or `\`.
-- **Windows setup scripts**: the setup/issue-command runner is a `.cmd` batch file unless the script starts with a `#!` line. Never derive it from the user's terminal-shell preference. See [`docs/reference/windows-setup-shell.md`](./docs/reference/windows-setup-shell.md).
+- **Windows setup scripts**: the setup/issue-command runner is a `.cmd` batch file unless the script starts with a `#!` line — never derive that from the user's terminal-shell preference, and never launch a `.cmd` runner with a bare `cmd.exe /c` from a Git Bash pane (MSYS rewrites the `/c`). See [`docs/reference/windows-setup-shell.md`](./docs/reference/windows-setup-shell.md).
 - **Linux native modules**: keep the glibc floor at Ubuntu 20.04 / glibc 2.31. A module compiled from source on a newer runner can reference symbol versions absent on the floor and crash the app on startup. See [`docs/reference/linux-glibc-compatibility.md`](./docs/reference/linux-glibc-compatibility.md); packaging fails if a bundled native binary needs newer glibc.
 
 ## SSH Use Case

--- a/docs/reference/windows-setup-shell.md
+++ b/docs/reference/windows-setup-shell.md
@@ -35,13 +35,45 @@ language a project's setup script is written in. Deriving the runner from it had
 
 A `#!` line is per-project, explicit, and identical for everyone who checks the repo out.
 
+The same rule applies to the per-user setup command in **Settings → repository hooks**
+(`repo.hookSettings.scripts.setup`): it is merged into the same script that reaches the runner, so a
+POSIX one-liner stored there needs its own `#!` line to run under bash on Windows.
+
+## What the `#!` line does and does not select
+
+The generated runner is always executed by bash (`bash <runner>`; Git Bash on native Windows), on
+every platform. The `#!` line therefore does two things:
+
+- It declares the script is written for a POSIX shell, which is what selects the bash runner.
+- Its option flags are replayed with `set`, so `#!/usr/bin/env -S bash -euo pipefail` really does
+  get `pipefail`. Without that replay the flags would be silently dropped, because `bash <runner>`
+  never parses the interpreter line.
+
+The interpreter name itself is not honored beyond "is this a POSIX shell": `#!/bin/sh` and
+`#!/bin/zsh` scripts run under bash, exactly as they already did on macOS and Linux.
+
 ## Requirements for the bash runner
 
 A `#!` line only takes effect when Orca can actually launch bash from the configured terminal — the
 terminal shell must resolve to Git Bash (`resolveWindowsGitBashShellPath`). The generated runner
 uses MSYS `/c/...` paths, which Cygwin and the WSL shim do not accept, and the launch command is
-typed into whatever shell the terminal opened with. When Git Bash is not available the script falls
-back to the `.cmd` runner; the `#!` line is dropped rather than executed.
+typed into whatever shell the terminal opened with.
+
+When bash is not available (a PowerShell/cmd terminal, or an SSH-to-Windows host, which always uses
+the remote's `.cmd` runner) the `#!` script is **not** executed under cmd. The generated `.cmd`
+runner prints why and exits 1, because running the interpreter-agnostic prefix of a bash script
+(`pnpm install`, `git submodule update`) and only failing at the first bash-only line leaves a
+half-set-up worktree that looks finished.
+
+## Launching a `.cmd` runner from a Git Bash terminal
+
+The runner format and the shell that types the launch command are independent: a Git Bash terminal
+with a batch-syntax setup script gets a `.cmd` runner launched from a bash pane. `cmd.exe /c
+"C:\..."` cannot be used there — MSYS rewrites the bare `/c` switch into a drive path, so cmd opens
+interactively and the runner never executes (issue #6896). Those launches reuse the PowerShell
+`ProcessStartInfo` launcher (`buildWindowsCmdRunnerDelayedLaunchCommand`), which carries the switch
+and the runner path outside the command line. `WorktreeSetupLaunch.shell` therefore describes the
+launching pane; the runner file's `.cmd`/`.sh` extension describes the format.
 
 WSL worktrees and non-Windows platforms are unaffected: they always use the bash runner. SSH hosts
 choose their runner from the remote path format, never from local Windows preferences.

--- a/docs/reference/windows-setup-shell.md
+++ b/docs/reference/windows-setup-shell.md
@@ -1,0 +1,47 @@
+# Windows setup-runner shell
+
+On native Windows, Orca writes the `orca.yaml` setup script (and the issue command) to a generated
+runner file and types a launch command into a terminal. The runner is a **`.cmd` batch file by
+default**, exactly as it has been since setup hooks shipped.
+
+A script opts into bash by starting with a `#!` interpreter line:
+
+```yaml
+scripts:
+  setup: |
+    #!/usr/bin/env bash
+    [ -f .env ] || cp .env.example .env
+    pnpm install
+```
+
+Without that line the script keeps running under `cmd.exe`:
+
+```yaml
+scripts:
+  setup: |
+    copy .env.example .env
+    xcopy /E assets dist
+```
+
+## Why the script declares it, not the terminal preference
+
+`terminalWindowsShell` says which shell *interactive terminals* open in. It says nothing about the
+language a project's setup script is written in. Deriving the runner from it had two consequences:
+
+- Windows users with batch-syntax setup scripts silently switched to bash on upgrade, so `copy`,
+  `xcopy`, `set VAR=value`, and `if errorlevel 1` stopped working.
+- Two people on the same repo got different interpreters for the same `orca.yaml`, so no project
+  could write a setup script that worked for all of its Windows contributors.
+
+A `#!` line is per-project, explicit, and identical for everyone who checks the repo out.
+
+## Requirements for the bash runner
+
+A `#!` line only takes effect when Orca can actually launch bash from the configured terminal — the
+terminal shell must resolve to Git Bash (`resolveWindowsGitBashShellPath`). The generated runner
+uses MSYS `/c/...` paths, which Cygwin and the WSL shim do not accept, and the launch command is
+typed into whatever shell the terminal opened with. When Git Bash is not available the script falls
+back to the `.cmd` runner; the `#!` line is dropped rather than executed.
+
+WSL worktrees and non-Windows platforms are unaffected: they always use the bash runner. SSH hosts
+choose their runner from the remote path format, never from local Windows preferences.

--- a/docs/reference/windows-setup-shell.md
+++ b/docs/reference/windows-setup-shell.md
@@ -47,7 +47,9 @@ every platform. The `#!` line therefore does two things:
 - It declares the script is written for a POSIX shell, which is what selects the bash runner.
 - Its option flags are replayed with `set`, so `#!/usr/bin/env -S bash -euo pipefail` really does
   get `pipefail`. Without that replay the flags would be silently dropped, because `bash <runner>`
-  never parses the interpreter line.
+  never parses the interpreter line. Only the flags `set` itself accepts
+  (`[--abefhkmnptuvxBCHP] [-o option]`) are replayed; invocation-only ones such as `-l` are
+  dropped, because `set -l` exits 2 and would abort the runner before its first line.
 
 The interpreter name itself is not honored beyond "is this a POSIX shell": `#!/bin/sh` and
 `#!/bin/zsh` scripts run under bash, exactly as they already did on macOS and Linux.
@@ -74,6 +76,11 @@ interactively and the runner never executes (issue #6896). Those launches reuse 
 `ProcessStartInfo` launcher (`buildWindowsCmdRunnerDelayedLaunchCommand`), which carries the switch
 and the runner path outside the command line. `WorktreeSetupLaunch.shell` therefore describes the
 launching pane; the runner file's `.cmd`/`.sh` extension describes the format.
+
+The `wait-for-setup` gate follows the same split. The pane types the gate and already quoted the
+agent startup command for itself, so a `.cmd` runner launched from a Git Bash pane still gets the
+bash gate — PowerShell's `Invoke-Expression` cannot parse POSIX `'\''` escaping. The gate wraps the
+same `ProcessStartInfo` launcher, so the batch runner is never handed to bash.
 
 WSL worktrees and non-Windows platforms are unaffected: they always use the bash runner. SSH hosts
 choose their runner from the remote path format, never from local Windows preferences.

--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -1,3 +1,8 @@
+import type * as NodeChildProcess from 'node:child_process'
+import type * as NodeFs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import type { Repo } from '../shared/types'
 
 import { describe, expect, it, vi } from 'vitest'
@@ -209,6 +214,31 @@ describe('createSetupRunnerScript', () => {
     expect(runner).toContain('call # not a shebang')
     expect(runner).toContain('call rem still batch')
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'runs a script whose shebang carries invocation-only bash flags',
+    async () => {
+      // Regression: `set` rejects `-l`/`-s`/`-i` with exit 2, and the runner's own `set -e` turns
+      // that into an aborted setup before the first user line.
+      const { buildPosixRunnerScript } = await import('./hooks')
+      const { mkdtempSync, rmSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+      const { execFileSync } = await vi.importActual<typeof NodeChildProcess>('node:child_process')
+
+      const dir = mkdtempSync(join(tmpdir(), 'orca-posix-runner-'))
+      try {
+        const runnerPath = join(dir, 'setup-runner.sh')
+        writeFileSync(
+          runnerPath,
+          buildPosixRunnerScript('#!/bin/bash -l\necho SETUP_RAN\n'),
+          'utf-8'
+        )
+
+        expect(execFileSync('bash', [runnerPath], { encoding: 'utf-8' })).toContain('SETUP_RAN')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('derives ORCA_WORKSPACE_NAME from a POSIX worktree path', async () => {
     const originalPlatform = process.platform

--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -94,7 +94,7 @@ describe('createSetupRunnerScript', () => {
       const result = createSetupRunnerScript(
         { ...makeRepo(), path: 'C:\\Users\\jinwo\\git\\orca' },
         'C:\\repo\\feature',
-        'pnpm install',
+        '#!/usr/bin/env bash\npnpm install',
         undefined,
         { family: 'posix' }
       )
@@ -113,7 +113,7 @@ describe('createSetupRunnerScript', () => {
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
         'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\n',
+        '#!/usr/bin/env bash\nset -e\n#!/usr/bin/env bash\npnpm install\n',
         'utf-8'
       )
       // Why: chmod over a native Windows path is meaningless; only the WSL branch sets the bit.
@@ -184,6 +184,17 @@ describe('createSetupRunnerScript', () => {
     // expansion itself or `!world!` is consumed as a variable reference.
     expect(runner).toContain('setlocal EnableExtensions DisableDelayedExpansion')
     expect(runner).toContain('call echo hello!world!')
+  })
+
+  it('drops a leading shebang instead of calling it as a batch command', async () => {
+    const { buildWindowsRunnerScript } = await import('./hooks')
+
+    // Why: a shebang script falls back here when Git Bash is unavailable; `call #!/...`
+    // would abort on errorlevel before any real setup line ran.
+    const runner = buildWindowsRunnerScript('#!/usr/bin/env bash\npnpm install')
+
+    expect(runner).not.toContain('#!')
+    expect(runner).toContain('call pnpm install')
   })
 
   it('derives ORCA_WORKSPACE_NAME from a POSIX worktree path', async () => {

--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -113,7 +113,7 @@ describe('createSetupRunnerScript', () => {
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
         'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\n#!/usr/bin/env bash\npnpm install\n',
+        '#!/usr/bin/env bash\nset -e\npnpm install\n',
         'utf-8'
       )
       // Why: chmod over a native Windows path is meaningless; only the WSL branch sets the bit.
@@ -186,15 +186,28 @@ describe('createSetupRunnerScript', () => {
     expect(runner).toContain('call echo hello!world!')
   })
 
-  it('drops a leading shebang instead of calling it as a batch command', async () => {
+  it('refuses to run a shebang script as a batch command', async () => {
     const { buildWindowsRunnerScript } = await import('./hooks')
 
-    // Why: a shebang script falls back here when Git Bash is unavailable; `call #!/...`
-    // would abort on errorlevel before any real setup line ran.
-    const runner = buildWindowsRunnerScript('#!/usr/bin/env bash\npnpm install')
+    // Regression: a POSIX script reaching the cmd runner (no Git Bash terminal, or an SSH
+    // Windows host) must not have its interpreter-agnostic prefix executed under cmd —
+    // `pnpm install` would run and only a later bash-only line would fail, leaving the
+    // worktree half set up.
+    const runner = buildWindowsRunnerScript('#!/usr/bin/env bash\npnpm install\nsource .env')
 
-    expect(runner).not.toContain('#!')
-    expect(runner).toContain('call pnpm install')
+    expect(runner).not.toContain('call pnpm install')
+    expect(runner).not.toContain('call source .env')
+    expect(runner).toContain('needs a POSIX shell')
+    expect(runner).toContain('exit /b 1')
+  })
+
+  it('keeps a `#` comment that is not an interpreter line', async () => {
+    const { buildWindowsRunnerScript } = await import('./hooks')
+
+    const runner = buildWindowsRunnerScript('# not a shebang\nrem still batch')
+
+    expect(runner).toContain('call # not a shebang')
+    expect(runner).toContain('call rem still batch')
   })
 
   it('derives ORCA_WORKSPACE_NAME from a POSIX worktree path', async () => {

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -1282,7 +1282,7 @@ describe('createSetupRunnerScript', () => {
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         'C:\\repo\\.git\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\n#!/usr/bin/env bash\npnpm install\nnpm run build\n',
+        '#!/usr/bin/env bash\nset -e\npnpm install\nnpm run build\n',
         'utf-8'
       )
       expect(chmodSyncMock).not.toHaveBeenCalled()
@@ -1327,8 +1327,71 @@ describe('createSetupRunnerScript', () => {
       )
       expect(result).toMatchObject({
         runnerScriptPath: 'C:\\repo\\.git\\orca\\setup-runner.cmd',
-        shell: { family: 'cmd' }
+        // Why: `shell` is the pane that types the launch command — still Git Bash here. The
+        // runner's own .cmd extension is what says the file is batch.
+        shell: { family: 'posix' }
       })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('hands a Git Bash pane a launch command MSYS cannot rewrite for a cmd runner', async () => {
+    // Regression (#6896): `cmd.exe /c "C:\...\setup-runner.cmd"` typed into Git Bash has its
+    // `/c` switch rewritten into a drive path, so cmd opens interactively and setup never runs.
+    gitExecFileSyncMock.mockReset()
+    gitExecFileSyncMock.mockReturnValue('C:\\repo\\.git\\orca\\setup-runner.cmd\n')
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      const { createSetupRunnerScript } = await import('./hooks')
+      const { buildSetupRunnerCommand } = await import('../shared/setup-runner-command')
+      const result = createSetupRunnerScript(
+        makeRepo(),
+        'C:\\repo-worktree',
+        'copy .env.example .env',
+        undefined,
+        { family: 'posix' }
+      )
+
+      const command = buildSetupRunnerCommand(result.runnerScriptPath, 'windows', result.shell)
+
+      expect(command).not.toContain('cmd.exe /c')
+      // Why: the batch runner must never be handed to bash either.
+      expect(command).not.toContain('bash ')
+      expect(command).toContain('powershell.exe')
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('replays interpreter flags declared on the shebang line', async () => {
+    // Regression: the runner is launched as `bash <path>`, so `-euo pipefail` on the script's
+    // own `#!` line never reaches the interpreter unless the runner re-applies it.
+    gitExecFileSyncMock.mockReset()
+    gitExecFileSyncMock.mockReturnValue('C:\\repo\\.git\\orca\\setup-runner.sh\n')
+    const fs = await import('node:fs')
+    const writeFileSyncMock = vi.mocked(fs.writeFileSync)
+    writeFileSyncMock.mockClear()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      const { createSetupRunnerScript } = await import('./hooks')
+      createSetupRunnerScript(
+        makeRepo(),
+        'C:\\repo-worktree',
+        '#!/usr/bin/env -S bash -euo pipefail\nmake build | tee build.log',
+        undefined,
+        { family: 'posix' }
+      )
+
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        'C:\\repo\\.git\\orca\\setup-runner.sh',
+        '#!/usr/bin/env bash\nset -e\nset -euo pipefail\nmake build | tee build.log\n',
+        'utf-8'
+      )
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
@@ -1473,7 +1536,7 @@ describe('createIssueCommandRunnerScript', () => {
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         'C:\\repo\\.git\\orca\\issue-command-runner.sh',
-        '#!/usr/bin/env bash\nset -e\n#!/usr/bin/env bash\ngh issue view 42\n',
+        '#!/usr/bin/env bash\nset -e\ngh issue view 42\n',
         'utf-8'
       )
       expect(result.shell).toEqual({ family: 'posix' })
@@ -1502,7 +1565,8 @@ describe('createIssueCommandRunnerScript', () => {
         ['rev-parse', '--git-path', 'orca/issue-command-runner.cmd'],
         { cwd: 'C:\\repo-worktree' }
       )
-      expect(result.shell).toEqual({ family: 'cmd' })
+      // Why: the runner file is batch (.cmd) while the pane that launches it is still Git Bash.
+      expect(result.shell).toEqual({ family: 'posix' })
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -1255,7 +1255,7 @@ describe('createSetupRunnerScript', () => {
       }
     }) as unknown as Repo
 
-  it('writes POSIX setup runners for Git Bash on native Windows paths', async () => {
+  it('writes POSIX setup runners for shebang-declared scripts on native Windows paths', async () => {
     gitExecFileSyncMock.mockReset()
     gitExecFileSyncMock.mockReturnValue('C:\\repo\\.git\\orca\\setup-runner.sh\n')
     const fs = await import('node:fs')
@@ -1271,7 +1271,7 @@ describe('createSetupRunnerScript', () => {
       const result = createSetupRunnerScript(
         makeRepo(),
         'C:\\repo-worktree',
-        'pnpm install\r\nnpm run build',
+        '#!/usr/bin/env bash\r\npnpm install\r\nnpm run build',
         undefined,
         { family: 'posix' }
       )
@@ -1282,13 +1282,52 @@ describe('createSetupRunnerScript', () => {
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
         'C:\\repo\\.git\\orca\\setup-runner.sh',
-        '#!/usr/bin/env bash\nset -e\npnpm install\nnpm run build\n',
+        '#!/usr/bin/env bash\nset -e\n#!/usr/bin/env bash\npnpm install\nnpm run build\n',
         'utf-8'
       )
       expect(chmodSyncMock).not.toHaveBeenCalled()
       expect(result).toMatchObject({
         runnerScriptPath: 'C:\\repo\\.git\\orca\\setup-runner.sh',
         shell: { family: 'posix' }
+      })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('keeps batch setup scripts on cmd.exe when the terminal is Git Bash', async () => {
+    // Regression (#6967): a Git Bash terminal preference used to hand pre-existing
+    // batch setup scripts to bash, where `copy`/`xcopy`/`if errorlevel` do not exist.
+    gitExecFileSyncMock.mockReset()
+    gitExecFileSyncMock.mockReturnValue('C:\\repo\\.git\\orca\\setup-runner.cmd\n')
+    const fs = await import('node:fs')
+    const writeFileSyncMock = vi.mocked(fs.writeFileSync)
+    writeFileSyncMock.mockClear()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      const { createSetupRunnerScript } = await import('./hooks')
+      const result = createSetupRunnerScript(
+        makeRepo(),
+        'C:\\repo-worktree',
+        'copy .env.example .env\r\nxcopy /E assets dist',
+        undefined,
+        { family: 'posix' }
+      )
+
+      expect(gitExecFileSyncMock).toHaveBeenCalledWith(
+        ['rev-parse', '--git-path', 'orca/setup-runner.cmd'],
+        { cwd: 'C:\\repo-worktree' }
+      )
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        'C:\\repo\\.git\\orca\\setup-runner.cmd',
+        expect.stringContaining('call copy .env.example .env\r\n'),
+        'utf-8'
+      )
+      expect(result).toMatchObject({
+        runnerScriptPath: 'C:\\repo\\.git\\orca\\setup-runner.cmd',
+        shell: { family: 'cmd' }
       })
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
@@ -1409,12 +1448,43 @@ describe('createIssueCommandRunnerScript', () => {
       hookSettings: { mode: 'auto', scripts: { setup: '', archive: '' } }
     }) as unknown as Repo
 
-  it('writes a POSIX issue-command runner when setup resolves to Git Bash', async () => {
+  it('writes a POSIX issue-command runner when a shebang declares bash and setup resolves to Git Bash', async () => {
     gitExecFileSyncMock.mockReset()
     gitExecFileSyncMock.mockReturnValue('C:\\repo\\.git\\orca\\issue-command-runner.sh\n')
     const fs = await import('node:fs')
     const writeFileSyncMock = vi.mocked(fs.writeFileSync)
     writeFileSyncMock.mockClear()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      const { createIssueCommandRunnerScript } = await import('./hooks')
+      const result = createIssueCommandRunnerScript(
+        makeRepo(),
+        'C:\\repo-worktree',
+        '#!/usr/bin/env bash\ngh issue view 42',
+        undefined,
+        { family: 'posix' }
+      )
+
+      expect(gitExecFileSyncMock).toHaveBeenCalledWith(
+        ['rev-parse', '--git-path', 'orca/issue-command-runner.sh'],
+        { cwd: 'C:\\repo-worktree' }
+      )
+      expect(writeFileSyncMock).toHaveBeenCalledWith(
+        'C:\\repo\\.git\\orca\\issue-command-runner.sh',
+        '#!/usr/bin/env bash\nset -e\n#!/usr/bin/env bash\ngh issue view 42\n',
+        'utf-8'
+      )
+      expect(result.shell).toEqual({ family: 'posix' })
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('keeps a plain issue command on the cmd runner under a Git Bash terminal', async () => {
+    gitExecFileSyncMock.mockReset()
+    gitExecFileSyncMock.mockReturnValue('C:\\repo\\.git\\orca\\issue-command-runner.cmd\n')
     const originalPlatform = process.platform
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
 
@@ -1429,15 +1499,10 @@ describe('createIssueCommandRunnerScript', () => {
       )
 
       expect(gitExecFileSyncMock).toHaveBeenCalledWith(
-        ['rev-parse', '--git-path', 'orca/issue-command-runner.sh'],
+        ['rev-parse', '--git-path', 'orca/issue-command-runner.cmd'],
         { cwd: 'C:\\repo-worktree' }
       )
-      expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\issue-command-runner.sh',
-        '#!/usr/bin/env bash\nset -e\ngh issue view 42\n',
-        'utf-8'
-      )
-      expect(result.shell).toEqual({ family: 'posix' })
+      expect(result.shell).toEqual({ family: 'cmd' })
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -9,7 +9,12 @@ import { shouldWaitForSetupBeforeAgentStartup } from '../shared/setup-agent-star
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../shared/terminal-git-credential-guard'
 import { parseOrcaYaml } from '../shared/orca-yaml'
 import { nativeWindowsPathToPosixShellPath } from '../shared/setup-runner-command'
-import { isShebangLine, scriptDeclaresPosixShell } from '../shared/setup-script-shebang'
+import {
+  isShebangLine,
+  parseSetupScriptShebang,
+  scriptDeclaresPosixShell,
+  stripLeadingShebangLine
+} from '../shared/setup-script-shebang'
 import { resolveWindowsShellStartupFamily } from '../shared/windows-terminal-shell'
 import { resolveWindowsGitBashShellPath } from './git-bash'
 import { gitExecFileSync, promptGuardShellEnv } from './git/runner'
@@ -398,19 +403,30 @@ function getHookWslContext(
   }
 }
 
+// Why: cmd cannot run a POSIX script, and executing its interpreter-agnostic prefix (`pnpm
+// install`, `git submodule update`) before dying on the first bash-only line is worse than not
+// starting: half-applied setup looks like a working worktree.
+const WINDOWS_RUNNER_SHEBANG_REFUSAL = [
+  'echo Orca setup: this script starts with a "#!" interpreter line, so it needs a POSIX shell. 1>&2',
+  'echo Orca setup: this worktree runs setup through cmd.exe, which cannot execute it. 1>&2',
+  'echo Orca setup: set the Windows terminal shell to Git Bash, or rewrite the script in cmd syntax. 1>&2',
+  'exit /b 1',
+  ''
+].join('\r\n')
+
 export function buildWindowsRunnerScript(script: string): string {
   // Why: launchers invoke this runner under `cmd /v:on`, and EnableExtensions does not reset an
   // inherited delayed-expansion state — without this, every `!` in a user setup line is eaten.
-  let runnerScript = '@echo off\r\nsetlocal EnableExtensions DisableDelayedExpansion\r\n'
+  const header = '@echo off\r\nsetlocal EnableExtensions DisableDelayedExpansion\r\n'
+  let runnerScript = header
   let isFirstLine = true
 
   for (const rawLine of iterateLfScriptLines(script)) {
     const command = rawLine.trim()
-    // Why: a leading `#!` declares an interpreter; `call`ing it would abort the run on errorlevel.
     if (isFirstLine) {
       isFirstLine = false
       if (isShebangLine(command)) {
-        continue
+        return `${header}${WINDOWS_RUNNER_SHEBANG_REFUSAL}`
       }
     }
     if (!command) {
@@ -471,7 +487,15 @@ export function getSetupRunnerEnvVars(repo: Repo, worktreePath: string): Record<
 }
 
 export function buildPosixRunnerScript(script: string): string {
-  return `#!/usr/bin/env bash\nset -e\n${normalizeCrlfScriptLineEndings(script)}\n`
+  // Why: the runner is always launched as `bash <path>`, so flags on the script's own `#!` line
+  // are never seen by the interpreter — replay them through `set` or a script that asked for
+  // `-euo pipefail` silently loses pipefail, and drop the now-duplicate interpreter line.
+  const shebang = parseSetupScriptShebang(script)
+  const declaredOptions = shebang?.shellOptions.length
+    ? `set ${shebang.shellOptions.join(' ')}\n`
+    : ''
+  const body = shebang ? stripLeadingShebangLine(script) : script
+  return `#!/usr/bin/env bash\nset -e\n${declaredOptions}${normalizeCrlfScriptLineEndings(body)}\n`
 }
 
 function normalizeCrlfScriptLineEndings(script: string): string {
@@ -546,8 +570,12 @@ function createWorktreeRunnerScript(args: {
       ? setupShell
       : { family: 'cmd' }
     : { family: 'posix' }
+  // Why: `shell` tells the launcher which shell types the command, not which format the runner
+  // file is in — the .cmd/.sh extension already carries that. Reporting the runner family here
+  // would make a Git Bash pane receive `cmd.exe /c ...`, whose `/c` MSYS rewrites into a drive
+  // path (issue #6896), so setup would open an interactive cmd and never run.
   const launchShell: SetupRunnerShell | undefined = nativeWindowsWorktree
-    ? runnerShell
+    ? (setupShell ?? { family: 'cmd' })
     : process.platform === 'win32' && runtimeTarget?.wslDistro
       ? { family: 'posix', executable: 'wsl.exe' }
       : undefined
@@ -598,7 +626,7 @@ function createWorktreeRunnerScript(args: {
     envVars,
     // Why: WSL git returns /mnt paths that Node converts back to C:\ for file
     // writes; retain the runtime signal so launch converts them to /mnt again.
-    // On native Windows it mirrors the family the runner file was written in.
+    // On native Windows it is the terminal's family, i.e. the shell that types the command.
     ...(launchShell ? { shell: launchShell } : {}),
     ...(waitForAgentStartup === true ? { waitForAgentStartup: true } : {})
   }
@@ -629,8 +657,9 @@ export function resolveSetupRunnerShell(
       options.resolveGitBashShellPath ??
       ((shell: string) => resolveWindowsGitBashShellPath(shell, { platform }))
     if (resolveGitBashShellPath(configuredShell)) {
-      // Note: this only reports that a bash runner *could* launch here. Whether one is
-      // used is decided per script by its `#!` line — see docs/reference/windows-setup-shell.md.
+      // Note: this reports the terminal's family — the shell that types the launch command, and
+      // therefore also that a bash runner *could* launch here. Whether one is written is decided
+      // per script by its `#!` line — see docs/reference/windows-setup-shell.md.
       return { family: 'posix' }
     }
   }

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -9,6 +9,7 @@ import { shouldWaitForSetupBeforeAgentStartup } from '../shared/setup-agent-star
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../shared/terminal-git-credential-guard'
 import { parseOrcaYaml } from '../shared/orca-yaml'
 import { nativeWindowsPathToPosixShellPath } from '../shared/setup-runner-command'
+import { isShebangLine, scriptDeclaresPosixShell } from '../shared/setup-script-shebang'
 import { resolveWindowsShellStartupFamily } from '../shared/windows-terminal-shell'
 import { resolveWindowsGitBashShellPath } from './git-bash'
 import { gitExecFileSync, promptGuardShellEnv } from './git/runner'
@@ -401,9 +402,17 @@ export function buildWindowsRunnerScript(script: string): string {
   // Why: launchers invoke this runner under `cmd /v:on`, and EnableExtensions does not reset an
   // inherited delayed-expansion state — without this, every `!` in a user setup line is eaten.
   let runnerScript = '@echo off\r\nsetlocal EnableExtensions DisableDelayedExpansion\r\n'
+  let isFirstLine = true
 
   for (const rawLine of iterateLfScriptLines(script)) {
     const command = rawLine.trim()
+    // Why: a leading `#!` declares an interpreter; `call`ing it would abort the run on errorlevel.
+    if (isFirstLine) {
+      isFirstLine = false
+      if (isShebangLine(command)) {
+        continue
+      }
+    }
     if (!command) {
       runnerScript += '\r\n'
       continue
@@ -500,8 +509,8 @@ export function createIssueCommandRunnerScript(
     script: command,
     runnerBaseName: 'issue-command-runner',
     runtimeTarget: getHookRuntimeTarget(projectRuntime),
-    // Why: issue commands run in the same terminal as setup, so a Git Bash setup
-    // runner must not be paired with a cmd issue runner in one session.
+    // Why: issue commands share the setup session's shell resolution; the runner still
+    // needs its own `#!` line to be treated as bash.
     setupShell
   })
 }
@@ -528,8 +537,14 @@ function createWorktreeRunnerScript(args: {
   // Why: WSL worktrees are Linux fs even though process.platform is 'win32'; use bash for WSL, .cmd for native Windows.
   const wslWorktree = isWslPath(worktreePath) || Boolean(runtimeTarget?.wslDistro)
   const nativeWindowsWorktree = process.platform === 'win32' && !wslWorktree
+  // Why: the terminal-shell preference says nothing about the language a project's script is
+  // written in, and every pre-existing Windows script was authored against the cmd runner. Only a
+  // `#!` line opts a script into bash, so the same orca.yaml runs identically for every Windows
+  // user of the repo instead of following whichever terminal each of them happens to prefer.
   const runnerShell: SetupRunnerShell = nativeWindowsWorktree
-    ? (setupShell ?? { family: 'cmd' })
+    ? setupShell?.family === 'posix' && scriptDeclaresPosixShell(script)
+      ? setupShell
+      : { family: 'cmd' }
     : { family: 'posix' }
   const launchShell: SetupRunnerShell | undefined = nativeWindowsWorktree
     ? runnerShell
@@ -583,8 +598,7 @@ function createWorktreeRunnerScript(args: {
     envVars,
     // Why: WSL git returns /mnt paths that Node converts back to C:\ for file
     // writes; retain the runtime signal so launch converts them to /mnt again.
-    // Issue-command runners take the same resolved shell, so one session never
-    // mixes a bash setup runner with a cmd issue runner.
+    // On native Windows it mirrors the family the runner file was written in.
     ...(launchShell ? { shell: launchShell } : {}),
     ...(waitForAgentStartup === true ? { waitForAgentStartup: true } : {})
   }
@@ -615,9 +629,8 @@ export function resolveSetupRunnerShell(
       options.resolveGitBashShellPath ??
       ((shell: string) => resolveWindowsGitBashShellPath(shell, { platform }))
     if (resolveGitBashShellPath(configuredShell)) {
-      // Note: Git Bash users with batch-syntax orca.yaml setup content get a bash
-      // interpreter from here on. The flip is intentional and documented in
-      // docs/reference/windows-setup-shell.md.
+      // Note: this only reports that a bash runner *could* launch here. Whether one is
+      // used is decided per script by its `#!` line — see docs/reference/windows-setup-shell.md.
       return { family: 'posix' }
     }
   }

--- a/src/main/runtime/orchestration/setup-completion-signal.test.ts
+++ b/src/main/runtime/orchestration/setup-completion-signal.test.ts
@@ -64,6 +64,19 @@ describe('orchestration setup completion signal', () => {
     expect(command).toContain('bash /c/repo/.git/orca/setup-runner.sh')
   })
 
+  it('keeps a batch runner on the Windows completion path from a Git Bash pane', () => {
+    // Regression (#6896): a Git Bash terminal with a batch setup script still gets a .cmd
+    // runner; observing it must not shell out to bash or type a bare `cmd.exe /c` switch.
+    const runnerPath = 'C:\\repo\\.git\\orca\\setup-runner.cmd'
+    const observed = buildObservedSetupCommand(runnerPath, 'windows', 'token-git-bash-cmd', {
+      family: 'posix'
+    })
+
+    expect(observed.command).toContain('powershell.exe -NoLogo -NoProfile -NonInteractive')
+    expect(observed.command).not.toContain('bash ')
+    expect(observed.env).toEqual({ ORCA_SETUP_RUNNER_PATH: runnerPath })
+  })
+
   it('recognizes one completion signal across output chunk boundaries', () => {
     const onComplete = vi.fn()
     const scanner = createSetupCompletionScanner('token-chunks', onComplete)

--- a/src/shared/setup-agent-sequencing.test.ts
+++ b/src/shared/setup-agent-sequencing.test.ts
@@ -218,6 +218,26 @@ describe('createSequencedSetupAgentCommands', () => {
     })
   })
 
+  it('keeps the cmd gate for a batch runner launched from a Git Bash pane', () => {
+    // Regression (#6896): a Git Bash terminal with a batch setup script still gets a .cmd
+    // runner, and the wait-for-setup gate must not try to run it under bash.
+    const result = createSequencedSetupAgentCommands({
+      runnerScriptPath: 'C:\\repo\\.git\\orca\\setup-runner.cmd',
+      startupCommand: 'claude',
+      platform: 'windows',
+      shell: { family: 'posix' },
+      nonce: 'nonce-gitbash-cmd'
+    })
+
+    expect(result.setupCommand).toContain(
+      'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand'
+    )
+    expect(result.setupCommand).not.toContain('bash -lc')
+    expect(decodePowerShellScript(result.setupCommand)).toContain(
+      "$runner = 'C:\\repo\\.git\\orca\\setup-runner.cmd'"
+    )
+  })
+
   it.skipIf(process.platform !== 'win32')(
     'executes the native Windows setup-to-agent sequence through cmd.exe',
     async () => {

--- a/src/shared/setup-agent-sequencing.test.ts
+++ b/src/shared/setup-agent-sequencing.test.ts
@@ -218,12 +218,13 @@ describe('createSequencedSetupAgentCommands', () => {
     })
   })
 
-  it('keeps the cmd gate for a batch runner launched from a Git Bash pane', () => {
+  it('launches a batch runner through the cmd launcher inside a Git Bash gate', () => {
     // Regression (#6896): a Git Bash terminal with a batch setup script still gets a .cmd
-    // runner, and the wait-for-setup gate must not try to run it under bash.
+    // runner, and the gate must not hand that runner to bash. The gate itself stays POSIX
+    // because the Git Bash pane types it and quoted the startup command for bash.
     const result = createSequencedSetupAgentCommands({
       runnerScriptPath: 'C:\\repo\\.git\\orca\\setup-runner.cmd',
-      startupCommand: 'claude',
+      startupCommand: "claude 'fix the user'\\''s login'",
       platform: 'windows',
       shell: { family: 'posix' },
       nonce: 'nonce-gitbash-cmd'
@@ -232,9 +233,22 @@ describe('createSequencedSetupAgentCommands', () => {
     expect(result.setupCommand).toContain(
       'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand'
     )
-    expect(result.setupCommand).not.toContain('bash -lc')
+    expect(result.setupCommand).not.toMatch(/bash\s+\S*setup-runner/)
     expect(decodePowerShellScript(result.setupCommand)).toContain(
       "$runner = 'C:\\repo\\.git\\orca\\setup-runner.cmd'"
+    )
+    // Why: PowerShell's `Invoke-Expression` cannot parse the POSIX `'\''` escaping a Git Bash
+    // pane produces, so the gate that evaluates the startup command must be bash.
+    expect(result.setupCommand).toMatch(/^bash -lc /)
+    expect(result.startupCommand).toMatch(/^bash -lc /)
+    expect(result.startupCommand).not.toContain('Invoke-Expression')
+    expect(result.startupCommand).toContain('eval "$ORCA_SEQUENCED_STARTUP_COMMAND"')
+    // Why: bash writes and reads the marker here, so it needs the /c/... form of the path.
+    expect(result.setupCommand).toContain(
+      '/c/repo/.git/orca/setup-runner.cmd.nonce-gitbash-cmd.done'
+    )
+    expect(result.startupCommand).toContain(
+      '/c/repo/.git/orca/setup-runner.cmd.nonce-gitbash-cmd.done'
     )
   })
 

--- a/src/shared/setup-agent-sequencing.ts
+++ b/src/shared/setup-agent-sequencing.ts
@@ -1,5 +1,6 @@
 import { encodePowerShellCommand } from './powershell-command-encoding'
 import {
+  nativeWindowsPathToPosixShellPath,
   resolveSetupRunnerCommand,
   type SetupRunnerCommandPlatform,
   type SetupRunnerCommandShell,
@@ -41,12 +42,20 @@ export function createSequencedSetupAgentCommands(args: {
 }): SequencedSetupAgentCommands {
   const nonce = args.nonce ?? createSetupAgentSequenceNonce()
   const resolution = resolveSetupRunnerCommand(args.runnerScriptPath, args.platform, args.shell)
+  // Why: the gate is typed into the terminal pane and `startupCommand` is already quoted for that
+  // pane, so a batch runner launched from a Git Bash pane still needs the bash gate — PowerShell's
+  // `Invoke-Expression` cannot parse the POSIX `'\''` escaping the pane's quoting produces. The
+  // runner itself still launches through `resolution.command`, never through bash.
+  const posixGateForWindowsRunner = resolution.shell === 'windows' && args.shell?.family === 'posix'
+  const markerBasePath = posixGateForWindowsRunner
+    ? nativeWindowsPathToPosixShellPath(resolution.runnerScriptPathForShell)
+    : resolution.runnerScriptPathForShell
   // Why: overlapping gated launches of the same setup runner must not race on
   // a shared completion marker.
-  const markerPath = `${resolution.runnerScriptPathForShell}.${nonce}.done`
+  const markerPath = `${markerBasePath}.${nonce}.done`
   const waitTimeoutSeconds = args.waitTimeoutSeconds ?? DEFAULT_WAIT_TIMEOUT_SECONDS
 
-  if (resolution.shell === 'windows') {
+  if (resolution.shell === 'windows' && !posixGateForWindowsRunner) {
     return {
       setupCommand: buildWindowsSetupCommand(
         resolution.runnerScriptPathForShell,

--- a/src/shared/setup-runner-command.test.ts
+++ b/src/shared/setup-runner-command.test.ts
@@ -61,6 +61,51 @@ describe('buildSetupRunnerCommand', () => {
       'bash /c/repo/.git/orca/setup-runner.sh'
     )
   })
+
+  it('never hands a batch runner to bash, even from a Git Bash pane', () => {
+    // Regression: a Git Bash terminal with a batch-syntax setup script gets a .cmd runner,
+    // so the launch shell being POSIX must not be read as "the runner is a shell script".
+    const command = buildSetupRunnerCommand('C:\\repo\\.git\\orca\\setup-runner.cmd', 'windows', {
+      family: 'posix'
+    })
+
+    expect(command).not.toContain('bash ')
+    expect(command).not.toContain('/c/repo')
+  })
+
+  it('avoids the bare /c switch when a POSIX pane launches a batch runner', () => {
+    // Regression (#6896): MSYS rewrites `cmd.exe /c` into a drive path inside Git Bash, so cmd
+    // opens interactively and the runner payload never executes.
+    const command = buildSetupRunnerCommand('C:\\repo\\.git\\orca\\setup-runner.cmd', 'windows', {
+      family: 'posix'
+    })
+
+    expect(command).not.toContain('cmd.exe /c')
+    expect(command).toMatch(
+      /^powershell\.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand [A-Za-z0-9+/=]+$/
+    )
+  })
+
+  it('keeps the batch runner path in native form for a POSIX pane launch', () => {
+    // Why: the PowerShell launcher hands the path to cmd, which cannot read /c/... MSYS paths;
+    // marker and completion paths derive from this value too.
+    expect(
+      resolveSetupRunnerCommand('C:\\repo\\.git\\orca\\setup-runner.cmd', 'windows', {
+        family: 'posix'
+      })
+    ).toMatchObject({
+      runnerScriptPathForShell: 'C:\\repo\\.git\\orca\\setup-runner.cmd',
+      shell: 'windows'
+    })
+  })
+
+  it('still uses bash for a POSIX runner launched from a POSIX pane', () => {
+    expect(
+      buildSetupRunnerCommand('C:\\repo\\.git\\orca\\setup-runner.sh', 'windows', {
+        family: 'posix'
+      })
+    ).toBe('bash /c/repo/.git/orca/setup-runner.sh')
+  })
 })
 
 describe('buildSetupRunnerCommand cmd metacharacter guard', () => {

--- a/src/shared/setup-runner-command.ts
+++ b/src/shared/setup-runner-command.ts
@@ -60,7 +60,10 @@ export function resolveSetupRunnerCommand(
         shell: 'posix'
       }
     }
-    if (shell?.family === 'posix' || /\.sh$/i.test(runnerScriptPath)) {
+    // Why: `shell` is the shell that types the command; the runner file's own extension decides
+    // what can execute it. A batch runner never goes to bash even from a Git Bash pane.
+    const cmdRunnerFile = isWindowsCmdRunnerPath(runnerScriptPath)
+    if (!cmdRunnerFile && (shell?.family === 'posix' || /\.sh$/i.test(runnerScriptPath))) {
       // Why: WSL shells need /mnt/... paths, while Git Bash expects /c/... when replaying deferred setup scripts.
       if (isWslExecutable(shell?.executable)) {
         const wslPath = nativeWindowsPathToWslShellPath(runnerScriptPath)
@@ -79,11 +82,15 @@ export function resolveSetupRunnerCommand(
       }
     }
     return {
-      // Why: some path characters survive no amount of quoting on a cmd command line, so those
-      // paths take a delayed-expansion launcher instead. Every other path keeps the plain form.
-      command: windowsRunnerPathNeedsCmdGuard(runnerScriptPath)
-        ? buildWindowsCmdRunnerDelayedLaunchCommand(runnerScriptPath)
-        : `cmd.exe /c ${quoteWindowsArg(runnerScriptPath)}`,
+      // Why: some path characters survive no amount of quoting on a cmd command line, and a Git
+      // Bash pane rewrites the bare `/c` switch itself into a drive path (issue #6896) so cmd
+      // opens interactively and the runner never starts. Both take the delayed-expansion
+      // launcher, which passes the switch through a PowerShell ProcessStartInfo instead. Every
+      // other case keeps the plain form.
+      command:
+        shell?.family === 'posix' || windowsRunnerPathNeedsCmdGuard(runnerScriptPath)
+          ? buildWindowsCmdRunnerDelayedLaunchCommand(runnerScriptPath)
+          : `cmd.exe /c ${quoteWindowsArg(runnerScriptPath)}`,
       runnerScriptPathForShell: runnerScriptPath,
       shell: 'windows'
     }
@@ -94,6 +101,11 @@ export function resolveSetupRunnerCommand(
     runnerScriptPathForShell: runnerScriptPath,
     shell: 'posix'
   }
+}
+
+/** True when the runner file is a batch script, which only cmd can execute. */
+export function isWindowsCmdRunnerPath(runnerScriptPath: string): boolean {
+  return /\.(cmd|bat)$/i.test(runnerScriptPath)
 }
 
 export function isWslUncPath(path: string): boolean {

--- a/src/shared/setup-script-shebang.test.ts
+++ b/src/shared/setup-script-shebang.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { isShebangLine, scriptDeclaresPosixShell } from './setup-script-shebang'
+
+describe('scriptDeclaresPosixShell', () => {
+  it('accepts the common env and absolute-path forms', () => {
+    expect(scriptDeclaresPosixShell('#!/usr/bin/env bash\npnpm install')).toBe(true)
+    expect(scriptDeclaresPosixShell('#!/bin/sh -e\npnpm install')).toBe(true)
+    expect(scriptDeclaresPosixShell('#!/usr/bin/env -S bash -euo pipefail\npnpm install')).toBe(
+      true
+    )
+    expect(scriptDeclaresPosixShell('#!/bin/zsh')).toBe(true)
+  })
+
+  it('rejects scripts with no interpreter line', () => {
+    // Regression: batch-syntax setup scripts must stay on the cmd runner.
+    expect(scriptDeclaresPosixShell('copy .env.example .env\nxcopy /E assets dist')).toBe(false)
+    expect(scriptDeclaresPosixShell('')).toBe(false)
+    expect(scriptDeclaresPosixShell('pnpm install\n#!/usr/bin/env bash')).toBe(false)
+    expect(scriptDeclaresPosixShell('# !/usr/bin/env bash\npnpm install')).toBe(false)
+  })
+
+  it('rejects interpreters that are not POSIX shells', () => {
+    expect(scriptDeclaresPosixShell('#!/usr/bin/env node\nconsole.log(1)')).toBe(false)
+    expect(scriptDeclaresPosixShell('#!/usr/bin/env python3\nprint(1)')).toBe(false)
+  })
+
+  it('tolerates CRLF and Windows-style interpreter paths', () => {
+    expect(scriptDeclaresPosixShell('#!/usr/bin/env bash\r\npnpm install')).toBe(true)
+    expect(scriptDeclaresPosixShell('#!C:\\tools\\git\\bin\\bash.exe\r\npnpm install')).toBe(true)
+  })
+})
+
+describe('isShebangLine', () => {
+  it('detects interpreter lines regardless of leading whitespace', () => {
+    expect(isShebangLine('#!/usr/bin/env bash')).toBe(true)
+    expect(isShebangLine('  #!/bin/sh')).toBe(true)
+    expect(isShebangLine('#comment')).toBe(false)
+    expect(isShebangLine('pnpm install')).toBe(false)
+  })
+})

--- a/src/shared/setup-script-shebang.test.ts
+++ b/src/shared/setup-script-shebang.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { isShebangLine, scriptDeclaresPosixShell } from './setup-script-shebang'
+import {
+  isShebangLine,
+  parseSetupScriptShebang,
+  scriptDeclaresPosixShell,
+  stripLeadingShebangLine
+} from './setup-script-shebang'
 
 describe('scriptDeclaresPosixShell', () => {
   it('accepts the common env and absolute-path forms', () => {
@@ -27,6 +32,46 @@ describe('scriptDeclaresPosixShell', () => {
   it('tolerates CRLF and Windows-style interpreter paths', () => {
     expect(scriptDeclaresPosixShell('#!/usr/bin/env bash\r\npnpm install')).toBe(true)
     expect(scriptDeclaresPosixShell('#!C:\\tools\\git\\bin\\bash.exe\r\npnpm install')).toBe(true)
+  })
+})
+
+describe('parseSetupScriptShebang', () => {
+  it('keeps the interpreter flags a script declares', () => {
+    // Regression: the runner is launched as `bash <path>`, so flags survive only if they are
+    // parsed out here and replayed with `set` — otherwise `pipefail` is silently lost.
+    expect(parseSetupScriptShebang('#!/usr/bin/env -S bash -euo pipefail\nmake')).toEqual({
+      interpreter: 'bash',
+      shellOptions: ['-euo', 'pipefail']
+    })
+    expect(parseSetupScriptShebang('#!/bin/bash -e -x\nmake')).toEqual({
+      interpreter: 'bash',
+      shellOptions: ['-e', '-x']
+    })
+    expect(parseSetupScriptShebang('#!/bin/sh\nmake')).toEqual({
+      interpreter: 'sh',
+      shellOptions: []
+    })
+  })
+
+  it('ignores interpreter arguments that `set` cannot apply', () => {
+    expect(parseSetupScriptShebang('#!/bin/bash --norc\nmake')?.shellOptions).toEqual([])
+    expect(parseSetupScriptShebang('#!/bin/bash -o\nmake')?.shellOptions).toEqual(['-o'])
+  })
+
+  it('returns null without an interpreter line', () => {
+    expect(parseSetupScriptShebang('pnpm install')).toBeNull()
+    expect(parseSetupScriptShebang('#!/usr/bin/env')).toBeNull()
+  })
+})
+
+describe('stripLeadingShebangLine', () => {
+  it('removes only a leading interpreter line', () => {
+    expect(stripLeadingShebangLine('#!/usr/bin/env bash\npnpm install\n')).toBe('pnpm install\n')
+    expect(stripLeadingShebangLine('#!/usr/bin/env bash\r\npnpm install')).toBe('pnpm install')
+    expect(stripLeadingShebangLine('pnpm install\n#!/usr/bin/env bash')).toBe(
+      'pnpm install\n#!/usr/bin/env bash'
+    )
+    expect(stripLeadingShebangLine('#!/usr/bin/env bash')).toBe('')
   })
 })
 

--- a/src/shared/setup-script-shebang.test.ts
+++ b/src/shared/setup-script-shebang.test.ts
@@ -54,8 +54,22 @@ describe('parseSetupScriptShebang', () => {
   })
 
   it('ignores interpreter arguments that `set` cannot apply', () => {
+    // Regression: `set` rejects invocation-only flags with exit 2, and the runner's `set -e`
+    // turns that into an aborted setup before its first line runs.
     expect(parseSetupScriptShebang('#!/bin/bash --norc\nmake')?.shellOptions).toEqual([])
-    expect(parseSetupScriptShebang('#!/bin/bash -o\nmake')?.shellOptions).toEqual(['-o'])
+    expect(parseSetupScriptShebang('#!/bin/bash -l\nmake')?.shellOptions).toEqual([])
+    expect(parseSetupScriptShebang('#!/bin/bash -s\nmake')?.shellOptions).toEqual([])
+    expect(parseSetupScriptShebang('#!/bin/bash -i\nmake')?.shellOptions).toEqual([])
+    // Why: `-r` is accepted by `set` on some shells but silently restricts the rest of setup.
+    expect(parseSetupScriptShebang('#!/bin/bash -r\nmake')?.shellOptions).toEqual([])
+    expect(parseSetupScriptShebang('#!/bin/bash -ex -l\nmake')?.shellOptions).toEqual(['-ex'])
+    // Why: a bare `-o` would print the whole shell-option table into the setup terminal.
+    expect(parseSetupScriptShebang('#!/bin/bash -o\nmake')?.shellOptions).toEqual([])
+    expect(parseSetupScriptShebang('#!/bin/bash -euo\nmake')?.shellOptions).toEqual([])
+    expect(parseSetupScriptShebang('#!/bin/bash +o posix\nmake')?.shellOptions).toEqual([
+      '+o',
+      'posix'
+    ])
   })
 
   it('returns null without an interpreter line', () => {

--- a/src/shared/setup-script-shebang.ts
+++ b/src/shared/setup-script-shebang.ts
@@ -1,0 +1,44 @@
+// Why: the interpreter a setup/issue-command script is written for is a property of the script,
+// not of the user's terminal preference, so a `#!` line is how a project declares it.
+
+const POSIX_SHELL_BASENAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'ash'])
+
+/** True when `line` is a `#!` interpreter line (leading whitespace tolerated). */
+export function isShebangLine(line: string): boolean {
+  return line.trimStart().startsWith('#!')
+}
+
+/** True when the script's first line is a `#!` line naming a POSIX shell. */
+export function scriptDeclaresPosixShell(script: string): boolean {
+  const firstLine = script.split('\n', 1)[0] ?? ''
+  if (!isShebangLine(firstLine)) {
+    return false
+  }
+
+  const tokens = firstLine.trim().slice(2).trim().split(/\s+/).filter(Boolean)
+  const interpreter = shebangInterpreterBasename(tokens)
+  return interpreter !== null && POSIX_SHELL_BASENAMES.has(interpreter)
+}
+
+function shebangInterpreterBasename(tokens: string[]): string | null {
+  for (let index = 0; index < tokens.length; index++) {
+    const basename = executableBasename(tokens[index])
+    // Why: `env` (and its `-S` split-string form) only forwards to the real interpreter.
+    if (basename === 'env' || basename.startsWith('-')) {
+      continue
+    }
+    return basename || null
+  }
+  return null
+}
+
+function executableBasename(token: string): string {
+  return (
+    token
+      .replaceAll('\\', '/')
+      .split('/')
+      .pop()
+      ?.toLowerCase()
+      .replace(/\.exe$/, '') ?? ''
+  )
+}

--- a/src/shared/setup-script-shebang.ts
+++ b/src/shared/setup-script-shebang.ts
@@ -2,34 +2,84 @@
 // not of the user's terminal preference, so a `#!` line is how a project declares it.
 
 const POSIX_SHELL_BASENAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'ash'])
+// Why: `-e`, `+e`, `-euo`; `--norc` and interpreter arguments are not `set` options.
+const SHELL_OPTION_FLAG_PATTERN = /^[-+][a-zA-Z]+$/
+const SHELL_OPTION_NAME_PATTERN = /^[a-z_]+$/
+
+export type SetupScriptShebang = {
+  /** Lowercased interpreter basename, e.g. `bash` for `#!/usr/bin/env -S bash -e`. */
+  interpreter: string
+  /** Interpreter flags the generated runner replays through `set`, e.g. `['-euo', 'pipefail']`. */
+  shellOptions: string[]
+}
 
 /** True when `line` is a `#!` interpreter line (leading whitespace tolerated). */
 export function isShebangLine(line: string): boolean {
   return line.trimStart().startsWith('#!')
 }
 
-/** True when the script's first line is a `#!` line naming a POSIX shell. */
-export function scriptDeclaresPosixShell(script: string): boolean {
+/** Parses the script's leading `#!` line, or null when it has none. */
+export function parseSetupScriptShebang(script: string): SetupScriptShebang | null {
   const firstLine = script.split('\n', 1)[0] ?? ''
   if (!isShebangLine(firstLine)) {
-    return false
+    return null
   }
 
   const tokens = firstLine.trim().slice(2).trim().split(/\s+/).filter(Boolean)
-  const interpreter = shebangInterpreterBasename(tokens)
-  return interpreter !== null && POSIX_SHELL_BASENAMES.has(interpreter)
+  const interpreterIndex = findInterpreterIndex(tokens)
+  if (interpreterIndex === -1) {
+    return null
+  }
+
+  return {
+    interpreter: executableBasename(tokens[interpreterIndex]),
+    shellOptions: parseShellOptions(tokens.slice(interpreterIndex + 1))
+  }
 }
 
-function shebangInterpreterBasename(tokens: string[]): string | null {
+/** True when the script's first line is a `#!` line naming a POSIX shell. */
+export function scriptDeclaresPosixShell(script: string): boolean {
+  const shebang = parseSetupScriptShebang(script)
+  return shebang !== null && POSIX_SHELL_BASENAMES.has(shebang.interpreter)
+}
+
+/** Drops a leading `#!` line; the generated runner carries its own interpreter line. */
+export function stripLeadingShebangLine(script: string): string {
+  if (!isShebangLine(script.split('\n', 1)[0] ?? '')) {
+    return script
+  }
+  const lineEnd = script.indexOf('\n')
+  return lineEnd === -1 ? '' : script.slice(lineEnd + 1)
+}
+
+function findInterpreterIndex(tokens: string[]): number {
   for (let index = 0; index < tokens.length; index++) {
     const basename = executableBasename(tokens[index])
     // Why: `env` (and its `-S` split-string form) only forwards to the real interpreter.
-    if (basename === 'env' || basename.startsWith('-')) {
+    if (basename === '' || basename === 'env' || basename.startsWith('-')) {
       continue
     }
-    return basename || null
+    return index
   }
-  return null
+  return -1
+}
+
+function parseShellOptions(tokens: string[]): string[] {
+  const options: string[] = []
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]
+    if (!SHELL_OPTION_FLAG_PATTERN.test(token)) {
+      continue
+    }
+    options.push(token)
+    // Why: `-o`/`-euo` take the option name as a separate argument (`pipefail`).
+    const optionName = tokens[index + 1]
+    if (token.endsWith('o') && optionName && SHELL_OPTION_NAME_PATTERN.test(optionName)) {
+      options.push(optionName)
+      index++
+    }
+  }
+  return options
 }
 
 function executableBasename(token: string): string {

--- a/src/shared/setup-script-shebang.ts
+++ b/src/shared/setup-script-shebang.ts
@@ -2,8 +2,13 @@
 // not of the user's terminal preference, so a `#!` line is how a project declares it.
 
 const POSIX_SHELL_BASENAMES = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'ash'])
-// Why: `-e`, `+e`, `-euo`; `--norc` and interpreter arguments are not `set` options.
-const SHELL_OPTION_FLAG_PATTERN = /^[-+][a-zA-Z]+$/
+// Why: only the letters `set` itself accepts (`set [--abefhkmnptuvxBCHP] [-o option]`). An
+// invocation-only flag such as `-l` or `-r` makes `set` exit 2, which under the runner's `set -e`
+// aborts setup before its first line runs.
+const SET_OPTION_FLAG_PATTERN = /^[-+][abefhkmnptuvxBCHP]+$/
+// Why: `-o`/`-euo` name their option in the next token; a trailing `-o` with no name would make
+// `set` dump the whole shell-option table into the setup terminal instead.
+const SET_LONG_OPTION_FLAG_PATTERN = /^[-+][abefhkmnptuvxBCHP]*o$/
 const SHELL_OPTION_NAME_PATTERN = /^[a-z_]+$/
 
 export type SetupScriptShebang = {
@@ -68,15 +73,16 @@ function parseShellOptions(tokens: string[]): string[] {
   const options: string[] = []
   for (let index = 0; index < tokens.length; index++) {
     const token = tokens[index]
-    if (!SHELL_OPTION_FLAG_PATTERN.test(token)) {
+    if (SET_LONG_OPTION_FLAG_PATTERN.test(token)) {
+      const optionName = tokens[index + 1]
+      if (optionName && SHELL_OPTION_NAME_PATTERN.test(optionName)) {
+        options.push(token, optionName)
+        index++
+      }
       continue
     }
-    options.push(token)
-    // Why: `-o`/`-euo` take the option name as a separate argument (`pipefail`).
-    const optionName = tokens[index + 1]
-    if (token.endsWith('o') && optionName && SHELL_OPTION_NAME_PATTERN.test(optionName)) {
-      options.push(optionName)
-      index++
+    if (SET_OPTION_FLAG_PATTERN.test(token)) {
+      options.push(token)
     }
   }
   return options


### PR DESCRIPTION
## Defect

`resolveSetupRunnerShell` (src/main/hooks.ts) derives the native-Windows setup-runner shell from the `terminalWindowsShell` **terminal** preference. When that preference resolves to Git Bash it returns `{ family: 'posix' }`, and `createWorktreeRunnerScript` writes the project's setup script to a `.sh` file launched with `bash`.

That was applied retroactively to setup scripts that already existed. Before #6967 every native-Windows setup script ran under `cmd.exe`, so **every** pre-existing Windows setup script is cmd-authored.

## Concrete failure scenario

A Windows user has `terminalWindowsShell` set to Git Bash — a perfectly reasonable terminal preference — and an `orca.yaml` setup hook written in batch:

```yaml
scripts:
  setup: |
    copy .env.example .env
    set NODE_ENV=test
    if errorlevel 1 exit /b 1
    xcopy /E assets dist
```

They upgrade. The same script is now handed to bash: `copy` and `xcopy` do not exist, `set NODE_ENV=test` sets positional parameters instead of an env var, `if errorlevel 1` is a syntax error, and `assets dist` backslash paths get eaten by bash escaping. Setup breaks with no migration and no warning, and it looks like Orca broke their project.

There is a second, steady-state half of the same defect: because the interpreter came from a *per-user* preference, two contributors on the same repo got different interpreters for the same `orca.yaml`. No project could write a Windows setup script that worked for all of its contributors.

## The fix

The interpreter is a property of the script, not of the terminal the user likes, so the script declares it the standard way — a leading `#!` line.

- Native Windows keeps the historical `.cmd` runner **unless** the script's first line is a `#!` naming a POSIX shell. No existing script changes behavior on upgrade.
- `resolveSetupRunnerShell` keeps its existing role as the *feasibility* gate: a bash runner still requires the configured terminal to resolve to Git Bash, because the launch command is typed into that shell and the runner uses MSYS `/c/...` paths that Cygwin and the WSL shim reject. Its return value now means "a bash runner could launch here", and the per-script `#!` decides whether one is used.
- `buildWindowsRunnerScript` drops a leading `#!` line instead of `call`ing it. A declared-bash script that falls back to cmd (Git Bash not installed) now fails on a real setup line rather than aborting on errorlevel at line one.
- New `src/shared/setup-script-shebang.ts` parses the interpreter line: `#!/usr/bin/env bash`, `#!/bin/sh -e`, `#!/usr/bin/env -S bash -euo pipefail`, and Windows `bash.exe` paths all count; `node`/`python3` and comment-only first lines do not.

Issue-command runners go through the same code path and get the same rule, so an issue command authored for cmd is not flipped either.

### Why this option

The alternatives were weighed:

- *Record the shell a script was authored against.* Requires persistent per-repo state, can't distinguish "upgrading user" from "new user", and freezes a repo on whatever it was first run with — a user who later writes a bash script stays on cmd forever.
- *Detect batch-only idioms.* A heuristic guessing user intent, which is the same class of silent-wrong-behavior this PR is fixing, and it still has to pick a side for the large majority of scripts that are ambiguous (`pnpm install`).
- *A `#!` line.* Explicit, zero state, zero heuristics, standard, per-project, and identical for every contributor who checks the repo out. Chosen.

Unchanged: WSL worktrees, macOS/Linux (always bash), and SSH hosts (runner format follows the remote path format, never local Windows preferences).

## Verification

All tests use runtime platform overrides, so they run on any host.

New/changed tests:
- `src/shared/setup-script-shebang.test.ts` — interpreter-line parsing, including CRLF, `env -S`, non-shell interpreters, and a non-first-line `#!`.
- `src/main/hooks.test.ts` — "keeps batch setup scripts on cmd.exe when the terminal is Git Bash" (the reported regression: `{ family: 'posix' }` + `copy`/`xcopy` script still produces `setup-runner.cmd`), plus the issue-command equivalent, plus the existing POSIX-runner test updated to declare a shebang.
- `src/main/hooks-runner.test.ts` — `buildWindowsRunnerScript` drops a leading shebang instead of `call`ing it.

I reverted `src/main/hooks.ts` (`git stash push src/main/hooks.ts`), confirmed all three new regression tests fail without the fix, then restored it (`git stash pop`) and confirmed they pass.

```
npx vitest run --config config/vitest.config.ts \
  src/main/hooks.test.ts src/main/hooks-runner.test.ts \
  src/shared/setup-script-shebang.test.ts src/shared/setup-runner-command.test.ts \
  src/main/ipc/worktrees-windows.test.ts src/main/ipc/worktrees.test.ts
# 6 files, 379 tests passed

npx vitest run --config config/vitest.config.ts \
  src/shared/setup-agent-sequencing.test.ts src/shared/setup-agent-sequencing.windows.test.ts \
  src/main/ipc/worktree-logic.test.ts src/main/ipc/worktree-logic-wsl.test.ts \
  src/main/runtime/orchestration
# 32 files, 406 tests passed

npx tsc --noEmit -p config/tsconfig.node.json   # clean
npx oxlint <touched files>                       # clean
npm run check:max-lines-ratchet                  # OK, no new bypasses
```

