### PR TITLE
fix(i18n): localize the status bar Resource Manager tooltip and remote-host count

### DIFF
--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -7,6 +7,13 @@
     "count": 1
   },
   {
+    "filePath": "src/renderer/src/components/sidebar/WorktreeCard.tsx",
+    "kind": "jsx-attribute:label",
+    "text": "sidebar",
+    "dynamic": false,
+    "count": 1
+  },
+  {
     "filePath": "src/renderer/src/components/settings/appearance-search.ts",
     "kind": "object-property:keywords",
     "text": "语言",

--- a/config/scripts/audit-localization-coverage.mjs
+++ b/config/scripts/audit-localization-coverage.mjs
@@ -60,6 +60,14 @@ const USER_VISIBLE_OBJECT_METHODS = new Set([
   'warning'
 ])
 const USER_VISIBLE_OBJECT_NAMES = new Set(['toast'])
+// Why: only comparison operands are code, not copy. Bailing on every non-`+`
+// operator hid whole subtrees behind `cond && <JSX/>` guards and `?? 'fallback'`.
+const COPY_PRESERVING_BINARY_OPERATORS = new Set([
+  ts.SyntaxKind.PlusToken,
+  ts.SyntaxKind.QuestionQuestionToken,
+  ts.SyntaxKind.BarBarToken,
+  ts.SyntaxKind.AmpersandAmpersandToken
+])
 
 function normalizePath(root, filePath) {
   return path.relative(root, filePath).split(path.sep).join('/')
@@ -226,7 +234,7 @@ function isRenderedJsxExpression(node) {
       continue
     }
     if (ts.isBinaryExpression(current)) {
-      if (current.operatorToken.kind !== ts.SyntaxKind.PlusToken) {
+      if (!COPY_PRESERVING_BINARY_OPERATORS.has(current.operatorToken.kind)) {
         return false
       }
       current = current.parent
@@ -318,7 +326,8 @@ function classifyStringNode(node) {
     findAncestor(
       node,
       (ancestor) =>
-        ts.isBinaryExpression(ancestor) && ancestor.operatorToken.kind !== ts.SyntaxKind.PlusToken
+        ts.isBinaryExpression(ancestor) &&
+        !COPY_PRESERVING_BINARY_OPERATORS.has(ancestor.operatorToken.kind)
     )
   ) {
     return undefined

--- a/config/scripts/audit-localization-coverage.test.mjs
+++ b/config/scripts/audit-localization-coverage.test.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { collectLocalizationCandidates } from './audit-localization-coverage.mjs'
+
+const ROOT = process.cwd()
+
+function candidates(fileName, source) {
+  return collectLocalizationCandidates(`${ROOT}/src/renderer/src/${fileName}`, source, ROOT)
+}
+
+describe('localization coverage candidates', () => {
+  it('sees copy guarded by a nullish or logical fallback', () => {
+    const reports = candidates(
+      'Sample.tsx',
+      `export function Sample({ label, connecting }) {
+        return <span>{label ?? (connecting ? 'Connecting…' : 'Idle')}</span>
+      }`
+    )
+
+    expect(reports.map((report) => report.text)).toEqual(['Connecting…', 'Idle'])
+  })
+
+  it('sees copy nested inside a conditional JSX guard', () => {
+    const reports = candidates(
+      'Sample.tsx',
+      `export function Sample({ show }) {
+        return <div>{show && <button aria-label="Retry the sync" />}</div>
+      }`
+    )
+
+    expect(reports.map((report) => report.text)).toEqual(['Retry the sync'])
+  })
+
+  it('ignores literals used as comparison operands', () => {
+    const reports = candidates(
+      'Sample.tsx',
+      `export function Sample({ phase }) {
+        return <span>{phase === 'workspace conflict' ? phase : null}</span>
+      }`
+    )
+
+    expect(reports).toEqual([])
+  })
+})

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -280,7 +280,14 @@ export async function ensureWslCliAvailableForAgentSkillTerminal(
           'auto.components.settings.CliSkillRuntimeSetup.windowsPathUnknown',
           'WSL shell command PATH could not be checked'
         ),
-        { description: status.detail ?? 'Refresh CLI registration status and try again.' }
+        {
+          description:
+            status.detail ??
+            translate(
+              'auto.components.settings.CliSkillRuntimeSetup.refreshCliRegistration',
+              'Refresh CLI registration status and try again.'
+            )
+        }
       )
       return status
     }

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -1185,11 +1185,8 @@ export function ResourceUsageStatusSegment({
         <TooltipContent side="top" sideOffset={6}>
           <div className="space-y-0.5">
             {resourceManagerTooltipLines.map((line, index) => (
-              <div
-                key={`${index}:${line}`}
-                className={line === 'Space scan ready' ? 'text-primary' : ''}
-              >
-                {line}
+              <div key={`${index}:${line.text}`} className={line.emphasized ? 'text-primary' : ''}>
+                {line.text}
               </div>
             ))}
           </div>

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -1184,8 +1184,8 @@ export function ResourceUsageStatusSegment({
         </TooltipTrigger>
         <TooltipContent side="top" sideOffset={6}>
           <div className="space-y-0.5">
-            {resourceManagerTooltipLines.map((line, index) => (
-              <div key={`${index}:${line.text}`} className={line.emphasized ? 'text-primary' : ''}>
+            {resourceManagerTooltipLines.map((line) => (
+              <div key={line.id} className={line.emphasized ? 'text-primary' : ''}>
                 {line.text}
               </div>
             ))}

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -18,6 +18,11 @@ import {
 } from '../../../../shared/execution-host'
 import { isUserManagedRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import { RuntimeHostStatusRow, type RuntimeHostConnectionState } from './RuntimeHostStatusRow'
+import {
+  connectedHostCountLabel,
+  connectingHostsLabel,
+  workspaceSyncProblemLabel
+} from './ssh-status-segment-copy'
 import { SshTargetStatusRow } from './SshTargetStatusRow'
 import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../../shared/remote-runtime-shared-control-types'
 import { connectRuntimeEnvironmentAndRecordStatus } from './runtime-environment-explicit-connect'
@@ -57,10 +62,6 @@ function overallDotColor(
     case 'disconnected':
       return 'bg-muted-foreground/40'
   }
-}
-
-function connectedHostCountLabel(count: number): string {
-  return `${count} ${count === 1 ? 'host' : 'hosts'}`
 }
 
 function sshStatusForOverall(status: SshConnectionStatus): HostStatus {
@@ -286,9 +287,7 @@ export function SshStatusSegment({
     (t) => t.syncStatus?.phase === 'conflict' || t.syncStatus?.phase === 'error'
   )
   const syncProblemLabel = syncProblem
-    ? syncProblem.syncStatus?.phase === 'conflict'
-      ? 'Workspace conflict'
-      : 'Workspace sync error'
+    ? workspaceSyncProblemLabel(syncProblem.syncStatus?.phase)
     : null
   return (
     <DropdownMenu
@@ -340,7 +339,9 @@ export function SshStatusSegment({
                 <span className="text-[11px]">
                   <span className={syncProblem ? 'text-destructive' : 'text-muted-foreground'}>
                     {syncProblemLabel ??
-                      (anyConnecting ? 'Connecting…' : connectedHostCountLabel(connectedHostCount))}
+                      (anyConnecting
+                        ? connectingHostsLabel()
+                        : connectedHostCountLabel(connectedHostCount))}
                   </span>
                 </span>
               )}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -2369,7 +2369,11 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                   className="relative inline-flex size-5 cursor-pointer items-center justify-center rounded border border-border bg-secondary text-secondary-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
                   aria-label={
                     showFloatingWorkspaceAttentionDot
-                      ? `${floatingTerminalActionLabel}, new activity`
+                      ? translate(
+                          'auto.components.status.bar.StatusBar.floatingTerminalNewActivity',
+                          '{{label}}, new activity',
+                          { label: floatingTerminalActionLabel }
+                        )
                       : floatingTerminalActionLabel
                   }
                   onClick={() => {

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
@@ -27,8 +27,12 @@ describe('resource manager terminal copy', () => {
         spaceScanReady: false
       })
     ).toEqual([
-      { text: 'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions', emphasized: false },
-      { text: 'Terminal sessions are grouped by workspace.', emphasized: false }
+      {
+        id: 'summary',
+        text: 'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions',
+        emphasized: false
+      },
+      { id: 'sessions-hint', text: 'Terminal sessions are grouped by workspace.', emphasized: false }
     ])
   })
 
@@ -40,9 +44,13 @@ describe('resource manager terminal copy', () => {
         spaceScanReady: true
       })
     ).toEqual([
-      { text: 'Resource Manager - memory unavailable - 0 terminal sessions', emphasized: false },
-      { text: 'Space scan ready', emphasized: true },
-      { text: 'No terminal sessions yet.', emphasized: false }
+      {
+        id: 'summary',
+        text: 'Resource Manager - memory unavailable - 0 terminal sessions',
+        emphasized: false
+      },
+      { id: 'space-scan', text: 'Space scan ready', emphasized: true },
+      { id: 'sessions-hint', text: 'No terminal sessions yet.', emphasized: false }
     ])
   })
 
@@ -58,6 +66,21 @@ describe('resource manager terminal copy', () => {
     expect(lines.filter((line) => line.emphasized).map((line) => line.text)).toEqual([
       'Space scan ready'
     ])
+  })
+
+  // Why: the tooltip keys rows by id, so a repeated id would silently drop a row.
+  it('gives every tooltip row a unique id to key on', () => {
+    for (const spaceScanReady of [false, true]) {
+      for (const sessionCount of [0, 1, 4]) {
+        const ids = getResourceManagerTooltipLines({
+          memoryLabel: '512 MB',
+          sessionCount,
+          spaceScanReady
+        }).map((line) => line.id)
+
+        expect(new Set(ids).size).toBe(ids.length)
+      }
+    }
   })
 
   it('keeps the trigger label descriptive for screen readers', () => {

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+// Mirrors resource-memory-metric-copy.test.ts: assert the English source copy
+// through the catalog fallback, with placeholders filled the way i18next would.
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, options?: Record<string, unknown>) =>
+    fallback.replace(/\{\{(\w+)\}\}/g, (match, name: string) => String(options?.[name] ?? match))
+}))
+
 import {
   formatTerminalSessionCount,
   getResourceManagerAriaLabel,

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
@@ -27,8 +27,8 @@ describe('resource manager terminal copy', () => {
         spaceScanReady: false
       })
     ).toEqual([
-      'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions',
-      'Terminal sessions are grouped by workspace.'
+      { text: 'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions', emphasized: false },
+      { text: 'Terminal sessions are grouped by workspace.', emphasized: false }
     ])
   })
 
@@ -40,9 +40,23 @@ describe('resource manager terminal copy', () => {
         spaceScanReady: true
       })
     ).toEqual([
-      'Resource Manager - memory unavailable - 0 terminal sessions',
-      'Space scan ready',
-      'No terminal sessions yet.'
+      { text: 'Resource Manager - memory unavailable - 0 terminal sessions', emphasized: false },
+      { text: 'Space scan ready', emphasized: true },
+      { text: 'No terminal sessions yet.', emphasized: false }
+    ])
+  })
+
+  // Why: the tooltip used to tint this row by matching its English text, so any
+  // translated build lost the tint. The flag is what the segment reads now.
+  it('flags the space-scan row instead of leaving callers to match its wording', () => {
+    const lines = getResourceManagerTooltipLines({
+      memoryLabel: '512 MB',
+      sessionCount: 1,
+      spaceScanReady: true
+    })
+
+    expect(lines.filter((line) => line.emphasized).map((line) => line.text)).toEqual([
+      'Space scan ready'
     ])
   })
 

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
@@ -21,11 +21,18 @@ function spaceScanReadyLabel(): string {
   )
 }
 
