### PR TITLE
fix(i18n): localize the status bar resource and host labels

### DIFF
--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -1188,11 +1188,8 @@ export function ResourceUsageStatusSegment({
         <TooltipContent side="top" sideOffset={6}>
           <div className="space-y-0.5">
             {resourceManagerTooltipLines.map((line, index) => (
-              <div
-                key={`${index}:${line}`}
-                className={line === 'Space scan ready' ? 'text-primary' : ''}
-              >
-                {line}
+              <div key={`${index}:${line.text}`} className={line.emphasized ? 'text-primary' : ''}>
+                {line.text}
               </div>
             ))}
           </div>

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -19,6 +19,7 @@ import {
 import { isUserManagedRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import { RuntimeHostStatusRow, type RuntimeHostConnectionState } from './RuntimeHostStatusRow'
 import { SshTargetStatusRow } from './SshTargetStatusRow'
+import { connectedHostCountLabel, connectingHostsLabel } from './ssh-status-copy'
 import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../../shared/remote-runtime-shared-control-types'
 import { connectRuntimeEnvironmentAndRecordStatus } from './runtime-environment-explicit-connect'
 
@@ -60,10 +61,6 @@ function overallDotColor(
     case 'disconnected':
       return 'bg-muted-foreground/40'
   }
-}
-
-function connectedHostCountLabel(count: number): string {
-  return `${count} ${count === 1 ? 'host' : 'hosts'}`
 }
 
 function sshStatusForOverall(status: SshConnectionStatus): HostStatus {
@@ -343,7 +340,9 @@ export function SshStatusSegment({
                 <span className="text-[11px]">
                   <span className={syncProblem ? 'text-destructive' : 'text-muted-foreground'}>
                     {syncProblemLabel ??
-                      (anyConnecting ? 'Connecting…' : connectedHostCountLabel(connectedHostCount))}
+                      (anyConnecting
+                        ? connectingHostsLabel()
+                        : connectedHostCountLabel(connectedHostCount))}
                   </span>
                 </span>
               )}

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
@@ -19,8 +19,8 @@ describe('resource manager terminal copy', () => {
         spaceScanReady: false
       })
     ).toEqual([
-      'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions',
-      'Terminal sessions are grouped by workspace.'
+      { text: 'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions', emphasized: false },
+      { text: 'Terminal sessions are grouped by workspace.', emphasized: false }
     ])
   })
 
