### PR TITLE
feat(mobile): preview videos in the file viewer

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -197,6 +197,7 @@ import { MobileTerminalLiveInputStatus } from '../../../../src/session/MobileTer
 import { MobileTerminalInputActions } from '../../../../src/session/MobileTerminalInputActions'
 import { resolveMobileFileTabDoc } from '../../../../src/files/mobile-file-tab-doc'
 import { captureMobileFileMutationOwnership } from '../../../../src/files/mobile-file-mutation-ownership'
+import { MobileFileVideoPreview } from '../../../../src/files/MobileFileVideoPreview'
 import { useMobileFileTapHandlers } from '../../../../src/session/use-mobile-file-tap-handlers'
 import { useLiveWorktreeName } from '../../../../src/session/use-live-worktree-name'
 import { useMissingWorktreeBounce } from '../../../../src/session/use-missing-worktree-bounce'
@@ -682,6 +683,17 @@ function FileReader({
           />
         </ScrollView>
       </View>
+    )
+  }
+
+  if (doc.kind === 'video') {
+    return (
+      <MobileFileVideoPreview
+        relativePath={relativePath || title}
+        base64={doc.base64}
+        mimeType={doc.mimeType}
+        title={title}
+      />
     )
   }
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -46,6 +46,7 @@
     "expo-secure-store": "^55.0.13",
     "expo-splash-screen": "^55.0.20",
     "expo-status-bar": "^55.0.6",
