### PR TITLE
fix(terminal): rate-cap WebGL glyph-atlas recovery on streaming output

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   unregisterLivePaneManager
 } from '@/lib/pane-manager/pane-manager-registry'
 import {
+  resetTerminalWebglAtlasRecoveryBudgetForTesting,
   scheduleImagePasteWebglAtlasRecovery,
   scheduleTabRevealWebglAtlasRecovery,
   scheduleTerminalWebglAtlasRecovery,
@@ -16,10 +17,12 @@ describe('terminal WebGL atlas recovery', () => {
   function registerManager(): {
     resetWebglTextureAtlases: Mock<() => void>
     refreshAllPanes: Mock<() => void>
+    scheduleRevealPresent: Mock<() => void>
   } {
     const manager = {
       resetWebglTextureAtlases: vi.fn<() => void>(),
-      refreshAllPanes: vi.fn<() => void>()
+      refreshAllPanes: vi.fn<() => void>(),
+      scheduleRevealPresent: vi.fn<() => void>()
     }
     registerLivePaneManager(manager)
     registeredManagers.push(manager)
@@ -36,6 +39,7 @@ describe('terminal WebGL atlas recovery', () => {
     vi.clearAllTimers()
     vi.useRealTimers()
     vi.unstubAllGlobals()
+    resetTerminalWebglAtlasRecoveryBudgetForTesting()
   })
 
   it('clears atlases and refreshes panes through the post-paste redraw window', () => {
@@ -270,6 +274,147 @@ describe('terminal WebGL atlas recovery', () => {
       expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
       expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
     }
+  })
+
+  it('caps shared-atlas wipes under a sustained alt-screen redraw cadence', () => {
+    // Field regression (F0BMLFAFWF7 on 1.4.167): 442 full shared-glyph-atlas
+    // wipes in 6.2 minutes. A TUI redrawing just slower than the quiet window
+    // clears the debounce on every parse, so the trailing edge fires each time
+    // — the debounce bounds nothing at this cadence.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    for (let elapsed = 0; elapsed < 60_000; elapsed += 300) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(300)
+    }
+
+    expect(manager.resetWebglTextureAtlases.mock.calls.length).toBeLessThanOrEqual(30)
+  })
+
+  it('keeps the wipe gap bounded under a sustained redraw cadence, not burst-then-starve', () => {
+    // Review regression: a fixed count over a rolling 60s window spends its whole
+    // allowance in the first 30s and then starves for 33s. The over-budget path
+    // only re-presents the buffers — it never rebuilds the glyph atlas — so a
+    // vim-style rewrite stayed garbled for half a minute. The refill must be
+    // continuous so the worst-case gap degrades to the refill interval.
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const wipeTimes: number[] = []
+    const manager = {
+      resetWebglTextureAtlases: vi.fn(() => wipeTimes.push(Date.now())),
+      refreshAllPanes: vi.fn(),
+      scheduleRevealPresent: vi.fn()
+    }
+    registerLivePaneManager(manager)
+    registeredManagers.push(manager)
+
+    // Five minutes of the field cadence (F0BMLFAFWF7 ran ~1 redraw/s for hours).
+    for (let elapsed = 0; elapsed < 300_000; elapsed += 300) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(300)
+    }
+
+    const gaps = wipeTimes.slice(1).map((at, index) => at - wipeTimes[index]!)
+    expect(Math.max(...gaps)).toBeLessThanOrEqual(6_500)
+    // Still a large cut from the unbounded ~200 wipes/min the debounce allowed.
+    expect(wipeTimes.length).toBeLessThanOrEqual(75)
+  })
+
+  it('presents from the live buffers when a settle is over the wipe budget', () => {
+    // De-escalation: a suppressed settle must still recover stale pixels, just
+    // without wiping the atlas shared by every same-config terminal.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTerminalWebglAtlasRecovery()
+    vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealPresent).not.toHaveBeenCalled()
+
+    // Second settle lands inside the minimum interval → present, no wipe.
+    scheduleTerminalWebglAtlasRecovery()
+    vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealPresent).toHaveBeenCalledTimes(1)
+  })
+
+  it('recovers the wipe budget when the wall clock steps backwards', () => {
+    // Sleep/resume, NTP correction and SSH host-clock skew can move Date.now()
+    // backwards; the bucket must not wedge until the clock catches up.
+    vi.useFakeTimers()
+    vi.setSystemTime(600_000)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTerminalWebglAtlasRecovery()
+    vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(60_000)
+    scheduleTerminalWebglAtlasRecovery()
+    vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps paste and reveal recovery immediate after the streaming budget is spent', () => {
+    // Reveal/paste are one-shot user-visible events; the streaming rate cap must
+    // never defer or downgrade them.
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      })
+    )
+    const manager = registerManager()
+
+    for (let elapsed = 0; elapsed < 60_000; elapsed += 300) {
+      scheduleTerminalWebglAtlasRecovery()
+      vi.advanceTimersByTime(300)
+    }
+    manager.resetWebglTextureAtlases.mockClear()
+    manager.refreshAllPanes.mockClear()
+
+    scheduleTabRevealWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
+
+    manager.resetWebglTextureAtlases.mockClear()
+    scheduleImagePasteWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
   })
 
   it('coalesces the terminal-output callers onto one shared timer while paste stays immediate', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
@@ -1,4 +1,7 @@
-import { resetAndRefreshAllTerminalWebglAtlases } from '@/lib/pane-manager/pane-manager-registry'
+import {
+  presentAllTerminalPanesWithoutAtlasClear,
+  resetAndRefreshAllTerminalWebglAtlases
+} from '@/lib/pane-manager/pane-manager-registry'
 
 const ATLAS_RECOVERY_DELAYS_MS = [120, 500]
 
@@ -7,7 +10,25 @@ const ATLAS_RECOVERY_DELAYS_MS = [120, 500]
 // (STA-1365). Wait for output to go quiet so recovery runs once, on settle.
 export const TERMINAL_OUTPUT_RECOVERY_QUIET_MS = 200
 
+// Why: the debounce bounds nothing against a TUI redrawing just slower than the
+// quiet window — every parse then trips the trailing edge. Field bundle
+// F0BMLFAFWF7 recorded 442 shared-atlas wipes in 6.2 min (~1/s, sustained for
+// hours). Bound how often the streaming path may escalate to a wipe; over-budget
+// settles present from the live buffers instead.
+const TERMINAL_OUTPUT_RECOVERY_MIN_INTERVAL_MS = 3_000
+// Why: a token bucket, not a fixed-window count. A count over a rolling 60s
+// window burns its whole allowance in the first 30s of a sustained stream and
+// then starves for 33s, and the only recovery left in that hole is a buffer
+// re-present, which never rebuilds the glyph atlas — so vim-style rewrites stay
+// garbled for half a minute. Refilling continuously keeps the same sustained
+// ceiling while degrading the worst-case wipe gap to the refill interval.
+const TERMINAL_OUTPUT_RECOVERY_BURST_WIPES = 10
+const TERMINAL_OUTPUT_RECOVERY_REFILL_INTERVAL_MS = 6_000
+
 let terminalOutputRecoveryDebounceTimer: ReturnType<typeof setTimeout> | null = null
+let terminalOutputRecoveryWipeTokens = TERMINAL_OUTPUT_RECOVERY_BURST_WIPES
+let terminalOutputRecoveryTokensRefilledAt: number | null = null
+let terminalOutputRecoveryLastWipeAt: number | null = null
 
 function scheduleNextFrame(callback: () => void): void {
   if (typeof globalThis.requestAnimationFrame === 'function') {
@@ -22,6 +43,14 @@ function resetAtlasesAndRefreshPanes(): void {
     // Why: the glyph atlas is shared across same-config terminals, so the
     // recovery reset must be followed by repainting each rebuilt render model.
     resetAndRefreshAllTerminalWebglAtlases()
+  } catch {
+    /* ignore - terminal pane may have unmounted after scheduling recovery */
+  }
+}
+
+function presentPanesWithoutAtlasClear(): void {
+  try {
+    presentAllTerminalPanesWithoutAtlasClear()
   } catch {
     /* ignore - terminal pane may have unmounted after scheduling recovery */
   }
@@ -56,6 +85,51 @@ export function scheduleTerminalWebglAtlasRecovery(): void {
   }
   terminalOutputRecoveryDebounceTimer = globalThis.setTimeout(() => {
     terminalOutputRecoveryDebounceTimer = null
-    resetAtlasesAndRefreshPanes()
+    if (consumeTerminalOutputRecoveryWipeBudget()) {
+      resetAtlasesAndRefreshPanes()
+      return
+    }
+    presentPanesWithoutAtlasClear()
   }, TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
+}
+
+// Test seam: the wipe budget is module-global, so a suite of scheduler tests
+// would otherwise inherit the previous test's spent budget.
+export function resetTerminalWebglAtlasRecoveryBudgetForTesting(): void {
+  terminalOutputRecoveryWipeTokens = TERMINAL_OUTPUT_RECOVERY_BURST_WIPES
+  terminalOutputRecoveryTokensRefilledAt = null
+  terminalOutputRecoveryLastWipeAt = null
+}
+
+function refillTerminalOutputRecoveryWipeTokens(now: number): void {
+  const elapsedMs = now - (terminalOutputRecoveryTokensRefilledAt ?? now)
+  terminalOutputRecoveryTokensRefilledAt = now
+  // Why: wall-clock can step backwards (NTP, system sleep, VM resume); treat that
+  // as a fresh bucket so recovery can't wedge until the clock catches up.
+  if (elapsedMs < 0) {
+    terminalOutputRecoveryWipeTokens = TERMINAL_OUTPUT_RECOVERY_BURST_WIPES
+    terminalOutputRecoveryLastWipeAt = null
+    return
+  }
+  terminalOutputRecoveryWipeTokens = Math.min(
+    TERMINAL_OUTPUT_RECOVERY_BURST_WIPES,
+    terminalOutputRecoveryWipeTokens + elapsedMs / TERMINAL_OUTPUT_RECOVERY_REFILL_INTERVAL_MS
+  )
+}
+
+function consumeTerminalOutputRecoveryWipeBudget(): boolean {
+  const now = Date.now()
+  refillTerminalOutputRecoveryWipeTokens(now)
+  if (
+    terminalOutputRecoveryLastWipeAt != null &&
+    now - terminalOutputRecoveryLastWipeAt < TERMINAL_OUTPUT_RECOVERY_MIN_INTERVAL_MS
+  ) {
+    return false
+  }
+  if (terminalOutputRecoveryWipeTokens < 1) {
+    return false
+  }
+  terminalOutputRecoveryWipeTokens -= 1
+  terminalOutputRecoveryLastWipeAt = now
+  return true
 }

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -10,6 +10,7 @@ type RegisteredPaneManager = {
   getPanes?: (limit?: number) => { id: number; terminal: unknown }[]
   getPaneCount?: () => number
   isVisibleForAtlasRecovery?: () => boolean
+  scheduleRevealPresent?: () => void
 }
 
 const liveManagers = new Set<RegisteredPaneManager>()
@@ -73,6 +74,28 @@ export function resetAndRefreshAllTerminalWebglAtlases(): void {
     } catch {
       // Why: a pane can unmount between atlas reset and repaint; later
       // managers still need to repaint from their xterm buffers.
+    }
+  }
+}
+
+/**
+ * Re-presents every live pane from its xterm buffer without touching the shared
+ * glyph atlas.
+ *
+ * Why: the de-escalated recovery step. A wipe rebuilds every same-config
+ * terminal's render model; a present only asks the compositor for a fresh frame,
+ * so a busy TUI can keep recovering stale pixels without the global churn.
+ */
+export function presentAllTerminalPanesWithoutAtlasClear(): void {
+  for (const manager of liveManagers) {
+    if (manager.isVisibleForAtlasRecovery?.() === false) {
+      continue
+    }
+    try {
+      manager.scheduleRevealPresent?.()
+    } catch {
+      // Why: best-effort during teardown; one disposed manager must not block
+      // sibling terminals from re-presenting.
     }
   }
 }


### PR DESCRIPTION
## What this fixes

**Signature:** renderer `render-process-gone { reason: "crashed" }` on Windows (`exitCode -36861` / `-1`) and Linux (`139` = SIGSEGV) after a long session in which the app wiped the **shared** xterm WebGL glyph atlas roughly once per second, for minutes-to-hours, right up to the moment the renderer died.

**Scope:** this is work item 10 in `/tmp/crash-plan.md`, scoped to **11 of the 127 reports** in this batch — triage subgroup G5-B ("sustained global WebGL glyph-atlas thrash", `crash-triage.json` group `G5-win-crashed (16) + G5b-linux-crashed (4)`).

**Be explicit about the confidence level:** the plan labels this item **`CORRELATIONAL ONLY — G5-B: atlas thrash → renderer death. 442 resets/6.2 min is real and undamped; that it causes the SIGSEGV is not shown.`** That is still true after this change. This PR is a **bounded mitigation of a measured, undesirable workload on the crashing code path**, not a proven crash fix. What is proven is that the churn is real, unbounded, and app-generated; what is *not* proven is that removing it removes the SIGSEGV. Do not close the G5-B reports on merge — re-measure the field rate first.

### Root cause

`scheduleTerminalWebglAtlasRecovery` was a bare 200 ms trailing-edge debounce with no minimum interval and no rate cap:

- `src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts:79-94` — every call clears the pending timer and re-arms it; when it finally fires it calls `resetAtlasesAndRefreshPanes()` unconditionally.
- It is armed from **every foreground alt-screen parse**: `src/renderer/src/components/terminal-pane/pty-connection.ts:6203` and `:6329`.

A debounce only bounds a *burst*. It bounds **nothing** against a producer whose gaps are consistently *longer* than the quiet window. A TUI agent (`claude`) that redraws with ~300 ms–1 s pauses clears the timer, then goes quiet for 200 ms, then trips the trailing edge — on essentially every redraw. Each trailing edge runs `clearTextureAtlas()` (GPU texture free + realloc of the atlas **shared by every same-config terminal**) plus a forced repaint of every pane in every visible manager (`src/renderer/src/lib/pane-manager/pane-manager-registry.ts:50-78`, `pane-webgl-renderer.ts:127-146`).

Prior art that did **not** cover this: `2f73775ffc fix(terminal): bound fullscreen atlas recovery (#12061)` bounded the *fan-out* (`isVisibleForAtlasRecovery`), not the *frequency*. F0BMLFAFWF7 is on 1.4.167 — after that commit — and still shows 1.22 wipes/s.

### Representative reports

| Report | Platform / exit | Version | Measured atlas wipes | Slack |
|---|---|---|---|---|
| `F0BMLFAFWF7` | linux 7.0.0-28-generic, `139` (SIGSEGV) | 1.4.167 | **442 in 6.04 min = 73.2/min (1.22/s)** | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785776647348489) |
| `F0BLZLG0CBZ` | win32 10.0.22631, `-36861` | 1.4.163 | **402 in 9.89 min = 40.6/min** | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785656638177439) |
| `F0BMFE3FDC5` | win32 10.0.26200, `-36861` | 1.4.164 | **257 in 4.88 min = 52.7/min** | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785735656634349) |
| `F0BMA00J203` | win32 10.0.26200, `-1` | 1.4.164 | **247 in 4.94 min = 50.0/min** | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785687140598579) |

