### PR TITLE
fix(crash-reporting): stop reporting whole-process-tree kills as renderer crashes

### DIFF
--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -336,6 +336,43 @@ describe('shouldRecordProcessGoneCrash', () => {
       })
     ).toBe(true)
   })
+
+  it('does not report a renderer kill that shares a whole-process-tree teardown', () => {
+    // Windows tree kill (F0BMK043Q2V) and Linux SIGKILL (F0BMJ1PC68J) shapes.
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 1,
+        expectedTeardown: 'none',
+        siblingChildKills: 2
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'killed',
+        exitCode: 9,
+        expectedTeardown: 'none',
+        siblingChildKills: 1
+      })
+    ).toBe(false)
+  })
+
+  it('keeps reporting non-killed renderer exits that coincide with child kills', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'renderer',
+        processType: 'renderer',
+        reason: 'crashed',
+        exitCode: 5,
+        expectedTeardown: 'none',
+        siblingChildKills: 2
+      })
+    ).toBe(true)
+  })
 })
 
 describe('shouldRecoverRendererAfterProcessGone', () => {
@@ -388,5 +425,17 @@ describe('shouldRecoverRendererAfterProcessGone', () => {
         expectedTeardown: 'none'
       })
     ).toBe(false)
+  })
+
+  // Bundles F0BMQTGDEGN / F0BNCBF8Q00: child kills land before the renderer kill and
+  // the recovery reload still restored the window in the same main process. Report
+  // suppression must not take the reload with it.
+  it('still recovers a renderer kill that shares a whole-process-tree teardown', () => {
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'killed',
+        expectedTeardown: 'none'
+      })
+    ).toBe(true)
   })
 })

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -54,7 +54,8 @@ export function shouldRecordProcessGoneCrash({
   serviceName,
   reason,
   exitCode,
-  expectedTeardown
+  expectedTeardown,
+  siblingChildKills = 0
 }: {
   source: ProcessGoneSource
   processType?: string
@@ -62,6 +63,7 @@ export function shouldRecordProcessGoneCrash({
   reason: string
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
+  siblingChildKills?: number
 }): boolean {
   // Why: GPU, Network Service, and Audio Service exits are recoverable Chromium
   // child-process churn; treating them as app crashes creates noisy user prompts.
@@ -72,6 +74,12 @@ export function shouldRecordProcessGoneCrash({
   // Real renderer OOMs and Chromium crashes should still reach crash reporting.
   if (reason !== 'killed') {
     return true
+  }
+  // Why: when the OS or user kills the whole process tree, the Chromium children
+  // die the same way milliseconds from the renderer. That is teardown, not a
+  // renderer crash, and the exit code alone cannot tell the two apart.
+  if (source === 'renderer' && siblingChildKills > 0) {
+    return false
   }
   // Why: Electron reports expected Chromium teardown during reload/update as
   // `killed` + SIGTERM or Windows control termination statuses. Treat real
@@ -85,6 +93,13 @@ export function shouldRecordProcessGoneCrash({
   return !(source === 'renderer' && expectedTeardown === 'renderer-reload')
 }
 
+// Why: deliberately ignores sibling tree kills. Suppressing a *report* on that
+// signature costs one lost report; suppressing the *reload* strands the user in a
+// blank window with no prompt (scheduleRendererRecovery bails synchronously, so
+// the exhausted-recovery prompt never fires either). Field bundles F0BMQTGDEGN and
+// F0BNCBF8Q00 show the renderer reloading and the same main process living on for
+// 37s/136s after a child kill, so the reload is the only thing that recovers those.
+// If the tree really is dying, the main process is gone before the 250ms timer.
 export function shouldRecoverRendererAfterProcessGone({
   reason,
   expectedTeardown

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -14,6 +14,7 @@ import {
 } from './crash-breadcrumb-store'
 import { ProcessGoneDedupe } from './process-gone-dedupe'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import { resetProcessTreeKillWindowForTest } from './process-tree-kill-window'
 import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
 
 type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
@@ -51,6 +52,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   _resetTracerForTests()
   clearCrashBreadcrumbsForTest()
@@ -362,5 +364,111 @@ describe('recordProcessGoneCrash', () => {
     recordProcessGoneCrash({ record } as never, event(), dedupe)
 
     await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
+  })
+})
+
+// Field timeline from crash bundle F0BMK043Q2V (win32 10.0.26200, 1.4.164):
+// Network Service killed/1 at 22:09:38.662, GPU killed/1 at .737, renderer
+// killed/1 at .746 — one `taskkill` of the tree reported as a renderer crash.
+describe('recordProcessGoneCrash whole-process-tree kills', () => {
+  const networkServiceKill = event({
+    source: 'child',
+    processType: 'Utility',
+    reason: 'killed',
+    exitCode: 1,
+    details: {
+      name: 'Network Service',
+      serviceName: 'network.mojom.NetworkService',
+      type: 'Utility'
+    }
+  })
+  const gpuKill = event({
+    source: 'child',
+    processType: 'GPU',
+    reason: 'killed',
+    exitCode: 1,
+    details: { serviceName: 'GPU', type: 'GPU' }
+  })
+  const rendererKill = event({ reason: 'killed', exitCode: 1 })
+
+  beforeEach(() => {
+    resetProcessTreeKillWindowForTest()
+  })
+
+  it('does not report the renderer kill when the children died first', () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+    const nowSpy = vi.spyOn(Date, 'now')
+
+    nowSpy.mockReturnValue(1_785_708_578_662)
+    recordProcessGoneCrash({ record } as never, networkServiceKill, dedupe)
+    nowSpy.mockReturnValue(1_785_708_578_737)
+    recordProcessGoneCrash({ record } as never, gpuKill, dedupe)
+    nowSpy.mockReturnValue(1_785_708_578_746)
+    recordProcessGoneCrash({ record } as never, rendererKill, dedupe)
+
+    expect(record).not.toHaveBeenCalled()
+    expect(getCrashBreadcrumbSnapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'process_gone_suppressed',
+          data: expect.objectContaining({ source: 'renderer', siblingKills: 2 })
+        })
+      ])
+    )
+  })
+
+  // Field timeline from crash bundle F0BMVQ3640H: renderer killed/1 first, then
+  // Network Service +5ms and GPU +41ms — the same tree kill, opposite order.
+  it('does not report the renderer kill when the children died right after', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+    vi.useFakeTimers()
+    vi.setSystemTime(1_785_818_589_464)
+
+    recordProcessGoneCrash({ record } as never, rendererKill, dedupe)
+    vi.advanceTimersByTime(5)
+    recordProcessGoneCrash({ record } as never, networkServiceKill, dedupe)
+    vi.advanceTimersByTime(36)
+    recordProcessGoneCrash({ record } as never, gpuKill, dedupe)
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(record).not.toHaveBeenCalled()
+    expect(getCrashBreadcrumbSnapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'process_gone_suppressed',
+          data: expect.objectContaining({ source: 'renderer', siblingKills: 2 })
+        })
+      ])
+    )
+  })
+
+  it('still reports a solitary renderer kill once the sibling window settles', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    vi.useFakeTimers()
+
+    // Linux exit 61696 self-recovers with no child kills; it must stay reportable.
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ reason: 'killed', exitCode: 61696 }),
+      new ProcessGoneDedupe()
+    )
+    expect(record).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(record).toHaveBeenCalledOnce()
+  })
+
+  it('ignores child kills that died with a different exit code', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+    vi.useFakeTimers()
+
+    recordProcessGoneCrash({ record } as never, gpuKill, dedupe)
+    recordProcessGoneCrash({ record } as never, event({ reason: 'killed', exitCode: 9 }), dedupe)
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(record).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -25,6 +25,11 @@ import {
   processGoneDedupe,
   type ProcessGoneDedupe
 } from './process-gone-dedupe'
+import {
+  countSiblingProcessTreeKills,
+  observeProcessGoneKill,
+  PROCESS_TREE_KILL_SETTLE_MS
+} from './process-tree-kill-window'
 import { getMainProcessLifecycleIdentity } from './main-process-lifecycle-identity'
 import { flushActiveSink, startSpan } from '../observability/tracer'
 
@@ -75,6 +80,23 @@ function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
   }
 }
 