@@ -32,9 +32,23 @@ describe('resource manager terminal copy', () => {
         spaceScanReady: true
       })
     ).toEqual([
-      'Resource Manager - memory unavailable - 0 terminal sessions',
-      'Space scan ready',
-      'No terminal sessions yet.'
+      { text: 'Resource Manager - memory unavailable - 0 terminal sessions', emphasized: false },
+      { text: 'Space scan ready', emphasized: true },
+      { text: 'No terminal sessions yet.', emphasized: false }
+    ])
+  })
+
+  // Why: the segment used to tint the space-scan row by comparing it against the
+  // English text, so a translated build lost the tint. The flag replaces that.
+  it('flags the space-scan row instead of leaving callers to match its text', () => {
+    const lines = getResourceManagerTooltipLines({
+      memoryLabel: '512 MB',
+      sessionCount: 1,
+      spaceScanReady: true
+    })
+
+    expect(lines.filter((line) => line.emphasized).map((line) => line.text)).toEqual([
+      'Space scan ready'
     ])
   })
 

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
@@ -1,5 +1,17 @@
+import { translate } from '@/i18n/i18n'
+
 export function formatTerminalSessionCount(count: number): string {
-  return `${count} terminal session${count === 1 ? '' : 's'}`
+  return count === 1
+    ? translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.terminalSessionCountOne',
+        '{{value0}} terminal session',
+        { value0: count }
+      )
+    : translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.terminalSessionCountOther',
+        '{{value0}} terminal sessions',
+        { value0: count }
+      )
 }
 
 export function getResourceManagerTooltipLines(args: {
@@ -10,20 +22,42 @@ export function getResourceManagerTooltipLines(args: {
   const rawMemoryLabel = args.memoryLabel.trim()
   const memoryLabel =
     rawMemoryLabel === '' || rawMemoryLabel === '-' || rawMemoryLabel === '—'
-      ? 'memory unavailable'
+      ? translate(
+          'auto.components.status.bar.ResourceUsageStatusSegment.memoryUnavailable',
+          'memory unavailable'
+        )
       : rawMemoryLabel
   const lines = [
-    `Resource Manager - ${memoryLabel} - ${formatTerminalSessionCount(args.sessionCount)}`
+    translate(
+      'auto.components.status.bar.ResourceUsageStatusSegment.tooltipHeadline',
+      'Resource Manager - {{value0}} - {{value1}}',
+      { value0: memoryLabel, value1: formatTerminalSessionCount(args.sessionCount) }
+    )
   ]
 
   if (args.spaceScanReady) {
-    lines.push('Space scan ready')
+    lines.push(
+      translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.spaceScanReady',
+        'Space scan ready'
+      )
+    )
   }
 
   if (args.sessionCount > 0) {
-    lines.push('Terminal sessions are grouped by workspace.')
+    lines.push(
+      translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.sessionsGroupedByWorkspace',
+        'Terminal sessions are grouped by workspace.'
+      )
+    )
   } else {
-    lines.push('No terminal sessions yet.')
+    lines.push(
+      translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.noTerminalSessions',
+        'No terminal sessions yet.'
+      )
+    )
   }
 
   return lines
@@ -33,10 +67,21 @@ export function getResourceManagerAriaLabel(args: {
   sessionCount: number
   spaceScanReady: boolean
 }): string {
-  const parts = ['Resource Manager', formatTerminalSessionCount(args.sessionCount)]
+  const parts = [
+    translate(
+      'auto.components.status.bar.ResourceUsageStatusSegment.resourceManager',
+      'Resource Manager'
+    ),
+    formatTerminalSessionCount(args.sessionCount)
+  ]
 
   if (args.spaceScanReady) {
-    parts.push('Space scan ready')
+    parts.push(
+      translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.spaceScanReady',
+        'Space scan ready'
+      )
+    )
   }
 
   return parts.join(', ')

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
@@ -14,11 +14,18 @@ export function formatTerminalSessionCount(count: number): string {
       )
 }
 