### The fix

`terminal-webgl-atlas-recovery.ts` — put a **token bucket** in front of the escalation to a shared-atlas wipe, on the streaming path only:

- `TERMINAL_OUTPUT_RECOVERY_MIN_INTERVAL_MS = 3_000` (`:20`) — no two streaming wipes closer than 3 s.
- `TERMINAL_OUTPUT_RECOVERY_BURST_WIPES = 10`, `TERMINAL_OUTPUT_RECOVERY_REFILL_INTERVAL_MS = 6_000` (`:27-28`) — 10-wipe burst, refilling one wipe per 6 s, i.e. a sustained ceiling of 10/min.
- Over-budget settles **de-escalate rather than drop**: `presentAllTerminalPanesWithoutAtlasClear()` (`pane-manager-registry.ts:88-100`) re-presents every live pane from its xterm buffer via the pre-existing `scheduleRevealPresent`, without touching the shared atlas.
- A backwards wall-clock step (sleep/resume, NTP, SSH host skew) resets the bucket rather than wedging it (`:104-118`).
- **Paste and tab-reveal keep their immediate 3-stage burst** — they do not go through the bucket at all (`scheduleImagePasteWebglAtlasRecovery` / `scheduleTabRevealWebglAtlasRecovery`).

A fixed count over a rolling 60 s window was tried and rejected in review: it spends the whole allowance in the first 30 s of a sustained stream and then starves for ~33 s, and the over-budget path never rebuilds the glyph atlas — so a vim-style full-screen rewrite stayed garbled for half a minute. Continuous refill keeps the same sustained ceiling with a worst-case wipe gap of ~6 s. There is a regression test for exactly that (see below).

