### PR TITLE
Expose active workspace in macOS window metadata

### DIFF
--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -30,6 +30,7 @@ import {
 import { installMainWindowWebviewSecurity } from './main-window-webview-security'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { installWindowsPathRegistryChangeListener } from '../pty/windows-path-registry-change'
+import { installWorkspaceWindowMetadataListener } from './workspace-window-metadata'
 
 export { WINDOW_QUIT_RENDERER_ACK_TIMEOUT_MS }
 
@@ -81,6 +82,7 @@ export function createMainWindow(
   // forced per-frame WindowServer alpha compositing (#8482). Applies at creation only, so it needs a restart.
   const platformBlurOptions =
     blur && process.platform === 'win32' ? { backgroundMaterial: 'acrylic' as const } : {}
+  const baseWindowTitle = opts?.title ?? 'Orca'
 
   const mainWindow = new BrowserWindow({
     width: savedBounds?.width ?? defaultBounds.width,
@@ -88,7 +90,7 @@ export function createMainWindow(
     ...(savedBounds ? { x: savedBounds.x, y: savedBounds.y } : {}),
     minWidth: MIN_WIDTH,
     minHeight: MIN_HEIGHT,
-    title: opts?.title ?? 'Orca',
+    title: baseWindowTitle,
     show: false,
     // Why: macOS swallows the app-activating click by default, so clicking back into Orca needed a second click (Windows/Linux already deliver it).
     acceptFirstMouse: true,
@@ -127,6 +129,10 @@ export function createMainWindow(
   })
   const rendererWebContentsId = mainWindow.webContents.id
   installWindowsPathRegistryChangeListener(mainWindow)
+  const disposeWorkspaceWindowMetadata = installWorkspaceWindowMetadataListener(
+    mainWindow,
+    baseWindowTitle
+  )
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
 
@@ -193,6 +199,7 @@ export function createMainWindow(
     browserManager.setDictationShortcutForwardingPredicate(null)
     powerMonitor.removeListener('resume', onSystemResume)
     clearTrustedUIRendererWebContentsId(rendererWebContentsId)
+    disposeWorkspaceWindowMetadata()
     state.dispose()
   })
 

--- a/src/main/window/workspace-window-metadata.test.ts
+++ b/src/main/window/workspace-window-metadata.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WORKSPACE_WINDOW_METADATA_CHANNEL } from '../../shared/workspace-window-metadata'
+
+const { ipcMainOnMock, ipcMainRemoveListenerMock } = vi.hoisted(() => ({
+  ipcMainOnMock: vi.fn(),
+  ipcMainRemoveListenerMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    on: ipcMainOnMock,
+    removeListener: ipcMainRemoveListenerMock
+  }
+}))
+
+import {
+  installWorkspaceWindowMetadataListener,
+  normalizeWorkspaceWindowMetadata
+} from './workspace-window-metadata'
+
+function createWindow(): {
+  window: Electron.BrowserWindow
+  setRepresentedFilename: ReturnType<typeof vi.fn>
+  setTitle: ReturnType<typeof vi.fn>
+} {
+  const setRepresentedFilename = vi.fn()
+  const setTitle = vi.fn()
+  return {
+    window: {
+      webContents: { id: 42 },
+      isDestroyed: vi.fn(() => false),
+      setRepresentedFilename,
+      setTitle
+    } as unknown as Electron.BrowserWindow,
+    setRepresentedFilename,
+    setTitle
+  }
+}
+
+describe('workspace window metadata', () => {
+  beforeEach(() => {
+    ipcMainOnMock.mockReset()
+    ipcMainRemoveListenerMock.mockReset()
+  })
+
+  it('updates macOS document metadata only for the owning renderer', () => {
+    const { window, setRepresentedFilename, setTitle } = createWindow()
+    const dispose = installWorkspaceWindowMetadataListener(window, 'Orca: local-dev', 'darwin')
+    const listener = ipcMainOnMock.mock.calls[0]?.[1]
+
+    expect(ipcMainOnMock).toHaveBeenCalledWith(
+      WORKSPACE_WINDOW_METADATA_CHANNEL,
+      expect.any(Function)
+    )
+
+    listener({ sender: { id: 99 } }, { displayName: 'ignored', localPath: '/tmp/ignored' })
+    expect(setTitle).not.toHaveBeenCalled()
+
+    listener(
+      { sender: { id: 42 } },
+      { displayName: 'stevie-vs-orca', localPath: '/tmp/orca/worktree' }
+    )
+    expect(setRepresentedFilename).toHaveBeenLastCalledWith('/tmp/orca/worktree')
+    expect(setTitle).toHaveBeenLastCalledWith('stevie-vs-orca — Orca: local-dev')
+
+    listener({ sender: { id: 42 } }, { displayName: null, localPath: null })
+    expect(setRepresentedFilename).toHaveBeenLastCalledWith('')
+    expect(setTitle).toHaveBeenLastCalledWith('Orca: local-dev')
+
+    dispose()
+    expect(ipcMainRemoveListenerMock).toHaveBeenCalledWith(
+      WORKSPACE_WINDOW_METADATA_CHANNEL,
+      listener
+    )
+  })
+
+  it('does not install native metadata handling on other platforms', () => {
+    const { window } = createWindow()
+    const dispose = installWorkspaceWindowMetadataListener(window, 'Orca', 'linux')
+
+    expect(ipcMainOnMock).not.toHaveBeenCalled()
+    dispose()
+    expect(ipcMainRemoveListenerMock).not.toHaveBeenCalled()
+  })
+
+  it('bounds labels and accepts only absolute, null-free paths', () => {
+    expect(
+      normalizeWorkspaceWindowMetadata({
+        displayName: '  workspace  ',
+        localPath: '/Users/example/workspace'
+      })
+    ).toEqual({ displayName: 'workspace', localPath: '/Users/example/workspace' })
+    expect(
+      normalizeWorkspaceWindowMetadata({ displayName: '', localPath: 'relative/workspace' })
+    ).toEqual({ displayName: null, localPath: null })
+    expect(
+      normalizeWorkspaceWindowMetadata({ displayName: 42, localPath: '/tmp/bad\0path' })
+    ).toEqual({ displayName: null, localPath: null })
+    expect(
+      normalizeWorkspaceWindowMetadata({
+        displayName: 'x'.repeat(513),
+        localPath: `/${'x'.repeat(32_768)}`
+      })
+    ).toEqual({ displayName: null, localPath: null })
+  })
+})

--- a/src/main/window/workspace-window-metadata.ts
+++ b/src/main/window/workspace-window-metadata.ts
@@ -1,0 +1,70 @@
+import { ipcMain, type BrowserWindow, type IpcMainEvent } from 'electron'
+import { posix } from 'node:path'
+import {
+  WORKSPACE_WINDOW_METADATA_CHANNEL,
+  type WorkspaceWindowMetadata
+} from '../../shared/workspace-window-metadata'
+
+const MAX_WORKSPACE_DISPLAY_NAME_LENGTH = 512
+const MAX_REPRESENTED_PATH_LENGTH = 32_768
+
+function normalizeDisplayName(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed && trimmed.length <= MAX_WORKSPACE_DISPLAY_NAME_LENGTH ? trimmed : null
+}
+
+function normalizeLocalPath(value: unknown): string | null {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_REPRESENTED_PATH_LENGTH ||
+    value.includes('\0') ||
+    !posix.isAbsolute(value)
+  ) {
+    return null
+  }
+  return value
+}
+
+export function normalizeWorkspaceWindowMetadata(value: unknown): WorkspaceWindowMetadata {
+  if (!value || typeof value !== 'object') {
+    return { displayName: null, localPath: null }
+  }
+  const candidate = value as Record<string, unknown>
+  return {
+    displayName: normalizeDisplayName(candidate.displayName),
+    localPath: normalizeLocalPath(candidate.localPath)
+  }
+}
+
+export function installWorkspaceWindowMetadataListener(
+  window: BrowserWindow,
+  baseWindowTitle: string,
+  platform: NodeJS.Platform = process.platform
+): () => void {
+  if (platform !== 'darwin') {
+    return () => {}
+  }
+
+  const rendererWebContentsId = window.webContents.id
+  const onWorkspaceWindowMetadata = (event: IpcMainEvent, value: unknown): void => {
+    if (event.sender.id !== rendererWebContentsId || window.isDestroyed()) {
+      return
+    }
+    const metadata = normalizeWorkspaceWindowMetadata(value)
+    // Why: representedFilename becomes macOS AXDocument, while the title gives
+    // time trackers a useful fallback without making remote paths look local.
+    window.setRepresentedFilename(metadata.localPath ?? '')
+    window.setTitle(
+      metadata.displayName ? `${metadata.displayName} — ${baseWindowTitle}` : baseWindowTitle
+    )
+  }
+
+  ipcMain.on(WORKSPACE_WINDOW_METADATA_CHANNEL, onWorkspaceWindowMetadata)
+  return () => {
+    ipcMain.removeListener(WORKSPACE_WINDOW_METADATA_CHANNEL, onWorkspaceWindowMetadata)
+  }
+}

