### PR TITLE
fix(relay): make fenceAndCloseNow stop the liveness safety net

### DIFF
--- a/src/main/runtime/relay/desktop-relay-service.test.ts
+++ b/src/main/runtime/relay/desktop-relay-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { MobilePairingConnectionContext } from '../runtime-rpc'
 import { DesktopRelayService, pairingAuthorizationForContext } from './desktop-relay-service'
 
@@ -58,6 +58,47 @@ describe('pairingAuthorizationForContext', () => {
         relayHostId
       )
     ).toThrow('stale_relay_connection')
+  })
+})
+
+describe('liveness safety net lifecycle', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('fences hard: the tick stops on fence and re-arms on the next auth mutation', () => {
+    // Why: a tick surviving the pre-sign-out fence could catch the window
+    // before the profile wipe and briefly resurrect a broker.
+    vi.useFakeTimers()
+    const coordinator = {
+      reconcile: vi.fn(),
+      ensureLive: vi.fn(),
+      fenceAndCloseNow: vi.fn(),
+      stop: vi.fn()
+    }
+    const service = Object.create(DesktopRelayService.prototype) as DesktopRelayService
+    Object.assign(service, {
+      coordinator,
+      demandLedger: { nextPendingExpiry: () => null },
+      stopped: false,
+      livenessTimer: null,
+      demandExpiryTimer: null
+    })
+
+    service.start()
+    vi.advanceTimersByTime(5 * 60_000)
+    expect(coordinator.ensureLive).toHaveBeenCalledTimes(1)
+
+    service.fenceAndCloseNow()
+    expect(coordinator.fenceAndCloseNow).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(30 * 60_000)
+    expect(coordinator.ensureLive).toHaveBeenCalledTimes(1)
+
+    service.authMutated()
+    vi.advanceTimersByTime(5 * 60_000)
+    expect(coordinator.ensureLive).toHaveBeenCalledTimes(2)
+
+    service.stop()
+    vi.advanceTimersByTime(30 * 60_000)
+    expect(coordinator.ensureLive).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -96,9 +96,6 @@ export class DesktopRelayService {
 
   start(): void {
     this.refreshDemand()
-    if (!this.livenessTimer) {
-      this.livenessTimer = setInterval(() => this.ensureLive(), RELAY_LIVENESS_INTERVAL_MS)
-    }
   }
 
   // Safe to call from any wake signal (power resume, network change).
@@ -113,6 +110,13 @@ export class DesktopRelayService {
   }
 
   fenceAndCloseNow(): void {
+    // Why: a fence must be hard — a surviving liveness tick could catch the
+    // window between the pre-sign-out fence and the profile wipe and briefly
+    // resurrect a broker. The next auth mutation re-arms via refreshDemand.
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer)
+      this.livenessTimer = null
+    }
     this.coordinator.fenceAndCloseNow()
   }
 
@@ -306,6 +310,9 @@ export class DesktopRelayService {
   private refreshDemand(): void {
     if (this.stopped) {
       return
+    }
+    if (!this.livenessTimer) {
+      this.livenessTimer = setInterval(() => this.ensureLive(), RELAY_LIVENESS_INTERVAL_MS)
     }
     if (this.demandExpiryTimer) {
       clearTimeout(this.demandExpiryTimer)


### PR DESCRIPTION
Follow-up to #12432, found during release review of its cherry-pick onto v1.4.168-rc.3 (credit: the release agent).

`fenceAndCloseNow()` didn't clear the 5-minute liveness interval — only `stop()` did — so after a sign-out fence the safety net kept ticking. Mostly benign (each tick's reconcile re-reads the auth context and bails on `!context || !relayEntitled`), but a tick landing in the window **between the pre-sign-out fence and the profile wipe** could briefly resurrect a broker, making the fence soft instead of hard.

Fix: the fence clears the interval; `refreshDemand()` (start, auth mutation, demand change) re-arms it, so a subsequent sign-in restores the safety net. `stop()` behavior unchanged.

Test: red-before/green-after lifecycle test — tick fires while started, goes silent after fence (30 simulated minutes), resumes after `authMutated()`, silent after `stop()`. Verified failing against the pre-fix service.

Not needed for the v1.4.168 promotion — this hardens `main`; the RC cherry-pick of #12432 stands as reviewed.