### PR TITLE
perf(tabs): index tab agent status by tab instead of scanning the global map

### DIFF
--- a/src/renderer/src/lib/tab-agent-status-index.test.ts
+++ b/src/renderer/src/lib/tab-agent-status-index.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveFocusedCompletedTabAgent,
+  resolveFocusedRetainedTabAgent,
+  resolveFocusedTabAgent,
+  resolveSiblingCompletedTabAgent,
+  resolveSiblingRetainedTabAgent,
+  resolveSiblingTabAgent
+} from './tab-agent'
+import { agentTypeToIconAgent } from './agent-status'
+import { isTerminalLeafId, parsePaneKey } from '../../../shared/stable-pane-id'
+import type {
+  AgentStatusEntry,
+  AgentStatusState,
+  AgentType
+} from '../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../shared/types'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+
+// ─── Oracle: the pre-index full-map scans, kept here (not in src) so the
+// randomized suite can assert the indexed resolvers are byte-identical. ───
+
+function oracleAnyTabAgent(
+  map: Record<string, AgentStatusEntry>,
+  tabId: string,
+  excludedLeafId?: string
+): TuiAgent | null {
+  for (const [paneKey, entry] of Object.entries(map)) {
+    const parsed = parsePaneKey(paneKey)
+    if (parsed?.tabId === tabId && parsed.leafId !== excludedLeafId) {
+      const agent = entry.state === 'done' ? null : agentTypeToIconAgent(entry.agentType)
+      if (agent) {
+        return agent
+      }
+    }
+  }
+  return null
+}
+
+function oracleAnyCompletedTabAgent(
+  map: Record<string, AgentStatusEntry>,
+  tabId: string,
+  excludedLeafId?: string
+): TuiAgent | null {
+  for (const [paneKey, entry] of Object.entries(map)) {
+    const parsed = parsePaneKey(paneKey)
+    if (parsed?.tabId === tabId && parsed.leafId !== excludedLeafId) {
+      const agent = entry.state === 'done' ? agentTypeToIconAgent(entry.agentType) : null
+      if (agent) {
+        return agent
+      }
+    }
+  }
+  return null
+}
+
+function oracleAnyRetainedTabAgent(
+  map: Record<string, RetainedAgentEntry>,
+  tabId: string,
+  excludedLeafId?: string
+): TuiAgent | null {
+  for (const [paneKey, retained] of Object.entries(map)) {
+    const parsed = parsePaneKey(paneKey)
+    if (parsed?.tabId === tabId && parsed.leafId !== excludedLeafId) {
+      const agent = agentTypeToIconAgent(retained.agentType)
+      if (agent) {
+        return agent
+      }
+    }
+  }
+  return null
+}
+
+function activeLeafOf(layout: TerminalLayoutSnapshot | undefined): string | null {
+  const activeLeafId = layout?.activeLeafId
+  return activeLeafId && isTerminalLeafId(activeLeafId) ? activeLeafId : null
+}
+
+const ORACLES = {
+  focused: (
+    map: Record<string, AgentStatusEntry>,
+    layout: TerminalLayoutSnapshot | undefined,
+    tabId: string
+  ): TuiAgent | null => {
+    const activeLeafId = activeLeafOf(layout)
+    if (activeLeafId) {
+      const entry = map[`${tabId}:${activeLeafId}`]
+      return !entry || entry.state === 'done' ? null : agentTypeToIconAgent(entry.agentType)
+    }
+    return oracleAnyTabAgent(map, tabId)
+  },
+  sibling: (
+    map: Record<string, AgentStatusEntry>,
+    layout: TerminalLayoutSnapshot | undefined,
+    tabId: string
+  ): TuiAgent | null => {
+    const activeLeafId = activeLeafOf(layout)
+    return activeLeafId ? oracleAnyTabAgent(map, tabId, activeLeafId) : null
+  },
+  focusedCompleted: (
+    map: Record<string, AgentStatusEntry>,
+    layout: TerminalLayoutSnapshot | undefined,
+    tabId: string
+  ): TuiAgent | null => {
+    const activeLeafId = activeLeafOf(layout)
+    if (activeLeafId) {
+      const entry = map[`${tabId}:${activeLeafId}`]
+      return !entry || entry.state !== 'done' ? null : agentTypeToIconAgent(entry.agentType)
+    }
+    return oracleAnyCompletedTabAgent(map, tabId)
+  },
+  siblingCompleted: (
+    map: Record<string, AgentStatusEntry>,
+    layout: TerminalLayoutSnapshot | undefined,
+    tabId: string
+  ): TuiAgent | null => {
+    const activeLeafId = activeLeafOf(layout)
+    return activeLeafId ? oracleAnyCompletedTabAgent(map, tabId, activeLeafId) : null
+  },
+  focusedRetained: (
+    map: Record<string, RetainedAgentEntry>,
+    layout: TerminalLayoutSnapshot | undefined,
+    tabId: string
+  ): TuiAgent | null => {
+    const activeLeafId = activeLeafOf(layout)
+    if (activeLeafId) {
+      return agentTypeToIconAgent(map[`${tabId}:${activeLeafId}`]?.agentType)
+    }
+    return oracleAnyRetainedTabAgent(map, tabId)
+  },
+  siblingRetained: (
+    map: Record<string, RetainedAgentEntry>,
+    layout: TerminalLayoutSnapshot | undefined,
+    tabId: string
+  ): TuiAgent | null => {
+    const activeLeafId = activeLeafOf(layout)
+    return activeLeafId ? oracleAnyRetainedTabAgent(map, tabId, activeLeafId) : null
+  }
+}
+
+// ─── Fixtures ───
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function leafId(n: number): string {
+  const hex = n.toString(16).padStart(12, '0')
+  return `11111111-1111-4111-8111-${hex}`
+}
+
+const STATES: readonly AgentStatusState[] = ['working', 'blocked', 'waiting', 'done']
+// Mixes iconable agents with ones agentTypeToIconAgent rejects.
+const AGENT_TYPES: readonly (AgentType | undefined)[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'pi',
+  'omp',
+  'unknown',
+  'some-custom-agent',
+  undefined
+]
+
+function statusEntry(
+  paneKey: string,
+  state: AgentStatusState,
+  agentType?: AgentType
+): AgentStatusEntry {
+  return {
+    state,
+    prompt: '',
+    updatedAt: 0,
+    stateStartedAt: 0,
+    paneKey,
+    stateHistory: [],
+    ...(agentType ? { agentType } : {})
+  }
+}
+
+function retainedEntry(paneKey: string, agentType: AgentType): RetainedAgentEntry {
+  const tabId = paneKey.slice(0, paneKey.indexOf(':'))
+  const tab: TerminalTab = {
+    id: tabId,
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  return {
+    entry: { ...statusEntry(paneKey, 'done', agentType), state: 'done' },
+    worktreeId: tab.worktreeId,
+    tab,
+    agentType,
+    startedAt: 0
+  }
+}
+
+function layoutOf(activeLeafId: string | null): TerminalLayoutSnapshot {
+  return { root: null, activeLeafId, expandedLeafId: null }
+}
+
+type RandomCase = {
+  statusMap: Record<string, AgentStatusEntry>
+  retainedMap: Record<string, RetainedAgentEntry>
+  probes: { tabId: string; layout: TerminalLayoutSnapshot | undefined }[]
+}
+
+function generateCase(random: () => number): RandomCase {
+  const tabCount = 1 + Math.floor(random() * 6)
+  const tabIds = Array.from({ length: tabCount }, (_, i) => `tab-${i}`)
+  const paneKeys: string[] = []
+  for (const tabId of tabIds) {
+    const leafCount = 1 + Math.floor(random() * 4)
+    for (let leaf = 0; leaf < leafCount; leaf += 1) {
+      paneKeys.push(`${tabId}:${leafId(leaf)}`)
+    }
+  }
+  // Malformed keys the resolvers must skip, plus a shuffle so insertion order varies.
+  paneKeys.push('tab-0:not-a-uuid', 'no-colon-key', `:${leafId(0)}`, `tab-0:${leafId(0)}:extra`)
+  for (let i = paneKeys.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1))
+    ;[paneKeys[i], paneKeys[j]] = [paneKeys[j]!, paneKeys[i]!]
+  }
+
+  const statusMap: Record<string, AgentStatusEntry> = {}
+  const retainedMap: Record<string, RetainedAgentEntry> = {}
+  for (const paneKey of paneKeys) {
+    if (random() < 0.8) {
+      const state = STATES[Math.floor(random() * STATES.length)]!
+      statusMap[paneKey] = statusEntry(
+        paneKey,
+        state,
+        AGENT_TYPES[Math.floor(random() * AGENT_TYPES.length)]
+      )
+    }
+    if (random() < 0.5) {
+      const agentType = AGENT_TYPES[Math.floor(random() * AGENT_TYPES.length)] ?? 'claude'
+      retainedMap[paneKey] = retainedEntry(paneKey, agentType)
+    }
+  }
+
+  const probes = tabIds.concat('tab-absent').map((tabId) => {
+    const roll = random()
+    const layout =
+      roll < 0.2
+        ? undefined
+        : roll < 0.35
+          ? layoutOf(null)
+          : roll < 0.45
+            ? layoutOf('not-a-uuid')
+            : layoutOf(leafId(Math.floor(random() * 5)))
+    return { tabId, layout }
+  })
+  return { statusMap, retainedMap, probes }
+}
+
+function expectParity(testCase: RandomCase): void {
+  for (const { tabId, layout } of testCase.probes) {
+    const { statusMap, retainedMap } = testCase
+    expect(resolveFocusedTabAgent(statusMap, layout, tabId)).toBe(
+      ORACLES.focused(statusMap, layout, tabId)
+    )
+    expect(resolveSiblingTabAgent(statusMap, layout, tabId)).toBe(
+      ORACLES.sibling(statusMap, layout, tabId)
+    )
+    expect(resolveFocusedCompletedTabAgent(statusMap, layout, tabId)).toBe(
+      ORACLES.focusedCompleted(statusMap, layout, tabId)
+    )
+    expect(resolveSiblingCompletedTabAgent(statusMap, layout, tabId)).toBe(
+      ORACLES.siblingCompleted(statusMap, layout, tabId)
+    )
+    expect(resolveFocusedRetainedTabAgent(retainedMap, layout, tabId)).toBe(
+      ORACLES.focusedRetained(retainedMap, layout, tabId)
+    )
+    expect(resolveSiblingRetainedTabAgent(retainedMap, layout, tabId)).toBe(
+      ORACLES.siblingRetained(retainedMap, layout, tabId)
+    )
+  }
+}
+
+describe('tab agent status index parity with the pre-index full-map scan', () => {
+  it('matches the oracle across 250 randomized status maps', () => {
+    const random = mulberry32(0xc0ffee)
+    for (let caseIndex = 0; caseIndex < 250; caseIndex += 1) {
+      expectParity(generateCase(random))
+    }
+  })
+
+  it('returns the first done sibling in insertion order when siblings run different agents', () => {
+    const map = {
+      [`tab-1:${leafId(0)}`]: statusEntry(`tab-1:${leafId(0)}`, 'done', 'codex'),
+      [`tab-1:${leafId(1)}`]: statusEntry(`tab-1:${leafId(1)}`, 'done', 'claude'),
+      [`tab-1:${leafId(2)}`]: statusEntry(`tab-1:${leafId(2)}`, 'done', 'gemini')
+    }
+    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(2)), 'tab-1')).toBe('codex')
+    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(0)), 'tab-1')).toBe('claude')
+    // Fresh identity, reversed insertion order → first match flips.
+    const reversed = Object.fromEntries(Object.entries(map).toReversed())
+    expect(resolveSiblingCompletedTabAgent(reversed, layoutOf(leafId(2)), 'tab-1')).toBe('claude')
+  })
+
+  it('excludes the active leaf and skips non-iconable agents', () => {
+    const map = {
+      [`tab-1:${leafId(0)}`]: statusEntry(`tab-1:${leafId(0)}`, 'done', 'unknown'),
+      [`tab-1:${leafId(1)}`]: statusEntry(`tab-1:${leafId(1)}`, 'done', 'claude'),
+      [`tab-2:${leafId(2)}`]: statusEntry(`tab-2:${leafId(2)}`, 'done', 'codex')
+    }
+    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(1)), 'tab-1')).toBeNull()
+    expect(resolveSiblingCompletedTabAgent(map, layoutOf(leafId(0)), 'tab-1')).toBe('claude')
+  })
+
+  it('ignores pane keys parsePaneKey rejects and empty maps', () => {
+    const malformed = {
+      'tab-1:not-a-uuid': statusEntry('tab-1:not-a-uuid', 'done', 'claude'),
+      'tab-1': statusEntry('tab-1', 'done', 'claude'),
+      [`:${leafId(0)}`]: statusEntry(`:${leafId(0)}`, 'done', 'claude')
+    }
+    expect(resolveFocusedCompletedTabAgent(malformed, undefined, 'tab-1')).toBeNull()
+    expect(resolveSiblingCompletedTabAgent(malformed, layoutOf(leafId(9)), 'tab-1')).toBeNull()
+    expect(resolveFocusedCompletedTabAgent({}, undefined, 'tab-1')).toBeNull()
+    expect(resolveFocusedRetainedTabAgent({}, undefined, 'tab-1')).toBeNull()
+  })
+
+  it('re-indexes when the store replaces the map identity', () => {
+    const paneKey = `tab-1:${leafId(0)}`
+    const before = { [paneKey]: statusEntry(paneKey, 'done', 'claude') }
+    expect(resolveFocusedCompletedTabAgent(before, undefined, 'tab-1')).toBe('claude')
+    const after = { [paneKey]: statusEntry(paneKey, 'done', 'codex') }
+    expect(resolveFocusedCompletedTabAgent(after, undefined, 'tab-1')).toBe('codex')
+    expect(resolveFocusedCompletedTabAgent(before, undefined, 'tab-1')).toBe('claude')
+  })
+})

