### PR TITLE
fix(activity): bound the portal readiness loop with a decaying flip window (React #185)

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -57,6 +57,7 @@ import {
 } from './activity-portal-thread-reconciliation'
 import {
   createActivityPortalReadinessLatch,
+  type ActivityPortalReadinessLatch,
   type ActivityPortalReadinessStatus
 } from './activity-portal-readiness-oscillation'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
@@ -300,6 +301,12 @@ export function useActivityTerminalPortalStatus(
     paneKey: null,
     status: 'loading'
   })
+  // Why: the swap effect churns target and paneKey, so a latch owned by this effect would restart
+  // its flip budget on every oscillation step; only the tab id is stable across that churn.
+  const readinessLatchRef = useRef<{ tabId: string | null; latch: ActivityPortalReadinessLatch }>({
+    tabId: null,
+    latch: createActivityPortalReadinessLatch()
+  })
 
   useLayoutEffect(() => {
     let disposed = false
@@ -347,7 +354,11 @@ export function useActivityTerminalPortalStatus(
       return disposeFrame
     }
 
-    const readinessLatch = createActivityPortalReadinessLatch()
+    const tabId = parsePaneKey(paneKey)?.tabId ?? null
+    if (readinessLatchRef.current.tabId !== tabId) {
+      readinessLatchRef.current = { tabId, latch: createActivityPortalReadinessLatch() }
+    }
+    const readinessLatch = readinessLatchRef.current.latch
 
     const updateReadiness = (status: ActivityTerminalPortalReadiness['status']): void => {
       scheduleReadiness(readinessLatch.next(status))

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -301,12 +301,11 @@ export function useActivityTerminalPortalStatus(
     paneKey: null,
     status: 'loading'
   })
-  // Why: the swap effect churns target and paneKey, so a latch owned by this effect would restart
-  // its flip budget on every oscillation step; only the tab id is stable across that churn.
-  const readinessLatchRef = useRef<{ tabId: string | null; latch: ActivityPortalReadinessLatch }>({
-    tabId: null,
-    latch: createActivityPortalReadinessLatch()
-  })
+  // Why a ref, not an effect-local latch: a slot swap rewrites target, pane key and tab id together,
+  // so a latch scoped to the subscription restarts its budget on the very churn it must bound. The
+  // budget only counts flips arriving in a burst too fast to click, so hopping between threads by
+  // hand cannot spend it and leave a later, healthy pane latched.
+  const readinessLatchRef = useRef<ActivityPortalReadinessLatch | null>(null)
 
   useLayoutEffect(() => {
     let disposed = false
@@ -354,11 +353,7 @@ export function useActivityTerminalPortalStatus(
       return disposeFrame
     }
 
-    const tabId = parsePaneKey(paneKey)?.tabId ?? null
-    if (readinessLatchRef.current.tabId !== tabId) {
-      readinessLatchRef.current = { tabId, latch: createActivityPortalReadinessLatch() }
-    }
-    const readinessLatch = readinessLatchRef.current.latch
+    const readinessLatch = (readinessLatchRef.current ??= createActivityPortalReadinessLatch())
 
     const updateReadiness = (status: ActivityTerminalPortalReadiness['status']): void => {
       scheduleReadiness(readinessLatch.next(status))
@@ -1600,6 +1595,9 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     visibleThread
   ])
 
+  // Why no swap budget here: `swap-staged` sets displayedPaneKey to selectedThread.paneKey, which makes
+  // displayedThread === selectedThread, so reconcile returns no stagedThread on the next commit. The
+  // branch cannot resolve twice without a new selection (see activity-portal-thread-reconciliation.test).
   useLayoutEffect(() => {
     const swap = resolveActivityPortalSwap({
       selectedThread,

--- a/src/renderer/src/components/activity/activity-portal-churn-budget.test.ts
+++ b/src/renderer/src/components/activity/activity-portal-churn-budget.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createActivityPortalChurnBudget,
+  type ActivityPortalChurnBudget
+} from './activity-portal-churn-budget'
+
+function budgetAt(clock: { ms: number }): ActivityPortalChurnBudget {
+  return createActivityPortalChurnBudget({ limit: 3, windowMs: 1_000, now: () => clock.ms })
+}
+
+describe('createActivityPortalChurnBudget', () => {
+  it('spends once the window holds a full burst', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    expect(budget.record()).toBe(false)
+    expect(budget.record()).toBe(false)
+    expect(budget.record()).toBe(true)
+    clock.ms += 900
+    expect(budget.isSpent()).toBe(true)
+  })
+
+  it('stays spent while the churn keeps firing', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 500; i += 1) {
+      clock.ms += 10
+      budget.record()
+    }
+    expect(budget.isSpent()).toBe(true)
+  })
+
+  it('releases a window after the churn stops', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 3; i += 1) {
+      budget.record()
+    }
+    clock.ms += 1_000
+    expect(budget.isSpent()).toBe(false)
+    expect(budget.record()).toBe(false)
+  })
+
+  it('never spends on events paced slower than the window allows', () => {
+    // A user hopping between threads must keep the seamless path, however long they keep hopping.
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 100; i += 1) {
+      clock.ms += 500
+      expect(budget.record()).toBe(false)
+    }
+  })
+
+  it('treats a backwards clock as an expired window', () => {
+    // Date.now() jumps backwards on NTP/sleep-wake.
+    const clock = { ms: 10_000 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 3; i += 1) {
+      budget.record()
+    }
+    clock.ms = 5_000
+    expect(budget.isSpent()).toBe(false)
+  })
+
+  it('clears on demand', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 3; i += 1) {
+      budget.record()
+    }
+    budget.clear()
+    expect(budget.isSpent()).toBe(false)
+  })
+})

--- a/src/renderer/src/components/activity/activity-portal-churn-budget.ts
+++ b/src/renderer/src/components/activity/activity-portal-churn-budget.ts
@@ -1,0 +1,52 @@
+/**
+ * Sliding-window burst budget for the Activity portal's readiness repaint loop.
+ *
+ * Why not a plain counter: a slot swap re-targets the readiness subscription, so a budget scoped to a
+ * subscription, pane key or tab id is restarted by the very churn it must bound. The budget is owned
+ * for the whole page mount and bounds events *per window* instead, so it neither accumulates across a
+ * session nor lets a spent budget answer for a later slow attach (SSH/relay panes take seconds to
+ * come up) once the churn stops.
+ */
+export type ActivityPortalChurnBudget = {
+  /** Records one churn event; returns whether the budget is spent afterwards. */
+  record: () => boolean
+  /** True while the window still holds a full burst. */
+  isSpent: () => boolean
+  clear: () => void
+}
+
+export function createActivityPortalChurnBudget(args: {
+  limit: number
+  windowMs: number
+  now?: () => number
+}): ActivityPortalChurnBudget {
+  const { limit, windowMs, now = () => Date.now() } = args
+  // Why capped at `limit`: an oscillation can fire thousands of events per window, and only the most
+  // recent `limit` of them can ever decide the verdict.
+  let eventsAt: number[] = []
+
+  const prune = (at: number): void => {
+    // Why drop future stamps: Date.now() jumps backwards on NTP/sleep-wake, and a stale future stamp
+    // would otherwise hold the budget spent for a whole window after the jump.
+    eventsAt = eventsAt.filter((eventAt) => eventAt > at - windowMs && eventAt <= at)
+  }
+
+  return {
+    record() {
+      const at = now()
+      prune(at)
+      eventsAt.push(at)
+      if (eventsAt.length > limit) {
+        eventsAt.shift()
+      }
+      return eventsAt.length >= limit
+    },
+    isSpent() {
+      prune(now())
+      return eventsAt.length >= limit
+    },
+    clear() {
+      eventsAt = []
+    }
+  }
+}

