### PR TITLE
fix(native-chat): classify diff lines whose content begins with -- or ++

### DIFF
--- a/mobile/src/session/mobile-native-chat-diff.test.ts
+++ b/mobile/src/session/mobile-native-chat-diff.test.ts
@@ -36,6 +36,18 @@ describe('diffFromText', () => {
     expect(diffFromText('Here is a list:\n- one bullet\nthat is all')).toBeNull()
   })
 
+  // Parity guard: the mobile module re-exports the shared parser, so the -- / ++
+  // content collision must stay fixed on both platforms.
+  it('counts a removed -- comment line despite the --- prefix collision', () => {
+    const lines = diffFromText('@@ -1,2 +1,2 @@\n ctx\n---sql comment\n+new')
+    expect(lines).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: '--sql comment' },
+      { kind: 'add', text: 'new' }
+    ])
+  })
+
   it('caps large diffs before creating render rows', () => {
     const text = Array.from(
       { length: 1_000 },

--- a/src/renderer/src/components/native-chat/native-chat-diff.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-diff.test.ts
@@ -136,6 +136,35 @@ describe('diffFromText', () => {
     expect(diffFromText('-- legacy comment')).toBeNull()
   })
 
+  it('classifies a --- content deletion in header-less agent-tool output', () => {
+    const diff = diffFromText('---sql comment\n+new\n-more context')
+    expect(diff).toEqual([
+      { kind: 'del', text: '--sql comment' },
+      { kind: 'add', text: 'new' },
+      { kind: 'del', text: 'more context' }
+    ])
+  })
+
+  it('does not read an adjacent --x / ++y content pair as a file header', () => {
+    const diff = diffFromText('@@ -1,2 +1,2 @@\n ctx\n---note\n+++flag')
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: '--note' },
+      { kind: 'add', text: '++flag' }
+    ])
+  })
+
+  it('does not read a spaced -- / ++ content pair inside a hunk as a file header', () => {
+    const diff = diffFromText('@@ -1,2 +1,2 @@\n ctx\n--- note\n+++ flag')
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,2 +1,2 @@' },
+      { kind: 'context', text: ' ctx' },
+      { kind: 'del', text: '-- note' },
+      { kind: 'add', text: '++ flag' }
+    ])
+  })
+
   it('handles /dev/null headers for an added file', () => {
     const diff = diffFromText('--- /dev/null\n+++ b/x.sql\n+-- new comment\n+SELECT 1;')
     expect(diff?.filter((l) => l.kind === 'add').map((l) => l.text)).toEqual([

--- a/src/renderer/src/components/native-chat/native-chat-diff.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-diff.test.ts
@@ -60,4 +60,88 @@ describe('diffFromText', () => {
     expect(diff?.filter((l) => l.kind === 'add').map((l) => l.text)).toEqual(['new'])
     expect(diff?.filter((l) => l.kind === 'del').map((l) => l.text)).toEqual(['old'])
   })
+
+  it('treats a removed line whose content starts with -- as a deletion', () => {
+    const diff = diffFromText(
+      '@@ -1,4 +1,1 @@\n SELECT 1;\n--- legacy comment\n-SELECT 2;\n-SELECT 3;'
+    )
+    expect(diff).toEqual([
+      { kind: 'meta', text: '@@ -1,4 +1,1 @@' },
+      { kind: 'context', text: ' SELECT 1;' },
+      { kind: 'del', text: '-- legacy comment' },
+      { kind: 'del', text: 'SELECT 2;' },
+      { kind: 'del', text: 'SELECT 3;' }
+    ])
+  })
+
+  it('treats an added line whose content starts with ++ as an addition', () => {
+    const diff = diffFromText('@@ -1,1 +1,3 @@\n ctx\n+++flag\n+normal')
+    expect(diff?.filter((l) => l.kind === 'add').map((l) => l.text)).toEqual(['++flag', 'normal'])
+  })
+
+  it('classifies a C-style --i deletion inside a hunk', () => {
+    const diff = diffFromText('@@ -1,3 +1,2 @@\n int i;\n---i;\n-return i;')
+    expect(diff?.filter((l) => l.kind === 'del').map((l) => l.text)).toEqual(['--i;', 'return i;'])
+  })
+
+  it('keeps real file headers as meta in full git diff output', () => {
+    const diff = diffFromText(
+      [
+        'diff --git a/a.sql b/a.sql',
+        'index 9eff25c..33791bf 100644',
+        '--- a/a.sql',
+        '+++ b/a.sql',
+        '@@ -1,3 +1,2 @@',
+        ' SELECT 1;',
+        '--- legacy comment',
+        ' SELECT 2;'
+      ].join('\n')
+    )
+    expect(diff?.filter((l) => l.kind === 'meta').map((l) => l.text)).toEqual([
+      'diff --git a/a.sql b/a.sql',
+      'index 9eff25c..33791bf 100644',
+      '--- a/a.sql',
+      '+++ b/a.sql',
+      '@@ -1,3 +1,2 @@'
+    ])
+    expect(diff?.filter((l) => l.kind === 'del').map((l) => l.text)).toEqual(['-- legacy comment'])
+  })
+
+  it('detects the second file headers in a multi-file diff', () => {
+    const diff = diffFromText(
+      [
+        'diff --git a/a.sql b/a.sql',
+        '--- a/a.sql',
+        '+++ b/a.sql',
+        '@@ -1,2 +1,1 @@',
+        '--- legacy comment',
+        ' SELECT 2;',
+        'diff --git a/b.lua b/b.lua',
+        '--- a/b.lua',
+        '+++ b/b.lua',
+        '@@ -1,2 +1,1 @@',
+        '--- lua comment',
+        ' print(1)'
+      ].join('\n')
+    )
+    expect(diff?.filter((l) => l.kind === 'del').map((l) => l.text)).toEqual([
+      '-- legacy comment',
+      '-- lua comment'
+    ])
+  })
+
+  it('renders a single-line change once hunk headers prove it is a diff', () => {
+    expect(diffFromText('@@ -1,2 +1,1 @@\n SELECT 1;\n--- legacy comment')).not.toBeNull()
+    // Without diff structure the two-marker prose guard still applies.
+    expect(diffFromText('-- legacy comment')).toBeNull()
+  })
+
+  it('handles /dev/null headers for an added file', () => {
+    const diff = diffFromText('--- /dev/null\n+++ b/x.sql\n+-- new comment\n+SELECT 1;')
+    expect(diff?.filter((l) => l.kind === 'add').map((l) => l.text)).toEqual([
+      '-- new comment',
+      'SELECT 1;'
+    ])
+    expect(diff?.filter((l) => l.kind === 'del')).toEqual([])
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-diff.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-diff.test.ts
@@ -173,4 +173,23 @@ describe('diffFromText', () => {
     ])
     expect(diff?.filter((l) => l.kind === 'del')).toEqual([])
   })
+
+  it('leaves a YAML document separator out of the marker count', () => {
+    expect(diffFromText('---\na: 1\n---\nb: 2')).toBeNull()
+  })
+
+  it('keeps a Markdown thematic break as meta rather than a deletion', () => {
+    const diff = diffFromText('Intro\n-----\n- alpha\n- beta')
+    expect(diff).toEqual([
+      { kind: 'context', text: 'Intro' },
+      { kind: 'meta', text: '-----' },
+      { kind: 'del', text: ' alpha' },
+      { kind: 'del', text: ' beta' }
+    ])
+  })
+
+  it('still reads a bare --- inside a hunk as a deletion', () => {
+    const diff = diffFromText('@@ -1,3 +1,1 @@\n ctx\n---\n-SELECT 1;')
+    expect(diff?.filter((l) => l.kind === 'del').map((l) => l.text)).toEqual(['--', 'SELECT 1;'])
+  })
 })

--- a/src/shared/native-chat-diff.ts
+++ b/src/shared/native-chat-diff.ts
@@ -13,6 +13,39 @@ const DIFF_TRUNCATED_LINE: NativeChatDiffLine = {
   text: '… diff truncated …'
 }
 
+const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/
+// Lines that open a new file section, so any hunk before them has ended.
+const FILE_SECTION_START =
+  /^(?:diff |index |old mode |new mode |new file mode |deleted file mode |similarity index |dissimilarity index |rename |copy |Binary files )/
+
+/**
+ * Indices of the `--- <old>` / `+++ <new>` file headers. A bare `---`/`+++`
+ * prefix is not enough to spot one: a removed line whose content began with `--`
+ * (SQL/Lua `-- comment`, C `--i`) is emitted as `---<content>`. Real headers
+ * always come as an adjacent pair and never appear inside a hunk.
+ */
+function fileHeaderIndices(lines: string[]): Set<number> {
+  const indices = new Set<number>()
+  let inHunk = false
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? ''
+    if (line.startsWith('@@')) {
+      inHunk = true
+      continue
+    }
+    if (FILE_SECTION_START.test(line)) {
+      inHunk = false
+      continue
+    }
+    if (!inHunk && line.startsWith('--- ') && (lines[index + 1] ?? '').startsWith('+++ ')) {
+      indices.add(index)
+      indices.add(index + 1)
+      index += 1
+    }
+  }
+  return indices
+}
+
 function toLines(value: unknown, maxLines: number): { lines: string[]; truncated: boolean } {
   if (typeof value !== 'string') {
     return { lines: [], truncated: false }
@@ -62,23 +95,35 @@ export function diffFromText(
     return null
   }
   const bounded = toLines(text, maxLines)
+  const headers = fileHeaderIndices(bounded.lines)
   let added = 0
   let removed = 0
-  const lines = bounded.lines.map((line): NativeChatDiffLine => {
-    if (line.startsWith('@@') || line.startsWith('diff ') || line.startsWith('index ')) {
+  const lines = bounded.lines.map((line, index): NativeChatDiffLine => {
+    if (
+      headers.has(index) ||
+      line.startsWith('@@') ||
+      line.startsWith('diff ') ||
+      line.startsWith('index ')
+    ) {
       return { kind: 'meta', text: line }
     }
-    if (line.startsWith('+') && !line.startsWith('+++')) {
+    if (line.startsWith('+')) {
       added += 1
       return { kind: 'add', text: line.slice(1) }
     }
-    if (line.startsWith('-') && !line.startsWith('---')) {
+    if (line.startsWith('-')) {
       removed += 1
       return { kind: 'del', text: line.slice(1) }
     }
     return { kind: 'context', text: line }
   })
-  if (added + removed < 2) {
+  // A hunk header or `diff --git` proves this really is diff text, so a
+  // single-line change renders; without one, two markers guard against
+  // colouring prose that merely opens a line with `-`.
+  const isStructuredDiff = bounded.lines.some(
+    (line) => HUNK_HEADER.test(line) || line.startsWith('diff --git ')
+  )
+  if (added + removed < (isStructuredDiff ? 1 : 2)) {
     return null
   }
   return bounded.truncated ? [...lines.slice(0, maxLines - 1), DIFF_TRUNCATED_LINE] : lines

--- a/src/shared/native-chat-diff.ts
+++ b/src/shared/native-chat-diff.ts
@@ -17,33 +17,53 @@ const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/
 // Lines that open a new file section, so any hunk before them has ended.
 const FILE_SECTION_START =
   /^(?:diff |index |old mode |new mode |new file mode |deleted file mode |similarity index |dissimilarity index |rename |copy |Binary files )/
+// Markdown thematic break or YAML document separator, not a marker.
+const BARE_RULE = /^(?:-{3,}|\+{3,})$/
+
+type DiffStructure = {
+  /** Lines that are structure rather than content, so they never count as add/del. */
+  metaIndices: Set<number>
+  /** The text carries a hunk header or `diff --git`, so it is provably a diff. */
+  isStructuredDiff: boolean
+}
 
 /**
- * Indices of the `--- <old>` / `+++ <new>` file headers. A bare `---`/`+++`
- * prefix is not enough to spot one: a removed line whose content began with `--`
+ * Locates the `--- <old>` / `+++ <new>` file headers. A bare `---`/`+++` prefix
+ * is not enough to spot one: a removed line whose content began with `--`
  * (SQL/Lua `-- comment`, C `--i`) is emitted as `---<content>`. Real headers
  * always come as an adjacent pair and never appear inside a hunk.
  */
-function fileHeaderIndices(lines: string[]): Set<number> {
-  const indices = new Set<number>()
+function scanDiffStructure(lines: string[]): DiffStructure {
+  const metaIndices = new Set<number>()
+  let isStructuredDiff = false
   let inHunk = false
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? ''
     if (line.startsWith('@@')) {
       inHunk = true
+      isStructuredDiff ||= HUNK_HEADER.test(line)
       continue
     }
     if (FILE_SECTION_START.test(line)) {
       inHunk = false
+      isStructuredDiff ||= line.startsWith('diff --git ')
       continue
     }
-    if (!inHunk && line.startsWith('--- ') && (lines[index + 1] ?? '').startsWith('+++ ')) {
-      indices.add(index)
-      indices.add(index + 1)
+    // Only marker lines can be a header or a rule; skip context and prose early.
+    if (inHunk || !(line.startsWith('-') || line.startsWith('+'))) {
+      continue
+    }
+    if (BARE_RULE.test(line)) {
+      metaIndices.add(index)
+      continue
+    }
+    if (line.startsWith('--- ') && (lines[index + 1] ?? '').startsWith('+++ ')) {
+      metaIndices.add(index)
+      metaIndices.add(index + 1)
       index += 1
     }
   }
-  return indices
+  return { metaIndices, isStructuredDiff }
 }
 
 function toLines(value: unknown, maxLines: number): { lines: string[]; truncated: boolean } {
@@ -95,12 +115,12 @@ export function diffFromText(
     return null
   }
   const bounded = toLines(text, maxLines)
-  const headers = fileHeaderIndices(bounded.lines)
+  const { metaIndices, isStructuredDiff } = scanDiffStructure(bounded.lines)
   let added = 0
   let removed = 0
   const lines = bounded.lines.map((line, index): NativeChatDiffLine => {
     if (
-      headers.has(index) ||
+      metaIndices.has(index) ||
       line.startsWith('@@') ||
       line.startsWith('diff ') ||
       line.startsWith('index ')
@@ -117,12 +137,8 @@ export function diffFromText(
     }
     return { kind: 'context', text: line }
   })
-  // A hunk header or `diff --git` proves this really is diff text, so a
-  // single-line change renders; without one, two markers guard against
-  // colouring prose that merely opens a line with `-`.
-  const isStructuredDiff = bounded.lines.some(
-    (line) => HUNK_HEADER.test(line) || line.startsWith('diff --git ')
-  )
+  // Proven diff text renders a single-line change; without that proof, two
+  // markers guard against colouring prose that merely opens a line with `-`.
   if (added + removed < (isStructuredDiff ? 1 : 2)) {
     return null
   }


### PR DESCRIPTION
## What was broken (ELI5)

When an agent showed you a diff in chat, any line it removed that happened to start with `--` — the way comments begin in SQL and Lua, or a `--i` counter in C — came out plain grey instead of red, with a stray dash glued to the front. The same happened to added lines starting with `++`. Worse, if that was the *only* change in the diff, Orca decided the text was not a diff at all and showed no colours whatsoever. Now those lines are coloured correctly and a one-line change still renders as a proper diff.

## Root cause

`src/shared/native-chat-diff.ts:67-83` (at base `29bfc1e22c`) classified each line by prefix alone:

```ts
if (line.startsWith('+') && !line.startsWith('+++')) { added += 1; ... }
if (line.startsWith('-') && !line.startsWith('---')) { removed += 1; ... }
```

The `!startsWith('---')` / `!startsWith('+++')` exclusions exist to skip the `--- a/file` / `+++ b/file` file headers. But `---` and `+++` identify a header by *structural position*, not by prefix. Git prefixes every removed line with a single `-`, so a removed `-- comment` is emitted verbatim as `--- comment` and an added `++flag` as `+++flag`. Those content lines hit the exclusion, fell through to `context`, kept their marker, and were never counted.

Second, `src/shared/native-chat-diff.ts:84` gated on `added + removed < 2`. A real `git diff` that deletes one `-- comment` yields `removed = 1`, so even after correct classification the whole coloured diff was still discarded — which is why the primary repro rendered nothing at all.

Both platforms shared the defect: `mobile/src/session/mobile-native-chat-diff.ts` and `src/renderer/src/components/native-chat/native-chat-diff.ts` are pure re-exports of the shared module. The only other classifier of raw diff text, `countDiffLines` in `src/main/gitlab/work-item-details.ts`, already carries the equivalent `inHunk` fix from #12133 and needed no change.

## The fix

`src/shared/native-chat-diff.ts` — one shared layer, so desktop and mobile are both fixed:

1. A new `fileHeaderIndices(lines)` pre-pass marks the indices of *real* headers: an adjacent `--- <old>` / `+++ <new>` pair (marker **plus space**) that is **not inside a hunk**. It tracks `inHunk` — set by `@@`, cleared by a file-section line (`diff `, `index `, `new file mode`, `rename `, `Binary files `, …) — so each file in a multi-file diff re-detects its own headers. Classification then drops the prefix exclusions entirely: inside a hunk, every `+`/`-` line is content. Headers are now `kind: 'meta'` (muted, alongside `diff `/`index `) instead of falling through to `context`.

   Why both conditions and not just one: the pre-existing test feeds `'--- a/x\n+++ b/x\n-old\n+new'` with no `@@` at all, so header detection has to work header-less — the adjacent marker+space pair supplies that, and keeps working for `--- /dev/null`, `--no-prefix`, and POSIX `diff -u` tab-timestamp headers. The `inHunk` half is what stops a *spaced* `-- note` deletion sitting next to a `++ flag` addition from being eaten as a header pair.

2. The count gate now requires just one marker when the text carries proof it is a diff — a strict `@@ -n,m +n,m @@` hunk header or a `diff --git ` line — and keeps the two-marker guard otherwise. That guard exists only to avoid colouring prose, and prose does not contain those tokens. Both existing prose tests (`'just a sentence with - a dash'`, `'+only one add line'`) still return `null`.

Pure string parsing: no platform, SSH, folder-workspace, or git-binary surface is touched, and the Git 2.25 baseline is unaffected.

## Reproduction

**1. Real git really emits the colliding line.** In a scratch repo, a 3-line `a.sql` containing `-- legacy comment`, with that line deleted:

```
$ git diff -- a.sql
diff --git a/a.sql b/a.sql
index 9eff25c..33791bf 100644
--- a/a.sql
+++ b/a.sql
@@ -1,3 +1,2 @@
 SELECT 1;
--- legacy comment
 SELECT 2;
```

**2. Scratch vitest calling the real exported `diffFromText` at base commit** — all four cases fail:

```
 FAIL  src/shared/__scratch-12335.test.ts > repro > SQL comment deletion is rendered as a diff
AssertionError: expected null not to be null   // diffFromText(<the real git diff above>) === null

 FAIL  ... > mixed: -- comment del classified as del
AssertionError: expected undefined to deeply equal [ '-- legacy comment', 'SELECT 2;' ]
+ Received: undefined            // '@@ -1,3 +1,1 @@\n SELECT 1;\n--- legacy comment\n-SELECT 2;' -> null

 FAIL  ... > ++flag add classified as add
AssertionError: expected undefined to deeply equal [ '++flag', 'normal' ]
+ Received: undefined            // '@@ -1,1 +1,3 @@\n ctx\n+++flag\n+normal' -> null

 FAIL  ... > C --i decrement deletion
AssertionError: expected undefined to deeply equal [ '--i;', 'return i;' ]
+ Received: undefined            // '@@ -1,3 +1,2 @@\n int i;\n---i;\n-return i;' -> null
```

**3. Direct dump of the classification** (padded with a third deletion so the two-marker gate passes, isolating the misclassification from the drop). Input `'@@ -1,4 +1,1 @@\n SELECT 1;\n--- legacy comment\n-SELECT 2;\n-SELECT 3;'`:

```
[
  { "kind": "meta",    "text": "@@ -1,4 +1,1 @@" },
  { "kind": "context", "text": " SELECT 1;" },
  { "kind": "context", "text": "--- legacy comment" },   <-- should be { kind: 'del', text: '-- legacy comment' }
  { "kind": "del",     "text": "SELECT 2;" },
  { "kind": "del",     "text": "SELECT 3;" }
]
```

The deleted SQL comment rendered grey-as-context with its leading `-` still attached, and did not count toward `removed`.

**4. RED before GREEN.** With the source file reverted to `29bfc1e22c` and this PR's tests in place:

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/native-chat-diff.test.ts
     × treats a removed line whose content starts with -- as a deletion
     × treats an added line whose content starts with ++ as an addition
     × classifies a C-style --i deletion inside a hunk
     × keeps real file headers as meta in full git diff output
     × detects the second file headers in a multi-file diff
     × renders a single-line change once hunk headers prove it is a diff
     × classifies a --- content deletion in header-less agent-tool output
     × does not read an adjacent --x / ++y content pair as a file header
     × does not read a spaced -- / ++ content pair inside a hunk as a file header
 Test Files  1 failed (1)
      Tests  9 failed | 9 passed (18)
```

**5. End-to-end against real git bytes.** A throwaway test piped the actual `git diff` output from step 1 through the fixed `diffFromText`: dels come back as `['-- legacy comment', '--i;']` and all five header/meta lines stay `meta`. `Test Files 1 passed (1) / Tests 1 passed (1)`.

## Relationship to #12335

Full credit to **@YuriNachos** for finding, reporting, and diagnosing this in #12335 — the root-cause analysis there (including the link to the sibling `countDiffLines` fix in #12133) is correct and independently matched what I found.

**Adopted from #12335:**
- Their three test vectors, which are genuinely good and cover cases mine missed: the header-less agent-tool deletion `'---sql comment\n+new\n-more context'` (no `@@` anywhere), and the adjacent `---note` / `+++flag` content pair that must not be read as a header.
- Their mobile parity test in `mobile/src/session/mobile-native-chat-diff.test.ts`. The mobile module is a pure re-export, so the fix applies automatically — but a parity test guards against future divergence, and I had not written one.
- Their core insight that the header rule must key off the canonical `--- <old>` / `+++ <new>` **pair** rather than a lone prefix, and must not depend on `@@` (agent-tool output can be header-less). My implementation reached the same requirement independently.

**Done differently, and why.** #12335 uses the pair rule *alone*. Running this PR's tests against that implementation leaves two real failures:

```
 FAIL  ... > does not read a spaced -- / ++ content pair inside a hunk as a file header
AssertionError: expected null to deeply equal [ { kind: 'meta', …(1) }, …(3) ]
     // '@@ -1,2 +1,2 @@\n ctx\n--- note\n+++ flag' -> null

 FAIL  ... > keeps real file headers as meta in full git diff output
AssertionError: expected undefined to deeply equal [ 'diff --git a/a.sql b/a.sql', …(4) ]
     // the verbatim git diff from step 1 -> null
 Tests  3 failed | 15 passed (18)
```

1. **The pair rule needs the `inHunk` guard too.** #12335 requires marker+space (`--- ` / `+++ `) and notes that `--x` next to `++y` is therefore safe. That holds for the no-space form, but a *spaced* SQL/Lua comment is the common case: deleting `-- note` emits `--- note` (space included), and if the next line adds `++ flag` the pair rule swallows both as a header — mid-hunk. This PR's `fileHeaderIndices` refuses header detection inside a hunk, so structural position decides, and it still works header-less because the pair rule covers that half.
2. **The `added + removed < 2` gate is the other half of the bug.** #12335 leaves it untouched, so the PR's own headline repro — the real `git diff` deleting one `-- legacy comment`, which yields `removed = 1` — still returns `null` and renders nothing. Relaxing the gate to one marker when a strict hunk header or `diff --git ` line is present is what actually makes that diff appear.
3. Real file headers render as `meta` (muted, consistent with `diff `/`index `) rather than `context`. #12335 preserves the old `context` fallthrough. Minor, and open to reverting if maintainers prefer the previous look.

One inherently ambiguous case is accepted by design in both implementations: a header-less snippet whose first two lines are a deleted `-- x` and an added `++ y` still reads as a header pair. No emitter produces that (git always ships a `@@`), and disambiguating would require guessing at path shape, which would break legitimate `--no-prefix` and spaces-in-path headers.

## Testing

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/ src/main/gitlab
 Test Files  73 passed (73)
      Tests  857 passed (857)

$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/native-chat-diff.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)

$ npx tsc --noEmit -p config/tsconfig.node.json && npx tsc --noEmit -p config/tsconfig.tc.web.json
TYPECHECK_OK

$ npx oxlint src/shared/native-chat-diff.ts \
    src/renderer/src/components/native-chat/native-chat-diff.test.ts \
    mobile/src/session/mobile-native-chat-diff.test.ts
(clean, exit 0)
```

RED-before-GREEN is quoted verbatim in Reproduction step 4: 9 failed / 9 passed with the source reverted, 18 passed with the fix. The mobile parity test could not be executed in this checkout (mobile dependencies including `expo` are not installed here, so `mobile/tsconfig.json` fails to resolve `expo/tsconfig.base.json`); its exact vector was verified against the shared module it re-exports, and CI runs the mobile suite.

No visual proof: this bug is not observable as a layout or styling change — the terminal and test evidence above carries it.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## Follow-up: bare `---` / `+++` rules

Dropping the prefix exclusions had one side effect worth closing. A **bare** `---` — a Markdown thematic break or a YAML document separator — has no path after the marker, so it is never a file header, but it was landing in the `-` content branch:

```
input: '---\na: 1\n---\nb: 2'      (YAML document separator)
before this commit: NULL                                    <- correctly rejected as prose
after the prefix exclusions were dropped:
  del:'--' | context:'a: 1' | del:'--' | context:'b: 2'     <- renders as a red diff
```

`diffFromText` runs on every tool *result*, so a `Read` of any `.md` or `.yaml` hits this. Markdown frontmatter followed by a bullet list already tripped the two-marker gate before this PR, but the `---` itself is now painted red and mangled to `--`.

A bare rule is only plausibly content *inside* a hunk, so `scanDiffStructure` marks it as meta when outside one — four lines, reusing the `inHunk` state the pre-pass already tracks:

```ts
if (BARE_RULE.test(line)) {
  metaIndices.add(index)
  continue
}
```

`'@@ -1,3 +1,1 @@\n ctx\n---\n-SELECT 1;'` still yields `del: '--'`, so a genuinely deleted `--` line is unaffected. Three test vectors added.

## Performance

`diffFromText` is called in the render body of every tool-result row, so the added pre-pass is on a render path. Measured at the 120-line render cap (`DEFAULT_MAX_DIFF_LINES`), best of 5 runs x 20k calls:

| input | base | this PR |
| --- | --- | --- |
| 120-line git diff (renders) | 3.29 µs | 4.90 µs |
| 120-line prose (returns null — the common tool result) | 2.60 µs | 4.33 µs |

Two changes keep that cost flat rather than additive:

1. The standalone `isStructuredDiff` scan is folded into the pre-pass, which already walks every line and already tests `@@` and `diff ` — one fewer traversal and closure for the same answer.
2. Only lines opening with `-` or `+` can be a header or a rule, so context and prose lines skip both remaining tests. Prose: 5.12 µs -> 4.33 µs (−15%). This also removes the duplicated `!inHunk` check.

The residual ~1.6 µs is the pre-pass itself and is the price of the correctness fix. It is bounded by `MAX_DIFF_CHARS` and `maxLines`, so the worst case is fixed regardless of tool-output size; at realistic block counts the aggregate stays well inside a frame. Separately, the call site recomputes on every parent render — pre-existing, unchanged here, and not worth folding into a bug fix without a measured symptom.

## Verification

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/native-chat/ src/main/gitlab
 Test Files  73 passed (73)
      Tests  860 passed (860)

$ npx tsc --noEmit -p config/tsconfig.node.json && npx tsc --noEmit -p config/tsconfig.tc.web.json
TYPECHECK_OK

$ npx oxlint src/shared/native-chat-diff.ts src/renderer/src/components/native-chat/native-chat-diff.test.ts
(clean, exit 0)
```