### PR TITLE
fix(codex): block launches with unproven runtime auth

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -17,6 +17,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
+import type * as NodeFs from 'node:fs'
 import type * as ShellStartupEnv from '../pty/shell-startup-env'
 
 const testState = {
@@ -710,7 +711,18 @@ describe('CodexRuntimeHomeService', () => {
     expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
   })
 
-  it('never launches another account on a cold start with no provenance record', async () => {
+  it.each([
+    ['no provenance', (path: string) => rmSync(path, { force: true })],
+    [
+      'selected-account provenance',
+      (path: string) =>
+        writeFileSync(
+          path,
+          `${JSON.stringify({ owner: 'managed', accountId: 'account-b' })}\n`,
+          'utf-8'
+        )
+    ]
+  ])('never launches another account on a cold start with %s', async (_label, setProvenance) => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     writeFileSync(
       getSystemCodexAuthPath(),
@@ -724,11 +736,11 @@ describe('CodexRuntimeHomeService', () => {
       'account-b',
       createCodexAuthJson('b@example.com', 'acct-b', 'b')
     )
-    // Pre-provenance install: the mirror still holds account A, settings already
-    // select account B, and nothing on disk records who wrote those bytes.
+    // A retained pane can overwrite the mirror after B's provenance commits.
+    // Neither missing nor stale provenance can overrule the current bytes.
     mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
     writeFileSync(runtimeAuthPath, authA, 'utf-8')
-    rmSync(getSharedRuntimeAuthProvenancePath(), { force: true })
+    setProvenance(getSharedRuntimeAuthProvenancePath())
     rmSync(join(homeB, 'auth.json'), { force: true })
     const store = createStore(
       createSettings({
@@ -794,32 +806,41 @@ describe('CodexRuntimeHomeService', () => {
     expect(existsSync(runtimeAuthPath)).toBe(false)
   })
 
-  it('survives a runtime auth delete the filesystem refuses', async () => {
+  it('blocks launch when a readable stale runtime auth cannot be deleted', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     writeFileSync(
       getSystemCodexAuthPath(),
       createCodexAuthJson('system@example.com', 'acct-system', 'system'),
       'utf-8'
     )
-    const homeA = createManagedAuth(
-      testState.userDataDir,
-      'account-a',
-      createCodexAuthJson('a@example.com', 'acct-a', 'a')
-    )
+    const authA = createCodexAuthJson('a@example.com', 'acct-a', 'a')
+    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
     const homeB = createManagedAuth(
       testState.userDataDir,
       'account-b',
       createCodexAuthJson('b@example.com', 'acct-b', 'b')
     )
-    // Stands in for a Windows AV/EBUSY lock: the mirror auth.json cannot be
-    // removed, and the branch is only reached because reads are already failing.
-    mkdirSync(runtimeAuthPath, { recursive: true })
+    // A Windows sharing violation can deny delete while still allowing Codex to
+    // read the credential, so model those operations independently.
+    writeFileSync(runtimeAuthPath, authA, 'utf-8')
     writeFileSync(
       getSharedRuntimeAuthProvenancePath(),
       `${JSON.stringify({ owner: 'managed', accountId: 'account-a' })}\n`,
       'utf-8'
     )
     rmSync(join(homeB, 'auth.json'), { force: true })
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof NodeFs>('node:fs')
+      return {
+        ...actual,
+        rmSync: (path: Parameters<typeof rmSync>[0], options?: Parameters<typeof rmSync>[1]) => {
+          if (path === runtimeAuthPath) {
+            throw new Error('simulated Windows sharing violation')
+          }
+          return actual.rmSync(path, options)
+        }
+      }
+    })
     const store = createStore(
       createSettings({
         codexManagedAccounts: [
@@ -834,12 +855,13 @@ describe('CodexRuntimeHomeService', () => {
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
 
-    expect(() => service.prepareForCodexLaunch()).not.toThrow()
-    // The bytes survived the failed delete, so they must at least be fenced off.
+    expect(() => service.prepareForCodexLaunch()).toThrow(
+      'Cannot safely launch Codex while stale runtime auth remains.'
+    )
+    expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(authA)
     expect(JSON.parse(readFileSync(getSharedRuntimeAuthProvenancePath(), 'utf-8'))).toEqual({
       owner: 'fenced'
     })
-    rmSync(runtimeAuthPath, { recursive: true, force: true })
   })
 
   it('refuses to read runtime auth back into a duplicate account while a home is unreadable', async () => {
@@ -930,7 +952,7 @@ describe('CodexRuntimeHomeService', () => {
     )
   })
 
-  it('keeps a mirrored api-key credential no identity claim can attribute', async () => {
+  it('keeps an unattributable api-key credential Orca mirrored in the same run', async () => {
     const runtimeAuthPath = getRuntimeCodexAuthPath()
     writeFileSync(
       getSystemCodexAuthPath(),
@@ -939,13 +961,6 @@ describe('CodexRuntimeHomeService', () => {
     )
     const apiKeyAuth = `${JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-managed' })}\n`
     const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', apiKeyAuth)
-    // Pre-provenance install, cold start: the mirror holds the selected account's
-    // own api-key credential — bytes carrying no id_token to identify — while its
-    // auth.json reads torn mid-rotation.
-    mkdirSync(getRuntimeCodexHomePath(), { recursive: true })
-    writeFileSync(runtimeAuthPath, apiKeyAuth, 'utf-8')
-    rmSync(getSharedRuntimeAuthProvenancePath(), { force: true })
-    writeFileSync(join(managedHomePath, 'auth.json'), '{"OPENAI_API_K', 'utf-8')
     const store = createStore(
       createSettings({
         codexManagedAccounts: [
@@ -957,10 +972,48 @@ describe('CodexRuntimeHomeService', () => {
     )
     vi.spyOn(console, 'warn').mockImplementation(() => {})
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-    new CodexRuntimeHomeService(store as never)
+    const service = new CodexRuntimeHomeService(store as never)
+
+    // Exact same-run bytes prove ownership even without identity claims.
+    writeFileSync(join(managedHomePath, 'auth.json'), '{"OPENAI_API_K', 'utf-8')
+    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
 
     expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(apiKeyAuth)
     expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-1')
+  })
+
+  it('drops a pre-provenance api-key credential when the selected owner cannot be proven', async () => {
+    const runtimeAuthPath = getRuntimeCodexAuthPath()
+    writeFileSync(
+      getSystemCodexAuthPath(),
+      createCodexAuthJson('system@example.com', 'acct-system', 'system'),
+      'utf-8'
+    )
+    const authA = `${JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-a' })}\n`
+    const authB = `${JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'sk-b' })}\n`
+    const homeA = createManagedAuth(testState.userDataDir, 'account-a', authA)
+    const homeB = createManagedAuth(testState.userDataDir, 'account-b', authB)
+    writeFileSync(runtimeAuthPath, authA, 'utf-8')
+    rmSync(getSharedRuntimeAuthProvenancePath(), { force: true })
+    rmSync(join(homeB, 'auth.json'), { force: true })
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          createCodexAccountRecord('account-a', 'a@example.com', 'acct-a', homeA),
+          createCodexAccountRecord('account-b', 'b@example.com', 'acct-b', homeB)
+        ],
+        activeCodexManagedAccountId: 'account-b',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-b', wsl: {} }
+      })
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+    expect(existsSync(runtimeAuthPath)).toBe(false)
+    expect(readFileSync(join(homeA, 'auth.json'), 'utf-8')).toBe(authA)
+    expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe('account-b')
   })
 
   it('reads a renamed account refresh back into its own home despite a stale record email', async () => {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -931,11 +931,8 @@ export class CodexRuntimeHomeService {
     }
   }
 
-  // Why: an unreadable managed auth.json says nothing about who the shared
-  // runtime home currently holds. The credential's own identity claims answer
-  // that without touching the unreadable home; Orca's write records and its
-  // provenance file are corroboration, not the only evidence — a torn or fenced
-  // provenance file is no proof the bytes belong to somebody else.
+  // Why: stale panes can overwrite the mirror after provenance is committed, so
+  // launch ownership needs current-byte identity or Orca's exact same-run write.
   private sharedRuntimeAuthBelongsToAccount(account: CodexManagedAccount): boolean {
     if (!existsSync(this.getRuntimeAuthPath())) {
       return true
@@ -950,14 +947,7 @@ export class CodexRuntimeHomeService {
         return true
       }
     }
-    const status = this.resolveSharedRuntimeAuthProvenanceStatus()
-    if (status.kind === 'committed') {
-      return status.provenance.owner === 'managed' && status.provenance.accountId === account.id
-    }
-    // Why: with no committed record left, only claims that contradict this
-    // account prove the mirror is somebody else's. Deleting bytes nothing can
-    // attribute logs the user out over the very absence the grace window covers.
-    return runtimeAuth !== null && codexAuthCouldBelongToManagedAccount(runtimeAuth, account)
+    return false
   }
 
   // Why: the absence may still heal, so keep the selection — but leave no other
@@ -966,28 +956,30 @@ export class CodexRuntimeHomeService {
   private clearRuntimeAuthForUnprovenSelection(): void {
     const runtimeAuthPath = this.getRuntimeAuthPath()
     try {
-      try {
-        // Why: a refresh Codex wrote into the mirror belongs to whoever owns
-        // those bytes; persist it to that owner's home — managed or ~/.codex —
-        // first, then fence so a delete the OS refuses (Windows AV lock, EBUSY)
-        // still leaves the surviving bytes marked untrusted.
-        const readBackResult = this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
-          updateLastWrittenAuthJson: false
-        })
-        if (readBackResult === 'rejected') {
-          this.readBackRefreshedSystemDefaultAuth()
-        }
-        this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
-      } finally {
-        // Why: neither the rescue nor the fence may cancel the delete — leaving
-        // another identity's credentials for the launch is the defect itself.
-        this.lastWrittenAuthJson = null
-        rmSync(runtimeAuthPath, { force: true })
+      // Why: a refresh Codex wrote into the mirror belongs to whoever owns
+      // those bytes; persist it to that owner's home — managed or ~/.codex —
+      // first, then fence so later syncs cannot adopt the removed bytes.
+      const readBackResult = this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
+        updateLastWrittenAuthJson: false
+      })
+      if (readBackResult === 'rejected') {
+        this.readBackRefreshedSystemDefaultAuth()
       }
+      this.persistSharedRuntimeAuthProvenance({ owner: 'fenced' })
     } catch (error) {
-      // Why: this branch only runs because the filesystem already refused a
-      // read; a second failure must not throw out of launch preparation.
-      console.warn('[codex-runtime-home] Failed to clear unproven runtime auth:', error)
+      // Why: rescue and metadata are best-effort; neither may leave another
+      // identity's credentials in the home returned to the launch.
+      console.warn('[codex-runtime-home] Failed to rescue or fence unproven runtime auth:', error)
+    }
+    this.lastWrittenAuthJson = null
+    try {
+      rmSync(runtimeAuthPath, { force: true })
+    } catch (error) {
+      // Why: a fence is Orca metadata that Codex does not read. If Windows or
+      // another host keeps auth.json locked, failing launch is the safe result.
+      throw new Error('Cannot safely launch Codex while stale runtime auth remains.', {
+        cause: error
+      })
     }
   }
 

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -17,10 +17,11 @@ const CODEX_ROLLOUT_LAYOUT_PATH = new RegExp(`(?:^|/)sessions/${CLAIMED_CODEX_RO
 /** `resume` pins CODEX_HOME to the account that owns the rollout. `fresh` means
  *  provenance could not be verified, so the caller drops the resume argv — an
  *  unverifiable rollout must never resume under whichever account is selected now.
+ *  `reconcileSharedRuntimeAuth` revalidates mutable shared-home auth before spawn.
  *  `claimedCodexProvenance` gates the user-facing notice: a path that claimed real
  *  Codex layout is worth reporting, stale cross-agent metadata is not. */
 export type CodexSessionResumePreparation =
-  | { outcome: 'resume'; codexHomePath: string }
+  | { outcome: 'resume'; codexHomePath: string; reconcileSharedRuntimeAuth?: boolean }
   | { outcome: 'fresh'; claimedCodexProvenance: boolean }
 
 // Why: fold only Win32's extended drive spelling; \\.\ device namespaces and every other \\?\ form

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1020,7 +1020,7 @@ async function prepareCodexSessionResumeForLaunch(args: {
   const settingsStore = store
   // Why: a `fresh` outcome must skip migration, trust and hook repair entirely — there is
   // no verified origin home to prepare, so the PTY layer drops the resume argv (#10793).
-  return prepareCodexSessionResume({
+  const preparation = await prepareCodexSessionResume({
     sessionId: args.providerSession.id,
     transcriptPath: args.providerSession.transcriptPath,
     trustedCodexHomes: trustedHomes,
@@ -1082,6 +1082,14 @@ async function prepareCodexSessionResumeForLaunch(args: {
       return resumeHome
     }
   })
+  return preparation.outcome === 'resume'
+    ? {
+        ...preparation,
+        reconcileSharedRuntimeAuth:
+          normalizeRuntimePathForComparison(preparation.codexHomePath) ===
+          normalizeRuntimePathForComparison(getOrcaManagedCodexHomePath())
+      }
+    : preparation
 }
 
 // Why: restore the window the close handler may have hidden to tray, or reopen it (dock-reactivation style) if fully torn down.

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1930,6 +1930,44 @@ describe('registerPtyHandlers', () => {
       expect(env.ORCA_CODEX_HOME).toBe('/managed/origin/home')
     })
 
+    it('blocks a shared-runtime resume when auth reconciliation fails', async () => {
+      const selectedHome = vi.fn(() => {
+        throw new Error('Cannot safely launch Codex while stale runtime auth remains.')
+      })
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        selectedHome,
+        undefined,
+        undefined,
+        undefined,
+        {
+          prepareCodexSessionResume: async () => ({
+            outcome: 'resume' as const,
+            codexHomePath: '/managed/shared-mirror/home',
+            reconcileSharedRuntimeAuth: true
+          })
+        }
+      )
+
+      await expect(
+        handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          command: 'codex resume session-a',
+          launchAgent: 'codex',
+          resumeProviderSession: {
+            key: 'session_id',
+            id: 'session-a',
+            transcriptPath: '/managed/shared-mirror/home/sessions/2026/07/20/rollout-a.jsonl'
+          }
+        })
+      ).rejects.toThrow('Cannot safely launch Codex while stale runtime auth remains.')
+
+      expect(selectedHome).toHaveBeenCalledTimes(1)
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
     it('overrides an unmarked custom home when the resumed session originated in real home', async () => {
       const selectedHome = vi.fn(() => '/managed/current/home')
       const systemHome = '/Users/example/.codex'
@@ -16751,17 +16789,19 @@ describe('registerPtyHandlers', () => {
       codexManagedAccounts: [{ id: 'account-b', managedHomePath: '/managed/current/home' }]
     })
     handlers.clear()
+    const resolveHome = vi.fn(() => '/managed/shared-mirror/home')
     registerPtyHandlers(
       mainWindow as never,
       runtime as never,
-      vi.fn(() => '/managed/current/home'),
+      resolveHome,
       getSettings as never,
       undefined,
       undefined,
       {
         prepareCodexSessionResume: async () => ({
           outcome: 'resume' as const,
-          codexHomePath: '/managed/shared-mirror/home'
+          codexHomePath: '/managed/shared-mirror/home',
+          reconcileSharedRuntimeAuth: true
         })
       }
     )
@@ -16780,6 +16820,7 @@ describe('registerPtyHandlers', () => {
       }
     })
 
+    expect(resolveHome).toHaveBeenCalledTimes(1)
     expect(recordCodexPaneAccountMock).not.toHaveBeenCalled()
     expect(forgetCodexPaneAccountMock).toHaveBeenCalledWith('pty-runtime-resumed')
   })

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4033,7 +4033,7 @@ export function registerPtyHandlers(
   }
 
   type CodexResumeLaunch = {
-    codexResumeHome: { codexHomePath: string } | null
+    codexResumeHome: Extract<CodexSessionResumePreparation, { outcome: 'resume' }> | null
     command: string | undefined
     notifyResumeUnavailable: boolean
     droppedResumeArgv: boolean
@@ -4084,6 +4084,20 @@ export function registerPtyHandlers(
         providerSession
       }
     })
+
+  const reconcileSharedRuntimeResumeHome = (
+    resumeHome: Extract<CodexSessionResumePreparation, { outcome: 'resume' }>,
+    resolveCurrentHome: () => string | null
+  ): string => {
+    if (!resumeHome.reconcileSharedRuntimeAuth) {
+      return resumeHome.codexHomePath
+    }
+    const currentHome = resolveCurrentHome()
+    if (!codexHomePathsEqual(currentHome, resumeHome.codexHomePath)) {
+      throw new Error(CODEX_RESUME_AUTH_UNAVAILABLE_MESSAGE)
+    }
+    return resumeHome.codexHomePath
+  }
 
   /** Why: buildPtyHostEnv prefers ORCA_SEQUENCED_STARTUP_COMMAND over the launch command
    *  and the sequenced wrapper `eval`s it, so a dropped resume argv has to go there too. */
@@ -4362,7 +4376,15 @@ export function registerPtyHandlers(
           ? getCompatibleSelectedCodexHomePath(
               codexSelectionTarget,
               codexResumeHome
-                ? codexResumeHome.codexHomePath
+                ? reconcileSharedRuntimeResumeHome(codexResumeHome, () =>
+                    getCompatibleSelectedCodexHomePath(
+                      codexSelectionTarget,
+                      getSelectedCodexHomePath?.(codexSelectionTarget, env, {
+                        workspacePath: cwd,
+                        launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+                      }) ?? null
+                    )
+                  )
                 : (getSelectedCodexHomePath?.(codexSelectionTarget, env, {
                     workspacePath: cwd,
                     launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
@@ -5745,7 +5767,15 @@ export function registerPtyHandlers(
             ? getCompatibleSelectedCodexHomePath(
                 codexSelectionTarget,
                 codexResumeHome
-                  ? codexResumeHome.codexHomePath
+                  ? reconcileSharedRuntimeResumeHome(codexResumeHome, () =>
+                      getCompatibleSelectedCodexHomePath(
+                        codexSelectionTarget,
+                        getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
+                          workspacePath: cwd,
+                          launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+                        }) ?? null
+                      )
+                    )
                   : (getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
                       workspacePath: cwd,
                       launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined


### PR DESCRIPTION
## Summary

- require current credential identity or an exact same-run mirror before preserving runtime auth through managed-home unavailability
- ignore stale committed provenance when retained panes have replaced the runtime credential
- fail launch if a locked runtime auth file cannot be removed, since provenance metadata is not read by Codex
- revalidate shared-mirror auth before both renderer and runtime-controller automatic resume spawns
- preserve same-run API-key grace, recoverable refresh read-back, and account-owned/real-home resume precedence

## Context

Follow-up to #12407. Missing provenance and opaque API-key credentials could make account A appear compatible with selected account B. A Windows sharing violation could then leave readable stale bytes in the home returned for launch, and verified automatic resumes could bypass normal launch-home preparation.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/pty.test.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/codex-accounts/codex-credential-absence-grace.test.ts src/main/codex-accounts/managed-codex-auth-readiness.test.ts` (608 passed)
- `pnpm typecheck:node`
- direct code-quality, type-aware, and React Doctor Oxlint scans on changed files
- `pnpm check:max-lines-ratchet`
- `git diff --check`
- Electron smoke on a disposable profile; screenshot attached in PR comments