--- a/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
+++ b/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
@@ -12,6 +12,10 @@ import {
 import type { NativeFileDropPayload } from '../../shared/native-file-drop'
 import type { ClipboardImageThumbnail } from '../../shared/clipboard-image'
 import type { ReadClipboardTextOptions } from '../../shared/clipboard-text'
+import {
+  WORKSPACE_WINDOW_METADATA_CHANNEL,
+  type WorkspaceWindowMetadata
+} from '../../shared/workspace-window-metadata'
 import { subscribeNativeFileDrop } from '../preload-runtime-support'
 import type { PreloadApi } from '../api-types'
 
@@ -126,6 +130,9 @@ export const uiClipboardAndWindowControlsApi = {
   setZoomLevel: (level: number): void => webFrame.setZoomLevel(level),
   syncTrafficLights: (zoomFactor: number): void =>
     ipcRenderer.send('ui:sync-traffic-lights', zoomFactor),
+  setWorkspaceWindowMetadata: (metadata: WorkspaceWindowMetadata): void => {
+    ipcRenderer.send(WORKSPACE_WINDOW_METADATA_CHANNEL, metadata)
+  },
   setMarkdownEditorFocused: (focused: boolean): void => {
     ipcRenderer.send('ui:setMarkdownEditorFocused', focused)
   },

--- a/src/preload/api/ui-window-api.ts
+++ b/src/preload/api/ui-window-api.ts
@@ -5,6 +5,7 @@ import type {
   RichMarkdownContextMenuCommandPayload,
   RichMarkdownContextMenuTableTarget
 } from '../../shared/rich-markdown-context-menu'
+import type { WorkspaceWindowMetadata } from '../../shared/workspace-window-metadata'
 
 export type UiWindowApi = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
@@ -32,6 +33,7 @@ export type UiWindowApi = {
   getZoomLevel: () => number
   setZoomLevel: (level: number) => void
   syncTrafficLights: (zoomFactor: number) => void
+  setWorkspaceWindowMetadata: (metadata: WorkspaceWindowMetadata) => void
   setMarkdownEditorFocused: (focused: boolean) => void
   setRichMarkdownContextMenuTarget: (target: RichMarkdownContextMenuTableTarget | null) => void
   setTerminalInputFocused: (focused: boolean) => void

--- a/src/renderer/src/app-shell/AppBackgroundServices.tsx
+++ b/src/renderer/src/app-shell/AppBackgroundServices.tsx
@@ -4,6 +4,7 @@ import { AgentHibernationGate } from '../components/AgentHibernationGate'
 import { AiVaultTabTitleSyncGate } from '../components/AiVaultTabTitleSyncGate'
 import RetainedAgentsSyncGate from '../components/dashboard/RetainedAgentsSyncGate'
 import { WorkspacePortScanner } from '../components/ports/WorkspacePortScanner'
+import { WorkspaceWindowMetadataSyncGate } from '../components/WorkspaceWindowMetadataSyncGate'
 import { MacosTccPromptNoticeHost } from '../hooks/MacosTccPromptNoticeHost'
 import { useAppStore } from '../store'
 import { StructuredAgentSessionStatusBridge } from '../components/native-chat/StructuredAgentSessionStatusBridge'
@@ -28,6 +29,7 @@ export function AppBackgroundServices(): React.JSX.Element {
       {/* Why: leaf-mounted retention sync keeps agent-status subscriptions out of the App render tree. */}
       <RetainedAgentsSyncGate />
       <AiVaultTabTitleSyncGate />
+      <WorkspaceWindowMetadataSyncGate />
       {dashboardPopoutEnabled ? (
         <Suspense fallback={null}>
           <DashboardPopoutBridge />

--- a/src/renderer/src/components/WorkspaceWindowMetadataSyncGate.tsx
+++ b/src/renderer/src/components/WorkspaceWindowMetadataSyncGate.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import { selectWorkspaceWindowMetadata } from '@/store/workspace-window-metadata-selector'
+
+export function WorkspaceWindowMetadataSyncGate(): null {
+  const metadata = useAppStore(useShallow(selectWorkspaceWindowMetadata))
+
+  useEffect(() => {
+    window.api.ui.setWorkspaceWindowMetadata(metadata)
+  }, [metadata])
+
+  return null
+}

--- a/src/renderer/src/store/workspace-window-metadata-selector.test.ts
+++ b/src/renderer/src/store/workspace-window-metadata-selector.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { toSshExecutionHostId } from '../../../shared/execution-host'
+import type { Worktree } from '../../../shared/worktree/types'
+import { selectWorkspaceWindowMetadata } from './workspace-window-metadata-selector'
+
+type SelectorState = Parameters<typeof selectWorkspaceWindowMetadata>[0]
+
+function createState(overrides: Partial<SelectorState> = {}): SelectorState {
+  const worktree = {
+    displayName: 'stevie-vs-orca',
+    hostId: 'local',
+    path: '/Users/example/statvis-dev/worktrees/stevie-vs-orca'
+  } satisfies Pick<Worktree, 'displayName' | 'hostId' | 'path'>
+  return {
+    activePendingCreationId: null,
+    activeView: 'terminal',
+    activeWorkspaceExecutionHostId: 'local',
+    activeWorktreeId: 'worktree-1',
+    pendingWorktreeCreations: {},
+    getKnownWorktreeById: vi.fn(() => worktree),
+    ...overrides
+  }
+}
+
+describe('selectWorkspaceWindowMetadata', () => {
+  it('reports the active local Git worktree name and path', () => {
+    expect(selectWorkspaceWindowMetadata(createState())).toEqual({
+      displayName: 'stevie-vs-orca',
+      localPath: '/Users/example/statvis-dev/worktrees/stevie-vs-orca'
+    })
+  })
+
+  it('uses folder workspace projections through the shared worktree lookup', () => {
+    const getKnownWorktreeById = vi.fn(() => ({
+      displayName: 'Local notes',
+      hostId: 'local' as const,
+      path: '/Users/example/notes'
+    }))
+    expect(
+      selectWorkspaceWindowMetadata(
+        createState({ activeWorktreeId: 'folder:notes', getKnownWorktreeById })
+      )
+    ).toEqual({ displayName: 'Local notes', localPath: '/Users/example/notes' })
+    expect(getKnownWorktreeById).toHaveBeenCalledWith('folder:notes', 'local')
+  })
+
+  it('reports remote workspace names without representing remote paths as local files', () => {
+    const sshHostId = toSshExecutionHostId('dev-vps')
+    expect(
+      selectWorkspaceWindowMetadata(
+        createState({
+          activeWorkspaceExecutionHostId: sshHostId,
+          getKnownWorktreeById: vi.fn(() => ({
+            displayName: 'remote-task',
+            hostId: sshHostId,
+            path: '/srv/orca/remote-task'
+          }))
+        })
+      )
+    ).toEqual({ displayName: 'remote-task', localPath: null })
+  })
+
+  it('clears metadata outside an active workspace surface', () => {
+    const pendingWorktreeCreations = { creation: {} }
+    for (const state of [
+      createState({ activeView: 'settings' }),
+      createState({ activeWorktreeId: null }),
+      createState({ activePendingCreationId: 'creation', pendingWorktreeCreations }),
+      createState({ getKnownWorktreeById: vi.fn(() => undefined) })
+    ]) {
+      expect(selectWorkspaceWindowMetadata(state)).toEqual({
+        displayName: null,
+        localPath: null
+      })
+    }
+  })
+})

--- a/src/renderer/src/store/workspace-window-metadata-selector.ts
+++ b/src/renderer/src/store/workspace-window-metadata-selector.ts
@@ -1,0 +1,46 @@
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
+import type { Worktree } from '../../../shared/worktree/types'
+import type { WorkspaceWindowMetadata } from '../../../shared/workspace-window-metadata'
+import type { AppState } from './types'
+
+type WorkspaceWindowMetadataState = Pick<
+  AppState,
+  'activePendingCreationId' | 'activeView' | 'activeWorkspaceExecutionHostId' | 'activeWorktreeId'
+> & {
+  pendingWorktreeCreations: Readonly<Record<string, unknown>>
+  getKnownWorktreeById: (
+    worktreeId: string,
+    executionHostId?: ExecutionHostId
+  ) => Pick<Worktree, 'displayName' | 'hostId' | 'path'> | undefined
+}
+
+const EMPTY_WORKSPACE_WINDOW_METADATA: WorkspaceWindowMetadata = {
+  displayName: null,
+  localPath: null
+}
+
+export function selectWorkspaceWindowMetadata(
+  state: WorkspaceWindowMetadataState
+): WorkspaceWindowMetadata {
+  const hasActivePendingCreation =
+    state.activePendingCreationId !== null &&
+    state.pendingWorktreeCreations[state.activePendingCreationId] !== undefined
+  if (state.activeView !== 'terminal' || !state.activeWorktreeId || hasActivePendingCreation) {
+    return EMPTY_WORKSPACE_WINDOW_METADATA
+  }
+
+  const worktree = state.getKnownWorktreeById(
+    state.activeWorktreeId,
+    state.activeWorkspaceExecutionHostId ?? undefined
+  )
+  if (!worktree) {
+    return EMPTY_WORKSPACE_WINDOW_METADATA
+  }
+
+  const executionHostId =
+    state.activeWorkspaceExecutionHostId ?? worktree.hostId ?? LOCAL_EXECUTION_HOST_ID
+  return {
+    displayName: worktree.displayName,
+    localPath: executionHostId === LOCAL_EXECUTION_HOST_ID ? worktree.path : null
+  }
+}

--- a/src/renderer/src/web/preload-api/web-ui-api.ts
+++ b/src/renderer/src/web/preload-api/web-ui-api.ts
@@ -237,6 +237,7 @@ export function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onSystemResumed: () => noopUnsubscribe,
     onFileDrop: () => noopUnsubscribe,
     syncTrafficLights: () => {},
+    setWorkspaceWindowMetadata: () => {},
     setMarkdownEditorFocused: () => {},
     setRichMarkdownContextMenuTarget: () => {},
     setTerminalInputFocused: () => {},

--- a/src/shared/workspace-window-metadata.ts
+++ b/src/shared/workspace-window-metadata.ts
@@ -1,0 +1,6 @@
+export const WORKSPACE_WINDOW_METADATA_CHANNEL = 'ui:set-workspace-window-metadata'
+
+export type WorkspaceWindowMetadata = {
+  displayName: string | null
+  localPath: string | null
+}


### PR DESCRIPTION
## Summary

Orca's custom macOS window currently exposes a generic native title and no represented document, so document-aware utilities can identify Orca but not the active workspace.

This PR:

- sets the native title to `<workspace> — <base Orca title>` while a workspace is active
- calls Electron's [`BrowserWindow.setRepresentedFilename`](https://www.electronjs.org/docs/latest/tutorial/represented-file) with the active local workspace directory, which exposes the path through standard macOS window/document metadata
- clears the workspace metadata on settings, tasks, landing, and worktree-creation surfaces
- reports remote/SSH workspace names without representing their remote paths as local files
- supports both Git worktrees and folder workspaces through Orca's existing workspace lookup

This is host-owned rather than a plugin capability: sandboxed plugin panels should not receive a primitive that can mutate another window's native metadata.

## Screenshots

No visual change. Orca's native title remains hidden by the custom titlebar; this change is for macOS accessibility/document consumers such as time trackers and window automation.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the clean Node 24 full run completed 45,488 tests successfully and hit two unrelated process-startup races: a 100 ms helper child-PID fixture and a Codex app-server child-PID fixture. The Codex file passes isolated under Node 24; the macOS helper suite passes isolated under Node 25. The changed suites pass 88/88 after rebasing.
- [x] `pnpm build`
- [x] Added focused regression coverage for local Git worktrees, folder workspaces, SSH workspaces, inactive surfaces, malformed IPC payloads, sender isolation, listener cleanup, and non-macOS behavior

## AI Review Report

The review checked:

- **Cross-platform compatibility:** native handling is registered only on macOS; Windows/Linux behavior, shortcuts, labels, shells, and file paths are unchanged. The web preload implements a no-op contract and all desktop/web typechecks and builds pass.
- **Local/SSH/runtime compatibility:** local Git and folder workspaces publish their path; every non-local execution host publishes only its display name. Remote paths are never passed to a local macOS API.
- **Agent/integration/provider compatibility:** the selector uses provider-neutral workspace state and does not change agent launches, terminals, Git providers, or integrations.
- **Performance:** the renderer uses a shallow metadata projection, so IPC occurs only when the active name/path changes. The main listener performs bounded validation and two synchronous BrowserWindow property updates; there is no filesystem or network work.
- **UI quality:** there is no renderer-visible UI change, and the base Orca/dev-instance title is preserved when workspace metadata is added or cleared.

No feature-specific issues remained after review. I tightened path validation to macOS/POSIX absolute paths so the test and runtime semantics stay platform-correct.

## Security Audit

- The main process accepts updates only from the owning renderer `webContents.id`; plugin/webview senders cannot spoof the main window.
- IPC input is treated as `unknown`, type-checked, length-bounded, and restricted to null-free absolute POSIX paths before reaching Electron.
- The path is used only as native window metadata. This adds no file reads/writes, command execution, auth, secrets, dependencies, or network access.
- The listener is removed with the BrowserWindow lifecycle.

## Notes

- macOS-only by design because represented filenames are a macOS BrowserWindow capability.
- Remote workspace titles remain useful to time trackers, but `AXDocument` is intentionally empty for SSH/runtime paths.
- Not manually verified in Timing.app; behavior is covered through Electron's documented represented-file API and focused main/renderer tests.
- X handle: N/A (none listed on my GitHub profile).
