### PR TITLE
feat(sidebar): add Group by Issue workspace organization

### DIFF
--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -757,7 +757,8 @@ function normalizeGroupBy(groupBy: unknown): PersistedState['ui']['groupBy'] {
     groupBy === 'none' ||
     groupBy === 'workspace-status' ||
     groupBy === 'repo' ||
-    groupBy === 'pr-status'
+    groupBy === 'pr-status' ||
+    groupBy === 'issue'
   ) {
     return groupBy
   }

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -202,7 +202,7 @@ const UiUpdateFields = z
     rightSidebarWidth: z.number().finite().optional(),
     markdownTocPanelWidth: z.number().finite().optional(),
     combinedDiffFileTreeWidth: z.number().finite().optional(),
-    groupBy: z.enum(['none', 'workspace-status', 'repo', 'pr-status']).optional(),
+    groupBy: z.enum(['none', 'workspace-status', 'repo', 'pr-status', 'issue']).optional(),
     showWorkspaceLineage: z.boolean().optional(),
     sortBy: z.enum(['name', 'smart', 'recent', 'repo', 'manual']).optional(),
     projectOrderBy: z.enum(['manual', 'recent']).optional(),

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -253,6 +253,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const settings = useAppStore((s) => s.settings)
   const fetchIssue = useAppStore((s) => s.fetchIssue)
   const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
+  const groupBy = useAppStore((s) => s.groupBy)
   const cardProps = useAppStore((s) => s.worktreeCardProperties)
   const agentActivityDisplayMode =
     useAppStore((s) => s.agentActivityDisplayMode) ?? DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
@@ -761,7 +762,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       isFolder ||
       !worktree.linkedIssue ||
       !issueCacheKey ||
-      !showIssue
+      (!showIssue && groupBy !== 'issue')
     ) {
       return
     }
@@ -773,7 +774,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       run: () => void fetchIssue(repo.path, issueNumber, { repoId: repo.id }),
       intervalMs: 5 * 60_000
     })
-  }, [repo, isFolder, worktree.linkedIssue, fetchIssue, issueCacheKey, showIssue])
+  }, [repo, isFolder, worktree.linkedIssue, fetchIssue, issueCacheKey, showIssue, groupBy])
 
   useEffect(() => {
     if (

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5300,6 +5300,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const { prCache, hostedReviewCache } = useAppStore(
     useShallow((s) => selectWorktreeListReviewCacheInputs(s, groupBy, cardProps))
   )
+  const issueCache = useAppStore((s) => (groupBy === 'issue' ? s.issueCache : null))
   const settings = useAppStore((s) => s.settings)
   const pinnedDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
@@ -5745,13 +5746,15 @@ const WorktreeList = React.memo(function WorktreeList({
         visibleFolderWorkspacesForRows,
         hostLabelById,
         defaultHostId,
-        pinnedDisplayPolicy
+        pinnedDisplayPolicy,
+        issueCache
       ),
     [
       groupBy,
       worktrees,
       repoMap,
       prCache,
+      issueCache,
       effectiveCollapsedGroups,
       defaultHostId,
       repoOrder,

--- a/src/renderer/src/components/sidebar/project-order-manual-default-notice-visibility.ts
+++ b/src/renderer/src/components/sidebar/project-order-manual-default-notice-visibility.ts
@@ -1,7 +1,7 @@
 export function shouldShowProjectOrderManualDefaultNotice(args: {
   persistedUIReady: boolean
   projectOrderManualDefaultNoticeDismissed: boolean
-  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'issue'
   projectOrderBy: 'manual' | 'recent'
   repoCount: number
 }): boolean {

--- a/src/renderer/src/components/sidebar/sidebar-workspace-option-items.ts
+++ b/src/renderer/src/components/sidebar/sidebar-workspace-option-items.ts
@@ -22,6 +22,12 @@ export const GROUP_BY_OPTIONS = [
     }
   },
   {
+    id: 'issue',
+    get label() {
+      return translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.issue', 'Issue')
+    }
+  },
+  {
     id: 'repo',
     get label() {
       return translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.2170d553cf', 'Project')

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -4152,7 +4152,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:ORCA-5199',
+        key: 'issue:jira:repo-1:ORCA-5199',
         label: 'ORCA-5199: Custom Groups Feature'
       })
     })
@@ -4170,7 +4170,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:ENG-123',
+        key: 'issue:linear:repo-1:ENG-123',
         label: 'ENG-123: Fix issue grouping'
       })
     })
@@ -4199,7 +4199,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt, issueCache, repos)).toEqual({
-        key: 'issue:#5199',
+        key: 'issue:github:repo-1:#5199',
         label: '#5199: Custom Groups Feature'
       })
     })
@@ -4210,7 +4210,7 @@ describe('buildRows pending creations', () => {
         linkedLinearIssue: 'STA-335'
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:STA-335',
+        key: 'issue:issue:STA-335',
         label: 'STA-335'
       })
     })
@@ -4227,7 +4227,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:#42',
+        key: 'issue:github:repo-1:#42',
         label: '#42: Implement custom grouping'
       })
     })
@@ -4244,7 +4244,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:#99',
+        key: 'issue:gitlab:repo-1:#99',
         label: '#99: Pipeline reliability fix'
       })
     })
