### PR TITLE
fix(gitlab): forward GITLAB_HOST to WSL-routed glab through WSLENV

### DIFF
--- a/src/main/git/runner-glab-ported-host-wsl.test.ts
+++ b/src/main/git/runner-glab-ported-host-wsl.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WslModule from '../wsl'
+
+const { execFileMock, execFileSyncMock, spawnMock, getDefaultWslDistroMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  spawnMock: vi.fn(),
+  getDefaultWslDistroMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
+  spawn: spawnMock
+}))
+
+vi.mock('../wsl', async (importOriginal) => ({
+  ...(await importOriginal<typeof WslModule>()),
+  getDefaultWslDistro: getDefaultWslDistroMock
+}))
+
+import { glabExecFileAsync, setDefaultWslDistroOverride } from './runner'
+
+const PORTED_HOST = 'gitlab.internal:8443'
+
+function execFileCall(index: number): {
+  binary: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+} {
+  const [binary, args, options] = execFileMock.mock.calls[index] as [
+    string,
+    string[],
+    { env?: NodeJS.ProcessEnv }
+  ]
+  return { binary, args, env: options.env ?? {} }
+}
+
+function wslEnvNames(env: NodeJS.ProcessEnv): string[] {
+  return (env.WSLENV ?? '').split(':').filter(Boolean)
+}
+
+function resolveOk(): void {
+  execFileMock.mockImplementation((_binary, _args, _options, callback) => {
+    callback(null, { stdout: '{}', stderr: '' })
+  })
+}
+
+// Why: `--hostname host:port` is stripped for glab, so if GITLAB_HOST does not
+// cross into the distro the call reaches WSL carrying no host at all.
+describe('glab ported-host forwarding into WSL', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    execFileMock.mockReset()
+    spawnMock.mockReset()
+    getDefaultWslDistroMock.mockReset()
+    getDefaultWslDistroMock.mockReturnValue(null)
+    setDefaultWslDistroOverride(null)
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  })
+
+  // Why: a local WSL workspace routes by distro on the first attempt — no
+  // host-missing fallback involved, so this path is not SSH-only.
+  it('forwards GITLAB_HOST to a distro-routed glab on the first attempt', async () => {
+    resolveOk()
+
+    await glabExecFileAsync(['api', '--hostname', PORTED_HOST, 'projects/g%2Fp/issues/9'], {
+      cwd: String.raw`C:\repo`,
+      wslDistro: 'Ubuntu'
+    })
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    const { binary, args, env } = execFileCall(0)
+    expect(binary).toBe('wsl.exe')
+    expect(args).not.toContain('--hostname')
+    expect(env.GITLAB_HOST).toBe(PORTED_HOST)
+    expect(wslEnvNames(env)).toContain('GITLAB_HOST')
+  })
+
+  it('forwards GITLAB_HOST when a UNC workspace cwd alone routes glab into WSL', async () => {
+    resolveOk()
+
+    await glabExecFileAsync(['api', '--hostname', PORTED_HOST, 'projects/g%2Fp/issues/9'], {
+      cwd: String.raw`\\wsl.localhost\Ubuntu\home\me\repo`
+    })
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    const { binary, env } = execFileCall(0)
+    expect(binary).toBe('wsl.exe')
+    expect(env.GITLAB_HOST).toBe(PORTED_HOST)
+    expect(wslEnvNames(env)).toContain('GITLAB_HOST')
+  })
+
+  it('forwards GITLAB_HOST through the default-distro fallback for cwd-less calls', async () => {
+    getDefaultWslDistroMock.mockReturnValue('Ubuntu')
+    execFileMock
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' }))
+      })
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(null, { stdout: '{}', stderr: '' })
+      })
+
+    await glabExecFileAsync(['api', '--hostname', PORTED_HOST, 'user'])
+
+    const { binary, args, env } = execFileCall(1)
+    expect(binary).toBe('wsl.exe')
+    expect(args).toEqual(['-d', 'Ubuntu', '--', 'bash', '-c', "'glab' 'api' 'user'"])
+    expect(env.GITLAB_HOST).toBe(PORTED_HOST)
+    expect(wslEnvNames(env)).toContain('GITLAB_HOST')
+  })
+
+  // Why: clobbering WSLENV would drop the git-auth entry the same spawn relies on.
+  it('keeps an existing WSLENV entry when adding GITLAB_HOST', async () => {
+    resolveOk()
+
+    await glabExecFileAsync(['auth', 'status', '--hostname', PORTED_HOST], {
+      cwd: String.raw`C:\repo`,
+      wslDistro: 'Ubuntu',
+      env: { WSLENV: 'GIT_SSH_COMMAND' }
+    })
+
+    const { env } = execFileCall(0)
+    expect(wslEnvNames(env)).toEqual(['GIT_SSH_COMMAND', 'GITLAB_HOST'])
+  })
+
+  it('leaves a port-less hostname on the command line', async () => {
+    resolveOk()
+
+    await glabExecFileAsync(['api', '--hostname', 'gitlab.internal', 'user'], {
+      cwd: String.raw`C:\repo`,
+      wslDistro: 'Ubuntu'
+    })
+
+    const { args, env } = execFileCall(0)
+    expect(args.at(-1)).toContain("'--hostname' 'gitlab.internal'")
+    expect(env.GITLAB_HOST).toBeUndefined()
+  })
+})

