### PR TITLE
Fix Windows git/gh attribution wrappers rejecting a piped stdin argument

### DIFF
--- a/src/main/attribution/terminal-attribution-win32-dash-argument.test.ts
+++ b/src/main/attribution/terminal-attribution-win32-dash-argument.test.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyTerminalAttributionEnv } from './terminal-attribution'
+
+// Why (#12046 follow-up): `powershell.exe -File <script> ... -` fails argument
+// binding with PSArgumentException before the script runs, so any command
+// carrying a bare `-` must never be dispatched to the PowerShell wrapper.
+describe('win32 attribution wrappers with a bare `-` argument', () => {
+  let tmpRoot: string | null = null
+
+  afterEach(() => {
+    if (tmpRoot) {
+      rmSync(tmpRoot, { force: true, recursive: true })
+      tmpRoot = null
+    }
+  })
+
+  function shimDir(): string {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'orca-attribution-dash-'))
+    const userDataPath = join(tmpRoot, 'user-data')
+    const baseEnv: Record<string, string> = {
+      Path: 'C:\\Windows\\system32',
+      SystemRoot: 'C:\\Windows'
+    }
+    applyTerminalAttributionEnv(baseEnv, {
+      enabled: true,
+      platform: 'win32',
+      shellFamily: 'native-windows',
+      userDataPath
+    })
+    return join(userDataPath, 'orca-terminal-attribution', 'win32')
+  }
+
+  it('guards the git PowerShell dispatch behind a bare-dash check', () => {
+    const wrapper = readFileSync(join(shimDir(), 'git.cmd'), 'utf8')
+    const guardAt = wrapper.indexOf('call :orca_has_bare_dash %*')
+    const dispatchAt = wrapper.indexOf('powershell.exe')
+
+    expect(guardAt).toBeGreaterThan(-1)
+    expect(guardAt).toBeLessThan(dispatchAt)
+    expect(wrapper).toContain('if not errorlevel 1 goto run')
+    expect(wrapper).toContain(':orca_has_bare_dash')
+    expect(wrapper).toContain('if "%~1"=="-" exit /b 0')
+  })
+
+  it('guards the gh PowerShell dispatch behind a bare-dash check', () => {
+    const wrapper = readFileSync(join(shimDir(), 'gh.cmd'), 'utf8')
+    const guardAt = wrapper.indexOf('call :orca_has_bare_dash %*')
+    const dispatchAt = wrapper.indexOf('powershell.exe')
+
+    expect(guardAt).toBeGreaterThan(-1)
+    expect(guardAt).toBeLessThan(dispatchAt)
+    expect(wrapper).toContain(':orca_has_bare_dash')
+  })
+
+  const itWindows = process.platform === 'win32' ? it : it.skip
+
+  // Why: the guard exists for a runtime failure, so the real regression is a
+  // real `git commit -F -` through the generated wrapper on a real Windows host.
+  itWindows('commits a message piped through `git commit -F -`', () => {
+    const dir = shimDir()
+    const gitCmd = join(dir, 'git.cmd')
+    const repo = mkdtempSync(join(tmpdir(), 'orca-attribution-dash-repo-'))
+    try {
+      const git = (...args: string[]): void => {
+        spawnSync('git', args, { cwd: repo, encoding: 'utf8' })
+      }
+      git('init', '-q', '-b', 'main')
+      git('config', 'user.email', 'test@example.com')
+      git('config', 'user.name', 'Test')
+      writeFileSync(join(repo, 'a.txt'), 'hello\n')
+      git('add', '.')
+
+      const env = {
+        ...process.env,
+        ORCA_ENABLE_GIT_ATTRIBUTION: '1',
+        ORCA_REAL_GIT: spawnSync('where', ['git.exe'], { encoding: 'utf8' }).stdout.split(
+          /\r?\n/
+        )[0]
+      }
+      const result = spawnSync('cmd.exe', ['/d', '/c', gitCmd, 'commit', '-F', '-'], {
+        cwd: repo,
+        env,
+        input: 'piped subject\n',
+        encoding: 'utf8'
+      })
+
+      expect(result.stderr).not.toContain('PSArgumentException')
+      expect(result.status).toBe(0)
+      expect(
+        spawnSync('git', ['log', '-1', '--format=%B'], { cwd: repo, encoding: 'utf8' }).stdout
+      ).toContain('piped subject')
+    } finally {
+      rmSync(repo, { force: true, recursive: true })
+    }
+  })
+})

--- a/src/main/attribution/terminal-attribution.ts
+++ b/src/main/attribution/terminal-attribution.ts
@@ -8,7 +8,7 @@ import { ORCA_GIT_COMMIT_TRAILER } from '../../shared/orca-attribution'
 import { resolvePathEnvKey } from '../pty/windows-environment-path'
 
 const ATTRIBUTION_ROOT_DIR = 'orca-terminal-attribution'