+/**
+ * `emphasized` marks the space-scan row the tooltip tints. The segment used to
+ * recognize that row by comparing it against the English text, which stops
+ * matching the moment the copy comes from the catalog.
+ */
+export type ResourceManagerTooltipLine = { text: string; emphasized: boolean }
+
 export function getResourceManagerTooltipLines(args: {
   memoryLabel: string
   sessionCount: number
   spaceScanReady: boolean
-}): string[] {
+}): ResourceManagerTooltipLine[] {
   const rawMemoryLabel = args.memoryLabel.trim()
   const memoryLabel =
     rawMemoryLabel === '' || rawMemoryLabel === '-' || rawMemoryLabel === '—'
@@ -36,33 +43,34 @@ export function getResourceManagerTooltipLines(args: {
       : rawMemoryLabel
   // Why: whole lines are single keys — locales reorder the summary and repunctuate
   // its separators, so it can't be concatenated from translated fragments here.
-  const lines = [
-    translate(
-      'auto.components.status.bar.resource.manager.terminal.copy.tooltipSummary',
-      'Resource Manager - {{memory}} - {{sessions}}',
-      { memory: memoryLabel, sessions: formatTerminalSessionCount(args.sessionCount) }
-    )
+  const lines: ResourceManagerTooltipLine[] = [
+    {
+      text: translate(
+        'auto.components.status.bar.resource.manager.terminal.copy.tooltipSummary',
+        'Resource Manager - {{memory}} - {{sessions}}',
+        { memory: memoryLabel, sessions: formatTerminalSessionCount(args.sessionCount) }
+      ),
+      emphasized: false
+    }
   ]
 
   if (args.spaceScanReady) {
-    lines.push(spaceScanReadyLabel())
+    lines.push({ text: spaceScanReadyLabel(), emphasized: true })
   }
 
-  if (args.sessionCount > 0) {
-    lines.push(
-      translate(
-        'auto.components.status.bar.resource.manager.terminal.copy.sessionsGroupedByWorkspace',
-        'Terminal sessions are grouped by workspace.'
-      )
-    )
-  } else {
-    lines.push(
-      translate(
-        'auto.components.status.bar.resource.manager.terminal.copy.noTerminalSessions',
-        'No terminal sessions yet.'
-      )
-    )
-  }
+  lines.push({
+    text:
+      args.sessionCount > 0
+        ? translate(
+            'auto.components.status.bar.resource.manager.terminal.copy.sessionsGroupedByWorkspace',
+            'Terminal sessions are grouped by workspace.'
+          )
+        : translate(
+            'auto.components.status.bar.resource.manager.terminal.copy.noTerminalSessions',
+            'No terminal sessions yet.'
+          ),
+    emphasized: false
+  })
 
   return lines
 }

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
@@ -1,5 +1,24 @@
+import { translate } from '@/i18n/i18n'
+
 export function formatTerminalSessionCount(count: number): string {
-  return `${count} terminal session${count === 1 ? '' : 's'}`
+  return count === 1
+    ? translate(
+        'auto.components.status.bar.resource.manager.terminal.copy.terminalSessionCount_one',
+        '{{count}} terminal session',
+        { count }
+      )
+    : translate(
+        'auto.components.status.bar.resource.manager.terminal.copy.terminalSessionCount_other',
+        '{{count}} terminal sessions',
+        { count }
+      )
+}
+
+function spaceScanReadyLabel(): string {
+  return translate(
+    'auto.components.status.bar.resource.manager.terminal.copy.spaceScanReady',
+    'Space scan ready'
+  )
 }
 
 export function getResourceManagerTooltipLines(args: {
@@ -10,20 +29,39 @@ export function getResourceManagerTooltipLines(args: {
   const rawMemoryLabel = args.memoryLabel.trim()
   const memoryLabel =
     rawMemoryLabel === '' || rawMemoryLabel === '-' || rawMemoryLabel === '—'
-      ? 'memory unavailable'
+      ? translate(
+          'auto.components.status.bar.resource.manager.terminal.copy.memoryUnavailable',
+          'memory unavailable'
+        )
       : rawMemoryLabel
+  // Why: whole lines are single keys — locales reorder the summary and repunctuate
+  // its separators, so it can't be concatenated from translated fragments here.
   const lines = [
-    `Resource Manager - ${memoryLabel} - ${formatTerminalSessionCount(args.sessionCount)}`
+    translate(
+      'auto.components.status.bar.resource.manager.terminal.copy.tooltipSummary',
+      'Resource Manager - {{memory}} - {{sessions}}',
+      { memory: memoryLabel, sessions: formatTerminalSessionCount(args.sessionCount) }
+    )
   ]
 
   if (args.spaceScanReady) {
-    lines.push('Space scan ready')
+    lines.push(spaceScanReadyLabel())
   }
 
   if (args.sessionCount > 0) {
-    lines.push('Terminal sessions are grouped by workspace.')
+    lines.push(
+      translate(
+        'auto.components.status.bar.resource.manager.terminal.copy.sessionsGroupedByWorkspace',
+        'Terminal sessions are grouped by workspace.'
+      )
+    )
   } else {
-    lines.push('No terminal sessions yet.')
+    lines.push(
+      translate(
+        'auto.components.status.bar.resource.manager.terminal.copy.noTerminalSessions',
+        'No terminal sessions yet.'
+      )
+    )
   }
 
   return lines
@@ -33,11 +71,19 @@ export function getResourceManagerAriaLabel(args: {
   sessionCount: number
   spaceScanReady: boolean
 }): string {
-  const parts = ['Resource Manager', formatTerminalSessionCount(args.sessionCount)]
+  const sessions = formatTerminalSessionCount(args.sessionCount)
 
   if (args.spaceScanReady) {
-    parts.push('Space scan ready')
+    return translate(
+      'auto.components.status.bar.resource.manager.terminal.copy.ariaLabelWithSpaceScan',
+      'Resource Manager, {{sessions}}, {{spaceScan}}',
+      { sessions, spaceScan: spaceScanReadyLabel() }
+    )
   }
 
-  return parts.join(', ')
+  return translate(
+    'auto.components.status.bar.resource.manager.terminal.copy.ariaLabel',
+    'Resource Manager, {{sessions}}',
+    { sessions }
+  )
 }

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts
@@ -25,8 +25,16 @@ function spaceScanReadyLabel(): string {
  * `emphasized` marks the space-scan row the tooltip tints. The segment used to
  * recognize that row by comparing it against the English text, which stops
  * matching the moment the copy comes from the catalog.
+ *
+ * `id` names the row's role. Each role appears at most once per tooltip, so it is
+ * a unique React key that survives locale switches and memory/count updates —
+ * unlike the translated text, which locales are free to duplicate across rows.
  */
-export type ResourceManagerTooltipLine = { text: string; emphasized: boolean }
+export type ResourceManagerTooltipLine = {
+  id: 'summary' | 'space-scan' | 'sessions-hint'
+  text: string
+  emphasized: boolean
+}
 
 export function getResourceManagerTooltipLines(args: {
   memoryLabel: string
@@ -45,6 +53,7 @@ export function getResourceManagerTooltipLines(args: {
   // its separators, so it can't be concatenated from translated fragments here.
   const lines: ResourceManagerTooltipLine[] = [
     {
+      id: 'summary',
       text: translate(
         'auto.components.status.bar.resource.manager.terminal.copy.tooltipSummary',
         'Resource Manager - {{memory}} - {{sessions}}',
@@ -55,10 +64,11 @@ export function getResourceManagerTooltipLines(args: {
   ]
 
   if (args.spaceScanReady) {
-    lines.push({ text: spaceScanReadyLabel(), emphasized: true })
+    lines.push({ id: 'space-scan', text: spaceScanReadyLabel(), emphasized: true })
   }
 
   lines.push({
+    id: 'sessions-hint',
     text:
       args.sessionCount > 0
         ? translate(

--- a/src/renderer/src/components/status-bar/ssh-status-segment-copy.test.ts
+++ b/src/renderer/src/components/status-bar/ssh-status-segment-copy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, options?: Record<string, unknown>) =>
+    fallback.replace(/\{\{(\w+)\}\}/g, (match, name: string) => String(options?.[name] ?? match))
+}))
+
+import {
+  connectedHostCountLabel,
+  connectingHostsLabel,
+  workspaceSyncProblemLabel
+} from './ssh-status-segment-copy'
+
+describe('ssh status segment copy', () => {
+  it('keeps the host noun singular for a lone connected host', () => {
+    expect(connectedHostCountLabel(0)).toBe('0 hosts')
+    expect(connectedHostCountLabel(1)).toBe('1 host')
+    expect(connectedHostCountLabel(4)).toBe('4 hosts')
+  })
+
+  it('distinguishes a sync conflict from a sync failure', () => {
+    expect(connectingHostsLabel()).toBe('Connecting…')
+    expect(workspaceSyncProblemLabel('conflict')).toBe('Workspace conflict')
+    expect(workspaceSyncProblemLabel('error')).toBe('Workspace sync error')
+  })
+})

--- a/src/renderer/src/components/status-bar/ssh-status-segment-copy.ts
+++ b/src/renderer/src/components/status-bar/ssh-status-segment-copy.ts
@@ -1,0 +1,31 @@
+import { translate } from '@/i18n/i18n'
+
+export function connectedHostCountLabel(count: number): string {
+  return count === 1
+    ? translate(
+        'auto.components.status.bar.SshStatusSegment.connectedHostCount_one',
+        '{{count}} host',
+        { count }
+      )
+    : translate(
+        'auto.components.status.bar.SshStatusSegment.connectedHostCount_other',
+        '{{count}} hosts',
+        { count }
+      )
+}
+
+export function connectingHostsLabel(): string {
+  return translate('auto.components.status.bar.SshStatusSegment.connecting', 'Connecting…')
+}
+
+export function workspaceSyncProblemLabel(phase: string | undefined): string {
+  return phase === 'conflict'
+    ? translate(
+        'auto.components.status.bar.SshStatusSegment.workspaceConflict',
+        'Workspace conflict'
+      )
+    : translate(
+        'auto.components.status.bar.SshStatusSegment.workspaceSyncError',
+        'Workspace sync error'
+      )
+}

--- a/src/renderer/src/components/status-bar/status-bar-copy-localization.test.tsx
+++ b/src/renderer/src/components/status-bar/status-bar-copy-localization.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+/**
+ * The Resource Manager tooltip and the SSH segment's host count were built from
+ * bare English literals inside helper functions, so they stayed English while
+ * every label around them translated. The coverage audit cannot see values
+ * returned from helpers, so only a runtime assertion against the real catalog
+ * keeps them honest — same reasoning as
+ * `src/renderer/src/i18n/settings-status-label-localization.test.ts`.
+ */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { SshConnectionStatus } from '../../../../shared/ssh-types'
+import { i18n } from '@/i18n/i18n'
+import {
+  formatTerminalSessionCount,
+  getResourceManagerAriaLabel,
+  getResourceManagerTooltipLines
+} from './resource-manager-terminal-copy'
+import { SshStatusSegment } from './SshStatusSegment'
+
+type StoreState = {
+  sshConnectionStates: Map<string, { status: SshConnectionStatus }>
+  sshTargetLabels: Map<string, string>
+  remoteWorkspaceSyncStatusByTargetId: Record<string, { phase: string }>
+}
+
+let storeState: StoreState = {
+  sshConnectionStates: new Map(),
+  sshTargetLabels: new Map(),
+  remoteWorkspaceSyncStatusByTargetId: {}
+}
+
+vi.mock('../../store', () => {
+  const state = (): Record<string, unknown> => ({
+    ...storeState,
+    settings: null,
+    runtimeEnvironments: [],
+    runtimeStatusByEnvironmentId: new Map(),
+    setRuntimeEnvironmentStatus: vi.fn(),
+    hydrateRuntimeEnvironmentStatuses: vi.fn(),
+    setActiveView: vi.fn(),
+    openSettingsTarget: vi.fn(),
+    recordFeatureInteraction: vi.fn(),
+    fetchRuntimeEnvironmentRepos: vi.fn(),
+    fetchWorktrees: vi.fn(),
+    fetchWorktreeLineage: vi.fn()
+  })
+  const useAppStore = (selector: (value: Record<string, unknown>) => unknown): unknown =>
+    selector(state())
+  useAppStore.getState = state
+  return { useAppStore }
+})
+
+function setSshTargets(
+  entries: { id: string; label: string; status: SshConnectionStatus; syncPhase?: string }[]
+): void {
+  storeState = {
+    sshConnectionStates: new Map(entries.map((entry) => [entry.id, { status: entry.status }])),
+    sshTargetLabels: new Map(entries.map((entry) => [entry.id, entry.label])),
+    remoteWorkspaceSyncStatusByTargetId: Object.fromEntries(
+      entries.flatMap((entry) => (entry.syncPhase ? [[entry.id, { phase: entry.syncPhase }]] : []))
+    )
+  }
+}
+
+function triggerText(): string {
+  return screen.getByRole('button').textContent ?? ''
+}
+
+describe('status-bar copy under a non-English UI language', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('ja')
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  afterAll(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('translates both plural forms of the terminal session count', () => {
+    expect(formatTerminalSessionCount(1)).toBe('1 件のターミナルセッション')
+    expect(formatTerminalSessionCount(5)).toBe('5 件のターミナルセッション')
+  })
+
+  it('translates every Resource Manager tooltip line', () => {
+    expect(
+      getResourceManagerTooltipLines({
+        memoryLabel: '512 MB',
+        sessionCount: 2,
+        spaceScanReady: true
+      })
+    ).toEqual([
+      'リソースマネージャー - 512 MB - 2 件のターミナルセッション',
+      '容量スキャンの準備完了',
+      'ターミナルセッションはワークスペースごとにグループ化されます。'
+    ])
+  })
+
+  it('translates the memory-unavailable and empty-session tooltip lines', () => {
+    expect(
+      getResourceManagerTooltipLines({ memoryLabel: '—', sessionCount: 0, spaceScanReady: false })
+    ).toEqual([
+      'リソースマネージャー - メモリ情報を取得できません - 0 件のターミナルセッション',
+      'ターミナルセッションはまだありません。'
+    ])
+  })
+
+  it('translates the Resource Manager trigger label read by screen readers', () => {
+    expect(getResourceManagerAriaLabel({ sessionCount: 1, spaceScanReady: true })).toBe(
+      'リソースマネージャー、1 件のターミナルセッション、容量スキャンの準備完了'
+    )
+    expect(getResourceManagerAriaLabel({ sessionCount: 3, spaceScanReady: false })).toBe(
+      'リソースマネージャー、3 件のターミナルセッション'
+    )
+  })
+
+  it('translates the connected host count next to the translated aria label', () => {
+    setSshTargets([
+      { id: 'ssh-1', label: 'builder', status: 'connected' },
+      { id: 'ssh-2', label: 'openclaw', status: 'connected' }
+    ])
+    render(<SshStatusSegment compact={false} iconOnly={false} />)
+
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('リモートホスト接続状態')
+    expect(triggerText()).toContain('2 台のホスト')
+  })
+
+  it('translates the singular host count', () => {
+    setSshTargets([{ id: 'ssh-1', label: 'builder', status: 'connected' }])
+    render(<SshStatusSegment compact={false} iconOnly={false} />)
+
+    expect(triggerText()).toContain('1 台のホスト')
+  })
+
+  it('translates the connecting and workspace-sync states', () => {
+    setSshTargets([{ id: 'ssh-1', label: 'builder', status: 'connecting' }])
+    render(<SshStatusSegment compact={false} iconOnly={false} />)
+    expect(triggerText()).toContain('接続中…')
+    cleanup()
+
+    setSshTargets([
+      { id: 'ssh-1', label: 'builder', status: 'connected', syncPhase: 'conflict' },
+      { id: 'ssh-2', label: 'openclaw', status: 'connected', syncPhase: 'error' }
+    ])
+    render(<SshStatusSegment compact={false} iconOnly={false} />)
+    expect(triggerText()).toContain('ワークスペースの競合')
+    cleanup()
+
+    setSshTargets([{ id: 'ssh-1', label: 'builder', status: 'connected', syncPhase: 'error' }])
+    render(<SshStatusSegment compact={false} iconOnly={false} />)
+    expect(triggerText()).toContain('ワークスペースの同期エラー')
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-copy-localization.test.tsx
+++ b/src/renderer/src/components/status-bar/status-bar-copy-localization.test.tsx
@@ -94,11 +94,16 @@ describe('status-bar copy under a non-English UI language', () => {
       })
     ).toEqual([
       {
+        id: 'summary',
         text: 'リソースマネージャー - 512 MB - 2 件のターミナルセッション',
         emphasized: false
       },
-      { text: '容量スキャンの準備完了', emphasized: true },
-      { text: 'ターミナルセッションはワークスペースごとにグループ化されます。', emphasized: false }
+      { id: 'space-scan', text: '容量スキャンの準備完了', emphasized: true },
+      {
+        id: 'sessions-hint',
+        text: 'ターミナルセッションはワークスペースごとにグループ化されます。',
+        emphasized: false
+      }
     ])
   })
 
@@ -122,10 +127,11 @@ describe('status-bar copy under a non-English UI language', () => {
       getResourceManagerTooltipLines({ memoryLabel: '—', sessionCount: 0, spaceScanReady: false })
     ).toEqual([
       {
+        id: 'summary',
         text: 'リソースマネージャー - メモリ情報を取得できません - 0 件のターミナルセッション',
         emphasized: false
       },
-      { text: 'ターミナルセッションはまだありません。', emphasized: false }
+      { id: 'sessions-hint', text: 'ターミナルセッションはまだありません。', emphasized: false }
     ])
   })
 

--- a/src/renderer/src/components/status-bar/status-bar-copy-localization.test.tsx
+++ b/src/renderer/src/components/status-bar/status-bar-copy-localization.test.tsx
@@ -93,18 +93,39 @@ describe('status-bar copy under a non-English UI language', () => {
         spaceScanReady: true
       })
     ).toEqual([
-      'リソースマネージャー - 512 MB - 2 件のターミナルセッション',
-      '容量スキャンの準備完了',
-      'ターミナルセッションはワークスペースごとにグループ化されます。'
+      {
+        text: 'リソースマネージャー - 512 MB - 2 件のターミナルセッション',
+        emphasized: false
+      },
+      { text: '容量スキャンの準備完了', emphasized: true },
+      { text: 'ターミナルセッションはワークスペースごとにグループ化されます。', emphasized: false }
     ])
+  })
+
+  // Why: the tint used to be selected by `line === 'Space scan ready'`, so it
+  // silently vanished for every non-English locale once the copy translated.
+  it('keeps the space-scan row flagged when its copy is no longer English', () => {
+    const lines = getResourceManagerTooltipLines({
+      memoryLabel: '512 MB',
+      sessionCount: 2,
+      spaceScanReady: true
+    })
+
+    const emphasized = lines.filter((line) => line.emphasized)
+    expect(emphasized).toHaveLength(1)
+    expect(emphasized[0]?.text).toBe('容量スキャンの準備完了')
+    expect(emphasized[0]?.text).not.toBe('Space scan ready')
   })
 
   it('translates the memory-unavailable and empty-session tooltip lines', () => {
     expect(
       getResourceManagerTooltipLines({ memoryLabel: '—', sessionCount: 0, spaceScanReady: false })
     ).toEqual([
-      'リソースマネージャー - メモリ情報を取得できません - 0 件のターミナルセッション',
-      'ターミナルセッションはまだありません。'
+      {
+        text: 'リソースマネージャー - メモリ情報を取得できません - 0 件のターミナルセッション',
+        emphasized: false
+      },
+      { text: 'ターミナルセッションはまだありません。', emphasized: false }
     ])
   })
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -415,7 +415,8 @@
               "8d6eedf97e": "Failed to register the Orca CLI in PATH.",
               "0f116999f1": "Restart your shell or add the Orca CLI directory to PATH before setup.",
               "15cbedc3e3": "Install the Orca CLI before running agent skill setup.",
-              "windowsPathUnknown": "Orca could not check your Windows user PATH"
+              "windowsPathUnknown": "Orca could not check your Windows user PATH",
+              "refreshCliRegistration": "Refresh CLI registration status and try again."
             }
           }
         }
@@ -631,6 +632,9 @@
             "0b01ff98d2": "Port",
             "7d732521ec": "Comment"
           }
+        },
+        "activation": {
+          "cannotOpenFolderWorkspace": "Cannot open folder workspace"
         }
       },
       "folderWorkspacePathStatus": {
@@ -3262,7 +3266,12 @@
             "runtime_disconnect_failed": "Disconnect failed",
             "runtime_reconnecting": "Reconnecting",
             "runtime_last_close_reason": "Closed: {{value0}}",
-            "runtime_reconnect_attempt": "Attempt {{value0}}"
+            "runtime_reconnect_attempt": "Attempt {{value0}}",
+            "connectedHostCount_one": "{{count}} host",
+            "connectedHostCount_other": "{{count}} hosts",
+            "connecting": "Connecting…",
+            "workspaceConflict": "Workspace conflict",
+            "workspaceSyncError": "Workspace sync error"
           },
           "StatusBar": {
             "9659e38343": "Ports",
@@ -3322,7 +3331,8 @@
             "antigravityUsage": "Antigravity Usage",
             "antigravityUsageDetails": "Open Antigravity usage details",
             "grokUsageAria": "Open Grok usage details",
-            "grokUsageMenu": "Grok Usage"
+            "grokUsageMenu": "Grok Usage",
+            "floatingTerminalNewActivity": "{{label}}, new activity"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3547,6 +3557,21 @@
               "metric": {
                 "workingSetDescription": "Summed working set (WS). Shared pages can appear in more than one process.",
                 "rssDescription": "Summed resident set size (RSS). Shared or aliased pages can appear in more than one process."
+              }
+            },
+            "manager": {
+              "terminal": {
+                "copy": {
+                  "terminalSessionCount_one": "{{count}} terminal session",
+                  "terminalSessionCount_other": "{{count}} terminal sessions",
+                  "memoryUnavailable": "memory unavailable",
+                  "tooltipSummary": "Resource Manager - {{memory}} - {{sessions}}",
+                  "spaceScanReady": "Space scan ready",
+                  "sessionsGroupedByWorkspace": "Terminal sessions are grouped by workspace.",
+                  "noTerminalSessions": "No terminal sessions yet.",
+                  "ariaLabel": "Resource Manager, {{sessions}}",
+                  "ariaLabelWithSpaceScan": "Resource Manager, {{sessions}}, {{spaceScan}}"
+                }
               }
             }
           }
@@ -5792,7 +5817,8 @@
           "f00d6aa9b5": "WSL is not available on this machine.",
           "7c776ff9d8": "wsl",
           "fc0fcf72fd": "Register the WSL shell command before skill setup.",
-          "windowsPathUnknown": "WSL shell command PATH could not be checked"
+          "windowsPathUnknown": "WSL shell command PATH could not be checked",
+          "refreshCliRegistration": "Refresh CLI registration status and try again."
         },
         "CommitMessageAiPane": {
           "841ed9884a": "Used by repositories that have not customized Source Control AI.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -349,7 +349,8 @@
               "8d6eedf97e": "No se pudo registrar Orca CLI en PATH.",
               "0f116999f1": "Reinicia tu shell o agrega el directorio de Orca CLI a PATH antes de la configuración.",
               "15cbedc3e3": "Instala la CLI de Orca antes de configurar skills para agentes.",
-              "windowsPathUnknown": "Orca could not check your Windows user PATH"
+              "windowsPathUnknown": "Orca could not check your Windows user PATH",
+              "refreshCliRegistration": "Actualiza el estado de registro de la CLI e inténtalo de nuevo."
             }
           }
         }
@@ -560,6 +561,9 @@
             "0b01ff98d2": "Puerto",
             "7d732521ec": "Comentario"
           }
+        },
+        "activation": {
+          "cannotOpenFolderWorkspace": "No se puede abrir el espacio de trabajo de carpeta"
         }
       },
       "folderWorkspacePathStatus": {
@@ -3174,7 +3178,12 @@
             "runtime_disconnect_failed": "No se pudo desconectar",
             "runtime_reconnecting": "Reconectando",
             "runtime_last_close_reason": "Cerrado: {{value0}}",
-            "runtime_reconnect_attempt": "Intento {{value0}}"
+            "runtime_reconnect_attempt": "Intento {{value0}}",
+            "connectedHostCount_one": "{{count}} host",
+            "connectedHostCount_other": "{{count}} hosts",
+            "connecting": "Conectando…",
+            "workspaceConflict": "Conflicto del espacio de trabajo",
+            "workspaceSyncError": "Error de sincronización del espacio de trabajo"
           },
           "StatusBar": {
             "9659e38343": "Puertos",
@@ -3234,7 +3243,8 @@
             "antigravityUsage": "Uso de Antigravity",
             "antigravityUsageDetails": "Abrir detalles de uso de Antigravity",
             "grokUsageAria": "Abrir detalles de uso de Grok",
-            "grokUsageMenu": "Uso de Grok"
+            "grokUsageMenu": "Uso de Grok",
+            "floatingTerminalNewActivity": "{{label}}, nueva actividad"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -3443,6 +3453,21 @@
               "metric": {
                 "workingSetDescription": "Suma del conjunto de trabajo (WS). Las páginas compartidas pueden aparecer en más de un proceso.",
                 "rssDescription": "Suma del tamaño del conjunto residente (RSS). Las páginas compartidas o con alias pueden aparecer en más de un proceso."
+              }
+            },
+            "manager": {
+              "terminal": {
+                "copy": {
+                  "terminalSessionCount_one": "{{count}} sesión de terminal",
+                  "terminalSessionCount_other": "{{count}} sesiones de terminal",
+                  "memoryUnavailable": "memoria no disponible",
+                  "tooltipSummary": "Administrador de recursos - {{memory}} - {{sessions}}",
+                  "spaceScanReady": "Escaneo de espacio listo",
+                  "sessionsGroupedByWorkspace": "Las sesiones de terminal se agrupan por espacio de trabajo.",
+                  "noTerminalSessions": "Aún no hay sesiones de terminal.",
+                  "ariaLabel": "Administrador de recursos, {{sessions}}",
+                  "ariaLabelWithSpaceScan": "Administrador de recursos, {{sessions}}, {{spaceScan}}"
+                }
               }
             }
           },
