### PR TITLE
fix(mobile): keep paged chat history coherent across reconnect replays (STA-3333)

### DIFF
--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -133,19 +133,64 @@ describe('applyMobileNativeChatStreamFrame', () => {
     const merger = createNativeChatMerger()
     replaceList(merger, ['old-1', 'shared', 'old-tail'].map(message))
 
+    // `hasMore: true` so the authoritative-removal rule can't short-circuit —
+    // the contiguity scan itself must reject the interleaved new message.
     const replay = [message('shared'), message('compacted-summary'), message('old-tail')]
     expect(
       applyMobileNativeChatStreamFrame({
         merger,
-        frame: { type: 'snapshot', messages: replay, hasMore: false, beforeOffset: 0 },
+        frame: { type: 'snapshot', messages: replay, hasMore: true, beforeOffset: 9 },
         limit: 100,
         replaceSnapshot: false
       })
     ).toEqual({
       kind: 'messages',
       messages: replay,
-      hasMore: false,
-      beforeOffset: 0,
+      hasMore: true,
+      beforeOffset: 9,
+      windowReplaced: true
+    })
+  })
+
+  it('replaces a replay that repeats retained ids out of order', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['a', 'b', 'c'].map(message))
+
+    const replay = [message('a'), message('c'), message('b')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: true, beforeOffset: 4 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: true,
+      beforeOffset: 4,
+      windowReplaced: true
+    })
+  })
+
+  it('replaces a replay that stops short of the retained newest row', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['a', 'b', 'c'].map(message))
+
+    // Merging would keep 'c', a row the replayed window no longer carries.
+    const replay = [message('a'), message('b')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: true, beforeOffset: 1 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: true,
+      beforeOffset: 1,
       windowReplaced: true
     })
   })

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -103,6 +103,27 @@ describe('applyMobileNativeChatStreamFrame', () => {
     })
   })
 
+  it('ignores replay paging metadata that describes a row other than our oldest', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['p1', 'p2', 'a', 'b'].map(message))
+
+    // `beforeOffset` here points before 'a', not before 'p1'. Adopting it would
+    // make the next loadEarlier re-fetch 'p1'/'p2' and prepend them twice.
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: {
+          type: 'snapshot',
+          messages: [message('a'), message('b')],
+          hasMore: true,
+          beforeOffset: 500
+        },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({ kind: 'messages', messages: ['p1', 'p2', 'a', 'b'].map(message) })
+  })
+
   it('replaces the window when a reconnect replay is disjoint from history', () => {
     const merger = createNativeChatMerger()
     replaceList(merger, [message('old-1'), message('old-2')])
@@ -245,6 +266,33 @@ describe('applyMobileNativeChatStreamFrame', () => {
       kind: 'messages',
       messages: [message('new')],
       hasMore: false,
+      windowReplaced: true
+    })
+  })
+
+  it('still treats the base snapshot as authoritative after a replacement frame', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['a', 'b'].map(message))
+
+    // A replacement is not this subscription's base snapshot, so the first real
+    // snapshot still replaces — merging would keep 'a', which it does not carry.
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: {
+          type: 'snapshot',
+          messages: [message('b'), message('c')],
+          hasMore: true,
+          beforeOffset: 77
+        },
+        limit: 100,
+        replaceSnapshot: true
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: [message('b'), message('c')],
+      hasMore: true,
+      beforeOffset: 77,
       windowReplaced: true
     })
   })

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -237,6 +237,29 @@ describe('applyMobileNativeChatStreamFrame', () => {
     })
   })
 
+  it('replaces retained history when a single row precedes an authoritative replay', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['removed-1', 'a', 'b'].map(message))
+
+    // Boundary of the `firstIndex > 0` rule: one dropped row is still a dropped
+    // row, and merging here would strand 'removed-1' the host no longer has.
+    const replay = [message('a'), message('b')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: false, beforeOffset: 0 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: false,
+      beforeOffset: 0,
+      windowReplaced: true
+    })
+  })
+
   it('keeps the pagination cursor when an append does not trim history', () => {
     const merger = createNativeChatMerger()
     replaceList(merger, [message('a')])

--- a/mobile/src/session/mobile-native-chat-stream-frame.test.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.test.ts
@@ -32,7 +32,8 @@ describe('applyMobileNativeChatStreamFrame', () => {
       kind: 'messages',
       messages: [message('a'), message('b')],
       hasMore: true,
-      beforeOffset: 123
+      beforeOffset: 123,
+      windowReplaced: true
     })
   })
 
