### PR TITLE
test(terminal): pin Korean intermediate commit

### DIFF
--- a/tests/e2e/terminal-macos-2set-korean-native.spec.ts
+++ b/tests/e2e/terminal-macos-2set-korean-native.spec.ts
@@ -195,8 +195,9 @@ test.describe('Native macOS 2-Set Korean terminal input @headful', () => {
       testInfo,
       testRepoPath,
       electronApp.process().pid!,
-      [5, 40, 1, 15, 46, 3, 36],
-      '한글'
+      [5, 40, 1, 15, 46, 3],
+      '한글',
+      { committedText: '한', preeditText: '글' }
     )
   })
 


### PR DESCRIPTION
## Summary

- assert `한` reaches xterm `onData` while `글` remains native 2-Set Korean preedit
- retain the same exact `한글` PTY-byte assertion after physical Enter
- reuse the existing ordinary-input negative and stock-xterm mutation

No production code changes. This is issue-specific evidence for #11914, #12063, STA-3197, and STA-3198.

## Verification

- targeted oxlint and React Doctor lint
- oxfmt
- Electron E2E build and Playwright discovery (5 native macOS cases)

## Remaining certification

The physical test must be rerun on the final restacked landing head when it will not interrupt the active Mac session. Reporter confirmation remains separate.