### PR TITLE
fix(plugins): reject locale ids Intl cannot parse

### DIFF
--- a/src/shared/plugins/plugin-content-pack-contributions.test.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.test.ts
@@ -120,11 +120,23 @@ describe('content-pack manifest contributions', () => {
 
   it.each([
     ['language pack', { languagePacks: [{ locale: 'en_US', path: 'locale.json' }] }],
+    // Shape-legal but not well-formed: the old regex let these through, and the
+    // pack then loaded with dates silently falling back to English.
+    ['duplicate region', { languagePacks: [{ locale: 'en-US-US', path: 'locale.json' }] }],
+    ['unknown subtag', { languagePacks: [{ locale: 'en-aaa', path: 'locale.json' }] }],
     ['language pack path', { languagePacks: [{ locale: 'pt-BR', path: '../outside.json' }] }],
     ['VM recipe', { vmRecipes: [{ path: '\\\\server\\recipe.json' }] }],
     ['agent profile', { agents: [{ path: 'agents/../profile.json' }] }]
   ])('rejects unsafe or malformed %s contributions', (_label, contributes) => {
     expect(parsePluginManifest(manifest(contributes)).ok).toBe(false)
+  })
+
+  it.each(['ru', 'pt-BR', 'zh-Hans-CN', 'en-US'])('accepts the well-formed locale %s', (locale) => {
+    expect(
+      parsePluginManifest(manifest({ languagePacks: [{ locale, path: 'locale.json' }] }))
+    ).toMatchObject({
+      ok: true
+    })
   })
 
   it('rejects duplicate ids, locales, paths, and bindings', () => {

--- a/src/shared/plugins/plugin-content-pack-contributions.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.ts
@@ -7,13 +7,30 @@ export const PLUGIN_KEYBINDING_LIMIT = 256
 export const PLUGIN_VM_RECIPE_LIMIT = 64
 export const PLUGIN_AGENT_PROFILE_LIMIT = 64
 
+/** True when Intl can parse the tag's grammar, not just its shape. */
+function isWellFormedLocaleId(value: string): boolean {
+  try {
+    Intl.getCanonicalLocales(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
 // Why: locale ids become i18next bundle keys and filenames. This bounded BCP
 // 47 subset covers current community packs without accepting path syntax.
+// The shape check alone is looser than BCP 47 in one direction: tags like
+// `en-US-US` or `en-aaa` match it but are not well-formed, so Intl throws on
+// them. That throw surfaces nowhere — the pack installs, every string
+// translates, and only dates and relative times quietly fall back to English.
+// Delegating the grammar to Intl rejects the tag at install instead, where the
+// pack author can still fix it.
 export const pluginLocaleIdSchema = z
   .string()
   .min(2)
   .max(35)
   .regex(/^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/, 'must be a portable locale identifier')
+  .refine(isWellFormedLocaleId, 'must be a well-formed locale identifier')
 
 export const pluginLanguagePackContributionSchema = z
   .object({


### PR DESCRIPTION
## Summary

Repurposed from canonicalizing the locale at read time to rejecting it at install, per review.

`pluginLocaleIdSchema` checks the *shape* of a locale id, not its grammar, and the shape check is looser than BCP 47 in one direction: `en-US-US` (duplicate region) and `en-aaa` (a subtag that is neither a region nor a script) both match `/^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/`.

A pack declaring one installs cleanly, loads, and translates every string. Then `Intl.DateTimeFormat` throws inside `getIntlLocale()`, the `catch` at `src/renderer/src/i18n/i18n.ts:106-113` swallows it, and dates and relative times fall back to English with nothing logged. The pack author sees a working pack with English dates and no way to tell why.

The fix is one `.refine` on the schema delegating the grammar to `Intl.getCanonicalLocales`, so the tag is rejected at install where the author can still act on it. No new module, no cache, no renderer change. The bundled `pt-BR` pack is unaffected, as is every other well-formed tag.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — `src/shared/plugins` green at 147 tests; the 8 unrelated files that fail here fail identically on a clean `upstream/main` checkout (Node 26 against the required Node 24: `node-pty` ABI and timing-sensitive watchers)
- [x] `pnpm build`
- [x] Added tests: two rejection cases (`en-US-US`, `en-aaa`) alongside the existing `en_US` case, and a positive case pinning `ru`, `pt-BR`, `zh-Hans-CN`, `en-US` so the refine cannot start rejecting real packs

## AI Review Report

Reviewed for scope, blast radius, and cross-platform behavior.

- **Blast radius.** `pluginLocaleIdSchema` has exactly one consumer, `pluginLanguagePackContributionSchema`; grep across `src/` confirms no other import. Nothing outside manifest parsing changes.
- **Regression risk on existing packs.** Every locale tag shipped or plausibly shipped was run through the new schema: `pt-BR` (bundled), `ru`, `en-US`, `zh-Hans-CN`, `ja`, `ko`, `es`. All pass. The added positive test pins four of them so a future tightening cannot silently break them.
- **Cross-platform.** `Intl.getCanonicalLocales` is ECMA-402, present in every Node and Chromium build this project targets; no platform branch, no path handling, no shell, no shortcut or label. Verified the behaviour is identical under the repo's Node 24 target and the Node 26 used locally. Nothing Electron-specific is touched.
- **Behaviour delta.** Brute-forced the tags the regex accepts through old and new logic. The only difference is that tags `Intl` cannot parse are now rejected at parse time instead of loading and failing silently later. No previously-valid tag becomes invalid.

## Security Audit

- **Input handling.** The change only *narrows* what the manifest accepts, so it cannot widen the attack surface. Locale ids become i18next bundle keys and filenames; the existing regex already excluded path syntax, and that regex is unchanged — `.refine` runs after it.
- **Error handling.** `Intl.getCanonicalLocales` throws `RangeError` on malformed input; the helper catches and returns `false` rather than letting it escape into manifest parsing. It catches everything deliberately — any throw from this call means the tag is unusable.
- **No new surface.** No command execution, no path resolution, no auth, no secrets, no IPC, no new dependency. `Intl` is a language built-in.
- **Follow-up.** None required for this change.

## Notes

One measurement worth flagging. I bucketed every tag the current schema accepts by what `Intl` does with it — all two-letter primary subtags against typical second subtags (regions, scripts, and shape-legal fakes of both):

| | count | share | example |
|---|---|---|---|
| `Intl` throws — caught by this PR | 1352 | 22% | `en-US-US`, `en-aaa` |
| canonical, but no plural rules | 3698 | 61% | `xx`, `aa-US`, `zz-ZZ` |
| fully working | 1034 | 17% | `af`, `pt-BR` |

```js
const RE = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/
for (const tag of candidates) {
  if (!RE.test(tag)) continue
  try { Intl.getCanonicalLocales(tag) } catch { throws.push(tag); continue }
  ;(Intl.PluralRules.supportedLocalesOf(tag).length ? works : silent).push(tag)
}
```

This PR closes the 22%. The 61% is well-formed-but-unknown tags: they pass `getCanonicalLocales`, the pack loads, and `Intl.PluralRules.supportedLocalesOf` returns empty — same silent English fallback, different cause. `.refine` structurally cannot catch those, because the grammar is valid.

That is the half #12505 addresses, which is why I don't think it rests on the same premise. Its core claim — the synthetic `plugin<hex>` language never gets plural rules regardless of how valid the declared locale is — holds after this change. It currently imports `canonicalizePackLocale`, which this PR removes, so I'll rebase it off this branch once the direction here is settled.

Separately and out of scope: the regex is also *narrower* than BCP 47 in places. `en-US-u-ca-buddhist` and `en-a-bbb` are legal but rejected, because a single-letter extension singleton doesn't fit `{2,8}`. Happy to open that separately if it's worth having.