-const ATTRIBUTION_SHIM_VERSION = '6'
+const ATTRIBUTION_SHIM_VERSION = '7'
 const ORCA_PRODUCT_URL = 'https://github.com/stablyai/orca'
 const ORCA_GH_FOOTER = `Made with [Orca](${ORCA_PRODUCT_URL}) 🐋`
 const SHELL_DOLLAR = '$'
@@ -645,6 +645,8 @@ if not "%ORCA_ENABLE_GIT_ATTRIBUTION%"=="1" goto run
 if "%ORCA_ATTRIBUTION_BYPASS%"=="1" goto run
 call :orca_is_git_commit %*
 if errorlevel 1 goto run
+call :orca_has_bare_dash %*
+if not errorlevel 1 goto run
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0git-wrapper.ps1" %*
 exit /b %ERRORLEVEL%
 :run
@@ -679,6 +681,15 @@ goto orca_is_git_commit
 :skip_one
 shift
 goto orca_is_git_commit
+
+rem Why: powershell.exe -File rejects a bare "-" while binding arguments, so the
+rem script never runs. Pass those straight to git, which is what the PS wrapper
+rem does with a stdin message anyway.
+:orca_has_bare_dash
+if "%~1"=="" exit /b 1
+if "%~1"=="-" exit /b 0
+shift
+goto orca_has_bare_dash
 `
 
 const WIN32_GH_CMD_WRAPPER = String.raw`@echo off
@@ -689,6 +700,8 @@ if /I "%~1"=="pr" if /I "%~2"=="create" goto wrap
 if /I "%~1"=="issue" if /I "%~2"=="create" goto wrap
 goto run
 :wrap
+call :orca_has_bare_dash %*
+if not errorlevel 1 goto run
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0gh-wrapper.ps1" %*
 exit /b %ERRORLEVEL%
 :run
@@ -699,6 +712,14 @@ if defined ORCA_REAL_GH (
   exit /b 127
 )
 exit /b %ERRORLEVEL%
+
+rem Why: powershell.exe -File rejects a bare "-" while binding arguments, so the
+rem script never runs. Creating without the footer beats not creating at all.
+:orca_has_bare_dash
+if "%~1"=="" exit /b 1
+if "%~1"=="-" exit /b 0
+shift
+goto orca_has_bare_dash
 `
 
 const WIN32_GIT_PS_WRAPPER = String.raw`$ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary

Post-merge correction to #12218 (issue #12046), found by running the Windows attribution wrappers on a real Windows host.

`powershell.exe -File <script> ... -` fails **argument binding** before the script executes:

```
git-wrapper.ps1 : Cannot process argument because the value of argument "name" is not valid.
Change the value of the "name" argument and run the operation again.
    + CategoryInfo          : InvalidArgument: (:) [git-wrapper.ps1], PSArgumentException
    + FullyQualifiedErrorId : Argument,git-wrapper.ps1
```

PowerShell treats a lone `-` as a parameter prefix with an empty name. `git.cmd` dispatches every `git commit …` to `git-wrapper.ps1`, and `gh.cmd` dispatches every `gh pr create` / `gh issue create` to `gh-wrapper.ps1`, so on a Windows Orca terminal with `enableGitHubAttribution` on:

- `git commit -F -` failed with that PowerShell error instead of reading the message from stdin
- `gh pr create --body-file -` and `gh issue create --body-file -` failed the same way

This is newly reachable in practice. Before #12218 the attribution shim directory only won when its PATH spelling happened to sort first in the block; #12218 made the shim deterministically first, so these wrappers now run on every invocation rather than intermittently.

Both `.cmd` wrappers now check for a bare `-` argument and take their existing passthrough (`:run`) path instead of dispatching to PowerShell.

The behaviour this restores is what the PowerShell wrapper already intended for `git`: `Test-UnsupportedCommitMessageSource` classifies a `-F` target that is not an existing path as unsupported and passes the command through to real git unchanged. Routing it at the `.cmd` layer reaches the same result without the crash. For `gh`, passthrough means the created PR/issue does not get the Orca footer — creating it without the footer is strictly better than the command not running, and that trade-off is stated rather than hidden.

`ATTRIBUTION_SHIM_VERSION` is bumped `6` → `7` so already-generated shim directories are rewritten instead of being served from the version cache.

Commands that carry a bare `-` but never routed to PowerShell (`git checkout -`, `git log -`) were already correct and are unchanged.

## ELI5

Orca puts small `git` and `gh` stand-ins on the PATH inside its Windows terminals so it can add its attribution line. For commits it hands the job to a PowerShell helper. PowerShell refuses to start a script when one of the arguments is a lone dash — and a lone dash is exactly how you tell git "read the message from what I'm piping you". So `git commit -F -` died with a PowerShell error instead of committing. The stand-ins now spot that lone dash and call real git directly.