@@ -42,7 +43,12 @@ describe('applyMobileNativeChatStreamFrame', () => {
 
     const result = applyMobileNativeChatStreamFrame({
       merger,
-      frame: { type: 'snapshot', messages: [message('b'), message('c'), message('d')] },
+      frame: {
+        type: 'snapshot',
+        messages: [message('b'), message('c'), message('d')],
+        hasMore: true,
+        beforeOffset: 20
+      },
       limit: 3,
       replaceSnapshot: false
     })
@@ -50,7 +56,118 @@ describe('applyMobileNativeChatStreamFrame', () => {
     expect(result).toMatchObject({
       kind: 'messages',
       messages: [message('b'), message('c'), message('d')],
-      cursorInvalidated: true
+      cursorInvalidated: true,
+      hasMore: true
+    })
+  })
+
+  it('refreshes paging metadata when a replay still starts at the retained oldest row', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, [message('a'), message('b')])
+
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: {
+          type: 'snapshot',
+          messages: [message('a'), message('b')],
+          hasMore: false,
+          beforeOffset: 0
+        },
+        limit: 40,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: [message('a'), message('b')],
+      hasMore: false,
+      beforeOffset: 0
+    })
+  })
+
+  it('keeps paged-in history when a reconnect replay overlaps it', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['p1', 'p2', 'a', 'b'].map(message))
+
+    const result = applyMobileNativeChatStreamFrame({
+      merger,
+      // Replayed window: the retained tail plus what arrived while disconnected.
+      frame: { type: 'snapshot', messages: [message('a'), message('b'), message('c')] },
+      limit: 100,
+      replaceSnapshot: false
+    })
+
+    expect(result).toEqual({
+      kind: 'messages',
+      messages: ['p1', 'p2', 'a', 'b', 'c'].map(message)
+    })
+  })
+
+  it('replaces the window when a reconnect replay is disjoint from history', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, [message('old-1'), message('old-2')])
+
+    // A long outage (or compaction while away) cannot be stitched without a gap.
+    const result = applyMobileNativeChatStreamFrame({
+      merger,
+      frame: {
+        type: 'snapshot',
+        messages: [message('fresh-1'), message('fresh-2')],
+        hasMore: true,
+        beforeOffset: 900
+      },
+      limit: 100,
+      replaceSnapshot: false
+    })
+
+    expect(result).toEqual({
+      kind: 'messages',
+      messages: [message('fresh-1'), message('fresh-2')],
+      hasMore: true,
+      beforeOffset: 900,
+      windowReplaced: true
+    })
+  })
+
+  it('replaces a partially overlapping replay that no longer extends the retained tail', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['old-1', 'shared', 'old-tail'].map(message))
+
+    const replay = [message('shared'), message('compacted-summary'), message('old-tail')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: false, beforeOffset: 0 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: false,
+      beforeOffset: 0,
+      windowReplaced: true
+    })
+  })
+
+  it('replaces retained history when replay metadata says no earlier rows remain', () => {
+    const merger = createNativeChatMerger()
+    replaceList(merger, ['removed-1', 'removed-2', 'a', 'b'].map(message))
+
+    const replay = [message('a'), message('b')]
+    expect(
+      applyMobileNativeChatStreamFrame({
+        merger,
+        frame: { type: 'snapshot', messages: replay, hasMore: false, beforeOffset: 0 },
+        limit: 100,
+        replaceSnapshot: false
+      })
+    ).toEqual({
+      kind: 'messages',
+      messages: replay,
+      hasMore: false,
+      beforeOffset: 0,
+      windowReplaced: true
     })
   })
 
@@ -79,7 +196,12 @@ describe('applyMobileNativeChatStreamFrame', () => {
         limit: 40,
         replaceSnapshot: false
       })
