### PR TITLE
fix(terminal): damp cold-park verdict oscillation (React #185) — 10 crashes

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.test.ts
@@ -169,4 +169,45 @@ describe('getTerminalTabColdParkRecheckDelayMs', () => {
       })
     ).toBe(250)
   })
+
+  // Why: a flip-damped tab is long past every hysteresis deadline, so the pin
+  // expiry is the only wakeup left — drop it and the tab never re-parks.
+  it('wakes at the flip-damping pin deadline when all ordinary deadlines have passed', () => {
+    expect(
+      getTerminalTabColdParkRecheckDelayMs({
+        parkingEnabled: true,
+        hiddenSinceMs: 1_000,
+        nowMs: 1_000_000,
+        coldParkDelayMs: 100,
+        hotRetainMs: 1_000,
+        parkVerdictPinUntilMs: 1_060_000
+      })
+    ).toBe(60_000)
+  })
+
+  // Why: the earliest pending deadline wins — a pin must not delay a nearer
+  // cool-down wakeup, and vice versa.
+  it('takes the nearest of the pin and cool-down deadlines', () => {
+    const base = {
+      parkingEnabled: true,
+      hiddenSinceMs: 1_000,
+      nowMs: 2_500,
+      coldParkDelayMs: 100,
+      hotRetainMs: 1_000
+    }
+    expect(
+      getTerminalTabColdParkRecheckDelayMs({
+        ...base,
+        parkCooldownUntilMs: 2_750,
+        parkVerdictPinUntilMs: 62_500
+      })
+    ).toBe(250)
+    expect(
+      getTerminalTabColdParkRecheckDelayMs({
+        ...base,
+        parkCooldownUntilMs: 62_500,
+        parkVerdictPinUntilMs: 2_750
+      })
+    ).toBe(250)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.ts
@@ -18,6 +18,7 @@ function nextColdParkDeadlineDelayMs(args: {
   hotRetainMs: number
   retentionTtlMs?: number
   parkCooldownUntilMs?: number | null
+  parkVerdictPinUntilMs?: number | null
 }): number | null {
   if (!args.parkingEnabled || args.hiddenSinceMs === null) {
     return null
@@ -27,7 +28,9 @@ function nextColdParkDeadlineDelayMs(args: {
     args.hiddenSinceMs + args.hotRetainMs,
     ...(args.retentionTtlMs !== undefined ? [args.hiddenSinceMs + args.retentionTtlMs] : []),
     // Why: the cool-down holds past-deadline candidates out of the parked set; without this wakeup nothing re-parks them.
-    ...(args.parkCooldownUntilMs != null ? [args.parkCooldownUntilMs] : [])
+    ...(args.parkCooldownUntilMs != null ? [args.parkCooldownUntilMs] : []),
+    // Why: same for the flip-damping pin — and it is worse, because the pin's job is to stop the churn that would otherwise re-run the verdict effect.
+    ...(args.parkVerdictPinUntilMs != null ? [args.parkVerdictPinUntilMs] : [])
   ].filter((deadlineMs) => deadlineMs > args.nowMs)
   return pendingDeadlines.length === 0 ? null : Math.min(...pendingDeadlines) - args.nowMs
 }
@@ -60,6 +63,8 @@ export function getTerminalTabColdParkRecheckDelayMs(args: {
   coldParkDelayMs?: number
   hotRetainMs?: number
   parkCooldownUntilMs?: number | null
+  /** Provided only for tabs damped out of the parked set by flip churn. */
+  parkVerdictPinUntilMs?: number | null
 }): number | null {
   return nextColdParkDeadlineDelayMs({
     parkingEnabled: args.parkingEnabled,
@@ -67,6 +72,7 @@ export function getTerminalTabColdParkRecheckDelayMs(args: {
     nowMs: args.nowMs,
     coldParkDelayMs: args.coldParkDelayMs ?? TERMINAL_TAB_COLD_PARK_DELAY_MS,
     hotRetainMs: args.hotRetainMs ?? TERMINAL_TAB_HOT_RETAIN_MS,
-    parkCooldownUntilMs: args.parkCooldownUntilMs
+    parkCooldownUntilMs: args.parkCooldownUntilMs,
+    parkVerdictPinUntilMs: args.parkVerdictPinUntilMs
   })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
@@ -1,0 +1,245 @@
+/** @vitest-environment happy-dom */
+/**
+ * Cold-park verdict oscillation (crash cluster: React #185 in the terminal overlay).
+ *
+ * Why this shape: canWatcherCoverParkedTerminalTab is re-derived from store and
+ * registry state that mounting/unmounting the very pane the verdict controls
+ * rewrites, and the parked watchers write the tab model back. The pane stand-in
+ * models that edge — mounted pane grants coverage, parked pane withdraws it,
+ * and either transition re-mints the tab array the cold-park effect depends on.
+ *
+ * Why the store-write chain is parameterised: React bails on *commits*, not on
+ * flips, so a damping threshold expressed in flips is only safe if it holds at
+ * the real cycle's commits-per-flip cost (pane-connect updateTabPtyId, the
+ * watcher-sync writes, the overlay's own subscriber renders). The chain models
+ * that cost so the derived burst limit stays regression-tested.
+ */
+import { act, useEffect, useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalTab } from '../../../../shared/types'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const park = vi.hoisted(() => ({
+  worktreeId: 'repo::/wt-park-loop',
+  /** Whether the byte watchers could cover the tab if it parked right now. */
+  coverage: true
+}))
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useAppStore = create(() => ({
+    pendingStartupByTabId: {} as Record<string, unknown>,
+    runtimeStatusByEnvironmentId: new Map<string, unknown>(),
+    settings: {} as Record<string, unknown>,
+    terminalLayoutsByTabId: {} as Record<string, unknown>,
+    runtimePaneTitlesByTabId: {} as Record<string, unknown>,
+    tabsByWorktree: {} as Record<string, TerminalTab[]>
+  }))
+  return { useAppStore }
+})
+
+vi.mock('./terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: () => park.coverage,
+  disposeParkedTerminalWatchersForWorktree: () => {},
+  resolveParkedTerminalPaneCandidates: () => [],
+  syncParkedTerminalTabWatchers: () => {}
+}))
+
+vi.mock('./terminal-parking-e2e-overrides', () => ({
+  getTerminalParkingPolicyOverrides: () => ({ coldParkDelayMs: 0, hotRetainMs: 0 })
+}))
+
+import { useAppStore } from '../../store'
+import {
+  TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_COMMIT_COST
+} from './terminal-park-verdict-flip-telemetry'
+import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
+
+/** The most recently hidden tab holds the last-active retain exemption. */
+const EXEMPT_TAB_ID = 'tab-a'
+const PARKABLE_TAB_ID = 'tab-b'
+/** Stops an unfixed loop from hanging the run if React ever raises its bail. */
+const RENDER_HARD_STOP = 500
+/** +1: the pin lands in the passive effect observing the burst flip, so the
+ *  verdict settles one flip after damping engages. */
+const SETTLED_FLIP_BUDGET = TERMINAL_TAB_PARK_FLIP_BURST_LIMIT + 1
+const EMPTY_ASSIGNMENTS = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
+const EMPTY_PORTALS: never[] = []
+
+type ParkingStoreState = { tabsByWorktree: Record<string, TerminalTab[]> }
+
+const parkingStore = useAppStore as unknown as {
+  setState: (partial: (state: ParkingStoreState) => Partial<ParkingStoreState>) => void
+}
+
+function terminalTab(id: string): TerminalTab {
+  return { id, ptyId: `${park.worktreeId}@@session-${id}`, title: id } as TerminalTab
+}
+
+let tabModelRevision = 0
+
+// Models the store writes a pane mount/unmount produces — updateTabPtyId on
+// connect, parked-watcher title writes — both of which re-mint the tab array.
+function rewriteTabModel(tabId: string): void {
+  tabModelRevision += 1
+  const revision = tabModelRevision
+  parkingStore.setState((state) => ({
+    tabsByWorktree: {
+      ...state.tabsByWorktree,
+      [park.worktreeId]: (state.tabsByWorktree[park.worktreeId] ?? []).map((tab) =>
+        tab.id === tabId ? { ...tab, title: `${tab.id}-${revision}` } : tab
+      )
+    }
+  }))
+}
+
+/** Store writes a single park transition costs; each lands in its own commit. */
+let storeCommitsPerParkTransition = 1
+let paneMountCount = 0
+
+/** The pane whose mount/unmount the park verdict authorizes. */
+function TerminalPaneStandIn(): null {
+  useEffect(() => {
+    paneMountCount += 1
+  }, [])
+  return null
+}
+
+/**
+ * The store writes a park transition drags behind it — pane-connect
+ * updateTabPtyId, then the watcher-sync writes that each only see the tab model
+ * the previous write produced. Coverage is re-derived from the last of them, so
+ * the verdict cannot flip until the whole chain has committed. Why staged
+ * rather than batched: nested commits are what React counts against
+ * NESTED_UPDATE_LIMIT, so this is the per-flip cost the damping must beat.
+ */
+function ParkTransitionStoreWrites({ parked }: { parked: boolean }): null {
+  const pendingWritesRef = useRef(storeCommitsPerParkTransition)
+  const lastParkedRef = useRef(parked)
+  const [writeTick, setWriteTick] = useState(0)
+  useEffect(() => {
+    if (lastParkedRef.current !== parked) {
+      lastParkedRef.current = parked
+      pendingWritesRef.current = storeCommitsPerParkTransition
+    }
+    if (pendingWritesRef.current <= 0) {
+      return
+    }
+    pendingWritesRef.current -= 1
+    if (pendingWritesRef.current === 0) {
+      // A mounted pane grants byte-watcher coverage; a parked one withdraws it.
+      park.coverage = !parked
+    }
+    rewriteTabModel(PARKABLE_TAB_ID)
+    setWriteTick((tick) => tick + 1)
+  }, [parked, writeTick])
+  return null
+}
+
+let hostRenderCount = 0
+let parkVerdictFlipCount = 0
+let lastParkVerdict = false
+
+function OverlayHost(): React.JSX.Element | null {
+  hostRenderCount += 1
+  const terminalTabs = useAppStore(
+    (state) => (state as ParkingStoreState).tabsByWorktree[park.worktreeId]
+  ) as TerminalTab[]
+  const parkedTerminalTabIds = useTerminalTabColdParking({
+    worktreeId: park.worktreeId,
+    terminalTabs,
+    assignments: EMPTY_ASSIGNMENTS,
+    isWorktreeActive: false,
+    coldParkTerminalPanes: false,
+    shouldMeasureHiddenWorktree: false,
+    activityTerminalPortals: EMPTY_PORTALS,
+    activationDeferredMountTabIds: null
+  })
+  const parked = parkedTerminalTabIds.has(PARKABLE_TAB_ID)
+  if (parked !== lastParkVerdict) {
+    parkVerdictFlipCount += 1
+  }
+  lastParkVerdict = parked
+  if (hostRenderCount > RENDER_HARD_STOP) {
+    return null
+  }
+  return (
+    <>
+      {parked ? null : <TerminalPaneStandIn />}
+      <ParkTransitionStoreWrites parked={parked} />
+    </>
+  )
+}
+
+function renderOverlayHost(root: Root): unknown {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  let thrown: unknown = null
+  try {
+    act(() => {
+      root.render(<OverlayHost />)
+    })
+  } catch (error) {
+    thrown = error
+  }
+  consoleError.mockRestore()
+  return thrown
+}
+
+describe('cold-park verdict oscillation', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    park.coverage = true
+    hostRenderCount = 0
+    parkVerdictFlipCount = 0
+    lastParkVerdict = false
+    tabModelRevision = 0
+    paneMountCount = 0
+    storeCommitsPerParkTransition = 1
+    parkingStore.setState(() => ({
+      tabsByWorktree: {
+        [park.worktreeId]: [terminalTab(EXEMPT_TAB_ID), terminalTab(PARKABLE_TAB_ID)]
+      }
+    }))
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  it('settles the park verdict when watcher coverage tracks the pane it unmounts', () => {
+    root = createRoot(container)
+    const thrown = renderOverlayHost(root)
+
+    // Damping must land inside the burst window and settle on the safe side:
+    // the pane stays mounted, so bells/titles/completions never go silent.
+    expect(thrown).toBeNull()
+    expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDGET)
+    expect(lastParkVerdict).toBe(false)
+    expect(paneMountCount).toBeGreaterThan(0)
+  })
+
+  // Why: the burst limit is derived from React's 50-commit bail divided by an
+  // assumed worst-case commits-per-flip. Running the loop at exactly that cost
+  // is what keeps the derivation honest — a limit tuned on a one-write-per-flip
+  // model pins only after React has already thrown #185.
+  it('settles at the assumed worst-case commit cost per park transition', () => {
+    storeCommitsPerParkTransition = TERMINAL_TAB_PARK_FLIP_COMMIT_COST
+    root = createRoot(container)
+    const thrown = renderOverlayHost(root)
+
+    expect(thrown).toBeNull()
+    expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDGET)
+    expect(lastParkVerdict).toBe(false)
+    expect(paneMountCount).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS,
+  TERMINAL_TAB_PARK_FLIP_COMMIT_COST,
   TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
   TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+  getParkVerdictUnparkPinUntilMs,
   recordParkVerdictFlips,
   type ParkVerdictFlipRecord
 } from './terminal-park-verdict-flip-telemetry'
@@ -12,6 +16,8 @@ vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
 }))
 
 const TAB = 'tab-1'
