### PR TITLE
fix(mobile): report a partly-sent ask answer honestly (STA-3333)

### DIFF
--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -375,8 +375,9 @@ describe('useMobileNativeChatAnswerSend', () => {
   })
 
   it('cancels delayed keystrokes when the acknowledged input lease is lost', async () => {
+    const onSendError = vi.fn()
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
-    await mount({ sendRequest } as unknown as RpcClient, vi.fn())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
 
     const prompt: AskPrompt = {
       questions: [
@@ -395,5 +396,126 @@ describe('useMobileNativeChatAnswerSend', () => {
 
     await expect(result).resolves.toBe(false)
     expect(sendRequest).toHaveBeenCalledTimes(1)
+    // q1's digit DID land before the lease loss aborted the chain, so the remote
+    // selector sits on q2 — ending silently left the card looking cleanly sent.
+    expect(onSendError).toHaveBeenCalledWith('Answer partly sent — check chat before retrying')
+  })
+
+  it('reports the half-stepped selector when Stop aborts a paced answer', async () => {
+    const onSendError = vi.fn()
+    const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
+
+    const prompt: AskPrompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'q2', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] }
+      ]
+    }
+    let result: Promise<boolean> | undefined
+    await act(async () => {
+      result = answerSend?.answerAsk(prompt, [{ indices: [1] }, { indices: [0] }])
+    })
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      answerSend?.cancelPending()
+      await vi.runAllTimersAsync()
+    })
+
+    await expect(result).resolves.toBe(false)
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(onSendError).toHaveBeenCalledWith('Answer partly sent — check chat before retrying')
+  })
+
+  it('reports a superseded chain whose first group already moved the selector', async () => {
+    const onSendError = vi.fn()
+    const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
+
+    const prompt: AskPrompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'q2', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] }
+      ]
+    }
+    let first: Promise<boolean> | undefined
+    await act(async () => {
+      first = answerSend?.answerAsk(prompt, [{ indices: [1] }, { indices: [0] }])
+    })
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+
+    // Changing the answer mid-sequence supersedes the chain, but q1's digit is
+    // already committed on the host — the replacement starts from a moved selector.
+    await act(async () => {
+      void answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+      await vi.runAllTimersAsync()
+    })
+
+    await expect(first).resolves.toBe(false)
+    expect(onSendError).toHaveBeenCalledWith('Answer partly sent — check chat before retrying')
+  })
+
+  it('keeps an ambiguous write ambiguous when the chain is aborted after it', async () => {
+    const onSendError = vi.fn()
+    let rejectWrite: (error: Error) => void = () => undefined
+    const sendRequest = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectWrite = reject
+        })
+    )
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
+
+    let result: Promise<boolean> | undefined
+    await act(async () => {
+      result = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+      await Promise.resolve()
+    })
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      answerSend?.cancelPending()
+      rejectWrite(markRpcDeliveryUnknown(new Error('Connection closed')))
+      await vi.runAllTimersAsync()
+    })
+
+    await expect(result).resolves.toBe(false)
+    // The abort says nothing about whether the in-flight keystroke landed.
+    expect(onSendError).toHaveBeenCalledWith('Answer unconfirmed — check chat before retrying')
+  })
+
+  it('stays silent when an aborted chain never got a keystroke onto the wire', async () => {
+    const onSendError = vi.fn()
+    let settleWrite: (response: unknown) => void = () => undefined
+    const sendRequest = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          settleWrite = resolve
+        })
+    )
+    await mount({ sendRequest } as unknown as RpcClient, onSendError)
+
+    let result: Promise<boolean> | undefined
+    await act(async () => {
+      result = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+      await Promise.resolve()
+    })
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      answerSend?.cancelPending()
+      settleWrite({
+        id: 'send',
+        ok: true as const,
+        result: { send: { accepted: false } },
+        _meta: { runtimeId: 'runtime' }
+      })
+      await vi.runAllTimersAsync()
+    })
+
+    await expect(result).resolves.toBe(false)
+    // Nothing reached the PTY and the user already moved on — no banner to raise.
+    expect(onSendError).not.toHaveBeenCalled()
   })
 })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -142,8 +142,12 @@ export function useMobileNativeChatAnswerSend(args: {
         }
         return outcome === 'accepted'
       }