-    ).toEqual({ kind: 'messages', messages: [message('new')], hasMore: false })
+    ).toEqual({
+      kind: 'messages',
+      messages: [message('new')],
+      hasMore: false,
+      windowReplaced: true
+    })
   })
 
   it('surfaces snapshot errors and ignores unrelated frames', () => {

--- a/mobile/src/session/mobile-native-chat-stream-frame.ts
+++ b/mobile/src/session/mobile-native-chat-stream-frame.ts
@@ -19,10 +19,47 @@ export type AppliedMobileNativeChatFrame =
       hasMore?: boolean
       beforeOffset?: number
       cursorInvalidated?: boolean
+      /** The frame replaced the whole retained window (replacement, first
+       *  snapshot, or a replay snapshot disjoint from local history) — the
+       *  caller must reset its paging window/cursor to the frame's. */
+      windowReplaced?: boolean
     }
 
+function replayRetainedTailStart(
+  merger: NativeChatMerger,
+  messages: readonly NativeChatMessage[],
+  hasMore: boolean | undefined
+): number | null {
+  const firstIndex = messages[0] ? merger.indexById.get(messages[0].id) : undefined
+  if (firstIndex === undefined) {
+    return null
+  }
+  // `hasMore: false` is authoritative: retained rows before the replay window
+  // were removed while disconnected, even when the newest IDs still match.
+  if (hasMore === false && firstIndex > 0) {
+    return null
+  }
+  let expectedIndex = firstIndex
+  let sawNewMessage = false
+  for (const message of messages) {
+    const existingIndex = merger.indexById.get(message.id)
+    if (existingIndex === undefined) {
+      sawNewMessage = true
+    } else if (sawNewMessage || existingIndex !== expectedIndex) {
+      return null
+    } else {
+      expectedIndex += 1
+    }
+  }
+  return expectedIndex === merger.list.length ? firstIndex : null
+}
+
 /** Applies runtime stream frames while preserving the initial-snapshot versus
- *  reconnect-replay distinction owned by the session hook. */
+ *  reconnect-replay distinction owned by the session hook. A replay snapshot
+ *  that extends a contiguous retained tail merges in by id — paged-in history
+ *  survives a socket blip instead of collapsing to the replayed window. A
+ *  discontinuous replay (long outage, compaction while away) can't be stitched
+ *  without a gap, so it falls back to the fresh authoritative window. */
 export function applyMobileNativeChatStreamFrame(args: {
   merger: NativeChatMerger
   frame: MobileNativeChatStreamFrame
@@ -42,22 +79,39 @@ export function applyMobileNativeChatStreamFrame(args: {
   if (!Array.isArray(frame.messages)) {
     return { kind: 'ignored' }
   }
-  if (frame.type === 'replacement' || (frame.type === 'snapshot' && replaceSnapshot)) {
+  const replayStartIndex =
+    frame.type === 'snapshot' && !replaceSnapshot && merger.list.length > 0
+      ? replayRetainedTailStart(merger, frame.messages, frame.hasMore)
+      : null
+  if (frame.type === 'replacement' || (frame.type === 'snapshot' && replayStartIndex === null)) {
     replaceList(merger, frame.messages)
     return {
       kind: 'messages',
       messages: merger.list,
       hasMore: frame.hasMore,
+      windowReplaced: true,
       ...(frame.beforeOffset == null ? {} : { beforeOffset: frame.beforeOffset })
     }
   }
   const previousFirstId = merger.list[0]?.id
   const messages = applyAppend(merger, frame.messages, limit)
+  const cursorInvalidated = Boolean(previousFirstId && messages[0]?.id !== previousFirstId)
+  const replayStillStartsAtOldest = frame.type === 'snapshot' && replayStartIndex === 0
   return {
     kind: 'messages',
     messages,
     // Why: once the bounded live window drops its oldest row, the snapshot's
     // byte cursor no longer describes the oldest retained message.
-    ...(previousFirstId && messages[0]?.id !== previousFirstId ? { cursorInvalidated: true } : {})
+    ...(cursorInvalidated ? { cursorInvalidated: true } : {}),
+    // A trimmed replay creates page-able history even if the prior window had
+    // none; otherwise only a replay sharing our oldest row owns its metadata.
+    ...(frame.type === 'snapshot' && cursorInvalidated
+      ? { hasMore: true }
+      : replayStillStartsAtOldest
+        ? {
+            ...(frame.hasMore == null ? {} : { hasMore: frame.hasMore }),
+            ...(frame.beforeOffset == null ? {} : { beforeOffset: frame.beforeOffset })
+          }
+        : {})
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -333,6 +333,30 @@ describe('useMobileNativeChatSession', () => {
     expect(state?.hasMore).toBe(false)
   })
 
+  it('keeps the base snapshot authoritative when a live append arrives first', async () => {
+    const sendRequest = vi.fn()
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    // Only a snapshot marks the base as delivered, so an append landing first
+    // must not demote the real base snapshot to a reconnect replay.
+    await act(async () =>
+      emit({ type: 'appended', messages: [message('early-a'), message('early-b')] })
+    )
+    await act(async () =>
+      emit({
+        type: 'snapshot',
+        messages: [message('early-b'), message('base-c')],
+        hasMore: true,
+        beforeOffset: 3
+      })
+    )
+
+    expect(state?.messages.map((entry) => entry.id)).toEqual(['early-b', 'base-c'])
+  })
+
   it('rejects a cursor page invalidated by live trim and retries with a growing tail', async () => {
     let resolveCursorPage: (response: unknown) => void = () => {}
     const sendRequest = vi

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -174,6 +174,143 @@ describe('useMobileNativeChatSession', () => {
     }
   )
 
+  it('keeps paged-in history across an auto-reconnect replay snapshot', async () => {
+    // The transport replays the subscription with its original params after an
+    // in-place reconnect, so the replayed snapshot is the newest initial window
+    // again. It must merge into the grown history, not truncate it back to 40.
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        messages: Array.from({ length: 60 }, (_unused, index) => message(`paged-${index}`)),
+        hasMore: false,
+        beforeOffset: 40
+      }
+    })
+    const window = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: window, hasMore: true, beforeOffset: 100 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+    expect(state?.messages).toHaveLength(100)
+
+    // Reconnect replay: the same newest-40 window. History survives untouched.
+    await act(async () =>
+      emit({ type: 'snapshot', messages: window, hasMore: true, beforeOffset: 100 })
+    )
+    expect(state?.messages).toHaveLength(100)
+    expect(state?.messages[0]?.id).toBe('paged-0')
+
+    // A replay carrying one message that arrived while away merges it in; the
+    // grown window stays bounded, so only the single oldest row trims.
+    await act(async () =>
+      emit({
+        type: 'snapshot',
+        messages: [...window, message('live-1')],
+        hasMore: true,
+        beforeOffset: 100
+      })
+    )
+    expect(state?.messages).toHaveLength(100)
+    expect(state?.messages[0]?.id).toBe('paged-1')
+    expect(state?.messages.at(-1)?.id).toBe('live-1')
+  })
+
+  it('enables paging when a replay trims a window that previously had no earlier rows', async () => {
+    // Never settles: this asserts the request the replay's cursor produces.
+    const sendRequest = vi.fn(() => new Promise<never>(() => {}))
+    const window = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: window, hasMore: false, beforeOffset: 0 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    await act(async () =>
+      emit({
+        type: 'snapshot',
+        messages: [...window.slice(1), message('live-1')],
+        hasMore: true,
+        beforeOffset: 10
+      })
+    )
+
+    expect(state?.messages[0]?.id).toBe('win-1')
+    expect(state?.hasMore).toBe(true)
+    act(() => state?.loadEarlier())
+    expect(sendRequest).toHaveBeenCalledWith('nativeChat.readSession', {
+      agent: 'claude',
+      sessionId: 'session',
+      limit: 100
+    })
+  })
+
+  it('drops paged rows that an authoritative replay says were removed', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        messages: Array.from({ length: 60 }, (_unused, index) => message(`paged-${index}`)),
+        hasMore: false,
+        beforeOffset: 40
+      }
+    })
+    const window = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: window, hasMore: true, beforeOffset: 100 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    await act(async () => {
+      state?.loadEarlier()
+      await Promise.resolve()
+    })
+    expect(state?.messages).toHaveLength(100)
+
+    await act(async () =>
+      emit({ type: 'snapshot', messages: window, hasMore: false, beforeOffset: 0 })
+    )
+
+    expect(state?.messages).toEqual(window)
+    expect(state?.hasMore).toBe(false)
+  })
+
+  it('clears a stale cursor when a replacement omits paging metadata', async () => {
+    // Never settles: this asserts the request the cleared cursor produces.
+    const sendRequest = vi.fn(() => new Promise<never>(() => {}))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({
+        type: 'snapshot',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`)),
+        hasMore: true,
+        beforeOffset: 100
+      })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+
+    await act(async () =>
+      emit({
+        type: 'replacement',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`new-${index}`))
+      })
+    )
+    act(() => state?.loadEarlier())
+
+    expect(sendRequest).toHaveBeenCalledWith('nativeChat.readSession', {
+      agent: 'claude',
+      sessionId: 'session',
+      limit: 100
+    })
+  })
+
   it('rejects a cursor page invalidated by live trim and retries with a growing tail', async () => {
     let resolveCursorPage: (response: unknown) => void = () => {}
     const sendRequest = vi

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -333,6 +333,38 @@ describe('useMobileNativeChatSession', () => {
     expect(state?.hasMore).toBe(false)
   })
 
+  it('fences an in-flight older page when a merging replay re-cuts the byte cursor', async () => {
+    let resolveEarlier: (response: unknown) => void = () => {}
+    const sendRequest = vi.fn(
+      () => new Promise((resolve) => (resolveEarlier = resolve))
+    ) as unknown as RpcClient['sendRequest']
+    const retained = Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`))
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({ type: 'snapshot', messages: retained, hasMore: true, beforeOffset: 100 })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    act(() => state?.loadEarlier())
+
+    // The replay merges (same rows, no trim), but the host re-cut the file, so
+    // it carries a new cursor. The page already in flight was addressed with the
+    // old offset and would write that stale cursor back over the fresh one.
+    await act(async () =>
+      emit({ type: 'snapshot', messages: retained, hasMore: true, beforeOffset: 250 })
+    )
+    await act(async () => {
+      resolveEarlier({
+        ok: true,
+        result: { messages: [message('stale-page')], hasMore: true, beforeOffset: 40 }
+      })
+      await Promise.resolve()
+    })
+
+    expect(state?.messages.some((entry) => entry.id === 'stale-page')).toBe(false)
+    expect(state?.loadingEarlier).toBe(false)
+  })
+
   it('keeps the base snapshot authoritative when a live append arrives first', async () => {
     const sendRequest = vi.fn()
     const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -311,6 +311,28 @@ describe('useMobileNativeChatSession', () => {
     })
   })
 
+  it('clears hasMore when a replaced window is shorter than the initial page', async () => {
+    // A replaced window without paging metadata is judged by its own length:
+    // shorter than a full page means the whole transcript is on screen.
+    const sendRequest = vi.fn()
+    const subscribe: RpcClient['subscribe'] = vi.fn((_method, _params, onData) => {
+      emit = onData
+      onData({
+        type: 'snapshot',
+        messages: Array.from({ length: 40 }, (_unused, index) => message(`win-${index}`)),
+        hasMore: true,
+        beforeOffset: 100
+      })
+      return () => {}
+    })
+    await mount({ sendRequest, subscribe } as unknown as RpcClient)
+    expect(state?.hasMore).toBe(true)
+
+    await act(async () => emit({ type: 'replacement', messages: [message('only')] }))
+
+    expect(state?.hasMore).toBe(false)
+  })
+
   it('rejects a cursor page invalidated by live trim and retries with a growing tail', async () => {
     let resolveCursorPage: (response: unknown) => void = () => {}
     const sendRequest = vi

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -92,6 +92,9 @@ export function useMobileNativeChatSession(args: {
   const sessionIdRef = useRef<string | null>(sessionId)
   sessionIdRef.current = sessionId
   const streamGenerationRef = useRef(0)
+  // Whether this subscription already delivered its base snapshot; later
+  // snapshots on the same subscription are reconnect replays, not fresh bases.
+  const snapshotSeenRef = useRef(false)
 
   // Replace the base list (read results are an ordered tail). Resets the merger
   // cache so the index is rebuilt once over the new base.
@@ -107,6 +110,7 @@ export function useMobileNativeChatSession(args: {
     streamGenerationRef.current += 1
     limitRef.current = INITIAL_LIMIT
     loadingEarlierRef.current = false
+    snapshotSeenRef.current = false
     setLoadingEarlier(false)
     setList([])
     setError(undefined)
@@ -133,20 +137,11 @@ export function useMobileNativeChatSession(args: {
           return
         }
         const frame = raw as MobileNativeChatStreamFrame
-        if (frame.type === 'replacement' || frame.type === 'snapshot') {
-          // Why: replacement and reconnect snapshots are authoritative windows;
-          // stale page limits/results must not constrain the fresh generation.
-          streamGenerationRef.current += 1
-          limitRef.current = INITIAL_LIMIT
-          loadingEarlierRef.current = false
-          setLoadingEarlier(false)
-        }
-        const replaceSnapshot = frame.type === 'snapshot'
         const applied = applyMobileNativeChatStreamFrame({
           merger: mergerRef.current,
           frame,
           limit: limitRef.current,
-          replaceSnapshot
+          replaceSnapshot: !snapshotSeenRef.current
         })
         if (applied.kind === 'ignored') {
           return
@@ -156,11 +151,28 @@ export function useMobileNativeChatSession(args: {
           setError(applied.error)
           return
         }
+        if (frame.type === 'snapshot') {
+          snapshotSeenRef.current = true
+        }
+        if (applied.windowReplaced || frame.type === 'snapshot') {
+          // Why: any authoritative window (and any replay merge) invalidates an
+          // in-flight older-page request; stale results must not land on it.
+          streamGenerationRef.current += 1
+          loadingEarlierRef.current = false
+          setLoadingEarlier(false)
+        }
+        if (applied.windowReplaced) {
+          // Only a genuinely fresh window resets the grown read window — an
+          // overlapping reconnect replay keeps the paged-in history and limit.
+          limitRef.current = INITIAL_LIMIT
+          beforeOffsetRef.current = applied.beforeOffset ?? null
+          setHasMore(applied.hasMore ?? applied.messages.length >= INITIAL_LIMIT)
+        }
         setMessages(applied.messages)
-        if (applied.hasMore != null) {
+        if (!applied.windowReplaced && applied.hasMore != null) {
           setHasMore(applied.hasMore)
         }
-        if (applied.beforeOffset != null) {
+        if (!applied.windowReplaced && applied.beforeOffset != null) {
           beforeOffsetRef.current = applied.beforeOffset
         }
         if (applied.cursorInvalidated) {


### PR DESCRIPTION
## Summary

Auto-reconnect no longer truncates native-chat history back to the initial 40 messages.

The mobile transport replays `nativeChat.subscribe` with its original params after an in-place reconnect, so the replayed `snapshot` is the newest initial window again. The session hook treated *every* snapshot as a fresh base and replaced the list — so after paging in older history, a socket blip silently threw that history away.

The hook now tracks whether the current subscription already delivered its base snapshot; later snapshots on the same subscription are reconnect replays, and the frame applier decides how to fold them in:

- **Overlapping replay** — a replay that extends a contiguous retained tail merges in by id, so paged-in history survives the blip.
- **Disjoint replay** (long outage, compaction while away) — cannot be stitched without a silent gap, so it falls back to the fresh authoritative window.
- **Authoritative paging metadata** — `hasMore: false` on a replay is authoritative: retained rows older than the replay window really were removed, so they are dropped even when the newest ids still match. A replay that still starts at our oldest retained row refreshes `hasMore`/`beforeOffset`; a replay whose merge trimmed the window sets `hasMore: true`, because a trim creates page-able history even if the previous window had none.
- **Stale-cursor avoidance** — only a genuinely replaced window resets the grown read limit and cursor (an overlapping replay keeps both). Any snapshot bumps the stream generation so an in-flight older-page request cannot land its result on the new window, and a replaced window that carries no paging metadata clears the stale `beforeOffset` instead of reusing it.

Split from #12373 (the STA-3333 QA sweep), which bundled ten fixes. This PR is independent of that branch, targets `main`, and carries **only** the reconnect replay/history-merge fix and its regression tests. The other fixes in #12373 — including the manual-reconnect cached-transcript UI behavior — are deliberately **not** included here. #12373 remains open and untouched.

Refs STA-3333.

## Screenshots

`No visual change` — this is transport/state-merge logic. The user-visible effect is the absence of a defect: scrolled-back history stays on screen through a reconnect instead of snapping back to the last 40 messages.

## Testing

- [x] `pnpm lint` — root `oxlint` clean, `audit:code-quality:native` clean, `check:max-lines-ratchet` OK (no new bypasses, no `max-lines` disables added), `oxlint --config config/oxlint-react-doctor.json` clean on the changed source, `oxfmt --check` clean
- [x] `pnpm typecheck` — mobile `tsc --noEmit` exit 0
- [x] `pnpm test` — full mobile suite: **403 files, 3028 passed / 3 skipped**; `src/session`: **114 files, 921 passed**; the two directly affected spec files: **31 passed**, no unhandled rejections
- [ ] `pnpm build` — not run; no build-affecting changes (CI covers it)
- [x] Added or updated high-quality tests that would catch regressions

**Tests are verified non-vacuous.** With the spec files at this head and the two source files reverted to `main`, **15 of the 31 tests in those files fail**; all 31 pass with the fix. Reproduce by running the two spec files after `git checkout $(git merge-base HEAD origin/main) -- mobile/src/session/mobile-native-chat-stream-frame.ts mobile/src/session/use-mobile-native-chat-session.ts`.

Whole-PR reversion is a deliberately weak probe for part of this change, because the pre-PR code often reached the same *result* by replacing on every snapshot. Tests that do not discriminate at that granularity are kept as contract locks and pinned by a targeted mutation instead — see below.

**Every branch of the new logic is mutation-covered.** Fourteen mutations of the changed source each turn the suite red: deleting the `sawNewMessage` guard, the contiguity ordering check, the retained-tail anchor, the `hasMore: false` authoritative rule, the `replayStartIndex === 0` metadata anchor, the `!replaceSnapshot` base-snapshot gate, the trimmed-replay `hasMore: true` branch, `windowReplaced` on the replace path, the `>= INITIAL_LIMIT` fallback, the `snapshotSeenRef` write (both deleting it and setting it unconditionally), the snapshot arm of the in-flight-page fence, and **both** directions of the `firstIndex > 0` bound (`>= 0` and `> 1`). Each rejection branch is killed by exactly one test. The mutations that still survive are equivalent — they cannot change observable behavior — and are enumerated in Notes below.

Frame-seam tests (`mobile-native-chat-stream-frame.test.ts`): overlapping replay merges; disjoint replay replaces; a partially-overlapping replay that no longer extends the retained tail replaces; a replay repeating retained ids out of order replaces; a replay stopping short of the retained newest row replaces; `hasMore: false` drops retained older rows; a replay still starting at the oldest row refreshes paging metadata, while one starting partway into paged-in history does **not** adopt it; a trimming replay reports `hasMore: true`; a snapshot following a `replacement` still replaces; a replay with exactly one dropped row ahead of it replaces (the `firstIndex > 0` boundary); `windowReplaced` on first snapshot / replacement.

Hook tests (`use-mobile-native-chat-session.test.ts`): paged-in history (100 rows) survives a replay and a replay carrying a new message (bounded window trims exactly one oldest row); a trimming replay enables paging on a window that previously had none; an authoritative replay drops paged rows it says were removed; a replacement omitting paging metadata clears the stale cursor; a replaced window shorter than the initial page clears `hasMore`; a live `appended` frame arriving before the base snapshot does not demote that snapshot to a replay; a merging replay that re-cuts the byte cursor fences the older-page request already in flight. The pre-existing `can page again after an authoritative snapshot/replacement resets a maxed-out read window` test still passes unchanged.

## AI Review Report

Reviewed with focus on:

1. **Replay-window semantics.** Verified the disjoint-replay fallback preserves the pre-existing "authoritative snapshot resets a maxed-out window" behavior — that test passes unmodified. Checked the contiguity scan (`replayRetainedTailStart`) rejects every shape it cannot stitch: unknown first id, a gap in the middle, a new message followed by a known one (compaction reorder), and a run that does not reach the end of the retained list. `hasMore: false` with a non-zero start index is treated as authoritative removal rather than overlap.
2. **Stale-cursor / in-flight paging safety.** Every snapshot (merged or replaced) bumps `streamGenerationRef`, so a resolving `nativeChat.readSession` from before the replay is dropped by the existing generation guard. Confirmed `beforeOffsetRef` is cleared (not left stale) when a replaced window omits `beforeOffset`, which was the latent bug behind a cursor pointing into a window that no longer exists.
3. **Scope containment.** The hook's public signature and return type are unchanged, so `use-mobile-native-chat-controller.ts` and all other consumers are untouched. No refactors, no style cleanup, no dependency changes — `mobile/pnpm-lock.yaml` was reverted after a local `pnpm install` so no lockfile churn ships.
4. **Render purity.** No new state, effects, or render-time writes were added to the hook; the change is confined to refs and the existing subscription callback. Confirmed against the react-doctor gate.
5. **Cross-platform compatibility (macOS, Linux, Windows).** Explicitly checked: this PR touches no keyboard shortcuts or accelerators, no shortcut labels, no file paths or path joining, no shell or process invocation, no Git commands, and no Electron main/renderer or IPC surface. The changed code is React Native transport/state logic that is byte-identical across iOS and Android clients and agnostic of the desktop host OS. It is equally correct over SSH and relay connections — reconnect replay is precisely the SSH/remote case this fixes — and makes no assumption that a workspace is a git worktree rather than a folder workspace.

## Security Audit

No new untrusted-input parsing, no command execution, no path handling, no auth or secret handling, no dependency changes, and no new IPC/RPC surface (the fix reuses the existing `nativeChat.subscribe` / `nativeChat.readSession` methods with unchanged params). The added logic is pure in-memory list reconciliation over message ids already present in frames the client accepted. Message ids are used only as `Map` keys for dedup and ordering — never interpolated into a query, path, or command. The merge is bounded by the existing window cap (`MAX_MESSAGES`, `boundNativeChatWindow`), so a hostile or buggy host cannot use replay frames to grow the retained list without limit. No follow-up needed.

## Notes

- Merge-replays stay bounded by the grown window, so a replay carrying new tail messages trims the same number of oldest rows; the cursor then falls back to the growing-tail read, matching existing live-append trim behavior.
- A `replacement` frame arriving before any snapshot still counts as a fresh base and does not mark the subscription's base snapshot as seen — matching the validated reference behavior.
- The mutants that still survive are equivalent, not uncovered. Dropping the `merger.list.length > 0` precondition changes nothing — an empty retained list already fails the first-id lookup and reaches the same replace path. The same holds for the two `!applied.windowReplaced` guards on `hasMore`/`beforeOffset` (the `windowReplaced` branch has already assigned the same value from the same variable) and for the `snapshotSeenRef` reset in the effect (masked because `setList([])` empties the merger before subscribing). These are defense-in-depth; no test can distinguish them.
- **Correction to an earlier revision of this description.** The `|| frame.type === 'snapshot'` arm of the in-flight-page fence was previously described here as defensive rather than load-bearing. That was wrong. A replay can merge cleanly *and* carry a re-cut `beforeOffset`, which the hook adopts via `replayStillStartsAtOldest`; the page already in flight was addressed with the old offset, so without the fence it lands and writes its own stale cursor back over the fresh one, leaving the next `loadEarlier` addressed from an offset that no longer describes the file. Row order stays correct throughout, which is why ordering-only reasoning missed it. It is now pinned by a test that is the sole failure under that mutation.
- An empty replay `snapshot` still replaces the whole retained window, discarding paged-in history. This is identical to pre-PR behavior and is left unchanged here rather than pinned, since "an empty replay carries no information" is a defensible alternative reading and settling it belongs in its own change.
- Split from #12373; the remaining fixes in that PR (manual-reconnect cached transcript, stale agent status, ask-card dismissal, loadEarlier error surfacing, viewport anchoring, answer-send abort reporting, PTY write lock, streaming bubble, tool-row labels) are out of scope here and stay with #12373.




