### PR TITLE
fix: keep IME-owned palette chords in renderer

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1306,7 +1306,7 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenCalledWith('ui:dictationKeyDown')
   })
 
-  it('forwards ctrl/cmd+j to the worktree palette toggle event', () => {
+  it('leaves worktree palette shortcuts to the renderer', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
       on: vi.fn((event, handler) => {
@@ -1363,12 +1363,10 @@ describe('createMainWindow', () => {
     ]) {
       const preventDefault = vi.fn()
       windowHandlers['before-input-event']({ preventDefault } as never, input as never)
-      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(preventDefault).not.toHaveBeenCalled()
     }
 
-    expect(webContents.send).toHaveBeenCalledTimes(2)
-    expect(webContents.send).toHaveBeenNthCalledWith(1, 'ui:toggleWorktreePalette')
-    expect(webContents.send).toHaveBeenNthCalledWith(2, 'ui:toggleWorktreePalette')
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:toggleWorktreePalette')
   })
 
   it('suppresses auto-repeat quick-command menu toggles from before-input-event', () => {
@@ -1576,7 +1574,7 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenCalledWith('ui:openQuickOpen')
   })
 
-  it('notifies before Orca-first captures a risky terminal-focused shortcut', () => {
+  it('leaves terminal-focused worktree palette capture to the renderer', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
       on: vi.fn((event, handler) => {
@@ -1634,11 +1632,12 @@ describe('createMainWindow', () => {
       } as never
     )
 
-    expect(preventDefault).toHaveBeenCalledTimes(1)
-    expect(webContents.send).toHaveBeenNthCalledWith(1, 'ui:terminalShortcutCaptured', {
-      actionId: 'worktree.palette'
-    })
-    expect(webContents.send).toHaveBeenNthCalledWith(2, 'ui:toggleWorktreePalette')
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith(
+      'ui:terminalShortcutCaptured',
+      expect.anything()
+    )
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:toggleWorktreePalette')
   })
 
   it('notifies before Orca-first captures a terminal-focused double-tap shortcut', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -662,9 +662,6 @@ export function createMainWindow(
       case 'toggleRightSidebar':
         mainWindow.webContents.send('ui:toggleRightSidebar')
         return
-      case 'toggleWorktreePalette':
-        mainWindow.webContents.send('ui:toggleWorktreePalette')
-        return
       case 'toggleFloatingTerminal':
         mainWindow.webContents.send('ui:toggleFloatingTerminal')
         return
@@ -709,6 +706,9 @@ export function createMainWindow(
     }
   ): boolean => {
     const { focusedShortcutContext, isAutoRepeat } = options
+    if (action.type === 'toggleWorktreePalette') {
+      return false
+    }
     if (
       floatingTerminalInputFocused &&
       (action.type === 'toggleLeftSidebar' || action.type === 'toggleRightSidebar')

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -640,7 +640,9 @@ export function createMainWindow(
   const doubleTapDetector = new ModifierDoubleTapDetector()
 
   // Why: one mapping of action → IPC/side effect, shared by the keydown and double-tap paths so they can't drift.
-  const sendResolvedWindowShortcutAction = (action: WindowShortcutAction): void => {
+  const sendResolvedWindowShortcutAction = (
+    action: Exclude<WindowShortcutAction, { type: 'toggleWorktreePalette' }>
+  ): void => {
     switch (action.type) {
       // The renderer's DictationController re-checks enabled/sttModel and ignores hold mode, so this path needs no voice guards.
       case 'dictationKeyDown':

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1952,6 +1952,9 @@ function App(): React.JSX.Element {
       const gesture = resolveImeModifierGesture(imeOwnedModifierGesture, e)
       imeOwnedModifierGesture = gesture.active
       if (gesture.owned || isImeOwnedKeyboardEvent(e)) {
+        if (gesture.preventDefault) {
+          e.preventDefault()
+        }
         doubleTapDetector.reset()
         return
       }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,6 +27,7 @@ import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import {
   isImeOwnedKeyboardEvent,
+  markImeOwnedShortcutEvent,
   resolveImeModifierGesture
 } from '@/lib/ime-composition-keyboard-event'
 import {
@@ -1952,8 +1953,8 @@ function App(): React.JSX.Element {
       const gesture = resolveImeModifierGesture(imeOwnedModifierGesture, e)
       imeOwnedModifierGesture = gesture.active
       if (gesture.owned || isImeOwnedKeyboardEvent(e)) {
-        if (gesture.preventDefault) {
-          e.preventDefault()
+        if (gesture.carried) {
+          markImeOwnedShortcutEvent(e)
         }
         doubleTapDetector.reset()
         return

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -26,6 +26,10 @@ import { syncZoomCSSVar } from '@/lib/ui-zoom'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import {
+  isImeOwnedKeyboardEvent,
+  resolveImeModifierGesture
+} from '@/lib/ime-composition-keyboard-event'
+import {
   isPairedWebClientWindow,
   shouldRenderDesktopWindowChrome
 } from '@/lib/desktop-window-chrome'
@@ -1572,6 +1576,7 @@ function App(): React.JSX.Element {
 
   useEffect(() => {
     const doubleTapDetector = new ModifierDoubleTapDetector()
+    let imeOwnedModifierGesture = false
 
     const createRegisteredCommandHandlers = (
       input?: ShortcutDispatchInput,
@@ -1866,6 +1871,18 @@ function App(): React.JSX.Element {
         return
       }
 
+      if (matchShortcut('worktree.palette')) {
+        input.preventDefault()
+        notifyTerminalCapture('worktree.palette')
+        const store = useAppStore.getState()
+        if (store.activeModal === 'worktree-palette') {
+          store.closeModal()
+        } else {
+          store.openModal('worktree-palette')
+        }
+        return
+      }
+
       // Skip editable surfaces so TipTap's Cmd+B bold works; this renderer-side fallback covers the blur→press IPC race (docs/markdown-cmd-b-bold-design.md).
       if (isEditableTarget(input.target)) {
         return
@@ -1932,6 +1949,12 @@ function App(): React.JSX.Element {
     }
 
     const onKeyDown = (e: KeyboardEvent): void => {
+      const gesture = resolveImeModifierGesture(imeOwnedModifierGesture, e)
+      imeOwnedModifierGesture = gesture.active
+      if (gesture.owned || isImeOwnedKeyboardEvent(e)) {
+        doubleTapDetector.reset()
+        return
+      }
       const detected = doubleTapDetector.process(
         toModifierDoubleTapEvent({
           type: 'keyDown',
@@ -1972,6 +1995,12 @@ function App(): React.JSX.Element {
     }
 
     const onKeyUp = (e: KeyboardEvent): void => {
+      const gesture = resolveImeModifierGesture(imeOwnedModifierGesture, e)
+      imeOwnedModifierGesture = gesture.active
+      if (gesture.owned || isImeOwnedKeyboardEvent(e)) {
+        doubleTapDetector.reset()
+        return
+      }
       doubleTapDetector.process(
         toModifierDoubleTapEvent({
           type: 'keyUp',
@@ -1987,7 +2016,10 @@ function App(): React.JSX.Element {
     }
 
     // Why: a window blur mid-gesture must not leave the detector armed.
-    const onBlur = (): void => doubleTapDetector.reset()
+    const onBlur = (): void => {
+      imeOwnedModifierGesture = false
+      doubleTapDetector.reset()
+    }
 
     window.addEventListener('keydown', onKeyDown, { capture: true })
     window.addEventListener('keyup', onKeyUp, { capture: true })

--- a/src/renderer/src/components/native-chat/native-chat-shortcut.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-shortcut.test.ts
@@ -4,10 +4,21 @@ import {
   nativeChatToggleShortcutLabel
 } from './native-chat-shortcut'
 
-type Combo = Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'>
+type Combo = Pick<
+  KeyboardEvent,
+  'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'defaultPrevented'
+>
 
 function combo(overrides: Partial<Combo>): Combo {
-  return { key: 'j', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, ...overrides }
+  return {
+    key: 'j',
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    ...overrides
+  }
 }
 
 describe('nativeChatToggleShortcutLabel', () => {
@@ -52,6 +63,15 @@ describe('matchesNativeChatToggleShortcut', () => {
   it('rejects a different key', () => {
     expect(
       matchesNativeChatToggleShortcut(combo({ key: 'k', metaKey: true, shiftKey: true }), true)
+    ).toBe(false)
+  })
+
+  it('yields events already owned by the app dispatcher', () => {
+    expect(
+      matchesNativeChatToggleShortcut(
+        combo({ ctrlKey: true, shiftKey: true, defaultPrevented: true }),
+        false
+      )
     ).toBe(false)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-shortcut.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-shortcut.test.ts
@@ -3,6 +3,7 @@ import {
   matchesNativeChatToggleShortcut,
   nativeChatToggleShortcutLabel
 } from './native-chat-shortcut'
+import { markImeOwnedShortcutEvent } from '@/lib/ime-composition-keyboard-event'
 
 type Combo = Pick<
   KeyboardEvent,
@@ -67,6 +68,12 @@ describe('matchesNativeChatToggleShortcut', () => {
   })
 
   it('yields events already owned by the app dispatcher', () => {
+    const event = combo({ ctrlKey: true, shiftKey: true })
+    markImeOwnedShortcutEvent(event)
+    expect(matchesNativeChatToggleShortcut(event, false)).toBe(false)
+  })
+
+  it('yields ordinary shortcuts prevented by the app dispatcher', () => {
     expect(
       matchesNativeChatToggleShortcut(
         combo({ ctrlKey: true, shiftKey: true, defaultPrevented: true }),

--- a/src/renderer/src/components/native-chat/native-chat-shortcut.ts
+++ b/src/renderer/src/components/native-chat/native-chat-shortcut.ts
@@ -17,10 +17,13 @@ export function nativeChatToggleShortcutLabel(isMac: boolean): string {
 /** True when the event is the native-chat toggle chord for the given platform.
  *  Pure so it can be unit-tested without a DOM. */
 export function matchesNativeChatToggleShortcut(
-  e: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'>,
+  e: Pick<
+    KeyboardEvent,
+    'key' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'defaultPrevented'
+  >,
   isMac: boolean
 ): boolean {
-  if (e.altKey || !e.shiftKey) {
+  if (e.defaultPrevented || e.altKey || !e.shiftKey) {
     return false
   }
   // Primary modifier is Cmd on Mac, Ctrl on Linux/Windows — and must be the

--- a/src/renderer/src/components/native-chat/native-chat-shortcut.ts
+++ b/src/renderer/src/components/native-chat/native-chat-shortcut.ts
@@ -1,3 +1,5 @@
+import { isMarkedImeOwnedShortcutEvent } from '@/lib/ime-composition-keyboard-event'
+
 /** Platform-correct binding for the native-chat view toggle.
  *
  *  Key: Cmd/Ctrl + Shift + J. The primary modifier follows AGENTS.md — metaKey
@@ -23,7 +25,7 @@ export function matchesNativeChatToggleShortcut(
   >,
   isMac: boolean
 ): boolean {
-  if (e.defaultPrevented || e.altKey || !e.shiftKey) {
+  if (e.defaultPrevented || isMarkedImeOwnedShortcutEvent(e) || e.altKey || !e.shiftKey) {
     return false
   }
   // Primary modifier is Cmd on Mac, Ctrl on Linux/Windows — and must be the

--- a/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-toggle-shortcut.ts
@@ -98,9 +98,9 @@ export function useNativeChatToggleShortcut(worktreeId: string, isWorktreeActive
       e.stopPropagation()
       state.toggleTabViewMode(tab.id)
     }
-    window.addEventListener('keydown', onKeyDown, { capture: true })
+    window.addEventListener('keydown', onKeyDown)
     return () => {
-      window.removeEventListener('keydown', onKeyDown, { capture: true })
+      window.removeEventListener('keydown', onKeyDown)
     }
   }, [worktreeId, isWorktreeActive])
 }

--- a/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
@@ -50,7 +50,7 @@ describe('isImeCompositionKeyDown', () => {
       ctrlKey: true,
       isComposing: true
     })
-    expect(gesture).toEqual({ active: true, owned: true, preventDefault: false })
+    expect(gesture).toEqual({ active: true, carried: false, owned: true })
 
     gesture = resolveImeModifierGesture(gesture.active, {
       ctrlKey: true,
@@ -62,18 +62,18 @@ describe('isImeCompositionKeyDown', () => {
       shiftKey: true,
       isComposing: false
     })
-    expect(gesture).toEqual({ active: true, owned: true, preventDefault: true })
+    expect(gesture).toEqual({ active: true, carried: true, owned: true })
 
     gesture = resolveImeModifierGesture(gesture.active, {
       isComposing: false
     })
-    expect(gesture).toEqual({ active: false, owned: true, preventDefault: true })
+    expect(gesture).toEqual({ active: false, carried: true, owned: true })
     expect(
       resolveImeModifierGesture(false, {
         ctrlKey: true,
         shiftKey: true,
         isComposing: false
       })
-    ).toEqual({ active: false, owned: false, preventDefault: false })
+    ).toEqual({ active: false, carried: false, owned: false })
   })
 })

--- a/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { isImeCompositionKeyDown, isImeOwnedKeyboardEvent } from './ime-composition-keyboard-event'
+import {
+  isImeCompositionKeyDown,
+  isImeOwnedKeyboardEvent,
+  resolveImeModifierGesture
+} from './ime-composition-keyboard-event'
 
 function keyEvent(nativeEvent: { isComposing?: boolean; keyCode?: number }): ReactKeyboardEvent {
   return {
@@ -33,5 +37,43 @@ describe('isImeCompositionKeyDown', () => {
     const shift = { code: 'ShiftLeft', shiftKey: true, isComposing: false }
     expect(isImeOwnedKeyboardEvent({ ...shift, key: 'Process', keyCode: 229 })).toBe(true)
     expect(isImeOwnedKeyboardEvent({ ...shift, key: 'Shift', keyCode: 16 })).toBe(false)
+  })
+
+  it('owns the marked Windows palette chord without swallowing the ordinary chord', () => {
+    const chord = { key: 'J', code: 'KeyJ', ctrlKey: true, shiftKey: true, keyCode: 74 }
+    expect(isImeOwnedKeyboardEvent({ ...chord, isComposing: true })).toBe(true)
+    expect(isImeOwnedKeyboardEvent({ ...chord, isComposing: false })).toBe(false)
+  })
+
+  it('keeps ownership through the recorded marked modifiers and unmarked dispatch key', () => {
+    let gesture = resolveImeModifierGesture(false, {
+      ctrlKey: true,
+      isComposing: true
+    })
+    expect(gesture).toEqual({ active: true, owned: true })
+
+    gesture = resolveImeModifierGesture(gesture.active, {
+      ctrlKey: true,
+      shiftKey: true,
+      isComposing: true
+    })
+    gesture = resolveImeModifierGesture(gesture.active, {
+      ctrlKey: true,
+      shiftKey: true,
+      isComposing: false
+    })
+    expect(gesture).toEqual({ active: true, owned: true })
+
+    gesture = resolveImeModifierGesture(gesture.active, {
+      isComposing: false
+    })
+    expect(gesture).toEqual({ active: false, owned: true })
+    expect(
+      resolveImeModifierGesture(false, {
+        ctrlKey: true,
+        shiftKey: true,
+        isComposing: false
+      })
+    ).toEqual({ active: false, owned: false })
   })
 })

--- a/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
@@ -50,7 +50,7 @@ describe('isImeCompositionKeyDown', () => {
       ctrlKey: true,
       isComposing: true
     })
-    expect(gesture).toEqual({ active: true, owned: true })
+    expect(gesture).toEqual({ active: true, owned: true, preventDefault: false })
 
     gesture = resolveImeModifierGesture(gesture.active, {
       ctrlKey: true,
@@ -62,18 +62,18 @@ describe('isImeCompositionKeyDown', () => {
       shiftKey: true,
       isComposing: false
     })
-    expect(gesture).toEqual({ active: true, owned: true })
+    expect(gesture).toEqual({ active: true, owned: true, preventDefault: true })
 
     gesture = resolveImeModifierGesture(gesture.active, {
       isComposing: false
     })
-    expect(gesture).toEqual({ active: false, owned: true })
+    expect(gesture).toEqual({ active: false, owned: true, preventDefault: true })
     expect(
       resolveImeModifierGesture(false, {
         ctrlKey: true,
         shiftKey: true,
         isComposing: false
       })
-    ).toEqual({ active: false, owned: false })
+    ).toEqual({ active: false, owned: false, preventDefault: false })
   })
 })

--- a/src/renderer/src/lib/ime-composition-keyboard-event.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.ts
@@ -27,10 +27,11 @@ export function isImeOwnedKeyboardEvent(event: object): boolean {
 export function resolveImeModifierGesture(
   active: boolean,
   event: ImeModifierGestureEvent
-): { active: boolean; owned: boolean } {
+): { active: boolean; owned: boolean; preventDefault: boolean } {
   const hasModifier = Boolean(event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
-  const owned = active || (hasModifier && isImeOwnedKeyboardEvent(event))
-  return { active: owned && hasModifier, owned }
+  const marked = isImeOwnedKeyboardEvent(event)
+  const owned = active || (hasModifier && marked)
+  return { active: owned && hasModifier, owned, preventDefault: active && !marked }
 }
 
 /**

--- a/src/renderer/src/lib/ime-composition-keyboard-event.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.ts
@@ -6,6 +6,13 @@ type ImeKeyboardEvent = {
   nativeEvent?: { isComposing?: boolean; keyCode?: number }
 }
 
+type ImeModifierGestureEvent = ImeKeyboardEvent & {
+  altKey?: boolean
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+}
+
 /** True when the IME, rather than Orca, owns a keyboard event. */
 export function isImeOwnedKeyboardEvent(event: object): boolean {
   const candidate = event as ImeKeyboardEvent
@@ -15,6 +22,15 @@ export function isImeOwnedKeyboardEvent(event: object): boolean {
     candidate.nativeEvent?.isComposing === true ||
     candidate.nativeEvent?.keyCode === 229
   )
+}
+
+export function resolveImeModifierGesture(
+  active: boolean,
+  event: ImeModifierGestureEvent
+): { active: boolean; owned: boolean } {
+  const hasModifier = Boolean(event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
+  const owned = active || (hasModifier && isImeOwnedKeyboardEvent(event))
+  return { active: owned && hasModifier, owned }
 }
 
 /**

--- a/src/renderer/src/lib/ime-composition-keyboard-event.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.ts
@@ -13,6 +13,8 @@ type ImeModifierGestureEvent = ImeKeyboardEvent & {
   shiftKey?: boolean
 }
 
+const IME_OWNED_SHORTCUT_EVENT = Symbol('imeOwnedShortcutEvent')
+
 /** True when the IME, rather than Orca, owns a keyboard event. */
 export function isImeOwnedKeyboardEvent(event: object): boolean {
   const candidate = event as ImeKeyboardEvent
@@ -27,11 +29,19 @@ export function isImeOwnedKeyboardEvent(event: object): boolean {
 export function resolveImeModifierGesture(
   active: boolean,
   event: ImeModifierGestureEvent
-): { active: boolean; owned: boolean; preventDefault: boolean } {
+): { active: boolean; carried: boolean; owned: boolean } {
   const hasModifier = Boolean(event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
   const marked = isImeOwnedKeyboardEvent(event)
   const owned = active || (hasModifier && marked)
-  return { active: owned && hasModifier, owned, preventDefault: active && !marked }
+  return { active: owned && hasModifier, carried: active && !marked, owned }
+}
+
+export function markImeOwnedShortcutEvent(event: object): void {
+  Object.defineProperty(event, IME_OWNED_SHORTCUT_EVENT, { value: true })
+}
+
+export function isMarkedImeOwnedShortcutEvent(event: object): boolean {
+  return (event as { [IME_OWNED_SHORTCUT_EVENT]?: boolean })[IME_OWNED_SHORTCUT_EVENT] === true
 }
 
 /**


### PR DESCRIPTION
## Summary

- yield the worktree-palette chord from Electron main to the existing renderer shortcut owner
- carry IME ownership through the recorded Windows marked-modifier to unmarked-dispatch-key sequence
- preserve ordinary English Ctrl+Shift+J, terminal shortcut policy, and browser-guest forwarding

## Slimness

One effect-local boolean, one pure resolver, and an event-lifetime-only private Symbol marker. No class, timer, locale classifier, IPC, document-wide composition tracker, or xterm change.

## Validation

- focused tests: 146 passed
- type-aware static analysis, typecheck, focused oxlint, and diff check
- all PR checks pass
- independent code review loop: clean
- native Windows Korean: palette remains closed; native chat retains the same node, value, focus, and visibility
- ordinary English: palette opens exactly once; Escape restores the same native-chat node, value, and focus
- controlled gesture-carry bypass: Korean positive opens the palette while English control remains correct
- landing production-build equivalence: 869 files, zero manifest differences, SHA-256 `c3a685171d86c00de5758a428b3712bf46a9049849fbf5f2e8342628f503892a`
- retained evidence metadata SHA-256: `d70ff6c6977a9435f6e483e493d3feb64f71ff65d9f3f9b97baba169479bbb9b`

Stacked on #12526.