+/** Slower than the burst window, so only the notice limit can fire. */
+const SLOW_CHURN_STEP_MS = TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS * 4
 
 function observe(args: {
   records: Map<string, ParkVerdictFlipRecord>
@@ -31,6 +37,16 @@ beforeEach(() => {
   recordBreadcrumb.mockClear()
 })
 
+// Why asserted: the whole point of the burst trigger is that it is derived from
+// React's 50-commit bail, not copied from the breadcrumb notice limit. If the
+// two ever converge again the damping stops firing before React throws #185.
+describe('burst damping threshold', () => {
+  it('stays under React NESTED_UPDATE_LIMIT at the assumed commits-per-flip cost', () => {
+    expect(TERMINAL_TAB_PARK_FLIP_BURST_LIMIT * TERMINAL_TAB_PARK_FLIP_COMMIT_COST).toBeLessThan(50)
+    expect(TERMINAL_TAB_PARK_FLIP_BURST_LIMIT).toBeLessThan(TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT)
+  })
+})
+
 describe('recordParkVerdictFlips', () => {
   it('stays silent for a stable verdict', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
@@ -42,7 +58,7 @@ describe('recordParkVerdictFlips', () => {
     expect(records.get(TAB)?.flips).toBe(0)
   })
 
-  it('emits one breadcrumb per window once the verdict churns', () => {
+  it('emits one burst breadcrumb once the verdict churns at render cadence', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 40; i += 1) {
       observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
@@ -51,32 +67,59 @@ describe('recordParkVerdictFlips', () => {
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ tabId: TAB, flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT })
+      expect.objectContaining({
+        tabId: TAB,
+        trigger: 'burst',
+        flips: TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+        pinnedForMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+      })
     )
   })
 
-  // Why: flips saturates at the notice limit, so elapsedMs is the only field
-  // that tells a runaway loop apart from slow churn — assert both ends.
-  it('reports elapsedMs so a tight loop is distinguishable from slow churn', () => {
+  // Why: the two triggers answer different questions — 'burst' means damping
+  // engaged before React could bail, 'window' means churn too slow to loop.
+  it('separates a damped burst from slow churn', () => {
     const tightRecords = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 40; i += 1) {
       observe({ records: tightRecords, parked: i % 2 === 0, nowMs: 1_000 + i })
     }
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT, elapsedMs: 12 })
+      expect.objectContaining({
+        trigger: 'burst',
+        flips: TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+        elapsedMs: TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+        windowMs: TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS
+      })
     )
 
     recordBreadcrumb.mockClear()
 
     const slowRecords = new Map<string, ParkVerdictFlipRecord>()
-    for (let i = 0; i < 13; i += 1) {
-      observe({ records: slowRecords, parked: i % 2 === 0, nowMs: 1_000 + i * 4_000 })
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      observe({ records: slowRecords, parked: i % 2 === 0, nowMs: 1_000 + i * SLOW_CHURN_STEP_MS })
     }
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT, elapsedMs: 48_000 })
+      expect.objectContaining({
+        trigger: 'window',
+        flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
+        elapsedMs: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT * SLOW_CHURN_STEP_MS,
+        windowMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+      })
     )
+  })
+
+  // Why: slow churn must not be damped — parking it out for a minute would cost
+  // a mounted pane's memory for a verdict that was never near React's bail.
+  it('does not pin churn spread past the burst window', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * SLOW_CHURN_STEP_MS })
+    }
+
+    expect(records.get(TAB)?.pinnedUntilMs ?? null).toBeNull()
   })
 
   it('re-arms after the window elapses', () => {
@@ -116,23 +159,27 @@ describe('recordParkVerdictFlips', () => {
     expect(records.get(TAB)?.flips).toBe(1)
   })
 
-  it('honours flipWindowMs and noticeLimit overrides', () => {
+  it('honours the window, notice, burst-window and burst-limit overrides', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 10; i += 1) {
       recordParkVerdictFlips({
         records,
         liveTabIds: new Set([TAB]),
         nextParkedTabIds: i % 2 === 0 ? new Set([TAB]) : new Set(),
-        nowMs: 1_000 + i,
-        flipWindowMs: 500,
-        noticeLimit: 3
+        nowMs: 1_000 + i * 100,
+        flipWindowMs: 5_000,
+        noticeLimit: 3,
+        burstWindowMs: 10,
+        burstLimit: 2
       })
     }
 
+    // Why 'window': the 100ms step outruns the 10ms burst window, so the burst
+    // counter resets on every flip and only the notice limit can fire.
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ flips: 3, windowMs: 500 })
+      expect.objectContaining({ trigger: 'window', flips: 3, windowMs: 5_000 })
     )
   })
 
