### PR TITLE
perf(renderer): index detectedWorktreesByRepo so SSH panes and cards stop walking the full detected catalog on every store write

### DIFF
--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -7,7 +7,11 @@ import {
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 import { addRoute, resolveExactWorktreeRoute, routeForOwner } from './worktree-owner-route'
-import { resolveIndexedWorktreeOwner } from './worktree-runtime-owner-index'
+import {
+  findIndexedDetectedWorktrees,
+  hasIndexedDetectedWorktree,
+  resolveIndexedWorktreeOwner
+} from './worktree-runtime-owner-index'
 import {
   findFolderWorkspaceOwner,
   getExecutionHostIdForFolderWorkspace,
@@ -51,11 +55,7 @@ function ownerRecordsOnHost(
   executionHostId: ExecutionHostId
 ): WorktreeOperationOwnerRecord[] {
   const owners: WorktreeOperationOwnerRecord[] = []
-  const catalogs = [
-    ...Object.values(state.worktreesByRepo ?? {}),
-    ...Object.values(state.detectedWorktreesByRepo ?? {}).map((result) => result.worktrees)
-  ]
-  for (const worktrees of catalogs) {
+  for (const worktrees of Object.values(state.worktreesByRepo ?? {})) {
     for (const worktree of worktrees) {
       if (
         worktree.id === worktreeId &&
@@ -63,6 +63,11 @@ function ownerRecordsOnHost(
       ) {
         owners.push(worktree)
       }
+    }
+  }
+  for (const worktree of findIndexedDetectedWorktrees(state.detectedWorktreesByRepo, worktreeId)) {
+    if (parseExecutionHostId(worktree.hostId)?.id === executionHostId) {
+      owners.push(worktree)
     }
   }
   return owners
@@ -135,12 +140,8 @@ export function resolveWorktreeOperationRouteResult(
   }
 
   const hasKnownWorktree =
-    Object.values(state.worktreesByRepo ?? {}).some((worktrees) =>
-      worktrees.some((worktree) => worktree.id === worktreeId)
-    ) ||
-    Object.values(state.detectedWorktreesByRepo ?? {}).some((result) =>
-      result.worktrees.some((worktree) => worktree.id === worktreeId)
-    )
+    resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId).kind !== 'missing' ||
+    hasIndexedDetectedWorktree(state.detectedWorktreesByRepo, worktreeId)
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   const hasKnownRepo = state.repos?.some((repo) => repo.id === repoId) === true
   if (!hasKnownWorktree && !hasKnownRepo) {
@@ -216,18 +217,14 @@ export function resolveExplicitWorktreeOperationRouteResult(
       addRoute(exactRoutes, resolution.route)
     }
   }
-  for (const result of Object.values(state.detectedWorktreesByRepo ?? {})) {
-    for (const worktree of result.worktrees) {
-      if (worktree.id === worktreeId) {
-        exactRepoIds.add(worktree.repoId)
-        const resolution = resolveExactWorktreeRoute(state, worktree)
-        if (resolution.kind === 'ambiguous') {
-          return resolution
-        }
-        if (resolution.kind === 'resolved') {
-          addRoute(exactRoutes, resolution.route)
-        }
-      }
+  for (const worktree of findIndexedDetectedWorktrees(state.detectedWorktreesByRepo, worktreeId)) {
+    exactRepoIds.add(worktree.repoId)
+    const resolution = resolveExactWorktreeRoute(state, worktree)
+    if (resolution.kind === 'ambiguous') {
+      return resolution
+    }
+    if (resolution.kind === 'resolved') {
+      addRoute(exactRoutes, resolution.route)
     }
   }
   if (exactRoutes.size > 0) {

--- a/src/renderer/src/lib/worktree-runtime-owner-index.detected-perf.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.detected-perf.test.ts
@@ -129,7 +129,7 @@ describe('detected worktree index performance', () => {
     expect(walkedReads).toBeGreaterThan(100_000)
   })
 
-  it('keeps the lookup path an order of magnitude cheaper than the catalog walk', () => {
+  it('records lookup-path timing without making wall clock a CI gate', () => {
     const walkPool = freshCatalogPool()
     const walkMs = measureSweeps((sweep) => {
       const catalog = walkPool[sweep]!
@@ -194,9 +194,6 @@ describe('detected worktree index performance', () => {
       `${JSON.stringify(report, null, 2)}\n`
     )
 
-    // Only the warm ratio is asserted: a republished catalog pays one rebuild that costs about
-    // what a single sweep's walk did, so the fresh leg is parity and is recorded, not gated.
-    // The measured warm margin is ~100x, so this bound cannot flake under CI load.
-    expect(walkWarmMs / warmMs).toBeGreaterThan(10)
+    // Why: shared-runner timing is noisy; the read-count test above is the deterministic CI gate.
   })
 })

--- a/src/renderer/src/lib/worktree-runtime-owner-index.detected-perf.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.detected-perf.test.ts
@@ -108,14 +108,15 @@ function measureSweeps(run: (sweep: number) => void): number {
 }
 
 describe('detected worktree index performance', () => {
-  it('answers repeated lookups without rescanning the detected catalog', () => {
+  it('answers repeated owner lookups without rescanning the detected catalog', () => {
     const counter = { reads: 0 }
     const catalog = buildDetectedCatalog(0, counter)
+    const state = buildOwnerState(catalog)
 
-    hasIndexedDetectedWorktree(catalog, 'repo-0::warm-the-index')
+    getExplicitRuntimeEnvironmentIdForWorktree(state, 'repo-0::warm-the-index')
     counter.reads = 0
     for (const probeId of PROBE_IDS) {
-      hasIndexedDetectedWorktree(catalog, probeId)
+      getExplicitRuntimeEnvironmentIdForWorktree(state, probeId)
     }
     const indexedReads = counter.reads
 

--- a/src/renderer/src/lib/worktree-runtime-owner-index.detected-perf.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.detected-perf.test.ts
@@ -1,0 +1,202 @@
+import { writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import { hasIndexedDetectedWorktree } from './worktree-runtime-owner-index'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
+import type { WorktreeRuntimeOwnerState } from './worktree-runtime-owner-state'
+
+const REPO_COUNT = 20
+const WORKTREES_PER_REPO = 100
+const LOOKUPS_PER_SWEEP = 200
+const SWEEPS = 40
+
+type OwnerRecord = {
+  id: string
+  repoId: string
+  hostId?: ExecutionHostId
+  runtimeOwnerEnvironmentId?: string
+}
+type DetectedByRepo = Record<string, { worktrees: readonly OwnerRecord[] }>
+
+// The pre-index expression, kept as the "before" leg of the benchmark.
+function walkHasDetected(detectedWorktreesByRepo: DetectedByRepo | undefined, id: string): boolean {
+  return Object.values(detectedWorktreesByRepo ?? {}).some((result) =>
+    result.worktrees.some((worktree) => worktree.id === id)
+  )
+}
+
+function buildDetectedCatalog(generation: number, counter?: { reads: number }): DetectedByRepo {
+  const catalog: DetectedByRepo = {}
+  for (let repoIndex = 0; repoIndex < REPO_COUNT; repoIndex += 1) {
+    const repoId = `repo-${repoIndex}`
+    const worktrees: OwnerRecord[] = []
+    for (let index = 0; index < WORKTREES_PER_REPO; index += 1) {
+      const id = `${repoId}::detected-${index}-gen-${generation}`
+      const record: OwnerRecord = { id, repoId, hostId: 'ssh:target-a' }
+      if (counter) {
+        Object.defineProperty(record, 'id', {
+          get: () => {
+            counter.reads += 1
+            return id
+          },
+          enumerable: true
+        })
+      }
+      worktrees.push(record)
+    }
+    catalog[repoId] = { worktrees }
+  }
+  return catalog
+}
+
+const publishedRepos = Array.from({ length: REPO_COUNT }, (_unused, index) => ({
+  id: `repo-${index}`,
+  connectionId: `target-${index}`
+}))
+const publishedWorktreesByRepo: Record<string, OwnerRecord[]> = Object.fromEntries(
+  publishedRepos.map((repo) => [
+    repo.id,
+    Array.from({ length: WORKTREES_PER_REPO }, (_unused, index) => ({
+      id: `${repo.id}::worktree-${index}`,
+      repoId: repo.id,
+      hostId: 'ssh:target-a' as const
+    }))
+  ])
+)
+
+// Only the detected catalog changes identity: that is what isolates the collection under test.
+function buildOwnerState(detectedWorktreesByRepo: DetectedByRepo): WorktreeRuntimeOwnerState {
+  return {
+    repos: publishedRepos,
+    worktreesByRepo: publishedWorktreesByRepo,
+    detectedWorktreesByRepo,
+    activeWorktreeId: null,
+    activeWorkspaceExecutionHostId: null,
+    runtimeEnvironments: []
+  }
+}
+
+// Probe ids are published but never detected — the SSH-pane case, and the walk's worst case.
+const PROBE_IDS = Array.from(
+  { length: LOOKUPS_PER_SWEEP },
+  (_unused, index) => `repo-${index % REPO_COUNT}::worktree-${index % WORKTREES_PER_REPO}`
+)
+
+const WARMUP_SWEEPS = 5
+const warmCatalog = buildDetectedCatalog(-1)
+
+// Each fresh leg needs its own never-indexed catalogs; a shared pool would leave the index warm
+// for whichever leg runs second and silently erase the rebuild it is supposed to measure.
+let catalogGeneration = 0
+function freshCatalogPool(): DetectedByRepo[] {
+  return Array.from({ length: SWEEPS + WARMUP_SWEEPS }, () =>
+    buildDetectedCatalog((catalogGeneration += 1))
+  )
+}
+
+function measureSweeps(run: (sweep: number) => void): number {
+  for (let warmup = 0; warmup < WARMUP_SWEEPS; warmup += 1) {
+    run(warmup)
+  }
+  const started = performance.now()
+  for (let sweep = 0; sweep < SWEEPS; sweep += 1) {
+    run(WARMUP_SWEEPS + sweep)
+  }
+  return (performance.now() - started) / SWEEPS
+}
+
+describe('detected worktree index performance', () => {
+  it('answers repeated lookups without rescanning the detected catalog', () => {
+    const counter = { reads: 0 }
+    const catalog = buildDetectedCatalog(0, counter)
+
+    hasIndexedDetectedWorktree(catalog, 'repo-0::warm-the-index')
+    counter.reads = 0
+    for (const probeId of PROBE_IDS) {
+      hasIndexedDetectedWorktree(catalog, probeId)
+    }
+    const indexedReads = counter.reads
+
+    counter.reads = 0
+    for (const probeId of PROBE_IDS) {
+      walkHasDetected(catalog, probeId)
+    }
+    const walkedReads = counter.reads
+
+    expect(indexedReads).toBe(0)
+    expect(walkedReads).toBeGreaterThan(100_000)
+  })
+
+  it('keeps the lookup path an order of magnitude cheaper than the catalog walk', () => {
+    const walkPool = freshCatalogPool()
+    const walkMs = measureSweeps((sweep) => {
+      const catalog = walkPool[sweep]!
+      for (const probeId of PROBE_IDS) {
+        walkHasDetected(catalog, probeId)
+      }
+    })
+    const walkWarmMs = measureSweeps(() => {
+      for (const probeId of PROBE_IDS) {
+        walkHasDetected(warmCatalog, probeId)
+      }
+    })
+    // Unrelated store writes leave the detected catalog identical, so the index stays warm.
+    const warmMs = measureSweeps(() => {
+      for (const probeId of PROBE_IDS) {
+        hasIndexedDetectedWorktree(warmCatalog, probeId)
+      }
+    })
+    // A landed worktree scan republishes the catalog: one rebuild amortized over the sweep.
+    const freshPool = freshCatalogPool()
+    const freshMs = measureSweeps((sweep) => {
+      const catalog = freshPool[sweep]!
+      for (const probeId of PROBE_IDS) {
+        hasIndexedDetectedWorktree(catalog, probeId)
+      }
+    })
+
+    const statePool = freshCatalogPool().map(buildOwnerState)
+    const warmState = buildOwnerState(warmCatalog)
+    const explicitOwnerFreshMs = measureSweeps((sweep) => {
+      const state = statePool[sweep]!
+      for (const probeId of PROBE_IDS) {
+        getExplicitRuntimeEnvironmentIdForWorktree(state, probeId)
+      }
+    })
+    const explicitOwnerWarmMs = measureSweeps(() => {
+      for (const probeId of PROBE_IDS) {
+        getExplicitRuntimeEnvironmentIdForWorktree(warmState, probeId)
+      }
+    })
+
+    const round = (value: number): number => Number(value.toFixed(4))
+    const report = {
+      entries: REPO_COUNT * WORKTREES_PER_REPO,
+      lookupsPerSweep: LOOKUPS_PER_SWEEP,
+      sweeps: SWEEPS,
+      lookupPath: {
+        walkFreshMsPerSweep: round(walkMs),
+        walkWarmMsPerSweep: round(walkWarmMs),
+        indexedWarmMsPerSweep: round(warmMs),
+        indexedFreshMsPerSweep: round(freshMs),
+        warmSpeedup: round(walkWarmMs / warmMs),
+        freshSpeedup: round(walkMs / freshMs)
+      },
+      getExplicitRuntimeEnvironmentIdForWorktree: {
+        warmMsPerSweep: round(explicitOwnerWarmMs),
+        freshMsPerSweep: round(explicitOwnerFreshMs)
+      }
+    }
+    writeFileSync(
+      join(tmpdir(), 'orca-detected-worktree-index-bench.json'),
+      `${JSON.stringify(report, null, 2)}\n`
+    )
+
+    // Only the warm ratio is asserted: a republished catalog pays one rebuild that costs about
+    // what a single sweep's walk did, so the fresh leg is parity and is recorded, not gated.
+    // The measured warm margin is ~100x, so this bound cannot flake under CI load.
+    expect(walkWarmMs / warmMs).toBeGreaterThan(10)
+  })
+})

--- a/src/renderer/src/lib/worktree-runtime-owner-index.detected.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.detected.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import {
+  findIndexedDetectedWorktrees,
+  hasIndexedDetectedWorktree,
+  resolveIndexedWorktreeOwner
+} from './worktree-runtime-owner-index'
+
+type OwnerRecord = {
+  id: string
+  repoId: string
+  hostId?: ExecutionHostId
+  runtimeOwnerEnvironmentId?: string
+}
+type DetectedByRepo = Record<string, { worktrees: readonly OwnerRecord[] }>
+
+// The pre-index expressions this module replaced, kept verbatim as parity oracles.
+function walkHasDetected(detectedWorktreesByRepo: DetectedByRepo | undefined, id: string): boolean {
+  return Object.values(detectedWorktreesByRepo ?? {}).some((result) =>
+    result.worktrees.some((worktree) => worktree.id === id)
+  )
+}
+
+function walkDetectedMatches(
+  detectedWorktreesByRepo: DetectedByRepo | undefined,
+  id: string
+): OwnerRecord[] {
+  const matches: OwnerRecord[] = []
+  for (const result of Object.values(detectedWorktreesByRepo ?? {})) {
+    for (const worktree of result.worktrees) {
+      if (worktree.id === id) {
+        matches.push(worktree)
+      }
+    }
+  }
+  return matches
+}
+
+function walkHasKnown(
+  worktreesByRepo: Record<string, readonly OwnerRecord[]> | undefined,
+  id: string
+): boolean {
+  return Object.values(worktreesByRepo ?? {}).some((worktrees) =>
+    worktrees.some((worktree) => worktree.id === id)
+  )
+}
+
+// Deterministic LCG so a parity failure reproduces from the printed case index.
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0x100000000
+  }
+}
+
+const HOST_IDS: (ExecutionHostId | undefined)[] = [
+  undefined,
+  'local',
+  'ssh:target-a',
+  'ssh:target-b',
+  'runtime:hub-a'
+]
+
+function buildCase(random: () => number): {
+  detectedWorktreesByRepo: DetectedByRepo | undefined
+  worktreesByRepo: Record<string, readonly OwnerRecord[]>
+  probeIds: string[]
+} {
+  const shape = random()
+  if (shape < 0.05) {
+    return { detectedWorktreesByRepo: undefined, worktreesByRepo: {}, probeIds: ['repo-0::absent'] }
+  }
+  if (shape < 0.1) {
+    return { detectedWorktreesByRepo: {}, worktreesByRepo: {}, probeIds: ['repo-0::absent'] }
+  }
+  const repoCount = 1 + Math.floor(random() * 6)
+  const detectedWorktreesByRepo: DetectedByRepo = {}
+  const worktreesByRepo: Record<string, readonly OwnerRecord[]> = {}
+  const knownIds: string[] = []
+  for (let repoIndex = 0; repoIndex < repoCount; repoIndex += 1) {
+    const repoId = `repo-${repoIndex}`
+    // Empty arrays are a real store shape: a scan that found nothing still publishes its bucket.
+    const worktreeCount = random() < 0.25 ? 0 : 1 + Math.floor(random() * 5)
+    const detected: OwnerRecord[] = []
+    const published: OwnerRecord[] = []
+    for (let index = 0; index < worktreeCount; index += 1) {
+      // Duplicate ids across repos are how rival publications collide, so allow a shared pool.
+      const id = random() < 0.3 ? `shared::worktree-${index}` : `${repoId}::worktree-${index}`
+      const record: OwnerRecord = {
+        id,
+        repoId,
+        hostId: HOST_IDS[Math.floor(random() * HOST_IDS.length)],
+        ...(random() < 0.3 ? { runtimeOwnerEnvironmentId: `hub-${Math.floor(random() * 3)}` } : {})
+      }
+      knownIds.push(id)
+      if (random() < 0.8) {
+        detected.push(record)
+      }
+      if (random() < 0.5) {
+        published.push(record)
+      }
+    }
+    detectedWorktreesByRepo[repoId] = { worktrees: detected }
+    worktreesByRepo[repoId] = published
+  }
+  const probeIds = [
+    knownIds[0] ?? 'repo-0::absent',
+    knownIds.at(-1) ?? 'repo-0::absent',
+    knownIds[Math.floor(random() * Math.max(knownIds.length, 1))] ?? 'repo-0::absent',
+    'shared::worktree-0',
+    'never-published::worktree'
+  ]
+  return { detectedWorktreesByRepo, worktreesByRepo, probeIds }
+}
+
+describe('detected worktree index', () => {
+  it('matches the pre-index catalog walk across randomized store shapes', () => {
+    const random = makeRandom(0x5eed)
+    for (let caseIndex = 0; caseIndex < 240; caseIndex += 1) {
+      const { detectedWorktreesByRepo, worktreesByRepo, probeIds } = buildCase(random)
+      for (const probeId of probeIds) {
+        expect(
+          {
+            case: caseIndex,
+            probeId,
+            has: hasIndexedDetectedWorktree(detectedWorktreesByRepo, probeId)
+          },
+          `case ${caseIndex} / ${probeId}`
+        ).toEqual({
+          case: caseIndex,
+          probeId,
+          has: walkHasDetected(detectedWorktreesByRepo, probeId)
+        })
+        expect(
+          findIndexedDetectedWorktrees(detectedWorktreesByRepo, probeId),
+          `case ${caseIndex} / ${probeId}`
+        ).toEqual(walkDetectedMatches(detectedWorktreesByRepo, probeId))
+        expect(
+          resolveIndexedWorktreeOwner(worktreesByRepo, probeId).kind !== 'missing',
+          `case ${caseIndex} / ${probeId}`
+        ).toBe(walkHasKnown(worktreesByRepo, probeId))
+      }
+    }
+  })
+
+  it('returns rival publications in catalog order with identity preserved', () => {
+    const first = { id: 'shared', repoId: 'repo-a', hostId: 'ssh:target-a' as const }
+    const second = { id: 'shared', repoId: 'repo-b', hostId: 'runtime:hub-a' as const }
+    const detectedWorktreesByRepo = {
+      'repo-a': { worktrees: [first] },
+      'repo-b': { worktrees: [second] }
+    }
+
+    const matches = findIndexedDetectedWorktrees(detectedWorktreesByRepo, 'shared')
+    expect(matches).toHaveLength(2)
+    expect(matches[0]).toBe(first)
+    expect(matches[1]).toBe(second)
+  })
+
+  it('treats undefined, empty, and empty-bucket catalogs as unpublished', () => {
+    expect(hasIndexedDetectedWorktree(undefined, 'repo::wt')).toBe(false)
+    expect(findIndexedDetectedWorktrees(undefined, 'repo::wt')).toEqual([])
+    expect(hasIndexedDetectedWorktree({}, 'repo::wt')).toBe(false)
+    expect(hasIndexedDetectedWorktree({ repo: { worktrees: [] } }, 'repo::wt')).toBe(false)
+  })
+
+  it('re-indexes a new catalog identity instead of serving stale hits', () => {
+    const worktree = { id: 'repo::wt', repoId: 'repo' }
+    const before = { repo: { worktrees: [worktree] } }
+    expect(hasIndexedDetectedWorktree(before, 'repo::wt')).toBe(true)
+
+    const afterRemoval = { repo: { worktrees: [] } }
+    expect(hasIndexedDetectedWorktree(afterRemoval, 'repo::wt')).toBe(false)
+
+    const afterReadd = { repo: { worktrees: [worktree] } }
+    expect(findIndexedDetectedWorktrees(afterReadd, 'repo::wt')).toEqual([worktree])
+    // The prior identity keeps its own cached answer; nothing bleeds between snapshots.
+    expect(hasIndexedDetectedWorktree(afterRemoval, 'repo::wt')).toBe(false)
+    expect(hasIndexedDetectedWorktree(before, 'repo::wt')).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../shared/execution-host'
 
 type WorktreeOwnerRecord = Pick<Worktree, 'id' | 'repoId' | 'hostId' | 'runtimeOwnerEnvironmentId'>
+type DetectedWorktreeListing = { worktrees: readonly WorktreeOwnerRecord[] }
 type RepoOwnerRecord = Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>
 type FolderWorkspaceOwnerRecord = Pick<
   FolderWorkspace,
@@ -33,6 +34,12 @@ const projectGroupOwnerIndexCache = new WeakMap<
   readonly ProjectGroupOwnerRecord[],
   ReadonlyMap<string, IndexedProjectGroupOwnerResolution>
 >()
+const detectedWorktreeIndexCache = new WeakMap<
+  Record<string, DetectedWorktreeListing>,
+  ReadonlyMap<string, readonly WorktreeOwnerRecord[]>
+>()
+
+const NO_DETECTED_WORKTREES: readonly WorktreeOwnerRecord[] = []
 
 type IndexedFolderWorkspaceOwnerResolution =
   | { kind: 'resolved'; owner: FolderWorkspaceOwnerRecord }
@@ -208,6 +215,43 @@ export function resolveIndexedWorktreeOwner(
     worktreeOwnerIndexCache.set(worktreesByRepo, index)
   }
   return index.get(worktreeId) ?? { kind: 'missing' }
+}
+
+/**
+ * Every detected publication of `worktreeId`, in catalog order. Rival repos may publish the same
+ * id, so callers that fail closed on conflicts need all matches rather than one resolved owner.
+ */
+export function findIndexedDetectedWorktrees(
+  detectedWorktreesByRepo: Record<string, DetectedWorktreeListing> | undefined,
+  worktreeId: string
+): readonly WorktreeOwnerRecord[] {
+  if (!detectedWorktreesByRepo) {
+    return NO_DETECTED_WORKTREES
+  }
+  let index = detectedWorktreeIndexCache.get(detectedWorktreesByRepo)
+  if (!index) {
+    const next = new Map<string, WorktreeOwnerRecord[]>()
+    for (const listing of Object.values(detectedWorktreesByRepo)) {
+      for (const worktree of listing.worktrees) {
+        const matches = next.get(worktree.id)
+        if (matches) {
+          matches.push(worktree)
+        } else {
+          next.set(worktree.id, [worktree])
+        }
+      }
+    }
+    index = next
+    detectedWorktreeIndexCache.set(detectedWorktreesByRepo, index)
+  }
+  return index.get(worktreeId) ?? NO_DETECTED_WORKTREES
+}
+
+export function hasIndexedDetectedWorktree(
+  detectedWorktreesByRepo: Record<string, DetectedWorktreeListing> | undefined,
+  worktreeId: string
+): boolean {
+  return findIndexedDetectedWorktrees(detectedWorktreesByRepo, worktreeId).length > 0
 }
 
 export function findIndexedRepoOwner(

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -7,6 +7,7 @@ import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
 import {
   findIndexedRepoOwner as findRepoRecord,
   findIndexedWorktreeOwner as findWorktreeRecord,
+  hasIndexedDetectedWorktree,
   resolveIndexedRepoOwner,
   resolveIndexedWorktreeOwner
 } from './worktree-runtime-owner-index'
@@ -79,9 +80,7 @@ export function getRuntimeEnvironmentIdForWorktree(
     const owner = indexedOwner.owner
     const projectedRuntimeOwner = getProjectedRuntimeOwnerEnvironmentId(owner)
     const parsedHost = parseExecutionHostId(owner.hostId)
-    const hasDetectedOwner = Object.values(state.detectedWorktreesByRepo ?? {}).some((result) =>
-      result.worktrees.some((worktree) => worktree.id === worktreeId)
-    )
+    const hasDetectedOwner = hasIndexedDetectedWorktree(state.detectedWorktreesByRepo, worktreeId)
     if (!hasDetectedOwner && (projectedRuntimeOwner || parsedHost)) {
       return (
         projectedRuntimeOwner || (parsedHost?.kind === 'runtime' ? parsedHost.environmentId : null)
@@ -125,9 +124,7 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
       workspaceScope.folderWorkspaceId
     )
   }
-  const hasDetectedOwner = Object.values(state.detectedWorktreesByRepo ?? {}).some((result) =>
-    result.worktrees.some((worktree) => worktree.id === worktreeId)
-  )
+  const hasDetectedOwner = hasIndexedDetectedWorktree(state.detectedWorktreesByRepo, worktreeId)
   if (hasDetectedOwner) {
     // Why: detected-only rows are selectable before the primary catalog lands; use the same
     // ambiguity-aware explicit provenance as filesystem and terminal operations.
@@ -177,9 +174,7 @@ export function getExecutionHostIdForWorktree(
   if (workspaceScope?.type === 'folder') {
     return getExecutionHostIdForFolderWorkspace(state, workspaceScope.folderWorkspaceId)
   }
-  const hasDetectedOwner = Object.values(state.detectedWorktreesByRepo ?? {}).some((result) =>
-    result.worktrees.some((worktree) => worktree.id === worktreeId)
-  )
+  const hasDetectedOwner = hasIndexedDetectedWorktree(state.detectedWorktreesByRepo, worktreeId)
   if (hasDetectedOwner) {
     const resolution = resolveExplicitWorktreeOperationRouteResult(state, worktreeId)
     if (resolution.kind === 'resolved') {


### PR DESCRIPTION
## Summary

SSH-owned terminal panes and sidebar worktree cards resolve their runtime owner inside retained Zustand selectors, so `getExplicitRuntimeEnvironmentIdForWorktree` runs once **per mounted pane and per rendered card, on every store write**. That function opened with an uncached `Object.values(state.detectedWorktreesByRepo ?? {}).some(r => r.worktrees.some(...))` — a full scan of every detected worktree of every repo. For a user with many remote worktrees this is the single largest multiplier on the store-write path: 30 SSH cards × a 2,000-entry detected catalog is 60,000 string comparisons per unrelated store write.

`worktree-runtime-owner-index.ts` already maintains WeakMap-keyed, immutable-slice indexes for `worktreesByRepo`, `repos`, `folderWorkspaces`, and `projectGroups`. `detectedWorktreesByRepo` was the only major collection without one. This PR adds it and converts the walk sites.

**New index** (`worktree-runtime-owner-index.ts`), following the existing idiom exactly:
- `findIndexedDetectedWorktrees(detectedWorktreesByRepo, worktreeId)` → every detected publication of that id, in catalog order.
- `hasIndexedDetectedWorktree(...)` → the existence predicate the three `hasDetectedOwner` sites need.

A **list** index rather than a resolved-owner index is deliberate: rival repos can publish the same worktree id, and `resolveExplicitWorktreeOperationRouteResult` must see *all* of them to fail closed on a conflict. Collapsing to one owner would change routing behavior.

**Converted call sites** (all behavior-preserving):
- `worktree-runtime-owner.ts` — the three `hasDetectedOwner` walks in `getRuntimeEnvironmentIdForWorktree`, `getExplicitRuntimeEnvironmentIdForWorktree`, and `getExecutionHostIdForWorktree`.
- `worktree-operation-route.ts` — the detected half of `ownerRecordsOnHost`, the detected half of `hasKnownWorktree`, and the detected-publication loop in `resolveExplicitWorktreeOperationRouteResult`.
- `worktree-operation-route.ts` `hasKnownWorktree` also stops walking `worktreesByRepo`: it now asks the **already-built** worktree owner index (`resolveIndexedWorktreeOwner(...).kind !== 'missing'`), which that code path populates a few lines earlier. No new index, exact same answer.

Correctness rests on the detected catalog being replaced rather than mutated. Verified: every store write goes through immutable replacement, and `applyDetectedWorktreeUpdates` (`store/slices/worktrees.ts:813`) explicitly returns the *same* object identity when nothing changed — which is precisely what keeps the index warm across unrelated writes.

No user-visible behavior change.

## Screenshots

No visual change.

## Measurement

Micro-bench: 20 repos × 100 detected worktrees (2,000 entries), 200 lookups per sweep, 40 sweeps, 5 warm-up sweeps, each leg given its own never-indexed catalog pool so no leg silently inherits a warm index. Committed as `worktree-runtime-owner-index.detected-perf.test.ts`; it writes its report to `$TMPDIR/orca-detected-worktree-index-bench.json`. Numbers below are the median of 3 isolated local runs (Apple silicon, Node 26).

**Lookup path** (ms per 200-call sweep):

| Scenario | Before (walk) | After (index) | Speedup |
| --- | --- | --- | --- |
| Catalog identity stable across sweeps | 1.14 | **0.0088** | **~130x** |
| Catalog republished every sweep | 1.12 | 0.35 | ~3.2x |

**End-to-end `getExplicitRuntimeEnvironmentIdForWorktree`** (ms per 200-call sweep). Measured as a true A/B: the identical bench was run against the pre-change source (`git stash` of the three source files) and then against this branch, 3 runs each.

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| Detected catalog identity stable | 0.516 | **0.093** | **~5.5x** |
| Detected catalog republished every sweep | 0.518 | 0.496 | ~1.0x (parity) |

Absolute cost after warm-up is **0.0088 ms** on the lookup path and **0.093 ms** end-to-end per 200-call sweep, both well inside the 0.5 ms budget.

**Honest caveat on the republish case.** Building the 2,000-entry index costs roughly what one 200-call walk cost, so a sweep that *starts* with a freshly republished catalog is a wash, not a win — the target of ">=10x" holds on the warm path (~130x) but not on that leg, and I did not want to report a number the change does not deliver. Break-even is ~75–170 lookups per catalog identity. That is comfortably met in practice because a detected-worktree scan republishes the catalog only when its contents actually change (seconds apart), while the store takes many writes per second and each write re-runs the selector for every SSH pane and card. The perf test records both timing legs as informational benchmark evidence without using wall-clock results as a CI gate.

The non-timing CI guarantee is deterministic: the detected records are instrumented with a counting `id` getter, and the test asserts 200 warm `getExplicitRuntimeEnvironmentIdForWorktree` owner lookups perform **0** detected-record reads while the old walk performs **>100,000**. That covers the actual retained-selector hot path and cannot flake under load.

## Testing

- [x] `pnpm lint` — `npx oxlint src/renderer/src/lib/` clean; changed-code quality gate run explicitly: `node config/scripts/check-changed-code-quality.mjs -- a6b14eb04c9a` → `code quality: 0`, `type-aware code quality: 0`, `React Doctor: 0`, across **5 changed files** (non-vacuous — matches the diff).
- [x] `pnpm typecheck` — `typecheck:tsc:web`, `typecheck:tsc:node`, `typecheck:tsc:cli` all clean (`--composite false`, so no stale-tsbuildinfo pass).
- [x] `pnpm test` — targeted: `src/renderer/src/lib/` 372 files / 3,535 passed; `src/renderer/src/store` + `components/terminal-pane` + `components/sidebar` 589 files / 7,131 passed. `oxfmt --check` clean.
- [ ] `pnpm build` — not run; renderer-only pure-function change with typecheck green across all three projects.
- [x] Added or updated high-quality tests

New tests in `worktree-runtime-owner-index.detected.test.ts`:
- **Randomized parity, 240 cases × 5 probes each (1,200 assertions per predicate)** against the pre-index walks kept verbatim in the test as oracles. Seeded LCG so any failure reproduces from the printed case index. Covers: id present in first repo / last repo / absent entirely, `undefined` catalog, empty catalog, repos publishing empty worktree arrays, and ids duplicated across repos. Record shapes mirror the store types (`id`, `repoId`, optional `hostId` across local/ssh/runtime, optional `runtimeOwnerEnvironmentId`). The predicate matches on **`id`**, not path — the tests pin that.
- **Ordering and identity**: rival publications come back in catalog order, and the returned records are the same object references (`toBe`), which is what the downstream ambiguity checks depend on.
- **Invalidation**: a new catalog identity with changed content is re-indexed, including the remove-then-re-add sequence, and each prior identity keeps its own correct answer — no bleed between snapshots.

## AI Review Report

I reviewed the diff myself rather than delegating, focusing on the ways an index can silently diverge from the walk it replaces:

- **Staleness / cache invalidation** — the top risk. Audited every write to `detectedWorktreesByRepo` in `store/slices/worktrees.ts` and `store/slices/repos.ts`: all are immutable replacements (`{...s.detectedWorktreesByRepo}`, `Object.fromEntries`, fresh `nextByRepo`). No in-place mutation, so a content change always yields a new identity and a rebuilt index. Pinned by test.
- **Iteration order** — `Object.values` insertion order is preserved because repo ids are non-integer-like strings; the pre-change code used the same `Object.values`, so ordering is parity by construction. This matters because `resolveExplicitWorktreeOperationRouteResult` early-returns on the first ambiguous match, and `ownerRecordsOnHost` must keep published-before-detected order. Both verified in the diff and covered by the ordering test.
- **Over-collapsing duplicates** — rejected a resolved-owner index in favor of a list index precisely so conflicting publications still reach the fail-closed paths.
- **`hasKnownWorktree` rewrite** — confirmed `resolveIndexedWorktreeOwner(...).kind !== 'missing'` is exactly `.some(w => w.id === id)`: the index sets an entry for every id (resolved or ambiguous) and returns `missing` only when absent. Included in the randomized parity test rather than argued.
- **Empty-array aliasing** — `NO_DETECTED_WORKTREES` is a shared constant returned on miss; it is `readonly`-typed and no caller mutates it.
- **Memory** — WeakMap-keyed, so an index is collected with its catalog; no unbounded growth.
- **Cross-platform (macOS / Linux / Windows)** — this change is pure in-memory data-structure work in the renderer. It touches no paths, no shell or command execution, no keyboard shortcuts or accelerators, no shortcut labels, no `path` joining, no Electron main/renderer platform branches, and no Git invocation. There is nothing platform-dependent in the diff. The one platform-adjacent detail is the perf test's report file, which uses `os.tmpdir()` + `path.join` rather than a hardcoded `/tmp`, so it is correct on Windows too. Applies equally to SSH-backed and folder workspaces: folder workspaces short-circuit on the `parseWorkspaceKey` branch before these lookups and are unaffected, and SSH-owned worktrees are the primary beneficiary.

What I changed as a result of review: kept wall-clock measurements report-only after repeated runs showed shared-runner variance, and retained the deterministic record-read count as the CI gate.

## Security Audit

Low risk. No input parsing, command execution, path handling, authentication, secrets, IPC, or dependency changes. The diff adds an in-memory lookup table over data the renderer already holds and reads; no new data crosses a trust boundary and no new surface is exposed. The one security-adjacent property worth stating is that the change is **fail-closed preserving**: `resolveExplicitWorktreeOperationRouteResult` and `getExecutionHostIdForWorktree` deliberately refuse to resolve (→ `ambiguous` / `runtime:unresolved-owner`) when rival hosts publish the same worktree id, which is what stops a remote-owned worktree from being routed to a local PTY. Because the index preserves every duplicate publication and its order, those conflict paths see exactly the same inputs as before — verified by the ordering test and by the randomized parity oracle. No follow-up needed.

## Notes

- Deliberately left out of scope, all still doing full walks, each a separate concern from indexing the detected catalog:
  - `worktree-operation-route.ts` `ownerRecordsOnHost` still walks `worktreesByRepo` (its detected half is now indexed). The existing `findIndexedWorktreeOwnerForHost` is **not** a drop-in: it collapses duplicates and returns `null` on ambiguity, whereas this caller needs every match. Indexing it properly needs a second list index — worth doing, but not in a PR about detected worktrees.
  - `editor-file-operation-owner.ts:123` `isWorktreePublished` runs the identical predicate over both catalogs. It sits on user-initiated file operations, not the store-write path, so it is not part of this hot path; it is now a one-line conversion whenever someone wants it.
  - `WorktreeCard.tsx:377-382` does a linear `s.runtimeEnvironments.find(...)` per card per store write. Real, and flagged in the task, but `runtimeEnvironments` is a small catalog and it lives in a different module family from the worktree owner indexes; folding it in here would have made this two concerns. Left as a follow-up.
  - `runtime-session-mirror-owners.ts:37` and `direct-ssh-target-scope.ts:70` iterate the whole detected catalog rather than looking up one id, so an id-keyed index does not apply.
- The perf test's wall-clock legs are report-only: the numbers land in `$TMPDIR/orca-detected-worktree-index-bench.json` on every run, while deterministic record-read counts provide the CI gate.
