### PR TITLE
Clarify remote file mutation version mismatch messages

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -389,7 +389,7 @@ describe('RuntimeFileCommands', () => {
     const { commands } = createRuntimeFileCommands()
 
     await expect(commands.renameFileExplorerPath('id:wt-1', 'old.ts', 'new.ts')).rejects.toThrow(
-      'newer Orca client'
+      'Orca client paired with this server is out of date'
     )
 
     expect(getSshFilesystemProvider).not.toHaveBeenCalled()
@@ -402,7 +402,7 @@ describe('RuntimeFileCommands', () => {
 
     await expect(
       commands.renameFileExplorerPath('id:wt-1', 'old.ts', 'new.ts', 0, 'ssh-1')
-    ).rejects.toThrow('newer Orca client')
+    ).rejects.toThrow('Orca client paired with this server is out of date')
 
     expect(getSshFilesystemProvider).not.toHaveBeenCalled()
     expect(renameMock).not.toHaveBeenCalled()

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -101,7 +101,7 @@ export const WINDOWS_RUNTIME_FILE_WATCH_CLOSE_DEADLINE_MS = 10_000
 const TERMINAL_FILE_GRANT_TTL_MS = 10 * 60 * 1000
 const OPEN_NOFOLLOW = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
 const RUNTIME_FILE_MUTATION_UPDATE_REQUIRED =
-  'Remote file changes require a newer Orca client. Update the paired client and try again.'
+  'Remote file changes are unavailable because the Orca client paired with this server is out of date. Update the client, reconnect, and try again.'
 
 function assertRuntimeFileMutationExpectation(
   connectionId: string | undefined,

--- a/src/renderer/src/web/web-file-mutation-methods.test.ts
+++ b/src/renderer/src/web/web-file-mutation-methods.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE } from '../../../shared/protocol-version'
 import type { SshConnectionState } from '../../../shared/ssh-types'
 import type { Worktree } from '../../../shared/types'
 import { createWebFileMutationMethods } from './web-file-mutation-methods'
@@ -271,13 +272,21 @@ describe('paired web file mutation methods', () => {
     expect(getSshState).not.toHaveBeenCalled()
   })
 
-  it('rejects an old HUB before reading SSH state or sending a mutation', async () => {
-    assertMutationSupported.mockRejectedValueOnce(new Error('Update the HUB'))
+  it('rejects an outdated remote Orca server before reading SSH state or mutating', async () => {
+    expect(FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE).toContain(
+      "remote Orca server is out of date, so Orca can't upload or change files"
+    )
+    expect(FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE).toContain(
+      'Settings > General > Updates > Remote Orca Servers'
+    )
+    assertMutationSupported.mockRejectedValueOnce(
+      new Error(FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE)
+    )
     const methods = createWebFileMutationMethods({ captureSession })
 
     await expect(
       methods.deletePath({ targetPath: '/ssh/repo/dir', recursive: true })
-    ).rejects.toThrow('Update the HUB')
+    ).rejects.toThrow(FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE)
     expect(getSshState).not.toHaveBeenCalled()
     expect(callRuntimeResult).not.toHaveBeenCalled()
   })

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -72,7 +72,7 @@ export const AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY =
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
-  'Remote file changes require a newer Orca server. Update the HUB and try again.'
+  "This workspace's remote Orca server is out of date, so Orca can't upload or change files there. To update it, open Settings > General > Updates > Remote Orca Servers. Reconnect, then try again."
 
 export const RUNTIME_CAPABILITIES = [
   'runtime.status.compat.v1',


### PR DESCRIPTION
## Summary

Improves error messages when remote file mutation operations fail due to version mismatches between Orca client and server. Messages now clearly explain which component is out of date and guide users to the remediation step.

## Changes

- **Server-to-client error**: Updated to explain that the paired Orca client is out of date and must be updated and reconnected
- **Client-to-server error**: Updated to identify the remote server as out of date and direct users to Settings > General > Updates > Remote Orca Servers
- Introduced `FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE` constant for consistent client-side messaging
- Updated test cases in `orca-runtime-files.test.ts` and `web-file-mutation-methods.test.ts` to match new error text

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — Test updates validate new error messages
- [x] `pnpm build`
- [x] Updated high-quality tests that verify new messaging

## AI Review Report

Message clarifications only—changes isolated to error strings and test expectations. No logic changes.

## Security Audit

No security impact. Changes affect only user-facing error messages without modifying input handling, command execution, or authentication logic.

## Notes

Messages are now platform-agnostic and provide actionable guidance for both local and SSH workflows.