--- a/src/renderer/src/lib/tab-agent-status-index.test.ts
+++ b/src/renderer/src/lib/tab-agent-status-index.test.ts
@@ -209,6 +209,19 @@ function layoutOf(activeLeafId: string | null): TerminalLayoutSnapshot {
   return { root: null, activeLeafId, expandedLeafId: null }
 }
 
+function countEntryScans<T extends object>(source: T): { source: T; scans: () => number } {
+  let scanCount = 0
+  return {
+    source: new Proxy(source, {
+      ownKeys: (target) => {
+        scanCount += 1
+        return Reflect.ownKeys(target)
+      }
+    }),
+    scans: () => scanCount
+  }
+}
+
 type RandomCase = {
   statusMap: Record<string, AgentStatusEntry>
   retainedMap: Record<string, RetainedAgentEntry>
@@ -338,5 +351,36 @@ describe('tab agent status index parity with the pre-index full-map scan', () =>
     const after = { [paneKey]: statusEntry(paneKey, 'done', 'codex') }
     expect(resolveFocusedCompletedTabAgent(after, undefined, 'tab-1')).toBe('codex')
     expect(resolveFocusedCompletedTabAgent(before, undefined, 'tab-1')).toBe('claude')
+  })
+
+  it('scans each source identity once across tabs and resolver variants', () => {
+    const firstPaneKey = `tab-1:${leafId(0)}`
+    const secondPaneKey = `tab-2:${leafId(1)}`
+    const status = countEntryScans({
+      [firstPaneKey]: statusEntry(firstPaneKey, 'working', 'claude'),
+      [secondPaneKey]: statusEntry(secondPaneKey, 'done', 'codex')
+    })
+    const retained = countEntryScans({
+      [firstPaneKey]: retainedEntry(firstPaneKey, 'claude'),
+      [secondPaneKey]: retainedEntry(secondPaneKey, 'codex')
+    })
+
+    for (const tabId of ['tab-1', 'tab-2', 'tab-absent']) {
+      const layout = layoutOf(leafId(9))
+      resolveFocusedTabAgent(status.source, undefined, tabId)
+      resolveSiblingTabAgent(status.source, layout, tabId)
+      resolveFocusedCompletedTabAgent(status.source, undefined, tabId)
+      resolveSiblingCompletedTabAgent(status.source, layout, tabId)
+      resolveFocusedRetainedTabAgent(retained.source, undefined, tabId)
+      resolveSiblingRetainedTabAgent(retained.source, layout, tabId)
+    }
+
+    expect(status.scans()).toBe(1)
+    expect(retained.scans()).toBe(1)
+
+    const replacement = countEntryScans({ ...status.source })
+    resolveFocusedTabAgent(replacement.source, undefined, 'tab-1')
+    resolveFocusedCompletedTabAgent(replacement.source, undefined, 'tab-2')
+    expect(replacement.scans()).toBe(1)
   })
 })

