### PR TITLE
Show "Except default branch" filter only when "Hide sleeping" is on

### DIFF
--- a/src/renderer/src/components/sidebar/FilterToggleRow.test.tsx
+++ b/src/renderer/src/components/sidebar/FilterToggleRow.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+/**
+ * Guards the sub-option indent: Tailwind v4 emits `px-*` as `padding-inline`,
+ * which outranks a physical `pl-*` override and silently flattens the nesting.
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FilterToggleRow } from './FilterToggleRow'
+
+let container: HTMLDivElement
+let root: Root
+
+function renderRow(indented: boolean): HTMLElement {
+  act(() => {
+    root.render(
+      <FilterToggleRow
+        icon={null}
+        label="Row"
+        checked={false}
+        onChange={vi.fn()}
+        indented={indented}
+      />
+    )
+  })
+  const row = container.querySelector('[role="switch"]')
+  if (!(row instanceof HTMLElement)) {
+    throw new Error('FilterToggleRow did not render a switch')
+  }
+  return row
+}
+
+function paddingClasses(row: HTMLElement): string[] {
+  return row.className.split(/\s+/).filter((cls) => /^p[xlr]?-/.test(cls))
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('FilterToggleRow', () => {
+  it('indents a sub-option past the row above it', () => {
+    const indented = paddingClasses(renderRow(true))
+    const flat = paddingClasses(renderRow(false))
+    expect(indented).toContain('pl-7')
+    expect(flat).toContain('pl-2')
+  })
+
+  it('never pairs the indent with a padding-inline utility that would outrank it', () => {
+    expect(paddingClasses(renderRow(true)).filter((cls) => cls.startsWith('px-'))).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/FilterToggleRow.tsx
+++ b/src/renderer/src/components/sidebar/FilterToggleRow.tsx
@@ -34,8 +34,10 @@ export function FilterToggleRow({
       aria-label={ariaLabel}
       onClick={() => onChange(!checked)}
       className={cn(
-        'flex w-full items-center justify-between gap-2 rounded-[5px] px-2 py-1.5 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-        indented && 'pl-6'
+        // Why pl-* and not px-2 + pl-6: Tailwind v4 emits px as padding-inline,
+        // which outranks a physical pl-6 override and flattens the indent.
+        'flex w-full items-center justify-between gap-2 rounded-[5px] py-1.5 pr-2 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        indented ? 'pl-7' : 'pl-2'
       )}
     >
       <span

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -31,6 +31,7 @@ import { FilterToggleRow } from './FilterToggleRow'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { searchRepos } from '@/lib/repo-search'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
+import { isSleepingSweepExemptionNarrowingList } from './visible-worktrees'
 import { translate } from '@/i18n/i18n'
 
 type SidebarFilterProps = {
@@ -111,15 +112,19 @@ const SidebarFilter = React.memo(function SidebarFilter({
   const selectedCount = selectedRepoIdSet.size
   const hasRepoFilter = selectedCount > 0
   const hasSleepingFilter = showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES
+  // Why counted: turning the exemption off is the only way that row narrows the
+  // list — but only while its parent row is on, which is also when it renders.
+  const hasSleepingExemptionFilter = isSleepingSweepExemptionNarrowingList(
+    showSleepingWorkspaces,
+    alwaysShowDefaultBranchWorkspace
+  )
   const hasAnyFilter =
     hasSleepingFilter ||
     hideDefaultBranchWorkspace ||
     hideAutomationGeneratedWorkspaces ||
     hideCliCreatedWorkspaces ||
     hideDetachedHeadWorkspaces ||
-    // Why counted: turning the exemption off is the only way this row narrows
-    // the list, so the badge and Reset filters must both notice it.
-    !alwaysShowDefaultBranchWorkspace ||
+    hasSleepingExemptionFilter ||
     hasRepoFilter
   const activeFilterCount =
     (hasSleepingFilter ? 1 : 0) +
@@ -127,7 +132,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
     (hideAutomationGeneratedWorkspaces ? 1 : 0) +
     (hideCliCreatedWorkspaces ? 1 : 0) +
     (hideDetachedHeadWorkspaces ? 1 : 0) +
-    (alwaysShowDefaultBranchWorkspace ? 0 : 1) +
+    (hasSleepingExemptionFilter ? 1 : 0) +
     selectedCount
 
   const filteredRepos = useMemo(() => searchRepos(repos, query), [repos, query])
@@ -221,20 +226,24 @@ const SidebarFilter = React.memo(function SidebarFilter({
           onChange={(hideSleeping) => setShowSleepingWorkspaces(!hideSleeping)}
           shortcutLabel={sleepingShortcut === 'Unassigned' ? undefined : sleepingShortcut}
         />
-        <FilterToggleRow
-          indented
-          icon={<GitBranch className="size-3.5" />}
-          label={translate(
-            'auto.components.sidebar.SidebarFilter.keepDefaultBranch',
-            'Except default branch'
-          )}
-          ariaLabel={translate(
-            'auto.components.sidebar.SidebarFilter.keepDefaultBranchAria',
-            'Keep the default branch visible while hiding sleeping workspaces'
-          )}
-          checked={alwaysShowDefaultBranchWorkspace}
-          onChange={setAlwaysShowDefaultBranchWorkspace}
-        />
+        {/* Why gated: the exemption only has an effect while sleeping workspaces
+            are being swept, so it stays hidden until its parent row is on. */}
+        {!showSleepingWorkspaces && (
+          <FilterToggleRow
+            indented
+            icon={<GitBranch className="size-3.5" />}
+            label={translate(
+              'auto.components.sidebar.SidebarFilter.keepDefaultBranch',
+              'Except default branch'
+            )}
+            ariaLabel={translate(
+              'auto.components.sidebar.SidebarFilter.keepDefaultBranchAria',
+              'Keep the default branch visible while hiding sleeping workspaces'
+            )}
+            checked={alwaysShowDefaultBranchWorkspace}
+            onChange={setAlwaysShowDefaultBranchWorkspace}
+          />
+        )}
         <FilterToggleRow
           icon={<GitBranch className="size-3.5" />}
           label={translate(

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+/**
+ * The "Except default branch" exemption only bites during the "Hide sleeping"
+ * sweep, so its row must stay out of the filter list until the parent row is on.
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mocks.state)
+}))
+
+import SidebarWorkspaceFilterSection from './SidebarWorkspaceFilterSection'
+
+const EXEMPTION_LABEL = 'Except default branch'
+
+function setState(overrides: Record<string, unknown> = {}): void {
+  mocks.state = {
+    showSleepingWorkspaces: true,
+    setShowSleepingWorkspaces: vi.fn(),
+    hideDefaultBranchWorkspace: false,
+    setHideDefaultBranchWorkspace: vi.fn(),
+    hideAutomationGeneratedWorkspaces: false,
+    setHideAutomationGeneratedWorkspaces: vi.fn(),
+    hideCliCreatedWorkspaces: false,
+    setHideCliCreatedWorkspaces: vi.fn(),
+    hideDetachedHeadWorkspaces: false,
+    setHideDetachedHeadWorkspaces: vi.fn(),
+    alwaysShowDefaultBranchWorkspace: true,
+    setAlwaysShowDefaultBranchWorkspace: vi.fn(),
+    ...overrides
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+function render(): void {
+  act(() => {
+    root.render(<SidebarWorkspaceFilterSection />)
+  })
+}
+
+function rowLabels(): string[] {
+  return Array.from(container.querySelectorAll('[role="switch"]')).map(
+    (el) => el.textContent?.trim() ?? ''
+  )
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('SidebarWorkspaceFilterSection', () => {
+  it('hides the default-branch exemption row while sleeping workspaces are shown', () => {
+    setState({ showSleepingWorkspaces: true })
+    render()
+    expect(rowLabels()).not.toContain(EXEMPTION_LABEL)
+  })
+
+  it('shows the exemption row once "Hide sleeping" is ticked', () => {
+    setState({ showSleepingWorkspaces: false })
+    render()
+    expect(rowLabels()).toContain(EXEMPTION_LABEL)
+  })
+
+  it('keeps the exemption row hidden even when it is switched off', () => {
+    setState({ showSleepingWorkspaces: true, alwaysShowDefaultBranchWorkspace: false })
+    render()
+    expect(rowLabels()).not.toContain(EXEMPTION_LABEL)
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -38,20 +38,24 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
         checked={!showSleepingWorkspaces}
         onChange={(hideSleeping) => setShowSleepingWorkspaces(!hideSleeping)}
       />
-      <FilterToggleRow
-        indented
-        icon={<GitBranch className="size-3.5" />}
-        label={translate(
-          'auto.components.sidebar.SidebarWorkspaceFilterSection.keepDefaultBranch',
-          'Except default branch'
-        )}
-        ariaLabel={translate(
-          'auto.components.sidebar.SidebarWorkspaceFilterSection.keepDefaultBranchAria',
-          'Keep the default branch visible while hiding sleeping workspaces'
-        )}
-        checked={alwaysShowDefaultBranchWorkspace}
-        onChange={setAlwaysShowDefaultBranchWorkspace}
-      />
+      {/* Why gated: the exemption only has an effect while sleeping workspaces
+          are being swept, so it stays hidden until its parent row is on. */}
+      {!showSleepingWorkspaces && (
+        <FilterToggleRow
+          indented
+          icon={<GitBranch className="size-3.5" />}
+          label={translate(
+            'auto.components.sidebar.SidebarWorkspaceFilterSection.keepDefaultBranch',
+            'Except default branch'
+          )}
+          ariaLabel={translate(
+            'auto.components.sidebar.SidebarWorkspaceFilterSection.keepDefaultBranchAria',
+            'Keep the default branch visible while hiding sleeping workspaces'
+          )}
+          checked={alwaysShowDefaultBranchWorkspace}
+          onChange={setAlwaysShowDefaultBranchWorkspace}
+        />
+      )}
       <FilterToggleRow
         icon={<GitBranch className="size-3.5" />}
         label={translate(

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
+import { isSleepingSweepExemptionNarrowingList } from './visible-worktrees'
 import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
 import SidebarWorkspaceFilterSection from './SidebarWorkspaceFilterSection'
 import { getSidebarHostVisibilityLabel, shouldShowHostScopeControls } from './sidebar-host-options'
@@ -79,13 +80,19 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const hasRepoFilter = selectedCount > 0
   const hasSleepingFilter = showSleepingWorkspaces !== DEFAULT_SHOW_SLEEPING_WORKSPACES
   const hasHostVisibilityFilter = visibleWorkspaceHostIds !== null
+  // Why gated on the parent row: the exemption only narrows the list during the
+  // "Hide sleeping" sweep, which is also the only time its row is rendered.
+  const hasSleepingExemptionFilter = isSleepingSweepExemptionNarrowingList(
+    showSleepingWorkspaces,
+    alwaysShowDefaultBranchWorkspace
+  )
   const hasAnyFilter =
     hasSleepingFilter ||
     hideDefaultBranchWorkspace ||
     hideAutomationGeneratedWorkspaces ||
     hideCliCreatedWorkspaces ||
     hideDetachedHeadWorkspaces ||
-    !alwaysShowDefaultBranchWorkspace ||
+    hasSleepingExemptionFilter ||
     hasRepoFilter ||
     hasHostVisibilityFilter
   const activeFilterCount =
@@ -94,7 +101,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
     (hideAutomationGeneratedWorkspaces ? 1 : 0) +
     (hideCliCreatedWorkspaces ? 1 : 0) +
     (hideDetachedHeadWorkspaces ? 1 : 0) +
-    (alwaysShowDefaultBranchWorkspace ? 0 : 1) +
+    (hasSleepingExemptionFilter ? 1 : 0) +
     (hasHostVisibilityFilter ? 1 : 0) +
     selectedCount
   const activeFilterLabel = `${activeFilterCount} ${activeFilterCount === 1 ? 'filter' : 'filters'}`

--- a/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-filter-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   computeClearFilterActions,
   isDefaultBranchWorkspace,
+  isSleepingSweepExemptionNarrowingList,
   sidebarHasActiveFilters
 } from './visible-worktrees'
 import type { Worktree } from '../../../../shared/types'
@@ -111,6 +112,21 @@ describe('sidebarHasActiveFilters', () => {
 
   it('returns true when only host visibility is narrowed', () => {
     expect(sidebarHasActiveFilters(filterState({ visibleWorkspaceHostIds: ['local'] }))).toBe(true)
+  })
+})
+
+describe('isSleepingSweepExemptionNarrowingList', () => {
+  it('is false while sleeping workspaces are shown, even when opted out', () => {
+    expect(isSleepingSweepExemptionNarrowingList(true, false)).toBe(false)
+  })
+
+  it('is true only when the sweep is on and the exemption is opted out', () => {
+    expect(isSleepingSweepExemptionNarrowingList(false, false)).toBe(true)
+    expect(isSleepingSweepExemptionNarrowingList(false, true)).toBe(false)
+  })
+
+  it('treats a missing flag as the on default', () => {
+    expect(isSleepingSweepExemptionNarrowingList(false, undefined)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -54,6 +54,18 @@ export function isSleepingSweepExemptWorkspace(
   return alwaysShowDefaultBranchWorkspace !== false && worktree.isMainWorktree
 }
 
+/**
+ * Whether turning the exemption off is currently narrowing the list. It only
+ * bites during the "Hide sleeping" sweep, so its row — and the filter badge on
+ * both menu surfaces — ignores it while sleeping workspaces are shown.
+ */
+export function isSleepingSweepExemptionNarrowingList(
+  showSleepingWorkspaces: boolean,
+  alwaysShowDefaultBranchWorkspace: boolean | undefined
+): boolean {
+  return !showSleepingWorkspaces && alwaysShowDefaultBranchWorkspace === false
+}
+
 export function isAutomationGeneratedWorkspace(worktree: Worktree): boolean {
   return worktree.automationProvenance?.kind === 'created-by-automation'
 }


### PR DESCRIPTION
## Summary

The `Except default branch` sub-toggle sat permanently under `Hide sleeping` in both workspace filter surfaces, even though the exemption only does anything during the hide-sleeping sweep (`computeVisibleWorktreeIds` applies it inside the `!showSleepingWorkspaces` branch). It now renders only once the parent `Hide sleeping` toggle is ticked.

Two follow-ons fall out of that:

- The filter badge follows the same rule — a hidden, no-op exemption no longer inflates the active-filter count in either menu.
- The row's indent was silently broken: Tailwind v4 emits `px-2` as `padding-inline`, which outranks the physical `pl-6` override, so the sub-option rendered flush with its siblings (measured 8px, same as every other row). Splitting the base padding restores the nesting.

## Visual proof

Captured from the dev build over CDP (workspace options menu, same instance, HMR-swapped between the old and new components).

| Before — `Hide sleeping` off | After — `Hide sleeping` off | After — `Hide sleeping` on |
| --- | --- | --- |
| <img width="320" alt="before: exemption row always shown, flush with its siblings" src="https://github.com/user-attachments/assets/cef5bffe-dc1e-4ddf-a694-013d1ab9d0f4"> | <img width="320" alt="after: exemption row hidden" src="https://github.com/user-attachments/assets/6c073728-d58f-493c-b0bb-4456a5393ce1"> | <img width="320" alt="after: exemption row appears indented under its parent" src="https://github.com/user-attachments/assets/f6c71938-01bc-41a9-a468-bbc470b0376d"> |
| Row is visible, switched on, with nothing to act on — and reads as a sibling, not a sub-option. | Row is gone; the list starts at `Hide default branch`. | Row returns indented under its parent, and the badge counts `1`. |

## Changes

- `SidebarFilter.tsx` / `SidebarWorkspaceFilterSection.tsx`: gate the indented exemption row on `!showSleepingWorkspaces`.
- `visible-worktrees.ts`: new shared `isSleepingSweepExemptionNarrowingList` predicate so the two badge counters can't drift.
- `SidebarFilter.tsx` / `SidebarWorkspaceOptionsMenu.tsx`: count the exemption only when it actually narrows the list.
- `FilterToggleRow.tsx`: `py-1.5 pr-2` + `pl-7`/`pl-2` instead of `px-2` + `pl-6`, so the sub-option indent survives Tailwind v4's logical-property cascade (verified 28px vs 8px in the running app).
- Persisted state is untouched — flipping `Hide sleeping` off and back on restores the user's exemption choice.

## Testing

- `SidebarWorkspaceFilterSection.test.tsx` (new): row hidden while sleeping shown, visible once hide-sleeping is on, still hidden when opted out with sleeping shown.
- `FilterToggleRow.test.tsx` (new): the indented row keeps a left-padding utility and never pairs it with a `px-*` that would outrank it.
- `sidebar-filter-state.test.ts`: unit coverage for the new predicate.
- `vitest run` on the sidebar filter suites — 45 passed.
- `tsc --noEmit -p config/tsconfig.tc.web.json` + `oxlint` clean.