---

## Fix evidence

### 1. RED without the source fix

Scratch worktree at the branch commit, then `git checkout origin/main --` on **only** the two source files (`terminal-webgl-atlas-recovery.ts`, `pane-manager-registry.ts`), test file left at branch state:

```
$ git worktree add /tmp/prproof-w10-atlas-rate crashfix/w10-atlas-rate --detach
$ ln -s /Users/nwparker/orca/crashwork/w10-atlas-rate/node_modules /tmp/prproof-w10-atlas-rate/node_modules
$ git checkout origin/main -- src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts src/renderer/src/lib/pane-manager/pane-manager-registry.ts
$ pnpm exec vitest run --config config/vitest.config.ts --reporter=verbose src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
```

The reverted source also removes the `resetTerminalWebglAtlasRecoveryBudgetForTesting` test seam, so the first run failed all 14 tests in `afterEach` with `TypeError: resetTerminalWebglAtlasRecoveryBudgetForTesting is not a function` — which masks *which* assertions actually regress. The load-bearing failures from that first run were still visible:

```
 FAIL  ... > caps shared-atlas wipes under a sustained alt-screen redraw cadence
AssertionError: expected 200 to be less than or equal to 30

 FAIL  ... > keeps the wipe gap bounded under a sustained redraw cadence, not burst-then-starve
AssertionError: expected 1000 to be less than or equal to 75

 FAIL  ... > presents from the live buffers when a settle is over the wipe budget
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times

 Test Files  1 failed (1)
      Tests  14 failed (14)
```

