### PR TITLE
fix(mobile): preserve transformed IME replacements

### DIFF
--- a/mobile/src/terminal/terminal-live-text-commit.test.ts
+++ b/mobile/src/terminal/terminal-live-text-commit.test.ts
@@ -25,6 +25,26 @@ describe('terminal live native replacement commits', () => {
     ).toEqual({ committedText: 'ab', payload: 'b' })
   })
 
+  it('replaces the full field when UIKit transforms the proposed input', () => {
+    expect(
+      deriveTerminalLiveCommit('ㅇ', {
+        text: '아',
+        replacementText: 'ㅏ',
+        replacementRange: { start: 1, end: 1 }
+      })
+    ).toEqual({ committedText: '아', payload: '\x7f아' })
+  })
+
+  it('emits nothing when a proposed transform leaves the field unchanged', () => {
+    expect(
+      deriveTerminalLiveCommit('a', {
+        text: 'a',
+        replacementText: '´',
+        replacementRange: { start: 1, end: 1 }
+      })
+    ).toEqual({ committedText: 'a', payload: '' })
+  })
+
   it('derives deletion from the native range and counts emoji as one terminal character', () => {
     expect(
       deriveTerminalLiveCommit('a😀', {
@@ -35,14 +55,21 @@ describe('terminal live native replacement commits', () => {
     ).toEqual({ committedText: 'a', payload: '\x7f' })
   })
 
-  it('emits nothing for the collapsed pre-delete cursor snapshot', () => {
+  it('uses the authoritative field text for a collapsed transformed deletion', () => {
     expect(
       deriveTerminalLiveCommit('a', {
         text: '',
         replacementText: '',
         replacementRange: { start: 1, end: 1 }
       })
-    ).toBeNull()
+    ).toEqual({ committedText: '', payload: '\x7f' })
+    expect(
+      deriveTerminalLiveCommit('😀', {
+        text: '',
+        replacementText: '',
+        replacementRange: { start: 2, end: 2 }
+      })
+    ).toEqual({ committedText: '', payload: '\x7f' })
   })
 
   it('emits nothing for a cancelled preedit or ambiguous non-suffix replacement', () => {

--- a/mobile/src/terminal/terminal-live-text-commit.ts
+++ b/mobile/src/terminal/terminal-live-text-commit.ts
@@ -41,17 +41,19 @@ export function deriveTerminalLiveCommit(
   ) {
     return null
   }
-
-  const retainedText = committedText.slice(0, start)
-  const nextCommittedText = retainedText + change.replacementText
-  if (change.text !== nextCommittedText) {
-    return null
+  if (change.text === committedText) {
+    return { committedText, payload: '' }
   }
 
-  const eraseCount = Array.from(committedText.slice(start)).length
+  const retainedText = committedText.slice(0, start)
+  const predictedText = retainedText + change.replacementText
+  const operationMatchesText = change.text === predictedText
+  const replacementStart = operationMatchesText ? start : 0
+
+  const eraseCount = Array.from(committedText.slice(replacementStart)).length
   return {
-    committedText: nextCommittedText,
-    payload: TERMINAL_DEL_BYTE.repeat(eraseCount) + change.replacementText
+    committedText: change.text,
+    payload: TERMINAL_DEL_BYTE.repeat(eraseCount) + change.text.slice(replacementStart)
   }
 }
 

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -102,6 +102,21 @@ const ORDINARY_ABC_TRACE: readonly RecordedChange[] = [
   { text: 'abc', isComposing: false, replacementText: 'c', start: 2, end: 2 }
 ]
 
+const RECORDED_IOS_KOREAN_TRANSFORM_TRACE: readonly RecordedChange[] = [
+  { text: 'ㅇ', isComposing: false, replacementText: 'ㅇ', start: 0, end: 0 },
+  { text: '아', isComposing: false, replacementText: 'ㅏ', start: 1, end: 1 },
+  { text: '안', isComposing: false, replacementText: 'ㄴ', start: 1, end: 1 },
+  { text: '안ㄴ', isComposing: false, replacementText: 'ㄴ', start: 1, end: 1 },
+  { text: '안녀', isComposing: false, replacementText: 'ㅕ', start: 2, end: 2 },
+  { text: '안녕', isComposing: false, replacementText: 'ㅇ', start: 2, end: 2 },
+  { text: '안녕ㅎ', isComposing: false, replacementText: 'ㅎ', start: 2, end: 2 },
+  { text: '안녕하', isComposing: false, replacementText: 'ㅏ', start: 3, end: 3 },
+  { text: '안녕핫', isComposing: false, replacementText: 'ㅅ', start: 3, end: 3 },
+  { text: '안녕하세', isComposing: false, replacementText: 'ㅔ', start: 3, end: 3 },
+  { text: '안녕하셍', isComposing: false, replacementText: 'ㅇ', start: 4, end: 4 },
+  { text: '안녕하세요', isComposing: false, replacementText: 'ㅛ', start: 4, end: 4 }
+]
+
 const RECORDED_ANDROID_GBOARD_BACKSPACE_TRACE: readonly RecordedChange[] = [
   { text: 'a', isComposing: false, replacementText: 'a', start: 0, end: 0 },
   { text: '', isComposing: false, replacementText: '', start: 0, end: 1 }
@@ -398,6 +413,25 @@ describe('terminal live input commit hook', () => {
     await vi.waitFor(() => expect(english.sent).toEqual(['a', 'b', 'c']))
   })
 
+  it('replays iOS Korean post-change transforms without normalizing text', async () => {
+    const korean = createHarness()
+    replay(korean.handlers, RECORDED_IOS_KOREAN_TRANSFORM_TRACE)
+    korean.handlers.handleLiveInputSubmit()
+
+    await vi.waitFor(() => expect(korean.sent.at(-1)).toBe('\r'))
+    const terminalText = korean.sent
+      .join('')
+      .split('')
+      .reduce((text, character) =>
+        character === '\x7f' ? Array.from(text).slice(0, -1).join('') : text + character
+      )
+    expect(terminalText).toBe('안녕하세요\r')
+
+    const english = createHarness()
+    replay(english.handlers, ORDINARY_ABC_TRACE)
+    await vi.waitFor(() => expect(english.sent).toEqual(['a', 'b', 'c']))
+  })
+
   it('emits nothing for the recorded Pinyin cancellation trace', () => {
     const { handlers, sent } = createHarness()
     const changes = [
@@ -429,13 +463,39 @@ describe('terminal live input commit hook', () => {
     expect(sent).toEqual([])
   })
 
-  it('emits nothing when native replacement evidence is absent', () => {
+  it('blocks sends when native replacement evidence is absent', async () => {
     const { handlers, sent } = createHarness()
     handlers.handleLiveInputChange({
       nativeEvent: {
         text: 'mutable snapshot'
       } as never
     })
+    handlers.handleLiveInputSubmit()
     expect(sent).toEqual([])
+    await expect(handlers.handleLiveInputAccessoryBytes({ bytes: '\r' })).resolves.toEqual({
+      kind: 'suppress-raw'
+    })
+  })
+
+  it('blocks an incomplete command until native evidence reconciles', async () => {
+    const { handlers, sent } = createHarness()
+    change(handlers, ORDINARY_ABC_TRACE[0])
+    change(handlers, {
+      text: 'ab',
+      isComposing: false,
+      replacementText: 'b',
+      start: -1,
+      end: 1
+    })
+
+    handlers.handleLiveInputSubmit()
+    await expect(handlers.handleLiveInputAccessoryBytes({ bytes: '\r' })).resolves.toEqual({
+      kind: 'suppress-raw'
+    })
+    expect(sent).toEqual(['a'])
+
+    change(handlers, ORDINARY_ABC_TRACE[1])
+    handlers.handleLiveInputSubmit()
+    await vi.waitFor(() => expect(sent).toEqual(['a', 'b', '\r']))
   })
 })

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -131,6 +131,7 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
         typeof nativeEvent.replacementText !== 'string' ||
         !nativeEvent.replacementRange
       ) {
+        isComposingRef.current = true
         return
       }
 
@@ -139,10 +140,11 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
         replacementText: nativeEvent.replacementText,
         replacementRange: nativeEvent.replacementRange
       })
-      isComposingRef.current = false
       if (!commit) {
+        isComposingRef.current = true
         return
       }
+      isComposingRef.current = false
       committedTextRef.current = commit.committedText
       if (commit.payload.length > 0) {
         void queueSend(activeHandle, commit.payload)


### PR DESCRIPTION
## Summary

- preserve authoritative iOS post-change text when UIKit transforms the proposed replacement outside its reported raw range
- fall back to one exact full-field replacement operation, without normalization, locale rules, or mutable-buffer diffing
- keep submit, accessory, and external sends blocked when native replacement evidence is structurally invalid

## Evidence

A native iOS 26.1 Korean 2-set trace for `안녕하세요` reports NFC field text with `isComposing:false`, while `replacementText` is compatibility jamo. For example, committed `ㅇ` is followed by authoritative `text:"아"`, proposed `replacementText:"ㅏ"`, range `[1,1]`. The prior strict operation check sends only the first `ㅇ` and drops the rest.

The recorded 12-event fixture now resolves to exact `안녕하세요\r`; ordinary `abc` remains incremental and unchanged. Structurally invalid evidence emits nothing and blocks Enter/accessory input until a valid event reconciles state.

## Validation

- focused mobile Vitest: 2 files / 21 tests
- mobile TypeScript
- scoped oxlint and oxfmt
- `git diff --check`

This PR is stacked on #12553 to keep the native-chat and mobile ownership reviews separate.