### PR TITLE
fix(grok): stop the Windows Grok hook mangling ! in hook fields, and cover the script with tests

### DIFF
--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -267,12 +267,9 @@ describe('GrokHookService', () => {
     expect(script).toContain('/hook/grok')
     if (process.platform === 'win32') {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
-      expect(script).toContain('if not defined GROK_HOME goto :orca_grok_home_ready')
-      expect(script).toContain('%GROK_HOME:~4096,1%')
+      // Why: windows-grok-hook-script.test.ts pins the GROK_HOME guard shape itself,
+      // and does so on every platform rather than only on Windows runners.
       expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
-      expect(script).toContain('%ORCA_GROK_HOME:~4096,1%')
-      expect(script).toContain('if not defined ORCA_GROK_HOME goto :orca_grok_home_ready')
-      expect(script).toContain('if "%ORCA_GROK_HOME:~-1%"=="\\"')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands

--- a/src/main/grok/windows-grok-hook-script.test.ts
+++ b/src/main/grok/windows-grok-hook-script.test.ts
@@ -1,0 +1,224 @@
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildWindowsGrokHookScript } from './windows-grok-hook-script'
+
+/**
+ * Conservative model of cmd's read-then-evaluate order: `%VAR:~n%` is expanded
+ * while the line is read, so a read is only safe once an earlier line has proven
+ * the variable defined. A value we cannot prove non-empty counts as undefined.
+ */
+function findUnguardedSubstringReads(lines: readonly string[]): string[] {
+  const defined = new Set<string>()
+  const unguarded: string[] = []
+
+  for (const line of lines) {
+    for (const [, name] of line.matchAll(/%([A-Za-z_]\w*):~/g)) {
+      if (!defined.has(name)) {
+        unguarded.push(line)
+      }
+    }
+    const guarded = line.match(/^if not defined (\w+) goto :/)
+    if (guarded) {
+      defined.add(guarded[1])
+    }
+    // A value is provably non-empty only if something outside an expansion survives:
+    // `set "V=%OTHER%"` may undefine V, `set "V=%V%."` cannot.
+    for (const [, name, value] of line.matchAll(/set "(\w+)=([^"]*)"/g)) {
+      if (value.replaceAll(/%[^%]*%/g, '') === '') {
+        defined.delete(name)
+      } else {
+        defined.add(name)
+      }
+    }
+  }
+
+  return unguarded
+}
+
+describe('buildWindowsGrokHookScript', () => {
+  // Why (#9358 / #9941): an unguarded `%VAR:~n%` on an undefined variable leaves a
+  // bare `~n` token, which cmd rejects at parse time and aborts the hook with 255.
+  it('never reads a substring expansion unless the variable is defined', () => {
+    const lines = buildWindowsGrokHookScript().split('\r\n')
+
+    expect(lines.filter((line) => line.includes(':~')).length).toBeGreaterThan(0)
+    expect(findUnguardedSubstringReads(lines)).toEqual([])
+  })
+
+  // Why: delayed expansion would eat every `!` in a percent-expanded value on the
+  // curl line, corrupting grokHome/paneKey and dropping worktreeId.
+  it('disables delayed expansion inherited from the caller', () => {
+    const lines = buildWindowsGrokHookScript().split('\r\n')
+
+    expect(lines).toContain('setlocal DisableDelayedExpansion')
+    expect(lines.filter((line) => line.includes('!'))).toEqual([])
+  })
+
+  it('re-checks the envelope after appending the trailing-backslash sentinel', () => {
+    const lines = buildWindowsGrokHookScript().split('\r\n')
+    const appended = lines.indexOf(
+      'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
+    )
+
+    expect(appended).toBeGreaterThan(-1)
+    expect(lines[appended + 1]).toBe('if not "%ORCA_GROK_HOME:~4096,1%"=="" set "ORCA_GROK_HOME="')
+  })
+})
+
+// Why: the failure mode is cmd's own parser, so only a real cmd.exe run proves it.
+describe.skipIf(process.platform !== 'win32')('buildWindowsGrokHookScript (win32)', () => {
+  const dirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  function writeScript(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-grok-hook-'))
+    dirs.push(dir)
+    const scriptPath = join(dir, 'grok-hook.cmd')
+    writeFileSync(scriptPath, buildWindowsGrokHookScript())
+    return scriptPath
+  }
+
+  type HookRun = {
+    status: number | null
+    stderr: string
+    grokHome: string | null
+    paneKey: string | null
+    worktreeId: string | null
+  }
+
+  const PANE_KEY = 'tab!1:pane!2'
+  const WORKTREE_ID = 'repo::C:/Users/test/wip!fix'
+
+  /**
+   * Why: `spawnSync` would hold the event loop for the child's whole lifetime, so
+   * the listener below could never answer curl and every field would read back null.
+   */
+  function runHook(
+    grokHome: string | undefined,
+    options: { delayedExpansion?: boolean } = {}
+  ): Promise<HookRun> {
+    return new Promise((resolve, reject) => {
+      let posted: URLSearchParams | undefined
+      const server = createServer((req, res) => {
+        let body = ''
+        req.on('data', (chunk: Buffer) => {
+          body += chunk.toString()
+        })
+        req.on('end', () => {
+          posted = new URLSearchParams(body)
+          res.writeHead(200).end()
+        })
+      })
+      server.on('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address()
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          ORCA_AGENT_HOOK_PORT: String(typeof address === 'object' && address ? address.port : 0),
+          ORCA_AGENT_HOOK_TOKEN: 'test-token',
+          ORCA_PANE_KEY: PANE_KEY,
+          ORCA_WORKTREE_ID: WORKTREE_ID
+        }
+        delete env.ORCA_AGENT_HOOK_ENDPOINT
+        delete env.GROK_HOME
+        if (grokHome !== undefined) {
+          env.GROK_HOME = grokHome
+        }
+
+        const flags = options.delayedExpansion ? ['/d', '/v:on', '/c'] : ['/d', '/c']
+        const child = spawn('cmd.exe', [...flags, writeScript()], { env })
+        let stderr = ''
+        child.stderr.on('data', (chunk: Buffer) => {
+          stderr += chunk.toString()
+        })
+        child.on('error', reject)
+        child.stdin.end('{"session_id":"s"}')
+        child.on('close', (status) => {
+          server.close(() =>
+            resolve({
+              status,
+              stderr,
+              grokHome: posted?.get('grokHome') ?? null,
+              paneKey: posted?.get('paneKey') ?? null,
+              worktreeId: posted?.get('worktreeId') ?? null
+            })
+          )
+        })
+      })
+    })
+  }
+
+  it('exits 0 and posts an empty grokHome when GROK_HOME is unset', async () => {
+    const result = await runHook(undefined)
+
+    expect(result.stderr).not.toContain('syntax')
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('')
+  })
+
+  it('exits 0 and posts an empty grokHome when GROK_HOME is empty', async () => {
+    const result = await runHook('')
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('')
+  })
+
+  it('posts a normal GROK_HOME unchanged', async () => {
+    const result = await runHook('C:\\Users\\test\\.grok')
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('C:\\Users\\test\\.grok')
+  })
+
+  // Why: an unescaped trailing backslash would escape curl's closing argv quote and
+  // swallow the payload option that follows it.
+  it('neutralizes a trailing backslash in GROK_HOME', async () => {
+    const result = await runHook('C:\\Users\\test\\.grok\\')
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('C:\\Users\\test\\.grok\\.')
+  })
+
+  it('drops a GROK_HOME past the envelope limit', async () => {
+    const result = await runHook(`C:\\${'a'.repeat(4094)}`)
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('')
+  })
+
+  // Why: the sentinel pushes a 4096-char value to 4097, which the listener rejects
+  // outright — drop it here instead of posting a value that cannot be read back.
+  it('drops a GROK_HOME the trailing-backslash sentinel would push past the limit', async () => {
+    const result = await runHook(`C:\\${'a'.repeat(4092)}\\`)
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('')
+  })
+
+  it('preserves an exclamation mark in GROK_HOME', async () => {
+    const result = await runHook('C:\\Users\\test\\a!b!c')
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('C:\\Users\\test\\a!b!c')
+  })
+
+  // Why: a caller with delayed expansion on would otherwise consume `!` in every
+  // posted field, not just grokHome.
+  it('preserves exclamation marks when the caller enables delayed expansion', async () => {
+    const result = await runHook('C:\\Users\\test\\a!b!c', { delayedExpansion: true })
+
+    expect(result.status).toBe(0)
+    expect(result.grokHome).toBe('C:\\Users\\test\\a!b!c')
+    expect(result.paneKey).toBe(PANE_KEY)
+    expect(result.worktreeId).toBe(WORKTREE_ID)
+  })
+})