To isolate the behavioural regression from the missing seam, I appended a no-op `export function resetTerminalWebglAtlasRecoveryBudgetForTesting(): void {}` **to the scratch copy only** and re-ran. This is the clean red proof — exactly the 3 new behavioural tests fail, all 11 pre-existing tests still pass:

```
 RUN  v4.1.5 /private/tmp/prproof-w10-atlas-rate

 ✓ ... > clears atlases and refreshes panes through the post-paste redraw window 2ms
 ✓ ... > refreshes after each scheduled atlas reset 1ms
 ✓ ... > falls back to a timeout when animation frames are unavailable 0ms
 ✓ ... > continues recovery when a manager throws after scheduling 1ms
 ✓ ... > recovers immediately on a tab reveal, not through the streaming debounce 0ms
 ✓ ... > does not recover mid-stream while terminal output keeps arriving 0ms
 ✓ ... > recovers exactly once after terminal output settles, not a 3-stage burst 0ms
 ✓ ... > does not clear mid-stream when a settle is followed by resumed streaming 0ms
 × ... > caps shared-atlas wipes under a sustained alt-screen redraw cadence 2ms
   → expected 200 to be less than or equal to 30
 × ... > keeps the wipe gap bounded under a sustained redraw cadence, not burst-then-starve 3ms
   → expected 1000 to be less than or equal to 75
 × ... > presents from the live buffers when a settle is over the wipe budget 0ms
   → expected "vi.fn()" to be called 1 times, but got 2 times
 ✓ ... > recovers the wipe budget when the wall clock steps backwards 1ms
 ✓ ... > keeps paste and reveal recovery immediate after the streaming budget is spent 1ms
 ✓ ... > coalesces the terminal-output callers onto one shared timer while paste stays immediate 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts > terminal WebGL atlas recovery > caps shared-atlas wipes under a sustained alt-screen redraw cadence
AssertionError: expected 200 to be less than or equal to 30
 ❯ src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts:299:64
    297|     }
    298|
    299|     expect(manager.resetWebglTextureAtlases.mock.calls.length).toBeLes…
       |                                                                ^
    300|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯

 FAIL  src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts > terminal WebGL atlas recovery > keeps the wipe gap bounded under a sustained redraw cadence, not burst-then-starve
AssertionError: expected 1000 to be less than or equal to 75
 ❯ src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts:335:30
    333|     expect(Math.max(...gaps)).toBeLessThanOrEqual(6_500)
    334|     // Still a large cut from the unbounded ~200 wipes/min the debounc…
    335|     expect(wipeTimes.length).toBeLessThanOrEqual(75)
       |                              ^
    336|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯

 FAIL  src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts > terminal WebGL atlas recovery > presents from the live buffers when a settle is over the wipe budget
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts:359:46
    357|     scheduleTerminalWebglAtlasRecovery()
    358|     vi.advanceTimersByTime(TERMINAL_OUTPUT_RECOVERY_QUIET_MS)
    359|     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
       |                                              ^
    360|     expect(manager.scheduleRevealPresent).toHaveBeenCalledTimes(1)
    361|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯


 Test Files  1 failed (1)
      Tests  3 failed | 11 passed (14)
```