@@ -5624,7 +5649,8 @@
           "f00d6aa9b5": "WSL no está disponible en esta máquina.",
           "7c776ff9d8": "wsl",
           "fc0fcf72fd": "Registra el comando de shell de WSL antes de configurar el skill.",
-          "windowsPathUnknown": "WSL shell command PATH could not be checked"
+          "windowsPathUnknown": "WSL shell command PATH could not be checked",
+          "refreshCliRegistration": "Actualiza el estado de registro de la CLI e inténtalo de nuevo."
         },
         "CommitMessageAiPane": {
           "841ed9884a": "Usado por repositorios que no han personalizado Source Control AI.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -349,7 +349,8 @@
               "8d6eedf97e": "Orca CLI を PATH に登録できませんでした。",
               "0f116999f1": "セットアップ前にシェルを再起動するか、Orca CLI ディレクトリを PATH に追加します。",
               "15cbedc3e3": "agent スキル セットアップを実行する前に、Orca CLI をインストールします。",
-              "windowsPathUnknown": "Orca could not check your Windows user PATH"
+              "windowsPathUnknown": "Orca could not check your Windows user PATH",
+              "refreshCliRegistration": "CLI の登録状態を更新してから、もう一度お試しください。"
             }
           }
         }
@@ -560,6 +561,9 @@
             "0b01ff98d2": "ポート",
             "7d732521ec": "コメント"
           }