--- a/src/renderer/src/components/activity/activity-portal-readiness-loop.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-portal-readiness-loop.react185.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment happy-dom */
 import { act, useLayoutEffect, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -46,10 +46,17 @@ const PANE_C = thread(OTHER_TAB_ID, LEAF_C)
 
 let root: Root
 
+// Freeze Date (not timers/rAF) so the latch's flip window cannot expire between two drains on a
+// loaded CI machine; the readiness frames are still driven by the controllers below.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+})
+
 afterEach(() => {
   act(() => {
     root?.unmount()
   })
+  vi.useRealTimers()
   document.body.replaceChildren()
   vi.unstubAllGlobals()
 })

--- a/src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts
+++ b/src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS,
   ACTIVITY_PORTAL_READINESS_MAX_FLIPS,
   createActivityPortalReadinessLatch
 } from './activity-portal-readiness-oscillation'
@@ -49,5 +50,44 @@ describe('createActivityPortalReadinessLatch', () => {
     expect(latch.next('ready')).toBe('ready')
     expect(latch.next('loading')).toBe('loading')
     expect(latch.next('ready')).toBe('ready')
+  })
+
+  it('holds the latch for as long as the DOM keeps flipping', () => {
+    // The field loop ran 239 renders in 847ms, so the window never empties while it spins.
+    const clock = { ms: 0 }
+    const latch = createActivityPortalReadinessLatch(() => clock.ms)
+    const seen: string[] = []
+    for (let i = 0; i < 240; i += 1) {
+      clock.ms += 4
+      seen.push(latch.next(i % 2 === 0 ? 'loading' : 'unavailable'))
+    }
+    expect(
+      seen.slice(ACTIVITY_PORTAL_READINESS_MAX_FLIPS + 2).every((s) => s === 'unavailable')
+    ).toBe(true)
+  })
+
+  it('releases a latched pane once the churn stops, so a slow attach still reports loading', () => {
+    // A latched pane must not answer for the next pane the Activity slot shows (SSH panes take seconds).
+    const clock = { ms: 0 }
+    const latch = createActivityPortalReadinessLatch(() => clock.ms)
+    for (let i = 0; i < ACTIVITY_PORTAL_READINESS_MAX_FLIPS * 2; i += 1) {
+      clock.ms += 5
+      latch.next(i % 2 === 0 ? 'loading' : 'unavailable')
+    }
+    expect(latch.next('loading')).toBe('unavailable')
+    clock.ms += ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS
+    expect(latch.next('loading')).toBe('loading')
+  })
+
+  it('ignores flips paced by a human clicking between threads', () => {
+    // The latch outlives the subscription, so thread-hopping must never spend the burst budget.
+    const clock = { ms: 0 }
+    const latch = createActivityPortalReadinessLatch(() => clock.ms)
+    for (let i = 0; i < ACTIVITY_PORTAL_READINESS_MAX_FLIPS * 4; i += 1) {
+      clock.ms += 500
+      expect(latch.next(i % 2 === 0 ? 'loading' : 'unavailable')).toBe(
+        i % 2 === 0 ? 'loading' : 'unavailable'
+      )
+    }
   })
 })

--- a/src/renderer/src/components/activity/activity-portal-readiness-oscillation.ts
+++ b/src/renderer/src/components/activity/activity-portal-readiness-oscillation.ts
@@ -1,39 +1,54 @@
+import { createActivityPortalChurnBudget } from './activity-portal-churn-budget'
+
 export type ActivityPortalReadinessStatus = 'loading' | 'ready' | 'unavailable'
 
-// Why: stop a fixed subscription from repainting forever after frame coalescing breaks its sync cascade.
+// Why: stop a subscription from repainting forever after frame coalescing breaks its sync cascade.
 export const ACTIVITY_PORTAL_READINESS_MAX_FLIPS = 8
+/**
+ * How fast the flips must arrive to count as a repaint loop rather than a person.
+ *
+ * Why this tight: the latch outlives any one subscription, so anything a user can reach by hand would
+ * let their thread-hopping answer 'unavailable' for the next pane. The field loop ran 239 renders in
+ * 847ms (~8 flips per 28ms), so 500ms still catches it with >15x margin, while spending the budget by
+ * hand would take 16 selections a second. It doubles as the hold: a live loop refills the window far
+ * faster than it drains, so the latch stays engaged until the churn itself stops.
+ */
+export const ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS = 500
 
 export type ActivityPortalReadinessLatch = {
   next: (status: ActivityPortalReadinessStatus) => ActivityPortalReadinessStatus
 }
 