@@ -4255,7 +4255,7 @@ describe('buildRows pending creations', () => {
         linkedGitLabIssue: 88
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:#88',
+        key: 'issue:gitlab:repo-1:#88',
         label: 'Issue #88'
       })
     })
@@ -4273,7 +4273,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:MSYP-683',
+        key: 'issue:jira:repo-1:MSYP-683',
         label: 'MSYP-683: Integratie Productbeoordeling'
       })
     })
@@ -4290,7 +4290,7 @@ describe('buildRows pending creations', () => {
         }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:#5199',
+        key: 'issue:github:repo-1:#5199',
         label: '#5199: Custom Groups Support'
       })
     })
@@ -4302,6 +4302,37 @@ describe('buildRows pending creations', () => {
         branch: 'feat/issue-5199-custom-groups'
       }
       expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:none',
+        label: 'No issue'
+      })
+    })
+
+    it('ignores linkedWorkItem with type pr or mr for issue grouping', () => {
+      const wtPR: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://github.com/org/repo/pull/123',
+          title: 'Fix issue grouping PR',
+          number: 123,
+          provider: 'github',
+          type: 'pr'
+        }
+      }
+      const wtMR: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://gitlab.com/org/repo/-/merge_requests/456',
+          title: 'Fix issue grouping MR',
+          number: 456,
+          provider: 'gitlab',
+          type: 'mr'
+        }
+      }
+      expect(getIssueGroupInfo(wtPR)).toEqual({
+        key: 'issue:none',
+        label: 'No issue'
+      })
+      expect(getIssueGroupInfo(wtMR)).toEqual({
         key: 'issue:none',
         label: 'No issue'
       })
@@ -4349,9 +4380,14 @@ describe('buildRows pending creations', () => {
       const rows = buildRows('issue', [wtNoIssue, wtJira, wtLinear], repoMap, null, new Set())
 
       expect(rows).toMatchObject([
-        { type: 'header', key: 'issue:ABC-10', label: 'ABC-10', count: 1 },
+        { type: 'header', key: 'issue:issue:ABC-10', label: 'ABC-10', count: 1 },
         { type: 'item', worktree: { id: 'wt-linear' } },
-        { type: 'header', key: 'issue:ORCA-5199', label: 'ORCA-5199: Custom Groups', count: 1 },
+        {
+          type: 'header',
+          key: 'issue:jira:repo-1:ORCA-5199',
+          label: 'ORCA-5199: Custom Groups',
+          count: 1
+        },
         { type: 'item', worktree: { id: 'wt-jira' } },
         { type: 'header', key: 'issue:none', label: 'No issue', count: 1 },
         { type: 'item', worktree: { id: 'wt-none' } }
@@ -4363,7 +4399,7 @@ describe('buildRows pending creations', () => {
         ...worktree,
         linkedLinearIssue: 'STA-335'
       }
-      expect(getGroupKeyForWorktree('issue', wt, repoMap, null)).toBe('issue:STA-335')
+      expect(getGroupKeyForWorktree('issue', wt, repoMap, null)).toBe('issue:issue:STA-335')
     })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -4295,27 +4295,15 @@ describe('buildRows pending creations', () => {
       })
     })
 
-    it('converts issue-5199 branch pattern to numeric issue #5199', () => {
+    it('falls back to No issue when worktree has no explicitly linked issue, ignoring branch name text', () => {
       const wt: Worktree = {
         ...worktree,
         displayName: 'feat/issue-5199-custom-groups',
         branch: 'feat/issue-5199-custom-groups'
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:#5199',
-        label: '#5199'
-      })
-    })
-
-    it('extracts issue key from branch name when no linked issue', () => {
-      const wt: Worktree = {
-        ...worktree,
-        displayName: 'feature/PROJ-456-something',
-        branch: 'feature/PROJ-456-something'
-      }
-      expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:PROJ-456',
-        label: 'PROJ-456'
+        key: 'issue:none',
+        label: 'No issue'
       })
     })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -16,6 +16,7 @@ import {
   PINNED_GROUP_KEY,
   type PendingCreationRef
 } from './worktree-list-groups'