--- a/src/main/git/runner.test.ts
+++ b/src/main/git/runner.test.ts
@@ -55,6 +55,43 @@ describe('redirectPortedHostnameToEnv', () => {
     expect(options.env).toEqual({ A: '1' })
   })
 
+  // Why: wsl.exe only forwards variables named in WSLENV, so a WSL-routed glab
+  // never sees GITLAB_HOST unless it is listed there.
+  it('names GITLAB_HOST in WSLENV on Windows', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    const { options } = redirectPortedHostnameToEnv(
+      ['api', '--hostname', 'gitlab.internal:8443', 'user'],
+      { env: {} }
+    )
+
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.internal:8443')
+    expect(options.env?.WSLENV?.split(':')).toContain('GITLAB_HOST')
+  })
+
+  it('appends to an existing WSLENV instead of replacing it', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    const { options } = redirectPortedHostnameToEnv(
+      ['api', '--hostname', 'gitlab.internal:8443', 'user'],
+      { env: { WSLENV: 'GIT_SSH_COMMAND' } }
+    )
+
+    expect(options.env?.WSLENV?.split(':')).toEqual(['GIT_SSH_COMMAND', 'GITLAB_HOST'])
+  })
+
+  it('leaves WSLENV alone off Windows', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    const { options } = redirectPortedHostnameToEnv(
+      ['api', '--hostname', 'gitlab.internal:8443', 'user'],
+      { env: {} }
+    )
+
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.internal:8443')
+    expect(options.env?.WSLENV).toBeUndefined()
+  })
+
   it('preserves existing env entries alongside GITLAB_HOST', () => {
     const { options } = redirectPortedHostnameToEnv(
       ['auth', 'status', '--hostname', 'gl.example.org:3001'],

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1516,9 +1516,14 @@ export function redirectPortedHostnameToEnv(
   if (!/^[^/\s]+:\d+$/.test(host)) {
     return { args, options }
   }
+  const env: NodeJS.ProcessEnv = { ...(options.env ?? process.env), GITLAB_HOST: host }
+  if (process.platform === 'win32') {
+    // Why: spawn env stops at the wsl.exe boundary unless WSLENV names the var.
+    addWslEnvKeys(env, ['GITLAB_HOST'])
+  }
   return {
     args: [...args.slice(0, i), ...args.slice(i + 2)],
-    options: { ...options, env: { ...(options.env ?? process.env), GITLAB_HOST: host } }
+    options: { ...options, env }
   }
 }
 

--- a/src/main/gitlab/client.test.ts
+++ b/src/main/gitlab/client.test.ts
@@ -173,6 +173,34 @@ describe('gitlab client — viewer & paste-URL lookup', () => {
       )
     })
 
+    // Why: pins that a ported host reaches glab without a connectionId — the
+    // redirect into GITLAB_HOST is not an SSH-only path.
+    it('passes a ported self-hosted hostname through the local WSL lookup', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          id: 202,
+          iid: 9,
+          title: 'ported bug',
+          state: 'opened',
+          web_url: 'https://gitlab.internal:8443/g/p/-/issues/9'
+        })
+      })
+
+      await getWorkItemByProjectRef(
+        '/repo',
+        { host: 'gitlab.internal:8443', path: 'g/p' },
+        9,
+        'issue',
+        null,
+        { wslDistro: 'Ubuntu' }
+      )
+
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+        ['api', '--hostname', 'gitlab.internal:8443', 'projects/g%2Fp/issues/9'],
+        { cwd: '/repo', wslDistro: 'Ubuntu' }
+      )
+    })
+
     it('returns null when the API errors', async () => {
       glabExecFileAsyncMock.mockRejectedValueOnce(new Error('not found'))
       const item = await getWorkItemByProjectRef(


### PR DESCRIPTION
## Summary

Fixes #12557 — on Windows, a ported self-hosted GitLab host is moved into `GITLAB_HOST` but never reaches a WSL-routed `glab`, so the command runs against glab's default host instead of the workspace's instance.

`redirectPortedHostnameToEnv()` strips `--hostname host:port` (glab's flag rejects a port) and sets `GITLAB_HOST` on the spawn env. But `wsl.exe` forwards only variables named in `WSLENV`, so the Linux `glab` process starts without it — and since the flag was stripped at the same time, the call ends up carrying no host information at all.

`runner.ts` already documents this exact constraint for the locale (`"env on wsl.exe stays Windows-side (WSLENV forwards only named vars)"`, #7808) and already has the helper for it: `nonInteractiveGitEnv()` calls `addWslEnvKeys()` to forward `GIT_SSH_COMMAND` in three places. This applies the same treatment to `GITLAB_HOST`, guarded on `win32` so nothing changes elsewhere.

## Screenshots

No visual change — main-process process-spawn plumbing.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added `src/main/git/runner-glab-ported-host-wsl.test.ts` — five cases driving `glabExecFileAsync()` end to end against a mocked `child_process`, asserting the exact env handed to the `wsl.exe` spawn on all three routes into WSL (explicit distro override, UNC workspace cwd, cwd-less default-distro fallback), plus one case pinning that an existing `WSLENV` entry survives and one guarding the port-less branch this must not touch. Four of the five fail on an unmodified `main`.
- [x] Added 3 cases to `src/main/git/runner.test.ts` covering `redirectPortedHostnameToEnv()` in isolation: `GITLAB_HOST` named in `WSLENV`, an existing `WSLENV` extended rather than replaced, and non-Windows platforms left untouched.
- [x] Added 1 case to `src/main/gitlab/client.test.ts` pinning that a ported host reaches `glab` with a null `connectionId`.

Pre-existing failures on this machine, reproduced on an unmodified `main` and unrelated to this PR: `release-rc-history` and `publish-complete-draft-releases` (this machine has `tag.gpgsign` enabled globally), `plugin-install`, `updater`, `agent-exec-handler`, and `automation-schedules`.

## AI Review Report

Reviewed with Claude Code. Checks and findings:

- **Followed the repository's own precedent rather than inventing one.** `addWslEnvKeys()` is the established mechanism here; the change mirrors `nonInteractiveGitEnv()`'s `GIT_SSH_COMMAND` forwarding, including the `process.platform === 'win32'` guard so no other platform gains a `WSLENV` entry.
- **`WSLENV` is extended, not replaced.** `addWslEnvKeys()` appends and de-duplicates, so an existing `GIT_SSH_COMMAND` entry survives — asserted at both the unit and the spawn level, since clobbering it would break WSL git auth.
- **The fix sits at the entry point, so it covers every caller.** `redirectPortedHostnameToEnv()` runs at the top of `glabExecFileAsync()` and the env it returns is what reaches `execFileCapture()`, including on the retry that swaps in the default-distro fallback.
- **A review pass corrected this description.** An earlier revision claimed the bug required an SSH workspace; that was wrong and understated the blast radius. See Notes.
- **Scope kept to the ported branch.** Port-less hosts still leave `--hostname` on the command line, which an existing test (`"leaves a port-less --hostname untouched"`) pins as intentional; that path is untouched and now also guarded at the spawn level.
- **Cross-platform (macOS/Linux/Windows):** the new behaviour is behind a `win32` check and covered by a test that asserts `WSLENV` stays `undefined` on darwin. No shortcuts, labels, or path handling are involved.
- **SSH / remote / local:** all three reach this code, which is the correction above. SSH workspaces route through their own provider for git, but their `glab` calls still spawn Windows-side.
- **Git-provider compatibility:** GitLab-only by construction — `GITLAB_HOST` is glab's own variable, and the `gh` path is untouched.
- **Performance:** one string join per affected call, on a path that already spawns a process.

## Security Audit

`GITLAB_HOST` is a hostname resolved from the repository's own remote, not user free-text, and it was already being placed in the spawn environment before this change — the only difference is that `wsl.exe` is now told to forward it.

- **No secrets cross the boundary.** `WSLENV` names one variable; tokens continue to come from glab's own config or `GITLAB_TOKEN`/`GLAB_TOKEN`, which are untouched.
- **Additive, so no unrelated Windows-side value is exposed to the distro.** `addWslEnvKeys()` appends to any existing `WSLENV` and never rewrites other entries.
- **Marginally reduces exposure overall**, since the host stays out of the process argument list.

No new input parsing, command execution, path handling, auth, dependency, or IPC surface.

## Notes

**Not reproduced on a live Windows host — please weigh that when reviewing.** Reaching this needs three things at once:

1. **Windows.**
2. **A `glab` call that routes through WSL.** There are three such routes, and all three are covered by the new spawn-level tests: an explicit `wslDistro`, a workspace `cwd` under a `\\wsl.localhost\…` UNC path (both resolved by `resolveCommand()`), and the cwd-less default-distro fallback gated on `isHostCommandMissing(err, 'glab')`.
3. **A self-hosted instance on a non-default port.** `hostIdentityFromUrl()` keeps the URL port for http(s) remotes because that port is the API endpoint; port-less hosts deliberately keep `--hostname` on the command line and are unaffected.

**Correction to an earlier revision of this description.** It claimed a fourth condition — an SSH workspace — on the grounds that `--hostname` is only appended when `connectionId` is set, and concluded that "local and local-WSL workspaces never reach this path". That is wrong. `glabHostnameArgs()` is the only `--hostname` site gated on `connectionId`; three others are not:

- `isGlabConfiguredForRemoteHost()` → `glab auth status --hostname <host>`
- `getWorkItemByProjectRef()` (paste-URL lookup)
- `getRateLimit()`, which passes no `cwd` at all and so lands squarely on the default-distro fallback

The repo's own existing test, `"routes local WSL pasted-project lookup through glab execution options"` in `src/main/gitlab/client.test.ts`, already pins a `connectionId: null` WSL lookup emitting `--hostname`. A ported-host variant of it is added here. The practical effect of the correction: this is not a rare SSH-only edge case, and a local WSL workspace on a ported self-hosted instance hits it.

What is verified, absent a live repro: the variable was not named in `WSLENV`; `wsl.exe` forwards only named variables (this file's own comment for the locale case, #7808, plus the `GIT_SSH_COMMAND` precedent in the same file); and the new tests fail on an unmodified `main` and pass with the fix.
