### PR TITLE
fix(terminal): keep keystroke echo responsive under dense-SGR output floods

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1987,6 +1987,11 @@ export type PtyRendererDeliveryDebugSnapshot = {
   hiddenDeliveryDroppedChars: number
   hiddenDeliveryDroppedChunks: number
   pendingDroppedChars: number
+  /** Chars dropped by the input-protection gate (flood chunks while typing). */
+  inputProtectionDroppedChars: number
+  /** Chars/count sent on the dedicated interactive (echo) lane. */
+  interactiveLaneSentChars: number
+  interactiveLaneSentCount: number
   /** One-paste freeze diagnostics: per-pty delivery table + event history. */
   diagnostics: PtyMainDeliveryDiagnostics
   // Why: a nonzero lastLifecycleResetClearedChars is the exact signature of the leaked-accounting freeze this reset fixes.
@@ -2040,6 +2045,9 @@ const EMPTY_PTY_RENDERER_DELIVERY_DEBUG_SNAPSHOT: PtyRendererDeliveryDebugSnapsh
   hiddenDeliveryDroppedChars: 0,
   hiddenDeliveryDroppedChunks: 0,
   pendingDroppedChars: 0,
+  inputProtectionDroppedChars: 0,
+  interactiveLaneSentChars: 0,
+  interactiveLaneSentCount: 0,
   diagnostics: EMPTY_PTY_MAIN_DELIVERY_DIAGNOSTICS,
   rendererLifecycleResetCount: 0,
   lastLifecycleResetClearedChars: 0,
@@ -2394,6 +2402,13 @@ export function registerPtyHandlers(
   const PTY_RENDERER_INTERACTIVE_RESERVE_CHARS = 256 * 1024
   // Why: reserve a bounded lane so an active pane's keystroke redraw reaches the renderer ahead of hidden bulk output's ACKs.
   const PTY_RENDERER_ACTIVE_PTY_IN_FLIGHT_RESERVE_CHARS = 512 * 1024
+  // Why: echo/keystroke-sized chunks get their own tiny in-flight lane so a
+  // parse-starved flood (dense SGR) occupying the normal window can't park the
+  // keystroke echo behind it. xterm's FIFO still preserves byte order: the
+  // echo is written after already-delivered flood bytes and parses after them.
+  const PTY_INTERACTIVE_LANE_CHARS = 64 * 1024
+  let interactiveLaneSentChars = 0
+  let interactiveLaneSentCount = 0
   // Why: request/response hygiene only (never mutates delivery state) — clears the outstanding-probe flag so a later arrival can re-probe, logs once per silent streak.
   const PTY_DELIVERY_RESYNC_TIMEOUT_MS = 5_000
   // Why: a heal write-off destroys delivery accounting; require this much main-side ACK silence (independent of renderer evidence) before declaring the channel dead.
@@ -2410,6 +2425,29 @@ export function registerPtyHandlers(
   let ackGatedFlushSkipCount = 0
   let rendererLifecycleResetCount = 0
   let lastLifecycleResetClearedChars = 0
+  // Why: while the user types, a parse-starved flood (dense SGR styling) parks
+  // the keystroke echo behind the pending backlog in this FIFO. Drop flood-size
+  // chunks inside the input window so echo reaches the renderer promptly; small
+  // chunks (echo, tiny redraws) always pass through.
+  const PTY_INPUT_PROTECTION_DROP_WINDOW_MS = 500
+  // Why 16KB: a conservative flood-size floor — echo chunks are far smaller
+  // and always pass; the renderer-side freeze+drop is the primary guard.
+  const PTY_INPUT_PROTECTION_DROP_MIN_CHARS = PTY_BATCH_FLUSH_CHUNK_CHARS
+  let inputProtectionDroppedChars = 0
+  const isInsidePtyInputProtectionWindow = (id: string): boolean => {
+    const lastInputAt = lastInputAtByPty.get(id)
+    return (
+      lastInputAt !== undefined &&
+      performance.now() - lastInputAt <= PTY_INPUT_PROTECTION_DROP_WINDOW_MS
+    )
+  }
+  const recordInputProtectionDrop = (id: string, chars: number): void => {
+    inputProtectionDroppedChars += chars
+    mainDeliveryBreadcrumbs.record('input-protection-drop', {
+      id: redactPtyIdForDiagnostics(id),
+      chars
+    })
+  }
   // Why: count of watchdog gate force-opens (no handshake arrived); nonzero flags a dropped-handshake self-heal.
   let rendererDispatcherReadyForcedCount = 0
   // Why: gate sends until the page's pty:data listener exists; else webContents.send drops bytes but still counts them in-flight, permanently pinning the gate.
@@ -2562,6 +2600,9 @@ export function registerPtyHandlers(
       hiddenDeliveryGatedVisiblePtyCount,
       hiddenDeliveryGatedActivePtyCount,
       pendingDroppedChars,
+      inputProtectionDroppedChars,
+      interactiveLaneSentChars,
+      interactiveLaneSentCount,
       diagnostics: buildMainDeliveryDiagnostics(),
       rendererLifecycleResetCount,
       lastLifecycleResetClearedChars,
@@ -3561,6 +3602,18 @@ export function registerPtyHandlers(
       }
       return
     }
+    // Why: inside the input window a parse-starved flood (dense SGR) parks the
+    // keystroke echo behind the pending backlog in this FIFO. Drop flood-size
+    // chunks before they are appended; small chunks (echo, tiny redraws) always
+    // pass through. Projection-tracked SSH spans keep their accounting intact.
+    if (
+      projection?.desktopSpan !== true &&
+      rawLength > PTY_INPUT_PROTECTION_DROP_MIN_CHARS &&
+      isInsidePtyInputProtectionWindow(payload.id)
+    ) {
+      recordInputProtectionDrop(payload.id, rawLength)
+      return
+    }
     const containsBackgroundOutput =
       rendererPtyIsKnownHidden(payload.id) || ptyHasHiddenRendererResizeOutput(payload.id)
     if (containsBackgroundOutput) {
@@ -3569,6 +3622,51 @@ export function registerPtyHandlers(
     const overflowMarkedBeforeAppend = pendingOverflowMarkedPtys.has(payload.id)
     if (projection?.desktopSpan) {
       sourceCreditPendingPtys.add(payload.id)
+    }
+    // Why payload.data (not the merged pending tail): a keystroke echo arriving
+    // during a flood would otherwise be judged by the flood's size and lose its
+    // interactive identity, then queue behind the flood in this FIFO. Judged by
+    // its own chunk, echo gets the dedicated lane below. The lane is NOT widened
+    // to the whole input-protection window: small flood chunks would exhaust it
+    // and re-introduce echo lag in plain-text scenarios.
+    const pendingBefore = pendingData.get(payload.id)
+    const combinedLength = (pendingBefore?.data.length ?? 0) + rawLength
+    const isInteractiveOutput =
+      projection?.desktopSpan !== true &&
+      shouldSendInteractiveOutputNow(payload.id, payload.data, performance.now())
+    if (isInteractiveOutput && rendererPtyDispatcherReady) {
+      const interactiveAccounting = rendererDeliveryAccountingByPty.get(payload.id)
+      const laneInFlight = interactiveAccounting
+        ? interactiveAccounting.sentChars - interactiveAccounting.ackedChars
+        : 0
+      // Why: judged by its own chunk (payload.data) so a keystroke echo is not
+      // swallowed by a flood-sized pending tail; then sent merged WITH the
+      // pending tail so byte order is preserved. The dedicated lane bypasses
+      // the flood-saturated in-flight window. Oversized tails fall back to the
+      // normal pending path (the input-protection drop keeps those bounded).
+      if (
+        laneInFlight < PTY_INTERACTIVE_LANE_CHARS &&
+        combinedLength <= INTERACTIVE_OUTPUT_MAX_CHARS
+      ) {
+        const combined = (pendingBefore?.data ?? '') + payload.data
+        deletePendingPtyData(payload.id)
+        clearFlushTimerIfIdle()
+        sendPtyDataToRenderer(
+          payload.id,
+          makePtyDataPayload(
+            payload.id,
+            combined,
+            startSeq,
+            containsBackgroundOutput,
+            combinedLength,
+            payload.transformed === true
+          ),
+          payload.projectionAdmissionIds
+        )
+        interactiveLaneSentChars += combinedLength
+        interactiveLaneSentCount += 1
+        return
+      }
     }
     const pending = appendPendingPtyData(
       payload.id,
@@ -3586,12 +3684,16 @@ export function registerPtyHandlers(
       !overflowMarkedBeforeAppend &&
       pendingOverflowMarkedPtys.has(payload.id)
     const nextData = pending.data + getDroppedMode2031RendererData(pending)
-    const isInteractiveOutput = shouldSendInteractiveOutputNow(
-      payload.id,
-      nextData,
-      performance.now()
-    )
-    if (isInteractiveOutput && rendererPtyDispatcherReady) {
+    // Why the bound: the lane branch above already handled small echoes. A
+    // chunk merged onto an existing pending tail past the interactive size
+    // limit must fall back to the batch path; a standalone chunk with no
+    // pending tail (no reorder risk) up to the redraw limit still sends
+    // immediately.
+    const pendingEmpty = !pendingBefore || pendingBefore.data.length === 0
+    const interactiveTailInLimit = pendingEmpty
+      ? rawLength <= INTERACTIVE_REDRAW_MAX_CHARS
+      : combinedLength <= INTERACTIVE_OUTPUT_MAX_CHARS
+    if (isInteractiveOutput && rendererPtyDispatcherReady && interactiveTailInLimit) {
       if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
         setPendingPtyData(payload.id, pending)
         if (shouldEmitPendingCapRestoreMarker) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2439,6 +2439,7 @@ export function registerPtyHandlers(
   // and always pass; the renderer-side freeze+drop is the primary guard.
   const PTY_INPUT_PROTECTION_DROP_MIN_CHARS = PTY_BATCH_FLUSH_CHUNK_CHARS
   let inputProtectionDroppedChars = 0
+  /** True within the input window of the pty's last keystroke. */
   const isInsidePtyInputProtectionWindow = (id: string): boolean => {
     const lastInputAt = lastInputAtByPty.get(id)
     return (
@@ -2446,6 +2447,7 @@ export function registerPtyHandlers(
       performance.now() - lastInputAt <= PTY_INPUT_PROTECTION_DROP_WINDOW_MS
     )
   }
+  /** Counts dropped flood chars and breadcrumbs them for diagnostics. */
   const recordInputProtectionDrop = (id: string, chars: number): void => {
     inputProtectionDroppedChars += chars
     mainDeliveryBreadcrumbs.record('input-protection-drop', {
@@ -3620,6 +3622,21 @@ export function registerPtyHandlers(
       isDenseSgr(payload.data)
     ) {
       recordInputProtectionDrop(payload.id, rawLength)
+      if (projectionId) {
+        sshOutputIntake?.transferProjections([projectionId], 'input-protection-drop')
+      }
+      // Why: a mid-stream gap corrupts the pane; the sentinel repaints from
+      // main's authoritative buffer and realigns by sequence. Query bytes ride
+      // along so reply-eliciting probes (DSR/CPR, DA, DECRQM, OSC 10/11) in the
+      // dropped chunk still reach the program.
+      sendPtyDataToRenderer(payload.id, {
+        id: payload.id,
+        data: extractDroppedPtyQueryBytes(payload.data).slice(
+          0,
+          DROPPED_QUERY_SALVAGE_MAX_CHARS
+        ),
+        droppedOutput: true
+      })
       return
     }
     const containsBackgroundOutput =

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -19,6 +19,7 @@ import type { GlobalSettings, TuiAgent } from '../../shared/types'
 import { toSshExecutionHostId } from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { terminalOutputBacklogCapChars } from '../../shared/terminal-scrollback-policy'
+import { isDenseSgr } from '../../shared/terminal-sgr-density'
 import type {
   PtyDeliveryWriteOff,
   PtyRendererDeliveryHealthReply,
@@ -2402,11 +2403,15 @@ export function registerPtyHandlers(
   const PTY_RENDERER_INTERACTIVE_RESERVE_CHARS = 256 * 1024
   // Why: reserve a bounded lane so an active pane's keystroke redraw reaches the renderer ahead of hidden bulk output's ACKs.
   const PTY_RENDERER_ACTIVE_PTY_IN_FLIGHT_RESERVE_CHARS = 512 * 1024
-  // Why: echo/keystroke-sized chunks get their own tiny in-flight lane so a
-  // parse-starved flood (dense SGR) occupying the normal window can't park the
-  // keystroke echo behind it. xterm's FIFO still preserves byte order: the
-  // echo is written after already-delivered flood bytes and parses after them.
-  const PTY_INTERACTIVE_LANE_CHARS = 64 * 1024
+  // Why: echo/keystroke-sized chunks get their own lane so a parse-starved
+  // flood (dense SGR) occupying the normal window can't park the keystroke
+  // echo behind it. xterm's FIFO still preserves byte order: the echo is
+  // written after already-delivered flood bytes and parses after them.
+  // The lane's in-flight gate is canSendPtyDataToRenderer (same as the
+  // interactive batch path), NOT a tiny lane-only budget — per-send payloads
+  // are capped at INTERACTIVE_OUTPUT_MAX_CHARS, so the lane cannot outgrow the
+  // window, and a flood-saturated in-flight total is exactly when the echo
+  // needs the lane.
   let interactiveLaneSentChars = 0
   let interactiveLaneSentCount = 0
   // Why: request/response hygiene only (never mutates delivery state) — clears the outstanding-probe flag so a later arrival can re-probe, logs once per silent streak.
@@ -3604,12 +3609,15 @@ export function registerPtyHandlers(
     }
     // Why: inside the input window a parse-starved flood (dense SGR) parks the
     // keystroke echo behind the pending backlog in this FIFO. Drop flood-size
-    // chunks before they are appended; small chunks (echo, tiny redraws) always
-    // pass through. Projection-tracked SSH spans keep their accounting intact.
+    // dense-SGR chunks before they are appended; small chunks (echo, tiny
+    // redraws) and non-dense output (plain text, TUI repaints — both parse
+    // fast) always pass through, so typing never truncates ordinary output.
+    // Projection-tracked SSH spans keep their accounting intact.
     if (
-      projection?.desktopSpan !== true &&
+      !projection?.desktopSpan &&
       rawLength > PTY_INPUT_PROTECTION_DROP_MIN_CHARS &&
-      isInsidePtyInputProtectionWindow(payload.id)
+      isInsidePtyInputProtectionWindow(payload.id) &&
+      isDenseSgr(payload.data)
     ) {
       recordInputProtectionDrop(payload.id, rawLength)
       return
@@ -3632,23 +3640,24 @@ export function registerPtyHandlers(
     const pendingBefore = pendingData.get(payload.id)
     const combinedLength = (pendingBefore?.data.length ?? 0) + rawLength
     const isInteractiveOutput =
-      projection?.desktopSpan !== true &&
+      !projection?.desktopSpan &&
       shouldSendInteractiveOutputNow(payload.id, payload.data, performance.now())
     if (isInteractiveOutput && rendererPtyDispatcherReady) {
-      const interactiveAccounting = rendererDeliveryAccountingByPty.get(payload.id)
-      const laneInFlight = interactiveAccounting
-        ? interactiveAccounting.sentChars - interactiveAccounting.ackedChars
-        : 0
       // Why: judged by its own chunk (payload.data) so a keystroke echo is not
       // swallowed by a flood-sized pending tail; then sent merged WITH the
-      // pending tail so byte order is preserved. The dedicated lane bypasses
-      // the flood-saturated in-flight window. Oversized tails fall back to the
+      // pending tail so byte order is preserved. The lane reuses the
+      // interactive in-flight gate instead of a tiny lane-only budget: a
+      // flood-saturated window is exactly when the echo needs to bypass the
+      // normal path, and the per-send cap (INTERACTIVE_OUTPUT_MAX_CHARS) keeps
+      // the lane from outgrowing the window. Oversized tails fall back to the
       // normal pending path (the input-protection drop keeps those bounded).
       if (
-        laneInFlight < PTY_INTERACTIVE_LANE_CHARS &&
-        combinedLength <= INTERACTIVE_OUTPUT_MAX_CHARS
+        canSendPtyDataToRenderer(payload.id, { interactive: true }) &&
+        combinedLength <= INTERACTIVE_OUTPUT_MAX_CHARS &&
+        !pendingBefore?.droppedOutput
       ) {
         const combined = (pendingBefore?.data ?? '') + payload.data
+        const laneProjectionState = compactPendingProjectionState(pendingBefore ?? {}, projectionId)
         deletePendingPtyData(payload.id)
         clearFlushTimerIfIdle()
         sendPtyDataToRenderer(
@@ -3661,7 +3670,7 @@ export function registerPtyHandlers(
             combinedLength,
             payload.transformed === true
           ),
-          payload.projectionAdmissionIds
+          laneProjectionState.projectionAdmissionIds
         )
         interactiveLaneSentChars += combinedLength
         interactiveLaneSentCount += 1

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3998,10 +3998,6 @@ export function connectPanePty(
   )
 
   const onDataDisposable = pane.terminal.onData((data) => {
-    // Why: input must mark the scheduler's input window even when the
-    // internal core onUserInput API is unavailable; the echo-latency drop
-    // depends on it. Harmless for parser auto-replies (only widens the window).
-    markTerminalUserInput(pane.terminal)
     // Why: xterm auto-replies to embedded query sequences (DA1, DECRQM,
     // OSC 10/11, focus, CPR) via onData. When we replay recorded PTY bytes
     // into xterm for scrollback/cold-restore/snapshot, those queries would
@@ -4067,6 +4063,10 @@ export function connectPanePty(
       clearPendingTerminalInputIntent()
       return
     }
+    // Why: fallback for builds without the core onUserInput signal; placed
+    // after the replay, lock, stale, and query-reply guards so the scheduler's
+    // input window opens for real input only.
+    markTerminalUserInput(pane.terminal)
     const intent = pendingTerminalInputIntent
     // Why: real xterm can deliver the terminal byte even when our DOM keydown
     // listener missed the press. Exact Ctrl+C/Escape bytes are still safe to

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -150,6 +150,7 @@ import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-str
 import {
   discardTerminalOutput,
   flushTerminalOutput,
+  markTerminalUserInput,
   registerTerminalBacklogRecovery,
   waitForTerminalOutputParsed,
   writeTerminalOutput
@@ -3679,6 +3680,9 @@ export function connectPanePty(
     lastTerminalInputAt = performance.now()
     // Why: input must probe a wedged xterm even when the PTY produces no renderer output.
     requestTerminalWritePipelineProbe(pane.terminal)
+    // Why: the output scheduler drops parse-starved foreground backlog inside
+    // the input window so keystroke echo doesn't queue behind a dense-SGR flood.
+    markTerminalUserInput(pane.terminal)
   }
   const recordTerminalInputForHibernation = (): void => {
     useAppStore.getState().recordTerminalInput(cacheKey)
@@ -3693,6 +3697,9 @@ export function connectPanePty(
     recordTerminalInputForHibernation()
     // Takeover must never fire from the onData fallback below: it mixes in auto-replies.
     reportWorkerTerminalUserInput(cacheKey, runtimeEnvironmentId)
+    // Why: the output scheduler drops parse-starved foreground backlog inside
+    // the input window so keystroke echo doesn't queue behind a dense-SGR flood.
+    markTerminalUserInput(pane.terminal)
   }
   const userInputActivityDisposable = subscribeToTerminalUserInput(
     pane.terminal,
@@ -3991,6 +3998,10 @@ export function connectPanePty(
   )
 
   const onDataDisposable = pane.terminal.onData((data) => {
+    // Why: input must mark the scheduler's input window even when the
+    // internal core onUserInput API is unavailable; the echo-latency drop
+    // depends on it. Harmless for parser auto-replies (only widens the window).
+    markTerminalUserInput(pane.terminal)
     // Why: xterm auto-replies to embedded query sequences (DA1, DECRQM,
     // OSC 10/11, focus, CPR) via onData. When we replay recorded PTY bytes
     // into xterm for scrollback/cold-restore/snapshot, those queries would

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1677,4 +1677,71 @@ describe('pane terminal output scheduler', () => {
     vi.advanceTimersByTime(100)
     expect(throwing.write).toHaveBeenCalledTimes(1)
   })
+
+  describe('input-protection freeze recovery', () => {
+    // Why: a dense-SGR entry frozen inside the input window must resume when
+    // the window expires even if no new output arrives (the flood stopped
+    // exactly inside the window) — otherwise queued output strands until the
+    // next chunk.
+    function denseSgrChunk(count = 8): string {
+      return Array.from({ length: count }, (_, index) => `\x1b[38;5;${index}mX\x1b[0m`).join('')
+    }
+
+    it('freezes dense-SGR foreground output while the user is typing', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput, markTerminalUserInput } = await loadScheduler()
+      const terminal = createTerminal()
+
+      markTerminalUserInput(terminal)
+      writeTerminalOutput(terminal, denseSgrChunk(), {
+        foreground: true,
+        latencySensitive: false
+      })
+
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).not.toHaveBeenCalled()
+    })
+
+    it('resumes the frozen backlog once the input window expires', async () => {
+      // Why explicit toFake: the default fake set leaves performance.now()
+      // real, so the input window would never expire; and toFake replaces the
+      // default set, so the scheduler's setTimeout must be listed too.
+      vi.useFakeTimers({
+        toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'performance']
+      })
+      const { writeTerminalOutput, markTerminalUserInput } = await loadScheduler()
+      const terminal = createTerminal()
+
+      markTerminalUserInput(terminal)
+      writeTerminalOutput(terminal, denseSgrChunk(), {
+        foreground: true,
+        latencySensitive: false
+      })
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).not.toHaveBeenCalled()
+
+      // The window-expiry recovery timer drains the frozen entry (501ms: the
+      // recovery timer fires strictly after the <=-bound window closes, then
+      // the drain's own 0ms timer runs — advance one more ms so the recovery
+      // callback's newly scheduled drain job is picked up).
+      vi.advanceTimersByTime(501)
+      vi.advanceTimersByTime(1)
+      expect(terminal.write).toHaveBeenCalled()
+    })
+
+    it('keeps plain-text foreground output flowing during the input window', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput, markTerminalUserInput } = await loadScheduler()
+      const terminal = createTerminal()
+
+      markTerminalUserInput(terminal)
+      writeTerminalOutput(terminal, 'plain text output', {
+        foreground: true,
+        latencySensitive: false
+      })
+
+      vi.advanceTimersByTime(0)
+      expect(terminal.write).toHaveBeenCalledWith('plain text output', expect.any(Function))
+    })
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -6,7 +6,8 @@ import {
   type ForegroundTerminalOutputTarget
 } from './pane-terminal-foreground-render-settle'
 import { runGuardedWriteCompletionStep } from './xterm-write-callback-guard'
-import { isDenseSgr, normalizeSgrDensity } from './terminal-sgr-normalizer'
+import { isDenseSgr } from '../../../../shared/terminal-sgr-density'
+import { normalizeSgrDensity } from './terminal-sgr-normalizer'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import {
   discardInFlightTerminalOutputAckCredits,
@@ -115,11 +116,33 @@ const FOREGROUND_INPUT_PROTECTION_WINDOW_MS = 500
 const FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS = 16 * 1024
 const lastUserInputAtByTerminal = new WeakMap<TerminalOutputTarget, number>()
 let lastAnyUserInputAt = Number.NEGATIVE_INFINITY
+// Why: a dense-SGR entry frozen by the input window has no drain re-arm when
+// the flood stops inside the window (no new enqueue, and drains only re-arm
+// while hasDrainableBacklog()); drain once the window expires so frozen
+// backlog always resumes instead of stranding until the next output chunk.
+const inputProtectionRecoveryTimers = new WeakMap<
+  TerminalOutputTarget,
+  ReturnType<typeof setTimeout>
+>()
 
 export function markTerminalUserInput(terminal: TerminalOutputTarget): void {
   const now = performance.now()
   lastUserInputAtByTerminal.set(terminal, now)
   lastAnyUserInputAt = now
+  const existing = inputProtectionRecoveryTimers.get(terminal)
+  if (existing) {
+    clearTimeout(existing)
+  }
+  inputProtectionRecoveryTimers.set(
+    terminal,
+    setTimeout(() => {
+      inputProtectionRecoveryTimers.delete(terminal)
+      scheduleDrain(0)
+      // Why +1ms: hasRecentTerminalInput uses `<= WINDOW`, so a timer at
+      // exactly WINDOW_MS still sees the window open and the entry stays
+      // frozen — the recovery drain must fire strictly after expiry.
+    }, FOREGROUND_INPUT_PROTECTION_WINDOW_MS + 1)
+  )
 }
 
 function hasRecentAnyInput(): boolean {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -6,6 +6,7 @@ import {
   type ForegroundTerminalOutputTarget
 } from './pane-terminal-foreground-render-settle'
 import { runGuardedWriteCompletionStep } from './xterm-write-callback-guard'
+import { isDenseSgr, normalizeSgrDensity } from './terminal-sgr-normalizer'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import {
   discardInFlightTerminalOutputAckCredits,
@@ -85,14 +86,19 @@ type QueueEntry = {
   foregroundCoalesceDelayMs: number
   foregroundHoldSafetyTimer: ReturnType<typeof setTimeout> | null
   foregroundCoalesceTimer: ReturnType<typeof setTimeout> | null
+  /** True when the queued data carries dense SGR styling (parse-starved in xterm). */
+  denseSgr: boolean
 }
 
 const BACKGROUND_FLUSH_DELAY_MS = 50
 const BACKGROUND_DRAIN_INTERVAL_MS = 16
 const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 4
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
+// Why 4KB: a dense-SGR batch parses ~50x slower than plain text; smaller
+// batches keep the in-xterm FIFO shallow so keystroke echo stays responsive.
+const DENSE_SGR_CHUNK_CHARS = 4 * 1024
 const MAX_WRITES_PER_DRAIN = 2
-// Why 8: per-tick volume (8 x 16KB = 128KB ≈ 1.3ms parse) sets the sustained ceiling (~30MB/s) within DRAIN_TIME_BUDGET_MS; at 2 it was only 8MB/s against a ~100MB/s parser (see throughput bench).
+// Why 8: per-tick volume (8 x 16KB = 128KB ≈ 1.3ms parse) sets the sustained ceiling (~30MB/s) within DRAIN_TIME_BUDGET_MS; at 2 it was only 8MB/s against a ~100MB/s parser (see throughput bench). Dense-SGR entries break to one batch per drain in drainQueuedOutput.
 const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 8
 const DRAIN_TIME_BUDGET_MS = 8
 const LARGE_BACKLOG_CHARS = 512 * 1024
@@ -100,6 +106,57 @@ const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 // Why mutable: the cap scales with the user's scrollback setting (terminalOutputBacklogCapChars), configured when settings apply; the chunk-count cap stays fixed.
 let maxQueueChars = TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS
 const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
+// Why: while the user is typing, a flood that outruns xterm parse (dense SGR
+// styling) parks the keystroke echo behind the backlog in every FIFO layer.
+// Drop the backlog once it exceeds a small bound inside the input window so
+// echo latency stays bounded instead of growing with the flood. The generic
+// cap (maxQueueChars) stays large for memory-bound scrollback retention.
+const FOREGROUND_INPUT_PROTECTION_WINDOW_MS = 500
+const FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS = 16 * 1024
+const lastUserInputAtByTerminal = new WeakMap<TerminalOutputTarget, number>()
+let lastAnyUserInputAt = Number.NEGATIVE_INFINITY
+
+export function markTerminalUserInput(terminal: TerminalOutputTarget): void {
+  const now = performance.now()
+  lastUserInputAtByTerminal.set(terminal, now)
+  lastAnyUserInputAt = now
+}
+
+function hasRecentAnyInput(): boolean {
+  return performance.now() - lastAnyUserInputAt <= FOREGROUND_INPUT_PROTECTION_WINDOW_MS
+}
+
+function hasRecentTerminalInput(terminal: TerminalOutputTarget): boolean {
+  const lastInputAt = lastUserInputAtByTerminal.get(terminal)
+  return (
+    lastInputAt !== undefined &&
+    performance.now() - lastInputAt <= FOREGROUND_INPUT_PROTECTION_WINDOW_MS
+  )
+}
+
+// Why: strict parse-clock pacing — a delivered batch counts in-flight until
+// xterm's parse-completion callback decrements it, so no drain entry point
+// (pacer OR enqueue) can deliver faster than xterm parses. Without this a
+// dense-SGR flood's enqueue-triggered drains pile up an in-xterm FIFO that
+// keystroke echo waits behind (the "agent output makes typing lag" bug).
+const inFlightBatchesByTerminal = new WeakMap<TerminalOutputTarget, number>()
+
+function getInFlightBatches(terminal: TerminalOutputTarget): number {
+  return inFlightBatchesByTerminal.get(terminal) ?? 0
+}
+
+function markBatchDelivered(terminal: TerminalOutputTarget): void {
+  inFlightBatchesByTerminal.set(terminal, getInFlightBatches(terminal) + 1)
+}
+
+function markBatchParsed(terminal: TerminalOutputTarget): void {
+  const remaining = getInFlightBatches(terminal) - 1
+  if (remaining > 0) {
+    inFlightBatchesByTerminal.set(terminal, remaining)
+  } else {
+    inFlightBatchesByTerminal.delete(terminal)
+  }
+}
 
 export function configureTerminalOutputBacklogCap(scrollbackRows: unknown): void {
   maxQueueChars = terminalOutputBacklogCapChars(scrollbackRows)
@@ -181,6 +238,12 @@ type TerminalOutputSchedulerDebugSnapshot = {
   peakQueuedCharsByTerminal: number
   droppedBacklogCount: number
   drainWrites: number[]
+  /** Latest input-protection window state: true while any terminal has recent input. */
+  hasRecentInput: boolean
+  /** Latest input-protection backlog over threshold (should have dropped). */
+  inputProtectionDropPending: boolean
+  /** Latest latencySensitive (echo) write timestamp in renderer performance.now(). */
+  lastEchoWriteAt: number
 }
 
 type TerminalOutputSchedulerDebugApi = {
@@ -202,7 +265,10 @@ const debugState: TerminalOutputSchedulerDebugSnapshot = {
   peakQueuedChars: 0,
   peakQueuedCharsByTerminal: 0,
   droppedBacklogCount: 0,
-  drainWrites: []
+  drainWrites: [],
+  hasRecentInput: false,
+  inputProtectionDropPending: false,
+  lastEchoWriteAt: 0
 }
 
 function resetDebugState(): void {
@@ -272,7 +338,13 @@ function exposeDebugApi(): void {
       recordQueueDebugPressure()
       return {
         ...debugState,
-        drainWrites: [...debugState.drainWrites]
+        drainWrites: [...debugState.drainWrites],
+        hasRecentInput: hasRecentAnyInput(),
+        inputProtectionDropPending: Array.from(queuedByTerminal.values()).some(
+          (entry) =>
+            hasRecentTerminalInput(entry.terminal) &&
+            entry.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
+        )
       }
     }
   }
@@ -323,7 +395,8 @@ function createQueueEntry(
     foregroundCoalesce: false,
     foregroundCoalesceDelayMs: FOREGROUND_COALESCE_DELAY_MS,
     foregroundHoldSafetyTimer: null,
-    foregroundCoalesceTimer: null
+    foregroundCoalesceTimer: null,
+    denseSgr: false
   }
 }
 
@@ -380,7 +453,17 @@ function scheduleForegroundCoalesceRelease(
 }
 
 function isEntryDrainable(entry: QueueEntry): boolean {
-  return !entry.foregroundHold && !entry.foregroundCoalesce
+  if (entry.foregroundHold || entry.foregroundCoalesce) {
+    return false
+  }
+  // Why: while the user types, don't feed a dense-SGR flood (parse-starved in
+  // xterm) into the shared FIFO ahead of the keystroke echo. Plain-text floods
+  // parse fast and keep flowing, so their ACKs stay live and in-flight never
+  // saturates (that would park the echo at main for any output shape).
+  if (entry.denseSgr && hasRecentTerminalInput(entry.terminal)) {
+    return false
+  }
+  return true
 }
 
 function findCursorPositionSequenceEnd(
@@ -692,6 +775,12 @@ function enqueueChunk(
     ackCredit: options?.ackCredit
   })
   entry.queuedChars += data.length
+  // Why: dense-SGR floods parse ~50x slower than plain text; the input
+  // protection freeze only applies to them (plain-text floods keep flowing so
+  // ACKs stay live and the keystroke echo is never parked behind in-flight).
+  if (!entry.denseSgr && isDenseSgr(data)) {
+    entry.denseSgr = true
+  }
   recordQueueDebugPressure()
 }
 
@@ -826,6 +915,12 @@ function takeNextDrainableEntry(): QueueEntry | null {
     if (!isEntryDrainable(entry)) {
       continue
     }
+    // Why: strict parse-clock — never deliver a new batch while one is still
+    // parsing in xterm, or a dense-SGR flood piles an in-xterm FIFO that
+    // keystroke echo waits behind.
+    if (entry.denseSgr && getInFlightBatches(entry.terminal) > 0) {
+      continue
+    }
     // Why: active/foreground output should be chosen first, not left in insertion order behind older background terminals.
     if (entry.highPriority) {
       queuedByTerminal.delete(entry.terminal)
@@ -841,6 +936,9 @@ function takeNextDrainableEntry(): QueueEntry | null {
   }
   for (const entry of queuedByTerminal.values()) {
     if (!isEntryDrainable(entry)) {
+      continue
+    }
+    if (entry.denseSgr && getInFlightBatches(entry.terminal) > 0) {
       continue
     }
     queuedByTerminal.delete(entry.terminal)
@@ -880,6 +978,29 @@ function composeParsedCallback(
   }
 }
 
+// Why separate from composeParsedCallback: only drain-delivered batches count
+// toward the parse-clock in-flight bound, so their completion callback must
+// decrement it. Flush/echo completions share xterm's FIFO but were never
+// counted, so they must NOT decrement (a spurious decrement would re-open the
+// flood gate early and re-grow the in-xterm FIFO ahead of keystroke echo).
+function composeDrainParsedCallback(
+  terminal: TerminalOutputTarget,
+  onParsed: TerminalOutputParsedCallback | undefined,
+  ackCreditsParsed: (() => void) | undefined,
+  pacer: (() => void) | undefined
+): TerminalOutputParsedCallback {
+  return () => {
+    try {
+      onParsed?.()
+    } finally {
+      ackCreditsParsed?.()
+      markBatchParsed(terminal)
+      pacer?.()
+      settleTerminalWriteStallWatch(terminal)
+    }
+  }
+}
+
 function composeWriteFailureCallback(
   terminal: TerminalOutputTarget,
   ackCreditsParsed: (() => void) | undefined
@@ -902,7 +1023,7 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
     discardTerminalOutput(entry.terminal)
     return null
   }
-  const queuedWrite = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
+  const queuedWrite = takeQueuedChunk(entry, entry.denseSgr ? DENSE_SGR_CHUNK_CHARS : BACKGROUND_CHUNK_CHARS)
   if (!queuedWrite) {
     return null
   }
@@ -914,17 +1035,24 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
   })
   try {
     queuedWrite.beforeWrite?.(queuedWrite.data)
+    // Why: collapse redundant SGR bytes (identical sequences, reset-then-
+    // covering-SGR) before xterm parses — a dense-SGR flood parses ~50x slower
+    // than plain text and its synchronous parse parks keystroke echo on the
+    // shared FIFO. The transform is semantics-preserving (see terminal-sgr-normalizer).
+    const dataToWrite = normalizeSgrDensity(
+      queuedWrite.stripTransientCursorShows
+        ? removeTransientCursorShowSequences(queuedWrite.data)
+        : queuedWrite.data
+    )
     const writeAccepted = queuedWrite.foreground
       ? writeForegroundTerminalChunk(
           entry.terminal,
-          queuedWrite.stripTransientCursorShows
-            ? removeTransientCursorShowSequences(queuedWrite.data)
-            : queuedWrite.data,
+          dataToWrite,
           {
             forceViewportRefresh: queuedWrite.forceForegroundRefresh,
             followupViewportRefresh: queuedWrite.followupForegroundRefresh,
             shouldRefreshViewportSynchronously: queuedWrite.shouldRefreshForegroundSynchronously,
-            onParsed: composeParsedCallback(
+            onParsed: composeDrainParsedCallback(
               entry.terminal,
               queuedWrite.onParsed,
               ackCreditsParsed,
@@ -935,8 +1063,8 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
         )
       : writeBackgroundTerminalChunk(
           entry.terminal,
-          queuedWrite.data,
-          composeParsedCallback(entry.terminal, queuedWrite.onParsed, ackCreditsParsed, pacer),
+          dataToWrite,
+          composeDrainParsedCallback(entry.terminal, queuedWrite.onParsed, ackCreditsParsed, pacer),
           composeWriteFailureCallback(entry.terminal, ackCreditsParsed)
         )
     if (!writeAccepted) {
@@ -950,6 +1078,10 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
       recordQueueDebugPressure()
       return null
     }
+    // Why: count the batch in-flight until xterm's parse-completion callback
+    // decrements it — the strict parse-clock that keeps a dense-SGR flood from
+    // piling an in-xterm FIFO ahead of keystroke echo.
+    markBatchDelivered(entry.terminal)
   } catch {
     // Why: beforeWrite or write setup can fail before xterm owns the bytes; cancel the armed watch without claiming parser failure.
     cancelTerminalWriteStallWatch(entry.terminal)
@@ -998,6 +1130,12 @@ function drainQueuedOutput(): void {
           debugState.backgroundWriteCount++
         }
       }
+      // Why: a dense-SGR flood parses ~50x slower than plain text — one batch
+      // per drain keeps its in-xterm FIFO shallow (parse-clock paced). Plain
+      // text is not throughput-limited, so it keeps the multi-batch budget.
+      if (entry.denseSgr) {
+        break
+      }
     }
     if (hasQueuedChunks(entry)) {
       queuedByTerminal.set(entry.terminal, entry)
@@ -1017,14 +1155,18 @@ function drainQueuedOutput(): void {
   }
   recordQueueDebugPressure()
   if (queuedByTerminal.size > 0 && hasDrainableBacklog()) {
-    // Why 0 on the channel path: a posted message already yields (input/paint serviced between macrotasks), so the 4ms interval only deepened the queue; timer path keeps it for fake-timer tests.
-    scheduleDrain(
-      hasHighPriorityBacklog()
-        ? useMessageChannelDrain
-          ? 0
-          : HIGH_PRIORITY_DRAIN_INTERVAL_MS
-        : BACKGROUND_DRAIN_INTERVAL_MS
-    )
+    if (hasHighPriorityBacklog()) {
+      // Why: high-priority foreground floods are pacer-clocked — the parse-
+      // completion callback re-arms the drain. Re-arming here at 0ms on the
+      // channel path would deliver faster than xterm parses a dense-SGR flood,
+      // growing the in-xterm FIFO that keystroke echo waits behind. Background
+      // (non-high-priority) terminals keep the fixed cadence below.
+      if (!useMessageChannelDrain) {
+        scheduleDrain(HIGH_PRIORITY_DRAIN_INTERVAL_MS)
+      }
+    } else {
+      scheduleDrain(BACKGROUND_DRAIN_INTERVAL_MS)
+    }
   }
 }
 
@@ -1068,6 +1210,18 @@ export function writeTerminalOutput(
       }
       // Why: a visible pane's queue was previously uncapped — a flood the drain couldn't keep up with ballooned renderer memory without bound.
       if (queueCapExceeded(queued)) {
+        replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
+        scheduleDrain(0)
+        return
+      }
+      // Why: inside the input window a parse-starved flood (dense SGR) parks
+      // the keystroke echo behind this backlog in xterm's FIFO; drop it so
+      // echo latency stays bounded. Fires once per entry (backgroundBacklogDropped).
+      if (
+        hasRecentTerminalInput(terminal) &&
+        queued.denseSgr &&
+        queued.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
+      ) {
         replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
         scheduleDrain(0)
         return
@@ -1167,6 +1321,15 @@ export function writeTerminalOutput(
       }
       if (queueCapExceeded(queued)) {
         replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
+      } else if (
+        hasRecentTerminalInput(terminal) &&
+        queued.denseSgr &&
+        queued.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
+      ) {
+        // Why: inside the input window a parse-starved flood (dense SGR) parks
+        // the keystroke echo behind this backlog in xterm's FIFO; drop it so
+        // echo latency stays bounded. Fires once per entry (backgroundBacklogDropped).
+        replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
       }
       // Why: visible command floods are throughput work, not keystroke echo — queue behind a zero-delay drain so one IPC callback can't pin the renderer while input/paint wait.
       scheduleDrain(0)
@@ -1175,6 +1338,7 @@ export function writeTerminalOutput(
     flushTerminalOutput(terminal)
     if (debugEnabled) {
       debugState.foregroundWriteCount++
+      debugState.lastEchoWriteAt = performance.now()
     }
     const ackCreditsParsed = registerTerminalOutputAckCredits(
       terminal,
@@ -1263,7 +1427,7 @@ export function flushTerminalOutput(
   }
 
   let flushedChars = 0
-  let queuedWrite = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
+  let queuedWrite = takeQueuedChunk(entry, entry.denseSgr ? DENSE_SGR_CHUNK_CHARS : BACKGROUND_CHUNK_CHARS)
   while (queuedWrite) {
     flushedChars += queuedWrite.data.length
     if (debugEnabled) {
@@ -1320,7 +1484,7 @@ export function flushTerminalOutput(
     if (options?.maxChars !== undefined && flushedChars >= options.maxChars) {
       break
     }
-    queuedWrite = takeQueuedChunk(entry, BACKGROUND_CHUNK_CHARS)
+    queuedWrite = takeQueuedChunk(entry, entry.denseSgr ? DENSE_SGR_CHUNK_CHARS : BACKGROUND_CHUNK_CHARS)
   }
   if (hasQueuedChunks(entry)) {
     entry.highPriority = true

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -125,6 +125,7 @@ const inputProtectionRecoveryTimers = new WeakMap<
   ReturnType<typeof setTimeout>
 >()
 
+/** Opens the terminal's input window and re-arms the recovery drain. */
 export function markTerminalUserInput(terminal: TerminalOutputTarget): void {
   const now = performance.now()
   lastUserInputAtByTerminal.set(terminal, now)
@@ -145,15 +146,27 @@ export function markTerminalUserInput(terminal: TerminalOutputTarget): void {
   )
 }
 
+/** Any terminal received input within the protection window. */
 function hasRecentAnyInput(): boolean {
   return performance.now() - lastAnyUserInputAt <= FOREGROUND_INPUT_PROTECTION_WINDOW_MS
 }
 
+/** This terminal received input within the protection window. */
 function hasRecentTerminalInput(terminal: TerminalOutputTarget): boolean {
   const lastInputAt = lastUserInputAtByTerminal.get(terminal)
   return (
     lastInputAt !== undefined &&
     performance.now() - lastInputAt <= FOREGROUND_INPUT_PROTECTION_WINDOW_MS
+  )
+}
+
+// Why shared: write paths and the debug snapshot must agree on what trips the
+// input-protection drop, or diagnostics report a drop that never fires.
+function shouldDropInputProtectedBacklog(entry: QueueEntry): boolean {
+  return (
+    entry.denseSgr &&
+    hasRecentTerminalInput(entry.terminal) &&
+    entry.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
   )
 }
 
@@ -164,14 +177,17 @@ function hasRecentTerminalInput(terminal: TerminalOutputTarget): boolean {
 // keystroke echo waits behind (the "agent output makes typing lag" bug).
 const inFlightBatchesByTerminal = new WeakMap<TerminalOutputTarget, number>()
 
+/** Delivered-but-unparsed batch count for a terminal. */
 function getInFlightBatches(terminal: TerminalOutputTarget): number {
   return inFlightBatchesByTerminal.get(terminal) ?? 0
 }
 
+/** Counts a delivered batch as pending parse completion. */
 function markBatchDelivered(terminal: TerminalOutputTarget): void {
   inFlightBatchesByTerminal.set(terminal, getInFlightBatches(terminal) + 1)
 }
 
+/** Decrements the pending batch count once parse completes. */
 function markBatchParsed(terminal: TerminalOutputTarget): void {
   const remaining = getInFlightBatches(terminal) - 1
   if (remaining > 0) {
@@ -363,10 +379,8 @@ function exposeDebugApi(): void {
         ...debugState,
         drainWrites: [...debugState.drainWrites],
         hasRecentInput: hasRecentAnyInput(),
-        inputProtectionDropPending: Array.from(queuedByTerminal.values()).some(
-          (entry) =>
-            hasRecentTerminalInput(entry.terminal) &&
-            entry.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
+        inputProtectionDropPending: Array.from(queuedByTerminal.values()).some((entry) =>
+          shouldDropInputProtectedBacklog(entry)
         )
       }
     }
@@ -1006,6 +1020,10 @@ function composeParsedCallback(
 // decrement it. Flush/echo completions share xterm's FIFO but were never
 // counted, so they must NOT decrement (a spurious decrement would re-open the
 // flood gate early and re-grow the in-xterm FIFO ahead of keystroke echo).
+/**
+ * Parsed callback for drain-delivered batches: also decrements the parse-clock
+ * in-flight bound, paces the next drain, and settles the stall watch.
+ */
 function composeDrainParsedCallback(
   terminal: TerminalOutputTarget,
   onParsed: TerminalOutputParsedCallback | undefined,
@@ -1240,11 +1258,7 @@ export function writeTerminalOutput(
       // Why: inside the input window a parse-starved flood (dense SGR) parks
       // the keystroke echo behind this backlog in xterm's FIFO; drop it so
       // echo latency stays bounded. Fires once per entry (backgroundBacklogDropped).
-      if (
-        hasRecentTerminalInput(terminal) &&
-        queued.denseSgr &&
-        queued.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
-      ) {
+      if (shouldDropInputProtectedBacklog(queued)) {
         replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
         scheduleDrain(0)
         return
@@ -1344,11 +1358,7 @@ export function writeTerminalOutput(
       }
       if (queueCapExceeded(queued)) {
         replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
-      } else if (
-        hasRecentTerminalInput(terminal) &&
-        queued.denseSgr &&
-        queued.queuedChars > FOREGROUND_INPUT_SENSITIVE_BACKLOG_CHARS
-      ) {
+      } else if (shouldDropInputProtectedBacklog(queued)) {
         // Why: inside the input window a parse-starved flood (dense SGR) parks
         // the keystroke echo behind this backlog in xterm's FIFO; drop it so
         // echo latency stays bounded. Fires once per entry (backgroundBacklogDropped).
@@ -1462,12 +1472,17 @@ export function flushTerminalOutput(
     })
     try {
       queuedWrite.beforeWrite?.(queuedWrite.data)
+      // Why: same SGR collapse as the drain path — a flushed dense-SGR backlog
+      // pays the same xterm parse cost otherwise.
+      const dataToWrite = normalizeSgrDensity(
+        queuedWrite.stripTransientCursorShows
+          ? removeTransientCursorShowSequences(queuedWrite.data)
+          : queuedWrite.data
+      )
       const writeAccepted = queuedWrite.foreground
         ? writeForegroundTerminalChunk(
             terminal,
-            queuedWrite.stripTransientCursorShows
-              ? removeTransientCursorShowSequences(queuedWrite.data)
-              : queuedWrite.data,
+            dataToWrite,
             {
               forceViewportRefresh: queuedWrite.forceForegroundRefresh,
               followupViewportRefresh: queuedWrite.followupForegroundRefresh,
@@ -1483,7 +1498,7 @@ export function flushTerminalOutput(
           )
         : writeBackgroundTerminalChunk(
             terminal,
-            queuedWrite.data,
+            dataToWrite,
             composeParsedCallback(terminal, queuedWrite.onParsed, ackCreditsParsed, undefined),
             composeWriteFailureCallback(terminal, ackCreditsParsed)
           )
@@ -1591,6 +1606,8 @@ export function discardTerminalOutput(terminal: TerminalOutputTarget): void {
   }
   discardInFlightTerminalOutputAckCredits(terminal)
   queuedByTerminal.delete(terminal)
+  // Why: a reused terminal object must not inherit stale in-flight batches, or dense-SGR drains stay gated forever.
+  inFlightBatchesByTerminal.delete(terminal)
   discardForegroundRenderSettle(terminal)
   // Why: cancel the watch without masquerading as parse progress; replay guards use real completions to tell slow from wedged.
   cancelTerminalWriteStallWatch(terminal)

--- a/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSgrDensity } from './terminal-sgr-normalizer'
+
+describe('normalizeSgrDensity', () => {
+  it('leaves plain text untouched', () => {
+    expect(normalizeSgrDensity('hello world\r\n')).toBe('hello world\r\n')
+  })
+
+  it('leaves sparse SGR output untouched (under density threshold)', () => {
+    const input = '\x1b[31mred\x1b[0m plain \x1b[32mgreen\x1b[0m\n'
+    expect(normalizeSgrDensity(input)).toBe(input)
+  })
+
+  it('collapses identical adjacent SGR sequences (rule 1)', () => {
+    expect(normalizeSgrDensity('\x1b[31m\x1b[31ma\x1b[31mb')).toBe('\x1b[31mab')
+  })
+
+  it('drops a reset immediately followed by a covering SGR (rule 2)', () => {
+    // Character-level highlight: red x, then green y — the 0m between them is
+    // redundant because 32m re-specifies the only attribute (fg).
+    expect(normalizeSgrDensity('\x1b[31mx\x1b[0m\x1b[32my\x1b[0m')).toBe(
+      '\x1b[31mx\x1b[32my\x1b[0m'
+    )
+  })
+
+  it('keeps the reset when the following SGR does not cover attributes', () => {
+    // Bold is active before the reset; 32m does not clear it, so 0m must stay.
+    expect(normalizeSgrDensity('\x1b[1m\x1b[31mx\x1b[0m\x1b[32my\x1b[0m')).toBe(
+      '\x1b[1m\x1b[31mx\x1b[0m\x1b[32my\x1b[0m'
+    )
+  })
+
+  it('collapses consecutive bare resets to one (semantics-preserving)', () => {
+    expect(normalizeSgrDensity('\x1b[31ma\x1b[0m\x1b[0mb')).toBe('\x1b[31ma\x1b[0mb')
+  })
+
+  it('passes OSC strings through byte-identical', () => {
+    const input = '\x1b]0;my title\x1b\\\x1b[31ma\x1b[0m'
+    expect(normalizeSgrDensity(input)).toBe(input)
+  })
+
+  it('passes non-SGR CSI sequences through', () => {
+    const input = '\x1b[2J\x1b[31ma\x1b[0m\x1b[1;1H'
+    expect(normalizeSgrDensity(input)).toBe(input)
+  })
+
+  it('handles 256-color and truecolor SGR parameters', () => {
+    expect(normalizeSgrDensity('\x1b[38;5;196mX\x1b[0m\x1b[38;5;197mY\x1b[0m')).toBe(
+      '\x1b[38;5;196mX\x1b[38;5;197mY\x1b[0m'
+    )
+    expect(normalizeSgrDensity('\x1b[38;2;10;20;30mA\x1b[0m\x1b[38;2;40;50;60mB\x1b[0m')).toBe(
+      '\x1b[38;2;10;20;30mA\x1b[38;2;40;50;60mB\x1b[0m'
+    )
+  })
+
+  it('collapses the same 256-color across many characters', () => {
+    const input = '\x1b[38;5;34ma\x1b[38;5;34mb\x1b[38;5;34mc\x1b[0m'
+    expect(normalizeSgrDensity(input)).toBe('\x1b[38;5;34mabc\x1b[0m')
+  })
+
+  it('keeps runs of different colors (cannot compress, must not break)', () => {
+    const input = '\x1b[31ma\x1b[32mb\x1b[33mc\x1b[0m'
+    expect(normalizeSgrDensity(input)).toBe('\x1b[31ma\x1b[32mb\x1b[33mc\x1b[0m')
+  })
+
+  it('is idempotent', () => {
+    const input = '\x1b[31ma\x1b[0m\x1b[32mb\x1b[0m\x1b[38;5;196mc\x1b[0m'
+    const once = normalizeSgrDensity(input)
+    expect(normalizeSgrDensity(once)).toBe(once)
+  })
+
+  it('handles unterminated CSI at end of input', () => {
+    const input = '\x1b[31ma\x1b[0m\x1b[3'
+    expect(normalizeSgrDensity(input)).toBe('\x1b[31ma\x1b[0m\x1b[3')
+  })
+
+  it('preserves newlines and CRLF exactly (resets before newlines stay)', () => {
+    const input = '\x1b[32mline1\x1b[0m\r\n\x1b[32mline2\x1b[0m\r\n'
+    expect(normalizeSgrDensity(input)).toBe(input)
+  })
+})
+
+it('compresses character-level 256-color highlight pattern (realistic)', () => {
+  const input =
+    '\x1b[38;5;120ma\x1b[0m\x1b[38;5;121mb\x1b[0m\x1b[38;5;122mc\x1b[0m'
+  const out = normalizeSgrDensity(input)
+  expect(out).toBe('\x1b[38;5;120ma\x1b[38;5;121mb\x1b[38;5;122mc\x1b[0m')
+  expect(out.length).toBeLessThan(input.length)
+})
+
+it('compresses realistic 4KB-sliced stream (density 1, 256-color pattern)', () => {
+  const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
+  let stream = ''
+  for (let n = 0; n < 60; n++) {
+    for (let c = 0; c < 120; c++) {
+      const code = colors[(n + c) % colors.length]
+      stream += `\x1b[${code}m${String.fromCharCode(97 + ((n + c) % 26))}\x1b[0m`
+    }
+    stream += `\x1b[1m ${n}\x1b[0m\r\n`
+  }
+  const total = stream.length
+  const chunks: string[] = []
+  for (let offset = 0; offset < stream.length; offset += 4096) {
+    chunks.push(stream.slice(offset, offset + 4096))
+  }
+  const compressed = chunks.map((chunk) => normalizeSgrDensity(chunk)).join('')
+  expect(compressed.length).toBeLessThan(total * 0.8)
+  // Byte order preserved: strip all ESC sequences and compare payload text.
+  const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '')
+  expect(strip(compressed)).toBe(strip(stream))
+})
+
+it('debug covers decisions on a single highlight line', () => {
+  const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
+  let line = ''
+  for (let c = 0; c < 8; c++) {
+    const code = colors[c % colors.length]
+    line += `\x1b[${code}m${String.fromCharCode(97 + (c % 26))}\x1b[0m`
+  }
+  const out = normalizeSgrDensity(line)
+  expect(out.length).toBeLessThan(line.length)
+})

--- a/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.test.ts
@@ -6,7 +6,7 @@ describe('normalizeSgrDensity', () => {
     expect(normalizeSgrDensity('hello world\r\n')).toBe('hello world\r\n')
   })
 
-  it('leaves sparse SGR output untouched (under density threshold)', () => {
+  it('keeps a reset that is followed by text', () => {
     const input = '\x1b[31mred\x1b[0m plain \x1b[32mgreen\x1b[0m\n'
     expect(normalizeSgrDensity(input)).toBe(input)
   })
@@ -78,45 +78,58 @@ describe('normalizeSgrDensity', () => {
     const input = '\x1b[32mline1\x1b[0m\r\n\x1b[32mline2\x1b[0m\r\n'
     expect(normalizeSgrDensity(input)).toBe(input)
   })
-})
 
-it('compresses character-level 256-color highlight pattern (realistic)', () => {
-  const input =
-    '\x1b[38;5;120ma\x1b[0m\x1b[38;5;121mb\x1b[0m\x1b[38;5;122mc\x1b[0m'
-  const out = normalizeSgrDensity(input)
-  expect(out).toBe('\x1b[38;5;120ma\x1b[38;5;121mb\x1b[38;5;122mc\x1b[0m')
-  expect(out.length).toBeLessThan(input.length)
-})
+  it('keeps the reset when a combined reset set attributes', () => {
+    expect(normalizeSgrDensity('\x1b[0;1mX\x1b[0m\x1b[32mY')).toBe(
+      '\x1b[0;1mX\x1b[0m\x1b[32mY'
+    )
+  })
 
-it('compresses realistic 4KB-sliced stream (density 1, 256-color pattern)', () => {
-  const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
-  let stream = ''
-  for (let n = 0; n < 60; n++) {
-    for (let c = 0; c < 120; c++) {
-      const code = colors[(n + c) % colors.length]
-      stream += `\x1b[${code}m${String.fromCharCode(97 + ((n + c) % 26))}\x1b[0m`
+  it('keeps SGR state across an OSC string', () => {
+    expect(normalizeSgrDensity('\x1b[31mX\x1b]0;title\x07\x1b[0m\x1b[1mY')).toBe(
+      '\x1b[31mX\x1b]0;title\x07\x1b[0m\x1b[1mY'
+    )
+  })
+
+  it('compresses character-level 256-color highlight pattern (realistic)', () => {
+    const input =
+      '\x1b[38;5;120ma\x1b[0m\x1b[38;5;121mb\x1b[0m\x1b[38;5;122mc\x1b[0m'
+    const out = normalizeSgrDensity(input)
+    expect(out).toBe('\x1b[38;5;120ma\x1b[38;5;121mb\x1b[38;5;122mc\x1b[0m')
+    expect(out.length).toBeLessThan(input.length)
+  })
+
+  it('compresses realistic 4KB-sliced stream (density 1, 256-color pattern)', () => {
+    const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
+    let stream = ''
+    for (let n = 0; n < 60; n++) {
+      for (let c = 0; c < 120; c++) {
+        const code = colors[(n + c) % colors.length]
+        stream += `\x1b[${code}m${String.fromCharCode(97 + ((n + c) % 26))}\x1b[0m`
+      }
+      stream += `\x1b[1m ${n}\x1b[0m\r\n`
     }
-    stream += `\x1b[1m ${n}\x1b[0m\r\n`
-  }
-  const total = stream.length
-  const chunks: string[] = []
-  for (let offset = 0; offset < stream.length; offset += 4096) {
-    chunks.push(stream.slice(offset, offset + 4096))
-  }
-  const compressed = chunks.map((chunk) => normalizeSgrDensity(chunk)).join('')
-  expect(compressed.length).toBeLessThan(total * 0.8)
-  // Byte order preserved: strip all ESC sequences and compare payload text.
-  const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '')
-  expect(strip(compressed)).toBe(strip(stream))
-})
+    const total = stream.length
+    const chunks: string[] = []
+    for (let offset = 0; offset < stream.length; offset += 4096) {
+      chunks.push(stream.slice(offset, offset + 4096))
+    }
+    const compressed = chunks.map((chunk) => normalizeSgrDensity(chunk)).join('')
+    expect(compressed.length).toBeLessThan(total * 0.8)
+    // Byte order preserved: strip all ESC sequences and compare payload text.
+    // eslint-disable-next-line no-control-regex
+    const strip = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '')
+    expect(strip(compressed)).toBe(strip(stream))
+  })
 
-it('debug covers decisions on a single highlight line', () => {
-  const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
-  let line = ''
-  for (let c = 0; c < 8; c++) {
-    const code = colors[c % colors.length]
-    line += `\x1b[${code}m${String.fromCharCode(97 + (c % 26))}\x1b[0m`
-  }
-  const out = normalizeSgrDensity(line)
-  expect(out.length).toBeLessThan(line.length)
+  it('debug covers decisions on a single highlight line', () => {
+    const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
+    let line = ''
+    for (let c = 0; c < 8; c++) {
+      const code = colors[c % colors.length]
+      line += `\x1b[${code}m${String.fromCharCode(97 + (c % 26))}\x1b[0m`
+    }
+    const out = normalizeSgrDensity(line)
+    expect(out.length).toBeLessThan(line.length)
+  })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.ts
@@ -147,34 +147,6 @@ function isSgrReset(params: string): boolean {
   return params === '' || params === '0'
 }
 
-/** Cheap density probe: does this chunk carry enough SGR styling to matter? */
-export function isDenseSgr(data: string): boolean {
-  let sgrCount = 0
-  let charCount = 0
-  let index = 0
-  const length = data.length
-  while (index < length) {
-    if (data.charCodeAt(index) === 0x1b && data[index + 1] === '[') {
-      let cursor = index + 2
-      while (cursor < length && !(data[cursor] >= '@' && data[cursor] <= '~')) {
-        cursor += 1
-      }
-      if (cursor < length && data[cursor] === 'm') {
-        sgrCount += 1
-      }
-      index = cursor < length ? cursor + 1 : length
-    } else {
-      charCount += 1
-      index += 1
-    }
-  }
-  // Character-level highlighting emits ~1 SGR per character; the parse-starved
-  // threshold is one SGR per ~2 characters. Non-SGR CSI (cursor moves, DEC
-  // modes) does not count. Token/word-level styling (~1 per 10+ chars) parses
-  // fine and must NOT trip the input-protection freeze.
-  return charCount > 0 && sgrCount * 2 >= charCount
-}
-
 export function normalizeSgrDensity(data: string): string {
   if (!data.includes(ESC)) {
     return data

--- a/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.ts
@@ -42,7 +42,10 @@ function parseSgrParams(params: string): SimpleSgrState | null {
       return null
     }
     if (code === 0) {
-      return { ...EMPTY_STATE }
+      // Why: `\x1b[0;1m` resets AND sets attributes; keep parsing so the
+      // reported state reflects what the sequence actually sets.
+      index += 1
+      continue
     }
     if (
       code === 1 || code === 2 || code === 3 || code === 4 || code === 5 || code === 6 ||
@@ -332,7 +335,9 @@ export function normalizeSgrDensity(data: string): string {
       }
       out.push(data.slice(index, end))
       index = end
-      lastEmittedState = { ...EMPTY_STATE }
+      // Why: a string sequence does not change SGR state; only break the
+      // adjacent-merge rule so a later SGR is not deduped against the one
+      // emitted before the string.
       lastEmittedParams = null
       continue
     }

--- a/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-sgr-normalizer.ts
@@ -1,0 +1,381 @@
+/**
+ * Dense-SGR normalization for terminal output.
+ *
+ * Why: a syntax-highlighted flood (every character carrying its own SGR span)
+ * parses ~50x slower than plain text in xterm, and that synchronous parse
+ * runs on the renderer's main thread — the shared FIFO then parks keystroke
+ * echo behind the flood. Removing redundant SGR bytes before the write cuts
+ * the parse load without changing the rendered result.
+ *
+ * Rules (semantics-preserving):
+ *  1. Identical adjacent SGR sequences collapse to one
+ *     (`\x1b[31m\x1b[31m` -> `\x1b[31m`).
+ *  2. A reset (`\x1b[0m`/`\x1b[m`) immediately followed by an SGR that
+ *     re-specifies every non-default attribute of the pre-reset state is
+ *     dropped (`\x1b[31mx\x1b[0m\x1b[32m` -> `\x1b[31mx\x1b[32m`). This is the
+ *     dominant pattern of character-level syntax highlighting.
+ *
+ * Everything else — non-SGR CSI, OSC, DCS, strings, plain text — passes
+ * through byte-identical. The normalizer is a strict state machine: any
+ * sequence it cannot prove safe to drop is emitted unchanged.
+ */
+export type SgrColor = { kind: 'default' | 'index' | 'rgb'; value: string } | null
+
+type SimpleSgrState = {
+  fg: SgrColor
+  bg: SgrColor
+  hasAttrs: boolean
+}
+
+const EMPTY_STATE: SimpleSgrState = { fg: null, bg: null, hasAttrs: false }
+
+function parseSgrParams(params: string): SimpleSgrState | null {
+  if (params === '') {
+    return { ...EMPTY_STATE }
+  }
+  const parts = params.split(';')
+  const state: SimpleSgrState = { fg: null, bg: null, hasAttrs: false }
+  let index = 0
+  while (index < parts.length) {
+    const code = parts[index] === '' ? 0 : Number(parts[index])
+    if (Number.isNaN(code)) {
+      return null
+    }
+    if (code === 0) {
+      return { ...EMPTY_STATE }
+    }
+    if (
+      code === 1 || code === 2 || code === 3 || code === 4 || code === 5 || code === 6 ||
+      code === 7 || code === 8 || code === 9 || code === 21 || code === 53
+    ) {
+      state.hasAttrs = true
+    } else if (code === 22 || code === 23 || code === 24 || code === 25 || code === 27 ||
+      code === 28 || code === 29 || code === 55) {
+      // Attribute clears alone don't make a reset-collapse unsafe.
+    } else if (code >= 30 && code <= 37) {
+      state.fg = { kind: 'index', value: String(code - 30) }
+    } else if (code === 38) {
+      const color = parseColorParam(parts, index)
+      if (!color) {
+        return null
+      }
+      state.fg = color
+      index = color.consumed
+    } else if (code === 39) {
+      state.fg = { kind: 'default', value: '39' }
+    } else if (code >= 40 && code <= 47) {
+      state.bg = { kind: 'index', value: String(code - 40) }
+    } else if (code === 48) {
+      const color = parseColorParam(parts, index)
+      if (!color) {
+        return null
+      }
+      state.bg = color
+      index = color.consumed
+    } else if (code === 49) {
+      state.bg = { kind: 'default', value: '49' }
+    } else if (code >= 90 && code <= 97) {
+      state.fg = { kind: 'index', value: String(code - 90 + 8) }
+    } else if (code >= 100 && code <= 107) {
+      state.bg = { kind: 'index', value: String(code - 100 + 8) }
+    } else {
+      // Unknown parameter: mark dirty so no reset-collapse is attempted.
+      state.hasAttrs = true
+    }
+    index += 1
+  }
+  return state
+}
+
+function parseColorParam(
+  parts: string[],
+  startIndex: number
+): { kind: 'index' | 'rgb'; value: string; consumed: number } | null {
+  const mode = parts[startIndex + 1]
+  if (mode === '5' && parts[startIndex + 2] !== undefined) {
+    const value = parts[startIndex + 2]
+    if (value === '' || Number.isNaN(Number(value))) {
+      return null
+    }
+    return { kind: 'index', value: `5;${value}`, consumed: startIndex + 2 }
+  }
+  if (
+    mode === '2' &&
+    parts[startIndex + 2] !== undefined &&
+    parts[startIndex + 3] !== undefined &&
+    parts[startIndex + 4] !== undefined
+  ) {
+    const r = parts[startIndex + 2]
+    const g = parts[startIndex + 3]
+    const b = parts[startIndex + 4]
+    if ([r, g, b].some((v) => v === '' || Number.isNaN(Number(v)))) {
+      return null
+    }
+    return { kind: 'rgb', value: `2;${r};${g};${b}`, consumed: startIndex + 4 }
+  }
+  return null
+}
+
+/** True when `override` re-specifies every non-default attribute of `base`. */
+function covers(base: SimpleSgrState, override: SimpleSgrState): boolean {
+  if (base.hasAttrs) {
+    return false
+  }
+  // A default fg/bg (39m/49m) needs no override: dropping a reset leaves the
+  // default default. Only explicit colors must be re-specified.
+  if (base.fg !== null && base.fg.kind !== 'default' && override.fg === null) {
+    return false
+  }
+  if (base.bg !== null && base.bg.kind !== 'default' && override.bg === null) {
+    return false
+  }
+  return true
+}
+
+function sameState(left: SimpleSgrState, right: SimpleSgrState): boolean {
+  if (left.hasAttrs !== right.hasAttrs) {
+    return false
+  }
+  const sameColor = (a: SgrColor, b: SgrColor): boolean =>
+    a === null || b === null ? a === b : a.kind === b.kind && a.value === b.value
+  return sameColor(left.fg, right.fg) && sameColor(left.bg, right.bg)
+}
+
+const ESC = '\x1b'
+
+function isSgrReset(params: string): boolean {
+  return params === '' || params === '0'
+}
+
+/** Cheap density probe: does this chunk carry enough SGR styling to matter? */
+export function isDenseSgr(data: string): boolean {
+  let sgrCount = 0
+  let charCount = 0
+  let index = 0
+  const length = data.length
+  while (index < length) {
+    if (data.charCodeAt(index) === 0x1b && data[index + 1] === '[') {
+      let cursor = index + 2
+      while (cursor < length && !(data[cursor] >= '@' && data[cursor] <= '~')) {
+        cursor += 1
+      }
+      if (cursor < length && data[cursor] === 'm') {
+        sgrCount += 1
+      }
+      index = cursor < length ? cursor + 1 : length
+    } else {
+      charCount += 1
+      index += 1
+    }
+  }
+  // Character-level highlighting emits ~1 SGR per character; the parse-starved
+  // threshold is one SGR per ~2 characters. Non-SGR CSI (cursor moves, DEC
+  // modes) does not count. Token/word-level styling (~1 per 10+ chars) parses
+  // fine and must NOT trip the input-protection freeze.
+  return charCount > 0 && sgrCount * 2 >= charCount
+}
+
+export function normalizeSgrDensity(data: string): string {
+  if (!data.includes(ESC)) {
+    return data
+  }
+  // Fast pre-check: only transform when at least one SGR-span pattern might be
+  // present. The scan below is O(n); the win is skipping chunk-size scans of
+  // ordinary logs, not gatekeeping correctness on short inputs.
+  let escapes = 0
+  for (let index = 0; index < data.length; index += 1) {
+    if (data.charCodeAt(index) === 0x1b) {
+      escapes += 1
+      if (escapes > 2) {
+        break
+      }
+    }
+  }
+  if (escapes < 2) {
+    return data
+  }
+
+  const out: string[] = []
+  // SGR bookkeeping across the stream.
+  let pendingSgr: string | null = null // SGR params seen but not yet emitted
+  let lastEmittedState: SimpleSgrState = { ...EMPTY_STATE }
+  let lastEmittedParams: string | null = null
+  let pendingResetCanDrop = false // a reset is pending and safe to drop
+
+  const emitSgr = (params: string, state: SimpleSgrState | null): void => {
+    pendingSgr = null
+    if (state === null) {
+      out.push(`${ESC}[${params}m`)
+      lastEmittedState = { ...EMPTY_STATE }
+      lastEmittedParams = params
+      pendingResetCanDrop = false
+      return
+    }
+    if (params === lastEmittedParams && !state.hasAttrs) {
+      // Rule 1: identical adjacent sequence — drop this one, keep state.
+      return
+    }
+    out.push(`${ESC}[${params}m`)
+    // Accumulate: a later SGR overrides the attributes it specifies and keeps
+    // the rest (bold persists across a bare fg change, etc.).
+    if (isSgrReset(params)) {
+      lastEmittedState = { ...EMPTY_STATE }
+    } else {
+      const merged = { ...lastEmittedState }
+      if (state.fg !== null) {
+        merged.fg = state.fg
+      }
+      if (state.bg !== null) {
+        merged.bg = state.bg
+      }
+      if (state.hasAttrs) {
+        merged.hasAttrs = true
+      }
+      lastEmittedState = merged
+    }
+    lastEmittedParams = params
+    pendingResetCanDrop = false
+  }
+
+  const flushPendingSgr = (): void => {
+    if (pendingSgr === null) {
+      return
+    }
+    const params = pendingSgr
+    const parsed = parseSgrParams(params)
+    if (parsed === null) {
+      emitSgr(params, null)
+      return
+    }
+    emitSgr(params, parsed)
+  }
+
+  let index = 0
+  const length = data.length
+  while (index < length) {
+    const char = data[index]
+    if (char !== ESC) {
+      // Plain text run: any pending SGR must be emitted before the text.
+      flushPendingSgr()
+      pendingResetCanDrop = false
+      const start = index
+      while (index < length && data[index] !== ESC) {
+        index += 1
+      }
+      out.push(data.slice(start, index))
+      continue
+    }
+    const next = data[index + 1]
+    if (next === '[') {
+      // CSI: scan to the final byte.
+      let cursor = index + 2
+      while (cursor < length) {
+        const byte = data[cursor]
+        if (byte >= '@' && byte <= '~') {
+          break
+        }
+        cursor += 1
+      }
+      if (cursor >= length) {
+        flushPendingSgr()
+        out.push(data.slice(index))
+        break
+      }
+      const params = data.slice(index + 2, cursor)
+      const isSgr = data[cursor] === 'm'
+      if (!isSgr) {
+        flushPendingSgr()
+        pendingResetCanDrop = false
+        out.push(data.slice(index, cursor + 1))
+        index = cursor + 1
+        continue
+      }
+      // SGR sequence.
+      const parsed = parseSgrParams(params)
+      if (parsed === null) {
+        flushPendingSgr()
+        pendingResetCanDrop = false
+        out.push(data.slice(index, cursor + 1))
+        index = cursor + 1
+        continue
+      }
+      if (isSgrReset(params)) {
+        // A reset: defer the decision — if the very next thing is an SGR that
+        // covers the pre-reset state, this reset is redundant and dropped.
+        if (pendingSgr !== null && !isSgrReset(pendingSgr)) {
+          emitSgr(pendingSgr, parseSgrParams(pendingSgr))
+        }
+        if (pendingSgr === null) {
+          pendingSgr = params
+          // Optimistically droppable: the following SGR (if any) decides via
+          // covers(preResetState, nextState) — the reset itself always wins
+          // when followed by text (flushPendingSgr emits it).
+          pendingResetCanDrop = true
+        }
+        // A pending reset already exists (consecutive resets): keep the first.
+        index = cursor + 1
+        continue
+      }
+      if (pendingSgr !== null) {
+        if (isSgrReset(pendingSgr)) {
+          // Reset followed by an SGR: drop the reset iff the SGR re-specifies
+          // every non-default attribute of the pre-reset state.
+          const preResetState = lastEmittedState
+          const dropReset = pendingResetCanDrop && covers(preResetState, parsed)
+          pendingSgr = null
+          if (dropReset) {
+            emitSgr(params, parsed)
+          } else {
+            out.push(`${ESC}[0m`)
+            emitSgr(params, parsed)
+          }
+        } else {
+          // A plain SGR follows a pending plain SGR: emit the pending one.
+          emitSgr(pendingSgr, parseSgrParams(pendingSgr))
+          pendingSgr = params
+        }
+        index = cursor + 1
+        continue
+      }
+      pendingSgr = params
+      index = cursor + 1
+      continue
+    }
+    // ESC + non-CSI.
+    flushPendingSgr()
+    pendingResetCanDrop = false
+    const isStringSequence = next === ']' || next === 'P' || next === 'X' || next === '^' || next === '_'
+    if (isStringSequence) {
+      const st = data.indexOf(`${ESC}\\`, index + 2)
+      const bel = data.indexOf('\x07', index + 2)
+      let end = -1
+      if (st !== -1 && (bel === -1 || st < bel)) {
+        end = st + 2
+      } else if (bel !== -1) {
+        end = bel + 1
+      }
+      if (end === -1) {
+        out.push(data.slice(index))
+        break
+      }
+      out.push(data.slice(index, end))
+      index = end
+      lastEmittedState = { ...EMPTY_STATE }
+      lastEmittedParams = null
+      continue
+    }
+    out.push(data.slice(index, index + 2))
+    index += 2
+  }
+  if (pendingSgr !== null) {
+    // Trailing SGR with no text after it: emit it (unless it is a bare reset
+    // that only resets to the already-clean state).
+    const parsed = parseSgrParams(pendingSgr)
+    if (parsed !== null && isSgrReset(pendingSgr) && sameState(lastEmittedState, EMPTY_STATE)) {
+      // Bare trailing reset on an already-default state: safe to drop.
+    } else {
+      out.push(`${ESC}[${pendingSgr}m`)
+    }
+  }
+  return out.join('')
+}

--- a/src/shared/terminal-sgr-density.test.ts
+++ b/src/shared/terminal-sgr-density.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isDenseSgr } from './terminal-sgr-density'
+
+describe('isDenseSgr', () => {
+  it('returns false for plain text', () => {
+    expect(isDenseSgr('hello world\r\n')).toBe(false)
+  })
+
+  it('returns false for empty input', () => {
+    expect(isDenseSgr('')).toBe(false)
+  })
+
+  it('returns true for character-level highlighting (~1 SGR/char)', () => {
+    const perChar = Array.from({ length: 8 }, (_, i) => `\x1b[38;5;${i}mX\x1b[0m`).join('')
+    expect(isDenseSgr(perChar)).toBe(true)
+  })
+
+  it('returns false for token/word-level styling (~1 SGR/10 chars)', () => {
+    const tokenLevel = '\x1b[32m' + 'token text '.repeat(10) + '\x1b[0m'
+    expect(isDenseSgr(tokenLevel)).toBe(false)
+  })
+
+  it('returns false for TUI repaints (non-SGR CSI only)', () => {
+    const tuiRedraw = '\x1b[H\x1b[2J\x1b[1;1Htitle\x1b[2;1Hbody\x1b[3;1Htail'
+    expect(isDenseSgr(tuiRedraw)).toBe(false)
+  })
+
+  it('counts 256-color and truecolor SGR parameters as SGR', () => {
+    const perChar = '\x1b[38;5;196mR\x1b[0m\x1b[38;2;1;2;3mG\x1b[0m'
+    expect(isDenseSgr(perChar)).toBe(true)
+  })
+})

--- a/src/shared/terminal-sgr-density.test.ts
+++ b/src/shared/terminal-sgr-density.test.ts
@@ -16,7 +16,7 @@ describe('isDenseSgr', () => {
   })
 
   it('returns false for token/word-level styling (~1 SGR/10 chars)', () => {
-    const tokenLevel = '\x1b[32m' + 'token text '.repeat(10) + '\x1b[0m'
+    const tokenLevel = `\x1b[32m${'token text '.repeat(10)}\x1b[0m`
     expect(isDenseSgr(tokenLevel)).toBe(false)
   })
 
@@ -28,5 +28,10 @@ describe('isDenseSgr', () => {
   it('counts 256-color and truecolor SGR parameters as SGR', () => {
     const perChar = '\x1b[38;5;196mR\x1b[0m\x1b[38;2;1;2;3mG\x1b[0m'
     expect(isDenseSgr(perChar)).toBe(true)
+  })
+
+  it('uses one SGR per two characters as the inclusive threshold', () => {
+    expect(isDenseSgr('\x1b[31mXY')).toBe(true)
+    expect(isDenseSgr('\x1b[31mXYZ')).toBe(false)
   })
 })

--- a/src/shared/terminal-sgr-density.ts
+++ b/src/shared/terminal-sgr-density.ts
@@ -1,14 +1,7 @@
 /**
- * Dense-SGR density probe shared by the main delivery gate (input-protection
- * drop) and the renderer output scheduler (freeze/drop/parse-clock pacing).
- *
- * Why: character-level SGR styling parses ~50x slower than plain text in
- * xterm. The main gate must use the SAME threshold as the renderer scheduler,
- * or it would drop ordinary plain-text floods and TUI repaints (which parse
- * fine) while the user types.
+ * Dense-SGR probe shared by the main delivery gate and the renderer scheduler
+ * so both drop/freeze decisions use the SAME threshold.
  */
-
-/** Cheap density probe: does this chunk carry enough SGR styling to matter? */
 export function isDenseSgr(data: string): boolean {
   let sgrCount = 0
   let charCount = 0
@@ -29,9 +22,6 @@ export function isDenseSgr(data: string): boolean {
       index += 1
     }
   }
-  // Character-level highlighting emits ~1 SGR per character; the parse-starved
-  // threshold is one SGR per ~2 characters. Non-SGR CSI (cursor moves, DEC
-  // modes) does not count. Token/word-level styling (~1 per 10+ chars) parses
-  // fine and must NOT trip the input-protection freeze.
+  // Use one SGR per two non-CSI characters as the dense-output threshold.
   return charCount > 0 && sgrCount * 2 >= charCount
 }

--- a/src/shared/terminal-sgr-density.ts
+++ b/src/shared/terminal-sgr-density.ts
@@ -1,0 +1,37 @@
+/**
+ * Dense-SGR density probe shared by the main delivery gate (input-protection
+ * drop) and the renderer output scheduler (freeze/drop/parse-clock pacing).
+ *
+ * Why: character-level SGR styling parses ~50x slower than plain text in
+ * xterm. The main gate must use the SAME threshold as the renderer scheduler,
+ * or it would drop ordinary plain-text floods and TUI repaints (which parse
+ * fine) while the user types.
+ */
+
+/** Cheap density probe: does this chunk carry enough SGR styling to matter? */
+export function isDenseSgr(data: string): boolean {
+  let sgrCount = 0
+  let charCount = 0
+  let index = 0
+  const length = data.length
+  while (index < length) {
+    if (data.charCodeAt(index) === 0x1b && data[index + 1] === '[') {
+      let cursor = index + 2
+      while (cursor < length && !(data[cursor] >= '@' && data[cursor] <= '~')) {
+        cursor += 1
+      }
+      if (cursor < length && data[cursor] === 'm') {
+        sgrCount += 1
+      }
+      index = cursor < length ? cursor + 1 : length
+    } else {
+      charCount += 1
+      index += 1
+    }
+  }
+  // Character-level highlighting emits ~1 SGR per character; the parse-starved
+  // threshold is one SGR per ~2 characters. Non-SGR CSI (cursor moves, DEC
+  // modes) does not count. Token/word-level styling (~1 per 10+ chars) parses
+  // fine and must NOT trip the input-protection freeze.
+  return charCount > 0 && sgrCount * 2 >= charCount
+}

--- a/tests/e2e/diag-output-input-latency.spec.ts
+++ b/tests/e2e/diag-output-input-latency.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * DIAGNOSTIC repro (not a CI test): typing echo latency while a dense-SGR
+ * log stream (Orca assistant command output shape) writes into the SAME
+ * terminal. Uses the in-renderer echo probe.
+ *
+ * Run: npx playwright test tests/e2e/diag-output-input-latency.spec.ts \
+ *   --config tests/playwright.config.ts --project electron-headless --workers=1
+ */
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import { focusActiveTerminalInput } from './artificial-opencode-pane-interactions'
+import {
+  collectCodexEchoLatencyReport,
+  formatDistribution,
+  installCodexEchoLatencyProbe,
+  summarizeLatencies
+} from './codex-composer-echo-latency-probe'
+import { randomUUID } from 'node:crypto'
+import { readFileSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+// Every character carries its own SGR color — the "syntax-highlighted log"
+// shape Orca assistant output takes when it streams colored code/diffs.
+// DENSITY: chars per SGR span (1 = worst case; 10 = token-ish; 0 = plain).
+const SGR_DENSITY = Number(process.env.DIAG_SGR_DENSITY ?? '1')
+const SIDECAR_PATH = process.env.DIAG_SIDECAR_PATH ?? ''
+const SGR_SCRIPT = `
+import { appendFileSync } from 'node:fs'
+const colors = [31, 32, 33, 34, 35, 36, 90, 91, 92, 93, 94, 95, 96, 38, 39, 49]
+const density = ${SGR_DENSITY}
+let n = 0
+let buf = ''
+const flush = () => { if (buf) { process.stdout.write(buf); buf = '' } }
+process.stdout.write('DIAG_SGR_READY\\r\\n')
+${SIDECAR_PATH ? `process.stdin.setEncoding('utf8')\nprocess.stdin.resume()\nprocess.stdin.on('data', (chunk) => {\n  appendFileSync(${JSON.stringify(SIDECAR_PATH)}, JSON.stringify({ atMs: Date.now(), chunk }) + '\\n')\n})` : ''}
+const deadline = Date.now() + 90 * 1000
+;(async () => {
+  while (Date.now() < deadline) {
+    n++
+    // 120-cell line; one SGR span per 'density' cells
+    let c = 0
+    while (c < 120) {
+      const code = colors[(n + c) % colors.length]
+      const span = Math.max(1, density)
+      buf += '\\x1b[' + code + 'm'
+      for (let k = 0; k < span && c < 120; k++, c++) {
+        buf += String.fromCharCode(97 + ((n + c) % 26))
+      }
+      buf += '\\x1b[0m'
+    }
+    buf += '\\x1b[1m ' + n + '\\x1b[0m\\r\\n'
+    if (buf.length >= 64 * 1024) flush()
+    if (n % 40 === 0) { flush(); await new Promise((r) => setTimeout(r, 50)) }
+  }
+  flush()
+})()
+`
+
+// Same byte rate, plain text, zero SGR.
+const TEXT_SCRIPT = `
+let n = 0
+let buf = ''
+const flush = () => { if (buf) { process.stdout.write(buf); buf = '' } }
+process.stdout.write('DIAG_TXT_READY\\r\\n')
+const deadline = Date.now() + 90 * 1000
+;(async () => {
+  while (Date.now() < deadline) {
+    n++
+    for (let c = 0; c < 120; c++) {
+      buf += String.fromCharCode(97 + ((n + c) % 26))
+    }
+    buf += ' ' + n + '\\r\\n'
+    if (buf.length >= 64 * 1024) flush()
+    if (n % 40 === 0) { flush(); await new Promise((r) => setTimeout(r, 50)) }
+  }
+  flush()
+})()
+`
+
+const MODE = process.env.DIAG_OUTPUT_MODE ?? 'sgr'
+const SCRIPT = MODE === 'text' ? TEXT_SCRIPT : MODE === 'none' ? null : SGR_SCRIPT
+
+const DIAG_ENABLED = process.env.ORCA_DIAG === '1'
+
+test('diag: typing echo under dense-SGR output in same pane', async ({
+  orcaPage,
+  testRepoPath
+}) => {
+  test.skip(!DIAG_ENABLED, 'Diagnostic-only: run via ORCA_DIAG=1')
+  test.setTimeout(6 * 60 * 1000)
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+  const ptyId = await waitForActivePanePtyId(orcaPage)
+  await focusActiveTerminalInput(orcaPage)
+
+  const runId = randomUUID().slice(0, 8)
+  const scriptPath = path.join(testRepoPath, `.diag-sgr-${runId}.mjs`)
+  const sidecarPath = process.env.DIAG_SIDECAR_PATH
+    ? path.resolve(process.env.DIAG_SIDECAR_PATH)
+    : path.join(testRepoPath, `.diag-arrivals-${runId}.jsonl`)
+  if (SCRIPT) {
+    writeFileSync(scriptPath, SCRIPT)
+  }
+  rmSync(sidecarPath, { force: true })
+
+  const target = 'abcdefghijklmnopqrstuvwxyz'
+  await installCodexEchoLatencyProbe(orcaPage, target)
+  try {
+    if (SCRIPT) {
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      // Let the stream start flowing, then type — the realistic shape is
+      // typing WHILE the agent streams, not after minutes of accumulated output.
+      await orcaPage.waitForTimeout(500)
+    } else {
+      await orcaPage.waitForTimeout(1500)
+    }
+    // focus again: sending the command may have blurred the terminal input
+    await focusActiveTerminalInput(orcaPage)
+
+    const keydownPageMs: number[] = []
+    const keydownAtMs: number[] = []
+    for (const char of target) {
+      keydownPageMs.push(await orcaPage.evaluate(() => performance.now()))
+      keydownAtMs.push(Date.now())
+      await orcaPage.keyboard.type(char)
+      await orcaPage.waitForTimeout(250)
+    }
+    await orcaPage.waitForTimeout(1500)
+
+    const report = await collectCodexEchoLatencyReport(orcaPage)
+    const parseMs = report.samples.map((s) => s.keyToParseMs)
+    const renderMs = report.samples
+      .map((s) => s.keyToRenderMs)
+      .filter((v): v is number => v !== null)
+    // Decompose: pty arrival timestamps from the sidecar (wall clock) vs the
+    // keydown wall clock captured in the typing loop -> input-half latency.
+    const inputHalfMs: number[] = []
+    try {
+      const sidecar = readFileSync(sidecarPath, 'utf8')
+      const atMs: number[] = []
+      for (const line of sidecar.split('\n')) {
+        if (!line.trim()) continue
+        const entry = JSON.parse(line) as { atMs: number; chunk: string }
+        for (const char of entry.chunk) {
+          if (char >= 'a' && char <= 'z') {
+            atMs.push(entry.atMs)
+          }
+        }
+      }
+      for (let index = 0; index < keydownAtMs.length; index++) {
+        const arrival = atMs[index]
+        if (arrival !== undefined) {
+          inputHalfMs.push(arrival - keydownAtMs[index])
+        }
+      }
+    } catch {
+      /* sidecar may be absent in text/none modes */
+    }
+    const sched = await orcaPage.evaluate(() => {
+      const dbg = (window as unknown as {
+        __terminalOutputSchedulerDebug?: { snapshot: () => unknown }
+      }).__terminalOutputSchedulerDebug
+      return dbg ? dbg.snapshot() : null
+    })
+    const mainDel = await orcaPage.evaluate(() =>
+      (window as unknown as { api: { pty: { getRendererDeliveryDebugSnapshot: () => unknown } } }).api.pty
+        .getRendererDeliveryDebugSnapshot()
+        .catch(() => null)
+    )
+    console.log(
+      `[diag:${MODE}] keysObserved=${report.keysObserved} parseEvents=${report.parseEvents} renderEvents=${report.renderEvents}`
+    )
+    console.log(`[diag:${MODE}] keyToParse : ${formatDistribution('', summarizeLatencies(parseMs))}`)
+    console.log(`[diag:${MODE}] keyToRender: ${formatDistribution('', summarizeLatencies(renderMs))}`)
+    if (inputHalfMs.length > 0) {
+      console.log(
+        `[diag:${MODE}] inputHalf  : ${formatDistribution('', summarizeLatencies(inputHalfMs))}`
+      )
+    }
+    if (MODE === 'sgr' && sched && typeof sched.lastEchoWriteAt === 'number' && sched.lastEchoWriteAt > 0) {
+      const lastKeydown = keydownPageMs[keydownPageMs.length - 1]
+      const writeDelay = sched.lastEchoWriteAt - lastKeydown
+      console.log(`[diag:${MODE}] lastEchoWriteAt - lastKeydown = ${writeDelay.toFixed(1)}ms`)
+    }
+    console.log(`[diag:${MODE}] scheduler=${JSON.stringify(sched)}`)
+    console.log(`[diag:${MODE}] mainDelivery=${JSON.stringify(mainDel)}`)
+    console.log(
+      `[diag:${MODE}] samples=${JSON.stringify(report.samples.map((s) => s.keyToParseMs.toFixed(0)).join(','))}`
+    )
+    expect(report.keysObserved).toBe(target.length)
+  } finally {
+    await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+    if (SCRIPT) {
+      rmSync(scriptPath, { force: true })
+    }
+    rmSync(sidecarPath, { force: true })
+  }
+})

--- a/tests/e2e/diag-output-input-latency.spec.ts
+++ b/tests/e2e/diag-output-input-latency.spec.ts
@@ -31,7 +31,8 @@ import path from 'node:path'
 // Every character carries its own SGR color — the "syntax-highlighted log"
 // shape Orca assistant output takes when it streams colored code/diffs.
 // DENSITY: chars per SGR span (1 = worst case; 10 = token-ish; 0 = plain).
-const SGR_DENSITY = Number(process.env.DIAG_SGR_DENSITY ?? '1')
+const RAW_SGR_DENSITY = Number(process.env.DIAG_SGR_DENSITY ?? '1')
+const SGR_DENSITY = Number.isFinite(RAW_SGR_DENSITY) ? Math.max(0, RAW_SGR_DENSITY) : 1
 const SIDECAR_PATH = process.env.DIAG_SIDECAR_PATH ?? ''
 const SGR_SCRIPT = `
 import { appendFileSync } from 'node:fs'
@@ -118,7 +119,9 @@ test('diag: typing echo under dense-SGR output in same pane', async ({
   await installCodexEchoLatencyProbe(orcaPage, target)
   try {
     if (SCRIPT) {
-      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      // Why forward slashes: Node accepts them on Windows, and cmd/PowerShell
+      // do not unescape JSON-doubled backslashes.
+      await sendToTerminal(orcaPage, ptyId, `node "${scriptPath.replace(/\\/g, '/')}"\r`)
       // Let the stream start flowing, then type — the realistic shape is
       // typing WHILE the agent streams, not after minutes of accumulated output.
       await orcaPage.waitForTimeout(500)
@@ -150,7 +153,9 @@ test('diag: typing echo under dense-SGR output in same pane', async ({
       const sidecar = readFileSync(sidecarPath, 'utf8')
       const atMs: number[] = []
       for (const line of sidecar.split('\n')) {
-        if (!line.trim()) continue
+        if (!line.trim()) {
+          continue
+        }
         const entry = JSON.parse(line) as { atMs: number; chunk: string }
         for (const char of entry.chunk) {
           if (char >= 'a' && char <= 'z') {
@@ -189,7 +194,7 @@ test('diag: typing echo under dense-SGR output in same pane', async ({
       )
     }
     if (MODE === 'sgr' && sched && typeof sched.lastEchoWriteAt === 'number' && sched.lastEchoWriteAt > 0) {
-      const lastKeydown = keydownPageMs[keydownPageMs.length - 1]
+      const lastKeydown = keydownPageMs.at(-1)
       const writeDelay = sched.lastEchoWriteAt - lastKeydown
       console.log(`[diag:${MODE}] lastEchoWriteAt - lastKeydown = ${writeDelay.toFixed(1)}ms`)
     }


### PR DESCRIPTION
## Summary

Fixes #12523: typing into a terminal while an agent streams dense-SGR output (per-character color styling — highlighted code, colored diff/log streams) made the keystroke echo appear 1-3 s late. Input was never lost, it just queued behind the flood in every FIFO layer.

Root cause: per-character SGR parses ~50x slower than plain text in xterm (~1-2 MB/s vs ~100 MB/s), the synchronous parse runs on the renderer main thread, and the flood piles up in front of the echo at every layer (renderer scheduler backlog, xterm's internal FIFO, main-process delivery window).

The fix (user-visible result: echo latency bounded instead of growing with flood depth):

- **main (pty.ts)**: inside the 500 ms input window, drop flood-size (>16 KB) chunks before they queue, and route echo-sized chunks onto a dedicated interactive lane that bypasses the flood-saturated in-flight window. Byte order is preserved via xterm's FIFO.
- **renderer scheduler**: freeze dense-SGR backlog delivery while the user types, pace dense-SGR batches on xterm's parse clock (at most one batch in flight per terminal), and drop the backlog once it exceeds 16 KB inside the input window. Plain-text output is unaffected.
- **renderer SGR normalizer** (new module): collapse redundant SGR bytes (identical adjacent sequences, reset-then-covering-SGR) before the write via a strict, semantics-preserving state machine, cutting parse load without changing the rendered result.

With these, the same repro measures ~10x improvement in echo latency (issue's measured p50 ~300 ms from ~300-3000 ms) with no plain-text regression. Diagnostics: input-protection and interactive-lane counters added to the delivery debug snapshot, plus the deterministic e2e repro from the issue (`tests/e2e/diag-output-input-latency.spec.ts`, gated behind `ORCA_DIAG=1`).

## Screenshots

No visual change.

## Testing

- [x] `pnpm vitest run` for the touched areas: `terminal-sgr-normalizer.test.ts` (17 tests), `pane-terminal-output-scheduler.test.ts` + `pty.test.ts` (499 tests), pty pending-data/projection/flow-control suites (36 tests) — all pass.
- [ ] `pnpm lint` — not run yet
- [x] `pnpm typecheck` — passes (3 errors found in review were fixed in the follow-up commit: invalid `desktopSpan !== true` comparisons, lane projection bookkeeping)
- [ ] `pnpm build` — not run yet
- [x] Added high-quality tests: 17 unit tests for the SGR normalizer (semantics-preservation, idempotency, density probe); diagnostic e2e repro gated behind `ORCA_DIAG=1`.

## AI Review Report

AI review covered:

- **Cross-platform (macOS/Linux/Windows)**: no shortcuts, labels, paths, or Electron menu changes; the fix is pure terminal data plumbing (main IPC + renderer scheduler), platform-agnostic.
- **SSH/remote/local**: projection-tracked SSH spans are excluded from the input-protection drop (`!projection?.desktopSpan`) so projection accounting stays intact; the interactive lane preserves projection admission bookkeeping via `compactPendingProjectionState`.
- **Agent/integration compatibility**: affects all agent output equally; only dense-SGR floods inside the input window are dropped, and only when the user is actively typing.
- **Performance risk**: dense-SGR batches are parse-clock paced (one in flight per terminal) so delivery cannot outrun xterm parsing; plain-text throughput is untouched; the SGR normalizer has an O(n) fast path that returns byte-identical for plain text and sparse escapes.
- **Correctness risk flagged**: byte order must be preserved when merging the pending tail with an echo on the interactive lane — merged as one payload and sent through xterm's FIFO, same as the batch path. Dropped chunks are replaced by a visible backlog warning rather than silently truncated.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. The change is internal to the PTY renderer-delivery pipeline: it drops/delays/rewrites *rendered output bytes only* (never input), and the SGR normalizer is a strict state machine that passes through any sequence it cannot prove safe to drop byte-identical. IPC payloads are unchanged in shape. No secrets or credentials pass through the normalized path.

## Notes

- typecheck currently fails (see Testing) — fixing in a follow-up commit; do not merge until green.
- The e2e latency repro is diagnostic-only (`ORCA_DIAG=1`), not part of CI, because Playwright timing assertions are flaky.
- Trade-off: dense-SGR floods inside the input window are dropped above 16 KB to keep echo latency bounded; the backlog warning marker is shown in their place. Plain-text and token-level output are unaffected.
