### PR TITLE
fix(mobile): keep repeated-prefix native chat replies streaming (STA-3333)

### DIFF
--- a/mobile/src/session/MobileNativeChatOverlay.test.ts
+++ b/mobile/src/session/MobileNativeChatOverlay.test.ts
@@ -145,6 +145,21 @@ describe('MobileNativeChatOverlay streaming gate', () => {
     expect(streaming()).toBe('Done.')
   })
 
+  it('keeps the bubble across a peek at the terminal taken between turns', async () => {
+    // Same toggle, but taken while idle: the transcript empties before the next
+    // turn starts, so the gate has to reject that empty tail as a baseline.
+    const prior = [assistantTurn('a1', 'Done.')]
+    await render({ messages: prior })
+
+    await update({ show: false, messages: [] })
+    await update({ show: false, messages: [], streamLive: true })
+    await update({ messages: [], streamLive: true })
+    await update({ messages: [], streamingText: 'Done.', streamLive: true })
+    await update({ messages: prior, streamingText: 'Done.', streamLive: true })
+
+    expect(streaming()).toBe('Done.')
+  })
+
   it('hides a repeated part whose own turn landed during a mid-turn gap', async () => {
     // Between parts the status frame carries no assistant text (a tool call), so
     // the stream goes textless while the turn is still live and the part that

--- a/mobile/src/session/MobileNativeChatOverlay.test.ts
+++ b/mobile/src/session/MobileNativeChatOverlay.test.ts
@@ -136,19 +136,25 @@ describe('MobileNativeChatOverlay streaming gate', () => {
 
     await update({ show: false, messages: [], streamLive: true })
     expect(streaming()).toBe('hidden')
-    // Back on chat: the throttled status trails the first re-render by a tick.
-    await update({ messages: prior, streamLive: true })
+    // Back on chat the session withholds its transcript until a fresh read
+    // settles, so the throttled stream text returns a round trip ahead of it.
+    await update({ messages: [], streamLive: true })
+    await update({ messages: [], streamingText: 'Done.', streamLive: true })
     await update({ messages: prior, streamingText: 'Done.', streamLive: true })
 
     expect(streaming()).toBe('Done.')
   })
 
-  it('still hides the bubble when the reply landed while chat was hidden', async () => {
+  it('hides a repeated part whose own turn landed during a mid-turn gap', async () => {
+    // Between parts the status frame carries no assistant text (a tool call), so
+    // the stream goes textless while the turn is still live and the part that
+    // just finished lands in the transcript. Re-anchoring on that tick would
+    // adopt it as history and render it a second time.
     const prior = [assistantTurn('a1', 'Done.')]
     await render({ messages: prior })
     await update({ messages: prior, streamingText: 'Done.', streamLive: true })
+    expect(streaming()).toBe('Done.')
 
-    await update({ show: false, messages: [], streamLive: true })
     const landed = [...prior, assistantTurn('a2', 'Done.')]
     await update({ messages: landed, streamLive: true })
     await update({ messages: landed, streamingText: 'Done.', streamLive: true })

--- a/mobile/src/session/MobileNativeChatOverlay.test.ts
+++ b/mobile/src/session/MobileNativeChatOverlay.test.ts
@@ -1,0 +1,172 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { MobileNativeChatOverlay } from './MobileNativeChatOverlay'
+import type { MobileNativeChatController } from './use-mobile-native-chat-controller'
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles, absoluteFillObject: {} },
+  View: 'View'
+}))
+
+vi.mock('./MobileNativeChatView', () => ({ MobileNativeChatView: 'ChatView' }))
+
+function assistantTurn(id: string, text: string): NativeChatMessage {
+  return { id, role: 'assistant', blocks: [{ type: 'text', text }], timestamp: 0, source: 'hook' }
+}
+
+function suppressRendererWarning(): () => void {
+  const original = console.error
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+      return
+    }
+    original(...args)
+  })
+  return () => spy.mockRestore()
+}
+
+/** One render of the route: chat visible or not, the transcript it currently
+ *  holds, and the agent-status stream behind it. */
+type Tick = {
+  show?: boolean
+  messages?: NativeChatMessage[]
+  streamingText?: string
+  streamLive?: boolean
+  identity?: string
+}
+
+function overlayElement(tick: Tick): ReturnType<typeof createElement> {
+  const controller = {
+    showNativeChat: tick.show ?? true,
+    nativeChatSession: { messages: tick.messages ?? [], status: 'ready' },
+    nativeChatAgent: 'claude',
+    nativeChatAgentWorking: tick.streamLive ?? false,
+    nativeChatStreamingText: tick.streamingText,
+    nativeChatStreamLive: tick.streamLive ?? false,
+    nativeChatStreamScopeKey: tick.identity ?? 'tab-a',
+    chatPending: [],
+    chatComposerText: '',
+    setChatComposerText: vi.fn()
+  } as unknown as MobileNativeChatController
+  return createElement(MobileNativeChatOverlay, {
+    controller,
+    images: {} as never,
+    onMicPress: vi.fn(),
+    micActive: false,
+    dictationMode: 'toggle',
+    onMicPressIn: vi.fn(),
+    onMicPressOut: vi.fn(),
+    inputLockReason: null,
+    sendErrorMessage: null,
+    onClearSendError: vi.fn(),
+    keyboardInset: 0
+  })
+}
+
+describe('MobileNativeChatOverlay streaming gate', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  async function render(tick: Tick): Promise<void> {
+    const restore = suppressRendererWarning()
+    try {
+      await act(async () => {
+        renderer = create(overlayElement(tick))
+      })
+    } finally {
+      restore()
+    }
+  }
+
+  async function update(tick: Tick): Promise<void> {
+    await act(async () => {
+      renderer?.update(overlayElement(tick))
+    })
+  }
+
+  /** The bubble text handed to the chat list, or `'hidden'` when chat is off. */
+  function streaming(): string | null | 'hidden' {
+    const views = renderer!.root.findAll((node) => node.type === 'ChatView')
+    return views.length === 0 ? 'hidden' : (views[0].props.streaming as string | null)
+  }
+
+  it('keeps streaming a reply that repeats the previous turn as a prefix', async () => {
+    const prior = [assistantTurn('a1', 'The tests pass.')]
+    await render({ messages: prior })
+    expect(streaming()).toBeNull()
+
+    await update({ messages: prior, streamingText: 'The tests', streamLive: true })
+
+    expect(streaming()).toBe('The tests')
+  })
+
+  it('drops the streaming bubble once the reply lands as its own turn', async () => {
+    const prior = [assistantTurn('a1', 'Done.')]
+    await render({ messages: prior })
+    await update({ messages: prior, streamingText: 'Done.', streamLive: true })
+    expect(streaming()).toBe('Done.')
+
+    await update({
+      messages: [...prior, assistantTurn('a2', 'Done.')],
+      streamingText: 'Done.',
+      streamLive: true
+    })
+
+    expect(streaming()).toBeNull()
+  })
+
+  it('keeps the bubble across a peek at the terminal view', async () => {
+    // Toggling to the terminal unmounts the chat list and unsubscribes its
+    // transcript. The gate lives above that boundary, so the baseline survives
+    // and the repeated-prefix reply keeps streaming on the way back.
+    const prior = [assistantTurn('a1', 'Done.')]
+    await render({ messages: prior })
+    await update({ messages: prior, streamingText: 'Done.', streamLive: true })
+    expect(streaming()).toBe('Done.')
+
+    await update({ show: false, messages: [], streamLive: true })
+    expect(streaming()).toBe('hidden')
+    // Back on chat: the throttled status trails the first re-render by a tick.
+    await update({ messages: prior, streamLive: true })
+    await update({ messages: prior, streamingText: 'Done.', streamLive: true })
+
+    expect(streaming()).toBe('Done.')
+  })
+
+  it('still hides the bubble when the reply landed while chat was hidden', async () => {
+    const prior = [assistantTurn('a1', 'Done.')]
+    await render({ messages: prior })
+    await update({ messages: prior, streamingText: 'Done.', streamLive: true })
+
+    await update({ show: false, messages: [], streamLive: true })
+    const landed = [...prior, assistantTurn('a2', 'Done.')]
+    await update({ messages: landed, streamLive: true })
+    await update({ messages: landed, streamingText: 'Done.', streamLive: true })
+
+    expect(streaming()).toBeNull()
+  })
+
+  it("does not carry one chat's baseline into another stream identity", async () => {
+    const prior = [assistantTurn('a1', 'Shared answer text')]
+    await render({ messages: prior, identity: 'tab-a' })
+
+    await update({
+      messages: prior,
+      streamingText: 'Shared answer',
+      streamLive: true,
+      identity: 'tab-b'
+    })
+
+    expect(streaming()).toBeNull()
+  })
+})

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from 'react'
 import { StyleSheet, View } from 'react-native'
 import { MobileNativeChatView, type MobileNativeChatInputLockReason } from './MobileNativeChatView'
+import { foldMobileNativeChatMessages } from './mobile-native-chat-render-data'
 import type { MobileNativeChatImageAttachments } from './use-mobile-native-chat-image-attachments'
 import type { MobileNativeChatController } from './use-mobile-native-chat-controller'