--- a/src/renderer/src/lib/tab-agent-status-index.ts
+++ b/src/renderer/src/lib/tab-agent-status-index.ts
@@ -1,0 +1,117 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import type { TuiAgent } from '../../../shared/types'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import { agentTypeToIconAgent } from './agent-status'
+
+/**
+ * Per-tab index of icon-capable agent panes for the tab-bar resolvers in
+ * `tab-agent.ts`. Without it each of ~200 mounted tabs re-scanned (and
+ * re-parsed the pane key of) the whole global status map on every render.
+ *
+ * Panes keep the source map's insertion order because the resolvers return the
+ * FIRST match — order decides which icon a split tab shows.
+ */
+export type TabAgentPane = { readonly leafId: string; readonly agent: TuiAgent }
+
+type TabAgentPanesByTabId = ReadonlyMap<string, readonly TabAgentPane[]>
+
+const NO_PANES: readonly TabAgentPane[] = Object.freeze([])
+const EMPTY_INDEX: TabAgentPanesByTabId = new Map()
+
+function appendPane(index: Map<string, TabAgentPane[]>, tabId: string, pane: TabAgentPane): void {
+  const panes = index.get(tabId)
+  if (panes) {
+    panes.push(pane)
+  } else {
+    index.set(tabId, [pane])
+  }
+}
+
+// Why: the store replaces these maps on every write, so identity is an exact
+// invalidation signal — one scan per write instead of one per tab per render.
+let cachedStatusSource: Record<string, AgentStatusEntry> | null = null
+let cachedLiveIndex: TabAgentPanesByTabId = EMPTY_INDEX
+let cachedCompletedIndex: TabAgentPanesByTabId = EMPTY_INDEX
+
+function indexAgentStatus(source: Record<string, AgentStatusEntry>): void {
+  if (source === cachedStatusSource) {
+    return
+  }
+  const live = new Map<string, TabAgentPane[]>()
+  const completed = new Map<string, TabAgentPane[]>()
+  for (const [paneKey, entry] of Object.entries(source)) {
+    const agent = agentTypeToIconAgent(entry?.agentType)
+    if (!agent) {
+      continue
+    }
+    const parsed = parsePaneKey(paneKey)
+    if (!parsed) {
+      continue
+    }
+    appendPane(entry.state === 'done' ? completed : live, parsed.tabId, {
+      leafId: parsed.leafId,
+      agent
+    })
+  }
+  cachedLiveIndex = live
+  cachedCompletedIndex = completed
+  cachedStatusSource = source
+}
+
+/** Panes of `tabId` whose agent is still running (any non-`done` state). */
+export function selectLiveTabAgentPanes(
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>,
+  tabId: string
+): readonly TabAgentPane[] {
+  indexAgentStatus(agentStatusByPaneKey)
+  return cachedLiveIndex.get(tabId) ?? NO_PANES
+}
+
+/** Panes of `tabId` whose agent reported `done`. */
+export function selectCompletedTabAgentPanes(
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>,
+  tabId: string
+): readonly TabAgentPane[] {
+  indexAgentStatus(agentStatusByPaneKey)
+  return cachedCompletedIndex.get(tabId) ?? NO_PANES
+}
+
+let cachedRetainedSource: Record<string, RetainedAgentEntry> | null = null
+let cachedRetainedIndex: TabAgentPanesByTabId = EMPTY_INDEX
+
+/** Panes of `tabId` kept as sidebar completion evidence after the row went away. */
+export function selectRetainedTabAgentPanes(
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>,
+  tabId: string
+): readonly TabAgentPane[] {
+  if (retainedAgentsByPaneKey !== cachedRetainedSource) {
+    const retainedIndex = new Map<string, TabAgentPane[]>()
+    for (const [paneKey, retained] of Object.entries(retainedAgentsByPaneKey)) {
+      const agent = agentTypeToIconAgent(retained?.agentType)
+      if (!agent) {
+        continue
+      }
+      const parsed = parsePaneKey(paneKey)
+      if (!parsed) {
+        continue
+      }
+      appendPane(retainedIndex, parsed.tabId, { leafId: parsed.leafId, agent })
+    }
+    cachedRetainedIndex = retainedIndex
+    cachedRetainedSource = retainedAgentsByPaneKey
+  }
+  return cachedRetainedIndex.get(tabId) ?? NO_PANES
+}
+
+export function firstTabAgentExcludingLeaf(
+  panes: readonly TabAgentPane[],
+  excludedLeafId?: string
+): TuiAgent | null {
+  for (const pane of panes) {
+    if (pane.leafId !== excludedLeafId) {
+      return pane.agent
+    }
+  }
+  return null
+}

