### PR TITLE
fix(worktrees): preserve folder PTY owner scope

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -8380,6 +8380,8 @@ describe('registerWorktreeHandlers', () => {
       connectionId: 'conn-1'
     })
     getSshPtyProviderMock.mockReturnValue(sshPtyProvider)
+    // One global meta key can describe the same-id local copy; the resolved repo still owns this delete.
+    store.getWorktreeMeta.mockReturnValue(makeWorktreeMeta({ hostId: 'local' }))
 
     await handlers['worktrees:remove'](null, { worktreeId })
 
@@ -8393,6 +8395,37 @@ describe('registerWorktreeHandlers', () => {
       includeProviderInventory: true,
       includeLocalRegistry: false
     })
+  })
+
+  it('fences a mirrored runtime folder workspace sweep to its environment', async () => {
+    const runtimePtyProvider = {} as never
+    const worktreeId = 'repo-folder::/runtime/folder::workspace:child-1'
+    store.getRepo.mockReturnValue({
+      id: 'repo-folder',
+      path: '/runtime/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder',
+      executionHostId: 'runtime:env-1'
+    })
+    getLocalPtyProviderMock.mockReturnValue(runtimePtyProvider)
+
+    await handlers['worktrees:remove'](null, {
+      worktreeId,
+      hostId: 'runtime:env-1'
+    })
+
+    expect(killAllProcessesForWorktreeMock).toHaveBeenCalledWith(worktreeId, {
+      runtime: runtimeStub,
+      resolvedWorktreeId: worktreeId,
+      resolvedRuntimeEnvironmentId: 'env-1',
+      localProvider: runtimePtyProvider,
+      onPtyStopped: clearProviderPtyStateMock,
+      includeProviderInventory: false,
+      includeLocalRegistry: false
+    })
+    expect(getSshPtyProviderMock).not.toHaveBeenCalled()
   })
 
   it('runs the archive hook on remove when skipArchive is not set', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2297,9 +2297,9 @@ export function registerWorktreeHandlers(
             await withWorktreeRemoveStageSpan('pty_sweep', 'folder', async () => {
               // Folder projects can be SSH-backed, so fence the sweep to the owning host exactly
               // like the git paths — the local inventory must never reach a remote workspace's id.
-              const ownerHost = parseExecutionHostId(
-                resolveWorktreeRemovalOwnerHostId(store, args.worktreeId, repo, args.hostId)
-              )
+              // The resolved repo is authoritative here: path-derived metadata is shared by
+              // same-id host copies and can describe a different owner's workspace.
+              const ownerHost = parseExecutionHostId(removalHostId)
               const sshPtyProvider =
                 ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
               const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3943,7 +3943,9 @@ describe('OrcaRuntimeService', () => {
       displayName: 'Folder',
       badgeColor: 'blue',
       addedAt: 1,
-      kind: 'folder' as const
+      kind: 'folder' as const,
+      // removeManagedWorktree executes inside this selected runtime, where PTYs are local ids.
+      executionHostId: 'runtime:env-1' as const
     }
     const rootWorktreeId = 'folder-repo::/workspace/folder'
     const rootPriorWorktreeIds = ['folder-repo::/workspace/old-folder']

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23511,31 +23511,25 @@ export class OrcaRuntimeService {
               'Cannot delete the project root workspace. Remove the folder project instead.'
             )
           }
-          // Folder projects can be SSH-backed, so resolve the owner before sweeping.
-          const folderHost = parseExecutionHostId(
-            store.getWorktreeMeta(removalTarget.id)?.hostId ?? getRepoExecutionHostId(repo)
-          )
-          const folderSshPtyProvider =
-            folderHost?.kind === 'ssh' ? this.getSshProviderFn?.(folderHost.targetId) : undefined
-          const externalFolderHost = folderHost?.kind === 'ssh' || folderHost?.kind === 'runtime'
+          // This service runs inside the selected runtime, so runtime-stamped repos use its
+          // local PTY namespace; only a direct SSH connection is external from here.
+          const folderConnectionId = repo.connectionId?.trim() || null
+          const folderSshPtyProvider = folderConnectionId
+            ? this.getSshProviderFn?.(folderConnectionId)
+            : undefined
           const folderPtyProvider = folderSshPtyProvider ?? this.getLocalProvider()
           if (folderPtyProvider) {
             // Why: folder workspace deletion has no Git removal phase where PTYs
             // would otherwise be swept; tear them down before hiding the workspace.
             await killAllProcessesForWorktree(removalTarget.id, {
               runtime: this,
-              // External host inventories must never sweep a same-id local workspace.
               resolvedWorktreeId: removalTarget.id,
-              ...(folderHost?.kind === 'ssh' ? { resolvedConnectionId: folderHost.targetId } : {}),
-              ...(folderHost?.kind === 'runtime'
-                ? { resolvedRuntimeEnvironmentId: folderHost.environmentId }
-                : {}),
+              ...(folderConnectionId ? { resolvedConnectionId: folderConnectionId } : {}),
               localProvider: folderPtyProvider,
               onPtyStopped: this.onPtyStopped ?? undefined,
-              ...(externalFolderHost
+              ...(folderConnectionId
                 ? {
-                    includeProviderInventory:
-                      folderHost?.kind === 'ssh' && Boolean(folderSshPtyProvider),
+                    includeProviderInventory: Boolean(folderSshPtyProvider),
                     includeLocalRegistry: false
                   }
                 : {})


### PR DESCRIPTION
## Summary

Follow-up to #12388. The merged SSH host fence exposed two folder-workspace owner-scope regressions:

- Desktop IPC resolved the repo owner correctly, then let the single global worktree-meta entry override it. A same-ID workspace on another host could therefore redirect an SSH folder deletion to the wrong PTY sweep.
- `removeManagedWorktree` runs inside the selected runtime server, where that server's PTYs use local IDs. Treating a runtime-stamped repo as a desktop-side external mirror applied a `remote:<environment>@@` fence and skipped the runtime's legitimate PTYs before metadata removal.

Desktop IPC now uses the already-resolved repo host. Runtime RPC removal treats only direct SSH as external and keeps runtime-server PTYs on the local provider/registry path.

The documented local-delete residual from #12388 is unchanged: the graph API still has no expressible local-only/null-connection fence.

## Testing

- [x] Same-model focused re-review returned clean after the fixes
- [x] Affected suites: 1,269 passed, 1 skipped
- [x] Focused host regressions: 4 passed
- [x] Worktree teardown suites: 47 passed
- [x] `src/main/runtime/pty-waiver-source-invariant.test.ts`: 2 passed
- [x] `pnpm run typecheck:node`
- [x] Direct `oxlint` on the four changed files
- [x] `pnpm run check:max-lines-ratchet`
- [x] `git diff --check`

## Regression proof

- Reverting the SSH helper fence makes the #12388 same-ID regression fail by stopping both the SSH and local PTYs (`runtime=2`).
- Restoring the merged runtime-folder fence makes the runtime-stamped folder test fail with no local provider shutdown.
- Restoring metadata precedence in desktop folder removal makes the SSH test miss `getSshPtyProvider('conn-1')`.

## UI

No visual UI changed. Electron validation is limited to branch identity/startup and will be attached separately; the destructive duplicate-host scenario requires a configured SSH/runtime host and is proven by main-process regression tests.
