### PR TITLE
fix(runtime): isolate same-path folder workspace terminals

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3502,6 +3502,50 @@ describe('OrcaRuntimeService', () => {
     expect(terminals.terminals[0]?.worktreePath).toBe(TEST_FOLDER_WORKSPACE_PATH)
   })
 
+  it('keeps same-path folder workspace instance PTYs scoped to their exact ids', async () => {
+    const firstWorktreeId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
+    const secondWorktreeId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}22222222-2222-4222-8222-222222222222`
+    vi.mocked(listWorktrees).mockClear()
+    vi.mocked(listWorktrees).mockRejectedValue(
+      new Error('folder explicit-id fallback should not rescan worktrees')
+    )
+    const runtime = createRuntime()
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: 'first-folder-pty',
+          cwd: TEST_FOLDER_WORKSPACE_PATH,
+          title: 'first',
+          worktreeId: firstWorktreeId
+        },
+        {
+          id: 'second-folder-pty',
+          cwd: TEST_FOLDER_WORKSPACE_PATH,
+          title: 'second',
+          worktreeId: secondWorktreeId
+        }
+      ]
+    })
+
+    const terminals = await runtime.listTerminals(`id:${secondWorktreeId}`)
+
+    expect(listWorktrees).not.toHaveBeenCalled()
+    expect(terminals.terminals).toHaveLength(1)
+    expect(terminals.terminals[0]).toMatchObject({
+      ptyId: 'second-folder-pty',
+      worktreeId: secondWorktreeId,
+      worktreePath: TEST_FOLDER_WORKSPACE_PATH
+    })
+    const internals = runtime as unknown as {
+      ptysById: Map<string, { worktreeId: string }>
+    }
+    expect(internals.ptysById.get('first-folder-pty')).toBeUndefined()
+    expect(internals.ptysById.get('second-folder-pty')?.worktreeId).toBe(secondWorktreeId)
+  })
+
   it('routes PTY output through the PTY leaf index in large terminal graphs', () => {
     const runtime = new OrcaRuntimeService(store)
     const liveLeafCount = 2773

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -35854,8 +35854,8 @@ function runtimePathsEqual(left: string, right: string): boolean {
 }
 
 function runtimeWorktreeIdsEqual(left: string, right: string): boolean {
-  const parsedLeft = splitWorktreeIdForFilesystem(left)
-  const parsedRight = splitWorktreeIdForFilesystem(right)
+  const parsedLeft = splitWorktreeId(left)
+  const parsedRight = splitWorktreeId(right)
   return parsedLeft && parsedRight
     ? parsedLeft.repoId === parsedRight.repoId &&
         runtimePathsEqual(parsedLeft.worktreePath, parsedRight.worktreePath)
@@ -35863,7 +35863,10 @@ function runtimeWorktreeIdsEqual(left: string, right: string): boolean {
 }
 
 function runtimeWorktreeIdentityKey(worktreeId: string): string {
-  const parsed = splitWorktreeIdForFilesystem(worktreeId)
+  const parsed = splitWorktreeId(worktreeId)
+  // Why: folder project sessions share one filesystem path but own independent
+  // terminal graphs. Stripping ::workspace:<uuid> here merges their PTY refresh,
+  // sleep, and mutation state; only filesystem callers may strip that suffix.
   return parsed
     ? `${parsed.repoId}\0${normalizeRuntimePathForComparison(parsed.worktreePath)}`
     : worktreeId


### PR DESCRIPTION
## Summary

Folder projects intentionally support multiple independent workspace sessions backed by the same directory. Their IDs differ only by the synthetic `::workspace:<uuid>` suffix.

Runtime PTY ownership comparisons used `splitWorktreeIdForFilesystem`, which deliberately strips that suffix for cwd/filesystem operations. As a result, two distinct folder workspace instances compared equal. During controller inventory refresh, an exact target could select or rebind a sibling workspace's PTY; paired/mobile clients could then receive a stale or perpetually pending terminal handle and remain on **Loading terminal**.

This change keeps the suffix in runtime identity comparison and identity-map keys by using `splitWorktreeId`. Filesystem callers continue using `splitWorktreeIdForFilesystem`, so both sessions still launch in the shared physical directory.

## User-visible result

Multiple workspaces under one Folder project can keep separate terminal graphs even though they intentionally share a directory. Opening one workspace from Mobile no longer allows another same-path workspace's PTY to satisfy its terminal refresh.

## Regression coverage

The regression creates two live controller PTYs with the same folder path and different `::workspace:<uuid>` owners, requests the second workspace by exact ID, and proves only its own PTY is selected and recorded. The pre-fix comparison admits both because the UUID suffix is stripped.

## Validation

- `src/main/runtime/orca-runtime.test.ts`: 1,022 passed, 1 existing skip
- Node/CLI/Web TypeScript projects passed
- Focused Oxlint passed
- Focused formatter check passed
- `git diff --check` passed

## Relationship to #11868

This is complementary and substantially narrower. #11868 restores and reattaches persisted folder session snapshots across runtime generations and adds deletion/routing fences. This PR fixes the lower-level synthetic folder-project instance identity (`repo::path::workspace:<uuid>`) that currently collapses before those snapshot/materialization decisions. It does not duplicate the reattachment or tombstone work.