### PR TITLE
fix(relay): revive a dead relay broker without user interaction

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@
 import { existsSync, statSync } from 'node:fs'
 import { isAbsolute, join } from 'node:path'
 import os from 'node:os'
-import { app, BrowserWindow, dialog, ipcMain, nativeTheme, type Tray } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, nativeTheme, powerMonitor, type Tray } from 'electron'
 import { initTccPromptNotice, stopTccPromptNotice } from './macos-tcc-prompt-notice'
 import { electronApp, is } from '@electron-toolkit/utils'
 import {
@@ -2897,6 +2897,9 @@ void app.whenReady().then(async () => {
         provisionRelay: (context, params) => relayService.provisionRelay(context, params)
       })
       relayService.start()
+      // Why: sleeping past relay-token expiry kills the broker with no retry
+      // timer; resume is the moment that state becomes recoverable.
+      powerMonitor.on('resume', () => desktopRelayService?.ensureLive())
     } catch (error) {
       console.warn(
         '[relay] Desktop relay startup unavailable:',

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -42,12 +42,18 @@ export function pairingAuthorizationForContext(
     : null
 }
 
+// Why: a broker that died without arming a retry (sleep past token expiry,
+// transient auth read) must not stay dead until the user clicks Retry. The
+// cadence is slow because it is a safety net, not the primary retry path.
+const RELAY_LIVENESS_INTERVAL_MS = 5 * 60_000
+
 export class DesktopRelayService {
   private readonly coordinator: RelayAuthCoordinator
   private readonly revokeOutbox: RelayRevokeOutbox
   private readonly runtimeRpc: OrcaRuntimeRpcServer
   private readonly demandLedger: RelayDemandLedger
   private demandExpiryTimer: ReturnType<typeof setTimeout> | null = null
+  private livenessTimer: ReturnType<typeof setInterval> | null = null
   private stopped = false
 
   constructor(options: DesktopRelayServiceOptions) {
@@ -90,6 +96,16 @@ export class DesktopRelayService {
 
   start(): void {
     this.refreshDemand()
+    if (!this.livenessTimer) {
+      this.livenessTimer = setInterval(() => this.ensureLive(), RELAY_LIVENESS_INTERVAL_MS)
+    }
+  }
+
+  // Safe to call from any wake signal (power resume, network change).
+  ensureLive(): void {
+    if (!this.stopped) {
+      this.coordinator.ensureLive()
+    }
   }
 
   authMutated(): void {
@@ -216,6 +232,10 @@ export class DesktopRelayService {
     if (this.demandExpiryTimer) {
       clearTimeout(this.demandExpiryTimer)
       this.demandExpiryTimer = null
+    }
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer)
+      this.livenessTimer = null
     }
     this.coordinator.stop()
   }

--- a/src/main/runtime/relay/relay-auth-coordinator-recovery.test.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator-recovery.test.ts
@@ -257,3 +257,77 @@ describe('RelayAuthCoordinator transient recovery', () => {
     expect(openBroker).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('RelayAuthCoordinator liveness safety net', () => {
+  it('reopens a broker that died leaving no retry timer behind', async () => {
+    // Why: an auth refresh failing past token expiry closes the broker with
+    // no timer; only ensureLive (periodic/power-resume) can revive it.
+    vi.useFakeTimers()
+    const dead = { closeNow: vi.fn(), isLive: () => false }
+    const live = { closeNow: vi.fn(), isLive: () => true }
+    const openBroker = vi.fn().mockResolvedValueOnce(dead).mockResolvedValueOnce(live)
+    const coordinator = new RelayAuthCoordinator({
+      readContext: async () => context,
+      openBroker,
+      onStatus: vi.fn(),
+      random: () => 0.5
+    })
+
+    coordinator.reconcile()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(coordinator.getActiveBroker()).toBe(dead)
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(openBroker).toHaveBeenCalledOnce()
+
+    coordinator.ensureLive()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openBroker).toHaveBeenCalledTimes(2)
+    expect(dead.closeNow).toHaveBeenCalled()
+    expect(coordinator.getActiveBroker()).toBe(live)
+  })
+
+  it('does not disturb a live broker, a scheduled retry, or an open in flight', async () => {
+    vi.useFakeTimers()
+    const broker = { closeNow: vi.fn(), isLive: () => true }
+    let releaseOpen: ((value: typeof broker) => void) | undefined
+    const openBroker = vi
+      .fn()
+      .mockRejectedValueOnce(new RelayHttpError('assignment', 503, 30_000))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseOpen = resolve
+          })
+      )
+    const coordinator = new RelayAuthCoordinator({
+      readContext: async () => context,
+      openBroker,
+      onStatus: vi.fn(),
+      random: () => 0.5
+    })
+
+    coordinator.reconcile()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openBroker).toHaveBeenCalledOnce()
+
+    // A scheduled Retry-After timer owns recovery; ensureLive must not race it.
+    coordinator.ensureLive()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openBroker).toHaveBeenCalledOnce()
+
+    // The retry fires into a slow open; ensureLive must not preempt it.
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(openBroker).toHaveBeenCalledTimes(2)
+    coordinator.ensureLive()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openBroker).toHaveBeenCalledTimes(2)
+    releaseOpen?.(broker)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(coordinator.getActiveBroker()).toBe(broker)
+
+    // A live broker needs nothing.
+    coordinator.ensureLive()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openBroker).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/runtime/relay/relay-auth-coordinator.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator.ts
@@ -92,6 +92,22 @@ export class RelayAuthCoordinator {
     return this.ownership?.valid ? this.ownership.broker : null
   }
 
+  // Why: some broker deaths end with no retry timer — an auth refresh that
+  // fails past token expiry (laptop sleep), or a transient context read that
+  // returned null at open. Periodic/power-resume callers use this as a
+  // dead-man's switch; it never disturbs a live broker, a scheduled retry,
+  // or an open already in flight.
+  ensureLive(): void {
+    if (this.stopped || this.retryTimer || this.pendingOwnerships.size > 0) {
+      return
+    }
+    const ownership = this.ownership
+    if (ownership?.valid && (ownership.broker?.isLive?.() ?? true)) {
+      return
+    }
+    this.beginReconcile(false)
+  }
+
   async waitForActiveBroker(): Promise<CoordinatedRelayBroker | null> {
     while (!this.stopped) {
       const broker = this.getActiveBroker()


### PR DESCRIPTION
Follow-up from the relay incident handoff: *"the desktop still gives up permanently after its launch burst (no periodic broker retry — needs an orca-repo fix)"*.

## The gap

The coordinator retries **open failures** (transient HTTP/network, honoring Retry-After, 5min-capped jitter — #10147/#12076) and the origin pool retries **drain/close recovery** indefinitely. But two death paths end with `broker.closeNow()` and **no timer**:

1. `refreshAuthorization()` failing past `expiry + 60s` — the normal outcome of a laptop sleeping through relay-token expiry (`relay-session-broker.ts`).
2. `refreshAccessToken()` returning null on a transient auth-context read.

After that, only an external event (auth mutation, demand change, user Retry) ever calls `reconcile()` — a desktop that slept overnight stays `offline` until poked. This is the D7 follow-up from the incident review.

## The fix

- `RelayAuthCoordinator.ensureLive()`: a guarded reconcile that no-ops when there is a live broker (`isLive?.() ?? true`), a scheduled retry timer, or an open in flight — so it can never disturb the existing retry machinery or add Director load while recovery is already running. It reconciles with `resetRetry=false`, preserving backoff escalation.
- `DesktopRelayService`: 5-minute `setInterval` liveness tick (cleared on `stop()`), plus a public `ensureLive()`.
- `index.ts`: `powerMonitor.on('resume', …)` — sleep is the common trigger, so resume gets an immediate check instead of waiting up to 5 minutes.

Load: when registered, the tick costs one `isLive()` call (no I/O). When dead, one reconcile per 5 minutes worst case, still gated by the coordinator's own Retry-After handling — negligible next to the current retry cohort behavior.

## Tests

- `ensureLive` reopens a broker that died with no pending retry (closes the dead broker, activates the replacement)
- `ensureLive` no-ops against: a scheduled Retry-After timer, an open in flight, and a live broker
- all pre-existing coordinator/service tests unchanged and green (29 total)