### PR TITLE
fix(window): escalate renderer launch-failed to a Restart Orca prompt instead of reloading a dead webContents

### DIFF
--- a/src/main/app-relaunch.ts
+++ b/src/main/app-relaunch.ts
@@ -7,6 +7,7 @@ export type AppRelaunchReason =
   | 'gpu-fallback'
   | 'profile-switch'
   | 'profile-transfer'
+  | 'renderer-launch-failed'
   | 'renderer-request'
 
 export function relaunchApp(reason: AppRelaunchReason, data?: CrashReportBreadcrumbData): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -183,6 +183,11 @@ import {
   ensureAutoUpdaterConfigured
 } from './window/attach-main-window-services'
 import { createMainWindow, loadMainWindow } from './window/createMainWindow'
+import {
+  planRendererRecoveryPrompt,
+  RendererRecoveryPromptGate,
+  type RendererRecoveryAction
+} from './window/renderer-recovery-escalation'
 import { zoomDashboardPopoutIfFocused } from './window/dashboard-popout-window'
 import {
   createSystemTray,
@@ -1227,13 +1232,14 @@ function openMainWindow(): BrowserWindow {
         reason: details.reason,
         expectedTeardown: getExpectedTeardownScope(webContentsId)
       }),
-    onRendererRecoveryExhausted: ({ details, recentRecoveryCount }) => {
+    onRendererRecoveryExhausted: ({ details, recentRecoveryCount, recommendedAction }) => {
       recordDurableCrashBreadcrumb('renderer_recovery_circuit_breaker_open', {
         reason: details.reason,
         exitCode: details.exitCode ?? null,
-        recentRecoveryCount
+        recentRecoveryCount,
+        recommendedAction
       })
-      void presentRendererRecoveryPrompt(recentRecoveryCount)
+      void presentRendererRecoveryPrompt(recentRecoveryCount, recommendedAction)
     },
     deferLoad: true,
     title: devInstanceIdentity.name,
@@ -1508,28 +1514,43 @@ function sendOpenCrashReport(targetWindow?: BrowserWindow | null): void {
   webContents?.send('ui:openCrashReport')
 }
 
+const rendererRecoveryPromptGate = new RendererRecoveryPromptGate()
+
 // Why: on renderer crash-loop the breaker stops auto-reloading and the window goes blank, so a main-process dialog is the only retry/quit surface.
-async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promise<void> {
+async function presentRendererRecoveryPrompt(
+  recentRecoveryCount: number,
+  recommendedAction: RendererRecoveryAction
+): Promise<void> {
   if (isQuitting) {
     return
   }
   const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
+  const plan = planRendererRecoveryPrompt({ action: recommendedAction, recentRecoveryCount })
   const options = {
     type: 'error' as const,
-    buttons: ['Reload', 'Quit'],
-    defaultId: 0,
-    cancelId: 1,
+    buttons: plan.buttons,
+    defaultId: plan.defaultId,
+    cancelId: plan.cancelId,
     title: 'Orca keeps failing to load',
-    message: 'The app window crashed repeatedly and stopped reloading automatically.',
-    detail: `Orca tried to recover ${recentRecoveryCount} times in a row without success. This is often a graphics-driver or installation problem. Reload to try again, or quit and relaunch Orca.`
+    message: plan.message,
+    detail: plan.detail
   }
-  const { response } = window
-    ? await dialog.showMessageBox(window, options)
-    : await dialog.showMessageBox(options)
-  if (response === 0 && mainWindow && !mainWindow.isDestroyed()) {
+  const result = await rendererRecoveryPromptGate.show(() =>
+    window ? dialog.showMessageBox(window, options) : dialog.showMessageBox(options)
+  )
+  if (!result) {
+    return
+  }
+  const choice = plan.responses[result.response]
+  if (choice === 'relaunch') {
+    recordDurableCrashBreadcrumb('renderer_recovery_relaunch')
+    isQuitting = true
+    relaunchApp('renderer-launch-failed')
+    app.quit()
+  } else if (choice === 'reload' && mainWindow && !mainWindow.isDestroyed()) {
     recordDurableCrashBreadcrumb('renderer_recovery_manual_retry')
     loadMainWindow(mainWindow)
-  } else if (response === 1) {
+  } else if (choice === 'quit') {
     isQuitting = true
     app.quit()
   }

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -3280,7 +3280,7 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
-  it('bounds renderer launch-failed recovery with the crash-loop breaker', () => {
+  it('escalates again when a launch failure follows the host-driven manual retry', () => {
     vi.useFakeTimers()
 
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -3307,15 +3307,52 @@ describe('createMainWindow', () => {
       }
 
       driveLaunchFailure()
-      driveLaunchFailure()
-      driveLaunchFailure()
-      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+      expect(onRendererRecoveryExhausted).toHaveBeenCalledOnce()
 
+      // The field sequence: user answers the prompt with Reload, and the fresh renderer fails to launch too.
+      windowHandlers['did-finish-load']?.()
       driveLaunchFailure()
-      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+
+      expect(onRendererRecoveryExhausted).toHaveBeenCalledTimes(2)
+      expect(onRendererRecoveryExhausted).toHaveBeenLastCalledWith(
+        expect.objectContaining({ details, recommendedAction: 'relaunch' })
+      )
+      // Escalation never reloads the dead webContents; only the initial load ran.
+      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(1)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('escalates renderer launch-failed to a relaunch instead of reloading the dead webContents', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onRendererRecoveryExhausted = vi.fn()
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+
+    try {
+      createMainWindow(null, {
+        onRendererRecoveryExhausted,
+        shouldRecoverRenderer: (details) =>
+          shouldRecoverRendererAfterProcessGone({
+            reason: details.reason,
+            expectedTeardown: 'none'
+          })
+      })
+
+      const details = {
+        reason: 'launch-failed',
+        exitCode: 18
+      } as Electron.RenderProcessGoneDetails
+      windowHandlers['render-process-gone']?.({} as never, details)
+      vi.advanceTimersByTime(250)
+
+      // Only the initial load; a reload cannot spawn a process that failed to launch.
+      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(1)
       expect(onRendererRecoveryExhausted).toHaveBeenCalledOnce()
       expect(onRendererRecoveryExhausted).toHaveBeenCalledWith(
-        expect.objectContaining({ details, recentRecoveryCount: 3 })
+        expect.objectContaining({ details, recommendedAction: 'relaunch' })
       )
     } finally {
       consoleError.mockRestore()

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -44,6 +44,10 @@ import {
 import { getMainE2EConfig } from '../e2e-config'
 import { buildEditableContextMenuTemplate } from './editable-context-menu'
 import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId } from '../ipc/ui'
+import {
+  getRendererRecoveryAction,
+  type RendererRecoveryAction
+} from './renderer-recovery-escalation'
 import { resolveWindowCloseAction } from './window-close-decision'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { closeDashboardPopout } from './dashboard-popout-window'
@@ -189,11 +193,12 @@ type CreateMainWindowOptions = {
     details: Electron.RenderProcessGoneDetails,
     webContentsId: number
   ) => boolean
-  /** Called when consecutive auto-recoveries hit the circuit-breaker limit so the host can prompt instead of crash-looping. */
+  /** Called when auto-recovery stops — breaker limit hit, or a launch failure a reload can't fix — so the host can prompt instead of crash-looping. */
   onRendererRecoveryExhausted?: (info: {
     details: Electron.RenderProcessGoneDetails
     webContentsId: number
     recentRecoveryCount: number
+    recommendedAction: RendererRecoveryAction
   }) => void
   /** Defer renderer load until IPC handlers are registered, or eager renderer calls race into missing channels. */
   deferLoad?: boolean
@@ -586,13 +591,26 @@ export function createMainWindow(
       ) {
         return
       }
+      const recommendedAction = getRendererRecoveryAction(details.reason)
+      if (recommendedAction === 'relaunch') {
+        // Why: the renderer never spawned, so reloading the same webContents can only burn retries and leave a blank window.
+        // Every launch failure escalates — the host dedupes the dialog, so a failure after the user retried still gets a prompt.
+        opts?.onRendererRecoveryExhausted?.({
+          details,
+          webContentsId: rendererWebContentsId,
+          recentRecoveryCount: rendererRecoveryCircuitBreaker.recentRecoveryCount(Date.now()),
+          recommendedAction
+        })
+        return
+      }
       const recovery = rendererRecoveryCircuitBreaker.registerRecoveryAttempt(Date.now())
       if (!recovery.allowed) {
         // Why: too many reloads means it will just crash again; stop and let the host surface a recovery prompt.
         opts?.onRendererRecoveryExhausted?.({
           details,
           webContentsId: rendererWebContentsId,
-          recentRecoveryCount: recovery.recentRecoveryCount
+          recentRecoveryCount: recovery.recentRecoveryCount,
+          recommendedAction
         })
         return
       }

--- a/src/main/window/renderer-recovery-escalation.test.ts
+++ b/src/main/window/renderer-recovery-escalation.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  getRendererRecoveryAction,
+  planRendererRecoveryPrompt,
+  RendererRecoveryPromptGate
+} from './renderer-recovery-escalation'
+
+describe('getRendererRecoveryAction', () => {
+  it('recommends a relaunch when the renderer process never launched', () => {
+    expect(getRendererRecoveryAction('launch-failed')).toBe('relaunch')
+  })
+
+  it('recommends a reload for renderer deaths a fresh document can fix', () => {
+    expect(getRendererRecoveryAction('crashed')).toBe('reload')
+    expect(getRendererRecoveryAction('oom')).toBe('reload')
+    expect(getRendererRecoveryAction(undefined)).toBe('reload')
+  })
+})
+
+describe('planRendererRecoveryPrompt', () => {
+  it('offers Restart Orca first for a launch failure', () => {
+    const plan = planRendererRecoveryPrompt({ action: 'relaunch', recentRecoveryCount: 0 })
+
+    expect(plan.buttons).toEqual(['Restart Orca', 'Reload', 'Quit'])
+    expect(plan.responses).toEqual(['relaunch', 'reload', 'quit'])
+    expect(plan.responses[plan.defaultId]).toBe('relaunch')
+    expect(plan.responses[plan.cancelId]).toBe('quit')
+  })
+
+  it('keeps the reload/quit prompt for crash loops and reports the attempt count', () => {
+    const plan = planRendererRecoveryPrompt({ action: 'reload', recentRecoveryCount: 3 })
+
+    expect(plan.buttons).toEqual(['Reload', 'Quit'])
+    expect(plan.responses).toEqual(['reload', 'quit'])
+    expect(plan.responses[plan.defaultId]).toBe('reload')
+    expect(plan.responses[plan.cancelId]).toBe('quit')
+    expect(plan.detail).toContain('3 times')
+  })
+})
+
+describe('RendererRecoveryPromptGate', () => {
+  it('drops a prompt requested while one is already on screen', async () => {
+    const gate = new RendererRecoveryPromptGate()
+    let resolveFirst: ((value: string) => void) | undefined
+    const first = gate.show(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFirst = resolve
+        })
+    )
+    const second = vi.fn(async () => 'second')
+
+    expect(await gate.show(second)).toBeUndefined()
+    expect(second).not.toHaveBeenCalled()
+
+    resolveFirst?.('first')
+    expect(await first).toBe('first')
+  })
+
+  it('prompts again once the user has answered the previous dialog', async () => {
+    const gate = new RendererRecoveryPromptGate()
+
+    expect(await gate.show(async () => 'first')).toBe('first')
+    expect(await gate.show(async () => 'second')).toBe('second')
+  })
+
+  it('reopens after a rejected prompt so a dialog failure cannot wedge the gate shut', async () => {
+    const gate = new RendererRecoveryPromptGate()
+
+    await expect(
+      gate.show(async () => {
+        throw new Error('dialog failed')
+      })
+    ).rejects.toThrow('dialog failed')
+    expect(await gate.show(async () => 'next')).toBe('next')
+  })
+})

--- a/src/main/window/renderer-recovery-escalation.ts
+++ b/src/main/window/renderer-recovery-escalation.ts
@@ -1,0 +1,73 @@
+/** How Orca should answer a renderer loss once auto-recovery is off the table. */
+export type RendererRecoveryAction = 'relaunch' | 'reload'
+
+/** What the user picked in the recovery dialog. */
+export type RendererRecoveryPromptResponse = RendererRecoveryAction | 'quit'
+
+export type RendererRecoveryPromptPlan = {
+  buttons: string[]
+  defaultId: number
+  cancelId: number
+  message: string
+  detail: string
+  /** Response index -> action, so callers never hardcode button positions. */
+  responses: RendererRecoveryPromptResponse[]
+}
+
+/**
+ * `launch-failed` means the renderer process never spawned (sandbox, AV, or
+ * broken install). Reloading reuses the same webContents, so it can only burn
+ * the circuit breaker and leave a permanently blank window — only a fresh app
+ * process can recover.
+ */
+export function getRendererRecoveryAction(reason: string | undefined): RendererRecoveryAction {
+  return reason === 'launch-failed' ? 'relaunch' : 'reload'
+}
+
+export function planRendererRecoveryPrompt(input: {
+  action: RendererRecoveryAction
+  recentRecoveryCount: number
+}): RendererRecoveryPromptPlan {
+  if (input.action === 'relaunch') {
+    return {
+      buttons: ['Restart Orca', 'Reload', 'Quit'],
+      defaultId: 0,
+      cancelId: 2,
+      message: 'Orca could not start its window process.',
+      detail:
+        'The window process failed to launch, so reloading it cannot help. Restarting Orca gives it a fresh process. This is often caused by antivirus interference, a sandbox restriction, or a damaged installation.',
+      responses: ['relaunch', 'reload', 'quit']
+    }
+  }
+  return {
+    buttons: ['Reload', 'Quit'],
+    defaultId: 0,
+    cancelId: 1,
+    message: 'The app window crashed repeatedly and stopped reloading automatically.',
+    detail: `Orca tried to recover ${input.recentRecoveryCount} times in a row without success. This is often a graphics-driver or installation problem. Reload to try again, or quit and relaunch Orca.`,
+    responses: ['reload', 'quit']
+  }
+}
+
+/**
+ * Keeps at most one recovery dialog on screen. Scoped to "a prompt is up right
+ * now", never "we prompted once": a launch failure that lands after the user
+ * answered must get its own prompt, or the window stays blank with no recovery
+ * affordance at all.
+ */
+export class RendererRecoveryPromptGate {
+  private showing = false
+
+  /** Resolves undefined when a prompt is already on screen. */
+  async show<T>(showPrompt: () => Promise<T>): Promise<T | undefined> {
+    if (this.showing) {
+      return undefined
+    }
+    this.showing = true
+    try {
+      return await showPrompt()
+    } finally {
+      this.showing = false
+    }
+  }
+}


### PR DESCRIPTION
## What this fixes

**Crash signature:** win32 renderer `render-process-gone { reason: 'launch-failed', exitCode: 18 }`, answered by Orca with reloads of the same wedged `webContents`, ending in a permanently blank window that only a manual kill + restart clears.

**Coverage: 1 of the 127 crash reports in this batch** (report `F0BNMD7BZK2`, bundle `F0BMT3674Q2`, Orca 1.4.167, Windows 10.0.26100, Electron 43.1.0 / Chrome 150.0.7871.47). It is the only real crash in the `G7-other` triage group — the other 14 reports in that group are user-initiated Help > "Report Crash..." bug reports (11) and mis-indexed Settings > Privacy diagnostic uploads (3), which are handled by a separate work item. Low count, but the user-visible outcome is total: the app is unusable until the user finds Task Manager.

Slack crash-channel permalinks:
- The crash this PR is about: https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785808422117849 (`F0BNMD7BZK2`, `reason=launch-failed`, `exit=18`)
- Its diagnostic bundle: `F0BMT3674Q2` (submission `MAT2qPICsznto4yICyUoNQ`, 799 spans)

**Root cause (all citations are `origin/main`):**

1. `src/main/crash-reporting/process-gone-classification.ts:99` — `shouldRecoverRendererAfterProcessGone` treats `launch-failed` as recoverable: *"Launch failures can be transient and are bounded by the caller's renderer-recovery circuit breaker."*
2. `src/main/window/createMainWindow.ts:602` — the recovery it schedules is `loadMainWindow(mainWindow)` on the **same** `BrowserWindow`/`webContents` whose render-process host just failed to spawn. A reload asks Chromium to navigate a renderer that does not exist; it cannot create one. Each no-op reload still burns one slot of the circuit breaker (`renderer-recovery-circuit-breaker.ts:15` — 3 recoveries / 60 s).
3. `src/main/index.ts:1528` — once the breaker opens, the only recovery surface is a dialog with `buttons: ['Reload', 'Quit']`. "Reload" calls the same no-op `loadMainWindow`. There is no "Restart Orca", even though `relaunchApp()` already exists (`src/main/app-relaunch.ts:13`) and a full app restart is exactly what recovered the user 6 seconds later.

So Orca picked the wrong recovery verb for `launch-failed` and then offered the user that same wrong verb as the default button.

**The fix:**
- New pure module `src/main/window/renderer-recovery-escalation.ts`: `getRendererRecoveryAction(reason)` returns `'relaunch'` for `launch-failed` and `'reload'` for everything else (`:23`); `planRendererRecoveryPrompt()` builds the dialog (buttons, defaultId, cancelId, copy, and a response-index → action map so no caller hardcodes button positions); `RendererRecoveryPromptGate` keeps at most one dialog on screen.
- `src/main/window/createMainWindow.ts:594-604`: a `launch-failed` never schedules a reload — it escalates to the host immediately with `recommendedAction: 'relaunch'`.
- `src/main/index.ts:1533-1553`: the prompt becomes `['Restart Orca', 'Reload', 'Quit']` for launch failures, default `Restart Orca`, backed by `relaunchApp('renderer-launch-failed')` + `app.quit()`, with a `renderer_recovery_relaunch` durable breadcrumb so the next report shows whether the relaunch worked. The crash-loop prompt for every other reason is unchanged.

**Deduping is on "a prompt is on screen", not "we prompted once"** — the field data forces this; see the 15 ms gap in the timeline below.

**What this PR does NOT fix, stated plainly:** it does not fix the underlying Chromium launch failure. Per `node_modules/electron/electron.d.ts:11786-11790`, when `reason` is `launch-failed` the `exitCode` is "a platform-specific launch failure error code" — on Windows a Chromium/sandbox result code, not a process exit status — so `18` is not decodable from this data and no attempt is made to decode it. Environmental correlates in the bundle (workspace on `\\wsl.localhost\Ubuntu\...` with `wsl.exe timed out` git failures; 1.4.167 auto-update installed 30 minutes before the crash) are **correlation only**. This is a recovery-path fix: it converts "permanently blank window, kill the process yourself" into "one click restores the app". Nothing here makes the renderer launch succeed.

## Fix evidence

### 1. Red without the source fix

Scratch worktree at the branch commit with only the source files reverted to `origin/main` (`git checkout origin/main -- src/main/window/createMainWindow.ts src/main/index.ts src/main/app-relaunch.ts` and the new module removed); tests untouched.

```
$ cd /tmp/prproof-w11-launch-failed && npx vitest run --config config/vitest.config.ts --reporter=verbose src/main/window/createMainWindow.test.ts -t 'launch'

 RUN  v4.1.5 /private/tmp/prproof-w11-launch-failed

 × src/main/window/createMainWindow.test.ts > createMainWindow > escalates again when a launch failure follows the host-driven manual retry 3ms
   → expected "vi.fn()" to be called once, but got 0 times
 × src/main/window/createMainWindow.test.ts > createMainWindow > escalates renderer launch-failed to a relaunch instead of reloading the dead webContents 1ms
   → expected "vi.fn()" to be called 1 times, but got 2 times

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/window/createMainWindow.test.ts > createMainWindow > escalates again when a launch failure follows the host-driven manual retry
AssertionError: expected "vi.fn()" to be called once, but got 0 times
 ❯ src/main/window/createMainWindow.test.ts:3310:43
    3308|
    3309|       driveLaunchFailure()
    3310|       expect(onRendererRecoveryExhausted).toHaveBeenCalledOnce()
       |                                           ^
    3311|
    3312|       // The field sequence: user answers the prompt with Reload, and …

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  src/main/window/createMainWindow.test.ts > createMainWindow > escalates renderer launch-failed to a relaunch instead of reloading the dead webContents
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
 ❯ src/main/window/createMainWindow.test.ts:3352:46
    3350|
    3351|       // Only the initial load; a reload cannot spawn a process that f…
    3352|       expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(1)
       |                                              ^
    3353|       expect(onRendererRecoveryExhausted).toHaveBeenCalledOnce()
    3354|       expect(onRendererRecoveryExhausted).toHaveBeenCalledWith(

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed | 80 skipped (82)
   Duration  1.12s
```

Read the second failure literally: on `origin/main`, `loadFile` is called **2** times for a single `launch-failed` — the initial load plus one reload of a `webContents` whose process never spawned. That second call is the defect.

The new pure module's own suite cannot even resolve without the fix:

```
$ cd /tmp/prproof-w11-launch-failed && npx vitest run --config config/vitest.config.ts --reporter=verbose src/main/window/renderer-recovery-escalation.test.ts

⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/window/renderer-recovery-escalation.test.ts [ src/main/window/renderer-recovery-escalation.test.ts ]
Error: Cannot find module './renderer-recovery-escalation' imported from /private/tmp/prproof-w11-launch-failed/src/main/window/renderer-recovery-escalation.test.ts
 ❯ src/main/window/renderer-recovery-escalation.test.ts:2:1

Serialized Error: { code: 'ERR_MODULE_NOT_FOUND' }

 Test Files  1 failed (1)
      Tests  no tests
```

The scratch worktree was removed afterwards (`git worktree remove --force /tmp/prproof-w11-launch-failed`). No `git stash` was used at any point.

### 2. Green on this branch

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose src/main/window/createMainWindow.test.ts -t 'launch'

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w11-launch-failed
 ✓ src/main/window/createMainWindow.test.ts > createMainWindow > escalates again when a launch failure follows the host-driven manual retry 3ms
 ✓ src/main/window/createMainWindow.test.ts > createMainWindow > escalates renderer launch-failed to a relaunch instead of reloading the dead webContents 1ms
 Test Files  1 passed (1)
      Tests  2 passed | 80 skipped (82)
   Duration  366ms
```

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose src/main/window/renderer-recovery-escalation.test.ts

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w11-launch-failed

 ✓ src/main/window/renderer-recovery-escalation.test.ts > getRendererRecoveryAction > recommends a relaunch when the renderer process never launched 1ms
 ✓ src/main/window/renderer-recovery-escalation.test.ts > getRendererRecoveryAction > recommends a reload for renderer deaths a fresh document can fix 0ms
 ✓ src/main/window/renderer-recovery-escalation.test.ts > planRendererRecoveryPrompt > offers Restart Orca first for a launch failure 0ms
 ✓ src/main/window/renderer-recovery-escalation.test.ts > planRendererRecoveryPrompt > keeps the reload/quit prompt for crash loops and reports the attempt count 0ms
 ✓ src/main/window/renderer-recovery-escalation.test.ts > RendererRecoveryPromptGate > drops a prompt requested while one is already on screen 0ms
 ✓ src/main/window/renderer-recovery-escalation.test.ts > RendererRecoveryPromptGate > prompts again once the user has answered the previous dialog 0ms
 ✓ src/main/window/renderer-recovery-escalation.test.ts > RendererRecoveryPromptGate > reopens after a rejected prompt so a dialog failure cannot wedge the gate shut 1ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  92ms
```

### 3. Regression suites for every touched module

`src/main/window/` (contains `createMainWindow.ts`, the new `renderer-recovery-escalation.ts`):

```
$ npx vitest run --config config/vitest.config.ts src/main/window

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w11-launch-failed

 Test Files  22 passed (22)
      Tests  273 passed (273)
   Duration  3.40s
```

`src/main/app-relaunch.test.ts` (the `AppRelaunchReason` union) + `src/main/crash-reporting/` (the breaker and the process-gone classification this path reads):

```
$ npx vitest run --config config/vitest.config.ts src/main/app-relaunch.test.ts src/main/crash-reporting

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w11-launch-failed

 Test Files  14 passed (14)
      Tests  102 passed (102)
   Duration  466ms
```

Typecheck of the main/node project (`src/main/index.ts` has no unit suite of its own, so this is its compile-level coverage):

```
$ npx tsc --noEmit -p config/tsconfig.node.json
TSC_EXIT=0
```

**Zero failures, so there are no pre-existing failures to disclaim in these suites** — everything listed above is green on this branch.

**Windows verification status (verbatim from the batch metadata):** *"not required (main-process recovery logic; the Chromium launch failure itself is win32-only and not locally reproducible)"*. To be explicit about what that means: the crash occurred on Windows, and the Chromium-level launch failure cannot be reproduced on macOS or in CI. What is being fixed and tested here is Orca's platform-independent main-process response to a `render-process-gone` event, driven through the existing fault-injection harness in `createMainWindow.test.ts` which emits `{ reason: 'launch-failed', exitCode: 18 }` before any `did-finish-load`. The new prompt path itself has not been clicked through on a real Windows machine.

### 4. Field data — the defect happening in production

Crash report `F0BNMD7BZK2`, "Recent activity" tail, verbatim from `/Users/nwparker/.agent-slack/tmp/downloads/F0BNMD7BZK2.txt`:

```
- 2026-08-04T01:53:04.679Z: app_started (packaged=true, platform=win32, mainProcessPid=43196, ...)
- 2026-08-04T01:53:05.684Z: main_window_created
- 2026-08-04T01:53:08.633Z: renderer_recovery_reload (mainProcessPid=43196, ...)
- 2026-08-04T01:53:12.723Z: renderer_recovery_reload (mainProcessPid=43196, ...)
- 2026-08-04T01:53:13.015Z: renderer_recovery_reload (mainProcessPid=43196, ...)
- 2026-08-04T01:53:13.315Z: renderer_recovery_circuit_breaker_open (reason=launch-failed, exitCode=18, recentRecoveryCount=3, mainProcessPid=43196, ...)
- 2026-08-04T01:53:18.269Z: renderer_recovery_manual_retry (mainProcessPid=43196, ...)
```

Three automatic reloads, breaker opens, the user answers the Reload/Quit dialog with **Reload** (`renderer_recovery_manual_retry`) — four no-op recoveries in total, none of which could ever have worked.

The header of the same report shows there was no renderer alive to reload:

```
Reason: launch-failed
Exit code: 18
App version: 1.4.167
Platform: win32 10.0.26100 x64
...
- processMetricsRendererCount: 0
- processMetricsRendererWorkingSetMB: 0
- processMetricsGpuCount: 1
- processMetricsGpuWorkingSetMB: 108
- processMetricsBrowserCount: 1
- processMetricsBrowserWorkingSetMB: 215
```

Browser, GPU and utility children were healthy; the renderer count was zero.

Bundle `F0BMT3674Q2` (`electron.process_gone` spans, verbatim attributes):

```
electron.process_gone {"crash.source": "renderer", "crash.process_type": "renderer", "crash.reason": "launch-failed", "crash.exit_code": 18, "app.version": "1.4.167", "platform": "win32", "osRelease": "10.0.26100", "arch": "x64", "electronVersion": "43.1.0", "chromeVersion": "150.0.7871.47", "app.main_process.pid": 43196
electron.process_gone {... identical ...}
electron.process_gone {... identical ...}
total process_gone spans: 3
```

The span timeline from the same bundle (`startTimeUnixNano` converted to UTC) is what forces the "prompt is on screen" dedupe rule rather than a once-per-window latch:

```
01:53:08.382  electron.process_gone   launch-failed(18)
01:53:08.633  renderer_recovery_reload
01:53:12.723  renderer_recovery_reload
01:53:12.755  electron.process_gone   launch-failed(18)
01:53:13.015  renderer_recovery_reload
01:53:13.315  renderer_recovery_circuit_breaker_open   (recentRecoveryCount=3)
01:53:18.269  renderer_recovery_manual_retry           <- user pressed "Reload"
01:53:18.284  electron.process_gone   launch-failed(18)   <- 15 ms later
01:53:18.548  renderer_recovery_circuit_breaker_open
01:53:29.236  renderer_bootstrap_started                  <- next app process, clean
```

The manual retry failed **15 ms** after the user pressed the button. A once-per-window prompt latch would have swallowed that second escalation and left exactly the blank window this change exists to remove — hence `RendererRecoveryPromptGate`, which only suppresses a prompt while another is literally on screen. And `renderer_bootstrap_started` at `01:53:29.236` belongs to a **different main process**: a full app restart (which the user had to perform by hand) bootstrapped cleanly ~11 s later. That is the empirical basis for making "Restart Orca" the default button.

## ELI5

Imagine your car won't start because the engine never turns over. Orca's old response was to keep turning the key in the same ignition — three times automatically, then it popped up a message saying "the engine keeps failing" whose big default button was, again, "turn the key". The one thing that actually works — get out, close the door, and start the whole car fresh — wasn't offered at all.

Concretely: an Electron app has a "main" process (the app's brain) and a "renderer" process (the window's contents). On this user's Windows machine the renderer process failed to *spawn* — it never came into existence. Orca's crash-recovery code doesn't distinguish "the window's contents crashed" (where reloading the page genuinely fixes things, which is why that code exists) from "the window's contents could not be created". For the second case a reload is meaningless: you can't tell a process that doesn't exist to load a new page. So Orca reloaded three times, gave up, and showed a dialog offering the same useless reload. The user stared at a blank white window and had to kill the app from Task Manager. When they did, it started up perfectly.

This change teaches Orca the difference. If the renderer *never launched*, don't reload, don't waste the three retries — immediately show a dialog whose first and default button is "Restart Orca", which quits and relaunches the whole app. Plus one subtlety learned from the real crash: the user pressed the old "Reload" button and the next launch attempt failed 15 milliseconds later, so the dialog logic had to be "only one of these on screen at a time" rather than "only ever show this once" — otherwise the second failure would silently put the user right back in front of the blank window.

## Trade-offs

Not "none". These are real:

1. **Launch failures lose their automatic retries.** On `origin/main` a `launch-failed` got 3 automatic reloads before bothering the user; now the very first one shows a dialog (~250 ms sooner than the breaker prompt would have appeared, and after zero silent attempts). If a launch failure were genuinely transient — which the old code comment at `process-gone-classification.ts:99` asserts, and which this PR contradicts — a user who would previously have recovered silently now sees an error dialog. Evidence for the change: in the only field sample we have, all four attempts (3 auto + 1 manual) failed, and a reload of a non-existent process is not a mechanism that can succeed. Evidence against: **n=1**. Mitigation kept in place: "Reload" remains on the dialog as the second button, so the old behavior is one click away, and the escalation branch does not disable `shouldRecoverRendererAfterProcessGone` for any other reason.

2. **Launch failures no longer consume the circuit-breaker budget.** The escalation path reads `recentRecoveryCount()` for the breadcrumb but never calls `registerRecoveryAttempt` (`createMainWindow.ts:594-604`), because a launch failure isn't a reload. Consequence: in a mixed sequence (a couple of `crashed` reloads, then launch failures, then more `crashed` reloads), the launch failures don't push the breaker toward opening the way they used to. Deliberate, but it is a behavior change to the breaker's accounting.

3. **A user who keeps choosing "Reload" gets an unbounded sequence of dialogs.** The gate only prevents two dialogs being on screen at once; each new launch failure after the user answers gets its own prompt. This is the intended behavior (point 3 of the field timeline), and it can't spin — every iteration requires a human click — but it is strictly more dialogs than the old single-prompt-then-blank-window outcome.

4. **"Restart Orca" is a hard app restart.** It uses the same `relaunchApp()` + `app.quit()` mechanism already used by the GPU-fallback and renderer-requested restart paths (`app-relaunch.ts:13-19`). In this specific scenario there is no in-window state to lose (the renderer never rendered anything), but any main-process work in flight is terminated exactly as the existing "Quit" button would terminate it.

5. **The real bug is still out there.** This does not stop `launch-failed` from happening; the Chromium/Windows cause of exit code 18 is undiagnosed and undiagnosable from this bundle. The blank-window symptom is fixed; the launch failure is not. If it recurs, the new `renderer_recovery_relaunch` breadcrumb plus `app_relaunch_requested{reason:'renderer-launch-failed'}` will tell us whether the restart actually recovered the user — which is the diagnostic we lacked this time.

6. **The new prompt has never been seen on a real Windows machine.** Windows verification was scoped out (see metadata quote above) because the triggering condition can't be reproduced. The dialog's copy, button order, and default/cancel indices are covered by unit tests, not by a screenshot.

7. **Not fixed, deliberately, as a follow-up:** the plan also suggested lowering the breaker's `maxRecoveries` for `launch-failed` (`renderer-recovery-circuit-breaker.ts:15`). That is now moot for launch failures — they bypass the breaker entirely — so it was intentionally skipped rather than implemented; no separate mitigation needed.

## Adversarial review

**2 independent adversarial review rounds**, each with a fresh reviewer holding no memory of the previous round or of the implementation reasoning, followed by **1 fix round**.

What the rounds surfaced (as recorded in the branch's own commit message and visible in the resulting code and tests — the round-by-round transcripts are not reproduced here): the substantive finding was the prompt-dedupe scope. Because every launch failure now escalates, a naive once-per-window prompt latch would suppress the second escalation — which the field timeline shows arriving 15 ms after the user's manual retry — reproducing the exact blank-window state the change exists to eliminate. The fix round landed `RendererRecoveryPromptGate` (scoped to "a prompt is on screen right now", with a `finally` release so a rejected `showMessageBox` cannot wedge the gate shut) and added the regression test `escalates again when a launch failure follows the host-driven manual retry`, plus the three `RendererRecoveryPromptGate` cases. Related hardening from review: the dialog's response index is mapped to an action through `plan.responses` rather than compared against hardcoded button positions, so adding the third button cannot silently re-map "Quit" to "Reload".

**Final verdict: clean — zero blocking findings, zero major findings.**

**`/perf` skill review verdict: no regression.** The added work is a string comparison per `render-process-gone` event plus one boolean field on a class that already exists; the change strictly *removes* work on the launch-failed path (three reloads of an entire app document no longer happen).

Made with [Orca](https://github.com/stablyai/orca) 🐋