The numbers in that output are the whole argument:

- `expected 200 to be less than or equal to 30` — 60 s of fake time at a 300 ms redraw cadence produced **200 shared-atlas wipes** on `origin/main`. That is the field pattern, reproduced deterministically.
- `expected 1000 to be less than or equal to 75` — 5 minutes of the same cadence produced **1000 wipes**, i.e. the debounce never converges; it scales linearly with stream duration forever.

The scratch worktree was removed afterwards (`git worktree remove --force /tmp/prproof-w10-atlas-rate`). No `git stash` was used at any point; the branch worktree is byte-identical to the pushed commit (`git status --short` is empty).

### 2. GREEN with the fix

```
$ cd /Users/nwparker/orca/crashwork/w10-atlas-rate
$ pnpm exec vitest run --config config/vitest.config.ts --reporter=verbose src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w10-atlas-rate

 ✓ ... > clears atlases and refreshes panes through the post-paste redraw window 2ms
 ✓ ... > refreshes after each scheduled atlas reset 1ms
 ✓ ... > falls back to a timeout when animation frames are unavailable 0ms
 ✓ ... > continues recovery when a manager throws after scheduling 1ms
 ✓ ... > recovers immediately on a tab reveal, not through the streaming debounce 0ms
 ✓ ... > does not recover mid-stream while terminal output keeps arriving 0ms
 ✓ ... > recovers exactly once after terminal output settles, not a 3-stage burst 0ms
 ✓ ... > does not clear mid-stream when a settle is followed by resumed streaming 0ms
 ✓ ... > caps shared-atlas wipes under a sustained alt-screen redraw cadence 1ms
 ✓ ... > keeps the wipe gap bounded under a sustained redraw cadence, not burst-then-starve 2ms
 ✓ ... > presents from the live buffers when a settle is over the wipe budget 0ms
 ✓ ... > recovers the wipe budget when the wall clock steps backwards 0ms
 ✓ ... > keeps paste and reveal recovery immediate after the streaming budget is spent 0ms
 ✓ ... > coalesces the terminal-output callers onto one shared timer while paste stays immediate 0ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  01:41:07
   Duration  115ms (transform 30ms, setup 0ms, import 38ms, tests 10ms, environment 0ms)
```

