### PR TITLE
perf(terminal): stop the IME candidate anchor forcing layout on every compositionupdate

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.test.ts
@@ -193,6 +193,24 @@ describe('installTerminalImeCandidateAnchor', () => {
     expect(harness.style).toEqual({ top: `${2 * CELL_HEIGHT}px`, left: `${7 * CELL_WIDTH}px` })
   })
 
+  it("re-queues the correction after xterm's latest composition timer", () => {
+    const harness = createHarness()
+    harness.setLines(['Cursor Agent', '', '→ hello'])
+    harness.element.addEventListener('compositionupdate', () => {
+      window.setTimeout(() => {
+        harness.style.top = '0px'
+      }, 0)
+    })
+    installTerminalImeCandidateAnchor(harness.terminal)
+
+    harness.setCursor(0, 1)
+    fire(harness.element, 'compositionstart')
+    fire(harness.element, 'compositionupdate')
+    vi.runAllTimers()
+
+    expect(harness.style.top).toBe(`${2 * CELL_HEIGHT}px`)
+  })
+
   it('refreshes the deferred metrics and anchor after a refit', () => {
     const harness = createHarness()
     harness.setLines(['Cursor Agent', '', '→ hello'])

--- a/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.test.ts
@@ -193,6 +193,21 @@ describe('installTerminalImeCandidateAnchor', () => {
     expect(harness.style).toEqual({ top: `${2 * CELL_HEIGHT}px`, left: `${7 * CELL_WIDTH}px` })
   })
 
+  it('refreshes the deferred metrics and anchor after a refit', () => {
+    const harness = createHarness()
+    harness.setLines(['Cursor Agent', '', '→ hello'])
+    installTerminalImeCandidateAnchor(harness.terminal)
+    typeHangulSyllable(harness, 0, 5, 1)
+
+    Object.assign(harness.terminal, { cols: 40 })
+    harness.setLines(['Cursor Agent', '', '', '→ hello'])
+    harness.style.top = '0px'
+    vi.runAllTimers()
+
+    expect(harness.counts.rectReads).toBe(2)
+    expect(harness.style).toEqual({ top: `${3 * CELL_HEIGHT}px`, left: `${14 * CELL_WIDTH}px` })
+  })
+
   it('stops writing once the textarea has been detached', () => {
     const harness = createHarness()
     harness.setLines(['Cursor Agent', '', '→ hello'])

--- a/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.test.ts
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IBuffer, IBufferCell, IBufferLine, Terminal } from '@xterm/xterm'
+import { installTerminalImeCandidateAnchor } from './terminal-ime-candidate-anchor'
+
+const COLS = 80
+const ROWS = 24
+const CELL_WIDTH = 8
+const CELL_HEIGHT = 17
+
+type AnchorHarness = {
+  terminal: Terminal
+  element: HTMLElement
+  style: { top: string; left: string }
+  counts: { rectReads: number; styleWrites: number }
+  setCursor: (cursorX: number, cursorY: number) => void
+  setLines: (lines: string[]) => void
+}
+
+function makeLine(text: string): IBufferLine {
+  const chars = Array.from(text)
+  while (chars.length < COLS) {
+    chars.push(' ')
+  }
+  const cellAt = (column: number): IBufferCell | undefined => {
+    const char = chars[column]
+    return char === undefined
+      ? undefined
+      : ({ getWidth: () => 1, getChars: () => (char === ' ' ? '' : char) } as IBufferCell)
+  }
+  return {
+    isWrapped: false,
+    length: chars.length,
+    getCell: cellAt,
+    translateToString: (trimRight = false, start = 0, end = chars.length) => {
+      const result = chars.slice(start, end).join('')
+      return trimRight ? result.replace(/\s+$/, '') : result
+    }
+  } as IBufferLine
+}
+
+function createHarness(): AnchorHarness {
+  const counts = { rectReads: 0, styleWrites: 0 }
+  const element = document.createElement('div')
+  const screen = document.createElement('div')
+  screen.className = 'xterm-screen'
+  element.appendChild(screen)
+  document.body.appendChild(element)
+
+  screen.getBoundingClientRect = (): DOMRect => {
+    counts.rectReads++
+    return { width: COLS * CELL_WIDTH, height: ROWS * CELL_HEIGHT } as DOMRect
+  }
+
+  const style = { top: '', left: '' }
+  const textarea = {
+    isConnected: true,
+    style: new Proxy(style, {
+      set(target, key: string, value: string) {
+        counts.styleWrites++
+        target[key as 'top' | 'left'] = value
+        return true
+      }
+    })
+  } as unknown as HTMLTextAreaElement
+
+  let lines = ['']
+  const buffer = {
+    baseY: 0,
+    cursorX: 0,
+    cursorY: 0,
+    length: ROWS,
+    getLine: (row: number) => (row < lines.length ? makeLine(lines[row] ?? '') : makeLine(''))
+  } as unknown as IBuffer
+
+  const terminal = {
+    element,
+    textarea,
+    cols: COLS,
+    rows: ROWS,
+    buffer: { active: buffer }
+  } as unknown as Terminal
+
+  return {
+    terminal,
+    element,
+    style,
+    counts,
+    setCursor: (cursorX: number, cursorY: number) => {
+      Object.assign(buffer, { cursorX, cursorY })
+    },
+    setLines: (next: string[]) => {
+      lines = next
+    }
+  }
+}
+
+function fire(element: HTMLElement, type: string): void {
+  element.dispatchEvent(new Event(type))
+}
+
+/** One Hangul syllable: xterm sees compositionstart then one update per jamo. */
+function typeHangulSyllable(
+  harness: AnchorHarness,
+  cursorX: number,
+  updates = 3,
+  cursorY = 0
+): void {
+  harness.setCursor(cursorX, cursorY)
+  fire(harness.element, 'compositionstart')
+  for (let update = 0; update < updates; update++) {
+    fire(harness.element, 'compositionupdate')
+  }
+}
+
+describe('installTerminalImeCandidateAnchor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('returns null before the terminal has opened its DOM', () => {
+    expect(installTerminalImeCandidateAnchor({ element: null } as unknown as Terminal)).toBeNull()
+  })
+
+  it('keeps forced layout at one read per composition across a Hangul burst', () => {
+    const harness = createHarness()
+    installTerminalImeCandidateAnchor(harness.terminal)
+
+    for (let syllable = 0; syllable < 30; syllable++) {
+      typeHangulSyllable(harness, syllable)
+    }
+
+    // 30 compositions x 4 events: reads collapse to one per composition, and the
+    // 90 updates re-write nothing because the anchor is already on the textarea.
+    expect(harness.counts.rectReads).toBe(30)
+    expect(harness.counts.styleWrites).toBe(31)
+    expect(harness.style.left).toBe(`${29 * CELL_WIDTH}px`)
+  })
+
+  it('does no work for Latin input, which fires no composition events', () => {
+    const harness = createHarness()
+    installTerminalImeCandidateAnchor(harness.terminal)
+
+    fire(harness.element, 'keydown')
+    fire(harness.element, 'input')
+
+    expect(harness.counts).toEqual({ rectReads: 0, styleWrites: 0 })
+  })
+
+  it('re-corrects the anchor mid-composition after xterm rewrites the textarea', () => {
+    const harness = createHarness()
+    installTerminalImeCandidateAnchor(harness.terminal)
+    harness.setCursor(4, 2)
+    fire(harness.element, 'compositionstart')
+
+    // xterm's own compositionupdate handler repositions from its uncorrected
+    // cursor; long CJK compositions depend on us winning that back.
+    harness.style.top = '0px'
+    harness.setCursor(6, 2)
+    fire(harness.element, 'compositionupdate')
+
+    expect(harness.style).toEqual({ top: `${2 * CELL_HEIGHT}px`, left: `${6 * CELL_WIDTH}px` })
+  })
+
+  it('re-measures mid-composition when the terminal is refit to new dimensions', () => {
+    const harness = createHarness()
+    installTerminalImeCandidateAnchor(harness.terminal)
+    fire(harness.element, 'compositionstart')
+    expect(harness.counts.rectReads).toBe(1)
+
+    Object.assign(harness.terminal, { cols: 40 })
+    fire(harness.element, 'compositionupdate')
+
+    expect(harness.counts.rectReads).toBe(2)
+  })
+
+  it('coalesces the deferred Cursor Agent re-apply to one timer per burst', () => {
+    const harness = createHarness()
+    harness.setLines(['Cursor Agent', '', '→ hello'])
+    installTerminalImeCandidateAnchor(harness.terminal)
+
+    typeHangulSyllable(harness, 0, 5, 1)
+
+    expect(vi.getTimerCount()).toBe(1)
+    harness.style.top = '0px'
+    vi.runAllTimers()
+    expect(harness.style).toEqual({ top: `${2 * CELL_HEIGHT}px`, left: `${7 * CELL_WIDTH}px` })
+  })
+
+  it('stops writing once the textarea has been detached', () => {
+    const harness = createHarness()
+    harness.setLines(['Cursor Agent', '', '→ hello'])
+    installTerminalImeCandidateAnchor(harness.terminal)
+    typeHangulSyllable(harness, 0, 1, 1)
+
+    Object.assign(harness.terminal.textarea as object, { isConnected: false })
+    const writesBeforeTimer = harness.counts.styleWrites
+    harness.style.top = '0px'
+    vi.runAllTimers()
+
+    expect(harness.counts.styleWrites).toBe(writesBeforeTimer)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.ts
@@ -109,23 +109,29 @@ export function installTerminalImeCandidateAnchor(terminal: Terminal): (() => vo
     // each compositionupdate, so the correction has to land after that timer —
     // one pending timer per burst, re-reading the anchor when it fires.
     if (!isCursorAgent) {
+      if (deferredApply !== null) {
+        window.clearTimeout(deferredApply)
+        deferredApply = null
+      }
       return
     }
-    if (deferredApply === null) {
-      deferredApply = window.setTimeout(() => {
-        deferredApply = null
-        if (!textarea.isConnected) {
-          return
-        }
-        if (!metrics || metrics.cols !== terminal.cols || metrics.rows !== terminal.rows) {
-          metrics = measureCells()
-        }
-        if (metrics) {
-          const currentAnchor = resolveAnchor().anchor
-          applyAnchor(currentAnchor.row, currentAnchor.column, metrics)
-        }
-      }, 0)
+    // Re-queue after xterm's latest timer while keeping only one correction pending.
+    if (deferredApply !== null) {
+      window.clearTimeout(deferredApply)
     }
+    deferredApply = window.setTimeout(() => {
+      deferredApply = null
+      if (!textarea.isConnected) {
+        return
+      }
+      if (!metrics || metrics.cols !== terminal.cols || metrics.rows !== terminal.rows) {
+        metrics = measureCells()
+      }
+      if (metrics) {
+        const currentAnchor = resolveAnchor().anchor
+        applyAnchor(currentAnchor.row, currentAnchor.column, metrics)
+      }
+    }, 0)
   }
 
   terminal.element.addEventListener('compositionstart', handler)

--- a/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.ts
@@ -1,6 +1,13 @@
 import type { Terminal } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
 
+type ImeAnchorCellMetrics = {
+  cellWidth: number
+  cellHeight: number
+  cols: number
+  rows: number
+}
+
 /**
  * Keep the OS IME candidate window anchored to the cell the user is typing in.
  *
@@ -9,6 +16,13 @@ import { resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
  * from its own cursor, which can be stale or intentionally hidden by TUIs. We
  * force-sync after xterm's own composition handlers so the OS sees the corrected
  * location before it opens the candidate window.
+ *
+ * xterm rewrites the textarea's position from its own `compositionupdate`
+ * handler, so the update listener has to stay — CJK IMEs compose long sequences
+ * (romaji→kana→kanji, pinyin phrases) during which xterm's uncorrected position
+ * would otherwise win. Instead the update path is made free of forced layout:
+ * cell metrics are measured once per composition and reused, and a style write is
+ * skipped when the inline value already matches (a CSSOM read, not a layout one).
  *
  * Cell dimensions are derived from the public .xterm-screen element's bounds
  * (xterm sizes that element to cols*cellWidth × rows*cellHeight) rather than
@@ -24,14 +38,50 @@ export function installTerminalImeCandidateAnchor(terminal: Terminal): (() => vo
   }
   const screenElement = terminal.element.querySelector<HTMLElement>('.xterm-screen')
   const textarea = terminal.textarea
-  const handler = (): void => {
+  let metrics: ImeAnchorCellMetrics | null = null
+  let deferredApply: number | null = null
+  let deferredAnchor: { row: number; column: number } | null = null
+
+  const measureCells = (): ImeAnchorCellMetrics | null => {
     if (!screenElement) {
-      return
+      return null
     }
     const rect = screenElement.getBoundingClientRect()
     const cellWidth = rect.width / terminal.cols
     const cellHeight = rect.height / terminal.rows
     if (!(cellWidth > 0) || !(cellHeight > 0)) {
+      return null
+    }
+    return { cellWidth, cellHeight, cols: terminal.cols, rows: terminal.rows }
+  }
+
+  // Why: xterm rewrites these between our events, so compare against the live
+  // inline value — a CSSOM read, unlike getBoundingClientRect — and skip the
+  // write when it already matches instead of re-invalidating layout.
+  const writeOffset = (property: 'top' | 'left', value: string): void => {
+    if (textarea.style[property] !== value) {
+      textarea.style[property] = value
+    }
+  }
+
+  const applyAnchor = (row: number, column: number, cells: ImeAnchorCellMetrics): void => {
+    writeOffset('top', `${row * cells.cellHeight}px`)
+    writeOffset('left', `${column * cells.cellWidth}px`)
+  }
+
+  const handler = (event?: Event): void => {
+    if (!screenElement) {
+      return
+    }
+    // Re-measure per composition (font size or zoom may have changed since the
+    // last one); every compositionupdate then reuses it and forces no layout.
+    const staleMetrics =
+      !metrics || metrics.cols !== terminal.cols || metrics.rows !== terminal.rows
+    if (event?.type !== 'compositionupdate' || staleMetrics) {
+      metrics = measureCells()
+    }
+    const cells = metrics
+    if (!cells) {
       return
     }
     const buf = terminal.buffer.active
@@ -48,19 +98,24 @@ export function installTerminalImeCandidateAnchor(terminal: Terminal): (() => vo
       row: buf.cursorY,
       column: Math.min(buf.cursorX, terminal.cols - 1)
     }
-    const applyAnchor = (): void => {
-      textarea.style.top = `${anchor.row * cellHeight}px`
-      textarea.style.left = `${anchor.column * cellWidth}px`
+    applyAnchor(anchor.row, anchor.column, cells)
+    // Why: xterm re-positions the textarea from a setTimeout(0) of its own after
+    // each compositionupdate, so the correction has to land after that timer —
+    // one pending timer per burst, re-reading the anchor when it fires.
+    if (!cursorAgentAnchor) {
+      return
     }
-    applyAnchor()
-    if (cursorAgentAnchor) {
-      window.setTimeout(() => {
-        if (textarea.isConnected) {
-          applyAnchor()
+    deferredAnchor = anchor
+    if (deferredApply === null) {
+      deferredApply = window.setTimeout(() => {
+        deferredApply = null
+        if (textarea.isConnected && metrics && deferredAnchor) {
+          applyAnchor(deferredAnchor.row, deferredAnchor.column, metrics)
         }
       }, 0)
     }
   }
+
   terminal.element.addEventListener('compositionstart', handler)
   terminal.element.addEventListener('compositionupdate', handler)
   return handler

--- a/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-candidate-anchor.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
-import { resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
+import { resolveCursorAgentImeAnchor, type TerminalImeAnchor } from './terminal-ime-anchor'
 
 type ImeAnchorCellMetrics = {
   cellWidth: number
@@ -40,7 +40,6 @@ export function installTerminalImeCandidateAnchor(terminal: Terminal): (() => vo
   const textarea = terminal.textarea
   let metrics: ImeAnchorCellMetrics | null = null
   let deferredApply: number | null = null
-  let deferredAnchor: { row: number; column: number } | null = null
 
   const measureCells = (): ImeAnchorCellMetrics | null => {
     if (!screenElement) {
@@ -69,6 +68,26 @@ export function installTerminalImeCandidateAnchor(terminal: Terminal): (() => vo
     writeOffset('left', `${column * cells.cellWidth}px`)
   }
 
+  const resolveAnchor = (): { anchor: TerminalImeAnchor; isCursorAgent: boolean } => {
+    const buf = terminal.buffer.active
+    // Why: Cursor Agent draws its prompt UI while leaving xterm's public cursor
+    // on a blank row, so the OS IME anchor needs the rendered prompt row instead.
+    const cursorAgentAnchor = resolveCursorAgentImeAnchor({
+      buffer: buf,
+      rows: terminal.rows,
+      cols: terminal.cols,
+      cursorX: buf.cursorX,
+      cursorY: buf.cursorY
+    })
+    return {
+      anchor: cursorAgentAnchor ?? {
+        row: buf.cursorY,
+        column: Math.min(buf.cursorX, terminal.cols - 1)
+      },
+      isCursorAgent: cursorAgentAnchor !== null
+    }
+  }
+
   const handler = (event?: Event): void => {
     if (!screenElement) {
       return
@@ -84,33 +103,26 @@ export function installTerminalImeCandidateAnchor(terminal: Terminal): (() => vo
     if (!cells) {
       return
     }
-    const buf = terminal.buffer.active
-    // Why: Cursor Agent draws its prompt UI while leaving xterm's public cursor
-    // on a blank row, so the OS IME anchor needs the rendered prompt row instead.
-    const cursorAgentAnchor = resolveCursorAgentImeAnchor({
-      buffer: buf,
-      rows: terminal.rows,
-      cols: terminal.cols,
-      cursorX: buf.cursorX,
-      cursorY: buf.cursorY
-    })
-    const anchor = cursorAgentAnchor ?? {
-      row: buf.cursorY,
-      column: Math.min(buf.cursorX, terminal.cols - 1)
-    }
+    const { anchor, isCursorAgent } = resolveAnchor()
     applyAnchor(anchor.row, anchor.column, cells)
     // Why: xterm re-positions the textarea from a setTimeout(0) of its own after
     // each compositionupdate, so the correction has to land after that timer —
     // one pending timer per burst, re-reading the anchor when it fires.
-    if (!cursorAgentAnchor) {
+    if (!isCursorAgent) {
       return
     }
-    deferredAnchor = anchor
     if (deferredApply === null) {
       deferredApply = window.setTimeout(() => {
         deferredApply = null
-        if (textarea.isConnected && metrics && deferredAnchor) {
-          applyAnchor(deferredAnchor.row, deferredAnchor.column, metrics)
+        if (!textarea.isConnected) {
+          return
+        }
+        if (!metrics || metrics.cols !== terminal.cols || metrics.rows !== terminal.rows) {
+          metrics = measureCells()
+        }
+        if (metrics) {
+          const currentAnchor = resolveAnchor().anchor
+          applyAnchor(currentAnchor.row, currentAnchor.column, metrics)
         }
       }, 0)
     }


### PR DESCRIPTION
## Summary

Typing Korean/Japanese/Chinese in a terminal pane was laggy while ASCII typing was fine. `installTerminalImeCandidateAnchor()` registers one handler on both `compositionstart` and `compositionupdate`, and every event did a `getBoundingClientRect()` on `.xterm-screen` (forced sync layout) followed by two `textarea.style` writes (layout invalidation) — a read→write→read cycle repeated 3–4× per Hangul syllable, interleaved with xterm's own composition layout reads.

This keeps the anchor exactly as correct as before and removes the per-event forced layout:

- Cell metrics (`cellWidth`/`cellHeight`) are measured **once per composition** and reused by every `compositionupdate`, with a `cols`/`rows` staleness guard so a mid-composition refit still re-measures.
- Anchor style writes are skipped when the inline value already matches. Reading `textarea.style.top` is a CSSOM read, not a layout read, so this costs nothing and avoids re-invalidating layout.
- The deferred Cursor Agent correction keeps **one** pending `setTimeout` and re-queues it after xterm's latest composition timer, so xterm cannot clobber the final anchor. When it fires, it revalidates cell metrics and resolves the live anchor.

Latin input is untouched: it fires no composition events, so the handler never runs (covered by a test).

Fixes #12211

### Why the update listener was kept

The issue's cheapest suggestion — drop the `compositionupdate` listener and keep only `compositionstart` — is **not safe**, and verifying that was the first step here. xterm's own `CompositionHelper.compositionupdate()` calls `updateCompositionElements()`, which writes `_textarea.style.left/top` from its *uncorrected* cursor on every update, and then schedules a `setTimeout(0)` recursion that writes them again (`node_modules/@xterm/xterm/src/browser/input/CompositionHelper.ts:179-199, 726-765`). Removing our update listener would hand the textarea back to xterm mid-composition and regress the Cursor Agent anchor (where xterm's public cursor deliberately sits on a blank row). That matters most for exactly the IMEs the issue says are affected: Hangul is one composition per syllable, but Japanese romaji→kana→kanji and Chinese pinyin phrases compose long sequences, so a wrong anchor would persist for the whole conversion. A regression test asserts we re-correct the anchor after a simulated xterm clobber.

For the same reason the deferred re-apply stays on `setTimeout(0)` rather than moving to `requestAnimationFrame` as the issue suggests: it has to land *after* xterm's own deferred `updateCompositionElements(true)` timer, and a rAF callback can run before a pending timer task when the frame deadline arrives first. The remaining sync write is a pure style write with no read after it, so there is no read-write-read cycle left.

### Measured

Deterministic harness (`terminal-ime-candidate-anchor.test.ts`, happy-dom) drives a realistic Hangul burst — 30 syllables × (1 `compositionstart` + 3 `compositionupdate`) = 120 events — with a counting `getBoundingClientRect` and a `Proxy` over `textarea.style`:

| | forced-layout reads | style writes | pending timers (Cursor Agent burst) |
|---|---|---|---|
| before (`e8d4818b5a`) | **120** | **240** | 6 |
| after | **30** | **31** | 1 |

Reads drop from O(events) to O(compositions); writes drop to one per anchor change (2 for the first syllable, 1 per syllable after, since only `left` moves). Verified red-on-parent: reverting only the source file and re-running the harness fails with `expected 120 to be 30` and `expected 6 to be 1`.

## Screenshots

No intended visual change — only the cost and ordering of the anchor correction changed.

Active Korean composition at the terminal cursor:

![Active Korean IME composition](https://github.com/user-attachments/assets/101f441c-d556-4281-bf53-0cbe84de2e7b)

Committed Korean, Japanese, and Chinese output in the surrounding terminal UI:

![CJK terminal output](https://github.com/user-attachments/assets/57266549-9a00-46c3-9c49-2ecfb2820d06)

Electron QA on the final head drove 30 Hangul syllables × 4 composition events in the live renderer: **120 events, 30 `.xterm-screen` layout reads**.

## Testing

- [x] `pnpm lint` — `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:max-lines-ratchet` all clean
- [x] `pnpm typecheck`
- [x] `pnpm test` — new file 9/9; `src/renderer/src/lib/pane-manager` 628 passed, 1 skipped; `dashboard-popout` + `terminal-pane` 3086 passed
- [x] React Doctor changed-lines gate — 0 issues (`check:react-doctor:changed`, `lint:react-doctor:changed`)
- [x] Added or updated high-quality tests that would catch regressions

New tests: the counting harness above, plus coverage for no-work-on-Latin-input, mid-composition re-correction after an xterm clobber, mid-composition refit re-measurement, post-refit anchor refresh, xterm timer ordering, one pending correction, and no write after the textarea detaches.

## AI Review Report

Reviewed against the issue's claims rather than taking them at face value; the reported code shape was confirmed accurate against `src/` (not `app.asar`), including the shared handler, the per-event rect read, and the `setTimeout(0)` second write.

Risks checked:

- **Correctness of the invariant.** Read xterm's `CompositionHelper` source to confirm whether mid-composition repositioning is load-bearing. It is (see above), so the proposed listener removal was rejected in favour of making the update path free of layout.
- **Stale metrics.** Guarded by re-measuring at every `compositionstart` plus a `cols`/`rows` comparison in both the event and deferred paths, so a refit mid-composition re-measures before either write. A sub-cell resize that changes neither cols nor rows can leave metrics off by well under one cell until the next composition — deliberate, and strictly better than the previous behaviour's cost.
- **Skipped writes.** The skip compares against the *live* inline value, so an xterm clobber always causes a rewrite; it can only skip when the DOM already holds the value we want. Blink itself already no-ops an identical `setProperty`, so this is purely avoiding CSSOM churn.
- **Deferred correctness.** Each Cursor Agent event clears and re-queues the single pending correction after xterm's newest timer. The callback revalidates dimensions and resolves the live buffer anchor, so neither a refit nor xterm's deferred write can restore stale positioning.
- **Listener lifecycle (STA-3291 / #12348).** Install is once per pane in `openTerminal` (`pane-lifecycle.ts`) and once per preview in `installPreviewTerminalCompatibility`; neither is per-render. The exported signature is unchanged (`(() => void) | null`), so both existing dispose paths keep working untouched.
- **Cross-platform.** Renderer-only, no keyboard shortcuts, no path handling, no platform branches added or touched. IME composition events are Chromium-level and identical on macOS, Linux, and Windows; the Windows report in the issue thread ("first syllable one behind") exercises the same handler. No Electron main-process or IPC surface involved, so SSH and folder-workspace panes behave identically.

Not changed, and called out deliberately: `resolveCursorAgentImeAnchor`'s buffer scan still runs per event. It is pure JS with no layout involvement and early-returns unless the cursor is at column 0 on a blank row, so it is off the hot path for normal shells and TUIs. Caching it would need a render-driven invalidation to avoid a stale anchor when async agent output moves the prompt row mid-composition — out of scope for this PR.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change is confined to one renderer module that reads xterm's public buffer/geometry API and writes two inline CSS offsets on xterm's own textarea; all values written are numbers derived from cell geometry, never user text. No new dependencies. No follow-up needed.

## Notes

- The issue also asks for a setting to disable the anchor. Not added — with the per-event forced layout gone there is nothing left to opt out of, and a toggle would be a separate concern.
- The second comment on the issue (Windows, "first composed syllable appears one syllable late" in the agent prompt) describes a rendering-order symptom in a different surface and is not addressed here.