+        },
+        "activation": {
+          "cannotOpenFolderWorkspace": "フォルダーワークスペースを開けません"
         }
       },
       "folderWorkspacePathStatus": {
@@ -3174,7 +3178,12 @@
             "runtime_disconnect_failed": "切断に失敗しました",
             "runtime_reconnecting": "再接続中",
             "runtime_last_close_reason": "クローズ: {{value0}}",
-            "runtime_reconnect_attempt": "試行 {{value0}}"
+            "runtime_reconnect_attempt": "試行 {{value0}}",
+            "connectedHostCount_one": "{{count}} 台のホスト",
+            "connectedHostCount_other": "{{count}} 台のホスト",
+            "connecting": "接続中…",
+            "workspaceConflict": "ワークスペースの競合",
+            "workspaceSyncError": "ワークスペースの同期エラー"
           },
           "StatusBar": {
             "9659e38343": "ポート",
@@ -3234,7 +3243,8 @@
             "antigravityUsage": "Antigravity の使用状況",
             "antigravityUsageDetails": "Antigravity の使用状況詳細を開く",
             "grokUsageAria": "Grok の使用状況詳細を開く",
-            "grokUsageMenu": "Grok の使用状況"
+            "grokUsageMenu": "Grok の使用状況",
+            "floatingTerminalNewActivity": "{{label}}、新しいアクティビティ"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -3443,6 +3453,21 @@
               "metric": {
                 "workingSetDescription": "合計ワーキングセット(WS)。共有ページが複数のプロセスに表示されることがあります。",
                 "rssDescription": "合計レジデントセットサイズ(RSS)。共有またはエイリアスされたページが複数のプロセスに表示されることがあります。"
+              }
+            },
+            "manager": {
+              "terminal": {
+                "copy": {
+                  "terminalSessionCount_one": "{{count}} 件のターミナルセッション",
+                  "terminalSessionCount_other": "{{count}} 件のターミナルセッション",
+                  "memoryUnavailable": "メモリ情報を取得できません",
+                  "tooltipSummary": "リソースマネージャー - {{memory}} - {{sessions}}",
+                  "spaceScanReady": "容量スキャンの準備完了",
+                  "sessionsGroupedByWorkspace": "ターミナルセッションはワークスペースごとにグループ化されます。",
+                  "noTerminalSessions": "ターミナルセッションはまだありません。",
+                  "ariaLabel": "リソースマネージャー、{{sessions}}",
+                  "ariaLabelWithSpaceScan": "リソースマネージャー、{{sessions}}、{{spaceScan}}"
+                }
               }
             }
           },
