### PR TITLE
perf(terminal): gate mobile overlay ticks by pane pty affinity

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -106,16 +106,10 @@ import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { shouldPreserveTerminalScrollbackBuffers } from '../../../../shared/workspace-session-terminal-buffers'
 import {
   getMobileFitOverridePtyIds,
-  getFitOverrideForPty,
-  onOverrideChange
+  getFitOverrideForPty
 } from '@/lib/pane-manager/mobile-fit-overrides'
 import { shouldShowMobileDriverOverlay } from './mobile-driver-overlay-visibility'
-import {
-  getAllDrivers,
-  getDriverForPty,
-  isPtyLocked,
-  onDriverChange
-} from '@/lib/pane-manager/mobile-driver-state'
+import { getAllDrivers, getDriverForPty, isPtyLocked } from '@/lib/pane-manager/mobile-driver-state'
 import { shouldChatTakeOverMobileSurface } from '../native-chat/native-chat-send-eligibility'
 import { canToggleNativeChat } from '../native-chat/native-chat-availability'
 import {
@@ -126,10 +120,9 @@ import {
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { safeFit, safeFitAndThen } from '@/lib/pane-manager/pane-tree-ops'
-import { applyDesktopFitFallbackAfterReplay } from './desktop-fit-fallback'
 import { clearTerminalScrollbackAndFollowOutput } from '@/lib/pane-manager/terminal-scrollback-clear'
 import { captureTerminalShutdownLayout } from './terminal-shutdown-layout-capture'
-import { getOverrideAffectedPanes, getPanesNeedingOverrideFit } from './override-affected-panes'
+import { useMobileOverlayTicks } from './use-mobile-overlay-ticks'
 import {
   inspectRuntimeTerminalProcess,
   isRemoteRuntimePtyId
@@ -400,111 +393,7 @@ function TerminalPane(
   >({})
   const [sessionStateSaveFailureOpen, setSessionStateSaveFailureOpen] = useState(false)
   const daemonActions = useDaemonActions()
-  // Why: override state lives in a Map for perf; this counter forces a re-render on override change so the mobile-fit banner toggles.
-  const [, setOverrideTick] = useState(0)
-  useEffect(() => {
-    const pendingFitFrames = new Set<number>()
-    const pendingFallbackTimers = new Set<number>()
-
-    const scheduleFitFrame = (callback: () => void): void => {
-      const frameId = window.requestAnimationFrame(() => {
-        pendingFitFrames.delete(frameId)
-        callback()
-      })
-      pendingFitFrames.add(frameId)
-    }
-
-    const scheduleFallbackTimer = (callback: () => void): void => {
-      const timerId = window.setTimeout(() => {
-        pendingFallbackTimers.delete(timerId)
-        callback()
-      }, 100)
-      pendingFallbackTimers.add(timerId)
-    }
-
-    const unsubscribe = onOverrideChange((event) => {
-      setOverrideTick((n) => n + 1)
-      const manager = managerRef.current
-      if (!manager) {
-        return
-      }
-      // Why: pane IDs are per-tab, so resolve the affected PTY through this tab's live transport bindings, not global pane IDs.
-      const getAffectedPanes = (): ReturnType<typeof manager.getPanes> =>
-        getOverrideAffectedPanes(
-          manager.getPanes(),
-          (paneId) => paneTransportsRef.current.get(paneId)?.getPtyId(),
-          event.ptyId
-        )
-      if (event.mode === 'mobile-fit' || event.mode === 'remote-desktop-fit') {
-        // Why: when mobile drives, xterm must shrink to phone dims or the wide desktop grid garbles the phone-wrapped stream.
-        // Why: override events fan out to every terminal tab; skip the rAF unless this tab has a mis-parked pane.
-        const panesNeedingFit = getPanesNeedingOverrideFit(
-          getAffectedPanes(),
-          event.cols,
-          event.rows
-        )
-        if (panesNeedingFit.length === 0) {
-          return
-        }
-        scheduleFitFrame(() => {
-          for (const pane of getPanesNeedingOverrideFit(
-            getAffectedPanes(),
-            event.cols,
-            event.rows
-          )) {
-            safeFit(pane)
-          }
-        })
-        return
-      }
-      if (event.mode === 'desktop-fit') {
-        // Why: fitAddon.fit() measures the DOM, so run under rAF after layout settles; the timeout is a safety net if fit silently threw.
-        const fitAffectedPanes = (): void => {
-          for (const pane of getAffectedPanes()) {
-            safeFit(pane)
-          }
-        }
-        scheduleFitFrame(fitAffectedPanes)
-        // Why: direct-resize fallback if safeFit no-op'd, only while xterm is still at the prior mobile-fit dims; else event.cols/rows is a stale baseline that clobbers the fit.
-        scheduleFallbackTimer(() => {
-          for (const pane of getAffectedPanes()) {
-            // Why: skip 0×0 hidden panes; forcing desktop dims with no DOM geometry leaves a mismatched grid (fallback is only for the visible pane that failed to refit).
-            const rect = pane.container.getBoundingClientRect()
-            if (rect.width === 0 || rect.height === 0) {
-              continue
-            }
-            applyDesktopFitFallbackAfterReplay(pane, {
-              ...event,
-              // Why: the timeout/replay queue can outlive this pane binding; never apply old server dims to a replacement PTY.
-              shouldApply: () => getAffectedPanes().includes(pane)
-            })
-          }
-        })
-      }
-    })
-
-    return () => {
-      unsubscribe()
-      for (const frameId of pendingFitFrames) {
-        window.cancelAnimationFrame(frameId)
-      }
-      pendingFitFrames.clear()
-      for (const timerId of pendingFallbackTimers) {
-        window.clearTimeout(timerId)
-      }
-      pendingFallbackTimers.clear()
-    }
-  }, [])
-
-  // Why: driver state lives in a Map for perf; this counter re-renders on driver flips so the lock banner toggles. See docs/mobile-presence-lock.md.
-  const [, setDriverTick] = useState(0)
-  useEffect(
-    () =>
-      onDriverChange(() => {
-        setDriverTick((n) => n + 1)
-      }),
-    []
-  )
+  const { refreshMobileOverlays } = useMobileOverlayTicks({ managerRef, paneTransportsRef })
 
   // Pane title state keyed by ephemeral paneId, persisted via titlesByLeafId; ref keeps persistLayoutSnapshot closures fresh.
   const [paneTitles, setPaneTitles] = useState<Record<number, string>>({})
@@ -2609,7 +2498,7 @@ function TerminalPane(
       // Why: the banner was rendered for this PTY; if the slot now holds a different terminal, bail so a stale portal can't reclaim it.
       const currentPtyId = paneTransportsRef.current.get(pane.id)?.getPtyId() ?? null
       if (currentPtyId !== ptyId) {
-        setOverrideTick((n) => n + 1)
+        refreshMobileOverlays()
         return
       }
       const restored = await restoreTerminalFitToDesktop(ptyId, settingsRef.current ?? undefined)
@@ -2619,7 +2508,7 @@ function TerminalPane(
         pane.terminal.focus()
       }
     },
-    [scheduleRestoredTerminalRefit]
+    [refreshMobileOverlays, scheduleRestoredTerminalRefit]
   )
 
   const restoreAllTerminalFits = useCallback(

--- a/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks.perf.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks.perf.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import { act, cleanup, render } from '@testing-library/react'
+import { hydrateDrivers, setDriverForPty } from '@/lib/pane-manager/mobile-driver-state'
+import { hydrateOverrides, setFitOverride } from '@/lib/pane-manager/mobile-fit-overrides'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { useMobileOverlayTicks } from './use-mobile-overlay-ticks'
+
+// Why: the emitters are plain module listener Sets, so N mounted subscribers
+// under a real React render reproduce the fan-out exactly — no mocking needed.
+const SUBSCRIBER_COUNT = 10
+const FOREIGN_EVENT_COUNT = 20
+
+const emptyManagerRef = { current: { getPanes: () => [] } as unknown as PaneManager }
+
+type PaneTransportsRef = { current: ReadonlyMap<number, Pick<PtyTransport, 'getPtyId'>> }
+
+function paneTransportsRefFor(ptyId: string): PaneTransportsRef {
+  return { current: new Map([[1, { getPtyId: () => ptyId }]]) }
+}
+
+function Subscriber({
+  paneTransportsRef,
+  onRender
+}: {
+  paneTransportsRef: PaneTransportsRef
+  onRender: () => void
+}): null {
+  useMobileOverlayTicks({ managerRef: emptyManagerRef, paneTransportsRef })
+  onRender()
+  return null
+}
+
+function ownedPtyId(index: number): string {
+  return `owned-pty-${index}`
+}
+
+function mountSubscribers(): { renders: number[]; resetCounts: () => void } {
+  const renders = Array.from({ length: SUBSCRIBER_COUNT }, () => 0)
+  const transportRefs = renders.map((_, index) => paneTransportsRefFor(ownedPtyId(index)))
+  render(
+    <>
+      {transportRefs.map((paneTransportsRef, index) => (
+        <Subscriber
+          key={ownedPtyId(index)}
+          paneTransportsRef={paneTransportsRef}
+          onRender={() => {
+            renders[index] += 1
+          }}
+        />
+      ))}
+    </>
+  )
+  return {
+    renders,
+    resetCounts: () => renders.fill(0)
+  }
+}
+
+// Why: each emitter callback arrives from its own IPC/network task in the app,
+// so one act() per event models real commit boundaries; batching them all into
+// a single act() would collapse the storm React actually pays for.
+function emitInOwnTask(emit: () => void): void {
+  act(() => {
+    emit()
+  })
+}
+
+describe('useMobileOverlayTicks pty-affinity gate', () => {
+  afterEach(() => {
+    cleanup()
+    hydrateOverrides([])
+    hydrateDrivers([])
+  })
+
+  it('does not re-render subscribers for fit-override events on unowned ptys', () => {
+    const { renders, resetCounts } = mountSubscribers()
+    resetCounts()
+
+    for (let i = 0; i < FOREIGN_EVENT_COUNT; i++) {
+      emitInOwnTask(() => setFitOverride(`foreign-pty-${i}`, 'mobile-fit', 40, 20))
+    }
+
+    expect(renders).toEqual(Array.from({ length: SUBSCRIBER_COUNT }, () => 0))
+  })
+
+  it('does not re-render subscribers for driver events on unowned ptys', () => {
+    const { renders, resetCounts } = mountSubscribers()
+    resetCounts()
+
+    for (let i = 0; i < FOREIGN_EVENT_COUNT; i++) {
+      emitInOwnTask(() =>
+        setDriverForPty(`foreign-pty-${i}`, { kind: 'mobile', clientId: `client-${i}` })
+      )
+    }
+
+    expect(renders).toEqual(Array.from({ length: SUBSCRIBER_COUNT }, () => 0))
+  })
+
+  it('still re-renders exactly the owning subscriber for its own pty events', () => {
+    const { renders, resetCounts } = mountSubscribers()
+    resetCounts()
+
+    emitInOwnTask(() => setFitOverride(ownedPtyId(3), 'mobile-fit', 40, 20))
+    expect(renders[3]).toBe(1)
+
+    emitInOwnTask(() => setDriverForPty(ownedPtyId(7), { kind: 'mobile', clientId: 'phone' }))
+    expect(renders[7]).toBe(1)
+
+    expect(renders.reduce((total, count) => total + count, 0)).toBe(2)
+  })
+
+  it('keeps a full handle-rotation storm proportional to the panes that rotated', () => {
+    const { renders, resetCounts } = mountSubscribers()
+    resetCounts()
+
+    // Why: mirrors replaceFitOverridePtyId/replaceDriverPtyId — every reconnecting
+    // pane republishes state under a new handle and retires the old one.
+    for (let index = 0; index < SUBSCRIBER_COUNT; index++) {
+      emitInOwnTask(() => {
+        setFitOverride(ownedPtyId(index), 'mobile-fit', 40, 20)
+        setFitOverride(`rotated-away-${index}`, 'desktop-fit', 40, 20)
+      })
+    }
+
+    // One commit per rotating pane, in its own tab — not SUBSCRIBER_COUNT commits each.
+    expect(renders).toEqual(Array.from({ length: SUBSCRIBER_COUNT }, () => 1))
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks.ts
+++ b/src/renderer/src/components/terminal-pane/use-mobile-overlay-ticks.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from 'react'
+import { onDriverChange } from '@/lib/pane-manager/mobile-driver-state'
+import { onOverrideChange } from '@/lib/pane-manager/mobile-fit-overrides'
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
+import { applyDesktopFitFallbackAfterReplay } from './desktop-fit-fallback'
+import { getOverrideAffectedPanes, getPanesNeedingOverrideFit } from './override-affected-panes'
+import type { PtyTransport } from './pty-transport'
+
+export type MobileOverlayTickDeps = {
+  managerRef: { current: PaneManager | null }
+  // Why: the overlay render resolves each pane's pty through this map, so the
+  // tick gate must read the same binding to stay behavior-preserving.
+  paneTransportsRef: { current: ReadonlyMap<number, Pick<PtyTransport, 'getPtyId'>> }
+}
+
+function isPtyMountedInTab(
+  transports: ReadonlyMap<number, Pick<PtyTransport, 'getPtyId'>>,
+  ptyId: string
+): boolean {
+  for (const transport of transports.values()) {
+    if (transport.getPtyId() === ptyId) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Re-render this tab's mobile-fit / presence-lock overlays when the pane-manager
+ * state maps change, and refit panes the override moved.
+ *
+ * Both emitters are global listener sets: every event reaches every mounted tab.
+ * The pty-affinity check therefore runs *before* the tick, not just before the
+ * rAF work — a remote reconnect replays two handle-rotation events per pane, so
+ * an ungated tick costs (events x mounted panes) re-renders per network blip.
+ */
+export function useMobileOverlayTicks({ managerRef, paneTransportsRef }: MobileOverlayTickDeps): {
+  refreshMobileOverlays: () => void
+} {
+  // Why: override state lives in a Map for perf; this counter forces a re-render on override change so the mobile-fit banner toggles.
+  const [, setOverrideTick] = useState(0)
+  useEffect(() => {
+    const pendingFitFrames = new Set<number>()
+    const pendingFallbackTimers = new Set<number>()
+
+    const scheduleFitFrame = (callback: () => void): void => {
+      const frameId = window.requestAnimationFrame(() => {
+        pendingFitFrames.delete(frameId)
+        callback()
+      })
+      pendingFitFrames.add(frameId)
+    }
+
+    const scheduleFallbackTimer = (callback: () => void): void => {
+      const timerId = window.setTimeout(() => {
+        pendingFallbackTimers.delete(timerId)
+        callback()
+      }, 100)
+      pendingFallbackTimers.add(timerId)
+    }
+
+    const unsubscribe = onOverrideChange((event) => {
+      if (!isPtyMountedInTab(paneTransportsRef.current, event.ptyId)) {
+        return
+      }
+      setOverrideTick((n) => n + 1)
+      const manager = managerRef.current
+      if (!manager) {
+        return
+      }
+      // Why: pane IDs are per-tab, so resolve the affected PTY through this tab's live transport bindings, not global pane IDs.
+      const getAffectedPanes = (): ManagedPane[] =>
+        getOverrideAffectedPanes(
+          manager.getPanes(),
+          (paneId) => paneTransportsRef.current.get(paneId)?.getPtyId(),
+          event.ptyId
+        )
+      if (event.mode === 'mobile-fit' || event.mode === 'remote-desktop-fit') {
+        // Why: when mobile drives, xterm must shrink to phone dims or the wide desktop grid garbles the phone-wrapped stream.
+        // Why: skip the rAF unless this tab actually has a mis-parked pane.
+        const panesNeedingFit = getPanesNeedingOverrideFit(
+          getAffectedPanes(),
+          event.cols,
+          event.rows
+        )
+        if (panesNeedingFit.length === 0) {
+          return
+        }
+        scheduleFitFrame(() => {
+          for (const pane of getPanesNeedingOverrideFit(
+            getAffectedPanes(),
+            event.cols,
+            event.rows
+          )) {
+            safeFit(pane)
+          }
+        })
+        return
+      }
+      if (event.mode === 'desktop-fit') {
+        // Why: fitAddon.fit() measures the DOM, so run under rAF after layout settles; the timeout is a safety net if fit silently threw.
+        const fitAffectedPanes = (): void => {
+          for (const pane of getAffectedPanes()) {
+            safeFit(pane)
+          }
+        }
+        scheduleFitFrame(fitAffectedPanes)
+        // Why: direct-resize fallback if safeFit no-op'd, only while xterm is still at the prior mobile-fit dims; else event.cols/rows is a stale baseline that clobbers the fit.
+        scheduleFallbackTimer(() => {
+          for (const pane of getAffectedPanes()) {
+            // Why: skip 0×0 hidden panes; forcing desktop dims with no DOM geometry leaves a mismatched grid (fallback is only for the visible pane that failed to refit).
+            const rect = pane.container.getBoundingClientRect()
+            if (rect.width === 0 || rect.height === 0) {
+              continue
+            }
+            applyDesktopFitFallbackAfterReplay(pane, {
+              ...event,
+              // Why: the timeout/replay queue can outlive this pane binding; never apply old server dims to a replacement PTY.
+              shouldApply: () => getAffectedPanes().includes(pane)
+            })
+          }
+        })
+      }
+    })
+
+    return () => {
+      unsubscribe()
+      for (const frameId of pendingFitFrames) {
+        window.cancelAnimationFrame(frameId)
+      }
+      pendingFitFrames.clear()
+      for (const timerId of pendingFallbackTimers) {
+        window.clearTimeout(timerId)
+      }
+      pendingFallbackTimers.clear()
+    }
+  }, [managerRef, paneTransportsRef])
+
+  // Why: driver state lives in a Map for perf; this counter re-renders on driver flips so the lock banner toggles. See docs/mobile-presence-lock.md.
+  const [, setDriverTick] = useState(0)
+  useEffect(
+    () =>
+      onDriverChange((event) => {
+        if (!isPtyMountedInTab(paneTransportsRef.current, event.ptyId)) {
+          return
+        }
+        setDriverTick((n) => n + 1)
+      }),
+    [paneTransportsRef]
+  )
+
+  // Why: a pane whose transport was swapped under a live overlay portal has no
+  // pty affinity left to tick it; the reclaim path drops the stale banner itself.
+  const refreshMobileOverlays = useCallback((): void => {
+    setOverrideTick((n) => n + 1)
+  }, [])
+  return { refreshMobileOverlays }
+}


### PR DESCRIPTION
## Summary

Mobile fit-override and mobile-driver state live in module-level `Map`s with plain listener `Set`s (`mobile-fit-overrides.ts`, `mobile-driver-state.ts`). Neither emitter routes per-pty — every event is delivered to every mounted `TerminalPane`.

Both tick callbacks re-rendered the whole tab **before** checking whether the event's pty belonged to it:

- `onOverrideChange` ticked on the first statement; the `getAffectedPanes()` affinity filter was built afterwards and only guarded the rAF refit work.
- `onDriverChange` was worse — it did not even bind the event arg, so there was no filter at all.

The remote-exclusive amplifier is handle rotation. `replaceFitOverridePtyId` / `replaceDriverPtyId` are called only from `remote-runtime-pty-transport.ts` (resubscribe after a network blip), and each fires up to two `notifyChange` events. N remote panes reconnecting together therefore cost O(N²) renderer commits — triggered by exactly the flaky-link conditions remote users hit.

This PR moves the pty-affinity check ahead of both ticks, using the guard shape the repo already uses in `use-native-chat-can-send.ts` and `pty-connection.ts`. The gate reads the same `paneTransportsRef` binding the overlay render resolves each pane's pty through, so skipping a tick can never skip a visible change. The rAF/fallback-timer semantics for affected panes are unchanged.

The subscription pair is extracted verbatim into `useMobileOverlayTicks` (also drops 117 lines from `TerminalPane.tsx`) so the fan-out is directly measurable under a real React render.

**No user-visible behavior change** — this is a pure re-render reduction.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (`oxlint` clean on the touched tree; `audit:code-quality:native`, `check:reliability-gates`, `check:max-lines-ratchet` all pass)
- [x] `pnpm typecheck` (`tsc -p config/tsconfig.web.json --composite false`, clean)
- [x] `pnpm test` — `src/renderer/src/components/terminal-pane/`: 227 files / 2986 tests pass
- [ ] `pnpm build` — not run (renderer-only source change; typecheck covers the same graph)
- [x] Added or updated high-quality tests that would catch regressions

### Measured before/after

`use-mobile-overlay-ticks.perf.test.tsx` mounts **N = 10** real subscriber components under happy-dom and drives the real emitters (no mocks — they are plain module listener `Set`s). Each event is fired in its own `act()` because in the app each emitter callback arrives from its own IPC/network task.

The "before" numbers are the actual failure output from running this same test file against the unguarded code:

| Scenario | Before (renders) | After (renders) |
|---|---|---|
| M = 20 fit-override events for **other** ptys | **200** (20 × 10 subscribers) | **0** |
| M = 20 driver events for **other** ptys | **200** (20 × 10 subscribers) | **0** |
| 2 events for **owned** ptys (must still tick) | 20 (every subscriber ticked on both) | **2** — exactly the two owning subscribers |
| Full 10-pane handle-rotation storm (2 events per rotation) | **100** (10 commits × 10 subscribers) | **10** — one per rotating pane, in its own tab |

All four assertions fail red against the unguarded code and pass green with the gate.

### Field arithmetic

At N = 10 remote panes reconnecting together, rotation emits 2N = 20 events, each broadcast to all N = 10 mounted panes → **200 tick-driven re-render requests per blip**. React batches the two events of a single rotation (they fire synchronously in one promise callback), so the real committed cost is N commits × N panes = **100 re-renders per reconnect blip today**. After this change: **10** — one commit per pane that actually rotated, in its tab only. The saving grows quadratically with pane count.

### Related shipped bug (not touched here)

`src/main/runtime/orca-runtime.ts` carries a 200 ms global resize-suppression window added specifically because "the desktop renderer's re-render cascade (triggered by `setOverrideTick`) runs `safeFit` on ALL panes". That main-side window is **deliberately left alone in this PR** (one PR, one concern) — it can be revisited once this renderer-side filter has soaked.

## AI Review Report

Self-review focused on the risk that the gate suppresses a needed render:

- **Render-dependency audit.** Traced every consumer of the two tick counters. They feed exactly one render block — the `MobileDriverOverlay` / mobile-fit portal loop, which resolves each pane's pty via `paneTransportsRef.current.get(pane.id)?.getPtyId()` and then reads `getDriverForPty` / `getFitOverrideForPty`. The gate reads the *same* binding map, so an event with no matching transport in this tab provably cannot change this tab's render output. The other two reads (`getFitOverrideForPty` at the reclaim path, `getMobileOwnedTerminalPtyIds`) are inside callbacks, not render.
- **Gate is deliberately wider than the rAF filter.** It matches on the transport map alone, not `manager.getPanes() ∩ transports`, so a pane bound to a transport but transiently absent from the manager still ticks.
- **Handle-rotation ordering.** Verified both call sites assign `remotePtyId = toRemoteRuntimePtyId(...)` *before* calling `replace*PtyId`, so the new-handle event matches the rotating pane's live binding and still ticks; only the retired old-handle event is dropped, and nothing renders for a retired handle.
- **Stale-portal path preserved.** `restorePaneTerminalFit` force-ticked via `setOverrideTick` when the pane's transport had been swapped under a live overlay. That pane has no pty affinity left, so the gate would swallow it — the hook exports `refreshMobileOverlays()` and that call site now uses it. Behavior identical.
- **Hydration paths.** `hydrateOverrides` / `hydrateDrivers` notify per-pty, so they flow through the same affinity gate and still reach the owning tab.
- **Cross-platform.** Renderer-only; no keyboard shortcuts, accelerators, shortcut labels, path handling, shell invocation, or Electron platform branches touched. No `metaKey`/`ctrlKey`, no path separators, no `process.platform`. Equivalent on macOS, Linux, and Windows. SSH and folder-workspace cases are unaffected — the change is agnostic to how the pty was produced (local, SSH, or remote runtime), and the remote path is the one that benefits most.
- **react-doctor.** Clean on all changed lines. The one remaining warning in `TerminalPane.tsx` (`no-adjust-state-on-prop-change`) is pre-existing and untouched — verified by running the same config against the parent commit, where it reports at the same code, line 1642.

## Security Audit

No security-relevant surface. This PR adds no input handling, no command execution, no path handling, no auth or secrets, no dependency changes, and no new IPC. It only narrows which renderer components react to an existing in-process event, and it does not change what data those events carry or who receives them — the emitters' semantics are untouched, and no main-process code is modified. No follow-up needed.

## Notes

- Renderer-only. No emitter semantics changed, no main-process changes.
- Follow-up (deliberately out of scope): the 200 ms main-side resize-suppression window in `orca-runtime.ts` exists to paper over the cascade this PR removes at the source, and is a candidate for removal after soak.

## Reliability Gate

- **Invariant — `terminal-geometry.visible-convergence`:** an owned PTY's fit/driver event must still refresh its tab and preserve the existing refit, fallback, and reclaim behavior; a foreign PTY event must not tick or refit an unrelated tab.
- **Failure source:** global renderer listener fan-out during remote-runtime handle rotation caused quadratic tab renders during reconnect bursts.
- **Oracle:** the React count test requires zero foreign-PTY renders and exactly the owning subscriber for owned events; the manifest geometry gate preserves refit/size convergence; Electron QA drove 80 foreign events and verified responsive painted input.
- **Gate:** existing experimental, partial `terminal-geometry.visible-convergence` gate; 8 files / 1,678 passed / 1 skipped locally.
- **Provider/platform coverage:** PTY identity matching is provider-neutral. Local, daemon, SSH, WSL, remote-runtime, relay, folder-workspace, macOS, Linux, and Windows behavior is otherwise unchanged. Live QA covered macOS; live remote reconnect, Linux, Windows, and phone pairing remain unproved.
- **Performance budget:** deterministic N-subscriber counts prove foreign events schedule zero React renders and a rotation burst remains linear in affected panes. No polling, subprocess, timer loop, broad session inventory, or unbounded cache was added.
- **Diagnostics:** the deterministic render-count test and Electron QA artifact are the regression evidence; no production logging was added to this renderer-only hot path.
- **Residual gap:** the existing main-process resize-suppression window remains intentionally unchanged pending soak.