### PR TITLE
Prevent Command Code output from hijacking agent icons

### DIFF
--- a/src/renderer/src/components/terminal-pane/command-code-output-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/command-code-output-ownership.test.ts
@@ -15,13 +15,20 @@ describe('canCommandCodeOutputOwnPane', () => {
   it('rejects another agent owner or foreground process', () => {
     expect(canCommandCodeOutputOwnPane({ paneOwnerAgent: 'claude' })).toBe(false)
     expect(canCommandCodeOutputOwnPane({ foregroundAgent: 'claude' })).toBe(false)
+    expect(
+      canCommandCodeOutputOwnPane({
+        paneOwnerAgent: 'unknown',
+        retainedPaneOwnerAgent: 'claude'
+      })
+    ).toBe(false)
   })
 
   it('prefers the current foreground process over stale pane ownership', () => {
     expect(
       canCommandCodeOutputOwnPane({
         foregroundAgent: 'command-code',
-        paneOwnerAgent: 'claude'
+        paneOwnerAgent: 'claude',
+        retainedPaneOwnerAgent: 'claude'
       })
     ).toBe(true)
     expect(

--- a/src/renderer/src/components/terminal-pane/command-code-output-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/command-code-output-ownership.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { canCommandCodeOutputOwnPane } from './command-code-output-ownership'
+
+describe('canCommandCodeOutputOwnPane', () => {
+  it('allows the banner fallback when no stronger identity exists', () => {
+    expect(canCommandCodeOutputOwnPane({})).toBe(true)
+    expect(canCommandCodeOutputOwnPane({ paneOwnerAgent: 'unknown' })).toBe(true)
+  })
+
+  it('allows Command Code ownership evidence', () => {
+    expect(canCommandCodeOutputOwnPane({ paneOwnerAgent: 'command-code' })).toBe(true)
+    expect(canCommandCodeOutputOwnPane({ foregroundAgent: 'command-code' })).toBe(true)
+  })
+
+  it('rejects another agent owner or foreground process', () => {
+    expect(canCommandCodeOutputOwnPane({ paneOwnerAgent: 'claude' })).toBe(false)
+    expect(canCommandCodeOutputOwnPane({ foregroundAgent: 'claude' })).toBe(false)
+  })
+
+  it('prefers the current foreground process over stale pane ownership', () => {
+    expect(
+      canCommandCodeOutputOwnPane({
+        foregroundAgent: 'command-code',
+        paneOwnerAgent: 'claude'
+      })
+    ).toBe(true)
+    expect(
+      canCommandCodeOutputOwnPane({
+        foregroundAgent: 'claude',
+        paneOwnerAgent: 'command-code'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects output observed at a confirmed shell prompt', () => {
+    expect(canCommandCodeOutputOwnPane({ shellForeground: true })).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/command-code-output-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/command-code-output-ownership.ts
@@ -1,0 +1,20 @@
+import type { AgentType } from '../../../../shared/agent-status-types'
+import type { TuiAgent } from '../../../../shared/types'
+
+export function canCommandCodeOutputOwnPane(args: {
+  foregroundAgent?: TuiAgent | null
+  shellForeground?: boolean
+  paneOwnerAgent?: AgentType | null
+}): boolean {
+  if (args.foregroundAgent) {
+    return args.foregroundAgent === 'command-code'
+  }
+  if (args.shellForeground) {
+    return false
+  }
+  return (
+    !args.paneOwnerAgent ||
+    args.paneOwnerAgent === 'unknown' ||
+    args.paneOwnerAgent === 'command-code'
+  )
+}

--- a/src/renderer/src/components/terminal-pane/command-code-output-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/command-code-output-ownership.ts
@@ -5,6 +5,7 @@ export function canCommandCodeOutputOwnPane(args: {
   foregroundAgent?: TuiAgent | null
   shellForeground?: boolean
   paneOwnerAgent?: AgentType | null
+  retainedPaneOwnerAgent?: AgentType | null
 }): boolean {
   if (args.foregroundAgent) {
     return args.foregroundAgent === 'command-code'
@@ -12,9 +13,9 @@ export function canCommandCodeOutputOwnPane(args: {
   if (args.shellForeground) {
     return false
   }
-  return (
-    !args.paneOwnerAgent ||
-    args.paneOwnerAgent === 'unknown' ||
-    args.paneOwnerAgent === 'command-code'
-  )
+  const paneOwnerAgent =
+    args.paneOwnerAgent && args.paneOwnerAgent !== 'unknown'
+      ? args.paneOwnerAgent
+      : (args.retainedPaneOwnerAgent ?? args.paneOwnerAgent)
+  return !paneOwnerAgent || paneOwnerAgent === 'unknown' || paneOwnerAgent === 'command-code'
 }

--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts
@@ -406,7 +406,7 @@ describe('startParkedTerminalByteWatcher', () => {
   it('feeds Command Code output through the parked byte detector', async () => {
     const { dispose } = await startWatcher()
 
-    emit('# Command Code v0.27.2')
+    emit('# Command Code v0.27.2\r\n')
     emit('⌘ Parsing...')
 
     expect(commandStatusPolicy.onCommandCodeWorking).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/components/terminal-pane/parked-terminal-command-status.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-command-status.test.ts
@@ -16,6 +16,7 @@ const ROUTING = { connectionId: null }
 type MockStoreState = {
   tabsByWorktree: Record<string, { id: string; launchAgent?: AgentType }[]>
   agentStatusByPaneKey: Record<string, AgentStatusEntry | undefined>
+  retainedAgentsByPaneKey: Record<string, { agentType: AgentType } | undefined>
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   agentLaunchConfigByPaneKey: Record<string, { identity: { agentType?: AgentType } } | undefined>
   runtimePaneTitlesByTabId: Record<string, Record<number, string | undefined>>
@@ -46,6 +47,7 @@ function makeMockStoreState(): MockStoreState {
   return {
     tabsByWorktree: { [WORKTREE_ID]: [{ id: TAB_ID }] },
     agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
     paneForegroundAgentByPaneKey: {},
     agentLaunchConfigByPaneKey: {},
     runtimePaneTitlesByTabId: { [TAB_ID]: { [PANE_ID]: '✳ Build feature' } },
@@ -129,6 +131,19 @@ describe('createParkedTerminalCommandStatusPolicy', () => {
     policy.dispose()
   })
 
+  it('rejects scrape status when retained Claude identity owns the pane', async () => {
+    mockStoreState.retainedAgentsByPaneKey[PANE_KEY] = { agentType: 'claude' }
+    mockStoreState.agentStatusByPaneKey[PANE_KEY] = makeStatusEntry({ agentType: 'unknown' })
+    const policy = await createPolicy(PTY_ID_LOCAL)
+
+    policy.onCommandCodeWorking('False prompt')
+    policy.onCommandCodeDone('False prompt')
+    vi.advanceTimersByTime(DONE_SETTLE_MS)
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    policy.dispose()
+  })
+
   it('rejects scrape status when Claude launch metadata owns the pane', async () => {
     mockStoreState.tabsByWorktree[WORKTREE_ID] = [{ id: TAB_ID, launchAgent: 'claude' }]
     const policy = await createPolicy(PTY_ID_LOCAL)
@@ -155,6 +170,7 @@ describe('createParkedTerminalCommandStatusPolicy', () => {
   it('lets a current Command Code process reclaim stale Claude ownership', async () => {
     mockStoreState.tabsByWorktree[WORKTREE_ID] = [{ id: TAB_ID, launchAgent: 'claude' }]
     mockStoreState.agentStatusByPaneKey[PANE_KEY] = makeStatusEntry({ state: 'done' })
+    mockStoreState.retainedAgentsByPaneKey[PANE_KEY] = { agentType: 'claude' }
     mockStoreState.paneForegroundAgentByPaneKey[PANE_KEY] = {
       agent: 'command-code',
       shellForeground: false

--- a/src/renderer/src/components/terminal-pane/parked-terminal-command-status.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-command-status.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 const PTY_ID_LOCAL = 'pty-1'
 const PTY_ID_SSH = 'ssh:target-1@@pty-9'
@@ -13,7 +14,10 @@ const DONE_SETTLE_MS = 1500
 const ROUTING = { connectionId: null }
 
 type MockStoreState = {
+  tabsByWorktree: Record<string, { id: string; launchAgent?: AgentType }[]>
   agentStatusByPaneKey: Record<string, AgentStatusEntry | undefined>
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
+  agentLaunchConfigByPaneKey: Record<string, { identity: { agentType?: AgentType } } | undefined>
   runtimePaneTitlesByTabId: Record<string, Record<number, string | undefined>>
   setAgentStatus: ReturnType<typeof vi.fn>
   dropAgentStatus: ReturnType<typeof vi.fn>
@@ -40,7 +44,10 @@ vi.mock('@/lib/connection-owner-resolution', () => ({
 
 function makeMockStoreState(): MockStoreState {
   return {
+    tabsByWorktree: { [WORKTREE_ID]: [{ id: TAB_ID }] },
     agentStatusByPaneKey: {},
+    paneForegroundAgentByPaneKey: {},
+    agentLaunchConfigByPaneKey: {},
     runtimePaneTitlesByTabId: { [TAB_ID]: { [PANE_ID]: '✳ Build feature' } },
     setAgentStatus: vi.fn(),
     dropAgentStatus: vi.fn(),
@@ -107,6 +114,66 @@ describe('createParkedTerminalCommandStatusPolicy', () => {
     policy.onCommandCodeWorking('Fix the spinner')
 
     expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    policy.dispose()
+  })
+
+  it('rejects scrape status when a Claude hook owns the pane', async () => {
+    mockStoreState.agentStatusByPaneKey[PANE_KEY] = makeStatusEntry({ state: 'done' })
+    const policy = await createPolicy(PTY_ID_LOCAL)
+
+    policy.onCommandCodeWorking('False prompt')
+    policy.onCommandCodeDone('False prompt')
+    vi.advanceTimersByTime(DONE_SETTLE_MS)
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    policy.dispose()
+  })
+
+  it('rejects scrape status when Claude launch metadata owns the pane', async () => {
+    mockStoreState.tabsByWorktree[WORKTREE_ID] = [{ id: TAB_ID, launchAgent: 'claude' }]
+    const policy = await createPolicy(PTY_ID_LOCAL)
+
+    policy.onCommandCodeWorking('False prompt')
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    policy.dispose()
+  })
+
+  it('rejects scrape status when Claude is the foreground process', async () => {
+    mockStoreState.paneForegroundAgentByPaneKey[PANE_KEY] = {
+      agent: 'claude',
+      shellForeground: false
+    }
+    const policy = await createPolicy(PTY_ID_LOCAL)
+
+    policy.onCommandCodeWorking('False prompt')
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+    policy.dispose()
+  })
+
+  it('lets a current Command Code process reclaim stale Claude ownership', async () => {
+    mockStoreState.tabsByWorktree[WORKTREE_ID] = [{ id: TAB_ID, launchAgent: 'claude' }]
+    mockStoreState.agentStatusByPaneKey[PANE_KEY] = makeStatusEntry({ state: 'done' })
+    mockStoreState.paneForegroundAgentByPaneKey[PANE_KEY] = {
+      agent: 'command-code',
+      shellForeground: false
+    }
+    const policy = await createPolicy(PTY_ID_LOCAL)
+
+    policy.onCommandCodeWorking('New Command Code prompt')
+
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      PANE_KEY,
+      {
+        state: 'working',
+        prompt: 'New Command Code prompt',
+        agentType: 'command-code'
+      },
+      '✳ Build feature',
+      undefined,
+      ROUTING
+    )
     policy.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/parked-terminal-command-status.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-command-status.ts
@@ -74,7 +74,8 @@ export function createParkedTerminalCommandStatusPolicy(options: {
     return canCommandCodeOutputOwnPane({
       foregroundAgent: foreground?.agent,
       shellForeground: foreground?.shellForeground,
-      paneOwnerAgent
+      paneOwnerAgent,
+      retainedPaneOwnerAgent: state.retainedAgentsByPaneKey[paneKey]?.agentType
     })
   }
 

--- a/src/renderer/src/components/terminal-pane/parked-terminal-command-status.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-command-status.ts
@@ -5,6 +5,7 @@
  * (foreground process-confirm ladder, key-intent interrupt inference) stay with the mounted pane.
  */
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { dispatchTerminalCommandFinishedEvent } from '@/hooks/terminal-command-finished-event'
 import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
@@ -15,6 +16,7 @@ import {
   openCommandCodeDoneSettle,
   setCommandCodeDoneSettleExecutor
 } from './command-code-done-settle'
+import { canCommandCodeOutputOwnPane } from './command-code-output-ownership'
 
 export type ParkedTerminalCommandStatusPolicy = {
   onCommandFinished: (bestEffortExitCode: number | null) => void
@@ -57,6 +59,22 @@ export function createParkedTerminalCommandStatusPolicy(options: {
       paneKey,
       ptyId,
       expectedConnectionId: getConnectionIdFromState(state, worktreeId)
+    })
+  }
+
+  const canApplyCommandCodeOutputStatus = (): boolean => {
+    const state = useAppStore.getState()
+    const tab = (state.tabsByWorktree[worktreeId] ?? []).find((entry) => entry.id === tabId)
+    const foreground = state.paneForegroundAgentByPaneKey[paneKey]
+    const paneOwnerAgent = resolvePaneAgentOwner({
+      launchAgent: tab?.launchAgent,
+      startupLaunchAgent: state.agentLaunchConfigByPaneKey[paneKey]?.identity.agentType,
+      hookAgent: state.agentStatusByPaneKey[paneKey]?.agentType
+    })
+    return canCommandCodeOutputOwnPane({
+      foregroundAgent: foreground?.agent,
+      shellForeground: foreground?.shellForeground,
+      paneOwnerAgent
     })
   }
 
@@ -145,6 +163,9 @@ export function createParkedTerminalCommandStatusPolicy(options: {
 
     // Port of pty-connection's seedCommandCodeOutputWorkingStatus (store-level only).
     onCommandCodeWorking: (prompt: string): void => {
+      if (!canApplyCommandCodeOutputStatus()) {
+        return
+      }
       clearCommandCodeOutputDoneTimer()
       const routing = resolveRouting()
       if (!routing) {
@@ -178,6 +199,9 @@ export function createParkedTerminalCommandStatusPolicy(options: {
     // Port of pty-connection's scheduleCommandCodeOutputDoneStatus: Command Code keeps rendering
     // the composer while tools run, so only complete the row if no active repaint arrives.
     onCommandCodeDone: (prompt: string): void => {
+      if (!canApplyCommandCodeOutputStatus()) {
+        return
+      }
       const normalizedPrompt = prompt.trim()
       if (!normalizedPrompt) {
         cancelCommandCodeDoneSettle(paneKey)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17,6 +17,7 @@ import { TERMINAL_PASTE_DIRECT_MAX_BYTES } from './terminal-paste-coordinator'
 import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
+import type { AgentType } from '../../../../shared/agent-status-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import type { SshConnectionState } from '../../../../shared/ssh-types'
@@ -227,6 +228,7 @@ type StoreState = {
   consumePendingSnapshot: ReturnType<typeof vi.fn>
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
   agentStatusByPaneKey: Record<string, unknown>
+  retainedAgentsByPaneKey: Record<string, { agentType: AgentType }>
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   sleepingAgentSessionsByPaneKey: Record<string, unknown>
   suppressedPtyExitIds: Record<string, true>
@@ -928,6 +930,7 @@ describe('connectPanePty', () => {
       consumePendingSnapshot: vi.fn(() => null),
       runtimePaneTitlesByTabId: {},
       agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {},
       paneForegroundAgentByPaneKey: {},
       sleepingAgentSessionsByPaneKey: {},
       suppressedPtyExitIds: {},
@@ -19042,6 +19045,45 @@ describe('connectPanePty', () => {
 
       expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
       expect(mockStoreState.agentStatusByPaneKey[paneKey]).toBe(claudeStatus)
+    })
+
+    it('rejects Command Code facts when retained Claude identity owns the pane', async () => {
+      enableMainAuthority()
+      const { connectPanePty } = await import('./pty-connection')
+      const handler = await import('./terminal-side-effect-facts-handler')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      vi.useFakeTimers()
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const unknownStatus = {
+        paneKey,
+        state: 'working' as const,
+        prompt: '',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'unknown' as const,
+        stateHistory: []
+      }
+      mockStoreState.retainedAgentsByPaneKey[paneKey] = { agentType: 'claude' }
+      mockStoreState.agentStatusByPaneKey[paneKey] = unknownStatus
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as (ptyId: string) => void
+      onPtySpawn('pty-fact-retained-false-cc')
+      mockStoreState.setAgentStatus.mockClear()
+
+      handler._dispatchTerminalSideEffectBatchForTest({
+        ptyId: 'pty-fact-retained-false-cc',
+        seq: 1,
+        facts: [
+          { kind: 'command-code-working', prompt: 'False prompt' },
+          { kind: 'command-code-done', prompt: 'False prompt' }
+        ]
+      })
+      vi.advanceTimersByTime(2000)
+
+      expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+      expect(mockStoreState.agentStatusByPaneKey[paneKey]).toBe(unknownStatus)
     })
 
     it('keeps Command Code working when a working fact lands before the done settles', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -18999,6 +18999,51 @@ describe('connectPanePty', () => {
       })
     })
 
+    it('rejects Command Code facts when Claude owns the pane', async () => {
+      enableMainAuthority()
+      const { connectPanePty } = await import('./pty-connection')
+      const handler = await import('./terminal-side-effect-facts-handler')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      vi.useFakeTimers()
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const claudeStatus = {
+        paneKey,
+        state: 'done' as const,
+        prompt: 'Previous Claude turn',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'claude' as const,
+        stateHistory: []
+      }
+      mockStoreState.tabsByWorktree = {
+        'wt-1': [{ id: 'tab-1', ptyId: null, launchAgent: 'claude' }]
+      }
+      mockStoreState.agentStatusByPaneKey[paneKey] = claudeStatus
+      mockStoreState.paneForegroundAgentByPaneKey[paneKey] = {
+        agent: 'claude',
+        shellForeground: false
+      }
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as (ptyId: string) => void
+      onPtySpawn('pty-fact-false-cc')
+      mockStoreState.setAgentStatus.mockClear()
+
+      handler._dispatchTerminalSideEffectBatchForTest({
+        ptyId: 'pty-fact-false-cc',
+        seq: 1,
+        facts: [
+          { kind: 'command-code-working', prompt: 'False prompt' },
+          { kind: 'command-code-done', prompt: 'False prompt' }
+        ]
+      })
+      vi.advanceTimersByTime(2000)
+
+      expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
+      expect(mockStoreState.agentStatusByPaneKey[paneKey]).toBe(claudeStatus)
+    })
+
     it('keeps Command Code working when a working fact lands before the done settles', async () => {
       enableMainAuthority()
       const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2820,11 +2820,13 @@ export function connectPanePty(
   }
 
   const canApplyCommandCodeOutputStatus = (): boolean => {
-    const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
+    const state = useAppStore.getState()
+    const foreground = state.paneForegroundAgentByPaneKey[cacheKey]
     return canCommandCodeOutputOwnPane({
       foregroundAgent: foreground?.agent,
       shellForeground: foreground?.shellForeground,
-      paneOwnerAgent: getAuthoritativePaneAgent()
+      paneOwnerAgent: getAuthoritativePaneAgent(),
+      retainedPaneOwnerAgent: state.retainedAgentsByPaneKey[cacheKey]?.agentType
     })
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -267,6 +267,7 @@ import {
   openCommandCodeDoneSettle,
   setCommandCodeDoneSettleExecutor
 } from './command-code-done-settle'
+import { canCommandCodeOutputOwnPane } from './command-code-output-ownership'
 import { isTerminalTabParked } from './terminal-parked-watcher-registry'
 import {
   getExecutionHostIdForWorktree,
@@ -2818,7 +2819,19 @@ export function connectPanePty(
       .setAgentStatus(cacheKey, statusPayload, terminalTitle, undefined, routing)
   }
 
+  const canApplyCommandCodeOutputStatus = (): boolean => {
+    const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
+    return canCommandCodeOutputOwnPane({
+      foregroundAgent: foreground?.agent,
+      shellForeground: foreground?.shellForeground,
+      paneOwnerAgent: getAuthoritativePaneAgent()
+    })
+  }
+
   const seedCommandCodeOutputWorkingStatus = (prompt: string): void => {
+    if (!canApplyCommandCodeOutputStatus()) {
+      return
+    }
     clearCommandCodeOutputDoneTimer()
     const routing = resolveCurrentAgentStatusRouting()
     if (!routing) {
@@ -2885,6 +2898,9 @@ export function connectPanePty(
   )
   const clearCommandCodeOutputDoneTimer = (): void => cancelCommandCodeDoneSettle(cacheKey)
   const scheduleCommandCodeOutputDoneStatus = (prompt: string): void => {
+    if (!canApplyCommandCodeOutputStatus()) {
+      return
+    }
     const normalizedPrompt = prompt.trim()
     if (!normalizedPrompt) {
       cancelCommandCodeDoneSettle(cacheKey)

--- a/src/shared/command-code-output-status.test.ts
+++ b/src/shared/command-code-output-status.test.ts
@@ -29,7 +29,7 @@ describe('createCommandCodeOutputStatusDetector', () => {
     })
 
     expect(detector.observe('Thinking about unrelated shell output')).toBe(false)
-    expect(detector.observe('# Command Code v0.27.2')).toBe(false)
+    expect(detector.observe('# Command Code v0.27.2\r\n')).toBe(false)
     expect(detector.observe('⌘ Parsing...')).toBe(true)
 
     expect(onWorking).toHaveBeenCalledWith('')
@@ -43,7 +43,7 @@ describe('createCommandCodeOutputStatusDetector', () => {
     })
 
     expect(detector.observe('# Command')).toBe(false)
-    expect(detector.observe(' Code v0.27.2')).toBe(false)
+    expect(detector.observe(' Code v0.27.2\r\n')).toBe(false)
     expect(detector.observe('⌘ Parsing...')).toBe(true)
 
     expect(onWorking).toHaveBeenCalledWith('')
@@ -56,7 +56,7 @@ describe('createCommandCodeOutputStatusDetector', () => {
       onWorking
     })
 
-    expect(detector.observe('# C\x1b[35mommand Co\x1b[0mde v0.27.2')).toBe(false)
+    expect(detector.observe('# C\x1b[35mommand Co\x1b[0mde v0.27.2\r\n')).toBe(false)
     expect(detector.observe('⌘ Parsing...')).toBe(true)
 
     expect(onWorking).toHaveBeenCalledWith('')
@@ -86,6 +86,46 @@ describe('createCommandCodeOutputStatusDetector', () => {
 
     expect(onWorking).not.toHaveBeenCalled()
   })
+
+  it.each([
+    '# Command Code v1.2\r\n',
+    '# Command Code v1.2.3.4\r\n',
+    '# Command Code v01.2.3\r\n',
+    '# Command Code v1.2.3suffix\r\n',
+    '#\nCommand Code v1.2.3\r\n'
+  ])('does not arm for noncanonical banner %j', (banner) => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({ startupCommand: null, onWorking })
+
+    expect(detector.observe(banner)).toBe(false)
+    expect(detector.observe('✻ Thinking...')).toBe(false)
+
+    expect(onWorking).not.toHaveBeenCalled()
+  })
+
+  it('does not arm from a four-part version split at a PTY chunk boundary', () => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({ startupCommand: null, onWorking })
+
+    expect(detector.observe('# Command Code v1.2.3')).toBe(false)
+    expect(detector.observe('.4\r\n')).toBe(false)
+    expect(detector.observe('✻ Thinking...')).toBe(false)
+
+    expect(onWorking).not.toHaveBeenCalled()
+  })
+
+  it.each(['# Command Code v1.2.3\r\n', '# Command Code v1.2.3-beta.1+build.9\n'])(
+    'arms for canonical banner %j',
+    (banner) => {
+      const onWorking = vi.fn()
+      const detector = createCommandCodeOutputStatusDetector({ startupCommand: null, onWorking })
+
+      expect(detector.observe(banner)).toBe(false)
+      expect(detector.observe('✻ Thinking...')).toBe(true)
+
+      expect(onWorking).toHaveBeenCalledWith('')
+    }
+  )
 
   it.each([
     'Pondering',

--- a/src/shared/command-code-output-status.test.ts
+++ b/src/shared/command-code-output-status.test.ts
@@ -74,6 +74,19 @@ describe('createCommandCodeOutputStatusDetector', () => {
     expect(onWorking).not.toHaveBeenCalled()
   })
 
+  it('does not arm when another agent merely discusses Command Code', () => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({
+      startupCommand: null,
+      onWorking
+    })
+
+    expect(detector.observe('// Why: Command Code exposes transcript prompts')).toBe(false)
+    expect(detector.observe('\r\n✻ Thinking...')).toBe(false)
+
+    expect(onWorking).not.toHaveBeenCalled()
+  })
+
   it.each([
     'Pondering',
     'Contemplating',

--- a/src/shared/command-code-output-status.ts
+++ b/src/shared/command-code-output-status.ts
@@ -112,7 +112,16 @@ const ACTIVE_EXECUTION_STATUS_RE = new RegExp(
   `(?:^|[\\r\\n])\\s*(?:${COMMAND_CODE_STATUS_GLYPH_RE_SOURCE}\\s*)?(?:Executing:\\s+\\S|Running\\s*\\()`
 )
 const IDLE_PROMPT_RE = /(?:^|[\r\n])\s*[❯>]\s+Ask your question\.\.\./
-const COMMAND_CODE_BANNER_RE = /(?:^|[\r\n])\s*#\s*Command Code\s+v\d+(?:\.\d+){1,3}\b/
+const SEMVER_NUMBER_RE_SOURCE = '(?:0|[1-9]\\d*)'
+const SEMVER_PRERELEASE_IDENTIFIER_RE_SOURCE = '(?:0|[1-9]\\d*|\\d*[A-Za-z-][0-9A-Za-z-]*)'
+const SEMVER_BUILD_IDENTIFIER_RE_SOURCE = '[0-9A-Za-z-]+'
+const COMMAND_CODE_BANNER_RE = new RegExp(
+  `(?:^|[\\r\\n])[ \\t]*#[ \\t]+Command Code[ \\t]+v` +
+    `${SEMVER_NUMBER_RE_SOURCE}\\.${SEMVER_NUMBER_RE_SOURCE}\\.${SEMVER_NUMBER_RE_SOURCE}` +
+    `(?:-${SEMVER_PRERELEASE_IDENTIFIER_RE_SOURCE}(?:\\.${SEMVER_PRERELEASE_IDENTIFIER_RE_SOURCE})*)?` +
+    `(?:\\+${SEMVER_BUILD_IDENTIFIER_RE_SOURCE}(?:\\.${SEMVER_BUILD_IDENTIFIER_RE_SOURCE})*)?` +
+    `(?=[ \\t]*[\\r\\n])`
+)
 
 function cleanPromptCandidate(value: string): string {
   return cleanCommandCodePromptCandidate(stripTerminalControl(value))
@@ -233,17 +242,19 @@ export function createCommandCodeOutputStatusDetector(args: {
         : scanRawText
 
       if (!hasSeenCommandCodeUi) {
-        if (
-          !rawTextMayContainCommandCodeBanner(scanRawText) &&
-          !rawTextMayContainCommandCodeBanner(scanRawTextWithChunkBoundary)
-        ) {
+        if (!rawTextMayContainCommandCodeBanner(scanRawText)) {
           return false
         }
         const scanText = stripTerminalControl(scanRawText)
         const scanTextWithChunkBoundary = stripTerminalControl(scanRawTextWithChunkBoundary)
+        const previousTextWithChunkBoundaryLength = previousRawText
+          ? stripTerminalControl(`${previousRawText}\n`).length
+          : 0
         if (
           !COMMAND_CODE_BANNER_RE.test(scanText) &&
-          !COMMAND_CODE_BANNER_RE.test(scanTextWithChunkBoundary)
+          !COMMAND_CODE_BANNER_RE.test(
+            scanTextWithChunkBoundary.slice(previousTextWithChunkBoundaryLength)
+          )
         ) {
           return false
         }

--- a/src/shared/command-code-output-status.ts
+++ b/src/shared/command-code-output-status.ts
@@ -112,7 +112,7 @@ const ACTIVE_EXECUTION_STATUS_RE = new RegExp(
   `(?:^|[\\r\\n])\\s*(?:${COMMAND_CODE_STATUS_GLYPH_RE_SOURCE}\\s*)?(?:Executing:\\s+\\S|Running\\s*\\()`
 )
 const IDLE_PROMPT_RE = /(?:^|[\r\n])\s*[❯>]\s+Ask your question\.\.\./
-const COMMAND_CODE_BANNER_RE = /\bCommand Code\b/
+const COMMAND_CODE_BANNER_RE = /(?:^|[\r\n])\s*#\s*Command Code\s+v\d+(?:\.\d+){1,3}\b/
 
 function cleanPromptCandidate(value: string): string {
   return cleanCommandCodePromptCandidate(stripTerminalControl(value))


### PR DESCRIPTION
## Summary

- require the real horizontal Command Code banner grammar before the output scraper self-arms
- resolve mounted and parked pane ownership from foreground, shell, launch, live-hook, and retained-hook evidence
- preserve a retained agent owner when a live row is absent or reports `unknown`, while allowing real foreground Command Code evidence to reclaim the pane
- add chunk-boundary, banner-grammar, mounted-pane, parked-pane, and ownership-precedence regressions

## Root cause

At an agent turn boundary, the live hook row can already be cleared or reduced to `unknown` while retained pane identity still correctly owns the tab. Generic terminal output containing Command Code text followed by an activity frame could then create a fresh `command-code` status row and replace the displayed owner.

## Validation

- [x] 734 focused Vitest tests across 6 files
- [x] independent same-model review fix pass, followed by a fresh 717-test pass that returned `CLEAN`
- [x] TypeScript typecheck
- [x] max-lines ratchet and 65 reliability-manifest gates
- [x] Oxfmt, Oxlint, React Doctor, and diff checks on all changed files
- [x] isolated Electron repro through CDP: after a real `# Command Code v0.27.3` plus `✻ Thinking...` sequence, the pane remained `liveAgent=unknown`, `retainedAgent=claude`, and was not replaced by Command Code
- [x] full PR CI on Node 24 and Node 26, including macOS/Linux tests and Windows packaging

![Claude ownership remains after Command Code-like output](https://github.com/user-attachments/assets/b1916062-ced2-427b-8672-8a605a1d97e2)

## AI Review Report

A same-model, same-reasoning reviewer inspected correctness, regressions, scope, and performance. The first pass fixed retained-identity gaps and tightened banner parsing. A fresh second pass found no further material issues and returned `CLEAN` at commit `2087baf264`.

## Security Audit

- banner admission is bounded to the existing 4 KiB pre-arm window and requires a terminated horizontal header with strict three-part npm semver
- split-line headers, malformed or overlong versions, leading-zero cores, arbitrary suffix prefixes, and chunk-boundary partials are rejected
- no new command execution, IPC surface, provider request, filesystem access, polling, or persistence was added

## Terminal Reliability Contract

- **Invariant:** output-only Command Code detection may update a pane only when stronger current or retained evidence does not identify another agent
- **Failure source:** terminal text can mimic a Command Code banner while live hook state is clearing, including across PTY chunk boundaries
- **Oracle:** strict banner/activity parsing plus foreground-first ownership resolution, confirmed-shell rejection, and pane-scoped live/retained identity
- **Gate coverage:** focused mounted and parked regressions cover local and SSH routing; the existing terminal-status reliability gates remain the manifest-level gate, so no new gate entry is needed
- **Provider/platform coverage:** transport-agnostic state logic covers local, SSH, and folder workspaces on macOS, Linux, and Windows; no provider-specific path was introduced
- **Performance budget:** one O(1) retained-map lookup per existing ownership fact and the existing bounded 4 KiB scan; no new polling, timer, subscription, subprocess, or provider call
- **Diagnostics:** existing pane status, retained-owner, foreground-owner, and PTY routing state remain the inspection points
- **Residual gap:** Electron covers the mounted local path; parked and SSH behavior is covered deterministically at the policy/routing layer

## Notes

- Scope remains limited to Command Code output admission and ownership; no speculative SSH typed-command behavior was added.
- No mobile code path changed, so mobile emulator QA is not applicable.