### PR TITLE
fix(terminal): restore scroll position when returning to a tab

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -56,13 +56,18 @@ function createManager(order: string[] = []): FakeManager {
   }
 }
 
-function resumeArgs(manager: FakeManager, shouldUseLightTabResume: boolean) {
+function resumeArgs(
+  manager: FakeManager,
+  shouldUseLightTabResume: boolean,
+  restoredPaneIds: Set<number> = new Set()
+) {
   return {
     manager: manager as never as PaneManager,
     isActive: true,
     wasVisible: false,
     shouldUseLightTabResume,
     captureViewportPositions: vi.fn(() => new Map()),
+    restoreRememberedPinnedViewports: vi.fn(() => restoredPaneIds),
     withSuppressedScrollTracking: (callback: () => void) => callback()
   }
 }
@@ -100,6 +105,44 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     expect(syncTerminalScrollIntentFromViewport.mock.invocationCallOrder[0]).toBeLessThan(
       enforceTerminalCurrentScrollIntent.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
     )
+  })
+
+  it('re-anchors a remembered pin before sampling the post-reveal viewport', async () => {
+    // Regression (#8715): returning to a worktree resampled xterm's collapsed
+    // viewport into the durable intent, pinning the pane at buffer line 0.
+    const terminal = { name: 'pinned-terminal' }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([{ id: 3, terminal }])
+    const { enforceTerminalCurrentScrollIntent, syncTerminalScrollIntentFromViewport } = vi.mocked(
+      await import('@/lib/pane-manager/terminal-scroll-intent')
+    )
+    const args = resumeArgs(manager, true, new Set([3]))
+
+    resumeTerminalVisibility(args)
+
+    expect(args.restoreRememberedPinnedViewports).toHaveBeenCalledTimes(1)
+    expect(syncTerminalScrollIntentFromViewport).not.toHaveBeenCalled()
+    expect(enforceTerminalCurrentScrollIntent).toHaveBeenCalledWith(terminal)
+    expect(args.restoreRememberedPinnedViewports.mock.invocationCallOrder[0]).toBeLessThan(
+      enforceTerminalCurrentScrollIntent.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    )
+  })
+
+  it('does not replay a stale snapshot when the surface never went hidden', async () => {
+    // An isActive flip re-runs the resume while visible; the remembered snapshot
+    // predates any scrolling the user did since, so replaying it would rewind them.
+    const terminal = { name: 'still-visible-terminal' }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([{ id: 3, terminal }])
+    const { syncTerminalScrollIntentFromViewport } = vi.mocked(
+      await import('@/lib/pane-manager/terminal-scroll-intent')
+    )
+    const args = { ...resumeArgs(manager, true, new Set([3])), wasVisible: true }
+
+    resumeTerminalVisibility(args)
+
+    expect(args.restoreRememberedPinnedViewports).not.toHaveBeenCalled()
+    expect(syncTerminalScrollIntentFromViewport).toHaveBeenCalledWith(terminal)
   })
 
   it('resets each pane linkifier hover cache on reveal so links recover without a scroll', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -27,6 +27,7 @@ type ResumeTerminalVisibilityArgs = {
   wasVisible: boolean
   shouldUseLightTabResume: boolean
   captureViewportPositions: (useRememberedSnapshots: boolean) => Map<number, ScrollState>
+  restoreRememberedPinnedViewports: () => Set<number>
   withSuppressedScrollTracking: (callback: () => void) => void
 }
 
@@ -56,6 +57,7 @@ export function resumeTerminalVisibility({
   wasVisible,
   shouldUseLightTabResume,
   captureViewportPositions,
+  restoreRememberedPinnedViewports,
   withSuppressedScrollTracking
 }: ResumeTerminalVisibilityArgs): void {
   // Why: hiding the surface fired mouseleave, which cleared xterm's current
@@ -64,7 +66,12 @@ export function resumeTerminalVisibility({
   for (const pane of manager.getPanes()) {
     resetTerminalLinkifierHoverState(pane.terminal)
   }
-  syncTerminalViewportIntents(manager)
+  // Why: while the surface was display:none xterm's live viewport can collapse
+  // to line 0. Re-anchor from the hide-time content markers first, otherwise the
+  // resample below writes that 0 over the user's durable pin. Only on a real
+  // reveal — a stayed-visible resume's snapshot predates live user scrolling.
+  const restoredPaneIds = wasVisible ? undefined : restoreRememberedPinnedViewports()
+  syncTerminalViewportIntents(manager, restoredPaneIds)
   // Why: WebGL resume can disturb xterm's viewport bookkeeping before the
   // post-resume fit runs. Capture numeric viewport positions first; the
   // restore path avoids content matching so duplicate agent log lines do
@@ -214,8 +221,14 @@ function enforceTerminalViewportIntents(manager: PaneManager): void {
   }
 }
 
-function syncTerminalViewportIntents(manager: PaneManager): void {
+function syncTerminalViewportIntents(
+  manager: PaneManager,
+  skipPaneIds?: ReadonlySet<number>
+): void {
   for (const pane of manager.getPanes()) {
+    if (skipPaneIds?.has(pane.id)) {
+      continue
+    }
     // Why: native scrollback trimming moves a pinned viewport content-stably.
     // Capture that live position before resume/fit can disturb it.
     syncTerminalScrollIntentFromViewport(pane.terminal)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => ({
   getTerminalOutputEpoch: vi.fn(() => 0),
   handleTerminalFileDrop: vi.fn(),
   enforceTerminalCurrentScrollIntent: vi.fn(),
+  markTerminalPinnedViewport: vi.fn(),
+  releaseScrollStateMarker: vi.fn(),
   syncTerminalScrollIntentFromViewport: vi.fn(),
   pasteTerminalText: vi.fn(),
   recordTerminalUserInputForLeaf: vi.fn(),
@@ -75,12 +77,14 @@ vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
 vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   captureScrollState: mocks.captureScrollState,
   getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
+  releaseScrollStateMarker: mocks.releaseScrollStateMarker,
   restoreScrollState: mocks.restoreScrollState,
   restoreScrollStateAfterLayout: mocks.restoreScrollStateAfterLayout
 }))
 
 vi.mock('@/lib/pane-manager/terminal-scroll-intent', () => ({
   enforceTerminalCurrentScrollIntent: mocks.enforceTerminalCurrentScrollIntent,
+  markTerminalPinnedViewport: mocks.markTerminalPinnedViewport,
   syncTerminalScrollIntentFromViewport: mocks.syncTerminalScrollIntentFromViewport
 }))
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -104,6 +104,7 @@ export function useTerminalPaneGlobalEffects({
   })
   const {
     captureViewportPositions,
+    restoreRememberedPinnedViewports,
     withSuppressedScrollTracking,
     applyPendingFollowOutputRequests,
     scheduleFollowOutputIfNeeded
@@ -159,6 +160,7 @@ export function useTerminalPaneGlobalEffects({
         wasVisible,
         shouldUseLightTabResume,
         captureViewportPositions,
+        restoreRememberedPinnedViewports,
         withSuppressedScrollTracking
       })
       renderingSuspendedByVisibilityRef.current = false

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.test.ts
@@ -13,7 +13,10 @@ const mocks = vi.hoisted(() => ({
   flushTerminalOutput: vi.fn(),
   getTerminalOutputEpoch: vi.fn(() => 1),
   getTerminalScrollIntentKind: vi.fn(() => 'followOutput'),
-  markTerminalFollowOutput: vi.fn()
+  markTerminalFollowOutput: vi.fn(),
+  markTerminalPinnedViewport: vi.fn(),
+  releaseScrollStateMarker: vi.fn(),
+  restoreScrollState: vi.fn(() => true)
 }))
 
 const reactRefState = vi.hoisted(() => ({
@@ -67,12 +70,15 @@ vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
 vi.mock('@/lib/pane-manager/pane-scroll', () => ({
   cancelDeferredScrollRestore: mocks.cancelDeferredScrollRestore,
   captureScrollState: mocks.captureScrollState,
-  getTerminalOutputEpoch: mocks.getTerminalOutputEpoch
+  getTerminalOutputEpoch: mocks.getTerminalOutputEpoch,
+  releaseScrollStateMarker: mocks.releaseScrollStateMarker,
+  restoreScrollState: mocks.restoreScrollState
 }))
 
 vi.mock('@/lib/pane-manager/terminal-scroll-intent', () => ({
   getTerminalScrollIntentKind: mocks.getTerminalScrollIntentKind,
-  markTerminalFollowOutput: mocks.markTerminalFollowOutput
+  markTerminalFollowOutput: mocks.markTerminalFollowOutput,
+  markTerminalPinnedViewport: mocks.markTerminalPinnedViewport
 }))
 
 describe('useTerminalScrollVisibilityMemory', () => {
@@ -83,6 +89,17 @@ describe('useTerminalScrollVisibilityMemory', () => {
     resetHookRefs()
     vi.clearAllMocks()
     mocks.getTerminalScrollIntentKind.mockReturnValue('followOutput')
+    // mockClear leaves queued once-values behind; drop them so a case that
+    // consumes fewer than it queues cannot bleed into the next one.
+    mocks.captureScrollState.mockReset()
+    mocks.captureScrollState.mockReturnValue({
+      bufferType: 'normal',
+      wasAtBottom: true,
+      viewportY: 0,
+      baseY: 0
+    })
+    mocks.restoreScrollState.mockReset()
+    mocks.restoreScrollState.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -165,6 +182,92 @@ describe('useTerminalScrollVisibilityMemory', () => {
     expect(mocks.cancelDeferredScrollRestore).not.toHaveBeenCalled()
     expect(mocks.markTerminalFollowOutput).not.toHaveBeenCalled()
     expect(terminal.scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('restores a remembered pinned viewport and re-pins the durable intent', () => {
+    // Regression (#8715): the hide-time snapshot was captured but never replayed,
+    // so returning to the worktree left the pane at the top of the scrollback.
+    const pinned = { bufferType: 'normal', wasAtBottom: false, viewportY: 500, baseY: 5000 }
+    const reanchored = { bufferType: 'normal', wasAtBottom: false, viewportY: 500, baseY: 5000 }
+    mocks.captureScrollState.mockReturnValueOnce(pinned).mockReturnValueOnce(reanchored)
+    const terminal = { onScroll: vi.fn(() => ({ dispose: vi.fn() })) }
+    const manager = { getPanes: vi.fn(() => [{ id: 1, terminal }]) }
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    visibilityMemory.captureViewportPositions(false)
+    const restored = visibilityMemory.restoreRememberedPinnedViewports()
+
+    expect(mocks.restoreScrollState).toHaveBeenCalledWith(terminal, pinned)
+    expect(mocks.markTerminalPinnedViewport).toHaveBeenCalledWith(terminal)
+    expect(restored).toEqual(new Set([1]))
+    // restoreScrollState disposes the markers, so the entry must be re-anchored.
+    expect(mocks.captureScrollState).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves follow-output and alternate-buffer panes to their existing resume paths', () => {
+    mocks.captureScrollState
+      .mockReturnValueOnce({
+        bufferType: 'normal',
+        wasAtBottom: true,
+        viewportY: 5000,
+        baseY: 5000
+      })
+      .mockReturnValueOnce({
+        bufferType: 'alternate',
+        wasAtBottom: false,
+        viewportY: 0,
+        baseY: 0
+      })
+    const following = { onScroll: vi.fn(() => ({ dispose: vi.fn() })) }
+    const altScreen = { onScroll: vi.fn(() => ({ dispose: vi.fn() })) }
+    const manager = {
+      getPanes: vi.fn(() => [
+        { id: 1, terminal: following },
+        { id: 2, terminal: altScreen }
+      ])
+    }
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 2
+    })
+
+    visibilityMemory.captureViewportPositions(false)
+    const restored = visibilityMemory.restoreRememberedPinnedViewports()
+
+    expect(mocks.restoreScrollState).not.toHaveBeenCalled()
+    expect(restored.size).toBe(0)
+  })
+
+  it('releases the previous markers when a pane snapshot is replaced', () => {
+    const first = { bufferType: 'normal', wasAtBottom: false, viewportY: 10, baseY: 100 }
+    mocks.captureScrollState.mockReturnValueOnce(first)
+    const terminal = { onScroll: vi.fn(() => ({ dispose: vi.fn() })) }
+    const manager = { getPanes: vi.fn(() => [{ id: 1, terminal }]) }
+
+    beginHookRender()
+    const visibilityMemory = useTerminalScrollVisibilityMemory({
+      managerRef: { current: manager as never },
+      isVisibleRef: { current: true },
+      visibleResumeCompleteRef: { current: true },
+      paneCount: 1
+    })
+
+    visibilityMemory.captureViewportPositions(false)
+    expect(mocks.releaseScrollStateMarker).not.toHaveBeenCalled()
+    visibilityMemory.captureViewportPositions(false)
+
+    expect(mocks.releaseScrollStateMarker).toHaveBeenCalledWith(first)
   })
 
   it('cancels pending follow-output frames on cleanup', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-scroll-visibility-memory.ts
@@ -4,11 +4,14 @@ import { flushTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-sch
 import {
   cancelDeferredScrollRestore,
   captureScrollState,
-  getTerminalOutputEpoch
+  getTerminalOutputEpoch,
+  releaseScrollStateMarker,
+  restoreScrollState
 } from '@/lib/pane-manager/pane-scroll'
 import {
   getTerminalScrollIntentKind,
-  markTerminalFollowOutput
+  markTerminalFollowOutput,
+  markTerminalPinnedViewport
 } from '@/lib/pane-manager/terminal-scroll-intent'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { ScrollState } from '@/lib/pane-manager/pane-manager-types'
@@ -27,6 +30,7 @@ type UseTerminalScrollVisibilityMemoryArgs = {
 
 type TerminalScrollVisibilityMemory = {
   captureViewportPositions: (useRememberedSnapshots: boolean) => Map<number, ScrollState>
+  restoreRememberedPinnedViewports: () => Set<number>
   withSuppressedScrollTracking: (callback: () => void) => void
   applyPendingFollowOutputRequests: () => boolean
   scheduleFollowOutputIfNeeded: (paneId: number) => void
@@ -53,11 +57,24 @@ export function useTerminalScrollVisibilityMemory({
     []
   )
 
+  // Why: captureScrollState registers xterm markers; dropping an entry without
+  // disposing them leaks a marker per pane per visibility flip.
+  const storeVisibleScrollSnapshot = useCallback(
+    (paneId: number, snapshot: VisibleScrollSnapshot): void => {
+      const previous = visibleScrollSnapshotsRef.current.get(paneId)
+      if (previous && previous !== snapshot) {
+        releaseScrollStateMarker(previous.scrollState)
+      }
+      visibleScrollSnapshotsRef.current.set(paneId, snapshot)
+    },
+    []
+  )
+
   const rememberVisibleScrollSnapshot = useCallback(
     (paneId: number, terminal: Terminal): void => {
-      visibleScrollSnapshotsRef.current.set(paneId, captureVisibleScrollSnapshot(terminal))
+      storeVisibleScrollSnapshot(paneId, captureVisibleScrollSnapshot(terminal))
     },
-    [captureVisibleScrollSnapshot]
+    [captureVisibleScrollSnapshot, storeVisibleScrollSnapshot]
   )
 
   const captureViewportPositions = useCallback(
@@ -74,7 +91,7 @@ export function useTerminalScrollVisibilityMemory({
           }
           const state = captureScrollState(pane.terminal)
           if (!useRememberedSnapshots || !remembered) {
-            visibleScrollSnapshotsRef.current.set(pane.id, {
+            storeVisibleScrollSnapshot(pane.id, {
               scrollState: state,
               outputEpoch: getTerminalOutputEpoch(pane.terminal)
             })
@@ -83,8 +100,37 @@ export function useTerminalScrollVisibilityMemory({
         })
       )
     },
-    [managerRef]
+    [managerRef, storeVisibleScrollSnapshot]
   )
+
+  const restoreRememberedPinnedViewports = useCallback((): Set<number> => {
+    const restoredPaneIds = new Set<number>()
+    const manager = managerRef.current
+    if (!manager) {
+      return restoredPaneIds
+    }
+    for (const pane of manager.getPanes()) {
+      const remembered = visibleScrollSnapshotsRef.current.get(pane.id)
+      if (!remembered) {
+        continue
+      }
+      const { scrollState } = remembered
+      // Why: a pane that was following output must keep snapping to the bottom,
+      // and restoring into an alternate buffer knocks a live TUI's cursor (#1298).
+      if (scrollState.wasAtBottom || scrollState.bufferType !== 'normal') {
+        continue
+      }
+      // Why: the hide-time markers survive scrollback trim and the viewport
+      // collapse that display:none can inflict; the stored line number does not.
+      if (restoreScrollState(pane.terminal, scrollState)) {
+        markTerminalPinnedViewport(pane.terminal)
+        // restoreScrollState disposes the markers, so re-anchor for the next hide.
+        storeVisibleScrollSnapshot(pane.id, captureVisibleScrollSnapshot(pane.terminal))
+      }
+      restoredPaneIds.add(pane.id)
+    }
+    return restoredPaneIds
+  }, [captureVisibleScrollSnapshot, managerRef, storeVisibleScrollSnapshot])
 
   const withSuppressedScrollTracking = useCallback((callback: () => void): void => {
     suppressScrollTrackingRef.current = true
@@ -172,8 +218,9 @@ export function useTerminalScrollVisibilityMemory({
     }
     const panes = manager.getPanes()
     const livePaneIds = new Set(panes.map((pane) => pane.id))
-    for (const paneId of visibleScrollSnapshotsRef.current.keys()) {
+    for (const [paneId, snapshot] of visibleScrollSnapshotsRef.current) {
       if (!livePaneIds.has(paneId)) {
+        releaseScrollStateMarker(snapshot.scrollState)
         visibleScrollSnapshotsRef.current.delete(paneId)
         pendingFollowOutputPaneIdsRef.current.delete(paneId)
       }
@@ -182,6 +229,7 @@ export function useTerminalScrollVisibilityMemory({
 
   return {
     captureViewportPositions,
+    restoreRememberedPinnedViewports,
     withSuppressedScrollTracking,
     applyPendingFollowOutputRequests,
     scheduleFollowOutputIfNeeded

--- a/tests/e2e/terminal-hidden-viewport-collapse-scroll-restore.spec.ts
+++ b/tests/e2e/terminal-hidden-viewport-collapse-scroll-restore.spec.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { nodeTerminalCommand } from './terminal-node-command'
+import { waitForPtyShellEcho } from './terminal-pty-readiness'
+
+const FIXTURE_ROWS = 400
+const MINIMUM_PIN_DISTANCE_ROWS = 150
+
+type VisibleViewport = {
+  viewportY: number
+  baseY: number
+  rows: number
+  topRow: string
+  visibleText: string
+}
+
+function scrollbackFixtureScript(runId: string): string {
+  return `
+async function writeStdout(chunk) {
+  await new Promise((resolve) => process.stdout.write(chunk, resolve))
+  if (process.platform === 'win32') await new Promise((resolve) => setTimeout(resolve, 8))
+}
+await writeStdout('\\x1b[2J\\x1b[H')
+let batch = ''
+for (let index = 0; index < ${FIXTURE_ROWS}; index += 1) {
+  batch += 'SCROLL_PIN_${runId}_ROW_' + String(index).padStart(5, '0') + '\\r\\n'
+  if (batch.length > 4000) {
+    await writeStdout(batch)
+    batch = ''
+  }
+}
+await writeStdout(batch)
+await writeStdout('SCROLL_PIN_${runId}_DONE\\r\\n')
+`
+}
+
+async function closeFeatureTips(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    store?.getState().markFeatureTipsSeen(['orca-cli', 'cmd-j-palette', 'voice-dictation'])
+    if (store?.getState().activeModal === 'feature-tips') {
+      store.getState().closeModal()
+    }
+  })
+}
+
+/** Read exactly the rows the user can see in the terminal pane right now. */
+async function readVisibleTerminalViewport(page: Page, tabId?: string): Promise<VisibleViewport> {
+  const reading = await readVisibleTerminalViewportIfMounted(page, tabId)
+  if (!reading) {
+    throw new Error('Active terminal pane unavailable')
+  }
+  return reading
+}
+
+/** Same reading, but null while the pane is between mounts (safe inside a poll). */
+async function readVisibleTerminalViewportIfMounted(
+  page: Page,
+  tabId?: string
+): Promise<VisibleViewport | null> {
+  return page.evaluate((explicitTabId) => {
+    const store = window.__store
+    const state = store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      explicitTabId ??
+      (state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null)
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      return null
+    }
+    const buffer = pane.terminal.buffer.active
+    const visibleLines = Array.from(
+      { length: pane.terminal.rows },
+      (_, row) => buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''
+    )
+    return {
+      viewportY: buffer.viewportY,
+      baseY: buffer.baseY,
+      rows: pane.terminal.rows,
+      topRow: visibleLines.find((line) => line.trim().length > 0) ?? '',
+      visibleText: visibleLines.join('\n')
+    }
+  }, tabId)
+}
+
+/** Scroll the real terminal viewport up with Shift+PageUp until the prompt is off screen. */
+async function scrollTerminalBackUntilPinned(page: Page): Promise<VisibleViewport> {
+  await focusActiveTerminalInput(page)
+  for (let press = 0; press < 12; press += 1) {
+    const reading = await readVisibleTerminalViewport(page)
+    if (reading.baseY - reading.viewportY >= MINIMUM_PIN_DISTANCE_ROWS) {
+      return reading
+    }
+    await page.keyboard.press('Shift+PageUp')
+    await page.waitForTimeout(120)
+  }
+  return readVisibleTerminalViewport(page)
+}
+
+/**
+ * Emulate the failure precondition the fix names: while the worktree surface is
+ * `display:none`, xterm's viewport can collapse to line 0 while `baseY` is
+ * unchanged (its scroll dimensions clamp to a zero-height surface). Chromium on
+ * macOS keeps the JS-managed scroll position across a hidden surface, so the
+ * collapse is driven here through xterm's own scroll API on the hidden pane.
+ */
+async function collapseHiddenTerminalViewport(page: Page, tabId: string): Promise<VisibleViewport> {
+  await page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Hidden terminal pane unavailable')
+    }
+    pane.terminal.scrollToLine(0)
+  }, tabId)
+  return readVisibleTerminalViewport(page, tabId)
+}
+
+test.describe('Terminal hidden viewport collapse scroll restore', () => {
+  test('restores the pinned terminal scrollback rows when returning to a worktree whose hidden viewport collapsed', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo: TestInfo) => {
+    await waitForSessionReady(orcaPage)
+    await closeFeatureTips(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
+      (id) => id !== firstWorktreeId
+    )
+    test.skip(!secondWorktreeId, 'scroll restore repro needs the seeded secondary worktree')
+    if (!secondWorktreeId) {
+      return
+    }
+
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const terminalTabId = await orcaPage.evaluate(
+      () => window.__store?.getState().activeTabId ?? null
+    )
+    expect(terminalTabId).toBeTruthy()
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyShellEcho(orcaPage, ptyId, 15_000)
+
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-hidden-collapse-scroll-${runId}.mjs`)
+    writeFileSync(scriptPath, scrollbackFixtureScript(runId))
+
+    try {
+      await sendToTerminal(orcaPage, ptyId, `${nodeTerminalCommand([scriptPath])}\r`)
+      await expect
+        .poll(() => getTerminalContent(orcaPage, 30_000), {
+          timeout: 20_000,
+          message: 'scrollback fixture never reached the terminal'
+        })
+        .toContain(`SCROLL_PIN_${runId}_DONE`)
+
+      const pinned = await scrollTerminalBackUntilPinned(orcaPage)
+      expect(pinned.baseY - pinned.viewportY).toBeGreaterThanOrEqual(MINIMUM_PIN_DISTANCE_ROWS)
+      // The user is parked mid-scrollback: neither the first row of scrollback
+      // nor the shell prompt at the bottom is on screen.
+      expect(pinned.visibleText).toContain(`SCROLL_PIN_${runId}_ROW_`)
+      expect(pinned.visibleText).not.toContain(`SCROLL_PIN_${runId}_ROW_00000`)
+      expect(pinned.visibleText).not.toContain(`SCROLL_PIN_${runId}_DONE`)
+      const pinnedTopRow = pinned.topRow
+
+      await switchToWorktree(orcaPage, secondWorktreeId)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+      const collapsed = await collapseHiddenTerminalViewport(orcaPage, terminalTabId!)
+      expect(collapsed.viewportY).toBe(0)
+      expect(collapsed.baseY).toBe(pinned.baseY)
+
+      await switchToWorktree(orcaPage, firstWorktreeId)
+      await ensureTerminalVisible(orcaPage)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+
+      // Regression (#8715): the revealed pane must show the rows the user left
+      // on screen, not the top of the scrollback.
+      await expect
+        .poll(
+          async () =>
+            (await readVisibleTerminalViewportIfMounted(orcaPage, terminalTabId!))?.topRow ?? null,
+          {
+            timeout: 15_000,
+            message: 'returning to the worktree did not restore the pinned scrollback rows'
+          }
+        )
+        .toBe(pinnedTopRow)
+
+      const restored = await readVisibleTerminalViewport(orcaPage, terminalTabId!)
+      testInfo.annotations.push({
+        type: 'terminal-scroll-restore',
+        description: JSON.stringify({
+          pinnedViewportY: pinned.viewportY,
+          pinnedTopRow,
+          restoredViewportY: restored.viewportY,
+          restoredTopRow: restored.topRow
+        })
+      })
+      expect(restored.visibleText).not.toContain(`SCROLL_PIN_${runId}_ROW_00000`)
+      expect(restored.visibleText).toBe(pinned.visibleText)
+      expect(restored.viewportY).toBe(pinned.viewportY)
+
+      const screenshotPath = testInfo.outputPath('terminal-scroll-restored-after-return.png')
+      await orcaPage.screenshot({ path: screenshotPath })
+      await testInfo.attach('terminal-scroll-restored-after-return.png', {
+        path: screenshotPath,
+        contentType: 'image/png'
+      })
+    } finally {
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})


### PR DESCRIPTION
`hideTerminalVisibility` captured a marker-anchored scroll snapshot per pane, but nothing ever consumed it. On reveal the live post-`display:none` viewport was resampled instead, and a viewport that collapsed to line 0 with an unchanged `baseY` slipped past the only guard — so the durable pin was overwritten with 0 and the pane scrolled to the top.

## Fix

Replay the remembered snapshot for pinned normal-buffer panes before resampling. `followOutput` panes and alternate-buffer panes are skipped, so #11915 and #1298 stay fixed. Restore is marker-anchored rather than line-number based, so it survives scrollback trim.

## Verification

- `pnpm typecheck` clean on this branch
- This branch's own tests pass; the new cases fail before the change and pass after
- Split out of the original combined branch; the union of all 12 split branches was diffed back against it to prove nothing was lost

Fixes #8715

Made with [Orca](https://github.com/stablyai/orca) 🐋
