### PR TITLE
test(e2e): pick the board marquee start point from live geometry

### DIFF
--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -374,33 +374,43 @@ test.describe('Workspace board lane virtualization', () => {
       `[data-workspace-status="${emptyStatusId}"] [data-workspace-board-lane-scroll]`
     )
     const box = await laneScroll.boundingBox()
-    const emptyBox = await emptyLaneScroll.boundingBox()
-    if (!box || !emptyBox) {
-      throw new Error('Expected the marquee and empty start lanes to have bounding boxes')
+    if (!box) {
+      throw new Error('Expected the marquee lane to have a bounding box')
     }
 
-    // Why: the sidebar seam overlaps the board edge on CI, so start in a dedicated empty lane.
-    const startX = Math.round(emptyBox.x + Math.min(24, emptyBox.width / 4))
-    const startY = Math.round(box.y + 12)
-    const startTarget = await orcaPage.evaluate(
-      ({ x, y }) => {
-        const element = document.elementFromPoint(x, y)
-        return {
-          onSurface: Boolean(element?.closest('[data-workspace-board-selection-surface]')),
-          onIgnoredTarget: Boolean(
-            element?.closest('[data-workspace-board-card-id], a, button, input, [role="button"]')
-          )
+    // Why: CI can overlay individual lane pixels, so choose a live board-owned point.
+    const startPoint = await emptyLaneScroll.evaluate((element) => {
+      const ignored = [
+        '[data-workspace-board-card-id]',
+        'a',
+        'button',
+        'input',
+        'select',
+        'textarea',
+        '[role="button"]',
+        '[role="menu"]',
+        '[role="menuitem"]'
+      ].join(',')
+      const rect = element.getBoundingClientRect()
+      for (let y = Math.ceil(rect.top) + 6; y <= Math.floor(rect.top) + 40; y += 6) {
+        for (let x = Math.ceil(rect.left) + 8; x <= Math.floor(rect.right) - 8; x += 8) {
+          const target = document.elementFromPoint(x, y)
+          if (
+            target?.closest('[data-workspace-board-selection-surface]') &&
+            !target.closest(ignored)
+          ) {
+            return { x, y }
+          }
         }
-      },
-      { x: startX, y: startY }
-    )
-    expect(
-      startTarget,
-      `marquee start point (${startX}, ${startY}) must be empty board space; ` +
-        `emptyLane=${JSON.stringify(emptyBox)}`
-    ).toEqual({ onSurface: true, onIgnoredTarget: false })
+      }
+      return null
+    })
+    expect(startPoint, 'the empty start lane must expose board-owned space').not.toBeNull()
+    if (!startPoint) {
+      throw new Error('Expected empty board space for the marquee start')
+    }
 
-    await orcaPage.mouse.move(startX, startY)
+    await orcaPage.mouse.move(startPoint.x, startPoint.y)
     await orcaPage.mouse.down()
     await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80, { steps: 4 })
 

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -373,28 +373,85 @@ test.describe('Workspace board lane virtualization', () => {
       throw new Error('Expected the marquee lane and selection surface to have bounding boxes')
     }
 
-    await orcaPage.mouse.move(selectionBox.x + 4, box.y + 12)
+    // Why: the marquee may only start on empty board space — the board ignores a
+    // pointerdown on a card, and one that misses the board entirely never reaches
+    // its handler at all, so the browser text-selects instead and no marquee runs.
+    // The usable strip is the board's padding between its own left edge and the
+    // first lane's cards; starting a fixed 4px inside it hugs that outer edge and
+    // falls off it whenever layout rounds differently. Aim at the middle instead.
+    const firstCardBox = await laneCards.first().boundingBox()
+    if (!firstCardBox) {
+      throw new Error('Expected the first marquee card to have a bounding box')
+    }
+    const startX = Math.round((selectionBox.x + firstCardBox.x) / 2)
+    const startY = Math.round(box.y + 12)
+    const startTarget = await orcaPage.evaluate(
+      ({ x, y }) => {
+        const element = document.elementFromPoint(x, y)
+        return {
+          onSurface: Boolean(element?.closest('[data-workspace-board-selection-surface]')),
+          onIgnoredTarget: Boolean(
+            element?.closest('[data-workspace-board-card-id], a, button, input, [role="button"]')
+          )
+        }
+      },
+      { x: startX, y: startY }
+    )
+    expect(
+      startTarget,
+      `marquee start point (${startX}, ${startY}) must be empty board space; ` +
+        `selectionBox.x=${selectionBox.x} firstCard.x=${firstCardBox.x}`
+    ).toEqual({ onSurface: true, onIgnoredTarget: false })
+
+    await orcaPage.mouse.move(startX, startY)
     await orcaPage.mouse.down()
     await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80, { steps: 4 })
+
+    // Why: proves the board accepted the gesture. Without it a rejected
+    // pointerdown only shows up 15s later as "0 cards previewed", which reads as
+    // a virtualization bug rather than a marquee that never started.
+    await expect(orcaPage.locator('[data-workspace-board-selection-rect]')).toBeVisible()
     await expect
       .poll(() => lane.locator('[data-workspace-board-card-area-selected="true"]').count(), {
         timeout: 15_000
       })
       .toBeGreaterThan(0)
-    await laneScroll.evaluate(async (element) => {
-      for (let pass = 0; pass < 4; pass++) {
+    // Why: a measured card is much taller than the lane's row estimate, so each
+    // jump to the bottom re-measures the window and grows the spacer past the
+    // scrollTop the jump just landed on. A fixed pass budget commits the marquee
+    // mid-growth on a loaded machine — short of the last cards — so jump until
+    // the virtualizer stops moving the bottom instead.
+    const laneScrollSettle = await laneScroll.evaluate(async (element) => {
+      let settledPasses = 0
+      let passes = 0
+      while (settledPasses < 2 && passes < 40) {
+        passes += 1
         element.scrollTop = element.scrollHeight
         element.dispatchEvent(new Event('scroll', { bubbles: true }))
         await new Promise<void>((resolve) => {
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
         })
+        const maxScrollTop = element.scrollHeight - element.clientHeight
+        settledPasses = element.scrollTop >= maxScrollTop - 1 ? settledPasses + 1 : 0
+      }
+      return {
+        passes,
+        scrollTop: element.scrollTop,
+        maxScrollTop: element.scrollHeight - element.clientHeight
       }
     })
+    expect(
+      laneScrollSettle.scrollTop,
+      `lane scroll never settled at its bottom: ${JSON.stringify(laneScrollSettle)}`
+    ).toBeGreaterThanOrEqual(laneScrollSettle.maxScrollTop - 1)
+
     await orcaPage.mouse.move(box.x + box.width - 18, box.y + box.height - 12)
     await orcaPage.mouse.up()
 
-    await expect(
-      orcaPage.getByText(`${MARQUEE_WORKSPACE_COUNT} selected`, { exact: true })
-    ).toBeVisible()
+    // Why: assert the badge's text, not its presence — a marquee that stopped
+    // short reports the count it did commit instead of a bare locator timeout.
+    await expect(orcaPage.getByText(/^\d+ selected$/)).toHaveText(
+      `${MARQUEE_WORKSPACE_COUNT} selected`
+    )
   })
 })

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
+type MarqueeStartPoint = { x: number; y: number } | null
+type MarqueeStartProbe = {
+  point: MarqueeStartPoint
+  geometry: { surfaceLeft: number; laneScrollTop: number; cardLeft: number } | null
+  blockers: string[]
+}
+
 const SEEDED_WORKSPACE_COUNT = 300
 const MARQUEE_WORKSPACE_COUNT = 102
 const MANY_LANE_COUNT = 21
@@ -366,44 +373,123 @@ test.describe('Workspace board lane virtualization', () => {
     const laneCards = lane.locator('[data-workspace-board-card-id]')
     await expect.poll(() => laneCards.count(), { timeout: 15_000 }).toBeGreaterThan(3)
     const laneScroll = lane.locator('[data-workspace-board-lane-scroll]')
-    const selectionSurface = orcaPage.locator('[data-workspace-board-selection-surface]')
-    const box = await laneScroll.boundingBox()
-    const selectionBox = await selectionSurface.boundingBox()
-    if (!box || !selectionBox) {
-      throw new Error('Expected the marquee lane and selection surface to have bounding boxes')
-    }
 
-    // Why: the marquee may only start on empty board space — the board ignores a
-    // pointerdown on a card, and one that misses the board entirely never reaches
-    // its handler at all, so the browser text-selects instead and no marquee runs.
-    // The usable strip is the board's padding between its own left edge and the
-    // first lane's cards; starting a fixed 4px inside it hugs that outer edge and
-    // falls off it whenever layout rounds differently. Aim at the middle instead.
-    const firstCardBox = await laneCards.first().boundingBox()
-    if (!firstCardBox) {
-      throw new Error('Expected the first marquee card to have a bounding box')
-    }
-    const startX = Math.round((selectionBox.x + firstCardBox.x) / 2)
-    const startY = Math.round(box.y + 12)
-    const startTarget = await orcaPage.evaluate(
-      ({ x, y }) => {
-        const element = document.elementFromPoint(x, y)
-        return {
-          onSurface: Boolean(element?.closest('[data-workspace-board-selection-surface]')),
-          onIgnoredTarget: Boolean(
-            element?.closest('[data-workspace-board-card-id], a, button, input, [role="button"]')
-          )
+    // Why: the marquee only starts on empty board space — the board ignores a
+    // pointerdown on a card, and one that lands on anything stacked over the
+    // board never reaches its handler at all, so the browser text-selects and no
+    // marquee runs. A precomputed point cannot be trusted: the strip is a few px
+    // of board padding, and the sheet, sidebar and lane fill all keep resizing it
+    // after the card-count wait. Ask the live DOM which point is actually empty,
+    // scanning the strip between the board's left edge and the first card. The
+    // scan stays in the lane's top rows because the marquee anchors its range in
+    // content space — starting below the first card would exclude it from the 102.
+    const probeMarqueeStart = (): Promise<MarqueeStartProbe> =>
+      orcaPage.evaluate((status) => {
+        const IGNORED = [
+          '[data-workspace-board-card-id]',
+          'a',
+          'button',
+          'input',
+          'select',
+          'textarea',
+          '[role="button"]',
+          '[role="menu"]',
+          '[role="menuitem"]'
+        ].join(',')
+        const surface = document.querySelector<HTMLElement>(
+          '[data-workspace-board-selection-surface]'
+        )
+        const laneElement = document.querySelector<HTMLElement>(
+          `[data-workspace-status="${status}"]`
+        )
+        const scroll = laneElement?.querySelector<HTMLElement>('[data-workspace-board-lane-scroll]')
+        const card = laneElement?.querySelector<HTMLElement>('[data-workspace-board-card-id]')
+        if (!surface || !scroll || !card) {
+          return { point: null, geometry: null, blockers: ['board not mounted'] }
         }
-      },
-      { x: startX, y: startY }
-    )
-    expect(
-      startTarget,
-      `marquee start point (${startX}, ${startY}) must be empty board space; ` +
-        `selectionBox.x=${selectionBox.x} firstCard.x=${firstCardBox.x}`
-    ).toEqual({ onSurface: true, onIgnoredTarget: false })
+        const surfaceRect = surface.getBoundingClientRect()
+        const scrollRect = scroll.getBoundingClientRect()
+        const cardRect = card.getBoundingClientRect()
+        const geometry = {
+          surfaceLeft: Math.round(surfaceRect.left),
+          laneScrollTop: Math.round(scrollRect.top),
+          cardLeft: Math.round(cardRect.left)
+        }
+        const describe = (element: Element | null): string => {
+          if (!element) {
+            return 'null'
+          }
+          const classes =
+            typeof element.className === 'string' && element.className.trim().length > 0
+              ? `.${element.className.trim().split(/\s+/).slice(0, 3).join('.')}`
+              : ''
+          return `${element.tagName.toLowerCase()}${classes}`
+        }
+        const blockers: string[] = []
+        const top = Math.round(scrollRect.top)
+        for (let y = top + 6; y <= top + 40; y += 6) {
+          for (
+            let x = Math.ceil(surfaceRect.left) + 2;
+            x <= Math.floor(cardRect.left) - 2;
+            x += 2
+          ) {
+            const element = document.elementFromPoint(x, y)
+            const onSurface = Boolean(element?.closest('[data-workspace-board-selection-surface]'))
+            const onIgnoredTarget = Boolean(element?.closest(IGNORED))
+            if (onSurface && !onIgnoredTarget) {
+              return { point: { x, y }, geometry, blockers }
+            }
+            if (blockers.length < 6) {
+              blockers.push(
+                `(${x},${y})=${describe(element)}${onSurface ? ' onSurface' : ''}${
+                  onIgnoredTarget ? ' ignored' : ''
+                }`
+              )
+            }
+          }
+        }
+        return { point: null, geometry, blockers }
+      }, statusId)
 
-    await orcaPage.mouse.move(startX, startY)
+    // Why: one empty reading can be a frame mid-relayout. Two consecutive probes
+    // agreeing on the same point is what proves the strip has stopped moving.
+    let marqueeStart: MarqueeStartPoint = null
+    let probe = await probeMarqueeStart()
+    let previousKey = JSON.stringify(probe.point)
+    const probeDeadline = Date.now() + 15_000
+    while (Date.now() < probeDeadline) {
+      await orcaPage.waitForTimeout(100)
+      probe = await probeMarqueeStart()
+      const key = JSON.stringify(probe.point)
+      if (probe.point && key === previousKey) {
+        marqueeStart = probe.point
+        break
+      }
+      previousKey = key
+    }
+
+    // Why: a viewport that leaves the board no empty space is a layout this test
+    // cannot drive at all — report that instead of failing on it.
+    test.skip(
+      marqueeStart === null,
+      `no empty board space for the marquee start; geometry=${JSON.stringify(
+        probe.geometry
+      )} blockers=${probe.blockers.join(' | ')}`
+    )
+    const start = marqueeStart as { x: number; y: number }
+
+    const box = await laneScroll.boundingBox()
+    if (!box) {
+      throw new Error('Expected the marquee lane to have a bounding box')
+    }
+    const preflight = await probeMarqueeStart()
+    expect(
+      preflight.point,
+      `marquee start point (${start.x}, ${start.y}) must still be empty board space; ` +
+        `geometry=${JSON.stringify(preflight.geometry)} blockers=${preflight.blockers.join(' | ')}`
+    ).not.toBeNull()
+
+    await orcaPage.mouse.move(start.x, start.y)
     await orcaPage.mouse.down()
     await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80, { steps: 4 })
 

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -1,13 +1,6 @@
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
-type MarqueeStartPoint = { x: number; y: number } | null
-type MarqueeStartProbe = {
-  point: MarqueeStartPoint
-  geometry: { surfaceLeft: number; laneScrollTop: number; cardLeft: number } | null
-  blockers: string[]
-}
-
 const SEEDED_WORKSPACE_COUNT = 300
 const MARQUEE_WORKSPACE_COUNT = 102
 const MANY_LANE_COUNT = 21
@@ -315,8 +308,9 @@ test.describe('Workspace board lane virtualization', () => {
 
   test('selects the full lane across a single large marquee scroll jump', async ({ orcaPage }) => {
     const statusId = 'virtual-marquee'
+    const emptyStatusId = 'virtual-marquee-start'
     await orcaPage.evaluate(
-      ({ count, status }) => {
+      ({ count, emptyStatus, status }) => {
         const store = window.__store
         if (!store) {
           throw new Error('window.__store is not available')
@@ -360,10 +354,13 @@ test.describe('Workspace board lane virtualization', () => {
         })
         state.setWorkspaceStatuses([
           { id: status, label: 'Virtual marquee' },
-          ...state.workspaceStatuses.filter((entry) => entry.id !== status)
+          { id: emptyStatus, label: 'Marquee start' },
+          ...state.workspaceStatuses.filter(
+            (entry) => entry.id !== status && entry.id !== emptyStatus
+          )
         ])
       },
-      { count: MARQUEE_WORKSPACE_COUNT, status: statusId }
+      { count: MARQUEE_WORKSPACE_COUNT, emptyStatus: emptyStatusId, status: statusId }
     )
 
     await orcaPage.getByRole('button', { name: 'Workspace board' }).click()
@@ -373,123 +370,37 @@ test.describe('Workspace board lane virtualization', () => {
     const laneCards = lane.locator('[data-workspace-board-card-id]')
     await expect.poll(() => laneCards.count(), { timeout: 15_000 }).toBeGreaterThan(3)
     const laneScroll = lane.locator('[data-workspace-board-lane-scroll]')
-
-    // Why: the marquee only starts on empty board space — the board ignores a
-    // pointerdown on a card, and one that lands on anything stacked over the
-    // board never reaches its handler at all, so the browser text-selects and no
-    // marquee runs. A precomputed point cannot be trusted: the strip is a few px
-    // of board padding, and the sheet, sidebar and lane fill all keep resizing it
-    // after the card-count wait. Ask the live DOM which point is actually empty,
-    // scanning the strip between the board's left edge and the first card. The
-    // scan stays in the lane's top rows because the marquee anchors its range in
-    // content space — starting below the first card would exclude it from the 102.
-    const probeMarqueeStart = (): Promise<MarqueeStartProbe> =>
-      orcaPage.evaluate((status) => {
-        const IGNORED = [
-          '[data-workspace-board-card-id]',
-          'a',
-          'button',
-          'input',
-          'select',
-          'textarea',
-          '[role="button"]',
-          '[role="menu"]',
-          '[role="menuitem"]'
-        ].join(',')
-        const surface = document.querySelector<HTMLElement>(
-          '[data-workspace-board-selection-surface]'
-        )
-        const laneElement = document.querySelector<HTMLElement>(
-          `[data-workspace-status="${status}"]`
-        )
-        const scroll = laneElement?.querySelector<HTMLElement>('[data-workspace-board-lane-scroll]')
-        const card = laneElement?.querySelector<HTMLElement>('[data-workspace-board-card-id]')
-        if (!surface || !scroll || !card) {
-          return { point: null, geometry: null, blockers: ['board not mounted'] }
-        }
-        const surfaceRect = surface.getBoundingClientRect()
-        const scrollRect = scroll.getBoundingClientRect()
-        const cardRect = card.getBoundingClientRect()
-        const geometry = {
-          surfaceLeft: Math.round(surfaceRect.left),
-          laneScrollTop: Math.round(scrollRect.top),
-          cardLeft: Math.round(cardRect.left)
-        }
-        const describe = (element: Element | null): string => {
-          if (!element) {
-            return 'null'
-          }
-          const classes =
-            typeof element.className === 'string' && element.className.trim().length > 0
-              ? `.${element.className.trim().split(/\s+/).slice(0, 3).join('.')}`
-              : ''
-          return `${element.tagName.toLowerCase()}${classes}`
-        }
-        const blockers: string[] = []
-        const top = Math.round(scrollRect.top)
-        for (let y = top + 6; y <= top + 40; y += 6) {
-          for (
-            let x = Math.ceil(surfaceRect.left) + 2;
-            x <= Math.floor(cardRect.left) - 2;
-            x += 2
-          ) {
-            const element = document.elementFromPoint(x, y)
-            const onSurface = Boolean(element?.closest('[data-workspace-board-selection-surface]'))
-            const onIgnoredTarget = Boolean(element?.closest(IGNORED))
-            if (onSurface && !onIgnoredTarget) {
-              return { point: { x, y }, geometry, blockers }
-            }
-            if (blockers.length < 6) {
-              blockers.push(
-                `(${x},${y})=${describe(element)}${onSurface ? ' onSurface' : ''}${
-                  onIgnoredTarget ? ' ignored' : ''
-                }`
-              )
-            }
-          }
-        }
-        return { point: null, geometry, blockers }
-      }, statusId)
-
-    // Why: one empty reading can be a frame mid-relayout. Two consecutive probes
-    // agreeing on the same point is what proves the strip has stopped moving.
-    let marqueeStart: MarqueeStartPoint = null
-    let probe = await probeMarqueeStart()
-    let previousKey = JSON.stringify(probe.point)
-    const probeDeadline = Date.now() + 15_000
-    while (Date.now() < probeDeadline) {
-      await orcaPage.waitForTimeout(100)
-      probe = await probeMarqueeStart()
-      const key = JSON.stringify(probe.point)
-      if (probe.point && key === previousKey) {
-        marqueeStart = probe.point
-        break
-      }
-      previousKey = key
-    }
-
-    // Why: a viewport that leaves the board no empty space is a layout this test
-    // cannot drive at all — report that instead of failing on it.
-    test.skip(
-      marqueeStart === null,
-      `no empty board space for the marquee start; geometry=${JSON.stringify(
-        probe.geometry
-      )} blockers=${probe.blockers.join(' | ')}`
+    const emptyLaneScroll = orcaPage.locator(
+      `[data-workspace-status="${emptyStatusId}"] [data-workspace-board-lane-scroll]`
     )
-    const start = marqueeStart as { x: number; y: number }
-
     const box = await laneScroll.boundingBox()
-    if (!box) {
-      throw new Error('Expected the marquee lane to have a bounding box')
+    const emptyBox = await emptyLaneScroll.boundingBox()
+    if (!box || !emptyBox) {
+      throw new Error('Expected the marquee and empty start lanes to have bounding boxes')
     }
-    const preflight = await probeMarqueeStart()
-    expect(
-      preflight.point,
-      `marquee start point (${start.x}, ${start.y}) must still be empty board space; ` +
-        `geometry=${JSON.stringify(preflight.geometry)} blockers=${preflight.blockers.join(' | ')}`
-    ).not.toBeNull()
 
-    await orcaPage.mouse.move(start.x, start.y)
+    // Why: the sidebar seam overlaps the board edge on CI, so start in a dedicated empty lane.
+    const startX = Math.round(emptyBox.x + Math.min(24, emptyBox.width / 4))
+    const startY = Math.round(box.y + 12)
+    const startTarget = await orcaPage.evaluate(
+      ({ x, y }) => {
+        const element = document.elementFromPoint(x, y)
+        return {
+          onSurface: Boolean(element?.closest('[data-workspace-board-selection-surface]')),
+          onIgnoredTarget: Boolean(
+            element?.closest('[data-workspace-board-card-id], a, button, input, [role="button"]')
+          )
+        }
+      },
+      { x: startX, y: startY }
+    )
+    expect(
+      startTarget,
+      `marquee start point (${startX}, ${startY}) must be empty board space; ` +
+        `emptyLane=${JSON.stringify(emptyBox)}`
+    ).toEqual({ onSurface: true, onIgnoredTarget: false })
+
+    await orcaPage.mouse.move(startX, startY)
     await orcaPage.mouse.down()
     await orcaPage.mouse.move(box.x + box.width - 18, box.y + 80, { steps: 4 })
 

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -307,6 +307,7 @@ test.describe('Workspace board lane virtualization', () => {
   })
 
   test('selects the full lane across a single large marquee scroll jump', async ({ orcaPage }) => {
+    test.skip(true, 'Quarantined by https://github.com/stablyai/orca/issues/12415')
     const statusId = 'virtual-marquee'
     const emptyStatusId = 'virtual-marquee-start'
     await orcaPage.evaluate(


### PR DESCRIPTION
## Quarantine status

**This PR now quarantines this one marquee spec; it does not fix the Linux/Xvfb renderer divergence.** Four start-point strategies contradicted the visible CI layout, so https://github.com/stablyai/orca/issues/12415 records the full forensics and restore criteria. The remaining tests in the file stay active, and the scroll-settle/diagnostic improvements are retained for restoration.

## Summary

Deflakes `selects the full lane across a single large marquee scroll jump` in `tests/e2e/workspace-board-lane-virtualization.spec.ts`. It failed the e2e 10-of-10 shard on the v1.4.164 and v1.4.165-rc.0 release runs, and has now failed the `changed e2e specs` job twice more.

Split out of #12390 so the GitLab cache fix there isn't held up by this. **Test-side only — no product change.**

### What the three CI failures actually showed

| round | symptom | what it proved |
| --- | --- | --- |
| 1 | `Received: 0` at the preview poll; screenshot shows **native text selection and no marquee overlay** | the pointerdown was *rejected* — nothing called `preventDefault()`, so no marquee ever started |
| 2 | new guard fired: `start point (290, 195) … onSurface: false, onIgnoredTarget: false` | `elementFromPoint` returned something **outside the board entirely**, despite (290,195) sitting inside the measured 280..299 strip |

Round 1's trace gave the exact press point, `(284, 195)`. An `elementFromPoint` scan across that row shows the marquee's usable strip is only the board's `p-3` padding:

| x | on selection surface | inside a card |
| --- | --- | --- |
| 278–279 | **no** | – |
| 280–298 | yes | no |
| 299+ | yes | **yes** |

The original `selectionBox.x + 4` = 284 sat 4px from the cliff. My first fix aimed at the middle of that strip (290) — but round 2 proves that was still the wrong *shape* of fix: **any point computed before the probe runs can be invalidated before it is used**, because the sheet, the sidebar and the progressive lane fill all keep resizing the strip after the card-count wait. A point being in the strip when measured says nothing about what is stacked over it a moment later.

### Fix

Stop precomputing the point. Read the geometry and scan for an empty point **in the same DOM turn**:

- Walk a grid across the strip between the board's live left edge and the first card's live left edge, over the lane's **top rows only** — the marquee anchors its range in content space, so a start below the first card would drop it from the 102.
- Take the first point **the board itself reports as empty** (`onSurface && !onIgnoredTarget`), rather than asserting a guess is empty.
- Require **two consecutive probes to agree** on the same point, so a frame caught mid-relayout cannot win.
- Keep the precondition guard, now reporting live geometry plus the elements that blocked each rejected point.
- If no empty point exists at all, **`test.skip` with that reason** instead of failing on a layout the test cannot drive.

Also in this PR, from the first attempt (independent fragility, independently reproduced):

- **Lane scroll jumps until the virtualizer stops moving the bottom.** A measured card is 55px against the lane's 36px row estimate, so each `scrollTop = scrollHeight` grows the spacer past the scrollTop the jump landed on. The old fixed 4-pass budget converged on the *final* pass with zero margin (`4207==4207 → 4245<4682 → 4682<4701 → 4701==4701`). A/B with the budget cut to 2 passes reproduces a short commit deterministically (**101 selected**); the settle loop converges at pass 4 and holds (**102**).
- **The final assertion checks the badge's text**, so a short selection reports `Received: 101 selected` rather than a bare locator timeout.

No timeout bumps, no retries, no `waitForTimeout` as a substitute for a condition.

### Honesty about what is and isn't proven

I still could **not** reproduce the CI failure on this machine — CDP CPU throttling at 1×/10×/20× all passed, and `boundingBox()` already waits for a stable box, so there is no geometry drift here to catch. What I did prove, locally and non-vacuously:

- **The grid recovers from the round-2 symptom.** Injecting a high-z `position: fixed` element over the lane's top rows — i.e. exactly "something is stacked above the surface at the probed point" — makes the old approach unusable, and the new probe falls through to a lower row and still selects all 102.
- **The skip path works.** Forcing an impossible scan range makes the test report `1 skipped` with the geometry and blocker list, not a failure.
- **The scroll-settle change is non-vacuous** (the 2-pass A/B above).
- Forcing the point 1px left (279) reproduces the round-1 signature and the guard names it in one line.

If CI fails a fourth time, the guard now prints the live geometry *and* what occupied every rejected point, which should identify the blocking element directly. If it fails with the probe unable to find any point, it will skip rather than redden the run — and at that stage I'd recommend the sanctioned quarantine plus a tracking issue rather than a fourth guess.

## Screenshots

`No visual change` — E2E spec only; no product code touched.

## Testing

- [x] `pnpm lint` — `oxlint` clean on the changed spec; the pre-commit hook ran `oxlint`, react-doctor and `oxfmt` over it.
- [x] `pnpm typecheck` — passed (via `pnpm tc`) on current `main` (`194e1a8d4d`).
- [x] `pnpm test` — no unit-test surface in this change; the E2E suite is the relevant gate, below.
- [ ] `pnpm build` — **not run.** `electron-vite build --mode e2e` was run (required for the E2E suite) and succeeded; full packaging was not exercised. No build-surface change.
- [x] Added or updated high-quality tests that would catch regressions

E2E: whole spec file at `--repeat-each=4/5 --workers=2`, four runs → **20/20, 15/16, 16/16, 16/16**. The marquee test under change passed **every** execution.

The one failure was `bounds mounted lanes and cards while preserving a 21-status workflow` — a drag-and-drop test this PR does not touch. It did not recur across three subsequent full runs, and the unmodified spec passed 16/16 under the same load. I'm reporting it as an observed one-off rather than claiming it is proven unrelated.

## AI Review Report

Self-review focused on whether each iteration addressed the *observed* failure rather than a plausible one.

- Round 1's fix (scroll settle) was aimed at the wrong assertion entirely — the failure was upstream of the code I changed. Round 2's fix was the right area but the wrong shape: it replaced one precomputed point with a better precomputed point. This round changes the shape — the test now asks the DOM which point is usable instead of asserting its own arithmetic. That is what makes it robust to blockers I have not identified.
- Reviewed the new assertions for flake risk of their own: the probe reads geometry and hit-tests in one `evaluate`, so there is no measure-then-use window; the two-consecutive-agreement requirement covers mid-relayout frames; the selection-rect assertion uses auto-retrying `toBeVisible()` against an element that is always mounted while the board is open.
- Considered and rejected changing product code. The board's "only start a marquee on empty space" rule is correct; only the test's aim was wrong.
- Bounded the scan deliberately to the lane's top rows and documented why — a wider scan would find a point but silently break the 102-card assertion.

**Cross-platform compatibility explicitly reviewed for macOS, Linux, and Windows.** This is the crux: the failure is Linux/Xvfb-only in practice because layout and window size differ from macOS (CI is 1280×1024 with `--disable-gpu`; this suite's local window is wider). The fix therefore stops depending on absolute pixel arithmetic entirely and derives the press point from geometry hit-tested at runtime on whatever platform executes. No keyboard shortcuts, modifier keys or path handling are involved; no `metaKey`/`ctrlKey` was added. The spec is headless-Electron only.

Declining CodeRabbit's **Docstring Coverage (80%)** check per `AGENTS.md` ("Concise/Brief Non-obvious comments ONLY … 1 LINE if possible").

## Security Audit

No security surface. Confined to one E2E spec: it adjusts synthetic pointer coordinates and adds read-only DOM hit-testing (`document.elementFromPoint`, `closest`, class/visibility checks). No product code, no command execution, no path handling, no network, no credentials, no IPC, no new dependencies.

## Notes

- Follow-up (not in scope): `WORKSPACE_BOARD_CARD_ESTIMATED_HEIGHT = 36` in `WorkspaceKanbanLaneCardList.tsx` is ~35% under a measured card (55px), which makes the lane reflow `4988 → 5482` on first fill and is what makes the scroll-settle loop necessary. Retuning it needs a look at every card mode (`data-workspace-board-card-mode`), so it is not a deflake change.
- The companion GitLab cache fix is #12390.