## Fix proof

All of the following ran on a **real Windows 11 host** (build 26200.8875, Node v24.18.0, git 2.55.0.windows.3), driving the generated wrappers.

Before, at `origin/main`:

```
C) git commit -F -
   wrapper exit=1 err="git-wrapper.ps1 : Cannot process argument because the value of
                       argument \"name\" is not valid. ... PSArgumentException"
   bare    exit=0 err=""

D) gh pr create --body-file - => wrapper exit=1
   err="gh-wrapper.ps1 : Cannot process argument because the value of argument \"name\"
        is not valid. ... PSArgumentException"
```

After, on this branch, same probe on the same host:

```
C) git commit -F -
   wrapper exit=0 err=""

D) gh pr create --body-file - => wrapper exit=1
   err="could not determine the current branch: failed to run git: not on any branch"
```

`gh` still exits non-zero there only because the probe repo is in detached HEAD — that is real `gh` output reached through the wrapper, not a PowerShell failure. The `PSArgumentException` is gone from both.

Root cause isolated on the same host, unchanged by this fix (the wrapper simply no longer routes there):

```
A) powershell -File git-wrapper.ps1 commit -F -  => exit=1  PSArgumentException
B) powershell -File git-wrapper.ps1 commit -m ok => exit=1  (no binding error)
```

New regression test, run on the same Windows host:

```
✓ terminal-attribution-win32-dash-argument.test.ts > guards the git PowerShell dispatch behind a bare-dash check 7ms
✓ terminal-attribution-win32-dash-argument.test.ts > guards the gh PowerShell dispatch behind a bare-dash check 5ms
✓ terminal-attribution-win32-dash-argument.test.ts > commits a message piped through `git commit -F -` 217ms
```

The third case is the load-bearing one: it drives the generated `git.cmd` against real `git` with a real piped message and asserts both the exit code and that `PSArgumentException` is absent. It is gated on `process.platform === 'win32'`; the two structural cases run everywhere.

## No regressions

Real Windows host, this branch:

```
$ npx vitest run --config config/vitest.config.ts src/main/attribution src/main/pty \
    src/main/providers src/main/ipc/pty.test.ts src/main/daemon/pty-subprocess.test.ts \
    config/scripts/build-windows-cli-launcher.test.mjs

 Test Files  1 failed | 57 passed | 3 skipped (61)
      Tests  3 failed | 1243 passed | 77 skipped (1362)
```

The 3 failures are all in `src/main/ipc/pty.test.ts` and are pre-existing on `main`, unrelated to this change — they reproduce identically without this branch and are tracked in #12437 (two hardcode POSIX path separators, one expects a differently quoted startup command).

macOS, this branch:

```
$ npx vitest run --config config/vitest.config.ts src/main/attribution
 Test Files  3 passed (3)
      Tests  32 passed | 1 skipped (33)
```

`npx oxlint` on the changed files is clean and `npx oxfmt --check src/main/attribution/` reports all files correctly formatted.

## Cross-platform

- **Windows**: the only platform whose behaviour changes, and the platform this was found and verified on. Native `cmd` shells and PowerShell both reach the `.cmd` wrapper; the guard is inside it, so both are covered.
- **macOS / Linux**: untouched. The POSIX wrappers are separate constants and are not modified; nothing in this diff runs off Windows. The bumped shim version rewrites the POSIX shim files with byte-identical content.
- **Git Bash / WSL terminals on a Windows host**: these resolve to `shellFamily: 'posix'` and get the POSIX shim directory, not `win32`, so they were never affected and are unchanged.
- **SSH-remote**: unaffected. Remote shells build their env on the remote host via `ssh-pty-spawn-env.ts`; these wrappers are local-host only.
- **Folder workspaces (non-git)**: irrelevant to this diff — no repo metadata, no worktree assumptions.
- **Git compatibility**: no Git subcommand or option is added or changed, so the 2.25 baseline and `GitCapabilityCache` rules are not in play. The wrappers call plain `git`/`gh`, so GitLab and other providers are unaffected.
- No keyboard, accelerator, or shortcut-label surface. No native module, so the glibc floor is untouched.

## Performance

One extra `call` to a batch subroutine that scans argv per `git commit` / `gh …create` invocation, only when attribution is enabled. It replaces a `powershell.exe` process launch in the bare-`-` case, so that path gets faster.

## Security

No change to the auth surface, no IPC channel or payload change, and no new command execution — the guard only chooses between two dispatch paths that already existed. Arguments are still forwarded with `%*` and never re-quoted or interpolated. The `gh` passthrough case omits the Orca footer, which removes content rather than adding any.

Closes nothing on its own; corrects #12218 / #12046.

Made with [Orca](https://github.com/stablyai/orca) 🐋