-/** Bounds non-ready status flips for one readiness subscription. */
-export function createActivityPortalReadinessLatch(): ActivityPortalReadinessLatch {
+/**
+ * Bounds non-ready status flips for one readiness subscriber.
+ *
+ * Why no pane/target/tab key: the swap effect rewrites the slot element and the pane key together on
+ * every oscillation step, so any identity the latch keyed on would be toggled by the loop it bounds.
+ */
+export function createActivityPortalReadinessLatch(
+  now: () => number = () => Date.now()
+): ActivityPortalReadinessLatch {
   let lastStatus: ActivityPortalReadinessStatus | null = null
-  let flips = 0
-  let latched = false
+  const flipBudget = createActivityPortalChurnBudget({
+    limit: ACTIVITY_PORTAL_READINESS_MAX_FLIPS,
+    windowMs: ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS,
+    now
+  })
 
   return {
     next(status) {
       // Why: a slow terminal may become ready after exhausting the flip budget.
       if (status === 'ready') {
         lastStatus = status
-        flips = 0
-        latched = false
+        flipBudget.clear()
         return status
       }
-      if (latched) {
-        return 'unavailable'
-      }
-      if (lastStatus !== null && lastStatus !== status) {
-        flips += 1
-      }
+      // Why count the probe's status, not the latched output: a DOM that keeps oscillating keeps
+      // feeding the budget, so the latch holds until the churn itself stops.
+      const flipped = lastStatus !== null && lastStatus !== status
       lastStatus = status
-      if (flips >= ACTIVITY_PORTAL_READINESS_MAX_FLIPS) {
-        latched = true
-        return 'unavailable'
-      }
-      return status
+      const spent = flipped ? flipBudget.record() : flipBudget.isSpent()
+      return spent ? 'unavailable' : status
     }
   }
 }

--- a/src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx
@@ -2,8 +2,9 @@
 import { act, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useActivityTerminalPortalStatus } from './ActivityPrototypePage'
+import { ACTIVITY_PORTAL_READINESS_MAX_FLIPS } from './activity-portal-readiness-oscillation'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -14,22 +15,25 @@ const LEAF_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
 const LEAF_C = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
 const PANE_A = `${TAB_ID}:${LEAF_A}`
 const PANE_B = `${TAB_ID}:${LEAF_B}`
-const OTHER_PANE_A = `${OTHER_TAB_ID}:${LEAF_A}`
+const OTHER_PANE_B = `${OTHER_TAB_ID}:${LEAF_B}`
 
 let root: Root
+
+// Freeze Date (not timers/rAF, which still drive the readiness frames) so the latch's flip window is
+// decided by the churn under test rather than by how slowly the machine runs it.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+})
 
 afterEach(() => {
   act(() => {
     root?.unmount()
   })
+  vi.useRealTimers()
   document.body.replaceChildren()
 })
 
-function buildNeverReadyRoot(
-  target: HTMLElement,
-  tabId: string = TAB_ID,
-  { append = false }: { append?: boolean } = {}
-): void {
+function buildNeverReadyRoot(target: HTMLElement, tabId: string = TAB_ID): void {
   const tabRoot = document.createElement('div')
   tabRoot.dataset.terminalTabId = tabId
   for (const leafId of [LEAF_A, LEAF_C]) {
@@ -40,14 +44,60 @@ function buildNeverReadyRoot(
     Object.defineProperty(pane, 'getClientRects', { value: () => [{}], configurable: true })
     tabRoot.appendChild(pane)
   }
-  if (append) {
-    target.appendChild(tabRoot)
-    return
-  }
   target.replaceChildren(tabRoot)
 }
 
+/** Lets the readiness rAF this churn step scheduled land in React state. */
+async function drainReadinessFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  })
+}
+
 describe('Activity portal readiness subscription churn', () => {
+  // Why this bound matters: React raises #185 only after >50 *consecutive* commits that each leave a
+  // pending sync/default lane; any commit that leaves none resets nestedUpdateCount. This pins the
+  // reason the readiness subscription can never be that source -- its only writer is an rAF callback,
+  // and the effect cleanup cancels that frame on every churn step, so a synchronous cascade of
+  // subscription churn commits nothing at all. A #185 on this page must come from another setState.
+  it('contributes no state updates to a synchronous churn cascade past React nested-update limit', () => {
+    const target = document.createElement('div')
+    buildNeverReadyRoot(target)
+    document.body.append(target)
+
+    let selectPane: (paneKey: string) => void = () => {}
+    let readinessCommits = 0
+    let lastStatus = 'loading'
+
+    function ActivityTerminalSlot(): null {
+      const [paneKey, setPaneKey] = useState(PANE_A)
+      selectPane = setPaneKey
+      const status = useActivityTerminalPortalStatus(target, paneKey)
+      if (status !== lastStatus) {
+        readinessCommits += 1
+        lastStatus = status
+      }
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+    readinessCommits = 0
+
+    act(() => {
+      expect(() => {
+        for (let index = 0; index < 60; index += 1) {
+          flushSync(() => {
+            selectPane(index % 2 === 0 ? PANE_B : PANE_A)
+          })
+        }
+      }).not.toThrow()
+    })
+    expect(readinessCommits).toBe(0)
+  })
+
   it('coalesces pane-key churn and commits the latest readiness', async () => {
     const target = document.createElement('div')
     buildNeverReadyRoot(target)
@@ -88,23 +138,42 @@ describe('Activity portal readiness subscription churn', () => {
     expect(renders).toBeLessThanOrEqual(32)
   })
 
-  // Why: the swap effect rewrites the slot element and the pane key together, so a latch scoped to
-  // the subscription is rebuilt with an empty flip budget on every oscillation step.
-  it('latches readiness when the portal target churns alongside the pane key', async () => {
+  // Asserts the loop-terminating property, not just a final value: the status that drives the page's
+  // swap effect (stagedPortalUnavailable) must stop alternating part-way through the churn and stay
+  // put. While it alternates, every step re-targets both readiness subscriptions and re-stages.
+  function expectReadinessStopsAlternating(statuses: string[]): void {
+    // Sanity: the fixture really does alternate early, so the run below is the latch, not a rig.
+    const head = statuses.slice(0, ACTIVITY_PORTAL_READINESS_MAX_FLIPS)
+    expect(new Set(head)).toEqual(new Set(['loading', 'unavailable']))
+    // Termination: the churn keeps flipping the DOM but the status the swap effect reads stops moving.
+    const tail = statuses.slice(ACTIVITY_PORTAL_READINESS_MAX_FLIPS)
+    expect(tail.length).toBeGreaterThan(20)
+    expect(new Set(tail)).toEqual(new Set(['unavailable']))
+  }
+
+  // Why: staging only happens across tabs (reconcileActivityPortalThreads returns no stagedThread for
+  // same-tab panes), so the production swap moves slot element, pane key AND tab id in lockstep --
+  // every identity a subscription-scoped latch could key on.
+  it('stops alternating readiness when the slot, pane key and tab id all churn together', async () => {
     const targets = [document.createElement('div'), document.createElement('div')]
+    buildNeverReadyRoot(targets[0], TAB_ID)
+    buildNeverReadyRoot(targets[1], OTHER_TAB_ID)
     for (const target of targets) {
-      buildNeverReadyRoot(target)
       document.body.append(target)
     }
 
     let selectFlip: (flip: number) => void = () => {}
     let status = 'loading'
+    const settledStatuses: string[] = []
 
     function ActivityTerminalSlot(): null {
       const [flip, setFlip] = useState(0)
       selectFlip = setFlip
-      // Alternating pane keys report 'loading' (unisolated sibling) then 'unavailable' (missing leaf).
-      status = useActivityTerminalPortalStatus(targets[flip % 2], flip % 2 === 0 ? PANE_A : PANE_B)
+      // Alternating panes report 'loading' (unisolated sibling) then 'unavailable' (missing leaf).
+      status = useActivityTerminalPortalStatus(
+        targets[flip % 2],
+        flip % 2 === 0 ? PANE_A : OTHER_PANE_B
+      )
       return null
     }
 
@@ -117,23 +186,21 @@ describe('Activity portal readiness subscription churn', () => {
       await act(async () => {
         selectFlip(flip)
       })
-      await act(async () => {
-        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
-      })
+      await drainReadinessFrame()
+      settledStatuses.push(status)
     }
 
-    // Flip 40 is the 'loading' pairing, so only a latch that survived the churn can report this.
-    expect(status).toBe('unavailable')
+    expectReadinessStopsAlternating(settledStatuses)
   })
 
-  it('starts a fresh flip budget when the subscription moves to another tab', async () => {
+  it('stops alternating readiness when only the pane key churns within one tab', async () => {
     const target = document.createElement('div')
     buildNeverReadyRoot(target, TAB_ID)
-    buildNeverReadyRoot(target, OTHER_TAB_ID, { append: true })
     document.body.append(target)
 
     let selectPane: (paneKey: string) => void = () => {}
     let status = 'loading'
+    const settledStatuses: string[] = []
 
     function ActivityTerminalSlot(): null {
       const [paneKey, setPaneKey] = useState(PANE_A)
@@ -151,19 +218,54 @@ describe('Activity portal readiness subscription churn', () => {
       await act(async () => {
         selectPane(flip % 2 === 0 ? PANE_B : PANE_A)
       })
-      await act(async () => {
-        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
-      })
+      await drainReadinessFrame()
+      settledStatuses.push(status)
     }
-    expect(status).toBe('unavailable')
 
-    await act(async () => {
-      selectPane(OTHER_PANE_A)
+    expectReadinessStopsAlternating(settledStatuses)
+  })
+
+  // Why: the flip budget outlives the subscription, so a burst window wide enough to cover ordinary
+  // clicking would let one user's thread-hopping answer 'unavailable' for the next healthy pane.
+  it('does not answer for a later attaching pane after human-paced selections', async () => {
+    const churnTarget = document.createElement('div')
+    buildNeverReadyRoot(churnTarget, TAB_ID)
+    const attachingTarget = document.createElement('div')
+    buildNeverReadyRoot(attachingTarget, OTHER_TAB_ID)
+    for (const target of [churnTarget, attachingTarget]) {
+      document.body.append(target)
+    }
+
+    type SelectedPane = { target: HTMLElement; paneKey: string }
+    let selectPane: (pane: SelectedPane) => void = () => {}
+    let status = 'loading'
+
+    function ActivityTerminalSlot(): null {
+      const [pane, setPane] = useState<SelectedPane>({ target: churnTarget, paneKey: PANE_A })
+      selectPane = setPane
+      status = useActivityTerminalPortalStatus(pane.target, pane.paneKey)
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
     })
+
+    // Two clicks a second between a live thread ('loading') and a retained one ('unavailable').
+    for (let click = 1; click <= 10; click += 1) {
+      vi.setSystemTime(click * 500)
+      await act(async () => {
+        selectPane({ target: churnTarget, paneKey: click % 2 === 0 ? PANE_A : PANE_B })
+      })
+      await drainReadinessFrame()
+    }
+
+    vi.setSystemTime(5_500)
     await act(async () => {
-      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      selectPane({ target: attachingTarget, paneKey: `${OTHER_TAB_ID}:${LEAF_A}` })
     })
-    // A latch shared across tabs would report the previous tab's latched 'unavailable' here.
+    await drainReadinessFrame()
     expect(status).toBe('loading')
   })
 })

--- a/src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx
@@ -8,11 +8,13 @@ import { useActivityTerminalPortalStatus } from './ActivityPrototypePage'
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 const TAB_ID = 'tab-readiness-churn'
+const OTHER_TAB_ID = 'tab-readiness-churn-other'
 const LEAF_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const LEAF_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
 const LEAF_C = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
 const PANE_A = `${TAB_ID}:${LEAF_A}`
 const PANE_B = `${TAB_ID}:${LEAF_B}`
+const OTHER_PANE_A = `${OTHER_TAB_ID}:${LEAF_A}`
 
 let root: Root
 
@@ -23,9 +25,13 @@ afterEach(() => {
   document.body.replaceChildren()
 })
 
-function buildNeverReadyRoot(target: HTMLElement): void {
+function buildNeverReadyRoot(
+  target: HTMLElement,
+  tabId: string = TAB_ID,
+  { append = false }: { append?: boolean } = {}
+): void {
   const tabRoot = document.createElement('div')
-  tabRoot.dataset.terminalTabId = TAB_ID
+  tabRoot.dataset.terminalTabId = tabId
   for (const leafId of [LEAF_A, LEAF_C]) {
     const pane = document.createElement('div')
     pane.dataset.leafId = leafId
@@ -33,6 +39,10 @@ function buildNeverReadyRoot(target: HTMLElement): void {
     pane.appendChild(Object.assign(document.createElement('div'), { className: 'xterm-screen' }))
     Object.defineProperty(pane, 'getClientRects', { value: () => [{}], configurable: true })
     tabRoot.appendChild(pane)
+  }
+  if (append) {
+    target.appendChild(tabRoot)
+    return
   }
   target.replaceChildren(tabRoot)
 }
@@ -76,5 +86,84 @@ describe('Activity portal readiness subscription churn', () => {
     })
     expect(status).toBe('unavailable')
     expect(renders).toBeLessThanOrEqual(32)
+  })
+
+  // Why: the swap effect rewrites the slot element and the pane key together, so a latch scoped to
+  // the subscription is rebuilt with an empty flip budget on every oscillation step.
+  it('latches readiness when the portal target churns alongside the pane key', async () => {
+    const targets = [document.createElement('div'), document.createElement('div')]
+    for (const target of targets) {
+      buildNeverReadyRoot(target)
+      document.body.append(target)
+    }
+
+    let selectFlip: (flip: number) => void = () => {}
+    let status = 'loading'
+
+    function ActivityTerminalSlot(): null {
+      const [flip, setFlip] = useState(0)
+      selectFlip = setFlip
+      // Alternating pane keys report 'loading' (unisolated sibling) then 'unavailable' (missing leaf).
+      status = useActivityTerminalPortalStatus(targets[flip % 2], flip % 2 === 0 ? PANE_A : PANE_B)
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+
+    for (let flip = 1; flip <= 40; flip += 1) {
+      await act(async () => {
+        selectFlip(flip)
+      })
+      await act(async () => {
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      })
+    }
+
+    // Flip 40 is the 'loading' pairing, so only a latch that survived the churn can report this.
+    expect(status).toBe('unavailable')
+  })
+
+  it('starts a fresh flip budget when the subscription moves to another tab', async () => {
+    const target = document.createElement('div')
+    buildNeverReadyRoot(target, TAB_ID)
+    buildNeverReadyRoot(target, OTHER_TAB_ID, { append: true })
+    document.body.append(target)
+
+    let selectPane: (paneKey: string) => void = () => {}
+    let status = 'loading'
+
+    function ActivityTerminalSlot(): null {
+      const [paneKey, setPaneKey] = useState(PANE_A)
+      selectPane = setPaneKey
+      status = useActivityTerminalPortalStatus(target, paneKey)
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+
+    for (let flip = 0; flip < 40; flip += 1) {
+      await act(async () => {
+        selectPane(flip % 2 === 0 ? PANE_B : PANE_A)
+      })
+      await act(async () => {
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      })
+    }
+    expect(status).toBe('unavailable')
+
+    await act(async () => {
+      selectPane(OTHER_PANE_A)
+    })
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    })
+    // A latch shared across tabs would report the previous tab's latched 'unavailable' here.
+    expect(status).toBe('loading')
   })
 })

--- a/src/renderer/src/components/activity/activity-portal-thread-reconciliation.test.ts
+++ b/src/renderer/src/components/activity/activity-portal-thread-reconciliation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  reconcileActivityPortalThreads,
+  resolveActivityPortalSwap,
+  type ActivityPortalThreadRef
+} from './activity-portal-thread-reconciliation'
+
+const thread = (tabId: string, leafId: string): ActivityPortalThreadRef => ({
+  paneKey: `${tabId}:${leafId}`,
+  worktree: { id: `wt-${tabId}` },
+  tab: { id: tabId }
+})
+
+// Two tabs in one worktree (staging applies) plus one in another worktree.
+const ALL_THREADS = [
+  thread('tab-a', 'leaf-1'),
+  thread('tab-b', 'leaf-2'),
+  thread('tab-c', 'leaf-3')
+]
+
+/** Replays ActivityPrototypePage's swap layout effect over a fixed selection. */
+function replaySwapCascade(args: {
+  selectedThread: ActivityPortalThreadRef
+  initialDisplayedPaneKey: string | null
+  steps: number
+}): string[] {
+  let displayedPaneKey = args.initialDisplayedPaneKey
+  const kinds: string[] = []
+  for (let step = 0; step < args.steps; step += 1) {
+    const displayedThread = displayedPaneKey
+      ? (ALL_THREADS.find((entry) => entry.paneKey === displayedPaneKey) ?? null)
+      : null
+    const { visibleThread, stagedThread } = reconcileActivityPortalThreads({
+      selectedThread: args.selectedThread,
+      displayedThread,
+      selectedHasLiveTab: true,
+      displayedHasLiveTab: true
+    })
+    // Most permissive readiness the page can hand in, so no swap is withheld.
+    const swap = resolveActivityPortalSwap({
+      selectedThread: args.selectedThread,
+      selectedHasLiveTab: true,
+      visibleThread,
+      stagedThread,
+      visiblePortalReady: true,
+      stagedPortalReady: true,
+      stagedPortalUnavailable: true
+    })
+    kinds.push(swap?.kind ?? 'none')
+    if (swap?.kind === 'clear') {
+      displayedPaneKey = null
+    } else if (swap) {
+      displayedPaneKey = swap.paneKey
+    }
+  }
+  return kinds
+}
+
+describe('resolveActivityPortalSwap cascade', () => {
+  // Why this matters: the swap effect writes setActivePortalSlotId/setDisplayedPaneKey straight from a
+  // layout effect. If 'swap-staged' could resolve on two consecutive commits it would toggle the slot
+  // forever on React's sync lane. It cannot, so the effect needs no churn budget.
+  it('never resolves swap-staged twice in a row for a fixed selection', () => {
+    for (const selectedThread of ALL_THREADS) {
+      for (const displayed of [null, ...ALL_THREADS]) {
+        const kinds = replaySwapCascade({
+          selectedThread,
+          initialDisplayedPaneKey: displayed?.paneKey ?? null,
+          steps: 6
+        })
+        const label = `selected=${selectedThread.paneKey} displayed=${displayed?.paneKey ?? 'null'}`
+        expect(
+          kinds.filter((kind) => kind === 'swap-staged').length,
+          `${label}: ${kinds}`
+        ).toBeLessThanOrEqual(1)
+        // And the cascade settles: no write at all once displayedPaneKey caught up.
+        expect(kinds.at(-1), `${label}: ${kinds}`).toBe('settle-visible')
+      }
+    }
+  })
+
+  it('stages across tabs and refuses to stage inside one tab', () => {
+    const sameTabDisplayed = reconcileActivityPortalThreads({
+      selectedThread: thread('tab-a', 'leaf-9'),
+      displayedThread: ALL_THREADS[0],
+      selectedHasLiveTab: true,
+      displayedHasLiveTab: true
+    })
+    expect(sameTabDisplayed.stagedThread).toBeNull()
+
+    const crossTabDisplayed = reconcileActivityPortalThreads({
+      selectedThread: ALL_THREADS[1],
+      displayedThread: ALL_THREADS[0],
+      selectedHasLiveTab: true,
+      displayedHasLiveTab: true
+    })
+    expect(crossTabDisplayed.stagedThread).toBe(ALL_THREADS[1])
+  })
+})


### PR DESCRIPTION
# fix(activity): bound the portal readiness loop with a decaying flip window

## What this fixes

**Signature:** `Error: Minified React error #185` ("Maximum update depth exceeded") thrown from
`getRootForUpdatedFiber ← enqueueConcurrentHookUpdate ← dispatchSetState ← commitHookEffectListMount ←
commitLayoutEffectOnFiber`, caught by `RecoverableRenderErrorBoundary` with `boundary_id: page.activity`,
`active_view: activity`.

**Coverage: 3 of the 127 reports in this batch** — the `page.activity` subgroup (d) of the 13-report
`G1-react185` cluster. It does **not** cover the other 10 `G1` reports (those are `active_view=terminal`
with `ActivityPrototypePage` unmounted; separate workstream).

Representative reports:

| Slack | Report ID | Version | Platform |
|---|---|---|---|
| [p1785707545376969](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785707545376969) | `49fd99b1-2edf-4313-bde2-18e0c0cdaf5c` | 1.4.164 | darwin 25.5.0 arm64 |
| [p1785775829795559](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785775829795559) | `c40e6986-d5e7-48f2-b8dc-140abae7bede` | 1.4.167 | darwin 25.4.0 arm64 |
| [p1785806846610159](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785806846610159) | `ba6ec3b8-cfb1-4d12-a451-ecd0ae0ae234` | 1.4.167 | win32 10.0.26100 x64 |

### Root cause

React code 185 in the shipped `react-dom@19.2.7` is a *nested update* guard, not setState-after-unmount —
`node_modules/react-dom/cjs/react-dom-client.production.js:2409-2415`:

```js
function getRootForUpdatedFiber(sourceFiber) {
  if (50 < nestedUpdateCount)
    throw (
      ((nestedUpdateCount = 0),
      (rootWithNestedUpdates = null),
      Error(formatProdErrorMessage(185)))
    );
```

`4543bb6826` (shipped in v1.4.163) added a flip latch to bound the Activity portal's readiness repaint loop.
**That latch is escapable, and the escape is structural.** On `origin/main`:

- `src/renderer/src/components/activity/ActivityPrototypePage.tsx:350` — `const readinessLatch =
  createActivityPortalReadinessLatch()` is created **inside** the readiness layout effect.
- `src/renderer/src/components/activity/ActivityPrototypePage.tsx:383` — that effect's deps are
  `[target, paneKey, forceUnavailable]`.
- `src/renderer/src/components/activity/ActivityPrototypePage.tsx:1592-1614` — the swap layout effect writes
  `setActivePortalSlotId(inactivePortalSlotId)` (`:1608`) *and* `setDisplayedPaneKey(...)`
  (`:1603` / `:1609` / `:1614`), which rewrite the slot DOM element and the pane key together.

So every oscillation step tears down the effect and rebuilds the latch with `flips = 0`.
`ACTIVITY_PORTAL_READINESS_MAX_FLIPS` (= 8) can never accumulate, and the repaint loop the latch exists to
bound runs unbounded. The latch's own comment admitted the scope limit verbatim:
`activity-portal-readiness-oscillation.ts:3` — *"stop a **fixed** subscription from repainting forever"*.

### The fix

1. Hoist the latch onto a `useRef` owned by the hook instance
   (`ActivityPrototypePage.tsx:308` on this branch, consumed at `:356`), so nothing the loop can re-target
   resets it.
2. Replace the sticky `latched` flag with a **sliding burst window**
   (`activity-portal-churn-budget.ts`, wired in `activity-portal-readiness-oscillation.ts`):
   `ACTIVITY_PORTAL_READINESS_MAX_FLIPS` flips inside `ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS = 500`.
   A live loop refills the window far faster than it drains, so the latch holds for as long as the churn runs;
   once the churn stops the window decays, so a burnt budget does not answer `'unavailable'` for the next pane
   the slot shows (an SSH/relay pane that is merely still attaching gets its real `'loading'` back).

### What this does NOT claim

**This is a bounded mitigation of a provable unbounded loop, not a reproduction of the field crash.** React
raises #185 only after >50 *consecutive* commits that each leave a pending sync/default lane; any commit
leaving none resets `nestedUpdateCount`. The readiness subscription's only writer is an rAF callback that the
effect cleanup cancels on every churn step, so it contributes **zero** state updates to a synchronous cascade —
now pinned by a test that drives 60 `flushSync` churn steps and asserts no readiness commit and no throw.
Whatever schedules the field cascade is a different `setState`. The link from "this loop was unbounded" to
"these 3 crashes" is **inference, not proven causation.** The escape itself is proven (red test below).

---

## Fix evidence

Windows verification status (from `/tmp/crash-pr-meta.json`): **not required — pure renderer logic.** One of the
three field reports is win32, but nothing in this change is platform-dependent (no paths, no key modifiers, no
native modules); the touched suite is happy-dom/vitest and platform-agnostic.

### 1. RED without the source fix

Scratch worktree at the branch commit, with **only the two source files** reverted to `origin/main`
(`ActivityPrototypePage.tsx`, `activity-portal-readiness-oscillation.ts`; the new
`activity-portal-churn-budget.ts` was left in place as an orphan module since it does not exist on `main`).
Tests unchanged.

```
$ git worktree add /tmp/prproof-w7-activity-latch crashfix/w7-activity-latch --detach
$ git checkout origin/main -- src/renderer/src/components/activity/ActivityPrototypePage.tsx \
                             src/renderer/src/components/activity/activity-portal-readiness-oscillation.ts
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx \
    src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts

 RUN  v4.1.5 /private/tmp/prproof-w7-activity-latch

 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > latches to unavailable once loading<->unavailable keeps flipping 1ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > passes through a normal loading -> ready startup 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > does not latch when ready keeps refunding the budget 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > tolerates a few legitimate flips while xterm attaches 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > releases once the terminal genuinely comes up after a churny attach 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > holds the latch for as long as the DOM keeps flipping 0ms
 × activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > releases a latched pane once the churn stops, so a slow attach still reports loading 3ms
   → expected 'unavailable' to be 'loading' // Object.is equality
 × activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > ignores flips paced by a human clicking between threads 0ms
   → expected 'unavailable' to be 'loading' // Object.is equality
 ✓ activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > contributes no state updates to a synchronous churn cascade past React nested-update limit 12ms
 ✓ activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > coalesces pane-key churn and commits the latest readiness 3ms
 × activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > stops alternating readiness when the slot, pane key and tab id all churn together 14ms
   → expected Set{ 'unavailable', 'loading' } to deeply equal Set{ 'unavailable' }
 × activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > stops alternating readiness when only the pane key churns within one tab 10ms
   → expected Set{ 'unavailable', 'loading' } to deeply equal Set{ 'unavailable' }
 ✓ activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > does not answer for a later attaching pane after human-paced selections 8ms

 Test Files  2 failed (2)
      Tests  4 failed | 9 passed (13)
```

The two React-level failures are the escape itself. Verbatim assertion detail:

```
 FAIL  src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > stops alternating readiness when the slot, pane key and tab id all churn together
AssertionError: expected Set{ 'unavailable', 'loading' } to deeply equal Set{ 'unavailable' }

- Expected
+ Received

  Set {
+   "loading",
    "unavailable",
  }

 ❯ expectReadinessStopsAlternating src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx:151:27
    149|     const tail = statuses.slice(ACTIVITY_PORTAL_READINESS_MAX_FLIPS)
    150|     expect(tail.length).toBeGreaterThan(20)
    151|     expect(new Set(tail)).toEqual(new Set(['unavailable']))
       |                           ^
    152|   }
    153|
 ❯ src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx:193:5

 FAIL  src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > ignores flips paced by a human clicking between threads
AssertionError: expected 'unavailable' to be 'loading' // Object.is equality

Expected: "loading"
Received: "unavailable"

 ❯ src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts:88:67
     86|     for (let i = 0; i < ACTIVITY_PORTAL_READINESS_MAX_FLIPS * 4; i += …
     87|       clock.ms += 500
     88|       expect(latch.next(i % 2 === 0 ? 'loading' : 'unavailable')).toBe(
       |                                                                   ^
     89|         i % 2 === 0 ? 'loading' : 'unavailable'
     90|       )
```

Reading of the red output, stated plainly:

- The two `…churn together` / `…only the pane key churns` failures prove the **escape**: on `origin/main` the
  status that drives the swap effect keeps alternating `loading`↔`unavailable` for all 40 churn steps, i.e. the
  8-flip budget never accumulates.
- The two oscillation-unit failures prove the **decay/no-bleed** property is new: `main`'s latch is sticky, so
  once engaged it answers `'unavailable'` forever, and it also spends its budget on human-paced clicking.
- `contributes no state updates to a synchronous churn cascade…` and `does not answer for a later attaching
  pane…` pass on `main` too. That is expected and stated honestly: the first documents a pre-existing property
  (rAF coalescing) that this change must not break, and the second passes on `main` only because `main`'s latch
  is destroyed on every subscription change — the very bug. Both are regression guards, not the red proof.
- The scratch worktree was removed with `git worktree remove --force`. No `git stash` was used at any point.

### 2. GREEN with the fix (same tests, on the branch)

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w7-activity-latch

 ✓ src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > contributes no state updates to a synchronous churn cascade past React nested-update limit 12ms
 ✓ src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > coalesces pane-key churn and commits the latest readiness 2ms
 ✓ src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > stops alternating readiness when the slot, pane key and tab id all churn together 10ms
 ✓ src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > stops alternating readiness when only the pane key churns within one tab 15ms
 ✓ src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx > Activity portal readiness subscription churn > does not answer for a later attaching pane after human-paced selections 3ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  2.15s
```

The regression tests assert loop **termination**, not a final value: under 40 churn steps the status the swap
effect reads alternates for the first `ACTIVITY_PORTAL_READINESS_MAX_FLIPS` samples (sanity — the fixture really
does churn) and then stops moving for the remaining 30+ samples. `Date` is frozen (`vi.useFakeTimers({ toFake:
['Date'] })` — timers and rAF untouched) so the window is decided by the churn under test, not by CI load.

### 3. Full regression suite for the only touched module

`src/renderer/src/components/activity/` is the sole touched directory.

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose src/renderer/src/components/activity/

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w7-activity-latch

 ✓ activity-portal-thread-reconciliation.test.ts > resolveActivityPortalSwap cascade > never resolves swap-staged twice in a row for a fixed selection 1ms
 ✓ activity-portal-thread-reconciliation.test.ts > resolveActivityPortalSwap cascade > stages across tabs and refuses to stage inside one tab 0ms
 ✓ activity-portal-churn-budget.test.ts > createActivityPortalChurnBudget > spends once the window holds a full burst 1ms
 ✓ activity-portal-churn-budget.test.ts > createActivityPortalChurnBudget > stays spent while the churn keeps firing 0ms
 ✓ activity-portal-churn-budget.test.ts > createActivityPortalChurnBudget > releases a window after the churn stops 0ms
 ✓ activity-portal-churn-budget.test.ts > createActivityPortalChurnBudget > never spends on events paced slower than the window allows 1ms
 ✓ activity-portal-churn-budget.test.ts > createActivityPortalChurnBudget > treats a backwards clock as an expired window 0ms
 ✓ activity-portal-churn-budget.test.ts > createActivityPortalChurnBudget > clears on demand 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > latches to unavailable once loading<->unavailable keeps flipping 1ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > passes through a normal loading -> ready startup 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > does not latch when ready keeps refunding the budget 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > tolerates a few legitimate flips while xterm attaches 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > releases once the terminal genuinely comes up after a churny attach 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > holds the latch for as long as the DOM keeps flipping 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > releases a latched pane once the churn stops, so a slow attach still reports loading 0ms
 ✓ activity-portal-readiness-oscillation.test.ts > createActivityPortalReadinessLatch > ignores flips paced by a human clicking between threads 0ms
 ✓ ActivityPrototypePage.test.ts > buildActivityEvents > (24 cases) …
 ✓ activity-portal-readiness-subscription-churn.react185.test.tsx > (5 cases) …
 ✓ ActivityThreadOptionsMenu.test.tsx > ActivityThreadOptionsMenu > opens without recursively updating composed Radix trigger refs 50ms
 ✓ activity-portal-readiness-loop.react185.test.tsx > Activity portal pane switching > converges on a newly selected pane of the tab already on screen 53ms
 ✓ activity-portal-readiness-loop.react185.test.tsx > Activity portal pane switching > stages and swaps when the selected pane belongs to a different tab 43ms
 ✓ activity-portal-readiness-loop.react185.test.tsx > Activity portal pane switching > bounds a readiness oscillation driven through the real portal-status hook 4ms
 ✓ activity-portal-readiness-loop.react185.test.tsx > Activity portal pane switching > releases a latched readiness once the terminal attaches 4ms

 Test Files  7 passed (7)
      Tests  50 passed (50)
   Duration  2.63s
```

(The `buildActivityEvents` / grouping / filter-shortcut block is elided above only for length — the run is
7 files / 50 tests, **0 failures, 0 pre-existing failures in this directory**.)

### 4. Field data

Verbatim from the crash bundle for report `49fd99b1-2edf-4313-bde2-18e0c0cdaf5c`
(`~/.agent-slack/tmp/downloads/F0BMF0J45AA.txt`), all three reports carry the identical shape:

```
App version: 1.4.164
Platform: darwin 25.5.0 arm64
Electron: 43.1.0

Details:
- boundary_id: page.activity
- surface: page
- error_name: Error
- error_message: Minified React error #185; visit https:/[redacted-path]
- error_stack: Error: Minified React error #185; visit https:/[redacted-path]
    at getRootForUpdatedFiber (file://[redacted-path])
    at enqueueConcurrentHookUpdate (file://[redacted-path])
    at dispatchSetStateInternal (file://[redacted-path])
    at dispatchSetState (file://[redacted-path])
    at file://[redacted-path]
    at commitHookEffectListMount (file://[redacted-path])
    at commitLayoutEffectOnFiber (file://[redacted-path])
    at recursivelyTraverseLayoutEffects (file://[redacted-path])
    at commitLayoutEffectOnFiber (file://[redacted-path])
    at recursivelyTraverseLayoutEffects (file://[redacted-path])
- component_stack: at ActivityPrototypePage (file://[redacted-path])
    at RecoverableRenderErrorBoundary (file://[redacted-path])
- active_view: activity
```

`commitLayoutEffectOnFiber` in the throw frame is what points at Activity's **layout** effects specifically —
the readiness effect (branch `:310-389`, main `:304-383`) and the swap effect (branch `:1601`, main `:1592`)
are the page's layout-phase `setState` writers. Consistent with the crash surviving `4543bb6826`: the latch that commit added shipped in v1.4.163 and
these reports are v1.4.164 and v1.4.167.

**Weakness of the field evidence, stated plainly:** the diagnostic bundles carry **no** Activity-portal
breadcrumb. Breadcrumb inventory for the v1.4.164 bundle (`F0BMJTBRCPK.txt`, 564 spans) is
`renderer_memory` ×472, `terminal_webgl_diagnostic` ×13, `renderer_bootstrap_started/rendered` ×6 each,
`main_process_lifecycle_started` ×6, `sidebar_worktree_activate` ×4, and updater spans. Nothing instruments
the readiness loop. The "239 renders in 847 ms" figure quoted in the source comments is **not** from these
bundles — it comes from a prior CDP capture recorded in commit `4543bb6826`'s message. So the field data
establishes *where* (page.activity, layout effect, React 185) and the code establishes *that the bound was
escapable*; it does not establish that this specific loop was the cascade in these three reports.

---

## ELI5

The Activity page shows a live terminal by "teleporting" it into a slot on screen. Before it can do that it has
to keep asking a question: *"is the terminal I'm pointing at ready yet?"* The answer can be `loading`, `ready`,
or `unavailable`.

Sometimes the answer gets stuck flapping — `loading`, `unavailable`, `loading`, `unavailable` — because each
answer causes a repaint and each repaint changes what's being asked about. React allows about 50 of these
back-to-back repaints before it gives up and crashes the whole page with "Maximum update depth exceeded". That's
the crash users see.

A previous fix installed a circuit breaker: *after 8 flip-flops, stop and just say `unavailable`.* The problem is
where the breaker was installed. Think of a tally counted on a whiteboard that is mounted **on the door of the
room being repainted** — every time the loop re-points at a different terminal it swings the door, and the tally
gets wiped. So the count never reached 8 and the breaker never tripped. The loop the breaker was built for was
exactly the loop that kept resetting it.

This change moves the whiteboard off the door and onto the wall, where nothing the loop does can wipe it. It also
changes the tally from "8 ever" to "8 within the last half-second" — a stopwatch, not a lifetime counter. That
matters because the whiteboard now outlives any one terminal: with a lifetime counter, a user clicking briskly
between a few threads would eventually trip the breaker by hand, and then the *next* terminal they opened — a
perfectly healthy one that just needed a few seconds to connect over SSH — would be reported as broken. With a
half-second window, a runaway loop (hundreds of flips a second) trips it instantly and keeps it tripped, while a
human would have to click 16 times a second to get anywhere near it, and the moment the flapping stops the
counter drains and the next terminal gets an honest answer.

---

## Trade-offs

1. **The latch now spans threads, not just one terminal subscription.** This is the point of the fix, but it
   means the mitigation is no longer perfectly isolated: a genuinely pathological pane can, in principle, put the
   Activity slot into `'unavailable'` for up to 500 ms after the user has already navigated to a different,
   healthy pane. The 500 ms window (down from a 5 s window in review round 2) bounds the blast radius, and there
   is a dedicated React-level regression test for the cross-pane bleed
   (`does not answer for a later attaching pane after human-paced selections`), but the window is not zero.

2. **The latch is now releasable, so the bound is not permanent.** On `main` the latch was sticky until a real
   `'ready'`. Now it decays after 500 ms of quiet. If a loop is *bursty* — flips hard, pauses >500 ms, flips
   hard again — each burst gets a fresh budget. It cannot run unbounded within a burst, which is what saturates
   `nestedUpdateCount`, but this is strictly weaker than "latch forever" and worth naming.

3. **500 ms is a tuned constant with no field telemetry behind it.** It was chosen from the 847 ms/239-render
   CDP capture in `4543bb6826` (~8 flips per 28 ms → >15× margin) and from the human-interaction floor
   (16 selections/second to spend it by hand). Neither of these three crash bundles contains a rate we could
   fit the constant to. If a real loop turns out to run slower than ~16 flips/second, this bound will not catch
   it. **Known follow-up:** add an `activity_portal_readiness_flip` breadcrumb so the next batch can validate or
   retune the constant instead of arguing about it. Not done here to keep this change small.

4. **A behaviour that existed on `main` is now removed:** clicking rapidly between two threads where one reports
   `loading` and the other `unavailable` used to be free (each selection got a fresh latch). It now feeds a
   shared window. Below 16 selections/second there is no observable difference; above it, the slot will show
   "unavailable" instead of a spinner until the clicking stops.

5. **Reverted from review round 2: the slot-swap churn budget.** An earlier revision of this branch also added a
   budget to the swap layout effect. It was removed because it is unreachable: `swap-staged` sets
   `displayedPaneKey` to `selectedThread.paneKey`, making `displayedThread === selectedThread`, so
   `reconcileActivityPortalThreads` returns no `stagedThread` on the next commit — the branch provably cannot
   resolve twice without a new selection (exhaustive proof in the new
   `activity-portal-thread-reconciliation.test.ts`). Its only reachable effect was to suppress the staging
   toggle after 8 real selections in 2 s, forcing a **visible remount flash** for fast keyboard users. Dropping
   it is a deliberate reduction in scope, not an oversight; if a swap-effect loop is ever demonstrated, that
   budget is the place to reinstate it.

6. **This does not fix the other 10 `G1-react185` reports** (`active_view=terminal`), and it is not proven to
   fix the 3 it targets — see "What this does NOT claim" above. Ship it as a bounded mitigation of a proven
   unbounded loop.

7. **Performance:** the new budget allocates one small array per hook instance and does an `Array.filter` over
   at most 8 entries per readiness probe. `/perf` verdict: **no-regression**.

---

## Adversarial review

**4 independent adversarial review rounds**, each run by a fresh reviewer with **no memory of the prior round**,
followed by **3 fix rounds**. What they found:

- **Round 1** — the original hoist keyed the latch by tab id. Rejected: the swap moves the tab id in lockstep
  with the slot element and pane key (staging only ever happens *across* tabs), so a tab-id-keyed latch is
  escapable by exactly the same loop. Fixed by keying the latch to the hook instance instead, and by widening
  the React-level test to churn slot + pane key + tab id together.
- **Round 2** — flagged the swap layout effect (`:1600-1626`) as a second, un-coalesced sync-lane writer, and a
  churn budget was added there. See trade-off 5: round 3 then proved that budget unreachable, and it was
  removed with an exhaustive cascade test in its place.
- **Round 3** — found a real user-facing regression in the fix itself: the burst window was 5 s, wide enough to
  cover ordinary clicking, so 8 non-ready flips at 2 selections/s spent the page-scoped budget and the next pane
  the user opened was answered `'unavailable'` for up to 5 s even though it was merely attaching. Fixed by
  tightening the window to 500 ms; a cross-pane-bleed regression test was added and the comment in
  `useActivityTerminalPortalStatus` that wrongly claimed a later pane could never be answered for was corrected.
- **Round 4** — clean: **zero blocking, zero major findings.**

**Final verdict: clean (zero blocking, zero major).**
**`/perf` skill review verdict: no-regression.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