@@ -169,5 +216,54 @@ describe('recordParkVerdictFlips', () => {
     })
 
     expect(records.size).toBe(0)
+  })
+})
+
+describe('getParkVerdictUnparkPinUntilMs', () => {
+  function churnToBurst(records: Map<string, ParkVerdictFlipRecord>, startMs = 1_000): number {
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: startMs + i * 10 })
+    }
+    // The first observation only seeds the record, so flip N lands one step later.
+    return startMs + TERMINAL_TAB_PARK_FLIP_BURST_LIMIT * 10
+  }
+
+  it('does not pin a stable verdict', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    observe({ records, parked: true, nowMs: 1_000 })
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: 2_000 })).toBeNull()
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: 'missing', nowMs: 2_000 })).toBeNull()
+  })
+
+  // Why the deadline and not a boolean: the caller has to schedule a recheck at
+  // it, or the pin never lifts once it has stopped the churn that woke the
+  // verdict effect.
+  it('reports the pin deadline one window out, then re-arms', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    const pinnedAtMs = churnToBurst(records)
+    const pinUntilMs = pinnedAtMs + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinnedAtMs + 1 })).toBe(
+      pinUntilMs
+    )
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinUntilMs })).toBeNull()
+    expect(records.get(TAB)?.flips).toBe(0)
+    expect(records.get(TAB)?.burstFlips).toBe(0)
+
+    recordBreadcrumb.mockClear()
+    churnToBurst(records, pinUntilMs)
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinUntilMs + 1 })).not.toBe(
+      null
+    )
+  })
+
+  // Why: a backwards clock jump must release the pin, not strand it for a window.
+  it('releases the pin when the clock jumps backwards', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    churnToBurst(records)
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: 5 })).toBeNull()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -1,36 +1,111 @@
 /**
- * Cold-park verdict flip telemetry (observation only — changes no verdict).
+ * Cold-park verdict flip telemetry and damping.
  *
- * Why: crash cluster C5 (React #185 in TerminalPaneOverlayLayer) points at a
- * setState loop in the cold-parking passive effect, but no park-flip loop has
- * been reproduced, and the capture-coverage oscillator that looked like the
- * cause provably self-terminates (the unmount capture is never cleared on
- * remount, so coverage pins rather than alternates). This records whether the
- * rendered park verdict actually churns in the field. Deliberately no damping:
- * guarding a loop nobody has shown can run would add a park delay and a
- * retention path for no demonstrated benefit.
+ * Why: crash cluster C5 (React #185 in TerminalPaneOverlayLayer) is a park-flip
+ * loop — the veto (canWatcherCoverParkedTerminalTab) is re-derived from store
+ * and registry state that mounting/unmounting the very pane the verdict
+ * controls rewrites, so the verdict can alternate at render cadence. Field
+ * bundles carry 12 flips in as little as 348ms, which falsified the original
+ * "deliberately no damping" stance, so the record is a policy input too: a tab
+ * whose verdict bursts pins to NOT-parked for one window (the safe side — a
+ * mounted pane never goes silent for bells, titles or completions).
+ *
+ * Why two thresholds: React bails on *commits*, not on flips, and one flip in
+ * the real cycle costs many commits (pane-connect updateTabPtyId, the
+ * watcher-sync writes, the overlay's own subscriber renders). The damping
+ * trigger is therefore derived from React's commit budget and is far tighter
+ * than the breadcrumb notice limit, which exists only to keep the crumb rare.
  *
  * Reading the signal: breadcrumbs also emit a durable `renderer.breadcrumb`
- * trace span, so this is queryable without waiting for a crash bundle. `flips`
- * always equals the notice limit — `elapsedMs` is what separates a render loop
- * from slow churn. Silence only rules out churn at effect cadence; a same-tick
- * cascade can crash before the limit accumulates. If it fires, start with the
- * candidate selection in terminal-hidden-view-parking.ts.
+ * trace span, so this is queryable without waiting for a crash bundle.
+ * `trigger: 'burst'` is the damped render loop (and always pins); `'window'` is
+ * slow churn that never got near React's bail. A still-churning tab re-pins
+ * once per window, so a repeating crumb means the oscillator is still live.
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 
 export const TERMINAL_TAB_PARK_FLIP_WINDOW_MS = 60_000
-/** Flips per window that no sane park policy should reach. */
+/** Flips per window that no sane park policy should reach. Breadcrumb only. */
 export const TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT = 12
