### PR TITLE
fix(pty): restore macOS TCC attribution persistence

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -244,7 +244,16 @@ async function main(): Promise<void> {
           onAuthenticatedClientPair: () => deathWatch.notifyClientActivity()
         }
       : {}),
-    spawnSubprocess: (opts) => createPtySubprocess(opts),
+    spawnSubprocess: (opts) =>
+      createPtySubprocess({
+        ...opts,
+        ...(process.platform === 'darwin'
+          ? {
+              onMacosTccSpawnStrategy: (strategy) =>
+                daemonLog.log('macos-tcc-pty-spawn', { strategy })
+            }
+          : {})
+      }),
     onIdleShutdown: () => {
       deathWatch?.stop()
       shuttingDown = true

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -167,6 +167,7 @@ describe('createPtySubprocess', () => {
   it('spawns node-pty with correct options', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
+    const onMacosTccSpawnStrategy = vi.fn()
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
 
@@ -176,7 +177,8 @@ describe('createPtySubprocess', () => {
         cols: 80,
         rows: 24,
         cwd: '/home/user',
-        env: { SHELL: '/bin/bash', FOO: 'bar' }
+        env: { SHELL: '/bin/bash', FOO: 'bar' },
+        onMacosTccSpawnStrategy
       })
     } finally {
       if (platform) {
@@ -194,6 +196,7 @@ describe('createPtySubprocess', () => {
         name: 'xterm-256color'
       })
     )
+    expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith('direct')
   })
 
   it('expands variables in PATH before spawning a Windows shell', () => {

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -199,6 +199,33 @@ describe('createPtySubprocess', () => {
     expect(onMacosTccSpawnStrategy).toHaveBeenCalledWith('direct')
   })
 
+  it('does not report a spawn strategy when node-pty fails before launch', () => {
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('spawn failed')
+    })
+    const onMacosTccSpawnStrategy = vi.fn()
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+
+    try {
+      expect(() =>
+        createPtySubprocess({
+          sessionId: 'test',
+          cols: 80,
+          rows: 24,
+          env: { SHELL: '/bin/bash' },
+          onMacosTccSpawnStrategy
+        })
+      ).toThrow('spawn failed')
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(onMacosTccSpawnStrategy).not.toHaveBeenCalled()
+  })
+
   it('expands variables in PATH before spawning a Windows shell', () => {
     spawnMock.mockReturnValue(mockPtyProcess())
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -553,8 +553,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
 } {
   const spawnAt = (shellPath: string, shellArgs: string[], cwd: string): pty.IPty => {
     const wrapped = wrapShellSpawnForMacosTccAttribution(shellPath, shellArgs, args.env)
-    args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
-    return pty.spawn(wrapped.file, wrapped.args, {
+    const proc = pty.spawn(wrapped.file, wrapped.args, {
       name: args.env.TERM ?? 'xterm-256color',
       cols: args.cols,
       rows: args.rows,
@@ -563,6 +562,8 @@ function spawnDaemonPtyWithWindowsFallback(args: {
       // Why: legacy system ConPTY can corrupt full-width TUI rows in scrollback; bundled ConPTY has the wrap-marker behavior xterm expects.
       ...(process.platform === 'win32' ? { useConptyDll: true } : {})
     })
+    args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
+    return proc
   }
 
   try {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -126,6 +126,7 @@ export type PtySubprocessOptions = {
   shellOverride?: string
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
+  onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
 }
 
 function deleteRequestedDaemonEnvKeys(
@@ -543,6 +544,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
   cols: number
   rows: number
   windowsFallbackAttempts: WindowsShellSpawnAttempt[]
+  onMacosTccSpawnStrategy?: PtySubprocessOptions['onMacosTccSpawnStrategy']
 }): {
   process: pty.IPty
   shellPath: string
@@ -551,6 +553,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
 } {
   const spawnAt = (shellPath: string, shellArgs: string[], cwd: string): pty.IPty => {
     const wrapped = wrapShellSpawnForMacosTccAttribution(shellPath, shellArgs, args.env)
+    args.onMacosTccSpawnStrategy?.(wrapped.file === shellPath ? 'direct' : 'wrapped')
     return pty.spawn(wrapped.file, wrapped.args, {
       name: args.env.TERM ?? 'xterm-256color',
       cols: args.cols,
@@ -837,7 +840,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       env,
       cols: size.cols,
       rows: size.rows,
-      windowsFallbackAttempts
+      windowsFallbackAttempts,
+      onMacosTccSpawnStrategy: opts.onMacosTccSpawnStrategy
     })
     proc = spawned.process
     // Why: a Windows fallback (e.g. cmd.exe) carries its own argv-embedded startup command; adopt the winning shell's identity + delivery flag.

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -11651,7 +11651,7 @@ describe('registerPtyHandlers', () => {
     }
   })
 
-  posixOnlyIt('wraps macOS spawns in login(1) with SHELL re-asserted via env(1)', async () => {
+  posixOnlyIt('wraps macOS spawns in login(1) with SHELL restored by the trampoline', async () => {
     const originalShell = process.env.SHELL
     // Re-enable the TCC login wrapper the suite-level beforeEach disables.
     delete process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
@@ -11675,8 +11675,14 @@ describe('registerPtyHandlers', () => {
       expect(args).toEqual([
         '-flpq',
         userInfo().username,
-        '/usr/bin/env',
-        'SHELL=/bin/zsh',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-p',
+        '-c',
+        'export SHELL="$1"; shift; exec -l -- "$@"',
+        'orca-tcc-login',
+        '/bin/zsh',
         '/bin/zsh',
         '-l'
       ])

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -157,11 +157,24 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
     existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue(dirStats(true))
     accessSyncMock.mockReturnValue(undefined)
-    // Emulate the real wrapper: prepend /usr/bin/login in front of the shell.
-    wrapSpawnMock.mockImplementation((file: string, args: string[]) => ({
-      file: '/usr/bin/login',
-      args: ['-flpq', 'ada', file, ...args]
-    }))
+    wrapSpawnMock.mockImplementation(
+      (file: string, args: string[], env: Record<string, string | undefined>) => ({
+        file: '/usr/bin/login',
+        args: [
+          '-flpq',
+          'ada',
+          '/bin/bash',
+          '--noprofile',
+          '--norc',
+          '-c',
+          'export SHELL="$1"; shift; exec -l "$@"',
+          'orca-tcc-login',
+          env.SHELL || file,
+          file,
+          ...args
+        ]
+      })
+    )
   })
 
   afterEach(() => {
@@ -187,7 +200,19 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
     expect(wrapSpawnMock).toHaveBeenCalledWith('/bin/zsh', ['-l'], expect.any(Object))
     expect(ptySpawn).toHaveBeenCalledWith(
       '/usr/bin/login',
-      ['-flpq', 'ada', '/bin/zsh', '-l'],
+      [
+        '-flpq',
+        'ada',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/bin/zsh',
+        '/bin/zsh',
+        '-l'
+      ],
       expect.objectContaining({ cwd: '/work', cols: 80, rows: 24 })
     )
     // The reported shellPath stays the real shell so identity/name logic is intact.
@@ -221,7 +246,19 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
     )
     expect(ptySpawn).toHaveBeenLastCalledWith(
       '/usr/bin/login',
-      ['-flpq', 'ada', '/bin/bash', '-l'],
+      [
+        '-flpq',
+        'ada',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/bin/bash',
+        '/bin/bash',
+        '-l'
+      ],
       expect.objectContaining({ cwd: '/work' })
     )
     expect(result.shellPath).toBe('/bin/bash')

--- a/src/main/providers/local-pty-utils.test.ts
+++ b/src/main/providers/local-pty-utils.test.ts
@@ -157,24 +157,10 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
     existsSyncMock.mockReturnValue(true)
     statSyncMock.mockReturnValue(dirStats(true))
     accessSyncMock.mockReturnValue(undefined)
-    wrapSpawnMock.mockImplementation(
-      (file: string, args: string[], env: Record<string, string | undefined>) => ({
-        file: '/usr/bin/login',
-        args: [
-          '-flpq',
-          'ada',
-          '/bin/bash',
-          '--noprofile',
-          '--norc',
-          '-c',
-          'export SHELL="$1"; shift; exec -l "$@"',
-          'orca-tcc-login',
-          env.SHELL || file,
-          file,
-          ...args
-        ]
-      })
-    )
+    wrapSpawnMock.mockImplementation((file: string, args: string[]) => ({
+      file: '/wrapped/login',
+      args: ['wrapped', file, ...args]
+    }))
   })
 
   afterEach(() => {
@@ -199,20 +185,8 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
 
     expect(wrapSpawnMock).toHaveBeenCalledWith('/bin/zsh', ['-l'], expect.any(Object))
     expect(ptySpawn).toHaveBeenCalledWith(
-      '/usr/bin/login',
-      [
-        '-flpq',
-        'ada',
-        '/bin/bash',
-        '--noprofile',
-        '--norc',
-        '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
-        'orca-tcc-login',
-        '/bin/zsh',
-        '/bin/zsh',
-        '-l'
-      ],
+      '/wrapped/login',
+      ['wrapped', '/bin/zsh', '-l'],
       expect.objectContaining({ cwd: '/work', cols: 80, rows: 24 })
     )
     // The reported shellPath stays the real shell so identity/name logic is intact.
@@ -245,20 +219,8 @@ describe('spawnShellWithFallback macOS TCC login wrapping', () => {
       expect.objectContaining({ SHELL: '/bin/bash' })
     )
     expect(ptySpawn).toHaveBeenLastCalledWith(
-      '/usr/bin/login',
-      [
-        '-flpq',
-        'ada',
-        '/bin/bash',
-        '--noprofile',
-        '--norc',
-        '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
-        'orca-tcc-login',
-        '/bin/bash',
-        '/bin/bash',
-        '-l'
-      ],
+      '/wrapped/login',
+      ['wrapped', '/bin/bash', '-l'],
       expect.objectContaining({ cwd: '/work' })
     )
     expect(result.shellPath).toBe('/bin/bash')

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -67,12 +67,24 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     vi.clearAllMocks()
   })
 
-  it('wraps the shell in /usr/bin/login on macOS, preserving the shell args behind it', async () => {
+  it('uses the exact positional login-shell trampoline argv on macOS', async () => {
     setPlatform('darwin')
     await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/usr/bin/login',
-      args: ['-flpq', 'ada', '/usr/bin/env', 'SHELL=/bin/zsh', '/bin/zsh', '-l']
+      args: [
+        '-flpq',
+        'ada',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/bin/zsh',
+        '/bin/zsh',
+        '-l'
+      ]
     })
     expect(execFileMock).toHaveBeenCalledWith(
       '/usr/bin/login',
@@ -328,7 +340,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(execFileMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps bash rcfile args intact after the shell path', async () => {
+  it('keeps custom shell arguments intact after the shell path', async () => {
     setPlatform('darwin')
     await prepareMacosTccLoginShell()
     expect(
@@ -338,8 +350,13 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
       args: [
         '-flpq',
         'ada',
-        '/usr/bin/env',
-        'SHELL=/bin/bash',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/bin/bash',
         '/bin/bash',
         '--rcfile',
         '/orca/bash/rcfile'
@@ -354,7 +371,19 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
       wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'], { SHELL: '/opt/homebrew/bin/fish' })
     ).toEqual({
       file: '/usr/bin/login',
-      args: ['-flpq', 'ada', '/usr/bin/env', 'SHELL=/opt/homebrew/bin/fish', '/bin/zsh', '-l']
+      args: [
+        '-flpq',
+        'ada',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/opt/homebrew/bin/fish',
+        '/bin/zsh',
+        '-l'
+      ]
     })
   })
 
@@ -363,28 +392,47 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'], { SHELL: '' })).toEqual({
       file: '/usr/bin/login',
-      args: ['-flpq', 'ada', '/usr/bin/env', 'SHELL=/bin/zsh', '/bin/zsh', '-l']
+      args: [
+        '-flpq',
+        'ada',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/bin/zsh',
+        '/bin/zsh',
+        '-l'
+      ]
     })
   })
 
-  it('skips the env(1) interposition when the shell path would parse as an assignment', async () => {
+  it('passes spaces and equals signs positionally without interpolation', async () => {
     setPlatform('darwin')
     await prepareMacosTccLoginShell()
-    expect(wrapShellSpawnForMacosTccAttribution('/odd=dir/zsh', ['-l'])).toEqual({
+    expect(
+      wrapShellSpawnForMacosTccAttribution(
+        '/Applications/Custom Shell/bin/fish=debug',
+        ['--init-command', 'set label=a b'],
+        { SHELL: '/Applications/Custom Shell/bin/fish=debug' }
+      )
+    ).toEqual({
       file: '/usr/bin/login',
-      args: ['-flpq', 'ada', '/odd=dir/zsh', '-l']
-    })
-  })
-
-  it('still wraps with login when /usr/bin/env is missing, without interposition', async () => {
-    setPlatform('darwin')
-    existsSyncMock.mockImplementation(
-      (path: string) => path === '/usr/bin/login' || path === '/usr/bin/printf'
-    )
-    await prepareMacosTccLoginShell()
-    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
-      file: '/usr/bin/login',
-      args: ['-flpq', 'ada', '/bin/zsh', '-l']
+      args: [
+        '-flpq',
+        'ada',
+        '/bin/bash',
+        '--noprofile',
+        '--norc',
+        '-c',
+        'export SHELL="$1"; shift; exec -l "$@"',
+        'orca-tcc-login',
+        '/Applications/Custom Shell/bin/fish=debug',
+        '/Applications/Custom Shell/bin/fish=debug',
+        '--init-command',
+        'set label=a b'
+      ]
     })
   })
 

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import type * as ChildProcess from 'node:child_process'
 import type * as LoginSessionPtyProbe from './macos-login-session-pty-probe'
 
 const { existsSyncMock, userInfoMock, execFileMock, stdinEndMock, ptyProbeMock } = vi.hoisted(
@@ -13,7 +15,10 @@ const { existsSyncMock, userInfoMock, execFileMock, stdinEndMock, ptyProbeMock }
 
 vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
 vi.mock('node:os', () => ({ userInfo: userInfoMock }))
-vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof ChildProcess>()),
+  execFile: execFileMock
+}))
 vi.mock('./macos-login-session-pty-probe', async (importOriginal) => ({
   ...(await importOriginal<typeof LoginSessionPtyProbe>()),
   runMacosLoginSessionPtyProbe: ptyProbeMock
@@ -29,6 +34,7 @@ import {
 type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void
 const ACCEPTED_OUTCOME = { ok: true, conclusive: true, reason: 'accepted' } as const
 const REJECTED_OUTCOME = { ok: false, conclusive: true, reason: 'rejected' } as const
+const itOnPosixHost = process.platform === 'win32' ? it.skip : it
 
 describe('wrapShellSpawnForMacosTccAttribution', () => {
   let origPlatform: PropertyDescriptor | undefined
@@ -78,8 +84,9 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '/bin/bash',
         '--noprofile',
         '--norc',
+        '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
+        'export SHELL="$1"; shift; exec -l -- "$@"',
         'orca-tcc-login',
         '/bin/zsh',
         '/bin/zsh',
@@ -340,7 +347,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(execFileMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps custom shell arguments intact after the shell path', async () => {
+  it('preserves the non-login Bash shell-ready rcfile launch', async () => {
     setPlatform('darwin')
     await prepareMacosTccLoginShell()
     expect(
@@ -353,8 +360,9 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '/bin/bash',
         '--noprofile',
         '--norc',
+        '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
+        'export SHELL="$1"; shift; exec -- "$@"',
         'orca-tcc-login',
         '/bin/bash',
         '/bin/bash',
@@ -377,8 +385,9 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '/bin/bash',
         '--noprofile',
         '--norc',
+        '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
+        'export SHELL="$1"; shift; exec -l -- "$@"',
         'orca-tcc-login',
         '/opt/homebrew/bin/fish',
         '/bin/zsh',
@@ -398,8 +407,9 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '/bin/bash',
         '--noprofile',
         '--norc',
+        '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
+        'export SHELL="$1"; shift; exec -l -- "$@"',
         'orca-tcc-login',
         '/bin/zsh',
         '/bin/zsh',
@@ -425,8 +435,9 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         '/bin/bash',
         '--noprofile',
         '--norc',
+        '-p',
         '-c',
-        'export SHELL="$1"; shift; exec -l "$@"',
+        'export SHELL="$1"; shift; exec -l -- "$@"',
         'orca-tcc-login',
         '/Applications/Custom Shell/bin/fish=debug',
         '/Applications/Custom Shell/bin/fish=debug',
@@ -434,6 +445,31 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
         'set label=a b'
       ]
     })
+  })
+
+  it('terminates exec option parsing before a dash-prefixed shell name', async () => {
+    setPlatform('darwin')
+    await prepareMacosTccLoginShell()
+    const wrapped = wrapShellSpawnForMacosTccAttribution('-custom-shell', ['-l'])
+
+    expect(wrapped.args).toContain('export SHELL="$1"; shift; exec -l -- "$@"')
+    expect(wrapped.args.slice(-2)).toEqual(['-custom-shell', '-l'])
+  })
+
+  itOnPosixHost('ignores inherited BASH_ENV before evaluating the trampoline', () => {
+    const result = spawnSync(
+      '/bin/bash',
+      ['--noprofile', '--norc', '-p', '-c', 'printf "TRAMPOLINE_OK\\n"'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, BASH_ENV: '/dev/stdin' },
+        input: 'printf "BASH_ENV_EXECUTED\\n"\n'
+      }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('TRAMPOLINE_OK\n')
+    expect(result.stderr).toBe('')
   })
 
   it('is a no-op on non-macOS platforms', () => {

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { userInfo } from 'node:os'
+import { basename } from 'node:path'
 import {
   classifyLoginPreflightError,
   runMacosLoginSessionPtyProbe,
@@ -12,7 +13,8 @@ export type { LoginPreflightOutcome } from './macos-login-session-pty-probe'
 const MACOS_LOGIN_PATH = '/usr/bin/login'
 const MACOS_BASH_PATH = '/bin/bash'
 const MACOS_PRINTF_PATH = '/usr/bin/printf'
-const LOGIN_SHELL_TRAMPOLINE = 'export SHELL="$1"; shift; exec -l "$@"'
+const LOGIN_SHELL_TRAMPOLINE = 'export SHELL="$1"; shift; exec -l -- "$@"'
+const DIRECT_SHELL_TRAMPOLINE = 'export SHELL="$1"; shift; exec -- "$@"'
 const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 // Why: the death-watch probe runs off the spawn path, so it can afford a bound
 // that outlasts a PAM stack answering slowly rather than misreading it as a hang.
@@ -310,8 +312,8 @@ export async function probeMacosLoginSessionAlive(
  * to Orca and never persists it (#6996, #8985).
  *
  * A clean bash trampoline restores SHELL after login(1) overwrites it, then replaces
- * itself with a login instance of the configured shell. Values stay positional so
- * custom paths and arguments are never interpreted as shell source.
+ * itself with the configured shell. Values stay positional so custom paths and
+ * arguments are never interpreted as shell source.
  *
  * No-op off macOS, when already wrapped, when disabled via {@link DISABLE_ENV_VAR},
  * or when the login(1) PAM preflight rejects this process's user.
@@ -347,7 +349,14 @@ export function wrapShellSpawnForMacosTccAttribution(
   }
 
   const shellEnvValue = env?.SHELL || file
+  // Why: Bash ignores --rcfile when argv[0] marks it as a login shell; Orca's
+  // rcfile already reproduces login startup and must remain the active wrapper.
+  const trampoline =
+    basename(file).toLowerCase() === 'bash' && args.includes('--rcfile')
+      ? DIRECT_SHELL_TRAMPOLINE
+      : LOGIN_SHELL_TRAMPOLINE
 
+  // Why: -p blocks login(1)-preserved BASH_ENV and imported functions before the fixed trampoline runs.
   return {
     file: MACOS_LOGIN_PATH,
     args: [
@@ -356,8 +365,9 @@ export function wrapShellSpawnForMacosTccAttribution(
       MACOS_BASH_PATH,
       '--noprofile',
       '--norc',
+      '-p',
       '-c',
-      LOGIN_SHELL_TRAMPOLINE,
+      trampoline,
       'orca-tcc-login',
       shellEnvValue,
       file,

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -10,8 +10,9 @@ import {
 export type { LoginPreflightOutcome } from './macos-login-session-pty-probe'
 
 const MACOS_LOGIN_PATH = '/usr/bin/login'
-const MACOS_ENV_PATH = '/usr/bin/env'
+const MACOS_BASH_PATH = '/bin/bash'
 const MACOS_PRINTF_PATH = '/usr/bin/printf'
+const LOGIN_SHELL_TRAMPOLINE = 'export SHELL="$1"; shift; exec -l "$@"'
 const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 // Why: the death-watch probe runs off the spawn path, so it can afford a bound
 // that outlasts a PAM stack answering slowly rather than misreading it as a hang.
@@ -306,11 +307,11 @@ export async function probeMacosLoginSessionAlive(
  * Wrap a macOS shell spawn in `/usr/bin/login -flpq <user> …` so terminal children
  * get their own TCC identity instead of collapsing into Orca's bundle id — signed
  * CLIs like `op` otherwise re-prompt every launch because tccd attributes the grant
- * to Orca and never persists it (#6996). This mirrors how Terminal.app spawns shells.
+ * to Orca and never persists it (#6996, #8985).
  *
- * Why the env(1) interposition: login(1) overwrites SHELL from the account DB even
- * under -p, so `/usr/bin/env SHELL=<shell>` re-asserts the shell Orca actually runs
- * without disturbing login's attribution (skipped when the shell path contains `=`).
+ * A clean bash trampoline restores SHELL after login(1) overwrites it, then replaces
+ * itself with a login instance of the configured shell. Values stay positional so
+ * custom paths and arguments are never interpreted as shell source.
  *
  * No-op off macOS, when already wrapped, when disabled via {@link DISABLE_ENV_VAR},
  * or when the login(1) PAM preflight rejects this process's user.
@@ -346,13 +347,21 @@ export function wrapShellSpawnForMacosTccAttribution(
   }
 
   const shellEnvValue = env?.SHELL || file
-  const interposedShellEnv =
-    !file.includes('=') && existsSync(MACOS_ENV_PATH)
-      ? [MACOS_ENV_PATH, `SHELL=${shellEnvValue}`]
-      : []
 
   return {
     file: MACOS_LOGIN_PATH,
-    args: ['-flpq', username, ...interposedShellEnv, file, ...args]
+    args: [
+      '-flpq',
+      username,
+      MACOS_BASH_PATH,
+      '--noprofile',
+      '--norc',
+      '-c',
+      LOGIN_SHELL_TRAMPOLINE,
+      'orca-tcc-login',
+      shellEnvValue,
+      file,
+      ...args
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Replace the macOS `login -> env -> shell` chain with a clean Bash trampoline that `exec -l`s the configured shell, matching the working Ghostty launch shape.
- Pass `SHELL`, shell paths, and all shell arguments positionally without interpolation.
- Preserve custom and fallback shells, cwd, login semantics, disabled/non-macOS behavior, and preflight degradation.
- Record a value-free `macos-tcc-pty-spawn` daemon event with `wrapped` or `direct` strategy for live diagnosis.

Fixes #8985.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint not run; focused oxlint passed with denied warnings.
- [ ] `pnpm typecheck` — full typecheck not run; `pnpm run typecheck:node` passed.
- [ ] `pnpm test` — full suite not run; focused Vitest passed: 3 files, 160 tests.
- [ ] `pnpm build` — full production build not run; isolated development Electron build launched successfully.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused tests cover exact argv, custom/fallback shells, spaces, equals signs, disabled and non-macOS paths, preflight degradation, and spawn-strategy reporting.

Live macOS verification on the affected host:

1. The isolated dev daemon recorded `macos-tcc-pty-spawn` with `strategy=wrapped`.
2. The PTY process chain was `login -> bash --noprofile --norc -> exec -l zsh`; `SHELL`, cwd, and login argv were preserved.
3. The first `op vault list` invocation prompted once and exited 0 after approval.
4. A second invocation in the same PTY and a third invocation in a new PTY both exited 0 without another `AUTHREQ_PROMPTING` event.
5. `tccd` returned an allowed persisted decision for both later processes.

## AI Review Report

Reviewed every local user-terminal node-pty route: daemon primary, local primary, and Unix fallback. All continue through the centralized macOS wrapper after shell fallback resolution. Checked preflight fail-open behavior, positional argument safety, login-shell semantics, and daemon diagnostic privacy.

Cross-platform review confirmed that the wrapper and diagnostic wiring are macOS-gated; Linux and Windows retain direct spawning. No keyboard, UI label, provider, SSH, folder-workspace, path-separator, or Electron menu behavior changed.

## Security Audit

- Shell paths, `SHELL`, and arguments are positional parameters; no user-controlled value is interpolated into Bash source.
- The fixed trampoline is constant and uses `exec -l "$@"`.
- The diagnostic records only `wrapped` or `direct`; it does not log usernames, shell paths, cwd, environment values, arguments, or terminal contents.
- No dependencies, authentication flows, secrets, IPC schemas, or network behavior changed.

## Notes

The behavior is macOS-specific. The live gate used the isolated `com.stablyai.orca.dev` build and verified persistence across both a new `op` process and a new PTY on macOS 26.5.1 with 1Password CLI 2.38.1.