-      const wait = (ms: number): Promise<boolean> =>
-        new Promise((resolve) => {
+      const wait = (ms: number): Promise<boolean> => {
+        // Already superseded: schedule nothing, so the report is immediate.
+        if (generationRef.current !== generation) {
+          return Promise.resolve(false)
+        }
+        return new Promise((resolve) => {
           const delay = {
             timer: setTimeout(() => {
               delaysRef.current.delete(delay)
@@ -153,14 +157,18 @@ export function useMobileNativeChatAnswerSend(args: {
           }
           delaysRef.current.add(delay)
         })
+      }
       const fail = (): false => {
-        if (generationRef.current === generation) {
-          // Why: keystrokes that may have landed (ack lost / path cutover) must
-          // not read as a definite failure — a blind resend could double-step
-          // the selector. An earlier group that WAS accepted is the same hazard
-          // in definite form: a multi-question answer whose shared budget ran out
-          // mid-sequence left the remote selector half-stepped, and telling the
-          // user nothing was sent invites a retry on top of the advanced state.
+        // Why: keystrokes that may have landed (ack lost / path cutover) must
+        // not read as a definite failure — a blind resend could double-step
+        // the selector. An earlier group that WAS accepted is the same hazard
+        // in definite form: a multi-question answer whose shared budget ran out
+        // mid-sequence left the remote selector half-stepped, and telling the
+        // user nothing was sent invites a retry on top of the advanced state.
+        // A superseded/aborted chain (session swap, lease loss, Stop, newer
+        // answer) stays silent only while nothing was written yet: once a group
+        // landed, ending silently leaves the card looking cleanly sent.
+        if (generationRef.current === generation || sawAcceptedGroup || sawUnknownOutcome) {
           onSendError(
             sawAcceptedGroup
               ? 'Answer partly sent — check chat before retrying'
@@ -196,7 +204,7 @@ export function useMobileNativeChatAnswerSend(args: {
           return false
         }
         if (generationRef.current !== generation) {
-          return false
+          return fail()
         }
         return (await sendTerminal(formatAskAnswer(prompt, selections), true)) || fail()
       }
@@ -206,7 +214,7 @@ export function useMobileNativeChatAnswerSend(args: {
           : buildAskAnswerKeys(prompt, selections)
       for (let index = 0; index < groups.length; index += 1) {
         if (generationRef.current !== generation) {
-          return false
+          return fail()
         }
         const group = groups[index]!
         const body = 'raw' in group ? group.raw : sanitizeAskFreeText(group.text)
@@ -215,7 +223,7 @@ export function useMobileNativeChatAnswerSend(args: {
         }
         if (index < groups.length - 1) {
           if (!(await wait(MOBILE_NATIVE_CHAT_QUESTION_STEP_MS))) {
-            return false
+            return fail()
           }
           // Pacing is deliberate, not transport latency — don't charge it to the budget.
           deadline += MOBILE_NATIVE_CHAT_QUESTION_STEP_MS


### PR DESCRIPTION
## Summary

Split from #12373 (fix 7 of that PR's list) — this PR is independent and targets `main`; #12373 stays open and untouched.

A mobile ask-answer send for Claude/Codex is a paced sequence of keystroke groups, not one write. If the chain was aborted mid-sequence — chat session swap, acknowledged input lease loss, Stop, or a superseding answer — it returned silently, **even when earlier groups had already been accepted by the host**. The user saw the card end cleanly, while the remote selector actually sat half-stepped on a later question. Retrying then replayed a from-scratch key plan onto an advanced position and answered the wrong question.

Three abort paths bypassed the existing `fail()` reporter (`return false` instead of `return fail()`), and `fail()` itself only spoke while the chain was still the current generation — which an abort has by definition already invalidated. So the one case that most needed a warning was the one guaranteed to stay quiet.

Now:
- The abort paths route through `fail()`.
- `fail()` speaks when the chain **wrote something**, not only when it is still current: an accepted group reports `Answer partly sent — check chat before retrying`, an ambiguous one `Answer unconfirmed — check chat before retrying`.
- A chain that never got a keystroke onto the wire still stays silent, so an answer the user deliberately replaced does not raise a banner.
- `wait()` returns immediately when the chain is already superseded, so the report is not delayed by a full pacing step.

The wording and the accepted/unknown precedence are the ones already used by this hook's budget-exhaustion path and by the Stop sender, so no new user-facing vocabulary is introduced.

Deliberately **not** in this PR: the shared PTY write lock / send serialization (fix 8 of #12373). That is a separate concern and is being split separately — this change only identifies and reports a partial send.

## Screenshots

`No visual change` — the existing composer send-error banner is reused verbatim; only the conditions under which it is raised changed.

## Testing

- [x] `pnpm lint` — root `oxlint` and mobile `oxlint` clean on the changed files; `audit:code-quality:native` clean; `check:max-lines-ratchet` OK (352 grandfathered, no new bypasses); `lint:react-doctor:changed` clean. No `max-lines` disable added or bumped (source file is 248 lines against a 300 cap).
- [x] `pnpm typecheck` — mobile `tsc --noEmit` clean.
- [x] `pnpm test` — full mobile `src/session` suite: 114 files, 908 passed. Focused file: 21 passed.
- [ ] `pnpm build` — not run; no build-affecting change (pure hook logic, no new module, no dependency change). CI covers it.
- [x] Added or updated high-quality tests that would catch regressions

Tests added to `use-mobile-native-chat-answer-send.test.ts`, one per abort trigger plus a negative guard:
- input-lease loss mid-answer (extends the existing test, which previously asserted only the cancellation) → partly sent
- Stop mid-answer after a group landed → partly sent
- superseding answer after the first group moved the selector → partly sent
- abort after an ambiguous in-flight write → unconfirmed (not downgraded to a definite failure)
- abort with nothing on the wire → **silent** (guards against over-reporting)

Each of the four positive tests was confirmed to **fail** against the unmodified source and pass with it, so none is vacuous. The negative test passes both ways by design — it exists to pin the no-false-banner boundary.

## AI Review Report

Reviewed with focus on:

1. **Over-reporting.** The new condition is `generation === generation || sawAcceptedGroup || sawUnknownOutcome`, so an aborted chain that wrote nothing is still silent. Locked by the negative test. This matters because a deliberate answer change is a common, non-error interaction.
2. **Wrong-tab / stale-scope banners.** An aborted chain reports *after* the session may have swapped. Verified against `use-mobile-native-chat-send-error.ts`: `show()` compares the scope the callback was built for against the live scope and falls back to a toast when they differ or the banner is unmounted, so a late report cannot paint or wipe another tab's banner. This pre-existing guard is exactly what makes reporting from an aborted chain safe; no change was needed there.
3. **Double-banner on supersede.** The superseded chain raises the banner, then a successful replacement calls `onSendResolved` via `useNativeChatAcceptedAction` and retires it — the end state matches today's behavior, with the warning visible only if the replacement also fails or is slow.
4. **Message precedence.** `accepted` outranks `unknown`: a definitely-half-stepped selector is the more actionable warning, and an ambiguous write is never presented as a definite failure (double-send hazard).
5. **Return value.** `answerAsk` still resolves `false` on every abort, so the accepted-action wrapper does not retire the banner just raised. No caller contract changed.
6. **Cross-platform.** Explicitly checked: no keyboard shortcuts, accelerators, shortcut labels, file paths, or shell invocation are touched. This is React Native client logic, identical on iOS and Android, and agnostic of the desktop host OS — it behaves the same for native, WSL, and SSH-hosted panes and for both git-worktree and folder workspaces, since it only interprets the outcome of an existing `terminal.send` RPC. No Electron-specific surface involved.

## Security Audit

No new input parsing, command execution, path handling, auth, or secret handling. No IPC/RPC surface change — the same `terminal.send` request is made under the same conditions; only the client-side interpretation of an already-received outcome changed. The two new banner strings are fixed literals, never server-echoed content, so there is no injection or data-leak path. No dependency changes. Byte-for-byte, this PR writes nothing to the PTY that it did not write before — it only stops staying quiet about what it already wrote. No follow-up needed.

## Notes

- Pressing **Stop** mid-answer now raises `Answer partly sent` when groups already landed. That is intended: Stop cannot un-send committed keystrokes, and the selector really is half-stepped.
- Concurrent-write serialization (fix 8 of #12373) is **out of scope** here. Without it, a superseding answer still proceeds against the moved selector — this PR makes that situation *visible* rather than fixing the interleaving, which the write-lock split handles.
- Refs STA-3333.
