### PR TITLE
fix(linear): preserve filter labels after dropdown closes

### DIFF
--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx
@@ -1,10 +1,24 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import LinearIssueAttributeFilterDropdowns from './linear-issue-attribute-filter-dropdowns'
 import {
   clearLinearIssueAttributeFacet,
   countLinearIssueAttributeFilters,
   linearIssueAttributeFilterPillLabels
 } from './linear-issue-attribute-filter-sections'
 import type { LinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+
+const metadataMocks = vi.hoisted(() => ({
+  useTeamsStates: vi.fn(),
+  useTeamsLabels: vi.fn(),
+  useTeamsMembers: vi.fn()
+}))
+
+vi.mock('@/hooks/useIssueMetadata', () => metadataMocks)
+
+afterEach(cleanup)
 
 const sample: LinearIssueAttributeFilter = {
   stateIds: ['s1', 's2'],
@@ -36,5 +50,33 @@ describe('linear-issue-attribute-filter helpers', () => {
     expect(pills[0]?.value).toContain('Todo')
     expect(pills[2]?.value).toMatch(/Unassigned/i)
     expect(pills[3]?.value).toBe('Bug')
+  })
+})
+
+describe('LinearIssueAttributeFilterDropdowns', () => {
+  it('keeps an active filter label resolved while the dropdown is closed', () => {
+    metadataMocks.useTeamsStates.mockReturnValue({ data: [], loading: false, error: null })
+    metadataMocks.useTeamsLabels.mockImplementation((teamIds: string[]) => ({
+      data: teamIds.length > 0 ? [{ id: 'label-1', name: 'Bug' }] : [],
+      loading: false,
+      error: null
+    }))
+    metadataMocks.useTeamsMembers.mockReturnValue({ data: [], loading: false, error: null })
+
+    const team = { id: 'team-1', name: 'Engineering', key: 'ENG' }
+    render(
+      <LinearIssueAttributeFilterDropdowns
+        value={{ stateIds: [], priorities: [], assignee: null, labelIds: ['label-1'] }}
+        onChange={vi.fn()}
+        workspaceId="workspace-1"
+        isAllWorkspaces={false}
+        primaryTeam={team}
+        selectedTeamIds={[team.id]}
+        availableTeams={[team]}
+      />
+    )
+
+    expect(screen.getByText('Bug')).toBeTruthy()
+    expect(screen.queryByText('label-1')).toBeNull()
   })
 })

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
@@ -76,9 +76,14 @@ export default function LinearIssueAttributeFilterDropdowns({
 }: Props): React.JSX.Element {
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [openSection, setOpenSection] = useState<LinearIssueFilterSectionKey | null>(null)
+  const shouldLoadMetadata =
+    popoverOpen ||
+    value.stateIds.length > 0 ||
+    value.labelIds.length > 0 ||
+    value.assignee?.kind === 'user'
 
   const activeTeamIds = useMemo(() => {
-    if (!popoverOpen || isAllWorkspaces) {
+    if (!shouldLoadMetadata || isAllWorkspaces) {
       return [] as string[]
     }
     return resolveLinearIssueAttributeFilterTeamIds({
@@ -86,10 +91,12 @@ export default function LinearIssueAttributeFilterDropdowns({
       availableTeams,
       primaryTeamId: primaryTeam?.id ?? null
     })
-  }, [popoverOpen, isAllWorkspaces, selectedTeamIds, availableTeams, primaryTeam?.id])
+  }, [shouldLoadMetadata, isAllWorkspaces, selectedTeamIds, availableTeams, primaryTeam?.id])
 
   const concreteWorkspaceId =
-    popoverOpen && !isAllWorkspaces && workspaceId && workspaceId !== 'all' ? workspaceId : null
+    shouldLoadMetadata && !isAllWorkspaces && workspaceId && workspaceId !== 'all'
+      ? workspaceId
+      : null
 
   // Why: multi-team / All teams must union filter options across every selected team (#8739).
   const states = useTeamsStates(activeTeamIds, settings, concreteWorkspaceId)


### PR DESCRIPTION
## Summary

- keep Linear status, label, and user-assignee metadata loaded while an active filter needs its display name
- prevent applied filter chips from falling back to UUIDs when the dropdown closes
- add a regression test for a closed dropdown with an active label filter

Fixes #12520

## Screenshots

No visual design change. Applied filter chips now retain their readable Linear names after the dropdown closes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 45,371 passed; 7 unrelated tests failed. On focused rerun, relay/PTY and Electron startup tests passed; 3 existing `check-root-directory-entries` tests still failed.
- [ ] `pnpm build` — not run for this isolated renderer state fix
- [x] Added a regression test that fails when a closed dropdown drops label metadata
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/linear-issue-attribute-filter-dropdowns.test.tsx`

## AI Review Report

Traced the flow from `TaskPage` through the Linear filter dropdown, metadata hooks, and pill-label formatting. Reviewed the two-file diff for metadata lifecycle regressions, including all-workspaces mode, clearing filters, priority-only and unassigned-only filters, and active status/label/user-assignee filters. The change is platform-independent and does not alter shortcuts, paths, shells, or Electron-specific behavior on macOS, Linux, or Windows.

## Security Audit

This change only controls when existing read-only Linear metadata hooks remain active. It adds no input boundary, command execution, path handling, authentication, secret, dependency, IPC, or persistence changes.

## Notes

- The same renderer behavior applies to local, SSH, git-worktree, and folder workspace contexts.
- CI and preview remain pending.
