### PR TITLE
fix(terminal): keep text after the cursor visible during IME composition

### DIFF
--- a/src/renderer/src/components/dashboard-popout/preview-terminal-compatibility.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-compatibility.ts
@@ -6,6 +6,7 @@ import { installWindowsCtrlAltChordRepair } from '@/lib/pane-manager/terminal-wi
 import { attachTerminalMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-mouse-wheel'
 import { configureLazyArabicShapingJoiner } from '@/lib/pane-manager/terminal-arabic-shaping-joiner'
 import { installTerminalImeCandidateAnchor } from '@/lib/pane-manager/terminal-ime-candidate-anchor'
+import { installTerminalImeCompositionTail } from '@/lib/pane-manager/terminal-ime-composition-tail'
 import { normalizeTerminalTuiMouseWheelMultiplier } from '@/lib/pane-manager/pane-terminal-tui-wheel-reports'
 import { installPreviewTerminalLinks } from './preview-terminal-links'
 import { syncPreviewTerminalLigatures } from './preview-terminal-ligatures'
@@ -13,7 +14,8 @@ import { syncPreviewTerminalLigatures } from './preview-terminal-ligatures'
 /**
  * Brings the preview's emulator up to a pane's: Orca's Unicode 11 width shim,
  * Windows Ctrl+Alt chord classification, clickable links, ligatures, the TUI
- * wheel multiplier, lazy Arabic shaping, and the IME candidate anchor.
+ * wheel multiplier, lazy Arabic shaping, and the IME candidate anchor plus
+ * preedit tail overlay.
  *
  * Returns a disposer for everything bound to the terminal's DOM element, which
  * must run before that terminal is disposed or replaced.
@@ -40,12 +42,14 @@ export function installPreviewTerminalCompatibility(
   // and has no WebGL glyph atlas to compensate for.
   const disposeArabicShapingJoiner = configureLazyArabicShapingJoiner(terminal, () => false)
   const imeAnchorHandler = installTerminalImeCandidateAnchor(terminal)
+  const disposeImeCompositionTail = installTerminalImeCompositionTail(terminal)
 
   return () => {
     if (imeAnchorHandler && terminal.element) {
       terminal.element.removeEventListener('compositionstart', imeAnchorHandler)
       terminal.element.removeEventListener('compositionupdate', imeAnchorHandler)
     }
+    disposeImeCompositionTail?.()
     disposeArabicShapingJoiner()
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -137,6 +137,7 @@ export function createPaneDOM(
     paneMouseEnterHandler,
     paneDragCleanup,
     compositionHandler: null,
+    imeCompositionTailCleanup: null,
     focusClassSyncCleanup: null,
     terminalScrollIntentDisposable: null,
     linkifierMouseLeaveResetDisposable: null,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -16,6 +16,7 @@ import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-web
 import { configureLazyArabicShapingJoiner } from './terminal-arabic-shaping-joiner'
 import { TerminalLigaturesAddon } from './terminal-ligatures-addon'
 import { installTerminalImeCandidateAnchor } from './terminal-ime-candidate-anchor'
+import { installTerminalImeCompositionTail } from './terminal-ime-composition-tail'
 
 // ---------------------------------------------------------------------------
 // Pane creation, terminal open/close, addon management
@@ -86,6 +87,7 @@ export function openTerminal(pane: ManagedPaneInternal): void {
 
   // Store so disposePane() can remove it and avoid a memory leak.
   pane.compositionHandler = installTerminalImeCandidateAnchor(terminal)
+  pane.imeCompositionTailCleanup = installTerminalImeCompositionTail(terminal)
 
   pane.focusClassSyncCleanup = attachDomRendererFocusClassSync(terminal.element)
 
@@ -199,6 +201,8 @@ export function disposePane(
     pane.terminal.element?.removeEventListener('compositionupdate', pane.compositionHandler)
     pane.compositionHandler = null
   }
+  pane.imeCompositionTailCleanup?.()
+  pane.imeCompositionTailCleanup = null
   try {
     clearPendingSplitScrollRestore(pane)
   } catch {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -167,6 +167,8 @@ export type ManagedPaneInternal = {
   paneDragCleanup?: (() => void) | null
   // Stored so disposePane() can remove it and avoid a memory leak.
   compositionHandler: (() => void) | null
+  // Stored so disposePane() can remove the IME preedit tail overlay.
+  imeCompositionTailCleanup?: (() => void) | null
   // Stored so disposePane() can remove DOM-renderer focus synchronization.
   focusClassSyncCleanup?: (() => void) | null
   // Stored so disposePane() can remove user-scroll intent listeners.

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
@@ -21,6 +21,35 @@ function nextFrame(): Promise<void> {
   return new Promise((resolve) => requestAnimationFrame(() => resolve()))
 }
 
+/** happy-dom reports a zero-sized screen; 400px over 40 cols keeps the grid at a round 10px. */
+function mockCellGrid(screenElement: HTMLElement): void {
+  vi.spyOn(screenElement, 'getBoundingClientRect').mockReturnValue({
+    width: 400,
+    height: 120
+  } as DOMRect)
+}
+
+function parkViewportAtScrollbackOrigin(terminal: Terminal): void {
+  const active = terminal.buffer.active
+  const scrolled = {
+    get cursorX() {
+      return active.cursorX
+    },
+    get cursorY() {
+      return active.cursorY
+    },
+    get baseY() {
+      return active.baseY
+    },
+    viewportY: 0,
+    getLine: (row: number) => active.getLine(row)
+  }
+  Object.defineProperty(terminal, 'buffer', {
+    configurable: true,
+    get: () => ({ active: scrolled })
+  })
+}
+
 function openTerminal(theme?: ITheme): OpenedTerminal {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -159,29 +188,86 @@ describe('terminal IME composition tail', () => {
   })
 
   it('starts the tail on the cell the preedit ends on', async () => {
-    const { compositionView, container, screenElement, terminal, textarea } = openTerminal()
-    // 40 cols over 400px keeps the cell grid at a round 10px.
-    vi.spyOn(screenElement, 'getBoundingClientRect').mockReturnValue({
-      width: 400,
-      height: 120
-    } as DOMRect)
+    const { container, screenElement, terminal, textarea } = openTerminal()
+    mockCellGrid(screenElement)
     await write(terminal, '가나다라마')
     await write(terminal, CURSOR_BACK_3_SYLLABLES)
 
     compositionEvent(textarea, 'compositionstart')
     compositionEvent(textarea, 'compositionupdate', '바')
 
-    const preeditLeft = Number.parseFloat(compositionView.style.left || '0')
-    // 바 budgets two cells, so the tail resumes exactly two cells later.
-    expect(tailOf(container).style.left).toBe(`${preeditLeft + 20}px`)
+    // Cursor sits on column 4 and 바 budgets two cells, so the tail resumes on column 6.
+    expect(tailOf(container).style.left).toBe('60px')
+    expect(tailOf(container).style.top).toBe('0px')
+  })
+
+  it('places the first composition off the cell grid, not off the unset preedit box', async () => {
+    const { compositionView, container, screenElement, terminal, textarea } = openTerminal()
+    mockCellGrid(screenElement)
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    // xterm only assigns .composition-view geometry from compositionupdate.
+    expect(compositionView.style.left).toBe('')
+    compositionEvent(textarea, 'compositionstart')
+
+    expect(tailOf(container).style.left).toBe('40px')
+    expect(tailOf(container).style.display).toBe('block')
+  })
+
+  it('hides while the viewport is scrolled off the cursor row', async () => {
+    const { container, screenElement, terminal, textarea } = openTerminal()
+    mockCellGrid(screenElement)
+    // Fill the scrollback so the viewport can leave the cursor row behind.
+    await write(terminal, '\r\n'.repeat(20))
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+    expect(tailOf(container).style.display).toBe('block')
+    compositionEvent(textarea, 'compositionend', '바')
+
+    // happy-dom's zero-sized viewport makes scrollToTop a no-op, so park the
+    // viewport at the scrollback origin directly.
+    parkViewportAtScrollbackOrigin(terminal)
+    compositionEvent(textarea, 'compositionstart')
+
+    expect(tailOf(container).style.display).toBe('none')
+  })
+
+  it('re-measures the cell grid when the terminal resizes mid-composition', async () => {
+    const { container, screenElement, terminal, textarea } = openTerminal()
+    mockCellGrid(screenElement)
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+    expect(tailOf(container).style.left).toBe('40px')
+
+    // Same pixel width over half the columns doubles the cell width.
+    terminal.resize(20, 6)
+
+    expect(tailOf(container).style.left).toBe('80px')
+  })
+
+  it('layers a see-through theme background over the opaque surface behind it', async () => {
+    const { container, screenElement, terminal, textarea } = openTerminal({
+      background: 'rgba(20, 20, 20, 0.5)'
+    })
+    screenElement.style.backgroundColor = 'rgb(240, 240, 240)'
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+
+    const tail = tailOf(container)
+    expect(tail.style.backgroundColor).toBe('rgb(240, 240, 240)')
+    expect(tail.style.backgroundImage).toContain('rgba(20, 20, 20, 0.5)')
   })
 
   it('advances each repainted character on the cell grid, not on font metrics', async () => {
     const { container, screenElement, terminal, textarea } = openTerminal()
-    vi.spyOn(screenElement, 'getBoundingClientRect').mockReturnValue({
-      width: 400,
-      height: 120
-    } as DOMRect)
+    mockCellGrid(screenElement)
     await write(terminal, '가나다라마')
     await write(terminal, CURSOR_BACK_3_SYLLABLES)
 
@@ -201,6 +287,38 @@ describe('terminal IME composition tail', () => {
     compositionEvent(textarea, 'compositionstart')
 
     expect(tailOf(container).style.backgroundColor).toMatch(/#112233|rgb\(17, 34, 51\)/)
+  })
+
+  it.each(['#112233ff', '#123f'])(
+    'masks with the terminal background when its alpha hex %s is full',
+    async (background) => {
+      const { container, screenElement, terminal, textarea } = openTerminal({ background })
+      screenElement.style.backgroundColor = 'rgb(240, 240, 240)'
+      await write(terminal, '가나다라마')
+      await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+      compositionEvent(textarea, 'compositionstart')
+
+      const tail = tailOf(container)
+      expect(tail.style.backgroundColor).toBeTruthy()
+      expect(tail.style.backgroundColor).not.toBe('rgb(240, 240, 240)')
+      expect(tail.style.backgroundImage).toBe('none')
+    }
+  )
+
+  it('layers an alpha hex theme background that is not fully opaque', async () => {
+    const { container, screenElement, terminal, textarea } = openTerminal({
+      background: '#11223380'
+    })
+    screenElement.style.backgroundColor = 'rgb(240, 240, 240)'
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+
+    const tail = tailOf(container)
+    expect(tail.style.backgroundColor).toBe('rgb(240, 240, 240)')
+    expect(tail.style.backgroundImage).toContain('#11223380')
   })
 
   it.each(['rgba(20, 20, 20, 0.5)', 'rgb(20 20 20 / 50%)', 'hsla(0, 0%, 8%, 0.5)'])(

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
@@ -84,7 +84,12 @@ describe('terminal IME composition tail', () => {
     await write(terminal, CURSOR_BACK_3_SYLLABLES)
 
     const buffer = terminal.buffer.active
-    expect(buffer.getLine(buffer.cursorY)?.getCell(buffer.cursorX)?.getChars()).toBe('다')
+    expect(
+      buffer
+        .getLine(buffer.baseY + buffer.cursorY)
+        ?.getCell(buffer.cursorX)
+        ?.getChars()
+    ).toBe('다')
 
     compositionEvent(textarea, 'compositionstart')
     compositionEvent(textarea, 'compositionupdate', '바')
@@ -94,6 +99,20 @@ describe('terminal IME composition tail', () => {
     const tail = tailOf(container)
     expect(tail.textContent).toBe('다라마')
     expect(tail.style.display).toBe('block')
+  })
+
+  it('repaints the cursor row after the buffer has scrolled', async () => {
+    const { container, terminal, textarea } = openTerminal()
+    // Push the cursor row past the scrollback origin so cursorY no longer indexes it.
+    await write(terminal, 'scrolled away\r\n'.repeat(10))
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+    expect(terminal.buffer.active.baseY).toBeGreaterThan(0)
+
+    compositionEvent(textarea, 'compositionstart')
+    compositionEvent(textarea, 'compositionupdate', '바')
+
+    expect(tailOf(container).textContent).toBe('다라마')
   })
 
   it('stays hidden when the cursor is at the end of the row', async () => {
@@ -184,15 +203,18 @@ describe('terminal IME composition tail', () => {
     expect(tailOf(container).style.backgroundColor).toMatch(/#112233|rgb\(17, 34, 51\)/)
   })
 
-  it('rejects a see-through theme background that would double-expose the cells', async () => {
-    const { container, terminal, textarea } = openTerminal({ background: 'rgba(20, 20, 20, 0.5)' })
-    await write(terminal, '가나다라마')
-    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+  it.each(['rgba(20, 20, 20, 0.5)', 'rgb(20 20 20 / 50%)', 'hsla(0, 0%, 8%, 0.5)'])(
+    'rejects the see-through theme background %s that would double-expose the cells',
+    async (background) => {
+      const { container, terminal, textarea } = openTerminal({ background })
+      await write(terminal, '가나다라마')
+      await write(terminal, CURSOR_BACK_3_SYLLABLES)
 
-    compositionEvent(textarea, 'compositionstart')
+      compositionEvent(textarea, 'compositionstart')
 
-    expect(tailOf(container).style.backgroundColor).not.toContain('0.5')
-  })
+      expect(tailOf(container).style.backgroundColor).not.toBe(background)
+    }
+  )
 
   it('removes its element and listeners on cleanup', async () => {
     const { container, terminal, textarea } = openTerminal()

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+import { type ITheme, Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installTerminalImeCompositionTail } from './terminal-ime-composition-tail'
+
+// Move the cursor back three double-width Hangul syllables.
+const CURSOR_BACK_3_SYLLABLES = '\u001b[6D'
+const CURSOR_HOME = '\u001b[H'
+const openTerminals: Terminal[] = []
+const cleanups: (() => void)[] = []
+
+type OpenedTerminal = {
+  compositionView: HTMLElement
+  container: HTMLElement
+  screenElement: HTMLElement
+  terminal: Terminal
+  textarea: HTMLTextAreaElement
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+}
+
+function openTerminal(theme?: ITheme): OpenedTerminal {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal({ cols: 40, rows: 6, theme })
+  openTerminals.push(terminal)
+  terminal.open(container)
+  const compositionView = container.querySelector<HTMLElement>('.composition-view')
+  const screenElement = container.querySelector<HTMLElement>('.xterm-screen')
+  if (!compositionView || !screenElement || !terminal.textarea) {
+    throw new Error('xterm composition view, screen element, or textarea was not created')
+  }
+  const cleanup = installTerminalImeCompositionTail(terminal)
+  if (!cleanup) {
+    throw new Error('composition tail was not installed')
+  }
+  cleanups.push(cleanup)
+  return { compositionView, container, screenElement, terminal, textarea: terminal.textarea }
+}
+
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
+
+function tailOf(container: HTMLElement): HTMLElement {
+  const tail = container.querySelector<HTMLElement>('.orca-ime-composition-tail')
+  if (!tail) {
+    throw new Error('composition tail element is missing')
+  }
+  return tail
+}
+
+function compositionEvent(textarea: HTMLTextAreaElement, type: string, data?: string): void {
+  const event = new CompositionEvent(type, { bubbles: true })
+  if (data !== undefined) {
+    Object.defineProperty(event, 'data', { value: data })
+  }
+  textarea.dispatchEvent(event)
+}
+
+describe('terminal IME composition tail', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.()
+    }
+    while (openTerminals.length > 0) {
+      openTerminals.pop()?.dispose()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('repaints the row remainder that the preedit overlay covers', async () => {
+    const { compositionView, container, terminal, textarea } = openTerminal()
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    const buffer = terminal.buffer.active
+    expect(buffer.getLine(buffer.cursorY)?.getCell(buffer.cursorX)?.getChars()).toBe('다')
+
+    compositionEvent(textarea, 'compositionstart')
+    compositionEvent(textarea, 'compositionupdate', '바')
+
+    // The overlay xterm paints still hides 다; the tail restores it past the preedit.
+    expect(compositionView.textContent).not.toContain('다')
+    const tail = tailOf(container)
+    expect(tail.textContent).toBe('다라마')
+    expect(tail.style.display).toBe('block')
+  })
+
+  it('stays hidden when the cursor is at the end of the row', async () => {
+    const { container, terminal, textarea } = openTerminal()
+    await write(terminal, '가나다라마')
+
+    compositionEvent(textarea, 'compositionstart')
+    compositionEvent(textarea, 'compositionupdate', '바')
+
+    expect(tailOf(container).style.display).toBe('none')
+  })
+
+  it('clears the tail when the composition ends', async () => {
+    const { container, terminal, textarea } = openTerminal()
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+    compositionEvent(textarea, 'compositionupdate', '바')
+    expect(tailOf(container).style.display).toBe('block')
+
+    compositionEvent(textarea, 'compositionend', '바')
+
+    expect(tailOf(container).style.display).toBe('none')
+    expect(tailOf(container).textContent).toBe('')
+  })
+
+  it('re-reads the row when a committed syllable echoes mid-composition', async () => {
+    const { container, terminal, textarea } = openTerminal()
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+    compositionEvent(textarea, 'compositionupdate', '다')
+    expect(tailOf(container).textContent).toBe('다라마')
+
+    // The IME commits 다 and immediately opens the next composition; the shell
+    // redraws the reflowed line while that one is still active.
+    await write(terminal, `${CURSOR_HOME}가나다다라마${CURSOR_BACK_3_SYLLABLES}`)
+    await nextFrame()
+
+    expect(tailOf(container).style.display).toBe('block')
+    expect(tailOf(container).textContent).toBe('다라마')
+  })
+
+  it('starts the tail on the cell the preedit ends on', async () => {
+    const { compositionView, container, screenElement, terminal, textarea } = openTerminal()
+    // 40 cols over 400px keeps the cell grid at a round 10px.
+    vi.spyOn(screenElement, 'getBoundingClientRect').mockReturnValue({
+      width: 400,
+      height: 120
+    } as DOMRect)
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+    compositionEvent(textarea, 'compositionupdate', '바')
+
+    const preeditLeft = Number.parseFloat(compositionView.style.left || '0')
+    // 바 budgets two cells, so the tail resumes exactly two cells later.
+    expect(tailOf(container).style.left).toBe(`${preeditLeft + 20}px`)
+  })
+
+  it('advances each repainted character on the cell grid, not on font metrics', async () => {
+    const { container, screenElement, terminal, textarea } = openTerminal()
+    vi.spyOn(screenElement, 'getBoundingClientRect').mockReturnValue({
+      width: 400,
+      height: 120
+    } as DOMRect)
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+
+    const cells = [...tailOf(container).children] as HTMLElement[]
+    expect(cells.map((cell) => cell.textContent)).toEqual(['다', '라', '마'])
+    // Every Hangul syllable owns two 10px cells regardless of its glyph advance.
+    expect(cells.map((cell) => cell.style.width)).toEqual(['20px', '20px', '20px'])
+  })
+
+  it('masks with the terminal background when the theme is opaque', async () => {
+    const { container, terminal, textarea } = openTerminal({ background: '#112233' })
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+
+    expect(tailOf(container).style.backgroundColor).toMatch(/#112233|rgb\(17, 34, 51\)/)
+  })
+
+  it('rejects a see-through theme background that would double-expose the cells', async () => {
+    const { container, terminal, textarea } = openTerminal({ background: 'rgba(20, 20, 20, 0.5)' })
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+
+    expect(tailOf(container).style.backgroundColor).not.toContain('0.5')
+  })
+
+  it('removes its element and listeners on cleanup', async () => {
+    const { container, terminal, textarea } = openTerminal()
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    cleanups.pop()?.()
+
+    expect(container.querySelector('.orca-ime-composition-tail')).toBeNull()
+    compositionEvent(textarea, 'compositionstart')
+    expect(container.querySelector('.orca-ime-composition-tail')).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.test.ts
@@ -235,6 +235,24 @@ describe('terminal IME composition tail', () => {
     expect(tailOf(container).style.display).toBe('none')
   })
 
+  it('hides when the viewport leaves the cursor row mid-composition', async () => {
+    const { container, screenElement, terminal, textarea } = openTerminal()
+    mockCellGrid(screenElement)
+    await write(terminal, '\r\n'.repeat(20))
+    await write(terminal, '가나다라마')
+    await write(terminal, CURSOR_BACK_3_SYLLABLES)
+
+    compositionEvent(textarea, 'compositionstart')
+    expect(tailOf(container).style.display).toBe('block')
+
+    // Scrolling away without ending the composition must not leave the snapshot on screen.
+    parkViewportAtScrollbackOrigin(terminal)
+    compositionEvent(textarea, 'compositionupdate', '바')
+
+    expect(tailOf(container).style.display).toBe('none')
+    expect(tailOf(container).textContent).toBe('')
+  })
+
   it('re-measures the cell grid when the terminal resizes mid-composition', async () => {
     const { container, screenElement, terminal, textarea } = openTerminal()
     mockCellGrid(screenElement)

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
@@ -60,13 +60,8 @@ function findOpaqueSurface(start: Element): string {
   return '#000'
 }
 
-/**
- * What the covered cells actually sit on. A translucent terminal background —
- * `terminalBackgroundOpacity` bakes the alpha into `theme.background`, and
- * xterm then leaves the viewport translucent too — is layered over the first
- * opaque surface behind it rather than swapped for one, so the mask matches the
- * row it replaces instead of falling back to a black block on a light theme.
- */
+// A translucent theme background is layered over the surface behind it, not swapped for one,
+// or the mask drops a black block onto a light theme.
 function resolveBackdrop(
   terminal: Terminal,
   surfaceProbe: Element
@@ -198,13 +193,8 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
     tailElement.replaceChildren(...cells)
   }
 
-  /**
-   * Place the tail off the cell grid rather than off `.composition-view`. xterm
-   * only assigns that element's geometry from `compositionupdate`, so reading it
-   * on `compositionstart` would place the first composition of a terminal at the
-   * top-left corner; measuring its box would also inherit the bidi marks xterm
-   * wraps the preedit in and leave a ragged gap.
-   */
+  // Off the cell grid, not off .composition-view: xterm only positions that element from
+  // compositionupdate, so the first composition would land in the top-left corner.
   const resolveTailGeometry = (): { left: number; top: string; height: string } => {
     const buffer = terminal.buffer.active
     const preeditColumns = measureTerminalStringColumns(terminal, preedit) ?? preedit.length
@@ -267,9 +257,11 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
     resnapshotAndPaint()
   }
 
+  // Re-read rather than paint: a viewport moved since compositionstart leaves rowTail stale,
+  // and renderTailCells would repaint it over an unrelated row.
   const handleCompositionUpdate = (event: Event): void => {
     preedit = (event as CompositionEvent).data ?? ''
-    paint()
+    resnapshotAndPaint()
   }
 
   const handleCompositionEnd = (): void => {

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
@@ -1,17 +1,38 @@
-import type { Terminal } from '@xterm/xterm'
+import type { IBufferLine, Terminal } from '@xterm/xterm'
 import { measureTerminalStringColumns } from '../../../../shared/terminal-unicode-provider'
+
+/** Null when the color carries no alpha channel at all; otherwise 0..1. */
+function readFunctionalAlpha(argumentList: string): number | null {
+  const slash = argumentList.lastIndexOf('/')
+  const legacy = argumentList.split(',')
+  const raw = slash >= 0 ? argumentList.slice(slash + 1) : legacy.length === 4 ? legacy[3] : null
+  if (raw == null) {
+    return null
+  }
+  const trimmed = raw.trim()
+  const percent = trimmed.endsWith('%')
+  const alpha = Number.parseFloat(percent ? trimmed.slice(0, -1) : trimmed)
+  if (!Number.isFinite(alpha)) {
+    // `none`, custom properties: assume see-through rather than mask with an unknown.
+    return 0
+  }
+  return percent ? alpha / 100 : alpha
+}
 
 /** The tail masks the cells it repaints, so a see-through color would double-expose them. */
 function isOpaqueColor(color: string | undefined): boolean {
-  if (!color || color === 'transparent') {
+  const value = color?.trim().toLowerCase()
+  if (!value || value === 'transparent') {
     return false
   }
-  const rgba = /^rgba?\([^)]*?(?:,|\/)\s*(\d*\.?\d+)\s*\)$/.exec(color)
-  if (rgba) {
-    return Number.parseFloat(rgba[1]) >= 1
+  // Covers rgb/rgba/hsl/hsla/hwb/lab/oklch in both the legacy comma and the slash-alpha forms.
+  const functional = /^[a-z]+\(([^()]*)\)$/.exec(value)
+  if (functional) {
+    const alpha = readFunctionalAlpha(functional[1])
+    return alpha == null || alpha >= 1
   }
-  if (color.startsWith('#')) {
-    return color.length !== 5 && color.length !== 9
+  if (value.startsWith('#')) {
+    return value.length !== 5 && value.length !== 9
   }
   return true
 }
@@ -92,13 +113,17 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
     tailElement.style.display = 'none'
   }
 
-  const readRowTail = (): string => {
+  // cursorY is viewport-relative; getLine indexes the whole buffer, scrollback included.
+  const readCursorLine = (): IBufferLine | undefined => {
     const buffer = terminal.buffer.active
     if (buffer.cursorY < 0 || buffer.cursorY >= terminal.rows) {
-      return ''
+      return undefined
     }
-    return buffer.getLine(buffer.cursorY)?.translateToString(true, buffer.cursorX) ?? ''
+    return buffer.getLine(buffer.baseY + buffer.cursorY)
   }
+
+  const readRowTail = (): string =>
+    readCursorLine()?.translateToString(true, terminal.buffer.active.cursorX) ?? ''
 
   /**
    * Lay the tail out cell by cell. A plain text node advances on the font's own
@@ -111,7 +136,7 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
       return
     }
     const buffer = terminal.buffer.active
-    const line = buffer.getLine(buffer.cursorY)
+    const line = readCursorLine()
     if (!line) {
       tailElement.textContent = rowTail
       return

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
@@ -32,29 +32,53 @@ function isOpaqueColor(color: string | undefined): boolean {
     return alpha == null || alpha >= 1
   }
   if (value.startsWith('#')) {
-    return value.length !== 5 && value.length !== 9
+    const hex = value.slice(1)
+    if (!/^[\da-f]+$/.test(hex)) {
+      return false
+    }
+    // #rgba and #rrggbbaa still mask when the alpha channel is full.
+    if (hex.length === 4) {
+      return hex[3] === 'f'
+    }
+    if (hex.length === 8) {
+      return hex.slice(6) === 'ff'
+    }
+    return hex.length === 3 || hex.length === 6
   }
   return true
 }
 
-function resolveOpaqueBackdrop(
-  terminal: Terminal,
-  candidates: (Element | null | undefined)[]
-): string {
-  if (isOpaqueColor(terminal.options.theme?.background)) {
-    return terminal.options.theme?.background ?? ''
-  }
-  for (const element of candidates) {
-    if (!element) {
-      continue
-    }
+function findOpaqueSurface(start: Element): string {
+  let element: Element | null = start
+  while (element) {
     const background = window.getComputedStyle(element).backgroundColor
     if (isOpaqueColor(background)) {
       return background
     }
+    element = element.parentElement
   }
-  // xterm styles .composition-view opaque, so the preedit box itself always is.
   return '#000'
+}
+
+/**
+ * What the covered cells actually sit on. A translucent terminal background —
+ * `terminalBackgroundOpacity` bakes the alpha into `theme.background`, and
+ * xterm then leaves the viewport translucent too — is layered over the first
+ * opaque surface behind it rather than swapped for one, so the mask matches the
+ * row it replaces instead of falling back to a black block on a light theme.
+ */
+function resolveBackdrop(
+  terminal: Terminal,
+  surfaceProbe: Element
+): { color: string; overlay: string | null } {
+  const themeBackground = terminal.options.theme?.background
+  if (isOpaqueColor(themeBackground)) {
+    return { color: themeBackground ?? '', overlay: null }
+  }
+  return {
+    color: findOpaqueSurface(surfaceProbe),
+    overlay: themeBackground && themeBackground !== 'transparent' ? themeBackground : null
+  }
 }
 
 /**
@@ -97,8 +121,16 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
   let rowTail = ''
   let preedit = ''
   let cellWidth = 0
+  let cellHeight = 0
   let screenWidth = 0
   let repaintFrame: number | null = null
+
+  const measureCellGrid = (): void => {
+    const screenRect = screenElement.getBoundingClientRect()
+    screenWidth = screenRect.width
+    cellWidth = terminal.cols > 0 ? screenRect.width / terminal.cols : 0
+    cellHeight = terminal.rows > 0 ? screenRect.height / terminal.rows : 0
+  }
 
   const cancelScheduledRepaint = (): void => {
     if (repaintFrame != null) {
@@ -114,9 +146,14 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
   }
 
   // cursorY is viewport-relative; getLine indexes the whole buffer, scrollback included.
+  // A viewport scrolled off the cursor row leaves nothing to mask on screen.
   const readCursorLine = (): IBufferLine | undefined => {
     const buffer = terminal.buffer.active
-    if (buffer.cursorY < 0 || buffer.cursorY >= terminal.rows) {
+    if (
+      buffer.cursorY < 0 ||
+      buffer.cursorY >= terminal.rows ||
+      buffer.viewportY !== buffer.baseY
+    ) {
       return undefined
     }
     return buffer.getLine(buffer.baseY + buffer.cursorY)
@@ -162,30 +199,44 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
   }
 
   /**
-   * Start the tail on the cell the preedit ends on. Measuring the preedit box
-   * instead would inherit the bidi marks xterm wraps it in and leave a ragged
-   * gap; the cell budget is what the renderer itself lays text out on.
+   * Place the tail off the cell grid rather than off `.composition-view`. xterm
+   * only assigns that element's geometry from `compositionupdate`, so reading it
+   * on `compositionstart` would place the first composition of a terminal at the
+   * top-left corner; measuring its box would also inherit the bidi marks xterm
+   * wraps the preedit in and leave a ragged gap.
    */
-  const resolveTailLeft = (): number => {
-    const preeditLeft = Number.parseFloat(compositionView.style.left || '0')
-    if (cellWidth > 0) {
-      const columns = measureTerminalStringColumns(terminal, preedit) ?? preedit.length
-      return preeditLeft + columns * cellWidth
+  const resolveTailGeometry = (): { left: number; top: string; height: string } => {
+    const buffer = terminal.buffer.active
+    const preeditColumns = measureTerminalStringColumns(terminal, preedit) ?? preedit.length
+    if (cellWidth > 0 && cellHeight > 0) {
+      const column = Math.min(buffer.cursorX, terminal.cols - 1) + preeditColumns
+      return {
+        left: column * cellWidth,
+        top: `${buffer.cursorY * cellHeight}px`,
+        height: `${cellHeight}px`
+      }
     }
-    return preeditLeft + compositionView.offsetWidth
+    const preeditLeft = Number.parseFloat(compositionView.style.left || '0')
+    return {
+      left: preeditLeft + compositionView.offsetWidth,
+      top: compositionView.style.top,
+      height: compositionView.style.height
+    }
   }
 
   const paint = (): void => {
     if (!isComposing || !rowTail) {
       return
     }
-    const left = resolveTailLeft()
+    const { left, top, height } = resolveTailGeometry()
     tailElement.style.left = `${left}px`
-    tailElement.style.top = compositionView.style.top
-    tailElement.style.height = compositionView.style.height
-    tailElement.style.lineHeight = compositionView.style.lineHeight
-    tailElement.style.fontFamily = compositionView.style.fontFamily
-    tailElement.style.fontSize = compositionView.style.fontSize
+    tailElement.style.top = top
+    tailElement.style.height = height
+    tailElement.style.lineHeight = height
+    tailElement.style.fontFamily = terminal.options.fontFamily ?? compositionView.style.fontFamily
+    tailElement.style.fontSize = terminal.options.fontSize
+      ? `${terminal.options.fontSize}px`
+      : compositionView.style.fontSize
     if (screenWidth > 0) {
       tailElement.style.maxWidth = `${Math.max(screenWidth - left, 0)}px`
     }
@@ -207,14 +258,12 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
     preedit = ''
     tailElement.style.color =
       terminal.options.theme?.foreground ?? window.getComputedStyle(screenElement).color
-    tailElement.style.backgroundColor = resolveOpaqueBackdrop(terminal, [
-      screenElement,
-      terminal.element,
-      terminal.element?.parentElement
-    ])
-    const screenRect = screenElement.getBoundingClientRect()
-    screenWidth = screenRect.width
-    cellWidth = terminal.cols > 0 ? screenRect.width / terminal.cols : 0
+    const backdrop = resolveBackdrop(terminal, screenElement)
+    tailElement.style.backgroundColor = backdrop.color
+    tailElement.style.backgroundImage = backdrop.overlay
+      ? `linear-gradient(${backdrop.overlay}, ${backdrop.overlay})`
+      : 'none'
+    measureCellGrid()
     resnapshotAndPaint()
   }
 
@@ -250,12 +299,20 @@ export function installTerminalImeCompositionTail(terminal: Terminal): (() => vo
   terminal.element?.addEventListener('compositionupdate', handleCompositionUpdate)
   terminal.element?.addEventListener('compositionend', handleCompositionEnd)
   const writeDisposable = terminal.onWriteParsed(handleWriteParsed)
+  // A resize or font change mid-composition invalidates the snapshotted grid.
+  const resizeDisposable = terminal.onResize(() => {
+    if (isComposing) {
+      measureCellGrid()
+      resnapshotAndPaint()
+    }
+  })
 
   return () => {
     terminal.element?.removeEventListener('compositionstart', handleCompositionStart)
     terminal.element?.removeEventListener('compositionupdate', handleCompositionUpdate)
     terminal.element?.removeEventListener('compositionend', handleCompositionEnd)
     writeDisposable.dispose()
+    resizeDisposable.dispose()
     cancelScheduledRepaint()
     tailElement.remove()
   }

--- a/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-composition-tail.ts
@@ -1,0 +1,237 @@
+import type { Terminal } from '@xterm/xterm'
+import { measureTerminalStringColumns } from '../../../../shared/terminal-unicode-provider'
+
+/** The tail masks the cells it repaints, so a see-through color would double-expose them. */
+function isOpaqueColor(color: string | undefined): boolean {
+  if (!color || color === 'transparent') {
+    return false
+  }
+  const rgba = /^rgba?\([^)]*?(?:,|\/)\s*(\d*\.?\d+)\s*\)$/.exec(color)
+  if (rgba) {
+    return Number.parseFloat(rgba[1]) >= 1
+  }
+  if (color.startsWith('#')) {
+    return color.length !== 5 && color.length !== 9
+  }
+  return true
+}
+
+function resolveOpaqueBackdrop(
+  terminal: Terminal,
+  candidates: (Element | null | undefined)[]
+): string {
+  if (isOpaqueColor(terminal.options.theme?.background)) {
+    return terminal.options.theme?.background ?? ''
+  }
+  for (const element of candidates) {
+    if (!element) {
+      continue
+    }
+    const background = window.getComputedStyle(element).backgroundColor
+    if (isOpaqueColor(background)) {
+      return background
+    }
+  }
+  // xterm styles .composition-view opaque, so the preedit box itself always is.
+  return '#000'
+}
+
+/**
+ * Keep the text after the cursor readable while an IME composition is open.
+ *
+ * Why: xterm paints the preedit into an opaque `.composition-view` anchored to
+ * the cursor cell, so composing mid-line hides whatever already sits there
+ * (stablyai/orca#12545). Nothing reaches the pty until the composition commits,
+ * so those cells still hold the old text — we repaint that row remainder just
+ * past the preedit, which reads as the insertion pushing it right. macOS
+ * Terminal.app behaves the same way; iTerm2 and stock xterm hide it.
+ *
+ * The tail is its own element rather than a child of `.composition-view`: xterm
+ * rewrites that element's textContent on every compositionupdate, clips it with
+ * `overflow: hidden`, and flips it to `direction: rtl`.
+ *
+ * Returns a cleanup function, or null when the terminal has not opened its DOM.
+ */
+export function installTerminalImeCompositionTail(terminal: Terminal): (() => void) | null {
+  const helperContainer = terminal.element?.querySelector<HTMLElement>('.xterm-helpers')
+  const compositionView = terminal.element?.querySelector<HTMLElement>('.composition-view')
+  const screenElement = terminal.element?.querySelector<HTMLElement>('.xterm-screen')
+  if (!helperContainer || !compositionView || !screenElement) {
+    return null
+  }
+
+  const tailElement = document.createElement('div')
+  tailElement.className = 'orca-ime-composition-tail'
+  tailElement.style.position = 'absolute'
+  tailElement.style.display = 'none'
+  tailElement.style.whiteSpace = 'pre'
+  tailElement.style.direction = 'ltr'
+  tailElement.style.overflow = 'hidden'
+  tailElement.style.pointerEvents = 'none'
+  // Below xterm's preedit box (z-index 1) so a wide glyph never clips it.
+  tailElement.style.zIndex = '0'
+  helperContainer.appendChild(tailElement)
+
+  let isComposing = false
+  let rowTail = ''
+  let preedit = ''
+  let cellWidth = 0
+  let screenWidth = 0
+  let repaintFrame: number | null = null
+
+  const cancelScheduledRepaint = (): void => {
+    if (repaintFrame != null) {
+      cancelAnimationFrame(repaintFrame)
+      repaintFrame = null
+    }
+  }
+
+  const hide = (): void => {
+    rowTail = ''
+    tailElement.textContent = ''
+    tailElement.style.display = 'none'
+  }
+
+  const readRowTail = (): string => {
+    const buffer = terminal.buffer.active
+    if (buffer.cursorY < 0 || buffer.cursorY >= terminal.rows) {
+      return ''
+    }
+    return buffer.getLine(buffer.cursorY)?.translateToString(true, buffer.cursorX) ?? ''
+  }
+
+  /**
+   * Lay the tail out cell by cell. A plain text node advances on the font's own
+   * metrics, which run tighter than the terminal's fixed cell grid and made the
+   * repainted text visibly cramped next to the rows around it.
+   */
+  const renderTailCells = (): void => {
+    if (cellWidth <= 0) {
+      tailElement.textContent = rowTail
+      return
+    }
+    const buffer = terminal.buffer.active
+    const line = buffer.getLine(buffer.cursorY)
+    if (!line) {
+      tailElement.textContent = rowTail
+      return
+    }
+    const cells: HTMLElement[] = []
+    for (let column = buffer.cursorX; column < terminal.cols; column++) {
+      const cell = line.getCell(column)
+      const columns = cell?.getWidth() ?? 0
+      if (!cell || columns === 0) {
+        continue
+      }
+      const cellElement = document.createElement('span')
+      cellElement.style.display = 'inline-block'
+      cellElement.style.width = `${columns * cellWidth}px`
+      cellElement.textContent = cell.getChars() || ' '
+      cells.push(cellElement)
+    }
+    // Stop the mask where the row's content does, not at the right margin.
+    while (cells.length > 0 && (cells.at(-1)?.textContent ?? '').trim() === '') {
+      cells.pop()
+    }
+    tailElement.replaceChildren(...cells)
+  }
+
+  /**
+   * Start the tail on the cell the preedit ends on. Measuring the preedit box
+   * instead would inherit the bidi marks xterm wraps it in and leave a ragged
+   * gap; the cell budget is what the renderer itself lays text out on.
+   */
+  const resolveTailLeft = (): number => {
+    const preeditLeft = Number.parseFloat(compositionView.style.left || '0')
+    if (cellWidth > 0) {
+      const columns = measureTerminalStringColumns(terminal, preedit) ?? preedit.length
+      return preeditLeft + columns * cellWidth
+    }
+    return preeditLeft + compositionView.offsetWidth
+  }
+
+  const paint = (): void => {
+    if (!isComposing || !rowTail) {
+      return
+    }
+    const left = resolveTailLeft()
+    tailElement.style.left = `${left}px`
+    tailElement.style.top = compositionView.style.top
+    tailElement.style.height = compositionView.style.height
+    tailElement.style.lineHeight = compositionView.style.lineHeight
+    tailElement.style.fontFamily = compositionView.style.fontFamily
+    tailElement.style.fontSize = compositionView.style.fontSize
+    if (screenWidth > 0) {
+      tailElement.style.maxWidth = `${Math.max(screenWidth - left, 0)}px`
+    }
+    renderTailCells()
+    tailElement.style.display = 'block'
+  }
+
+  const resnapshotAndPaint = (): void => {
+    rowTail = readRowTail()
+    if (!rowTail) {
+      hide()
+      return
+    }
+    paint()
+  }
+
+  const handleCompositionStart = (): void => {
+    isComposing = true
+    preedit = ''
+    tailElement.style.color =
+      terminal.options.theme?.foreground ?? window.getComputedStyle(screenElement).color
+    tailElement.style.backgroundColor = resolveOpaqueBackdrop(terminal, [
+      screenElement,
+      terminal.element,
+      terminal.element?.parentElement
+    ])
+    const screenRect = screenElement.getBoundingClientRect()
+    screenWidth = screenRect.width
+    cellWidth = terminal.cols > 0 ? screenRect.width / terminal.cols : 0
+    resnapshotAndPaint()
+  }
+
+  const handleCompositionUpdate = (event: Event): void => {
+    preedit = (event as CompositionEvent).data ?? ''
+    paint()
+  }
+
+  const handleCompositionEnd = (): void => {
+    isComposing = false
+    preedit = ''
+    cancelScheduledRepaint()
+    hide()
+  }
+
+  // Why: every Hangul syllable commits before the next one starts composing, so
+  // its echo lands mid-composition — re-read the row instead of dropping the
+  // tail, or it stays hidden from the second syllable onwards. Coalesced to one
+  // repaint per frame so streamed output cannot thrash layout.
+  const handleWriteParsed = (): void => {
+    if (!isComposing || repaintFrame != null) {
+      return
+    }
+    repaintFrame = requestAnimationFrame(() => {
+      repaintFrame = null
+      if (isComposing) {
+        resnapshotAndPaint()
+      }
+    })
+  }
+
+  terminal.element?.addEventListener('compositionstart', handleCompositionStart)
+  terminal.element?.addEventListener('compositionupdate', handleCompositionUpdate)
+  terminal.element?.addEventListener('compositionend', handleCompositionEnd)
+  const writeDisposable = terminal.onWriteParsed(handleWriteParsed)
+
+  return () => {
+    terminal.element?.removeEventListener('compositionstart', handleCompositionStart)
+    terminal.element?.removeEventListener('compositionupdate', handleCompositionUpdate)
+    terminal.element?.removeEventListener('compositionend', handleCompositionEnd)
+    writeDisposable.dispose()
+    cancelScheduledRepaint()
+    tailElement.remove()
+  }
+}

--- a/src/shared/terminal-unicode-provider.ts
+++ b/src/shared/terminal-unicode-provider.ts
@@ -5,6 +5,7 @@ type XtermTerminalWithUnicodeCore = {
   _core?: {
     unicodeService?: {
       _providers?: Record<string, IUnicodeVersionProvider>
+      getStringCellWidth?: (value: string) => number
     }
   }
 }
@@ -50,6 +51,19 @@ class OrcaUnicodeProvider implements IUnicodeVersionProvider {
 
     return this.baseProvider.charProperties(codepoint, preceding)
   }
+}
+
+/**
+ * Columns `value` occupies under the terminal's active width tables — the same
+ * budget the renderer lays cells out on. Null when the emulator has not exposed
+ * its unicode service (no DOM yet, or a future xterm without it).
+ */
+export function measureTerminalStringColumns(
+  terminal: XtermTerminalWithUnicodeCore,
+  value: string
+): number | null {
+  const columns = terminal._core?.unicodeService?.getStringCellWidth?.(value)
+  return typeof columns === 'number' ? columns : null
 }
 
 export function activateOrcaTerminalUnicodeProvider(terminal: XtermTerminalWithUnicodeCore): void {


### PR DESCRIPTION
Fixes #12545.

## Summary

Composing Korean in the middle of a line hid the character sitting at the cursor for the whole
composition. xterm paints the preedit into `.composition-view`, which upstream styles opaque
(`background: #000; position: absolute; z-index: 1`) and anchors to the cursor cell. Nothing reaches
the pty while composing, so that cell still holds its original character — the box simply covers it.

macOS Terminal.app renders the preedit as inserted text and keeps the following character visible;
iTerm2 and stock xterm hide it.

`installTerminalImeCompositionTail` repaints the row remainder just past the preedit while a
composition is open, so the composition reads as an insertion pushing the tail right.

The overlay is its own element rather than a child of `.composition-view`, which xterm rewrites on
every `compositionupdate`, clips with `overflow: hidden`, and flips to `direction: rtl`. Four details
matter:

- **Cell-grid layout and placement.** The tail is built cell by cell off the buffer with
  `width = columns × cellWidth`, and positioned from the cell grid rather than from
  `.composition-view`. A plain text node advances on the font's own metrics, which runs tighter than
  the terminal grid and looked visibly cramped. xterm also only assigns the preedit box its geometry
  on `compositionupdate`, so reading that element would place a terminal's first composition in the
  top-left corner. The grid is re-measured on `resize`.
- **Start column.** The tail begins on the cell the preedit *ends* on, measured through the
  emulator's own width tables (new `measureTerminalStringColumns` in
  `shared/terminal-unicode-provider.ts`). Measuring the preedit box instead inherits the bidi marks
  xterm wraps it in and leaves a ragged gap.
- **Commit echo.** Every Hangul syllable commits before the next one starts composing, so its echo
  lands mid-composition. The tail re-reads the row (coalesced to one repaint per frame) instead of
  being dropped — dropping it hid the tail from the second syllable onwards.
- **Scroll safety.** Row reads use `baseY + cursorY`, since `cursorY` is viewport-relative while
  `getLine` indexes the whole buffer. The tail hides entirely while the viewport is scrolled away
  from the cursor row, and re-reads on every `compositionupdate` so a viewport that moves
  mid-composition cannot leave a stale snapshot on screen.

Masking needs an opaque backdrop. A translucent `terminalBackgroundOpacity` theme is layered over
the first opaque surface behind it rather than swapped for one, so the mask matches the row it
replaces instead of dropping a black block onto a light theme.

## Screenshots

Captured from the packaged app driven through Playwright (`electron-headful`): type `가나다라마`,
walk the cursor back three syllables, then open a composition on `바`. Both frames are the same live
state — the "before" frame simply has the tail element suppressed, which is exactly the old
behavior.

**Before** — `다` is hidden under the preedit box for the whole composition:

<img width="2500" height="180" alt="before-tail-hidden-crop" src="https://github.com/user-attachments/assets/561e1c42-047b-4c0e-9437-e33a965a538e" />

```
p1318k@… orca-e2e-repo % 가 나 [바] 라 마
                                 ↑ 다 is gone
```

**After** — `다` is repainted just past the preedit, reading as an insertion pushing it right:

<img width="2500" height="180" alt="after-tail-visible-crop" src="https://github.com/user-attachments/assets/b94b4bd2-e862-452a-8b7e-a4882f96b815" />

```
p1318k@… orca-e2e-repo % 가 나 [바] 다 라 마
                                 ↑ 다 restored
```

The captured DOM state for the "after" frame: tail `textContent="다라마"`, `display=block`,
`left=440px`, against the preedit box at `left=424px` — the tail resumes exactly two cells (one
double-width syllable) past where the preedit starts.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 45,482 passing. 9 failures in 3 files (`check-root-directory-entries.test.mjs`,
      `codex-fetcher-pty-settle.test.ts`, `agent-exec-handler.test.ts`) reproduce identically on
      `origin/main` with none of this branch applied, so they are pre-existing and unrelated. The
      root-directory guard ones are a macOS-only artifact: the test shells out to `bash`, and the
      guard script uses `declare -A`, which macOS's bash 3.2 rejects.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`terminal-ime-composition-tail.test.ts` runs 20 cases against the real emulator: mid-line repaint,
end-of-row no-op, scrolled-buffer row read, viewport-scrolled-away hide, mid-composition viewport
move, cell-grid advance, preedit-end start column, first-composition placement, resize re-measure,
commit-echo re-read, composition-end cleanup, opaque / translucent / alpha-hex backdrops, and
listener + element teardown.

Every regression test was verified to fail against the pre-fix code before being kept.

Manually verified on macOS with the Korean 2-Set IME in the integrated terminal.

## AI Review Report

Reviewed with Claude Code across the risks below. CodeRabbit also reviewed the branch; all five of
its findings are fixed and confirmed resolved.

- **Cross-platform (macOS, Linux, Windows).** The change is renderer-only: it reads the xterm buffer
  and writes to a DOM element. No path handling, no shell invocation, no Electron main-process code,
  no keyboard shortcut or accelerator handling, and no `metaKey`/`ctrlKey` branching — so none of
  the usual platform divergences are touched. It hangs off the DOM `composition*` events, which
  behave the same on all three platforms. Manual verification is macOS-only (see Notes).
- **SSH / remote / local.** The tail operates on the emulator, not the transport: it reads
  `terminal.buffer.active` in the renderer and writes nothing to the pty. Local, remote and SSH
  panes take the identical path, and no round trip is added to composition handling. Installed in
  both pane lifecycle (`pane-lifecycle.ts`) and the dashboard popout preview
  (`preview-terminal-compatibility.ts`), with a disposer stored on the pane so `disposePane()` tears
  it down.
- **Agent / integration / git-provider.** Not touched — this is terminal rendering only.
- **Performance.** Per `compositionupdate`: one buffer line read plus up to `cols` span elements.
  Geometry comes from the cell grid measured at `compositionstart` and on `resize`, so no layout
  read was added per `compositionupdate` (keeping clear of #12211). Output-driven repaints from
  `onWriteParsed` are coalesced to one per animation frame. Cleanup covers the three composition
  listeners, the `onWriteParsed` and `onResize` disposables, a pending `requestAnimationFrame`, and
  the element itself.
- **UI quality.** The tail sits below the preedit box (`z-index: 0` against xterm's `1`) so a wide
  glyph never clips it, stops where the row's content stops rather than at the right margin, and
  clamps to the screen width. Backdrop resolution walks to the first opaque ancestor and layers a
  translucent theme over it, which was checked against both light and dark themes.

Flagged and changed as a result: `getLine(cursorY)` ignoring scrollback (repainted a stale row once
output scrolled), translucent CSS colors passing as opaque (`rgb(… / 50%)`, `hsla(…)`), fully
opaque alpha hex being rejected (`#ffff`, `#ffffffff`), and `compositionupdate` not resnapshotting
(left a stale tail after a viewport move). Each has a regression test.

## Security Audit

No input execution, path handling, IPC, auth, secrets, network access, or dependency changes.

- **Injection.** Repainted text is written with `textContent`, never `innerHTML`, so terminal output
  cannot inject markup.
- **CSS value interpolation.** The one interpolated value is the theme background, which reaches
  `style.backgroundImage` inside `linear-gradient(…)`. It can only get there after
  `isOpaqueColor()`, whose functional-color pattern is anchored and forbids nested parentheses, so
  the value cannot terminate the `linear-gradient()` early. `style.backgroundColor` drops invalid
  colors on its own. No injection path found. Malformed hex is now rejected outright rather than
  treated as opaque, since CSS would ignore it and leave the mask see-through.
- **Data exposure.** The overlay renders characters already present in the local terminal buffer,
  into the same window, for the duration of the composition. Nothing is persisted or transmitted.

No follow-up needed.

## Notes

- Per-cell colors are not carried into the overlay; the covered span renders in the theme's
  foreground/background for the duration of the composition.
- **Not manually verified on Linux or Windows.** The behavior is platform-neutral by construction
  (see above), but the IME stacks are not — `terminal-ime-e2e.yml` covers Linux X11 with
  `ibus-hangul` and would be the place to confirm it in CI.
- No CI has run on this PR: only `track-community-pr` executed, on the first commit. The remaining
  workflows appear to be waiting on maintainer approval for a fork PR.