### 3. Regression suite — every touched module, in full

Touched modules are `src/renderer/src/components/terminal-pane/` and `src/renderer/src/lib/pane-manager/`. Both directories, entirely:

```
$ pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane src/renderer/src/lib/pane-manager

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w10-atlas-rate


 Test Files  287 passed (287)
      Tests  3633 passed | 1 skipped (3634)
   Start at  01:41:55
   Duration  35.91s (transform 38.97s, setup 0ms, import 70.56s, tests 83.32s, environment 5.00s)
```

Zero failures — there are **no** pre-existing failures to disclaim in these two directories on macOS. The single skip is pre-existing and unrelated.

**Windows verification** (from `/tmp/crash-pr-meta.json`, entry `w10-atlas-rate`): *"full renderer suite run on Windows: same 5 pre-existing failures as the origin/main Windows baseline."* Those 5 are the known Windows baseline failures shared across this crash batch — `github-item-dialog`, `pull-request-page`, `monaco undo`, `SourceControl host-context`, `resource-session-classification` — all **pre-existing on `origin/main`** and untouched by this change. Note that the code here is platform-independent; only the *crash outcome* was win/linux-specific (Chromium GPU drivers), and that outcome is not locally reproducible on macOS.

**`/perf` skill verdict:** `no-regression`.

### 4. Field data — verbatim

`F0BMLFAFWF7` (diag bundle `F0BMLFAE1QV`), linux SIGSEGV, on 1.4.167 — i.e. *after* the #12061 fan-out bound. The retained breadcrumb ring, tail-end, verbatim from the bundle:

```json
{"createdAt":"2026-08-03T17:02:09.044Z","name":"renderer_memory","data":{"reason":"interval","usedHeapMB":46,"totalHeapMB":104,"heapLimitMB":4192,"heapSource":"v8","mallocedMB":1,"blinkAllocatedMB":67,"browserWebviews":0,"registeredBrowserGuests":0}}
{"createdAt":"2026-08-03T17:02:31.554Z","name":"terminal_webgl_diagnostic","data":{"managers":1,"mountedManagers":2,"kind":"webgl-atlas-reset","suppressedSinceLast":29}}
{"createdAt":"2026-08-03T17:03:01.586Z","name":"terminal_webgl_diagnostic","data":{"managers":1,"mountedManagers":2,"kind":"webgl-atlas-reset","suppressedSinceLast":29}}
{"createdAt":"2026-08-03T17:03:09.044Z","name":"renderer_memory","data":{"reason":"interval","usedHeapMB":55,"totalHeapMB":104,"heapLimitMB":4192,"heapSource":"v8","mallocedMB":1,"blinkAllocatedMB":139,"browserWebviews":0,"registeredBrowserGuests":0}}
{"createdAt":"2026-08-03T17:03:18.700Z","name":"agent_state_changed","data":{"agentType":"claude","state":"working","suppressedSinceLast":8}}
{"createdAt":"2026-08-03T17:03:31.608Z","name":"terminal_webgl_diagnostic","data":{"managers":1,"mountedManagers":2,"kind":"webgl-atlas-reset","suppressedSinceLast":22}}
```

...and the death 22 s later:

```json
"crash.source":"renderer","crash.process_type":"renderer","crash.reason":"crashed","crash.exit_code":139,"app.version":"1.4.167","platform":"linux","osRelease":"7.0.0-28-generic","electronVersion":"43.1.0","chromeVersion":"150.0.7871.47"
"exit":{"_tag":"Failure","cause":"renderer process gone: renderer crashed (139)"}
```

Read that breadcrumb encoding carefully: `suppressedSinceLast: 29` means the diagnostic emitter coalesced **29 additional wipes** it did not emit, so each visible crumb represents 30 real wipes. Summing `1 + suppressedSinceLast` over the 13 coalesced `webgl-atlas-reset` crumbs in this bundle:

```
$ python3 (sum 1+suppressedSinceLast over the retained ring in F0BMLFAE1QV.txt)
coalesced breadcrumbs: 13
total wipes: 442
first 2026-08-03T16:57:29.293Z last 2026-08-03T17:03:31.608Z
span sec 362.315 min 6.038583333333333
rate/s 1.2199329312890717 per min 73.1959758773443
```

Note the heap is flat at 40-57 MB of a 4192 MB limit across that entire window — this is *not* the OOM cluster, it is a live GPU-churn workload on a healthy renderer that then SIGSEGVs.

The same recount across every G5 bundle whose retained ring contains atlas crumbs:

```
F0BLZLG0CBZ 1.4.163 -36861  win32 -> 402 wipes in  9.89 min = 40.6 /min
F0BMA00J203 1.4.164 -1      win32 -> 247 wipes in  4.94 min = 50.0 /min
F0BM16LHFST 1.4.164 -36861  win32 ->  35 wipes in  2.26 min = 15.5 /min
F0BMLVAF3PW 1.4.164 139     linux ->   2 wipes in  0.02 min (ring truncated)
F0BMHMQLKEE 1.4.164 -36861  win32 ->  51 wipes in  2.25 min = 22.6 /min
F0BMGBSB2H4 1.4.164 -36861  win32 -> 174 wipes in  6.78 min = 25.7 /min
F0BMGNYJWHL 1.4.164 -36861  win32 -> 136 wipes in  3.87 min = 35.2 /min
F0BMFE3FDC5 1.4.164 -36861  win32 -> 257 wipes in  4.88 min = 52.7 /min
F0BMFGEKYGM 1.4.164 -1      win32 ->  12 wipes in  3.88 min =  3.1 /min
F0BMLFAFWF7 1.4.167 139     linux -> 442 wipes in  6.04 min = 73.2 /min
```

**Honesty note on the count.** The item is scoped to 11 reports per the triage/plan. My own independent recount found measurable sustained atlas churn in **9** bundles with the numbers above (plus one whose retained ring is truncated to a 1-second window, so it is neither confirmation nor refutation). The retained breadcrumb ring only covers the last few minutes before death, so absence of crumbs is not evidence of absence of churn — but I am not going to claim I re-verified 11 when I re-verified 9. Every wipe rate above is ≥15/min against a new sustained ceiling of 10/min, so all of them are over budget today.

---

## ELI5

Imagine a whiteboard shared by every terminal window in the app. On it is a hand-drawn copy of every letter shape the terminals need to paint text quickly. Drawing a character on screen is just "stamp the shape from the whiteboard" — fast, because the shape is already there.

Sometimes the whiteboard goes stale and text comes out garbled. The app's repair procedure is: **erase the whole whiteboard, redraw every letter, and force every terminal on screen to repaint itself.** That's expensive, but it's fine as a rare repair.

To avoid doing that repair while text is still streaming in, the app used a "wait for quiet" rule: *after output stops for 200 ms, do the repair.* The idea was that during a busy stream, output never stops for 200 ms, so the repair only runs once at the end.

The flaw: that rule only works against output that arrives *faster* than 200 ms apart. An AI coding agent redrawing its progress display pauses for about 300 ms–1 second between redraws. Every one of those pauses is longer than 200 ms. So the "wait for quiet" timer fired on **every single redraw** — the app erased and rebuilt the shared whiteboard, and repainted every terminal, about once a second, for hours. It's a smoke alarm that resets itself after 200 ms of silence and therefore goes off between every two words you say.

Real numbers from a real user's crash bundle: 442 full whiteboard erasures in 6 minutes, right up until the graphics driver killed the window.

The fix is a spending allowance, like a metro card. The streaming path now gets 10 "erase the whiteboard" rides up front, and earns one new ride every 6 seconds, and can never use two rides less than 3 seconds apart. When it's out of rides it doesn't do nothing — it does the cheap version: "everybody repaint from what you already have," which fixes stale pixels without touching the shared whiteboard.

Two things deliberately have unlimited rides: pasting an image, and switching to a tab you just revealed. Those are one-off things you're looking at right now, and making you wait 3 seconds for them would be worse than the churn.

One design detail worth the sentence: the allowance refills *continuously* (one ride per 6 s) instead of resetting in a lump every minute. The lump version was tried first and was worse — it burns all 10 rides in the first half minute of a stream, then leaves you with only the cheap repaint for the next 33 seconds, and the cheap repaint can't fix a genuinely corrupt whiteboard. So a full-screen editor redraw stayed garbled for half a minute. Continuous refill means you're never more than ~6 seconds from a real repair.

---

## Trade-offs

**This is a mitigation, not a proven crash fix.** Stated again because it matters: the causal link from atlas thrash to the SIGSEGV is unproven. The plan calls it `CORRELATIONAL ONLY`. If these 11 reports keep arriving after this ships, this change did not fix them — it only removed a confound. Merge it for the churn, not for the crash count.

**Real regressions this introduces:**

1. **Genuine glyph corruption can now persist for up to ~6 seconds during a sustained stream.** Before, a corrupt shared atlas was rebuilt within 200 ms of the next lull. Now, if the bucket is empty, the settle only re-presents from the buffers — which fixes stale/dropped pixels but does **not** rebuild the glyph atlas. If the atlas itself is genuinely bad (driver-lost texture), the user sees garbled glyphs until a token refills. Worst case ~6 s; with a full burst available, unbounded-fast as before. This is the deliberate trade the token bucket makes over a fixed window, and the `keeps the wipe gap bounded…not burst-then-starve` test pins the 6.5 s ceiling so it can't silently regress.

