### PR TITLE
fix(feedback): stop the Help menu funnelling ordinary bug reports into the crash channel

### DIFF
--- a/config/scripts/locale-value-overrides.mjs
+++ b/config/scripts/locale-value-overrides.mjs
@@ -5,6 +5,7 @@ import { ZH_VALUE_OVERRIDES } from './locale-zh-value-overrides.mjs'
 export const LOCALE_VALUE_OVERRIDES = {
   es: {
     'Explore Orca': 'Explorar Orca',
+    'Send Feedback...': 'Enviar comentarios...',
     'OpenCode Go': 'OpenCode Go',
     'Open in Cursor': 'Abrir en Cursor',
     'Local project, Git repo, or folder with many repos':
@@ -60,6 +61,7 @@ export const LOCALE_VALUE_OVERRIDES = {
     'Search...': '검색...',
     'Saving...': '저장 중...',
     'Report Crash...': '크래시 신고...',
+    'Send Feedback...': '피드백 보내기...',
     Mobile: '모바일',
     Checks: '검사',
     Assignees: '담당자',
@@ -220,6 +222,7 @@ export const LOCALE_VALUE_OVERRIDES = {
     'Search...': '搜索...',
     'Saving...': '保存中...',
     'Report Crash...': '报告崩溃...',
+    'Send Feedback...': '发送反馈...',
     Mobile: '移动端',
     Checks: '检查项',
     Assignees: '负责人',
@@ -428,6 +431,7 @@ export const LOCALE_VALUE_OVERRIDES = {
     'Search...': '検索...',
     'Saving...': '保存中...',
     'Report Crash...': 'クラッシュを報告...',
+    'Send Feedback...': 'フィードバックを送信...',
     Mobile: 'モバイル',
     Checks: 'チェック',
     Assignees: '担当者',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -184,6 +184,7 @@ import {
 } from './window/attach-main-window-services'
 import { createMainWindow, loadMainWindow } from './window/createMainWindow'
 import { zoomDashboardPopoutIfFocused } from './window/dashboard-popout-window'
+import { resolveHelpMenuEventTarget } from './window/help-menu-event-target'
 import {
   createSystemTray,
   destroySystemTray,
@@ -1490,28 +1491,20 @@ function openMainWindow(): BrowserWindow {
   return window
 }
 
-function sendOpenFeatureTour(targetWindow?: BrowserWindow | null): void {
-  const webContents =
-    targetWindow && !targetWindow.isDestroyed() ? targetWindow.webContents : mainWindow?.webContents
-  webContents?.send('ui:openFeatureTour')
-}
+type HelpMenuUiChannel =
+  | 'ui:openFeatureTour'
+  | 'ui:openSetupGuide'
+  | 'ui:openCrashReport'
+  | 'ui:openFeedback'
 
-function sendOpenSetupGuide(targetWindow?: BrowserWindow | null): void {
-  const webContents =
-    targetWindow && !targetWindow.isDestroyed() ? targetWindow.webContents : mainWindow?.webContents
-  webContents?.send('ui:openSetupGuide')
-}
-
-function sendOpenCrashReport(targetWindow?: BrowserWindow | null): void {
-  const webContents =
-    targetWindow && !targetWindow.isDestroyed() ? targetWindow.webContents : mainWindow?.webContents
-  webContents?.send('ui:openCrashReport')
-}
-
-function sendOpenFeedback(targetWindow?: BrowserWindow | null): void {
-  const webContents =
-    targetWindow && !targetWindow.isDestroyed() ? targetWindow.webContents : mainWindow?.webContents
-  webContents?.send('ui:openFeedback')
+// Why: the invoking window keeps hidden/E2E and multi-window flows on the right renderer, but the
+// dashboard pop-out mounts none of these listeners — route those clicks to the main window and raise it.
+function sendHelpMenuEvent(channel: HelpMenuUiChannel, targetWindow?: BrowserWindow | null): void {
+  const target = resolveHelpMenuEventTarget(targetWindow, mainWindow)
+  if (target.surfaceMainWindow) {
+    showMainWindowFromTray()
+  }
+  target.window?.webContents.send(channel)
 }
 
 // Why: on renderer crash-loop the breaker stops auto-reloading and the window goes blank, so a main-process dialog is the only retry/quit surface.
@@ -2661,23 +2654,22 @@ void app.whenReady().then(async () => {
     onOpenSetupGuide: (targetWindow) => {
       recordCrashBreadcrumb('setup_guide_opened')
       const targetBrowserWindow = targetWindow instanceof BrowserWindow ? targetWindow : null
-      sendOpenSetupGuide(targetBrowserWindow)
+      sendHelpMenuEvent('ui:openSetupGuide', targetBrowserWindow)
     },
     onOpenCrashReport: (targetWindow) => {
       recordCrashBreadcrumb('crash_report_opened')
       const targetBrowserWindow = targetWindow instanceof BrowserWindow ? targetWindow : null
-      sendOpenCrashReport(targetBrowserWindow)
+      sendHelpMenuEvent('ui:openCrashReport', targetBrowserWindow)
     },
     onOpenFeedback: (targetWindow) => {
       recordCrashBreadcrumb('feedback_opened')
       const targetBrowserWindow = targetWindow instanceof BrowserWindow ? targetWindow : null
-      sendOpenFeedback(targetBrowserWindow)
+      sendHelpMenuEvent('ui:openFeedback', targetBrowserWindow)
     },
     onOpenFeatureTour: (targetWindow) => {
       recordCrashBreadcrumb('feature_tour_opened')
-      // Why: use the invoking BrowserWindow so hidden/E2E and multi-window flows route to the right renderer, not global focus.
       const targetBrowserWindow = targetWindow instanceof BrowserWindow ? targetWindow : null
-      sendOpenFeatureTour(targetBrowserWindow)
+      sendHelpMenuEvent('ui:openFeatureTour', targetBrowserWindow)
     },
     // Why: menu zoom must act on the window the user is looking at — routing to
     // the main window while the dashboard pop-out is focused zooms behind it.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1508,6 +1508,12 @@ function sendOpenCrashReport(targetWindow?: BrowserWindow | null): void {
   webContents?.send('ui:openCrashReport')
 }
 
+function sendOpenFeedback(targetWindow?: BrowserWindow | null): void {
+  const webContents =
+    targetWindow && !targetWindow.isDestroyed() ? targetWindow.webContents : mainWindow?.webContents
+  webContents?.send('ui:openFeedback')
+}
+
 // Why: on renderer crash-loop the breaker stops auto-reloading and the window goes blank, so a main-process dialog is the only retry/quit surface.
 async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promise<void> {
   if (isQuitting) {
@@ -2661,6 +2667,11 @@ void app.whenReady().then(async () => {
       recordCrashBreadcrumb('crash_report_opened')
       const targetBrowserWindow = targetWindow instanceof BrowserWindow ? targetWindow : null
       sendOpenCrashReport(targetBrowserWindow)
+    },
+    onOpenFeedback: (targetWindow) => {
+      recordCrashBreadcrumb('feedback_opened')
+      const targetBrowserWindow = targetWindow instanceof BrowserWindow ? targetWindow : null
+      sendOpenFeedback(targetBrowserWindow)
     },
     onOpenFeatureTour: (targetWindow) => {
       recordCrashBreadcrumb('feature_tour_opened')

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -30,6 +30,7 @@ function buildMenuOptions() {
     onOpenSetupGuide: vi.fn(),
     onOpenFeatureTour: vi.fn(),
     onOpenCrashReport: vi.fn(),
+    onOpenFeedback: vi.fn(),
     onBeforeReload: vi.fn(),
     onZoomIn: vi.fn(),
     onZoomOut: vi.fn(),
@@ -272,6 +273,7 @@ describe('registerAppMenu', () => {
     expect(template.find((item) => item.label === 'File')).toBeUndefined()
     const helpLabels = getSubmenu(template, 'Help').map((item) => item.label)
     expect(helpLabels).toEqual([
+      'Send Feedback...',
       'Report Crash...',
       undefined,
       'Explore Orca',
@@ -309,6 +311,24 @@ describe('registerAppMenu', () => {
 
     expect(options.onOpenFeatureTour).toHaveBeenCalledTimes(1)
     expect(options.onOpenFeatureTour).toHaveBeenCalledWith(targetWindow)
+  })
+
+  it('offers Send Feedback above Report Crash so ordinary bugs skip the crash channel', () => {
+    const options = buildMenuOptions()
+    registerAppMenu(options)
+
+    const helpSubmenu = getSubmenu(getTemplate(), 'Help')
+    const helpLabels = helpSubmenu.map((item) => item.label)
+    const feedbackIndex = helpLabels.indexOf('Send Feedback...')
+    const crashIndex = helpLabels.indexOf('Report Crash...')
+    expect(feedbackIndex).toBeGreaterThanOrEqual(0)
+    expect(feedbackIndex).toBeLessThan(crashIndex)
+
+    const targetWindow = {} as Electron.BaseWindow
+    helpSubmenu[feedbackIndex]?.click?.({} as never, targetWindow, {} as Electron.KeyboardEvent)
+
+    expect(options.onOpenFeedback).toHaveBeenCalledTimes(1)
+    expect(options.onOpenFeedback).toHaveBeenCalledWith(targetWindow)
   })
 
   it('routes Report Crash through its callback', () => {

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -27,6 +27,7 @@ type RegisterAppMenuOptions = {
   onOpenSetupGuide: (window?: Electron.BaseWindow | null) => void
   onOpenFeatureTour: (window?: Electron.BaseWindow | null) => void
   onOpenCrashReport: (window?: Electron.BaseWindow | null) => void
+  onOpenFeedback: (window?: Electron.BaseWindow | null) => void
   onCheckForUpdates: (options: UpdateCheckOptions) => void
   onBeforeReload?: (options: { ignoreCache: boolean; webContentsId: number }) => void
   onZoomIn: () => void
@@ -48,6 +49,7 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     onOpenSetupGuide,
     onOpenFeatureTour,
     onOpenCrashReport,
+    onOpenFeedback,
     onCheckForUpdates,
     onBeforeReload,
     onZoomIn,
@@ -130,6 +132,13 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
   const crashReportItem: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.reportCrash', 'Report Crash...'),
     click: (_menuItem, window) => onOpenCrashReport(window)
+  }
+
+  // Why: without a feedback entry, Report Crash was Help's only actionable
+  // item, so ordinary bug reports landed in the crash channel.
+  const feedbackItem: Electron.MenuItemConstructorOptions = {
+    label: translateMain('menu.sendFeedback', 'Send Feedback...'),
+    click: (_menuItem, window) => onOpenFeedback(window)
   }
 
   // Why: the macOS app-menu (named after the app) is mandatory on darwin and
@@ -295,6 +304,7 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
   const helpMenu: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.help', 'Help'),
     submenu: [
+      feedbackItem,
       crashReportItem,
       { type: 'separator' },
       featureTourItem,

--- a/src/main/window/help-menu-event-target.test.ts
+++ b/src/main/window/help-menu-event-target.test.ts
@@ -1,0 +1,63 @@
+import type { BrowserWindow } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ isDashboardPopoutRenderer: vi.fn() }))
+
+vi.mock('./dashboard-popout-window', () => ({
+  isDashboardPopoutRenderer: mocks.isDashboardPopoutRenderer
+}))
+
+import { resolveHelpMenuEventTarget } from './help-menu-event-target'
+
+function fakeWindow(destroyed = false): BrowserWindow {
+  return {
+    isDestroyed: () => destroyed,
+    webContents: { id: destroyed ? 0 : 1 }
+  } as unknown as BrowserWindow
+}
+
+beforeEach(() => {
+  mocks.isDashboardPopoutRenderer.mockReset()
+  mocks.isDashboardPopoutRenderer.mockReturnValue(false)
+})
+
+describe('resolveHelpMenuEventTarget', () => {
+  it('keeps an ordinary invoking window so hidden and multi-window flows stay on their renderer', () => {
+    const invoking = fakeWindow()
+
+    expect(resolveHelpMenuEventTarget(invoking, fakeWindow())).toEqual({
+      window: invoking,
+      surfaceMainWindow: false
+    })
+  })
+
+  it('redirects the dashboard pop-out to the main window instead of dropping the click', () => {
+    mocks.isDashboardPopoutRenderer.mockReturnValue(true)
+    const mainWindow = fakeWindow()
+
+    expect(resolveHelpMenuEventTarget(fakeWindow(), mainWindow)).toEqual({
+      window: mainWindow,
+      surfaceMainWindow: true
+    })
+  })
+
+  it('falls back to the main window when the menu reports no invoking window', () => {
+    const mainWindow = fakeWindow()
+
+    expect(resolveHelpMenuEventTarget(null, mainWindow)).toEqual({
+      window: mainWindow,
+      surfaceMainWindow: false
+    })
+    expect(resolveHelpMenuEventTarget(fakeWindow(true), mainWindow).window).toBe(mainWindow)
+  })
+
+  it('reports no window rather than a destroyed main window', () => {
+    mocks.isDashboardPopoutRenderer.mockReturnValue(true)
+
+    expect(resolveHelpMenuEventTarget(fakeWindow(), fakeWindow(true))).toEqual({
+      window: null,
+      surfaceMainWindow: true
+    })
+    expect(resolveHelpMenuEventTarget(null, null).window).toBeNull()
+  })
+})

--- a/src/main/window/help-menu-event-target.ts
+++ b/src/main/window/help-menu-event-target.ts
@@ -1,0 +1,28 @@
+import type { BrowserWindow } from 'electron'
+import { isDashboardPopoutRenderer } from './dashboard-popout-window'
+
+export type HelpMenuEventTarget = {
+  window: BrowserWindow | null
+  /** The pop-out invoked the item, so the caller must raise the main window before sending. */
+  surfaceMainWindow: boolean
+}
+
+/**
+ * Resolve which window receives a Help-menu `ui:` event.
+ *
+ * Why: only the main window mounts those renderer listeners, so an item clicked
+ * while the dashboard pop-out is focused would otherwise be a silent no-op.
+ */
+export function resolveHelpMenuEventTarget(
+  invokingWindow: BrowserWindow | null | undefined,
+  mainWindow: BrowserWindow | null | undefined
+): HelpMenuEventTarget {
+  const liveMainWindow = mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
+  if (!invokingWindow || invokingWindow.isDestroyed()) {
+    return { window: liveMainWindow, surfaceMainWindow: false }
+  }
+  if (isDashboardPopoutRenderer(invokingWindow.webContents)) {
+    return { window: liveMainWindow, surfaceMainWindow: true }
+  }
+  return { window: invokingWindow, surfaceMainWindow: false }
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3106,6 +3106,7 @@ export type PreloadApi = {
     onOpenSetupGuide: (callback: () => void) => () => void
     onOpenFeatureTour: (callback: () => void) => () => void
     onOpenCrashReport: (callback: () => void) => () => void
+    onOpenFeedback: (callback: () => void) => () => void
     onToggleLeftSidebar: (callback: () => void) => () => void
     onToggleRightSidebar: (callback: () => void) => () => void
     onToggleWorktreePalette: (callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3443,6 +3443,11 @@ const api = {
       ipcRenderer.on('ui:openCrashReport', listener)
       return () => ipcRenderer.removeListener('ui:openCrashReport', listener)
     },
+    onOpenFeedback: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:openFeedback', listener)
+      return () => ipcRenderer.removeListener('ui:openFeedback', listener)
+    },
     onToggleLeftSidebar: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:toggleLeftSidebar', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -84,6 +84,7 @@ import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-
 import { OPEN_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
+import { SidebarFeedbackDialog } from './components/sidebar/SidebarFeedbackDialog'
 import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
 import { RecoverableRenderErrorBoundary } from './components/error-boundaries/RecoverableRenderErrorBoundary'
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
@@ -498,6 +499,8 @@ function App(): React.JSX.Element {
 
   const activeView = useAppStore((s) => s.activeView)
   const activeModal = useAppStore((s) => s.activeModal)
+  const feedbackDialogOpen = useAppStore((s) => s.feedbackDialogOpen)
+  const setFeedbackDialogOpen = useAppStore((s) => s.setFeedbackDialogOpen)
   const featureTipsSeenIds = useAppStore((s) => s.featureTipsSeenIds)
   const featureInteractions = useAppStore((s) => s.featureInteractions)
   const contextualToursAutoEligible = useAppStore((s) => s.contextualToursAutoEligible)
@@ -2729,6 +2732,18 @@ function App(): React.JSX.Element {
             >
               <CrashReportDialog />
             </RecoverableRenderErrorBoundary>
+            {/* Why: mounted at the root, not in the sidebar toolbar, so Help > Send Feedback still works with the sidebar collapsed or on Settings/Activity. */}
+            {feedbackDialogOpen ? (
+              <RecoverableRenderErrorBoundary
+                boundaryId="modal.feedback"
+                surface="modal"
+                reportAsCrash={false}
+                resetKey={activeModal}
+                compact
+              >
+                <SidebarFeedbackDialog open onOpenChange={setFeedbackDialogOpen} />
+              </RecoverableRenderErrorBoundary>
+            ) : null}
             {onboarding && shouldRenderOnboarding && !onboardingSettingsDetourActive ? (
               <Suspense fallback={null}>
                 <RecoverableRenderErrorBoundary

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -84,7 +84,7 @@ import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-
 import { OPEN_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
-import { SidebarFeedbackDialog } from './components/sidebar/SidebarFeedbackDialog'
+import { AppFeedbackDialog } from './components/feedback/AppFeedbackDialog'
 import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
 import { RecoverableRenderErrorBoundary } from './components/error-boundaries/RecoverableRenderErrorBoundary'
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
@@ -499,8 +499,6 @@ function App(): React.JSX.Element {
 
   const activeView = useAppStore((s) => s.activeView)
   const activeModal = useAppStore((s) => s.activeModal)
-  const feedbackDialogOpen = useAppStore((s) => s.feedbackDialogOpen)
-  const setFeedbackDialogOpen = useAppStore((s) => s.setFeedbackDialogOpen)
   const featureTipsSeenIds = useAppStore((s) => s.featureTipsSeenIds)
   const featureInteractions = useAppStore((s) => s.featureInteractions)
   const contextualToursAutoEligible = useAppStore((s) => s.contextualToursAutoEligible)
@@ -2733,17 +2731,15 @@ function App(): React.JSX.Element {
               <CrashReportDialog />
             </RecoverableRenderErrorBoundary>
             {/* Why: mounted at the root, not in the sidebar toolbar, so Help > Send Feedback still works with the sidebar collapsed or on Settings/Activity. */}
-            {feedbackDialogOpen ? (
-              <RecoverableRenderErrorBoundary
-                boundaryId="modal.feedback"
-                surface="modal"
-                reportAsCrash={false}
-                resetKey={activeModal}
-                compact
-              >
-                <SidebarFeedbackDialog open onOpenChange={setFeedbackDialogOpen} />
-              </RecoverableRenderErrorBoundary>
-            ) : null}
+            <RecoverableRenderErrorBoundary
+              boundaryId="modal.feedback"
+              surface="modal"
+              reportAsCrash={false}
+              resetKey={activeModal}
+              compact
+            >
+              <AppFeedbackDialog />
+            </RecoverableRenderErrorBoundary>
             {onboarding && shouldRenderOnboarding && !onboardingSettingsDetourActive ? (
               <Suspense fallback={null}>
                 <RecoverableRenderErrorBoundary

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.test.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CrashReportDialogSurface } from './CrashReportDialogSurface'
+
+vi.mock('sonner', () => ({
+  toast: {
+    dismiss: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+const crashSubmit = vi.fn()
+const feedbackSubmit = vi.fn()
+
+function renderUncapturedSurface(): void {
+  render(
+    <CrashReportDialogSurface
+      open
+      report={null}
+      loading={false}
+      onOpenChange={vi.fn()}
+      onReportChange={vi.fn()}
+    />
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  crashSubmit.mockResolvedValue({ ok: true, report: null })
+  feedbackSubmit.mockResolvedValue({ ok: true })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      gh: { viewer: vi.fn().mockResolvedValue({ login: 'octocat' }) },
+      crashReports: { submit: crashSubmit, copyLatestDiagnostics: vi.fn() },
+      feedback: { submit: feedbackSubmit }
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CrashReportDialogSurface without a captured crash report', () => {
+  it('reads as a user report rather than a crash', async () => {
+    renderUncapturedSurface()
+
+    expect(await screen.findByText('Tell us what went wrong')).toBeTruthy()
+    expect(screen.getByText(/reaches the Orca team as a user report/i)).toBeTruthy()
+  })
+
+  it('keeps the diagnostic bundle by submitting through the crash lane without a report id', async () => {
+    const user = userEvent.setup()
+    renderUncapturedSurface()
+
+    await user.type(await screen.findByRole('textbox'), 'Korean IME drops the last jamo')
+    await user.click(screen.getByRole('button', { name: /send report/i }))
+
+    await waitFor(() => expect(crashSubmit).toHaveBeenCalledTimes(1))
+    expect(feedbackSubmit).not.toHaveBeenCalled()
+    const submitted = crashSubmit.mock.calls[0][0]
+    expect(submitted.reportId).toBeUndefined()
+    expect(submitted.includeDiagnosticLogs).toBe(true)
+    expect(submitted.notes).toContain('Korean IME drops the last jamo')
+  })
+
+  it('still sends a log-only report when the user types no note', async () => {
+    const user = userEvent.setup()
+    renderUncapturedSurface()
+
+    // Why: two of the field reports were prose-free ("Not connecting SSH") — the
+    // bundle was the whole signal, so an empty note must not block submission.
+    await user.click(await screen.findByRole('button', { name: /send report/i }))
+
+    await waitFor(() => expect(crashSubmit).toHaveBeenCalledTimes(1))
+    expect(crashSubmit.mock.calls[0][0].includeDiagnosticLogs).toBe(true)
+  })
+
+  it('offers the diagnostic log toggle', async () => {
+    renderUncapturedSurface()
+
+    expect(await screen.findByText('Attach recent diagnostic logs')).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
-import { AlertTriangle, Clipboard, Send } from 'lucide-react'
+import { AlertTriangle, Clipboard, MessageSquareText, Send } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -39,9 +39,12 @@ function formatSummary(report: CrashReportRecord): string {
   }`
 }
 
+// Why: with no captured crash this surface is a plain bug report, so it reads as
+// one. The transport stays the crash lane because that is the only path that
+// carries the diagnostic bundle; ingest separates the two on report_source.
 function getDialogTitle(report: CrashReportRecord | null): string {
   if (!report) {
-    return 'Report a crash'
+    return 'Tell us what went wrong'
   }
   return report && isReactErrorBoundaryReport(report)
     ? 'Orca hit a recoverable UI error'
@@ -50,7 +53,7 @@ function getDialogTitle(report: CrashReportRecord | null): string {
 
 function getDialogDescription(report: CrashReportRecord | null): string {
   if (!report) {
-    return 'Send a privacy-safe crash report. Recent redacted diagnostic logs are included when available.'
+    return 'No crash was captured, so this reaches the Orca team as a user report. Recent redacted diagnostic logs are included when available.'
   }
   return report && isReactErrorBoundaryReport(report)
     ? 'Send a privacy-safe diagnostic report to help us understand the failed UI surface.'
@@ -59,7 +62,7 @@ function getDialogDescription(report: CrashReportRecord | null): string {
 
 function getNotesPlaceholder(report: CrashReportRecord | null): string {
   if (!report) {
-    return 'Optional: what happened?'
+    return 'What happened? (optional)'
   }
   return report && isReactErrorBoundaryReport(report)
     ? 'Optional: what were you doing before this UI error?'
@@ -170,6 +173,8 @@ export function CrashReportDialogSurface({
   const handleSubmit = async (): Promise<void> => {
     setSubmitting(true)
     try {
+      // Why: omitting reportId mints an uncaptured user report. It keeps the
+      // diagnostic bundle — often the only signal when the note is one line.
       const result = await window.api.crashReports.submit({
         ...(report ? { reportId: report.id } : {}),
         notes,
@@ -196,10 +201,15 @@ export function CrashReportDialogSurface({
         toast.warning(warningNotice.title, { description: warningNotice.description })
       } else {
         toast.success(
-          translate(
-            'auto.components.crash.report.CrashReportDialog.8e24fe4f75',
-            'Crash report sent.'
-          )
+          report
+            ? translate(
+                'auto.components.crash.report.CrashReportDialog.8e24fe4f75',
+                'Crash report sent.'
+              )
+            : translate(
+                'auto.components.crash.report.CrashReportDialog.userReportSent',
+                'Report sent. Thanks for the details.'
+              )
         )
       }
       onOpenChange(false)
@@ -235,7 +245,11 @@ export function CrashReportDialogSurface({
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-sm">
-            <AlertTriangle className="size-4 text-destructive" />
+            {report ? (
+              <AlertTriangle className="size-4 text-destructive" />
+            ) : (
+              <MessageSquareText className="size-4 text-muted-foreground" />
+            )}
             {getDialogTitle(report)}
           </DialogTitle>
           <DialogDescription className="text-xs">{getDialogDescription(report)}</DialogDescription>
@@ -272,8 +286,8 @@ export function CrashReportDialogSurface({
                     'Checking for crash reports...'
                   )
                 : translate(
-                    'auto.components.crash.report.CrashReportDialog.ead6fc0510',
-                    'No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.'
+                    'auto.components.crash.report.CrashReportDialog.noCapturedCrashFeedback',
+                    'No automatic crash report was captured. This is filed as a user report, with your description and recent diagnostic logs when available.'
                   )}
             </div>
           )}

--- a/src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx
+++ b/src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  submit: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    warning: vi.fn()
+  }
+}))
+
+import { useAppStore } from '@/store'
+import { AppFeedbackDialog } from './AppFeedbackDialog'
+
+function setDialogOpen(open: boolean): void {
+  act(() => {
+    useAppStore.getState().setFeedbackDialogOpen(open)
+  })
+}
+
+function getMessageBox(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText('What could we improve?') as HTMLTextAreaElement
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.submit.mockResolvedValue({ ok: true })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      feedback: { submit: mocks.submit },
+      gh: { viewer: vi.fn().mockResolvedValue({ login: 'octocat', email: null }) },
+      shell: { openUrl: vi.fn() }
+    }
+  })
+  useAppStore.setState({ feedbackDialogOpen: false })
+})
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState({ feedbackDialogOpen: false })
+})
+
+describe('AppFeedbackDialog', () => {
+  it('keeps the typed report when the dialog is dismissed and reopened', async () => {
+    const user = userEvent.setup()
+    render(<AppFeedbackDialog />)
+    setDialogOpen(true)
+
+    await user.type(
+      await screen.findByPlaceholderText('What could we improve?'),
+      'SSH pane freezes'
+    )
+    await user.click(await screen.findByLabelText('Submit anonymously'))
+
+    // Why: Escape and outside clicks are unguarded, so a reflex dismiss must not
+    // destroy a long report — the dialog stays mounted while closed.
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(useAppStore.getState().feedbackDialogOpen).toBe(false))
+    setDialogOpen(true)
+
+    expect(getMessageBox().value).toBe('SSH pane freezes')
+    expect((screen.getByLabelText('Submit anonymously') as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('still reports a failed submit that the user dismissed while it was in flight', async () => {
+    let rejectSubmit: ((error: Error) => void) | undefined
+    mocks.submit.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectSubmit = reject
+      })
+    )
+    const user = userEvent.setup()
+    render(<AppFeedbackDialog />)
+    setDialogOpen(true)
+
+    await user.type(await screen.findByPlaceholderText('What could we improve?'), 'Crash on resize')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(mocks.submit).toHaveBeenCalledTimes(1))
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(useAppStore.getState().feedbackDialogOpen).toBe(false))
+    await act(async () => {
+      rejectSubmit?.(new Error('network down'))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/renderer/src/components/feedback/AppFeedbackDialog.tsx
+++ b/src/renderer/src/components/feedback/AppFeedbackDialog.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useAppStore } from '@/store'
+import { SidebarFeedbackDialog } from '../sidebar/SidebarFeedbackDialog'
+
+/**
+ * App-root host for the feedback dialog, opened from the sidebar help menu or
+ * Help > Send Feedback.
+ *
+ * Why: it stays mounted while closed so the typed report and its attachments
+ * survive a reflex Escape, and so an in-flight submit still lands its toast.
+ */
+export function AppFeedbackDialog(): React.JSX.Element {
+  const open = useAppStore((s) => s.feedbackDialogOpen)
+  const setOpen = useAppStore((s) => s.setFeedbackDialogOpen)
+
+  return <SidebarFeedbackDialog open={open} onOpenChange={setOpen} />
+}

--- a/src/renderer/src/components/mobile/MobileHeroPairingStep.tsx
+++ b/src/renderer/src/components/mobile/MobileHeroPairingStep.tsx
@@ -107,7 +107,7 @@ export function MobileHeroPairingStep({
 }): React.JSX.Element {
   const copyPairingCodeRef = useRef<HTMLButtonElement | null>(null)
   const pairingWasReadyRef = useRef(pairingUrl != null && !pairLoading)
-  const sendRelayDiagnostics = useSendRelayMintFailureFeedback()
+  const relayDiagnostics = useSendRelayMintFailureFeedback()
   const emptyQrMessage =
     !pairLoading && pairQrDataUrl == null
       ? emptyPairingQrMessage({
@@ -164,11 +164,12 @@ export function MobileHeroPairingStep({
           onRetry={onRetryRelay}
           onCopyDiagnostics={onCopyRelayDiagnostics}
           onSendDiagnostics={() =>
-            void sendRelayDiagnostics({
+            void relayDiagnostics.send({
               failure: relayMintFailure,
               preferredConnectionMode: connectionMode
             })
           }
+          sendingDiagnostics={relayDiagnostics.sending}
           compact
           busy={pairLoading}
         />

--- a/src/renderer/src/components/mobile/MobileHeroPairingStep.tsx
+++ b/src/renderer/src/components/mobile/MobileHeroPairingStep.tsx
@@ -6,6 +6,7 @@ import { NetworkInterfacePicker } from './NetworkInterfacePicker'
 import { MobilePairingConnectionOptions } from '../settings/MobilePairingConnectionOptions'
 import { MobileRelayBetaNotice } from '../settings/MobileRelayBetaNotice'
 import { MobileRelayMintFailureNotice } from './mobile-relay-mint-failure-notice'
+import { useSendRelayMintFailureFeedback } from './relay-mint-failure-feedback'
 import { WindowsFirewallNotice } from './WindowsFirewallNotice'
 import type { MobilePairingConnectionMode } from '../../../../shared/mobile-pairing-connection-mode'
 import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
@@ -106,6 +107,7 @@ export function MobileHeroPairingStep({
 }): React.JSX.Element {
   const copyPairingCodeRef = useRef<HTMLButtonElement | null>(null)
   const pairingWasReadyRef = useRef(pairingUrl != null && !pairLoading)
+  const sendRelayDiagnostics = useSendRelayMintFailureFeedback()
   const emptyQrMessage =
     !pairLoading && pairQrDataUrl == null
       ? emptyPairingQrMessage({
@@ -161,6 +163,12 @@ export function MobileHeroPairingStep({
           onUseLan={onUseLan}
           onRetry={onRetryRelay}
           onCopyDiagnostics={onCopyRelayDiagnostics}
+          onSendDiagnostics={() =>
+            void sendRelayDiagnostics({
+              failure: relayMintFailure,
+              preferredConnectionMode: connectionMode
+            })
+          }
           compact
           busy={pairLoading}
         />

--- a/src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.test.tsx
+++ b/src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileRelayMintFailureNotice } from './mobile-relay-mint-failure-notice'
+import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
+
+const failure: MobileRelayMintFailure = {
+  code: 'relay_binding_failed',
+  stage: 'binding_failed',
+  message: 'Could not bind the relay session.'
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MobileRelayMintFailureNotice', () => {
+  it('offers sending the diagnostics to Orca instead of only copying them', async () => {
+    const user = userEvent.setup()
+    const onSendDiagnostics = vi.fn()
+    render(
+      <MobileRelayMintFailureNotice
+        failure={failure}
+        onUseLan={vi.fn()}
+        onRetry={vi.fn()}
+        onCopyDiagnostics={vi.fn()}
+        onSendDiagnostics={onSendDiagnostics}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Send to Orca' }))
+
+    expect(onSendDiagnostics).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.tsx
+++ b/src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.tsx
@@ -10,6 +10,7 @@ export function MobileRelayMintFailureNotice({
   onUseLan,
   onRetry,
   onCopyDiagnostics,
+  onSendDiagnostics,
   className,
   compact = false,
   busy = false
@@ -18,6 +19,8 @@ export function MobileRelayMintFailureNotice({
   onUseLan: () => void
   onRetry: () => void
   onCopyDiagnostics: () => void
+  /** Why: without a direct send, users pasted this JSON into the crash dialog. */
+  onSendDiagnostics?: () => void
   className?: string
   compact?: boolean
   busy?: boolean
@@ -122,6 +125,19 @@ export function MobileRelayMintFailureNotice({
               'Copy diagnostics'
             )}
           </Button>
+          {onSendDiagnostics ? (
+            <Button
+              type="button"
+              size={compact ? 'xs' : 'sm'}
+              variant="ghost"
+              onClick={onSendDiagnostics}
+            >
+              {translate(
+                'auto.components.mobile.MobileRelayMintFailureNotice.sendDiagnostics',
+                'Send to Orca'
+              )}
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.tsx
+++ b/src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.tsx
@@ -11,6 +11,7 @@ export function MobileRelayMintFailureNotice({
   onRetry,
   onCopyDiagnostics,
   onSendDiagnostics,
+  sendingDiagnostics = false,
   className,
   compact = false,
   busy = false
@@ -21,6 +22,7 @@ export function MobileRelayMintFailureNotice({
   onCopyDiagnostics: () => void
   /** Why: without a direct send, users pasted this JSON into the crash dialog. */
   onSendDiagnostics?: () => void
+  sendingDiagnostics?: boolean
   className?: string
   compact?: boolean
   busy?: boolean
@@ -131,11 +133,19 @@ export function MobileRelayMintFailureNotice({
               size={compact ? 'xs' : 'sm'}
               variant="ghost"
               onClick={onSendDiagnostics}
+              disabled={sendingDiagnostics}
+              className="w-28"
             >
-              {translate(
-                'auto.components.mobile.MobileRelayMintFailureNotice.sendDiagnostics',
-                'Send to Orca'
-              )}
+              {sendingDiagnostics ? <Loader2 className="animate-spin" /> : null}
+              {sendingDiagnostics
+                ? translate(
+                    'auto.components.mobile.MobileRelayMintFailureNotice.sendingDiagnostics',
+                    'Sending…'
+                  )
+                : translate(
+                    'auto.components.mobile.MobileRelayMintFailureNotice.sendDiagnostics',
+                    'Send to Orca'
+                  )}
             </Button>
           ) : null}
         </div>

--- a/src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx
+++ b/src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSendRelayMintFailureFeedback } from './relay-mint-failure-feedback'
+import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+const failure: MobileRelayMintFailure = {
+  code: 'relay_binding_failed',
+  stage: 'binding_failed',
+  message: 'Could not bind the relay session.'
+}
+
+function SendButton(): React.JSX.Element {
+  const send = useSendRelayMintFailureFeedback()
+  return (
+    <button type="button" onClick={() => void send({ failure, preferredConnectionMode: 'relay' })}>
+      send
+    </button>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('useSendRelayMintFailureFeedback', () => {
+  it('drops repeat clicks while a send is in flight so one gh spawn and one report go out', async () => {
+    const user = userEvent.setup()
+    let resolveViewer: (value: null) => void = () => {}
+    const viewer = vi.fn(() => new Promise<null>((resolve) => (resolveViewer = resolve)))
+    const submit = vi.fn(async () => ({ ok: true as const }))
+    vi.stubGlobal(
+      'window',
+      Object.assign(window, { api: { gh: { viewer }, feedback: { submit } } })
+    )
+
+    render(<SendButton />)
+    const button = screen.getByRole('button', { name: 'send' })
+    await user.click(button)
+    await user.click(button)
+    await user.click(button)
+
+    expect(viewer).toHaveBeenCalledTimes(1)
+    resolveViewer(null)
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx
+++ b/src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileRelayMintFailureNotice } from './mobile-relay-mint-failure-notice'
 import { useSendRelayMintFailureFeedback } from './relay-mint-failure-feedback'
 import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
 
@@ -17,12 +18,38 @@ const failure: MobileRelayMintFailure = {
 }
 
 function SendButton(): React.JSX.Element {
-  const send = useSendRelayMintFailureFeedback()
+  const relayDiagnostics = useSendRelayMintFailureFeedback()
   return (
-    <button type="button" onClick={() => void send({ failure, preferredConnectionMode: 'relay' })}>
+    <button
+      type="button"
+      onClick={() => void relayDiagnostics.send({ failure, preferredConnectionMode: 'relay' })}
+    >
       send
     </button>
   )
+}
+
+function RelayNoticeHarness(): React.JSX.Element {
+  const relayDiagnostics = useSendRelayMintFailureFeedback()
+  return (
+    <MobileRelayMintFailureNotice
+      failure={failure}
+      onUseLan={vi.fn()}
+      onRetry={vi.fn()}
+      onCopyDiagnostics={vi.fn()}
+      onSendDiagnostics={() =>
+        void relayDiagnostics.send({ failure, preferredConnectionMode: 'relay' })
+      }
+      sendingDiagnostics={relayDiagnostics.sending}
+    />
+  )
+}
+
+function stubFeedbackApi(
+  viewer: () => Promise<null>,
+  submit: () => Promise<{ ok: true } | { ok: false; error: string }>
+): void {
+  vi.stubGlobal('window', Object.assign(window, { api: { gh: { viewer }, feedback: { submit } } }))
 }
 
 afterEach(() => {
@@ -36,10 +63,7 @@ describe('useSendRelayMintFailureFeedback', () => {
     let resolveViewer: (value: null) => void = () => {}
     const viewer = vi.fn(() => new Promise<null>((resolve) => (resolveViewer = resolve)))
     const submit = vi.fn(async () => ({ ok: true as const }))
-    vi.stubGlobal(
-      'window',
-      Object.assign(window, { api: { gh: { viewer }, feedback: { submit } } })
-    )
+    stubFeedbackApi(viewer, submit)
 
     render(<SendButton />)
     const button = screen.getByRole('button', { name: 'send' })
@@ -50,5 +74,23 @@ describe('useSendRelayMintFailureFeedback', () => {
     expect(viewer).toHaveBeenCalledTimes(1)
     resolveViewer(null)
     await vi.waitFor(() => expect(submit).toHaveBeenCalledTimes(1))
+  })
+
+  it('disables Send to Orca and shows progress until the submit settles', async () => {
+    const user = userEvent.setup()
+    let resolveSubmit: (value: { ok: true }) => void = () => {}
+    const viewer = vi.fn(async () => null)
+    const submit = vi.fn(() => new Promise<{ ok: true }>((resolve) => (resolveSubmit = resolve)))
+    stubFeedbackApi(viewer, submit)
+
+    render(<RelayNoticeHarness />)
+    await user.click(screen.getByRole('button', { name: 'Send to Orca' }))
+
+    const sending = await screen.findByRole<HTMLButtonElement>('button', { name: 'Sending…' })
+    expect(sending.disabled).toBe(true)
+
+    resolveSubmit({ ok: true })
+    const sent = await screen.findByRole<HTMLButtonElement>('button', { name: 'Send to Orca' })
+    expect(sent.disabled).toBe(false)
   })
 })

--- a/src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
+++ b/src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
@@ -1,0 +1,62 @@
+import { useCallback } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
+
+type RelayMintFailureFeedbackArgs = {
+  failure: MobileRelayMintFailure
+  preferredConnectionMode: string
+}
+
+// Why: users share this payload — the selected address would leak a LAN/Tailscale IP or hostname.
+export function buildRelayMintFailureFeedback(args: RelayMintFailureFeedbackArgs): string {
+  return [
+    'Mobile pairing could not attach Orca Relay.',
+    '',
+    JSON.stringify(
+      {
+        kind: 'mobile_pairing_relay_failure',
+        preferredConnectionMode: args.preferredConnectionMode,
+        failure: args.failure,
+        at: new Date().toISOString()
+      },
+      null,
+      2
+    )
+  ].join('\n')
+}
+
+/** Why: without a direct send, users pasted these diagnostics into the crash dialog. */
+export function useSendRelayMintFailureFeedback(): (
+  args: RelayMintFailureFeedbackArgs
+) => Promise<void> {
+  return useCallback(async (args: RelayMintFailureFeedbackArgs): Promise<void> => {
+    try {
+      // Why: identity is best-effort; a missing gh session must not block the report.
+      const viewer = await window.api.gh.viewer().catch(() => null)
+      const result = await window.api.feedback.submit({
+        feedback: buildRelayMintFailureFeedback(args),
+        submitAnonymously: !viewer,
+        githubLogin: viewer?.login ?? null,
+        githubEmail: null
+      })
+      if (!result.ok) {
+        throw new Error(result.error)
+      }
+      toast.success(
+        translate(
+          'auto.components.mobile.MobileRelayMintFailureNotice.diagnosticsSent',
+          'Diagnostics sent to Orca'
+        )
+      )
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.mobile.MobileRelayMintFailureNotice.diagnosticsSendFailed',
+          'Failed to send diagnostics'
+        )
+      )
+      console.error('Failed to send relay pairing diagnostics:', error)
+    }
+  }, [])
+}

--- a/src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
+++ b/src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
@@ -30,7 +30,16 @@ export function buildRelayMintFailureFeedback(args: RelayMintFailureFeedbackArgs
 export function useSendRelayMintFailureFeedback(): (
   args: RelayMintFailureFeedbackArgs
 ) => Promise<void> {
+  // Why: the button has no busy state and the send is a `gh` subprocess plus an
+  // HTTPS post, so repeat clicks would file duplicate reports and queue extra
+  // spawns behind the shared gh concurrency limit.
+  const inFlightRef = useRef(false)
+
   return useCallback(async (args: RelayMintFailureFeedbackArgs): Promise<void> => {
+    if (inFlightRef.current) {
+      return
+    }
+    inFlightRef.current = true
     try {
       // Why: identity is best-effort; a missing gh session must not block the report.
       const viewer = await window.api.gh.viewer().catch(() => null)
@@ -57,6 +66,8 @@ export function useSendRelayMintFailureFeedback(): (
         )
       )
       console.error('Failed to send relay pairing diagnostics:', error)
+    } finally {
+      inFlightRef.current = false
     }
   }, [])
 }

--- a/src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
+++ b/src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
@@ -26,20 +26,26 @@ export function buildRelayMintFailureFeedback(args: RelayMintFailureFeedbackArgs
   ].join('\n')
 }
 
-/** Why: without a direct send, users pasted these diagnostics into the crash dialog. */
-export function useSendRelayMintFailureFeedback(): (
-  args: RelayMintFailureFeedbackArgs
-) => Promise<void> {
-  // Why: the button has no busy state and the send is a `gh` subprocess plus an
-  // HTTPS post, so repeat clicks would file duplicate reports and queue extra
-  // spawns behind the shared gh concurrency limit.
-  const inFlightRef = useRef(false)
+export type RelayMintFailureFeedbackSender = {
+  send: (args: RelayMintFailureFeedbackArgs) => Promise<void>
+  /** Why: main allows the submit 10s, so the button must show progress or users re-click. */
+  sending: boolean
+}
 
-  return useCallback(async (args: RelayMintFailureFeedbackArgs): Promise<void> => {
+/** Why: without a direct send, users pasted these diagnostics into the crash dialog. */
+export function useSendRelayMintFailureFeedback(): RelayMintFailureFeedbackSender {
+  // Why: a `gh` subprocess plus an HTTPS post, so repeat clicks would file duplicate
+  // reports and queue extra spawns behind the shared gh concurrency limit. The ref
+  // rejects clicks landing before React has flushed `sending` to the disabled button.
+  const inFlightRef = useRef(false)
+  const [sending, setSending] = useState(false)
+
+  const send = useCallback(async (args: RelayMintFailureFeedbackArgs): Promise<void> => {
     if (inFlightRef.current) {
       return
     }
     inFlightRef.current = true
+    setSending(true)
     try {
       // Why: identity is best-effort; a missing gh session must not block the report.
       const viewer = await window.api.gh.viewer().catch(() => null)
@@ -68,6 +74,9 @@ export function useSendRelayMintFailureFeedback(): (
       console.error('Failed to send relay pairing diagnostics:', error)
     } finally {
       inFlightRef.current = false
+      setSending(false)
     }
   }, [])
+
+  return { send, sending }
 }

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -288,7 +288,7 @@ export function MobilePane(): React.JSX.Element {
     ]
   )
 
-  const sendRelayDiagnostics = useSendRelayMintFailureFeedback()
+  const relayDiagnostics = useSendRelayMintFailureFeedback()
 
   const copyRelayDiagnostics = useCallback(async (): Promise<void> => {
     if (relayMintFailure == null) {
@@ -421,11 +421,12 @@ export function MobilePane(): React.JSX.Element {
           onRetry={() => void generateQR({ rotate: true })}
           onCopyDiagnostics={() => void copyRelayDiagnostics()}
           onSendDiagnostics={() =>
-            void sendRelayDiagnostics({
+            void relayDiagnostics.send({
               failure: relayMintFailure,
               preferredConnectionMode: connectionMode
             })
           }
+          sendingDiagnostics={relayDiagnostics.sending}
           busy={loading}
         />
       ) : null}

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -15,6 +15,7 @@ import { MobileAutoRestoreFitSection } from './MobileAutoRestoreFitSection'
 import { MobilePairingConnectionOptions } from './MobilePairingConnectionOptions'
 import { MobilePairingSetupSection } from './MobilePairingSetupSection'
 import { MobileRelayMintFailureNotice } from '../mobile/mobile-relay-mint-failure-notice'
+import { useSendRelayMintFailureFeedback } from '../mobile/relay-mint-failure-feedback'
 import { WindowsFirewallNotice } from '../mobile/WindowsFirewallNotice'
 import { translate } from '@/i18n/i18n'
 import {
@@ -287,6 +288,8 @@ export function MobilePane(): React.JSX.Element {
     ]
   )
 
+  const sendRelayDiagnostics = useSendRelayMintFailureFeedback()
+
   const copyRelayDiagnostics = useCallback(async (): Promise<void> => {
     if (relayMintFailure == null) {
       return
@@ -417,6 +420,12 @@ export function MobilePane(): React.JSX.Element {
           onUseLan={() => changeConnectionMode('local-only')}
           onRetry={() => void generateQR({ rotate: true })}
           onCopyDiagnostics={() => void copyRelayDiagnostics()}
+          onSendDiagnostics={() =>
+            void sendRelayDiagnostics({
+              failure: relayMintFailure,
+              preferredConnectionMode: connectionMode
+            })
+          }
           busy={loading}
         />
       ) : null}

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   appRestart: vi.fn(),
   updaterCheck: vi.fn(),
   shellOpenUrl: vi.fn(),
+  setFeedbackDialogOpen: vi.fn(),
   useShortcutKeyDetails: vi.fn(),
   setupProgress: {
     ready: true,
@@ -31,6 +32,7 @@ vi.mock('@/store', () => ({
       openModal: mocks.openModal,
       openSettingsPage: mocks.openSettingsPage,
       openSettingsTarget: mocks.openSettingsTarget,
+      setFeedbackDialogOpen: mocks.setFeedbackDialogOpen,
       updateStatus
     })
 }))
@@ -112,10 +114,6 @@ vi.mock('sonner', () => ({
     info: vi.fn(),
     error: vi.fn()
   }
-}))
-
-vi.mock('./SidebarFeedbackDialog', () => ({
-  SidebarFeedbackDialog: () => <div data-testid="feedback-dialog" />
 }))
 
 function installWindowApi(): void {
@@ -252,6 +250,20 @@ describe('SidebarSettingsHelpMenu', () => {
     expect(html).toContain('Discord')
     expect(html).toContain('viewBox="0 0 20 20"')
     expect(html).toContain('M16.0742 4.45014C14.9244 3.92097 13.7106 3.54556 12.4638 3.3335')
+  })
+
+  it('opens the app-root feedback dialog through the store instead of owning it locally', async () => {
+    const container = await renderMenu()
+    // Why: the dialog must not live here — this component unmounts when the sidebar
+    // collapses or Settings/Activity take over, which would strand Help > Send Feedback.
+    expect(container.querySelector('[data-testid="feedback-dialog"]')).toBeNull()
+    expect(container.innerHTML).not.toContain('role="dialog"')
+
+    await act(async () => {
+      findMenuItem(container, 'Send Feedback').click()
+    })
+
+    expect(mocks.setFeedbackDialogOpen).toHaveBeenCalledWith(true)
   })
 
   it('opens Discord invite through the shell bridge', async () => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -31,7 +31,6 @@ import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { showOnboardingFromRenderer } from '../onboarding/show-onboarding-event'
 import { SetupGuideProgressRing } from '../setup-guide/SetupGuideProgressRing'
 import { useSetupGuideProgress } from '../setup-guide/use-setup-guide-progress'
-import { SidebarFeedbackDialog } from './SidebarFeedbackDialog'
 import { translate } from '@/i18n/i18n'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from '@/lib/update-check-click-options'
 
@@ -87,6 +86,8 @@ function ExternalMenuItem({
 
 export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const openModal = useAppStore((s) => s.openModal)
+  // Why: the dialog itself is mounted at the app root so the OS Help menu can open it from any view.
+  const setFeedbackDialogOpen = useAppStore((s) => s.setFeedbackDialogOpen)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const updateStatus = useAppStore((s) => s.updateStatus)
@@ -94,7 +95,6 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
 
   const settingsShortcut = useShortcutKeyDetails('app.settings')
   const [menuOpen, setMenuOpen] = useState(false)
-  const [feedbackOpen, setFeedbackOpen] = useState(false)
   const [isRestartingOrca, setIsRestartingOrca] = useState(false)
   const lastShowOnboardingAtRef = React.useRef(0)
   const updateCheckModifiersRef = React.useRef(NO_UPDATE_CHECK_MODIFIERS)
@@ -167,170 +167,161 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   }
 
   return (
-    <>
-      <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            type="button"
+            aria-label={translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.a428c25998',
+              'Settings'
+            )}
+            className="text-muted-foreground"
+            onClick={openSettingsPage}
+          >
+            <Settings className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4} className="flex items-center gap-1.5">
+          {translate('auto.components.sidebar.SidebarSettingsHelpMenu.a428c25998', 'Settings')}
+          {settingsShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={settingsShortcut.keys}
+              doubleTap={settingsShortcut.doubleTap}
+              className="gap-0.5"
+              keyCapClassName="min-w-0 border-background/20 bg-background/10 px-1 py-0 text-[10px] text-background shadow-none"
+              separatorClassName="text-[10px] text-background/70"
+            />
+          ) : null}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu modal={false} open={menuOpen} onOpenChange={handleMenuOpenChange}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              type="button"
-              aria-label={translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.a428c25998',
-                'Settings'
-              )}
-              className="text-muted-foreground"
-              onClick={openSettingsPage}
-            >
-              <Settings className="size-3.5" />
-            </Button>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                type="button"
+                aria-label={translate(
+                  'auto.components.sidebar.SidebarSettingsHelpMenu.2991a0106c',
+                  'Help'
+                )}
+                className="text-muted-foreground"
+              >
+                <CircleHelp className="size-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent side="top" sideOffset={4} className="flex items-center gap-1.5">
-            {translate('auto.components.sidebar.SidebarSettingsHelpMenu.a428c25998', 'Settings')}
-            {settingsShortcut.keys.length > 0 ? (
-              <ShortcutKeyCombo
-                keys={settingsShortcut.keys}
-                doubleTap={settingsShortcut.doubleTap}
-                className="gap-0.5"
-                keyCapClassName="min-w-0 border-background/20 bg-background/10 px-1 py-0 text-[10px] text-background shadow-none"
-                separatorClassName="text-[10px] text-background/70"
-              />
-            ) : null}
+          <TooltipContent side="top" sideOffset={4}>
+            {translate('auto.components.sidebar.SidebarSettingsHelpMenu.2991a0106c', 'Help')}
           </TooltipContent>
         </Tooltip>
-        <DropdownMenu modal={false} open={menuOpen} onOpenChange={handleMenuOpenChange}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  type="button"
-                  aria-label={translate(
-                    'auto.components.sidebar.SidebarSettingsHelpMenu.2991a0106c',
-                    'Help'
-                  )}
-                  className="text-muted-foreground"
-                >
-                  <CircleHelp className="size-3.5" />
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={4}>
-              {translate('auto.components.sidebar.SidebarSettingsHelpMenu.2991a0106c', 'Help')}
-            </TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-52">
-            <DropdownMenuItem onSelect={openShortcutsSettings}>
-              <Keyboard className="size-3.5" />
+        <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-52">
+          <DropdownMenuItem onSelect={openShortcutsSettings}>
+            <Keyboard className="size-3.5" />
+            {translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.e565171a7c',
+              'Keyboard Shortcuts'
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setFeedbackDialogOpen(true)}>
+            <MessageSquareText className="size-3.5" />
+            {translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.4cf5b868d7',
+              'Send Feedback'
+            )}
+          </DropdownMenuItem>
+          {showMilestones ? (
+            <DropdownMenuItem onSelect={openMilestones}>
+              <img
+                src={logo}
+                alt=""
+                aria-hidden="true"
+                className="size-3.5 object-contain invert opacity-55 dark:invert-0"
+              />
               {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.e565171a7c',
-                'Keyboard Shortcuts'
+                'auto.components.sidebar.SidebarSettingsHelpMenu.f8a2c91d4e',
+                'Milestones'
               )}
+              <SetupGuideProgressRing
+                done={setupProgress.coreDoneCount}
+                total={setupProgress.coreTotal}
+                sizeClassName="size-4"
+                className="ml-auto"
+              />
             </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
-              <MessageSquareText className="size-3.5" />
-              {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.4cf5b868d7',
-                'Send Feedback'
-              )}
-            </DropdownMenuItem>
-            {showMilestones ? (
-              <DropdownMenuItem onSelect={openMilestones}>
-                <img
-                  src={logo}
-                  alt=""
-                  aria-hidden="true"
-                  className="size-3.5 object-contain invert opacity-55 dark:invert-0"
-                />
-                {translate(
-                  'auto.components.sidebar.SidebarSettingsHelpMenu.f8a2c91d4e',
-                  'Milestones'
-                )}
-                <SetupGuideProgressRing
-                  done={setupProgress.coreDoneCount}
-                  total={setupProgress.coreTotal}
-                  sizeClassName="size-4"
-                  className="ml-auto"
-                />
-              </DropdownMenuItem>
-            ) : null}
-            <DropdownMenuItem
-              className="whitespace-nowrap"
-              onClick={handleShowOnboarding}
-              onSelect={handleShowOnboarding}
-            >
-              <School className="size-3.5" />
-              {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.b7e4d2a19c',
-                'Onboarding'
-              )}
-            </DropdownMenuItem>
-            <ExternalMenuItem
-              label={translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.cdc87f897e',
-                'Docs'
-              )}
-              url={DOCS_URL}
-              icon={<BookOpen className="size-3.5" />}
-            />
-            <ExternalMenuItem
-              label={translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.5f83d86d92',
-                'Changelog'
-              )}
-              url={CHANGELOG_URL}
-              icon={<ScrollText className="size-3.5" />}
-            />
-            <DropdownMenuSeparator />
-            <ExternalMenuItem
-              label={translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.5687ab246a',
-                'GitHub'
-              )}
-              url={GITHUB_URL}
-              icon={<Github className="size-3.5" />}
-            />
-            <DropdownMenuItem onSelect={() => openExternalUrl(DISCORD_URL)}>
-              <DiscordIcon />
-              {translate('auto.components.sidebar.SidebarSettingsHelpMenu.eb9884e55b', 'Discord')}
-              <ExternalLink className="ml-auto size-3 text-muted-foreground" />
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => openExternalUrl(X_URL)}>
-              <XIcon />
-              {translate('auto.components.sidebar.SidebarSettingsHelpMenu.c4f8e1b72a', 'X')}
-              <ExternalLink className="ml-auto size-3 text-muted-foreground" />
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
-              onPointerDown={handleCheckForUpdatesPointerDown}
-              onSelect={handleCheckForUpdates}
-              title={updateCheckHint}
-            >
-              {updateStatus.state === 'checking' ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                <RefreshCw className="size-3.5" />
-              )}
-              {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
-                'Check for Updates'
-              )}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleRestartOrca} disabled={isRestartingOrca}>
-              <RotateCw className="size-3.5" />
-              {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.ad3d3ed7f1',
-                'Restart Orca'
-              )}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-      <SidebarFeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
-    </>
+          ) : null}
+          <DropdownMenuItem
+            className="whitespace-nowrap"
+            onClick={handleShowOnboarding}
+            onSelect={handleShowOnboarding}
+          >
+            <School className="size-3.5" />
+            {translate('auto.components.sidebar.SidebarSettingsHelpMenu.b7e4d2a19c', 'Onboarding')}
+          </DropdownMenuItem>
+          <ExternalMenuItem
+            label={translate('auto.components.sidebar.SidebarSettingsHelpMenu.cdc87f897e', 'Docs')}
+            url={DOCS_URL}
+            icon={<BookOpen className="size-3.5" />}
+          />
+          <ExternalMenuItem
+            label={translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.5f83d86d92',
+              'Changelog'
+            )}
+            url={CHANGELOG_URL}
+            icon={<ScrollText className="size-3.5" />}
+          />
+          <DropdownMenuSeparator />
+          <ExternalMenuItem
+            label={translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.5687ab246a',
+              'GitHub'
+            )}
+            url={GITHUB_URL}
+            icon={<Github className="size-3.5" />}
+          />
+          <DropdownMenuItem onSelect={() => openExternalUrl(DISCORD_URL)}>
+            <DiscordIcon />
+            {translate('auto.components.sidebar.SidebarSettingsHelpMenu.eb9884e55b', 'Discord')}
+            <ExternalLink className="ml-auto size-3 text-muted-foreground" />
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => openExternalUrl(X_URL)}>
+            <XIcon />
+            {translate('auto.components.sidebar.SidebarSettingsHelpMenu.c4f8e1b72a', 'X')}
+            <ExternalLink className="ml-auto size-3 text-muted-foreground" />
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
+            onPointerDown={handleCheckForUpdatesPointerDown}
+            onSelect={handleCheckForUpdates}
+            title={updateCheckHint}
+          >
+            {updateStatus.state === 'checking' ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+            {translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
+              'Check for Updates'
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={handleRestartOrca} disabled={isRestartingOrca}>
+            <RotateCw className="size-3.5" />
+            {translate(
+              'auto.components.sidebar.SidebarSettingsHelpMenu.ad3d3ed7f1',
+              'Restart Orca'
+            )}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   )
 }

--- a/src/renderer/src/hooks/ipc-events-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-test-harness.ts
@@ -121,6 +121,8 @@ export type IpcEventsHarness = {
   useIpcEvents: () => void
   createTerminal: (request: CreateTerminalRequest) => void
   requestTerminalCreate: (request: RequestTerminalCreateRequest) => void
+  /** Fires the Help > Send Feedback menu event the hook subscribed to. */
+  openFeedback: () => void
   replyTerminalCreate: ReturnType<typeof vi.fn>
 }
 
@@ -134,6 +136,7 @@ export async function loadIpcEventsHarness(
   const replyTerminalCreate = vi.fn()
   let createTerminalListener: ((request: CreateTerminalRequest) => void) | null = null
   let requestTerminalCreateListener: ((request: RequestTerminalCreateRequest) => void) | null = null
+  let openFeedbackListener: (() => void) | null = null
 
   vi.resetModules()
   vi.unstubAllGlobals()
@@ -187,6 +190,10 @@ export async function loadIpcEventsHarness(
           },
           onRequestTerminalCreate: (listener: (request: RequestTerminalCreateRequest) => void) => {
             requestTerminalCreateListener = listener
+            return () => {}
+          },
+          onOpenFeedback: (listener: () => void) => {
+            openFeedbackListener = listener
             return () => {}
           }
         }),
@@ -242,6 +249,12 @@ export async function loadIpcEventsHarness(
         throw new Error('Expected the request-terminal-create listener to be registered')
       }
       requestTerminalCreateListener(request)
+    },
+    openFeedback: () => {
+      if (typeof openFeedbackListener !== 'function') {
+        throw new Error('Expected the open-feedback listener to be registered')
+      }
+      openFeedbackListener()
     },
     replyTerminalCreate
   }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -9191,3 +9191,25 @@ describe('useIpcEvents silent terminal adoption (surfaceOwner: false)', () => {
     expect(storeState.setActiveTab).not.toHaveBeenCalled()
   })
 })
+
+describe('useIpcEvents Help > Send Feedback', () => {
+  // Regression: the listener used to live in SidebarSettingsHelpMenu, which is
+  // unmounted when the sidebar is collapsed or Settings/Activity/Space/Skills is
+  // active — the OS menu item was a silent no-op in exactly those states.
+  it('opens the feedback dialog with the sidebar collapsed on a sidebar-less view', async () => {
+    const setFeedbackDialogOpen = vi.fn()
+    const storeState = createHarnessStoreState({
+      tabsByWorktree: {},
+      activeView: 'settings',
+      sidebarOpen: false,
+      setFeedbackDialogOpen
+    })
+    const harness = await loadIpcEventsHarness(storeState)
+
+    harness.useIpcEvents()
+
+    // Throws if the hook never subscribed, so an unregistered listener fails loudly.
+    harness.openFeedback()
+    expect(setFeedbackDialogOpen).toHaveBeenCalledWith(true)
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1168,6 +1168,14 @@ export function useIpcEvents(): void {
       }) ?? (() => {})
     )
 
+    // Why: Help > Send Feedback must work with the sidebar collapsed or from Settings/Activity,
+    // where the sidebar help menu that owns the dialog trigger is unmounted.
+    unsubs.push(
+      window.api.ui.onOpenFeedback?.(() => {
+        useAppStore.getState().setFeedbackDialogOpen(true)
+      }) ?? (() => {})
+    )
+
     // Why: a phone stuck in a silent 4001 auth loop (lost device registry) reads as
     // "phone won't connect" with no clue on either end; main throttles to once per session.
     unsubs.push(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -91,7 +91,8 @@
     "openWorktreePalette": "Open Worktree Palette",
     "window": "Window",
     "help": "Help",
-    "paste": "Paste"
+    "paste": "Paste",
+    "sendFeedback": "Send Feedback..."
   },
   "tray": {
     "openOrca": "Open Orca",
@@ -12082,7 +12083,10 @@
           "useLan": "Use LAN",
           "retrying": "Retrying…",
           "retry": "Retry Relay",
-          "copyDiagnostics": "Copy diagnostics"
+          "copyDiagnostics": "Copy diagnostics",
+          "sendDiagnostics": "Send to Orca",
+          "diagnosticsSent": "Diagnostics sent to Orca",
+          "diagnosticsSendFailed": "Failed to send diagnostics"
         }
       },
       "gitlab": {
@@ -13454,7 +13458,9 @@
             "b2e36f53a1": "Failed to send crash report. Diagnostic ticket {{value0}} was uploaded but not linked.",
             "ead6fc0510": "No automatic crash report was captured. You can still send details and include recent diagnostic logs when available.",
             "b082f27490": "Attach recent diagnostic logs",
-            "e59f0b9427": "Sends a capped redacted log bundle with the report."
+            "e59f0b9427": "Sends a capped redacted log bundle with the report.",
+            "noCapturedCrashFeedback": "No automatic crash report was captured. This is filed as a user report, with your description and recent diagnostic logs when available.",
+            "userReportSent": "Report sent. Thanks for the details."
           },
           "submit": {
             "notice": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12086,7 +12086,8 @@
           "copyDiagnostics": "Copy diagnostics",
           "sendDiagnostics": "Send to Orca",
           "diagnosticsSent": "Diagnostics sent to Orca",
-          "diagnosticsSendFailed": "Failed to send diagnostics"
+          "diagnosticsSendFailed": "Failed to send diagnostics",
+          "sendingDiagnostics": "Sending…"
         }
       },
       "gitlab": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -64,7 +64,8 @@
     "openWorktreePalette": "Abrir paleta de worktrees",
     "window": "Ventana",
     "help": "Ayuda",
-    "paste": "Pegar"
+    "paste": "Pegar",
+    "sendFeedback": "Enviar comentarios..."
   },
   "tray": {
     "openOrca": "Abrir Orca",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -64,7 +64,8 @@
     "openWorktreePalette": "ワークツリーパレットを開く",
     "window": "ウィンドウ",
     "help": "ヘルプ",
-    "paste": "貼り付け"
+    "paste": "貼り付け",
+    "sendFeedback": "フィードバックを送信..."
   },
   "tray": {
     "openOrca": "Orcaを開く",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -64,7 +64,8 @@
     "openWorktreePalette": "워크트리 팔레트 열기",
     "window": "창",
     "help": "도움말",
-    "paste": "붙여넣기"
+    "paste": "붙여넣기",
+    "sendFeedback": "피드백 보내기..."
   },
   "tray": {
     "openOrca": "Orca 열기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -64,7 +64,8 @@
     "openWorktreePalette": "打开工作树面板",
     "window": "窗口",
     "help": "帮助",
-    "paste": "粘贴"
+    "paste": "粘贴",
+    "sendFeedback": "发送反馈..."
   },
   "tray": {
     "openOrca": "打开 Orca",

--- a/src/renderer/src/i18n/os-menu-locale-parity.test.ts
+++ b/src/renderer/src/i18n/os-menu-locale-parity.test.ts
@@ -1,0 +1,25 @@
+/**
+ * The `menu.*` namespace backs the OS menu bar, which every supported locale
+ * currently covers in full. A missing key there is invisible: translateMain()
+ * silently serves the English fallback next to localized siblings, and the
+ * catalog gate only warns because unrelated namespaces have known gaps.
+ */
+import { describe, expect, it } from 'vitest'
+import en from './locales/en.json'
+import es from './locales/es.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import zh from './locales/zh.json'
+
+const catalogs = { es, ja, ko, zh }
+
+describe('OS menu locale parity', () => {
+  it.each(Object.entries(catalogs))('%s translates every menu item', (_code, catalog) => {
+    const menu: Record<string, string> = catalog.menu
+    for (const [key, english] of Object.entries(en.menu)) {
+      expect(menu[key], `menu.${key} missing from catalog`).toBeDefined()
+      expect(menu[key]?.trim()).not.toBe('')
+      expect(menu[key], `menu.${key} fell back to the English source`).not.toBe(english)
+    }
+  })
+})

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -3539,3 +3539,15 @@ describe('createUISlice clearOsc52ClipboardDefaultOnNotice', () => {
     expect(setUI).toHaveBeenCalledWith({ osc52ClipboardDefaultOnNoticePending: false })
   })
 })
+
+describe('createUISlice feedbackDialogOpen', () => {
+  it('holds the feedback dialog outside the sidebar so any view can open it', () => {
+    const store = createUIStore()
+
+    expect(store.getState().feedbackDialogOpen).toBe(false)
+    store.getState().setFeedbackDialogOpen(true)
+    expect(store.getState().feedbackDialogOpen).toBe(true)
+    store.getState().setFeedbackDialogOpen(false)
+    expect(store.getState().feedbackDialogOpen).toBe(false)
+  })
+})

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -789,6 +789,9 @@ export type UISlice = {
   modalData: Record<string, unknown>
   openModal: (modal: UISlice['activeModal'], data?: Record<string, unknown>) => void
   closeModal: () => void
+  /** Why: the OS Help menu can request feedback from any view, so this lives outside the sidebar that hosts the menu button. */
+  feedbackDialogOpen: boolean
+  setFeedbackDialogOpen: (open: boolean) => void
   featureTipsSeenIds: FeatureTipId[]
   markFeatureTipsSeen: (ids: FeatureTipId[]) => void
   featureInteractions: FeatureInteractionState
@@ -1563,6 +1566,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     })
   },
   closeModal: () => set({ activeModal: 'none', modalData: {} }),
+  feedbackDialogOpen: false,
+  setFeedbackDialogOpen: (open) => set({ feedbackDialogOpen: open }),
   featureTipsSeenIds: [],
   markFeatureTipsSeen: (ids) =>
     set((s) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2680,6 +2680,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onOpenSetupGuide: () => noopUnsubscribe,
     onOpenFeatureTour: () => noopUnsubscribe,
     onOpenCrashReport: () => noopUnsubscribe,
+    onOpenFeedback: () => noopUnsubscribe,
     // No desktop main process to push state changes; the web client re-reads via ui.get on interaction.
     onStateChanged: () => noopUnsubscribe,
     onToggleLeftSidebar: () => noopUnsubscribe,


### PR DESCRIPTION
## What this fixes

**Signature:** `Reason: no captured crash report` / `- captured_crash_report: false` / `- report_source: help_menu`.

**Covers 11 of the 127 reports in this batch.** These are not crashes. They are ordinary bug reports that users filed through the OS menu bar's Help submenu, because "Report Crash…" was the only actionable item in it. Verified independently over the whole index, not taken on faith from triage:

```
$ python3 - <<'PY'   # over /tmp/crash-index.json
... count reports whose body contains 'Reason: no captured crash report'
PY
total index entries: 127
uncaptured help_menu reports: 11
['F0BLY6Q0MMM', 'F0BMBHBUSSH', 'F0BMBNGJ9N1', 'F0BMCBRNFQT', 'F0BMCC4Q0KG', 'F0BMDGUN1KQ',
 'F0BMJN07RNG', 'F0BMRGYU8CS', 'F0BMRU2UJ9L', 'F0BMSR9D7S8', 'F0BNC7T2DNC']
```

**Be clear about what this is:** this PR does not fix a crash. It eliminates 11 false-positive crash reports (8.7% of the batch) and fixes the product defect that produced them. The app never died in any of these — see the field data below.

### Root cause

1. **The OS Help submenu had no bug-report item.** `src/main/menu/register-app-menu.ts:295-310` on `origin/main`:

   ```ts
   const helpMenu: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.help', 'Help'),
     submenu: [
       crashReportItem,
       { type: 'separator' },
       featureTourItem,
       setupGuideItem,
       ...
   ```

   "Send Feedback" existed only in the in-app sidebar `(?)` menu (`src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx:232-238`), which is unmounted with the sidebar collapsed and on Settings/Activity/Space/Skills. The two Help surfaces were disjoint: the OS one had only crash reporting, the in-app one had only feedback.

2. **The crash dialog did nothing to redirect a bug reporter.** With `report === null` it still titled itself "Report a crash" and prompted "Optional: what happened?" (`src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx:42-66`), so nothing told the user they were in the wrong lane.

3. **The submitted body is hardcoded as a crash.** `src/shared/crash-reporting.ts:292-306` emits `'Status: uncaptured'`, `'Source: user-reported'`, `'Reason: no captured crash report'`, `'- report_source: help_menu'`, reached from `crashReports:submit` whenever `getRequestedCrashReport` returns null — which is by design for the menu path (`src/main/ipc/crash-reporting.ts:262-271`). The app never "detected" a crash here; the user opened the dialog and pressed Send.

4. **Aggravating path for 2 of the 11:** the mobile relay pairing failure banner offered only "Copy diagnostics" (`src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.tsx:114-124`). Both of those reports are that clipboard JSON pasted verbatim into the crash dialog.

5. **Found while fixing the above, and fixed here too:** all four `ui:` Help items (`ui:openFeedback`, `ui:openCrashReport`, `ui:openSetupGuide`, `ui:openFeatureTour`) were sent to the invoking `BrowserWindow`. The dashboard pop-out mounts none of those renderer listeners, so every one of them was a silent no-op while the pop-out was focused.

### Representative reports

| Report | Version / platform | User note (first line) | Slack |
| --- | --- | --- | --- |
| `F0BLY6Q0MMM` | 1.4.163 win32 10.0.26200 | `Korean IME: extra newline inserted when Shift+symbol follows Hangul composition` | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785616131631949) |
| `F0BMBHBUSSH` | 1.4.163 linux 5.15.0-139 | `{ "kind": "mobile_pairing_relay_failure", ... }` (pasted from Copy diagnostics) | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785652993409319) |
| `F0BMRGYU8CS` | 1.4.167 darwin 25.5.0 arm64 | `Not connecting SSH` | [permalink](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785790441885789) |

### What the fix does

- Adds **Send Feedback…** to the OS Help submenu, above Report Crash, on every platform (`register-app-menu.ts:139-143`, `:307`), routed through a new `ui:openFeedback` channel.
- Mounts the feedback dialog at the **app root** (`App.tsx:2741` → `AppFeedbackDialog.tsx`) driven by a new store flag (`store/slices/ui.ts` `feedbackDialogOpen`), so the menu item works with the sidebar collapsed and on sidebar-less views. `SidebarSettingsHelpMenu` no longer owns the dialog; it just flips the store flag. Because the dialog stays mounted while closed, a reflex Escape no longer throws away a long typed report, and a dismiss during an in-flight submit still lands its toast.
- Localizes the new menu entry in es/ja/ko/zh. It shipped English-only in an earlier commit on this branch, which put an English "Send Feedback…" directly above a localized "크래시 신고…" — steering exactly the non-English users this entry exists to help back into the crash channel. A new `os-menu-locale-parity` test now guards the whole `menu.*` namespace, because the existing catalog gate only *warns* on missing keys.
- Relabels the crash dialog when no report was captured: title "Tell us what went wrong", description "No crash was captured, so this reaches the Orca team as a user report…". **The transport intentionally stays the crash lane** — it is the only path that carries the diagnostic bundle, and ingest already receives `report_source: help_menu` + `captured_crash_report: false` to route on.
- Adds **Send to Orca** beside Copy diagnostics on the relay mint failure notice (both call sites: `MobileHeroPairingStep` and Settings › `MobilePane`), sending the identical payload through `feedback:submit`. It is in-flight guarded and shows a spinner.
- Routes Help-menu `ui:` events off the dashboard pop-out to the main window and raises it (`src/main/window/help-menu-event-target.ts`).

---

## Fix evidence

Windows verification: **not required for this item** (per `/tmp/crash-pr-meta.json`: `"windows": "not required"`). The change is menu construction, renderer store/dialog wiring, and locale JSON — no platform-conditional code paths.

### 1. RED without the source fix

Scratch worktree at the branch commit, source files reverted to `origin/main` (the three new source modules deleted), tests left exactly as they are on the branch. No `git stash` was used.

```
$ git worktree add /tmp/prproof-w4-help-feedback crashfix/w4-help-feedback --detach
$ ln -s .../w4-help-feedback/node_modules /tmp/prproof-w4-help-feedback/node_modules
$ git checkout origin/main -- config/scripts/locale-value-overrides.mjs src/main/index.ts \
    src/main/menu/register-app-menu.ts src/preload/api-types.ts src/preload/index.ts \
    src/renderer/src/App.tsx src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx \
    src/renderer/src/components/mobile/MobileHeroPairingStep.tsx \
    src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.tsx \
    src/renderer/src/components/settings/MobilePane.tsx \
    src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx \
    src/renderer/src/hooks/useIpcEvents.ts src/renderer/src/i18n/locales/*.json \
    src/renderer/src/store/slices/ui.ts src/renderer/src/web/web-preload-api.ts
$ rm -f src/main/window/help-menu-event-target.ts \
        src/renderer/src/components/feedback/AppFeedbackDialog.tsx \
        src/renderer/src/components/mobile/relay-mint-failure-feedback.ts
$ npx vitest run --config config/vitest.config.ts <the 9 touched test files>
```

Result — `EXIT=1`, **9 test files failed**:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/menu/register-app-menu.test.ts > registerAppMenu > keeps the macOS app-named menu with Settings and quit roles
AssertionError: expected [ 'Report Crash...', undefined, …(2) ] to deeply equal [ 'Send Feedback...', …(4) ]

- Expected
+ Received

  [
-   "Send Feedback...",
    "Report Crash...",
    undefined,
    "Explore Orca",
    "Getting Started with Orca",
  ]

 ❯ src/main/menu/register-app-menu.test.ts:275:24

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/10]⎯

 FAIL  src/main/menu/register-app-menu.test.ts > registerAppMenu > offers Send Feedback above Report Crash so ordinary bugs skip the crash channel
AssertionError: expected -1 to be greater than or equal to 0
 ❯ src/main/menu/register-app-menu.test.ts:324:27
    322|     const feedbackIndex = helpLabels.indexOf('Send Feedback...')
    323|     const crashIndex = helpLabels.indexOf('Report Crash...')
    324|     expect(feedbackIndex).toBeGreaterThanOrEqual(0)
       |                           ^

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[5/10]⎯

 FAIL  src/renderer/src/hooks/useIpcEvents.test.ts > useIpcEvents Help > Send Feedback > opens the feedback dialog with the sidebar collapsed on a sidebar-less view
Error: Expected the open-feedback listener to be registered
 ❯ Object.openFeedback src/renderer/src/hooks/ipc-events-test-harness.ts:255:15

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/10]⎯

 FAIL  src/renderer/src/components/crash-report/CrashReportDialogSurface.test.tsx > CrashReportDialogSurface without a captured crash report > reads as a user report rather than a crash
TestingLibraryElementError: Unable to find an element with the text: Tell us what went wrong.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/10]⎯

 FAIL  src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.test.tsx > MobileRelayMintFailureNotice > offers sending the diagnostics to Orca instead of only copying them
TestingLibraryElementError: Unable to find an accessible element with the role "button" and name "Send to Orca"

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/10]⎯

 FAIL  src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx > SidebarSettingsHelpMenu > opens the app-root feedback dialog through the store instead of owning it locally
TypeError: Cannot read properties of undefined (reading 'viewer')
 ❯ src/renderer/src/components/sidebar/SidebarFeedbackDialog.tsx:170:8

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[9/10]⎯

 FAIL  src/renderer/src/store/slices/ui.test.ts > createUISlice feedbackDialogOpen > holds the feedback dialog outside the sidebar so any view can open it
AssertionError: expected undefined to be false // Object.is equality

- Expected:
false

+ Received:
undefined

 ❯ src/renderer/src/store/slices/ui.test.ts:3547:49

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[10/10]⎯


 Test Files  9 failed (9)
      Tests  7 failed | 297 passed | 1 skipped (305)
   Start at  01:43:21
   Duration  12.04s
```

Three of the nine files fail at import rather than on an assertion, because the module the fix introduces does not exist on `origin/main` — stating that plainly rather than dressing it up as an assertion failure:

```
⎯⎯⎯⎯⎯⎯ Failed Suites 3 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/window/help-menu-event-target.test.ts [ src/main/window/help-menu-event-target.test.ts ]
Error: Cannot find module '/src/main/window/help-menu-event-target' imported from /private/tmp/prproof-w4-help-feedback/src/main/window/help-menu-event-target.test.ts
 ❯ src/main/window/help-menu-event-target.test.ts:10:1
     10| import { resolveHelpMenuEventTarget } from './help-menu-event-target'
       | ^

 FAIL  src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx [ ... ]
Error: Failed to resolve import "./AppFeedbackDialog" from "src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx". Does the file exist?

 FAIL  src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx [ ... ]
Error: Failed to resolve import "./relay-mint-failure-feedback" from "src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx". Does the file exist?
```

**Targeted red for the locale-parity guard.** Reverting *all* locale files also removes `menu.sendFeedback` from `en.json`, so the parity test would vacuously pass. To prove the guard actually catches the defect it was written for (the entry shipping English-only), the same scratch worktree was reset to the branch and only `es/ja/ko/zh.json` reverted:

```
$ git checkout origin/main -- src/renderer/src/i18n/locales/{es,ja,ko,zh}.json
$ npx vitest run --config config/vitest.config.ts src/renderer/src/i18n/os-menu-locale-parity.test.ts
EXIT=1

 ❯ src/renderer/src/i18n/os-menu-locale-parity.test.ts (4 tests | 4 failed) 8ms
     × es translates every menu item 5ms
     × ja translates every menu item 1ms
     × ko translates every menu item 1ms
     × zh translates every menu item 1ms

AssertionError: menu.sendFeedback missing from catalog: expected undefined to be defined
 ❯ src/renderer/src/i18n/os-menu-locale-parity.test.ts:20:61

 Test Files  1 failed (1)
      Tests  4 failed (4)
```

The scratch worktree was then removed with `git worktree remove --force` (confirmed gone).

### 2. GREEN with the fix

Same 9 files plus the locale-parity test, on the branch:

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/window/help-menu-event-target.test.ts src/main/menu/register-app-menu.test.ts \
    src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx \
    src/renderer/src/components/crash-report/CrashReportDialogSurface.test.tsx \
    src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx \
    src/renderer/src/components/mobile/mobile-relay-mint-failure-notice.test.tsx \
    src/renderer/src/i18n/os-menu-locale-parity.test.ts src/renderer/src/store/slices/ui.test.ts \
    src/renderer/src/hooks/useIpcEvents.test.ts \
    src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx

 Test Files  10 passed (10)
      Tests  316 passed | 1 skipped (317)
   Start at  01:41:34
   Duration  4.64s
```

The specific new cases:

```
 ✓ src/main/window/help-menu-event-target.test.ts > resolveHelpMenuEventTarget > keeps an ordinary invoking window so hidden and multi-window flows stay on their renderer 1ms
 ✓ src/main/window/help-menu-event-target.test.ts > resolveHelpMenuEventTarget > redirects the dashboard pop-out to the main window instead of dropping the click 0ms
 ✓ src/main/window/help-menu-event-target.test.ts > resolveHelpMenuEventTarget > falls back to the main window when the menu reports no invoking window 0ms
 ✓ src/main/window/help-menu-event-target.test.ts > resolveHelpMenuEventTarget > reports no window rather than a destroyed main window 0ms
 ✓ src/renderer/src/i18n/os-menu-locale-parity.test.ts > OS menu locale parity > es translates every menu item 2ms
 ✓ src/renderer/src/i18n/os-menu-locale-parity.test.ts > OS menu locale parity > ja translates every menu item 1ms
 ✓ src/renderer/src/i18n/os-menu-locale-parity.test.ts > OS menu locale parity > ko translates every menu item 1ms
 ✓ src/renderer/src/i18n/os-menu-locale-parity.test.ts > OS menu locale parity > zh translates every menu item 1ms
 ✓ src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx > useSendRelayMintFailureFeedback > drops repeat clicks while a send is in flight so one gh spawn and one report go out 83ms
 ✓ src/renderer/src/components/mobile/relay-mint-failure-feedback.test.tsx > useSendRelayMintFailureFeedback > disables Send to Orca and shows progress until the submit settles 25ms
 ✓ src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx > AppFeedbackDialog > keeps the typed report when the dialog is dismissed and reopened 124ms
 ✓ src/renderer/src/components/feedback/AppFeedbackDialog.test.tsx > AppFeedbackDialog > still reports a failed submit that the user dismissed while it was in flight 87ms
```

### 3. Regression suite — every touched module directory

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/menu src/main/window src/renderer/src/components/feedback \
    src/renderer/src/components/crash-report src/renderer/src/components/mobile \
    src/renderer/src/components/sidebar src/renderer/src/components/settings \
    src/renderer/src/hooks src/renderer/src/store src/renderer/src/i18n
EXIT=0

 Test Files  617 passed (617)
      Tests  6194 passed | 1 skipped (6195)
   Start at  01:44:06
   Duration  62.72s
```

**Zero failures — there are no pre-existing failures to name in these directories on this machine.**

Contract surfaces for the changed preload/IPC/report-format code:

```
$ npx vitest run --config config/vitest.config.ts src/preload \
    src/shared/crash-reporting.test.ts src/main/ipc/crash-reporting.test.ts

 Test Files  10 passed (10)
      Tests  49 passed (49)
```

Typecheck and the localization gate:

```
$ npx tsc --noEmit -p config/tsconfig.node.json    → exit 0, no output
$ npx tsc --noEmit -p config/tsconfig.tc.web.json  → exit 0, no output
$ npx oxlint <the 5 changed/new source files>      → no diagnostics

$ npm run verify:localization-catalog
Verified 11136 localization key references against en.json.
es.json coverage: 11808/11990 translated, 182 missing.
ja.json coverage: 11808/11990 translated, 182 missing.
ko.json coverage: 11808/11990 translated, 182 missing.
zh.json coverage: 11812/11990 translated, 178 missing.
```

(Those remaining "missing" counts are the pre-existing catalog gaps in unrelated namespaces — exactly the reason the gate only warns, and exactly why the new `menu.*` parity test was added as a hard assertion.)

### 4. Field data — proof the app never crashed

Every one of the 11 reports carries the machine-generated uncaptured header. Verbatim head of `F0BLY6Q0MMM`:

```
[Crash Report]

Report ID: not captured
Created: 2026-08-01T20:28:47.018Z
Status: uncaptured
Source: user-reported
Process: unknown
Reason: no captured crash report
Exit code: unknown
App version: 1.4.163
Platform: win32 10.0.26200 x64
Electron: 43.1.0
Chrome: 150.0.7871.47

Details:
- captured_crash_report: false
- report_source: help_menu

Diagnostic log:
- Status: attached
- Bundle submission ID: MDVmeG_iNK81jHvxxHTZbQ
- Spans: 6331
- Bytes: 4193967

User notes:
Korean IME: extra newline inserted when Shift+symbol follows Hangul composition
```

All 11 carry the same two markers:

```
F0BLY6Q0MMM: Reason: no captured crash report | - report_source: help_menu
F0BMCC4Q0KG: Reason: no captured crash report | - report_source: help_menu
F0BMJN07RNG: Reason: no captured crash report | - report_source: help_menu
F0BMBNGJ9N1: Reason: no captured crash report | - report_source: help_menu
F0BMCBRNFQT: Reason: no captured crash report | - report_source: help_menu
F0BMDGUN1KQ: Reason: no captured crash report | - report_source: help_menu
F0BMSR9D7S8: Reason: no captured crash report | - report_source: help_menu
F0BMRGYU8CS: Reason: no captured crash report | - report_source: help_menu
F0BMRU2UJ9L: Reason: no captured crash report | - report_source: help_menu
F0BMBHBUSSH: Reason: no captured crash report | - report_source: help_menu
F0BNC7T2DNC: Reason: no captured crash report | - report_source: help_menu
```

And all 9 attached diagnostic bundles contain **zero** `process_gone` spans — re-run for this PR, not quoted from triage:

```
$ for f in F0BMBJ58G4E F0BMEBK6BGS F0BMET7K1B4 F0BMD3HHELW F0BM997S64T \
           F0BM37XCG4X F0BNHEUAM9N F0BMKA03HFD F0BMMLFFNM9; do ... done
F0BMBJ58G4E process_gone_spans=0 total_spans=6332
F0BMEBK6BGS process_gone_spans=0 total_spans=6406
F0BMET7K1B4 process_gone_spans=0 total_spans=7065
F0BMD3HHELW process_gone_spans=0 total_spans=323
F0BM997S64T process_gone_spans=0 total_spans=116
F0BM37XCG4X process_gone_spans=0 total_spans=7211
F0BNHEUAM9N process_gone_spans=0 total_spans=2533
F0BMKA03HFD process_gone_spans=0 total_spans=2233
F0BMMLFFNM9 process_gone_spans=0 total_spans=7774
```

39,993 NDJSON lines across nine bundles, not one `electron.process_gone` or `electron.child_process_gone`. No process ever died.

What the users were actually reporting (first line of each note) — five Korean/Windows IME bugs, four SSH-connection bugs, two pasted relay-pairing JSON blobs:

```
F0BLY6Q0MMM   Korean IME: extra newline inserted when Shift+symbol follows Hangul composition
F0BMCC4Q0KG   Same root cause as #6147 (IME-committed characters bypassing the
F0BMJN07RNG   ▏ Title: Korean IME composition broken after recent update
F0BMBNGJ9N1   Korean IME input lag in built-in terminal
F0BMCBRNFQT   저는 한국 유저입니다. 한국어로 프롬프트를 하면 아래와 같이 자동으로 계쏙 줄바꿈이 됩니다.
F0BMDGUN1KQ   When using SSH to work on a remote server (Mac Mini in my case), the agentic chat-interface doe
F0BMSR9D7S8   After updating Orca to version 1.4.167, Remote SSH relay reconnection stopped working correctly
F0BMRGYU8CS   Not connecting SSH
F0BMRU2UJ9L   ssh 접속이 안됨.
F0BMBHBUSSH   {
F0BNC7T2DNC   {
```

Note that 6 of the 11 are from Korean-locale users, which is what makes the English-only menu entry (fixed here) a material part of the defect and not cosmetic polish.

**Causal strength, stated honestly.** The link between "Report Crash was the only Help item" and "users filed bugs as crashes" is a strong inference from the reports' own content and headers, not a controlled experiment. What *is* proven outright: (a) none of these 11 were crashes, (b) the OS Help menu had no feedback item on `origin/main`, (c) both of the relay-pairing reports are byte-identical to the payload the Copy-diagnostics button produces. Whether adding the menu entry reduces the false-positive rate to zero can only be measured after ship.

---

## ELI5

Imagine an office with two doors. The door on the hallway — the one everybody walks past — is labelled **"EMERGENCY: REPORT A FIRE."** The door for ordinary requests ("the printer is jammed") is inside the building, down a corridor, and half the time it isn't even there.

So when someone's printer jams, they do the only thing they can: they pull the fire alarm and write "printer jammed" on the incident form. Now the fire department gets eleven calls a week that aren't fires, and the real fires are harder to spot in the pile.

That's what happened here. Orca's menu bar had a Help menu whose only useful button was "Report Crash…". Users with Korean keyboard bugs, SSH connection problems, and phone-pairing failures had nowhere else to go, so they clicked it. The app dutifully filed each one as a crash report — even though it wrote right in the report that *no crash was captured*, and even though the attached logs show the app never so much as hiccuped.

The fix puts a second, clearly-labelled door right next to the first one: **"Send Feedback…"**, listed *above* Report Crash so it's what you see first. Three extra details mattered:

- The feedback form used to live inside the app's sidebar. If you'd collapsed the sidebar, or were on the Settings page, the form simply didn't exist to open. So the form was moved to live at the top level of the app, where the menu can always reach it.
- The new menu entry initially shipped in English only. A Korean user would have seen an English "Send Feedback…" sitting directly above a perfectly Korean "크래시 신고…" — and would reasonably have picked the Korean one, right back into the crash channel. Six of the eleven reports came from Korean-locale users, so it's now translated, with a test that fails the build if anyone adds a menu item in English only again.
- The phone-pairing error banner had a "Copy diagnostics" button and nothing else. Two users copied that blob and pasted it into the crash dialog because that was the only place to put it. There's now a "Send to Orca" button right next to it.

And if you do end up in the crash dialog with no crash to report, it no longer insists it's a crash — it says "Tell us what went wrong" and tells you it's going to the team as a user report.

---

## Trade-offs

Not "none". Here is everything that changes or got worse:

1. **This fixes zero crashes.** It removes 11 false positives from the crash channel (8.7% of the batch) and fixes the product defect behind them. Nobody's app stops crashing because of this PR. The *content* of those 11 reports — IME, SSH, relay pairing — is real user pain that other triage groups own.

2. **The remaining uncaptured reports still land in the crash channel.** By design: `crashReports:submit` is the only path that carries the diagnostic bundle, and the bundle is often the only usable signal when the note is one line ("Not connecting SSH"). Reports now arrive labelled and honestly presented, but the crash channel does not get cleaner until ingest routes on `report_source: help_menu` + `captured_crash_report: false`. **That ingest-side change is not in this PR and is required to realize the benefit.**

3. **Known follow-up, deliberately not fixed here:** user notes arrive truncated to ~200 characters in the Slack `.txt` (the bodies observed were 743/754/744 bytes) even though the app caps at 64,000. That truncation is server/Slack-bot side, outside this repo. Mitigation: raise the truncation in the ingest bot — until then, most of a report's body is destroyed on the way in, which independently pushes users to re-file.

4. **The crash dialog's title changes for genuinely-crashed-but-uncaptured users too.** If a real crash occurred and the crash reporter failed to capture it, the dialog now says "Tell us what went wrong" instead of "Report a crash". That is a softer framing than the situation warrants for that (rarer) case. Accepted because the uncaptured path is overwhelmingly the manual one — 11 of 11 in this batch.

5. **Help menu items now steal focus from the dashboard pop-out.** Clicking Send Feedback / Report Crash / Setup Guide / Explore Orca while the pop-out is focused raises the main window in front of it. Previously the click did nothing at all, silently. Raising the window is the lesser evil, but it *is* a new focus change that did not happen before.

6. **The feedback dialog is now mounted for the whole session**, closed, at the app root. That is what preserves a typed draft across a reflex Escape and keeps an in-flight submit's toast alive. Cost: one always-mounted (closed) Radix dialog. `/perf` reviewed this and found no regression from the mount itself.

7. **A typed feedback draft now survives dismissal for the rest of the session.** It clears on a successful send (`SidebarFeedbackDialog.tsx:249`) but there is no explicit "discard" affordance — a user who dismisses intending to abandon the draft will find it waiting next time they open the dialog.

8. **New CI friction:** `os-menu-locale-parity.test.ts` hard-fails if any `menu.*` key is added to `en.json` without es/ja/ko/zh. Intentional — the existing catalog gate only warns — but it does mean menu-bar changes now require translations in the same PR.

9. **The es/ja/ko/zh strings for "Send Feedback…" came from the repo's locale override table, not a native-speaker review.** They are consistent with the adjacent "Report Crash…" translations already shipped, but they have not been proofread by a speaker of each language.

10. **"Send to Orca" fires a `gh api user` subprocess** to attach the reporter's identity (best-effort; a missing `gh` session does not block the send). This is guarded against repeat clicks by an in-flight ref *and* a disabled+spinner button — that guard exists because `/perf` caught the unguarded version spawning a subprocess and filing a duplicate report per click.

---

## Adversarial review

**5 independent adversarial review rounds** were run on this change, each by a fresh reviewer with no memory of the prior rounds, producing **4 rounds of fixes**. Round-over-round, the reviews surfaced:

- The `ui:openFeedback` listener being unreachable from views that unmount the sidebar — which is why the dialog was lifted from `SidebarSettingsHelpMenu` to a root-mounted `AppFeedbackDialog` driven by a store flag.
- The root mount being *conditional*, which unmounted the dialog on every close and so discarded the typed report and its screenshots on a reflex Escape or outside click, and silenced both the success and failure toasts when a dismiss raced an in-flight submit. Fixed by mounting unconditionally.
- The new Help items targeting the invoking window, making all four `ui:` Help entries silent no-ops while the dashboard pop-out was focused. Fixed by `resolveHelpMenuEventTarget` plus raising the main window.
- The menu entry shipping in `en.json` only, so es/ja/ko/zh rendered an English "Send Feedback…" directly above a localized "Report Crash…" — actively steering non-English users (6 of the 11 reporters) back into the crash channel. Fixed, and guarded by the new `menu.*` parity test.
- "Send to Orca" having no visible busy state against main's 10s submit deadline, so nothing changed on screen and users kept clicking a button that was silently dropping their clicks. Fixed with a spinner/disabled treatment mirroring Retry Relay.

**Final verdict: clean — zero blocking findings, zero major findings.**

**`/perf` verdict:** a regression *was* found by `/perf` and fixed in-branch — the unguarded in-flight feedback submit, where each repeat click spawned its own `gh api user` subprocess against the shared `gh` concurrency limit and filed a duplicate report. The fix (in-flight ref + disabled button) is covered by `useSendRelayMintFailureFeedback > drops repeat clicks while a send is in flight so one gh spawn and one report go out`. No outstanding performance regressions.

Made with [Orca](https://github.com/stablyai/orca) 🐋
