### PR TITLE
fix(mobile): preserve soft keyboard deletion ranges

### DIFF
--- a/mobile/packages/react-native-terminal-input/android/src/main/java/com/orca/terminalinput/TerminalInputPackage.kt
+++ b/mobile/packages/react-native-terminal-input/android/src/main/java/com/orca/terminalinput/TerminalInputPackage.kt
@@ -113,6 +113,40 @@ private class TerminalReactEditText(
     return if (start >= 0 && end >= start) Pair(start, end) else null
   }
 
+  fun deletionReplacement(
+      beforeLength: Int,
+      afterLength: Int,
+      inCodePoints: Boolean,
+  ): Triple<Int, Int, String>? {
+    if (beforeLength < 0 || afterLength < 0) return null
+    val currentText = text?.toString() ?: return null
+    val orderedSelectionStart = minOf(selectionStart, selectionEnd)
+    val orderedSelectionEnd = maxOf(selectionStart, selectionEnd)
+    if (orderedSelectionStart < 0 || orderedSelectionEnd > currentText.length) return null
+    val composing = composingRange()
+    val retainedStart = minOf(orderedSelectionStart, composing?.first ?: orderedSelectionStart)
+    val retainedEnd = maxOf(orderedSelectionEnd, composing?.second ?: orderedSelectionEnd)
+    val beforeStart =
+        if (inCodePoints) {
+          val available = Character.codePointCount(currentText, 0, retainedStart)
+          Character.offsetByCodePoints(currentText, retainedStart, -minOf(beforeLength, available))
+        } else {
+          maxOf(0, retainedStart - beforeLength)
+        }
+    val afterEnd =
+        if (inCodePoints) {
+          val available = Character.codePointCount(currentText, retainedEnd, currentText.length)
+          Character.offsetByCodePoints(currentText, retainedEnd, minOf(afterLength, available))
+        } else {
+          minOf(currentText.length, retainedEnd + afterLength)
+        }
+    return Triple(
+        beforeStart,
+        afterEnd,
+        currentText.substring(retainedStart, retainedEnd),
+    )
+  }
+
   private fun dispatch(text: String, replacementText: String, start: Int, end: Int) {
     val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id) ?: return
     dispatcher.dispatchEvent(
@@ -161,15 +195,23 @@ private class TerminalInputConnection(
   }
 
   override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
-    val range = editText.replacementRange()
-    return editText.mutateInput(editText.composingRange() != null, "", range) {
+    val replacement = editText.deletionReplacement(beforeLength, afterLength, false)
+    return editText.mutateInput(
+        editText.composingRange() != null,
+        replacement?.third ?: "",
+        replacement?.let { Pair(it.first, it.second) },
+    ) {
       super.deleteSurroundingText(beforeLength, afterLength)
     }
   }
 
   override fun deleteSurroundingTextInCodePoints(beforeLength: Int, afterLength: Int): Boolean {
-    val range = editText.replacementRange()
-    return editText.mutateInput(editText.composingRange() != null, "", range) {
+    val replacement = editText.deletionReplacement(beforeLength, afterLength, true)
+    return editText.mutateInput(
+        editText.composingRange() != null,
+        replacement?.third ?: "",
+        replacement?.let { Pair(it.first, it.second) },
+    ) {
       super.deleteSurroundingTextInCodePoints(beforeLength, afterLength)
     }
   }

--- a/mobile/src/terminal/terminal-live-text-commit.test.ts
+++ b/mobile/src/terminal/terminal-live-text-commit.test.ts
@@ -35,6 +35,16 @@ describe('terminal live native replacement commits', () => {
     ).toEqual({ committedText: 'a', payload: '\x7f' })
   })
 
+  it('emits nothing for the collapsed pre-delete cursor snapshot', () => {
+    expect(
+      deriveTerminalLiveCommit('a', {
+        text: '',
+        replacementText: '',
+        replacementRange: { start: 1, end: 1 }
+      })
+    ).toBeNull()
+  })
+
   it('emits nothing for a cancelled preedit or ambiguous non-suffix replacement', () => {
     expect(
       deriveTerminalLiveCommit('', {

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -69,6 +69,11 @@ const ORDINARY_ABC_TRACE: readonly RecordedChange[] = [
   { text: 'abc', isComposing: false, replacementText: 'c', start: 2, end: 2 }
 ]
 
+const RECORDED_ANDROID_GBOARD_BACKSPACE_TRACE: readonly RecordedChange[] = [
+  { text: 'a', isComposing: false, replacementText: 'a', start: 0, end: 0 },
+  { text: '', isComposing: false, replacementText: '', start: 0, end: 1 }
+]
+
 const IOS_ROMAJI_RECORDED_PREFIX = 'あきカナたあbcabc'
 const RECORDED_IOS_ROMAJI_TRACE: readonly RecordedChange[] = [
   {
@@ -288,6 +293,16 @@ describe('terminal live input commit hook', () => {
     const { handlers, sent } = createHarness()
     replay(handlers, ORDINARY_ABC_TRACE)
     await vi.waitFor(() => expect(sent).toEqual(['a', 'b', 'c']))
+  })
+
+  it('replays the recorded Gboard Backspace replacement exactly once', async () => {
+    const { handlers, sent } = createHarness()
+
+    change(handlers, RECORDED_ANDROID_GBOARD_BACKSPACE_TRACE[0])
+    handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'Backspace' } })
+    change(handlers, RECORDED_ANDROID_GBOARD_BACKSPACE_TRACE[1])
+
+    await vi.waitFor(() => expect(sent).toEqual(['a', '\x7f']))
   })
 
   it('preserves rapid input order while transport sends are delayed', async () => {


### PR DESCRIPTION
## Summary

- derive Android deletion replacement ranges from the pre-operation selection/composing span
- preserve code-unit and code-point deletion semantics without diffing mutable buffers
- record the Gboard keypress/change order and reject the old collapsed deletion snapshot

## Why

Gboard dispatches native deletion before React Native's `onKeyPress('Backspace')`. The prior Android
adapter reported the post-delete cursor as `[1,1]`, so the range-derived terminal path correctly
rejected the ambiguous change and sent no DEL. The native adapter now reports the actual replaced
range `[0,1]`; React Native's keypress remains ignored while committed text exists, then the native
replacement emits exactly one DEL.

## Validation

- API 35 / Gboard: `a` + soft Backspace → exact PTY bytes `61 7f`
- API 35 / Gboard emoji: `😀` + soft Backspace → exact PTY bytes `f0 9f 98 80 7f`
- Gboard and Fcitx empty-field Backspace → one RN keypress and exactly one PTY DEL
- mutation `[0,1]` → `[1,1]`: positive fails with only `a`; 11 negatives pass
- 18/18 focused Vitest tests
- mobile TypeScript, oxlint, oxfmt, Kotlin compile, `:app:assembleDebug`, and `git diff --check`
- independent review verdict: CLEAN

## Design

No new class, file, tracker, timer, locale check, buffer diff, or event protocol. Production delta is
46 additions and 4 deletions in the existing Android adapter.