--- a/src/main/grok/windows-grok-hook-script.ts
+++ b/src/main/grok/windows-grok-hook-script.ts
@@ -25,7 +25,11 @@ const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok', 
 export function buildWindowsGrokHookScript(): string {
   return [
     '@echo off',
-    'setlocal',
+    // Why: a bare `setlocal` inherits delayed expansion from the caller (`cmd /v:on`
+    // or the Command Processor registry default), and every `!` in a percent-expanded
+    // value on the curl line is then eaten as a delayed reference — silently mangling
+    // paneKey and dropping worktreeId. `!` is legal in a Windows path.
+    'setlocal DisableDelayedExpansion',
     'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
     ...buildWindowsHookEnvironmentGuardLines(),
     'set "ORCA_GROK_HOME="',


### PR DESCRIPTION
## What changed since this PR was opened

The 255 crash this PR was written to fix **landed on `main` independently** as #11782 (`fix(windows): make managed grok-hook.cmd safe when GROK_HOME is unset`), which added `src/main/grok/windows-grok-hook-script.ts` using the same `goto`-past-the-substring-line technique proposed here.

Rather than land a duplicate module, this PR was rebased onto that implementation and narrowed to what `main` still gets wrong, plus the test coverage `main` never had.

## The remaining bug: a bare `setlocal` inherits delayed expansion

`main`'s script opens with a bare `setlocal`, which **inherits** the caller's delayed-expansion state (`cmd /v:on`, or the `HKCU\Software\Microsoft\Command Processor\DelayedExpansion` default). When it's on, every `!` in a percent-expanded value on the curl line is consumed as a delayed variable reference.

`!` is legal in a Windows directory name, so this silently corrupts real payloads. Measured on a Windows 11 host against a live HTTP listener, running `main`'s generated `grok-hook.cmd` with `GROK_HOME=C:\Users\a!b!c`, `ORCA_PANE_KEY=tab!1:pane!2`, `ORCA_WORKTREE_ID=repo::C:/wip!fix`:

| caller | grokHome | paneKey | worktreeId |
| --- | --- | --- | --- |
| `cmd /d /c` | `C:\Users\a!b!c` | `tab!1:pane!2` | `repo::C:/wip!fix` |
| `cmd /d /v:on /c` | **dropped** | **`tabpane:C:/wipfix`** | **`null`** |
| `/v:on`, after this PR | `C:\Users\a!b!c` | `tab!1:pane!2` | `repo::C:/wip!fix` |

A mangled `paneKey` misattributes the status event to the wrong pane; a dropped `worktreeId` loses it entirely. `setlocal DisableDelayedExpansion` pins the state off regardless of the caller — one word, no other behavior change.

Notably this is the same failure mode that made the delayed-expansion approach in #12326 unattractive; `main` is exposed to it through inheritance rather than through an explicit `EnableDelayedExpansion`.

## Test coverage

`main` has no test file for `windows-grok-hook-script.ts` — only `toContain` assertions inside `hook-service.test.ts` behind `if (process.platform === 'win32')`, which never execute on the Linux test runners. So the 255 regression itself is currently unguarded in CI.

Adds `src/main/grok/windows-grok-hook-script.test.ts`:

- **Structural (runs on every platform, so CI actually covers it).** `findUnguardedSubstringReads` walks the script with a conservative model of cmd's read-then-evaluate order and asserts no `%VAR:~n%` is read before an earlier line proved the variable defined. This is the invariant behind the 255 bug, checked generically rather than pinned to an exact line list. Plus: delayed expansion is disabled and no `!` appears; the envelope is re-checked after the trailing-backslash sentinel.
- **Behavioral (8 real `cmd.exe` runs against a live listener, win32-gated).** unset / empty / normal / trailing backslash / over-envelope / 4096-char-plus-sentinel / `!` / `!` under an inherited `/v:on`.

The duplicated win32-only `toContain` assertions in `hook-service.test.ts` are trimmed to the two that check the seam between the two modules; the guard shape is now pinned by the dedicated file on all platforms.

The behavioral helper uses async `spawn`, not `spawnSync`: `spawnSync` holds the event loop for the child's entire lifetime, so the in-process listener can never answer curl and every field reads back `null`. The earlier revision of this PR used `spawnSync` and all 6 of its behavioral tests failed when actually run on Windows.

## Verification

Run on a real Windows 11 host (not simulated).

```
$ npx vitest run src/main/grok
 Test Files  3 passed (3)
      Tests  23 passed (23)

$ npx tsc --noEmit -p config/tsconfig.node.json --composite false
TSC_EXIT=0

$ npx oxlint --config .oxlintrc.json src/main/grok src/main/agent-hooks --deny-warnings
LINT_EXIT=0
```

Each new test was mutation-checked to confirm it fails without the corresponding source behavior:

| mutation | tests that caught it |
| --- | --- |
| `setlocal DisableDelayedExpansion` → `setlocal` | `disables delayed expansion inherited from the caller`, `preserves exclamation marks when the caller enables delayed expansion` |
| drop `if not defined GROK_HOME goto` (the original 255 bug) | `never reads a substring expansion unless the variable is defined`, `exits 0 … when GROK_HOME is unset`, `… when GROK_HOME is empty` |
| drop the post-sentinel envelope re-check | `re-checks the envelope after appending the trailing-backslash sentinel`, `drops a GROK_HOME the trailing-backslash sentinel would push past the limit` |

Every mutation is caught by both a cross-platform structural test and a real-`cmd.exe` test, so the 255 regression is now covered on Linux CI runners too.

## Scope

POSIX branch untouched — it already handles unset via `[ -n "${GROK_HOME:-}" ]`, so SSH/remote installs are unaffected. No wire-format change: the same fields are posted, with values that are now byte-exact rather than occasionally mangled.

## Review notes

Credit to **@CountClaw** (#12326) for the original diagnosis of the 255 crash.

CodeRabbit raised three findings on the earlier revision of this PR; all three were reproduced on the Windows host and are resolved here — the `spawnSync` event-loop block (tests rewritten with `spawn`), the inherited delayed expansion (`DisableDelayedExpansion`), and the post-sentinel envelope re-check (already present in `main`'s implementation, now pinned by a test).

Made with [Orca](https://github.com/stablyai/orca) 🐋
