### PR TITLE
fix: preserve native macOS input-method punctuation

### DIFF
--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.test.ts
@@ -23,7 +23,7 @@ describe('preview terminal IME action ownership', () => {
     })
   })
 
-  function install(): void {
+  function install(kittyKeyboardActive = false): void {
     const terminal = {
       attachCustomKeyEventHandler: (next: (event: KeyboardEvent) => boolean) => {
         handler = next
@@ -39,7 +39,7 @@ describe('preview terminal IME action ownership', () => {
         macOptionAsAlt: 'false',
         keybindings: undefined,
         terminalInput: null,
-        kittyKeyboardActive: () => false,
+        kittyKeyboardActive: () => kittyKeyboardActive,
         terminalShortcutPolicy: 'orca-first'
       })
     })
@@ -90,5 +90,19 @@ describe('preview terminal IME action ownership', () => {
     Object.defineProperty(event, 'keyCode', { value: 82 })
 
     expect(handler?.(event)).toBe(true)
+  })
+
+  it('leaves physical Backslash to native macOS keypress', () => {
+    shortcutPlatform.value = 'darwin'
+    install()
+
+    expect(handler?.(new KeyboardEvent('keydown', { code: 'Backslash', key: '\\' }))).toBe(false)
+  })
+
+  it('keeps physical Backslash in xterm while kitty reporting is active', () => {
+    shortcutPlatform.value = 'darwin'
+    install(true)
+
+    expect(handler?.(new KeyboardEvent('keydown', { code: 'Backslash', key: '\\' }))).toBe(true)
   })
 })

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -9,7 +9,7 @@ import {
   type PreviewShortcutContext
 } from './preview-terminal-shortcuts'
 import { isImeOwnedKeyboardEvent } from '@/lib/ime-composition-keyboard-event'
-import { shouldBypassXtermForMacImeStart } from '@/components/terminal-pane/xterm-bypass-policy'
+import { shouldBypassXtermForMacNativeText } from '@/components/terminal-pane/xterm-bypass-policy'
 
 /**
  * Installs the preview terminal's ONE custom key handler (xterm allows a single
@@ -99,7 +99,13 @@ export function installPreviewTerminalKeyHandler(args: {
     if (isImeOwnedKeyboardEvent(event)) {
       return true
     }
-    if (shouldBypassXtermForMacImeStart(event, platform === 'darwin')) {
+    if (
+      shouldBypassXtermForMacNativeText(
+        event,
+        platform === 'darwin',
+        args.getShortcutContext().kittyKeyboardActive()
+      )
+    ) {
       return false
     }
     if (event.type !== 'keydown') {

--- a/src/renderer/src/components/terminal-pane/terminal-stock-composition.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-stock-composition.test.ts
@@ -48,6 +48,16 @@ function keyup(textarea: HTMLTextAreaElement, key: string, code: string, keyCode
   textarea.dispatchEvent(event)
 }
 
+function keypress(textarea: HTMLTextAreaElement, key: string, code: string, keyCode: number): void {
+  const event = new KeyboardEvent('keypress', { bubbles: true, code, key })
+  Object.defineProperties(event, {
+    charCode: { value: keyCode },
+    keyCode: { value: keyCode },
+    which: { value: keyCode }
+  })
+  textarea.dispatchEvent(event)
+}
+
 function compositionText(textarea: HTMLTextAreaElement, data: string): void {
   textarea.setSelectionRange(0, textarea.value.length)
   composition(textarea, 'compositionupdate', data)
@@ -142,6 +152,28 @@ describe('stock xterm composition ownership', () => {
     keydown(textarea, 'a', 65)
 
     expect(emitted.join('')).toBe('`a')
+    terminal.dispose()
+  })
+
+  it('uses native Qingg punctuation while preserving the ABC control', () => {
+    const { emitted, terminal, textarea } = openTerminal()
+    terminal.attachCustomKeyEventHandler(
+      (event) =>
+        !shouldBypassXtermKeyboardEvent(event, {
+          isMac: true,
+          hasSelection: false,
+          kittyKeyboardFlags: 0
+        })
+    )
+
+    keydown(textarea, '\\', 220, false, 'Backslash')
+    keypress(textarea, '\\', 'Backslash', 0x3001)
+    keyup(textarea, '\\', 'Backslash', 220)
+    keydown(textarea, '\\', 220, false, 'Backslash')
+    keypress(textarea, '\\', 'Backslash', 92)
+    keyup(textarea, '\\', 'Backslash', 220)
+
+    expect(emitted.join('')).toBe('、\\')
     terminal.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -937,7 +937,8 @@ export function useTerminalPaneLifecycle({
 
           const shouldBypass = shouldBypassXtermKeyboardEvent(e, {
             isMac,
-            hasSelection: pane.terminal.hasSelection()
+            hasSelection: pane.terminal.hasSelection(),
+            kittyKeyboardFlags: paneKittyKeyboardModesRef.current.get(pane.id)?.flags ?? 0
           })
           return !shouldBypass
         })

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-non-mac.test.ts
@@ -120,6 +120,15 @@ describe('shouldBypassXtermKeyboardEvent — Windows/Linux', () => {
     expect(shouldBypassXtermKeyboardEvent(event({ key: 'c', code: 'KeyC' }), noSel)).toBe(false)
   })
 
+  it('does not bypass physical Backslash', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: '\\', code: 'Backslash', keyCode: 220 }), {
+        ...noSel,
+        kittyKeyboardFlags: 0
+      })
+    ).toBe(false)
+  })
+
   it('bubbles Shift+non-ASCII printable text so the active keyboard layout wins', () => {
     expect(
       shouldBypassXtermKeyboardEvent(event({ key: 'Ф', code: 'KeyA', shiftKey: true }), noSel)

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -144,6 +144,47 @@ describe('shouldBypassXtermKeyboardEvent — macOS', () => {
     ).toBe(false)
   })
 
+  it('leaves physical Backslash to native keypress when kitty reporting is inactive', () => {
+    for (const type of ['keydown', 'keyup']) {
+      expect(
+        shouldBypassXtermKeyboardEvent(
+          event({ type, key: '\\', code: 'Backslash', keyCode: 220 }),
+          { ...noSel, kittyKeyboardFlags: 0 }
+        )
+      ).toBe(true)
+    }
+  })
+
+  it('does not bypass the native Backslash keypress', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(
+        event({ type: 'keypress', key: '\\', code: 'Backslash', keyCode: 0x3001 }),
+        { ...noSel, kittyKeyboardFlags: 0 }
+      )
+    ).toBe(false)
+  })
+
+  it('keeps modified or kitty-reported Backslash in xterm', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: '|', code: 'Backslash', shiftKey: true }), {
+        ...noSel,
+        kittyKeyboardFlags: 0
+      })
+    ).toBe(false)
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: '\\', code: 'Backslash', ctrlKey: true }), {
+        ...noSel,
+        kittyKeyboardFlags: 0
+      })
+    ).toBe(false)
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: '\\', code: 'Backslash' }), {
+        ...noSel,
+        kittyKeyboardFlags: 1
+      })
+    ).toBe(false)
+  })
+
   it('bubbles Shift+non-ASCII printable text so the active keyboard layout wins', () => {
     expect(
       shouldBypassXtermKeyboardEvent(event({ key: 'Ф', code: 'KeyA', shiftKey: true }), opts)

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -28,6 +28,7 @@ export type XtermBypassEvent = {
 
 export type XtermBypassOptions = {
   isMac: boolean
+  kittyKeyboardFlags?: number
   /** True when the terminal has a current text selection — Ctrl+C on
    *  Windows/Linux should only bubble to clipboard when something is selected,
    *  otherwise it must reach the shell as SIGINT. */