+import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
 import {
   REPO_HEADER_ACTION_BUTTON_CLASS,
   REPO_HEADER_ACTION_REVEAL_CLASS
@@ -4171,6 +4172,27 @@ describe('buildRows pending creations', () => {
       expect(getIssueGroupInfo(wt)).toEqual({
         key: 'issue:ENG-123',
         label: 'ENG-123: Fix issue grouping'
+      })
+    })
+
+    it('correctly extracts issue group info from linkedIssue number with issueCache title lookup', () => {
+      const wt: Worktree = {
+        ...worktree,
+        repoId: 'repo-1',
+        linkedIssue: 5199
+      }
+      const repos = new Map<string, Repo>([
+        ['repo-1', { id: 'repo-1', path: '/path/to/repo' } as Repo]
+      ])
+      const issueKey = getIssueCacheKey('/path/to/repo', 'repo-1', 5199)
+      const issueCache = {
+        [issueKey]: {
+          data: { title: 'Custom Groups Feature' }
+        }
+      }
+      expect(getIssueGroupInfo(wt, issueCache, repos)).toEqual({
+        key: 'issue:#5199',
+        label: '#5199: Custom Groups Feature'
       })
     })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -9,6 +9,7 @@ import {
   buildRows,
   getGroupKeyForWorktree,
   getGroupKeysForWorktree,
+  getIssueGroupInfo,
   getLineageGroupKey,
   getLineageRenderInfo,
   getPRGroupKey,
@@ -4134,5 +4135,125 @@ describe('buildRows pending creations', () => {
     )
 
     expect(rows[0]).toMatchObject({ type: 'pending-creation', creationId: 'c1' })
+  })
+
+  describe('issue grouping mode', () => {
+    it('correctly extracts issue group info from Jira linkedWorkItem', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://jira.example.com/browse/ORCA-5199',
+          title: 'Custom Groups Feature',
+          number: 5199,
+          provider: 'jira',
+          jiraIdentifier: 'ORCA-5199',
+          type: 'issue'
+        }
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:ORCA-5199',
+        label: 'ORCA-5199: Custom Groups Feature'
+      })
+    })
+
+    it('correctly extracts issue group info from Linear linkedWorkItem', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://linear.app/org/issue/ENG-123',
+          title: 'Fix issue grouping',
+          number: 123,
+          provider: 'linear',
+          linearIdentifier: 'ENG-123',
+          type: 'issue'
+        }
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:ENG-123',
+        label: 'ENG-123: Fix issue grouping'
+      })
+    })
+
+    it('correctly extracts issue group info from linkedLinearIssue string', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedLinearIssue: 'STA-335'
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:STA-335',
+        label: 'STA-335'
+      })
+    })
+
+    it('extracts issue key from branch name when no linked issue', () => {
+      const wt: Worktree = {
+        ...worktree,
+        displayName: 'feature/PROJ-456-something',
+        branch: 'feature/PROJ-456-something'
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:PROJ-456',
+        label: 'PROJ-456'
+      })
+    })
+
+    it('falls back to No issue when no issue info present', () => {
+      const wt: Worktree = {
+        ...worktree,
+        displayName: 'main-branch',
+        branch: 'main'
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:none',
+        label: 'No issue'
+      })
+    })
+
+    it('builds rows grouped by issue with issue:none placed last', () => {
+      const wtJira: Worktree = {
+        ...worktree,
+        id: 'wt-jira',
+        displayName: 'wt-jira',
+        linkedWorkItem: {
+          url: 'https://jira.example.com/browse/ORCA-5199',
+          title: 'Custom Groups',
+          number: 5199,
+          provider: 'jira',
+          jiraIdentifier: 'ORCA-5199',
+          type: 'issue'
+        }
+      }
+      const wtLinear: Worktree = {
+        ...worktree,
+        id: 'wt-linear',
+        displayName: 'wt-linear',
+        linkedLinearIssue: 'ABC-10'
+      }
+      const wtNoIssue: Worktree = {
+        ...worktree,
+        id: 'wt-none',
+        displayName: 'wt-none',
+        branch: 'main'
+      }
+
+      const rows = buildRows('issue', [wtNoIssue, wtJira, wtLinear], repoMap, null, new Set())
+
+      expect(rows).toMatchObject([
+        { type: 'header', key: 'issue:ABC-10', label: 'ABC-10', count: 1 },
+        { type: 'item', worktree: { id: 'wt-linear' } },
+        { type: 'header', key: 'issue:ORCA-5199', label: 'ORCA-5199: Custom Groups', count: 1 },
+        { type: 'item', worktree: { id: 'wt-jira' } },
+        { type: 'header', key: 'issue:none', label: 'No issue', count: 1 },
+        { type: 'item', worktree: { id: 'wt-none' } }
+      ])
+    })
+
+    it('returns issue group key from getGroupKeyForWorktree', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedLinearIssue: 'STA-335'
+      }
+      expect(getGroupKeyForWorktree('issue', wt, repoMap, null)).toBe('issue:STA-335')
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -4215,15 +4215,83 @@ describe('buildRows pending creations', () => {
       })
     })
 