+
+/** react-dom 19.2.x NESTED_UPDATE_LIMIT — the commit budget a loop must beat. */
+const REACT_NESTED_UPDATE_LIMIT = 50
+/**
+ * Commits the pinned verdict still costs to settle after damping engages — the
+ * pin lands in the passive effect that observes the burst, so the verdict
+ * settles one flip later. Measured at 5 by terminal-cold-park-verdict-loop.
+ */
+const PARK_PIN_SETTLE_COMMITS = 6
+/**
+ * Commits one verdict flip costs, worst case: the pane mount/unmount, the
+ * pane-connect updateTabPtyId, the parked-watcher writes (clearTabLaunchAgent,
+ * setTabLayout, updateTabTitle) and the overlay's zustand subscriber renders.
+ * Raising this tightens the burst limit automatically — never hand-tune both.
+ */
+export const TERMINAL_TAB_PARK_FLIP_COMMIT_COST = 12
+/**
+ * Flips that must pin before React throws #185. Deliberately NOT the notice
+ * limit: at the commit cost above, 12 flips is ~144 commits, so a notice-limit
+ * pin never fires in the field — React bails long before it.
+ */
+export const TERMINAL_TAB_PARK_FLIP_BURST_LIMIT = Math.max(
+  2,
+  Math.floor(
+    (REACT_NESTED_UPDATE_LIMIT - PARK_PIN_SETTLE_COMMITS) / TERMINAL_TAB_PARK_FLIP_COMMIT_COST
+  )
+)
+/**
+ * Burst horizon. Only a render-cadence loop reaches the burst limit inside it:
+ * an honest park needs the 30s cold-park hysteresis in one direction, so
+ * sub-second park/unpark round trips are always the pathology.
+ */
+export const TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS = 1_000
 
 export type ParkVerdictFlipRecord = {
   parked: boolean
   windowStartMs: number
   flips: number
   notified: boolean
+  burstStartMs: number
+  burstFlips: number
+  /** Set when a flip burst engaged damping; the verdict stays unparked until then. */
+  pinnedUntilMs?: number | null
 }
 
-/** Records park-verdict churn per tab; emits one breadcrumb per window. */
+function resetFlipWindows(record: ParkVerdictFlipRecord, nowMs: number): void {
+  record.windowStartMs = nowMs
+  record.flips = 0
+  record.notified = false
+  record.burstStartMs = nowMs
+  record.burstFlips = 0
+  record.pinnedUntilMs = null
+}
+
+/**
+ * When this tab's NOT-parked damping pin expires, or null when it is unpinned.
+ * Callers must schedule a recheck at the returned deadline: the pin's whole job
+ * is to stop the churn that would otherwise re-run the verdict effect, so
+ * without that wakeup nothing ever re-parks the tab. Expiry reopens the window
+ * so a still-churning tab re-pins (and re-breadcrumbs) instead of pinning
+ * forever on one old burst.
+ */
+export function getParkVerdictUnparkPinUntilMs(args: {
+  records: Map<string, ParkVerdictFlipRecord>
+  tabId: string
+  nowMs: number
+}): number | null {
+  const record = args.records.get(args.tabId)
+  if (record?.pinnedUntilMs == null) {
+    return null
+  }
+  if (args.nowMs >= record.pinnedUntilMs || args.nowMs < record.windowStartMs) {
+    resetFlipWindows(record, args.nowMs)
+    return null
+  }
+  return record.pinnedUntilMs
+}
+
+/** Records park-verdict churn per tab; damps bursts and breadcrumbs the rest. */
 export function recordParkVerdictFlips(args: {
   records: Map<string, ParkVerdictFlipRecord>
   liveTabIds: ReadonlySet<string>
@@ -38,6 +113,8 @@ export function recordParkVerdictFlips(args: {
   nowMs: number
   flipWindowMs?: number
   noticeLimit?: number
+  burstWindowMs?: number
+  burstLimit?: number
 }): void {
   const {
     records,
@@ -45,7 +122,9 @@ export function recordParkVerdictFlips(args: {
     nextParkedTabIds,
     nowMs,
     flipWindowMs = TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
-    noticeLimit = TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT
+    noticeLimit = TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
+    burstWindowMs = TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS,
+    burstLimit = TERMINAL_TAB_PARK_FLIP_BURST_LIMIT
   } = args
 
   for (const tabId of Array.from(records.keys())) {
@@ -59,7 +138,15 @@ export function recordParkVerdictFlips(args: {
     const record = records.get(tabId)
 
     if (!record) {
-      records.set(tabId, { parked, windowStartMs: nowMs, flips: 0, notified: false })
+      records.set(tabId, {
+        parked,
+        windowStartMs: nowMs,
+        flips: 0,
+        notified: false,
+        burstStartMs: nowMs,
+        burstFlips: 0,
+        pinnedUntilMs: null
+      })
       continue
     }
     if (parked === record.parked) {
@@ -70,20 +157,40 @@ export function recordParkVerdictFlips(args: {
     // elapsed value as a fresh window rather than trusting the delta.
     const elapsedMs = nowMs - record.windowStartMs
     if (elapsedMs >= flipWindowMs || elapsedMs < 0) {
-      record.windowStartMs = nowMs
-      record.flips = 0
-      record.notified = false
+      resetFlipWindows(record, nowMs)
+    }
+    const burstElapsedMs = nowMs - record.burstStartMs
+    if (burstElapsedMs >= burstWindowMs || burstElapsedMs < 0) {
+      record.burstStartMs = nowMs
+      record.burstFlips = 0
     }
 
     record.parked = parked
     record.flips += 1
+    record.burstFlips += 1
 
-    if (!record.notified && record.flips >= noticeLimit) {
-      record.notified = true
-      // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
-      // field that separates a render loop from slow benign churn.
+    if (record.pinnedUntilMs == null && record.burstFlips >= burstLimit) {
+      record.pinnedUntilMs = nowMs + flipWindowMs
       recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
         tabId,
+        trigger: 'burst',
+        flips: record.burstFlips,
+        elapsedMs: nowMs - record.burstStartMs,
+        windowMs: burstWindowMs,
+        pinnedForMs: flipWindowMs
+      })
+      continue
+    }
+    // Why pinnedUntilMs gates this: the burst crumb already reported the same
+    // window, so a second crumb would only double the volume the notice limit
+    // exists to keep down.
+    if (record.pinnedUntilMs == null && !record.notified && record.flips >= noticeLimit) {
+      record.notified = true
+      // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
+      // field that separates slow churn from a burst the damping already caught.
+      recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
+        tabId,
+        trigger: 'window',
         flips: record.flips,
         elapsedMs: nowMs - record.windowStartMs,
         windowMs: flipWindowMs

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -11,7 +11,9 @@ const mocks = vi.hoisted(() => ({
     terminalLayoutsByTabId: {} as Record<string, { ptyIdsByLeafId?: Record<string, string> }>
   },
   exemptTabIds: new Set<string>(),
-  exemptSelectCalls: 0
+  exemptSelectCalls: 0,
+  /** Toggled to churn the park verdict the way the crash cluster does. */
+  watcherCoverage: true
 }))
 
 vi.mock('../../store', () => ({
@@ -35,15 +37,23 @@ vi.mock('./terminal-eviction-exempt-tabs', () => ({
 }))
 
 vi.mock('./terminal-parked-tab-watchers', () => ({
-  canWatcherCoverParkedTerminalTab: () => true,
+  canWatcherCoverParkedTerminalTab: () => mocks.watcherCoverage,
   disposeParkedTerminalWatchersForWorktree: vi.fn(),
   syncParkedTerminalTabWatchers: vi.fn()
+}))
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: vi.fn()
 }))
 
 import {
   TERMINAL_TAB_COLD_PARK_DELAY_MS,
   TERMINAL_TAB_HOT_RETAIN_MS
 } from './terminal-hidden-view-parking'
+import {
+  TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+} from './terminal-park-verdict-flip-telemetry'
 import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
 
 const WORKTREE_ID = 'wt-1'
@@ -75,6 +85,7 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
     vi.useRealTimers()
     mocks.exemptTabIds = new Set()
     mocks.exemptSelectCalls = 0
+    mocks.watcherCoverage = true
     mocks.storeState.terminalLayoutsByTabId = {}
     mocks.storeState.runtimeStatusByEnvironmentId = new Map()
   })
@@ -104,6 +115,41 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
       expect(result.current).toEqual(expected)
       unmount()
     }
+  })
+
+  // Why: the flip-damping pin removes the tab from the parked set, and every
+  // hysteresis deadline of a long-hidden tab is already past — so the pin
+  // deadline is the only wakeup that can ever re-park it. Without scheduling
+  // it, damping silently becomes a permanent unpark: the pane (~4-5MB) stays
+  // mounted for the life of the window, which is the renderer-OOM cluster.
+  it('re-parks a damped tab once the pin expires with no other store change', () => {
+    const { result, rerender } = renderHook(
+      (args: ReturnType<typeof hookArgs>) => useTerminalTabColdParking(args),
+      { initialProps: hookArgs(false) }
+    )
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_HOT_RETAIN_MS + 1)
+    })
+    expect(result.current).toEqual(new Set(['tab-2']))
+
+    // Churn the coverage veto at render cadence — no clock advance, so every
+    // flip lands inside the burst window and damping engages.
+    for (let flip = 0; flip <= TERMINAL_TAB_PARK_FLIP_BURST_LIMIT + 1; flip += 1) {
+      mocks.watcherCoverage = flip % 2 === 1
+      act(() => {
+        rerender(hookArgs(false))
+      })
+    }
+    mocks.watcherCoverage = true
+    act(() => {
+      rerender(hookArgs(false))
+    })
+    expect(result.current.size).toBe(0)
+
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
+    })
+    expect(result.current).toEqual(new Set(['tab-2']))
   })
 
   // Why: the worktree layer preserves hiddenSince through a background-measure

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -21,6 +21,7 @@ import {
   type TerminalTabColdParkCandidate
 } from './terminal-hidden-view-parking'
 import {
+  getParkVerdictUnparkPinUntilMs,
   recordParkVerdictFlips,
   type ParkVerdictFlipRecord
 } from './terminal-park-verdict-flip-telemetry'
