### PR TITLE
fix(crash-diagnostics): sample the near-death renderer heap (unblocks the 42-crash OOM cluster)

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -5,6 +5,11 @@ import {
   recordCoalescedCrashBreadcrumb,
   recordCrashBreadcrumb
 } from './crash-breadcrumb-store'
+import {
+  MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS,
+  RENDERER_MEMORY_HIGHWATER_RATIOS,
+  RENDERER_MEMORY_SURFACES
+} from '../../shared/renderer-memory-highwater'
 
 afterEach(() => {
   vi.useRealTimers()
@@ -50,7 +55,8 @@ describe('crash breadcrumb store', () => {
   })
 
   it('caps retained high-water profiles', () => {
-    for (let index = 0; index < 5; index += 1) {
+    const overflow = MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS + 1
+    for (let index = 0; index < overflow; index += 1) {
       recordCrashBreadcrumb('renderer_memory_highwater', {
         rendererSurface: `surface-${index}`,
         thresholdPct: 80
@@ -59,7 +65,66 @@ describe('crash breadcrumb store', () => {
 
     expect(
       getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.rendererSurface)
-    ).toEqual(['surface-1', 'surface-2', 'surface-3', 'surface-4'])
+    ).toEqual(
+      Array.from(
+        { length: MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS },
+        (_, index) => `surface-${index + 1}`
+      )
+    )
+  })
+
+  // The retained key is `<surface>:<thresholdPct>`, so the budget must track
+  // thresholds x surfaces. It once lagged at 4 against 8 emitted profiles, and
+  // oldest-first eviction dropped every main-window one — including the 95%
+  // near-death profile the OOM reports exist to carry.
+  it('retains every threshold profile that both renderer surfaces can emit', () => {
+    for (const surface of RENDERER_MEMORY_SURFACES) {
+      for (const ratio of RENDERER_MEMORY_HIGHWATER_RATIOS) {
+        recordCrashBreadcrumb('renderer_memory_highwater', {
+          rendererSurface: surface,
+          thresholdPct: Math.round(ratio * 100)
+        })
+      }
+    }
+
+    const profiles = getCrashBreadcrumbSnapshot().map(
+      (breadcrumb) => `${breadcrumb.data?.rendererSurface}:${breadcrumb.data?.thresholdPct}`
+    )
+
+    expect(profiles).toHaveLength(
+      RENDERER_MEMORY_SURFACES.length * RENDERER_MEMORY_HIGHWATER_RATIOS.length
+    )
+    for (const surface of RENDERER_MEMORY_SURFACES) {
+      for (const ratio of RENDERER_MEMORY_HIGHWATER_RATIOS) {
+        expect(profiles).toContain(`${surface}:${Math.round(ratio * 100)}`)
+      }
+    }
+  })
+
+  // Retained profiles spend the ring budget rather than extending it, so the
+  // newest events lose slots one-for-one instead of the snapshot growing.
+  it('never exceeds the ring size once high-water profiles are retained', () => {
+    for (const surface of RENDERER_MEMORY_SURFACES) {
+      for (const ratio of RENDERER_MEMORY_HIGHWATER_RATIOS) {
+        recordCrashBreadcrumb('renderer_memory_highwater', {
+          rendererSurface: surface,
+          thresholdPct: Math.round(ratio * 100)
+        })
+      }
+    }
+    for (let index = 0; index < 40; index += 1) {
+      recordCrashBreadcrumb(`event_${index}`, { index })
+    }
+
+    const snapshot = getCrashBreadcrumbSnapshot()
+    expect(snapshot).toHaveLength(30)
+    expect(
+      snapshot.filter((breadcrumb) => breadcrumb.name === 'renderer_memory_highwater')
+    ).toHaveLength(MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS)
+    expect(snapshot.at(-1)?.name).toBe('event_39')
+    expect(snapshot.map((breadcrumb) => breadcrumb.name)).not.toContain(
+      `event_${39 - (30 - MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS)}`
+    )
   })
 
   it('redacts sensitive breadcrumb fields before they can be snapshotted', () => {

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -4,10 +4,12 @@ import {
   type CrashReportBreadcrumbData,
   type CrashReportBreadcrumb
 } from '../../shared/crash-reporting'
+import { MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS } from '../../shared/renderer-memory-highwater'
 
 const MAX_BREADCRUMBS = 30
-// Why: retain two thresholds for each renderer surface without growing the ring.
-const MAX_RETAINED_BREADCRUMBS = 4
+// Why derived: eviction is oldest-first, so a budget smaller than the emitted
+// (surface x threshold) profiles drops the near-death one.
+const MAX_RETAINED_BREADCRUMBS = MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS
 // Why: coalesceKey embeds an open-string agentType (length-trimmed only, never
 // enum-checked), so the key space is unbounded over a long multi-agent/SSH session.
 // Bound the coalesce map the same way ProcessGoneDedupe bounds its key map.
@@ -163,7 +165,11 @@ export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {
   resolveAllPendingCoalescedBreadcrumbs()
   // Why: long sessions must retain threshold profiles without growing the 30-entry budget.
   const retained = [...retainedBreadcrumbs.values()]
-  const recent = breadcrumbs.slice(-(MAX_BREADCRUMBS - retained.length))
+  // Why a start index rather than slice(-budget): a retained budget that ever
+  // reaches MAX_BREADCRUMBS makes the budget 0, and slice(-0) returns the whole
+  // ring. Counting forward degrades to [] with no branch to leave untested.
+  const recentBudget = MAX_BREADCRUMBS - retained.length
+  const recent = breadcrumbs.slice(Math.max(0, breadcrumbs.length - recentBudget))
   return [...retained, ...recent]
     .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
     .map((breadcrumb) => ({

--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -78,6 +78,7 @@ describe('renderer crash diagnostics', () => {
       name: 'renderer_memory',
       data: {
         reason: 'startup',
+        rendererSurface: 'main',
         usedHeapMB: 32,
         totalHeapMB: 64,
         heapLimitMB: 512,
@@ -218,6 +219,145 @@ describe('renderer crash diagnostics', () => {
     expect(highwaterCalls()).toHaveLength(2)
     expect(getElementsByTagName).toHaveBeenCalledTimes(3)
     expect(querySelectorAll).toHaveBeenCalledTimes(3)
+
+    unregister()
+  })
+
+  it('emits highwater samples inside the last 20% of the heap limit', async () => {
+    // Why: the 42-crash OOM cluster dies at 90-97% of the limit. With samples
+    // only at 60/80% the nearest profile is ~60min stale and names nothing.
+    const memory = (window.performance as unknown as { memory: Record<string, number> }).memory
+    vi.stubGlobal('document', {
+      getElementsByTagName: () => ({ length: 1 }),
+      querySelectorAll: () => ({ length: 0 })
+    })
+
+    diagnostics.installRendererCrashDiagnostics()
+    const tick = setIntervalMock.mock.calls[0][0] as () => void
+    memory.usedJSHeapSize = 0.92 * memory.jsHeapSizeLimit
+    tick()
+    memory.usedJSHeapSize = 0.96 * memory.jsHeapSizeLimit
+    tick()
+
+    const thresholds = recordBreadcrumbMock.mock.calls
+      .filter((call) => (call[0] as { name: string }).name === 'renderer_memory_highwater')
+      .map((call) => (call[0] as { data: { thresholdPct: number } }).data.thresholdPct)
+    expect(thresholds).toEqual([60, 80, 90, 95])
+  })
+
+  it('carries both shipped byte contributors on the routine renderer_memory breadcrumb', async () => {
+    // Why the real registrations rather than stand-ins: the sub-A leak grows
+    // outside the zustand store, so a trend carrying only storeKB still cannot
+    // name it. F0BM6V4KEBV died at 78% of the limit, where no highwater level
+    // fires and this crumb is the only attribution there is — which is also why
+    // no document is stubbed here: 32MB of 512MB crosses nothing.
+    const { useAppStore } = await import('../store')
+    const { registerLivePaneManager, unregisterLivePaneManager } =
+      await import('./pane-manager/pane-manager-registry')
+    useAppStore.setState({ worktrees: [{ id: 'w1' }, { id: 'w2' }] } as never)
+    const paneManager = {
+      resetWebglTextureAtlases: () => undefined,
+      getPaneCount: () => 2,
+      getPanes: () =>
+        [1, 2].map((id) => ({
+          id,
+          terminal: { cols: 200, buffer: { active: { length: 5000 } } }
+        }))
+    }
+    registerLivePaneManager(paneManager)
+
+    diagnostics.installRendererCrashDiagnostics()
+
+    const routine = recordBreadcrumbMock.mock.calls.find(
+      (call) => (call[0] as { name: string }).name === 'renderer_memory'
+    )?.[0] as { data: Record<string, number> }
+    expect(routine.data['storeKB.__totalKB']).toBeGreaterThan(0)
+    // 2 panes x 5000 rows x 200 cols x 16B ~= 31MB of scrollback.
+    expect(routine.data['terminals.estBufferKB']).toBeGreaterThan(30_000)
+    expect(routine.data['terminals.estPanes']).toBe(2)
+
+    unregisterLivePaneManager(paneManager)
+  })
+
+  it('carries truncated byte attribution on the routine renderer_memory breadcrumb', async () => {
+    // Why: two isolated highwater snapshots cannot show a ramp; the 60s crumb
+    // must carry a byte TREND so a report localizes the retainer on its own.
+    const profile = await import('./renderer-memory-profile')
+    const unregister = profile.registerRendererMemoryProfileContributor(
+      'storeKB',
+      () => ({ worktrees: 120, __totalKB: 4200, tabs: 900, agents: 5, prs: 60, drafts: 2 }),
+      { trendLimit: 5 }
+    )
+
+    diagnostics.installRendererCrashDiagnostics()
+
+    const routine = recordBreadcrumbMock.mock.calls.find(
+      (call) => (call[0] as { name: string }).name === 'renderer_memory'
+    )?.[0] as { data: Record<string, unknown> }
+    expect(routine.data).toMatchObject({
+      'storeKB.__totalKB': 4200,
+      'storeKB.tabs': 900,
+      'storeKB.worktrees': 120,
+      'storeKB.prs': 60,
+      'storeKB.agents': 5
+    })
+    expect(routine.data).not.toHaveProperty('storeKB.drafts')
+
+    unregister()
+  })
+
+  it('censuses the store once on a sample that also profiles the highwater', async () => {
+    // Why: the trend and the highwater profile share one contributor. Walking the
+    // store twice is worst exactly at 90/95%, where there is no headroom for the
+    // transient allocation the census makes.
+    const memory = (window.performance as unknown as { memory: Record<string, number> }).memory
+    memory.usedJSHeapSize = 0.96 * memory.jsHeapSizeLimit
+    vi.stubGlobal('document', {
+      getElementsByTagName: () => ({ length: 1 }),
+      querySelectorAll: () => ({ length: 0 })
+    })
+    let censuses = 0
+    const profile = await import('./renderer-memory-profile')
+    const unregister = profile.registerRendererMemoryProfileContributor(
+      'storeKB',
+      () => {
+        censuses += 1
+        return { __totalKB: 4200 }
+      },
+      { trendLimit: 5 }
+    )
+
+    diagnostics.installRendererCrashDiagnostics()
+
+    expect(
+      recordBreadcrumbMock.mock.calls.filter(
+        (call) => (call[0] as { name: string }).name === 'renderer_memory_highwater'
+      )
+    ).toHaveLength(4)
+    expect(censuses).toBe(1)
+
+    unregister()
+  })
+
+  it('tags every routine renderer_memory sample with its renderer surface', async () => {
+    // Why: main and the dashboard popout push into the same 30-slot main-process
+    // ring, each with its own storeKB census. Untagged, the byte trend this crumb
+    // exists to expose interleaves two unrelated heaps into one unreadable series.
+    const profile = await import('./renderer-memory-profile')
+    const unregister = profile.registerRendererMemoryProfileContributor(
+      'storeKB',
+      () => ({ __totalKB: 12 }),
+      { trendLimit: 5 }
+    )
+
+    diagnostics.installRendererCrashDiagnostics('dashboard-popout')
+    const tick = setIntervalMock.mock.calls[0][0] as () => void
+    tick()
+
+    const surfaces = recordBreadcrumbMock.mock.calls
+      .filter((call) => (call[0] as { name: string }).name === 'renderer_memory')
+      .map((call) => (call[0] as { data: { rendererSurface?: string } }).data.rendererSurface)
+    expect(surfaces).toEqual(['dashboard-popout', 'dashboard-popout'])
 
     unregister()
   })

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -2,20 +2,27 @@ import type {
   CrashReportBreadcrumbData,
   CrashReportDetailValue
 } from '../../../shared/crash-reporting'
+// Why the levels live in shared/: one detailed breadcrumb per (surface,
+// threshold) is retained in the main process, whose budget is derived from them.
+import {
+  RENDERER_MEMORY_HIGHWATER_RATIOS,
+  type RendererSurface
+} from '../../../shared/renderer-memory-highwater'
 import {
   getBrowserWebviewMemoryProfile,
   type BrowserWebviewMemoryProfile
 } from '../components/browser-pane/webview-registry'
 import { recordRendererCrashBreadcrumb } from './crash-breadcrumb-recorder'
-import { collectRendererMemoryProfileCounts } from './renderer-memory-profile'
+import {
+  collectRendererMemoryProfileCounts,
+  collectRendererMemoryTrendCounts,
+  createRendererMemoryCensus,
+  type RendererMemoryCensus
+} from './renderer-memory-profile'
 
 const RENDERER_MEMORY_SAMPLE_INTERVAL_MS = 60_000
 const BYTES_PER_MEGABYTE = 1024 * 1024
 const BYTES_PER_KILOBYTE = 1024
-// Why: one detailed breadcrumb per threshold names what grew before an OOM.
-const RENDERER_MEMORY_HIGHWATER_RATIOS = [0.6, 0.8] as const
-
-type RendererSurface = 'main' | 'dashboard-popout'
 
 type BrowserPerformanceMemory = {
   usedJSHeapSize?: number
@@ -117,11 +124,17 @@ function recordRendererMemory(reason: string): void {
     return
   }
   const browserWebviews = getBrowserWebviewMemoryProfile()
+  // Why one census per sample: the highwater profile below repeats this pass's
+  // contributors, and near-OOM is the worst moment to walk the store twice.
+  const census = createRendererMemoryCensus()
 
   recordRendererCrashBreadcrumb(
     'renderer_memory',
     compactBreadcrumbData({
       reason,
+      // Why: main and the dashboard popout each sample into the same ring, so an
+      // untagged series reads as a sawtooth between two unrelated heaps.
+      rendererSurface,
       usedHeapMB: toMegabytes(memory.usedJSHeapSize),
       totalHeapMB: toMegabytes(memory.totalJSHeapSize),
       heapLimitMB: toMegabytes(memory.jsHeapSizeLimit),
@@ -129,15 +142,19 @@ function recordRendererMemory(reason: string): void {
       mallocedMB: toMegabytes(memory.mallocedBytes),
       blinkAllocatedMB: toMegabytes(memory.blinkAllocatedBytes),
       browserWebviews: browserWebviews.browserWebviewCount,
-      registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount
+      registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount,
+      // Why on every sample: a byte trend across the session localizes a
+      // retainer that two near-death snapshots cannot.
+      ...collectRendererMemoryTrendCounts(census)
     })
   )
-  recordRendererMemoryHighwater(memory, browserWebviews)
+  recordRendererMemoryHighwater(memory, browserWebviews, census)
 }
 
 function recordRendererMemoryHighwater(
   memory: HeapMetrics,
-  browserWebviews: BrowserWebviewMemoryProfile
+  browserWebviews: BrowserWebviewMemoryProfile,
+  census: RendererMemoryCensus
 ): void {
   const used = memory.usedJSHeapSize
   const limit = memory.jsHeapSizeLimit
@@ -170,7 +187,7 @@ function recordRendererMemoryHighwater(
     terminalElements: document.querySelectorAll('.xterm').length,
     browserWebviews: browserWebviews.browserWebviewCount,
     registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount,
-    ...collectRendererMemoryProfileCounts()
+    ...collectRendererMemoryProfileCounts(census)
   })
   for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
     if (ratio < threshold || emittedHighwaterRatios.has(threshold)) {

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -237,4 +237,11 @@ export function getLivePaneMemoryProfileCounts(): Record<string, number> {
 
 // Why here: contributors push in (crash-diagnostics stays a leaf); same-name
 // re-registration on dev HMR overwrites, so no disposal hook is needed.
-registerRendererMemoryProfileContributor('terminals', getLivePaneMemoryProfileCounts)
+// Why trendLimit: scrollback bytes live outside the zustand store, so storeKB
+// cannot see them and the one-shot highwater profiles sample them once — the
+// 78%-of-limit death in F0BM6V4KEBV never reached even the 90% level. The
+// census above is sample-capped arithmetic, far cheaper than the storeKB walk
+// it rides along with. 2 keys carries estBufferKB plus the pane count it scales.
+registerRendererMemoryProfileContributor('terminals', getLivePaneMemoryProfileCounts, {
+  trendLimit: 2
+})

--- a/src/renderer/src/lib/renderer-memory-profile.test.ts
+++ b/src/renderer/src/lib/renderer-memory-profile.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   collectRendererMemoryProfileCounts,
+  collectRendererMemoryTrendCounts,
+  createRendererMemoryCensus,
   registerRendererMemoryProfileContributor,
   summarizeStateCollectionSizes
 } from './renderer-memory-profile'
@@ -134,6 +136,115 @@ describe('collectRendererMemoryProfileCounts', () => {
     expect(contributor).not.toHaveBeenCalled()
   })
 })
+
+describe('collectRendererMemoryTrendCounts', () => {
+  it('keeps only the heaviest keys of trend-tagged contributors', () => {
+    unregisters.push(
+      registerRendererMemoryProfileContributor(
+        'storeKB',
+        () => ({ tabs: 900, __totalKB: 4200, worktrees: 120, prs: 60, agents: 5, drafts: 2 }),
+        { trendLimit: 5 }
+      )
+    )
+    register('store', () => ({ worktrees: 40 }))
+
+    expect(collectRendererMemoryTrendCounts()).toEqual({
+      'storeKB.__totalKB': 4200,
+      'storeKB.tabs': 900,
+      'storeKB.worktrees': 120,
+      'storeKB.prs': 60,
+      'storeKB.agents': 5
+    })
+  })
+
+  it('bounds the aggregate trend budget and contains throwing contributors', () => {
+    unregisters.push(
+      registerRendererMemoryProfileContributor(
+        'broken',
+        () => {
+          throw new Error('boom')
+        },
+        { trendLimit: 4 }
+      )
+    )
+    unregisters.push(
+      registerRendererMemoryProfileContributor(
+        'runaway',
+        () => Object.fromEntries(Array.from({ length: 500 }, (_, index) => [`key${index}`, index])),
+        { trendLimit: 500 }
+      )
+    )
+
+    const counts = collectRendererMemoryTrendCounts()
+    expect(counts['broken.error']).toBe(1)
+    expect(Object.keys(counts)).toHaveLength(8)
+  })
+})
+
+// A sample that crosses a threshold runs both censuses, and storeKB walks every
+// top-level store slice with a transient allocation the size of what it measures
+// — the last thing to do twice with no heap headroom left.
+describe('a census shared across one sample pass', () => {
+  it('reads each contributor once for both the trend and the profile', () => {
+    let reads = 0
+    unregisters.push(
+      registerRendererMemoryProfileContributor(
+        'storeKB',
+        () => {
+          reads += 1
+          return { __totalKB: 4200, tabs: 900 }
+        },
+        { trendLimit: 5 }
+      )
+    )
+    const census = createRendererMemoryCensus()
+
+    const trend = collectRendererMemoryTrendCounts(census)
+    const profile = collectRendererMemoryProfileCounts(census)
+
+    expect(reads).toBe(1)
+    expect(trend).toEqual({ 'storeKB.__totalKB': 4200, 'storeKB.tabs': 900 })
+    expect(profile).toEqual({ 'storeKB.__totalKB': 4200, 'storeKB.tabs': 900 })
+  })
+
+  it('keeps a fresh census per sample so the trend still moves', () => {
+    let size = 10
+    unregisters.push(
+      registerRendererMemoryProfileContributor('storeKB', () => ({ __totalKB: (size += 10) }), {
+        trendLimit: 1
+      })
+    )
+
+    expect(collectRendererMemoryTrendCounts(createRendererMemoryCensus())).toEqual({
+      'storeKB.__totalKB': 20
+    })
+    expect(collectRendererMemoryTrendCounts(createRendererMemoryCensus())).toEqual({
+      'storeKB.__totalKB': 30
+    })
+  })
+
+  it('reports a throwing contributor in both censuses without re-running it', () => {
+    let reads = 0
+    unregisters.push(
+      registerRendererMemoryProfileContributor(
+        'broken',
+        () => {
+          reads += 1
+          throw new Error('boom')
+        },
+        { trendLimit: 4 }
+      )
+    )
+    const census = createRendererMemoryCensus()
+
+    expect(collectRendererMemoryTrendCounts(census)).toEqual({ 'broken.error': 1 })
+    expect(collectRendererMemoryProfileCounts(census)).toEqual({ 'broken.error': 1 })
+    expect(reads).toBe(1)
+  })
+})
+
+// The shipped contributors are measured against MAX_PROFILE_COUNTS in
+// renderer-memory-shipped-contributors.test.ts, which registers them for real.
 
 describe('summarizeStateCollectionSizes', () => {
   it('reports the largest collections first, capped at the limit', () => {

--- a/src/renderer/src/lib/renderer-memory-profile.ts
+++ b/src/renderer/src/lib/renderer-memory-profile.ts
@@ -10,21 +10,48 @@ export type RendererMemoryProfileCounts = Record<string, number>
 
 type RendererMemoryProfileContributor = () => RendererMemoryProfileCounts
 
-const contributors = new Map<string, RendererMemoryProfileContributor>()
+type RendererMemoryProfileOptions = {
+  /** Heaviest keys to also carry on the routine renderer_memory breadcrumb. */
+  trendLimit?: number
+}
+
+type RegisteredContributor = {
+  collect: RendererMemoryProfileContributor
+  trendLimit: number
+}
+
+/**
+ * Per-sample memo shared by the trend and profile censuses.
+ *
+ * Why: crossing 90%/95% runs both in one pass, and the storeKB contributor walks
+ * every top-level store slice with a transient allocation the size of what it
+ * measures — exactly when the heap has no headroom to walk it twice.
+ */
+export type RendererMemoryCensus = Map<string, RendererMemoryProfileCounts | null>
+
+export function createRendererMemoryCensus(): RendererMemoryCensus {
+  return new Map()
+}
+
+const contributors = new Map<string, RegisteredContributor>()
 
 // Why: breadcrumbs are retained per session; a misbehaving contributor must not
 // bloat every crash report. 32 counts is plenty to name a leaking subsystem.
 const MAX_COUNTS_PER_CONTRIBUTOR = 32
 // Why: individually bounded contributors can still create unbounded near-OOM work in aggregate.
-const MAX_PROFILE_COUNTS = 64
+export const MAX_PROFILE_COUNTS = 64
 // Why: empty contributors do not consume the count budget but must not make collection unbounded.
 const MAX_PROFILE_CONTRIBUTORS = 64
 const MAX_CONTRIBUTOR_NAME_LENGTH = 64
 const MAX_COUNT_KEY_LENGTH = 80
+// Why far below MAX_PROFILE_COUNTS: this rides every 60s sample, not just the
+// near-OOM ones, and every retained breadcrumb pays for it.
+export const MAX_TREND_COUNTS = 8
 
 export function registerRendererMemoryProfileContributor(
   name: string,
-  contributor: RendererMemoryProfileContributor
+  contributor: RendererMemoryProfileContributor,
+  options?: RendererMemoryProfileOptions
 ): () => void {
   if (
     name.length === 0 ||
@@ -33,26 +60,106 @@ export function registerRendererMemoryProfileContributor(
   ) {
     return () => undefined
   }
-  contributors.set(name, contributor)
+  contributors.set(name, { collect: contributor, trendLimit: options?.trendLimit ?? 0 })
   return () => {
-    if (contributors.get(name) === contributor) {
+    if (contributors.get(name)?.collect === contributor) {
       contributors.delete(name)
     }
   }
 }
 
-export function collectRendererMemoryProfileCounts(): RendererMemoryProfileCounts {
+/**
+ * Heaviest keys of trend-tagged contributors, for the routine renderer_memory
+ * breadcrumb.
+ *
+ * Why: highwater profiles are two isolated snapshots. A crash report can only
+ * name a retainer if the byte attribution appears as a ramp across the whole
+ * session, so a truncated slice of it rides every sample.
+ */
+export function collectRendererMemoryTrendCounts(
+  census?: RendererMemoryCensus
+): RendererMemoryProfileCounts {
+  const counts: RendererMemoryProfileCounts = {}
+  let collected = 0
+  for (const [name, entry] of contributors) {
+    if (entry.trendLimit <= 0 || collected >= MAX_TREND_COUNTS) {
+      continue
+    }
+    try {
+      const ranked = rankContributorCounts(readContribution(name, entry, census))
+      const keep = Math.min(entry.trendLimit, MAX_TREND_COUNTS - collected)
+      for (const [key, value] of ranked.slice(0, keep)) {
+        counts[`${name}.${key}`] = value
+        collected += 1
+      }
+    } catch {
+      counts[`${name}.error`] = 1
+      collected += 1
+    }
+  }
+  return counts
+}
+
+/** Throws on failure so both censuses keep funnelling it into `${name}.error`. */
+function readContribution(
+  name: string,
+  entry: RegisteredContributor,
+  census?: RendererMemoryCensus
+): RendererMemoryProfileCounts {
+  const memoized = census?.get(name)
+  if (memoized) {
+    return memoized
+  }
+  if (memoized === null) {
+    throw new Error(`renderer memory contributor failed: ${name}`)
+  }
+  try {
+    const contribution = entry.collect()
+    census?.set(name, contribution)
+    return contribution
+  } catch (error) {
+    census?.set(name, null)
+    throw error
+  }
+}
+
+function rankContributorCounts(contribution: RendererMemoryProfileCounts): [string, number][] {
+  const ranked: [string, number][] = []
+  let inspected = 0
+  for (const key in contribution) {
+    if (inspected >= MAX_COUNTS_PER_CONTRIBUTOR) {
+      break
+    }
+    inspected += 1
+    if (
+      !Object.hasOwn(contribution, key) ||
+      key.length === 0 ||
+      key.length > MAX_COUNT_KEY_LENGTH
+    ) {
+      continue
+    }
+    const value = contribution[key]
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      ranked.push([key, value])
+    }
+  }
+  return ranked.sort((a, b) => b[1] - a[1])
+}
+
+export function collectRendererMemoryProfileCounts(
+  census?: RendererMemoryCensus
+): RendererMemoryProfileCounts {
   const counts: RendererMemoryProfileCounts = {}
   let collected = 0
   let visited = 0
-  for (const [name, contributor] of contributors) {
+  for (const [name, entry] of contributors) {
     if (collected >= MAX_PROFILE_COUNTS || visited >= MAX_PROFILE_CONTRIBUTORS) {
       break
     }
     visited += 1
     // Why: a broken contributor must never take down memory reporting itself.
     try {
-      const contribution = contributor()
+      const contribution = readContribution(name, entry, census)
       let inspected = 0
       for (const key in contribution) {
         if (inspected >= MAX_COUNTS_PER_CONTRIBUTOR || collected >= MAX_PROFILE_COUNTS) {

--- a/src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts
+++ b/src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  registerLivePaneManager,
+  unregisterLivePaneManager
+} from './pane-manager/pane-manager-registry'
+import {
+  MAX_PROFILE_COUNTS,
+  MAX_TREND_COUNTS,
+  collectRendererMemoryProfileCounts,
+  collectRendererMemoryTrendCounts,
+  createRendererMemoryCensus
+} from './renderer-memory-profile'
+import { useAppStore } from '../store'
+import type { AppState } from '../store/types'
+
+/**
+ * Drives the contributors the app actually registers — importing ../store and
+ * pane-manager-registry for their registration side effects — instead of
+ * hand-written stand-ins that can only restate the test's own setup.
+ */
+
+const paneManager = {
+  resetWebglTextureAtlases: () => undefined,
+  getPaneCount: () => 3,
+  getPanes: () =>
+    [1, 2, 3].map((id) => ({
+      id,
+      terminal: { cols: 200, buffer: { active: { length: 5000 } } }
+    }))
+}
+
+/** Saturates every slice limit so each contributor emits its widest census. */
+function fillStoreWithProbeSlices(): string[] {
+  const keys = Array.from({ length: 40 }, (_, index) => `__profileProbe${index}`)
+  useAppStore.setState(
+    Object.fromEntries(
+      keys.map((key, index) => [key, Array.from({ length: index + 1 }, () => 'x'.repeat(64))])
+    ) as unknown as Partial<AppState>
+  )
+  return keys
+}
+
+afterEach(() => {
+  unregisterLivePaneManager(paneManager)
+})
+
+describe('shipped renderer memory contributors', () => {
+  it('fits the widest census of every registered contributor inside MAX_PROFILE_COUNTS', () => {
+    // Why the real registry: a fake census cannot notice the store raising its
+    // slice limit, a fourth contributor arriving, or terminals adding keys —
+    // any of which silently truncates the near-death profile mid-contributor.
+    const probeKeys = fillStoreWithProbeSlices()
+    registerLivePaneManager(paneManager)
+
+    const counts = collectRendererMemoryProfileCounts()
+    const prefixes = new Set(Object.keys(counts).map((key) => key.split('.')[0]))
+
+    expect(Object.keys(counts).length).toBeLessThanOrEqual(MAX_PROFILE_COUNTS)
+    expect([...prefixes].sort()).toEqual(['store', 'storeKB', 'terminals'])
+    // Truncation stops mid-contributor, so the last registered one loses keys first.
+    expect(counts['terminals.estBufferKB']).toBeGreaterThan(0)
+    expect(counts['storeKB.__totalKB']).toBeGreaterThan(0)
+    expect(Object.keys(counts).filter((key) => key.startsWith('store.'))).toHaveLength(20)
+    expect(probeKeys.some((key) => counts[`store.${key}`] !== undefined)).toBe(true)
+  })
+
+  it('carries both byte contributors on the routine trend within MAX_TREND_COUNTS', () => {
+    // Why terminals too: the sub-A leak grows outside the zustand store, and
+    // xterm scrollback is the byte source storeKB structurally cannot see.
+    fillStoreWithProbeSlices()
+    registerLivePaneManager(paneManager)
+
+    const counts = collectRendererMemoryTrendCounts(createRendererMemoryCensus())
+
+    expect(Object.keys(counts).length).toBeLessThanOrEqual(MAX_TREND_COUNTS)
+    expect(counts['storeKB.__totalKB']).toBeGreaterThan(0)
+    // 3 panes x 5000 rows x 200 cols x 16B ~= 46MB of scrollback.
+    expect(counts['terminals.estBufferKB']).toBeGreaterThan(40_000)
+    expect(Object.keys(counts).filter((key) => key.startsWith('terminals.'))).toHaveLength(2)
+  })
+
+  it('reads each contributor once when a sample both trends and profiles', () => {
+    // Why: crossing 90/95% runs both censuses in one pass, with no heap headroom
+    // left to walk the store twice.
+    fillStoreWithProbeSlices()
+    registerLivePaneManager(paneManager)
+    const census = createRendererMemoryCensus()
+
+    collectRendererMemoryTrendCounts(census)
+    const before = census.get('storeKB')
+    collectRendererMemoryProfileCounts(census)
+
+    expect(before).toBeDefined()
+    expect(census.get('storeKB')).toBe(before)
+    expect(census.get('terminals')).toBeDefined()
+  })
+})

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -109,8 +109,12 @@ registerRendererMemoryProfileContributor('store', () =>
 
 // Why bytes too: counts miss value-weight growth (97b9e86d leaked ~700MB while
 // its biggest slice grew by 4 entries); sampled KB names what got FAT.
-registerRendererMemoryProfileContributor('storeKB', () =>
-  estimateStateCollectionKB(useAppStore.getState(), 16)
+// Why trendLimit 5: __totalKB always outranks any single slice, so 5 carries
+// the total plus the top 4 slices onto every routine renderer_memory crumb.
+registerRendererMemoryProfileContributor(
+  'storeKB',
+  () => estimateStateCollectionKB(useAppStore.getState(), 16),
+  { trendLimit: 5 }
 )
 
 export type { AppState } from './types'

--- a/src/shared/renderer-memory-highwater.ts
+++ b/src/shared/renderer-memory-highwater.ts
@@ -1,0 +1,23 @@
+/**
+ * Shape of the renderer_memory_highwater breadcrumb series, shared so the
+ * main-process retention budget cannot drift from what the renderer emits.
+ */
+
+// Why these levels: the OOM cluster dies at 90-97% of the heap limit; at the
+// observed ~25MB/min ramp an 0.8-only profile is ~60min stale by then.
+export const RENDERER_MEMORY_HIGHWATER_RATIOS = [0.6, 0.8, 0.9, 0.95] as const
+
+// Each surface samples its own heap into the same breadcrumb ring.
+export const RENDERER_MEMORY_SURFACES = ['main', 'dashboard-popout'] as const
+
+export type RendererSurface = (typeof RENDERER_MEMORY_SURFACES)[number]
+
+/**
+ * One retained breadcrumb per (surface, threshold) profile.
+ *
+ * Why derived: a hand-written cap silently evicts oldest-first, so adding a
+ * threshold would drop the near-death main-window profile these reports exist
+ * to carry.
+ */
+export const MAX_RETAINED_RENDERER_MEMORY_BREADCRUMBS =
+  RENDERER_MEMORY_HIGHWATER_RATIOS.length * RENDERER_MEMORY_SURFACES.length


### PR DESCRIPTION
## What this fixes

**Signature:** renderer death at 90-97% of `heapLimitMB`, reported on four different platform exit encodings — macOS `exit 5` (SIGTRAP), Windows `-536870904` / `0xE0000008` (`reason: oom`), two heap-shaped `-36861` Windows reports, and one Linux SIGKILL.

**Coverage: 42 of the 127 reports in this batch** (G4 `darwin-exit5` 32 + G3 sub-A `renderer-oom` 7 + G5-B heap-shaped 2 + G6-D 1). They were triaged as four independent groups; they are one defect.

**This PR fixes 0 of those 42 crashes on its own.** It is diagnostics only. It ships no leak fix and does not change the heap ceiling (`renderer-heap-headroom.ts:24` is already at the V8 pointer-compression cage). It is ranked first in the plan because the retainer is genuinely unknown today, the existing instrumentation is structurally incapable of naming it, and this is the only path to the other 42.

### Root cause of the *diagnostic* gap (what is actually fixed here)

1. **The near-death heap was never profiled.** `src/renderer/src/lib/crash-diagnostics.ts:16` (on `main`) is `const RENDERER_MEMORY_HIGHWATER_RATIOS = [0.6, 0.8] as const`. The cluster dies at 90-97%, so the newest detailed profile in every bundle is the 80% one — between 60 minutes and 4.5 hours before death, at the observed ramp rates.
2. **The routine 60s breadcrumb carried no byte attribution.** `crash-diagnostics.ts:120-140` emitted only `usedHeapMB`/`totalHeapMB`/`heapLimitMB`/`mallocedMB`/`blinkAllocatedMB`. A report therefore contained exactly two attribution points (60% and 80%) and a long flat list of naked megabyte totals — no trend, no retainer.
3. **The routine breadcrumb was not tagged with its renderer surface.** The high-water crumb carries `rendererSurface`; the routine one did not. The main window and the dashboard popout push into the same 30-slot main-process ring (`crash-breadcrumb-store.ts:8`, `MAX_BREADCRUMBS = 30`), so any byte series read off it interleaves two unrelated heaps.
4. **The main-process retention budget was hand-written and too small.** `src/main/crash-reporting/crash-breadcrumb-store.ts:10` (on `main`) is `const MAX_RETAINED_BREADCRUMBS = 4`, while the retained key is `<surface>:<thresholdPct>` (`crash-breadcrumb-store.ts:54-58`) and eviction is oldest-first. Four thresholds x two surfaces = 8 profiles against 4 slots, and because the main window emits before the popout, **every main-window profile is evicted first — including the 95% one this change exists to produce.** This budget is now derived in `src/shared/renderer-memory-highwater.ts`, so it cannot drift from what the renderer emits.
5. **Crossing 90/95% would have walked the store census twice** — once for the routine trend, once for the high-water profile — at exactly the moment there is no heap headroom to do it. Both now share one `RendererMemoryCensus` per sample (`renderer-memory-profile.ts`).

Items 4 and 5 were found by `/perf` against an earlier revision of this branch and fixed in-branch; see the Adversarial review section.

### Representative field reports

| Report | Platform / exit | Slack |
|---|---|---|
| `F0BMB7LAAMU` | win32 10.0.26200, `-536870904`, `reason: oom`, v1.4.163 | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785606869260479 |
| `F0BM6V4KEBV` | win32 10.0.26200, `-536870904`, `reason: oom`, v1.4.163 | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785606662103009 |
| `F0BMHAVU5QC` | darwin 25.5.0 arm64, `exit 5`, v1.4.163 | https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785618245731309 |

---

## Fix evidence

### 1. Field data — the defect, verbatim from the real bundles

**`F0BMB7LAAMU`** — the whole report contains exactly two attribution points, 2h10m apart, and the newest one is **4h31m before death**:

```
- 2026-08-01T06:46:52.116Z: renderer_memory_highwater (rendererSurface=main, usedHeapMB=2542, totalHeapMB=2677, heapLimitMB=4192, ... store.openFiles=1132, store.settings=180, store.ptyIdsByTabId=41, ... thresholdPct=60)
- 2026-08-01T08:56:52.645Z: renderer_memory_highwater (rendererSurface=main, usedHeapMB=3399, totalHeapMB=3485, heapLimitMB=4192, ... store.openFiles=1132, store.settings=180, store.ptyIdsByTabId=41, ... thresholdPct=80)
```

Crash `Created: 2026-08-01T13:28:44.966Z`. The 27 routine crumbs in between are all of this shape — no byte attribution, no surface tag:

```
- 2026-08-01T13:02:02.387Z: renderer_memory (reason=interval, usedHeapMB=3884, totalHeapMB=4005, heapLimitMB=4192, heapSource=v8, mallocedMB=1, blinkAllocatedMB=8, browserWebviews=0, registeredBrowserGuests=0)
...
- 2026-08-01T13:27:58.966Z: renderer_memory (reason=interval, usedHeapMB=3945, totalHeapMB=4042, heapLimitMB=4192, heapSource=v8, mallocedMB=1, blinkAllocatedMB=8, browserWebviews=0, registeredBrowserGuests=0)
```

3945 / 4192 = **94.1% of the limit at the last sample before death**, with the newest profile stuck at 80%.

I diffed the two profiles' store censuses programmatically rather than by eye:

```
$ python3 -c "...re.findall(r'(store\.[A-Za-z]+)=(\d+)', line)..."
60% store fields: 20
80% store fields: 20
identical: True
diff: {}
```

**All 20 store slices are byte-for-byte identical while the heap grew 3399 - 2542 = 857 MB.** The leak is outside the zustand store, which is exactly where `storeKB` cannot see it — hence `terminals.estBufferKB` (xterm scrollback) is added to the trend alongside `storeKB`, not instead of it.

**`F0BM6V4KEBV`** — peaked at 78% and died there, so the 80% level never fired at all:

```
- 2026-08-01T17:14:01.512Z: renderer_memory_highwater (rendererSurface=main, usedHeapMB=2552, ... thresholdPct=60)
- 2026-08-01T17:42:01.458Z: renderer_memory (reason=interval, usedHeapMB=3280, totalHeapMB=3452, heapLimitMB=4192, ...)
- 2026-08-01T17:43:01.453Z: renderer_memory (reason=interval, usedHeapMB=3253, totalHeapMB=3426, heapLimitMB=4192, ...)
Created: 2026-08-01T17:43:39.931Z
```

3280 / 4192 = 78.2%. `grep -c highwater` on that bundle returns **1**. One profile, 29 minutes before death, is the entire byte record for that crash. Adding thresholds does not help this report — a byte trend on the routine crumb is the only thing that would have.

**`F0BMHAVU5QC`** (macOS, `exit 5`) — the same shape with a clean 60-minute stale window:

```
- 2026-08-01T20:03:32.599Z: renderer_memory_highwater (rendererSurface=main, usedHeapMB=3402, totalHeapMB=3583, heapLimitMB=4192, ... thresholdPct=80)
- 2026-08-01T21:03:32.525Z: renderer_memory (reason=interval, usedHeapMB=3926, totalHeapMB=4116, heapLimitMB=4192, heapSource=v8, mallocedMB=1, blinkAllocatedMB=49, browserWebviews=0, registeredBrowserGuests=0)
Created: 2026-08-01T21:03:58.815Z
```

3926 / 4192 = 93.7%, profiled last at 81%, 60 minutes earlier.

### 2. Red without the source fix

Scratch worktree at the branch commit, `node_modules` symlinked, **only source files reverted to `origin/main`** (tests untouched). No `git stash` was used anywhere.

Stage A — `git checkout origin/main -- src/renderer/src/lib/crash-diagnostics.ts src/main/crash-reporting/crash-breadcrumb-store.ts`:

```
 RUN  v4.1.5 /private/tmp/prproof-w1a-heap-diag

 × src/main/crash-reporting/crash-breadcrumb-store.test.ts > crash breadcrumb store > caps retained high-water profiles 3ms
   → expected [ 'surface-5', 'surface-6', …(2) ] to deeply equal [ 'surface-1', 'surface-2', …(6) ]
 × src/main/crash-reporting/crash-breadcrumb-store.test.ts > crash breadcrumb store > retains every threshold profile that both renderer surfaces can emit 1ms
   → expected [ 'dashboard-popout:60', …(3) ] to have a length of 8 but got 4
 × src/main/crash-reporting/crash-breadcrumb-store.test.ts > crash breadcrumb store > never exceeds the ring size once high-water profiles are retained 1ms
   → expected [ { …(3) }, { …(3) }, { …(3) }, …(1) ] to have a length of 8 but got 4
 × src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > installs startup, error, rejection, and memory breadcrumbs once 4ms
   → expected "vi.fn()" to be called with arguments: [ { name: 'renderer_memory', …(1) } ]
 × src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > emits highwater samples inside the last 20% of the heap limit 1ms
   → expected [ 60, 80 ] to deeply equal [ 60, 80, 90, 95 ]
 × src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > carries both shipped byte contributors on the routine renderer_memory breadcrumb 2160ms
   → actual value must be number or bigint, received "undefined"
 × src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > carries truncated byte attribution on the routine renderer_memory breadcrumb 3ms
   → expected { reason: 'startup', …(6) } to match object { 'storeKB.__totalKB': 4200, …(4) }
 × src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > censuses the store once on a sample that also profiles the highwater 1ms
   → expected [ [ { …(2) } ], [ { …(2) } ] ] to have a length of 4 but got 2
 × src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > tags every routine renderer_memory sample with its renderer surface 1ms
   → expected [ undefined, undefined ] to deeply equal [ 'dashboard-popout', …(1) ]

 Test Files  2 failed (2)
      Tests  9 failed | 23 passed (32)
```

Two of those failures are worth reading closely.

`expected [ 60, 80 ] to deeply equal [ 60, 80, 90, 95 ]` is the near-death gap itself: at 96% of the limit the pre-fix renderer emits nothing past 80%.

`expected [ 'dashboard-popout:60', …(3) ] to have a length of 8 but got 4` is the eviction bug. The test emits `main:60/80/90/95` first, then `dashboard-popout:60/80/90/95`. With `MAX_RETAINED_BREADCRUMBS = 4` and oldest-first eviction, the four survivors all start at `dashboard-popout` — **every main-window profile, including the 95% one, is dropped before the report is written.**

The surface-tag failure is verbatim:

```
 FAIL  src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > installs startup, error, rejection, and memory breadcrumbs once
@@ -4,11 +4,10 @@
        "browserWebviews": 4,
        "heapLimitMB": 512,
        "heapSource": "quantized",
        "reason": "startup",
        "registeredBrowserGuests": 3,
-       "rendererSurface": "main",
        "totalHeapMB": 64,
        "usedHeapMB": 32,
      },
      "name": "renderer_memory",
    },
```

Stage B — additionally `git checkout origin/main -- src/renderer/src/lib/renderer-memory-profile.ts src/renderer/src/store/index.ts src/renderer/src/lib/pane-manager/pane-manager-registry.ts`:

```
 × src/renderer/src/lib/renderer-memory-profile.test.ts > collectRendererMemoryTrendCounts > keeps only the heaviest keys of trend-tagged contributors 2ms
   → collectRendererMemoryTrendCounts is not a function
 × src/renderer/src/lib/renderer-memory-profile.test.ts > collectRendererMemoryTrendCounts > bounds the aggregate trend budget and contains throwing contributors 0ms
   → collectRendererMemoryTrendCounts is not a function
 × src/renderer/src/lib/renderer-memory-profile.test.ts > a census shared across one sample pass > reads each contributor once for both the trend and the profile 0ms
   → createRendererMemoryCensus is not a function
 × src/renderer/src/lib/renderer-memory-profile.test.ts > a census shared across one sample pass > keeps a fresh census per sample so the trend still moves 0ms
   → createRendererMemoryCensus is not a function
 × src/renderer/src/lib/renderer-memory-profile.test.ts > a census shared across one sample pass > reports a throwing contributor in both censuses without re-running it 0ms
   → createRendererMemoryCensus is not a function
 × src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts > shipped renderer memory contributors > fits the widest census of every registered contributor inside MAX_PROFILE_COUNTS 4ms
   → expected value must be number or bigint, received "undefined"
 × src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts > shipped renderer memory contributors > carries both byte contributors on the routine trend within MAX_TREND_COUNTS 1ms
   → createRendererMemoryCensus is not a function
 × src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts > shipped renderer memory contributors > reads each contributor once when a sample both trends and profiles 0ms
   → createRendererMemoryCensus is not a function

 Test Files  2 failed (2)
      Tests  8 failed | 12 passed (20)
```

Being straight about the weight of this second block: five of these eight are missing-export `TypeError`s, not assertion failures — the trend/census API does not exist on `main` at all, so those tests cannot be red in a more interesting way. The behavioural reds that carry the argument are in Stage A.

The scratch worktree was removed afterwards (`git worktree remove --force /tmp/prproof-w1a-heap-diag`) and the branch worktree re-verified clean.

### 3. Green with the fix

```
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/main/crash-reporting/crash-breadcrumb-store.test.ts \
    src/renderer/src/lib/crash-diagnostics.test.ts \
    src/renderer/src/lib/renderer-memory-profile.test.ts \
    src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts

 ✓ src/main/crash-reporting/crash-breadcrumb-store.test.ts > crash breadcrumb store > caps retained high-water profiles 0ms
 ✓ src/main/crash-reporting/crash-breadcrumb-store.test.ts > crash breadcrumb store > retains every threshold profile that both renderer surfaces can emit 0ms
 ✓ src/main/crash-reporting/crash-breadcrumb-store.test.ts > crash breadcrumb store > never exceeds the ring size once high-water profiles are retained 0ms
 ✓ src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > emits highwater samples inside the last 20% of the heap limit 1ms
 ✓ src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > carries both shipped byte contributors on the routine renderer_memory breadcrumb 1253ms
 ✓ src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > carries truncated byte attribution on the routine renderer_memory breadcrumb 2ms
 ✓ src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > censuses the store once on a sample that also profiles the highwater 1ms
 ✓ src/renderer/src/lib/crash-diagnostics.test.ts > renderer crash diagnostics > tags every routine renderer_memory sample with its renderer surface 1ms
 ✓ src/renderer/src/lib/renderer-memory-profile.test.ts > collectRendererMemoryTrendCounts > keeps only the heaviest keys of trend-tagged contributors 0ms
 ✓ src/renderer/src/lib/renderer-memory-profile.test.ts > collectRendererMemoryTrendCounts > bounds the aggregate trend budget and contains throwing contributors 0ms
 ✓ src/renderer/src/lib/renderer-memory-profile.test.ts > a census shared across one sample pass > reads each contributor once for both the trend and the profile 0ms
 ✓ src/renderer/src/lib/renderer-memory-profile.test.ts > a census shared across one sample pass > keeps a fresh census per sample so the trend still moves 0ms
 ✓ src/renderer/src/lib/renderer-memory-profile.test.ts > a census shared across one sample pass > reports a throwing contributor in both censuses without re-running it 0ms
 ✓ src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts > shipped renderer memory contributors > fits the widest census of every registered contributor inside MAX_PROFILE_COUNTS 3ms
 ✓ src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts > shipped renderer memory contributors > carries both byte contributors on the routine trend within MAX_TREND_COUNTS 1ms
 ✓ src/renderer/src/lib/renderer-memory-shipped-contributors.test.ts > shipped renderer memory contributors > reads each contributor once when a sample both trends and profiles 1ms

 Test Files  4 passed (4)
      Tests  52 passed (52)
   Duration  1.41s
```

(Trimmed to the tests this PR is about; all 52 in those four files pass, none skipped.)

### 4. Budget headroom, measured rather than asserted

The `renderer-memory-shipped-contributors.test.ts` suite drives the contributors the app *really* registers (`store`, `storeKB`, `terminals`) instead of stand-ins. I instrumented a throwaway copy of it to print the actual widths (temp file created outside the tracked tree's history and deleted; `git status --short` clean afterwards):

```
AssertionError: expected 'WIDEST=40/64' to be 'probe'
AssertionError: expected 'TREND=7/8:terminals.estBufferKB|terminals.estPanes|storeKB.__totalKB|storeKB.__profileProbe36|storeKB.__profileProbe37|storeKB.__profileProbe38|storeKB.__profileProbe39' to be 'probe'
```

So at their widest the shipped contributors occupy **40 of `MAX_PROFILE_COUNTS = 64`** on the near-death profile and **7 of `MAX_TREND_COUNTS = 8`** on the routine crumb, with both byte sources present. (The commit message says 41 for the profile; the exact figure moves with the probe fixture — the guarantee under test is the `<= 64` bound, not the constant.)

### 5. Full regression suites for every touched module

`src/main/crash-reporting`, `src/shared`, `src/renderer/src/store`, `src/renderer/src/lib/pane-manager`:

```
 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w1a-heap-diag

 Test Files  621 passed | 3 skipped (624)
      Tests  6812 passed | 16 skipped (6828)
   Duration  20.40s
```

`src/renderer/src/lib` (the whole tree, recursive):

```
 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w1a-heap-diag

 Test Files  372 passed (372)
      Tests  3548 passed | 1 skipped (3549)
   Duration  26.14s
```

**Zero failures, so there are no pre-existing failures to name in these modules.** The skips are pre-existing and unrelated.

### Windows verification

**Not required for this change** — it is in-process renderer/main diagnostics with no platform-conditional code path, no filesystem paths, and no shell invocation. Per `/tmp/crash-pr-meta.json`: `"windows": "not required (in-process diagnostics)"`. Note this matters for the *cluster*: 7 of the 42 covered crashes are Windows `0xE0000008` and 32 are macOS `exit 5`. The instrumentation is identical on both because it reads `performance.memory` / the V8 heap-statistics bridge, which is Chromium-provided on every platform. The Phase 1b mitigation that follows this PR **will** need Windows validation.

---

## ELI5

Imagine a warehouse that keeps catching fire, and every time it does you get a report from the security camera system. The reports all say the same useless thing: "the warehouse was 94% full when it burned down."

You want to know *what* filled it. The system does take detailed inventory photos — but only when the warehouse hits 60% full and 80% full. The fires all happen somewhere between 90% and 97%. So the newest inventory photo you have is typically an hour old, and in one case four and a half hours old. Meanwhile, every minute, the system dutifully records a single number — "94% full", "94% full", "94% full" — and nothing at all about *what is in there*.

Worse, when we checked the two inventory photos we do get from one fire, every single labelled shelf held exactly the same number of boxes in both — yet 857 MB more stuff had appeared between them. So whatever is filling the warehouse isn't on any shelf we photograph. It's stacked in the aisles.

Three things changed:

1. **Take inventory photos at 90% and 95% too.** The 95% photo lands roughly two minutes before the fire instead of an hour.
2. **Put a short inventory summary on every single minute-by-minute reading** — the total weight plus the four heaviest shelves, and separately an estimate of the stuff in the aisles (terminal scrollback, which is the thing no shelf label covers). Two photos give you two dots; a number on every reading gives you a *slope*, and a slope tells you what's growing.
3. **Stamp each reading with which building it came from.** There are two warehouses (the main window and the popped-out dashboard) filing into one shared logbook, and unlabelled readings from both were interleaved into one nonsense line.

There was also a filing-cabinet bug: the logbook only kept 4 inventory photos, but with two buildings and four checkpoints there are now 8, and it threw away the oldest first — which meant it threw away *every photo from the main building*, including the 95% one this whole change exists to produce. That's fixed by computing the cabinet size from the number of buildings times checkpoints, instead of writing "4" by hand.

None of this puts out a fire. It just means the next fire comes with an inventory list instead of a shrug.

---

## Trade-offs

Stated plainly, including the things that got worse:

- **This ships zero crash fixes.** All 42 crashes in the cluster will keep happening at the same rate after this merges. The value is entirely in the *next* batch of reports being diagnosable. If you are measuring this PR by crash-rate delta, it will read as a no-op, and that is the honest expectation.
- **Every crash report gets bigger.** The routine `renderer_memory` breadcrumb now carries up to 7 extra numeric fields (`MAX_TREND_COUNTS = 8`), and there are up to ~27 of those crumbs per report. Reports also now retain 8 high-water profiles instead of 4. Bundle size and ingest cost go up measurably.
- **The ring buffer gives up 4 more slots to retained profiles.** `MAX_BREADCRUMBS` is still 30, and retained profiles now spend 8 of them instead of 4. So **4 fewer recent non-memory breadcrumbs survive into every crash report**, for all crash types, not just OOM ones. This is a real regression in trail depth for unrelated investigations; the alternative (growing the ring) was rejected to keep report size bounded. `never exceeds the ring size once high-water profiles are retained` locks the 30 in place so this can't creep further without a test change.
- **The routine sample now does real work every 60 seconds.** `storeKB` walks every top-level store slice with a transient allocation proportional to what it measures, and it used to run only when a threshold was crossed. It now runs on every sample. `/perf` flagged the worse version of this (two walks per near-OOM sample); the census memo brings it to one walk per sample, but one-per-60s is still strictly more than before.
- **`terminals.estBufferKB` is an estimate, not a measurement.** It is `panes x rows x cols x 16 bytes`. It does not model xterm's actual buffer representation and will be wrong in absolute terms. It is intended to be read as a *trend*, and the PR should not be taken as claiming a byte-accurate scrollback figure.
- **The 90/95% profiles run at the worst possible moment.** Emitting a detailed profile at 95% of the heap limit allocates while the heap is nearly exhausted. The census sharing and the count budgets bound this, but there is a non-zero chance the profiling pass itself is the allocation that tips a renderer over. We accepted that: a crash at 95% with a profile attached is strictly more useful than the same crash without one.
- **Known follow-up, deliberately not fixed here:** the plan's Phase 1b — reacting to heap pressure (force-park + hidden-pane scrollback demotion at >=80%) instead of merely watching the renderer ramp to 96% and reporting it. That is the change that would actually reduce the 42. It is a separate PR and needs validation on **both** macOS and Windows. Mitigation until then: none — the crashes continue.
- **Correlation, not causation, on the retainer.** Nothing in this PR proves that terminal scrollback is the leak. The `857 MB with an identical store census` finding proves only that it is *not* in the store. `terminals.estBufferKB` is a hypothesis being instrumented, and if it comes back small then plan item 6 (bounding eviction-exempt mounted panes) is wrong and the retainer is somewhere else entirely.

---

## Adversarial review

- **4 independent adversarial review rounds.** Each round was run by a fresh reviewer with no memory of the prior round and no access to the previous rounds' findings — so agreement across rounds is independent confirmation, not an echo.
- **3 fix rounds** followed those reviews. The substantive findings were: the threshold levels and the retention budget being able to drift apart (fixed by moving both behind `src/shared/renderer-memory-highwater.ts` and deriving the budget as `ratios.length x surfaces.length`); the routine crumb being untagged and therefore unreadable across two renderer surfaces; the budget assertions being written against hand-made stand-in contributors that could only restate the test's own setup (fixed by `renderer-memory-shipped-contributors.test.ts`, which drives the real `store` / `storeKB` / `terminals` registrations); and a latent `slice(-0)` hazard in `getCrashBreadcrumbSnapshot` that would have returned the entire ring if the retained budget ever reached `MAX_BREADCRUMBS` (replaced with a forward start index).
- **Final verdict: clean — zero blocking findings, zero major findings.**
- **`/perf` verdict: a regression was found by `/perf` and fixed in-branch.** Two issues: (1) the retained-breadcrumb budget overflowed — 8 emitted profiles against 4 retained slots, evicting every main-window profile; and (2) a duplicate store census on any sample that both trends and profiles, i.e. exactly the 90/95% samples with no heap headroom left. Both are fixed in this branch and both have regression tests (`retains every threshold profile that both renderer surfaces can emit`, `censuses the store once on a sample that also profiles the highwater`).

Made with [Orca](https://github.com/stablyai/orca) 🐋