2. **The budget is process-global, not per-manager or per-pane.** One extremely busy terminal can spend the whole allowance and starve a *different* terminal's legitimate recovery for up to 3 s. This is intentional — the atlas being protected is itself global, so a per-pane budget would not bound the thing that actually costs GPU work — but it is a real cross-pane interference channel that did not exist before.

3. **`Date.now()`, not a monotonic clock.** The bucket reads wall time. A backwards step resets the bucket (tested), which is safe-open, but a large *forwards* jump (host sleep/resume, SSH host clock correction) instantly refills the burst. Safe-open in both directions, but it means the ceiling is not strictly enforced across clock discontinuities. `performance.now()` would be strictly better; it was not used because the existing module has no clock injection seam and adding one was out of scope for a crash-batch PR.

4. **Module-global mutable state with a `…ForTesting` reset export.** `resetTerminalWebglAtlasRecoveryBudgetForTesting` exists purely so suite ordering doesn't leak a spent budget between tests. It is test-only API in production code. The alternative (dependency-inject a clock + bucket) is cleaner and is the right follow-up if this module grows again.

**Known follow-ups deliberately not done in this PR:**

5. **The call sites in `pty-connection.ts:6203` / `:6329` were not touched.** Both the plan and the triage fix-sketch recommend *also* not scheduling a full wipe from every alt-screen parse, and escalating to `clearTextureAtlas()` only when the render-desync sentinel actually observes corruption. This PR bounds the consequence but leaves the over-eager trigger in place. Mitigation for now: the rate cap makes the over-eager trigger cheap. Proper fix: gate the schedule on the desync sentinel — separate PR, needs its own e2e evidence.

6. **No reliability gate for wipes-per-minute was added.** The plan asks for a gate asserting resets/min stays bounded under a 1 Hz TUI redraw. The existing `tests/e2e/terminal-webgl-atlas-budget.spec.ts` covers atlas *page bindability* (`keeps shared glyph pages bindable through overflow and recovery`, `rebuilds cached vertices after attaching a different shared atlas`), **not** frequency. The vitest fake-timer test in this PR pins frequency at the unit level only; a real-app 1 Hz redraw gate is still missing. Mitigation: add it alongside the `pty-connection.ts` trigger change in the follow-up, where it has something to guard.

7. **No field re-measurement plan is wired up.** There is no dashboard alert on `webgl-atlas-reset` rate. Verifying that this actually took effect in production means manually re-running the `suppressedSinceLast` sum over post-merge bundles. Worth a small ingest rule.

**Not a trade-off:** paste and tab-reveal latency are unchanged — they bypass the bucket entirely, pinned by `keeps paste and reveal recovery immediate after the streaming budget is spent`, which drains the budget with 60 s of streaming and then asserts both paths still fire their full immediate 3-stage burst.

---

## Adversarial review

**2 independent adversarial review rounds** were run against this change, followed by **1 fix round**. Each round used a **fresh reviewer with no memory of the prior round** — no shared context, no summary of earlier findings, re-deriving the defect and the fix from the diff and the field bundles.

What the rounds found:

- The substantive finding was the **burst-then-starve flaw in the original rate limiter**. The first implementation used a fixed wipe count over a rolling 60 s window. The reviewer's objection: under a sustained stream that allowance is spent in the first ~30 s, and the only recovery left for the remaining ~33 s is the buffer re-present, which never rebuilds the glyph atlas — so a genuinely corrupt atlas during a vim-style full-screen rewrite stays garbled for half a minute. The user-visible outcome would have been *worse* than the churn being fixed. Resolved by replacing the fixed window with a continuously-refilling token bucket (same sustained ceiling, worst-case gap bounded to the ~6 s refill interval) and pinning it with the `keeps the wipe gap bounded…not burst-then-starve` regression test, which asserts both `max(gap) <= 6_500` and a total wipe count `<= 75` over 5 minutes.
- The clock-safety and immediate-path questions were also raised and are pinned by dedicated tests: `recovers the wipe budget when the wall clock steps backwards` and `keeps paste and reveal recovery immediate after the streaming budget is spent`.
- Minor findings that were deliberately **not** fixed are listed as follow-ups in Trade-offs above (items 3-7), rather than being quietly dropped.

**Final verdict: clean — zero blocking findings, zero major findings.**

**`/perf` skill review verdict: `no-regression`.** The change removes work from the hot path (fewer `clearTextureAtlas()` + all-pane repaint cycles) and adds only two arithmetic comparisons and a `Date.now()` per debounce settle, i.e. at most once per 200 ms of quiet.

Made with [Orca](https://github.com/stablyai/orca) 🐋