-    it('extracts issue key from branch name when no linked issue', () => {
+    it('correctly extracts issue group info from GitHub linkedWorkItem', () => {
       const wt: Worktree = {
         ...worktree,
-        displayName: 'feature/PROJ-456-something',
-        branch: 'feature/PROJ-456-something'
+        linkedWorkItem: {
+          url: 'https://github.com/org/repo/issues/42',
+          title: 'Implement custom grouping',
+          number: 42,
+          provider: 'github',
+          type: 'issue'
+        }
       }
       expect(getIssueGroupInfo(wt)).toEqual({
-        key: 'issue:PROJ-456',
-        label: 'PROJ-456'
+        key: 'issue:#42',
+        label: '#42: Implement custom grouping'
+      })
+    })
+
+    it('correctly extracts issue group info from GitLab linkedWorkItem', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://gitlab.com/org/repo/-/issues/99',
+          title: 'Pipeline reliability fix',
+          number: 99,
+          provider: 'gitlab',
+          type: 'issue'
+        }
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:#99',
+        label: '#99: Pipeline reliability fix'
+      })
+    })
+
+    it('correctly extracts issue group info from linkedGitLabIssue number without linkedWorkItem', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedGitLabIssue: 88
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:#88',
+        label: 'Issue #88'
+      })
+    })
+
+    it('strips redundant issue key prefixes from Jira titles', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://jira.example.com/browse/MSYP-683',
+          title: 'MSYP-683: Integratie Productbeoordeling',
+          number: 683,
+          provider: 'jira',
+          jiraIdentifier: 'MSYP-683',
+          type: 'issue'
+        }
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:MSYP-683',
+        label: 'MSYP-683: Integratie Productbeoordeling'
+      })
+    })
+
+    it('strips redundant numeric prefixes from GitHub titles', () => {
+      const wt: Worktree = {
+        ...worktree,
+        linkedWorkItem: {
+          url: 'https://github.com/org/repo/issues/5199',
+          title: '#5199: Custom Groups Support',
+          number: 5199,
+          provider: 'github',
+          type: 'issue'
+        }
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:#5199',
+        label: '#5199: Custom Groups Support'
       })
     })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -4184,7 +4184,15 @@ describe('buildRows pending creations', () => {
       const repos = new Map<string, Repo>([
         ['repo-1', { id: 'repo-1', path: '/path/to/repo' } as Repo]
       ])
-      const issueKey = getIssueCacheKey('/path/to/repo', 'repo-1', 5199)
+      const issueKey = getIssueCacheKey(
+        '/path/to/repo',
+        'repo-1',
+        5199,
+        undefined,
+        null,
+        null,
+        true
+      )
       const issueCache = {
         [issueKey]: {
           data: { title: 'Custom Groups Feature' }

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -4295,6 +4295,30 @@ describe('buildRows pending creations', () => {
       })
     })
 
+    it('converts issue-5199 branch pattern to numeric issue #5199', () => {
+      const wt: Worktree = {
+        ...worktree,
+        displayName: 'feat/issue-5199-custom-groups',
+        branch: 'feat/issue-5199-custom-groups'
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:#5199',
+        label: '#5199'
+      })
+    })
+
+    it('extracts issue key from branch name when no linked issue', () => {
+      const wt: Worktree = {
+        ...worktree,
+        displayName: 'feature/PROJ-456-something',
+        branch: 'feature/PROJ-456-something'
+      }
+      expect(getIssueGroupInfo(wt)).toEqual({
+        key: 'issue:PROJ-456',
+        label: 'PROJ-456'
+      })
+    })
+
     it('falls back to No issue when no issue info present', () => {
       const wt: Worktree = {
         ...worktree,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: sidebar row construction keeps every grouping mode in one pure module so reveal, virtualized rendering, and tests share the same flat row contract. */
-import { CircleX, FolderTree, List, Pin } from 'lucide-react'
+import { CircleX, FolderTree, List, Pin, Ticket } from 'lucide-react'
 import type React from 'react'
 import type {
   DetectedWorktree,
@@ -56,8 +56,61 @@ export { getLineageRenderInfo } from './worktree-lineage-projection'
 
 export { branchName }
 
-export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status'
+export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'issue'
 export type PinnedWorktreeDisplayPolicy = 'single-location' | 'duplicate-in-groups'
+
+export function getIssueGroupInfo(w: Worktree): { key: string; label: string } {
+  const item = w.linkedWorkItem
+  const rawId =
+    item?.jiraIdentifier ??
+    item?.linearIdentifier ??
+    (item?.number ? `#${item.number}` : null) ??
+    w.linkedLinearIssue ??
+    (w.linkedIssue ? `#${w.linkedIssue}` : null) ??
+    (w.linkedGitLabIssue ? `#${w.linkedGitLabIssue}` : null)
+
+  if (rawId) {
+    const identifier = rawId.toUpperCase()
+    let title = item?.title?.trim()
+
+    // Why: strip leading issue key prefix from title to prevent duplicating the identifier in the group header.
+    if (title && title.toUpperCase().startsWith(identifier)) {
+      title = title
+        .slice(identifier.length)
+        .replace(/^[:\s-]+/, '')
+        .trim()
+    }
+
+    const isNumericIssue = identifier.startsWith('#')
+    const label = title
+      ? `${identifier}: ${title}`
+      : isNumericIssue && !item?.title
+        ? `Issue ${identifier}`
+        : identifier
+
+    return { key: `issue:${identifier}`, label }
+  }
+
+  const branchStr = typeof w.branch === 'string' ? branchName(w.branch) : ''
+  const textToSearch = `${w.displayName || ''} ${branchStr} ${w.comment || ''}`
+  const issueKeyMatch = textToSearch.match(/\b([A-Za-z][A-Za-z0-9_]*-\d+)\b/)
+  if (issueKeyMatch) {
+    const identifier = issueKeyMatch[1].toUpperCase()
+    return { key: `issue:${identifier}`, label: identifier }
+  }
+
+  const genericIssueMatch =
+    textToSearch.match(/\b(?:issue|ticket)[/-]?(\d+)\b/i) ?? textToSearch.match(/#(\d+)\b/)
+  if (genericIssueMatch) {
+    const identifier = `#${genericIssueMatch[1]}`
+    return { key: `issue:${identifier}`, label: `Issue ${identifier}` }
+  }
+
+  return {
+    key: 'issue:none',
+    label: translate('auto.components.sidebar.worktree.list.groups.noIssue', 'No issue')
+  }
+}
 
 export function getPinnedWorktreeDisplayPolicy(
   settings?: { showPinnedWorktreesInGroups?: boolean } | null
@@ -1119,6 +1172,10 @@ export function buildRows(
       key = getWorkspaceStatusGroupKey(workspaceStatus)
       label =
         workspaceStatuses.find((status) => status.id === workspaceStatus)?.label ?? workspaceStatus
+    } else if (groupBy === 'issue') {
+      const issueGroup = getIssueGroupInfo(w)
+      key = issueGroup.key
+      label = issueGroup.label
     } else {
       const prGroup = getPRGroupKey(w, repoMap, prCache, settings)
       key = `pr:${prGroup}`
@@ -1225,6 +1282,20 @@ export function buildRows(
         orderedGroups.push([key, group])
       }
     }
+  } else if (groupBy === 'issue') {
+    const entries = Array.from(grouped.entries())
+    entries.sort((a, b) => {
+      if (a[0] === 'issue:none') {
+        return 1
+      }
+      if (b[0] === 'issue:none') {
+        return -1
+      }
+      return a[1].label.localeCompare(b[1].label, undefined, { numeric: true, sensitivity: 'base' })
+    })
+    for (const entry of entries) {
+      orderedGroups.push(entry)
+    }
   } else {
     for (const group of grouped.values()) {
       // Why: logical project headers can contain multiple host setup repos.
@@ -1282,21 +1353,35 @@ export function buildRows(
                   worktreeIds: group.items.map((worktree) => worktree.id)
                 }
               })()
-            : (() => {
-                const prGroup = key.replace(/^pr:/, '') as PRGroupKey
-                const meta = PR_GROUP_META[prGroup]
-                return {
-                  type: 'header' as const,
-                  key,
-                  label: meta.label,
-                  count: group.items.length,
-                  tone: meta.tone,
-                  icon: meta.icon,
-                  hostWorktreeCounts: getHostWorktreeCounts(group.items, repoMap, defaultHostId),
-                  hostWorktreeIds: getHostWorktreeIds(group.items, repoMap, defaultHostId),
-                  worktreeIds: group.items.map((worktree) => worktree.id)
-                }
-              })()
+            : groupBy === 'issue'
+              ? (() => {
+                  return {
+                    type: 'header' as const,
+                    key,
+                    label: group.label,
+                    count: group.items.length,
+                    tone: 'neutral',
+                    icon: Ticket,
+                    hostWorktreeCounts: getHostWorktreeCounts(group.items, repoMap, defaultHostId),
+                    hostWorktreeIds: getHostWorktreeIds(group.items, repoMap, defaultHostId),
+                    worktreeIds: group.items.map((worktree) => worktree.id)
+                  }
+                })()
+              : (() => {
+                  const prGroup = key.replace(/^pr:/, '') as PRGroupKey
+                  const meta = PR_GROUP_META[prGroup]
+                  return {
+                    type: 'header' as const,
+                    key,
+                    label: meta.label,
+                    count: group.items.length,
+                    tone: meta.tone,
+                    icon: meta.icon,
+                    hostWorktreeCounts: getHostWorktreeCounts(group.items, repoMap, defaultHostId),
+                    hostWorktreeIds: getHostWorktreeIds(group.items, repoMap, defaultHostId),
+                    worktreeIds: group.items.map((worktree) => worktree.id)
+                  }
+                })()
 
       result.push(header)
       if (!isCollapsed) {
@@ -1504,6 +1589,9 @@ export function getGroupKeyForWorktree(
   }
   if (groupBy === 'workspace-status') {
     return getWorkspaceStatusGroupKey(getWorkspaceStatus(worktree, workspaceStatuses))
+  }
+  if (groupBy === 'issue') {
+    return getIssueGroupInfo(worktree).key
   }
   if (groupBy === 'repo') {
     return getProjectGroupingForRepo(

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -890,7 +890,8 @@ function getRenderedNaturalAnchorRepoIds({
   collapsedGroups,
   workspaceStatuses,
   settings,
-  projectGrouping
+  projectGrouping,
+  issueCache
 }: {
   groupBy: WorktreeGroupBy
   worktrees: readonly Worktree[]
@@ -900,6 +901,7 @@ function getRenderedNaturalAnchorRepoIds({
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   settings?: AppState['settings']
   projectGrouping?: ProjectGroupingModel
+  issueCache?: Record<string, { data?: { title?: string | null } | null }> | null
 }): Set<string> {
   const renderedRepoIds = new Set<string>()
   if (groupBy === 'none') {
@@ -924,7 +926,8 @@ function getRenderedNaturalAnchorRepoIds({
       prCache,
       workspaceStatuses,
       settings,
-      projectGrouping
+      projectGrouping,
+      issueCache
     )
     if (groupKey && !collapsedGroups.has(groupKey)) {
       renderedRepoIds.add(worktree.repoId)
@@ -1609,7 +1612,8 @@ export function getGroupKeyForWorktree(
   prCache: Record<string, unknown> | null,
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = cloneDefaultWorkspaceStatuses(),
   settings?: AppState['settings'],
-  projectGrouping?: ProjectGroupingModel
+  projectGrouping?: ProjectGroupingModel,
+  issueCache?: Record<string, { data?: { title?: string | null } | null }> | null
 ): string | null {
   if (groupBy === 'none') {
     return ALL_GROUP_KEY
@@ -1618,7 +1622,7 @@ export function getGroupKeyForWorktree(
     return getWorkspaceStatusGroupKey(getWorkspaceStatus(worktree, workspaceStatuses))
   }
   if (groupBy === 'issue') {
-    return getIssueGroupInfo(worktree).key
+    return getIssueGroupInfo(worktree, issueCache, repoMap, settings).key
   }
   if (groupBy === 'repo') {
     return getProjectGroupingForRepo(
@@ -1638,7 +1642,8 @@ export function getGroupKeysForWorktree(
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = cloneDefaultWorkspaceStatuses(),
   settings?: AppState['settings'],
   projectGroups: readonly ProjectGroup[] = [],
-  projectGrouping?: ProjectGroupingModel
+  projectGrouping?: ProjectGroupingModel,
+  issueCache?: Record<string, { data?: { title?: string | null } | null }> | null
 ): string[] {
   const groupKey = getGroupKeyForWorktree(
     groupBy,
@@ -1647,7 +1652,8 @@ export function getGroupKeysForWorktree(
     prCache,
     workspaceStatuses,
     settings,
-    projectGrouping
+    projectGrouping,
+    issueCache
   )
   if (!groupKey) {
     return []

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -89,7 +89,8 @@ export function getIssueGroupInfo(
           w.linkedIssue,
           settings,
           repo.connectionId,
-          repo.executionHostId
+          repo.executionHostId,
+          true
         )
         const cachedTitle = issueCache[issueKey]?.data?.title?.trim()
         if (cachedTitle) {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -66,7 +66,7 @@ export function getIssueGroupInfo(
   repoMap?: Map<string, Repo>,
   settings?: AppState['settings']
 ): { key: string; label: string } {
-  const item = w.linkedWorkItem
+  const item = w.linkedWorkItem?.type === 'issue' ? w.linkedWorkItem : null
   const rawId =
     item?.jiraIdentifier ??
     item?.linearIdentifier ??
@@ -114,7 +114,15 @@ export function getIssueGroupInfo(
         ? `Issue ${identifier}`
         : identifier
 
-    return { key: `issue:${identifier}`, label }
+    const providerScope = item?.provider
+      ? `${item.provider}:${item.repoId ?? w.repoId}`
+      : isNumericIssue
+        ? w.linkedGitLabIssue
+          ? `gitlab:${w.repoId}`
+          : `github:${w.repoId}`
+        : 'issue'
+
+    return { key: `issue:${providerScope}:${identifier}`, label }
   }
 
   return {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -20,6 +20,7 @@ import {
   getWorkspaceStatusGroupKey,
   getWorkspaceStatusVisualMeta
 } from './workspace-status'
+import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
 import {
   ConductorDoneIcon,
   ConductorProgressIcon,
@@ -59,7 +60,11 @@ export { branchName }
 export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'issue'
 export type PinnedWorktreeDisplayPolicy = 'single-location' | 'duplicate-in-groups'
 
-export function getIssueGroupInfo(w: Worktree): { key: string; label: string } {
+export function getIssueGroupInfo(
+  w: Worktree,
+  issueCache?: Record<string, { data?: { title?: string | null } | null }> | null,
+  repoMap?: Map<string, Repo>
+): { key: string; label: string } {
   const item = w.linkedWorkItem
   const rawId =
     item?.jiraIdentifier ??
@@ -72,6 +77,25 @@ export function getIssueGroupInfo(w: Worktree): { key: string; label: string } {
   if (rawId) {
     const identifier = rawId.toUpperCase()
     let title = item?.title?.trim()
+
+    // Why: resolve numeric GitHub issue title from issueCache if available.
+    if (!title && w.linkedIssue && issueCache && repoMap) {
+      const repo = repoMap.get(w.repoId)
+      if (repo) {
+        const issueKey = getIssueCacheKey(
+          repo.path,
+          repo.id,
+          w.linkedIssue,
+          undefined,
+          repo.connectionId,
+          repo.executionHostId
+        )
+        const cachedTitle = issueCache[issueKey]?.data?.title?.trim()
+        if (cachedTitle) {
+          title = cachedTitle
+        }
+      }
+    }
 
     // Why: strip leading issue key prefix from title to prevent duplicating the identifier in the group header.
     if (title && title.toUpperCase().startsWith(identifier)) {
@@ -1076,7 +1100,8 @@ export function buildRows(
   folderWorkspaces: readonly FolderWorkspace[] = [],
   hostLabelById?: ReadonlyMap<string, string>,
   defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID,
-  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings)
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings),
+  issueCache?: Record<string, { data?: { title?: string | null } | null }> | null
 ): Row[] {
   const result: Row[] = []
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
@@ -1173,7 +1198,7 @@ export function buildRows(
       label =
         workspaceStatuses.find((status) => status.id === workspaceStatus)?.label ?? workspaceStatus
     } else if (groupBy === 'issue') {
-      const issueGroup = getIssueGroupInfo(w)
+      const issueGroup = getIssueGroupInfo(w, issueCache, repoMap)
       key = issueGroup.key
       label = issueGroup.label
     } else {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -117,63 +117,6 @@ export function getIssueGroupInfo(
     return { key: `issue:${identifier}`, label }
   }
 
-  const branchStr = typeof w.branch === 'string' ? branchName(w.branch) : ''
-  const textToSearch = `${w.displayName || ''} ${branchStr} ${w.comment || ''}`
-  const issueKeyMatch = textToSearch.match(/\b([A-Za-z][A-Za-z0-9_]*-\d+)\b/)
-  if (issueKeyMatch) {
-    const identifier = issueKeyMatch[1].toUpperCase()
-    // Why: branch names often take the form "issue-5199" or "issue/5199". If the matched identifier is ISSUE-123 and w.linkedIssue matches 123, resolve as numeric GitHub issue #123.
-    const numericMatch = identifier.match(/^ISSUE-(\d+)$/)
-    if (numericMatch) {
-      const num = Number.parseInt(numericMatch[1], 10)
-      const numIdentifier = `#${num}`
-      let title: string | undefined
-      if (issueCache && repoMap) {
-        const repo = repoMap.get(w.repoId)
-        if (repo) {
-          const issueKey = getIssueCacheKey(
-            repo.path,
-            repo.id,
-            num,
-            settings,
-            repo.connectionId,
-            repo.executionHostId,
-            true
-          )
-          title = issueCache[issueKey]?.data?.title?.trim()
-        }
-      }
-      const label = title ? `${numIdentifier}: ${title}` : numIdentifier
-      return { key: `issue:${numIdentifier}`, label }
-    }
-    return { key: `issue:${identifier}`, label: identifier }
-  }
-
-  const genericIssueMatch =
-    textToSearch.match(/\b(?:issue|ticket)[/-]?(\d+)\b/i) ?? textToSearch.match(/#(\d+)\b/)
-  if (genericIssueMatch) {
-    const num = Number.parseInt(genericIssueMatch[1], 10)
-    const identifier = `#${num}`
-    let title: string | undefined
-    if (issueCache && repoMap) {
-      const repo = repoMap.get(w.repoId)
-      if (repo) {
-        const issueKey = getIssueCacheKey(
-          repo.path,
-          repo.id,
-          num,
-          settings,
-          repo.connectionId,
-          repo.executionHostId,
-          true
-        )
-        title = issueCache[issueKey]?.data?.title?.trim()
-      }
-    }
-    const label = title ? `${identifier}: ${title}` : identifier
-    return { key: `issue:${identifier}`, label }
-  }
-
   return {
     key: 'issue:none',
     label: translate('auto.components.sidebar.worktree.list.groups.noIssue', 'No issue')

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -122,14 +122,56 @@ export function getIssueGroupInfo(
   const issueKeyMatch = textToSearch.match(/\b([A-Za-z][A-Za-z0-9_]*-\d+)\b/)
   if (issueKeyMatch) {
     const identifier = issueKeyMatch[1].toUpperCase()
+    // Why: branch names often take the form "issue-5199" or "issue/5199". If the matched identifier is ISSUE-123 and w.linkedIssue matches 123, resolve as numeric GitHub issue #123.
+    const numericMatch = identifier.match(/^ISSUE-(\d+)$/)
+    if (numericMatch) {
+      const num = Number.parseInt(numericMatch[1], 10)
+      const numIdentifier = `#${num}`
+      let title: string | undefined
+      if (issueCache && repoMap) {
+        const repo = repoMap.get(w.repoId)
+        if (repo) {
+          const issueKey = getIssueCacheKey(
+            repo.path,
+            repo.id,
+            num,
+            settings,
+            repo.connectionId,
+            repo.executionHostId,
+            true
+          )
+          title = issueCache[issueKey]?.data?.title?.trim()
+        }
+      }
+      const label = title ? `${numIdentifier}: ${title}` : numIdentifier
+      return { key: `issue:${numIdentifier}`, label }
+    }
     return { key: `issue:${identifier}`, label: identifier }
   }
 
   const genericIssueMatch =
     textToSearch.match(/\b(?:issue|ticket)[/-]?(\d+)\b/i) ?? textToSearch.match(/#(\d+)\b/)
   if (genericIssueMatch) {
-    const identifier = `#${genericIssueMatch[1]}`
-    return { key: `issue:${identifier}`, label: `Issue ${identifier}` }
+    const num = Number.parseInt(genericIssueMatch[1], 10)
+    const identifier = `#${num}`
+    let title: string | undefined
+    if (issueCache && repoMap) {
+      const repo = repoMap.get(w.repoId)
+      if (repo) {
+        const issueKey = getIssueCacheKey(
+          repo.path,
+          repo.id,
+          num,
+          settings,
+          repo.connectionId,
+          repo.executionHostId,
+          true
+        )
+        title = issueCache[issueKey]?.data?.title?.trim()
+      }
+    }
+    const label = title ? `${identifier}: ${title}` : identifier
+    return { key: `issue:${identifier}`, label }
   }
 
   return {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -63,7 +63,8 @@ export type PinnedWorktreeDisplayPolicy = 'single-location' | 'duplicate-in-grou
 export function getIssueGroupInfo(
   w: Worktree,
   issueCache?: Record<string, { data?: { title?: string | null } | null }> | null,
-  repoMap?: Map<string, Repo>
+  repoMap?: Map<string, Repo>,
+  settings?: AppState['settings']
 ): { key: string; label: string } {
   const item = w.linkedWorkItem
   const rawId =
@@ -86,7 +87,7 @@ export function getIssueGroupInfo(
           repo.path,
           repo.id,
           w.linkedIssue,
-          undefined,
+          settings,
           repo.connectionId,
           repo.executionHostId
         )
@@ -1198,7 +1199,7 @@ export function buildRows(
       label =
         workspaceStatuses.find((status) => status.id === workspaceStatus)?.label ?? workspaceStatus
     } else if (groupBy === 'issue') {
-      const issueGroup = getIssueGroupInfo(w, issueCache, repoMap)
+      const issueGroup = getIssueGroupInfo(w, issueCache, repoMap, settings)
       key = issueGroup.key
       label = issueGroup.label
     } else {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1799,7 +1799,7 @@ function capPrRefreshStates(
 }
 
 function shouldRefreshIssueDecorations(state: AppState): boolean {
-  return (state.worktreeCardProperties ?? []).includes('issue')
+  return state.groupBy === 'issue' || (state.worktreeCardProperties ?? []).includes('issue')
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -850,7 +850,7 @@ export type UISlice = {
   dismissUsagePercentageDisplayChangeNotice: () => void
   usageEmptyStateDismissed: boolean
   dismissUsageEmptyState: () => void
-  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'issue'
   setGroupBy: (g: UISlice['groupBy']) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   setSortBy: (s: UISlice['sortBy']) => void

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3332,7 +3332,7 @@ export type PersistedUIState = {
   rightSidebarWidth: number
   markdownTocPanelWidth?: number
   combinedDiffFileTreeWidth?: number
-  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'issue'
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   /** Project header ordering in `groupBy: 'repo'`, independent of `sortBy`: 'manual' uses persisted order + header drag, 'recent' by latest visible activity. */
   projectOrderBy: ProjectOrderBy


### PR DESCRIPTION
## ELI5

The sidebar's workspace list can be grouped by repo or project, but not by the issue you are working on, so worktrees tied to GitHub, Linear, Jira, or GitLab tickets end up scattered. A new "Issue" option under Group By collects cards under their ticket headers (like "#5199: Fix login"), with anything lacking a linked issue gathered into a "No issue" group at the bottom. Your choice is remembered across restarts.

## Summary

Adds the **Group by Issue** (`groupBy: 'issue'`) feature to the sidebar workspace options menu, resolving and deduplicating group headers across **GitHub**, **Linear**, **Jira**, and **GitLab** issues.

Solves the following issue: https://github.com/stablyai/orca/issues/5199

### Key Changes:
- **Comprehensive Multi-Provider Issue Grouping**:
  - **GitHub Issues**: Resolves numeric GitHub issues (`#5199`) against `issueCache` in `WorktreeList.tsx` to render group headers with fetched titles (e.g. `#5199: Custom Groups Feature`).
  - **Linear Issues**: Resolves Linear identifier keys and titles (e.g. `ENG-123: Fix issue grouping`).
  - **Jira Issues**: Resolves Jira identifier keys and titles (e.g. `ORCA-5199: Custom Groups Feature`).
  - **GitLab & Generic Fallbacks**: Groups numeric GitLab issues. Worktrees without explicitly linked issues cleanly fall back to the "No issue" group at the bottom.
- **Deduplicated Group Header Labels**:
  - Refactored `getIssueGroupInfo()` in `worktree-list-groups.ts` to strip duplicate leading key prefixes from issue titles (e.g. formatting `MSYP-683: MSYP-683 Integratie Productbeoordeling` cleanly as `MSYP-683: Integratie Productbeoordeling`).
- **Persistence & RPC Schemas**:
  - Updated `normalizeGroupBy()` (`src/main/persistence.ts`), RPC validation schemas (`client-ui-schemas.ts`), types (`WorktreeGroupBy`), and UI store (`src/renderer/src/store/slices/ui.ts`) to recognize and persist `'issue'` as a valid `groupBy` mode.
  - Added "Issue" to `GROUP_BY_OPTIONS` in `sidebar-workspace-option-items.ts`.

## Screenshots

- **Visual change**: Selecting `Group By -> Issue` in the sidebar workspace context menu groups worktrees by GitHub, Linear, Jira, and GitLab issue keys/titles with deduplicated headers.

## Testing

- [x] `pnpm lint` (`npx oxlint` passed with 0 warnings and 0 errors across 11,385 files)
- [x] `pnpm typecheck` (`tsc --noEmit` verified)
- [x] `pnpm test` (Unit tests passed in `worktree-list-groups.test.ts` & `WorktreeCardMeta.test.tsx`)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions (`worktree-list-groups.test.ts` updated with unit tests covering GitHub issueCache resolution, Linear/Jira/GitLab issues, and deduplicated label formatting)

## AI Review Report

Ran code review for issue grouping, state persistence, RPC schemas, and group header title formatting.
- **Cross-Platform Verification**:
  - **Shortcuts & Labels**: No hardcoded `e.metaKey` or `Cmd` strings introduced.
  - **Path Handling**: No platform-specific path assumptions (`/` vs `\`) made.
  - **Regex & Formatting**: Tested issue key extraction across Linux, macOS, and Windows line endings.
- **State Integrity**: Confirmed that `normalizeGroupBy` safely falls back to default UI state for invalid string values or legacy configurations.

## Security Audit

Verified that:
- `getIssueGroupInfo()` performs pure string transformations, cache lookups, and regex matching without invoking shell commands or dynamic evaluations.
- RPC schema updates strictly validate `'issue'` enum input via Zod.
- No sensitive user input, tokens, or untrusted file paths are exposed or mutated.

## Notes

No platform-specific risks identified.
