### PR TITLE
fix(codex): do not silently run the previous account when managed auth is unreadable

### DIFF
--- a/src/main/codex-accounts/codex-auth-identity.ts
+++ b/src/main/codex-accounts/codex-auth-identity.ts
@@ -50,6 +50,26 @@ export function codexAuthMatchesManagedAccount(
   )
 }
 
+// Why: an unreadable managed home cannot be compared byte-for-byte, so only the
+// account record itself can rule that home out as the credential's owner.
+export function codexAuthCouldBelongToManagedAccount(
+  runtimeAuthContents: string,
+  account: CodexManagedAccount
+): boolean {
+  const identity = readIdentityFromAuthContents(runtimeAuthContents)
+  if (!identity) {
+    return true
+  }
+  const accountEmail = normalizeField(account.email)
+  if (accountEmail && identity.email && accountEmail !== identity.email) {
+    return false
+  }
+  return (
+    identityFieldMatches(normalizeField(account.providerAccountId), identity.providerAccountId) &&
+    identityFieldMatches(normalizeField(account.workspaceAccountId), identity.workspaceAccountId)
+  )
+}
+
 // Why: the shared mirror may still hold managed credentials; only the same
 // positively identified system account may ever be read back to ~/.codex.
 export function codexAuthMatchesSystemDefaultIdentity(

--- a/src/main/codex-accounts/codex-auth-identity.ts
+++ b/src/main/codex-accounts/codex-auth-identity.ts
@@ -29,8 +29,17 @@ export function codexAuthMatchesManagedAccount(
     normalizeField(account.workspaceAccountId),
     managedIdentity?.workspaceAccountId
   )
-  const emailMatches = Boolean(selectedEmail && identity.email && selectedEmail === identity.email)
-  if (selectedEmail && identity.email && selectedEmail !== identity.email) {
+  const emailMatches = identityFieldsAgree(selectedEmail, identity.email)
+  if (
+    identityContradictsSelection(
+      {
+        email: selectedEmail,
+        providerAccountId: selectedProviderId,
+        workspaceAccountId: selectedWorkspaceId
+      },
+      identity
+    )
+  ) {
     return false
   }
   if (!identityFieldMatches(selectedProviderId, identity.providerAccountId)) {
@@ -57,16 +66,16 @@ export function codexAuthCouldBelongToManagedAccount(
   account: CodexManagedAccount
 ): boolean {
   const identity = readIdentityFromAuthContents(runtimeAuthContents)
-  if (!identity) {
-    return true
-  }
-  const accountEmail = normalizeField(account.email)
-  if (accountEmail && identity.email && accountEmail !== identity.email) {
-    return false
-  }
   return (
-    identityFieldMatches(normalizeField(account.providerAccountId), identity.providerAccountId) &&
-    identityFieldMatches(normalizeField(account.workspaceAccountId), identity.workspaceAccountId)
+    !identity ||
+    !identityContradictsSelection(
+      {
+        email: normalizeField(account.email),
+        providerAccountId: normalizeField(account.providerAccountId),
+        workspaceAccountId: normalizeField(account.workspaceAccountId)
+      },
+      identity
+    )
   )
 }
 
@@ -259,4 +268,34 @@ function firstNonNull(...values: (string | null | undefined)[]): string | null {
 
 function identityFieldMatches(selectedField: string | null, runtimeField: string | null): boolean {
   return !selectedField || Boolean(runtimeField && selectedField === runtimeField)
+}
+
+// Why: only a claim both sides carry can rule an account out — a credential with
+// no identity claims (api key, PAT, bedrock) contradicts nothing. A ChatGPT
+// rename leaves the record email stale, so a matching account id outranks it.
+function identityContradictsSelection(
+  selected: CodexAuthIdentity,
+  identity: CodexAuthIdentity
+): boolean {
+  if (
+    identityFieldsConflict(selected.providerAccountId, identity.providerAccountId) ||
+    identityFieldsConflict(selected.workspaceAccountId, identity.workspaceAccountId)
+  ) {
+    return true
+  }
+  return (
+    identityFieldsConflict(selected.email, identity.email) &&
+    !identityFieldsAgree(selected.providerAccountId, identity.providerAccountId)
+  )
+}
+
+function identityFieldsAgree(selectedField: string | null, runtimeField: string | null): boolean {
+  return Boolean(selectedField && runtimeField && selectedField === runtimeField)
+}
+
+function identityFieldsConflict(
+  selectedField: string | null,
+  runtimeField: string | null
+): boolean {
+  return Boolean(selectedField && runtimeField && selectedField !== runtimeField)
 }

--- a/src/main/codex-accounts/codex-credential-absence-grace.test.ts
+++ b/src/main/codex-accounts/codex-credential-absence-grace.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -53,6 +53,21 @@ describe('CodexCredentialAbsenceGrace', () => {
     expect(grace.assess(authPath, 100_000)).toEqual({ state: 'missing', durable: false })
     expect(grace.assess(authPath, 100_000 + CODEX_CREDENTIAL_ABSENCE_GRACE_MS)).toEqual({
       state: 'missing',
+      durable: true
+    })
+  })
+
+  it('keeps a permission-denied read inside the grace window before it turns durable', () => {
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      return
+    }
+    const grace = new CodexCredentialAbsenceGrace()
+    writeFileSync(authPath, VALID_AUTH, 'utf-8')
+    chmodSync(authPath, 0o000)
+
+    expect(grace.assess(authPath, 1_000)).toEqual({ state: 'unreadable', durable: false })
+    expect(grace.assess(authPath, 1_000 + CODEX_CREDENTIAL_ABSENCE_GRACE_MS)).toEqual({
+      state: 'unreadable',
       durable: true
     })
   })

--- a/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
+++ b/src/main/codex-accounts/managed-codex-auth-readiness.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -206,6 +206,18 @@ describe('waitForManagedCodexAuthReady', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[codex-auth-readiness] Managed credential remained unavailable after 1500ms'
     )
+  })
+
+  it('separates an absent credential from one that cannot be read', () => {
+    const fixture = createFixture()
+    expect(readStoredCodexCredentialState(join(fixture.home, 'auth.json'))).toBe('missing')
+
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      return
+    }
+    writeAuth(fixture.home, testChatGptAuth)
+    chmodSync(join(fixture.home, 'auth.json'), 0o000)
+    expect(readStoredCodexCredentialState(join(fixture.home, 'auth.json'))).toBe('unreadable')
   })
 
   it('does not gate system, WSL, or unmanaged custom homes', async () => {

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import type { GlobalSettings } from '../../shared/types'
+import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
 import type * as ShellStartupEnv from '../pty/shell-startup-env'
 
 const testState = {
@@ -257,6 +257,25 @@ function createManagedAuth(rootDir: string, accountId: string, auth: string): st
   writeFileSync(join(managedHomePath, '.orca-managed-home'), `${accountId}\n`, 'utf-8')
   writeFileSync(join(managedHomePath, 'auth.json'), auth, 'utf-8')
   return managedHomePath
+}
+
+function createCodexAccountRecord(
+  id: string,
+  email: string,
+  providerAccountId: string,
+  managedHomePath: string
+): CodexManagedAccount {
+  return {
+    id,
+    email,
+    managedHomePath,
+    providerAccountId,
+    workspaceLabel: null,
+    workspaceAccountId: providerAccountId,
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1
+  }
 }
 
 function encodeJwtPart(value: Record<string, unknown>): string {
@@ -657,6 +676,217 @@ describe('CodexRuntimeHomeService', () => {
 
     expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(managedAuth)
     expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
+  })
+
+  it('keeps runtime auth the selected account still owns when provenance is unreadable', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    const managedAuth = createCodexAuthJson('user@example.com', 'acct-user', 'managed')
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    // Cold start: the mirror holds the selected account's own credential, but a
+    // torn provenance file can no longer say so and its auth.json reads torn.
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, managedAuth, 'utf-8')
+    writeFileSync(getSharedRuntimeAuthProvenancePath(), 'not-json', 'utf-8')
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"tokens":{"acc', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-1', 'user@example.com', 'acct-user', managedHomePath)
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(managedAuth)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
+  })
+
+  it('never launches another account on a cold start with no provenance record', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a')
+    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    // Pre-provenance install: the mirror still holds account A, settings already
+    // select account B, and nothing on disk records who wrote those bytes.
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, authA, 'utf-8')
+    rmSync(getSharedRuntimeAuthProvenancePath(), { force: true })
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-a', 'a@example.com', 'acct-a', homeA),
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+    expect(existsSync(runtimeAuthPath) ? readFileSync(runtimeAuthPath, 'utf-8') : null).not.toBe(
+      authA
+    )
+    expect(readFileSync(join(homeA, 'auth.json'), 'utf-8')).toBe(authA)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-b')
+  })
+
+  it('persists a mirror-only system-default refresh before dropping unproven runtime auth', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system', 1)
+    const systemAuthRefreshed = createCodexAuthJson(
+      'system@example.com',
+      'acct-system',
+      'system-refreshed',
+      2
+    )
+    writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    // Codex rotated the system-default credential inside the mirror; ~/.codex is
+    // still the older copy Orca mirrored, so the refresh lives only here.
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, systemAuthRefreshed, 'utf-8')
+    writeFileSync(
+      getSharedRuntimeAuthProvenancePath(),
+      `${JSON.stringify({ owner: 'system-default', authJson: systemAuth })}\n`,
+      'utf-8'
+    )
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuthRefreshed)
+    expect(existsSync(runtimeAuthPath)).toBe(false)
+  })
+
+  it('survives a runtime auth delete the filesystem refuses', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const homeA = createManagedAuth(
+      testState.userDataDir,
+      'account-a',
+      createCodexAuthJson('a@example.com', 'acct-a', 'a')
+    )
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    // Stands in for a Windows AV/EBUSY lock: the mirror auth.json cannot be
+    // removed, and the branch is only reached because reads are already failing.
+    mkdirSync(runtimeAuthPath, { recursive: true })
+    writeFileSync(
+      getSharedRuntimeAuthProvenancePath(),
+      `${JSON.stringify({ owner: 'managed', accountId: 'account-a' })}\n`,
+      'utf-8'
+    )
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-a', 'a@example.com', 'acct-a', homeA),
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(() => service.prepareForCodexLaunch()).not.toThrow()
+    // The bytes survived the failed delete, so they must at least be fenced off.
+    expect(JSON.parse(readFileSync(getSharedRuntimeAuthProvenancePath(), 'utf-8'))).toEqual({
+      owner: 'fenced'
+    })
+    rmSync(runtimeAuthPath, { recursive: true, force: true })
+  })
+
+  it('refuses to read runtime auth back into a duplicate account while a home is unreadable', async () => {
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      return
+    }
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const authX = createCodexAuthJson('x@example.com', 'acct-x', 'x', 1)
+    const authXRefreshed = createCodexAuthJson('x@example.com', 'acct-x', 'x-refreshed', 2)
+    // Two records for the same identity: one home unreadable, one readable.
+    const homeX1 = createManagedAuth(testState.userDataDir, 'account-x1', authX)
+    const homeX2 = createManagedAuth(testState.userDataDir, 'account-x2', authX)
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, authXRefreshed, 'utf-8')
+    writeFileSync(
+      getSharedRuntimeAuthProvenancePath(),
+      `${JSON.stringify({ owner: 'managed', accountId: 'account-x1' })}\n`,
+      'utf-8'
+    )
+    chmodSync(join(homeX1, 'auth.json'), 0o000)
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-x1', 'x@example.com', 'acct-x', homeX1),
+          createCodexAccountRecord('account-x2', 'x@example.com', 'acct-x', homeX2),
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(readFileSync(join(homeX2, 'auth.json'), 'utf-8')).toBe(authX)
   })
 
   it('repoints legacy active host CODEX_HOME to the shared runtime home on startup', async () => {

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -543,6 +543,69 @@ describe('CodexRuntimeHomeService', () => {
     }
   )
 
+  it('preserves the mirrored refresh of the account the runtime home actually holds', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a', 1)
+    const authARefreshed = createCodexAuthJson('a@example.com', 'acct-a', 'a-refreshed', 2)
+    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    // A crash left account A's refreshed tokens in the mirror while settings
+    // already select account B, whose auth.json was never written.
+    writeFileSync(runtimeAuthPath, authARefreshed, 'utf-8')
+    writeFileSync(
+      getSharedRuntimeAuthProvenancePath(),
+      `${JSON.stringify({ owner: 'managed', accountId: 'account-a' })}\n`,
+      'utf-8'
+    )
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-a',
+            email: 'a@example.com',
+            managedHomePath: homeA,
+            providerAccountId: 'acct-a',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-a',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          },
+          {
+            id: 'account-b',
+            email: 'b@example.com',
+            managedHomePath: homeB,
+            providerAccountId: 'acct-b',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-b',
+            createdAt: 2,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2
+          }
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(existsSync(runtimeAuthPath)).toBe(false)
+    expect(readFileSync(join(homeA, 'auth.json'), 'utf-8')).toBe(authARefreshed)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-b')
+  })
+
   it('keeps the runtime auth through the grace window while the selected account rotates', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -467,6 +467,121 @@ describe('CodexRuntimeHomeService', () => {
     expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBeNull()
   })
 
+  it.each([
+    ['missing', (authPath: string) => rmSync(authPath, { force: true })],
+    [
+      'unreadable',
+      (authPath: string) => {
+        chmodSync(authPath, 0o000)
+      }
+    ]
+  ])(
+    'never launches the previously synced account when the selected account auth is %s',
+    async (label, breakAuth) => {
+      if (label === 'unreadable' && (process.platform === 'win32' || process.getuid?.() === 0)) {
+        return
+      }
+      const runtimeAuthPath = getRuntimeCodexAuthPath()
+      const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
+      const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a')
+      const authB = createCodexAuthJson('b@example.com', 'acct-b', 'b')
+      writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
+      const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+      const homeB = createManagedAuth(testState.userDataDir, 'account-b', authB)
+      const store = createStore(
+        createSettings({
+          codexManagedAccounts: [
+            {
+              id: 'account-a',
+              email: 'a@example.com',
+              managedHomePath: homeA,
+              providerAccountId: 'acct-a',
+              workspaceLabel: null,
+              workspaceAccountId: 'acct-a',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'account-b',
+              email: 'b@example.com',
+              managedHomePath: homeB,
+              providerAccountId: 'acct-b',
+              workspaceLabel: null,
+              workspaceAccountId: 'acct-b',
+              createdAt: 2,
+              updatedAt: 2,
+              lastAuthenticatedAt: 2
+            }
+          ],
+          activeCodexManagedAccountId: 'account-a',
+          activeCodexManagedAccountIdsByRuntime: { host: 'account-a', wsl: {} }
+        })
+      )
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+      expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(authA)
+
+      store.updateSettings({
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+      breakAuth(join(homeB, 'auth.json'))
+
+      expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+
+      // The selection survives the grace window, but the launch must never run
+      // as account A while the UI says account B.
+      expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-b')
+      expect(existsSync(runtimeAuthPath) ? readFileSync(runtimeAuthPath, 'utf-8') : null).not.toBe(
+        authA
+      )
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[codex-runtime-home] Active managed account auth.json unavailable while the runtime home holds another account, clearing runtime auth'
+      )
+    }
+  )
+
+  it('keeps the runtime auth through the grace window while the selected account rotates', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system')
+    const managedAuth = createCodexAuthJson('user@example.com', 'acct-user', 'managed')
+    writeFileSync(getSystemCodexAuthPath(), systemAuth, 'utf-8')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'user@example.com',
+            managedHomePath,
+            providerAccountId: 'acct-user',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-user',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(managedAuth)
+
+    // Codex rewrites the selected account's auth.json in place: the runtime home
+    // already holds that same account, so its credentials must survive the race.
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"tokens":{"acc', 'utf-8')
+    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(managedAuth)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
+  })
+
   it('repoints legacy active host CODEX_HOME to the shared runtime home on startup', async () => {
     const legacyLaunchHomePath = join(
       testState.userDataDir,

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -889,6 +889,154 @@ describe('CodexRuntimeHomeService', () => {
     expect(readFileSync(join(homeX2, 'auth.json'), 'utf-8')).toBe(authX)
   })
 
+  it('drops another account from the mirror even when the fence write fails', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a')
+    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    // Stands in for a Windows AV lock on the provenance file: the fence cannot
+    // be written, while auth.json itself is perfectly deletable.
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, authA, 'utf-8')
+    rmSync(getSharedRuntimeAuthProvenancePath(), { force: true })
+    mkdirSync(getSharedRuntimeAuthProvenancePath(), { recursive: true })
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-a', 'a@example.com', 'acct-a', homeA),
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+    expect(existsSync(runtimeAuthPath) ? readFileSync(runtimeAuthPath, 'utf-8') : null).not.toBe(
+      authA
+    )
+  })
+
+  it('keeps a mirrored api-key credential no identity claim can attribute', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const apiKeyAuth = `${JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-managed' })}\n`
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', apiKeyAuth)
+    // Pre-provenance install, cold start: the mirror holds the selected account's
+    // own api-key credential — bytes carrying no id_token to identify — while its
+    // auth.json reads torn mid-rotation.
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, apiKeyAuth, 'utf-8')
+    rmSync(getSharedRuntimeAuthProvenancePath(), { force: true })
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"OPENAI_API_K', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-1', 'user@example.com', 'acct-user', managedHomePath)
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(apiKeyAuth)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
+  })
+
+  it('reads a renamed account refresh back into its own home despite a stale record email', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const authA = createCodexAuthJson('new@example.com', 'acct-a', 'a', 1)
+    const authARefreshed = createCodexAuthJson('new@example.com', 'acct-a', 'a-refreshed', 2)
+    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+    const homeB = createManagedAuth(
+      testState.userDataDir,
+      'account-b',
+      createCodexAuthJson('b@example.com', 'acct-b', 'b')
+    )
+    // Account A was renamed on the ChatGPT side after it was added, so its record
+    // email is stale while the mirrored refresh carries the new one.
+    writeFileSync(runtimeAuthPath, authARefreshed, 'utf-8')
+    writeFileSync(
+      getSharedRuntimeAuthProvenancePath(),
+      `${JSON.stringify({ owner: 'managed', accountId: 'account-a' })}\n`,
+      'utf-8'
+    )
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-a', 'old@example.com', 'acct-a', homeA),
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(readFileSync(join(homeA, 'auth.json'), 'utf-8')).toBe(authARefreshed)
+    expect(existsSync(runtimeAuthPath)).toBe(false)
+  })
+
+  it('keeps the mirror of a renamed account whose record email is stale', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const renamedAuth = createCodexAuthJson('new@example.com', 'acct-user', 'managed')
+    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', renamedAuth)
+    // Torn provenance can no longer vouch for the mirror, and the only remaining
+    // evidence is a credential whose email no longer matches the record.
+    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
+    writeFileSync(runtimeAuthPath, renamedAuth, 'utf-8')
+    writeFileSync(getSharedRuntimeAuthProvenancePath(), 'not-json', 'utf-8')
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"tokens":{"acc', 'utf-8')
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-1', 'old@example.com', 'acct-user', managedHomePath)
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    new CodexRuntimeHomeService(store as never)
+
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(renamedAuth)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
+  })
+
   it('repoints legacy active host CODEX_HOME to the shared runtime home on startup', async () => {
     const legacyLaunchHomePath = join(
       testState.userDataDir,

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -543,68 +543,82 @@ describe('CodexRuntimeHomeService', () => {
     }
   )
 
-  it('preserves the mirrored refresh of the account the runtime home actually holds', async () => {
-    const runtimeAuthPath = getRuntimeCodexAuthPath()
-    writeFileSync(
-      getSystemCodexAuthPath(),
-      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
-      'utf-8'
-    )
-    const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a', 1)
-    const authARefreshed = createCodexAuthJson('a@example.com', 'acct-a', 'a-refreshed', 2)
-    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
-    const homeB = createManagedAuth(
-      testState.userDataDir,
-      'account-b',
-      createCodexAuthJson('b@example.com', 'acct-b', 'b')
-    )
-    // A crash left account A's refreshed tokens in the mirror while settings
-    // already select account B, whose auth.json was never written.
-    writeFileSync(runtimeAuthPath, authARefreshed, 'utf-8')
-    writeFileSync(
-      getSharedRuntimeAuthProvenancePath(),
-      `${JSON.stringify({ owner: 'managed', accountId: 'account-a' })}\n`,
-      'utf-8'
-    )
-    rmSync(join(homeB, 'auth.json'), { force: true })
-    const store = createStore(
-      createSettings({
-        codexManagedAccounts: [
-          {
-            id: 'account-a',
-            email: 'a@example.com',
-            managedHomePath: homeA,
-            providerAccountId: 'acct-a',
-            workspaceLabel: null,
-            workspaceAccountId: 'acct-a',
-            createdAt: 1,
-            updatedAt: 1,
-            lastAuthenticatedAt: 1
-          },
-          {
-            id: 'account-b',
-            email: 'b@example.com',
-            managedHomePath: homeB,
-            providerAccountId: 'acct-b',
-            workspaceLabel: null,
-            workspaceAccountId: 'acct-b',
-            createdAt: 2,
-            updatedAt: 2,
-            lastAuthenticatedAt: 2
-          }
-        ],
-        activeCodexManagedAccountId: 'account-b',
-        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
-      })
-    )
-    vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-    new CodexRuntimeHomeService(store as never)
+  it.each([
+    ['missing', (authPath: string) => rmSync(authPath, { force: true })],
+    [
+      'unreadable',
+      (authPath: string) => {
+        chmodSync(authPath, 0o000)
+      }
+    ]
+  ])(
+    'preserves the mirrored refresh of the account the runtime home actually holds when the selected account auth is %s',
+    async (label, breakAuth) => {
+      if (label === 'unreadable' && (process.platform === 'win32' || process.getuid?.() === 0)) {
+        return
+      }
+      const runtimeAuthPath = getRuntimeCodexAuthPath()
+      writeFileSync(
+        getSystemCodexAuthPath(),
+        createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+        'utf-8'
+      )
+      const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a', 1)
+      const authARefreshed = createCodexAuthJson('a@example.com', 'acct-a', 'a-refreshed', 2)
+      const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+      const homeB = createManagedAuth(
+        testState.userDataDir,
+        'account-b',
+        createCodexAuthJson('b@example.com', 'acct-b', 'b')
+      )
+      // A crash left account A's refreshed tokens in the mirror while settings
+      // already select account B, whose own auth.json cannot be read.
+      writeFileSync(runtimeAuthPath, authARefreshed, 'utf-8')
+      writeFileSync(
+        getSharedRuntimeAuthProvenancePath(),
+        `${JSON.stringify({ owner: 'managed', accountId: 'account-a' })}\n`,
+        'utf-8'
+      )
+      breakAuth(join(homeB, 'auth.json'))
+      const store = createStore(
+        createSettings({
+          codexManagedAccounts: [
+            {
+              id: 'account-a',
+              email: 'a@example.com',
+              managedHomePath: homeA,
+              providerAccountId: 'acct-a',
+              workspaceLabel: null,
+              workspaceAccountId: 'acct-a',
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            },
+            {
+              id: 'account-b',
+              email: 'b@example.com',
+              managedHomePath: homeB,
+              providerAccountId: 'acct-b',
+              workspaceLabel: null,
+              workspaceAccountId: 'acct-b',
+              createdAt: 2,
+              updatedAt: 2,
+              lastAuthenticatedAt: 2
+            }
+          ],
+          activeCodexManagedAccountId: 'account-b',
+          activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+        })
+      )
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      new CodexRuntimeHomeService(store as never)
 
-    expect(existsSync(runtimeAuthPath)).toBe(false)
-    expect(readFileSync(join(homeA, 'auth.json'), 'utf-8')).toBe(authARefreshed)
-    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-b')
-  })
+      expect(existsSync(runtimeAuthPath)).toBe(false)
+      expect(readFileSync(join(homeA, 'auth.json'), 'utf-8')).toBe(authARefreshed)
+      expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-b')
+    }
+  )
 
   it('keeps the runtime auth through the grace window while the selected account rotates', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -949,6 +949,11 @@ export class CodexRuntimeHomeService {
   // identity's credentials behind for the launch. Logged out beats logged in as
   // someone else, and fencing stops later syncs adopting the removed bytes.
   private clearRuntimeAuthForUnprovenSelection(): void {
+    // Why: a refresh Codex wrote into the mirror belongs to whoever owns those
+    // bytes; persist it to that account's home before dropping them.
+    this.readBackRefreshedTokensFromPath(this.getRuntimeAuthPath(), {
+      updateLastWrittenAuthJson: false
+    })
     rmSync(this.getRuntimeAuthPath(), { force: true })
     this.lastWrittenAuthJson = null
     this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -1281,7 +1281,15 @@ export class CodexRuntimeHomeService {
       if (!existsSync(managedAuthPath)) {
         continue
       }
-      const managedAuthContents = readFileSync(managedAuthPath, 'utf-8')
+      let managedAuthContents: string
+      try {
+        managedAuthContents = readFileSync(managedAuthPath, 'utf-8')
+      } catch {
+        // Why: an unreadable home can never be the match, but letting the read
+        // throw abandons the scan for every other account — dropping a refresh
+        // the runtime home holds for one of them.
+        continue
+      }
       if (codexAuthMatchesManagedAccount(runtimeAuthContents, account, managedAuthContents)) {
         matches.push({ account, managedAuthPath, managedAuthContents })
       }

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -72,6 +72,7 @@ import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-pa
 import { invalidateCodexSessionBackfillMarker } from '../codex/codex-session-backfill-marker'
 import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
 import {
+  codexAuthCouldBelongToManagedAccount,
   codexAuthIsFresher,
   codexAuthMatchesManagedAccount,
   codexAuthMatchesSystemDefaultIdentity
@@ -741,7 +742,7 @@ export class CodexRuntimeHomeService {
     const authAbsence = this.credentialAbsenceGrace.assess(activeAuthPath)
     if (authAbsence.state !== 'present' && authAbsence.state !== 'incomplete') {
       if (!authAbsence.durable) {
-        if (this.sharedRuntimeAuthBelongsToAccount(activeAccount.id)) {
+        if (this.sharedRuntimeAuthBelongsToAccount(activeAccount)) {
           // Why: mid-rotation reads look missing/unreadable for a moment; skip
           // this sync without deselecting and let a settled read decide later.
           console.warn(
@@ -931,32 +932,106 @@ export class CodexRuntimeHomeService {
   }
 
   // Why: an unreadable managed auth.json says nothing about who the shared
-  // runtime home currently holds, so only Orca's own provenance can prove those
-  // bytes belong to the selected account. Pre-provenance installs have no record
-  // to consult and fall back to the in-memory sync state.
-  private sharedRuntimeAuthBelongsToAccount(accountId: string): boolean {
+  // runtime home currently holds. The credential's own identity claims answer
+  // that without touching the unreadable home; Orca's write records and its
+  // provenance file are corroboration, not the only evidence — a torn or fenced
+  // provenance file is no proof the bytes belong to somebody else.
+  private sharedRuntimeAuthBelongsToAccount(account: CodexManagedAccount): boolean {
     if (!existsSync(this.getRuntimeAuthPath())) {
       return true
     }
-    const status = this.resolveSharedRuntimeAuthProvenanceStatus()
-    if (status.kind === 'committed') {
-      return status.provenance.owner === 'managed' && status.provenance.accountId === accountId
+    const runtimeAuth = this.readRuntimeAuthForProvenance()
+    if (runtimeAuth !== null) {
+      if (codexAuthMatchesManagedAccount(runtimeAuth, account, null)) {
+        return true
+      }
+      // Why: Orca itself mirrored these exact bytes for this account this run.
+      if (this.lastSyncedAccountId === account.id && this.lastWrittenAuthJson === runtimeAuth) {
+        return true
+      }
     }
-    return status.kind === 'missing' && this.lastSyncedAccountId === accountId
+    const status = this.resolveSharedRuntimeAuthProvenanceStatus()
+    return (
+      status.kind === 'committed' &&
+      status.provenance.owner === 'managed' &&
+      status.provenance.accountId === account.id
+    )
   }
 
   // Why: the absence may still heal, so keep the selection — but leave no other
   // identity's credentials behind for the launch. Logged out beats logged in as
   // someone else, and fencing stops later syncs adopting the removed bytes.
   private clearRuntimeAuthForUnprovenSelection(): void {
-    // Why: a refresh Codex wrote into the mirror belongs to whoever owns those
-    // bytes; persist it to that account's home before dropping them.
-    this.readBackRefreshedTokensFromPath(this.getRuntimeAuthPath(), {
-      updateLastWrittenAuthJson: false
-    })
-    rmSync(this.getRuntimeAuthPath(), { force: true })
-    this.lastWrittenAuthJson = null
-    this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
+    const runtimeAuthPath = this.getRuntimeAuthPath()
+    try {
+      // Why: a refresh Codex wrote into the mirror belongs to whoever owns those
+      // bytes; persist it to that owner's home — managed or ~/.codex — first.
+      const readBackResult = this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
+        updateLastWrittenAuthJson: false
+      })
+      if (readBackResult === 'rejected') {
+        this.readBackRefreshedSystemDefaultAuth()
+      }
+      // Why: fence before deleting so a delete the OS refuses (Windows AV lock,
+      // EBUSY) still leaves the surviving bytes marked untrusted.
+      this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
+      this.lastWrittenAuthJson = null
+      rmSync(runtimeAuthPath, { force: true })
+    } catch (error) {
+      // Why: this branch only runs because the filesystem already refused a
+      // read; a second failure must not throw out of launch preparation.
+      console.warn('[codex-runtime-home] Failed to clear unproven runtime auth:', error)
+    }
+  }
+
+  // Why: a token Codex refreshed inside the mirror has no managed home to fall
+  // back to when the mirror holds the user's own ~/.codex credential, so persist
+  // it there before the unproven mirror is dropped.
+  private readBackRefreshedSystemDefaultAuth(): void {
+    const runtimeAuth = this.readRuntimeAuthForProvenance()
+    const systemDefaultAuth = this.readSystemDefaultAuth()
+    if (runtimeAuth === null || systemDefaultAuth === null || runtimeAuth === systemDefaultAuth) {
+      return
+    }
+    const claim = this.resolveSystemDefaultMirrorClaim(
+      runtimeAuth,
+      this.resolveSharedRuntimeAuthProvenanceStatus()
+    )
+    if (
+      !claim.ownershipProven ||
+      claim.mirroredAuthJson === null ||
+      systemDefaultAuth !== claim.mirroredAuthJson ||
+      !this.runtimeAuthMatchesSystemDefaultIdentity(runtimeAuth, systemDefaultAuth)
+    ) {
+      return
+    }
+    this.writeSystemDefaultAuth(runtimeAuth)
+    this.captureSystemDefaultSnapshot({ force: true })
+  }
+
+  // Why: which ~/.codex bytes the mirror was seeded from, and whether the system
+  // default can be proven to own the mirror at all.
+  private resolveSystemDefaultMirrorClaim(
+    runtimeAuth: string,
+    provenanceStatus: CodexSharedRuntimeAuthProvenanceStatus
+  ): { ownershipProven: boolean; mirroredAuthJson: string | null } {
+    const provenance = provenanceStatus.kind === 'committed' ? provenanceStatus.provenance : null
+    const snapshotAuth =
+      this.readSystemDefaultSnapshot(this.getSystemDefaultSnapshotPath())?.authJson ?? null
+    const preProvenanceRuntimeRefreshProven =
+      provenanceStatus.kind === 'missing' &&
+      snapshotAuth !== null &&
+      this.runtimeAuthMatchesSystemDefaultIdentity(runtimeAuth, snapshotAuth) &&
+      codexAuthIsMonotonicallyFresher(runtimeAuth, snapshotAuth)
+    return {
+      ownershipProven: provenance?.owner === 'system-default' || preProvenanceRuntimeRefreshProven,
+      mirroredAuthJson:
+        provenance?.owner === 'system-default'
+          ? provenance.authJson
+          : provenanceStatus.kind === 'missing'
+            ? (this.lastWrittenAuthJson ?? snapshotAuth)
+            : null
+    }
   }
 
   private safeSyncForCurrentSelection(): void {
@@ -1273,6 +1348,7 @@ export class CodexRuntimeHomeService {
       managedAuthPath: string
       managedAuthContents: string
     }[] = []
+    let unreadableHomeCouldOwnRuntimeAuth = false
     for (const account of this.store.getSettings().codexManagedAccounts) {
       if (expectedAccountId && account.id !== expectedAccountId) {
         continue
@@ -1285,9 +1361,16 @@ export class CodexRuntimeHomeService {
       try {
         managedAuthContents = readFileSync(managedAuthPath, 'utf-8')
       } catch {
-        // Why: an unreadable home can never be the match, but letting the read
+        // Why: an unreadable home can never be compared, but letting the read
         // throw abandons the scan for every other account — dropping a refresh
-        // the runtime home holds for one of them.
+        // the runtime home holds for one of them. Only its record can rule it
+        // out as the owner; when it cannot, the scan is no longer unambiguous.
+        if (
+          !expectedAccountId &&
+          codexAuthCouldBelongToManagedAccount(runtimeAuthContents, account)
+        ) {
+          unreadableHomeCouldOwnRuntimeAuth = true
+        }
         continue
       }
       if (codexAuthMatchesManagedAccount(runtimeAuthContents, account, managedAuthContents)) {
@@ -1295,6 +1378,9 @@ export class CodexRuntimeHomeService {
       }
     }
 
+    if (unreadableHomeCouldOwnRuntimeAuth) {
+      return { kind: 'ambiguous' }
+    }
     if (matches.length === 1) {
       return { kind: 'matched', ...matches[0] }
     }
@@ -1699,21 +1785,10 @@ export class CodexRuntimeHomeService {
         })
         return
       }
-      const snapshot = this.readSystemDefaultSnapshot(this.getSystemDefaultSnapshotPath())
-      const snapshotAuth = snapshot?.authJson ?? null
-      const preProvenanceRuntimeRefreshProven =
-        provenanceStatus.kind === 'missing' &&
-        snapshotAuth !== null &&
-        this.runtimeAuthMatchesSystemDefaultIdentity(runtimeAuth, snapshotAuth) &&
-        codexAuthIsMonotonicallyFresher(runtimeAuth, snapshotAuth)
-      const systemDefaultOwnershipProven =
-        provenance?.owner === 'system-default' || preProvenanceRuntimeRefreshProven
-      const mirroredSystemDefaultAuth =
-        provenance?.owner === 'system-default'
-          ? provenance.authJson
-          : provenanceStatus.kind === 'missing'
-            ? (this.lastWrittenAuthJson ?? snapshotAuth)
-            : null
+      const {
+        ownershipProven: systemDefaultOwnershipProven,
+        mirroredAuthJson: mirroredSystemDefaultAuth
+      } = this.resolveSystemDefaultMirrorClaim(runtimeAuth, provenanceStatus)
       if (!existsSync(systemDefaultAuthPath)) {
         if (mirroredSystemDefaultAuth !== null && runtimeAuth === mirroredSystemDefaultAuth) {
           this.clearRuntimeAuthAfterSystemDefaultLogout(runtimeAuthPath)

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -951,11 +951,13 @@ export class CodexRuntimeHomeService {
       }
     }
     const status = this.resolveSharedRuntimeAuthProvenanceStatus()
-    return (
-      status.kind === 'committed' &&
-      status.provenance.owner === 'managed' &&
-      status.provenance.accountId === account.id
-    )
+    if (status.kind === 'committed') {
+      return status.provenance.owner === 'managed' && status.provenance.accountId === account.id
+    }
+    // Why: with no committed record left, only claims that contradict this
+    // account prove the mirror is somebody else's. Deleting bytes nothing can
+    // attribute logs the user out over the very absence the grace window covers.
+    return runtimeAuth !== null && codexAuthCouldBelongToManagedAccount(runtimeAuth, account)
   }
 
   // Why: the absence may still heal, so keep the selection — but leave no other
@@ -964,19 +966,24 @@ export class CodexRuntimeHomeService {
   private clearRuntimeAuthForUnprovenSelection(): void {
     const runtimeAuthPath = this.getRuntimeAuthPath()
     try {
-      // Why: a refresh Codex wrote into the mirror belongs to whoever owns those
-      // bytes; persist it to that owner's home — managed or ~/.codex — first.
-      const readBackResult = this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
-        updateLastWrittenAuthJson: false
-      })
-      if (readBackResult === 'rejected') {
-        this.readBackRefreshedSystemDefaultAuth()
+      try {
+        // Why: a refresh Codex wrote into the mirror belongs to whoever owns
+        // those bytes; persist it to that owner's home — managed or ~/.codex —
+        // first, then fence so a delete the OS refuses (Windows AV lock, EBUSY)
+        // still leaves the surviving bytes marked untrusted.
+        const readBackResult = this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
+          updateLastWrittenAuthJson: false
+        })
+        if (readBackResult === 'rejected') {
+          this.readBackRefreshedSystemDefaultAuth()
+        }
+        this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
+      } finally {
+        // Why: neither the rescue nor the fence may cancel the delete — leaving
+        // another identity's credentials for the launch is the defect itself.
+        this.lastWrittenAuthJson = null
+        rmSync(runtimeAuthPath, { force: true })
       }
-      // Why: fence before deleting so a delete the OS refuses (Windows AV lock,
-      // EBUSY) still leaves the surviving bytes marked untrusted.
-      this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
-      this.lastWrittenAuthJson = null
-      rmSync(runtimeAuthPath, { force: true })
     } catch (error) {
       // Why: this branch only runs because the filesystem already refused a
       // read; a second failure must not throw out of launch preparation.

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -741,11 +741,21 @@ export class CodexRuntimeHomeService {
     const authAbsence = this.credentialAbsenceGrace.assess(activeAuthPath)
     if (authAbsence.state !== 'present' && authAbsence.state !== 'incomplete') {
       if (!authAbsence.durable) {
-        // Why: mid-rotation reads look missing/unreadable for a moment; skip
-        // this sync without deselecting and let a settled read decide later.
+        if (this.sharedRuntimeAuthBelongsToAccount(activeAccount.id)) {
+          // Why: mid-rotation reads look missing/unreadable for a moment; skip
+          // this sync without deselecting and let a settled read decide later.
+          console.warn(
+            '[codex-runtime-home] Active managed account auth.json unavailable, keeping selection through grace window'
+          )
+          return
+        }
+        // Why: the runtime home still holds another account, so riding out the
+        // grace would launch that account under this selection. Not being able
+        // to read the selected account is no license to run a different one.
         console.warn(
-          '[codex-runtime-home] Active managed account auth.json unavailable, keeping selection through grace window'
+          '[codex-runtime-home] Active managed account auth.json unavailable while the runtime home holds another account, clearing runtime auth'
         )
+        this.clearRuntimeAuthForUnprovenSelection()
         return
       }
       console.warn(
@@ -918,6 +928,30 @@ export class CodexRuntimeHomeService {
       console.warn('[codex-runtime-home] Failed to recover missing managed auth:', error)
       return 'rejected'
     }
+  }
+
+  // Why: an unreadable managed auth.json says nothing about who the shared
+  // runtime home currently holds, so only Orca's own provenance can prove those
+  // bytes belong to the selected account. Pre-provenance installs have no record
+  // to consult and fall back to the in-memory sync state.
+  private sharedRuntimeAuthBelongsToAccount(accountId: string): boolean {
+    if (!existsSync(this.getRuntimeAuthPath())) {
+      return true
+    }
+    const status = this.resolveSharedRuntimeAuthProvenanceStatus()
+    if (status.kind === 'committed') {
+      return status.provenance.owner === 'managed' && status.provenance.accountId === accountId
+    }
+    return status.kind === 'missing' && this.lastSyncedAccountId === accountId
+  }
+
+  // Why: the absence may still heal, so keep the selection — but leave no other
+  // identity's credentials behind for the launch. Logged out beats logged in as
+  // someone else, and fencing stops later syncs adopting the removed bytes.
+  private clearRuntimeAuthForUnprovenSelection(): void {
+    rmSync(this.getRuntimeAuthPath(), { force: true })
+    this.lastWrittenAuthJson = null
+    this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
   }
 
   private safeSyncForCurrentSelection(): void {


### PR DESCRIPTION
## Defect

`CodexRuntimeHomeService.syncForCurrentSelection` treats a missing/unreadable managed `auth.json` as "not settled yet" and returns early to protect the selection from a rotation race. In the shared runtime-home lane that early return leaves the runtime home exactly as it was — holding the **previously synced account's** credentials — and `prepareForCodexLaunch` then hands that home to the launch.

The credential-absence grace window therefore answered "I can't read account B" with "then run as account A".

## Failure scenario

1. Account A is selected and synced; the shared runtime home holds A's `auth.json`.
2. The user switches to account B. B's `auth.json` cannot be read — home on a disconnected network drive, never provisioned, removed, or held under an `EPERM`/`EACCES` lock by Windows AV.
3. `syncForCurrentSelection` sees `missing`/`unreadable`, the absence is inside the grace window, and it returns without touching the runtime home.
4. Settings (and the account picker) show **B**. Codex launches with the runtime home still containing **A**'s credentials.

Result: wrong quota, wrong identity, work attributed to the wrong account — silently. The readiness gate in `resolveCodexHomeAfterManagedAuthReadiness` cannot catch this, because the shared runtime home is not one of the managed account homes it inspects, so `isCodexHomeAuthReadyForLaunch` reports it ready regardless of whose credentials are inside.

## Fix

Absence of evidence about B is not evidence for A. The grace window now short-circuits **only when Orca can prove the runtime home already holds the selected account** — via the shared-runtime-auth provenance record, falling back to the in-memory `lastSyncedAccountId` on pre-provenance installs that have no record to consult.

When it cannot prove that, the runtime auth is removed and the provenance is fenced:

- the selection survives (the absence may still heal, and a settled read decides later, exactly as before);
- the launch is **logged out rather than logged in as someone else**;
- a warning is logged naming the condition.

Before removing them, the mirrored bytes are read back to whichever managed account owns them (identity + freshness proven, the same helper an account switch uses). On a cold start whose mirror still holds the previous account, no outgoing read-back has run yet, so a token refresh Codex wrote there exists nowhere else — with refresh-token rotation, dropping it would force that account to log in again.

The durable path (absence outliving the grace window → deselect + restore the system default) is unchanged, as is the legitimate case this window was built for: when Codex rewrites the *selected* account's `auth.json` in place, provenance proves the runtime home is already that account, so its credentials survive the race untouched.

## Verification

- New `runtime-home-service.test.ts` cases: with A synced and B selected, `prepareForCodexLaunch()` must not leave A's credentials in the runtime home — parameterized over ENOENT (`auth.json` removed) and EACCES/EPERM (`chmod 000`, skipped on Windows/root).
- New cold-start case: the mirror holds account A's *refreshed* tokens with provenance `managed/account-a` while settings already select B (whose `auth.json` was never written) — the refresh lands in A's managed home and the mirror is cleared.
- New still-settling case: torn mid-write `auth.json` for the *selected* account keeps the runtime credentials and the selection through the grace window.
- `codex-credential-absence-grace.test.ts`: a permission-denied read stays transient inside the window and turns durable after it.
- `managed-codex-auth-readiness.test.ts`: `readStoredCodexCredentialState` separates `missing` (ENOENT) from `unreadable` (permission denied).
- Reverted `runtime-home-service.ts` to `origin/main` and confirmed all three new wrong-account cases fail (`expected A's auth not to be A's auth`), then restored it and confirmed they pass.
- `npx vitest run --config config/vitest.config.ts src/main/codex-accounts/` → 13 files, 285 tests passing.
- `npx tsc --noEmit -p config/tsconfig.node.json` clean; `oxlint` (default + code-quality-native) clean; max-lines ratchet clean (no new suppressions).

Platform notes: no platform-specific behavior added; the EACCES tests self-skip on Windows and as root. The WSL and self-contained per-account-home lanes are untouched (they launch under the account's own home, so they never carry another account's credentials).