@@ -46,7 +47,11 @@ function isSingleNonAsciiPrintableText(key: string): boolean {
   return codePoint !== undefined && codePoint >= 0x80
 }
 
-export function shouldBypassXtermForMacImeStart(event: XtermBypassEvent, isMac: boolean): boolean {
+export function shouldBypassXtermForMacNativeText(
+  event: XtermBypassEvent,
+  isMac: boolean,
+  kittyKeyboardActive = false
+): boolean {
   if (
     !isMac ||
     !isXtermHandledKeyEvent(event.type) ||
@@ -58,7 +63,9 @@ export function shouldBypassXtermForMacImeStart(event: XtermBypassEvent, isMac: 
     return false
   }
   // Why: macOS key bindings can replace layout text only after keydown; leave keypress/input to Chromium.
-  return isSingleNonAsciiPrintableText(event.key)
+  return (
+    isSingleNonAsciiPrintableText(event.key) || (!kittyKeyboardActive && event.code === 'Backslash')
+  )
 }
 
 function isXtermHandledKeyEvent(type: string): boolean {
@@ -136,7 +143,7 @@ export function shouldBypassXtermKeyboardEvent(
   }
 
   const { isMac, hasSelection } = options
-  if (shouldBypassXtermForMacImeStart(event, isMac)) {
+  if (shouldBypassXtermForMacNativeText(event, isMac, (options.kittyKeyboardFlags ?? 0) !== 0)) {
     return true
   }
   const platformModifierHeld = isMac


### PR DESCRIPTION
## Summary

- leave unmodified macOS physical Backslash keydown/keyup to the native keypress path
- preserve xterm ownership when kitty keyboard reporting is active in panes and interactive previews
- cover Qingg, ABC, modifiers, non-macOS, and stock-xterm delivery without source detection

## Why this is slim

Production changes are 14 net lines in three existing files. This adds no class, tracker, locale classifier, input-source lookup, glyph table, or xterm patch.

## Evidence

- exact-build native Qingg PTY: `e380810a` (`、\n`)
- ABC control PTY: `5c0a` (`\\\n`)
- disabling only this rule makes Qingg regress to `5c0a`
- native Qingg sequence: Backslash keydown, U+3001 keypress, `beforeinput`/`input` data `、`
- 68 focused tests pass, including pane/preview parity
- renderer typecheck, oxlint, and `git diff --check` pass

Stacked on #12512.