+    "expo-video": "^55.0.19",
     "lowlight": "^3.3.0",
     "lucide-react-native": "^1.14.0",
     "mermaid": "11.16.1",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       expo-status-bar:
         specifier: ^55.0.6
         version: 55.0.6(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      expo-video:
+        specifier: ^55.0.19
+        version: 55.0.19(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -4434,6 +4437,13 @@ packages:
     resolution: {integrity: sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==}
     peerDependencies:
       expo: '*'
+
+  expo-video@55.0.19:
+    resolution: {integrity: sha512-/B3aDy+cAGYdtpQa2RSxZGnm2kj53iEKKsZUwaA1I959bkeWFxrjQw0L58RGQhorS5PAImNWH4GSA9b5IslOyg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo@55.0.27:
     resolution: {integrity: sha512-uB8fbowkb/Xel2/x4b+cFfg76GGb2lhgaPVdm/ago+QL/852VJP+bUU6LzQVszQFmCTMHCJyrQ4l8enThCnfxw==}
@@ -12232,6 +12242,12 @@ snapshots:
   expo-updates-interface@55.1.6(expo@55.0.27):
     dependencies:
       expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+
+  expo-video@55.0.19(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+    dependencies:
+      expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      react: 19.2.6
+      react-native: 0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6)
 
   expo@55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:

--- a/mobile/src/files/MobileFilePreviewBody.tsx
+++ b/mobile/src/files/MobileFilePreviewBody.tsx
@@ -4,6 +4,7 @@ import type { MobileFilePreviewResult } from './mobile-file-preview-request'
 import { MobileFileMarkdownPreview } from './MobileFileMarkdownPreview'
 import { MobileFilePreviewEditableSource } from './MobileFilePreviewEditableSource'
 import { MobileFilePreviewSourceText } from './MobileFilePreviewSourceText'
+import { MobileFileVideoPreview } from './MobileFileVideoPreview'
 import type { MobileFilePreviewLineColumn } from './mobile-file-preview-line-column'
 import { filePreviewStyles as styles } from './mobile-file-preview-styles'
 
@@ -69,6 +70,16 @@ export function MobileFilePreviewBody({ preview, ...options }: Props) {
           />
         </ScrollView>
       </View>
+    )
+  }
+  if (preview.kind === 'video') {
+    return (
+      <MobileFileVideoPreview
+        relativePath={options.relativePath}
+        base64={preview.base64}
+        mimeType={preview.mimeType}
+        title={options.title}
+      />
     )
   }
   if (preview.kind === 'markdown') {

--- a/mobile/src/files/MobileFilePreviewScreen.tsx
+++ b/mobile/src/files/MobileFilePreviewScreen.tsx
@@ -7,6 +7,7 @@ import { getWorktreeLabel } from '../session/worktree-label'
 import { colors, spacing } from '../theme/mobile-theme'
 import { useForceReconnect, useHostClient } from '../transport/client-context'
 import {
+  isMobileFilePreviewTextResult,
   loadMobileFilePreview,
   previewError,
   saveMobileTerminalArtifactPreview,
@@ -118,12 +119,11 @@ export function MobileFilePreviewScreen({ route }: Props) {
         setSaveError(result.message)
         return
       }
-      const loadedContent =
-        result.status === 'ready' && result.kind !== 'image'
-          ? result.content
-          : result.status === 'empty'
-            ? ''
-            : null
+      const loadedContent = isMobileFilePreviewTextResult(result)
+        ? result.content
+        : result.status === 'empty'
+          ? ''
+          : null
       if (loadedContent !== null) {
         if (!preserveDirtyDraft) {
           setDraftContent(loadedContent)

--- a/mobile/src/files/MobileFileVideoPreview.tsx
+++ b/mobile/src/files/MobileFileVideoPreview.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Text, View } from 'react-native'
+import { useEvent } from 'expo'
+import { useVideoPlayer, VideoView } from 'expo-video'
+import { colors } from '../theme/mobile-theme'
+import { filePreviewStyles as styles } from './mobile-file-preview-styles'
+import {
+  deleteMobileVideoPreviewFile,
+  mobileVideoPreviewFileName,
+  writeMobileVideoPreviewFile
+} from './mobile-video-preview-cache-file'
+
+type Props = {
+  relativePath: string
+  base64: string
+  mimeType: string
+  title: string
+}
+
+// Plays a video the host returned as base64 (files.readPreview). The bytes are
+// staged in the cache directory because the native players cannot open a data URI.
+export function MobileFileVideoPreview({ relativePath, base64, mimeType, title }: Props) {
+  const [stagedUri, setStagedUri] = useState<string | null>(null)
+  const [stageError, setStageError] = useState('')
+
+  useEffect(() => {
+    let staged: string | null = null
+    try {
+      staged = writeMobileVideoPreviewFile(
+        mobileVideoPreviewFileName(relativePath, mimeType),
+        base64
+      )
+      setStageError('')
+      setStagedUri(staged)
+    } catch (err) {
+      setStagedUri(null)
+      setStageError(err instanceof Error ? err.message : 'Unable to open this video')
+    }
+    return () => {
+      setStagedUri(null)
+      if (staged) {
+        deleteMobileVideoPreviewFile(staged)
+      }
+    }
+  }, [base64, mimeType, relativePath])
+
+  const player = useVideoPlayer(stagedUri, (instance) => {
+    instance.loop = false
+  })
+  const statusChange = useEvent(player, 'statusChange')
+  const status = statusChange?.status ?? player.status
+
+  if (stageError || status === 'error') {
+    return (
+      <View style={styles.state}>
+        <Text style={styles.errorText}>
+          {stageError || statusChange?.error?.message || 'Unable to play this video'}
+        </Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.videoContainer}>
+      <VideoView
+        style={styles.video}
+        player={player}
+        contentFit="contain"
+        accessibilityLabel={`${title} video`}
+      />
+      {status === 'readyToPlay' ? null : (
+        <View style={styles.videoLoading} pointerEvents="none">
+          <ActivityIndicator size="small" color={colors.textSecondary} />
+        </View>
+      )}
+    </View>
+  )
+}

--- a/mobile/src/files/file-tree.ts
+++ b/mobile/src/files/file-tree.ts
@@ -46,6 +46,7 @@ const BINARY_EXTENSIONS = new Set([
   '.ico',
   '.jpeg',
   '.jpg',
+  '.m4v',
   '.mov',
   '.mp3',
   '.mp4',

--- a/mobile/src/files/mobile-file-explorer-row.tsx
+++ b/mobile/src/files/mobile-file-explorer-row.tsx
@@ -84,8 +84,7 @@ function TreeRow(props: {
   const { item, expanded, onPreviewFile, onToggleDirectory } = props
   const isDirectory = item.kind === 'directory'
   const isExpanded = expanded.has(item.relativePath)
-  // Images and videos render in the mobile viewer (via files.readPreview), so those
-  // binaries are openable; only non-previewable binaries are unavailable.
+  // Only binaries the mobile viewer can render (images, videos) stay openable.
   const previewable =
     item.kind !== 'directory' &&
     canPreviewMobileFileRow({ kind: item.kind, relativePath: item.relativePath })

--- a/mobile/src/files/mobile-file-explorer-row.tsx
+++ b/mobile/src/files/mobile-file-explorer-row.tsx
@@ -4,9 +4,11 @@ import {
   ChevronRight,
   File,
   FileText,
+  FileVideo,
   Folder,
   Image as ImageIcon
 } from 'lucide-react-native'
+import { classifyMobileArtifact } from '../session/mobile-artifact-kind'
 import { triggerSelection } from '../platform/haptics'
 import { colors, spacing } from '../theme/mobile-theme'
 import { type FileExplorerRow, isMarkdownPath, type TreeNode } from './file-tree'
@@ -82,12 +84,13 @@ function TreeRow(props: {
   const { item, expanded, onPreviewFile, onToggleDirectory } = props
   const isDirectory = item.kind === 'directory'
   const isExpanded = expanded.has(item.relativePath)
-  // Images render in the mobile viewer (via files.readPreview), so a binary
-  // image is openable; only non-previewable binaries are unavailable.
+  // Images and videos render in the mobile viewer (via files.readPreview), so those
+  // binaries are openable; only non-previewable binaries are unavailable.
   const previewable =
     item.kind !== 'directory' &&
     canPreviewMobileFileRow({ kind: item.kind, relativePath: item.relativePath })
-  const isImage = item.kind === 'binary' && previewable
+  const previewableBinaryKind =
+    item.kind === 'binary' && previewable ? classifyMobileArtifact(item.relativePath) : null
   const disabled = item.kind === 'binary' && !previewable
   const markdown = item.kind === 'text' && isMarkdownPath(item.relativePath)
 
@@ -129,8 +132,10 @@ function TreeRow(props: {
         <Folder size={17} color={colors.textSecondary} />
       ) : markdown ? (
         <FileText size={17} color={disabled ? colors.textMuted : colors.textSecondary} />
-      ) : isImage ? (
+      ) : previewableBinaryKind === 'image' ? (
         <ImageIcon size={17} color={colors.textSecondary} />
+      ) : previewableBinaryKind === 'video' ? (
+        <FileVideo size={17} color={colors.textSecondary} />
       ) : (
         <File size={17} color={disabled ? colors.textMuted : colors.textSecondary} />
       )}

--- a/mobile/src/files/mobile-file-preview-editability.ts
+++ b/mobile/src/files/mobile-file-preview-editability.ts
@@ -1,6 +1,7 @@
-import type {
-  MobileFilePreviewResult,
-  MobileFilePreviewSource
+import {
+  isMobileFilePreviewTextResult,
+  type MobileFilePreviewResult,
+  type MobileFilePreviewSource
 } from './mobile-file-preview-request'
 
 export function isEditableMobileTerminalArtifactPreview(
@@ -11,8 +12,7 @@ export function isEditableMobileTerminalArtifactPreview(
     return false
   }
   return (
-    (preview.status === 'ready' && preview.kind !== 'image' && !preview.truncated) ||
-    preview.status === 'empty'
+    (isMobileFilePreviewTextResult(preview) && !preview.truncated) || preview.status === 'empty'
   )
 }
 

--- a/mobile/src/files/mobile-file-preview-navigation.test.ts
+++ b/mobile/src/files/mobile-file-preview-navigation.test.ts
@@ -60,9 +60,13 @@ describe('mobile-file-preview-navigation', () => {
     expect(scheduleClose).toHaveBeenCalledWith(expect.any(Function), 0)
   })
 
-  it('keeps non-image binary rows disabled while previewing text and raster images', () => {
+  it('keeps unplayable binary rows disabled while previewing text, raster images, and videos', () => {
     expect(canPreviewMobileFileRow({ kind: 'text', relativePath: 'src/app.ts' })).toBe(true)
     expect(canPreviewMobileFileRow({ kind: 'binary', relativePath: 'assets/logo.webp' })).toBe(true)
+    expect(canPreviewMobileFileRow({ kind: 'binary', relativePath: 'assets/demo.mp4' })).toBe(true)
+    expect(canPreviewMobileFileRow({ kind: 'binary', relativePath: 'assets/clip.webm' })).toBe(
+      false
+    )
     expect(canPreviewMobileFileRow({ kind: 'binary', relativePath: 'archive.zip' })).toBe(false)
   })
 })

--- a/mobile/src/files/mobile-file-preview-navigation.ts
+++ b/mobile/src/files/mobile-file-preview-navigation.ts
@@ -1,4 +1,4 @@
-import { classifyMobileArtifact } from '../session/mobile-artifact-kind'
+import { isMobileBinaryPreviewPath } from '../session/mobile-artifact-kind'
 import {
   createMobileFilePreviewHref,
   type MobileFilePreviewHref,
@@ -33,5 +33,5 @@ export function canPreviewMobileFileRow(item: {
   kind: 'text' | 'binary'
   relativePath: string
 }): boolean {
-  return item.kind === 'text' || classifyMobileArtifact(item.relativePath) === 'image'
+  return item.kind === 'text' || isMobileBinaryPreviewPath(item.relativePath)
 }

--- a/mobile/src/files/mobile-file-preview-request.test.ts
+++ b/mobile/src/files/mobile-file-preview-request.test.ts
@@ -44,6 +44,49 @@ describe('mobile-file-preview-request', () => {
     })
   })
 
+  it('selects readPreview for playable videos, including terminal artifacts', () => {
+    expect(createMobileFilePreviewRequest('wt-1', 'assets/demo.mp4')).toEqual({
+      method: 'files.readPreview',
+      params: { worktree: 'id:wt-1', relativePath: 'assets/demo.mp4' }
+    })
+    expect(
+      createMobileFilePreviewRequest({
+        source: 'terminalArtifact',
+        worktreeId: 'wt-1',
+        absolutePath: '/tmp/screen.mov',
+        grantId: 'grant-1'
+      })
+    ).toEqual({
+      method: 'files.readTerminalArtifactPreview',
+      params: { worktree: 'id:wt-1', absolutePath: '/tmp/screen.mov', grantId: 'grant-1' }
+    })
+  })
+
+  it('loads videos as raw base64 so the player can stage them on disk', async () => {
+    const client = clientWith(
+      ok({ content: 'dmlkZW8=', isBinary: true, isVideo: true, mimeType: 'video/mp4' })
+    )
+
+    await expect(loadMobileFilePreview(client, 'wt-1', 'assets/demo.mp4')).resolves.toEqual({
+      status: 'ready',
+      kind: 'video',
+      base64: 'dmlkZW8=',
+      mimeType: 'video/mp4'
+    })
+  })
+
+  it.each([
+    ['missing isVideo', { content: 'dmlkZW8=', isBinary: true, mimeType: 'video/mp4' }],
+    ['image flag only', { content: 'dmlkZW8=', isBinary: true, isImage: true }],
+    ['empty content', { content: '', isBinary: true, isVideo: true, mimeType: 'video/mp4' }]
+  ])('rejects invalid video preview results: %s', (_label, result) => {
+    expect(normalizeMobileFilePreviewResponse('assets/demo.mp4', ok(result))).toEqual({
+      status: 'error',
+      message: 'Binary preview unavailable',
+      reconnect: false
+    })
+  })
+
   it('loads images through readPreview and never calls files.open', async () => {
     const client = clientWith(
       ok({ content: 'aW1hZ2U=', isBinary: true, isImage: true, mimeType: 'image/png' })

--- a/mobile/src/files/mobile-file-preview-request.ts
+++ b/mobile/src/files/mobile-file-preview-request.ts
@@ -1,7 +1,8 @@
-import { classifyMobileArtifact } from '../session/mobile-artifact-kind'
+import { isMobileBinaryPreviewPath } from '../session/mobile-artifact-kind'
 import type { RpcFailure, RpcResponse } from '../transport/types'
 import type { RpcClient } from '../transport/rpc-client'
 import {
+  isMobileFilePreviewTextResult,
   normalizeMobileFilePreviewResponse,
   previewError,
   type MobileFilePreviewResult
@@ -14,6 +15,7 @@ import {
 
 export {
   formatPreviewByteLength,
+  isMobileFilePreviewTextResult,
   normalizeMobileFilePreviewResponse,
   previewError
 } from './mobile-file-preview-response'
@@ -60,10 +62,9 @@ export function createMobileFilePreviewRequest(
       ? { source: 'worktree' as const, worktreeId: worktreeIdOrSource, relativePath: relativePath! }
       : worktreeIdOrSource
   if (source.source === 'terminalArtifact') {
-    const method =
-      classifyMobileArtifact(source.absolutePath) === 'image'
-        ? 'files.readTerminalArtifactPreview'
-        : 'files.readTerminalArtifact'
+    const method = isMobileBinaryPreviewPath(source.absolutePath)
+      ? 'files.readTerminalArtifactPreview'
+      : 'files.readTerminalArtifact'
     return {
       method,
       params: {
@@ -74,8 +75,7 @@ export function createMobileFilePreviewRequest(
     }
   }
   return {
-    method:
-      classifyMobileArtifact(source.relativePath) === 'image' ? 'files.readPreview' : 'files.read',
+    method: isMobileBinaryPreviewPath(source.relativePath) ? 'files.readPreview' : 'files.read',
     params: {
       worktree: `id:${source.worktreeId}`,
       relativePath: source.relativePath
@@ -251,7 +251,7 @@ function terminalArtifactPreviewMatchesBase(
   if (preview.status === 'empty') {
     return baseContent.length === 0
   }
-  return preview.status === 'ready' && preview.kind !== 'image' && preview.content === baseContent
+  return isMobileFilePreviewTextResult(preview) && preview.content === baseContent
 }
 
 function previewPathForSource(source: MobileFilePreviewSource): string {

--- a/mobile/src/files/mobile-file-preview-response.ts
+++ b/mobile/src/files/mobile-file-preview-response.ts
@@ -22,6 +22,14 @@ export type MobileFilePreviewResult =
     }
   | {
       status: 'ready'
+      kind: 'video'
+      // Kept as raw base64 (not a data URI): the player needs the bytes on disk,
+      // and re-splitting a multi-megabyte data URI would double peak memory.
+      base64: string
+      mimeType: string
+    }
+  | {
+      status: 'ready'
       kind: MobileFilePreviewTextKind
       content: string
       truncated: boolean
@@ -48,10 +56,24 @@ export function normalizeMobileFilePreviewResponse(
   }
 
   const result = (response as RpcSuccess).result
-  if (classifyMobileArtifact(relativePath) === 'image') {
+  const artifactKind = classifyMobileArtifact(relativePath)
+  if (artifactKind === 'image') {
     return normalizeImagePreviewResult(result)
   }
+  if (artifactKind === 'video') {
+    return normalizeVideoPreviewResult(result)
+  }
   return normalizeTextPreviewResult(relativePath, result)
+}
+
+// Text arms carry editable content; image/video previews never do.
+export function isMobileFilePreviewTextResult(
+  result: MobileFilePreviewResult
+): result is Extract<
+  MobileFilePreviewResult,
+  { status: 'ready'; kind: MobileFilePreviewTextKind }
+> {
+  return result.status === 'ready' && result.kind !== 'image' && result.kind !== 'video'
 }
 
 export function previewError(message: string): MobileFilePreviewResult {
@@ -98,30 +120,44 @@ export function formatPreviewByteLength(byteLength: number): string {
 }
 
 function normalizeImagePreviewResult(result: unknown): MobileFilePreviewResult {
-  if (!result || typeof result !== 'object') {
-    return previewError('binary_file')
-  }
-  const preview = result as {
-    content?: unknown
-    isBinary?: unknown
-    isImage?: unknown
-    mimeType?: unknown
-  }
-  if (
-    preview.isBinary !== true ||
-    preview.isImage !== true ||
-    typeof preview.mimeType !== 'string' ||
-    preview.mimeType.length === 0 ||
-    typeof preview.content !== 'string' ||
-    preview.content.length === 0
-  ) {
+  const media = readBinaryPreviewMedia(result, 'isImage')
+  if (!media) {
     return previewError('binary_file')
   }
   return {
     status: 'ready',
     kind: 'image',
-    dataUri: `data:${preview.mimeType};base64,${preview.content}`
+    dataUri: `data:${media.mimeType};base64,${media.content}`
   }
+}
+
+function normalizeVideoPreviewResult(result: unknown): MobileFilePreviewResult {
+  const media = readBinaryPreviewMedia(result, 'isVideo')
+  if (!media) {
+    return previewError('binary_file')
+  }
+  return { status: 'ready', kind: 'video', base64: media.content, mimeType: media.mimeType }
+}
+
+function readBinaryPreviewMedia(
+  result: unknown,
+  flag: 'isImage' | 'isVideo'
+): { content: string; mimeType: string } | null {
+  if (!result || typeof result !== 'object') {
+    return null
+  }
+  const preview = result as Record<string, unknown>
+  if (
+    preview.isBinary !== true ||
+    preview[flag] !== true ||
+    typeof preview.mimeType !== 'string' ||
+    preview.mimeType.length === 0 ||
+    typeof preview.content !== 'string' ||
+    preview.content.length === 0
+  ) {
+    return null
+  }
+  return { content: preview.content, mimeType: preview.mimeType }
 }
 
 function normalizeTextPreviewResult(

--- a/mobile/src/files/mobile-file-preview-styles.ts
+++ b/mobile/src/files/mobile-file-preview-styles.ts
@@ -152,8 +152,6 @@ export const filePreviewStyles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.editorSurface
   },
-  // Fills the pane and letterboxes inside itself (contentFit="contain"), so portrait
-  // recordings get the same room as landscape ones.
   video: {
     flex: 1
   },

--- a/mobile/src/files/mobile-file-preview-styles.ts
+++ b/mobile/src/files/mobile-file-preview-styles.ts
@@ -148,6 +148,20 @@ export const filePreviewStyles = StyleSheet.create({
   image: {
     backgroundColor: colors.editorSurface
   },
+  videoContainer: {
+    flex: 1,
+    backgroundColor: colors.editorSurface
+  },
+  // Fills the pane and letterboxes inside itself (contentFit="contain"), so portrait
+  // recordings get the same room as landscape ones.
+  video: {
+    flex: 1
+  },
+  videoLoading: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
   editContainer: {
     flex: 1,
     backgroundColor: colors.editorSurface,

--- a/mobile/src/files/mobile-file-tab-doc.ts
+++ b/mobile/src/files/mobile-file-tab-doc.ts
@@ -13,6 +13,7 @@ export type MobileFileTabDoc =
   | { status: 'ready'; kind: 'file'; content: string; truncated: boolean; byteLength: number }
   | { status: 'ready'; kind: 'diff'; lines: MobileDiffLine[]; truncated: boolean }
   | { status: 'ready'; kind: 'image'; dataUri: string }
+  | { status: 'ready'; kind: 'video'; base64: string; mimeType: string }
   | { status: 'ready'; kind: 'html'; content: string }
 
 export type MobileFileTabDocRequest = {
@@ -55,7 +56,7 @@ export async function resolveMobileFileTabDoc(
   }
 
   const artifactKind = classifyMobileArtifact(relativePath)
-  if (artifactKind === 'image') {
+  if (artifactKind === 'image' || artifactKind === 'video') {
     const preview = await client.sendRequest('files.readPreview', { worktree, relativePath })
     if (!preview.ok) {
       throw new Error((preview as RpcFailure).error.message)
@@ -63,7 +64,14 @@ export async function resolveMobileFileTabDoc(
     const result = (preview as RpcSuccess).result as {
       content: string
       isImage?: boolean
+      isVideo?: boolean
       mimeType?: string
+    }
+    if (artifactKind === 'video') {
+      if (!result.isVideo || !result.mimeType || !result.content) {
+        throw new Error('binary_file')
+      }
+      return { status: 'ready', kind: 'video', base64: result.content, mimeType: result.mimeType }
     }
     const dataUri = result.isImage ? buildImageDataUri(result.mimeType, result.content) : null
     if (!dataUri) {

--- a/mobile/src/files/mobile-video-preview-cache-file.test.ts
+++ b/mobile/src/files/mobile-video-preview-cache-file.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('expo-file-system', () => ({
+  File: vi.fn(),
+  Paths: { cache: 'file:///cache' }
+}))
+
+import { File as FsFile } from 'expo-file-system'
+import {
+  deleteMobileVideoPreviewFile,
+  mobileVideoPreviewFileName,
+  writeMobileVideoPreviewFile
+} from './mobile-video-preview-cache-file'
+
+const FileMock = vi.mocked(FsFile)
+
+beforeEach(() => {
+  FileMock.mockReset()
+})
+
+describe('mobile-video-preview-cache-file', () => {
+  it('names the staged file after its container so the native player picks a demuxer', () => {
+    expect(mobileVideoPreviewFileName('assets/demo.mp4', 'video/mp4')).toMatch(/\.mp4$/)
+    expect(mobileVideoPreviewFileName('assets/demo.mov', 'video/quicktime')).toMatch(/\.mov$/)
+    expect(mobileVideoPreviewFileName('assets/demo.mp4', 'video/unknown')).toMatch(/\.mp4$/)
+  })
+
+  it('keeps one cache slot per source path and separates different paths', () => {
+    const same = mobileVideoPreviewFileName('assets/demo.mp4', 'video/mp4')
+    expect(mobileVideoPreviewFileName('assets/demo.mp4', 'video/mp4')).toBe(same)
+    expect(mobileVideoPreviewFileName('other/demo.mp4', 'video/mp4')).not.toBe(same)
+  })
+
+  it('writes base64 bytes into the cache directory and returns the file uri', () => {
+    const create = vi.fn()
+    const write = vi.fn()
+    FileMock.mockImplementation(function () {
+      return { create, write, uri: 'file:///cache/orca-video-preview-1.mp4' } as never
+    })
+
+    expect(writeMobileVideoPreviewFile('orca-video-preview-1.mp4', 'dmlkZW8=')).toBe(
+      'file:///cache/orca-video-preview-1.mp4'
+    )
+    expect(FileMock).toHaveBeenCalledWith('file:///cache', 'orca-video-preview-1.mp4')
+    expect(create).toHaveBeenCalledWith({ overwrite: true })
+    expect(write).toHaveBeenCalledWith('dmlkZW8=', { encoding: 'base64' })
+  })
+
+  it('swallows a failed cleanup so leaving the preview never throws', () => {
+    FileMock.mockImplementation(function () {
+      return {
+        delete: () => {
+          throw new Error('ENOENT')
+        }
+      } as never
+    })
+
+    expect(() => deleteMobileVideoPreviewFile('file:///cache/gone.mp4')).not.toThrow()
+  })
+})

--- a/mobile/src/files/mobile-video-preview-cache-file.ts
+++ b/mobile/src/files/mobile-video-preview-cache-file.ts
@@ -1,0 +1,43 @@
+import { File as FsFile, Paths } from 'expo-file-system'
+
+// Native players (AVPlayer/ExoPlayer) only open a real file — they reject base64
+// data URIs — so a video preview is staged in the cache directory first. The
+// extension has to match the container: AVPlayer picks its demuxer from it.
+const VIDEO_PREVIEW_FILE_PREFIX = 'orca-video-preview-'
+const VIDEO_PREVIEW_EXTENSIONS: Record<string, string> = {
+  'video/mp4': 'mp4',
+  'video/quicktime': 'mov'
+}
+
+// Named after the source path so re-opening the same file reuses one cache slot
+// instead of leaking a staged copy per visit.
+export function mobileVideoPreviewFileName(sourcePath: string, mimeType: string): string {
+  const extension = VIDEO_PREVIEW_EXTENSIONS[mimeType.toLowerCase()] ?? 'mp4'
+  return `${VIDEO_PREVIEW_FILE_PREFIX}${hashPreviewSourcePath(sourcePath)}.${extension}`
+}
+
+export function writeMobileVideoPreviewFile(fileName: string, base64: string): string {
+  const file = new FsFile(Paths.cache, fileName)
+  file.create({ overwrite: true })
+  file.write(base64, { encoding: 'base64' })
+  return file.uri
+}
+
+export function deleteMobileVideoPreviewFile(uri: string): void {
+  try {
+    new FsFile(uri).delete()
+  } catch {
+    // Best-effort: the OS reclaims the cache directory, and a failed unlink must
+    // not break navigating away from the preview.
+  }
+}
+
+// FNV-1a: repository paths contain separators and unicode that can't go in a file name.
+function hashPreviewSourcePath(sourcePath: string): string {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < sourcePath.length; index += 1) {
+    hash ^= sourcePath.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}

--- a/mobile/src/session/mobile-artifact-kind.test.ts
+++ b/mobile/src/session/mobile-artifact-kind.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { classifyMobileArtifact } from './mobile-artifact-kind'
+import { classifyMobileArtifact, isMobileBinaryPreviewPath } from './mobile-artifact-kind'
 
 describe('classifyMobileArtifact', () => {
   it('classifies raster image extensions (case-insensitive)', () => {
@@ -10,6 +10,24 @@ describe('classifyMobileArtifact', () => {
 
   it('treats svg as other (RN Image cannot decode svg data URIs; render as source)', () => {
     expect(classifyMobileArtifact('logo.svg')).toBe('other')
+  })
+
+  it('classifies natively playable video extensions (case-insensitive)', () => {
+    for (const p of ['clip.mp4', 'a/b/demo.MOV', 'c.m4v']) {
+      expect(classifyMobileArtifact(p)).toBe('video')
+    }
+  })
+
+  it('treats webm/mkv as other (iOS cannot decode them)', () => {
+    expect(classifyMobileArtifact('clip.webm')).toBe('other')
+    expect(classifyMobileArtifact('clip.mkv')).toBe('other')
+  })
+
+  it('routes images and videos to the base64 preview reads', () => {
+    expect(isMobileBinaryPreviewPath('assets/logo.png')).toBe(true)
+    expect(isMobileBinaryPreviewPath('assets/demo.mp4')).toBe(true)
+    expect(isMobileBinaryPreviewPath('index.html')).toBe(false)
+    expect(isMobileBinaryPreviewPath('src/app.ts')).toBe(false)
   })
 
   it('classifies html extensions', () => {

--- a/mobile/src/session/mobile-artifact-kind.ts
+++ b/mobile/src/session/mobile-artifact-kind.ts
@@ -1,14 +1,19 @@
-// Classifies a file path into how the mobile viewer should render it. Images
-// route through files.readPreview (base64) and render as an <Image>; HTML routes
-// through files.read (text) and renders in a sandboxed WebView with a source
-// toggle; everything else stays on the existing text/syntax path.
-export type MobileArtifactKind = 'image' | 'html' | 'other'
+// Classifies a file path into how the mobile viewer should render it. Images and
+// videos route through files.readPreview (base64) and render as an <Image> or a
+// native player; HTML routes through files.read (text) and renders in a sandboxed
+// WebView with a source toggle; everything else stays on the existing text/syntax path.
+export type MobileArtifactKind = 'image' | 'video' | 'html' | 'other'
 
 // Raster image extensions React Native's <Image> can decode from a base64 data
 // URI (host returns these via files.readPreview). SVG is intentionally excluded:
 // RN <Image> can't render image/svg+xml data URIs, so .svg falls through to the
 // text path and renders as (meaningful) XML source instead of a blank image.
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'ico'])
+
+// Container formats both AVPlayer (iOS) and ExoPlayer (Android) decode. WebM/MKV
+// are excluded: iOS can't play them, so they stay on the unavailable-binary path
+// instead of opening a player that fails.
+const VIDEO_EXTENSIONS = new Set(['mp4', 'm4v', 'mov'])
 
 const HTML_EXTENSIONS = new Set(['html', 'htm'])
 
@@ -22,10 +27,20 @@ function extensionOf(path: string): string {
   return base.slice(dot + 1).toLowerCase()
 }
 
+// Images and videos come back as base64 from the *Preview read methods; text
+// kinds use the plain reads.
+export function isMobileBinaryPreviewPath(path: string): boolean {
+  const kind = classifyMobileArtifact(path)
+  return kind === 'image' || kind === 'video'
+}
+
 export function classifyMobileArtifact(path: string): MobileArtifactKind {
   const ext = extensionOf(path)
   if (IMAGE_EXTENSIONS.has(ext)) {
     return 'image'
+  }
+  if (VIDEO_EXTENSIONS.has(ext)) {
+    return 'video'
   }
   if (HTML_EXTENSIONS.has(ext)) {
     return 'html'

--- a/mobile/src/session/mobile-session-route-types.ts
+++ b/mobile/src/session/mobile-session-route-types.ts
@@ -90,6 +90,7 @@ export type FileDocState =
   | { status: 'ready'; kind: 'file'; content: string; truncated: boolean; byteLength: number }
   | { status: 'ready'; kind: 'diff'; lines: MobileDiffLine[]; truncated: boolean }
   | { status: 'ready'; kind: 'image'; dataUri: string }
+  | { status: 'ready'; kind: 'video'; base64: string; mimeType: string }
   | { status: 'ready'; kind: 'html'; content: string }
   | { status: 'error'; message: string }
 

--- a/src/main/providers/filesystem-provider-contract.ts
+++ b/src/main/providers/filesystem-provider-contract.ts
@@ -16,6 +16,8 @@ export type FileReadResult = {
   content: string
   isBinary: boolean
   isImage?: boolean
+  /** Set for video containers mobile can play natively (mp4/m4v/mov). */
+  isVideo?: boolean
   mimeType?: string
 }
 

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -97,6 +97,7 @@ import {
 import { beginWatcherInstall } from '../ipc/watcher-removal-gate'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
 import { toSshExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
+import { VIDEO_FILE_MIME_TYPES } from '../../shared/video-file-extensions'
 import { renameLocalPathSerializedByDestination } from '../destination-serialized-local-rename'
 import {
   NodeFileReadTooLargeError,
@@ -206,6 +207,7 @@ const MOBILE_BINARY_EXTENSIONS = new Set([
   '.ico',
   '.jpeg',
   '.jpg',
+  '.m4v',
   '.mov',
   '.mp3',
   '.mp4',
@@ -268,6 +270,20 @@ const RUNTIME_PREVIEWABLE_BINARY_MIME_TYPES: Record<string, string> = {
   '.bmp': 'image/bmp',
   '.ico': 'image/x-icon',
   '.pdf': 'application/pdf'
+}
+
+// Kept apart from the image map so a preview can flag which media kind it carries
+// instead of claiming every previewable binary is an image.
+function runtimePreviewableBinaryMedia(
+  filePath: string
+): { mimeType: string; isImage: true } | { mimeType: string; isVideo: true } | null {
+  const extension = extname(filePath).toLowerCase()
+  const imageMimeType = RUNTIME_PREVIEWABLE_BINARY_MIME_TYPES[extension]
+  if (imageMimeType) {
+    return { mimeType: imageMimeType, isImage: true }
+  }
+  const videoMimeType = VIDEO_FILE_MIME_TYPES[extension]
+  return videoMimeType ? { mimeType: videoMimeType, isVideo: true } : null
 }
 
 function trackRuntimeFileWatcherUnsubscribe(
@@ -1661,8 +1677,8 @@ export class RuntimeFileCommands {
     }
 
     const filePath = await resolveAuthorizedPath(target.path, this.host.requireStore())
-    const mimeType = RUNTIME_PREVIEWABLE_BINARY_MIME_TYPES[extname(filePath).toLowerCase()]
-    const maxBytes = mimeType ? binaryMaxBytes : MOBILE_FILE_READ_MAX_BYTES
+    const media = runtimePreviewableBinaryMedia(filePath)
+    const maxBytes = media ? binaryMaxBytes : MOBILE_FILE_READ_MAX_BYTES
     let buffer: Buffer
     try {
       buffer = (await readNodeFileWithinLimit(filePath, maxBytes)).buffer
@@ -1672,13 +1688,12 @@ export class RuntimeFileCommands {
       }
       throw error
     }
-    if (mimeType) {
+    if (media) {
       return assertPreviewWithinTransportBudget(
         {
           content: buffer.toString('base64'),
           isBinary: true,
-          isImage: true,
-          mimeType
+          ...media
         },
         maxContentBytes
       )
@@ -2616,8 +2631,8 @@ async function readLocalTerminalArtifactPreviewFromHandle(
     throw new Error('Cannot preview a directory')
   }
   assertTerminalFileGrantFresh(grant, fileStats)
-  const mimeType = RUNTIME_PREVIEWABLE_BINARY_MIME_TYPES[extname(grant.absolutePath).toLowerCase()]
-  if (mimeType) {
+  const media = runtimePreviewableBinaryMedia(grant.absolutePath)
+  if (media) {
     const binaryMaxBytes =
       maxContentBytes === undefined
         ? LOCAL_PREVIEWABLE_BINARY_MAX_BYTES
@@ -2632,8 +2647,7 @@ async function readLocalTerminalArtifactPreviewFromHandle(
     return {
       content: buffer.toString('base64'),
       isBinary: true,
-      isImage: true,
-      mimeType
+      ...media
     }
   }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4256,23 +4256,31 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('previews playable videos as base64 so mobile can hand them to a native player', async () => {
+  it.each([
+    ['demo.mp4', 'video/mp4'],
+    ['demo.m4v', 'video/mp4'],
+    ['demo.mov', 'video/quicktime']
+  ])('previews %s as base64 so mobile can hand it to a native player', async (name, mimeType) => {
     const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-video-preview-'))
-    await writeFile(join(folderPath, 'demo.mp4'), Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66]))
+    await writeFile(join(folderPath, name), Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66]))
     const folderWorkspace = makeFolderWorkspace({ folderPath })
     const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
     const runtime = new OrcaRuntimeService(
       createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
     )
 
-    await expect(
-      runtime.readFileExplorerPreview(`id:${TEST_FOLDER_WORKSPACE_KEY}`, 'demo.mp4')
-    ).resolves.toEqual({
-      content: 'AAAAGGY=',
-      isBinary: true,
-      isVideo: true,
-      mimeType: 'video/mp4'
-    })
+    try {
+      await expect(
+        runtime.readFileExplorerPreview(`id:${TEST_FOLDER_WORKSPACE_KEY}`, name)
+      ).resolves.toEqual({
+        content: 'AAAAGGY=',
+        isBinary: true,
+        isVideo: true,
+        mimeType
+      })
+    } finally {
+      await rm(folderPath, { recursive: true, force: true })
+    }
   })
 
   it('routes SSH folder workspace file explorer paths through the filesystem provider', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4256,6 +4256,25 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('previews playable videos as base64 so mobile can hand them to a native player', async () => {
+    const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-video-preview-'))
+    await writeFile(join(folderPath, 'demo.mp4'), Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66]))
+    const folderWorkspace = makeFolderWorkspace({ folderPath })
+    const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
+    const runtime = new OrcaRuntimeService(
+      createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
+    )
+
+    await expect(
+      runtime.readFileExplorerPreview(`id:${TEST_FOLDER_WORKSPACE_KEY}`, 'demo.mp4')
+    ).resolves.toEqual({
+      content: 'AAAAGGY=',
+      isBinary: true,
+      isVideo: true,
+      mimeType: 'video/mp4'
+    })
+  })
+
   it('routes SSH folder workspace file explorer paths through the filesystem provider', async () => {
     const folderPath = '/srv/platform'
     const fsProvider = {

--- a/src/main/ssh/ssh-filesystem-stream-reader.ts
+++ b/src/main/ssh/ssh-filesystem-stream-reader.ts
@@ -65,10 +65,9 @@ export async function readFileViaStream(
   return new Promise<FileReadResult>((resolve, reject) => {
     let buffer: Buffer | null = null
     let resultEncoding: 'base64' | 'utf-8' = RESULT_ENCODING_BASE64
-    let isBinary = false
-    let isImage: boolean | undefined
-    let isVideo: boolean | undefined
-    let mimeType: string | undefined
+    // Carried from the metadata frame to the result; optional media flags are only
+    // present when the relay sent them, so old relays stay wire-compatible.
+    let resultFields: Omit<FileReadResult, 'content'> = { isBinary: false }
     let totalSize = 0
     let expectedSeq = 0
     let receivedChunks = 0
@@ -208,13 +207,7 @@ export async function readFileViaStream(
         resultEncoding === RESULT_ENCODING_BASE64
           ? buffer.toString('base64')
           : buffer.toString('utf-8')
-      succeed({
-        content,
-        isBinary,
-        ...(isImage !== undefined ? { isImage } : {}),
-        ...(isVideo !== undefined ? { isVideo } : {}),
-        ...(mimeType !== undefined ? { mimeType } : {})
-      })
+      succeed({ content, ...resultFields })
     }
 
     const handleStreamError = (params: Record<string, unknown>): void => {
@@ -293,20 +286,16 @@ export async function readFileViaStream(
           return
         }
         const metadata = rawMetadata as StreamMetadataResponse
-        isBinary = metadata.isBinary
-        isImage = metadata.isImage
-        isVideo = metadata.isVideo
-        mimeType = metadata.mimeType
+        resultFields = {
+          isBinary: metadata.isBinary,
+          ...(metadata.isImage !== undefined ? { isImage: metadata.isImage } : {}),
+          ...(metadata.isVideo !== undefined ? { isVideo: metadata.isVideo } : {}),
+          ...(metadata.mimeType !== undefined ? { mimeType: metadata.mimeType } : {})
+        }
         resultEncoding = metadata.resultEncoding ?? RESULT_ENCODING_BASE64
 
         if (metadata.empty) {
-          succeed({
-            content: '',
-            isBinary: metadata.isBinary,
-            ...(metadata.isImage !== undefined ? { isImage: metadata.isImage } : {}),
-            ...(metadata.isVideo !== undefined ? { isVideo: metadata.isVideo } : {}),
-            ...(metadata.mimeType !== undefined ? { mimeType: metadata.mimeType } : {})
-          })
+          succeed({ content: '', ...resultFields })
           return
         }
 

--- a/src/main/ssh/ssh-filesystem-stream-reader.ts
+++ b/src/main/ssh/ssh-filesystem-stream-reader.ts
@@ -15,6 +15,7 @@ type StreamMetadataResponse = {
   totalSize: number
   isBinary: boolean
   isImage?: boolean
+  isVideo?: boolean
   mimeType?: string
   resultEncoding?: 'base64' | 'utf-8'
   empty?: boolean
@@ -66,6 +67,7 @@ export async function readFileViaStream(
     let resultEncoding: 'base64' | 'utf-8' = RESULT_ENCODING_BASE64
     let isBinary = false
     let isImage: boolean | undefined
+    let isVideo: boolean | undefined
     let mimeType: string | undefined
     let totalSize = 0
     let expectedSeq = 0
@@ -210,6 +212,7 @@ export async function readFileViaStream(
         content,
         isBinary,
         ...(isImage !== undefined ? { isImage } : {}),
+        ...(isVideo !== undefined ? { isVideo } : {}),
         ...(mimeType !== undefined ? { mimeType } : {})
       })
     }
@@ -292,6 +295,7 @@ export async function readFileViaStream(
         const metadata = rawMetadata as StreamMetadataResponse
         isBinary = metadata.isBinary
         isImage = metadata.isImage
+        isVideo = metadata.isVideo
         mimeType = metadata.mimeType
         resultEncoding = metadata.resultEncoding ?? RESULT_ENCODING_BASE64
 
@@ -300,6 +304,7 @@ export async function readFileViaStream(
             content: '',
             isBinary: metadata.isBinary,
             ...(metadata.isImage !== undefined ? { isImage: metadata.isImage } : {}),
+            ...(metadata.isVideo !== undefined ? { isVideo: metadata.isVideo } : {}),
             ...(metadata.mimeType !== undefined ? { mimeType: metadata.mimeType } : {})
           })
           return

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -1,31 +1,30 @@
 import { open, readFile, stat } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
-import { extname } from 'node:path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { MAX_CONCURRENT_STREAMS, STREAM_ACK_WINDOW_CHUNKS, STREAM_CHUNK_SIZE } from './protocol'
 import { TooManyStreamsError, type RelayStreamRegistry } from './fs-stream-registry'
 import {
   BINARY_PROBE_BYTES,
-  IMAGE_MIME_TYPES,
   MAX_PREVIEWABLE_BINARY_SIZE,
   MAX_TEXT_FILE_SIZE,
   isBinaryBuffer,
-  isBinaryFilePrefix
+  isBinaryFilePrefix,
+  previewableBinaryMedia
 } from './fs-handler-utils'
 
 export async function readRelayFileContent(filePath: string) {
   const stats = await stat(filePath)
-  const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
-  const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+  const media = previewableBinaryMedia(filePath)
+  const sizeLimit = media ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
   if (stats.size > sizeLimit) {
     throw new Error(
       `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
     )
   }
 
-  if (mimeType) {
+  if (media) {
     const buffer = await readFile(filePath)
-    return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
+    return { content: buffer.toString('base64'), isBinary: true, ...media }
   }
 
   if (stats.size > BINARY_PROBE_BYTES && (await isBinaryFilePrefix(filePath))) {
@@ -44,6 +43,7 @@ export type StreamMetadata = {
   totalSize: number
   isBinary: boolean
   isImage?: boolean
+  isVideo?: boolean
   mimeType?: string
   /** On-the-wire encoding of each chunk's `data` field. Always 'base64'. */
   chunkEncoding?: 'base64'
@@ -79,8 +79,8 @@ export async function readRelayFileStreamMetadata(
   pumpOptions?: StreamPumpOptions
 ): Promise<StreamMetadata> {
   const stats = await stat(filePath)
-  const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
-  const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+  const media = previewableBinaryMedia(filePath)
+  const sizeLimit = media ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
   if (stats.size > sizeLimit) {
     throw new Error(
       `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
@@ -90,16 +90,15 @@ export async function readRelayFileStreamMetadata(
   if (stats.size === 0) {
     return {
       totalSize: 0,
-      isBinary: !!mimeType,
-      mimeType,
-      isImage: mimeType ? true : undefined,
+      isBinary: !!media,
+      ...media,
       empty: true
     }
   }
   // Why: unlike the legacy single-shot path, streaming does not read the full
   // buffer before classifying content. Probe every unknown file so small binary
   // files do not get decoded as UTF-8 text over SSH.
-  if (!mimeType && (await isBinaryFilePrefix(filePath))) {
+  if (!media && (await isBinaryFilePrefix(filePath))) {
     return { totalSize: 0, isBinary: true, empty: true }
   }
 
@@ -138,11 +137,10 @@ export async function readRelayFileStreamMetadata(
   return {
     streamId,
     totalSize: stats.size,
-    isBinary: !!mimeType,
-    isImage: mimeType ? true : undefined,
-    mimeType,
+    isBinary: !!media,
+    ...media,
     chunkEncoding: 'base64',
-    resultEncoding: mimeType ? 'base64' : 'utf-8'
+    resultEncoding: media ? 'base64' : 'utf-8'
   }
 }
 

--- a/src/relay/fs-handler-previewable-media.test.ts
+++ b/src/relay/fs-handler-previewable-media.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { readRelayFileContent } from './fs-handler-file-read'
+
+describe('relay previewable media reads', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-media-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns base64 plus a video flag for playable containers', async () => {
+    const filePath = path.join(tmpDir, 'clip.mp4')
+    writeFileSync(filePath, Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66]))
+
+    await expect(readRelayFileContent(filePath)).resolves.toEqual({
+      content: 'AAAAGGY=',
+      isBinary: true,
+      isVideo: true,
+      mimeType: 'video/mp4'
+    })
+  })
+
+  it('keeps images on the image flag', async () => {
+    const filePath = path.join(tmpDir, 'logo.png')
+    writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+    await expect(readRelayFileContent(filePath)).resolves.toMatchObject({
+      isBinary: true,
+      isImage: true,
+      mimeType: 'image/png'
+    })
+  })
+
+  it('leaves containers mobile cannot decode on the binary path', async () => {
+    const filePath = path.join(tmpDir, 'clip.webm')
+    writeFileSync(filePath, Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x00]))
+
+    await expect(readRelayFileContent(filePath)).resolves.toEqual({
+      content: '',
+      isBinary: true
+    })
+  })
+})

--- a/src/relay/fs-handler-terminal-artifact.ts
+++ b/src/relay/fs-handler-terminal-artifact.ts
@@ -2,13 +2,13 @@ import { constants } from 'node:fs'
 import type { Stats } from 'node:fs'
 import { chmod, open, realpath, rename, rm, writeFile } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
-import { basename, dirname, extname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import {
-  IMAGE_MIME_TYPES,
   isBinaryBuffer,
   MAX_PREVIEWABLE_BINARY_SIZE,
-  MAX_TEXT_FILE_SIZE
+  MAX_TEXT_FILE_SIZE,
+  previewableBinaryMedia
 } from './fs-handler-utils'
 
 type TerminalArtifactStat = {
@@ -36,14 +36,14 @@ export async function readVerifiedTerminalArtifact(params: Record<string, unknow
   const handle = await openVerifiedTerminalArtifact(filePath, options, constants.O_RDONLY)
   try {
     await verifiedHandleStat(handle, options)
-    const mimeType = terminalArtifactImageMimeType(filePath)
+    const media = terminalArtifactPreviewableMedia(filePath)
     const sizeLimit = Math.min(
-      options.maxBytes ?? (mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE),
-      mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+      options.maxBytes ?? (media ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE),
+      media ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
     )
     const buffer = await readBoundedFileFromHandle(handle, sizeLimit)
-    if (mimeType) {
-      return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
+    if (media) {
+      return { content: buffer.toString('base64'), isBinary: true, ...media }
     }
     if (isBinaryBuffer(buffer)) {
       return { content: '', isBinary: true }
@@ -104,11 +104,13 @@ async function openStatClose(filePath: string): Promise<Stats> {
   }
 }
 
-function terminalArtifactImageMimeType(filePath: string): string | undefined {
-  const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
+function terminalArtifactPreviewableMedia(
+  filePath: string
+): { mimeType: string; isImage: true } | { mimeType: string; isVideo: true } | null {
+  const media = previewableBinaryMedia(filePath)
   // Why: mobile renders SVG terminal artifacts as source text; returning image
   // data from the relay would make SSH disagree with local artifact previews.
-  return mimeType === 'image/svg+xml' ? undefined : mimeType
+  return media?.mimeType === 'image/svg+xml' ? null : media
 }
 
 async function readBoundedFileFromHandle(handle: FileHandle, maxBytes: number): Promise<Buffer> {

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -7,6 +7,7 @@
  */
 import { spawn } from 'node:child_process'
 import { open } from 'node:fs/promises'
+import { extname } from 'node:path'
 import {
   buildRgArgs,
   createAccumulator,
@@ -15,6 +16,7 @@ import {
   SEARCH_TIMEOUT_MS as SHARED_SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
 import { IMAGE_FILE_MIME_TYPES } from '../shared/image-file-extensions'
+import { VIDEO_FILE_MIME_TYPES } from '../shared/video-file-extensions'
 import type { SearchResult as SharedSearchResult } from '../shared/code-search-types'
 import {
   absorbPendingRipgrepSpawnError,
@@ -41,6 +43,20 @@ export const DEFAULT_MAX_RESULTS = 2000
 export const IMAGE_MIME_TYPES: Record<string, string> = {
   ...IMAGE_FILE_MIME_TYPES,
   '.pdf': 'application/pdf'
+}
+
+// Why: previewable binaries are not all images — mobile plays video containers in a
+// native player, so a read reports which media kind it carries.
+export function previewableBinaryMedia(
+  filePath: string
+): { mimeType: string; isImage: true } | { mimeType: string; isVideo: true } | null {
+  const extension = extname(filePath).toLowerCase()
+  const imageMimeType = IMAGE_MIME_TYPES[extension]
+  if (imageMimeType) {
+    return { mimeType: imageMimeType, isImage: true }
+  }
+  const videoMimeType = VIDEO_FILE_MIME_TYPES[extension]
+  return videoMimeType ? { mimeType: videoMimeType, isVideo: true } : null
 }
 
 // ─── Binary detection ────────────────────────────────────────────────

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -447,6 +447,8 @@ export type RuntimeFilePreviewResult = {
   content: string
   isBinary: boolean
   isImage?: boolean
+  /** Set for the video containers mobile can play natively (mp4/m4v/mov). */
+  isVideo?: boolean
   mimeType?: string
   imageDimensions?: RasterImageDimensions
 }

--- a/src/shared/video-file-extensions.ts
+++ b/src/shared/video-file-extensions.ts
@@ -1,0 +1,10 @@
+// Containers the mobile viewer can play natively (AVPlayer on iOS, ExoPlayer on
+// Android). WebM/MKV are left out: iOS cannot decode them, so they stay on the
+// unavailable-binary path instead of opening a player that fails.
+export const VIDEO_FILE_MIME_TYPES: Record<string, string> = {
+  '.mp4': 'video/mp4',
+  '.m4v': 'video/mp4',
+  '.mov': 'video/quicktime'
+}
+
+export const VIDEO_FILE_EXTENSIONS = Object.freeze(Object.keys(VIDEO_FILE_MIME_TYPES))


### PR DESCRIPTION
## Summary

Videos (`.mp4`, `.m4v`, `.mov`) can now be previewed in the mobile file viewer. Tapping one previously showed "Binary preview unavailable", because the host reported every previewable binary as `isImage` and React Native has no player component.

How it works:

- **`isVideo` on the preview payload.** `files.readPreview` / `files.readTerminalArtifactPreview` (and the relay's `fs.readFile` / `fs.readFileStream` / `fs.readTerminalArtifact`) now report *which* media kind they carry instead of claiming everything previewable is an image. `src/shared/video-file-extensions.ts` is the single source for the container→MIME map, and `isVideo` is threaded through the SSH stream reader and the filesystem provider contract so SSH worktrees behave the same as local ones.
- **The bytes are staged on disk before playback.** AVPlayer and ExoPlayer cannot open a base64 data URI, so `MobileFileVideoPreview` writes the preview into the app cache and hands the file to `expo-video`. The cache file's extension matters — AVPlayer picks its demuxer from it — and it is named after the source path so re-opening reuses one slot instead of leaking a copy per visit.
- **WebM/MKV stay unavailable.** iOS cannot decode them, so they fall through to the existing unavailable-binary path rather than opening a player that fails — same reasoning as the existing SVG exclusion.

Wired into both the file-preview route and session file tabs; the explorer row gate and icon were updated to match.

## Screenshots

An `.mp4` opened from the mobile file explorer, playing through `expo-video`'s native player. The transport (play/pause, ±10s, scrubber), fullscreen, AirPlay and mute all come from the OS; a 16:9 video letterboxes inside the portrait pane via `contentFit="contain"`.

<img width="320" alt="mp4 previewing in the mobile file viewer with native playback controls" src="https://raw.githubusercontent.com/Lironeee/orca/pr-12570-assets/pr-assets/mobile-video-preview-player.png" />

Verified on an iOS 26.5 simulator against a real paired desktop runtime built from this branch (not a mock); `.mov` was checked the same way.

## Testing

- [x] `pnpm lint` — oxlint clean on both projects (also enforced by pre-commit on every changed file)
- [x] `pnpm typecheck` — `tsconfig.node.json` and the mobile project both clean
- [x] `pnpm test` — mobile 3047 pass; desktop `src/main/runtime`, `src/main/ssh`, `src/main/providers`, `src/relay` pass. The two `src/relay/agent-exec-handler.test.ts` failures reproduce unmodified on `main` and are unrelated to this change.
- [x] `pnpm build` — `build:cli` + `build:electron-vite` succeeded; that build is what the simulator test ran against.
- [x] Added tests: video classification (including the WebM/MKV exclusion), preview-request routing for worktree and terminal-artifact sources, response normalization and its rejection cases, cache-file staging/naming/cleanup, and the desktop + relay preview reads.

## AI Review Report

Reviewed with Claude Code while building, focused on: the preview transport contract (does anything else key off `isImage`?), SSH/relay parity, memory behaviour of multi-MB base64 payloads, and player lifecycle.

- **Transport contract.** Every producer of `isImage` was audited before adding `isVideo`, so no consumer silently treats a video as an image. The text/image narrowing in the mobile preview types was replaced with an explicit `isMobileFilePreviewTextResult` guard, which made the compiler point at each affected site.
- **SSH parity.** The relay path (`fs-handler-file-read`, `fs-handler-terminal-artifact`) and the SSH stream reader carry `isVideo` too, so SSH worktrees are not silently degraded. Relays predating this simply omit the flag and fall back to the existing unavailable-binary message.
- **Cross-platform (macOS / Linux / Windows).** No new keyboard shortcuts, shortcut labels, or platform branches. Paths use `expo-file-system`'s `Paths.cache` on mobile and `node:path`'s `extname`/`join` on desktop. The desktop and relay changes are plain Node fs/path work with no OS-specific behaviour, so the host side behaves identically on all three.
- **Mobile platforms.** Verified on iOS. Android is **not** verified — `expo-video` uses ExoPlayer there and MP4/M4V/MOV are within its supported containers, but I had no Android device in this session. Worth a second pair of eyes before merge if that matters.
- **Agents, integrations, git providers.** Nothing provider- or agent-specific is touched: this sits on the file-preview transport, below any agent or git-provider surface, and adds no provider branches.
- **Performance.** The preview is a user-initiated tap, not a hot path. Video bytes ride the same single-shot base64 response images already use and stay bounded by the 10 MB cap; the staged cache file is written once per open and deleted on unmount, so nothing accumulates. No new work was added to list/scroll paths — the explorer row only gained an extension classification it already computed for images.
- **UI quality.** Follows `docs/STYLEGUIDE.md`: the player pane uses existing `mobile-theme` tokens (`colors.editorSurface`) with no new hex values, and the loading state reuses the shared preview `state`/`errorText` styles. The mobile palette is dark-only, so there is no light-mode variant to check. Playback controls are the OS player's, so they match platform conventions by construction.
- **SSH / remote.** The `isVideo` flag is carried through the relay and the SSH stream reader, so an SSH worktree previews video the same way a local one does; a relay predating this simply omits the flag and the client falls back to the existing message. Under SSH latency the preview shows the normal loading state until the bytes land — the same behaviour images already have — and the cap keeps the transfer bounded.
- **Flagged and changed.** CodeRabbit caught a stat-then-read window on the previewable-binary path (pre-existing, but videos make it much easier to hit). Fixed in 22bfd68: the read now goes through a single handle and the cap is enforced against what that handle returns, rather than trusting an earlier `stat` of the path.

## Security Audit

- **Path handling.** No new path construction from user input. Previews still go through `resolveFileExplorerPath` + `resolveAuthorizedPath`, and terminal artifacts keep their existing grant checks (`O_NOFOLLOW`, canonical-path and stat-identity verification) — video reads reuse those paths unchanged.
- **Resource limits.** Videos are bound by the existing 10 MB previewable-binary cap, now enforced against the opened handle instead of a prior `stat` (above), closing a TOCTOU that could have allocated an unbounded buffer.
- **Untrusted content.** Video bytes are handed to the OS media frameworks, not parsed in-process. The staged cache file lives in the app's private cache directory, is named from a hash of the source path (no traversal from repository names), is overwritten rather than appended, and is deleted when the preview unmounts.
- **Dependency.** Adds `expo-video` 55.0.19, a first-party Expo SDK package matching the project's Expo version. No new network access, no new permissions, and its config plugin is not enabled (no background playback or PiP).
- **No changes** to auth, the IPC surface, command execution, or secrets handling.

## Notes

- Adds `expo-video` (SDK 55) — **a dev-client rebuild is required** for anyone running this branch.
- **Tested on iOS only.** Android should work (ExoPlayer handles these containers) but I could not verify it here.
- SSH worktrees go through the relay path, which carries `isVideo` too; that path was covered by unit tests rather than a live SSH host.
- Videos above the 10 MB previewable-binary cap still report "File too large for mobile preview". Chunked streaming for larger files is a natural follow-up.
- Tapping a video path in a terminal still does nothing: that goes through `files.open`, which opens a tab on the **desktop**, and the desktop editor has no video viewer. Left alone deliberately rather than opening a broken desktop tab.

X / Twitter: [@Lironedev](https://x.com/Lironedev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