--- a/src/renderer/src/lib/tab-agent.ts
+++ b/src/renderer/src/lib/tab-agent.ts
@@ -1,8 +1,14 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot, TuiAgent } from '../../../shared/types'
-import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { agentTypeToIconAgent } from './agent-status'
+import {
+  firstTabAgentExcludingLeaf,
+  selectCompletedTabAgentPanes,
+  selectLiveTabAgentPanes,
+  selectRetainedTabAgentPanes
+} from './tab-agent-status-index'
 
 /**
  * Resolve a terminal tab's agent from hook-reported status — the PRIMARY
@@ -44,16 +50,10 @@ function resolveAnyTabAgent(
   tabId: string,
   excludedLeafId?: string
 ): TuiAgent | null {
-  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
-    const parsedPaneKey = parsePaneKey(paneKey)
-    if (parsedPaneKey?.tabId === tabId && parsedPaneKey.leafId !== excludedLeafId) {
-      const agent = agentFromStatusEntry(entry)
-      if (agent) {
-        return agent
-      }
-    }
-  }
-  return null
+  return firstTabAgentExcludingLeaf(
+    selectLiveTabAgentPanes(agentStatusByPaneKey, tabId),
+    excludedLeafId
+  )
 }
 
 function agentFromStatusEntry(entry: AgentStatusEntry | undefined): TuiAgent | null {
@@ -93,16 +93,10 @@ function resolveAnyCompletedTabAgent(
   tabId: string,
   excludedLeafId?: string
 ): TuiAgent | null {
-  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
-    const parsedPaneKey = parsePaneKey(paneKey)
-    if (parsedPaneKey?.tabId === tabId && parsedPaneKey.leafId !== excludedLeafId) {
-      const agent = completedAgentFromStatusEntry(entry)
-      if (agent) {
-        return agent
-      }
-    }
-  }
-  return null
+  return firstTabAgentExcludingLeaf(
+    selectCompletedTabAgentPanes(agentStatusByPaneKey, tabId),
+    excludedLeafId
+  )
 }
 
 function completedAgentFromStatusEntry(entry: AgentStatusEntry | undefined): TuiAgent | null {
@@ -142,16 +136,10 @@ function resolveAnyRetainedTabAgent(
   tabId: string,
   excludedLeafId?: string
 ): TuiAgent | null {
-  for (const [paneKey, retained] of Object.entries(retainedAgentsByPaneKey)) {
-    const parsedPaneKey = parsePaneKey(paneKey)
-    if (parsedPaneKey?.tabId === tabId && parsedPaneKey.leafId !== excludedLeafId) {
-      const agent = agentFromRetainedEntry(retained)
-      if (agent) {
-        return agent
-      }
-    }
-  }
-  return null
+  return firstTabAgentExcludingLeaf(
+    selectRetainedTabAgentPanes(retainedAgentsByPaneKey, tabId),
+    excludedLeafId
+  )
 }
 
 function agentFromRetainedEntry(entry: RetainedAgentEntry | undefined): TuiAgent | null {


### PR DESCRIPTION
## Summary

Tab-bar agent-icon resolution no longer scans the entire global agent-status map once per tab per render. `resolveAnyCompletedTabAgent` (and its live/retained twins in `src/renderer/src/lib/tab-agent.ts`) did `Object.entries(agentStatusByPaneKey)` plus a `parsePaneKey` on every key, and `useTabAgent` calls them for every mounted tab on every render — with 200 worktrees/tabs and hundreds of status entries that is ~10^5 `parsePaneKey` calls per render pass.

CPU profiles taken on the prod app with 200 worktrees showed `resolveSiblingCompletedTabAgent` / `resolveAnyCompletedTabAgent` in **every** profile: 4.6% self-time during a cold worktree switch (~12% of the switch window including the surrounding frames in the same chunk) and 1.5% during steady-state churn.

This adds `src/renderer/src/lib/tab-agent-status-index.ts`: a per-tab index of icon-capable panes, cached on the *identity* of the source map. The store replaces `agentStatusByPaneKey` / `retainedAgentsByPaneKey` on every write (and keeps the identity when nothing changed), so identity is an exact invalidation signal — one scan per store write instead of one per tab per render. This is the same idiom already used by `terminal-tab-agent-type-index.ts`.

Behavior-preserving: the index keeps each tab's panes in the source map's **insertion order**, because the resolvers return the FIRST match and a split tab with two done panes running different agents would otherwise flip its icon. Focused-pane lookups were already O(1) and are unchanged.

### Measured

Micro-benchmark (scratch script, not committed): 800 entries across 200 tabs × 4 leaves, mixed `done`/`working`; per render pass a fresh map identity (the real pattern: a store write replaces the map, then all tabs re-render) then 200 tabs × (`resolveFocusedCompletedTabAgent` + `resolveSiblingCompletedTabAgent`); 100 render passes; best of two timed runs after warm-up.

| | total (100 passes) | per render pass |
|---|---|---|
| old (full-map scan) | 1203.9 ms | **12.039 ms** |
| new (identity-cached index) | 25.2 ms | **0.252 ms** |

**47.9× faster**, 0.252 ms per simulated render pass (target was ≥10× and <1 ms). Both implementations returned identical results over the whole run (parity sink 23400 = 23400).

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (full gate, passed)
- [x] `pnpm typecheck` (`pnpm run tc`, after `rm -f config/*.tsbuildinfo`)
- [x] `pnpm test` — targeted: all of `src/renderer/src/lib` + `src/renderer/src/components/tab-bar` (407 files, 3794 passed / 1 skipped). Full-repo `pnpm test` not run locally; CI covers it.
- [ ] `pnpm build` (not run; no build-surface change — renderer-only TS)
- [x] Added or updated high-quality tests

New `src/renderer/src/lib/tab-agent-status-index.test.ts`:
- **Parity oracle suite**: the pre-index full-map scans are kept *in the test* as an oracle and 250 seeded-random cases (varying tab counts, leaf counts, done/working/blocked/waiting mixes, shuffled insertion orders, iconable + non-iconable + missing agent types, malformed pane keys, present/absent/invalid `activeLeafId`) assert all six exported resolvers return identical results.
- Targeted edge cases: multiple done siblings running different agents (including a reversed-insertion-order map to prove order is load-bearing), excluded active leaf, non-iconable agent skipped in favour of a later pane, pane keys `parsePaneKey` rejects, empty maps, and re-indexing when the store replaces the map identity.
- Mutation-checked: reversing the index iteration order makes 2 of the 5 tests fail, so the suite really does pin insertion order.

Also ran, since the pre-commit hook was not executable in this worktree: `config/scripts/check-changed-code-quality.mjs` (0 new findings across 3 changed files, incl. type-aware + the react-doctor oxlint plugin) and `config/scripts/check-react-doctor-changed.mjs` (0 issues).

## AI Review Report

Self-review of the diff with the following risks checked:

- **Semantic equivalence** — the old loop parsed the key, matched `tabId`, excluded `leafId`, then took the first entry whose agent resolved non-null; the index applies exactly those filters at build time and preserves order. Entries that fail `parsePaneKey` or whose `agentType` is not iconable (`undefined`, `'unknown'`, custom names) are dropped at build time, which is equivalent to the old `continue`. Verified empirically by the 250-case oracle suite rather than by inspection alone.
- **Iteration order** — the resolver returns the FIRST match, so order is behavior, not an implementation detail. Pinned by a dedicated test with a reversed-insertion-order map.
- **Cache invalidation** — audited every write to `agentStatusByPaneKey` / `retainedAgentsByPaneKey` in `store/slices/agent-status.ts`: all replace the record (`nextLive`, spread copies, `removePaneKeys`, `movePaneKeyedRecord`); no in-place mutation, no immer drafts. Identity-keying is therefore exact. A stale index would require mutating a map in place, which no code path does.
- **Cache thrash** — the live and completed indexes share one cache slot (one pass builds both) and the retained index has its own, so `useTabAgent`'s four calls per tab hit the cache. Only alternating between two different map objects would thrash, which the store never does.
- **Retention** — the cache holds a reference to the current store map only (single slot, overwritten on the next identity change), so no unbounded growth and nothing is kept alive that the store had already dropped.
- **Cross-platform (macOS / Linux / Windows)** — no platform-dependent code touched: no keyboard shortcuts or modifier keys, no shortcut labels, no filesystem paths or path separators, no shell/process invocation, no Electron main-process or IPC surface. Pure renderer-side data structures (`Map`, `Object.entries`, string compare) with identical behavior on all three platforms. `Array#toReversed` in the test is ES2023, available in the Electron/Node runtimes the repo already targets (already used elsewhere in `src/renderer`). Nothing here is specific to local vs SSH/remote worktrees or to git-worktree vs folder workspaces — both feed the same pane-key-shaped map.
- **Public API** — `tab-agent.ts` exports are unchanged; its only non-test importer (`use-tab-agent.ts`) needed no edit.

Flagged and addressed: an initial version used `Array#reverse()` in a test, which `oxlint` rejects (`unicorn/no-array-reverse`) → switched to `toReversed()`.

## Security Audit

Low risk; no new attack surface.

- **Input handling** — pane keys still go through the existing `parsePaneKey` validator (single-colon, UUID leaf); malformed keys are dropped exactly as before, and a test covers that. No new parsing, no regex added, no user-controlled string is interpolated anywhere.
- **Command execution / path handling / auth / secrets / dependencies** — none touched. No new dependencies, no `child_process`, no filesystem access, no credentials.
- **IPC** — none touched. This code only reads already-materialized renderer store state; it does not receive, forward, or trust any new IPC payload.
- **Denial-of-service shape** — the change strictly *reduces* work (O(tabs × entries) → O(entries) per store write). Memory grows by one small index (`tabId → [{leafId, agent}]`) over entries that were already retained in the store, bounded by the map that already exists.

No follow-up needed.

## Notes

- The benchmark was a scratch vitest script (vitest swallows `console`, so it wrote results to `/tmp/tab-agent-bench.txt`); it is intentionally not committed, since it duplicates the pre-index implementation which now lives in the parity test as the oracle.
- The same identity-cache idiom already exists in `src/renderer/src/components/terminal-pane/terminal-tab-agent-type-index.ts`; that selector is left alone — this PR is scoped to the `tab-agent.ts` resolvers.
- The live (non-`done`) resolvers `resolveSiblingTabAgent` / `resolveFocusedTabAgent` had the identical full-map-scan shape and are indexed here too, since one pass builds both the live and completed indexes.
