### PR TITLE
fix(renderer): land the lazy-chunk recovery reload instead of letting the navigation guard veto it

### DIFF
--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -286,16 +286,19 @@ function registerAppReloadHandler(
   activeAppReloadHandlerToken = handlerToken
   const mainWebContents = mainWindow.webContents
   ipcMain.removeHandler('app:reload')
-  ipcMain.handle('app:reload', (event) => {
+  // Returns whether the reload was actually issued so a declined sender (the dashboard
+  // pop-out, a stale window) can fall back instead of waiting on a reload that never comes.
+  ipcMain.handle('app:reload', (event): boolean => {
     if (
       mainWindow.isDestroyed() ||
       mainWebContents.isDestroyed() ||
       event.sender !== mainWebContents
     ) {
-      return
+      return false
     }
     onBeforeRendererReload?.({ webContentsId: mainWebContents.id, ignoreCache: false })
     mainWebContents.reload()
+    return true
   })
   mainWindow.on('closed', () => {
     if (activeAppReloadHandlerToken !== handlerToken) {

--- a/src/main/window/privileged-window-navigation.test.ts
+++ b/src/main/window/privileged-window-navigation.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WebContents } from 'electron'
+import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+
+const openExternalMock = vi.hoisted(() => vi.fn())
+const isMock = vi.hoisted(() => ({ dev: false }))
+
+vi.mock('electron', () => ({
+  shell: { openExternal: openExternalMock }
+}))
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: isMock
+}))
+
+const PACKAGED_DOCUMENT_URL =
+  'file:///Applications/Orca.app/Contents/Resources/app.asar/out/renderer/index.html'
+
+type NavigationHandler = (event: { preventDefault: () => void }, url: string) => void
+
+function installPolicy(currentUrl: string): NavigationHandler {
+  const handlers: Record<string, NavigationHandler> = {}
+  const contents = {
+    setWindowOpenHandler: vi.fn(),
+    getURL: vi.fn(() => currentUrl),
+    on: vi.fn((event: string, handler: NavigationHandler) => {
+      handlers[event] = handler
+    })
+  }
+  installPrivilegedWindowNavigationPolicy(contents as unknown as WebContents)
+  return handlers['will-navigate']
+}
+
+describe('installPrivilegedWindowNavigationPolicy', () => {
+  beforeEach(() => {
+    openExternalMock.mockClear()
+    isMock.dev = false
+    // Why: a dev shell exports this; stub (not mutate) so the value is restored for other suites.
+    vi.stubEnv('ELECTRON_RENDERER_URL', undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('lets the renderer reload its own packaged document', () => {
+    const willNavigate = installPolicy(PACKAGED_DOCUMENT_URL)
+    const preventDefault = vi.fn()
+
+    willNavigate({ preventDefault }, PACKAGED_DOCUMENT_URL)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('lets the dashboard pop-out reload its own query-bearing document', () => {
+    const popoutUrl =
+      'file:///Applications/Orca.app/Contents/Resources/app.asar/out/renderer/popout.html?view=kanban'
+    const willNavigate = installPolicy(popoutUrl)
+    const preventDefault = vi.fn()
+
+    willNavigate({ preventDefault }, popoutUrl)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('still blocks a different local file from the packaged document', () => {
+    const willNavigate = installPolicy(PACKAGED_DOCUMENT_URL)
+    const preventDefault = vi.fn()
+
+    willNavigate({ preventDefault }, 'file:///etc/passwd')
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('still blocks remote navigation and hands it to the OS browser', () => {
+    const willNavigate = installPolicy(PACKAGED_DOCUMENT_URL)
+    const preventDefault = vi.fn()
+
+    willNavigate({ preventDefault }, 'https://example.com/docs')
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/docs')
+  })
+
+  it('lets the dev server reload its own origin', () => {
+    isMock.dev = true
+    vi.stubEnv('ELECTRON_RENDERER_URL', 'http://localhost:5173')
+    const willNavigate = installPolicy('http://localhost:5173/index.html')
+    const preventDefault = vi.fn()
+
+    willNavigate({ preventDefault }, 'http://localhost:5173/login')
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('still blocks a sibling packaged document', () => {
+    const willNavigate = installPolicy(PACKAGED_DOCUMENT_URL)
+    const preventDefault = vi.fn()
+
+    willNavigate(
+      { preventDefault },
+      'file:///Applications/Orca.app/Contents/Resources/app.asar/out/renderer/popout.html'
+    )
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/window/privileged-window-navigation.ts
+++ b/src/main/window/privileged-window-navigation.ts
@@ -2,6 +2,29 @@ import { shell, type WebContents } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { normalizeExternalBrowserUrl } from '../../shared/browser-url'
 
+/**
+ * A reload is a renderer-initiated navigation to the document already loaded here, so the
+ * blanket guard below strands recovery reloads (lazy-chunk recovery, GH auth retry). Re-entering
+ * the same URL grants no privilege the live document does not already hold.
+ */
+function isOwnDocumentNavigation(contents: WebContents, url: string): boolean {
+  try {
+    const current = contents.getURL()
+    if (!current) {
+      return false
+    }
+    const target = new URL(url)
+    const loaded = new URL(current)
+    // Hash-only changes never reach will-navigate; ignore the fragment so they cannot differ.
+    target.hash = ''
+    loaded.hash = ''
+    return target.href === loaded.href
+  } catch {
+    // A destroyed WebContents or malformed URL is never a self-navigation.
+    return false
+  }
+}
+
 /** Keep remote documents from inheriting an Orca window's privileged preload. */
 export function installPrivilegedWindowNavigationPolicy(contents: WebContents): void {
   contents.setWindowOpenHandler(({ url }) => {
@@ -13,6 +36,9 @@ export function installPrivilegedWindowNavigationPolicy(contents: WebContents): 
   })
 
   contents.on('will-navigate', (event, url) => {
+    if (isOwnDocumentNavigation(contents, url)) {
+      return
+    }
     const externalUrl = normalizeExternalBrowserUrl(url)
     if (externalUrl) {
       if (is.dev && process.env.ELECTRON_RENDERER_URL) {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -983,8 +983,9 @@ export type AppApi = {
    *  sessions survive and can reattach after the new process starts. */
   restart: () => Promise<void>
   /** Reloads the current app renderer through main so expected renderer
-   *  teardown can be classified before Electron emits process-gone events. */
-  reload: () => Promise<void>
+   *  teardown can be classified before Electron emits process-gone events.
+   *  Resolves false when main declines the sender (e.g. the dashboard pop-out). */
+  reload: () => Promise<boolean>
   /** Stages the renderer's final state synchronously before unload. */
   stageBeforeUnloadSync: (args: {
     sessions: { state: WorkspaceSessionState; hostId?: ExecutionHostId }[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -500,7 +500,7 @@ const api = {
         throw error
       }
     },
-    reload: (): Promise<void> => ipcRenderer.invoke('app:reload'),
+    reload: (): Promise<boolean> => ipcRenderer.invoke('app:reload'),
     stageBeforeUnloadSync: (args: Parameters<PreloadApi['app']['stageBeforeUnloadSync']>[0]) => {
       const result = ipcRenderer.sendSync('app:stage-before-unload-sync', args) as {
         ok?: unknown

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -326,71 +326,117 @@ function WindowControls(): React.JSX.Element {
   )
 }
 
-const Landing = lazy(() => import('./components/Landing'))
+// reloadKey names the failing chunk on the recovery breadcrumbs and LazyChunkLoadError.
+const Landing = lazy(() => import('./components/Landing'), { reloadKey: 'landing' })
 const WorktreeCreationPanel = lazy(
-  () => import('./components/worktree-creation/WorktreeCreationPanel')
+  () => import('./components/worktree-creation/WorktreeCreationPanel'),
+  { reloadKey: 'worktree-creation-panel' }
 )
-const TaskPage = lazy(() => import('./components/TaskPage'))
-const AutomationsPage = lazy(() => import('./components/automations/AutomationsPage'))
-const ActivityPrototypePage = lazy(() => import('./components/activity/ActivityPrototypePage'))
-const Settings = lazy(() => import('./components/settings/Settings'))
-const SkillsPage = lazy(() => import('./components/skills/SkillsPage'))
-const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/WorkspaceSpacePage'))
-const MobilePage = lazy(() => import('./components/mobile/MobilePage'))
-const QuickOpen = lazy(() => import('./components/QuickOpen'))
-const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'))
+const TaskPage = lazy(() => import('./components/TaskPage'), { reloadKey: 'task-page' })
+const AutomationsPage = lazy(() => import('./components/automations/AutomationsPage'), {
+  reloadKey: 'automations-page'
+})
+const ActivityPrototypePage = lazy(() => import('./components/activity/ActivityPrototypePage'), {
+  reloadKey: 'activity-prototype-page'
+})
+const Settings = lazy(() => import('./components/settings/Settings'), { reloadKey: 'settings' })
+const SkillsPage = lazy(() => import('./components/skills/SkillsPage'), {
+  reloadKey: 'skills-page'
+})
+const WorkspaceSpacePage = lazy(() => import('./components/workspace-space/WorkspaceSpacePage'), {
+  reloadKey: 'workspace-space-page'
+})
+const MobilePage = lazy(() => import('./components/mobile/MobilePage'), {
+  reloadKey: 'mobile-page'
+})
+const QuickOpen = lazy(() => import('./components/QuickOpen'), { reloadKey: 'quick-open' })
+const WorktreeJumpPalette = lazy(() => import('./components/WorktreeJumpPalette'), {
+  reloadKey: 'worktree-jump-palette'
+})
 const WorkspaceCleanupDialog = lazy(
-  () => import('./components/workspace-cleanup/WorkspaceCleanupDialog')
+  () => import('./components/workspace-cleanup/WorkspaceCleanupDialog'),
+  { reloadKey: 'workspace-cleanup-dialog' }
 )
-const Terminal = lazy(() => import('./components/Terminal'))
-const StatusBar = lazy(() =>
-  import('./components/status-bar/StatusBar').then((module) => ({ default: module.StatusBar }))
+const Terminal = lazy(() => import('./components/Terminal'), { reloadKey: 'terminal' })
+const StatusBar = lazy(
+  () =>
+    import('./components/status-bar/StatusBar').then((module) => ({ default: module.StatusBar })),
+  { reloadKey: 'status-bar' }
 )
-const SetupGuideModal = lazy(() => import('./components/setup-guide/SetupGuideModal'))
-const FeatureWallModal = lazy(() => import('./components/feature-wall/FeatureWallModal'))
-const FeatureTipsModal = lazy(() => import('./components/feature-tips/FeatureTipsModal'))
-const AddRepoDialog = lazy(() => import('./components/sidebar/AddRepoDialog'))
-const NonGitFolderDialog = lazy(() => import('./components/sidebar/NonGitFolderDialog'))
+const SetupGuideModal = lazy(() => import('./components/setup-guide/SetupGuideModal'), {
+  reloadKey: 'setup-guide-modal'
+})
+const FeatureWallModal = lazy(() => import('./components/feature-wall/FeatureWallModal'), {
+  reloadKey: 'feature-wall-modal'
+})
+const FeatureTipsModal = lazy(() => import('./components/feature-tips/FeatureTipsModal'), {
+  reloadKey: 'feature-tips-modal'
+})
+const AddRepoDialog = lazy(() => import('./components/sidebar/AddRepoDialog'), {
+  reloadKey: 'add-repo-dialog'
+})
+const NonGitFolderDialog = lazy(() => import('./components/sidebar/NonGitFolderDialog'), {
+  reloadKey: 'non-git-folder-dialog'
+})
 const AddProjectFromFolderDialog = lazy(
-  () => import('./components/sidebar/AddProjectFromFolderDialog')
+  () => import('./components/sidebar/AddProjectFromFolderDialog'),
+  { reloadKey: 'add-project-from-folder-dialog' }
 )
-const ProjectAddedDialog = lazy(() => import('./components/sidebar/ProjectAddedDialog'))
-const DeleteWorktreeDialog = lazy(() => import('./components/sidebar/DeleteWorktreeDialog'))
-const DictationController = lazy(() =>
-  import('./components/dictation/DictationController').then((module) => ({
-    default: module.DictationController
-  }))
+const ProjectAddedDialog = lazy(() => import('./components/sidebar/ProjectAddedDialog'), {
+  reloadKey: 'project-added-dialog'
+})
+const DeleteWorktreeDialog = lazy(() => import('./components/sidebar/DeleteWorktreeDialog'), {
+  reloadKey: 'delete-worktree-dialog'
+})
+const DictationController = lazy(
+  () =>
+    import('./components/dictation/DictationController').then((module) => ({
+      default: module.DictationController
+    })),
+  { reloadKey: 'dictation-controller' }
 )
-const SshPassphraseDialog = lazy(() =>
-  import('./components/settings/SshPassphraseDialog').then((module) => ({
-    default: module.SshPassphraseDialog
-  }))
+const SshPassphraseDialog = lazy(
+  () =>
+    import('./components/settings/SshPassphraseDialog').then((module) => ({
+      default: module.SshPassphraseDialog
+    })),
+  { reloadKey: 'ssh-passphrase-dialog' }
 )
-const UpdateCard = lazy(() =>
-  import('./components/UpdateCard').then((module) => ({ default: module.UpdateCard }))
+const UpdateCard = lazy(
+  () => import('./components/UpdateCard').then((module) => ({ default: module.UpdateCard })),
+  { reloadKey: 'update-card' }
 )
 const RemoteServerUpdateDialog = lazy(
-  () => import('./components/settings/RemoteServerUpdateDialog')
+  () => import('./components/settings/RemoteServerUpdateDialog'),
+  { reloadKey: 'remote-server-update-dialog' }
 )
-const ContextualTourOverlay = lazy(() =>
-  import('./components/contextual-tours/ContextualTourOverlay').then((module) => ({
-    default: module.ContextualTourOverlay
-  }))
+const ContextualTourOverlay = lazy(
+  () =>
+    import('./components/contextual-tours/ContextualTourOverlay').then((module) => ({
+      default: module.ContextualTourOverlay
+    })),
+  { reloadKey: 'contextual-tour-overlay' }
 )
-const SetupGuideTelemetryObserver = lazy(() =>
-  import('./components/setup-guide/SetupGuideTelemetryObserver').then((module) => ({
-    default: module.SetupGuideTelemetryObserver
-  }))
+const SetupGuideTelemetryObserver = lazy(
+  () =>
+    import('./components/setup-guide/SetupGuideTelemetryObserver').then((module) => ({
+      default: module.SetupGuideTelemetryObserver
+    })),
+  { reloadKey: 'setup-guide-telemetry-observer' }
 )
-const FloatingTerminalPanel = lazy(() =>
-  import('./components/floating-terminal/FloatingTerminalPanel').then((module) => ({
-    default: module.FloatingTerminalPanel
-  }))
+const FloatingTerminalPanel = lazy(
+  () =>
+    import('./components/floating-terminal/FloatingTerminalPanel').then((module) => ({
+      default: module.FloatingTerminalPanel
+    })),
+  { reloadKey: 'floating-terminal-panel' }
 )
 // Why: lazy so the WebP asset + overlay module aren't fetched unless the experimental flag is on.
-const PetOverlay = lazy(() => import('./components/pet/PetOverlay'))
+const PetOverlay = lazy(() => import('./components/pet/PetOverlay'), { reloadKey: 'pet-overlay' })
 // Why: lazy so onboarding's step modules + assets aren't fetched for users past first-launch.
-const OnboardingFlow = lazy(() => import('./components/onboarding/OnboardingFlow'))
+const OnboardingFlow = lazy(() => import('./components/onboarding/OnboardingFlow'), {
+  reloadKey: 'onboarding-flow'
+})
 
 function applyRemoteWorkspacePatchStatus(
   targetId: string,

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -305,7 +305,8 @@ describe('renderer startup runtime routing', () => {
   it('does not load the terminal workbench on the no-workspace landing path', () => {
     const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
 
-    expect(source).toContain("const Terminal = lazy(() => import('./components/Terminal'))")
+    // Trailing paren omitted so the assertion tolerates lazyWithRetry options (reloadKey).
+    expect(source).toContain("const Terminal = lazy(() => import('./components/Terminal')")
     expect(source).not.toContain("from './components/Terminal'")
     expect(source).toContain('const hasMountedTerminalWorkbenchRef = useRef(false)')
     expect(source).toContain('hasMountedTerminalWorkbenchRef.current = true')
@@ -337,10 +338,10 @@ describe('renderer startup runtime routing', () => {
       'utf8'
     )
 
-    expect(appSource).toContain("lazy(() => import('./components/sidebar/AddRepoDialog'))")
-    expect(appSource).toContain("lazy(() => import('./components/sidebar/NonGitFolderDialog'))")
+    expect(appSource).toContain("lazy(() => import('./components/sidebar/AddRepoDialog')")
+    expect(appSource).toContain("lazy(() => import('./components/sidebar/NonGitFolderDialog')")
     expect(appSource).toContain("import('./components/sidebar/AddProjectFromFolderDialog')")
-    expect(appSource).toContain("lazy(() => import('./components/sidebar/ProjectAddedDialog'))")
+    expect(appSource).toContain("lazy(() => import('./components/sidebar/ProjectAddedDialog')")
     expect(appSource).toContain("activeModal === 'add-repo'")
     expect(appSource).toContain("activeModal === 'confirm-non-git-folder'")
     expect(appSource).toContain("activeModal === 'confirm-add-project-from-folder'")

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -3,14 +3,19 @@ import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
 
-const FileExplorer = lazy(() => import('./FileExplorer'))
-const SourceControl = lazy(() => import('./SourceControl'))
-const ChecksPanel = lazy(() => import('./ChecksPanel'))
-const PortsPanel = lazy(() => import('./PortsPanel'))
-const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
-const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
-const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
-const PluginPanel = lazy(() => import('./PluginPanel'))
+// reloadKey names the failing chunk on the recovery breadcrumbs and LazyChunkLoadError.
+const FileExplorer = lazy(() => import('./FileExplorer'), { reloadKey: 'file-explorer' })
+const SourceControl = lazy(() => import('./SourceControl'), { reloadKey: 'source-control' })
+const ChecksPanel = lazy(() => import('./ChecksPanel'), { reloadKey: 'checks-panel' })
+const PortsPanel = lazy(() => import('./PortsPanel'), { reloadKey: 'ports-panel' })
+const AiVaultPanel = lazy(() => import('./AiVaultPanel'), { reloadKey: 'ai-vault-panel' })
+const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'), {
+  reloadKey: 'folder-workspace-worktrees-panel'
+})
+const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'), {
+  reloadKey: 'folder-workspace-pr-checks-panel'
+})
+const PluginPanel = lazy(() => import('./PluginPanel'), { reloadKey: 'plugin-panel' })
 
 type RightSidebarPanelContentProps = {
   effectiveTab: ActiveRightSidebarTab

--- a/src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts
+++ b/src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts
@@ -3,9 +3,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
 import { requestLazyChunkRecoveryReload } from './lazy-chunk-recovery-reload'
 
+type HostReload = () => Promise<boolean>
+
+function installHostBridge(reload: HostReload): void {
+  ;(window as unknown as { api: unknown }).api = { app: { reload } }
+}
+
 describe('requestLazyChunkRecoveryReload', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    delete (window as unknown as { api?: unknown }).api
   })
 
   it('refuses the reload when the staged checkpoint never reaches disk', async () => {
@@ -35,5 +42,50 @@ describe('requestLazyChunkRecoveryReload', () => {
     ).resolves.toBe('unload-vetoed')
 
     expect(order).toEqual(['flushed', 'reload'])
+  })
+
+  it('asks the host for a browser-initiated reload instead of navigating in-document', async () => {
+    const locationReload = vi.spyOn(window.location, 'reload').mockImplementation(() => undefined)
+    const hostReload = vi.fn(async () => {
+      // A real landed reload destroys the document; veto so the wait settles.
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+      return true
+    })
+    installHostBridge(hostReload)
+
+    await expect(requestLazyChunkRecoveryReload(window, async () => undefined)).resolves.toBe(
+      'unload-vetoed'
+    )
+
+    expect(hostReload).toHaveBeenCalledTimes(1)
+    expect(locationReload).not.toHaveBeenCalled()
+  })
+
+  it('falls back in-document when the host declines the sender', async () => {
+    const locationReload = vi.spyOn(window.location, 'reload').mockImplementation(() => {
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+    })
+    const hostReload = vi.fn(async () => false)
+    installHostBridge(hostReload)
+
+    await expect(requestLazyChunkRecoveryReload(window, async () => undefined)).resolves.toBe(
+      'unload-vetoed'
+    )
+
+    expect(hostReload).toHaveBeenCalledTimes(1)
+    expect(locationReload).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back in-document when the host reload rejects', async () => {
+    const locationReload = vi.spyOn(window.location, 'reload').mockImplementation(() => {
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+    })
+    installHostBridge(() => Promise.reject(new Error('no host bridge')))
+
+    await expect(requestLazyChunkRecoveryReload(window, async () => undefined)).resolves.toBe(
+      'unload-vetoed'
+    )
+
+    expect(locationReload).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/lib/lazy-chunk-recovery-reload.ts
+++ b/src/renderer/src/lib/lazy-chunk-recovery-reload.ts
@@ -47,6 +47,24 @@ function waitForRefusedNavigation(win: Window): RefusedNavigationWait {
   return { outcome, cancel }
 }
 
+/**
+ * A browser-initiated reload cannot be vetoed by the main-process navigation guard, unlike
+ * `location.reload()`. Resolves false when there is no host bridge or main declined this
+ * sender (the dashboard pop-out), i.e. the in-document reload is still required.
+ */
+async function requestHostReload(settled: Promise<unknown>): Promise<boolean> {
+  const hostReload = window.api?.app?.reload
+  if (typeof hostReload !== 'function') {
+    return false
+  }
+  try {
+    // Race the refusal wait: a landed reload can tear this document down before the reply.
+    return await Promise.race([hostReload(), settled.then(() => true)])
+  } catch {
+    return false
+  }
+}
+
 /** Resolves only if the navigation is refused; a landed reload destroys this document. */
 export async function requestLazyChunkRecoveryReload(
   win: Window,
@@ -69,7 +87,9 @@ export async function requestLazyChunkRecoveryReload(
   try {
     const refused = waitForRefusedNavigation(win)
     cancelRefusalWait = refused.cancel
-    win.location.reload()
+    if (!(await requestHostReload(refused.outcome))) {
+      win.location.reload()
+    }
     return await refused.outcome
   } catch {
     return 'request-failed'

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -547,7 +547,11 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       getFeatureWallAssetBaseUrl: () => Promise.resolve('/'),
       relaunch: () => Promise.resolve(window.location.reload()),
       restart: () => Promise.resolve(window.location.reload()),
-      reload: () => Promise.resolve(window.location.reload()),
+      // The web host reloads in-document itself, so report it as issued.
+      reload: () => {
+        window.location.reload()
+        return Promise.resolve(true)
+      },
       stageBeforeUnloadSync: ({ sessions, ui }) => {
         // Why: beforeunload cannot await the paired runtime, so the web adapter
         // guarantees immediate browser-local durability for the final snapshot.


### PR DESCRIPTION
## What this fixes

**Signature:** a lazy chunk `import()` rejects (`TypeError: Failed to fetch dynamically imported module: file://…`, or a native `SyntaxError` from corrupt bytes), the built-in recovery reload is requested, and it **never lands** — `lazy_chunk_reload` → exactly 10 s → `lazy_chunk_reload_vetoed outcome=never-landed`. The raw error is then rethrown to `RecoverableRenderErrorBoundary`, which files a `react-error-boundary` crash report, and the affected surface stays dead until the user quits and relaunches.

**Coverage: 4 of the 127 crash reports in this batch** (triage group `G2-chunkload`, subgroups 1 and 2). The count is small; the severity is not — each one is a permanently dead Settings page / right sidebar / floating workspace overlay / cleanup modal for the rest of the session.

Representative reports:

| Report | Version / platform | Boundary | Slack |
|---|---|---|---|
| `e2cbcfbb-1dd2-44a2-8dbd-00266a048dd5` (`F0BMMEPCT97`) | 1.4.165, darwin 25.5.0 arm64 | `page.settings` | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785742899243969 |
| `68ad006c-20cf-44c5-9d76-59bd29be80a1` (`F0BMSUFU8TT`) | 1.4.167, linux 7.1.5-zen x64 | `right-sidebar` | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785785753463049 |
| `F0BMNUFQY5C` | 1.4.167, linux 7.1.5-zen x64 | `overlay.floating-workspace` | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785784985959979 |
| `F0BM7F1PBR9` | 1.4.103, linux 7.1.3-arch1 x64 | `modal.workspace-cleanup` | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785620272891299 |

The fifth report in the same Slack triage bucket (`F0BMCB62875`, `sidebar.worktrees`, `hast-util-raw` `startTag` SyntaxError) carries **no** lazy-chunk breadcrumb and is deliberately **out of scope** — it is being re-triaged separately. This PR does not claim it.

### Root cause

The recovery path was structurally inert on the packaged desktop surface:

1. `src/renderer/src/lib/lazy-chunk-recovery-reload.ts:91` (pre-fix line 72) issued `win.location.reload()` — a **renderer-initiated** navigation.
2. `src/main/window/privileged-window-navigation.ts:57` calls `event.preventDefault()` **unconditionally** on `will-navigate`. `normalizeExternalBrowserUrl` returns `null` for `file:` (`src/shared/browser-url.ts:329-331`), so the packaged renderer's own `file://…/index.html` reload skipped the `openExternal` branch and fell straight through to the blanket `preventDefault()`. The only escape hatch was gated on `is.dev && process.env.ELECTRON_RENDERER_URL` — dev only, no packaged `file://` counterpart.
3. Because the navigation dies at `will-navigate`, `beforeunload` never runs, `will-prevent-unload` (`createMainWindow.ts:1028-1034`) never fires, and no `window:unload-prevented` IPC is sent. So the wait in `lazy-chunk-recovery-reload.ts:45` always burns the full `RELOAD_SETTLE_GRACE_MS = 10_000` and resolves `'never-landed'`.
4. `lazy-with-retry.ts:193` then rethrows the **raw** error. The `LazyChunkLoadError` sentinel — the only error `RecoverableRenderErrorBoundary.tsx:52-54` suppresses — is produced solely when the reload guard state is `'reload-landed'` (`lazy-with-retry.ts:73`), which was unreachable. Hence: crash report + dead surface, every time.

This is why it worked in `npm run dev` (dev origin exempt) and on the paired-web host (no navigation guard) but never in a packaged build — and why CI stayed green: `createMainWindow.test.ts:232-236` positively asserted that a `file://` `will-navigate` **is** preventDefault'd, and `lazy-with-retry.right-sidebar-syntax-error.test.ts:36-38` mocks `window.location.reload` so the reload is *assumed* to work.

### What changed

- `src/renderer/src/lib/lazy-chunk-recovery-reload.ts:55-92` — prefer the **browser-initiated** `app:reload` bridge (`mainWebContents.reload()`), which no `will-navigate` guard can veto. `win.location.reload()` is kept as the paired-web / declined-sender / bridge-missing fallback.
- `src/main/window/attach-main-window-services.ts:291-302` — `app:reload` now returns `boolean` so a sender the handler declines (the dashboard pop-out, a stale window) falls back immediately instead of waiting out the 10 s grace.
- `src/main/window/privileged-window-navigation.ts:10-40` — `will-navigate` to the WebContents' **own** document (`contents.getURL()`, fragment-insensitive) is allowed through. Everything else, including `file:///etc/passwd` and sibling packaged documents, stays blocked.
- `src/renderer/src/App.tsx` + `right-sidebar-panel-content.tsx` — pass `reloadKey` at every lazy call site so the breadcrumbs name the failing chunk instead of reporting `unknown`.

---

## Fix evidence

### 1. Regression test is RED without the source fix

Scratch worktree at the branch commit with **only** the source files reverted to `origin/main` (`git checkout origin/main -- src/main/window/privileged-window-navigation.ts src/main/window/attach-main-window-services.ts src/renderer/src/lib/lazy-chunk-recovery-reload.ts src/preload/index.ts src/preload/api-types.ts src/renderer/src/web/web-preload-api.ts src/renderer/src/App.tsx src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx`), tests untouched:

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/main/window/privileged-window-navigation.test.ts \
    src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts \
    src/renderer/src/app-startup-routing.test.ts

 RUN  v4.1.5 /private/tmp/prproof-w3-lazychunk

 × src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the renderer reload its own packaged document 3ms
   → expected "vi.fn()" to not be called at all, but actually been called 1 times
 × src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the dashboard pop-out reload its own query-bearing document 0ms
   → expected "vi.fn()" to not be called at all, but actually been called 1 times
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > still blocks a different local file from the packaged document 0ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > still blocks remote navigation and hands it to the OS browser 1ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the dev server reload its own origin 0ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > still blocks a sibling packaged document 0ms
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > refuses the reload when the staged checkpoint never reaches disk 2ms
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > navigates only after the checkpoint is durably written 1ms
 × src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > asks the host for a browser-initiated reload instead of navigating in-document 10003ms
   → expected 'never-landed' to be 'unload-vetoed' // Object.is equality
 × src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > falls back in-document when the host declines the sender 0ms
   → expected "vi.fn()" to be called 1 times, but got 0 times
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > falls back in-document when the host reload rejects 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the renderer reload its own packaged document
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

 ❯ src/main/window/privileged-window-navigation.test.ts:52:32
     50|     willNavigate({ preventDefault }, PACKAGED_DOCUMENT_URL)
     51|
     52|     expect(preventDefault).not.toHaveBeenCalled()
       |                                ^
     53|     expect(openExternalMock).not.toHaveBeenCalled()
     54|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

 FAIL  src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > asks the host for a browser-initiated reload instead of navigating in-document
AssertionError: expected 'never-landed' to be 'unload-vetoed' // Object.is equality

Expected: "unload-vetoed"
Received: "never-landed"

 ❯ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts:56:80

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯

 FAIL  src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > falls back in-document when the host declines the sender
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts:75:24
     73|     )
     74|
     75|     expect(hostReload).toHaveBeenCalledTimes(1)
       |                        ^
     76|     expect(locationReload).toHaveBeenCalledTimes(1)
     77|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯

 Test Files  2 failed | 1 passed (3)
      Tests  4 failed | 30 passed (34)
   Duration  10.21s (transform 140ms, setup 0ms, import 199ms, tests 10.02s, environment 109ms)
```

Two things worth reading closely in that output:

- The renderer repro takes **10003 ms** and resolves `'never-landed'` — the exact `RELOAD_SETTLE_GRACE_MS` stall the field bundles show at 10.004 s. The test reproduces the production timing, not just the production return value.
- `still blocks a different local file from the packaged document`, `still blocks remote navigation…` and `still blocks a sibling packaged document` pass **both** with and without the fix. That is intentional: they are the security assertions, and they are meant to be invariant.
- `falls back in-document when the host reload rejects` also passes without the fix. Being explicit: that one is **coverage, not a repro** — `location.reload()` is called on both branches. The repro is carried by the other three.

The scratch worktree was created with `git worktree add … --detach` and removed with `git worktree remove --force`. No `git stash` was used at any point; the branch worktree is clean (`git status --short` → 0 lines, HEAD still `7b3579ba607`).

### 2. Same tests GREEN on the branch

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/main/window/privileged-window-navigation.test.ts \
    src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w3-lazychunk

 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > refuses the reload when the staged checkpoint never reaches disk 2ms
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > navigates only after the checkpoint is durably written 1ms
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > asks the host for a browser-initiated reload instead of navigating in-document 0ms
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > falls back in-document when the host declines the sender 0ms
 ✓ src/renderer/src/lib/lazy-chunk-recovery-reload.test.ts > requestLazyChunkRecoveryReload > falls back in-document when the host reload rejects 0ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the renderer reload its own packaged document 1ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the dashboard pop-out reload its own query-bearing document 0ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > still blocks a different local file from the packaged document 0ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > still blocks remote navigation and hands it to the OS browser 1ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > lets the dev server reload its own origin 0ms
 ✓ src/main/window/privileged-window-navigation.test.ts > installPrivilegedWindowNavigationPolicy > still blocks a sibling packaged document 0ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Duration  211ms (transform 100ms, setup 0ms, import 160ms, tests 7ms, environment 108ms)
```

Note the 10003 ms stall is gone (211 ms total run) — the recovery reload now settles instead of timing out.

### 3. Full test directories for every touched module — GREEN

Main process + preload (`src/main/window/**`, `src/preload/**`):

```
$ npx vitest run --config config/vitest.config.ts src/main/window src/preload

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w3-lazychunk

 Test Files  30 passed (30)
      Tests  296 passed (296)
   Duration  3.65s (transform 8.46s, setup 0ms, import 10.41s, tests 1.02s, environment 1ms)
```

Renderer (`src/renderer/src/lib`, `src/renderer/src/web`, `src/renderer/src/components/right-sidebar`, plus the `App.tsx` source-shape guard `app-startup-routing.test.ts`):

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/lib src/renderer/src/web \
    src/renderer/src/components/right-sidebar \
    src/renderer/src/app-startup-routing.test.ts

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w3-lazychunk

 Test Files  569 passed | 1 skipped (570)
      Tests  5415 passed | 4 skipped (5419)
   Duration  24.16s (transform 70.80s, setup 0ms, import 210.73s, tests 62.25s, environment 11.91s)
```

**Zero failures in either run.** The 1 skipped file / 4 skipped tests are pre-existing `it.skip`s unrelated to this change.

Typecheck of the project that `pnpm typecheck` starts with (the one a round-1 reviewer found broken; see Adversarial review):

```
$ npx tsc --noEmit -p config/tsconfig.node.json
$ echo $?
0
```

**Windows verification** (recorded for this work item in the batch metadata): *full renderer suite run on Windows: same 5 pre-existing failures as the origin/main Windows baseline.* Those 5 — `github-item-dialog`, `pull-request-page`, `monaco undo`, `SourceControl host-context`, `resource-session-classification` — are **pre-existing on `origin/main`** and are not touched by this change. Nothing in this fix is Windows-specific: the `will-navigate` guard applies identically to every packaged `file://` renderer on all three platforms. The observed field reports are darwin (1) and linux (3); no Windows report landed in this group, but nothing protects Windows from the same defect.

### 4. Field evidence — the defect happening in production

Report `F0BMMEPCT97` (`e2cbcfbb-1dd2-44a2-8dbd-00266a048dd5`), 1.4.165, darwin 25.5.0 arm64, `packaged=true`. Verbatim from the uploaded bundle:

```
Report ID: e2cbcfbb-1dd2-44a2-8dbd-00266a048dd5
Created: 2026-08-03T07:35:22.457Z
Source: renderer
Process: react-render
Reason: react-error-boundary
App version: 1.4.165
Platform: darwin 25.5.0 arm64
Electron: 43.1.0

- 2026-08-03T07:34:24.974Z: main_process_lifecycle_started (packaged=true, platform=darwin, mainProcessPid=10535, …)
- 2026-08-03T07:34:25.978Z: renderer_bootstrap_started (dev=false)
- 2026-08-03T07:35:12.441Z: lazy_chunk_reload (reloadKey=unknown, message=Failed to fetch dynamically imported module: file://[redacted-path])
- 2026-08-03T07:35:22.445Z: lazy_chunk_reload_vetoed (reloadKey=unknown, message=Failed to fetch dynamically imported module: file://[redacted-path], outcome=never-landed)
```

`07:35:12.441` → `07:35:22.445` is **10.004 s** — `RELOAD_SETTLE_GRACE_MS` to the millisecond, and there is **no `renderer_bootstrap_started` in between**: the document provably never reloaded. The attached diagnostic bundle `F0BMD9N1X8B` shows the request happening twice, exhausting `MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2`:

```
"breadcrumb.name":"lazy_chunk_reload","breadcrumb.data":{"reloadKey":"unknown","message":"Failed to fetch dynamically imported module: file://[redacted-path]"}          @ 1785742512441000000
"breadcrumb.name":"lazy_chunk_reload_vetoed","breadcrumb.data":{"reloadKey":"unknown","message":"…","outcome":"never-landed"}                                             @ 1785742522445000000
"breadcrumb.name":"lazy_chunk_reload","breadcrumb.data":{"reloadKey":"unknown","message":"…"}                                                                             @ 1785742522500000000
"breadcrumb.name":"lazy_chunk_reload_vetoed","breadcrumb.data":{"reloadKey":"unknown","message":"…","outcome":"never-landed"}                                             @ 1785742532504000000
```

Report `F0BMSUFU8TT` (`68ad006c-20cf-44c5-9d76-59bd29be80a1`), 1.4.167, linux, `right-sidebar` — same shape, and note this build **postdates** the diagnostics commit that first surfaced the `never-landed` outcome, i.e. the behaviour was still live on the latest shipped version:

```
Report ID: 68ad006c-20cf-44c5-9d76-59bd29be80a1
Created: 2026-08-03T19:35:04.569Z
Reason: react-error-boundary
App version: 1.4.167
Platform: linux 7.1.5-zen1-2-zen x64

- 2026-08-03T19:35:04.206Z: lazy_chunk_reload (reloadKey=unknown, message=Failed to fetch dynamically imported module: file://[redacted-path])
```

Report `F0BMNUFQY5C`, 1.4.167, linux, `overlay.floating-workspace`:

```
- 2026-08-03T19:21:58.679Z: lazy_chunk_reload (reloadKey=unknown, message=Failed to fetch dynamically imported module: file://[redacted-path])
```

And the older linux `modal.workspace-cleanup` report (`F0BM7F1PBR9`, 1.4.103) shows the corrupt-bytes variant of the same mechanism in its diagnostic bundle `F0BLYB7G0VD`:

```
"breadcrumb.name":"lazy_chunk_reload","breadcrumb.data":{"reloadKey":"unknown","message":"Unexpected token '}'"}   @ 1785619175153000000
```

Every one of those `reloadKey=unknown` values is the secondary defect this PR also closes.

---

## ELI5

Orca doesn't load its whole interface up front. It loads pieces on demand — open Settings, and only then does it go fetch the "Settings" file off disk. Think of a restaurant that keeps most ingredients in a back freezer and fetches them per order.

When Orca updates itself while you're using it, the files on disk get swapped underneath the running app. So the app can walk to the freezer, reach for the Settings box, and find it gone or half-rewritten. Orca already had a plan for that: "if a piece is missing, just reload the whole window — a fresh start will pick up the new files." That is the right plan.

The problem: Orca also has a security guard whose job is to stop the app window from ever navigating somewhere it shouldn't — a bouncer at the door checking that no web page can sneak into the privileged app window. That bouncer was written to say **no to everything**, including the app saying "let me back into my own room." So when the recovery code said "reload me," the bouncer silently blocked it. No error, no bounce message — just nothing happening. The recovery code then waited exactly ten seconds for a reload that was never coming, gave up, and reported a crash. The Settings page (or sidebar, or overlay) stayed broken until you fully quit the app.

The fix is two parts:

1. **Ask the manager instead of the door.** Orca's main process — the part of the app that *owns* the window — can reload the window directly, and the bouncer doesn't get a say in that, because it isn't the page pushing on the door from inside. The recovery code now asks the manager first, and only pushes on the door itself if there's no manager available (which is the case in Orca's browser/web mode, where there is no bouncer to begin with).
2. **Teach the bouncer to recognize the room's own occupant.** "Let me back into the room I'm already in" is now allowed. Any other destination — a different file on your computer, a website — is still refused exactly as before. Re-entering the same page grants no permission the page didn't already have.

Plus a small housekeeping change: every one of these on-demand pieces now carries a name tag, so when one does fail, the crash report says *which* piece broke instead of `unknown`. Previously every single report was anonymous, which is why nobody could tell which part of the app was dying.

---

## Trade-offs

Not "none." Stated plainly:

1. **A security guard got looser, on an inferred mechanism.** `will-navigate` no longer blocks navigation to the WebContents' own current URL. That is a real, permanent relaxation of the privileged-window navigation policy. The plan gated this edit on a 60-second packaged-build check (devtools: does `location.reload()` actually get eaten?) — **that check was not run.** The mechanism is inferred from Electron 43's docs (`will-navigate` documents exclusions for `loadURL`/`back`/in-page navigation but not for reload) and from the field timing, not observed directly. Two independent reviewers examined the relaxation and could not break it: the policy is installed on exactly two WebContents (`createMainWindow.ts:439`, `dashboard-popout-window.ts:179`), `<webview>` guests have their own WebContents and are unaffected, and `will-navigate` is main-frame-only in Electron 43 so comparing against `contents.getURL()` is sound. `file:///etc/passwd`, sibling packaged documents, and remote URLs are still blocked, with tests. **But if `location.reload()` turns out not to emit `will-navigate` at all, this hunk buys nothing and should be dropped** — change (1), the `app:reload` routing, fixes the crash on its own. Suggested mitigation: run the packaged-build console check before or shortly after merge; if it shows `location.reload()` working, revert the `privileged-window-navigation.ts` hunk.

2. **The recovery reload now actually reloads — and that reload runs the local-PTY orphan sweep.** Flagged as a round-1 minor and deliberately not fixed. `app:reload` routes through `onBeforeRendererReload` → `markExpectedRendererReload` (`src/main/index.ts:1353-1356`), never `markRecoveryReloadInFlight`, so `isRecoveryReloadInFlight` is false and `pty.ts:3944-3952` runs `lp.advanceGeneration()` + `lp.killOrphanedPtys(generation - 1)` on the resulting `did-finish-load`. Local PTYs survive the first reload (they are one generation behind), but a reattached session keeps a stale generation, so a *second* app-initiated reload could sweep live local agent PTYs — the exact loss class #5787 carved out for crash/freeze-recovery reloads. This could not happen before **because the reload never landed**, so it is genuinely new exposure introduced by making the fix work. Bounded by `MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2`. Known follow-up; suggested mitigation is to have `requestHostReload` pass `{ reason: 'lazy-chunk-recovery' }` and have `onBeforeRendererReload` call `markRecoveryReloadInFlight` for that reason, keeping the user-clicked GH-auth reload on the current sweeping path.

3. **The `reloadKey` work is incomplete — nine call sites still report `unknown`.** Raised in both review rounds, not fixed. `src/renderer/src/components/sidebar/index.tsx:21-25` (WorktreeMetaDialog, RemoveFolderDialog, WorktreeVisibilityDialog, OrcaYamlTrustDialog, ForgetSshWorkspaceDialog) and `src/renderer/src/components/status-bar/StatusBar.tsx:113,116,121,124` (Pet / ResourceUsage / Ports / Ssh segments — StatusBar itself got a key, its four segments did not). If one of those nine chunks is the one an update strands, triage is still blind. The four boundaries covered by this PR's field reports *do* all map to sites that got a key. Follow-up: add the nine keys and relax `app-startup-routing.test.ts:355` the same way the four assertions in this diff were.

4. **`app:reload`'s new boolean return is not asserted by any test.** Round-2 minor, not fixed. It is the sole input to the renderer's fallback decision; if a later refactor drops the `return true`, the renderer sees `undefined`, treats it as "not issued", and fires `win.location.reload()` on top of the main-process reload — two concurrent main-frame navigations during restart preparation. The two existing handler tests only assert side effects. Follow-up: assert `.resolves.toBe(true)` / `.resolves.toBe(false)` on the existing cases in `attach-main-window-services.test.ts`.

5. **`requestHostReload` reads the module-global `window`** while its caller reloads the injected `win` parameter (`lazy-chunk-recovery-reload.ts:56` vs `:91`). Nit-level, latent only. The single production caller always passes the global `window`, so behaviour is identical today. Follow-up: thread `win` through.

6. **This does not fix the trigger.** The reason chunks go missing in the first place — the macOS updater performing repeated in-place installs of the *same version* (diag `F0BMD9N1X8B` shows three `updater.install` spans for 1.4.165 at 07:07:05Z, 07:33:22Z and 07:34:01Z, with nine renderer bootstraps) — is a separate bug and needs its own ticket. This PR converts an unrecoverable dead surface into a self-healing reload; it does not stop the bundle from being swapped under a live renderer.

7. **No end-to-end proof on a packaged build.** The evidence above is unit-level plus field breadcrumbs. Nobody truncated `out/renderer/assets/Settings-*.js` under a running packaged app and watched it recover. The causal chain (guard blocks → beforeunload never runs → `never-landed` at exactly 10.004 s) is strongly consistent with the field data and the code, but the end-to-end recovery is not directly demonstrated.

8. **No new user-facing recovery UI.** The plan suggested surfacing "Orca was updated — restart to finish" when the reload budget is exhausted. Not in this PR; on repeated failure the user still gets the generic error-boundary fallback.

On the plus side, one thing got measurably *better* beyond the fix: the 10-second Suspense stall over a permanently dead surface is gone, because the reload now settles instead of timing out.

---

## Adversarial review

**2 independent adversarial review rounds**, each run by a **fresh reviewer with no memory of the prior round**, plus **1 fix round** in between.

- **Round 1 — not clean.** Found **1 blocking**: `delete process.env.ELECTRON_RENDERER_URL` in the new main-process test failed typecheck with `TS2704` (`electron-vite/node.d.ts` declares `readonly ELECTRON_RENDERER_URL?: string`, and `config/tsconfig.node.json` includes `src/main/**/*`), which would have failed the required `pnpm typecheck` CI job. Also 3 minor + 1 nit: the incomplete `reloadKey` coverage, the PTY-orphan-sweep exposure, the unverified navigation-guard relaxation, and the module-global `window` read.
  The fix round replaced the delete with `vi.stubEnv('ELECTRON_RENDERER_URL', undefined)` + `afterEach(vi.unstubAllEnvs)` (vitest deletes the key on `undefined`, faithfully preserving intent, and restores ambient state for other suites in the worker — the original line leaked a permanent `process.env` mutation), and added a genuinely load-bearing `lets the dev server reload its own origin` test that only passes if the stub really reaches `process.env`.
- **Round 2 — clean: zero blocking, zero major.** The fresh reviewer independently re-derived the repro (reverted the source files, got the same 4 failures including the 10.005 s `never-landed`), re-derived the field evidence from the raw bundles, confirmed `tsc` exit 0 on all three `pnpm typecheck` projects, and attempted to break the security relaxation without success. Remaining output was 2 minor + 2 nit — all four are listed above in Trade-offs as accepted known follow-ups, not silently dropped.

Both reviewers verified the repro was real rather than tautological, and both explicitly confirmed the branch worktree was left clean with no `git stash` created.

**`/perf` skill review verdict: no regression.** No new timers or intervals (the only timer is the pre-existing 10 s grace, cleared on every exit path). No work added to typing / scroll / terminal-output / tab-switch hot paths — the ~35 new `{ reloadKey }` option objects are evaluated once at module load inside module-scope `const X = lazy(...)` declarations, not per render. No new store subscriptions, selector churn, disk writes, or unbounded collections. IPC delta is one extra `invoke('app:reload')` per recovery attempt, capped at 2 per document, on the crash-recovery path only. Main-process cost of the new guard is one `getURL()` plus two `new URL()` parses per `will-navigate`, on exactly two WebContents (not on browser webviews) — effectively never in normal use. `/perf` called the change a **net perf win**: it removes a 10-second Suspense stall over a dead surface.

Made with [Orca](https://github.com/stablyai/orca) 🐋
