### PR TITLE
test(terminal): retain paired native IME trace

### DIFF
--- a/tests/e2e/terminal-codex-local-typing-latency.spec.ts
+++ b/tests/e2e/terminal-codex-local-typing-latency.spec.ts
@@ -399,7 +399,6 @@ test.describe('local Codex terminal typing latency', () => {
         `[codex-korean-ime] onData=${JSON.stringify(nativeTrace.onData.join(''))} ` +
           `screen=${JSON.stringify(nativeContent.slice(-500))}`
       )
-      await attachTerminalImeBoundaryEvidence(orcaPage, testInfo, 'native-macos-codex-korean')
       await testInfo.attach('native-macos-codex-korean.png', {
         body: await orcaPage.screenshot(),
         contentType: 'image/png'
@@ -420,6 +419,8 @@ test.describe('local Codex terminal typing latency', () => {
             .replaceAll('\n', '')
         )
         .toContain(`${committedKorean.trim()}abc`)
+
+      await attachTerminalImeBoundaryEvidence(orcaPage, testInfo, 'native-macos-codex-korean')
 
       expect(committedKorean).toBe(`${KOREAN_TUI_EXPECTED} `)
       expect(nativeContent).toContain(KOREAN_TUI_TEXT)


### PR DESCRIPTION
## Summary

- retain the ordinary `abc` control in the same native macOS Codex IME trace artifact
- keep the existing physical Korean full-screen regression and production path unchanged

## Why this is slim

This moves one existing evidence attachment by one statement. It adds no production class, state, timer, locale rule, buffer, tracker, or xterm behavior.

## Validation

- physical Apple 2-Set Korean in the real Codex full-screen composer: pass
- 70 compositions / 210 composition updates / five exact Korean phrase repetitions
- same mounted terminal ordinary `abc` negative: exact after the TUI key-release reports are stripped
- input source restored to ABC
- deleted candidate-anchor restoration mutation remains separately discriminating: Korean adds forced layout/buffer/style work while ordinary input stays exact

Evidence for #12211 / STA-3261.
