### PR TITLE
fix(relay): preserve user ZDOTDIR in the zsh overlay instead of collapsing to $HOME (#12507)

### DIFF
--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -8,6 +8,9 @@ import { getRelayShellLaunchConfig } from './pty-shell-launch'
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
 
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const itWithZsh = hasZsh ? it : it.skip
+
 function runInteractiveBashRcfile(rcfile: string, homeDir: string): string {
   const result = spawnSync(
     'bash',
@@ -136,6 +139,58 @@ describe('getRelayShellLaunchConfig', () => {
       'export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
     )
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'overlay .zshenv falls back to the preserved ORCA_ORIG_ZDOTDIR, not $HOME (#12507)',
+    () => {
+      getRelayShellLaunchConfig('/bin/zsh', {
+        HOME: homeDir,
+        ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-overlay'
+      })
+      const zshenv = readFileSync(
+        join(homeDir, '.orca-relay', 'shell-ready', 'zsh', '.zshenv'),
+        'utf8'
+      )
+      // The overlay path always matches this arm (ZDOTDIR is the overlay dir),
+      // so hard-coding $HOME here discarded the user's real ZDOTDIR.
+      expect(zshenv).toContain(
+        '*/shell-ready/zsh) export ORCA_USER_ZDOTDIR="${ORCA_ORIG_ZDOTDIR:-$HOME}" ;;'
+      )
+      expect(zshenv).not.toContain('*/shell-ready/zsh) export ORCA_USER_ZDOTDIR="$HOME" ;;')
+    }
+  )
+
+  itWithZsh(
+    'resolves ORCA_USER_ZDOTDIR to the real config dir under the relay overlay, not $HOME (#12507)',
+    () => {
+      // Reporter's XDG layout: real zsh config lives elsewhere and the relay
+      // preserved it into ORCA_ORIG_ZDOTDIR, while the shell was launched with
+      // ZDOTDIR pointing at the overlay dir.
+      const realConfig = join(homeDir, '.config', 'zsh')
+      mkdirSync(realConfig, { recursive: true })
+      getRelayShellLaunchConfig('/bin/zsh', {
+        HOME: homeDir,
+        ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-overlay'
+      })
+      const zshRoot = join(homeDir, '.orca-relay', 'shell-ready', 'zsh')
+      const zshenv = join(zshRoot, '.zshenv')
+
+      const result = spawnSync(
+        'zsh',
+        ['-fc', 'source "$1"; printf "%s" "$ORCA_USER_ZDOTDIR"', 'zsh', zshenv],
+        {
+          encoding: 'utf8',
+          env: { HOME: homeDir, ZDOTDIR: zshRoot, ORCA_ORIG_ZDOTDIR: realConfig },
+          timeout: 5000
+        }
+      )
+
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(0)
+      // Before the fix this returned homeDir; the preserved config dir must win.
+      expect(result.stdout).toBe(realConfig)
+    }
+  )
 
   it.skipIf(process.platform === 'win32')(
     'wraps zsh when MiMo home must survive shell startup',

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -91,7 +91,10 @@ esac
 [[ -f "$ORCA_ORIG_ZDOTDIR/.zshenv" ]] && source "$ORCA_ORIG_ZDOTDIR/.zshenv"
 export ORCA_USER_ZDOTDIR="\${ZDOTDIR:-\${ORCA_ORIG_ZDOTDIR:-$HOME}}"
 case "\${ORCA_USER_ZDOTDIR%/}" in
-  */shell-ready/zsh) export ORCA_USER_ZDOTDIR="$HOME" ;;
+  # Why ORCA_ORIG_ZDOTDIR, not $HOME: ZDOTDIR is the overlay path here (the relay
+  # launched zsh with it), so this arm always fires; falling back to $HOME would
+  # discard the user's real preserved ZDOTDIR (#12507).
+  */shell-ready/zsh) export ORCA_USER_ZDOTDIR="\${ORCA_ORIG_ZDOTDIR:-$HOME}" ;;
 esac
 export ZDOTDIR=${quotePosixSingle(zshDir)}
 `


### PR DESCRIPTION
## What this fixes

Fixes #12507.

On an SSH/relay remote zsh session with an XDG-style layout (real config in `~/.config/zsh`, a `~/.zshrc` shim that sources `$ZDOTDIR/.zshrc`), every Orca pane starts with `ZDOTDIR=$HOME`. That makes the shim source itself — infinite recursion until zsh aborts with `recursion limit exceeded` on every shell start (the reporter measured `oh-my-posh init` running 499 times per shell), and the user's real zsh config (aliases, plugins, fzf bindings) silently never loads.

## Root cause

The relay zsh overlay wrapper (`src/relay/pty-shell-launch.ts`) launches zsh with `ZDOTDIR` pointing at the overlay dir, then derives the user's real value:

```zsh
export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"
case "${ORCA_USER_ZDOTDIR%/}" in
  */shell-ready/zsh) export ORCA_USER_ZDOTDIR="$HOME" ;;   # <- bug
esac
```

At this point `$ZDOTDIR` is always the overlay path (that's what the relay launched zsh with), so `ORCA_USER_ZDOTDIR` is always the overlay path and the case arm always fires. It hard-coded `$HOME`, throwing away the correctly preserved `ORCA_ORIG_ZDOTDIR`. Every later overlay file resolves `_orca_home` from `ORCA_USER_ZDOTDIR` and ends up exporting `ZDOTDIR=$HOME`.

The preserve step itself works — `ORCA_ORIG_ZDOTDIR` holds the real config dir. The fallback just discarded it.

Unlike the local/WSL template in `shell-templates.ts` (which `unset ZDOTDIR` before sourcing the user `.zshenv`, so the user's `${ZDOTDIR:-…}` guard resolves correctly), the relay path sources the user `.zshenv` with `ZDOTDIR` still set to the overlay, so only the relay path is affected.

## The fix

Fall the case arm back to the preserved value instead of `$HOME`:

```zsh
*/shell-ready/zsh) export ORCA_USER_ZDOTDIR="${ORCA_ORIG_ZDOTDIR:-$HOME}" ;;
```

No regression: the cases that previously hard-coded `$HOME` (origin unset, or origin itself an overlay path — already normalized to `$HOME` by the earlier `ORCA_ORIG_ZDOTDIR` guard) still resolve to `$HOME`. Only the case with a genuinely preserved config dir changes, and that's the bug.

## Tests

`src/relay/pty-shell-launch.test.ts`:
- A **real-zsh regression test** that reproduces the reporter's env (`ZDOTDIR`=overlay dir, `ORCA_ORIG_ZDOTDIR`=real config dir), sources the generated overlay `.zshenv`, and asserts `ORCA_USER_ZDOTDIR` resolves to the real config dir (it returned `$HOME` before the fix). Skips where zsh isn't installed.
- A wrapper-content assertion that the case arm falls back to `${ORCA_ORIG_ZDOTDIR:-$HOME}` and no longer contains the bare `$HOME` form.

Both fail on the pre-fix wrapper and pass after. Full `src/relay/pty-shell-launch.test.ts` suite (14) passes; `pnpm lint` and `pnpm typecheck` pass.

## No visual change

No UI changes. This only affects the generated relay zsh overlay startup script.

## AI coding agent review summary

- **Cross-platform**: change is inside the POSIX (zsh) relay wrapper only; the `win32` branch of `getRelayShellLaunchConfig` returns before it, and bash wrappers are untouched. The local/WSL `shell-templates.ts` path is intentionally not changed — it already handles this correctly via `unset ZDOTDIR`.
- **SSH / remote / local**: this is a remote/relay-only code path (SSH relay overlay). Local sessions use `shell-templates.ts` and are unaffected.
- **Agent / integration compatibility**: shell-startup only; no agent- or provider-specific logic. Fixes every agent that runs under a relay zsh with a non-`$HOME` ZDOTDIR.
- **Performance**: none — the fix removes an infinite-recursion / repeated-init failure mode; it does not add work.
- **Security**: no new inputs or execution; `ORCA_ORIG_ZDOTDIR` is an already-preserved relay-controlled value, quoted the same as the prior `$HOME`.
- **UI quality**: N/A.

## Testing notes

Relay/SSH-specific. Verified on macOS with zsh 5.9 via the real-zsh test above; the wrapper is shell-only so it applies identically to Linux/WSL relay hosts. Manual repro: SSH-relay into a host whose `~/.zshenv` exports `ZDOTDIR="${ZDOTDIR:-$HOME/.config/zsh}"`, open an Orca pane, run `echo $ZDOTDIR $ORCA_ORIG_ZDOTDIR $ORCA_USER_ZDOTDIR` — before: all `$HOME`; after: the preserved `~/.config/zsh`.

X handle: Seeun Park (@chappse6)