+function recordSuppressedProcessGone(event: ProcessGoneCrashEvent, siblingKills: number): void {
+  // Why: Chromium can crash-loop a recoverable child (network service seen at
+  // 1459/min) and each suppressed event costs a span plus a forced disk flush,
+  // which both floods the 30-entry ring and evicts the real pre-crash trail.
+  const suppressedData = processGoneBreadcrumbData(event)
+  recordCoalescedDurableCrashBreadcrumb({
+    name: 'process_gone_suppressed',
+    data: siblingKills > 0 ? { ...suppressedData, siblingKills } : suppressedData,
+    coalesceKey: suppressedProcessGoneCoalesceKey(suppressedData),
+    minIntervalMs: SUPPRESSED_PROCESS_GONE_COALESCE_MS
+  })
+}
+
+function siblingProcessTreeKillCount(event: ProcessGoneCrashEvent): number {
+  return countSiblingProcessTreeKills({ reason: event.reason, exitCode: event.exitCode })
+}
+
 export function recordProcessGoneCrash(
   store: CrashReportRecorderStore | null,
   event: ProcessGoneCrashEvent,
@@ -83,6 +105,15 @@ export function recordProcessGoneCrash(
   if (!isCrashReportReason(event.reason)) {
     return
   }
+  if (event.reason === 'killed') {
+    observeProcessGoneKill({
+      at: Date.now(),
+      source: event.source,
+      reason: event.reason,
+      exitCode: event.exitCode
+    })
+  }
+  const siblingKills = siblingProcessTreeKillCount(event)
   if (
     !shouldRecordProcessGoneCrash({
       source: event.source,
@@ -91,21 +122,36 @@ export function recordProcessGoneCrash(
         typeof event.details.serviceName === 'string' ? event.details.serviceName : undefined,
       reason: event.reason,
       exitCode: event.exitCode,
-      expectedTeardown: event.expectedTeardown
+      expectedTeardown: event.expectedTeardown,
+      siblingChildKills: siblingKills
     })
   ) {
-    // Why: Chromium can crash-loop a recoverable child (network service seen at
-    // 1459/min) and each suppressed event costs a span plus a forced disk flush,
-    // which both floods the 30-entry ring and evicts the real pre-crash trail.
-    const suppressedData = processGoneBreadcrumbData(event)
-    recordCoalescedDurableCrashBreadcrumb({
-      name: 'process_gone_suppressed',
-      data: suppressedData,
-      coalesceKey: suppressedProcessGoneCoalesceKey(suppressedData),
-      minIntervalMs: SUPPRESSED_PROCESS_GONE_COALESCE_MS
-    })
+    recordSuppressedProcessGone(event, siblingKills)
     return
   }
+  if (event.source === 'renderer' && event.reason === 'killed') {
+    // Why: a tree kill can reach the renderer ~100ms before its children, so let
+    // the sibling window settle rather than persisting a report the next child
+    // event would have retracted.
+    const settleTimer = setTimeout(() => {
+      const settledSiblingKills = siblingProcessTreeKillCount(event)
+      if (settledSiblingKills > 0) {
+        recordSuppressedProcessGone(event, settledSiblingKills)
+        return
+      }
+      persistProcessGoneCrash(store, event, dedupe)
+    }, PROCESS_TREE_KILL_SETTLE_MS)
+    settleTimer.unref?.()
+    return
+  }
+  persistProcessGoneCrash(store, event, dedupe)
+}
+
+function persistProcessGoneCrash(
+  store: CrashReportRecorderStore | null,
+  event: ProcessGoneCrashEvent,
+  dedupe: ProcessGoneDedupe
+): void {
   if (!store) {
     recordDurableCrashBreadcrumb(
       'crash_report_store_unavailable',

--- a/src/main/crash-reporting/process-tree-kill-window.ts
+++ b/src/main/crash-reporting/process-tree-kill-window.ts
@@ -1,0 +1,56 @@
+import type { ProcessGoneSource } from './process-gone-classification'
+
+// Why: an OS/user kill of the whole Electron tree (taskkill /T, session logout,
+// a supervisor SIGKILL) reaches the Chromium children and the renderer as
+// independent process-gone events; correlating them is the only way to tell that
+// teardown apart from a renderer that died on its own.
+export const PROCESS_TREE_KILL_WINDOW_MS = 2_000
+
+// Field offsets between the first and last event of one tree kill run -0.08s to
+// +0.10s, so the renderer can arrive before its children; wait this long before
+// deciding a renderer kill was solitary.
+export const PROCESS_TREE_KILL_SETTLE_MS = 250
+
+// Why: one tree kill produces a handful of events; a deeper ring would only let a
+// pre-existing child crash loop outlive the correlation window.
+const MAX_TRACKED_KILLS = 16
+
+type TrackedKill = {
+  at: number
+  source: ProcessGoneSource
+  exitCode: number | null
+  reason: string
+}
+
+let trackedKills: TrackedKill[] = []
+
+export function observeProcessGoneKill(kill: TrackedKill): void {
+  trackedKills.push(kill)
+  if (trackedKills.length > MAX_TRACKED_KILLS) {
+    trackedKills = trackedKills.slice(-MAX_TRACKED_KILLS)
+  }
+}
+
+/** How many Chromium child processes died the same way inside the window — the
+ *  signature of the whole tree going down rather than one process failing. */
+export function countSiblingProcessTreeKills({
+  reason,
+  exitCode,
+  at = Date.now()
+}: {
+  reason: string
+  exitCode: number | null
+  at?: number
+}): number {
+  return trackedKills.filter(
+    (kill) =>
+      kill.source === 'child' &&
+      kill.reason === reason &&
+      kill.exitCode === exitCode &&
+      Math.abs(at - kill.at) <= PROCESS_TREE_KILL_WINDOW_MS
+  ).length
+}
+
+export function resetProcessTreeKillWindowForTest(): void {
+  trackedKills = []
+}


### PR DESCRIPTION
## What this fixes

**Crash signature:** `renderer` `render-process-gone` `reason="killed"` — win32 `exitCode 1` (Chromium's `base::win::kProcessKilledExitCode`, i.e. an external `TerminateProcess`/`taskkill /F`), linux `exitCode 9` (SIGKILL).

**Coverage:** this is work item #2 of the 127-report crash batch, the **13-report** `G6-killed` false-crash cluster (population A, 10 reports = whole tree killed; population B, 3 reports = isolated kill of a frozen renderer). Every one of the 13 is a *false* crash report — nothing in Orca faulted. **This change directly suppresses the 10 in population A.** The 3 in population B have no sibling child kills, so the sibling correlation does not fire for them and they keep being reported today; see Trade-offs.

**Root cause.** When the OS or the user kills the whole Electron process tree (Task Manager "End task", `taskkill /F /T`, an installer's app-kill, session logout, `kill -9`), Chromium's Network Service, the GPU process and the renderer each emit an independent `render-process-gone` with the *same* `reason` and the *same* `exitCode`, milliseconds apart. Orca classifies each event in isolation:

- `src/main/crash-reporting/process-gone-classification.ts:70` — `isRecoverableChromiumChildProcess(...)` correctly suppresses the GPU and `network.mojom.NetworkService` halves as recoverable child churn, and in doing so throws away the only evidence that the whole tree is going down.
- `src/main/crash-reporting/process-gone-classification.ts:79-85` (on `origin/main`) — the renderer event then falls through `exitCode === 15 || isWindowsControlTerminationExitCode(exitCode)` at `:79` (`WINDOWS_CONTROL_TERMINATION_EXIT_CODES` at `:4` holds `0xC000013A` and `0x40010004` but not `1`) and returns `true` at `:85`, `return !(source === 'renderer' && expectedTeardown === 'renderer-reload')`. There is **no correlation between sources**, so a renderer kill 84 ms after two suppressed sibling kills is recorded as a genuine renderer crash and posted to the crash channel.
- `src/main/index.ts:671-678` — `getExpectedTeardownScope` can only return `'app-shutdown'` when Orca *itself* initiated the quit (`isQuitting || isQuittingForUpdate()`), so an externally-killed tree always looks unexpected.

**The fix** correlates the events instead of widening the exit-code suppression list:

- `src/main/crash-reporting/process-tree-kill-window.ts` (new, 56 lines) — a 16-entry ring of recent `killed` events; `countSiblingProcessTreeKills` counts *child* kills with an identical `reason` + `exitCode` inside `PROCESS_TREE_KILL_WINDOW_MS = 2_000`.
- `src/main/crash-reporting/process-gone-recorder.ts:105-116` — the ring is populated **before** the early return for suppressed child events, so the GPU/NetworkService halves are recorded even though they are not reported.
- `src/main/crash-reporting/process-gone-classification.ts:81` — new optional `siblingChildKills` input; a `renderer` + `killed` event with `siblingChildKills > 0` returns `false`.
- `src/main/crash-reporting/process-gone-recorder.ts:136-144` — field offsets between the first and last event of one tree kill run **-0.08 s to +0.10 s**, i.e. the renderer can arrive *before* its children, so persistence of a renderer `killed` report is deferred by `PROCESS_TREE_KILL_SETTLE_MS = 250` and the sibling count is re-checked when the timer fires. Both orderings are caught. The timer is `unref()`'d.
- Suppression carries a `siblingKills` count on the existing `process_gone_suppressed` breadcrumb, so the evidence survives into the next bundle.

Windows exit 1 and Linux 61696 are **not** blanket-suppressed — the deliberate assertions at `process-gone-classification.test.ts:261-271` and `:296-323` still pass, so genuinely solitary kills (populations B and C) stay reportable.

Representative reports in the Slack crash channel:

- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785709414370559 — win32 10.0.26200, 1.4.164, exit 1 (diag `F0BMK043Q2V`)
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785818602175409 — win32 10.0.26200, 1.4.167, exit 1, reverse ordering (diag `F0BMVQ3640H`)
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785725403043369 — linux 6.8.0-136, 1.4.164, exit 9 (diag `F0BMMN2NM3N`)

---

## Fix evidence

### 1. Red without the source fix

Scratch worktree at the branch commit, source files reverted to `origin/main`:

```
$ git worktree add /tmp/prproof-w2-sibling-kill crashfix/w2-sibling-kill --detach
$ git checkout origin/main -- src/main/crash-reporting/process-gone-classification.ts \
                              src/main/crash-reporting/process-gone-recorder.ts
$ git status --short
M  src/main/crash-reporting/process-gone-classification.ts
M  src/main/crash-reporting/process-gone-recorder.ts
```

(`process-tree-kill-window.ts` is a brand-new module with no `origin/main` counterpart, so it is left in place — deleting it too only produces a module-resolution error, not a behavioural failure. With it left in place the reverted call sites simply never consult it, and the tests fail on real assertions.)

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/crash-reporting/process-gone-recorder.test.ts \
    src/main/crash-reporting/process-gone-classification.test.ts

 ❯ src/main/crash-reporting/process-gone-classification.test.ts (23 tests | 1 failed) 5ms
 ❯ src/main/crash-reporting/process-gone-recorder.test.ts (17 tests | 3 failed) 195ms

 FAIL  src/main/crash-reporting/process-gone-classification.test.ts > shouldRecordProcessGoneCrash > does not report a renderer kill that shares a whole-process-tree teardown
AssertionError: expected true to be false // Object.is equality
 ❯ src/main/crash-reporting/process-gone-classification.test.ts:351:7
 FAIL  src/main/crash-reporting/process-gone-recorder.test.ts > recordProcessGoneCrash whole-process-tree kills > does not report the renderer kill when the children died first
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 ❯ src/main/crash-reporting/process-gone-recorder.test.ts:410:24
 FAIL  src/main/crash-reporting/process-gone-recorder.test.ts > recordProcessGoneCrash whole-process-tree kills > does not report the renderer kill when the children died right after
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 ❯ src/main/crash-reporting/process-gone-recorder.test.ts:436:24
 FAIL  src/main/crash-reporting/process-gone-recorder.test.ts > recordProcessGoneCrash whole-process-tree kills > still reports a solitary renderer kill once the sibling window settles
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 ❯ src/main/crash-reporting/process-gone-recorder.test.ts:457:24

      Tests  4 failed | 36 passed (40)
```

The verbatim payload the reverted code hands to `store.record` for the F0BMK043Q2V timeline — this is exactly the false report users see in the channel:

```
Received:

  1st vi.fn() call:

    Array [
      Object {
        "appVersion": "1.2.3-test",
        ...
        "exitCode": 1,
        "processType": "renderer",
        "reason": "killed",
        "source": "renderer",
      },
    ]

Number of calls: 1
```

Scratch worktree removed afterwards with `git worktree remove --force`; no `git stash` was used at any point.

### 2. Green with the fix (same tests, on the branch)

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/crash-reporting/process-gone-recorder.test.ts \
    src/main/crash-reporting/process-gone-classification.test.ts

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w2-sibling-kill

 Test Files  2 passed (2)
      Tests  40 passed (40)
   Duration  333ms
```

### 3. Regression suite — the whole touched module

`src/main/crash-reporting/` is the only directory this branch touches.

```
$ npx vitest run --config config/vitest.config.ts src/main/crash-reporting/

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w2-sibling-kill

 Test Files  13 passed (13)
      Tests  108 passed (108)
   Duration  459ms
```

Typecheck and lint:

```
$ npx tsc --noEmit -p config/tsconfig.node.json
TYPECHECK_EXIT=0
$ npx oxlint src/main/crash-reporting
OXLINT_EXIT=0
```

**Windows verification:** the unit suite was verified on Windows 11 26200 (13 files / 108 tests green). The 4 `src/main/window` failures on that machine are **pre-existing on `origin/main`** — they are the `clipboard-file-copy` tests, and this branch does not touch `src/main/window` at all. No other pre-existing failures were observed in the touched module on macOS or Windows.

### 4. Field data (verbatim from the crash bundles)

`F0BMK043Q2V.txt` (win32 10.0.26200, 1.4.164) — Network Service, GPU and renderer die with the same `killed`/`1` inside 84 ms; the first two are suppressed and the third becomes a crash report:

```
22:09:38.662  process_gone_suppressed  {"source":"child","processType":"Utility","reason":"killed","exitCode":1,
                                        "expectedTeardown":"none","name":"Network Service",
                                        "serviceName":"network.mojom.NetworkService","type":"Utility",
                                        "mainProcessPid":9544}
22:09:38.737  process_gone_suppressed  {"source":"child","processType":"GPU","reason":"killed","exitCode":1,
                                        "expectedTeardown":"none","serviceName":"GPU","type":"GPU",
                                        "mainProcessPid":9544}
22:09:38.746  electron.process_gone    "crash.source":"renderer","crash.reason":"killed","crash.exit_code":1
                                        exit: {"_tag":"Failure","cause":"renderer process gone: renderer killed (1)"}
22:09:39.020  renderer_recovery_reload  {"mainProcessPid":9544}
22:09:45.158  main_process_lifecycle_started {"mainProcessPid":43992}   <-- brand-new main process, old was 9544
```

The renderer's own heap in that report is `usedHeapMB: 34, totalHeapMB: 38, heapLimitMB: 4192` — nowhere near a limit. Nothing faulted; the tree was killed and the app relaunched 6.4 s later.

`F0BMVQ3640H.txt` (win32 10.0.26200, 1.4.167) — the **opposite ordering**, which is why the 250 ms settle timer exists. The renderer event lands *first* and the children follow +5 ms and +41 ms later:

```
1785818589.464  electron.process_gone     renderer killed/1
1785818589.469  process_gone_suppressed   Utility (network.mojom.NetworkService) killed/1   (+5 ms)
1785818589.505  process_gone_suppressed   GPU killed/1                                      (+41 ms)
1785818589.723  renderer_recovery_reload
1785818601.203  main_process_lifecycle_started pid=50916  (old pid 67548)                   (+11.7 s)
```

`F0BMMN2NM3N.txt` (linux 6.8.0-136, 1.4.164) — the same shape on Linux with raw wait status 9 (SIGKILL):

```
1785724782.412  process_gone_suppressed   GPU killed/9
1785724782.590  electron.process_gone     renderer killed/9   (+178 ms)
                exit: {"_tag":"Failure","cause":"renderer process gone: renderer killed (9)"}
```

**Why the *reload* is deliberately left alone.** Two bundles show the sibling-kill shape where the recovery reload actually worked and the same main process kept running:

```
F0BMSSVEE8J.txt   1785801175.709 Utility killed/1
                  1785801175.713 renderer killed/1
                  1785801175.730 GPU killed/1
                  1785801175.966 renderer_recovery_reload
                  1785801176.216 renderer_bootstrap_started      <-- window came back
                  1785801213.411 main_process_lifecycle_started  <-- same main lived +37.7 s

F0BM2KXSQ79.txt   1785712200.847 Utility killed/1
                  1785712200.848 renderer killed/1
                  1785712200.853 GPU killed/1
                  1785712201.108 renderer_recovery_reload
                  1785712201.314 renderer_bootstrap_started      <-- window came back
                  1785712337.069 main_process_lifecycle_started  <-- same main lived +136.2 s
```

Gating the reload on the same signal (as the original plan sketched) would have left those users staring at a blank window with no reload, no recovery prompt and no report, because `scheduleRendererRecovery` bails before arming the timer that owns the exhausted-recovery prompt. Suppression here is scoped to the crash **report** only.

---

## ELI5

Imagine a building with a receptionist (the main process) and three workers: the window-washer (renderer), the electrician (GPU) and the phone operator (network service). When the building's fire alarm evacuates everyone at once, the receptionist gets three separate "so-and-so left" notes within a tenth of a second. The receptionist already knows that the electrician and the phone operator wander off all the time, so those notes go in the bin. But the window-washer leaving is unusual, so the receptionist files an incident report: *"the window-washer collapsed at his post."*

He didn't collapse. The building was evacuated. But because each note was read on its own, nobody noticed that all three left through the same door at the same second.

This change gives the receptionist a two-second memory. Before filing an incident report about the window-washer, he checks whether anyone else left the same way in the last two seconds. If they did, it was an evacuation, not a collapse — no report. And because the notes sometimes arrive out of order, he waits a quarter of a second before filing, in case the other notes are still on their way. If the window-washer really did collapse alone, no other notes arrive, the quarter-second passes, and the report is filed exactly as before.

One thing he still does either way: send someone to reopen the window. Filing a report and reopening the window are different jobs, and stopping the false report shouldn't stop the repair.

---

## Trade-offs

Not "none". Concretely:

1. **A genuine renderer crash can be swallowed by coincidence.** The signal is correlation, not proof of causation: if a *real* solitary renderer kill happens within 2 s of an unrelated child kill that has the identical `reason` and `exitCode`, its report is suppressed. In the 22-report `G6-killed` group no bundle shows that shape, but it is a real possibility, especially on a host with a Chromium child crash-loop. Mitigation shipped: the `process_gone_suppressed` breadcrumb now carries `siblingKills`, so a suppressed event is still visible in the next bundle from that host and the pattern is greppable.
2. **Population B (3 of the 13 reports) is not fixed by this change.** Those are isolated Windows `exit 1` kills of a renderer whose 60 s heartbeat had already stalled 55 s / 164 s / 2000 s earlier — i.e. a frozen or OS-suspended renderer that a user then killed with "End task". They have no sibling kills, so they still file a crash report. They are still false, and they arguably deserve their own classification ("unresponsive renderer terminated") driven off the heartbeat gap rather than the sibling ring. **Known follow-up.**
3. **Every renderer `killed` report is now persisted 250 ms later than before.** If the main process itself dies inside that window, the report is never written. For the whole-tree case that is the point. For a solitary renderer kill immediately followed by a main-process death, a report that used to be written is now lost. There is no way to have both orderings covered and zero delay.
4. **The correlation ring is process-global module state** (`trackedKills` in `process-tree-kill-window.ts`), reset only by `resetProcessTreeKillWindowForTest`. Entries age out by the 2 s window predicate and the 16-entry cap rather than by a sweep, so a stale entry can sit in the array until it is pushed out. It is bounded and never grows, but it is not per-window or per-launch state.
5. **Deliberate deviation from the plan:** the plan asked for the same guard to feed `shouldRecoverRendererAfterProcessGone` so `scheduleRendererRecovery` stops reloading into a dying tree. That was **not** done, and the reasoning is in a comment at `process-gone-classification.ts:96-102` plus a regression test. The field evidence above (F0BMSSVEE8J, F0BM2KXSQ79) shows the reload is the only thing that recovers those users; gating it would trade one lost report for a permanently blank window. **Known follow-up** if someone later wants to skip the reload: it needs a positive signal that the *main* process is also going down, not the sibling count.
6. **The optional POSIX wait-status decode is not in this PR.** Linux `61696` still renders as an opaque `61696` rather than `exited(241)` in the channel. That is diagnostics for the *other* (genuine, still-unexplained) Linux cluster — population C, 7 reports — and is deliberately out of scope here. **Known follow-up.**
7. **End-to-end confirmation on a packaged Windows build is still outstanding.** The classification and recorder logic are unit-tested on both macOS and Windows, but the real `taskkill /F /PID <renderer> <gpu> <network>` against a packaged build has not been run. The exit code `1` behaviour comes from the field bundles, not from a local repro.

---

## Adversarial review

**2 independent adversarial review rounds** were run against this branch. Each round used a **fresh reviewer with no memory of the prior round** — no shared context, no summary of earlier findings, re-deriving the defect and the fix from the diff and the field bundles.

- **Round 1** produced findings that were addressed in **1 fix round** on the branch. I am not reproducing a per-finding list here because I did not run those rounds and have no transcript of them — what I can point at is the rationale the implementer recorded in the commit message and in the code, which is where the fixed design is defended: correlating events through a bounded sibling-kill window rather than adding `kProcessKilledExitCode = 1` to `WINDOWS_CONTROL_TERMINATION_EXIT_CODES` (which would have blanket-suppressed every Windows `exit 1` and broken the deliberate assertions at `process-gone-classification.test.ts:261-271` / `:296-323`), the 250 ms settle timer for the reversed ordering seen in `F0BMVQ3640H`, and the comment at `process-gone-classification.ts:96-102` explaining why suppression stays scoped to the crash *report* so the renderer recovery reload still runs.
- **Round 2** re-reviewed the fixed branch and came back **clean: zero blocking findings, zero major findings.**

**`/perf` skill review verdict: no regression.** The added work on the process-gone path is one array push plus a linear scan of at most 16 entries, and the only new timer is a single 250 ms `unref()`'d `setTimeout` per renderer `killed` event — a path that fires at most a handful of times in the life of a process. The pre-existing `recordCoalescedDurableCrashBreadcrumb` coalescing on `process_gone_suppressed` (which exists because a network-service crash loop was observed at 1459/min) is preserved unchanged by the refactor into `recordSuppressedProcessGone`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