+/**
+ * One tooltip row. `emphasized` marks the space-scan row the segment tints;
+ * the caller used to recognize it by comparing against the English text, which
+ * silently stopped matching once the copy went through the catalog.
+ */
+export type ResourceManagerTooltipLine = { text: string; emphasized: boolean }
+
 export function getResourceManagerTooltipLines(args: {
   memoryLabel: string
   sessionCount: number
   spaceScanReady: boolean
-}): string[] {
+}): ResourceManagerTooltipLine[] {
   const rawMemoryLabel = args.memoryLabel.trim()
   const memoryLabel =
     rawMemoryLabel === '' || rawMemoryLabel === '-' || rawMemoryLabel === '—'
@@ -27,38 +34,40 @@ export function getResourceManagerTooltipLines(args: {
           'memory unavailable'
         )
       : rawMemoryLabel
-  const lines = [
-    translate(
-      'auto.components.status.bar.ResourceUsageStatusSegment.tooltipHeadline',
-      'Resource Manager - {{value0}} - {{value1}}',
-      { value0: memoryLabel, value1: formatTerminalSessionCount(args.sessionCount) }
-    )
+  const lines: ResourceManagerTooltipLine[] = [
+    {
+      text: translate(
+        'auto.components.status.bar.ResourceUsageStatusSegment.tooltipHeadline',
+        'Resource Manager - {{value0}} - {{value1}}',
+        { value0: memoryLabel, value1: formatTerminalSessionCount(args.sessionCount) }
+      ),
+      emphasized: false
+    }
   ]
 
   if (args.spaceScanReady) {
-    lines.push(
-      translate(
+    lines.push({
+      text: translate(
         'auto.components.status.bar.ResourceUsageStatusSegment.spaceScanReady',
         'Space scan ready'
-      )
-    )
+      ),
+      emphasized: true
+    })
   }
 
-  if (args.sessionCount > 0) {
-    lines.push(
-      translate(
-        'auto.components.status.bar.ResourceUsageStatusSegment.sessionsGroupedByWorkspace',
-        'Terminal sessions are grouped by workspace.'
-      )
-    )
-  } else {
-    lines.push(
-      translate(
-        'auto.components.status.bar.ResourceUsageStatusSegment.noTerminalSessions',
-        'No terminal sessions yet.'
-      )
-    )
-  }
+  lines.push({
+    text:
+      args.sessionCount > 0
+        ? translate(
+            'auto.components.status.bar.ResourceUsageStatusSegment.sessionsGroupedByWorkspace',
+            'Terminal sessions are grouped by workspace.'
+          )
+        : translate(
+            'auto.components.status.bar.ResourceUsageStatusSegment.noTerminalSessions',
+            'No terminal sessions yet.'
+          ),
+    emphasized: false
+  })
 
   return lines
 }

--- a/src/renderer/src/components/status-bar/ssh-status-copy.ts
+++ b/src/renderer/src/components/status-bar/ssh-status-copy.ts
@@ -1,0 +1,17 @@
+import { translate } from '@/i18n/i18n'
+
+/** Host count shown on the collapsed remote-hosts segment. */
+export function connectedHostCountLabel(count: number): string {
+  return count === 1
+    ? translate('auto.components.status.bar.SshStatusSegment.hostCountOne', '{{value0}} host', {
+        value0: count
+      })
+    : translate('auto.components.status.bar.SshStatusSegment.hostCountOther', '{{value0}} hosts', {
+        value0: count
+      })
+}
+
+/** Placeholder shown while at least one host is still connecting. */
+export function connectingHostsLabel(): string {
+  return translate('auto.components.status.bar.SshStatusSegment.connectingHosts', 'Connecting…')
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3181,7 +3181,15 @@
             "b8f4a2c1d0e3": "{{value0}} orphans",
             "c7e3b1a0d9f2": "Kill {{value0}} orphan terminal",
             "d8f4c2b1e0a3": "Kill {{value0}} orphan terminals",
-            "e9a5d3c2b1f0": "Kill {{value0}}?"
+            "e9a5d3c2b1f0": "Kill {{value0}}?",
+            "terminalSessionCountOne": "{{value0}} terminal session",
+            "terminalSessionCountOther": "{{value0}} terminal sessions",
+            "memoryUnavailable": "memory unavailable",
+            "tooltipHeadline": "Resource Manager - {{value0}} - {{value1}}",
+            "spaceScanReady": "Space scan ready",
+            "sessionsGroupedByWorkspace": "Terminal sessions are grouped by workspace.",
+            "noTerminalSessions": "No terminal sessions yet.",
+            "resourceManager": "Resource Manager"
           },
           "SshStatusSegment": {
             "3ad70e0365": "Manage Remote Hosts…",
@@ -3206,7 +3214,10 @@
             "runtime_disconnect_failed": "Disconnect failed",
             "runtime_reconnecting": "Reconnecting",
             "runtime_last_close_reason": "Closed: {{value0}}",
-            "runtime_reconnect_attempt": "Attempt {{value0}}"
+            "runtime_reconnect_attempt": "Attempt {{value0}}",
+            "hostCountOne": "{{value0}} host",
+            "hostCountOther": "{{value0}} hosts",
+            "connectingHosts": "Connecting…"
           },
           "StatusBar": {
             "9659e38343": "Ports",

--- a/src/renderer/src/i18n/status-bar-copy-localization.test.ts
+++ b/src/renderer/src/i18n/status-bar-copy-localization.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The status bar builds its Resource Manager tooltip and remote-host count in
+ * helper functions, which the coverage audit does not inspect — it looks at JSX
+ * attributes and object properties, not values returned by helpers. These
+ * assertions pin the catalog contract so a helper that goes back to a bare
+ * literal fails here.
+ */
+import { describe, expect, it } from 'vitest'
+import en from './locales/en.json'
+
+function lookup(key: string): string | undefined {
+  const value = key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
+      en as unknown
+    )
+  return typeof value === 'string' ? value : undefined
+}
+
+const REQUIRED_KEYS: Record<string, string> = {
+  // Resource Manager tooltip and screen-reader label
+  'auto.components.status.bar.ResourceUsageStatusSegment.resourceManager': 'Resource Manager',
+  'auto.components.status.bar.ResourceUsageStatusSegment.tooltipHeadline':
+    'Resource Manager - {{value0}} - {{value1}}',
+  'auto.components.status.bar.ResourceUsageStatusSegment.memoryUnavailable': 'memory unavailable',
+  'auto.components.status.bar.ResourceUsageStatusSegment.spaceScanReady': 'Space scan ready',
+  'auto.components.status.bar.ResourceUsageStatusSegment.terminalSessionCountOne':
+    '{{value0}} terminal session',
+  'auto.components.status.bar.ResourceUsageStatusSegment.terminalSessionCountOther':
+    '{{value0}} terminal sessions',
+  'auto.components.status.bar.ResourceUsageStatusSegment.sessionsGroupedByWorkspace':
+    'Terminal sessions are grouped by workspace.',
+  'auto.components.status.bar.ResourceUsageStatusSegment.noTerminalSessions':
+    'No terminal sessions yet.',
+  // Remote hosts segment
+  'auto.components.status.bar.SshStatusSegment.hostCountOne': '{{value0}} host',
+  'auto.components.status.bar.SshStatusSegment.hostCountOther': '{{value0}} hosts',
+  'auto.components.status.bar.SshStatusSegment.connectingHosts': 'Connecting…'
+}
+
+describe('status bar helper copy', () => {
+  it.each(Object.entries(REQUIRED_KEYS))('keeps %s in the English catalog', (key, expected) => {
+    expect(lookup(key)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary

The status bar renders the Resource Manager tooltip and the remote-host count from bare literals inside helper functions, so both stay English while everything around them is translated.

`resource-manager-terminal-copy.ts` builds the whole tooltip without touching the catalog:

```ts
export function formatTerminalSessionCount(count: number): string {
  return `${count} terminal session${count === 1 ? '' : 's'}`
}
// …
lines.push('Terminal sessions are grouped by workspace.')
```

`SshStatusSegment.tsx` does the same for the collapsed segment:

```ts
function connectedHostCountLabel(count: number): string {
  return `${count} ${count === 1 ? 'host' : 'hosts'}`
}
```

**Why the coverage gate does not catch it.** `audit-localization-coverage.mjs` inspects JSX attributes and object properties, not values returned by helper functions, so `pnpm verify:localization-coverage` passes while the strings ship untranslated. This is the same class of defect as [#11826](https://github.com/stablyai/orca/pull/11826); that sweep counted 57 such helpers across the renderer, and this PR takes the status bar ones.

### What changed

| Area | Strings |
|---|---|
| Resource Manager tooltip | headline, memory-unavailable fallback, space-scan row, grouped/empty session rows |
| Resource Manager screen-reader label | segment name + session count |
| Remote hosts segment | host count (singular/plural) + `Connecting…` |

`sync:localization-catalog` added **11 keys**; nothing was removed or reworded (11948 → 11959, 0 deletions, 0 value changes). English wording is byte-identical.

### A latent bug this surfaces

The segment tinted one tooltip row by comparing it against the English text:

```tsx
className={line === 'Space scan ready' ? 'text-primary' : ''}
```

That comparison stops matching the moment the copy comes from the catalog, so simply routing the string through `translate()` would have dropped the tint in every non-English build. `getResourceManagerTooltipLines` now returns `{ text, emphasized }` and the segment reads the flag. A test pins it so the text-matching pattern cannot come back.

Notes on the approach:

- Keys are stable and semantic (`sessionsGroupedByWorkspace`, `hostCountOther`) rather than content hashes, matching `config/i18n-translation-source.md`: *"a feature developer adds a stable message ID and current English copy once"*.
- Plural forms use two explicit keys selected by a ternary, matching how the rest of the codebase selects plurals rather than introducing `count`.
- Host helpers moved to `ssh-status-copy.ts` so `SshStatusSegment.tsx` keeps its headroom under the 400-line gate — the same split accepted in #11826.

## Screenshots

**No visual change in English** — every string keeps its exact English wording, so an English build renders identically.

The defect is only visible in a localized build. From a Russian language pack on current `main`, before this PR — the tooltip and `0 hosts` sit in English next to a fully translated status bar:

![Status bar](https://raw.githubusercontent.com/smwbev/orca-russian/main/docs/screenshots/status-bar-resource-manager.png)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`src/renderer/src/i18n/status-bar-copy-localization.test.ts` pins all 11 keys to their English text, so a helper that reverts to a bare literal fails the suite. `resource-manager-terminal-copy.test.ts` gains a case asserting that the space-scan row is flagged rather than recognized by its wording.

The full suite reports 44520 passed with 20 pre-existing failures across 8 files — `omp-shell-wrapper.node-pty`, `ssh-posix-command-wrapper`, `updater`, `terminal-ime-hangul-syllable-flush`, `terminal-ime-xterm-composition-cancel`, `automation-schedules`, `external-automation-jobs-file`, and `macos-computer-helper-owner-loss-processes`. All of them reproduce on a clean `upstream/main` checkout on this machine (macOS, Node 26), and none touch the status bar or i18n. The status-bar suite specifically is green: 38 files, 268 tests.

## AI Review Report

Reviewed the diff for correctness, localization behavior, and cross-platform impact on macOS, Linux, and Windows.

- **Flagged and fixed:** the `line === 'Space scan ready'` comparison described above. Routing the copy through the catalog without this change would have been a silent visual regression in every translated build — caught before pushing, and now covered by a test.
- **Cross-platform:** the change touches UI copy and its lookup path only. No paths, shell invocations, keyboard shortcuts, path separators, or Electron platform APIs are involved. `Connecting…` uses U+2026, already present in this file. The memory label (`3.69 GB · Σ RSS`) is produced upstream by `memoryMetricCopy` and is passed through unchanged as an interpolation value on all platforms.
- **Verified:** English output is unchanged, confirmed by the pre-existing assertions in `resource-manager-terminal-copy.test.ts`; the full status-bar suite (38 files, 268 tests) passes.

## Security Audit

- **Input handling:** `memoryLabel` originates from the daemon resource snapshot over IPC. It previously reached the DOM via template concatenation and now reaches it as an i18next interpolation value — the same data on the same path, no new source of untrusted input.
- **Escaping:** the renderer sets `interpolation.escapeValue: false`, but these strings render as React text nodes (`{line.text}`), so React escapes them. No `dangerouslySetInnerHTML`, no HTML assembly.
- **Command execution / paths / auth / secrets / dependencies:** untouched. No new IPC channels, no new dependencies, no filesystem or process access.

## Notes

Plural forms are selected with a ternary because that is the existing convention. This keeps two-form languages working and leaves languages with more plural categories approximated, which is the subject of [#12106](https://github.com/stablyai/orca/issues/12106) — no change to that is proposed here.
