### PR TITLE
fix(mobile): open the host editor deterministically via a route action

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react-native'
 import type { RpcClient } from '../../../src/transport/rpc-client'
 import { loadHosts, updateLastConnected } from '../../../src/transport/host-store'
+import { hostRouteEditRedirect } from '../../../src/transport/host-edit-navigation'
 import { removeHostAndCloseClient } from '../../../src/transport/host-removal-lifecycle'
 import {
   useHostClient,
@@ -123,6 +124,19 @@ export function HostScreen({
   const router = useRouter()
   const pathname = usePathname()
   const insets = useSafeAreaInsets()
+  // Why: Edit host lands here with `action=edit` (see navigateToMobileHostEdit) —
+  // redirecting after mount is deterministic where a frame-timed replace from the
+  // home screen raced the nested stack commit. The embedded sidebar instance must
+  // not redirect too, or the routed screen and sidebar would both navigate.
+  useEffect(() => {
+    if (embedded) {
+      return
+    }
+    const redirect = hostRouteEditRedirect(action, hostId)
+    if (redirect) {
+      router.replace(redirect)
+    }
+  }, [embedded, action, hostId, router])
   // Why: cap and center the list on wide/tablet canvases; on phones isWideLayout is false so it stays edge-to-edge.
   const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
   const [initialCache] = useState(() =>

--- a/mobile/src/transport/host-edit-navigation.test.ts
+++ b/mobile/src/transport/host-edit-navigation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mobileHostEditRoute, navigateToMobileHostEdit } from './host-edit-navigation'
+import {
+  hostRouteEditRedirect,
+  mobileHostEditRoute,
+  navigateToMobileHostEdit
+} from './host-edit-navigation'
 
 describe('mobileHostEditRoute', () => {
   it('keeps the dynamic host segment explicit for a cold host navigator', () => {
@@ -8,22 +12,30 @@ describe('mobileHostEditRoute', () => {
       params: { hostId: 'host-1' }
     })
   })
+})
 
-  it('mounts a cold host navigator before replacing its index with edit', () => {
-    let nextFrame: FrameRequestCallback | null = null
+describe('navigateToMobileHostEdit', () => {
+  it('lands on the host index with an explicit edit action instead of a frame-timed replace', () => {
     const push = vi.fn()
     const replace = vi.fn()
-    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-      nextFrame = callback
-      return 1
-    })
 
     navigateToMobileHostEdit({ push, replace }, 'host-1')
-    expect(push).toHaveBeenCalledWith('/h/host-1')
-    expect(replace).not.toHaveBeenCalled()
 
-    nextFrame?.(0)
-    expect(replace).toHaveBeenCalledWith(mobileHostEditRoute('host-1'))
-    vi.unstubAllGlobals()
+    expect(push).toHaveBeenCalledWith('/h/host-1?action=edit')
+    expect(replace).not.toHaveBeenCalled()
+  })
+})
+
+describe('hostRouteEditRedirect', () => {
+  it('redirects the mounted index route to the edit screen', () => {
+    expect(hostRouteEditRedirect('edit', 'host-1')).toEqual(mobileHostEditRoute('host-1'))
+  })
+
+  it.each([
+    ['a different action', 'newWorktree', 'host-1'],
+    ['no action', undefined, 'host-1'],
+    ['a missing host id', 'edit', undefined]
+  ])('stays put for %s', (_label, action, hostId) => {
+    expect(hostRouteEditRedirect(action, hostId)).toBeNull()
   })
 })

--- a/mobile/src/transport/host-edit-navigation.ts
+++ b/mobile/src/transport/host-edit-navigation.ts
@@ -3,6 +3,8 @@ type HostEditRouter = {
   replace: (href: ReturnType<typeof mobileHostEditRoute>) => void
 }
 
+export const HOST_ROUTE_EDIT_ACTION = 'edit'
+
 export function mobileHostEditRoute(hostId: string) {
   return {
     pathname: '/h/[hostId]/edit' as const,
@@ -10,10 +12,21 @@ export function mobileHostEditRoute(hostId: string) {
   }
 }
 
+export function hostRouteEditRedirect(
+  routeAction: string | undefined,
+  hostId: string | undefined
+): ReturnType<typeof mobileHostEditRoute> | null {
+  if (routeAction !== HOST_ROUTE_EDIT_ACTION || !hostId) {
+    return null
+  }
+  return mobileHostEditRoute(hostId)
+}
+
 export function navigateToMobileHostEdit(router: HostEditRouter, hostId: string): void {
-  // Why: a cold nested host navigator resolves a deep push to its index route.
-  router.push(`/h/${hostId}`)
-  requestAnimationFrame(() => {
-    router.replace(mobileHostEditRoute(hostId))
-  })
+  // Why: a cold nested host navigator resolves a deep push to its index route,
+  // and a frame-timed replace could fire before that stack committed — the
+  // replace was then swallowed and the user stranded on the index screen.
+  // Land on the index route with an explicit action param instead and let the
+  // mounted screen redirect itself to the edit form (see HostScreen).
+  router.push(`/h/${hostId}?action=${HOST_ROUTE_EDIT_ACTION}`)
 }


### PR DESCRIPTION
## What this fixes

**Edit host** could still strand the user on the host worktree list screen instead of opening the edit form — the symptom #11635 addressed, still reproducible on `mobile-android-v0.0.37` (Galaxy Z Fold, cover display, 120Hz).

## Root cause

`navigateToMobileHostEdit` pushed the host index and scheduled the edit `replace` in a single `requestAnimationFrame`:

```ts
router.push(`/h/${hostId}`)
requestAnimationFrame(() => {
  router.replace(mobileHostEditRoute(hostId))
})
```

On a 120Hz display the rAF callback can fire ~8ms later — before the nested host stack commits — so the `replace` is swallowed and the user is left on an empty index screen. Reproduced consistently on device; the failure is timing-dependent, which is why it survives on some hardware and not others.

## The fix

Drop the frame-timed replace and reuse the existing route-action pattern (`action=newWorktree`): push `/h/{hostId}?action=edit` and let the mounted `HostScreen` redirect itself to the edit form. Mount-driven navigation is deterministic — no race with the navigator commit.

- `host-edit-navigation.ts`: `navigateToMobileHostEdit` now pushes the index route with `action=edit`; new pure helper `hostRouteEditRedirect` decides the redirect.
- `app/h/[hostId]/index.tsx`: redirects to the edit route after mount when `action=edit`. The `embedded` (tablet sidebar) instance does not redirect, so only the routed screen navigates.
- Tests updated: push carries the action param, no replace at call time; `hostRouteEditRedirect` covered for the edit action, other actions, and a missing host id.

## Validation

- `pnpm vitest run` — 403 files, 3015 tests passed
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- Back stack shape is unchanged (home → edit after the replace), matching the previous intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