+import { useMobileNativeChatStreamingBubble } from './use-mobile-native-chat-streaming-bubble'
 
 type Props = {
   controller: MobileNativeChatController
@@ -22,7 +25,9 @@ type Props = {
 }
 
 /** Keeps the terminal mounted underneath chat so its PTY subscription survives
- *  view toggles while the native surface owns the visible composer. */
+ *  view toggles while the native surface owns the visible composer. Also owns
+ *  the streaming gate: this component stays mounted across those toggles, while
+ *  the chat list below it does not. */
 export function MobileNativeChatOverlay({
   controller,
   images,
@@ -36,20 +41,27 @@ export function MobileNativeChatOverlay({
   onClearSendError,
   keyboardInset
 }: Props): React.JSX.Element | null {
+  const session = controller.nativeChatSession
+  const folded = useMemo(() => foldMobileNativeChatMessages(session.messages), [session.messages])
+  const streaming = useMobileNativeChatStreamingBubble(
+    folded,
+    controller.nativeChatStreamingText,
+    controller.nativeChatStreamScopeKey,
+    controller.nativeChatStreamLive
+  )
   if (!controller.showNativeChat) {
     return null
   }
-  const session = controller.nativeChatSession
   return (
     <View style={styles.overlay}>
       <MobileNativeChatView
         messages={session.messages}
+        folded={folded}
         status={session.status}
         error={session.error}
         agent={controller.nativeChatAgent}
         agentWorking={controller.nativeChatAgentWorking}
-        streamingText={controller.nativeChatStreamingText}
-        streamIdentity={controller.nativeChatStreamIdentity}
+        streaming={streaming}
         onStop={controller.handleNativeChatStop}
         ask={controller.nativeChatAsk}
         onAnswerAsk={controller.handleNativeChatAnswerAsk}

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -49,6 +49,7 @@ export function MobileNativeChatOverlay({
         agent={controller.nativeChatAgent}
         agentWorking={controller.nativeChatAgentWorking}
         streamingText={controller.nativeChatStreamingText}
+        streamIdentity={controller.nativeChatStreamIdentity}
         onStop={controller.handleNativeChatStop}
         ask={controller.nativeChatAsk}
         onAnswerAsk={controller.handleNativeChatAnswerAsk}

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MobileNativeChatView } from './MobileNativeChatView'
 
 vi.mock('react-native', () => ({
@@ -58,6 +59,9 @@ vi.mock('./MobileNativeChatComposer', async () => {
 })
 
 type Overrides = {
+  messages?: Parameters<typeof MobileNativeChatView>[0]['messages']
+  streamingText?: string
+  streamIdentity?: string
   sendErrorMessage?: string | null
   onClearSendError?: () => void
   inputLockReason?: 'disconnected' | 'waiting' | null
@@ -73,6 +77,23 @@ function suppressRendererWarning(): () => void {
     original(...args)
   })
   return () => spy.mockRestore()
+}
+
+function assistantTurn(id: string, text: string): NativeChatMessage {
+  return { id, role: 'assistant', blocks: [{ type: 'text', text }], timestamp: 0, source: 'hook' }
+}
+
+function chatViewElement(overrides: Overrides): ReturnType<typeof createElement> {
+  return createElement(MobileNativeChatView, {
+    messages: [],
+    status: 'ready',
+    streamIdentity: 'test-stream',
+    onSend: vi.fn().mockResolvedValue(true),
+    pending: [],
+    composerText: '',
+    onComposerTextChange: vi.fn(),
+    ...overrides
+  })
 }
 
 describe('MobileNativeChatView send-error banner', () => {
@@ -91,21 +112,23 @@ describe('MobileNativeChatView send-error banner', () => {
     const restore = suppressRendererWarning()
     try {
       await act(async () => {
-        renderer = create(
-          createElement(MobileNativeChatView, {
-            messages: [],
-            status: 'ready',
-            onSend: overrides.onSend ?? vi.fn().mockResolvedValue(true),
-            pending: [],
-            composerText: '',
-            onComposerTextChange: vi.fn(),
-            ...overrides
-          })
-        )
+        renderer = create(chatViewElement(overrides))
       })
     } finally {
       restore()
     }
+  }
+
+  async function update(overrides: Overrides = {}): Promise<void> {
+    await act(async () => {
+      renderer?.update(chatViewElement(overrides))
+    })
+  }
+
+  /** Ids of the rows the list is currently rendering. */
+  function listIds(): string[] {
+    const list = renderer!.root.find((node) => node.type === 'FlatList')
+    return (list.props.data as { id: string }[]).map((row) => row.id)
   }
 
   function banners(): ReactTestInstance[] {
@@ -160,5 +183,38 @@ describe('MobileNativeChatView send-error banner', () => {
     await pressSend()
 
     expect(onClearSendError).toHaveBeenCalledOnce()
+  })
+
+  it('keeps streaming a reply that repeats the previous turn as a prefix', async () => {
+    const prior = [assistantTurn('a1', 'The tests pass.')]
+    await render({ messages: prior })
+    expect(listIds()).toEqual(['a1'])
+
+    await update({ messages: prior, streamingText: 'The tests' })
+
+    expect(listIds()).toEqual(['a1', 'streaming'])
+  })
+
+  it('drops the streaming bubble once the reply lands as its own turn', async () => {
+    const prior = [assistantTurn('a1', 'Done.')]
+    await render({ messages: prior })
+    await update({ messages: prior, streamingText: 'Done.' })
+    expect(listIds()).toEqual(['a1', 'streaming'])
+
+    await update({
+      messages: [...prior, assistantTurn('a2', 'Done.')],
+      streamingText: 'Done.'
+    })
+
+    expect(listIds()).toEqual(['a1', 'a2'])
+  })
+
+  it("does not carry one chat's baseline into another stream identity", async () => {
+    const prior = [assistantTurn('a1', 'Shared answer text')]
+    await render({ messages: prior, streamIdentity: 'tab-a' })
+
+    await update({ messages: prior, streamingText: 'Shared answer', streamIdentity: 'tab-b' })
+
+    expect(listIds()).toEqual(['a1'])
   })
 })

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -60,8 +60,8 @@ vi.mock('./MobileNativeChatComposer', async () => {
 
 type Overrides = {
   messages?: Parameters<typeof MobileNativeChatView>[0]['messages']
-  streamingText?: string
-  streamIdentity?: string
+  folded?: Parameters<typeof MobileNativeChatView>[0]['folded']
+  streaming?: string | null
   sendErrorMessage?: string | null
   onClearSendError?: () => void
   inputLockReason?: 'disconnected' | 'waiting' | null
@@ -86,8 +86,9 @@ function assistantTurn(id: string, text: string): NativeChatMessage {
 function chatViewElement(overrides: Overrides): ReturnType<typeof createElement> {
   return createElement(MobileNativeChatView, {
     messages: [],
+    folded: [],
     status: 'ready',
-    streamIdentity: 'test-stream',
+    streaming: null,
     onSend: vi.fn().mockResolvedValue(true),
     pending: [],
     composerText: '',
@@ -96,7 +97,7 @@ function chatViewElement(overrides: Overrides): ReturnType<typeof createElement>
   })
 }
 
-describe('MobileNativeChatView send-error banner', () => {
+describe('MobileNativeChatView', () => {
   let renderer: ReactTestRenderer | null = null
 
   beforeEach(() => {
@@ -185,36 +186,15 @@ describe('MobileNativeChatView send-error banner', () => {
     expect(onClearSendError).toHaveBeenCalledOnce()
   })
 
-  it('keeps streaming a reply that repeats the previous turn as a prefix', async () => {
-    const prior = [assistantTurn('a1', 'The tests pass.')]
-    await render({ messages: prior })
+  // The gate that decides `streaming` lives in MobileNativeChatOverlay, which
+  // outlives this view; see MobileNativeChatOverlay.test.ts.
+  it('appends the gated streaming bubble after the folded transcript', async () => {
+    const folded = [assistantTurn('a1', 'The tests pass.')]
+    await render({ folded })
     expect(listIds()).toEqual(['a1'])
 
-    await update({ messages: prior, streamingText: 'The tests' })
+    await update({ folded, streaming: 'The tests' })
 
     expect(listIds()).toEqual(['a1', 'streaming'])
-  })
-
-  it('drops the streaming bubble once the reply lands as its own turn', async () => {
-    const prior = [assistantTurn('a1', 'Done.')]
-    await render({ messages: prior })
-    await update({ messages: prior, streamingText: 'Done.' })
-    expect(listIds()).toEqual(['a1', 'streaming'])
-
-    await update({
-      messages: [...prior, assistantTurn('a2', 'Done.')],
-      streamingText: 'Done.'
-    })
-
-    expect(listIds()).toEqual(['a1', 'a2'])
-  })
-
-  it("does not carry one chat's baseline into another stream identity", async () => {
-    const prior = [assistantTurn('a1', 'Shared answer text')]
-    await render({ messages: prior, streamIdentity: 'tab-a' })
-
-    await update({ messages: prior, streamingText: 'Shared answer', streamIdentity: 'tab-b' })
-
-    expect(listIds()).toEqual(['a1'])
   })
 })

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -16,12 +16,10 @@ import { colors } from '../theme/mobile-theme'
 import { styles } from './mobile-native-chat-view-styles'
 import {
   buildMobileNativeChatTransientData,
-  foldMobileNativeChatMessages,
   mobileNativeChatEmptyState,
   type MobileNativeChatPendingItem
 } from './mobile-native-chat-render-data'
 import { useMobileNativeChatAskDismiss } from './use-mobile-native-chat-ask-dismiss'
-import { useMobileNativeChatStreamingBubble } from './use-mobile-native-chat-streaming-bubble'
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
@@ -40,7 +38,10 @@ import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 export type MobileNativeChatInputLockReason = 'disconnected' | 'waiting'
 
 type Props = {
+  /** Raw transcript, only for telling "still loading" from "loaded and empty". */
   messages: NativeChatMessage[]
+  /** `messages` with noise stripped and tool turns folded in, from the overlay. */
+  folded: NativeChatMessage[]
   status: MobileNativeChatStatus
   error?: string
   /** Resolved agent for this chat; names the empty-state copy (desktop parity). */
@@ -48,11 +49,9 @@ type Props = {
   agentWorking?: boolean
   /** Interrupt the agent mid-turn (shown as a Stop button on the working bar). */
   onStop?: () => void
-  /** Live partial assistant text while a turn is still streaming (from the agent
-   *  status hook). Shown as an in-progress bubble until the transcript catches up. */
-  streamingText?: string
-  /** Scopes streaming catch-up state to the active host/workspace/tab/session. */
-  streamIdentity: string
+  /** Live partial assistant text to show as an in-progress bubble, already gated
+   *  by the overlay against the transcript catching up. */
+  streaming: string | null
   hasMore?: boolean
   loadingEarlier?: boolean
   onLoadEarlier?: () => void
@@ -105,13 +104,13 @@ type Props = {
 
 export function MobileNativeChatView({
   messages,
+  folded,
   status,
   error,
   agent,
   agentWorking,
   onStop,
-  streamingText,
-  streamIdentity,
+  streaming,
   hasMore,
   loadingEarlier,
   onLoadEarlier,
@@ -169,15 +168,9 @@ export function MobileNativeChatView({
   // `data` is the list source: folded transcript + synthetic streaming bubble +
   // route-owned optimistic queued messages. Memoize on the same deps so the
   // downstream autoscroll effects/`renderItem` keep referential stability.
-  const foldedMessages = useMemo(() => foldMobileNativeChatMessages(messages), [messages])
-  const streaming = useMobileNativeChatStreamingBubble(
-    foldedMessages,
-    streamingText,
-    streamIdentity
-  )
   const { data } = useMemo(
-    () => buildMobileNativeChatTransientData({ folded: foldedMessages, streaming, pending }),
-    [foldedMessages, streaming, pending]
+    () => buildMobileNativeChatTransientData({ folded, streaming, pending }),
+    [folded, streaming, pending]
   )
 
   // Follow the tail as the conversation grows and keep the newest message above

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -21,6 +21,7 @@ import {
   type MobileNativeChatPendingItem
 } from './mobile-native-chat-render-data'
 import { useMobileNativeChatAskDismiss } from './use-mobile-native-chat-ask-dismiss'
+import { useMobileNativeChatStreamingBubble } from './use-mobile-native-chat-streaming-bubble'
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
@@ -50,6 +51,8 @@ type Props = {
   /** Live partial assistant text while a turn is still streaming (from the agent
    *  status hook). Shown as an in-progress bubble until the transcript catches up. */
   streamingText?: string
+  /** Scopes streaming catch-up state to the active host/workspace/tab/session. */
+  streamIdentity: string
   hasMore?: boolean
   loadingEarlier?: boolean
   onLoadEarlier?: () => void
@@ -108,6 +111,7 @@ export function MobileNativeChatView({
   agentWorking,
   onStop,
   streamingText,
+  streamIdentity,
   hasMore,
   loadingEarlier,
   onLoadEarlier,
@@ -166,9 +170,14 @@ export function MobileNativeChatView({
   // route-owned optimistic queued messages. Memoize on the same deps so the
   // downstream autoscroll effects/`renderItem` keep referential stability.
   const foldedMessages = useMemo(() => foldMobileNativeChatMessages(messages), [messages])
+  const streaming = useMobileNativeChatStreamingBubble(
+    foldedMessages,
+    streamingText,
+    streamIdentity
+  )
   const { data } = useMemo(
-    () => buildMobileNativeChatTransientData({ folded: foldedMessages, streamingText, pending }),
-    [foldedMessages, streamingText, pending]
+    () => buildMobileNativeChatTransientData({ folded: foldedMessages, streaming, pending }),
+    [foldedMessages, streaming, pending]
   )
 
   // Follow the tail as the conversation grows and keep the newest message above

--- a/mobile/src/session/mobile-native-chat-render-data.test.ts
+++ b/mobile/src/session/mobile-native-chat-render-data.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import {
-  buildMobileNativeChatData,
+  buildMobileNativeChatTransientData,
+  foldMobileNativeChatMessages,
   mobileNativeChatEmptyState
 } from './mobile-native-chat-render-data'
 
@@ -50,13 +51,22 @@ describe('mobileNativeChatEmptyState', () => {
   })
 })
 
-describe('buildMobileNativeChatData', () => {
+/** Mirrors the view: fold the raw transcript, then assemble the list. */
+function build(
+  messages: NativeChatMessage[],
+  streaming: string | null,
+  pending: Parameters<typeof buildMobileNativeChatTransientData>[0]['pending']
+): NativeChatMessage[] {
+  return buildMobileNativeChatTransientData({
+    folded: foldMobileNativeChatMessages(messages),
+    streaming,
+    pending
+  }).data
+}
+
+describe('buildMobileNativeChatTransientData', () => {
   it('appends pending optimistic messages at the tail as user turns', () => {
-    const { data } = buildMobileNativeChatData({
-      messages: [assistant('a1', 'hello')],
-      streamingText: undefined,
-      pending: [{ id: 'p1', text: 'queued' }]
-    })
+    const data = build([assistant('a1', 'hello')], null, [{ id: 'p1', text: 'queued' }])
     const last = data[data.length - 1]
     expect(last.id).toBe('p1')
     expect(last.role).toBe('user')
@@ -64,10 +74,9 @@ describe('buildMobileNativeChatData', () => {
   })
 
   it('renders a pending send with images as text followed by image-ref thumbnails', () => {
-    const { data } = buildMobileNativeChatData({
-      messages: [],
-      pending: [{ id: 'p1', text: 'look', images: ['file:///a.jpg', 'file:///b.jpg'] }]
-    })
+    const data = build([], null, [
+      { id: 'p1', text: 'look', images: ['file:///a.jpg', 'file:///b.jpg'] }
+    ])
     const last = data[data.length - 1]
     expect(last.role).toBe('user')
     expect(last.blocks).toEqual([
@@ -78,10 +87,7 @@ describe('buildMobileNativeChatData', () => {
   })
 
   it('renders an image-only pending send (no text) as just the thumbnail', () => {
-    const { data } = buildMobileNativeChatData({
-      messages: [],
-      pending: [{ id: 'p1', text: '', images: ['file:///a.jpg'] }]
-    })
+    const data = build([], null, [{ id: 'p1', text: '', images: ['file:///a.jpg'] }])
     expect(data[data.length - 1].blocks).toEqual([{ type: 'image-ref', url: 'file:///a.jpg' }])
   })
 
@@ -89,14 +95,15 @@ describe('buildMobileNativeChatData', () => {
     // Claude records an attached image as `[Image: source: /path]` + an
     // `[Image #1] `-prefixed caption turn; the fold must merge them into one
     // user turn with an image-ref block instead of showing raw marker text.
-    const { data } = buildMobileNativeChatData({
-      messages: [
+    const data = build(
+      [
         user('u1', '[Image: source: /tmp/a.png]'),
         user('u2', '[Image #1] look at this'),
         assistant('a1', 'nice photo')
       ],
-      pending: []
-    })
+      null,
+      []
+    )
     const merged = data.find((message) => message.role === 'user')
     expect(merged?.blocks).toEqual([
       { type: 'image-ref', path: '/tmp/a.png' },
@@ -105,49 +112,20 @@ describe('buildMobileNativeChatData', () => {
   })
 
   it('renders a lone image marker turn (no caption) as an image-ref block', () => {
-    const { data } = buildMobileNativeChatData({
-      messages: [user('u1', '[Image: source: /tmp/a.png]')],
-      pending: []
-    })
+    const data = build([user('u1', '[Image: source: /tmp/a.png]')], null, [])
     expect(data[0]?.blocks).toEqual([{ type: 'image-ref', path: '/tmp/a.png' }])
   })
 
-  it('adds a synthetic streaming bubble while the partial text leads the transcript', () => {
-    const { streaming, data } = buildMobileNativeChatData({
-      messages: [user('u1', 'hi')],
-      streamingText: 'thinking out loud',
-      pending: []
-    })
-    expect(streaming).toBe('thinking out loud')
-    expect(data.some((m) => m.id === 'streaming')).toBe(true)
+  it('appends a synthetic bubble for gated streaming text, between transcript and pending', () => {
+    // Whether text streams at all is the gate's call
+    // (`mobile-native-chat-streaming-gate.test.ts`); this only places it.
+    const data = build([user('u1', 'hi')], 'thinking out loud', [{ id: 'p1', text: 'queued' }])
+    expect(data.map((message) => message.id)).toEqual(['u1', 'streaming', 'p1'])
+    expect(data[1].blocks).toEqual([{ type: 'text', text: 'thinking out loud' }])
   })
 
-  it('shows a short new streaming reply even after a longer previous turn', () => {
-    // The last folded turn is a long completed reply; a short new stream must not
-    // be suppressed just for being shorter than the prior turn.
-    const { streaming, data } = buildMobileNativeChatData({
-      messages: [assistant('a1', 'This is a long completed previous answer that ran on a while')],
-      streamingText: 'Ok',
-      pending: []
-    })
-    expect(streaming).toBe('Ok')
-    expect(data.some((m) => m.id === 'streaming')).toBe(true)
-  })
-
-  it('drops the streaming bubble once the real assistant turn already contains it', () => {
-    const { streaming, data } = buildMobileNativeChatData({
-      messages: [assistant('a1', 'done answer')],
-      streamingText: 'done',
-      pending: []
-    })
-    expect(streaming).toBeNull()
-    expect(data.some((m) => m.id === 'streaming')).toBe(false)
-  })
-
-  it('returns no streaming bubble for empty/whitespace streaming text', () => {
-    expect(
-      buildMobileNativeChatData({ messages: [], streamingText: '   ', pending: [] }).streaming
-    ).toBeNull()
-    expect(buildMobileNativeChatData({ messages: [], pending: [] }).streaming).toBeNull()
+  it('omits the bubble when the gate withheld the streaming text', () => {
+    const data = build([assistant('a1', 'done answer')], null, [])
+    expect(data.some((message) => message.id === 'streaming')).toBe(false)
   })
 })

--- a/mobile/src/session/mobile-native-chat-render-data.ts
+++ b/mobile/src/session/mobile-native-chat-render-data.ts
@@ -7,6 +7,10 @@ import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { foldToolMessages } from './mobile-native-chat-blocks'
 import { normalizeImageTranscriptMessages } from './mobile-native-chat-image-transcript-markers'
 import { stripNoiseMessages } from './mobile-native-chat-noise'
+import {
+  createMobileNativeChatStreamingGate,
+  deriveMobileNativeChatStreaming
+} from './mobile-native-chat-streaming-gate'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 
 /** The centered empty-state copy for a chat with no messages, mirroring the
@@ -46,7 +50,9 @@ export type MobileNativeChatPendingItem = {
 /** Derive the list data from the raw transcript: fold tool turns into the
  *  assistant turn, optionally append a synthetic streaming bubble, then the
  *  route-owned optimistic "queued" messages at the tail. Returns the
- *  intermediate `folded`/`streaming` so the caller can memoize on them. */
+ *  intermediate `folded`/`streaming` so the caller can memoize on them.
+ *  One-shot form: derives the streaming bubble through a fresh gate (no
+ *  cross-tick memory); the live view threads its own gate instead. */
 export function buildMobileNativeChatData({
   messages,
   streamingText,
@@ -57,7 +63,12 @@ export function buildMobileNativeChatData({
   pending: MobileNativeChatPendingItem[]
 }): { folded: NativeChatMessage[]; streaming: string | null; data: NativeChatMessage[] } {
   const folded = foldMobileNativeChatMessages(messages)
-  return buildMobileNativeChatTransientData({ folded, streamingText, pending })
+  const { streaming } = deriveMobileNativeChatStreaming(
+    createMobileNativeChatStreamingGate(),
+    folded,
+    streamingText
+  )
+  return buildMobileNativeChatTransientData({ folded, streaming, pending })
 }
 
 export function foldMobileNativeChatMessages(messages: NativeChatMessage[]): NativeChatMessage[] {
@@ -68,16 +79,14 @@ export function foldMobileNativeChatMessages(messages: NativeChatMessage[]): Nat
 
 export function buildMobileNativeChatTransientData({
   folded,
-  streamingText,
+  streaming,
   pending
 }: {
   folded: NativeChatMessage[]
-  streamingText?: string
+  /** Streaming bubble text, already gated by `deriveMobileNativeChatStreaming`. */
+  streaming: string | null
   pending: MobileNativeChatPendingItem[]
 }): { folded: NativeChatMessage[]; streaming: string | null; data: NativeChatMessage[] } {
-  // Only show the streaming bubble while its text leads the transcript — once the
-  // real assistant turn lands with the same text, drop the synthetic one.
-  const streaming = deriveStreaming(folded, streamingText)
   const data: NativeChatMessage[] = [
     ...folded,
     ...(streaming
@@ -105,27 +114,4 @@ export function buildMobileNativeChatTransientData({
     }))
   ]
   return { folded, streaming, data }
-}
-
-function deriveStreaming(folded: NativeChatMessage[], streamingText?: string): string | null {
-  const text = streamingText?.trim()
-  if (!text) {
-    return null
-  }
-  const last = folded[folded.length - 1]
-  const lastText =
-    last?.role === 'assistant'
-      ? last.blocks
-          .filter((b) => b.type === 'text')
-          .map((b) => (b.type === 'text' ? b.text : ''))
-          .join('')
-          .trim()
-      : ''
-  // Hide the synthetic bubble only once the real turn has landed leading with the
-  // streamed text. A bare length compare would suppress a short new reply behind a
-  // longer previous turn; a completed prior turn won't start with the new prefix.
-  if (lastText.startsWith(text)) {
-    return null
-  }
-  return text
 }

--- a/mobile/src/session/mobile-native-chat-render-data.ts
+++ b/mobile/src/session/mobile-native-chat-render-data.ts
@@ -7,10 +7,6 @@ import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { foldToolMessages } from './mobile-native-chat-blocks'
 import { normalizeImageTranscriptMessages } from './mobile-native-chat-image-transcript-markers'
 import { stripNoiseMessages } from './mobile-native-chat-noise'
-import {
-  createMobileNativeChatStreamingGate,
-  deriveMobileNativeChatStreaming
-} from './mobile-native-chat-streaming-gate'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 
 /** The centered empty-state copy for a chat with no messages, mirroring the
@@ -47,36 +43,15 @@ export type MobileNativeChatPendingItem = {
   images?: string[]
 }
 
-/** Derive the list data from the raw transcript: fold tool turns into the
- *  assistant turn, optionally append a synthetic streaming bubble, then the
- *  route-owned optimistic "queued" messages at the tail. Returns the
- *  intermediate `folded`/`streaming` so the caller can memoize on them.
- *  One-shot form: derives the streaming bubble through a fresh gate (no
- *  cross-tick memory); the live view threads its own gate instead. */
-export function buildMobileNativeChatData({
-  messages,
-  streamingText,
-  pending
-}: {
-  messages: NativeChatMessage[]
-  streamingText?: string
-  pending: MobileNativeChatPendingItem[]
-}): { folded: NativeChatMessage[]; streaming: string | null; data: NativeChatMessage[] } {
-  const folded = foldMobileNativeChatMessages(messages)
-  const { streaming } = deriveMobileNativeChatStreaming(
-    createMobileNativeChatStreamingGate(),
-    folded,
-    streamingText
-  )
-  return buildMobileNativeChatTransientData({ folded, streaming, pending })
-}
-
 export function foldMobileNativeChatMessages(messages: NativeChatMessage[]): NativeChatMessage[] {
   // Normalize first (desktop assembler parity): image marker turns fold into
   // image-ref blocks instead of rendering as raw `[Image: …]` text.
   return foldToolMessages(stripNoiseMessages(normalizeImageTranscriptMessages(messages)))
 }
 
+/** Assemble the list data the chat renders: the folded transcript, then a
+ *  synthetic bubble for the streaming text the gate let through, then the
+ *  route-owned optimistic "queued" messages at the tail. */
 export function buildMobileNativeChatTransientData({
   folded,
   streaming,

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -159,6 +159,22 @@ describe('deriveMobileNativeChatStreaming', () => {
     expect(results).toEqual([null, 'second answer', null, 'second answer'])
   })
 
+  it('does not treat the previous turn as a segment start after re-anchoring', () => {
+    // The textless anchor clears the remembered text too. Keeping it would read
+    // the next turn's opener as a new segment, re-anchor onto the reply that
+    // just landed, and render it a second time as a bubble.
+    const prior = [assistant('a1', 'context')]
+    const firstLanded = [...prior, assistant('a2', 'Alpha done')]
+    const secondLanded = [...firstLanded, assistant('a3', 'Beta reply')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'Alpha', live: true },
+      { folded: firstLanded }, // turn ended — re-anchor onto a2
+      { folded: secondLanded, text: 'Beta', live: true } // a3 already landed
+    ])
+    expect(results).toEqual([null, 'Alpha', null, null])
+  })
+
   it('re-anchors when a new reply part replaces the stream mid-turn', () => {
     const prior = [assistant('a1', 'context')]
     const partOneLanded = [...prior, assistant('a2', 'part one full text')]

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -17,14 +17,16 @@ function assistant(id: string, text: string): NativeChatMessage {
 }
 
 /** Run a sequence of (folded, streamingText) ticks through one gate. */
-function run(ticks: { folded: NativeChatMessage[]; text?: string }[]): {
+function run(ticks: { folded: NativeChatMessage[]; text?: string; live?: boolean }[]): {
   gate: MobileNativeChatStreamingGate
   results: (string | null)[]
 } {
   let gate = createMobileNativeChatStreamingGate()
   const results: (string | null)[] = []
   for (const tick of ticks) {
-    const step = deriveMobileNativeChatStreaming(gate, tick.folded, tick.text)
+    const step = deriveMobileNativeChatStreaming(gate, tick.folded, tick.text, {
+      streamLive: tick.live
+    })
     gate = step.gate
     results.push(step.streaming)
   }
@@ -77,6 +79,43 @@ describe('deriveMobileNativeChatStreaming', () => {
     expect(results).toEqual([null, 'answer', null, null])
   })
 
+  it('keeps the segment baseline through textless ticks while the turn is live', () => {
+    // Chat is hidden mid-stream: the transcript unsubscribes and the status
+    // stops reaching the gate, but the turn has not ended.
+    const prior = [assistant('a1', 'Done.')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'Done.', live: true },
+      { folded: [], live: true },
+      { folded: prior, text: 'Done.', live: true }
+    ])
+    expect(results).toEqual([null, 'Done.', null, 'Done.'])
+  })
+
+  it('still hides after a hidden gap once the reply landed as its own turn', () => {
+    const prior = [assistant('a1', 'Done.')]
+    const landed = [...prior, assistant('a2', 'Done.')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'Done.', live: true },
+      { folded: [], live: true },
+      { folded: landed, text: 'Done.', live: true }
+    ])
+    expect(results).toEqual([null, 'Done.', null, null])
+  })
+
+  it('anchors on a textless tick once the turn ends', () => {
+    const prior = [assistant('a1', 'first answer')]
+    const landed = [...prior, assistant('a2', 'second answer')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'second answer', live: true },
+      { folded: landed },
+      { folded: landed, text: 'second answer', live: true }
+    ])
+    expect(results).toEqual([null, 'second answer', null, 'second answer'])
+  })
+
   it('re-anchors when a new reply part replaces the stream mid-turn', () => {
     const prior = [assistant('a1', 'context')]
     const partOneLanded = [...prior, assistant('a2', 'part one full text')]
@@ -111,9 +150,11 @@ describe('deriveMobileNativeChatStreaming', () => {
     // scope resets to the mid-stream fallback rather than reusing its baseline.
     const repeatedId = [assistant('a1', 'new answer landed')]
     let gate = createMobileNativeChatStreamingGate('tab-a')
-    gate = deriveMobileNativeChatStreaming(gate, repeatedId, undefined, 'tab-a').gate
+    gate = deriveMobileNativeChatStreaming(gate, repeatedId, undefined, { scopeKey: 'tab-a' }).gate
 
-    const switched = deriveMobileNativeChatStreaming(gate, repeatedId, 'new answer', 'tab-b')
+    const switched = deriveMobileNativeChatStreaming(gate, repeatedId, 'new answer', {
+      scopeKey: 'tab-b'
+    })
 
     expect(switched.streaming).toBeNull()
     expect(switched.gate.scopeKey).toBe('tab-b')

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -106,6 +106,47 @@ describe('deriveMobileNativeChatStreaming', () => {
     expect(results).toEqual([null, 'Done.', null, null])
   })
 
+  it('hides a reply whose own turn landed before its status text arrived', () => {
+    // The pane stays `working` past the reply (a subagent or a background task
+    // is still live), and the transcript push beats the throttled status text.
+    // Anchoring on that textless tick would adopt the reply as pre-stream
+    // history and render it a second time as a bubble.
+    const prior = [assistant('a1', 'Done.')]
+    const landed = [...prior, assistant('a2', 'Done.')]
+    const { results } = run([
+      { folded: prior, live: true },
+      { folded: landed, live: true },
+      { folded: landed, text: 'Done.', live: true },
+      { folded: landed, text: 'Done.', live: true }
+    ])
+    expect(results).toEqual([null, null, null, null])
+  })
+
+  it('keeps the pre-stream baseline across a hidden gap taken between turns', () => {
+    // Peeking at the terminal while idle tears the transcript down to empty. An
+    // empty tail is not history: adopting it strands the baseline and swallows
+    // the repeated-prefix reply that arrives next.
+    const prior = [assistant('a1', 'Done.')]
+    const { results } = run([
+      { folded: prior },
+      { folded: [] },
+      { folded: [], live: true },
+      { folded: prior, text: 'Done.', live: true }
+    ])
+    expect(results).toEqual([null, null, null, 'Done.'])
+  })
+
+  it('anchors on the first tail it sees when mounted mid-turn', () => {
+    // Opening a workspace whose agent is already working: that first textless
+    // tick is the only pre-stream history the gate will ever get.
+    const prior = [assistant('a1', 'Done.')]
+    const { results } = run([
+      { folded: prior, live: true },
+      { folded: prior, text: 'Done.', live: true }
+    ])
+    expect(results).toEqual([null, 'Done.'])
+  })
+
   it('anchors on a textless tick once the turn ends', () => {
     const prior = [assistant('a1', 'first answer')]
     const landed = [...prior, assistant('a2', 'second answer')]
@@ -131,9 +172,9 @@ describe('deriveMobileNativeChatStreaming', () => {
     expect(results).toEqual([null, 'part one', null, 'part'])
   })
 
-  it('falls back to suppress-on-prefix when mounted mid-stream', () => {
-    // No idle tick ever observed: a duplicate bubble is worse than briefly
-    // hiding a mount-coincident repeated reply.
+  it('falls back to suppress-on-prefix when text arrives on the first tick', () => {
+    // No tail ever observed before the text: a duplicate bubble is worse than
+    // briefly hiding a mount-coincident repeated reply.
     const landed = [assistant('a1', 'flushed part still streaming in status')]
     const { results } = run([{ folded: landed, text: 'flushed part' }])
     expect(results).toEqual([null])

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  createMobileNativeChatStreamingGate,
+  deriveMobileNativeChatStreaming,
+  type MobileNativeChatStreamingGate
+} from './mobile-native-chat-streaming-gate'
+
+function assistant(id: string, text: string): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp: 0,
+    source: 'transcript'
+  }
+}
+
+/** Run a sequence of (folded, streamingText) ticks through one gate. */
+function run(ticks: { folded: NativeChatMessage[]; text?: string }[]): {
+  gate: MobileNativeChatStreamingGate
+  results: (string | null)[]
+} {
+  let gate = createMobileNativeChatStreamingGate()
+  const results: (string | null)[] = []
+  for (const tick of ticks) {
+    const step = deriveMobileNativeChatStreaming(gate, tick.folded, tick.text)
+    gate = step.gate
+    results.push(step.streaming)
+  }
+  return { gate, results }
+}
+
+describe('deriveMobileNativeChatStreaming', () => {
+  it('shows a genuine reply that repeats the previous turn as a prefix', () => {
+    const prior = [assistant('a1', 'The tests pass.')]
+    const { results } = run([
+      { folded: prior }, // idle tick anchors the pre-stream tail
+      { folded: prior, text: 'The' },
+      { folded: prior, text: 'The tests' },
+      { folded: prior, text: 'The tests pass.' }
+    ])
+    expect(results).toEqual([null, 'The', 'The tests', 'The tests pass.'])
+  })
+
+  it('hides the bubble once the real turn lands leading with the streamed text', () => {
+    const prior = [assistant('a1', 'earlier turn')]
+    const landed = [...prior, assistant('a2', 'fresh answer with a tail')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'fresh answer' },
+      { folded: landed, text: 'fresh answer' }
+    ])
+    expect(results).toEqual([null, 'fresh answer', null])
+  })
+
+  it('suppresses an identical repeated reply once its own turn lands', () => {
+    const prior = [assistant('a1', 'Done.')]
+    const landed = [...prior, assistant('a2', 'Done.')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'Done.' }, // repeated-prefix reply stays visible
+      { folded: landed, text: 'Done.' } // its own turn landed — hide
+    ])
+    expect(results).toEqual([null, 'Done.', null])
+  })
+
+  it('keeps hiding for the rest of a segment after the turn lands', () => {
+    const prior = [assistant('a1', 'earlier')]
+    const landed = [...prior, assistant('a2', 'answer body')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'answer' },
+      { folded: landed, text: 'answer' },
+      { folded: landed, text: 'answer bo' }
+    ])
+    expect(results).toEqual([null, 'answer', null, null])
+  })
+
+  it('re-anchors when a new reply part replaces the stream mid-turn', () => {
+    const prior = [assistant('a1', 'context')]
+    const partOneLanded = [...prior, assistant('a2', 'part one full text')]
+    const { results } = run([
+      { folded: prior },
+      { folded: prior, text: 'part one' },
+      { folded: partOneLanded, text: 'part one' }, // caught up — hide
+      // Part two is not an extension of part one: new segment, new baseline.
+      { folded: partOneLanded, text: 'part' }
+    ])
+    expect(results).toEqual([null, 'part one', null, 'part'])
+  })
+
+  it('falls back to suppress-on-prefix when mounted mid-stream', () => {
+    // No idle tick ever observed: a duplicate bubble is worse than briefly
+    // hiding a mount-coincident repeated reply.
+    const landed = [assistant('a1', 'flushed part still streaming in status')]
+    const { results } = run([{ folded: landed, text: 'flushed part' }])
+    expect(results).toEqual([null])
+  })
+
+  it('is idempotent for a repeated tick', () => {
+    const prior = [assistant('a1', 'The tests pass.')]
+    const first = run([{ folded: prior }, { folded: prior, text: 'The tests' }])
+    const again = deriveMobileNativeChatStreaming(first.gate, prior, 'The tests')
+    expect(again.streaming).toBe('The tests')
+    expect(again.gate).toBe(first.gate)
+  })
+
+  it('drops a prior chat baseline when the stream identity changes', () => {
+    // The other chat's tail must not license showing a bubble here — a swapped
+    // scope resets to the mid-stream fallback rather than reusing its baseline.
+    const repeatedId = [assistant('a1', 'new answer landed')]
+    let gate = createMobileNativeChatStreamingGate('tab-a')
+    gate = deriveMobileNativeChatStreaming(gate, repeatedId, undefined, 'tab-a').gate
+
+    const switched = deriveMobileNativeChatStreaming(gate, repeatedId, 'new answer', 'tab-b')
+
+    expect(switched.streaming).toBeNull()
+    expect(switched.gate.scopeKey).toBe('tab-b')
+    expect(switched.gate.baselineTailId).toBeNull()
+  })
+
+  it('returns null for empty or whitespace streaming text', () => {
+    const prior = [assistant('a1', 'x')]
+    expect(run([{ folded: prior, text: '   ' }]).results).toEqual([null])
+    expect(run([{ folded: prior }]).results).toEqual([null])
+  })
+
+  it('shows the first reply of an empty chat and hides it once the turn lands', () => {
+    const landed = [assistant('a1', 'Hello there')]
+    const { results } = run([
+      { folded: [] },
+      { folded: [], text: 'Hello' },
+      { folded: landed, text: 'Hello' }
+    ])
+    expect(results).toEqual([null, 'Hello', null])
+  })
+})

--- a/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.test.ts
@@ -81,15 +81,17 @@ describe('deriveMobileNativeChatStreaming', () => {
 
   it('keeps the segment baseline through textless ticks while the turn is live', () => {
     // Chat is hidden mid-stream: the transcript unsubscribes and the status
-    // stops reaching the gate, but the turn has not ended.
+    // stops reaching the gate, but the turn has not ended. Coming back, the
+    // stream text returns before the re-read transcript does.
     const prior = [assistant('a1', 'Done.')]
     const { results } = run([
       { folded: prior },
       { folded: prior, text: 'Done.', live: true },
       { folded: [], live: true },
+      { folded: [], text: 'Done.', live: true },
       { folded: prior, text: 'Done.', live: true }
     ])
-    expect(results).toEqual([null, 'Done.', null, 'Done.'])
+    expect(results).toEqual([null, 'Done.', null, 'Done.', 'Done.'])
   })
 
   it('still hides after a hidden gap once the reply landed as its own turn', () => {

--- a/mobile/src/session/mobile-native-chat-streaming-gate.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.ts
@@ -54,14 +54,26 @@ export function deriveMobileNativeChatStreaming(
   gate: MobileNativeChatStreamingGate,
   folded: readonly NativeChatMessage[],
   streamingText: string | undefined,
-  scopeKey: string | null = gate.scopeKey
+  options: {
+    scopeKey?: string | null
+    /** Whether the agent is still mid-turn. A textless tick then means "no
+     *  observation this render", not "the stream ended". */
+    streamLive?: boolean
+  } = {}
 ): { gate: MobileNativeChatStreamingGate; streaming: string | null } {
+  const scopeKey = options.scopeKey === undefined ? gate.scopeKey : options.scopeKey
   const scopedGate =
     gate.scopeKey === scopeKey ? gate : createMobileNativeChatStreamingGate(scopeKey)
   const text = streamingText?.trim() ?? ''
   const tail = folded.at(-1)
   const tailId = tail?.id ?? null
   if (!text) {
+    if (options.streamLive && scopedGate.prevText !== '') {
+      // A gap inside a live segment (chat hidden, transcript reloading, throttle
+      // not caught up): re-anchoring here would adopt the reply that just landed
+      // as pre-stream history and render it a second time as a bubble.
+      return { gate: scopedGate, streaming: null }
+    }
     // Idle: keep anchoring the baseline to the live tail so the next segment
     // knows which tail predates it.
     return { gate: advanceGate(scopedGate, '', tailId), streaming: null }
@@ -71,10 +83,9 @@ export function deriveMobileNativeChatStreaming(
   const segmentStart = scopedGate.prevText !== '' && !text.startsWith(scopedGate.prevText)
   const baselineTailId = segmentStart ? tailId : scopedGate.baselineTailId
   const tailLeadsWithStream = assistantTailText(tail).startsWith(text)
-  // baselineTailId === null: mounted mid-stream with no pre-stream observation —
-  // fall back to suppress-on-prefix (a duplicate bubble is worse than briefly
-  // hiding an improbable mount-coincident repeated reply).
-  const caughtUp = tailLeadsWithStream && (baselineTailId === null || tailId !== baselineTailId)
+  // A null baseline (mounted mid-stream, never saw an idle tick) is unequal to
+  // every real tail id, so this degrades to the legacy suppress-on-prefix rule.
+  const caughtUp = tailLeadsWithStream && tailId !== baselineTailId
   return {
     gate: advanceGate(scopedGate, text, baselineTailId),
     streaming: caughtUp ? null : text

--- a/mobile/src/session/mobile-native-chat-streaming-gate.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.ts
@@ -13,8 +13,8 @@ export type MobileNativeChatStreamingGate = {
   /** Streamed text seen on the previous tick ('' while idle). */
   prevText: string
   /** Folded tail message id when the current segment began; null while the
-   *  gate has never observed an idle tick (mounted mid-stream), where the
-   *  legacy suppress-on-prefix rule applies. */
+   *  gate has never observed a transcript tail (text arrived on its very first
+   *  tick), where the legacy suppress-on-prefix rule applies. */
   baselineTailId: string | null
 }
 
@@ -68,23 +68,23 @@ export function deriveMobileNativeChatStreaming(
   const tail = folded.at(-1)
   const tailId = tail?.id ?? null
   if (!text) {
-    if (options.streamLive && scopedGate.prevText !== '') {
-      // A gap inside a live segment (chat hidden, transcript reloading, throttle
-      // not caught up): re-anchoring here would adopt the reply that just landed
-      // as pre-stream history and render it a second time as a bubble.
-      return { gate: scopedGate, streaming: null }
-    }
-    // Idle: keep anchoring the baseline to the live tail so the next segment
-    // knows which tail predates it.
-    return { gate: advanceGate(scopedGate, '', tailId), streaming: null }
+    // Only a textless tick that carries a real tail and is outside a live turn
+    // is trustworthy pre-stream history. Mid-turn gaps (a tool call, a throttle
+    // lull, the transcript landing the reply before its status text) would
+    // otherwise adopt that reply as history and render it a second time as a
+    // bubble; a torn-down transcript carries no tail at all. The exception is a
+    // gate that has never anchored — mounted mid-turn, the first real tail it
+    // sees is the best pre-stream history it will ever get.
+    const canAnchor = tailId !== null && (!options.streamLive || scopedGate.baselineTailId === null)
+    return { gate: canAnchor ? advanceGate(scopedGate, '', tailId) : scopedGate, streaming: null }
   }
   // A stream that is not an extension of the previous tick is a new segment
   // (next reply part); re-anchor to the tail that predates it.
   const segmentStart = scopedGate.prevText !== '' && !text.startsWith(scopedGate.prevText)
   const baselineTailId = segmentStart ? tailId : scopedGate.baselineTailId
   const tailLeadsWithStream = assistantTailText(tail).startsWith(text)
-  // A null baseline (mounted mid-stream, never saw an idle tick) is unequal to
-  // every real tail id, so this degrades to the legacy suppress-on-prefix rule.
+  // A null baseline (text on the very first tick, no tail ever seen) is unequal
+  // to every real tail id, so this degrades to the legacy suppress-on-prefix rule.
   const caughtUp = tailLeadsWithStream && tailId !== baselineTailId
   return {
     gate: advanceGate(scopedGate, text, baselineTailId),

--- a/mobile/src/session/mobile-native-chat-streaming-gate.ts
+++ b/mobile/src/session/mobile-native-chat-streaming-gate.ts
@@ -1,0 +1,82 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+/** Decides whether the live streaming preview should render as a synthetic
+ *  bubble. Text alone can't tell "the transcript caught up with this stream"
+ *  from "a new reply happens to repeat the previous turn's prefix" — the old
+ *  prefix test swallowed genuine repeated-prefix replies. The gate keeps the
+ *  transcript tail observed when the current stream segment began: the bubble
+ *  hides only when the tail MOVED during the segment and leads with the
+ *  streamed text (the real turn landed), never for an older identical turn. */
+export type MobileNativeChatStreamingGate = {
+  /** Chat/session identity this baseline belongs to. */
+  scopeKey: string | null
+  /** Streamed text seen on the previous tick ('' while idle). */
+  prevText: string
+  /** Folded tail message id when the current segment began; null while the
+   *  gate has never observed an idle tick (mounted mid-stream), where the
+   *  legacy suppress-on-prefix rule applies. */
+  baselineTailId: string | null
+}
+
+export function createMobileNativeChatStreamingGate(
+  scopeKey: string | null = null
+): MobileNativeChatStreamingGate {
+  return { scopeKey, prevText: '', baselineTailId: null }
+}
+
+function assistantTailText(tail: NativeChatMessage | undefined): string {
+  if (!tail || tail.role !== 'assistant') {
+    return ''
+  }
+  return tail.blocks
+    .filter((block) => block.type === 'text')
+    .map((block) => (block.type === 'text' ? block.text : ''))
+    .join('')
+    .trim()
+}
+
+// Reuses the incoming gate object when nothing moved, so a caller can detect
+// "no change" by reference (and a render-time state adjustment can settle).
+function advanceGate(
+  gate: MobileNativeChatStreamingGate,
+  prevText: string,
+  baselineTailId: string | null
+): MobileNativeChatStreamingGate {
+  return gate.prevText === prevText && gate.baselineTailId === baselineTailId
+    ? gate
+    : { ...gate, prevText, baselineTailId }
+}
+
+/** Advance the gate one tick and derive the visible streaming text (null hides
+ *  the bubble). Pure and idempotent for a repeated (text, tail) pair, so a
+ *  re-render without new data cannot flip the decision. */
+export function deriveMobileNativeChatStreaming(
+  gate: MobileNativeChatStreamingGate,
+  folded: readonly NativeChatMessage[],
+  streamingText: string | undefined,
+  scopeKey: string | null = gate.scopeKey
+): { gate: MobileNativeChatStreamingGate; streaming: string | null } {
+  const scopedGate =
+    gate.scopeKey === scopeKey ? gate : createMobileNativeChatStreamingGate(scopeKey)
+  const text = streamingText?.trim() ?? ''
+  const tail = folded.at(-1)
+  const tailId = tail?.id ?? null
+  if (!text) {
+    // Idle: keep anchoring the baseline to the live tail so the next segment
+    // knows which tail predates it.
+    return { gate: advanceGate(scopedGate, '', tailId), streaming: null }
+  }
+  // A stream that is not an extension of the previous tick is a new segment
+  // (next reply part); re-anchor to the tail that predates it.
+  const segmentStart = scopedGate.prevText !== '' && !text.startsWith(scopedGate.prevText)
+  const baselineTailId = segmentStart ? tailId : scopedGate.baselineTailId
+  const tailLeadsWithStream = assistantTailText(tail).startsWith(text)
+  // baselineTailId === null: mounted mid-stream with no pre-stream observation —
+  // fall back to suppress-on-prefix (a duplicate bubble is worse than briefly
+  // hiding an improbable mount-coincident repeated reply).
+  const caughtUp = tailLeadsWithStream && (baselineTailId === null || tailId !== baselineTailId)
+  return {
+    gate: advanceGate(scopedGate, text, baselineTailId),
+    streaming: caughtUp ? null : text
+  }
+}

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -47,8 +47,12 @@ vi.mock('./use-mobile-native-chat-drafts', () => ({
 vi.mock('./use-mobile-native-chat-prompts', () => ({
   useMobileNativeChatPrompts: () => ({ permission: null, question: null, ask: null })
 }))
+const answerSendArgs: { streamIdentity?: string }[] = []
 vi.mock('./use-mobile-native-chat-answer-send', () => ({
-  useMobileNativeChatAnswerSend: () => ({ answerAsk: vi.fn(), cancelPending: vi.fn() })
+  useMobileNativeChatAnswerSend: (args: { streamIdentity?: string }) => {
+    answerSendArgs.push(args)
+    return { answerAsk: vi.fn(), cancelPending: vi.fn() }
+  }
 }))
 vi.mock('./mobile-native-chat-permission-send', () => ({
   useMobileNativeChatPermissionSend: () => vi.fn()
@@ -499,5 +503,21 @@ describe('useMobileNativeChatController streaming scope', () => {
     expect(controller?.nativeChatAgentWorking).toBe(false)
     expect(controller?.nativeChatStreamScopeKey).toBe(scopeKey)
     expect(controller?.nativeChatStreamLive).toBe(true)
+  })
+
+  it('keeps the delayed-send route guard view-gated, unlike the stream scope', () => {
+    // `streamIdentity` fences a delayed answer/stop to the route it was armed
+    // on, so it must still drop its session when chat closes — the scope key is
+    // the one that has to survive the toggle. Same string while chat is open.
+    const before = answerSendArgs.at(-1)?.streamIdentity
+    expect(before).toBe(controller?.nativeChatStreamScopeKey)
+
+    viewMode.isTabChatView = () => false
+    act(() => renderer?.update(createElement(Harness)))
+
+    const after = answerSendArgs.at(-1)?.streamIdentity
+    expect(after).not.toBe(before)
+    expect(after).not.toContain('session-1')
+    expect(controller?.nativeChatStreamScopeKey).toBe(before)
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -421,3 +421,83 @@ describe('useMobileNativeChatController launch-draft wiring', () => {
     expect(draftsArgs.at(-1)).toMatchObject({ launchDraft: null, chatActive: true })
   })
 })
+
+describe('useMobileNativeChatController streaming scope', () => {
+  let renderer: ReactTestRenderer | null = null
+  let controller: MobileNativeChatController | null = null
+  const clientStub = { sendRequest: vi.fn() }
+
+  const workingTab = {
+    type: 'terminal',
+    id: 'tab-1',
+    terminal: 'term-1',
+    launchAgent: 'claude',
+    agentStatus: {
+      state: 'working',
+      agentType: 'claude',
+      providerSession: { id: 'session-1' }
+    },
+    isActive: true
+  }
+
+  function Harness(): null {
+    controller = useMobileNativeChatController({
+      client: clientStub as unknown as RpcClient,
+      connState: 'connected',
+      hostId: 'h',
+      worktreeId: 'w',
+      activeSessionTab: workingTab as never,
+      activeSessionTabId: 'tab-1',
+      activeHandleRef: { current: 'term-1' },
+      deviceTokenRef: { current: null },
+      nativeChatTranscriptIsLocalReadable: true,
+      nativeChatInputLeaseReady: true,
+      onSendError: vi.fn(),
+      onSendResolved: vi.fn()
+    })
+    return null
+  }
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    viewMode.isTabChatView = () => true
+    const original = console.error
+    const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
+      if (typeof a[0] === 'string' && a[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      original(...a)
+    })
+    try {
+      act(() => {
+        renderer = create(createElement(Harness))
+      })
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    controller = null
+    viewMode.isTabChatView = () => true
+  })
+
+  it('holds the stream scope and liveness while the user peeks at the terminal', () => {
+    // Both feed the streaming gate, which lives above the chat view's mount and
+    // must not be reset by a view toggle.
+    expect(controller?.showNativeChat).toBe(true)
+    const scopeKey = controller?.nativeChatStreamScopeKey
+    expect(scopeKey).toContain('session-1')
+    expect(controller?.nativeChatStreamLive).toBe(true)
+
+    viewMode.isTabChatView = () => false
+    act(() => renderer?.update(createElement(Harness)))
+
+    expect(controller?.showNativeChat).toBe(false)
+    expect(controller?.nativeChatAgentWorking).toBe(false)
+    expect(controller?.nativeChatStreamScopeKey).toBe(scopeKey)
+    expect(controller?.nativeChatStreamLive).toBe(true)
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -49,6 +49,8 @@ export type MobileNativeChatController = {
   nativeChatSession: ReturnType<typeof useMobileNativeChatSession>
   nativeChatAgentWorking: boolean
   nativeChatStreamingText?: string
+  /** Host/workspace/tab/session identity for stateful streaming suppression. */
+  nativeChatStreamIdentity: string
   nativeChatPermission: ReturnType<typeof detectAgentPermission>
   nativeChatQuestion: ReturnType<typeof parseAgentQuestion>
   nativeChatAsk: ReturnType<typeof parseAskFromStatus>
@@ -273,6 +275,7 @@ export function useMobileNativeChatController(args: {
     nativeChatSession,
     nativeChatAgentWorking,
     nativeChatStreamingText,
+    nativeChatStreamIdentity: streamIdentity,
     nativeChatPermission,
     nativeChatQuestion,
     nativeChatAsk,

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -49,8 +49,10 @@ export type MobileNativeChatController = {
   nativeChatSession: ReturnType<typeof useMobileNativeChatSession>
   nativeChatAgentWorking: boolean
   nativeChatStreamingText?: string
-  /** Host/workspace/tab/session identity for stateful streaming suppression. */
-  nativeChatStreamIdentity: string
+  /** Agent mid-turn, regardless of whether chat is the visible view. */
+  nativeChatStreamLive: boolean
+  /** Host/workspace/tab/session scope for stateful streaming suppression. */
+  nativeChatStreamScopeKey: string
   nativeChatPermission: ReturnType<typeof detectAgentPermission>
   nativeChatQuestion: ReturnType<typeof parseAgentQuestion>
   nativeChatAsk: ReturnType<typeof parseAskFromStatus>
@@ -126,7 +128,12 @@ export function useMobileNativeChatController(args: {
   activeChatAgentRef.current = activeChatResolution?.agent ?? null
 
   const activeChatSessionId = activeChatResolution?.sessionId ?? null
-  const streamIdentity = `${hostId}\0${worktreeId}\0${activeSessionTabId ?? ''}\0${activeChatSessionId ?? ''}\0${activeHandleRef.current ?? ''}`
+  const routeKey = `${hostId}\0${worktreeId}\0${activeSessionTabId ?? ''}`
+  const streamIdentity = `${routeKey}\0${activeChatSessionId ?? ''}\0${activeHandleRef.current ?? ''}`
+  // Same chat, but keyed off the tab rather than the view-gated resolution:
+  // `streamIdentity` goes session-less the moment the user peeks at the terminal,
+  // and a scope that flips on a view toggle throws the gate's baseline away.
+  const streamScopeKey = `${routeKey}\0${activeSessionTab?.agentStatus?.providerSession?.id ?? ''}\0${activeHandleRef.current ?? ''}`
 
   const nativeChatSession = useMobileNativeChatSession({
     client,
@@ -162,6 +169,9 @@ export function useMobileNativeChatController(args: {
 
   const nativeChatStatus = activeChatResolution ? activeSessionTab?.agentStatus : null
   const nativeChatAgentWorking = nativeChatStatus?.state === 'working'
+  // Deliberately not gated on the chat view being visible: the streaming gate
+  // has to tell "hidden mid-turn" from "the turn ended".
+  const nativeChatStreamLive = activeSessionTab?.agentStatus?.state === 'working'
   // Throttle the streaming bubble: OpenCode emits a status frame per streamed
   // part, and each one re-renders and re-parses the whole accumulated markdown.
   const nativeChatStreamingText = useThrottledLatestValue(
@@ -275,7 +285,8 @@ export function useMobileNativeChatController(args: {
     nativeChatSession,
     nativeChatAgentWorking,
     nativeChatStreamingText,
-    nativeChatStreamIdentity: streamIdentity,
+    nativeChatStreamLive,
+    nativeChatStreamScopeKey: streamScopeKey,
     nativeChatPermission,
     nativeChatQuestion,
     nativeChatAsk,

--- a/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
+++ b/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import {
+  createMobileNativeChatStreamingGate,
+  deriveMobileNativeChatStreaming
+} from './mobile-native-chat-streaming-gate'
+
+/** Live streaming-bubble text for the chat list. The gate remembers which
+ *  transcript tail predates the current stream segment, so a reply that repeats
+ *  the previous turn's prefix still shows while streaming. */
+export function useMobileNativeChatStreamingBubble(
+  folded: readonly NativeChatMessage[],
+  streamingText: string | undefined,
+  scopeKey: string
+): string | null {
+  const [gate, setGate] = useState(() => createMobileNativeChatStreamingGate(scopeKey))
+  const step = deriveMobileNativeChatStreaming(gate, folded, streamingText, scopeKey)
+  if (step.gate !== gate) {
+    // Render-time state adjustment (derived-state pattern): the advance is
+    // idempotent for a repeated (text, tail) pair, so this settles in one pass.
+    setGate(step.gate)
+  }
+  return step.streaming
+}

--- a/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
+++ b/mobile/src/session/use-mobile-native-chat-streaming-bubble.ts
@@ -7,14 +7,21 @@ import {
 
 /** Live streaming-bubble text for the chat list. The gate remembers which
  *  transcript tail predates the current stream segment, so a reply that repeats
- *  the previous turn's prefix still shows while streaming. */
+ *  the previous turn's prefix still shows while streaming. Call this from a
+ *  component that outlives the chat list itself: the baseline has to survive the
+ *  view toggles that unmount it, or the next segment reverts to prefix-matching.
+ *  `streamLive` keeps those textless gaps from reading as an idle stream. */
 export function useMobileNativeChatStreamingBubble(
   folded: readonly NativeChatMessage[],
   streamingText: string | undefined,
-  scopeKey: string
+  scopeKey: string,
+  streamLive: boolean
 ): string | null {
   const [gate, setGate] = useState(() => createMobileNativeChatStreamingGate(scopeKey))
-  const step = deriveMobileNativeChatStreaming(gate, folded, streamingText, scopeKey)
+  const step = deriveMobileNativeChatStreaming(gate, folded, streamingText, {
+    scopeKey,
+    streamLive
+  })
   if (step.gate !== gate) {
     // Render-time state adjustment (derived-state pattern): the advance is
     // idempotent for a repeated (text, tail) pair, so this settles in one pass.


### PR DESCRIPTION
## Summary

Native chat could swallow a real assistant reply while it was still streaming. The streaming bubble was gated on text alone: if the newest folded transcript turn *started with* the streamed text, the bubble was hidden as "the transcript already caught up". That test can't tell catch-up from coincidence — when a new reply happens to repeat the previous turn's prefix ("Done.", "The tests pass.", any stock opener), the older turn matched and the live reply never rendered. The user saw the working indicator spin with no visible text until the whole turn landed.

The gate is now stateful. It records which transcript tail was live when the current stream segment began, and hides the bubble only when the tail *moved* during that segment **and** leads with the streamed text — i.e. the real turn actually landed. An older identical turn can no longer suppress anything. A stream that isn't an extension of the previous tick (the next reply part) re-anchors to the tail that predates it.

Two things make that baseline survivable in the real app:

- **Ownership.** The gate lives in `MobileNativeChatOverlay`, which returns `null` when chat is hidden but is never unmounted — so the baseline outlives the chat list below it. Putting it in the list would reset it on every chat↔terminal toggle, which is exactly when the bug bites.
- **Scope key, not route identity.** Gate state is keyed to `nativeChatStreamScopeKey` (host / workspace / tab), which is stable across view toggles. The pre-existing `streamIdentity` — which additionally encodes the *view* so a delayed answer-send or stop can't land in the wrong place — is deliberately **not** reused here; a view-gated key would drop the baseline on the very toggle this fix is about. Both are asserted against each other in `use-mobile-native-chat-controller.test.ts`.

`streamLive` (the pane's working state) distinguishes "no observation this render" from "the stream ended", so a textless tick mid-turn no longer re-anchors the baseline onto a reply that has just landed.

**Split from #12373** (fix 9 of 10 in that QA sweep), rebased onto `main` as an independent PR. #12373 stays open; none of its other fixes (reconnect history, cached transcript, stale status, prompt cards, paging, write lock, tool summaries) are included here.

Refs STA-3333.

## Screenshots

A/B on the iOS simulator against a mock desktop, same scenario, two Metro servers: **A = `main` (e9cf1067)**, **B = this branch at `fed9ca38`** — the only commit since is test-only, so the production code in these shots is the code at head. Bundle provenance was verified by grepping each served bundle (A has the old `lastText.startsWith` rule and none of the new gate symbols; B has `canAnchor`/`baselineTailId`/`nativeChatStreamScopeKey` and zero occurrences of the old rule).

**A — `main`: the reply is swallowed.** A prior "Done." turn exists; the agent starts a new reply that also begins "Done.". The pane shows *Agent is working* + Stop, but only **one** "Done." is on screen — the live reply never renders, and it is still absent 12 s later.

| main: reply swallowed | main: still swallowed 12s later |
|---|---|
| ![A-11-swallowed.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/A-11-swallowed.png?raw=true) | ![A-12-swallowed-persists.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/A-12-swallowed-persists.png?raw=true) |

**B — this branch: the reply streams, and does not duplicate.** Same scenario now renders the second "Done." live (left). When that reply's own turn lands while the pane is still working, the synthetic bubble is withdrawn and the count stays at two — no duplicate (right).

| branch: repeated-prefix reply streams | branch: its own turn lands, still 2 bubbles |
|---|---|
| ![R4-B1-repeated-prefix-streams.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/R4-B1-repeated-prefix-streams.png?raw=true) | ![R4-B2-turn-landed-no-dup.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/R4-B2-turn-landed-no-dup.png?raw=true) |

**B — the two orderings that previously broke it.** Left: the transcript lands the reply *before* the throttled status text arrives while the pane stays working (a subagent still running) — exactly two bubbles, no third. Right: a chat→terminal→chat peek taken *while idle* tears the transcript down to empty; the reply that arrives afterwards still streams, and is stable 12 s on.

| transcript beats the status text: no duplicate | after an idle terminal peek: still streams |
|---|---|
| ![R4-B3c-late-status-no-dup.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/R4-B3c-late-status-no-dup.png?raw=true) | ![R4-B4-after-peek-streams.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/R4-B4-after-peek-streams.png?raw=true) |

| the peek itself (idle, chat→terminal→chat) | stable 12s after the bubble appears |
|---|---|
| ![R4-B4d-back-to-chat-idle.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/R4-B4d-back-to-chat-idle.png?raw=true) | ![R4-B5-stable-12s.png](https://github.com/stablyai/orca/blob/1141d2b6435f42ccb92bdd7c20b49536d2e12d21/R4-B5-stable-12s.png?raw=true) |

## Testing

- [x] `pnpm lint` — root + mobile `oxlint`, `audit:code-quality:native`, `check:max-lines-ratchet` (352 grandfathered, no new bypasses), `oxfmt --check`: clean. No `max-lines` disables and no per-file cap bumps added.
- [x] `pnpm typecheck` — root three-project `tsc` and mobile `tsc --noEmit`: clean.
- [x] `pnpm test` — full mobile suite at `1c1afe52`: **405 files, 3035 passed / 3 skipped**. Root suite does not cover `mobile/` and no `src/` file is touched.
- [x] React Doctor changed-lines gate (`check:react-doctor:changed`): 0 issues.
- [x] `check:reliability-gates` — 65 gates, passed.
- [x] iOS simulator A/B against a mock desktop — see Screenshots. Both arms driven through the real UI (touch frames to the simulator; no OS-level input injection).
- [ ] `pnpm build` — not run; no build-affecting change (React Native UI logic only). CI covers it.
- [x] Added or updated high-quality tests that would catch regressions — see below.

`mobile-native-chat-streaming-gate.test.ts` (new, 17 tests) drives sequences of `(folded, streamingText, streamLive)` ticks through one gate and locks the decision table: the repeated-prefix reply stays visible (the actual regression), the bubble hides once the real turn lands, an identical repeated reply is suppressed only by *its own* turn, hiding persists for the rest of the segment, a new reply part re-anchors, re-anchoring also clears the remembered text so the next turn's opener isn't misread as a new segment, a hidden gap taken mid-turn keeps the baseline, a hidden gap taken *between* turns does not adopt the empty tail, a reply whose turn lands before its status text is not adopted as history, a gate mounted mid-turn anchors on the first tail it sees, the first-tick fallback, reference-identity idempotency for a repeated tick, scope-swap baseline reset, and empty/whitespace text.

`MobileNativeChatOverlay.test.ts` (new, 6 tests) exercises the same behaviors through the real component — including both chat↔terminal peek orderings and a scope swap — so the ownership/lifetime decision is covered, not just the pure function. `MobileNativeChatView.test.ts` keeps one placement test for the gated bubble; `mobile-native-chat-render-data.test.ts` now asserts only *placement* of the synthetic row (between transcript and pending), since whether it renders at all is the gate's call.

The suite was mutation-checked against the production source (never the tests): **28 mutants, 22 killed**. The decisive one reverts the gate to `main`'s rule by dropping the `tailId !== baselineTailId` clause — it fails **14 tests**, including the two that name the user-visible bug, which is what proves these tests could not pass against `main`. Others: dropping either conjunct of the anchor condition, inverting or removing segment-start detection, making `advanceGate` allocate a fresh object every render (kills all 6 overlay tests via an infinite render), reusing a gate across a scope change, collapsing `streamScopeKey` back to `streamIdentity`, view-gating `streamLive`, and bypassing the gate in the overlay.

Of the 6 survivors, 4 are provably equivalent mutants that no test can kill — `text.startsWith('')` is always true, so the `prevText !== ''` conjunct is redundant; `showLoading` on `folded` vs `messages` cannot differ because a loading session always returns the shared empty array; seeding the gate with a null scope is reset on the first derive; and `nativeChatAgentWorking` vs `nativeChatStreamLive` only diverge while chat is hidden, where the tail is null and the gate is inert anyway. The 5th (the assistant-role guard on the tail) is inherited unchanged from `main`. The 6th was a real gap in new code and is now closed by the 17th test.

## AI Review Report

Reviewed across four rounds of independent same-model passes on three dimensions (correctness, tests/scope, render+perf), looping until clean. Two real defects were found and fixed in `fed9ca38` before this report:

1. **Duplicate bubble (a regression vs `main`).** A textless status tick re-anchored the baseline onto a reply that had *just* landed in the transcript, so the next text tick rendered it a second time. Reproduced with a trace harness (`[null,null,"Done.","Done."]`) and fixed by refusing to anchor on textless ticks taken inside a live turn.
2. **Headline bug still reproduced on one path.** A chat→terminal peek taken *while idle* empties the transcript, and that empty tail was adopted as the baseline, stranding it (`[null,null,null,"Done.",null]` — flash, then vanish). Fixed by refusing to anchor on a null tail.

The combined condition — anchor only on a textless tick that carries a real tail and is either outside a live turn or on a gate that has never anchored — satisfies both plus the mount-mid-turn case. The one case it gives up is a transcript-first landing on the gate's *very first* tick (a ≤50 ms window), which degrades to `main`'s existing suppress-on-prefix behavior.

**The change cannot swallow a reply that `main` rendered.** `caughtUp` requires `tailLeadsWithStream`, which *is* `main`'s entire suppression predicate, plus a second conjunct — so this gate's suppression set is a strict subset of `main`'s. A randomized differential run (2.4M ticks over varied text / tail / `streamLive` / scope sequences) found zero cases where this branch returns `null` and `main` returns text. That bounds the whole regression surface to one class — a spurious extra bubble — rather than leaving it open-ended.

Other findings verified and addressed:

- **Render purity / loops.** The gate advances via the sanctioned derived-state render-time adjustment. `advanceGate` returns the *same object* when nothing moved, so a repeated `(text, tail)` pair produces no `setState` and the adjustment settles in one pass; the idempotency test asserts reference equality (`toBe`), so a future change that allocates a fresh gate per render — which would loop — fails the test. Convergence was proven twice by independent methods: exhaustive enumeration of the gate's state space (46,080 cases, three applications each — 0 non-settling, 0 flipped derived values) and randomized second passes (200,000 — 0 non-settling). Under real React, the worst case observed over 5,000 randomized updates was 2 passes, never 3, with no cross-component-update warnings.
- **Render cost.** Measured with `react-test-renderer` against `main` as baseline: the extra pass is confined to the overlay's own function body — React discards the children of a render-phase-updated pass — so `MobileNativeChatView` renders exactly **once per streaming tick, same as `main`**, and the fold `useMemo` recomputes **zero** times during a turn. Wall clock is +13.8 µs/tick vs `main` on a realistic ~6.5 KB reply, i.e. +0.28 ms of CPU per second of streaming, or 0.03% of the 50 ms throttle window. While chat is hidden the gate is fully inert: `streamingText` is view-gated to `undefined` and the session returns a reference-stable empty transcript, so `advanceGate` returns by reference and `setState` never fires — 0 view renders and 0 fold calls per tick. While the bubble is suppressed the branch is strictly *better* than `main`, which kept rebuilding list data as the raw text grew.
- **Cross-chat leakage.** The gate carries its own `scopeKey` and self-resets when the caller's identity differs, so a stale baseline from another tab can never license showing a bubble here; locked at both the gate and component level.
- **Dead code.** The test-only `buildMobileNativeChatData` one-shot helper was deleted rather than left as a second, diverging copy of the rule.

**Cross-platform:** no keyboard shortcuts, shortcut labels, file paths, shell invocation, git commands, or Electron main-process code are touched. This is React Native renderer logic that behaves identically on iOS and Android and is agnostic of the desktop host OS, so it is unaffected by the macOS/Linux/Windows and native/WSL/SSH host distinctions. It reads only already-parsed transcript messages, so local worktrees, SSH worktrees, and folder workspaces are all equivalent here. No git provider (GitHub/GitLab) surface is involved.

## Security Audit

No new input parsing from untrusted sources, no command execution, no path handling, no auth or secret handling, no dependency changes, and no IPC/RPC surface change (no new methods; existing subscribe/read paths are untouched). The gate holds two short strings and a message id in renderer memory and derives a boolean; it renders no new content — the streamed text was already rendered through the same `Text` path before this change, so there is no new injection surface. Agent-provided text is only compared with `String.prototype.startsWith`, never evaluated or interpolated into a command. No follow-up needed.

## Notes

- Scope is deliberately narrow: only the streaming bubble gate. The reconnect-replay, cached-transcript, stale-status, prompt-card, paging, write-lock, and tool-summary fixes from #12373 are **not** included and that PR remains open.
- Behavior when text arrives on the gate's very first tick is intentionally unchanged (legacy suppress-on-prefix): with no tail ever observed there is no baseline to judge against, and a duplicated bubble is the worse failure. It self-corrects on the next textless tick outside a turn.
- The gate treats a stream that isn't an extension of the previous tick as a new segment. If the upstream status feed ever delivers throttled partials out of order, the effect is a re-anchor (bubble shows), never a swallow.