@@ -5609,7 +5634,8 @@
           "f00d6aa9b5": "このマシンでは WSL を利用できません。",
           "7c776ff9d8": "wsl",
           "fc0fcf72fd": "スキルセットアップ前に WSL シェルコマンドを登録してください。",
-          "windowsPathUnknown": "WSL shell command PATH could not be checked"
+          "windowsPathUnknown": "WSL shell command PATH could not be checked",
+          "refreshCliRegistration": "CLI の登録状態を更新してから、もう一度お試しください。"
         },
         "CommitMessageAiPane": {
           "841ed9884a": "ソース管理 AI をカスタマイズしていない repos によって使用されます。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -349,7 +349,8 @@
               "8d6eedf97e": "PATH에 Orca CLI를 등록하지 못했습니다.",
               "0f116999f1": "설정하기 전에 셸을 다시 시작하거나 Orca CLI 디렉터리를 PATH에 추가하세요.",
               "15cbedc3e3": "agent 스킬 설정을 실행하기 전에 Orca CLI를 설치하십시오.",
-              "windowsPathUnknown": "Orca could not check your Windows user PATH"
+              "windowsPathUnknown": "Orca could not check your Windows user PATH",
+              "refreshCliRegistration": "CLI 등록 상태를 새로 고친 후 다시 시도하세요."
             }
           }
         }
