### PR TITLE
Center mobile native chat checkmarks

### DIFF
--- a/mobile/src/session/MobileNativeChatAsk.tsx
+++ b/mobile/src/session/MobileNativeChatAsk.tsx
@@ -282,6 +282,7 @@ const styles = StyleSheet.create({
   },
   option: {
     flexDirection: 'row',
+    alignItems: 'center',
     gap: spacing.sm,
     padding: spacing.sm,
     borderRadius: radii.card,
@@ -299,8 +300,7 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderColor: colors.textMuted,
     alignItems: 'center',
-    justifyContent: 'center',
-    marginTop: 1
+    justifyContent: 'center'
   },
   checkCircle: {
     borderRadius: 9


### PR DESCRIPTION
## Summary

- Vertically center the mobile native-chat option check/radio control against the full option content.
- Remove the previous one-pixel top offset so one-line and multi-line options share the same alignment.

## Screenshots

![Mobile native-chat options with vertically centered selection controls](https://github.com/user-attachments/assets/ae00eef6-e5ca-4647-8f4f-def606907f3c)

## Testing

- [x] `pnpm lint` (mobile workspace)
- [x] `pnpm typecheck` (mobile workspace)
- [ ] `pnpm test` — not run; this is a React Native layout-only change with no behavior change
- [ ] `pnpm build` — not run; the changed bundle was rendered in the iOS emulator
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed — pixel alignment was validated in the Orca iOS emulator for selected, unselected, one-line, and two-line options

## AI Review Report

Reviewed the focused style diff for selection-state consistency, single- and multi-line layout, and unintended spacing changes. The selected and unselected states were exercised in the Orca iPhone emulator; no issues remained after removing the old top offset.

Cross-platform compatibility was explicitly checked. The change uses React Native's platform-neutral flexbox alignment and does not touch shortcuts, labels, paths, shell behavior, Git behavior, SSH/folder workspaces, or Electron-specific code on macOS, Linux, or Windows.

## Security Audit

Styling-only change. It does not affect input handling, command execution, paths, authentication, secrets, dependencies, IPC, storage, or network behavior.

## Notes

- Visual-only mobile native-chat adjustment; no desktop behavior changes.
