### PR TITLE
fix(agent-history): fold trailing-slash, NFD/NFC, and project-fallback folder group keys

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts
@@ -664,7 +664,7 @@ describe('groupAiVaultSessions', () => {
     ]
 
     expect(groupAiVaultSessions(sessions, 'folder')).toEqual([
-      { key: '/users/ada/repo/app', label: 'repo/app', sessions }
+      { key: 'folder:/Users/ada/repo/app', label: 'repo/app', sessions }
     ])
     expect(groupAiVaultSessions(sessions, 'agent').map((group) => group.label)).toEqual([
       'Claude',
@@ -695,7 +695,7 @@ describe('groupAiVaultSessions', () => {
 
   it('falls back to folder grouping when project metadata is unavailable', () => {
     expect(groupAiVaultSessions([baseSession], 'project')).toEqual([
-      { key: '/users/ada/repo/app', label: 'repo/app', sessions: [baseSession] }
+      { key: 'folder:/Users/ada/repo/app', label: 'repo/app', sessions: [baseSession] }
     ])
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
@@ -7,6 +7,7 @@ import {
   buildAiVaultSessionProjectById,
   toAiVaultProjectKey
 } from './ai-vault-session-projects'
+import { groupAiVaultSessions } from '../../../../shared/ai-vault-session-filters'
 
 const baseSession: AiVaultSession = {
   id: 'claude:1',
@@ -381,6 +382,31 @@ describe('buildAiVaultProjectContext', () => {
       key: 'folder:/srv/orca/src',
       label: 'orca/src'
     })
+  })
+
+  it('emits a folder project key the shared folder grouping falls back to', () => {
+    const repo = makeRepo({ id: 'repo-1', displayName: 'Repo', path: '/repo' })
+    const resolved = makeSession({ id: 'claude:resolved', cwd: '/outside/path' })
+    const unresolved = makeSession({ id: 'claude:unresolved', cwd: '/outside/path/' })
+
+    const context = buildAiVaultProjectContext({
+      repos: [repo],
+      worktrees: [],
+      projectHostSetupProjection: makeProjection({ projects: [], setups: [] }),
+      activeRepo: repo,
+      activeWorktree: null,
+      sessions: [resolved]
+    })
+
+    // Both key builders must agree, or one folder shows two identically labelled headers.
+    const groups = groupAiVaultSessions([resolved, unresolved], 'project', {
+      sessionProjectById: context.sessionProjectById
+    })
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions.map((session) => session.id)).toEqual([
+      'claude:resolved',
+      'claude:unresolved'
+    ])
   })
 
   it('ignores blank setup paths instead of treating them as catch-all candidates', () => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts
@@ -9,10 +9,13 @@ import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { ProjectHostSetup, Repo, Worktree } from '../../../../shared/types'
 import {
   createNormalizedPathInsideOrEqualMatcher,
-  normalizeRuntimePathForComparison,
-  normalizeRuntimePathSeparators
+  normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
-import type { AiVaultSessionProject } from '../../../../shared/ai-vault-session-filters'
+import {
+  folderGroupKey,
+  folderLabel,
+  type AiVaultSessionProject
+} from '../../../../shared/ai-vault-session-filters'
 
 // Why: the plain project descriptor moved to /shared (so the lifted filter core
 // stays renderer-free). Re-export it here for renderer import parity.
@@ -308,20 +311,11 @@ function compareCandidates(left: SessionProjectCandidate, right: SessionProjectC
 }
 
 function folderProject(cwd: string): AiVaultSessionProject {
-  const normalizedPath = normalizeRuntimePathForComparison(cwd)
   return {
     kind: 'folder',
-    key: `folder:${normalizedPath}`,
-    label: compactFolderLabel(cwd)
+    key: folderGroupKey(cwd),
+    label: folderLabel(cwd)
   }
-}
-
-function compactFolderLabel(pathValue: string): string {
-  const parts = normalizeRuntimePathSeparators(pathValue).split('/').filter(Boolean)
-  if (parts.length >= 2) {
-    return parts.slice(-2).join('/')
-  }
-  return parts[0] ?? pathValue
 }
 
 function resolveActiveProjectKey(

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -3,6 +3,7 @@ import type { AiVaultSession } from './ai-vault-types'
 import {
   agentLabel,
   filterAiVaultSessions,
+  folderGroupKey,
   folderLabel,
   groupAiVaultSessions,
   parseVaultQuery
@@ -87,6 +88,89 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
   it('groups by folder', () => {
     const groups = groupAiVaultSessions([baseSession, otherSession], 'folder')
     expect(groups.map((group) => group.label).sort()).toEqual(['packages/ui', 'repo/app'])
+  })
+
+  it('folds trailing-slash and repeated-slash cwd spellings into one folder group', () => {
+    const groups = groupAiVaultSessions(
+      [
+        { ...baseSession, cwd: '/Users/ada/repo/app' },
+        { ...baseSession, id: 'claude:2', cwd: '/Users/ada/repo/app/' },
+        { ...baseSession, id: 'claude:3', cwd: '/Users/ada//repo/app//' }
+      ],
+      'folder'
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions).toHaveLength(3)
+    expect(groups[0].label).toBe('repo/app')
+  })
+
+  it('folds NFD and NFC cwd spellings into one folder group with an NFC label', () => {
+    const groups = groupAiVaultSessions(
+      [
+        { ...baseSession, cwd: '/Users/ada/Café/app'.normalize('NFD') },
+        { ...baseSession, id: 'claude:2', cwd: '/Users/ada/Café/app'.normalize('NFC') }
+      ],
+      'folder'
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions).toHaveLength(2)
+    expect(groups[0].label).toBe('Café/app'.normalize('NFC'))
+  })
+
+  it('folds separator and case variants of one Windows folder', () => {
+    const groups = groupAiVaultSessions(
+      [
+        { ...baseSession, cwd: 'C:\\Users\\Ada\\repo\\app' },
+        { ...baseSession, id: 'claude:2', cwd: 'c:/users/ada/repo/app/' }
+      ],
+      'folder'
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions).toHaveLength(2)
+  })
+
+  it('folds the two WSL UNC aliases of one folder into a single group', () => {
+    const groups = groupAiVaultSessions(
+      [
+        { ...baseSession, cwd: '//wsl.localhost/Ubuntu/home/ada/repo/app' },
+        { ...baseSession, id: 'claude:2', cwd: '//wsl$/Ubuntu/home/ada/repo/app' }
+      ],
+      'folder'
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions.map((session) => session.id)).toEqual(['claude:1', 'claude:2'])
+  })
+
+  it('keeps case-distinct POSIX folders in separate groups', () => {
+    const groups = groupAiVaultSessions(
+      [
+        { ...baseSession, cwd: '/home/ada/Foo' },
+        { ...baseSession, id: 'claude:2', cwd: '/home/ada/foo' }
+      ],
+      'folder'
+    )
+    expect(groups).toHaveLength(2)
+  })
+
+  it('folds the project-grouping fallback onto the resolved folder project key', () => {
+    const resolved = { ...baseSession, cwd: '/Users/ada/repo/app' }
+    const unresolved = { ...baseSession, id: 'claude:2', cwd: '/Users/ada/repo/app/' }
+    // Key literal, not folderGroupKey(), so the test still fails if both builders drift together.
+    const groups = groupAiVaultSessions([resolved, unresolved], 'project', {
+      sessionProjectById: new Map([
+        [
+          resolved.id,
+          { kind: 'folder' as const, key: 'folder:/Users/ada/repo/app', label: 'repo/app' }
+        ]
+      ])
+    })
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sessions).toHaveLength(2)
+  })
+
+  it('keys unknown cwd separately from real folders', () => {
+    expect(folderGroupKey(null)).toBe('unknown')
+    expect(folderGroupKey('/Users/ada/repo/app')).toBe('folder:/Users/ada/repo/app')
   })
 
   it('parses repo: and path: operators from the query', () => {

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -2,7 +2,11 @@
 // It lives in /shared (not renderer) so the mobile package can reuse it —
 // Metro only watches mobile/ + repo-root src/shared, never src/renderer.
 // INVARIANT: /shared is a leaf — this module must NOT import from src/renderer.
-import { isPathInsideOrEqual, normalizeRuntimePathSeparators } from './cross-platform-path'
+import {
+  isPathInsideOrEqual,
+  normalizeRuntimePathForComparison,
+  normalizeRuntimePathSeparators
+} from './cross-platform-path'
 import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
 import { parseWslUncPath } from './wsl-paths'
 import type {
@@ -143,11 +147,27 @@ export function folderLabel(pathValue: string | null): string {
   if (!pathValue) {
     return 'Unknown location'
   }
-  const parts = normalizeRuntimePathSeparators(pathValue).split('/').filter(Boolean)
+  // NFC so one folder renders the same header whichever spelling (macOS NFD vs
+  // agent-recorded NFC) reaches the group first.
+  const parts = normalizeRuntimePathSeparators(pathValue.normalize('NFC'))
+    .split('/')
+    .filter(Boolean)
   if (parts.length >= 2) {
     return parts.slice(-2).join('/')
   }
   return parts[0] ?? pathValue
+}
+
+/**
+ * Why comparison-normalized: cwd is copied verbatim out of agent transcripts, so
+ * one folder arrives with and without a trailing slash and in both NFD/NFC — each
+ * spelling otherwise became its own group under an identical `folderLabel`. Also
+ * avoids blanket lowercasing, which merged distinct case-sensitive POSIX folders.
+ * The `folder:` prefix matches the folder project key so project grouping and its
+ * fallback agree.
+ */
+export function folderGroupKey(pathValue: string | null): string {
+  return pathValue ? `folder:${normalizeRuntimePathForComparison(pathValue)}` : 'unknown'
 }
 
 export function agentLabel(agent: AiVaultAgent): string {
@@ -253,11 +273,7 @@ function getGroupIdentity(
       }
     }
   }
-  return { key: getFolderGroupKey(session.cwd), label: folderLabel(session.cwd) }
-}
-
-function getFolderGroupKey(pathValue: string | null): string {
-  return pathValue ? normalizeRuntimePathSeparators(pathValue).toLowerCase() : 'unknown'
+  return { key: folderGroupKey(session.cwd), label: folderLabel(session.cwd) }
 }
 
 function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {


### PR DESCRIPTION
## Screenshots

Before (duplicate identical folder headers) → After (one merged group):

![folder-group-before-after](https://github.com/user-attachments/assets/528136ac-8f4f-4f01-81da-6f4cb28fb4bf)

Illustrative mock of Agent Session History grouped by folder. Live behavior covered by regression tests in this PR.

## What was broken (ELI5)

In Agent Session History, sessions are stacked under a heading for the folder they ran in. One folder could show up as **two separate headings with the exact same name**, with that folder's sessions randomly split between them — because the folder path was recorded slightly differently by different agent runs (an extra `/` on the end, or an accented character stored a different-but-equivalent way). Now every spelling of the same folder lands under one heading. As a bonus, two genuinely different folders on a Linux/SSH box that differ only in capitalization no longer get silently squashed into one heading.

## Root cause

`groupAiVaultSessions` keys its group `Map` with `getFolderGroupKey(session.cwd)`.

`src/shared/ai-vault-session-filters.ts:259-261` (base commit `29bfc1e22c`):

```ts
function getFolderGroupKey(pathValue: string | null): string {
  return pathValue ? normalizeRuntimePathSeparators(pathValue).toLowerCase() : 'unknown'
}
```

`normalizeRuntimePathSeparators` (`src/shared/cross-platform-path.ts:7-13`) only backslash-folds and collapses repeated slashes. It does **not** trim a trailing slash and does **not** NFC-fold Unicode. So:

- `/Users/ada/Project` and `/Users/ada/Project/` produce two distinct keys, while `folderLabel` (`split('/').filter(Boolean)`) renders the **identical** string `ada/Project` for both — two pixel-identical headers splitting one folder.
- NFC `Café` vs NFD `Cafe\u0301` likewise produce two distinct keys with an identical rendered label. `normalizeRuntimePathForComparison`'s own docstring (`src/shared/cross-platform-path.ts:15-24`) cites exactly this as the #10832 cwd-mismatch bug.

Two more defects hang off the same line:

1. The unconditional `.toLowerCase()` is the mirror-image bug: on case-sensitive Linux/SSH hosts `/home/ada/Foo` and `/home/ada/foo` are two real folders, and they collapsed into one group under whichever label arrived first. Nothing else in the path layer does this — `normalizeRuntimePathForComparison`, `isPathInsideOrEqual`, and `relativePathInsideRoot` all lowercase Windows-flavored paths only.
2. There was a **second, drifting** folder-key builder. `folderProject()` (`src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts:310-315`) built `folder:${normalizeRuntimePathForComparison(cwd)}`, while `getGroupIdentity`'s project-mode fallback used the raw-lowercased key. In `project` grouping, a session with resolved project metadata got `folder:/Users/ada/repo/app` and a session whose metadata was missing got `/users/ada/repo/app` — one folder, two headers, again identical labels.

## The fix

Replace the ad-hoc key builder with the canonical comparison normalizer, promoted to an exported `folderGroupKey(cwd)` in `/shared` that emits the same `folder:<normalized>` shape `folderProject()` already used, and have `folderProject()` call it. `normalizeRuntimePathForComparison` gives NFC + trailing-slash trim + repeated-slash collapse + WSL UNC alias fold + Windows-only lowercase — the documented #10832 semantics — so the over-fold on POSIX case goes away with the same edit.

The renderer's duplicated `compactFolderLabel()` is deleted in favor of the shared `folderLabel()`, which now NFC-normalizes so the surviving header is byte-stable no matter which spelling reaches the group first.

Fixing this inside `/shared` covers both call sites: the desktop `AiVaultPanel` grouping and the mobile `SectionList` (`mobile/src/agent-history/agent-history-sections.ts`, which Metro watches). Group keys are only React keys and in-memory collapsed-group state (`AiVaultPanel.tsx:90`), so the `folder:` prefix carries no persisted-state migration cost.

## Reproduction

Scratch vitest file calling the real exported `groupAiVaultSessions(..., 'folder')` against the base commit:

```
stdout | repro 12337 > trailing slash
TRAILING SLASH => [
 { "key": "/users/ada/project",  "label": "ada/Project", "n": 1 },
 { "key": "/users/ada/project/", "label": "ada/Project", "n": 1 }
]

stdout | repro 12337 > NFC vs NFD
nfc bytes 15 nfd bytes 16 equal? false
NFC/NFD => [
 { "key": "/users/ada/café", "label": "ada/Café", "n": 1 },
 { "key": "/users/ada/café", "label": "ada/Café", "n": 1 }
]

 FAIL > trailing slash
AssertionError: expected [ { …(3) }, { …(3) } ] to have a length of 1 but got 2
 FAIL > NFC vs NFD
AssertionError: expected [ …(2) ] to have a length of 1 but got 2
```

Both cases yield two groups whose rendered `label` is pixel-identical. (The two NFC/NFD keys *print* identically but are different code-point sequences, hence distinct `Map` keys.)

The mirror-image over-fold:

```
stdout | repro 12337 b > over-folds case-sensitive POSIX folders
CASE FOLD => [{"key":"/home/ada/foo","label":"ada/Foo","n":2}]
AssertionError: expected [ { key: '/home/ada/foo', …(2) } ] to have a length of 2 but got 1
```

The helper that already exists handles all three:

```
stdout | repro 12337 b > existing helper already handles both variants
helper slash: /Users/ada/Project == /Users/ada/Project
helper nfd==nfc: true
helper windows: c:/users/ada/project
```

Red-before-green on the committed regression tests — reverting only the two source files to `29bfc1e22c` (keeping the tests) fails exactly the 8 new tests and nothing else:

```
 FAIL  src/shared/ai-vault-session-filters.test.ts > folds trailing-slash and repeated-slash cwd spellings into one folder group
 FAIL  src/shared/ai-vault-session-filters.test.ts > folds NFD and NFC cwd spellings into one folder group with an NFC label
 FAIL  src/shared/ai-vault-session-filters.test.ts > folds separator and case variants of one Windows folder
 FAIL  src/shared/ai-vault-session-filters.test.ts > folds the two WSL UNC aliases of one folder into a single group
 FAIL  src/shared/ai-vault-session-filters.test.ts > keeps case-distinct POSIX folders in separate groups
 FAIL  src/shared/ai-vault-session-filters.test.ts > folds the project-grouping fallback onto the resolved folder project key
 FAIL  src/shared/ai-vault-session-filters.test.ts > keys unknown cwd separately from real folders
 FAIL  src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts > emits a folder project key the shared folder grouping falls back to

 Test Files  2 failed (2)
      Tests  8 failed | 24 passed (32)
```

## Relationship to #12337

Credit to **@YuriNachos**, who found, reported, and diagnosed this in #12337 — the analysis there (trailing slash + NFC/NFD producing two keys under one identical `folderLabel`, and `normalizeRuntimePathForComparison` being the already-correct sibling that `isAiVaultSessionInWorkspacePath` uses) is exactly right, and this PR reaches the same core conclusion independently.

**Taken from #12337:** their WSL UNC alias test vector (`//wsl.localhost/Ubuntu/...` vs `//wsl$/Ubuntu/...` grouping as one) is a case I had missed and is now committed here.

**Done differently, and why:**

1. **POSIX case-folding.** #12337 keeps the trailing `.toLowerCase()` (`normalizeRuntimePathForComparison(pathValue).toLowerCase()`) and adds a test pinning it. That preserves the over-fold: `/home/ada/Foo` and `/home/ada/foo` are two real directories on Linux/SSH hosts and would still merge into one group under an arbitrary label. Every other comparison path in `cross-platform-path.ts` lowercases only when `isWindowsAbsolutePathLike` proves Windows semantics — including the WSL branch, which lowercases the distro segment specifically *because* "the distro/server portion remains case-insensitive" while the filesystem is not. This PR drops the blanket lowercase to match that established contract, and pins the POSIX-case-distinct behavior with a test.
2. **The second key builder.** #12337 patches only `getFolderGroupKey`, leaving `folderProject()`'s `folder:<path>` key untouched — and because #12337's key is lowercased while `folderProject()`'s is not, the two key spaces still disagree, so `project` grouping can still split one folder into two identically labelled headers when some sessions resolve project metadata and others don't. This PR unifies them on one exported `folderGroupKey`, with a cross-module regression test in `ai-vault-session-projects.test.ts`.
3. **Label stability.** #12337 leaves `folderLabel` un-normalized, so the surviving header's bytes depend on which spelling sorted first. This PR NFC-normalizes the label (which also lets `repo:` query terms match NFD-recorded cwds) and deletes the renderer's duplicate `compactFolderLabel`.

Blast radius is honestly larger here (5 files vs 2); the extra surface is the deduplication of the two key/label builders, which is what buys defect 2 and 3 above.

Closes #12337 conceptually — happy to close this in favor of theirs if maintainers prefer the smaller diff.

## Testing

```
$ npx vitest run --config config/vitest.config.ts \
    src/shared/ai-vault-session-filters.test.ts \
    src/renderer/src/components/right-sidebar/ai-vault-session-filters.test.ts \
    src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts \
    src/shared/cross-platform-path.test.ts
 Test Files  4 passed (4)
      Tests  70 passed (70)

$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/
 Test Files  186 passed (186)
      Tests  1687 passed (1687)

$ npx tsc --noEmit -p config/tsconfig.node.json --composite false   # exit 0
$ npx tsc --noEmit -p config/tsconfig.web.json --composite false    # exit 0
$ npx oxlint <5 changed files>                                      # no diagnostics
$ npx oxfmt --check <changed files>   → All matched files use the correct format.
```

Known gap: mobile vitest cannot run in this worktree — all 4 pre-existing `mobile/src/agent-history` files fail with `TSConfckParseError: failed to resolve extends expo/tsconfig.base.json` (expo deps absent from the symlinked `node_modules`). That is a pre-existing environment limitation, not caused by this change; mobile consumes the fixed shared function unchanged.

Not addressed (separate, smaller gap): `parseVaultQuery`/`matchesQuery` still don't Unicode-fold free-text and `path:` terms, so a query typed in NFC won't substring-match an NFD `cwd`.

Made with [Orca](https://github.com/stablyai/orca) 🐋

