### PR TITLE
fix(browser): rerun guest retention after veto release

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -49,10 +49,12 @@ import { RetainedBrowserPaneOverlayLayer } from './browser-pane/BrowserPaneOverl
 import EmulatorPaneOverlayLayer from './emulator-pane/EmulatorPaneOverlayLayer'
 import {
   isBrowserAutomationVisible,
+  onBrowserAutomationVisibilityChange,
   useBrowserAutomationVisibilityForAny
 } from './browser-pane/browser-automation-visibility'
 import {
   isBrowserPageMobileDriven,
+  onBrowserDriverChange,
   useBrowserMobileDriverForAny
 } from '@/lib/pane-manager/browser-mobile-driver-state'
 import TerminalPaneOverlayLayer from './terminal-pane/TerminalPaneOverlayLayer'
@@ -788,6 +790,7 @@ function Terminal(): React.JSX.Element | null {
   const measurableBackgroundWorktreeTimersRef = useRef(new Map<string, number>())
   const [backgroundMountRevision, setBackgroundMountRevision] = useState(0)
   const [terminalParkingRevision, setTerminalParkingRevision] = useState(0)
+  const [browserGuestRetentionRevision, setBrowserGuestRetentionRevision] = useState(0)
   const [parkedTerminalWorktreeIds, setParkedTerminalWorktreeIds] = useState<ReadonlySet<string>>(
     () => new Set()
   )
@@ -1166,7 +1169,19 @@ function Terminal(): React.JSX.Element | null {
   ])
   // Why here: downloads outlive the pane-local state of hidden (unmounted)
   // BrowserPanes, and the eviction veto below must see them.
-  useEffect(() => installBrowserPageDownloadActivityTracking(), [])
+  useEffect(() => {
+    const invalidateRetention = (): void => {
+      setBrowserGuestRetentionRevision((revision) => revision + 1)
+    }
+    const removeDownloadTracking = installBrowserPageDownloadActivityTracking(invalidateRetention)
+    const removeAutomationTracking = onBrowserAutomationVisibilityChange(invalidateRetention)
+    const removeMobileTracking = onBrowserDriverChange(invalidateRetention)
+    return () => {
+      removeDownloadTracking()
+      removeAutomationTracking()
+      removeMobileTracking()
+    }
+  }, [])
   // Browser-guest retention budget (#12137 follow-up): hidden worktrees keep
   // webview guests alive for instant revisits, but only the most recently
   // activated few. Older ones have every guest FULLY destroyed through the
@@ -1231,7 +1246,12 @@ function Terminal(): React.JSX.Element | null {
         worktreeId
       )
     }
