### PR TITLE
fix(rate-limits): read Kimi usage credentials from the configured WSL runtime

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -183,6 +183,7 @@ import { RateLimitService } from './rate-limits/service'
 import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
+import { getKimiRuntimeTarget, resolveKimiHome } from './kimi/kimi-runtime-home'
 import { createAccountRuntimeTargetSettingsSync } from './rate-limits/account-runtime-target-sync'
 import {
   attachMainWindowServices,
@@ -2306,6 +2307,9 @@ void app.whenReady().then(async () => {
     codexRuntimeHome!.prepareForRateLimitFetch(target)
   )
   rateLimits.setCodexFetchTarget(getInitialCodexRateLimitTarget(store.getSettings()))
+  // Why: Kimi's CLI refreshes its OAuth token in whichever runtime it runs in, so the
+  // usage fetch must read the WSL-side credentials when that's the configured runtime (#12370).
+  rateLimits.setKimiHomeResolver(() => resolveKimiHome(getKimiRuntimeTarget(store!.getSettings())))
   rateLimits.setClaudeFetchTarget(getInitialClaudeRateLimitTarget(store.getSettings()))
   const syncAccountRuntimeTargets = createAccountRuntimeTargetSettingsSync(
     rateLimits,

--- a/src/main/kimi/kimi-runtime-home.test.ts
+++ b/src/main/kimi/kimi-runtime-home.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const wslMocks = vi.hoisted(() => ({
-  getDefaultWslDistro: vi.fn<() => string | null>(),
-  getWslHome: vi.fn<(distro: string) => string | null>()
+  listWslDistrosAsync: vi.fn<() => Promise<string[]>>(),
+  getWslHomeAsync: vi.fn<(distro: string) => Promise<string | null>>()
 }))
 
 vi.mock('../wsl', () => wslMocks)
@@ -52,8 +52,8 @@ describe('resolveKimiHome', () => {
 
   beforeEach(() => {
     delete process.env.KIMI_CODE_HOME
-    wslMocks.getDefaultWslDistro.mockReset().mockReturnValue('Ubuntu')
-    wslMocks.getWslHome.mockReset().mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\neil')
+    wslMocks.listWslDistrosAsync.mockReset().mockResolvedValue(['Ubuntu'])
+    wslMocks.getWslHomeAsync.mockReset().mockResolvedValue('\\\\wsl.localhost\\Ubuntu\\home\\neil')
   })
 
   afterEach(() => {
@@ -64,62 +64,62 @@ describe('resolveKimiHome', () => {
     }
   })
 
-  it('resolves the host home for a host target', () => {
-    expect(resolveKimiHome({ runtime: 'host', wslDistro: null }, 'win32')).toEqual({
+  it('resolves the host home for a host target', async () => {
+    expect(await resolveKimiHome({ runtime: 'host', wslDistro: null }, 'win32')).toEqual({
       runtime: 'host',
       wslDistro: null,
       path: getHostKimiHome()
     })
-    expect(wslMocks.getWslHome).not.toHaveBeenCalled()
+    expect(wslMocks.getWslHomeAsync).not.toHaveBeenCalled()
   })
 
-  it('resolves the WSL distro home for a WSL target', () => {
-    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
+  it('resolves the WSL distro home for a WSL target', async () => {
+    expect(await resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
       path: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
     })
   })
 
-  it('ignores the host KIMI_CODE_HOME when reading a WSL home', () => {
+  it('ignores the host KIMI_CODE_HOME when reading a WSL home', async () => {
     process.env.KIMI_CODE_HOME = 'D:\\kimi-home'
-    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32').path).toBe(
+    expect((await resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).path).toBe(
       '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
     )
   })
 
-  it('falls back to the default distro when none is configured', () => {
-    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toMatchObject({
+  it('falls back to the default distro when none is configured', async () => {
+    expect(await resolveKimiHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toMatchObject({
       wslDistro: 'Ubuntu'
     })
-    expect(wslMocks.getWslHome).toHaveBeenCalledWith('Ubuntu')
+    expect(wslMocks.getWslHomeAsync).toHaveBeenCalledWith('Ubuntu')
   })
 
-  it('reports no path when the distro home cannot be probed', () => {
-    wslMocks.getWslHome.mockReturnValue(null)
-    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
+  it('reports no path when the distro home cannot be probed', async () => {
+    wslMocks.getWslHomeAsync.mockResolvedValue(null)
+    expect(await resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
       path: null
     })
   })
 
-  it('reports no path when no distro exists at all', () => {
-    wslMocks.getDefaultWslDistro.mockReturnValue(null)
-    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toEqual({
+  it('reports no path when no distro exists at all', async () => {
+    wslMocks.listWslDistrosAsync.mockResolvedValue([])
+    expect(await resolveKimiHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toEqual({
       runtime: 'wsl',
       wslDistro: null,
       path: null
     })
   })
 
-  it('never probes WSL off Windows', () => {
-    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'darwin')).toEqual({
+  it('never probes WSL off Windows', async () => {
+    expect(await resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'darwin')).toEqual({
       runtime: 'host',
       wslDistro: null,
       path: getHostKimiHome()
     })
-    expect(wslMocks.getDefaultWslDistro).not.toHaveBeenCalled()
-    expect(wslMocks.getWslHome).not.toHaveBeenCalled()
+    expect(wslMocks.listWslDistrosAsync).not.toHaveBeenCalled()
+    expect(wslMocks.getWslHomeAsync).not.toHaveBeenCalled()
   })
 })

--- a/src/main/kimi/kimi-runtime-home.test.ts
+++ b/src/main/kimi/kimi-runtime-home.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const wslMocks = vi.hoisted(() => ({
+  getDefaultWslDistro: vi.fn<() => string | null>(),
+  getWslHome: vi.fn<(distro: string) => string | null>()
+}))
+
+vi.mock('../wsl', () => wslMocks)
+vi.mock('node:os', () => ({ homedir: () => 'C:\\Users\\neil' }))
+
+import { getHostKimiHome, getKimiRuntimeTarget, resolveKimiHome } from './kimi-runtime-home'
+import type { GlobalSettings } from '../../shared/types'
+
+function settings(overrides: Partial<GlobalSettings>): GlobalSettings {
+  return overrides as GlobalSettings
+}
+
+describe('getKimiRuntimeTarget', () => {
+  it('follows the configured WSL runtime on Windows', () => {
+    expect(
+      getKimiRuntimeTarget(
+        settings({ localAccountRuntime: 'wsl', localAccountWslDistro: ' Ubuntu ' }),
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+  })
+
+  it('pins to host off Windows even when the setting says wsl', () => {
+    expect(
+      getKimiRuntimeTarget(
+        settings({ localAccountRuntime: 'wsl', localAccountWslDistro: 'Ubuntu' }),
+        'darwin'
+      )
+    ).toEqual({ runtime: 'host', wslDistro: null })
+  })
+
+  it('follows the Windows runtime default when the policy is auto', () => {
+    expect(
+      getKimiRuntimeTarget(
+        settings({
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Debian' }
+        }),
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Debian' })
+  })
+})
+
+describe('resolveKimiHome', () => {
+  const originalKimiCodeHome = process.env.KIMI_CODE_HOME
+
+  beforeEach(() => {
+    delete process.env.KIMI_CODE_HOME
+    wslMocks.getDefaultWslDistro.mockReset().mockReturnValue('Ubuntu')
+    wslMocks.getWslHome.mockReset().mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\neil')
+  })
+
+  afterEach(() => {
+    if (originalKimiCodeHome === undefined) {
+      delete process.env.KIMI_CODE_HOME
+    } else {
+      process.env.KIMI_CODE_HOME = originalKimiCodeHome
+    }
+  })
+
+  it('resolves the host home for a host target', () => {
+    expect(resolveKimiHome({ runtime: 'host', wslDistro: null }, 'win32')).toEqual({
+      runtime: 'host',
+      wslDistro: null,
+      path: getHostKimiHome()
+    })
+    expect(wslMocks.getWslHome).not.toHaveBeenCalled()
+  })
+
+  it('resolves the WSL distro home for a WSL target', () => {
+    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
+    })
+  })
+
+  it('ignores the host KIMI_CODE_HOME when reading a WSL home', () => {
+    process.env.KIMI_CODE_HOME = 'D:\\kimi-home'
+    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32').path).toBe(
+      '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
+    )
+  })
+
+  it('falls back to the default distro when none is configured', () => {
+    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toMatchObject({
+      wslDistro: 'Ubuntu'
+    })
+    expect(wslMocks.getWslHome).toHaveBeenCalledWith('Ubuntu')
+  })
+
+  it('reports no path when the distro home cannot be probed', () => {
+    wslMocks.getWslHome.mockReturnValue(null)
+    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'win32')).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      path: null
+    })
+  })
+
+  it('reports no path when no distro exists at all', () => {
+    wslMocks.getDefaultWslDistro.mockReturnValue(null)
+    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: null }, 'win32')).toEqual({
+      runtime: 'wsl',
+      wslDistro: null,
+      path: null
+    })
+  })
+
+  it('never probes WSL off Windows', () => {
+    expect(resolveKimiHome({ runtime: 'wsl', wslDistro: 'Ubuntu' }, 'darwin')).toEqual({
+      runtime: 'host',
+      wslDistro: null,
+      path: getHostKimiHome()
+    })
+    expect(wslMocks.getDefaultWslDistro).not.toHaveBeenCalled()
+    expect(wslMocks.getWslHome).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/kimi/kimi-runtime-home.ts
+++ b/src/main/kimi/kimi-runtime-home.ts
@@ -6,7 +6,7 @@ import {
   type LocalAccountRuntimeTarget
 } from '../../shared/local-account-runtime'
 import type { GlobalSettings } from '../../shared/types'
-import { getDefaultWslDistro, getWslHome } from '../wsl'
+import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
 
 export type KimiHomeResolution = LocalAccountRuntimeTarget & {
   /** null when the WSL distro's home could not be probed (distro missing/stopped). */
@@ -34,21 +34,30 @@ export function getKimiRuntimeTarget(
   return resolveLocalAccountRuntimeTarget(settings, platform)
 }
 
-/** Resolve a runtime target to the Kimi home Orca should read (UNC path for WSL). */
-export function resolveKimiHome(
+/**
+ * Resolve a runtime target to the Kimi home Orca should read (UNC path for WSL).
+ * Async because it runs on every quota poll: the sync `wsl.exe` probes park
+ * Electron's main process for up to 5s each cycle while a distro is stopped.
+ */
+export async function resolveKimiHome(
   target: LocalAccountRuntimeTarget,
   platform: NodeJS.Platform = process.platform
-): KimiHomeResolution {
+): Promise<KimiHomeResolution> {
   if (target.runtime !== 'wsl' || platform !== 'win32') {
     return { runtime: 'host', wslDistro: null, path: getHostKimiHome() }
   }
-  const distro = target.wslDistro?.trim() || getDefaultWslDistro()
+  const distro = target.wslDistro?.trim() || (await defaultWslDistro())
   if (!distro) {
     return { runtime: 'wsl', wslDistro: null, path: null }
   }
-  const home = getWslHome(distro)
+  const home = await getWslHomeAsync(distro)
   // KIMI_CODE_HOME describes the Windows host process, never the distro's home.
   return { runtime: 'wsl', wslDistro: distro, path: home ? joinKimiHome(home) : null }
+}
+
+/** Async twin of `getDefaultWslDistro`, which shells out to wsl.exe synchronously. */
+async function defaultWslDistro(): Promise<string | null> {
+  return (await listWslDistrosAsync())[0] ?? null
 }
 
 function joinKimiHome(home: string): string {

--- a/src/main/kimi/kimi-runtime-home.ts
+++ b/src/main/kimi/kimi-runtime-home.ts
@@ -1,0 +1,56 @@
+import { homedir } from 'node:os'
+import { join, win32 as pathWin32 } from 'node:path'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  resolveLocalAccountRuntimeTarget,
+  type LocalAccountRuntimeTarget
+} from '../../shared/local-account-runtime'
+import type { GlobalSettings } from '../../shared/types'
+import { getDefaultWslDistro, getWslHome } from '../wsl'
+
+export type KimiHomeResolution = LocalAccountRuntimeTarget & {
+  /** null when the WSL distro's home could not be probed (distro missing/stopped). */
+  path: string | null
+}
+
+// Why: match the CLI's `KIMI_CODE_HOME ?? ~/.kimi-code` resolution so we read the
+// same files the running Kimi CLI writes.
+export function getHostKimiHome(): string {
+  return process.env.KIMI_CODE_HOME?.trim() || join(homedir(), '.kimi-code')
+}
+
+/**
+ * Kimi has no per-account runtime switcher, so it follows the local-account
+ * runtime policy. WSL is Windows-only — pin everywhere else so no `wsl.exe`
+ * probe is attempted on a stale `wsl` setting synced from a Windows machine.
+ */
+export function getKimiRuntimeTarget(
+  settings: GlobalSettings,
+  platform: NodeJS.Platform = process.platform
+): LocalAccountRuntimeTarget {
+  if (platform !== 'win32') {
+    return { runtime: 'host', wslDistro: null }
+  }
+  return resolveLocalAccountRuntimeTarget(settings, platform)
+}
+
+/** Resolve a runtime target to the Kimi home Orca should read (UNC path for WSL). */
+export function resolveKimiHome(
+  target: LocalAccountRuntimeTarget,
+  platform: NodeJS.Platform = process.platform
+): KimiHomeResolution {
+  if (target.runtime !== 'wsl' || platform !== 'win32') {
+    return { runtime: 'host', wslDistro: null, path: getHostKimiHome() }
+  }
+  const distro = target.wslDistro?.trim() || getDefaultWslDistro()
+  if (!distro) {
+    return { runtime: 'wsl', wslDistro: null, path: null }
+  }
+  const home = getWslHome(distro)
+  // KIMI_CODE_HOME describes the Windows host process, never the distro's home.
+  return { runtime: 'wsl', wslDistro: distro, path: home ? joinKimiHome(home) : null }
+}
+
+function joinKimiHome(home: string): string {
+  return parseWslUncPath(home) ? pathWin32.join(home, '.kimi-code') : join(home, '.kimi-code')
+}

--- a/src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
+++ b/src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+const files = vi.hoisted(() => new Map<string, string>())
+
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+vi.mock('node:fs', () => ({
+  existsSync: (path: string) => files.has(path),
+  readFileSync: (path: string) => {
+    const contents = files.get(path)
+    if (contents === undefined) {
+      throw new Error(`ENOENT: ${path}`)
+    }
+    return contents
+  }
+}))
+// Posix-shaped host home so `node:path.join` behaves the same on every test runner.
+vi.mock('node:os', () => ({ homedir: () => '/home/neil' }))
+
+import { fetchKimiRateLimits } from './kimi-fetcher'
+
+const HOST_CREDENTIALS = '/home/neil/.kimi-code/credentials/kimi-code.json'
+const WSL_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
+const WSL_CREDENTIALS = `${WSL_HOME}\\credentials\\kimi-code.json`
+
+function credentials(token: string, expiresInSeconds: number): string {
+  return JSON.stringify({
+    access_token: token,
+    expires_at: Math.floor(Date.now() / 1000) + expiresInSeconds
+  })
+}
+
+function usageResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      usage: { limit: '1000', remaining: '900' },
+      limits: [
+        {
+          window: { duration: 5, timeUnit: 'TIME_UNIT_HOUR' },
+          detail: { limit: '100', remaining: '40' }
+        }
+      ]
+    })
+  } as Response
+}
+
+describe('fetchKimiRateLimits with a WSL credentials home', () => {
+  beforeEach(() => {
+    files.clear()
+    netFetchMock.mockReset()
+    netFetchMock.mockResolvedValue(usageResponse())
+    // The Windows-side copy stopped rotating when the CLI moved into WSL.
+    files.set(HOST_CREDENTIALS, credentials('host-stale', -3 * 24 * 3600))
+    files.set(WSL_CREDENTIALS, credentials('wsl-fresh', 13 * 60))
+  })
+
+  it('reads the WSL token instead of the stale host one', async () => {
+    const result = await fetchKimiRateLimits({
+      home: { runtime: 'wsl', wslDistro: 'Ubuntu', path: WSL_HOME }
+    })
+
+    expect(result.status).toBe('ok')
+    expect(result.session?.usedPercent).toBe(60)
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+    expect(netFetchMock.mock.calls[0][1].headers.Authorization).toBe('Bearer wsl-fresh')
+  })
+
+  it('still reads the host home by default', async () => {
+    const result = await fetchKimiRateLimits()
+
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('delegated-refresh-required')
+    expect(result.error).toContain('on the computer running Orca')
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('points an expired WSL session at the distro to rerun kimi in', async () => {
+    files.set(WSL_CREDENTIALS, credentials('wsl-stale', -60))
+
+    const result = await fetchKimiRateLimits({
+      home: { runtime: 'wsl', wslDistro: 'Ubuntu', path: WSL_HOME }
+    })
+
+    expect(result.error).toBe(
+      'Kimi session expired — run kimi inside WSL (Ubuntu), then retry usage.'
+    )
+    expect(result.usageMetadata?.failureKind).toBe('delegated-refresh-required')
+  })
+
+  it('reports an unresolvable WSL home instead of falling back to host credentials', async () => {
+    const result = await fetchKimiRateLimits({
+      home: { runtime: 'wsl', wslDistro: 'Ubuntu', path: null }
+    })
+
+    expect(result.status).toBe('error')
+    expect(result.error).toBe('WSL Kimi home unavailable for Ubuntu')
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reports not signed in when the WSL home has no credentials file', async () => {
+    files.delete(WSL_CREDENTIALS)
+
+    const result = await fetchKimiRateLimits({
+      home: { runtime: 'wsl', wslDistro: 'Ubuntu', path: WSL_HOME }
+    })
+
+    expect(result.status).toBe('unavailable')
+  })
+})

--- a/src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
+++ b/src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
@@ -2,14 +2,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const netFetchMock = vi.hoisted(() => vi.fn())
 const files = vi.hoisted(() => new Map<string, string>())
+const STALLED = vi.hoisted(() => '__stalled_unc_read__')
 
 vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
-vi.mock('node:fs', () => ({
-  existsSync: (path: string) => files.has(path),
-  readFileSync: (path: string) => {
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => {
     const contents = files.get(path)
     if (contents === undefined) {
-      throw new Error(`ENOENT: ${path}`)
+      const error = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    }
+    if (contents === STALLED) {
+      // A distro that is down parks the UNC read instead of failing.
+      return await new Promise<string>(() => {})
     }
     return contents
   }
@@ -107,5 +113,28 @@ describe('fetchKimiRateLimits with a WSL credentials home', () => {
     })
 
     expect(result.status).toBe('unavailable')
+  })
+
+  // Last: an unsettled UNC read stays shared for its path by design, so the stalled
+  // distro gets its own home to avoid poisoning the other cases.
+  it('bounds a stalled UNC read instead of parking the poll cycle', async () => {
+    const stalledHome = '\\\\wsl.localhost\\Stopped\\home\\neil\\.kimi-code'
+    files.set(`${stalledHome}\\credentials\\kimi-code.json`, STALLED)
+    const timeoutController = new AbortController()
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal)
+
+    const pending = fetchKimiRateLimits({
+      home: { runtime: 'wsl', wslDistro: 'Stopped', path: stalledHome }
+    })
+    expect(timeout).toHaveBeenCalledWith(5_000)
+    await Promise.resolve()
+    await Promise.resolve()
+    timeoutController.abort()
+
+    const result = await pending
+    expect(result.status).toBe('error')
+    expect(result.error).toContain('(WSL Stopped)')
+    expect(netFetchMock).not.toHaveBeenCalled()
+    timeout.mockRestore()
   })
 })

--- a/src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
+++ b/src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const netFetchMock = vi.hoisted(() => vi.fn())
@@ -20,12 +21,12 @@ vi.mock('node:fs/promises', () => ({
     return contents
   }
 }))
-// Posix-shaped host home so `node:path.join` behaves the same on every test runner.
 vi.mock('node:os', () => ({ homedir: () => '/home/neil' }))
 
 import { fetchKimiRateLimits } from './kimi-fetcher'
 
-const HOST_CREDENTIALS = '/home/neil/.kimi-code/credentials/kimi-code.json'
+// Built with `join` so the key matches the separator the fetcher emits on this runner's platform.
+const HOST_CREDENTIALS = join('/home/neil', '.kimi-code', 'credentials', 'kimi-code.json')
 const WSL_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
 const WSL_CREDENTIALS = `${WSL_HOME}\\credentials\\kimi-code.json`
 

--- a/src/main/rate-limits/kimi-fetcher.test.ts
+++ b/src/main/rate-limits/kimi-fetcher.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const netFetchMock = vi.hoisted(() => vi.fn())
@@ -53,6 +54,11 @@ const USAGE_RESPONSE = {
     }
   ],
   subType: 'TYPE_PURCHASE'
+}
+
+// Built with `join` so the expectation matches the separator the fetcher emits on this platform.
+function hostCredentialsPath(kimiHome: string): string {
+  return join(kimiHome, 'credentials', 'kimi-code.json')
 }
 
 function freshCredentials(): string {
@@ -161,7 +167,7 @@ describe('fetchKimiRateLimits', () => {
     const result = await fetchKimiRateLimits()
 
     expect(result.status).toBe('ok')
-    expect(fsState.readPaths).toEqual(['/home/test/.kimi-code/credentials/kimi-code.json'])
+    expect(fsState.readPaths).toEqual([hostCredentialsPath('/home/test/.kimi-code')])
   })
 
   it('honors KIMI_CODE_HOME for the host home', async () => {
@@ -172,7 +178,7 @@ describe('fetchKimiRateLimits', () => {
     const result = await fetchKimiRateLimits()
 
     expect(result.status).toBe('ok')
-    expect(fsState.readPaths).toEqual(['/custom/kimi-home/credentials/kimi-code.json'])
+    expect(fsState.readPaths).toEqual([hostCredentialsPath('/custom/kimi-home')])
   })
 
   it('ignores a blank KIMI_CODE_HOME instead of reading from the process cwd', async () => {
@@ -182,6 +188,6 @@ describe('fetchKimiRateLimits', () => {
 
     await fetchKimiRateLimits()
 
-    expect(fsState.readPaths).toEqual(['/home/test/.kimi-code/credentials/kimi-code.json'])
+    expect(fsState.readPaths).toEqual([hostCredentialsPath('/home/test/.kimi-code')])
   })
 })

--- a/src/main/rate-limits/kimi-fetcher.test.ts
+++ b/src/main/rate-limits/kimi-fetcher.test.ts
@@ -1,28 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const netFetchMock = vi.hoisted(() => vi.fn())
-const fsState = vi.hoisted<{ credentials: string | null; readError: Error | null }>(() => ({
+const fsState = vi.hoisted<{
+  credentials: string | null
+  readError: Error | null
+  readPaths: string[]
+}>(() => ({
   credentials: null,
-  readError: null
+  readError: null,
+  readPaths: []
 }))
 
 vi.mock('electron', () => ({
   net: { fetch: netFetchMock }
 }))
 
-vi.mock('node:fs', () => ({
-  existsSync: () => fsState.credentials !== null,
-  readFileSync: () => {
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => {
+    fsState.readPaths.push(String(path))
     if (fsState.readError) {
       throw fsState.readError
     }
     if (fsState.credentials === null) {
-      throw new Error('ENOENT')
+      const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
     }
     return fsState.credentials
-  },
-  writeFileSync: () => {},
-  renameSync: () => {}
+  }
 }))
 
 vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
@@ -60,6 +65,7 @@ describe('fetchKimiRateLimits', () => {
     netFetchMock.mockReset()
     fsState.credentials = null
     fsState.readError = null
+    fsState.readPaths = []
   })
 
   afterEach(() => {
@@ -146,5 +152,36 @@ describe('fetchKimiRateLimits', () => {
       source: 'oauth'
     })
     expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reads the host ~/.kimi-code credentials by default', async () => {
+    fsState.credentials = freshCredentials()
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    const result = await fetchKimiRateLimits()
+
+    expect(result.status).toBe('ok')
+    expect(fsState.readPaths).toEqual(['/home/test/.kimi-code/credentials/kimi-code.json'])
+  })
+
+  it('honors KIMI_CODE_HOME for the host home', async () => {
+    vi.stubEnv('KIMI_CODE_HOME', '/custom/kimi-home')
+    fsState.credentials = freshCredentials()
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    const result = await fetchKimiRateLimits()
+
+    expect(result.status).toBe('ok')
+    expect(fsState.readPaths).toEqual(['/custom/kimi-home/credentials/kimi-code.json'])
+  })
+
+  it('ignores a blank KIMI_CODE_HOME instead of reading from the process cwd', async () => {
+    vi.stubEnv('KIMI_CODE_HOME', '   ')
+    fsState.credentials = freshCredentials()
+    netFetchMock.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE))
+
+    await fetchKimiRateLimits()
+
+    expect(fsState.readPaths).toEqual(['/home/test/.kimi-code/credentials/kimi-code.json'])
   })
 })

--- a/src/main/rate-limits/kimi-fetcher.ts
+++ b/src/main/rate-limits/kimi-fetcher.ts
@@ -1,12 +1,13 @@
 import { existsSync, readFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 as pathWin32 } from 'node:path'
 import { net } from 'electron'
 import type {
   ProviderRateLimits,
   RateLimitWindow,
   UsageRateLimitMetadata
 } from '../../shared/rate-limit-types'
+import { parseWslUncPath } from '../../shared/wsl-paths'
+import { getHostKimiHome, type KimiHomeResolution } from '../kimi/kimi-runtime-home'
 
 // Why: Kimi Code's managed coding plan exposes subscription usage at
 // `${base}/usages` (see packages/oauth/src/managed-usage.ts in the CLI bundle).
@@ -18,14 +19,11 @@ const API_TIMEOUT_MS = 10_000
 const SESSION_WINDOW_MINUTES = 300 // 5h
 const WEEKLY_WINDOW_MINUTES = 10080 // 7d
 
-function getKimiHome(): string {
-  // Why: match the CLI's `KIMI_CODE_HOME ?? ~/.kimi-code` resolution so we read
-  // the same OAuth credentials the running Kimi CLI writes.
-  return process.env.KIMI_CODE_HOME ?? join(homedir(), '.kimi-code')
-}
-
-function getCredentialsPath(): string {
-  return join(getKimiHome(), 'credentials', 'kimi-code.json')
+function getCredentialsPath(kimiHome: string): string {
+  // WSL homes arrive as `\\wsl.localhost\<distro>\...`, which only win32 join keeps intact.
+  return parseWslUncPath(kimiHome)
+    ? pathWin32.join(kimiHome, 'credentials', 'kimi-code.json')
+    : join(kimiHome, 'credentials', 'kimi-code.json')
 }
 
 type KimiCredentials = {
@@ -52,8 +50,8 @@ function parseCredentials(value: unknown): KimiCredentials | null {
   return credentials
 }
 
-function readCredentials(): CredentialsReadResult {
-  const path = getCredentialsPath()
+function readCredentials(kimiHome: string): CredentialsReadResult {
+  const path = getCredentialsPath(kimiHome)
   if (!existsSync(path)) {
     return { status: 'missing' }
   }
@@ -212,6 +210,14 @@ function mapUsageResponse(data: KimiUsageResponse): ProviderRateLimits {
   }
 }
 
+function expiredSessionMessage(home: KimiHomeResolution): string {
+  const where =
+    home.runtime === 'wsl'
+      ? `inside WSL (${home.wslDistro ?? 'default distro'})`
+      : 'on the computer running Orca'
+  return `Kimi session expired — run kimi ${where}, then retry usage.`
+}
+
 function result(
   status: ProviderRateLimits['status'],
   error: string | null,
@@ -231,7 +237,11 @@ function result(
 /**
  * Read-only subscription usage for Kimi Code.
  *
- * Why read-only: the access token lives in `~/.kimi-code/credentials/kimi-code.json`
+ * `home` selects which machine's credentials to read: on Windows the Kimi CLI
+ * often runs inside WSL, and only that copy is refreshed (#12370). Defaults to
+ * the host home.
+ *
+ * Why read-only: the access token lives in `<kimi home>/credentials/kimi-code.json`
  * and is refreshed by the Kimi CLI itself (15-min TTL, refresh-token rotation).
  * Orca must NEVER refresh or rewrite that file — a rotated refresh token would
  * log out a live `kimi` session. We only read the current token and call the
@@ -239,8 +249,18 @@ function result(
  * `/usage` command uses. The completion endpoint (the one Moonshot gates to
  * approved coding agents) is never touched here.
  */
-export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
-  const readResult = readCredentials()
+export async function fetchKimiRateLimits(options?: {
+  home?: KimiHomeResolution
+}): Promise<ProviderRateLimits> {
+  const home: KimiHomeResolution = options?.home ?? {
+    runtime: 'host',
+    wslDistro: null,
+    path: getHostKimiHome()
+  }
+  if (home.path === null) {
+    return result('error', `WSL Kimi home unavailable for ${home.wslDistro ?? 'default distro'}`)
+  }
+  const readResult = readCredentials(home.path)
   if (readResult.status === 'missing') {
     return result('unavailable', 'Not signed in to Kimi Code')
   }
@@ -255,11 +275,10 @@ export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
     // Why: don't refresh — the CLI owns the token lifecycle. Report a transient
     // error so the rate-limit service keeps the last good snapshot (stale
     // policy) until the user next runs Kimi and the CLI refreshes the file.
-    return result(
-      'error',
-      'Kimi session expired — run kimi on the computer running Orca, then retry usage.',
-      { failureKind: 'delegated-refresh-required', source: 'oauth' }
-    )
+    return result('error', expiredSessionMessage(home), {
+      failureKind: 'delegated-refresh-required',
+      source: 'oauth'
+    })
   }
 
   try {

--- a/src/main/rate-limits/kimi-fetcher.ts
+++ b/src/main/rate-limits/kimi-fetcher.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { join, win32 as pathWin32 } from 'node:path'
 import { net } from 'electron'
 import type {
@@ -8,6 +8,10 @@ import type {
 } from '../../shared/rate-limit-types'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { getHostKimiHome, type KimiHomeResolution } from '../kimi/kimi-runtime-home'
+import {
+  createAuthFilesystemOperation,
+  type SharedAuthFilesystemOperation
+} from './auth-filesystem-operation'
 
 // Why: Kimi Code's managed coding plan exposes subscription usage at
 // `${base}/usages` (see packages/oauth/src/managed-usage.ts in the CLI bundle).
@@ -15,6 +19,7 @@ import { getHostKimiHome, type KimiHomeResolution } from '../kimi/kimi-runtime-h
 // stays aligned with a user's self-hosted/staging config.
 const KIMI_BASE_URL = process.env.KIMI_CODE_BASE_URL ?? 'https://api.kimi.com/coding/v1'
 const API_TIMEOUT_MS = 10_000
+const CREDENTIALS_READ_TIMEOUT_MS = 5_000
 
 const SESSION_WINDOW_MINUTES = 300 // 5h
 const WEEKLY_WINDOW_MINUTES = 10080 // 7d
@@ -50,22 +55,65 @@ function parseCredentials(value: unknown): KimiCredentials | null {
   return credentials
 }
 
-function readCredentials(kimiHome: string): CredentialsReadResult {
-  const path = getCredentialsPath(kimiHome)
-  if (!existsSync(path)) {
-    return { status: 'missing' }
+const credentialsReadByPath = new Map<
+  string,
+  SharedAuthFilesystemOperation<CredentialsReadResult>
+>()
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+function readErrorMessage(err: unknown): string {
+  // Why: AbortSignal timeouts reject with a DOMException, not an Error.
+  const message = (err as { message?: unknown } | null)?.message
+  return typeof message === 'string' ? message : 'Unable to read Kimi credentials'
+}
+
+function getCredentialsRead(path: string): SharedAuthFilesystemOperation<CredentialsReadResult> {
+  const existing = credentialsReadByPath.get(path)
+  if (existing) {
+    return existing
   }
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
-    const credentials = parseCredentials(parsed)
-    return credentials
-      ? { status: 'ok', credentials }
-      : { status: 'error', error: 'Kimi credentials file is invalid' }
-  } catch (err) {
-    return {
-      status: 'error',
-      error: err instanceof Error ? err.message : 'Unable to read Kimi credentials'
+  // Why: aborting an fs promise does not cancel an already issued UNC request, so
+  // share one raw read per path until it settles (mirrors codex-fetcher's auth read).
+  const read = createAuthFilesystemOperation(path, async (): Promise<CredentialsReadResult> => {
+    let raw: string
+    try {
+      raw = await readFile(path, 'utf-8')
+    } catch (err) {
+      return isMissingPathError(err)
+        ? { status: 'missing' }
+        : { status: 'error', error: readErrorMessage(err) }
     }
+    try {
+      const credentials = parseCredentials(JSON.parse(raw))
+      return credentials
+        ? { status: 'ok', credentials }
+        : { status: 'error', error: 'Kimi credentials file is invalid' }
+    } catch (err) {
+      return { status: 'error', error: readErrorMessage(err) }
+    }
+  })
+  credentialsReadByPath.set(path, read)
+  const clearRead = (): void => {
+    if (credentialsReadByPath.get(path) === read) {
+      credentialsReadByPath.delete(path)
+    }
+  }
+  void read.result.then(clearRead, clearRead)
+  return read
+}
+
+async function readCredentials(kimiHome: string): Promise<CredentialsReadResult> {
+  const path = getCredentialsPath(kimiHome)
+  try {
+    // Why: a stopped distro parks a UNC read for minutes; bound it so a WSL home
+    // degrades to an error instead of stalling the poll cycle.
+    return await getCredentialsRead(path).wait(AbortSignal.timeout(CREDENTIALS_READ_TIMEOUT_MS))
+  } catch (err) {
+    return { status: 'error', error: readErrorMessage(err) }
   }
 }
 
@@ -210,6 +258,11 @@ function mapUsageResponse(data: KimiUsageResponse): ProviderRateLimits {
   }
 }
 
+// A bare "operation was aborted due to timeout" hides which machine stalled.
+function readErrorContext(home: KimiHomeResolution, error: string): string {
+  return home.runtime === 'wsl' ? `${error} (WSL ${home.wslDistro ?? 'default distro'})` : error
+}
+
 function expiredSessionMessage(home: KimiHomeResolution): string {
   const where =
     home.runtime === 'wsl'
@@ -260,12 +313,12 @@ export async function fetchKimiRateLimits(options?: {
   if (home.path === null) {
     return result('error', `WSL Kimi home unavailable for ${home.wslDistro ?? 'default distro'}`)
   }
-  const readResult = readCredentials(home.path)
+  const readResult = await readCredentials(home.path)
   if (readResult.status === 'missing') {
     return result('unavailable', 'Not signed in to Kimi Code')
   }
   if (readResult.status === 'error') {
-    return result('error', readResult.error)
+    return result('error', readErrorContext(home, readResult.error))
   }
   const creds = readResult.credentials
   if (typeof creds.access_token !== 'string' || creds.access_token.length === 0) {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1439,7 +1439,7 @@ describe('RateLimitService', () => {
       wslDistro: 'Ubuntu',
       path: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
     }
-    const resolver = vi.fn(() => home)
+    const resolver = vi.fn(async () => home)
     service.setKimiHomeResolver(resolver)
     mockFreshBackgroundProviderFetches()
     vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 10))

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1432,6 +1432,36 @@ describe('RateLimitService', () => {
     expect(state.opencodeGo?.session?.usedPercent).toBe(40)
   })
 
+  it('passes the resolved Kimi home into each fetch cycle', async () => {
+    const service = new RateLimitService()
+    const home = {
+      runtime: 'wsl' as const,
+      wslDistro: 'Ubuntu',
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\.kimi-code'
+    }
+    const resolver = vi.fn(() => home)
+    service.setKimiHomeResolver(resolver)
+    mockFreshBackgroundProviderFetches()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 10))
+
+    await service.refresh()
+    await service.refresh()
+
+    // Resolved per cycle so a runtime-policy change takes effect without a restart.
+    expect(resolver).toHaveBeenCalledTimes(2)
+    expect(fetchKimiRateLimits).toHaveBeenCalledWith({ home })
+  })
+
+  it('reads the host Kimi home when no resolver is wired', async () => {
+    const service = new RateLimitService()
+    mockFreshBackgroundProviderFetches()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 10))
+
+    await service.refresh()
+
+    expect(fetchKimiRateLimits).toHaveBeenCalledWith({ home: undefined })
+  })
+
   it('passes the selected WSL Codex home into active account rate-limit fetches', async () => {
     const service = new RateLimitService()
     const wslCodexHome =

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -39,6 +39,7 @@ export type InactiveCodexAccountInfo = {
 }
 
 type CodexHomePathResolver = (target?: CodexAccountSelectionTarget) => string | null
+type KimiHomeResolver = () => Promise<KimiHomeResolution>
 type ClaudeAuthPreparationResolver = (
   target?: ClaudeAccountSelectionTarget
 ) => Promise<ClaudeRuntimeAuthPreparation>
@@ -224,7 +225,7 @@ export class RateLimitService {
     wslDistro: null
   }
   // Why: resolved per cycle — the local-account runtime policy can flip between fetches.
-  private kimiHomeResolver: (() => KimiHomeResolution) | null = null
+  private kimiHomeResolver: KimiHomeResolver | null = null
   private claudeAuthPreparationResolver: ClaudeAuthPreparationResolver | null = null
   private claudeFetchTarget: NormalizedClaudeAccountSelectionTarget = {
     runtime: 'host',
@@ -263,8 +264,17 @@ export class RateLimitService {
     this.codexFetchTarget = normalizeCodexAccountSelectionTarget(target)
   }
 
-  setKimiHomeResolver(resolver: () => KimiHomeResolution): void {
+  setKimiHomeResolver(resolver: KimiHomeResolver): void {
     this.kimiHomeResolver = resolver
+  }
+
+  // Why: resolving a WSL home probes wsl.exe, so it must not run before the other
+  // providers' fetches are started; chaining keeps the no-resolver path immediate.
+  private fetchKimiWithResolvedHome(): Promise<ProviderRateLimits> {
+    const pendingHome = this.kimiHomeResolver?.()
+    return pendingHome
+      ? pendingHome.then((home) => fetchKimiRateLimits({ home }))
+      : fetchKimiRateLimits({ home: undefined })
   }
 
   setClaudeAuthPreparationResolver(resolver: ClaudeAuthPreparationResolver): void {
@@ -1668,7 +1678,7 @@ export class RateLimitService {
           workspaceIdOverride || undefined,
           this.networkProxySettingsResolver?.()
         ),
-        fetchKimiRateLimits({ home: this.kimiHomeResolver?.() }),
+        this.fetchKimiWithResolvedHome(),
         miniMaxConfigResult.error
           ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
           : fetchMiniMaxRateLimits({

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -21,6 +21,7 @@ import {
 } from '../claude-accounts/runtime-selection'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
+import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
@@ -222,6 +223,8 @@ export class RateLimitService {
     runtime: 'host',
     wslDistro: null
   }
+  // Why: resolved per cycle — the local-account runtime policy can flip between fetches.
+  private kimiHomeResolver: (() => KimiHomeResolution) | null = null
   private claudeAuthPreparationResolver: ClaudeAuthPreparationResolver | null = null
   private claudeFetchTarget: NormalizedClaudeAccountSelectionTarget = {
     runtime: 'host',
@@ -258,6 +261,10 @@ export class RateLimitService {
 
   setCodexFetchTarget(target?: CodexAccountSelectionTarget): void {
     this.codexFetchTarget = normalizeCodexAccountSelectionTarget(target)
+  }
+
+  setKimiHomeResolver(resolver: () => KimiHomeResolution): void {
+    this.kimiHomeResolver = resolver
   }
 
   setClaudeAuthPreparationResolver(resolver: ClaudeAuthPreparationResolver): void {
@@ -1661,7 +1668,7 @@ export class RateLimitService {
           workspaceIdOverride || undefined,
           this.networkProxySettingsResolver?.()
         ),
-        fetchKimiRateLimits(),
+        fetchKimiRateLimits({ home: this.kimiHomeResolver?.() }),
         miniMaxConfigResult.error
           ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
           : fetchMiniMaxRateLimits({


### PR DESCRIPTION
## What was broken (ELI5)

If you use Kimi Code on Windows and run it inside WSL (the Linux environment on your PC), Orca's usage meter for Kimi was permanently stuck on "Run Kimi to refresh" — even right after you used Kimi. Orca was looking for your Kimi login in the Windows side of the machine, while the copy that Kimi actually keeps up to date lives on the Linux side. Orca now reads the login from whichever runtime you configured Kimi to run in, so the Kimi usage numbers show up and stay current.

## Root cause

`getKimiHome()` hardcoded the Windows host's resolution and the fetcher took no target at all:

```
src/main/rate-limits/kimi-fetcher.ts:21-29 (at base 29bfc1e22c)
function getKimiHome(): string {
  return process.env.KIMI_CODE_HOME ?? join(homedir(), '.kimi-code')
}
function getCredentialsPath(): string {
  return join(getKimiHome(), 'credentials', 'kimi-code.json')
}
```

`fetchKimiRateLimits()` (`src/main/rate-limits/kimi-fetcher.ts:242`) took no arguments, and the caller `src/main/rate-limits/service.ts:1664` invoked it as a bare `fetchKimiRateLimits()` — in contrast with the adjacent `fetchCodexRateLimits({ codexHomePath, ... })` at `service.ts:1653-1657`, which is fed a WSL-resolved home.

Kimi's CLI rotates its OAuth token roughly every 15 minutes and writes it into the home of whichever runtime it runs in. With `localAccountRuntime: 'wsl'`, the CLI refreshes `\\wsl.localhost\<distro>\home\<user>\.kimi-code\credentials\kimi-code.json` while Orca kept reading the abandoned Windows copy. That copy is always expired, so the fetcher returned `failureKind: 'delegated-refresh-required'`, which maps to the status-bar string at `src/renderer/src/components/status-bar/usage-error-copy.ts:84` → "Run Kimi to refresh". Permanently.

## The fix

- `src/main/kimi/kimi-runtime-home.ts` (new): `getHostKimiHome()` (the CLI's host resolution, now in one place), `getKimiRuntimeTarget(settings, platform)` (wraps `resolveLocalAccountRuntimeTarget` and pins to `host` whenever `platform !== 'win32'`, because that resolver returns `wsl` on any platform when the setting says `wsl` — the same guard `getInitialCodexRateLimitTarget` uses, so SSH/Linux/mac hosts never probe `wsl.exe`), and `resolveKimiHome(target)` (distro from the target or the first installed distro, home from the cached `echo $HOME` probe, joined with win32 semantics because the result is a UNC path). `KIMI_CODE_HOME` stays host-only: it describes the Windows process, not the distro. An unprobeable distro yields `path: null` so Orca never silently falls back to the stale host copy.
- `src/main/rate-limits/kimi-fetcher.ts`: takes the resolved home (defaults to host, so nothing else changes), reads credentials through `createAuthFilesystemOperation` — async, deduped per path, bounded by a 5s `AbortSignal` — so a stopped distro degrades to an error instead of parking Electron's main process on a UNC read. `ENOENT`/`ENOTDIR` keep the old `existsSync` "not signed in" semantics. The expired-session copy now names the runtime ("run kimi inside WSL (Ubuntu)" vs "on the computer running Orca"), since that string is the entire user-visible symptom.
- `src/main/rate-limits/service.ts` + `src/main/index.ts`: `setKimiHomeResolver()`, re-resolved every poll cycle so flipping the local-account runtime policy takes effect on the next poll. Kimi has no per-account switcher (unlike Codex/Claude), so a `kimiFetchTarget` + `account-runtime-target-sync` entry would be dead weight. The resolver is chained rather than awaited up front so resolving a WSL home never delays the other providers' fetches, and it uses the async `wsl.exe` helpers (`listWslDistrosAsync` / `getWslHomeAsync`) rather than the sync ones the Codex path still uses.

Out of scope, deliberately: `src/main/kimi/hook-service.ts:38` and `src/main/ai-vault/session-scanner-kimi-paths.ts:21` duplicate the same host-only `.kimi-code` resolution, and `src/main/rate-limits/grok-auth.ts:5-12` has the identical host-only OAuth-home defect (Grok hits the same `delegated-refresh-required` dead end under WSL). Those mean installing hooks into / scanning sessions from the WSL filesystem — a feature change, not this credential-read bug. `getHostKimiHome()` is exported so they can adopt it when that work happens.

## Reproduction

**A) Code confirms the report at base `29bfc1e22c`** — see the root-cause section: the fetcher had zero WSL awareness (it imported only `node:fs`/`node:os`/`node:path`/`electron`).

**B) Harness repro** (scratch vitest file, created in-repo, run, then deleted; tree verified clean). Real fs + real temp dirs, `node:os.homedir()` mocked to a fake Windows host home, electron `net.fetch` mocked. Host home holds a token expired 3 days ago; a `wsl.localhost/Ubuntu/home/neil` home holds a token fresh for another 13 minutes — what a running WSL Kimi CLI would have just written.

```
$ npx vitest run src/main/rate-limits/kimi-wsl-scratch-repro.test.ts --reporter=verbose --disable-console-intercept
host creds   : /var/folders/.../kimi-wsl-repro-2uIbQz/C_Users_neil/.kimi-code/credentials/kimi-code.json
wsl creds    : /var/folders/.../kimi-wsl-repro-2uIbQz/wsl.localhost/Ubuntu/home/neil/.kimi-code/credentials/kimi-code.json
net.fetch calls: 0
result: {
  "provider": "kimi",
  "session": null,
  "weekly": null,
  "updatedAt": 1785828245660,
  "error": "Kimi session expired — run kimi on the computer running Orca, then retry usage.",
  "status": "error",
  "usageMetadata": {
    "failureKind": "delegated-refresh-required",
    "source": "oauth"
  }
}
 ✓ SCRATCH: kimi fetcher on a Windows host whose Kimi CLI runs in WSL > ignores the fresh WSL-side credentials and reports delegated-refresh-required
 Test Files  1 passed (1)
```

The fresh WSL token is never read and no usage request is even attempted.

**C) Real-host corroboration** on the `win-old` box (Windows 11 + WSL), showing the two homes really do diverge there:

```
PS C:\Users\neil\...> if (Test-Path "$env:USERPROFILE\.kimi-code\credentials\kimi-code.json") { echo HOSTCRED_EXISTS } else { echo HOSTCRED_MISSING }; wsl.exe -l -q
HOSTCRED_MISSING
Ubuntu
```

Kimi Code was not installed inside that distro at the time. It is now — see **E)** below for the live run.

**D) Regression proof** — the new tests fail against the base sources:

```
$ git show 29bfc1e22c:src/main/rate-limits/kimi-fetcher.ts > src/main/rate-limits/kimi-fetcher.ts
$ npx vitest run src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
     × reads the WSL token instead of the stale host one 19ms
     × still reads the host home by default 17ms
     × points an expired WSL session at the distro to rerun kimi in 15ms
     × reports an unresolvable WSL home instead of falling back to host credentials 15ms
     × bounds a stalled UNC read instead of parking the poll cycle 12ms
 Test Files  1 failed (1)
      Tests  5 failed | 1 passed (6)

$ git show 29bfc1e22c:src/main/rate-limits/service.ts > src/main/rate-limits/service.ts
$ npx vitest run src/main/rate-limits/service.test.ts -t 'Kimi home'
     × passes the resolved Kimi home into each fetch cycle 3ms
     × reads the host Kimi home when no resolver is wired 3ms
AssertionError: expected "vi.fn()" to be called with arguments: [ { home: undefined } ]
 Test Files  1 failed (1)
      Tests  2 failed | 73 skipped (75)
```

(Both files restored afterwards; the only passing case in the first run is the host-default control.)

**E) Live end-to-end verification against the real Kimi Code CLI** (added on re-verification, after rebasing onto `2c865cda66`). The real CLI is now installed inside the distro, and the whole path was exercised on a real Windows 11 + WSL2 box with **no fs mocks and no `wsl.exe` mock** — only electron's `net.fetch` is stubbed, so the assertion is about which credential file Orca reads and which token it sends.

```
$ wsl.exe -- bash -c 'npm install -g @moonshot-ai/kimi-code'   # added 6 packages
$ wsl.exe -- bash -c 'kimi --version'
0.34.0
```

First, the CLI's own contract, read out of the shipped bundle (`dist/main.mjs`) rather than assumed:

| What the fetcher assumes | What the shipped CLI does | |
|---|---|---|
| `KIMI_CODE_HOME ?? ~/.kimi-code` | `defaultKimiHome()`: `process.env["KIMI_CODE_HOME"]` else `join(homedir(), ".kimi-code")` | ✅ |
| `<home>/credentials/kimi-code.json` | `credentialsDir = join(homeDir, "credentials")`; `FileTokenStorage.pathFor` → `join(dir, "kimi-code.json")` via `resolveKimiTokenStorageName` (`"oauth/kimi-code"` → `"kimi-code"`) | ✅ |
| `GET https://api.kimi.com/coding/v1/usages` | `managedUsageUrl()` → `` `${baseUrl.replace(/\/+$/,"")}/usages` ``, default base `https://api.kimi.com/coding/v1` | ✅ |
| `expires_at` is Unix **seconds** | token freshness compares `nowAsSeconds() < expiresAt - 30` | ✅ |

Then the live run. The WSL home holds a token valid for another 13 min (what a running WSL CLI would have just written); the Windows host home holds one expired 3 days ago:

```
$ npx vitest run <live harness> --disable-console-intercept
resolved target : {"runtime":"wsl","wslDistro":null}
resolved home   : \\wsl.localhost\Ubuntu\root\.kimi-code     <- from a real wsl.exe probe
probe ms        : 1517
fetch url       : https://api.kimi.com/coding/v1/usages
auth header     : Bearer orca-e2e-probe-token                <- the WSL token, read over real UNC
result          : { "session": { "usedPercent": 65, ... }, "weekly": { "usedPercent": 9, ... },
                    "error": null, "status": "ok" }
 ✓ resolves the WSL home off a real wsl.exe probe and reads the real UNC token

host-only result: { "error": "Kimi session expired — run kimi on the computer running Orca,
                    then retry usage.", "status": "error",
                    "usageMetadata": { "failureKind": "delegated-refresh-required" } }
 ✓ CONTROL: the pre-fix host-only read hits the stale Windows copy and dead-ends
```

The control is the bug as reported: the host-only read finds the abandoned Windows copy, returns `delegated-refresh-required`, and the status bar renders "Run Kimi to refresh" forever. The fixed path resolves the distro home from a real `wsl.exe` probe, reads the real UNC file, and produces live quota windows.

**Cold-distro degradation, measured rather than argued.** With the distro stopped (`wsl.exe --terminate Ubuntu`):

```
resolved home   : null
probe ms        : 5135
```

`execFileUtf8`'s 5s cap fires, `resolveKimiHome` returns `path: null`, and the cycle surfaces "WSL Kimi home unavailable for Ubuntu" instead of blocking — the intended degradation. It self-heals: the probe boots the distro (`wsl -l -v` → `Running` afterwards), and `getWslHomeAsync` caches successes for the process lifetime, so the steady state spawns no further `wsl.exe`. Worst case is one *async* 5s probe per 15-minute poll — the sync helpers this PR deliberately avoids would have parked Electron's main process for that 5s.

The harness was scratch-only and deleted; `git status` is clean and the synthetic credentials were removed from both homes afterwards.

## Relationship to #12372

Credit to **@cengiz-io**, who found, reported (#12370) and fixed (#12372) this. I wrote this fix independently before reading his PR, then cross-referenced. We landed on the same root cause and the same shape (resolve the Kimi home from the local-account runtime target, mirror the Codex pattern, pin to host off Windows, never fall back to the stale host copy) — which is a good sign the diagnosis is right.

**Taken from his PR:** the credentials read itself. His version converts the sync `existsSync` + `readFileSync` to `node:fs/promises` behind `createAuthFilesystemOperation` (per-path dedup, `AbortSignal` bound, per-distro serialization). Mine kept the sync read, which is a real defect: a sync stat/read against `\\wsl.localhost\<distro>` on a stopped distro blocks Electron's main process — i.e. freezes the whole app — every poll cycle. His approach is strictly better and is what this PR ships.

**Kept from mine:**
- The resolution module lives in `src/main/kimi/` and exports `getHostKimiHome()`, so the three other host-only `.kimi-code` resolutions can adopt it later; his puts it under `rate-limits/` where only the fetcher can reach it.
- The fetcher receives the whole `{ runtime, wslDistro, path }` resolution, so the "run kimi inside WSL (Ubuntu)" message comes from the declared target rather than from re-parsing the credentials path as a UNC string.
- The unresolvable-home error lives in the fetcher instead of a second `getMissingWslKimiHomeResult` branch in `service.ts` — same user-visible result, ~16 fewer lines of service state.
- `wslDistro?.trim() || ...` and `KIMI_CODE_HOME?.trim() || ...`, so a blank setting or blank env var falls back instead of resolving to a relative path.

**Beyond both:** the runtime probe is async (`listWslDistrosAsync` / `getWslHomeAsync`). Both PRs originally used `getDefaultWslDistro()` / `getWslHome()`, which shell out to `wsl.exe` with `execFileSync` — up to 5s of blocked main process per poll when the distro is stopped, since only successes are cached. `ENOTDIR` is also treated as "not signed in" alongside `ENOENT`, preserving `existsSync` semantics his version narrowed to `ENOENT` only.

Fixes #12370.

## Testing

Rebased onto `2c865cda66` (the branch was 223 commits behind) and re-verified there, on Windows:

```
$ npx vitest run src/main/kimi/kimi-runtime-home.test.ts src/main/rate-limits/kimi-fetcher.test.ts src/main/rate-limits/kimi-fetcher-wsl-home.test.ts
 Test Files  3 passed (3)
      Tests   26 passed (26)

$ npx vitest run src/main/rate-limits src/main/kimi
 Test Files  3 failed | 30 passed (33)
      Tests  10 failed | 423 passed (433)

$ npx tsc --noEmit -p config/tsconfig.node.json
(clean)

$ npx oxlint src/main/kimi/ src/main/rate-limits/ src/main/index.ts
(no findings)

$ oxlint --config config/oxlint-code-quality-native-plugins.json --deny-warnings <8 changed files>
$ oxlint --type-aware --config config/oxlint-code-quality-type-aware.json --deny-warnings <8 changed files>
(no findings)

$ npm run check:max-lines-ratchet
max-lines ratchet OK — 352 grandfathered suppression(s), no new bypasses.
```

Those 10 failures are **pre-existing on `origin/main` and Windows-only**, not from this PR. Verified by reverting this branch's sources to `origin/main` in the same worktree and re-running: identical 10 failures (7 Claude cases in `service.test.ts`, 2 in `codex-fetcher.test.ts`, 1 in `kimi/hook-service.test.ts`), none of which this PR touches.

Re-verification did find and fix **4 real failures of this PR's own tests** (commit `ae9bd4d`): the host-home assertions hardcoded POSIX separators, so they only passed on a POSIX runner. On Windows `join` emits backslashes, so three `kimi-fetcher.test.ts` cases mismatched and one `kimi-fetcher-wsl-home.test.ts` fixture key never matched the path the fetcher read. Expectations now go through `path.join`, so they assert path *components* on every platform. This is why the green CI on the previous push was not sufficient evidence — the whole PR is about a Windows-only code path, and CI only runs Linux.

`oxfmt --check` reports issues on all 8 files locally, but it does the same on untouched `main` files (`src/main/wsl.ts`, `src/shared/local-account-runtime.ts`) — this checkout has `core.autocrlf=true`, so the working tree is CRLF. A checkout artifact, not a formatting defect; CI's LF checkout passes. `config/scripts/check-changed-code-quality.mjs` can't run here either (`spawnSync pnpm.cmd EINVAL` on Windows Node 24), so the two oxlint quality configs it wraps were run directly instead, as shown above.

New coverage: `kimi-runtime-home.test.ts` (10 — WSL/host target resolution incl. the off-Windows pin, auto policy, UNC home join, `KIMI_CODE_HOME` ignored for WSL, default-distro fallback, unprobeable home, no `wsl.exe` probe off Windows), `kimi-fetcher-wsl-home.test.ts` (6, path-aware fs mock — reads the fresh WSL token while the host copy is 3 days expired, host default unchanged, WSL-specific expired copy, unresolvable WSL home does not fall back to host, missing WSL creds → unavailable, stalled UNC read is bounded), `kimi-fetcher.test.ts` (+3 exact-read-path vectors adapted from #12372), `service.test.ts` (+2 — resolver result forwarded and re-resolved every cycle, host default when no resolver wired).

No visual proof: this bug is not observable in the UI beyond the status-bar string, so the terminal/test evidence above carries the proof.

Known follow-ups (not regressions from this PR): the Grok fetcher has the identical host-only OAuth-home defect, and Kimi's hook install / session scanning still resolve host-only. One more surfaced while reading the shipped CLI in **E)**: when a user overrides `KIMI_CODE_BASE_URL`/`KIMI_CODE_OAUTH_HOST`, the CLI scopes the credential slot to `credentials/kimi-code-env-<sha256:16>.json` (`resolveKimiCodeOAuthKey`) rather than `kimi-code.json`, so Orca reads the wrong file for self-hosted/staging configs. That predates this PR — the filename was already hardcoded on `main` — and it is orthogonal to the WSL home resolution, so it is left alone here.

Made with [Orca](https://github.com/stablyai/orca) 🐋