@@ -204,9 +205,24 @@ export function useTerminalTabColdParking(args: {
     // Why: a tab the byte watchers cannot cover (no capture, no layout
     // snapshot, legacy leaf ids) must never park — it would go silent for
     // bells/titles/completions, the failure that sank the first attempt.
+    // Coverage is re-derived from state the authorized unmount rewrites, so a
+    // churning verdict is damped to NOT-parked (a mounted pane never goes
+    // silent) instead of looping React into #185.
+    const parkVerdictPinUntilMsByTabId = new Map<string, number>()
     for (const terminalTab of terminalTabs) {
+      if (!nextColdParkedTerminalTabIds.has(terminalTab.id)) {
+        continue
+      }
+      const parkVerdictPinUntilMs = getParkVerdictUnparkPinUntilMs({
+        records: parkVerdictRecordsRef.current,
+        tabId: terminalTab.id,
+        nowMs
+      })
+      if (parkVerdictPinUntilMs !== null) {
+        parkVerdictPinUntilMsByTabId.set(terminalTab.id, parkVerdictPinUntilMs)
+      }
       if (
-        nextColdParkedTerminalTabIds.has(terminalTab.id) &&
+        parkVerdictPinUntilMs !== null ||
         !canWatcherCoverParkedTerminalTab(worktreeId, terminalTab)
       ) {
         nextColdParkedTerminalTabIds.delete(terminalTab.id)
@@ -230,6 +246,10 @@ export function useTerminalTabColdParking(args: {
         parkingEnabled: terminalParkingEnabled,
         hiddenSinceMs: candidate.hiddenSinceMs,
         parkCooldownUntilMs: measureParkCooldownUntilRef.current,
+        // Why: a pinned tab is past every hysteresis deadline, so the pin
+        // expiry is often the only pending wakeup left — and the pin exists
+        // precisely to stop the churn that would otherwise re-run this effect.
+        parkVerdictPinUntilMs: parkVerdictPinUntilMsByTabId.get(candidate.id) ?? null,
         nowMs,
         ...overrides
       })


### PR DESCRIPTION
## What this fixes

**Crash signature:** `Error: Minified React error #185` — "Maximum update depth exceeded" — thrown from
`getRootForUpdatedFiber ← enqueueConcurrentHookUpdate ← dispatchSetState ← commitHookEffectListMount`,
with `TerminalPaneOverlayLayer$1` at the top of the component stack. Reason `react-error-boundary`,
boundary `terminal.workbench`.

**Coverage:** the G1 React-#185 group is 13 of the 127 reports in this batch. This PR targets the
**10 terminal-surface crashes** in that group (subgroups a/b/c — `active_view=terminal`). The remaining
3 are `page.activity` and are handled separately (w7-activity-latch).

**Root cause.** The cold-park verdict is a passive-effect `setState` whose own veto is re-derived from
state that the verdict rewrites:

- `src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts:207-214` (origin/main) vetoes
  every park candidate through `canWatcherCoverParkedTerminalTab(worktreeId, terminalTab)`.
- `src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.ts:87` (origin/main) implements that
  predicate as `const state = useAppStore.getState()` — read **outside** React's dependency tracking — then
  `resolveParkedTerminalPaneCandidates(tab, state)`, which is driven by `terminalLayoutsByTabId`,
  `runtimePaneTitlesByTabId` and the module-level `capturedPanesByTabId` registry.
- All three of those are (re)written as a direct consequence of mounting/unmounting the very `TerminalPane`
  that parking mounts/unmounts. So: park → pane unmounts → layout/capture state changes → coverage veto flips
  → unpark → pane remounts → layout rewritten → park again. Each pass is one `setColdParkedTerminalTabIds`
  call from a passive effect, which is exactly the frame shape in the stacks above.
- Nothing damped it. `src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts:9-11`
  (origin/main) says so verbatim: *"Deliberately no damping: guarding a loop nobody has shown can run would add
  a park delay and a retention path for no demonstrated benefit."* Field data has now falsified that stance.
- React's bail is `if (50 < nestedUpdateCount) throw` in
  `node_modules/react-dom/cjs/react-dom-client.production.js:2414` (react-dom 19.2.7) — it counts **commits**,
  not flips.

**Representative reports (Slack):**

- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785609068281149 — win32 10.0.26200, 1.4.163,
  `terminal.workbench`; diag bundle `F0BMBA73ZJA` carries `terminal_park_verdict_churn` with **12 flips in 1186 ms**.
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785686708045359 — win32 10.0.26200, 1.4.164,
  `terminal.workbench`; diag bundle `F0BMJ4GGJE5` carries **12 flips in 2347 ms**, 23 s before the crash.
- https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785797323126119 — darwin 21.6.0, 1.4.167,
  `terminal.workbench`; diag bundle `F0BMU4BQGMP` carries **12 flips in 1355 ms**, 36 s before the crash.

**Two defects are fixed.**

1. *The oscillation is undamped.* A flip burst now pins the tab's verdict to NOT-parked for one window.
   NOT-parked is the safe side — a mounted pane never goes silent for bells, titles or completions, which is
   the failure that sank an earlier parking attempt.
2. *The damping, naively added, would have leaked memory forever.* A pinned tab has left the parked set with
   every hysteresis deadline already in the past, so `getTerminalTabColdParkRecheckDelayMs` returned `null` and
   no timer was armed. Since the pin exists precisely to stop the churn that would otherwise re-run the verdict
   effect, nothing could ever re-park the tab and its ~4-5 MB pane stayed mounted for the life of the window.
   The pin deadline is now a first-class recheck deadline alongside `parkCooldownUntilMs`.

The damping trigger is derived, not hand-tuned:
`TERMINAL_TAB_PARK_FLIP_BURST_LIMIT = max(2, floor((50 - 6) / 12)) = 3` flips inside a 1 s window, where 50 is
React's `NESTED_UPDATE_LIMIT`, 6 is the settle cost measured by the new repro, and 12 is the assumed worst-case
commits per flip. The old 12-flips-per-60 s breadcrumb limit is **kept as a breadcrumb limit only** — at 12
commits per flip it would be ~144 commits, so a pin at that threshold could never fire before React bailed.

---

## Fix evidence

### 1. Red without the source fix — the repro throws the real React #185

Scratch worktree at the branch commit, with **only the three source files** reverted to `origin/main`
(`terminal-park-verdict-flip-telemetry.ts`, `use-terminal-tab-cold-parking.ts`,
`terminal-cold-park-recheck-deadlines.ts`); tests untouched:

```
$ cd /tmp/prproof-w9-park-churn && git checkout origin/main -- \
    src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts \
    src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts \
    src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.ts
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx

 RUN  v4.1.5 /private/tmp/prproof-w9-park-churn

 ❯ src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx (2 tests | 2 failed) 30ms
     × settles the park verdict when watcher coverage tracks the pane it unmounts 25ms
     × settles at the assumed worst-case commit cost per park transition 4ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx > cold-park verdict oscillation > settles the park verdict when watcher coverage tracks the pane it unmounts
AssertionError: expected Error: Maximum update depth exceeded. Thi… to be null

- Expected:
null

+ Received:
Error {
  "message": "Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.",
}

 ❯ src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx:225:20
    223|     // Damping must land inside the burst window and settle on the saf…
    224|     // the pane stays mounted, so bells/titles/completions never go si…
    225|     expect(thrown).toBeNull()
       |                    ^
    226|     expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDG…
    227|     expect(lastParkVerdict).toBe(false)

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx > cold-park verdict oscillation > settles at the assumed worst-case commit cost per park transition
AssertionError: expected Error: Maximum update depth exceeded. Thi… to be null

- Expected:
null

+ Received:
Error {
  "message": "Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.",
}

 ❯ src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx:240:20

 Test Files  1 failed (1)
      Tests  2 failed (2)
   Start at  01:42:07
   Duration  567ms
```

This is the point of the proof: the reverted-source run does not fail on an assertion about damping, it
**reproduces the production crash itself** — React raises `Maximum update depth exceeded` (the dev-mode text of
minified error #185) inside the render, from the same passive-effect park verdict named in the crash stacks.
The second test is the same loop driven at the assumed worst-case 12 commits per flip.

Full reverted-source run of all four affected files — 12 failed / 20 passed:

```
 FAIL  …/terminal-park-verdict-flip-telemetry.test.ts > getParkVerdictUnparkPinUntilMs > does not pin a stable verdict
TypeError: getParkVerdictUnparkPinUntilMs is not a function
 ❯ src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts:235:12

 FAIL  …/use-terminal-tab-cold-parking.test.ts > useTerminalTabColdParking measure-clock contract > re-parks a damped tab once the pin expires with no other store change
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts:147:33

 Test Files  4 failed (4)
      Tests  12 failed | 20 passed (32)
   Start at  01:41:57
   Duration  2.70s
```

### 2. Red for the second defect in isolation — the memory-retention half

Same scratch worktree, everything at the branch commit **except** `terminal-cold-park-recheck-deadlines.ts`
reverted to `origin/main`. This isolates the pin-expiry scheduling: damping works, but the damped tab never
comes back, so its pane stays mounted forever.

```
$ git checkout origin/main -- src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.ts
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts

 ❯ src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts (7 tests | 1 failed) 30ms
     × re-parks a damped tab once the pin expires with no other store change 6ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  …/use-terminal-tab-cold-parking.test.ts > useTerminalTabColdParking measure-clock contract > re-parks a damped tab once the pin expires with no other store change
AssertionError: expected Set{} to deeply equal Set{ 'tab-2' }

- Expected
+ Received

- Set {
-   "tab-2",
- }
+ Set {}

 ❯ src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts:152:28
    150|       vi.advanceTimersByTime(TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
    151|     })
    152|     expect(result.current).toEqual(new Set(['tab-2']))
       |                            ^

 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
   Start at  01:42:20
   Duration  1.20s
```

The scratch worktree was created with `git worktree add --detach` + a `node_modules` symlink and removed
afterwards with `git worktree remove --force`. No `git stash` was used and no tracked file in the branch
worktree was modified.

### 3. Green with the fix

```
$ cd /Users/nwparker/orca/crashwork/w9-park-churn
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx \
    src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts \
    src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.test.ts

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w9-park-churn

 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > burst damping threshold > stays under React NESTED_UPDATE_LIMIT at the assumed commits-per-flip cost 1ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > stays silent for a stable verdict 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > emits one burst breadcrumb once the verdict churns at render cadence 1ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > separates a damped burst from slow churn 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > does not pin churn spread past the burst window 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > re-arms after the window elapses 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > treats a backwards clock jump as a fresh window 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > treats an exactly-elapsed window as expired 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > honours the window, notice, burst-window and burst-limit overrides 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > keeps per-tab windows and notices independent 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > recordParkVerdictFlips > drops records for tabs that no longer exist 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > getParkVerdictUnparkPinUntilMs > does not pin a stable verdict 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > getParkVerdictUnparkPinUntilMs > reports the pin deadline one window out, then re-arms 0ms
 ✓ …/terminal-park-verdict-flip-telemetry.test.ts > getParkVerdictUnparkPinUntilMs > releases the pin when the clock jumps backwards 0ms
 ✓ …/terminal-cold-park-verdict-loop.test.tsx > cold-park verdict oscillation > settles the park verdict when watcher coverage tracks the pane it unmounts 14ms
 ✓ …/terminal-cold-park-verdict-loop.test.tsx > cold-park verdict oscillation > settles at the assumed worst-case commit cost per park transition 3ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalWorktreeColdParkRecheckDelayMs > returns the next cold-park policy deadline 1ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalWorktreeColdParkRecheckDelayMs > schedules no recheck when the settings kill switch disables parking 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalWorktreeColdParkRecheckDelayMs > wakes at the retention TTL for budget candidates past the ordinary deadlines 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalWorktreeColdParkRecheckDelayMs > wakes at the measure cool-down deadline when all ordinary deadlines have passed 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalTabColdParkRecheckDelayMs > returns the next terminal-tab cold-park policy deadline 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalTabColdParkRecheckDelayMs > schedules no recheck when the settings kill switch disables parking 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalTabColdParkRecheckDelayMs > wakes at the measure cool-down deadline when all ordinary deadlines have passed 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalTabColdParkRecheckDelayMs > wakes at the flip-damping pin deadline when all ordinary deadlines have passed 0ms
 ✓ …/terminal-cold-park-recheck-deadlines.test.ts > getTerminalTabColdParkRecheckDelayMs > takes the nearest of the pin and cool-down deadlines 0ms

 Test Files  3 passed (3)
      Tests  25 passed (25)
   Start at  01:41:27
   Duration  1.59s
```

Including `use-terminal-tab-cold-parking.test.ts`, all four files: **4 passed / 32 tests passed**.

### 4. Regression suite — every touched module, then the whole renderer

Touched module directory (`src/renderer/src/components/terminal-pane`), which is where all seven changed files
live:

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w9-park-churn

 Test Files  231 passed (231)
      Tests  3019 passed (3019)
   Start at  01:42:32
   Duration  26.64s
```

Full renderer suite on macOS (darwin 25.3.0, arm64):

```
$ npx vitest run --config config/vitest.config.ts src/renderer

 RUN  v4.1.5 /Users/nwparker/orca/crashwork/w9-park-churn

 Test Files  2122 passed | 1 skipped (2123)
      Tests  19647 passed | 4 skipped (19651)
   Start at  01:43:08
   Duration  119.92s
```

**Zero failures on macOS — there are no pre-existing failures to disclaim here.**

**Windows verification.** The full renderer suite was also run on Windows: **5 failures, an identical set to the
`origin/main` Windows baseline** — `github-item-dialog`, `pull-request-page`, `monaco undo`, `SourceControl
host-context`, and `resource-session-classification`. All five are **pre-existing on `origin/main`** and
unrelated to terminal parking; this branch introduces no new Windows failure. Windows matters for this fix
because 6 of the 10 covered crashes are win32.

### 5. Field data — the defect happening in production

Verbatim breadcrumbs from the real diagnostic bundles (`renderer.breadcrumb` spans):

```
$ grep -o 'terminal_park_verdict_churn","breadcrumb.data":{[^}]*}' F0BMBBPT8ES.txt
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-4ec4ba0e-…","flips":12,"elapsedMs":17478,"windowMs":60000,"suppressedSinceLast":2}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-4ec4ba0e-…","flips":12,"elapsedMs":34328,"windowMs":60000,"suppressedSinceLast":1}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-5ba47c7e-…","flips":12,"elapsedMs":52143,"windowMs":60000}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-5ba47c7e-…","flips":12,"elapsedMs":30644,"windowMs":60000}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-5ba47c7e-…","flips":12,"elapsedMs":20011,"windowMs":60000}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-5e95e5ab-…","flips":12,"elapsedMs":1186,"windowMs":60000}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-5e95e5ab-…","flips":12,"elapsedMs":1697,"windowMs":60000}
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-5e95e5ab-…","flips":12,"elapsedMs":4889,"windowMs":60000}

$ grep -o 'terminal_park_verdict_churn","breadcrumb.data":{[^}]*}' F0BMU4BQGMP.txt
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-a9795b4d-…","flips":12,"elapsedMs":1355,"windowMs":60000}

$ grep -o 'terminal_park_verdict_churn","breadcrumb.data":{[^}]*}' F0BMJ4GGJE5.txt
terminal_park_verdict_churn","breadcrumb.data":{"tabId":"web-terminal-4521f8d5-…","flips":12,"elapsedMs":2347,"windowMs":60000}
```

Aggregated across every bundle referenced by the 127 reports in this batch, de-duplicated by crumb content
(several crashes attach the same diagnostic bundle twice, as report + diag):

```
distinct diagnostic bundles carrying the crumb : 9
total terminal_park_verdict_churn crumbs       : 88
crumbs with elapsedMs < 3000 (render cadence)  : 65
fastest 12 flips                               : 348 ms
flips value observed                           : [12]
```

12 park↔unpark round trips in 348 ms is ~34 flips/second. There is no honest park policy that does that: an
honest park has to clear the 30 s cold-park hysteresis in one direction. And the crash report itself confirms
the frame shape (`F0BMD9MQZ18`, win32 1.4.163):

```
- boundary_id: terminal.workbench
- error_message: Minified React error #185; visit https:/[redacted-path]
- error_stack: Error: Minified React error #185; …
    at getRootForUpdatedFiber …
    at enqueueConcurrentHookUpdate …
    at dispatchSetState …
    at commitHookEffectListMount …
    at commitPassiveMountOnFiber …
- component_stack: at TerminalPaneOverlayLayer$1 …
    at WorktreeSplitSurface$1 …
```

**Honest limit on the field evidence.** The churn breadcrumb is present in **4 of the 13** G1 bundles, not all
10 of the terminal crashes this PR claims to cover. React's `nestedUpdateCount` is root-global and the throw
lands on whichever fiber calls `setState` next, so a component stack does not identify the offender — the repo
reached this conclusion itself in `4543bb6826`. What is **proven** here is: (a) the loop is real and reachable
(the repro throws #185 on `origin/main` sources), and (b) it runs at render cadence in production, repeatedly,
in bundles that crashed. What is **not proven** is that this specific loop is what saturated the counter in
every one of the 10. Treat the coverage number as cluster-level attribution, not per-crash causation.

---

## ELI5

Imagine a room with a light on a motion sensor, plus a rule: *"only turn the light off if the security camera
can still see the room."*

The problem is that the camera is plugged into the same light switch. Turn the light off, and the camera goes
dark — so the rule says "camera can't see, turn the light back on." The light comes on, the camera works
again, so the rule says "camera's fine, turn the light off." Off, on, off, on, several times a second, forever.

That's the bug. The room is a terminal tab you aren't currently looking at. "Turning the light off" is Orca
unloading that tab's terminal view to save memory ("parking"). The "camera" is the background watcher that
keeps listening for the terminal's bell, title changes and finished commands while the view is unloaded — and
Orca correctly refuses to park a tab the watcher can't cover, because otherwise you'd stop getting notified.
But whether the watcher *can* cover the tab is worked out from bookkeeping that unloading the view itself
rewrites. So the decision feeds its own input.

The app itself has a safety cutout for this. The UI framework (React) counts how many times the screen gets
rebuilt in one go, and after 50 it gives up and throws an error rather than spin forever. That error is the
crash: "Maximum update depth exceeded." The whole terminal area dies and files a crash report.

**The fix, in two parts.** First: if a tab's park/unpark decision flips more than a few times in one second,
stop trusting it and freeze the answer on "stay loaded" for a minute. Stay-loaded is the safe answer — a loaded
tab never goes quiet on you; it just uses a few megabytes it didn't strictly need. Second, and this is the part
that's easy to get wrong: after freezing the answer, you must *also* set an alarm clock to reconsider a minute
later. The freeze works by stopping the very churn that was waking the decision up, so without an alarm the tab
would stay loaded forever and quietly leak memory. We now set that alarm.

One detail worth stating: the "few times in one second" threshold is *computed* from React's own 50-rebuild
budget rather than picked by hand. The original code had a diagnostic counter that only spoke up after 12
flips — but each flip costs roughly a dozen rebuilds, so 12 flips is ~144 rebuilds, and React would have
crashed long before the counter ever fired. That's why the crash was recorded but never prevented.

---

## Trade-offs

Real ones, stated plainly.

1. **A damped tab holds ~4-5 MB of pane memory for up to 60 s longer than it otherwise would.** This is the
   deliberate trade: the pin resolves to NOT-parked, which costs memory but never makes a terminal go silent.
   A tab whose oscillator is genuinely stuck will re-pin every window, so in the worst case it never parks at
   all while the churn lasts. Given that this batch also contains a 42-crash renderer-OOM cluster, retaining
   panes is not a free choice — it is a smaller harm than a hard crash, not a non-harm.

2. **A legitimate rapid park/unpark can be mistaken for churn.** The burst threshold is 3 flips inside 1 s.
   Fast worktree/tab switching that genuinely toggles a tab's hidden state three times in one second will pin
   that tab unparked for 60 s. The user-visible effect is only "this hidden tab did not free its memory as
   quickly as it should have," never a broken or silent terminal.

3. **The root cause is damped, not removed.** `canWatcherCoverParkedTerminalTab` still calls
   `useAppStore.getState()` outside React's dependency tracking on every pass
   (`terminal-parked-tab-watchers.ts:87`), so the feedback edge still exists — the pin just stops it running
   away. The plan's item (b) — evaluate coverage once per tab per park *episode* and cache it — was
   deliberately **not** done here, because caching a predicate that gates pane unmounting is a much larger,
   riskier change than a damper, and it needs its own repro for the stale-cache failure mode. **Known
   follow-up.** Suggested mitigation in the meantime: the new `trigger: 'burst'` breadcrumb is queryable as a
   durable `renderer.breadcrumb` span, so we can measure how often the damper actually engages before
   committing to the larger refactor. Related and also untouched: commit `49dc113a0f` added an async
   `terminalProviderHasAuthoritativeSnapshot` lookup as a *further* untracked, time-varying input to the same
   predicate; that makes the underlying oscillator strictly more volatile on `HEAD` than in the crashing
   builds.

4. **`TERMINAL_TAB_PARK_FLIP_COMMIT_COST = 12` is an assumed worst case, not a production measurement.** It is
   an enumeration of the commits one flip drags behind it (pane mount/unmount, pane-connect `updateTabPtyId`,
   the parked-watcher `clearTabLaunchAgent`/`setTabLayout`/`updateTabTitle` writes, the overlay's zustand
   subscriber renders). If the real cost is higher than 12, the pin could still land after React has already
   bailed. Two guards are in place: the repro runs the loop at exactly this cost and must still settle, and a
   unit test asserts `BURST_LIMIT * COMMIT_COST < 50`, so raising the assumed cost automatically tightens the
   limit. Neither guard makes the constant a measurement.

5. **Breadcrumb shape changed; existing queries need updating.** `terminal_park_verdict_churn` now carries a
   `trigger` field (`'burst'` | `'window'`) and the burst variant carries `pinnedForMs`. The crumb will also
   fire in situations where it previously stayed silent (3 flips in 1 s instead of 12 flips in 60 s), so
   expect its volume to go up. The per-window one-crumb-per-tab rate cap is unchanged. Any dashboard that
   assumed `flips === 12` will now see `flips === 3` on burst crumbs.

6. **A verdict that was already pinned suppresses the slow-churn (`'window'`) crumb for that window.** This is
   intentional — the burst crumb already reported the same window and a second one would only double volume —
   but it does mean the two triggers are not independently countable within a window.

7. **The header comment on `terminal-park-verdict-flip-telemetry.ts` reversed its own stated position.** The
   file previously argued *against* damping in writing. That reasoning was correct given what was known then
   and is wrong given the field data now; the rewritten header says so explicitly rather than quietly dropping
   it.

Not a trade-off but worth flagging: this PR does **not** fix the 3 `page.activity` crashes in the same G1
group. Those are a different driver (the Activity portal readiness latch) and are handled in a separate PR.

---

## Adversarial review

**2 independent adversarial review rounds**, each run by a **fresh reviewer with no memory of the prior round**
— no shared context, no summary of what the previous round had already accepted, so nothing was waved through
on the strength of an earlier pass. **1 fix round** followed.

What the rounds found:

- The damping threshold had originally been expressed in *flips* and set at the breadcrumb notice limit. A
  reviewer showed that React bails on **commits**, not flips, and that at the real cycle's commits-per-flip
  cost a 12-flip pin can never fire in the field — the repro at 12 commits per transition throws #185 after 5
  flips / 55 commits. The threshold was rederived from React's `NESTED_UPDATE_LIMIT` and the commit cost, and
  a unit test now pins the derivation (`BURST_LIMIT * COMMIT_COST < 50`, `BURST_LIMIT < NOTICE_LIMIT`), so the
  two limits cannot silently converge again.
- A reviewer found that the pin, as first written, was a **permanent unpark**: a pinned tab has every
  hysteresis deadline in the past, so `getTerminalTabColdParkRecheckDelayMs` returned `null`, no timer was
  armed, and — because the pin's whole job is to stop the churn that re-runs the verdict effect — nothing
  could ever re-park the tab. The pin deadline was promoted to a first-class recheck deadline and the
  isolating regression test in §2 above was added.

**Final verdict: clean — zero blocking findings, zero major findings.** The remaining minor finding that was
deliberately not fixed is item 3 in Trade-offs (cache the coverage predicate per park episode), listed there
as a known follow-up with its mitigation.

**`/perf` skill review verdict: no regression.** The damping path is a per-tab counter increment and two
integer comparisons inside an effect that already iterates the tab list; the pin adds one `Map` lookup per
park candidate and one extra deadline to an existing `Math.min`. No new subscriptions, timers, or store reads
were added — the pin reuses the existing recheck timer that the cool-down deadline already schedules.

Made with [Orca](https://github.com/stablyai/orca) 🐋