-  }, [renderedActiveWorktreeId, workspaceSurfaces, browserGuestRetentionBudgetEnabled])
+  }, [
+    renderedActiveWorktreeId,
+    workspaceSurfaces,
+    browserGuestRetentionBudgetEnabled,
+    browserGuestRetentionRevision
+  ])
   // Why: a slow post-reconnect step exposes workspaceSessionReady before hydration can populate snapshot capabilities.
   if (
     renderedActiveWorktreeId &&

--- a/src/renderer/src/components/browser-pane/browser-automation-visibility.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-automation-visibility.test.ts
@@ -19,8 +19,11 @@ describe('browser automation visibility leases', () => {
     const {
       acquireBrowserAutomationVisibility,
       isBrowserAutomationVisible,
+      onBrowserAutomationVisibilityChange,
       releaseBrowserAutomationVisibility
     } = await import('./browser-automation-visibility')
+    const listener = vi.fn()
+    const unsubscribe = onBrowserAutomationVisibilityChange(listener)
 
     const first = acquireBrowserAutomationVisibility('page-1')
     const second = acquireBrowserAutomationVisibility('page-1')
@@ -32,6 +35,11 @@ describe('browser automation visibility leases', () => {
 
     expect(releaseBrowserAutomationVisibility(second)).toBe(true)
     expect(isBrowserAutomationVisible('page-1')).toBe(false)
+    expect(listener).toHaveBeenCalledTimes(4)
+
+    unsubscribe()
+    acquireBrowserAutomationVisibility('page-2')
+    expect(listener).toHaveBeenCalledTimes(4)
   })
 
   it('installs a main-process bridge that keeps the page visible while waiting for paint', async () => {

--- a/src/renderer/src/components/browser-pane/browser-automation-visibility.ts
+++ b/src/renderer/src/components/browser-pane/browser-automation-visibility.ts
@@ -34,6 +34,10 @@ function subscribe(listener: () => void): () => void {
   }
 }
 
+export function onBrowserAutomationVisibilityChange(listener: () => void): () => void {
+  return subscribe(listener)
+}
+
 function getSnapshot(): number {
   return version
 }

--- a/src/renderer/src/components/browser-pane/browser-page-download-activity.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-download-activity.test.ts
@@ -74,21 +74,26 @@ describe('browser page download activity', () => {
   it('deactivates an interrupted download (no finished event ever fires) and reactivates on resume', async () => {
     const { hasActiveBrowserPageDownload, installBrowserPageDownloadActivityTracking } =
       await import('./browser-page-download-activity')
-    installBrowserPageDownloadActivityTracking()
+    const onEvictionVetoChange = vi.fn()
+    installBrowserPageDownloadActivityTracking(onEvictionVetoChange)
 
     requestedCallbacks[0]({ downloadId: 'dl-1', browserPageId: 'page-1' })
     progressCallbacks[0]({ downloadId: 'dl-1', state: 'interrupted' })
     expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
+    expect(onEvictionVetoChange).toHaveBeenCalledTimes(2)
 
     progressCallbacks[0]({ downloadId: 'dl-1', state: 'progressing' })
     expect(hasActiveBrowserPageDownload('page-1')).toBe(true)
 
-    // A null state is transport noise, not a transition.
+    // Duplicate progress and null transport noise are not transitions.
+    progressCallbacks[0]({ downloadId: 'dl-1', state: 'progressing' })
     progressCallbacks[0]({ downloadId: 'dl-1', state: null })
     expect(hasActiveBrowserPageDownload('page-1')).toBe(true)
+    expect(onEvictionVetoChange).toHaveBeenCalledTimes(3)
 
     finishedCallbacks[0]({ downloadId: 'dl-1' })
     expect(hasActiveBrowserPageDownload('page-1')).toBe(false)
+    expect(onEvictionVetoChange).toHaveBeenCalledTimes(4)
   })
 
   it('ignores duplicate start events, unknown progress and unknown finish events', async () => {

--- a/src/renderer/src/components/browser-pane/browser-page-download-activity.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-download-activity.ts
@@ -12,7 +12,11 @@ export function hasActiveBrowserPageDownload(browserPageId: string): boolean {
   return (activeDownloadCountByPageId.get(browserPageId) ?? 0) > 0
 }
 
-function setDownloadActive(download: TrackedDownload, active: boolean): void {
+function setDownloadActive(
+  download: TrackedDownload,
+  active: boolean,
+  onEvictionVetoChange: () => void
+): void {
   if (download.active === active) {
     return
   }
@@ -23,50 +27,61 @@ function setDownloadActive(download: TrackedDownload, active: boolean): void {
   } else {
     activeDownloadCountByPageId.set(download.browserPageId, count)
   }
+  onEvictionVetoChange()
 }
 
-function trackDownloadStarted(downloadId: string, browserPageId: string): void {
+function trackDownloadStarted(
+  downloadId: string,
+  browserPageId: string,
+  onEvictionVetoChange: () => void
+): void {
   if (trackedDownloadsById.has(downloadId)) {
     return
   }
   const download: TrackedDownload = { browserPageId, active: false }
   trackedDownloadsById.set(downloadId, download)
-  setDownloadActive(download, true)
+  setDownloadActive(download, true, onEvictionVetoChange)
 }
 
 // Why: an interrupted-resumable download never fires Chromium's 'done' (no
 // finished event), and Orca has no resume path — without this transition the
 // veto would outlive the download for the whole session. A resumed download
 // re-actives on its next 'progressing' tick, restoring the veto.
-function trackDownloadProgress(downloadId: string, state: 'progressing' | 'interrupted' | null): void {
+function trackDownloadProgress(
+  downloadId: string,
+  state: 'progressing' | 'interrupted' | null,
+  onEvictionVetoChange: () => void
+): void {
   const download = trackedDownloadsById.get(downloadId)
   if (!download || state === null) {
     return
   }
-  setDownloadActive(download, state === 'progressing')
+  setDownloadActive(download, state === 'progressing', onEvictionVetoChange)
 }
 
-function trackDownloadFinished(downloadId: string): void {
+function trackDownloadFinished(downloadId: string, onEvictionVetoChange: () => void): void {
   const download = trackedDownloadsById.get(downloadId)
   if (!download) {
     return
   }
-  setDownloadActive(download, false)
+  setDownloadActive(download, false, onEvictionVetoChange)
   trackedDownloadsById.delete(downloadId)
 }
 
 /** App-lifetime tracking; install once from the surface host (Terminal). The
  *  cleanup clears tracked state — a host unmount tears down every guest, so
  *  stale entries must not veto eviction after a remount. */
-export function installBrowserPageDownloadActivityTracking(): () => void {
+export function installBrowserPageDownloadActivityTracking(
+  onEvictionVetoChange: () => void = () => {}
+): () => void {
   const removeRequested = window.api.browser.onDownloadRequested((event) => {
-    trackDownloadStarted(event.downloadId, event.browserPageId)
+    trackDownloadStarted(event.downloadId, event.browserPageId, onEvictionVetoChange)
   })
   const removeProgress = window.api.browser.onDownloadProgress((event) => {
-    trackDownloadProgress(event.downloadId, event.state)
+    trackDownloadProgress(event.downloadId, event.state, onEvictionVetoChange)
   })
   const removeFinished = window.api.browser.onDownloadFinished((event) => {
-    trackDownloadFinished(event.downloadId)
+    trackDownloadFinished(event.downloadId, onEvictionVetoChange)
   })
   return () => {
     removeRequested()


### PR DESCRIPTION
## Summary

Follow-up to #12232. The merged interrupted-download fix updated only module-local veto state, so the Terminal guest-budget effect did not rerun when a download, automation lease, or mobile driver released its veto. An over-budget live guest could therefore remain retained until an unrelated worktree, surface, or setting change.

This change:

- invalidates the guest-retention pass when download activity crosses active/inactive
- subscribes the same pass to automation visibility and mobile-driver changes
- deduplicates duplicate progressing/null/unknown download events, avoiding work per progress tick
- removes download, automation, and mobile subscriptions with the Terminal host

The sanctioned eviction path is unchanged: selected worktrees still fully destroy their guests through destroyWorktreeBrowserGuests; no live guest is unmount-detached.

## Testing

- 48 focused Vitest cases across download activity, automation visibility, mobile driver state, guest retention selection, webview cleanup, and registry lifecycle
- pnpm run typecheck:web
- oxlint and type-aware lint on the changed renderer paths
- oxfmt check, max-lines ratchet, and git diff --check
- two same-model/xhigh audit passes; final pass returned CLEAN with no further edits

## Electron validation

Attached via CDP to the intended review-audit-12232 dev instance, selected the real workspace through the sidebar, opened a Browser tab through the New tab menu, and navigated to Example Domain. The rendered browser surface loaded successfully; backing store state showed the page URL as https://example.com/ with loading=false. The interrupted/resumed download transition is state/lifecycle behavior without a dedicated visible indicator, so that exact transition is covered by the deterministic activity tests rather than claimed from the screenshot.

![browser-retention-follow-up.png](https://github.com/user-attachments/assets/eeb06823-ad1c-4652-9677-13bba75001f5)

## Scope

Desktop renderer only; no mobile code changed. This PR is intentionally not merged.