### PR TITLE
refactor(terminal): remove stale mac focus override

### DIFF
--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -149,7 +149,6 @@ describe('regular terminal focus ownership', () => {
       activeElement: document.activeElement,
       syncFocused,
       releasedHelper,
-      isMac: false,
       scheduleRefocus: (callback) => scheduled.push(callback)
     })
 
@@ -192,7 +191,6 @@ describe('regular terminal focus ownership', () => {
       activeElement: document.activeElement,
       syncFocused,
       releasedHelper,
-      isMac: false,
       scheduleRefocus: (callback) => scheduled.push(callback)
     })
     for (const run of scheduled) {
@@ -225,7 +223,6 @@ describe('regular terminal focus ownership', () => {
       activeElement: document.activeElement,
       syncFocused,
       releasedHelper,
-      isMac: false,
       scheduleRefocus: (callback) => scheduled.push(callback)
     })
     for (const run of scheduled) {
@@ -263,7 +260,6 @@ describe('regular terminal focus ownership', () => {
       activeElement: document.activeElement,
       syncFocused,
       releasedHelper,
-      isMac: false,
       scheduleRefocus: (callback) => scheduled.push(callback)
     })
     // User clicks into another field before the deferred reclaim runs.
@@ -299,7 +295,6 @@ describe('regular terminal focus ownership', () => {
       activeElement: document.activeElement,
       syncFocused,
       releasedHelper,
-      isMac: false,
       scheduleRefocus: (callback) => scheduled.push(callback)
     })
     newerHelper.focus()
@@ -330,8 +325,7 @@ describe('regular terminal focus ownership', () => {
       container: pane,
       activeElement: document.activeElement,
       syncFocused,
-      releasedHelper,
-      isMac: false
+      releasedHelper
     })
 
     expect(synced).toBe(false)
@@ -347,8 +341,7 @@ describe('regular terminal focus ownership', () => {
       container: pane,
       activeElement: document.activeElement,
       syncFocused,
-      releasedHelper: null,
-      isMac: false
+      releasedHelper: null
     })
 
     expect(synced).toBe(false)
@@ -364,8 +357,7 @@ describe('regular terminal focus ownership', () => {
     const synced = resyncTerminalFocusForWindowFocus({
       container: pane,
       activeElement: document.activeElement,
-      syncFocused,
-      isMac: false
+      syncFocused
     })
 
     expect(synced).toBe(true)

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -82,8 +82,6 @@ export function resyncTerminalFocusForWindowFocus(args: {
    * helper rather than whichever helper is first in the DOM.
    */
   releasedHelper?: HTMLElement | null
-  /** Override the macOS check (tests). Defaults to the navigator user agent. */
-  isMac?: boolean
   /** Override the refocus scheduler (tests). Defaults to requestAnimationFrame. */
   scheduleRefocus?: RefocusScheduler
 }): boolean {
@@ -112,8 +110,7 @@ export function resyncTerminalFocusForWindowFocus(args: {
   // Why: defer the reclaim refocus to the next frame and only take focus if
   // nothing newer grabbed it — so a click into the sidebar/dialog/rename input
   // during reactivation isn't yanked back into the terminal. Applies on every
-  // platform (the reporter's bug is Linux); macOS additionally needs the blur
-  // first to rebuild a stale NSTextInputContext (see below).
+  // platform (the reporter's bug is Linux).
   if (needsProgrammaticFocus) {
     const schedule = args.scheduleRefocus ?? scheduleNextFrame
     schedule(() => {


### PR DESCRIPTION
## Summary

- remove the unused macOS override from terminal focus resynchronization
- delete stale prose implying a platform-specific focus path that no longer exists
- keep the existing cross-platform deferred focus ownership unchanged

## Scope

This is deletion-only IME ownership cleanup discovered during the stack review. It adds no behavior, class, state, or abstraction.

## Verification

- `regular-terminal-focus-ownership.test.ts`: 15/15 pass
- renderer typecheck passes
- targeted oxlint and `git diff --check` pass

Stacked on #12519.
