### PR TITLE
perf(renderer): bail out of identity-equal terminal layout and cache-timer writes

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1069,14 +1069,6 @@ function TerminalPane(
     }
   }, [tabId, setTabLayout, worktreeId])
 
-  // Why: the dedupe cache mirrors what one host holds for one tab, so drop it when either changes or the pane unmounts.
-  useEffect(() => {
-    const pusher = remotePaneLayoutPusherRef.current
-    return () => {
-      pusher?.reset()
-    }
-  }, [tabId, worktreeId])
-
   const clearPaneScrollback = useCallback(
     (pane: ManagedPane): void => {
       clearedScrollbackLeafIdsRef.current.add(pane.leafId)

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -136,8 +136,7 @@ import {
 } from '@/runtime/runtime-terminal-inspection'
 import {
   clearWebRuntimeTerminalBuffer,
-  closeWebRuntimeTerminal,
-  updateWebRuntimePaneLayout
+  closeWebRuntimeTerminal
 } from '@/runtime/web-runtime-session'
 import {
   armPrimarySelectionNativePasteSuppression,
@@ -158,6 +157,10 @@ import {
   planTerminalLiveLayoutInsertions
 } from './terminal-live-layout-reconciliation'
 import type { TerminalQuickCommand, TerminalQuickCommandScope } from '../../../../shared/types'
+import {
+  createRemotePaneLayoutPusher,
+  type RemotePaneLayoutPusher
+} from './remote-pane-layout-push'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
@@ -512,6 +515,8 @@ function TerminalPane(
   paneTitlesRef.current = paneTitles
   const removedTitleLeafIdsRef = useRef<Set<string>>(new Set())
   const clearedScrollbackLeafIdsRef = useRef<Set<string>>(new Set())
+  const remotePaneLayoutPusherRef = useRef<RemotePaneLayoutPusher | null>(null)
+  remotePaneLayoutPusherRef.current ??= createRemotePaneLayoutPusher()
   const [paneTitleOverlayRects, setPaneTitleOverlayRects] = useState<
     Record<number, PaneTitleOverlayRect>
   >({})
@@ -1057,18 +1062,20 @@ function TerminalPane(
       (ptyId) => typeof ptyId === 'string' && isRemoteRuntimePtyId(ptyId)
     )
     if (hasRemotePane) {
-      void updateWebRuntimePaneLayout({
-        worktreeId,
-        tabId,
-        root: layout.root,
-        expandedLeafId: layout.expandedLeafId,
-        ...(layout.titlesByLeafId ? { titlesByLeafId: layout.titlesByLeafId } : {})
-      })
+      remotePaneLayoutPusherRef.current?.push({ worktreeId, tabId, layout })
     }
     for (const leafId of currentLeafIds) {
       clearedScrollbackLeafIds.delete(leafId)
     }
   }, [tabId, setTabLayout, worktreeId])
+
+  // Why: the dedupe cache mirrors what one host holds for one tab, so drop it when either changes or the pane unmounts.
+  useEffect(() => {
+    const pusher = remotePaneLayoutPusherRef.current
+    return () => {
+      pusher?.reset()
+    }
+  }, [tabId, worktreeId])
 
   const clearPaneScrollback = useCallback(
     (pane: ManagedPane): void => {

--- a/src/renderer/src/components/terminal-pane/remote-pane-layout-push.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-pane-layout-push.test.ts
@@ -36,7 +36,7 @@ function makeLayout(overrides: Partial<TerminalLayoutSnapshot> = {}): TerminalLa
 
 describe('createRemotePaneLayoutPusher', () => {
   beforeEach(() => {
-    updateWebRuntimePaneLayout.mockClear()
+    updateWebRuntimePaneLayout.mockReset().mockResolvedValue(true)
   })
 
   it('pushes once across 100 persists of an unchanged layout', () => {
@@ -125,11 +125,33 @@ describe('createRemotePaneLayoutPusher', () => {
     expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(3)
   })
 
-  it('re-pushes after reset so a remount re-establishes host geometry', () => {
+  it('does not carry a cached layout across worktrees', () => {
     const pusher = createRemotePaneLayoutPusher()
     pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
-    pusher.reset()
+    pusher.push({ worktreeId: 'wt-2', tabId: 'tab-1', layout: makeLayout() })
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries an unchanged layout after a failed push', async () => {
+    updateWebRuntimePaneLayout.mockResolvedValueOnce(false)
+    const pusher = createRemotePaneLayoutPusher()
+    const input = { worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() }
+
+    pusher.push(input)
+    await Promise.resolve()
+    pusher.push(input)
+
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-pushes after a remount re-establishes host geometry', () => {
+    const pusher = createRemotePaneLayoutPusher()
     pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    createRemotePaneLayoutPusher().push({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      layout: makeLayout()
+    })
     expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/terminal-pane/remote-pane-layout-push.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-pane-layout-push.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Perf regression: layout persists fire on pane-title churn, and every one of
+ * them used to push a remote-runtime IPC round trip regardless of whether the
+ * host-visible layout had moved. Counting invocations at the mocked IPC boundary
+ * pins the before/after: 100 persists with an unchanged layout cost 100 pushes
+ * before the dedupe and 1 after.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+
+const updateWebRuntimePaneLayout = vi.fn()
+vi.mock('@/runtime/web-runtime-session', () => ({
+  updateWebRuntimePaneLayout: (...args: unknown[]) => updateWebRuntimePaneLayout(...args)
+}))
+
+const { createRemotePaneLayoutPusher } = await import('./remote-pane-layout-push')
+
+const PERSISTS = 100
+
+function makeLayout(overrides: Partial<TerminalLayoutSnapshot> = {}): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      ratio: 0.5,
+      first: { type: 'leaf', leafId: 'leaf-a' },
+      second: { type: 'leaf', leafId: 'leaf-b' }
+    },
+    activeLeafId: 'leaf-a',
+    expandedLeafId: null,
+    ptyIdsByLeafId: { 'leaf-a': 'remote:pty-a', 'leaf-b': 'remote:pty-b' },
+    titlesByLeafId: { 'leaf-a': 'build' },
+    ...overrides
+  }
+}
+
+describe('createRemotePaneLayoutPusher', () => {
+  beforeEach(() => {
+    updateWebRuntimePaneLayout.mockClear()
+  })
+
+  it('pushes once across 100 persists of an unchanged layout', () => {
+    const pusher = createRemotePaneLayoutPusher()
+    for (let i = 0; i < PERSISTS; i += 1) {
+      // Fresh object each time: persistLayoutSnapshot re-serializes on every call.
+      pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    }
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends the same payload the un-deduped path sent', () => {
+    const pusher = createRemotePaneLayoutPusher()
+    const layout = makeLayout()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout })
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      root: layout.root,
+      expandedLeafId: layout.expandedLeafId,
+      titlesByLeafId: layout.titlesByLeafId
+    })
+  })
+
+  it('omits titlesByLeafId when the layout carries no titles', () => {
+    const pusher = createRemotePaneLayoutPusher()
+    pusher.push({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      layout: makeLayout({ titlesByLeafId: undefined })
+    })
+    expect(updateWebRuntimePaneLayout.mock.calls[0][0]).not.toHaveProperty('titlesByLeafId')
+  })
+
+  it('pushes again for every host-visible change', () => {
+    const pusher = createRemotePaneLayoutPusher()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    pusher.push({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      layout: makeLayout({ expandedLeafId: 'leaf-a' })
+    })
+    pusher.push({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      layout: makeLayout({
+        expandedLeafId: 'leaf-a',
+        titlesByLeafId: { 'leaf-a': 'test' }
+      })
+    })
+    pusher.push({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      layout: makeLayout({
+        expandedLeafId: 'leaf-a',
+        titlesByLeafId: { 'leaf-a': 'test' },
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          ratio: 0.7,
+          first: { type: 'leaf', leafId: 'leaf-a' },
+          second: { type: 'leaf', leafId: 'leaf-b' }
+        }
+      })
+    })
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(4)
+  })
+
+  it('pushes again when a remote pane swaps its pty', () => {
+    // ptyIdsByLeafId is not in the payload, but a swap means a different host session.
+    const pusher = createRemotePaneLayoutPusher()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    pusher.push({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      layout: makeLayout({ ptyIdsByLeafId: { 'leaf-a': 'remote:pty-c', 'leaf-b': 'remote:pty-b' } })
+    })
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not carry a cached layout across tabs', () => {
+    const pusher = createRemotePaneLayoutPusher()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-2', layout: makeLayout() })
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(3)
+  })
+
+  it('re-pushes after reset so a remount re-establishes host geometry', () => {
+    const pusher = createRemotePaneLayoutPusher()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    pusher.reset()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-pane-layout-push.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-pane-layout-push.test.ts
@@ -17,6 +17,14 @@ const { createRemotePaneLayoutPusher } = await import('./remote-pane-layout-push
 
 const PERSISTS = 100
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve = (_value: T): void => undefined
+  const promise = new Promise<T>((complete) => {
+    resolve = complete
+  })
+  return { promise, resolve }
+}
+
 function makeLayout(overrides: Partial<TerminalLayoutSnapshot> = {}): TerminalLayoutSnapshot {
   return {
     root: {
@@ -142,6 +150,24 @@ describe('createRemotePaneLayoutPusher', () => {
     pusher.push(input)
 
     expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a stale failure invalidate a newer in-flight layout', async () => {
+    const first = deferred<boolean>()
+    const second = deferred<boolean>()
+    updateWebRuntimePaneLayout.mockImplementationOnce(() => first.promise)
+    updateWebRuntimePaneLayout.mockImplementationOnce(() => second.promise)
+    const pusher = createRemotePaneLayoutPusher()
+    const changedLayout = makeLayout({ expandedLeafId: 'leaf-a' })
+
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: makeLayout() })
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: changedLayout })
+    first.resolve(false)
+    await Promise.resolve()
+    pusher.push({ worktreeId: 'wt-1', tabId: 'tab-1', layout: changedLayout })
+
+    expect(updateWebRuntimePaneLayout).toHaveBeenCalledTimes(2)
+    second.resolve(true)
   })
 
   it('re-pushes after a remount re-establishes host geometry', () => {

--- a/src/renderer/src/components/terminal-pane/remote-pane-layout-push.ts
+++ b/src/renderer/src/components/terminal-pane/remote-pane-layout-push.ts
@@ -4,7 +4,6 @@ import { updateWebRuntimePaneLayout } from '@/runtime/web-runtime-session'
 
 export type RemotePaneLayoutPusher = {
   push: (input: { worktreeId: string; tabId: string; layout: TerminalLayoutSnapshot }) => void
-  reset: () => void
 }
 
 /**
@@ -13,23 +12,36 @@ export type RemotePaneLayoutPusher = {
  * Dedupe against the last push so unchanged layouts cost no remote round trip.
  */
 export function createRemotePaneLayoutPusher(): RemotePaneLayoutPusher {
-  let lastPushed: { tabId: string; snapshot: TerminalLayoutSnapshot } | null = null
+  let lastAttempt: {
+    id: number
+    worktreeId: string
+    tabId: string
+    snapshot: TerminalLayoutSnapshot
+  } | null = null
+  let nextAttemptId = 0
   return {
     push: ({ worktreeId, tabId, layout }) => {
-      if (lastPushed?.tabId === tabId && terminalLayoutEqual(lastPushed.snapshot, layout)) {
+      if (
+        lastAttempt?.worktreeId === worktreeId &&
+        lastAttempt.tabId === tabId &&
+        terminalLayoutEqual(lastAttempt.snapshot, layout)
+      ) {
         return
       }
-      lastPushed = { tabId, snapshot: layout }
+      const attempt = { id: ++nextAttemptId, worktreeId, tabId, snapshot: layout }
+      lastAttempt = attempt
       void updateWebRuntimePaneLayout({
         worktreeId,
         tabId,
         root: layout.root,
         expandedLeafId: layout.expandedLeafId,
         ...(layout.titlesByLeafId ? { titlesByLeafId: layout.titlesByLeafId } : {})
+      }).then((updated) => {
+        // Why: a disconnected or timed-out push carried no information, so the next persist must retry it.
+        if (!updated && lastAttempt?.id === attempt.id) {
+          lastAttempt = null
+        }
       })
-    },
-    reset: () => {
-      lastPushed = null
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/remote-pane-layout-push.ts
+++ b/src/renderer/src/components/terminal-pane/remote-pane-layout-push.ts
@@ -1,0 +1,35 @@
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
+import { updateWebRuntimePaneLayout } from '@/runtime/web-runtime-session'
+
+export type RemotePaneLayoutPusher = {
+  push: (input: { worktreeId: string; tabId: string; layout: TerminalLayoutSnapshot }) => void
+  reset: () => void
+}
+
+/**
+ * Pane geometry is host-authoritative for remote tabs, so persists must push it — but
+ * persists also fire on pane-title churn, which leaves the host-visible layout untouched.
+ * Dedupe against the last push so unchanged layouts cost no remote round trip.
+ */
+export function createRemotePaneLayoutPusher(): RemotePaneLayoutPusher {
+  let lastPushed: { tabId: string; snapshot: TerminalLayoutSnapshot } | null = null
+  return {
+    push: ({ worktreeId, tabId, layout }) => {
+      if (lastPushed?.tabId === tabId && terminalLayoutEqual(lastPushed.snapshot, layout)) {
+        return
+      }
+      lastPushed = { tabId, snapshot: layout }
+      void updateWebRuntimePaneLayout({
+        worktreeId,
+        tabId,
+        root: layout.root,
+        expandedLeafId: layout.expandedLeafId,
+        ...(layout.titlesByLeafId ? { titlesByLeafId: layout.titlesByLeafId } : {})
+      })
+    },
+    reset: () => {
+      lastPushed = null
+    }
+  }
+}

--- a/src/renderer/src/lib/terminal-layout-equality.ts
+++ b/src/renderer/src/lib/terminal-layout-equality.ts
@@ -1,0 +1,55 @@
+import type { TerminalLayoutSnapshot, TerminalPaneLayoutNode } from '../../../shared/types'
+
+function sameStringRecord(
+  a: Readonly<Record<string, string>> | undefined,
+  b: Readonly<Record<string, string>> | undefined
+): boolean {
+  const left = a ?? {}
+  const right = b ?? {}
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) => Object.prototype.hasOwnProperty.call(right, key) && left[key] === right[key]
+    )
+  )
+}
+
+export function terminalLayoutNodeEqual(
+  a: TerminalPaneLayoutNode | null | undefined,
+  b: TerminalPaneLayoutNode | null | undefined
+): boolean {
+  if (!a || !b) {
+    return !a && !b
+  }
+  if (a.type !== b.type) {
+    return false
+  }
+  if (a.type === 'leaf') {
+    return b.type === 'leaf' && a.leafId === b.leafId
+  }
+  return (
+    b.type === 'split' &&
+    a.direction === b.direction &&
+    a.ratio === b.ratio &&
+    terminalLayoutNodeEqual(a.first, b.first) &&
+    terminalLayoutNodeEqual(a.second, b.second)
+  )
+}
+
+/** Structural equality over every persisted layout field; drives store/IPC write bailouts. */
+export function terminalLayoutEqual(
+  a: TerminalLayoutSnapshot | undefined,
+  b: TerminalLayoutSnapshot
+): boolean {
+  return (
+    terminalLayoutNodeEqual(a?.root, b.root) &&
+    (a?.activeLeafId ?? null) === b.activeLeafId &&
+    (a?.expandedLeafId ?? null) === b.expandedLeafId &&
+    sameStringRecord(a?.ptyIdsByLeafId, b.ptyIdsByLeafId) &&
+    sameStringRecord(a?.buffersByLeafId, b.buffersByLeafId) &&
+    sameStringRecord(a?.scrollbackRefsByLeafId, b.scrollbackRefsByLeafId) &&
+    sameStringRecord(a?.titlesByLeafId, b.titlesByLeafId)
+  )
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -25,13 +25,13 @@ import type {
   TabGroup,
   TabGroupLayoutNode,
   TerminalLayoutSnapshot,
-  TerminalPaneLayoutNode,
   TerminalTab
 } from '../../../shared/types'
 import type { OpenFile } from '../store/slices/editor'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
+import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { getReachableRuntimeSessionMirrorTargets } from '@/lib/runtime-session-mirror-targets'
@@ -1421,59 +1421,6 @@ function isMirroredCommandCodeTurnBump(
     existing.state === 'working' &&
     entry.state === 'working' &&
     entry.stateStartedAt > existing.stateStartedAt
-  )
-}
-
-function sameStringRecord(
-  a: Readonly<Record<string, string>> | undefined,
-  b: Readonly<Record<string, string>> | undefined
-): boolean {
-  const left = a ?? {}
-  const right = b ?? {}
-  const leftKeys = Object.keys(left)
-  const rightKeys = Object.keys(right)
-  return (
-    leftKeys.length === rightKeys.length &&
-    leftKeys.every(
-      (key) => Object.prototype.hasOwnProperty.call(right, key) && left[key] === right[key]
-    )
-  )
-}
-
-function terminalLayoutNodeEqual(
-  a: TerminalPaneLayoutNode | null | undefined,
-  b: TerminalPaneLayoutNode | null | undefined
-): boolean {
-  if (!a || !b) {
-    return !a && !b
-  }
-  if (a.type !== b.type) {
-    return false
-  }
-  if (a.type === 'leaf') {
-    return b.type === 'leaf' && a.leafId === b.leafId
-  }
-  return (
-    b.type === 'split' &&
-    a.direction === b.direction &&
-    a.ratio === b.ratio &&
-    terminalLayoutNodeEqual(a.first, b.first) &&
-    terminalLayoutNodeEqual(a.second, b.second)
-  )
-}
-
-function terminalLayoutEqual(
-  a: TerminalLayoutSnapshot | undefined,
-  b: TerminalLayoutSnapshot
-): boolean {
-  return (
-    terminalLayoutNodeEqual(a?.root, b.root) &&
-    (a?.activeLeafId ?? null) === b.activeLeafId &&
-    (a?.expandedLeafId ?? null) === b.expandedLeafId &&
-    sameStringRecord(a?.ptyIdsByLeafId, b.ptyIdsByLeafId) &&
-    sameStringRecord(a?.buffersByLeafId, b.buffersByLeafId) &&
-    sameStringRecord(a?.scrollbackRefsByLeafId, b.scrollbackRefsByLeafId) &&
-    sameStringRecord(a?.titlesByLeafId, b.titlesByLeafId)
   )
 }
 

--- a/src/renderer/src/store/slices/terminal-write-identity-bailouts.test.ts
+++ b/src/renderer/src/store/slices/terminal-write-identity-bailouts.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Perf regression: setCacheTimerStartedAt and setTabLayout must not publish
+ * state when the write is a no-op.
+ *
+ * Both actions previously spread a fresh object and returned it unconditionally,
+ * so every redundant call produced a new AppState object and woke EVERY zustand
+ * subscriber — which, with per-pane selectors across all mounted panes, is an
+ * O(panes) sweep per write. The cadence is real: parked-terminal-byte-watcher
+ * writes a null cache timer on every agent working/exit/stale-title transition,
+ * and TerminalPane re-persists its layout on pane-title churn.
+ *
+ * These tests count subscriber wakeups on a real store; the pre-fix numbers are
+ * 1_000 (one per call), the post-fix numbers are 0.
+ */
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+import { createTestStore } from './store-test-helpers'
+
+const REPEATS = 1_000
+
+function makeLayout(overrides: Partial<TerminalLayoutSnapshot> = {}): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      ratio: 0.5,
+      first: { type: 'leaf', leafId: 'leaf-a' },
+      second: { type: 'leaf', leafId: 'leaf-b' }
+    },
+    activeLeafId: 'leaf-a',
+    expandedLeafId: null,
+    ptyIdsByLeafId: { 'leaf-a': 'pty-a', 'leaf-b': 'pty-b' },
+    titlesByLeafId: { 'leaf-a': 'build' },
+    ...overrides
+  }
+}
+
+describe('setCacheTimerStartedAt identity bailout', () => {
+  it('wakes zero subscribers across 1,000 null-over-null writes', () => {
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-a'
+    store.getState().setCacheTimerStartedAt(paneKey, null)
+
+    let wakeups = 0
+    const unsubscribe = store.subscribe(() => {
+      wakeups += 1
+    })
+    for (let i = 0; i < REPEATS; i += 1) {
+      store.getState().setCacheTimerStartedAt(paneKey, null)
+    }
+    unsubscribe()
+
+    expect(wakeups).toBe(0)
+    expect(store.getState().cacheTimerByKey[paneKey]).toBeNull()
+  })
+
+  it('wakes zero subscribers across 1,000 repeats of the same timestamp', () => {
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-a'
+    store.getState().setCacheTimerStartedAt(paneKey, 1_700_000_000_000)
+
+    let wakeups = 0
+    const unsubscribe = store.subscribe(() => {
+      wakeups += 1
+    })
+    for (let i = 0; i < REPEATS; i += 1) {
+      store.getState().setCacheTimerStartedAt(paneKey, 1_700_000_000_000)
+    }
+    unsubscribe()
+
+    expect(wakeups).toBe(0)
+  })
+
+  it('still publishes when the timestamp actually changes', () => {
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-a'
+    store.getState().setCacheTimerStartedAt(paneKey, null)
+
+    let wakeups = 0
+    const unsubscribe = store.subscribe(() => {
+      wakeups += 1
+    })
+    store.getState().setCacheTimerStartedAt(paneKey, 123)
+    store.getState().setCacheTimerStartedAt(paneKey, null)
+    unsubscribe()
+
+    expect(wakeups).toBe(2)
+    expect(store.getState().cacheTimerByKey[paneKey]).toBeNull()
+  })
+
+  it('records the first write for a key even when the value is null', () => {
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-a'
+
+    let wakeups = 0
+    const unsubscribe = store.subscribe(() => {
+      wakeups += 1
+    })
+    store.getState().setCacheTimerStartedAt(paneKey, null)
+    unsubscribe()
+
+    expect(wakeups).toBe(1)
+    expect(paneKey in store.getState().cacheTimerByKey).toBe(true)
+  })
+
+  it('still clears a stale :seed sentinel when the pane value is unchanged', () => {
+    // Without this carve-out the bailout would strand the sentinel and leave a phantom timer.
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-a'
+    store.getState().setCacheTimerStartedAt(paneKey, null)
+    store.setState((s) => ({ cacheTimerByKey: { ...s.cacheTimerByKey, 'tab-1:seed': 42 } }))
+
+    store.getState().setCacheTimerStartedAt(paneKey, null)
+
+    expect('tab-1:seed' in store.getState().cacheTimerByKey).toBe(false)
+  })
+})
+
+describe('setTabLayout identity bailout', () => {
+  it('wakes zero subscribers across 1,000 structurally identical snapshots', () => {
+    const store = createTestStore()
+    store.getState().setTabLayout('tab-1', makeLayout())
+
+    let wakeups = 0
+    const unsubscribe = store.subscribe(() => {
+      wakeups += 1
+    })
+    for (let i = 0; i < REPEATS; i += 1) {
+      // Fresh object each iteration: this is what persistLayoutSnapshot produces.
+      store.getState().setTabLayout('tab-1', makeLayout())
+    }
+    unsubscribe()
+
+    expect(wakeups).toBe(0)
+  })
+
+  it('keeps the stored snapshot reference stable when nothing changed', () => {
+    const store = createTestStore()
+    store.getState().setTabLayout('tab-1', makeLayout())
+    const first = store.getState().terminalLayoutsByTabId['tab-1']
+
+    store.getState().setTabLayout('tab-1', makeLayout())
+
+    expect(store.getState().terminalLayoutsByTabId['tab-1']).toBe(first)
+  })
+
+  it('publishes when any tracked field changes', () => {
+    const store = createTestStore()
+    store.getState().setTabLayout('tab-1', makeLayout())
+
+    const mutations: Partial<TerminalLayoutSnapshot>[] = [
+      { activeLeafId: 'leaf-b' },
+      { expandedLeafId: 'leaf-a' },
+      { titlesByLeafId: { 'leaf-a': 'test' } },
+      { ptyIdsByLeafId: { 'leaf-a': 'pty-a', 'leaf-b': 'pty-c' } },
+      { buffersByLeafId: { 'leaf-a': 'scrollback' } },
+      { scrollbackRefsByLeafId: { 'leaf-a': 'ref-1' } },
+      {
+        root: {
+          type: 'split',
+          direction: 'horizontal',
+          ratio: 0.5,
+          first: { type: 'leaf', leafId: 'leaf-a' },
+          second: { type: 'leaf', leafId: 'leaf-b' }
+        }
+      },
+      {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          ratio: 0.7,
+          first: { type: 'leaf', leafId: 'leaf-a' },
+          second: { type: 'leaf', leafId: 'leaf-b' }
+        }
+      }
+    ]
+
+    for (const mutation of mutations) {
+      store.getState().setTabLayout('tab-1', makeLayout())
+      let wakeups = 0
+      const unsubscribe = store.subscribe(() => {
+        wakeups += 1
+      })
+      store.getState().setTabLayout('tab-1', makeLayout(mutation))
+      unsubscribe()
+      expect(wakeups, `expected a publish for ${JSON.stringify(mutation)}`).toBe(1)
+    }
+  })
+
+  it('does not fire pane-ownership transfers for a bailed-out identical layout', () => {
+    // A duplicate-pty layout normalizes to a transfer; replaying the already-normalized
+    // snapshot must be inert, since normalization then finds nothing to move.
+    const store = createTestStore()
+    const duplicate = makeLayout({
+      ptyIdsByLeafId: { 'leaf-a': 'pty-a', 'leaf-b': 'pty-a' }
+    })
+    store.getState().setTabLayout('tab-1', duplicate)
+    const normalized = store.getState().terminalLayoutsByTabId['tab-1']
+    expect(normalized.ptyIdsByLeafId).not.toEqual(duplicate.ptyIdsByLeafId)
+
+    store.getState().markTerminalPaneUnread('tab-1:leaf-a')
+    const beforeUnread = { ...store.getState().unreadTerminalPanes }
+
+    for (let i = 0; i < REPEATS; i += 1) {
+      store.getState().setTabLayout('tab-1', { ...normalized })
+    }
+
+    expect(store.getState().terminalLayoutsByTabId['tab-1']).toBe(normalized)
+    expect(store.getState().unreadTerminalPanes).toEqual(beforeUnread)
+  })
+
+  it('still deletes the layout on a clearing call, and bails when already absent', () => {
+    const store = createTestStore()
+    store.getState().setTabLayout('tab-1', makeLayout())
+
+    store.getState().setTabLayout('tab-1', null)
+    expect('tab-1' in store.getState().terminalLayoutsByTabId).toBe(false)
+
+    let wakeups = 0
+    const unsubscribe = store.subscribe(() => {
+      wakeups += 1
+    })
+    store.getState().setTabLayout('tab-1', null)
+    unsubscribe()
+    expect(wakeups).toBe(0)
+  })
+})

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -54,6 +54,7 @@ import type { AgentStartedTelemetry } from '../../lib/worktree-activation'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { forgetAgentHibernationTabOutput } from '@/lib/agent-hibernation-output-activity'
 import { forgetForegroundTerminalTabs } from '@/lib/foreground-terminal-tabs'
+import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { forgetAgentStartupDeliveriesForTabs } from '@/lib/agent-startup-delivery-guards'
 import { clearTransientTerminalState, emptyLayoutSnapshot } from './terminal-helpers'
 import {
@@ -1266,15 +1267,18 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   setCacheTimerStartedAt: (key, ts) => {
     set((s) => {
-      const next = { ...s.cacheTimerByKey, [key]: ts }
       // Why: a real pane write clears any ':seed' sentinel from seedCacheTimersForIdleTabs, avoiding phantom timers when the seed key doesn't match the real pane.
       const colonIdx = key.indexOf(':')
-      if (colonIdx !== -1) {
-        const tabId = key.slice(0, colonIdx)
-        const suffix = key.slice(colonIdx + 1)
-        if (suffix !== 'seed') {
-          delete next[`${tabId}:seed`]
-        }
+      const suffix = colonIdx === -1 ? null : key.slice(colonIdx + 1)
+      const seedKey = colonIdx !== -1 && suffix !== 'seed' ? `${key.slice(0, colonIdx)}:seed` : null
+      const hasStaleSeed = seedKey !== null && seedKey in s.cacheTimerByKey
+      // Why: parked-pane watchers replay null-over-null on every working/exit transition; each redundant write runs every subscriber's selector.
+      if (s.cacheTimerByKey[key] === ts && !hasStaleSeed) {
+        return s
+      }
+      const next = { ...s.cacheTimerByKey, [key]: ts }
+      if (seedKey !== null) {
+        delete next[seedKey]
       }
       return { cacheTimerByKey: next }
     })
@@ -3649,20 +3653,27 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   setTabLayout: (tabId, layout) => {
     let ownershipTransfers: ReturnType<typeof resolveTerminalLayoutPtyOwnershipTransfers> = []
     set((s) => {
-      const next = { ...s.terminalLayoutsByTabId }
-      if (layout) {
-        const normalized = normalizeTerminalLayoutPtyOwnership(layout)
-        next[tabId] = normalized.snapshot
-        if (normalized.changed) {
-          ownershipTransfers = resolveTerminalLayoutPtyOwnershipTransfers(
-            layout,
-            normalized.snapshot
-          )
+      if (!layout) {
+        if (!(tabId in s.terminalLayoutsByTabId)) {
+          return s
         }
-      } else {
+        const next = { ...s.terminalLayoutsByTabId }
         delete next[tabId]
+        return { terminalLayoutsByTabId: next }
       }
-      return { terminalLayoutsByTabId: next }
+      const normalized = normalizeTerminalLayoutPtyOwnership(layout)
+      // Resolved before the bailout: normalization can transfer pane ownership even when the stored snapshot is untouched.
+      if (normalized.changed) {
+        ownershipTransfers = resolveTerminalLayoutPtyOwnershipTransfers(layout, normalized.snapshot)
+      }
+      // Why: pane-title churn re-persists structurally identical snapshots; bailing keeps every pane selector asleep.
+      const existing = s.terminalLayoutsByTabId[tabId]
+      if (existing && terminalLayoutEqual(existing, normalized.snapshot)) {
+        return s
+      }
+      return {
+        terminalLayoutsByTabId: { ...s.terminalLayoutsByTabId, [tabId]: normalized.snapshot }
+      }
     })
     transferNormalizedTerminalLayoutPtyOwnership(get(), tabId, ownershipTransfers)
   },

--- a/tests/e2e/paired-remote-pane-layout-retry.spec.ts
+++ b/tests/e2e/paired-remote-pane-layout-retry.spec.ts
@@ -1,0 +1,210 @@
+import type { Page } from '@stablyai/playwright-test'
+import type { RuntimeMobileSessionTabsResult } from '../../src/shared/runtime-types'
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import type { TerminalLayoutSnapshot } from '../../src/shared/types'
+import {
+  launchHeadlessPairedRuntimeHost,
+  type HeadlessPairedRuntimeHost
+} from './helpers/headless-paired-runtime-host'
+import { expect, test } from './helpers/orca-app'
+import {
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+
+async function callEnvironment<TResult>(
+  page: Page,
+  environmentId: string,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  return page.evaluate(
+    async ({ environmentId, method, params }) => {
+      const response = await window.api.runtimeEnvironments.call({
+        selector: environmentId,
+        method,
+        params
+      })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { environmentId, method, params }
+  ) as Promise<TResult>
+}
+
+async function openClientTab(page: Page, worktreeId: string, tabId: string): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          ({ tabId, worktreeId }) =>
+            (window.__store?.getState().tabsByWorktree[worktreeId] ?? []).some(
+              (tab) => tab.id === tabId
+            ),
+          { tabId, worktreeId }
+        ),
+      { timeout: 60_000, message: `paired client never mirrored host tab ${tabId}` }
+    )
+    .toBe(true)
+  await page.evaluate(
+    ({ tabId, worktreeId }) => {
+      const state = window.__store?.getState()
+      state?.setActiveView('terminal')
+      state?.setActiveWorktree(worktreeId)
+      state?.setActiveTab(tabId)
+      state?.setActiveTabType('terminal')
+    },
+    { tabId, worktreeId }
+  )
+  await expect
+    .poll(() => page.evaluate((id) => window.__paneManagers?.has(id) ?? false, tabId), {
+      timeout: 60_000,
+      message: `paired client pane for ${tabId} did not mount`
+    })
+    .toBe(true)
+}
+
+async function readHostLayout(
+  host: HeadlessPairedRuntimeHost,
+  worktreeId: string,
+  hostTabId: string
+): Promise<TerminalLayoutSnapshot | null> {
+  const snapshot = (
+    await host.client.call<RuntimeMobileSessionTabsResult>('session.tabs.list', {
+      worktree: `id:${worktreeId}`
+    })
+  ).result
+  return (
+    snapshot.tabs.find((tab) => tab.type === 'terminal' && tab.parentTabId === hostTabId)
+      ?.parentLayout ?? null
+  )
+}
+
+async function readClientLayout(page: Page, tabId: string): Promise<TerminalLayoutSnapshot | null> {
+  return page.evaluate((id) => window.__store?.getState().terminalLayoutsByTabId[id] ?? null, tabId)
+}
+
+async function setPaneTitle(page: Page, title: string): Promise<void> {
+  const isMac = await page.evaluate(() => navigator.userAgent.includes('Mac'))
+  await page
+    .locator('.xterm:visible')
+    .first()
+    .click({
+      button: isMac ? 'left' : 'right',
+      position: { x: 40, y: 40 },
+      modifiers: isMac ? ['Control'] : []
+    })
+  await page.getByText('Set Title…', { exact: true }).click()
+  const titleInput = page.getByRole('textbox', { name: 'Pane title' })
+  await expect(titleInput).toBeVisible()
+  await titleInput.fill(title)
+  await titleInput.press('Enter')
+  await expect(titleInput).toHaveCount(0)
+  await expect(page.getByRole('button', { name: `Edit pane title: ${title}` })).toBeVisible()
+}
+
+test('retries an identical remote pane layout after reconnect', async ({
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(240_000)
+  const title = `Reconnect retry ${Date.now()}`
+  const host = await launchHeadlessPairedRuntimeHost()
+  let client: PairedElectronClient | null = null
+  let observer: PairedElectronClient | null = null
+  let terminal: string | null = null
+
+  try {
+    await host.client.call('repo.add', { path: testRepoPath, kind: 'git' })
+    client = await launchPairedElectronClient(host.offer, testInfo, 'Pane layout retry client')
+    await expect
+      .poll(
+        () =>
+          client?.page.evaluate(() => window.__store?.getState().allWorktrees().length ?? 0) ?? 0,
+        { timeout: 60_000, message: 'paired client never saw a host worktree' }
+      )
+      .toBeGreaterThan(0)
+    const worktreeId = await client.page.evaluate(
+      () => window.__store?.getState().allWorktrees()[0]?.id ?? null
+    )
+    if (!worktreeId) {
+      throw new Error('Paired client did not receive the host worktree')
+    }
+
+    const created = await callEnvironment<{
+      tab: { parentTabId: string; terminal: string | null }
+    }>(client.page, client.environmentId, 'session.tabs.createTerminal', {
+      worktree: `id:${worktreeId}`,
+      activate: false,
+      select: false,
+      navigation: 'caller'
+    })
+    terminal = created.tab.terminal
+    if (!terminal) {
+      throw new Error('Host terminal was not created')
+    }
+    const hostTabId = created.tab.parentTabId
+    const webTabId = toWebTerminalSurfaceTabId(hostTabId)
+    await openClientTab(client.page, worktreeId, webTabId)
+
+    const terminalRoot = client.page.locator(`[data-terminal-tab-id="${webTabId}"]`).first()
+    await terminalRoot.evaluate((element) => {
+      element.setAttribute('data-layout-retry-owner', 'original')
+    })
+    await client.page.evaluate(async (selector) => {
+      await window.api.runtimeEnvironments.disconnect({ selector })
+    }, client.environmentId)
+
+    const failedPush = client.page.waitForEvent('console', {
+      predicate: (message) =>
+        message.type() === 'warning' &&
+        message.text().includes('[web-runtime-session] failed to update pane layout:'),
+      timeout: 30_000
+    })
+    await setPaneTitle(client.page, title)
+    await failedPush
+    const failedLayout = await readClientLayout(client.page, webTabId)
+    expect(Object.values(failedLayout?.titlesByLeafId ?? {})).toContain(title)
+    expect(
+      Object.values((await readHostLayout(host, worktreeId, hostTabId))?.titlesByLeafId ?? {})
+    ).not.toContain(title)
+
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate(async (selector) => {
+            const response = await window.api.runtimeEnvironments.connect({ selector })
+            return response.ok
+          }, client.environmentId),
+        { timeout: 60_000, message: 'paired client never reconnected to the host runtime' }
+      )
+      .toBe(true)
+    await expect(terminalRoot).toHaveAttribute('data-layout-retry-owner', 'original')
+
+    await setPaneTitle(client.page, title)
+    expect(await readClientLayout(client.page, webTabId)).toEqual(failedLayout)
+    await expect
+      .poll(
+        async () =>
+          Object.values(
+            (await readHostLayout(host, worktreeId, hostTabId))?.titlesByLeafId ?? {}
+          ).includes(title),
+        { timeout: 30_000, message: 'headless host never persisted the retried pane layout' }
+      )
+      .toBe(true)
+
+    observer = await launchPairedElectronClient(host.offer, testInfo, 'Pane layout retry observer')
+    await openClientTab(observer.page, worktreeId, webTabId)
+    await expect(
+      observer.page.getByRole('button', { name: `Edit pane title: ${title}` })
+    ).toBeVisible({ timeout: 30_000 })
+  } finally {
+    await observer?.dispose()
+    if (terminal) {
+      await host.client.call('terminal.closeTab', { terminal }).catch(() => undefined)
+    }
+    await client?.dispose()
+    await host.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

Two terminal-store writes published a new `AppState` on every call even when nothing changed, and one remote IPC fired on every layout persist regardless of whether the host-visible layout had moved. Because the renderer's per-pane selectors are O(mounted panes), each redundant publish ran every subscriber's selector across the whole app.

- **`setCacheTimerStartedAt`** spread `{ ...s.cacheTimerByKey, [key]: ts }` and returned unconditionally, while every sibling action in the slice guards. The cadence is real: `parked-terminal-byte-watcher` writes `null` on every `onAgentBecameWorking`, every `onAgentExited`, and every stale-working-title clear — i.e. repeated null-over-null writes per agent transition, per parked pane. Now bails when the stored value is already identical (strict equality, so it covers both `number` and `null`). The `:seed` sentinel clear is preserved: a real pane write with an unchanged value still proceeds when a stale `${tabId}:seed` entry exists, or the bailout would strand a phantom timer.
- **`setTabLayout`** spread `{ ...s.terminalLayoutsByTabId }` and returned unconditionally even when the normalized snapshot was structurally identical to the stored one. Its hot caller is `TerminalPane.persistLayoutSnapshot`, invoked from ~10 sites including an effect whose deps include `paneTitles` — so pane-title churn drove layout persistence. Now bails when `terminalLayoutEqual(existing, normalized.snapshot)`. Normalization still runs first, and pty-ownership transfers are resolved *before* the bailout so that side effect is unchanged for any layout that normalization actually rewrites.
- **Remote layout push.** After `setTabLayout`, if any pty was remote, `persistLayoutSnapshot` fired `updateWebRuntimePaneLayout` with no comparison against what was last pushed — one remote round trip per title change per tab. Extracted into `createRemotePaneLayoutPusher`, which dedupes in-flight and successful pushes by worktree, tab, and full snapshot; failed pushes re-arm the layout and remounts start with a fresh pusher.

The comparator that gates the layout write already existed as `terminalLayoutEqual` in `web-session-tabs-sync.ts`, module-private. It is now `src/renderer/src/lib/terminal-layout-equality.ts` and imported back into `web-session-tabs-sync.ts` unchanged — the moved implementation is character-identical, so the mirroring path's behavior is untouched.

No user-visible behavior changes: the only things eliminated are writes and IPCs that carried no new information.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:reliability-gates`, `check:max-lines-ratchet` all clean
- [x] `pnpm typecheck` — `config/tsconfig.tc.web.json` clean
- [x] `pnpm test` — `src/renderer` + `src/shared`: **23,181 passed**, 19 skipped. The only 2 failures are in `src/shared/setup-agent-sequencing.test.ts`, which fails identically on the parent commit (`9a97e737f5`) in this environment — a pre-existing local red (Node v26 vs the repo's pinned Node 24), unrelated to this diff.
- [x] `pnpm build` — not run; typecheck covers the compile surface and the diff is renderer-only TypeScript with no build-config or native-module changes.
- [x] Added or updated high-quality tests

### Measurements

Two new test files count the actual effect, and both are **red on the parent commit**:

**Store-level subscriber wakeups** (`terminal-write-identity-bailouts.test.ts`) — a subscriber counter attached to a real zustand store (`createTestStore`), 1,000 repeat writes each:

| Scenario | Before | After |
| --- | ---: | ---: |
| 1,000 null-over-null `setCacheTimerStartedAt` | 1,000 wakeups | **0** |
| 1,000 repeats of the same timestamp | 1,000 wakeups | **0** |
| 1,000 structurally identical `setTabLayout` snapshots | 1,000 wakeups | **0** |

Verified red on parent by reverting `terminals.ts` to `HEAD`: `expected 1000 to be +0` on all three, 6 of 10 tests failing.

**Remote-push count** (`remote-pane-layout-push.test.ts`) — IPC boundary mocked, 100 persist calls with an unchanged layout:

| | Before | After |
| --- | ---: | ---: |
| `updateWebRuntimePaneLayout` invocations | 100 | **1** |

Verified red by deleting the dedupe guard: `expected "vi.fn()" to be called 1 times, but got 100 times`.

**Comparator micro-bench** — realistic 8-leaf split snapshot (balanced split tree, UUID leaf ids, all four leaf-keyed records populated), 1M iterations × 5 runs after a 200k warm-up, Node v26.5.0 / Apple M5 Pro:

| Case | µs/call |
| --- | ---: |
| Fully equal (worst case — walks the whole tree and all 4 records) | **0.582** (runs: 0.581 / 0.582 / 0.582 / 0.585 / 0.610) |
| First-field difference (early exit) | **0.071** |

~0.58 µs against the 5 µs bar, i.e. the check costs roughly 1/8600th of a 5 ms frame budget, versus the O(panes) selector sweep it avoids. The bench was a throwaway; no timing assertion is committed, since wall-clock thresholds are flaky in CI.

Behavior coverage beyond the counters: publishes still happen for every tracked field (`root` shape, `direction`, `ratio`, `activeLeafId`, `expandedLeafId`, `ptyIdsByLeafId`, `buffersByLeafId`, `scrollbackRefsByLeafId`, `titlesByLeafId`); the first write for a key is recorded even when the value is `null`; a stale `:seed` sentinel is still cleared on an otherwise-unchanged pane write; the clearing call (`setTabLayout(tabId, null)`) still deletes and then bails when already absent; and a bailed-out identical layout is asserted to produce no pane-ownership transfers rather than that being assumed. The pusher tests also pin that the payload is byte-for-byte what the un-deduped path sent, that `titlesByLeafId` is still omitted when absent, and that the cache is not carried across tabs.

## AI Review Report

Self-review of the diff, focused on the ways an identity bailout can silently change behavior:

- **Dropped side effects.** The real hazard in `setTabLayout` is that `normalizeTerminalLayoutPtyOwnership` can rewrite a layout carrying a duplicate pty id, and `resolveTerminalLayoutPtyOwnershipTransfers` then moves pane-keyed store state. A naive bailout placed before that resolution would skip the transfer whenever the normalized result happened to match what was already stored. Transfers are therefore resolved *before* the equality check, so `transferNormalizedTerminalLayoutPtyOwnership` sees exactly what it saw before; only the state publish is skipped. Covered by a test that feeds a duplicate-pty layout, then replays the normalized snapshot 1,000 times and asserts both the stored reference and the pane-keyed maps are untouched.
- **`return s` vs `return {}`.** zustand 5 short-circuits on `Object.is(nextState, state)`, so returning the state object itself is what actually skips the listener sweep — returning `{}` would still `Object.assign` a fresh state and wake everyone. Both bailouts return `s`, matching the existing idiom in this slice (`markTerminalTabUnread`, `markTerminalPaneUnread`, `markAgentCompletionPaneUnread`).
- **The `:seed` carve-out.** Bailing purely on value equality would have stranded the `${tabId}:seed` sentinel that `seedCacheTimersForIdleTabs` plants, leaving a phantom countdown. The guard only fires when there is no stale sentinel to clear.
- **First-write-of-null.** `undefined === null` is false, so a key's first `null` write still lands and is still recorded; only the *second* identical write bails. Pinned by a test.
- **Comparator extraction fidelity.** Moved verbatim; `web-session-tabs-sync.ts` imports it and its mirroring call site is unchanged. Its whole test surface passes (285 files / 3,558 tests across `terminal-pane` + `runtime`).
- **Stale-cache risk on the remote push** — the one genuinely new piece of state. The cache is keyed by worktree and `tabId`; failed pushes re-arm only the current attempt, and the comparator includes `ptyIdsByLeafId`, so a remote reconnect that mints new pty ids re-pushes. The residual case is a host that loses its layout while re-adopting byte-identical pty ids; see Notes.
- **Cross-platform.** Reviewed for macOS / Linux / Windows: the diff adds no keyboard shortcuts, no shortcut labels, no path handling, no shell invocation, and no Electron main-process or platform-branching code. It is pure renderer state comparison plus one existing IPC call being made conditional. The SSH and folder-workspace paths are unaffected — `isRemoteRuntimePtyId` still gates the push exactly as before, and nothing here assumes a git worktree. No Git commands are added or changed, so the Git-version baseline is not in play. `react-doctor` reports one warning in `TerminalPane.tsx` at line 1649 (`no-adjust-state-on-prop-change`); it is present identically on the parent commit and is outside every line and effect this PR touches.

The same-model until-clean review returned clean after scoped fix and coverage passes, and `$electron` evidence is attached in the PR conversation.

## Security Audit

No new attack surface. The diff adds no input parsing, no command execution, no filesystem or path handling, no auth or secret handling, and no dependencies. The one IPC touched (`updateWebRuntimePaneLayout`) is unchanged in payload, sender, and validation — it is simply invoked less often, and the dedupe decision is made entirely from renderer-local state that the renderer already owned. The extracted comparator uses `Object.prototype.hasOwnProperty.call` for record comparison, preserving the original's prototype-pollution-safe key check. No follow-up needed.

## Notes

- **Remote-push cache staleness.** `createRemotePaneLayoutPusher` skips a push when the tab's full layout snapshot matches the last one pushed. It is keyed by tab and worktree, failed pushes re-arm the current attempt, and the comparator includes `ptyIdsByLeafId` — so a remote runtime that reconnects with fresh pty ids re-pushes. The one path that could theoretically skip a needed push is a host that loses its stored pane geometry while the client re-adopts byte-identical pty ids for the same leaves; in that case the host would also be replaying a stale layout back through `web-session-tabs-sync`, which changes the client snapshot and re-arms the push. Flagging it as the one behavioral edge worth watching.
- **Comparison is stricter than the payload.** The push payload is only `root` / `expandedLeafId` / `titlesByLeafId`, but the dedupe compares the whole snapshot. That is deliberate and conservative: equality on the full snapshot implies equality on the payload, so the dedupe can never skip a push whose payload actually differs.
- **Follow-up (not in scope).** The underlying amplifier is that the app's per-pane selectors are O(mounted panes) per store publish, so *any* redundant write is expensive. This PR removes two of the loudest writers; narrowing those selectors is the structural fix and belongs in its own change.

