### PR TITLE
fix(terminal): drop stale CSI 997 color-scheme replies at the PTY write boundary

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -184,6 +184,10 @@ import {
   isNativeWindowsLocalPtySpawn,
   markNativeWindowsConptyPty
 } from '../runtime/terminal-model-query-authority'
+import {
+  clearPtyColorSchemeReplyGate,
+  shouldDropStalePtyColorSchemeReply
+} from '../runtime/pty-color-scheme-reply-write-gate'
 import { setTerminalViewAttributes } from '../runtime/terminal-view-attribute-store'
 import { validateTerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyModelRestoreReason } from '../../shared/pty-model-restore-marker'
@@ -1877,6 +1881,9 @@ export function clearProviderPtyState(
   providerSnapshotRequiredPtys.delete(id)
   // Why: the Phase-5 ConPTY DA1 spawn record must not leak onto a reused id.
   clearNativeWindowsConptyPty(id)
+  // Why: stale-reply gate state belongs to the dead stream — a reused id must
+  // start ungated, not inherit an unsubscribed verdict.
+  clearPtyColorSchemeReplyGate(id)
   const paneKey = ptyPaneKey.get(id)
   const stillOwnsPaneKey = paneKey ? paneKeyPtyId.get(paneKey) === id : false
   // Why: drop the memory-collector registration so a dead PTY doesn't resolve its dead pid on every snapshot; no-op for never-registered (SSH-owned) PTYs.
@@ -5060,6 +5067,11 @@ export function registerPtyHandlers(
       }
     },
     write: (ptyId, data) => {
+      // Why: the runtime funnel carries remote-client and main-emulator query
+      // replies — the same stale CSI 997 race as renderer writes (#9993).
+      if (shouldDropStalePtyColorSchemeReply(ptyId, data)) {
+        return true
+      }
       try {
         getProviderForPty(ptyId).write(ptyId, data)
         return true
@@ -6453,6 +6465,13 @@ export function registerPtyHandlers(
     id: string,
     data: string
   ): boolean | Promise<boolean> => {
+    // Why: a CSI 997 reply decided from an older chunk can arrive after a newer
+    // chunk withdrew the mode-2031 subscription — main ingests output ahead of
+    // every reply route, so drop the stale report here instead of letting it
+    // land as the next reader's stdin (#9993).
+    if (shouldDropStalePtyColorSchemeReply(id, data)) {
+      return true
+    }
     try {
       const tooLarge = isTerminalInputTooLargeWithDeferredMeasurement(data)
       if (typeof tooLarge === 'boolean') {

--- a/src/main/runtime/issue-9993-fish-prompt-accept-stale-mode2031-reply.repro.test.ts
+++ b/src/main/runtime/issue-9993-fish-prompt-accept-stale-mode2031-reply.repro.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import {
+  _resetPtyColorSchemeReplyGateForTest,
+  shouldDropStalePtyColorSchemeReply
+} from './pty-color-scheme-reply-write-gate'
+
+// Regression for #9993 (still reproducible on v1.4.168, after #8206/#8214/#10817):
+// `^[[?997;1n^[[?997;1n` lands in the stdin of whatever runs next after every
+// fish prompt-accept, corrupting interactive prompts (brew/npx `[y/N]` etc).
+//
+// Byte-level ground truth, captured from fish 4.7.1 + Tide behind a nested PTY
+// inside an Orca 1.4.168 terminal: at command accept fish toggles mode 2031
+// once per repaint, each toggle its own PTY chunk, five chunks in ~5ms —
+//
+//   T+5.056  fish  ?2004l ?2031l          (withdraw)
+//   T+5.056  fish  ?2004h ?2031h          (re-subscribe — chunk ends subscribed)
+//   T+5.058  fish  ?2004l ?2031l          (withdraw)
+//   T+5.058  orca  CSI ?997;1n            (reply to 5.056h — stale on arrival)
+//   T+5.060  fish  OSC 0 + ?2004h ?2031h  (re-subscribe)
+//   T+5.060  fish  ?2004l ?2031l + 133;C  (final withdraw, command starts)
+//   T+5.061  orca  CSI ?997;1n            (reply to 5.060h — stale on arrival)
+//
+// Every responder decision was correct for the chunk it saw (#10817's
+// chunk-final contract holds); the replies lose to the NEXT chunk because they
+// cross a scheduling boundary (renderer IPC / remote protocol) before reaching
+// the PTY. Main ingests output ahead of every reply route, so the write gate
+// re-checks subscription state where the bytes enter the PTY.
+
+const PTY_ID = 'pty-9993'
+const DARK_REPORT = '\x1b[?997;1n'
+
+// fish 4.7.1 tty_handoff toggle chunks, verbatim from the trace.
+const FISH_WITHDRAW = '\x1b[?2004l\x1b[?2031l\x1b[>4;0m\x1b>'
+const FISH_RESUBSCRIBE = '\x1b[?2004h\x1b[?2031h\x1b[>4;1m\x1b='
+const FISH_TITLED_RESUBSCRIBE =
+  '\x1b]0;~/p/example-repo\x07\x1b[m\x1b[?2004h\x1b[?2031h\x1b[>4;1m\x1b=\r'
+const FISH_FINAL_WITHDRAW =
+  '\x1b[?2004l\x1b[?2031l\x1b[>4;0m\x1b>\r\n\x1b[m\x1b]133;C;cmdline_url=echo%20hi\x07'
+
+const store = {
+  getRepo: () => undefined,
+  getRepos: () => [],
+  addRepo: () => {},
+  updateRepo: () => undefined as never,
+  getAllWorktreeMeta: () => ({}),
+  getWorktreeMeta: () => undefined,
+  setWorktreeMeta: () => undefined as never,
+  removeWorktreeMeta: () => {},
+  getGitHubCache: () => ({ pr: {}, issue: {} }) as never,
+  getSettings: () => ({
+    workspaceDir: '/tmp/workspaces',
+    nestWorkspaces: false,
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: '',
+    terminalMainSideEffectAuthority: true,
+    terminalHiddenDeliveryGate: true,
+    terminalModelQueryAuthority: true
+  })
+}
+
+function createScanningRuntime(): OrcaRuntimeService {
+  const runtime = new OrcaRuntimeService(store, undefined, {
+    onTerminalSideEffects: () => {}
+  })
+  // Why: transient scanners (incl. mode 2031) only run once a fact consumer
+  // exists — mirror a desktop renderer attaching.
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+  return runtime
+}
+
+afterEach(() => {
+  _resetPtyColorSchemeReplyGateForTest()
+})
+
+describe('issue #9993: stale mode-2031 replies at fish prompt accept', () => {
+  it('drops both replies of the accept burst once newer chunks withdrew', () => {
+    const runtime = createScanningRuntime()
+    let at = 100
+    runtime.onPtyData(PTY_ID, FISH_WITHDRAW, at++)
+    runtime.onPtyData(PTY_ID, FISH_RESUBSCRIBE, at++)
+    runtime.onPtyData(PTY_ID, FISH_WITHDRAW, at++)
+    // The reply decided from the re-subscribe chunk arrives only now.
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(true)
+
+    runtime.onPtyData(PTY_ID, FISH_TITLED_RESUBSCRIBE, at++)
+    runtime.onPtyData(PTY_ID, FISH_FINAL_WITHDRAW, at++)
+    // Second late reply — the doubled `^[[?997;1n^[[?997;1n` from the report.
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(true)
+  })
+
+  it('passes the reply while fish still sits subscribed at the prompt', () => {
+    const runtime = createScanningRuntime()
+    runtime.onPtyData(PTY_ID, FISH_TITLED_RESUBSCRIBE, 100)
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(false)
+  })
+
+  it('feeds the gate from daemon-relayed 2031 facts even with no fact consumer', () => {
+    // Delegated scan authority: the daemon relays the withdrawal as a fact.
+    // The gate must learn it before any consumer gating — a queued reply can
+    // cross the write boundary regardless of consumer availability.
+    const runtime = new OrcaRuntimeService(store)
+    runtime.emitDaemonPtyTransientFact(PTY_ID, { kind: '2031-subscribe' })
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(false)
+    runtime.emitDaemonPtyTransientFact(PTY_ID, { kind: '2031-unsubscribe' })
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(true)
+  })
+
+  it('still answers a ?996n one-shot query after fish withdrew', () => {
+    const runtime = createScanningRuntime()
+    runtime.onPtyData(PTY_ID, FISH_RESUBSCRIBE, 100)
+    runtime.onPtyData(PTY_ID, FISH_WITHDRAW, 101)
+    runtime.onPtyData(PTY_ID, '\x1b[?996n', 102)
+    // The DSR answer reuses the CSI 997 bytes; exactly one must pass.
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply(PTY_ID, DARK_REPORT)).toBe(true)
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -938,6 +938,12 @@ import {
   shouldModelAnswerHiddenPtyQueries
 } from './terminal-model-query-authority'
 import {
+  notePtyColorSchemeScanGap,
+  observePtyMode2031Decision,
+  observePtyOutputForColorSchemeProtocol,
+  setPtyColorSchemeScanDelegated
+} from './pty-color-scheme-reply-write-gate'
+import {
   getTerminalViewAttributes,
   getTerminalViewColorQueryReplyColors,
   registerTerminalViewAttributesApplier
@@ -9393,6 +9399,9 @@ export class OrcaRuntimeService {
     // `Network: https://local.example.com:3001/`) so the workspace ports
     // panel can surface them in place of the kernel bind address.
     advertisedUrlWatcher.ingest(ptyId, data, at)
+    // Why: the stale-reply write gate scans raw bytes at ingestion — ahead of
+    // every reply route and independent of fact consumers or reply ownership.
+    observePtyOutputForColorSchemeProtocol(ptyId, data)
     // Why: reply ownership is captured per chunk, here at ingestion — the
     // same module state and tick as the hidden-gate drop sites — and rides
     // the writeChain link. A mark/setting/subscriber flip before the queued
@@ -9755,6 +9764,9 @@ export class OrcaRuntimeService {
   ): void {
     const entry = this.getOrCreatePtyTitleTrackerEntry(ptyId)
     entry.tracker.setTransientFactScanningSuppressed(delegated)
+    // Why: delivered bytes may be gapped while delegated — the write gate's raw
+    // scan stands down and the daemon's relayed 2031 facts feed it instead.
+    setPtyColorSchemeScanDelegated(ptyId, delegated)
     if (!delegated && scanSeedAnsi) {
       // Prime the freshly reset scanner carry with the emulator's dangling
       // incomplete escape at the handoff position — a sequence split across
@@ -9815,6 +9827,7 @@ export class OrcaRuntimeService {
     }
     this.oscTitleScanTailByPtyId.delete(ptyId)
     this.osc7ScanTailByPtyId.delete(ptyId)
+    notePtyColorSchemeScanGap(ptyId)
     this.agentStatusOscProcessorsByPtyId.delete(ptyId)
     this.disposeHeadlessTerminal(ptyId)
   }
@@ -9822,6 +9835,15 @@ export class OrcaRuntimeService {
   /** Record one derived side-effect fact: batched per chunk while applying
    *  bytes, emitted immediately for between-chunk facts (stale-title timer). */
   private recordTerminalSideEffectFact(ptyId: string, fact: TerminalSideEffectFact): void {
+    // Why: the stale-reply write gate needs ingestion-fresh subscription state
+    // even when no fact consumer is attached — a queued CSI 997 reply can cross
+    // the write boundary at any time (#9993). Covers byte-scanned decisions and
+    // daemon-relayed facts alike.
+    if (fact.kind === '2031-subscribe') {
+      observePtyMode2031Decision(ptyId, 'subscribed')
+    } else if (fact.kind === '2031-unsubscribe') {
+      observePtyMode2031Decision(ptyId, 'unsubscribed')
+    }
     if (!this.terminalSideEffectConsumerAvailable) {
       return
     }

--- a/src/main/runtime/pty-color-scheme-reply-write-gate.test.ts
+++ b/src/main/runtime/pty-color-scheme-reply-write-gate.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _resetPtyColorSchemeReplyGateForTest,
+  clearPtyColorSchemeReplyGate,
+  notePtyColorSchemeScanGap,
+  observePtyMode2031Decision,
+  observePtyOutputForColorSchemeProtocol,
+  setPtyColorSchemeScanDelegated,
+  shouldDropStalePtyColorSchemeReply
+} from './pty-color-scheme-reply-write-gate'
+
+const DARK_REPORT = '\x1b[?997;1n'
+const LIGHT_REPORT = '\x1b[?997;2n'
+
+afterEach(() => {
+  _resetPtyColorSchemeReplyGateForTest()
+})
+
+describe('pty color-scheme reply write gate', () => {
+  it('passes reports while the newest ingested chunk left the PTY subscribed', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', 'prompt \x1b[?2031h')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', LIGHT_REPORT)).toBe(false)
+  })
+
+  it('drops a report once a newer chunk withdrew the subscription (#9993 fish prompt-accept race)', () => {
+    // fish at command accept: h → responder decides to reply → l ingested by
+    // main → the reply write arrives. The reply was correct for its chunk and
+    // is stale by the time it reaches the PTY.
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h')
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', LIGHT_REPORT)).toBe(true)
+  })
+
+  it('passes when main never observed any 2031 state for the PTY', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', 'plain output, no escapes')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-untracked', DARK_REPORT)).toBe(false)
+  })
+
+  it('holds the previous verdict through an ambiguous split withdrawal, then drops', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h')
+    // Incomplete private-mode tail: no decision yet, prior subscribe stands.
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?20')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    observePtyOutputForColorSchemeProtocol('pty-1', '31l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('accepts authoritative decisions from the fact relay over a delegated scan', () => {
+    setPtyColorSchemeScanDelegated('pty-1', true)
+    // Gapped delivered bytes must not mint decisions while delegated.
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyMode2031Decision('pty-1', 'subscribed')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    observePtyMode2031Decision('pty-1', 'unsubscribed')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('resumes raw scanning after delegation ends', () => {
+    setPtyColorSchemeScanDelegated('pty-1', true)
+    observePtyMode2031Decision('pty-1', 'unsubscribed')
+    setPtyColorSchemeScanDelegated('pty-1', false)
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+  })
+
+  it('a data gap resets the scan carry without forgetting the last verdict', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h')
+    // Half-open escape, then a gap: the carry must not resolve across it.
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?20')
+    notePtyColorSchemeScanGap('pty-1')
+    observePtyOutputForColorSchemeProtocol('pty-1', '31l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+  })
+
+  it('lets one report through per observed ?996n query even while unsubscribed', () => {
+    // A DSR ?996n answer reuses the CSI 997 bytes; a one-shot query must be
+    // answered regardless of mode-2031 subscription state.
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', 'prompt \x1b[?996n tail')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('counts multiple ?996n queries in one chunk, including 8-bit CSI', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?996n\x9b?996n')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', LIGHT_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('ignores 996n text that is not a CSI query', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', 'echo 996n \x1b[996n')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('never touches writes that are not a standalone CSI 997 report', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', 'ls -la\r')).toBe(false)
+    // Bracketed paste of report-looking bytes is user input, not a reply.
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', `\x1b[200~${DARK_REPORT}\x1b[201~`)).toBe(
+      false
+    )
+    // Reports batched with other bytes are not responder writes either.
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', `${DARK_REPORT}y\r`)).toBe(false)
+  })
+
+  it('re-subscribing after a withdrawal passes reports again', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+  })
+
+  it('scopes state per PTY', () => {
+    observePtyOutputForColorSchemeProtocol('pty-a', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-b', '\x1b[?2031h')
+    expect(shouldDropStalePtyColorSchemeReply('pty-a', DARK_REPORT)).toBe(true)
+    expect(shouldDropStalePtyColorSchemeReply('pty-b', DARK_REPORT)).toBe(false)
+  })
+
+  it('clearing a PTY releases its verdict and pending query slots', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l\x1b[?996n')
+    clearPtyColorSchemeReplyGate('pty-1')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+  })
+
+  it('caps pending query slots so a flood cannot bank unlimited passes', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?996n'.repeat(16))
+    for (let i = 0; i < 4; i += 1) {
+      expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    }
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+})

--- a/src/main/runtime/pty-color-scheme-reply-write-gate.test.ts
+++ b/src/main/runtime/pty-color-scheme-reply-write-gate.test.ts
@@ -66,13 +66,30 @@ describe('pty color-scheme reply write gate', () => {
     expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
   })
 
-  it('a data gap resets the scan carry without forgetting the last verdict', () => {
+  it('a data gap resets the scan carry and fails the raw verdict open', () => {
     observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031h')
     // Half-open escape, then a gap: the carry must not resolve across it.
     observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?20')
     notePtyColorSchemeScanGap('pty-1')
     observePtyOutputForColorSchemeProtocol('pty-1', '31l')
     expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+  })
+
+  it('a gap clears an unsubscribed raw verdict — the gap may have hidden a ?2031h', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+    notePtyColorSchemeScanGap('pty-1')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    // A fresh authoritative decision re-arms the gate.
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('a gap while delegated keeps the daemon-relayed verdict', () => {
+    setPtyColorSchemeScanDelegated('pty-1', true)
+    observePtyMode2031Decision('pty-1', 'unsubscribed')
+    notePtyColorSchemeScanGap('pty-1')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
   })
 
   it('lets one report through per observed ?996n query even while unsubscribed', () => {
@@ -89,6 +106,38 @@ describe('pty color-scheme reply write gate', () => {
     observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?996n\x9b?996n')
     expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
     expect(shouldDropStalePtyColorSchemeReply('pty-1', LIGHT_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('recognizes a ?996n query split across chunks', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', 'prompt \x1b[?99')
+    observePtyOutputForColorSchemeProtocol('pty-1', '6n tail')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('does not double-count a completed query held next to a following chunk', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?996n')
+    observePtyOutputForColorSchemeProtocol('pty-1', ' tail')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(false)
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('a gap discards a split ?996n query carry', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?99')
+    notePtyColorSchemeScanGap('pty-1')
+    observePtyOutputForColorSchemeProtocol('pty-1', '6n')
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?2031l')
+    expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
+  })
+
+  it('a delegation toggle discards a split ?996n query carry', () => {
+    observePtyOutputForColorSchemeProtocol('pty-1', '\x1b[?99')
+    setPtyColorSchemeScanDelegated('pty-1', true)
+    observePtyOutputForColorSchemeProtocol('pty-1', '6n')
+    observePtyMode2031Decision('pty-1', 'unsubscribed')
     expect(shouldDropStalePtyColorSchemeReply('pty-1', DARK_REPORT)).toBe(true)
   })
 

--- a/src/main/runtime/pty-color-scheme-reply-write-gate.ts
+++ b/src/main/runtime/pty-color-scheme-reply-write-gate.ts
@@ -1,0 +1,152 @@
+/**
+ * Last-moment gate for CSI 997 color-scheme reports at the PTY write boundary.
+ *
+ * Every mode-2031 responder decides from the chunk it observed, then its reply
+ * crosses a scheduling boundary (renderer IPC, remote protocol, fact relay)
+ * before reaching the PTY. fish toggles ?2031h/?2031l around every prompt
+ * repaint — several times within ~5ms at command accept — so a reply that was
+ * correct for its chunk routinely lands after a later chunk withdrew the
+ * subscription and the shell handed stdin to a child (#9993). Main ingests PTY
+ * output ahead of every reply route, so it always holds fresher subscription
+ * state than the responder that produced the reply: gate here, where the bytes
+ * enter the PTY, instead of adding more timing rules at N decision sites.
+ *
+ * The gate keeps its own raw-byte scan so its state never depends on fact
+ * consumers or per-pane reply ownership. While a PTY's scan authority is
+ * delegated to the daemon the delivered bytes may be gapped, so the raw scan
+ * stands down and the daemon's relayed 2031 facts feed the state instead.
+ *
+ * A ?996n DSR answer uses the same CSI 997 bytes but must never be dropped —
+ * a one-shot query deserves its answer regardless of subscription state — so
+ * main also counts observed ?996n queries and lets one report through per
+ * pending query.
+ */
+import {
+  INITIAL_MODE_2031_REPLY_SCAN_STATE,
+  mode2031SequenceFor,
+  scanMode2031ReplyDecision,
+  type Mode2031ReplyScanState
+} from '../../shared/terminal-color-scheme-protocol'
+
+const MODE_2031_REPORTS: ReadonlySet<string> = new Set([
+  mode2031SequenceFor('dark'),
+  mode2031SequenceFor('light')
+])
+
+// Bound pending query slots: DSR answers are immediate, so real depth is 1.
+const MAX_PENDING_COLOR_SCHEME_QUERY_REPLIES = 4
+
+type PtyColorSchemeReplyGateState = {
+  mode2031FinalState: 'subscribed' | 'unsubscribed' | null
+  scanState: Mode2031ReplyScanState
+  scanDelegated: boolean
+  pendingColorSchemeQueryReplies: number
+}
+
+const gateStatesByPtyId = new Map<string, PtyColorSchemeReplyGateState>()
+
+function getOrCreateState(ptyId: string): PtyColorSchemeReplyGateState {
+  let state = gateStatesByPtyId.get(ptyId)
+  if (!state) {
+    state = {
+      mode2031FinalState: null,
+      scanState: INITIAL_MODE_2031_REPLY_SCAN_STATE,
+      scanDelegated: false,
+      pendingColorSchemeQueryReplies: 0
+    }
+    gateStatesByPtyId.set(ptyId, state)
+  }
+  return state
+}
+
+/** Feed one authoritative mode-2031 decision (daemon fact relay / main tracker). */
+export function observePtyMode2031Decision(
+  ptyId: string,
+  decision: 'subscribed' | 'unsubscribed'
+): void {
+  getOrCreateState(ptyId).mode2031FinalState = decision
+}
+
+/**
+ * While delegated, delivered bytes may be gapped (daemon keep-tail thinning) —
+ * the raw scan would mint phantom decisions, so it stands down in favor of the
+ * daemon's relayed facts. Boundaries reset the scan carry either way: a partial
+ * escape from before the toggle must not corrupt what follows.
+ */
+export function setPtyColorSchemeScanDelegated(ptyId: string, delegated: boolean): void {
+  const state = getOrCreateState(ptyId)
+  state.scanDelegated = delegated
+  state.scanState = INITIAL_MODE_2031_REPLY_SCAN_STATE
+}
+
+/** A gap in delivered output invalidates the raw-scan carry. */
+export function notePtyColorSchemeScanGap(ptyId: string): void {
+  const state = gateStatesByPtyId.get(ptyId)
+  if (state) {
+    state.scanState = INITIAL_MODE_2031_REPLY_SCAN_STATE
+  }
+}
+
+/**
+ * Feed one raw PTY output chunk at ingestion: tracks the chunk-final mode-2031
+ * subscription state and counts ?996n color-scheme queries so their answers
+ * pass the gate.
+ */
+export function observePtyOutputForColorSchemeProtocol(ptyId: string, data: string): void {
+  const tracked = gateStatesByPtyId.get(ptyId)
+  // Hot path: ordinary output touches no state and allocates nothing.
+  if (!tracked && !data.includes('\x1b') && !data.includes('\x9b')) {
+    return
+  }
+  const state = tracked ?? getOrCreateState(ptyId)
+  if (!state.scanDelegated) {
+    const result = scanMode2031ReplyDecision(state.scanState, data)
+    state.scanState = result.state
+    if (result.decision !== null) {
+      state.mode2031FinalState = result.decision
+    }
+  }
+  if (data.includes('\x1b[?996n') || data.includes('\x9b?996n')) {
+    let count = 0
+    for (let index = data.indexOf('996n'); index !== -1; index = data.indexOf('996n', index + 4)) {
+      const prefix = data.slice(Math.max(0, index - 3), index)
+      if (prefix.endsWith('\x1b[?') || prefix.endsWith('\x9b?')) {
+        count += 1
+      }
+    }
+    state.pendingColorSchemeQueryReplies = Math.min(
+      state.pendingColorSchemeQueryReplies + count,
+      MAX_PENDING_COLOR_SCHEME_QUERY_REPLIES
+    )
+  }
+}
+
+/**
+ * Whether an input write must be dropped as a stale color-scheme report.
+ * Only exact standalone CSI 997 reports are considered — responders send them
+ * as whole writes, and user input (typed or bracketed paste) never matches.
+ */
+export function shouldDropStalePtyColorSchemeReply(ptyId: string, data: string): boolean {
+  if (!MODE_2031_REPORTS.has(data)) {
+    return false
+  }
+  const state = gateStatesByPtyId.get(ptyId)
+  if (!state) {
+    return false
+  }
+  if (state.pendingColorSchemeQueryReplies > 0) {
+    state.pendingColorSchemeQueryReplies -= 1
+    return false
+  }
+  return state.mode2031FinalState === 'unsubscribed'
+}
+
+/** Wired into PTY teardown so a replacement stream starts ungated. */
+export function clearPtyColorSchemeReplyGate(ptyId: string): void {
+  gateStatesByPtyId.delete(ptyId)
+}
+
+/** Test seam: reset module state between tests. */
+export function _resetPtyColorSchemeReplyGateForTest(): void {
+  gateStatesByPtyId.clear()
+}

--- a/src/main/runtime/pty-color-scheme-reply-write-gate.ts
+++ b/src/main/runtime/pty-color-scheme-reply-write-gate.ts
@@ -36,11 +36,35 @@ const MODE_2031_REPORTS: ReadonlySet<string> = new Set([
 // Bound pending query slots: DSR answers are immediate, so real depth is 1.
 const MAX_PENDING_COLOR_SCHEME_QUERY_REPLIES = 4
 
+const COLOR_SCHEME_QUERY_SEQUENCES = ['\x1b[?996n', '\x9b?996n'] as const
+
+/**
+ * Longest input suffix that is a strict prefix of a ?996n query — the bounded
+ * (≤6 chars) carry that lets a query split across chunks still bank its slot.
+ * A complete query never carries: it was already counted.
+ */
+function incompleteColorSchemeQuerySuffix(input: string): string {
+  const window = input.slice(-6)
+  for (let start = 0; start < window.length; start += 1) {
+    const candidate = window.slice(start)
+    if (
+      COLOR_SCHEME_QUERY_SEQUENCES.some(
+        (query) => query.length > candidate.length && query.startsWith(candidate)
+      )
+    ) {
+      return candidate
+    }
+  }
+  return ''
+}
+
 type PtyColorSchemeReplyGateState = {
   mode2031FinalState: 'subscribed' | 'unsubscribed' | null
   scanState: Mode2031ReplyScanState
   scanDelegated: boolean
   pendingColorSchemeQueryReplies: number
+  /** Chunk-spanning carry: an incomplete ?996n query prefix ending the last chunk. */
+  queryScanTail: string
 }
 
 const gateStatesByPtyId = new Map<string, PtyColorSchemeReplyGateState>()
@@ -52,7 +76,8 @@ function getOrCreateState(ptyId: string): PtyColorSchemeReplyGateState {
       mode2031FinalState: null,
       scanState: INITIAL_MODE_2031_REPLY_SCAN_STATE,
       scanDelegated: false,
-      pendingColorSchemeQueryReplies: 0
+      pendingColorSchemeQueryReplies: 0,
+      queryScanTail: ''
     }
     gateStatesByPtyId.set(ptyId, state)
   }
@@ -77,13 +102,22 @@ export function setPtyColorSchemeScanDelegated(ptyId: string, delegated: boolean
   const state = getOrCreateState(ptyId)
   state.scanDelegated = delegated
   state.scanState = INITIAL_MODE_2031_REPLY_SCAN_STATE
+  state.queryScanTail = ''
 }
 
-/** A gap in delivered output invalidates the raw-scan carry. */
+/**
+ * A gap in delivered output invalidates every cross-chunk carry. The gap may
+ * also have hidden a ?2031h, so a raw-scan verdict fails open until the scan
+ * mints a new decision; a delegated verdict is daemon fact-relayed and stands.
+ */
 export function notePtyColorSchemeScanGap(ptyId: string): void {
   const state = gateStatesByPtyId.get(ptyId)
   if (state) {
     state.scanState = INITIAL_MODE_2031_REPLY_SCAN_STATE
+    state.queryScanTail = ''
+    if (!state.scanDelegated) {
+      state.mode2031FinalState = null
+    }
   }
 }
 
@@ -94,8 +128,9 @@ export function notePtyColorSchemeScanGap(ptyId: string): void {
  */
 export function observePtyOutputForColorSchemeProtocol(ptyId: string, data: string): void {
   const tracked = gateStatesByPtyId.get(ptyId)
+  const hasEscapeByte = data.includes('\x1b') || data.includes('\x9b')
   // Hot path: ordinary output touches no state and allocates nothing.
-  if (!tracked && !data.includes('\x1b') && !data.includes('\x9b')) {
+  if (!tracked && !hasEscapeByte) {
     return
   }
   const state = tracked ?? getOrCreateState(ptyId)
@@ -106,18 +141,27 @@ export function observePtyOutputForColorSchemeProtocol(ptyId: string, data: stri
       state.mode2031FinalState = result.decision
     }
   }
-  if (data.includes('\x1b[?996n') || data.includes('\x9b?996n')) {
-    let count = 0
-    for (let index = data.indexOf('996n'); index !== -1; index = data.indexOf('996n', index + 4)) {
-      const prefix = data.slice(Math.max(0, index - 3), index)
-      if (prefix.endsWith('\x1b[?') || prefix.endsWith('\x9b?')) {
-        count += 1
+  if (hasEscapeByte || state.queryScanTail) {
+    // Queries split across chunks must still bank a slot: scan carry + data.
+    const input = state.queryScanTail ? `${state.queryScanTail}${data}` : data
+    if (input.includes('\x1b[?996n') || input.includes('\x9b?996n')) {
+      let count = 0
+      for (
+        let index = input.indexOf('996n');
+        index !== -1;
+        index = input.indexOf('996n', index + 4)
+      ) {
+        const prefix = input.slice(Math.max(0, index - 3), index)
+        if (prefix.endsWith('\x1b[?') || prefix.endsWith('\x9b?')) {
+          count += 1
+        }
       }
+      state.pendingColorSchemeQueryReplies = Math.min(
+        state.pendingColorSchemeQueryReplies + count,
+        MAX_PENDING_COLOR_SCHEME_QUERY_REPLIES
+      )
     }
-    state.pendingColorSchemeQueryReplies = Math.min(
-      state.pendingColorSchemeQueryReplies + count,
-      MAX_PENDING_COLOR_SCHEME_QUERY_REPLIES
-    )
+    state.queryScanTail = incompleteColorSchemeQuerySuffix(input)
   }
 }
 


### PR DESCRIPTION
Refs #9993 (still reproducible on v1.4.168 after #8206 / #8214 / #10817)

## Summary

`^[[?997;1n^[[?997;1n` still lands in the stdin of whatever runs next after a fish prompt-accept, corrupting interactive prompts (`brew`/`npx` `[y/N]` confirmations, `git add -p`, any keystroke reader). Reproduced deterministically on v1.4.168.

### Root cause (byte-level ground truth)

Captured from fish 4.7.1 + Tide behind a nested PTY inside an Orca 1.4.168 terminal. At command accept, fish toggles mode 2031 once per repaint, each toggle its own PTY chunk, five chunks in ~5 ms:

```
T+5.056  fish  ?2004l ?2031l          (withdraw)
T+5.056  fish  ?2004h ?2031h          (re-subscribe — chunk ends subscribed)
T+5.058  fish  ?2004l ?2031l          (withdraw)
T+5.058  orca  CSI ?997;1n            (reply to the 5.056 h — stale on arrival)
T+5.060  fish  OSC 0 + ?2004h ?2031h  (re-subscribe)
T+5.060  fish  ?2004l ?2031l + 133;C  (final withdraw, command starts)
T+5.061  orca  CSI ?997;1n            (reply to the 5.060 h — stale on arrival)
T+5.061  fish  ^[[?997;1n^[[?997;1n   (both replies echoed / fed to the child)
```

Every responder decision here is **correct for the chunk it observed** — the #10817 chunk-final contract holds. The replies lose to the *next* chunk: each one crosses a scheduling boundary (renderer IPC, remote protocol, fact relay) before reaching the PTY, and by arrival fish has withdrawn in a later chunk and handed stdin to the command. In-process terminals answer in microseconds and never lose this race; a multi-process pipeline loses it on every prompt accept, doubled because two repaint subscribes get answered late. No amount of per-chunk decision hardening at the responder sites can close this — it is a race between reply latency and the next chunk.

### Fix

Main ingests PTY output ahead of every reply route, so at the moment a reply write reaches the PTY, main always holds fresher subscription state than the responder that produced it. This PR adds a last-moment gate at the write boundary (`pty-color-scheme-reply-write-gate.ts`), checked at both write funnels:

- the renderer `pty:write` provider path (`writePtyProviderInput`)
- the runtime controller write (remote clients, CLI `terminal.send`, main-emulator query replies)

A write that is exactly a standalone `CSI ?997;1n` / `CSI ?997;2n` report is dropped iff main's ingestion-fresh state says the subscription was withdrawn.

Design points:

- The gate keeps its own bounded raw-byte scan (reusing `scanMode2031ReplyDecision`) fed from `onPtyData`, so its state does not depend on fact consumers or per-pane reply ownership.
- While a PTY's scan authority is delegated to the daemon, delivered bytes may be gapped: the raw scan stands down and the daemon's relayed `2031-subscribe`/`2031-unsubscribe` facts feed the state instead. Any signal that can trigger a reply also feeds the gate first, so the gate can only ever be stricter than the responder that fired.
- A `?996n` DSR answer reuses the CSI 997 bytes and must never be dropped — observed queries bank one pass each (bounded at 4).
- Fail-open everywhere main has no state: never-observed PTYs, data gaps, teardown/reuse, killed switches. Only exact standalone report writes are ever considered, so keystrokes and bracketed paste can never match.

## Reproduction

On v1.4.168, fish 4.7.1 + Tide, in a regular pane or the floating terminal:

```
python3 -c 'import sys; d=sys.stdin.readline(); print("GOT:", repr(d))'
# type: hello<Enter>
GOT: '\x1b[?997;1n\x1b[?997;1nhello\n'     # before this PR
GOT: 'hello\n'                             # after this PR (verified on a dev build)
```

The repro test replays the captured chunk stream verbatim through `OrcaRuntimeService.onPtyData` and pins both drops, the pass-while-subscribed case, the daemon fact path, and the `?996n` pass.

Also verified live on a dev build: a program that subscribes and stays subscribed still receives exactly one `CSI ?997;1n` (gate pass), and the doubled leak is gone.

## Screenshots

No visual change.

## Testing

- [x] Changed-file `oxlint` (also runs in the pre-commit hook)
- [x] `pnpm typecheck:node`
- [x] `pnpm test` (focused): new gate unit suite (15) + repro suite (4), plus `orca-runtime` (1023), `pty` (327), `terminal-query-responder` (66), `daemon-background-transient-facts`, `terminal-output-side-effects`, `terminal-mode-2031-final-state`, `terminal-color-scheme-protocol` — all passing
- [x] `pnpm check:max-lines-ratchet`, `pnpm check:reliability-gates`, `git diff --check`
- [x] Added high-quality regression tests: `pty-color-scheme-reply-write-gate.test.ts` (unit) and `issue-9993-fish-prompt-accept-stale-mode2031-reply.repro.test.ts` (end-to-end through the runtime ingest path, chunk stream pinned from a real byte trace)

## AI Review Report

Reviewed with an AI coding agent. Main risks checked and addressed:

- **Over-dropping legitimate replies**: `?996n` answers share the CSI 997 bytes — covered by pending-query slots; subscribe-and-hold seeds and theme-flip pushes pass because the gate state is `subscribed`; never-observed PTYs fail open.
- **Feed staleness/divergence**: the raw scan runs at ingestion in `onPtyData`, strictly before renderer delivery and any reply route; delegated (gapped) streams switch to the daemon fact feed, and both boundaries reset the scan carry (mirroring `setTransientFactScanningSuppressed` semantics).
- **State leakage across PTY reuse**: cleared in `clearProviderPtyState` alongside the Phase-5 ConPTY spawn record.
- **Cross-platform**: the gate is byte-level and platform-neutral (local, daemon, SSH, folder workspaces, remote clients all cross the same two funnels); no shortcuts, labels, paths, or shell-specific behavior touched. ConPTY DA1 and other query replies are unaffected (exact-match on CSI 997 only).
- **Hot path cost**: ordinary output takes an allocation-free early return (no ESC/CSI byte and no tracked state).

## Security Audit

No new command execution, filesystem access, network surface, or IPC endpoints. The change only inspects bytes already flowing through existing write/ingest paths and can only *drop* two exact 9-byte sequences, never inject or transform input. Bracketed paste and batched user input cannot match the exact-write predicate.

## Notes

- The residual race window shrinks from a renderer/remote round-trip (milliseconds, lost on every fish prompt-accept) to main's ingest-to-write interval (sub-millisecond, same order as in-process terminals).
- #10913 (visibility-resume theme refresh) is unaffected: flips to a still-subscribed PTY pass the gate.
- If a future responder legitimately needs to answer while a PTY reads as withdrawn, it should feed `observePtyMode2031Decision` — see the module doc.