### PR TITLE
fix(worktrees): stop runtime-stamped folder PTYs and trust the resolved host on folder deletion

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -8380,6 +8380,8 @@ describe('registerWorktreeHandlers', () => {
       connectionId: 'conn-1'
     })
     getSshPtyProviderMock.mockReturnValue(sshPtyProvider)
+    // One global meta key can describe the same-id local copy; the resolved repo still owns this delete.
+    store.getWorktreeMeta.mockReturnValue(makeWorktreeMeta({ hostId: 'local' }))
 
     await handlers['worktrees:remove'](null, { worktreeId })
 
@@ -8393,6 +8395,37 @@ describe('registerWorktreeHandlers', () => {
       includeProviderInventory: true,
       includeLocalRegistry: false
     })
+  })
+
+  it('fences a mirrored runtime folder workspace sweep to its environment', async () => {
+    const runtimePtyProvider = {} as never
+    const worktreeId = 'repo-folder::/runtime/folder::workspace:child-1'
+    store.getRepo.mockReturnValue({
+      id: 'repo-folder',
+      path: '/runtime/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder',
+      executionHostId: 'runtime:env-1'
+    })
+    getLocalPtyProviderMock.mockReturnValue(runtimePtyProvider)
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId,
+      hostId: 'runtime:env-1'
+    })
+
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(worktreeId, {
+      runtime: runtimeStub,
+      resolvedWorktreeId: worktreeId,
+      resolvedRuntimeEnvironmentId: 'env-1',
+      localProvider: runtimePtyProvider,
+      onPtyStopped: clearProviderPtyStateMock,
+      includeProviderInventory: false,
+      includeLocalRegistry: false
+    })
+    expect(getSshPtyProviderMock).not.toHaveBeenCalled()
   })
 
   it('runs the archive hook on remove when skipArchive is not set', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2297,9 +2297,9 @@ export function registerWorktreeHandlers(
             await withWorktreeRemoveStageSpan('pty_sweep', 'folder', async () => {
               // Folder projects can be SSH-backed, so fence the sweep to the owning host exactly
               // like the git paths — the local inventory must never reach a remote workspace's id.
-              const ownerHost = parseExecutionHostId(
-                resolveWorktreeRemovalOwnerHostId(store, args.worktreeId, repo, args.hostId)
-              )
+              // The resolved repo is authoritative here: path-derived metadata is shared by
+              // same-id host copies and can describe a different owner's workspace.
+              const ownerHost = parseExecutionHostId(removalHostId)
               const sshPtyProvider =
                 ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
               const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3943,7 +3943,9 @@ describe('OrcaRuntimeService', () => {
       displayName: 'Folder',
       badgeColor: 'blue',
       addedAt: 1,
-      kind: 'folder' as const
+      kind: 'folder' as const,
+      // removeManagedWorktree executes inside this selected runtime, where PTYs are local ids.
+      executionHostId: 'runtime:env-1' as const
     }
     const rootWorktreeId = 'folder-repo::/workspace/folder'
     const rootPriorWorktreeIds = ['folder-repo::/workspace/old-folder']

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23511,31 +23511,25 @@ export class OrcaRuntimeService {
               'Cannot delete the project root workspace. Remove the folder project instead.'
             )
           }
-          // Folder projects can be SSH-backed, so resolve the owner before sweeping.
-          const folderHost = parseExecutionHostId(
-            store.getWorktreeMeta(removalTarget.id)?.hostId ?? getRepoExecutionHostId(repo)
-          )
-          const folderSshPtyProvider =
-            folderHost?.kind === 'ssh' ? this.getSshProviderFn?.(folderHost.targetId) : undefined
-          const externalFolderHost = folderHost?.kind === 'ssh' || folderHost?.kind === 'runtime'
+          // This service runs inside the selected runtime, so runtime-stamped repos use its
+          // local PTY namespace; only a direct SSH connection is external from here.
+          const folderConnectionId = repo.connectionId?.trim() || null
+          const folderSshPtyProvider = folderConnectionId
+            ? this.getSshProviderFn?.(folderConnectionId)
+            : undefined
           const folderPtyProvider = folderSshPtyProvider ?? this.getLocalProvider()
           if (folderPtyProvider) {
             // Why: folder workspace deletion has no Git removal phase where PTYs
             // would otherwise be swept; tear them down before hiding the workspace.
             await killAllProcessesForWorktree(removalTarget.id, {
               runtime: this,
-              // External host inventories must never sweep a same-id local workspace.
               resolvedWorktreeId: removalTarget.id,
-              ...(folderHost?.kind === 'ssh' ? { resolvedConnectionId: folderHost.targetId } : {}),
-              ...(folderHost?.kind === 'runtime'
-                ? { resolvedRuntimeEnvironmentId: folderHost.environmentId }
-                : {}),
+              ...(folderConnectionId ? { resolvedConnectionId: folderConnectionId } : {}),
               localProvider: folderPtyProvider,
               onPtyStopped: this.onPtyStopped ?? undefined,
-              ...(externalFolderHost
+              ...(folderConnectionId
                 ? {
-                    includeProviderInventory:
-                      folderHost?.kind === 'ssh' && Boolean(folderSshPtyProvider),
+                    includeProviderInventory: Boolean(folderSshPtyProvider),
                     includeLocalRegistry: false
                   }
                 : {})


### PR DESCRIPTION
## Summary

Fixes two folder-workspace gaps that the post-merge audit of #12388 found in the merged PTY-teardown fence, both with red-before evidence:

1. `removeManagedWorktree` treated a runtime stamp as an external desktop-mirror namespace and skipped stopping the selected runtime server's ordinary local PTYs — a PTY leak on runtime-stamped folder removal.
2. Desktop folder deletion trusted collision-prone global worktree metadata over the already-resolved repo host, risking teardown against the wrong host.

Authorship: the audit reviewer wrote and verified these changes in its worktree; the coordinator committed them verbatim for this gated follow-up. The deliberate residuals from #12388 (local-host fence, `stopMissingWorktreeTerminals` direct-SSH-only scope) are unchanged on purpose — runtime-server-local PTYs are intentionally not remote-environment-prefixed there.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Audit-run evidence: each fix has a red-before proof (reverting the runtime-folder handling makes the runtime-stamped folder test report zero local-provider shutdowns; restoring old metadata precedence makes the SSH-folder test report zero SSH-provider lookups); green-after 1269 passed / 1 skipped across the affected suites, plus node typecheck, direct oxlint, max-lines ratchet, and diff check. The changed-code-quality wrapper alone hit its known Node 26 engine-warning JSON parser issue.

## AI Review Report

This PR is itself the output of a subagents-until-clean post-merge audit of #12388 (adversarial fence verification across local/SSH/runtime hosts and folder/git worktrees). Per the standing merge gate it will additionally receive its own pre-merge review loop before merging. Cross-platform: host-kind logic only, no paths/shortcuts/shell changes.

## Security Audit

No new inputs, IPC, command execution, or secrets; the changes narrow which PTYs are stopped (leak fix) and bind teardown to the resolved owner host (wrong-host fix) — both reduce blast radius.

## Notes

Rides the next release train; not release-gating.
