### PR TITLE
fix(mobile): label native-chat tool rows with a clean, expandable input summary (STA-3333)

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -141,4 +141,14 @@ describe('MobileNativeChatMessage', () => {
       '{\n  "cmd": "git status",\n  "description": "Inspect changes"\n}'
     )
   })
+
+  it('does not echo the row label as detail when a row has nothing to expand', () => {
+    // The Tools toggle opens every row at once, bypassing the tap guard — a row
+    // whose formatted input is its own label would echo itself in a panel that
+    // no tap can dismiss.
+    const tree = render(toolMessage([{ type: 'tool-call', name: 'ListTodos', input: '{}' }]), {
+      toolsExpanded: true
+    })
+    expect(textIn(tree.root).filter((text) => text === '{}')).toHaveLength(1)
+  })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -1,7 +1,8 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { MAX_TOOL_RESULT_CHARS } from './mobile-native-chat-message-styles'
 
 vi.mock('react-native', async () => {
   const React = await import('react')
@@ -30,7 +31,11 @@ function userMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
   return { id: 'u1', role: 'user', blocks, timestamp: null, source: 'transcript' }
 }
 
-describe('MobileNativeChatMessage image-ref rendering', () => {
+function toolMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
+  return { id: 'a1', role: 'assistant', blocks, timestamp: null, source: 'transcript' }
+}
+
+describe('MobileNativeChatMessage', () => {
   let renderer: ReactTestRenderer | null = null
 
   beforeEach(() => {
@@ -41,7 +46,10 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     renderer = null
   })
 
-  function render(message: NativeChatMessage): ReactTestRenderer {
+  function render(
+    message: NativeChatMessage,
+    props: { toolsExpanded?: boolean } = {}
+  ): ReactTestRenderer {
     const original = console.error
     const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
       if (typeof a[0] === 'string' && a[0].includes('react-test-renderer is deprecated')) {
@@ -51,13 +59,16 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     })
     try {
       act(() => {
-        renderer = create(createElement(MobileNativeChatMessage, { message }))
+        renderer = create(createElement(MobileNativeChatMessage, { message, ...props }))
       })
     } finally {
       spy.mockRestore()
     }
     return renderer!
   }
+
+  const textIn = (node: ReactTestInstance): string[] =>
+    node.findAllByType('Text' as never).map((text) => String(text.children.join('')))
 
   it('renders a loadable preview URI as an image thumbnail', () => {
     const tree = render(userMessage([{ type: 'image-ref', url: 'file:///a.jpg', alt: 'a photo' }]))
@@ -83,5 +94,51 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       .findAllByType('Text' as never)
       .map((node) => String(node.children.join('')))
     expect(texts.some((text) => text.includes('/tmp/host.png'))).toBe(true)
+  })
+
+  it('labels a tool row with the target path instead of raw input JSON', () => {
+    const tree = render(
+      toolMessage([{ type: 'tool-call', name: 'Read', input: { file_path: 'src/index.ts' } }]),
+      { toolsExpanded: true }
+    )
+    const texts = textIn(tree.root)
+    expect(texts).toContain('src/index.ts')
+    expect(texts.some((text) => text.includes('"file_path":"src/index.ts"'))).toBe(false)
+  })
+
+  it('bounds expanded diff-less tool input before native text layout', () => {
+    const tree = render(
+      toolMessage([
+        { type: 'tool-call', name: 'CustomTool', input: { payload: 'x'.repeat(100_000) } }
+      ]),
+      { toolsExpanded: true }
+    )
+    const detail = textIn(tree.root).find((text) => text.startsWith('{\n'))
+    expect(detail).toHaveLength(MAX_TOOL_RESULT_CHARS + 1)
+    expect(detail?.endsWith('…')).toBe(true)
+  })
+
+  it('expands formatted detail for a collapsed JSON-string tool input', () => {
+    const tree = render(
+      toolMessage([
+        {
+          type: 'tool-call',
+          name: 'CustomTool',
+          input: '{"cmd":"git status","description":"Inspect changes"}'
+        }
+      ])
+    )
+    const pressableWith = (label: string): ReactTestInstance =>
+      tree.root.findAllByType('Pressable' as never).find((node) => textIn(node).includes(label))!
+
+    act(() => pressableWith('1×').props.onPress())
+    // The row label is the command, and the detail stays closed until tapped.
+    expect(textIn(tree.root)).toContain('git status')
+    expect(textIn(tree.root).some((text) => text.startsWith('{\n'))).toBe(false)
+
+    act(() => pressableWith('CustomTool').props.onPress())
+    expect(textIn(tree.root)).toContain(
+      '{\n  "cmd": "git status",\n  "description": "Inspect changes"\n}'
+    )
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -2,7 +2,7 @@ import { createElement } from 'react'
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
-import { MAX_TOOL_RESULT_CHARS } from './mobile-native-chat-message-styles'
+import { MAX_TOOL_DETAIL_LENGTH } from './mobile-native-chat-tool-summary'
 
 vi.mock('react-native', async () => {
   const React = await import('react')
@@ -114,7 +114,7 @@ describe('MobileNativeChatMessage', () => {
       { toolsExpanded: true }
     )
     const detail = textIn(tree.root).find((text) => text.startsWith('{\n'))
-    expect(detail).toHaveLength(MAX_TOOL_RESULT_CHARS + 1)
+    expect(detail).toHaveLength(MAX_TOOL_DETAIL_LENGTH + 1)
     expect(detail?.endsWith('…')).toBe(true)
   })
 
@@ -153,6 +153,16 @@ describe('MobileNativeChatMessage', () => {
     // The chevron has to agree with the panel, or the row claims to be open over
     // nothing and the tap that would close it is guarded off. Only the run header
     // is open here; the row itself stays collapsed.
+    expect(tree.root.findAllByType('ChevronDown' as never)).toHaveLength(1)
+    expect(tree.root.findAllByType('SquareChevronRight' as never)).toHaveLength(1)
+  })
+
+  it('does not expand a plain input that already fits in the row label', () => {
+    const input = 'x'.repeat(60)
+    const tree = render(toolMessage([{ type: 'tool-call', name: 'CustomTool', input }]), {
+      toolsExpanded: true
+    })
+    expect(textIn(tree.root).filter((text) => text === input)).toHaveLength(1)
     expect(tree.root.findAllByType('ChevronDown' as never)).toHaveLength(1)
     expect(tree.root.findAllByType('SquareChevronRight' as never)).toHaveLength(1)
   })

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -150,5 +150,10 @@ describe('MobileNativeChatMessage', () => {
       toolsExpanded: true
     })
     expect(textIn(tree.root).filter((text) => text === '{}')).toHaveLength(1)
+    // The chevron has to agree with the panel, or the row claims to be open over
+    // nothing and the tap that would close it is guarded off. Only the run header
+    // is open here; the row itself stays collapsed.
+    expect(tree.root.findAllByType('ChevronDown' as never)).toHaveLength(1)
+    expect(tree.root.findAllByType('SquareChevronRight' as never)).toHaveLength(1)
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -109,6 +109,10 @@ function ToolLine({
     result !== undefined ||
     preview.length > 40 ||
     (call !== undefined && isStructuredToolInput(call.input))
+  // The group toggle opens every line at once, bypassing the tap guard, so the
+  // panel has to consult it too — else a detail-less row echoes its own label
+  // under itself and no tap can dismiss it.
+  const showDetail = hasDetail && expanded
   // A tool that targets a file (Read/Edit/Write…) renders its preview as a
   // tappable link that opens the file, independent of the line's expand tap.
   const filePath = call ? toolFilePath(call.input) : null
@@ -120,7 +124,7 @@ function ToolLine({
         onPress={() => hasDetail && setExpanded((v) => !v)}
         hitSlop={6}
       >
-        {expanded ? (
+        {showDetail ? (
           <ChevronDown size={15} color={colors.textMuted} strokeWidth={2} />
         ) : (
           <SquareChevronRight size={15} color={colors.textMuted} strokeWidth={2} />
@@ -137,7 +141,7 @@ function ToolLine({
           </Text>
         ) : null}
       </Pressable>
-      {expanded ? (
+      {showDetail ? (
         <View style={styles.toolDetail}>
           {callDiff ? <DiffView lines={callDiff} /> : null}
           {callDetail ? <Text style={styles.mono}>{callDetail}</Text> : null}

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -17,7 +17,9 @@ import { isRenderableImageUri } from './mobile-native-chat-image-preview'
 import { MAX_TOOL_RESULT_CHARS, styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
 import {
-  summarizeToolInput,
+  describeToolInput,
+  formatToolInput,
+  isStructuredToolInput,
   summarizeToolRun,
   toolFilePath
 } from './mobile-native-chat-tool-summary'
@@ -46,6 +48,12 @@ function DiffView({ lines }: { lines: DiffLine[] }): React.JSX.Element {
   )
 }
 
+/** Cap a mono block at the same size as desktop's tool detail — native text
+ *  layout has no scroll container to absorb a runaway payload. */
+function boundedText(text: string): string {
+  return text.length > MAX_TOOL_RESULT_CHARS ? `${text.slice(0, MAX_TOOL_RESULT_CHARS)}…` : text
+}
+
 /** A single inline tool line — `▸ ToolName  preview` — that expands in place to
  *  show the call's diff/input or the result's body. Mirrors the reference design
  *  where tool calls read as flat lines in the conversation, not boxed blocks. */
@@ -63,11 +71,7 @@ function ResultBody({
   }
   return (
     <View style={[styles.toolResult, isError && styles.toolResultError]}>
-      <Text style={styles.mono}>
-        {output.length > MAX_TOOL_RESULT_CHARS
-          ? `${output.slice(0, MAX_TOOL_RESULT_CHARS)}…`
-          : output}
-      </Text>
+      <Text style={styles.mono}>{boundedText(output)}</Text>
     </View>
   )
 }
@@ -88,14 +92,23 @@ function ToolLine({
   const [expanded, setExpanded] = useState(defaultExpanded)
   const { call, result } = pair
   const name = call ? call.name : 'Result'
+  // The row label is a human summary (path / primary arg), never raw JSON; the
+  // expanded detail below carries the full formatted input.
   const preview = call
-    ? summarizeToolInput(call.input)
+    ? describeToolInput(call.input)
     : (result?.output.split('\n')[0]?.slice(0, 80) ?? '')
   // Why: collapsed tool rows are the common path; defer bounded diff parsing
-  // until the user asks to reveal the detail.
+  // and detail formatting until the user asks to reveal the detail.
   const callDiff = expanded && call ? diffFromToolCall(call.name, call.input, diffLineLimit) : null
   const resultDiff = expanded && result ? diffFromText(result.output, diffLineLimit) : null
-  const hasDetail = callDiff !== null || result !== undefined || preview.length > 40
+  // Bound before handing it to native text layout, like the result body.
+  const callDetail =
+    expanded && call && !callDiff ? boundedText(formatToolInput(call.input)) : undefined
+  const hasDetail =
+    callDiff !== null ||
+    result !== undefined ||
+    preview.length > 40 ||
+    (call !== undefined && isStructuredToolInput(call.input))
   // A tool that targets a file (Read/Edit/Write…) renders its preview as a
   // tappable link that opens the file, independent of the line's expand tap.
   const filePath = call ? toolFilePath(call.input) : null
@@ -127,7 +140,7 @@ function ToolLine({
       {expanded ? (
         <View style={styles.toolDetail}>
           {callDiff ? <DiffView lines={callDiff} /> : null}
-          {!callDiff && call && preview ? <Text style={styles.mono}>{preview}</Text> : null}
+          {callDetail ? <Text style={styles.mono}>{callDetail}</Text> : null}
           {result ? (
             <ResultBody output={result.output} isError={result.isError} diff={resultDiff} />
           ) : null}

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -14,14 +14,12 @@ import {
 } from './mobile-native-chat-blocks'
 import { diffFromText, diffFromToolCall, type DiffLine } from './mobile-native-chat-diff'
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
-import { MAX_TOOL_RESULT_CHARS, styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
+import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
 import {
-  describeToolInput,
-  formatToolInput,
-  isStructuredToolInput,
+  createToolInputDisplay,
   summarizeToolRun,
-  toolFilePath
+  truncateToolDetail
 } from './mobile-native-chat-tool-summary'
 
 const MAX_VISIBLE_TOOL_PAIRS = 6
@@ -48,12 +46,6 @@ function DiffView({ lines }: { lines: DiffLine[] }): React.JSX.Element {
   )
 }
 
-/** Cap a mono block at the same size as desktop's tool detail — native text
- *  layout has no scroll container to absorb a runaway payload. */
-function boundedText(text: string): string {
-  return text.length > MAX_TOOL_RESULT_CHARS ? `${text.slice(0, MAX_TOOL_RESULT_CHARS)}…` : text
-}
-
 /** A single inline tool line — `▸ ToolName  preview` — that expands in place to
  *  show the call's diff/input or the result's body. Mirrors the reference design
  *  where tool calls read as flat lines in the conversation, not boxed blocks. */
@@ -71,7 +63,7 @@ function ResultBody({
   }
   return (
     <View style={[styles.toolResult, isError && styles.toolResultError]}>
-      <Text style={styles.mono}>{boundedText(output)}</Text>
+      <Text style={styles.mono}>{truncateToolDetail(output)}</Text>
     </View>
   )
 }
@@ -92,30 +84,21 @@ function ToolLine({
   const [expanded, setExpanded] = useState(defaultExpanded)
   const { call, result } = pair
   const name = call ? call.name : 'Result'
-  // The row label is a human summary (path / primary arg), never raw JSON; the
-  // expanded detail below carries the full formatted input.
-  const preview = call
-    ? describeToolInput(call.input)
-    : (result?.output.split('\n')[0]?.slice(0, 80) ?? '')
+  const inputDisplay = call ? createToolInputDisplay(call.input) : null
+  const preview = inputDisplay?.label ?? result?.output.split('\n')[0]?.slice(0, 80) ?? ''
   // Why: collapsed tool rows are the common path; defer bounded diff parsing
   // and detail formatting until the user asks to reveal the detail.
   const callDiff = expanded && call ? diffFromToolCall(call.name, call.input, diffLineLimit) : null
   const resultDiff = expanded && result ? diffFromText(result.output, diffLineLimit) : null
-  // Bound before handing it to native text layout, like the result body.
-  const callDetail =
-    expanded && call && !callDiff ? boundedText(formatToolInput(call.input)) : undefined
-  const hasDetail =
-    callDiff !== null ||
-    result !== undefined ||
-    preview.length > 40 ||
-    (call !== undefined && isStructuredToolInput(call.input))
+  const callDetail = expanded && inputDisplay && !callDiff ? inputDisplay.formatDetail() : undefined
+  const hasDetail = callDiff !== null || result !== undefined || inputDisplay?.hasDetail === true
   // The group toggle opens every line at once, bypassing the tap guard, so the
   // panel has to consult it too — else a detail-less row echoes its own label
   // under itself and no tap can dismiss it.
   const showDetail = hasDetail && expanded
   // A tool that targets a file (Read/Edit/Write…) renders its preview as a
   // tappable link that opens the file, independent of the line's expand tap.
-  const filePath = call ? toolFilePath(call.input) : null
+  const filePath = inputDisplay?.filePath ?? null
   const openable = filePath !== null && onOpenFile !== undefined
   return (
     <View>

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -3,7 +3,6 @@ import { colors, radii, spacing, typography } from '../theme/mobile-theme'
 
 export const TEXT_SIZE = 17
 export const MONO_SIZE = 12
-export const MAX_TOOL_RESULT_CHARS = 4000
 
 export const styles = StyleSheet.create({
   row: {

--- a/mobile/src/session/mobile-native-chat-tool-summary.test.ts
+++ b/mobile/src/session/mobile-native-chat-tool-summary.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { briefToolArg, summarizeToolInput, toolFilePath } from './mobile-native-chat-tool-summary'
+import {
+  briefToolArg,
+  describeToolInput,
+  summarizeToolInput,
+  toolFilePath
+} from './mobile-native-chat-tool-summary'
 
 describe('summarizeToolInput', () => {
   it('passes short strings through, collapsing whitespace', () => {
@@ -50,6 +55,13 @@ describe('toolFilePath', () => {
     expect(toolFilePath({ command: 'ls' })).toBeNull()
     expect(toolFilePath('x')).toBeNull()
     expect(toolFilePath(null)).toBeNull()
+  })
+})
+
+describe('describeToolInput', () => {
+  it('is re-exported and labels rows with the path or primary argument', () => {
+    expect(describeToolInput({ file_path: 'src/a.ts', offset: 3 })).toBe('src/a.ts')
+    expect(describeToolInput('{"cmd":"git status"}')).toBe('git status')
   })
 })
 

--- a/mobile/src/session/mobile-native-chat-tool-summary.ts
+++ b/mobile/src/session/mobile-native-chat-tool-summary.ts
@@ -1,10 +1,13 @@
 export {
   briefToolArg,
   countToolCalls,
+  createToolInputDisplay,
   describeToolInput,
   formatToolInput,
   isStructuredToolInput,
+  MAX_TOOL_DETAIL_LENGTH,
   summarizeToolInput,
   summarizeToolRun,
-  toolFilePath
+  toolFilePath,
+  truncateToolDetail
 } from '../../../src/shared/native-chat-tool-summary'

--- a/mobile/src/session/mobile-native-chat-tool-summary.ts
+++ b/mobile/src/session/mobile-native-chat-tool-summary.ts
@@ -1,6 +1,9 @@
 export {
   briefToolArg,
   countToolCalls,
+  describeToolInput,
+  formatToolInput,
+  isStructuredToolInput,
   summarizeToolInput,
   summarizeToolRun,
   toolFilePath

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatBlock } from '../../../../shared/native-chat-types'
+import { NativeChatToolRun } from './NativeChatToolRun'
+
+afterEach(cleanup)
+
+describe('NativeChatToolRun', () => {
+  it('uses the shared clean label for a desktop tool row', () => {
+    const blocks: NativeChatBlock[] = [
+      {
+        type: 'tool-call',
+        name: 'Read',
+        input: '{"file_path":"src/index.ts","offset":10}'
+      }
+    ]
+
+    render(<NativeChatToolRun blocks={blocks} expandSignal />)
+
+    expect(screen.getByTitle('src/index.ts')).toHaveTextContent('src/index.ts')
+    expect(screen.queryByTitle('{"file_path":"src/index.ts","offset":10}')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -10,13 +10,11 @@ import {
 import { diffFromText, diffFromToolCall, type DiffLine } from './native-chat-diff'
 import {
   countToolCalls,
-  formatToolInput,
-  summarizeToolInput,
-  summarizeToolRun
+  createToolInputDisplay,
+  summarizeToolRun,
+  truncateToolDetail
 } from './native-chat-tool-summary'
 import { NativeChatDiffView } from './NativeChatDiffView'
-
-const MAX_TOOL_RESULT_CHARS = 4000
 
 /** A single inline tool line — `▸ ToolName  preview` — that expands in place to
  *  show the call's diff/input or the result's body. Tool calls read as flat
@@ -30,27 +28,26 @@ function ToolLine({ block }: { block: NativeChatBlock }): React.JSX.Element | nu
   let preview: string
   let diff: DiffLine[] | null = null
   let body: { output: string; isError?: boolean } | null = null
-  // Full, formatted input shown when a diff-less tool call is expanded.
   let detail: string | null = null
+  let inputHasDetail = false
 
   if (isToolCallBlock(block)) {
     name = block.name
-    preview = summarizeToolInput(block.input)
-    diff = diffFromToolCall(block.name, block.input)
-    detail = diff ? null : formatToolInput(block.input)
+    const inputDisplay = createToolInputDisplay(block.input)
+    preview = inputDisplay.label
+    inputHasDetail = inputDisplay.hasDetail
+    diff = expanded ? diffFromToolCall(block.name, block.input) : null
+    detail = expanded && !diff ? inputDisplay.formatDetail() : null
   } else if (isToolResultBlock(block)) {
     name = translate('components.native-chat.tool.result', 'Result')
     preview = block.output.split('\n')[0]?.slice(0, 80) ?? ''
-    diff = diffFromText(block.output)
+    diff = expanded ? diffFromText(block.output) : null
     body = { output: block.output, isError: block.isError }
   } else {
     return null
   }
 
-  // Only offer expansion when there's more than the inline preview already shows —
-  // avoids re-rendering the same truncated string in a box below it.
-  const detailAddsInfo = detail !== null && detail.replace(/\s+/g, ' ').trim() !== preview
-  const hasDetail = diff !== null || body !== null || detailAddsInfo
+  const hasDetail = diff !== null || body !== null || inputHasDetail
 
   return (
     <div>
@@ -94,16 +91,12 @@ function ToolLine({ block }: { block: NativeChatBlock }): React.JSX.Element | nu
                 body.isError ? 'text-destructive' : 'text-foreground/80'
               )}
             >
-              {body.output.length > MAX_TOOL_RESULT_CHARS
-                ? `${body.output.slice(0, MAX_TOOL_RESULT_CHARS)}…`
-                : body.output}
+              {truncateToolDetail(body.output)}
             </pre>
           ) : null}
           {!diff && !body && detail ? (
             <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-accent p-2 font-mono text-[11px] text-foreground/80 scrollbar-sleek">
-              {detail.length > MAX_TOOL_RESULT_CHARS
-                ? `${detail.slice(0, MAX_TOOL_RESULT_CHARS)}…`
-                : detail}
+              {detail}
             </pre>
           ) : null}
         </div>

--- a/src/renderer/src/components/native-chat/native-chat-tool-summary.ts
+++ b/src/renderer/src/components/native-chat/native-chat-tool-summary.ts
@@ -1,8 +1,10 @@
 export {
   briefToolArg,
   countToolCalls,
+  createToolInputDisplay,
   formatToolInput,
   summarizeToolInput,
   summarizeToolRun,
-  toolFilePath
+  toolFilePath,
+  truncateToolDetail
 } from '../../../../shared/native-chat-tool-summary'

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -172,6 +172,14 @@ describe('briefToolArg', () => {
     const blocks: NativeChatBlock[] = [{ type: 'tool-call', name: 'Bash', input: { command: '' } }]
     expect(summarizeToolRun(blocks)).toBe('Bash')
   })
+
+  it('still previews a primary argument that is populated but not a string', () => {
+    // Only a *blank* key means "no argument" — a mixed argv or a structured
+    // query is unrenderable as a label, not absent, so it keeps the preview.
+    expect(briefToolArg({ command: ['kill', '-9', 1234] })).toBe('{"command":["kill","-9",1234')
+    expect(briefToolArg({ command: 42 })).toBe('{"command":42}')
+    expect(briefToolArg({ query: { text: 'auth flow' } })).toBe('{"query":{"text":"auth flow"')
+  })
 })
 
 describe('summarizeToolRun', () => {

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -162,6 +162,16 @@ describe('briefToolArg', () => {
   it('falls back to the command preview when no path is present', () => {
     expect(briefToolArg({ command: 'git status --short' })).toBe('git status --short')
   })
+
+  it('keeps a blank primary argument out of the run header', () => {
+    // Skipping a blank key must not fall through to raw JSON — the row would
+    // read `Bash {"command":""}` where it used to read `Bash`.
+    expect(briefToolArg({ command: '' })).toBe('')
+    expect(briefToolArg({ cmd: '   ' })).toBe('')
+    expect(briefToolArg({ cmd: '', file_path: '' })).toBe('')
+    const blocks: NativeChatBlock[] = [{ type: 'tool-call', name: 'Bash', input: { command: '' } }]
+    expect(summarizeToolRun(blocks)).toBe('Bash')
+  })
 })
 
 describe('summarizeToolRun', () => {

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -84,6 +84,15 @@ describe('describeToolInput', () => {
     expect(toolFilePath({ path: 'src/c.ts' })).toBe('src/c.ts')
   })
 
+  it('does not count a blank search key as a search', () => {
+    // A whitespace-only `query` is no search term, but treating it as one
+    // suppresses `path` — costing the row its label, its link and its header
+    // argument all at once, and putting raw JSON back in the label.
+    expect(toolFilePath({ query: '   ', path: 'src/a.ts' })).toBe('src/a.ts')
+    expect(describeToolInput({ query: '   ', path: 'src/a.ts' })).toBe('src/a.ts')
+    expect(briefToolArg({ query: '   ', path: 'src/a.ts' })).toBe('a.ts')
+  })
+
   it('skips a present-but-blank key instead of falling through to raw JSON', () => {
     expect(describeToolInput({ command: '', query: 'needle' })).toBe('needle')
     expect(describeToolInput({ command: '   ', url: 'https://example.com' })).toBe(

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -1,14 +1,48 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { NativeChatBlock } from './native-chat-types'
 import {
   briefToolArg,
+  createToolInputDisplay,
   describeToolInput,
   formatToolInput,
   isStructuredToolInput,
+  MAX_TOOL_DETAIL_LENGTH,
   summarizeToolInput,
   summarizeToolRun,
-  toolFilePath
+  toolFilePath,
+  truncateToolDetail
 } from './native-chat-tool-summary'
+
+describe('createToolInputDisplay', () => {
+  it('builds the shared row model from one JSON-string parse', () => {
+    const parse = vi.spyOn(JSON, 'parse')
+    const display = createToolInputDisplay(
+      '{"file_path":"src/index.ts","description":"Read the entry point"}'
+    )
+
+    expect(display.label).toBe('src/index.ts')
+    expect(display.filePath).toBe('src/index.ts')
+    expect(display.hasDetail).toBe(true)
+    expect(display.formatDetail()).toBe(
+      '{\n  "file_path": "src/index.ts",\n  "description": "Read the entry point"\n}'
+    )
+    expect(parse).toHaveBeenCalledTimes(1)
+    parse.mockRestore()
+  })
+
+  it('only offers detail when the formatted input adds information', () => {
+    expect(createToolInputDisplay('x'.repeat(60)).hasDetail).toBe(false)
+    expect(createToolInputDisplay('x'.repeat(100)).hasDetail).toBe(true)
+    expect(createToolInputDisplay('{}').hasDetail).toBe(false)
+    expect(createToolInputDisplay('{"command":"ls"}').hasDetail).toBe(true)
+  })
+
+  it('bounds tool detail through the shared desktop and mobile cap', () => {
+    const detail = truncateToolDetail('x'.repeat(MAX_TOOL_DETAIL_LENGTH + 1))
+    expect(detail).toHaveLength(MAX_TOOL_DETAIL_LENGTH + 1)
+    expect(detail.endsWith('…')).toBe(true)
+  })
+})
 
 describe('describeToolInput', () => {
   it('labels a file-target call with its path, not raw JSON', () => {

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -1,6 +1,77 @@
 import { describe, expect, it } from 'vitest'
 import type { NativeChatBlock } from './native-chat-types'
-import { briefToolArg, summarizeToolInput, summarizeToolRun } from './native-chat-tool-summary'
+import {
+  briefToolArg,
+  describeToolInput,
+  formatToolInput,
+  isStructuredToolInput,
+  summarizeToolInput,
+  summarizeToolRun,
+  toolFilePath
+} from './native-chat-tool-summary'
+
+describe('describeToolInput', () => {
+  it('labels a file-target call with its path, not raw JSON', () => {
+    expect(describeToolInput({ file_path: '/repo/src/app/Main.tsx', offset: 10 })).toBe(
+      '/repo/src/app/Main.tsx'
+    )
+    expect(describeToolInput({ path: 'src/index.ts' })).toBe('src/index.ts')
+    expect(describeToolInput({ file_path: 'C:\\Users\\me\\project\\app.tsx' })).toBe(
+      'C:\\Users\\me\\project\\app.tsx'
+    )
+  })
+
+  it('labels a command-shaped call with its primary argument', () => {
+    expect(describeToolInput({ command: 'pnpm test', description: 'Run tests' })).toBe('pnpm test')
+    expect(describeToolInput({ pattern: 'foo.*bar', glob: '*.ts' })).toBe('foo.*bar')
+    expect(describeToolInput({ url: 'https://example.com', description: 'Fetch it' })).toBe(
+      'https://example.com'
+    )
+    expect(describeToolInput({ description: 'Only prose' })).toBe('Only prose')
+  })
+
+  it('falls back to the bounded JSON preview for other shapes', () => {
+    expect(describeToolInput({ todos: [{ id: 1 }] })).toBe(
+      summarizeToolInput({ todos: [{ id: 1 }] })
+    )
+    expect(describeToolInput({ command: '   ' })).toBe(summarizeToolInput({ command: '   ' }))
+    expect(describeToolInput('raw string input')).toBe('raw string input')
+    expect(describeToolInput(null)).toBe('')
+  })
+
+  it('truncates an overlong path like any other preview', () => {
+    const path = `/very/${'long/'.repeat(30)}file.ts`
+    expect(describeToolInput({ file_path: path }).length).toBeLessThanOrEqual(80)
+    expect(describeToolInput({ file_path: path })).toContain('…')
+  })
+})
+
+describe('Codex JSON-string tool arguments', () => {
+  it('normalizes them for labels, details, file links and run summaries', () => {
+    expect(describeToolInput('{"cmd":"git status --short"}')).toBe('git status --short')
+    expect(formatToolInput('{"cmd":"git status --short"}')).toBe(
+      '{\n  "cmd": "git status --short"\n}'
+    )
+    expect(toolFilePath('{"file_path":"src/index.ts"}')).toBe('src/index.ts')
+    expect(briefToolArg('{"file_path":"src/app/index.ts"}')).toBe('index.ts')
+    expect(briefToolArg('{"cmd":"git status --short"}')).toBe('git status --short')
+    expect(isStructuredToolInput('{"cmd":"ls"}')).toBe(true)
+  })
+
+  it('joins an argv-array command into one label', () => {
+    expect(describeToolInput('{"command":["bash","-lc","make"]}')).toBe('bash -lc make')
+    expect(briefToolArg({ command: ['bash', '-lc', 'make'] })).toBe('bash -lc make')
+  })
+
+  it('leaves prose and malformed JSON as plain strings', () => {
+    expect(describeToolInput('{ not json')).toBe('{ not json')
+    expect(formatToolInput('just prose')).toBe('just prose')
+    expect(toolFilePath('{"file_path":')).toBeNull()
+    expect(isStructuredToolInput('just prose')).toBe(false)
+    // A JSON scalar is not an argument object — keep the literal text.
+    expect(formatToolInput('"quoted"')).toBe('"quoted"')
+  })
+})
 
 describe('summarizeToolInput bounded preview', () => {
   it('collapses depth beyond the bound instead of serializing the whole tree', () => {

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -41,8 +41,13 @@ describe('describeToolInput', () => {
 
   it('truncates an overlong path like any other preview', () => {
     const path = `/very/${'long/'.repeat(30)}file.ts`
-    expect(describeToolInput({ file_path: path }).length).toBeLessThanOrEqual(80)
-    expect(describeToolInput({ file_path: path })).toContain('…')
+    const label = describeToolInput({ file_path: path })
+    expect(label.length).toBeLessThanOrEqual(80)
+    expect(label).toContain('…')
+    // A bounded JSON preview also satisfies the two assertions above, so pin the
+    // label to the path itself or this passes with path-labelling deleted.
+    expect(label).not.toContain('file_path')
+    expect(label.endsWith('/file.ts')).toBe(true)
   })
 
   it('keeps the filename when trimming an overlong path', () => {
@@ -112,6 +117,17 @@ describe('Codex JSON-string tool arguments', () => {
     expect(isStructuredToolInput('just prose')).toBe(false)
     // A JSON scalar is not an argument object — keep the literal text.
     expect(formatToolInput('"quoted"')).toBe('"quoted"')
+  })
+})
+
+describe('isStructuredToolInput', () => {
+  it('does not offer an expander whose detail would repeat the row label', () => {
+    // `{}` formats back to `{}` — the label itself.
+    expect(isStructuredToolInput({})).toBe(false)
+    expect(isStructuredToolInput([])).toBe(false)
+    expect(isStructuredToolInput('{}')).toBe(false)
+    expect(isStructuredToolInput({ command: 'ls' })).toBe(true)
+    expect(isStructuredToolInput([1])).toBe(true)
   })
 })
 

--- a/src/shared/native-chat-tool-summary.test.ts
+++ b/src/shared/native-chat-tool-summary.test.ts
@@ -44,6 +44,48 @@ describe('describeToolInput', () => {
     expect(describeToolInput({ file_path: path }).length).toBeLessThanOrEqual(80)
     expect(describeToolInput({ file_path: path })).toContain('…')
   })
+
+  it('keeps the filename when trimming an overlong path', () => {
+    // Head-truncating an absolute path drops the basename — the one part that
+    // tells two rows apart — so the trim has to come off the front.
+    const path = `/Users/me/orca/workspaces/orca/sta-3333/src/shared/${'nested/'.repeat(4)}app.tsx`
+    const label = describeToolInput({ file_path: path, offset: 10 })
+    expect(label.length).toBeLessThanOrEqual(80)
+    expect(label.startsWith('…')).toBe(true)
+    expect(label.endsWith('/app.tsx')).toBe(true)
+  })
+
+  it('distinguishes two long paths that share a deep prefix', () => {
+    const base = '/Users/me/orca/workspaces/orca/sta-3333-tool-summary/src/session/native'
+    const a = describeToolInput({ file_path: `${base}/MobileNativeChatMessage.tsx` })
+    const b = describeToolInput({ file_path: `${base}/MobileNativeChatComposer.tsx` })
+    expect(a).not.toBe(b)
+  })
+
+  it('names a search call by its pattern, not the directory it scanned', () => {
+    // `path` on a Grep/Glob is the scan root; labelling with it loses the term.
+    expect(describeToolInput({ pattern: 'summarizeToolInput', path: 'src/shared' })).toBe(
+      'summarizeToolInput'
+    )
+    expect(describeToolInput({ pattern: '**/*.tsx', path: 'mobile/src' })).toBe('**/*.tsx')
+    expect(describeToolInput({ query: 'auth flow', path: 'src' })).toBe('auth flow')
+    // ...and offers no open-file link, since that path is a folder.
+    expect(toolFilePath({ pattern: 'x', path: 'src/shared' })).toBeNull()
+    expect(briefToolArg({ pattern: 'x', path: 'src/shared' })).toBe('x')
+  })
+
+  it('still treats an explicit file target as one alongside a search term', () => {
+    expect(toolFilePath({ pattern: 'x', file_path: 'src/a.ts' })).toBe('src/a.ts')
+    expect(toolFilePath({ path: 'src/c.ts' })).toBe('src/c.ts')
+  })
+
+  it('skips a present-but-blank key instead of falling through to raw JSON', () => {
+    expect(describeToolInput({ command: '', query: 'needle' })).toBe('needle')
+    expect(describeToolInput({ command: '   ', url: 'https://example.com' })).toBe(
+      'https://example.com'
+    )
+    expect(briefToolArg({ cmd: '', query: 'needle' })).toBe('needle')
+  })
 })
 
 describe('Codex JSON-string tool arguments', () => {

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -7,6 +7,14 @@ const MAX_PREVIEW_DEPTH = 2
 const MAX_TOOL_RUN_SUMMARY_PARTS = 3
 const PRIMARY_ARG_KEYS = ['command', 'cmd', 'query', 'pattern', 'url', 'description'] as const
 const BRIEF_ARG_KEYS = ['command', 'cmd', 'query', 'pattern'] as const
+export const MAX_TOOL_DETAIL_LENGTH = 4000
+
+export type ToolInputDisplay = {
+  label: string
+  filePath: string | null
+  hasDetail: boolean
+  formatDetail: () => string
+}
 
 export function summarizeToolInput(input: unknown): string {
   const collapsed = toRawPreview(input).replace(/\s+/g, ' ').trim()
@@ -15,23 +23,44 @@ export function summarizeToolInput(input: unknown): string {
     : `${collapsed.slice(0, MAX_PREVIEW_LENGTH - 1)}…`
 }
 
+/** Build the renderer-independent row model from one normalization pass. Detail
+ *  formatting stays lazy because collapsed mobile rows never render it. */
+export function createToolInputDisplay(input: unknown): ToolInputDisplay {
+  const normalized = normalizeToolInput(input)
+  const filePath = normalizedToolFilePath(normalized)
+  const label = describeNormalizedToolInput(normalized, filePath)
+  return {
+    label,
+    filePath,
+    hasDetail: normalizedToolInputHasDetail(normalized, label),
+    formatDetail: () => truncateToolDetail(formatNormalizedToolInput(normalized))
+  }
+}
+
+export function truncateToolDetail(text: string): string {
+  return text.length > MAX_TOOL_DETAIL_LENGTH ? `${text.slice(0, MAX_TOOL_DETAIL_LENGTH)}…` : text
+}
+
 /** Human label for a tool line: the target file path, else the primary string
  *  argument (command/query/…), else the bounded JSON preview. Keeps raw
  *  `{"file_path":…}` JSON out of the tappable row label. */
 export function describeToolInput(input: unknown): string {
   const normalized = normalizeToolInput(input)
-  const path = toolFilePath(normalized)
+  return describeNormalizedToolInput(normalized, normalizedToolFilePath(normalized))
+}
+
+function describeNormalizedToolInput(input: unknown, path: string | null): string {
   if (path) {
     return summarizeToolPath(path)
   }
-  if (normalized && typeof normalized === 'object') {
+  if (input && typeof input === 'object') {
     // Concrete target/action first; prose `description` only as a last resort.
-    const primary = firstPrimaryToolArg(normalized as Record<string, unknown>, PRIMARY_ARG_KEYS)
+    const primary = firstPrimaryToolArg(input as Record<string, unknown>, PRIMARY_ARG_KEYS)
     if (primary) {
       return primary
     }
   }
-  return summarizeToolInput(normalized)
+  return summarizeToolInput(input)
 }
 
 /** Full, pretty-printed tool-call input for the expanded detail view. Structured
@@ -39,18 +68,21 @@ export function describeToolInput(input: unknown): string {
  *  (e.g. a question payload) reads cleanly instead of one long minified line;
  *  other strings pass through as-is. */
 export function formatToolInput(input: unknown): string {
-  const normalized = normalizeToolInput(input)
-  if (normalized === null || normalized === undefined) {
+  return formatNormalizedToolInput(normalizeToolInput(input))
+}
+
+function formatNormalizedToolInput(input: unknown): string {
+  if (input === null || input === undefined) {
     return ''
   }
-  if (typeof normalized === 'string') {
-    return normalized
+  if (typeof input === 'string') {
+    return input
   }
-  if (typeof normalized === 'number' || typeof normalized === 'boolean') {
-    return String(normalized)
+  if (typeof input === 'number' || typeof input === 'boolean') {
+    return String(input)
   }
   try {
-    return JSON.stringify(normalized, null, 2) ?? ''
+    return JSON.stringify(input, null, 2) ?? ''
   } catch {
     return ''
   }
@@ -59,21 +91,34 @@ export function formatToolInput(input: unknown): string {
 /** Whether the expanded detail would show structured JSON rather than repeating
  *  the row label — i.e. whether expanding the row is worth offering. */
 export function isStructuredToolInput(input: unknown): boolean {
-  const normalized = normalizeToolInput(input)
-  if (normalized === null || typeof normalized !== 'object') {
+  return isStructuredNormalizedToolInput(normalizeToolInput(input))
+}
+
+function isStructuredNormalizedToolInput(input: unknown): boolean {
+  if (input === null || typeof input !== 'object') {
     return false
   }
   // An empty object formats back to the row label verbatim, so offering the
   // expander would promise detail and then repeat the row.
-  return Array.isArray(normalized) ? normalized.length > 0 : Object.keys(normalized).length > 0
+  return Array.isArray(input) ? input.length > 0 : Object.keys(input).length > 0
+}
+
+function normalizedToolInputHasDetail(input: unknown, label: string): boolean {
+  if (isStructuredNormalizedToolInput(input)) {
+    return true
+  }
+  return typeof input === 'string' && input.replace(/\s+/g, ' ').trim() !== label
 }
 
 export function toolFilePath(input: unknown): string | null {
-  const normalized = normalizeToolInput(input)
-  if (!normalized || typeof normalized !== 'object') {
+  return normalizedToolFilePath(normalizeToolInput(input))
+}
+
+function normalizedToolFilePath(input: unknown): string | null {
+  if (!input || typeof input !== 'object') {
     return null
   }
-  const value = normalized as Record<string, unknown>
+  const value = input as Record<string, unknown>
   // A search call's `path` is usually the directory it scanned, so taking it as a
   // target would label the row with the scan root and link to a folder. Costs the
   // link on a file-scoped search; a dead link on every other search is worse.

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -74,8 +74,9 @@ export function toolFilePath(input: unknown): string | null {
     return null
   }
   const value = normalized as Record<string, unknown>
-  // A search call's `path` is the directory it scanned, not a file it opened —
-  // taking it would drop the pattern from the label and offer a link to a folder.
+  // A search call's `path` is usually the directory it scanned, so taking it as a
+  // target would label the row with the scan root and link to a folder. Costs the
+  // link on a file-scoped search; a dead link on every other search is worse.
   const directory = isSearchToolInput(value) ? undefined : value.path
   const path = value.file_path ?? value.filePath ?? directory ?? value.notebook_path
   return typeof path === 'string' && path.length > 0 ? path : null
@@ -89,9 +90,15 @@ export function briefToolArg(input: unknown): string {
       const parts = path.split(/[\\/]/).filter(Boolean)
       return parts.at(-1) ?? path
     }
-    const command = firstPrimaryToolArg(normalized as Record<string, unknown>, BRIEF_ARG_KEYS)
+    const value = normalized as Record<string, unknown>
+    const command = firstPrimaryToolArg(value, BRIEF_ARG_KEYS)
     if (command) {
       return command.slice(0, 28)
+    }
+    // A blank primary key means the call has no brief argument; falling through
+    // would stand its raw JSON in for one in the run header.
+    if (BRIEF_ARG_KEYS.some((key) => Object.prototype.hasOwnProperty.call(value, key))) {
+      return ''
     }
   }
   return summarizeToolInput(normalized).slice(0, 28)

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -13,49 +13,112 @@ export function summarizeToolInput(input: unknown): string {
     : `${collapsed.slice(0, MAX_PREVIEW_LENGTH - 1)}…`
 }
 
-/** Full, pretty-printed tool-call input for the expanded detail view. Strings
- *  pass through as-is; objects/arrays print as indented JSON so a diff-less call
- *  (e.g. a question payload) reads cleanly instead of one long minified line. */
+/** Human label for a tool line: the target file path, else the primary string
+ *  argument (command/query/…), else the bounded JSON preview. Keeps raw
+ *  `{"file_path":…}` JSON out of the tappable row label. */
+export function describeToolInput(input: unknown): string {
+  const normalized = normalizeToolInput(input)
+  const path = toolFilePath(normalized)
+  if (path) {
+    return summarizeToolInput(path)
+  }
+  if (normalized && typeof normalized === 'object') {
+    const value = normalized as Record<string, unknown>
+    // Concrete target/action first; prose `description` only as a last resort.
+    const primary =
+      value.command ?? value.cmd ?? value.query ?? value.pattern ?? value.url ?? value.description
+    const primarySummary = summarizePrimaryToolArg(primary)
+    if (primarySummary) {
+      return primarySummary
+    }
+  }
+  return summarizeToolInput(normalized)
+}
+
+/** Full, pretty-printed tool-call input for the expanded detail view. Structured
+ *  JSON strings and objects/arrays print as indented JSON so a diff-less call
+ *  (e.g. a question payload) reads cleanly instead of one long minified line;
+ *  other strings pass through as-is. */
 export function formatToolInput(input: unknown): string {
-  if (input === null || input === undefined) {
+  const normalized = normalizeToolInput(input)
+  if (normalized === null || normalized === undefined) {
     return ''
   }
-  if (typeof input === 'string') {
-    return input
+  if (typeof normalized === 'string') {
+    return normalized
   }
-  if (typeof input === 'number' || typeof input === 'boolean') {
-    return String(input)
+  if (typeof normalized === 'number' || typeof normalized === 'boolean') {
+    return String(normalized)
   }
   try {
-    return JSON.stringify(input, null, 2) ?? ''
+    return JSON.stringify(normalized, null, 2) ?? ''
   } catch {
     return ''
   }
 }
 
+/** Whether the expanded detail would show structured JSON rather than repeating
+ *  the row label — i.e. whether expanding the row is worth offering. */
+export function isStructuredToolInput(input: unknown): boolean {
+  const normalized = normalizeToolInput(input)
+  return normalized !== null && typeof normalized === 'object'
+}
+
 export function toolFilePath(input: unknown): string | null {
-  if (!input || typeof input !== 'object') {
+  const normalized = normalizeToolInput(input)
+  if (!normalized || typeof normalized !== 'object') {
     return null
   }
-  const value = input as Record<string, unknown>
+  const value = normalized as Record<string, unknown>
   const path = value.file_path ?? value.filePath ?? value.path ?? value.notebook_path
   return typeof path === 'string' && path.length > 0 ? path : null
 }
 
 export function briefToolArg(input: unknown): string {
-  if (input && typeof input === 'object') {
-    const value = input as Record<string, unknown>
+  const normalized = normalizeToolInput(input)
+  if (normalized && typeof normalized === 'object') {
+    const value = normalized as Record<string, unknown>
     const path = value.file_path ?? value.filePath ?? value.path ?? value.notebook_path
     if (typeof path === 'string' && path.length > 0) {
       const parts = path.split(/[\\/]/).filter(Boolean)
       return parts.at(-1) ?? path
     }
     const command = value.command ?? value.cmd ?? value.query ?? value.pattern
-    if (typeof command === 'string') {
-      return summarizeToolInput(command).slice(0, 28)
+    const commandSummary = summarizePrimaryToolArg(command)
+    if (commandSummary) {
+      return commandSummary.slice(0, 28)
     }
   }
-  return summarizeToolInput(input).slice(0, 28)
+  return summarizeToolInput(normalized).slice(0, 28)
+}
+
+/** Codex delivers tool arguments as a JSON string. Parse those into the object
+ *  shape every helper below already understands; leave prose strings alone. */
+function normalizeToolInput(input: unknown): unknown {
+  if (typeof input !== 'string') {
+    return input
+  }
+  const first = input.trimStart()[0]
+  if (first !== '{' && first !== '[') {
+    return input
+  }
+  try {
+    const parsed: unknown = JSON.parse(input)
+    return parsed !== null && typeof parsed === 'object' ? parsed : input
+  } catch {
+    return input
+  }
+}
+
+/** A label-worthy primary argument: a non-blank string, or an argv array. */
+function summarizePrimaryToolArg(input: unknown): string | null {
+  if (typeof input === 'string' && input.trim()) {
+    return summarizeToolInput(input)
+  }
+  if (Array.isArray(input) && input.length > 0 && input.every((part) => typeof part === 'string')) {
+    return summarizeToolInput(input.join(' '))
+  }
+  return null
 }
 
 export function summarizeToolRun(blocks: readonly NativeChatBlock[]): string {

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -60,7 +60,12 @@ export function formatToolInput(input: unknown): string {
  *  the row label — i.e. whether expanding the row is worth offering. */
 export function isStructuredToolInput(input: unknown): boolean {
   const normalized = normalizeToolInput(input)
-  return normalized !== null && typeof normalized === 'object'
+  if (normalized === null || typeof normalized !== 'object') {
+    return false
+  }
+  // An empty object formats back to the row label verbatim, so offering the
+  // expander would promise detail and then repeat the row.
+  return Array.isArray(normalized) ? normalized.length > 0 : Object.keys(normalized).length > 0
 }
 
 export function toolFilePath(input: unknown): string | null {

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -5,6 +5,8 @@ const MAX_PREVIEW_STRING_INPUT = 160
 const MAX_PREVIEW_COLLECTION_ITEMS = 8
 const MAX_PREVIEW_DEPTH = 2
 const MAX_TOOL_RUN_SUMMARY_PARTS = 3
+const PRIMARY_ARG_KEYS = ['command', 'cmd', 'query', 'pattern', 'url', 'description'] as const
+const BRIEF_ARG_KEYS = ['command', 'cmd', 'query', 'pattern'] as const
 
 export function summarizeToolInput(input: unknown): string {
   const collapsed = toRawPreview(input).replace(/\s+/g, ' ').trim()
@@ -20,16 +22,13 @@ export function describeToolInput(input: unknown): string {
   const normalized = normalizeToolInput(input)
   const path = toolFilePath(normalized)
   if (path) {
-    return summarizeToolInput(path)
+    return summarizeToolPath(path)
   }
   if (normalized && typeof normalized === 'object') {
-    const value = normalized as Record<string, unknown>
     // Concrete target/action first; prose `description` only as a last resort.
-    const primary =
-      value.command ?? value.cmd ?? value.query ?? value.pattern ?? value.url ?? value.description
-    const primarySummary = summarizePrimaryToolArg(primary)
-    if (primarySummary) {
-      return primarySummary
+    const primary = firstPrimaryToolArg(normalized as Record<string, unknown>, PRIMARY_ARG_KEYS)
+    if (primary) {
+      return primary
     }
   }
   return summarizeToolInput(normalized)
@@ -70,23 +69,24 @@ export function toolFilePath(input: unknown): string | null {
     return null
   }
   const value = normalized as Record<string, unknown>
-  const path = value.file_path ?? value.filePath ?? value.path ?? value.notebook_path
+  // A search call's `path` is the directory it scanned, not a file it opened —
+  // taking it would drop the pattern from the label and offer a link to a folder.
+  const directory = isSearchToolInput(value) ? undefined : value.path
+  const path = value.file_path ?? value.filePath ?? directory ?? value.notebook_path
   return typeof path === 'string' && path.length > 0 ? path : null
 }
 
 export function briefToolArg(input: unknown): string {
   const normalized = normalizeToolInput(input)
   if (normalized && typeof normalized === 'object') {
-    const value = normalized as Record<string, unknown>
-    const path = value.file_path ?? value.filePath ?? value.path ?? value.notebook_path
-    if (typeof path === 'string' && path.length > 0) {
+    const path = toolFilePath(normalized)
+    if (path) {
       const parts = path.split(/[\\/]/).filter(Boolean)
       return parts.at(-1) ?? path
     }
-    const command = value.command ?? value.cmd ?? value.query ?? value.pattern
-    const commandSummary = summarizePrimaryToolArg(command)
-    if (commandSummary) {
-      return commandSummary.slice(0, 28)
+    const command = firstPrimaryToolArg(normalized as Record<string, unknown>, BRIEF_ARG_KEYS)
+    if (command) {
+      return command.slice(0, 28)
     }
   }
   return summarizeToolInput(normalized).slice(0, 28)
@@ -108,6 +108,42 @@ function normalizeToolInput(input: unknown): unknown {
   } catch {
     return input
   }
+}
+
+/** A search call is named by what it looked for, so its `path` is a scan root
+ *  rather than a file target. */
+function isSearchToolInput(value: Record<string, unknown>): boolean {
+  return (
+    summarizePrimaryToolArg(value.query) !== null || summarizePrimaryToolArg(value.pattern) !== null
+  )
+}
+
+/** The first key that yields a label — a present-but-blank key must not swallow
+ *  the keys ranked after it. */
+function firstPrimaryToolArg(
+  value: Record<string, unknown>,
+  keys: readonly string[]
+): string | null {
+  for (const key of keys) {
+    const summary = summarizePrimaryToolArg(value[key])
+    if (summary) {
+      return summary
+    }
+  }
+  return null
+}
+
+/** A path is identified by its tail, so trim from the front: head-truncating an
+ *  absolute path drops the filename, the one part that tells two rows apart. */
+function summarizeToolPath(path: string): string {
+  const collapsed = path.replace(/\s+/g, ' ').trim()
+  if (collapsed.length <= MAX_PREVIEW_LENGTH) {
+    return collapsed
+  }
+  const tail = collapsed.slice(collapsed.length - (MAX_PREVIEW_LENGTH - 1))
+  // Start at a segment boundary so the label doesn't open mid-name.
+  const boundary = tail.search(/[\\/]/)
+  return `…${boundary > 0 ? tail.slice(boundary) : tail}`
 }
 
 /** A label-worthy primary argument: a non-blank string, or an argv array. */

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -96,8 +96,9 @@ export function briefToolArg(input: unknown): string {
       return command.slice(0, 28)
     }
     // A blank primary key means the call has no brief argument; falling through
-    // would stand its raw JSON in for one in the run header.
-    if (BRIEF_ARG_KEYS.some((key) => Object.prototype.hasOwnProperty.call(value, key))) {
+    // would stand its raw JSON in for one in the run header. Reaching here with a
+    // string key means it was blank — a structured one still earns the preview.
+    if (BRIEF_ARG_KEYS.some((key) => typeof value[key] === 'string')) {
       return ''
     }
   }


### PR DESCRIPTION
## Summary

Mobile tool rows in native chat labelled themselves with the raw tool-call input JSON — a `Read` showed `{"file_path":"src/index.ts","offset":10}` instead of the file it read — and tapping the row open just repeated that same truncated string as the "detail", so expanding revealed nothing new.

This makes the mobile tool row read as a clean, bounded, expandable summary:

- **Row label is a human summary.** New shared `describeToolInput` labels a row with the target file path, else the primary argument (`command` / `cmd` / `query` / `pattern` / `url`, falling back to `description`), else the existing bounded JSON preview. Concrete target/action wins over prose, so a Bash call labels with its command rather than its description.
- **Codex JSON-string inputs are understood.** Codex delivers tool arguments as a JSON *string* rather than an object, so every helper saw an opaque blob: no file path, no command label, no pretty-printed detail, and no tappable open-file link. The helpers now normalize a leading `{`/`[` string by parsing it into the object shape they already handle; prose strings, JSON scalars, and malformed JSON are left exactly as-is.
- **Expanded detail shows the real input, capped like desktop.** A diff-less call now expands to the fully formatted (pretty-printed) input rather than the row label repeated, bounded at `MAX_TOOL_RESULT_CHARS` (4000) — the same cap desktop applies to its tool detail, and the same cap the mobile result body already used. Native text layout has no scroll container to absorb a runaway payload, so this is bounded before it reaches layout. A structured input also makes the row expandable, which it previously wasn't unless the preview happened to exceed 40 chars. Conversely, a row with *nothing* to expand no longer renders a panel at all: the detail panel and the open-chevron are gated on the same `hasDetail` guard as the tap, so the Tools toggle — which opens every row at once, bypassing that tap — can no longer leave a row echoing its own label under itself with no way to dismiss it. This matches desktop `NativeChatToolRun.tsx`.

**Known limitation, pre-existing and left for follow-up.** `sanitizeToolInput` in `src/main/runtime/rpc/methods/native-chat.ts` clips a tool-call input that is a JSON *string* at `MOBILE_BLOCK_CHAR_CAP` (4000) and appends a truncation marker, which leaves it unparseable. So a Codex call whose arguments exceed 4000 chars — a write with large `content`, or a multi-line script — still falls back to the raw-JSON label, and loses its open-file link, where the byte-identical Claude call keeps both (the sanitizer shrinks *object* values key-by-key but truncates a string as one opaque blob). `main` showed raw JSON at every size, so nothing regresses; this PR simply doesn't reach that case. The contained fix is to parse the string main-side, sanitize the parsed object with the existing caps, and re-stringify — which keeps the wire shape a string — but that is a main-process change outside this PR's scope.

Split out of #12373 (item 10 of that QA sweep) as an independent, focused PR targeting `main`. #12373 stays open and is not affected by this branch.

Refs STA-3333.

## Screenshots

No visual change to layout, spacing, color, or typography — existing tokens and components only. The user-visible change is the text inside the existing tool row.

Desktop A/B captured with `playwright-cli` over CDP against a dev build of this branch, on a resumed read-only Codex session with 104 real `exec_command` calls. Same session, viewport, scroll offset and DOM in both frames; the only difference is `src/shared/native-chat-tool-summary.ts` (branch vs `origin/main`).

| Before (`origin/main`) | After (this branch) |
|---|---|
| ![before](https://github.com/stablyai/orca/blob/3f584c127ea02042706d3e33165140a4b0803b7b/01-before-main-tool-rows-raw-json.png?raw=true) | ![after](https://github.com/stablyai/orca/blob/3f584c127ea02042706d3e33165140a4b0803b7b/02-after-branch-tool-rows-clean-summary.png?raw=true) |

The `18×` run is the clearest case: on `main` the `{"cmd":"` prefix eats 8 of the 28 label characters, so two different calls render byte-identical labels (`exec_command {"cmd":"ps -p 20068 -o pid=,` twice); after the fix they read `ps -p 20068 -o pid=,pgid=,cw` and `…,pgid=,co` and are distinguishable.

Desktop parity — a Codex JSON-string call now pretty-prints in its expanded detail via the same `formatToolInput` normalization:

![expanded detail](https://github.com/stablyai/orca/blob/3f584c127ea02042706d3e33165140a4b0803b7b/03-after-branch-expanded-detail-pretty-printed.png?raw=true)

The per-call row label *inside* an expanded desktop run still uses `summarizeToolInput` (the raw bounded preview) — unchanged from `main`, and a desktop-renderer decision left outside this PR.

## Testing

- [x] `pnpm lint` — root `oxlint` clean, mobile `oxlint` clean, native + type-aware code-quality audits clean, `check:max-lines-ratchet` OK (352 grandfathered, no new bypasses), `lint:react-doctor:changed` exit 0 (the three `no-array-index-as-key` warnings it prints are pre-existing, on lines this PR does not touch)
- [x] `pnpm typecheck` — all three root tsc projects (`node`, `tc.cli`, `tc.web`) and mobile `tsc --noEmit` clean
- [x] `pnpm test` — 464 files / 4452 tests desktop+shared, 403 files / 3015 tests mobile, all passing
- [ ] `pnpm build` — not run; no build-affecting changes (pure string formatting + one renderer file), CI covers it
- [x] Added or updated high-quality tests that would catch regressions

Tests added: `describeToolInput` path/primary-argument/fallback/truncation labelling and the `url`-before-`description` ordering; a dedicated Codex JSON-string block covering label, formatted detail, file link, `briefToolArg`, `isStructuredToolInput`, argv-array joining, and the negative cases (prose, malformed JSON, JSON scalar); mobile renderer tests that the row labels with the path rather than raw JSON, that the expanded diff-less detail is capped at exactly `MAX_TOOL_RESULT_CHARS + 1` chars ending in `…`, that a Codex JSON-string call labels with its command and reveals pretty-printed JSON only once its row is tapped, that a row with nothing to expand renders no detail panel even when the Tools toggle opens every row, and that a present-but-blank primary argument keeps the run header reading `Bash` rather than `Bash {"command":""}` while a populated but non-string one (mixed argv, structured query) still falls back to the preview.

**Anti-vacuity check:** every new test was re-run against mutated source rather than only against a revert. Reverting the three source files (tests kept) fails all four original renderer/barrel tests; deleting the detail-panel guard fails the row-echo test; deleting the blank-argument guard fails the run-header test. Two things are deliberately *not* pinned and are cosmetic: the segment-boundary alignment inside `summarizeToolPath`, and the chevron half of the detail-panel guard.

## AI Review Report

Self-reviewed with focus on:

1. **Blast radius of the shared change.** `formatToolInput`, `toolFilePath` and `briefToolArg` are shared with the desktop renderer (`NativeChatToolRun.tsx`), so normalizing JSON-string input changes desktop behavior too. Verified this is strictly an improvement and intended parity: a Codex JSON-string call on desktop now pretty-prints in its detail and becomes expandable via the existing `detailAddsInfo` check, where it previously collapsed to detail-equals-preview. The desktop renderer itself is deliberately untouched (this PR is scoped to the mobile row label); its 897 existing tests pass unchanged.
2. **Parsing safety.** `normalizeToolInput` only attempts `JSON.parse` when the trimmed string starts with `{` or `[`, is wrapped in try/catch, and returns the original string on failure or when the parse yields a non-object — so prose, malformed JSON, and JSON scalars round-trip unchanged. Locked by test.
3. **Unbounded-output risk.** The new expanded detail is the *full* input, not the bounded preview, so it is capped before reaching React Native text layout; the cap is shared with the result body via one `boundedText` helper rather than duplicated. Verified with a 100 KB payload.
4. **Render cost.** Detail formatting is computed only when the row is expanded, matching the existing lazy-diff pattern. The collapsed path is not free, though: `describeToolInput`, `toolFilePath` and `isStructuredToolInput` each re-run the JSON-string normalization, so a collapsed Codex row costs 3 `JSON.parse` of its arguments per render (+1 per run-header render via `summarizeToolRun` → `briefToolArg`). Measured over 6 rows: 2 KB payload 0.81 → 0.87 ms (noise), 100 KB 0.70 → 1.47 ms. Sub-millisecond and bounded upstream by the 4000-char wire cap, so not worth memoizing here — but worth memoizing if these helpers ever move onto a hot virtualized list.
5. **Render purity / hooks.** No new hooks, effects, state, or dependencies; `ToolLine` remains a pure render. `lint:react-doctor:changed` passes.

**Cross-platform:** no keyboard shortcuts, shortcut labels, shell invocation, or filesystem path *construction* are touched. Path handling is read-only string inspection that already splits on `[\\/]`, and Windows backslash paths are covered by both pre-existing and newly added assertions. The change is React Native / renderer string formatting and is identical on iOS and Android and agnostic of the desktop host OS — it behaves the same for a local, WSL, SSH, or relay-backed session, and for folder workspaces as well as git worktrees, because it never inspects the workspace kind. No Git commands involved.

## Security Audit

No command execution, no auth, no secrets, no dependency changes, and no IPC/RPC surface change (no new methods; this is pure presentation over data the chat transcript already carries).

The one new input-handling surface is `JSON.parse` on agent-supplied tool-argument strings. It is gated on a leading `{`/`[`, wrapped in try/catch, and its result is only ever read as data — never evaluated, never used to construct a path or command, and never used for a filesystem or network operation. Parsed values flow through the pre-existing bounded-preview logic (length, collection-size, depth, and circular-reference caps) and render into plain `Text` nodes, so there is no injection or amplification surface. Deeply nested or oversized payloads are bounded by the existing preview caps for the label and by `MAX_TOOL_RESULT_CHARS` for the detail. `JSON.parse` on a hostile string is a memory cost only, and tool inputs are already fully materialized in the transcript before this code runs.

The existing `onOpenFile` link now also fires for Codex calls, since `toolFilePath` can finally read their path. That path goes to the same already-validated open-file handler used by object-input calls — this widens *which* calls get a link, not what the handler accepts.

## Notes

- Split from #12373, which remains open and unmerged. This branch is an Orca child worktree for lineage only — it is **not** a stacked Git branch: it was fast-forwarded to `origin/main` and targets `main`, so it can merge independently and in any order relative to #12373.
- Scoped deliberately to the tool-row summary. The other #12373 fixes (reconnect history, stale status, prompt cards, paging, write lock, streaming bubble) are not included here.
- `diffFromToolCall` still receives the raw, un-normalized `call.input`, so a Codex JSON-string `Edit` renders as formatted JSON rather than a diff — unchanged from `main`, and left alone as it belongs to the diff module rather than this summary scope. Worth a follow-up if Codex edit diffs are wanted on mobile.
- A tool call with an empty object input (`{}` or `[]`) is no longer advertised as expandable: its formatted detail is byte-identical to the row label, so offering the expander promised detail and then repeated the row — the same defect this PR removes. `isStructuredToolInput` now requires the collection to be non-empty; the lazy-detail path is untouched.
- **Known residual (pre-existing, not a regression):** the paired-mobile transport clips each tool-call block at 4000 chars (`MOBILE_BLOCK_CHAR_CAP`), and for a Codex JSON-*string* input that clip lands mid-JSON, so `JSON.parse` fails and the row falls back to the raw-JSON label. Measured against 29,947 real Codex tool calls across 1,981 transcripts, **0.2% exceed that cap** (`exec_command` median 221 chars, p95 740). Fixing it means parsing before sanitizing in the main-process RPC — a different layer, and it would also silently un-defer the `diffFromToolCall` gap noted above. Left for a follow-up rather than widened into this PR.