@@ -560,6 +561,9 @@
             "0b01ff98d2": "포트",
             "7d732521ec": "댓글"
           }
+        },
+        "activation": {
+          "cannotOpenFolderWorkspace": "폴더 워크스페이스를 열 수 없습니다"
         }
       },
       "folderWorkspacePathStatus": {
@@ -3174,7 +3178,12 @@
             "runtime_disconnect_failed": "연결 해제 실패",
             "runtime_reconnecting": "다시 연결 중",
             "runtime_last_close_reason": "닫힘: {{value0}}",
-            "runtime_reconnect_attempt": "{{value0}}번째 시도"
+            "runtime_reconnect_attempt": "{{value0}}번째 시도",
+            "connectedHostCount_one": "호스트 {{count}}개",
+            "connectedHostCount_other": "호스트 {{count}}개",
+            "connecting": "연결 중…",
+            "workspaceConflict": "워크스페이스 충돌",
+            "workspaceSyncError": "워크스페이스 동기화 오류"
           },
           "StatusBar": {
             "9659e38343": "포트",
@@ -3234,7 +3243,8 @@
             "antigravityUsage": "Antigravity 사용량",
             "antigravityUsageDetails": "Antigravity 사용량 세부 정보 열기",
             "grokUsageAria": "Grok 사용량 세부 정보 열기",
-            "grokUsageMenu": "Grok 사용량"
+            "grokUsageMenu": "Grok 사용량",
+            "floatingTerminalNewActivity": "{{label}}, 새 활동"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -3443,6 +3453,21 @@
               "metric": {
                 "workingSetDescription": "합산된 워킹 세트(WS). 공유 페이지가 둘 이상의 프로세스에 나타날 수 있습니다.",
                 "rssDescription": "합산된 레지던트 세트 크기(RSS). 공유 또는 별칭된 페이지가 둘 이상의 프로세스에 나타날 수 있습니다."
+              }
+            },
+            "manager": {
+              "terminal": {
+                "copy": {
+                  "terminalSessionCount_one": "터미널 세션 {{count}}개",
+                  "terminalSessionCount_other": "터미널 세션 {{count}}개",
+                  "memoryUnavailable": "메모리 정보 없음",
+                  "tooltipSummary": "리소스 관리자 - {{memory}} - {{sessions}}",
+                  "spaceScanReady": "공간 스캔 준비됨",
+                  "sessionsGroupedByWorkspace": "터미널 세션은 워크스페이스별로 그룹화됩니다.",
+                  "noTerminalSessions": "아직 터미널 세션이 없습니다.",
+                  "ariaLabel": "리소스 관리자, {{sessions}}",
+                  "ariaLabelWithSpaceScan": "리소스 관리자, {{sessions}}, {{spaceScan}}"
+                }
               }
             }
           },
@@ -5608,8 +5633,9 @@
           "0c9f3cf9da": "Orca가 글로벌 agent 스킬을 확인하고 설치하는 위치를 선택합니다.",
           "f00d6aa9b5": "이 컴퓨터에서는 WSL을 사용할 수 없습니다.",
           "7c776ff9d8": "wsl",
-          "fc0fcf72fd": "스킬 설정 전 WSL 셸 명령어를 등록하세요.",
-          "windowsPathUnknown": "WSL shell command PATH could not be checked"
+          "fc0fcf72fd": "스킬 설정 전 WSL 쉘 명령어를 등록하세요.",
+          "windowsPathUnknown": "WSL shell command PATH could not be checked",
+          "refreshCliRegistration": "CLI 등록 상태를 새로 고친 후 다시 시도하세요."
         },
         "CommitMessageAiPane": {
           "841ed9884a": "소스 제어 AI를 사용자 정의하지 않은 리포지토리에서 사용됩니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -349,7 +349,8 @@
               "8d6eedf97e": "无法在 PATH 中注册 Orca CLI。",
               "0f116999f1": "在安装之前重新启动 shell 或将 Orca CLI 目录添加到 PATH。",
               "15cbedc3e3": "在运行智能体技能设置之前安装 Orca CLI。",
-              "windowsPathUnknown": "Orca 无法检查您的 Windows 用户 PATH"
+              "windowsPathUnknown": "Orca 无法检查您的 Windows 用户 PATH",
+              "refreshCliRegistration": "请刷新 CLI 注册状态后重试。"
             }
           }
         }
@@ -560,6 +561,9 @@
             "0b01ff98d2": "端口",
             "7d732521ec": "评论"
           }
+        },
+        "activation": {
+          "cannotOpenFolderWorkspace": "无法打开文件夹工作区"
         }
       },
       "folderWorkspacePathStatus": {
@@ -3186,7 +3190,12 @@
             "runtime_disconnect_failed": "断开连接失败",
             "runtime_reconnecting": "重新连接中",
             "runtime_last_close_reason": "已关闭：{{value0}}",
-            "runtime_reconnect_attempt": "第 {{value0}} 次尝试"
+            "runtime_reconnect_attempt": "第 {{value0}} 次尝试",
+            "connectedHostCount_one": "{{count}} 个主机",
+            "connectedHostCount_other": "{{count}} 个主机",
+            "connecting": "正在连接…",
+            "workspaceConflict": "工作区冲突",
+            "workspaceSyncError": "工作区同步错误"
           },
           "StatusBar": {
             "9659e38343": "端口",
@@ -3246,7 +3255,8 @@
             "antigravityUsage": "Antigravity 使用量",
             "antigravityUsageDetails": "打开 Antigravity 使用详情",
             "grokUsageAria": "打开 Grok 使用详情",
-            "grokUsageMenu": "Grok 使用量"
+            "grokUsageMenu": "Grok 使用量",
+            "floatingTerminalNewActivity": "{{label}}，有新活动"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -3455,6 +3465,21 @@
               "metric": {
                 "workingSetDescription": "工作集 (WS) 的总和。共享页可能会出现在多个进程中。",
                 "rssDescription": "驻留集大小 (RSS) 的总和。共享页或别名映射页可能会出现在多个进程中。"
+              }
+            },
+            "manager": {
+              "terminal": {
+                "copy": {
+                  "terminalSessionCount_one": "{{count}} 个终端会话",
+                  "terminalSessionCount_other": "{{count}} 个终端会话",
+                  "memoryUnavailable": "内存信息不可用",
+                  "tooltipSummary": "资源管理器 - {{memory}} - {{sessions}}",
+                  "spaceScanReady": "空间扫描已就绪",
+                  "sessionsGroupedByWorkspace": "终端会话按工作区分组。",
+                  "noTerminalSessions": "暂无终端会话。",
+                  "ariaLabel": "资源管理器，{{sessions}}",
+                  "ariaLabelWithSpaceScan": "资源管理器，{{sessions}}，{{spaceScan}}"
+                }
               }
             }
           },
