### PR TITLE
test: pin Windows IME shortcut ownership

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -11,6 +11,7 @@ import {
 function makeKeyEvent(
   overrides: Partial<{
     key: string
+    code: string
     metaKey: boolean
     ctrlKey: boolean
     shiftKey: boolean
@@ -19,16 +20,39 @@ function makeKeyEvent(
     isComposing: boolean
     keyCode: number
   }>
-): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'repeat'> {
+) {
   return {
     key: 'g',
+    code: 'KeyG',
     metaKey: false,
     ctrlKey: false,
     shiftKey: false,
     altKey: false,
     repeat: false,
+    isComposing: false,
+    keyCode: 0,
     ...overrides
   }
+}
+
+function resolveShortcutAction(
+  overrides: Parameters<typeof makeKeyEvent>[0],
+  isMac = true,
+  isWindows = false
+) {
+  return resolveTerminalKeyboardShortcutAction(
+    makeKeyEvent(overrides),
+    isMac,
+    'false',
+    0,
+    isWindows,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    () => 'alt-enter',
+    () => true
+  )
 }
 
 describe('matchSearchNavigate', () => {
@@ -96,40 +120,40 @@ describe('matchSearchNavigate', () => {
 
 describe('resolveTerminalKeyboardShortcutAction', () => {
   it('routes macOS Shift+Enter with the active Windows PTY host bytes', () => {
-    expect(
-      resolveTerminalKeyboardShortcutAction(
-        makeKeyEvent({ key: 'Enter', shiftKey: true }),
-        true,
-        'false',
-        0,
-        false,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        () => 'alt-enter',
-        () => true
-      )
-    ).toEqual({ type: 'sendInput', data: '\x1b\r' })
+    expect(resolveShortcutAction({ key: 'Enter', shiftKey: true })).toEqual({
+      type: 'sendInput',
+      data: '\x1b\r'
+    })
   })
 
   it('refuses a marked real Enter before shortcut resolution', () => {
-    const event = makeKeyEvent({ key: 'Enter', shiftKey: true, isComposing: true, keyCode: 13 })
-    expect(
-      resolveTerminalKeyboardShortcutAction(
-        event,
-        true,
-        'false',
-        0,
+    const event = makeKeyEvent({
+      key: 'Enter',
+      code: 'Enter',
+      shiftKey: true,
+      isComposing: true,
+      keyCode: 13
+    })
+    expect(resolveShortcutAction(event)).toBeNull()
+  })
+
+  it('refuses marked copy without changing the ordinary clipboard shortcut', () => {
+    const resolve = (isComposing: boolean) =>
+      resolveShortcutAction(
+        {
+          key: 'c',
+          code: 'KeyC',
+          ctrlKey: true,
+          shiftKey: true,
+          isComposing,
+          keyCode: 67
+        },
         false,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        () => 'alt-enter',
-        () => true
+        true
       )
-    ).toBeNull()
+
+    expect(resolve(true)).toBeNull()
+    expect(resolve(false)).toEqual({ type: 'copySelection' })
   })
 })
 

--- a/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
@@ -28,4 +28,10 @@ describe('isImeCompositionKeyDown', () => {
   it('is false for a plain Enter outside of composition', () => {
     expect(isImeCompositionKeyDown(keyEvent({ isComposing: false, keyCode: 13 }))).toBe(false)
   })
+
+  it('keeps the recorded Process/ShiftLeft event IME-owned without treating ordinary Shift as IME', () => {
+    const shift = { code: 'ShiftLeft', shiftKey: true, isComposing: false }
+    expect(isImeOwnedKeyboardEvent({ ...shift, key: 'Process', keyCode: 229 })).toBe(true)
+    expect(isImeOwnedKeyboardEvent({ ...shift, key: 'Shift', keyCode: 16 })).toBe(false)
+  })
 })


### PR DESCRIPTION
Stacked on #12441. Test-only evidence for the existing generic IME ownership guard.

- Pins the recorded Windows `Process / ShiftLeft / keyCode 229` shape separately from ordinary Shift.
- Proves marked Shift+Enter is refused before terminal shortcut dispatch.
- Proves marked Ctrl+Shift+C cannot invoke Copy while the ordinary clipboard shortcut remains unchanged.
- Adds no production code or classes.

Validation:
- Focused Vitest: 27/27.
- Mutation: removing only `isImeOwnedKeyboardEvent` makes the marked Enter and Copy positives fail while ordinary controls pass.
- Oxlint.
- `git diff --check`.