@@ -5621,7 +5646,8 @@
           "f00d6aa9b5": "WSL 在此计算机上不可用。",
           "7c776ff9d8": "wsl",
           "fc0fcf72fd": "在技​​能设置之前注册 WSL shell 命令。",
-          "windowsPathUnknown": "无法检查 WSL shell 命令 PATH"
+          "windowsPathUnknown": "无法检查 WSL shell 命令 PATH",
+          "refreshCliRegistration": "请刷新 CLI 注册状态后重试。"
         },
         "CommitMessageAiPane": {
           "841ed9884a": "由未自定义源代码控制 AI 的存储库使用。",

--- a/src/renderer/src/lib/agent-skill-cli-prerequisite.ts
+++ b/src/renderer/src/lib/agent-skill-cli-prerequisite.ts
@@ -117,7 +117,14 @@ function showCliPrerequisiteWarning(status: CliInstallStatus): void {
         'auto.lib.agent.skill.cli.prerequisite.windowsPathUnknown',
         'Orca could not check your Windows user PATH'
       ),
-      { description: status.detail ?? 'Refresh CLI registration status and try again.' }
+      {
+        description:
+          status.detail ??
+          translate(
+            'auto.lib.agent.skill.cli.prerequisite.refreshCliRegistration',
+            'Refresh CLI registration status and try again.'
+          )
+      }
     )
     return
   }

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -19,6 +19,7 @@ import { buildSetupRunnerCommand } from './setup-runner'
 import { createSequencedSetupAgentCommands } from '../../../shared/setup-agent-sequencing'
 import { getSetupRunnerCommandPlatformForPath } from '../../../shared/setup-runner-command'
 import { agentKindToTuiAgent } from '../../../shared/agent-kind'
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
@@ -231,7 +232,13 @@ export function activateAndRevealFolderWorkspace(
     { runtimeEnvironmentId }
   )
   if (folderWorkspaceActivationBlocked(pathStatus)) {
-    toast.error(getFolderWorkspacePathStatusTitle(pathStatus) ?? 'Cannot open folder workspace', {
+    const title =
+      getFolderWorkspacePathStatusTitle(pathStatus) ??
+      translate(
+        'auto.lib.worktree.activation.cannotOpenFolderWorkspace',
+        'Cannot open folder workspace'
+      )
+    toast.error(title, {
       description: getFolderWorkspacePathStatusDescription(pathStatus) ?? folderWorkspace.folderPath
     })
     return false


### PR DESCRIPTION
## What was broken (ELI5)

If you set Orca's language to Japanese (or Spanish, Korean, Chinese), most of the app translates — but two bits of the bottom status bar stubbornly stayed in English. Hovering the Resource Manager showed an English tooltip ("Resource Manager - 3.69 GB · Σ RSS - 2 terminal sessions"), and the remote-hosts pill next to it read "2 hosts" even though the label a screen reader announced for the very same button was already Japanese. Now every line of that tooltip and the host count read in your chosen language, and the highlighted "space scan ready" row keeps its highlight in every language instead of only English.

## Root cause

Two independent layers.

**1. The strings.** They were assembled from bare literals inside helper functions rather than looked up in the catalog:

- `src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts:1-2` — `` `${count} terminal session${count === 1 ? '' : 's'}` ``
- `resource-manager-terminal-copy.ts:13,16,20,24,26` — `'memory unavailable'`, the `Resource Manager - … - …` summary, `'Space scan ready'`, `'Terminal sessions are grouped by workspace.'`, `'No terminal sessions yet.'`
- `src/renderer/src/components/status-bar/SshStatusSegment.tsx:65-67` — `` `${count} ${count === 1 ? 'host' : 'hosts'}` ``
- `SshStatusSegment.tsx:346` — the `?? 'Connecting…'` fallback and the adjacent `'Workspace conflict'` / `'Workspace sync error'` ternary

`SshStatusSegment.tsx` already imports `translate` at line 13 and uses it for every *other* label in the same render path, which is exactly the inconsistency the report names. `grep -n "SshStatusSegment" src/renderer/src/i18n/locales/en.json` shows the section at line 3186 has no host-count key, and no `terminal session` / `Space scan ready` key exists anywhere in `en.json`.

**2. Why the gate let it ship.** `classifyStringNode` in `config/scripts/audit-localization-coverage.mjs:311-366` only returns a kind for jsx-attribute / jsx-text / jsx-expression / user-visible-call / object-property, so a literal in a `return` statement classifies as `undefined`. It *also* bails at lines 316-322 on any ancestor binary expression whose operator is not `+` — which hides not just `?? 'Connecting…'` but every string nested under a `cond && <JSX/>` guard. Running the audit's own `collectLocalizationCandidates` over both files returns **0 candidates**, and `node config/scripts/audit-localization-coverage.mjs --check` passed clean on `main`.

**3. A latent bug the fix surfaces** (found by @smwbev, see below). `ResourceUsageStatusSegment.tsx:1193` tinted one tooltip row by comparing it against the English text:

```tsx
className={line === 'Space scan ready' ? 'text-primary' : ''}
```

That comparison stops matching the instant the copy comes from the catalog, so simply routing the string through `translate()` silently drops the highlight in every non-English build.

## The fix

**Strings.** Every literal in the status-bar render path now goes through `translate()`. The Resource Manager copy stays in `resource-manager-terminal-copy.ts`; the SSH labels move into a new `ssh-status-segment-copy.ts`, mirroring the directory's existing `resource-memory-metric-copy.ts` convention. That extraction was also forced: adding `translate()` inline pushed `SshStatusSegment.tsx` from 394 to 415 effective lines, past the 400 `max-lines` cap, and AGENTS.md forbids adding a disable.

The tooltip summary and the aria label are **whole-line keys** (`Resource Manager - {{memory}} - {{sessions}}`, `Resource Manager, {{sessions}}, {{spaceScan}}`) rather than fragments joined with `' - '` / `', '`. Those separators and that word order are sentence structure: ja and zh reorder and repunctuate them (`、` / `，`), which is visible in the screenshots below.

Catalog entries land in all five locales with real translations, reusing terminology already in the catalog (リソースマネージャー / 资源管理器 / Administrador de recursos, 台のホスト / 个主机, 接続中…). Both `_one` and `_other` are supplied per locale on purpose: the *code* picks the suffix, so a ja catalog with only `_other` would render the English `_one` source at `count === 1`.

**The tint.** `getResourceManagerTooltipLines` now returns `{ text, emphasized }[]` and the segment reads the flag, so the highlight no longer depends on the row's wording.

**Gate.** `classifyStringNode` now keeps walking through `??`, `||` and `&&` ancestors — only comparison operands are code — with the same set applied in `isRenderedJsxExpression`. That surfaced exactly 5 new candidates: 4 genuine unlocalized strings, now localized (StatusBar's `', new activity'` aria label, the duplicated `'Refresh CLI registration status and try again.'` toast description in `CliSkillRuntimeSetup` and `agent-skill-cli-prerequisite`, and worktree-activation's `'Cannot open folder workspace'` toast title), and 1 false positive (`label="sidebar"` is a `'sidebar' | 'source-control'` variant discriminator on `DetachedHeadBadge`), which got an allowlist entry.

I deliberately did **not** close the other half of the gate blind spot (classifying strings returned from helpers). I measured it with a probe reusing the audit's own AST walk: **1056 candidates** across the renderer, most real but some noise (Tailwind class strings from `: string` helpers, e.g. `overallDotColor` returning `'bg-emerald-500'`). A 1000-entry allowlist inside a bug fix would be unreviewable and would freeze the backlog in place. Instead I followed the repo's own established remediation for exactly this blind spot — `src/renderer/src/i18n/settings-status-label-localization.test.ts`, whose docblock names the same root cause — and pinned the contract with a runtime test that switches the real i18n instance to Japanese.

## Reproduction

Base commit: `git log --oneline -1` → `29bfc1e22c Fix Windows git/gh attribution wrappers rejecting a piped stdin argument (#12440)`.

A scratch vitest (since deleted) switched the real i18n instance to Japanese, called the real exported copy helpers, and rendered the real `SshStatusSegment` with 2 connected SSH targets:

```
i18n.language = ja
sanity, a real catalog key = リモートホスト
tooltip lines = [
  "Resource Manager - 512 MB - 2 terminal sessions",
  "Space scan ready",
  "Terminal sessions are grouped by workspace."
]
aria = Resource Manager, 1 terminal session, Space scan ready
count(1) = 1 terminal session
count(5) = 5 terminal sessions
 ✓ ... > shows what the Resource Manager copy renders under a Japanese UI 2ms
trigger aria-label = リモートホスト接続状態
trigger text = "2 hosts"
 ✓ ... > shows what the remote host count renders under a Japanese UI 227ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

With the UI in Japanese, the trigger's aria-label renders `リモートホスト接続状態` but its visible text renders the English `2 hosts`, and the whole tooltip stays English.

The gate blind spot, via a probe calling the audit's own `collectLocalizationCandidates`:

```
### src/renderer/src/components/status-bar/resource-manager-terminal-copy.ts -> 0 candidates
### src/renderer/src/components/status-bar/SshStatusSegment.tsx -> 0 candidates
```

and `node config/scripts/audit-localization-coverage.mjs --check` → `Localization coverage check passed with 12 allowlisted candidates.`

**Regression tests fail without the source fix.** Reverting only the source files (`git checkout 29bfc1e22c -- <sources>`, keeping the new tests) gives `Test Files 4 failed (4) / Tests 13 failed | 3 passed (16)`:

```
AssertionError: expected '1 terminal session' to be '1 件のターミナルセッション'
AssertionError: expected '2 hosts' to contain '2 台のホスト'
AssertionError: expected '1 host' to contain '1 台のホスト'
AssertionError: expected 'Connecting…' to contain '接続中…'
AssertionError: expected 'Resource Manager, 1 terminal session,…' to be 'リソースマネージャー、1 件のターミナルセッション、容量スキャンの準備完了'
AssertionError: expected [] to deeply equal [ 'Space scan ready' ]     # emphasized flag
AssertionError: expected [] to have a length of 1 but got +0           # tint under ja
AssertionError: expected [] to deeply equal [ 'Connecting…', 'Idle' ]  # audit: ?? / || fallback
AssertionError: expected [] to deeply equal [ 'Retry the sync' ]       # audit: && JSX guard
```

## Visual proof

Rendered through a scratch Vite harness (deleted before commit) that mounts the **real** exported copy helpers and the real `main.css` tokens with `i18n.changeLanguage('ja')`, inside the real `TooltipContent` surface classes (`bg-foreground … text-background`). Three states, same harness, only the source files swapped by `git checkout`.

**1. Before (`main`, 29bfc1e22c)** — the tooltip, the screen-reader label and the host pill are all English under a Japanese UI. The space-scan row *is* highlighted:

![proof-before.png](https://github.com/user-attachments/assets/6e35bc84-f926-4d5e-b6d7-ca9b40e0844d)

**2. Localizing the strings alone** — copy is Japanese, but the space-scan row has silently lost its highlight, because `line === 'Space scan ready'` no longer matches. This is the regression @smwbev caught:

![proof-intermediate.png](https://github.com/user-attachments/assets/fc20b5b8-423d-494f-aa7a-2bdda7f5dc1e)

**3. After (this PR)** — translated *and* the highlight is back, now driven by the `emphasized` flag. Note the `、` separators in the screen-reader label, which is why the aria label is a whole-line key:

![proof-after.png](https://github.com/user-attachments/assets/add3fffa-f540-41df-b3d8-b869dd3b25c5)

## Relationship to #12439

Full credit to **@smwbev** for finding, reporting and diagnosing this in #12439 — including correctly identifying that `audit-localization-coverage.mjs` cannot see values returned from helper functions, which is why the strings shipped untranslated in the first place. I worked the fix independently before reading their PR, then cross-referenced.

**What I took from #12439:** the `{ text, emphasized }` tooltip-line shape, and the reason for it. My independent fix localized `'Space scan ready'` but left `ResourceUsageStatusSegment.tsx:1193` comparing the row against its English text — a real regression in my version that @smwbev caught and I did not. Their structural fix (return the flag, don't re-derive it from wording) is strictly better than the alternative of exporting the label helper and comparing against `spaceScanReadyLabel()`, because it can't drift. Their unit test for the flag is adopted too, and extended with a ja-locale assertion that the emphasized row's text is *not* `'Space scan ready'`. Commit `6d1fdbc` is co-authored to them.

**What I did differently:**

- **Target locales.** #12439 adds keys to `en.json` only, so at runtime nothing changes for anyone — `translate()` already falls back to the same inline English default. This PR adds real es/ja/ko/zh translations, which is what recent i18n PRs in this repo do (`0d38053945`, `8fc892dd02`, and every locale-touching merge in the last month). Without them the reported symptom is unchanged for the users who hit it.
- **Sibling call sites.** #12439 covers the host count and `Connecting…`. This PR also covers the `'Workspace conflict'` / `'Workspace sync error'` ternary two lines away in the same span, plus the 4 strings the fixed gate surfaced elsewhere.
- **The gate itself.** #12439 documents the blind spot; this PR narrows it (`??` / `||` / `&&` now keep walking) and localizes what that turns up. The helper-return half stays open for the reasons measured above.
- **Sentence structure.** #12439 keeps `parts.join(', ')` for the aria label, which hardcodes English punctuation and ordering; this PR makes it a whole-line key so ja/zh can use `、`.
- **Test strength.** #12439's `status-bar-copy-localization.test.ts` asserts key/value pairs in `en.json`. That doesn't actually catch a helper reverting to a bare literal — the catalog entries would still be there. This PR renders under a real Japanese i18n instance and asserts the Japanese output, which does.

Closes #12439's issue; happy to defer to that PR on anything I got wrong.

## Testing

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/ src/renderer/src/i18n/ config/scripts/
 Test Files  142 passed (142)
      Tests  1028 passed | 5 skipped (1033)

$ npx vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-activation src/renderer/src/lib/agent-skill-cli-prerequisite src/renderer/src/components/settings/CliSkillRuntimeSetup
 Test Files  6 passed (6)
      Tests  86 passed (86)

$ npx tsc --noEmit -p config/tsconfig.tc.web.json     # clean
$ npx tsc --noEmit -p config/tsconfig.node.json       # clean
$ npx oxlint src/renderer/src/components/status-bar/  # clean
$ npx oxfmt --check src/renderer/src/components/status-bar/
All matched files use the correct format.

$ npm run audit:code-quality:native                   # clean
$ npm run check:max-lines-ratchet
max-lines ratchet OK — 352 grandfathered suppression(s), no new bypasses.

$ node config/scripts/audit-localization-coverage.mjs --check
Localization coverage check passed with 13 allowlisted candidates.

$ node config/scripts/verify-localization-catalog.mjs
Verified 11149 localization key references against en.json.
es.json coverage: 11825/12002 translated, 177 missing.
ja.json coverage: 11825/12002 translated, 177 missing.
ko.json coverage: 11825/12002 translated, 177 missing.
zh.json coverage: 11829/12002 translated, 173 missing.

$ node config/scripts/verify-localization-extraction.mjs
Extracted 9901 keys; 29 dynamic defaults are report-only, 2101 existing English
entries are not statically referenced, and 41 inline defaults differ.   # exit 0
```

Cross-platform: this change is UI copy and its lookup path only — no paths, shells, accelerators or platform APIs. `Connecting…` keeps U+2026, already used in the file. The memory label (`3.69 GB · Σ RSS`) is produced upstream by `memoryMetricCopy` and passes through as an interpolation value unchanged. Nothing here assumes a git worktree over a folder workspace, or local execution over SSH.

## Open questions for a maintainer

1. The helper-return half of the audit gap (1056 candidates) is left open on purpose. Worth its own PR plus a filter for `: string` helpers that return Tailwind classes/ids.
2. ja/ko/zh get identical `_one` and `_other` values because those languages don't inflect — required because the *code* picks the suffix. Confirm that matches how the localization team wants plural families filled.
3. `connectedHostCount_*` / `connecting` / `workspaceConflict` / `workspaceSyncError` keep the `auto.components.status.bar.SshStatusSegment.*` prefix even though the helpers now live in `ssh-status-segment-copy.ts`, to avoid catalog churn. Nothing enforces file/key correspondence; say the word if you'd rather have the file-derived prefix.

Made with [Orca](https://github.com/stablyai/orca) 🐋
