### PR TITLE
fix(editor): render Mermaid HTML labels without stripping foreignObject

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1671,12 +1671,11 @@ export default function MarkdownPreview({
         // Why: display uses IPC blob URLs, but Cmd/Ctrl-click opens the original target so local/SSH images use the normal file-link path.
         return <img {...props} src={resolvedSrc} alt={alt ?? ''} onClick={handleImageClick} />
       },
-      // Why: render language-mermaid blocks as SVG; opt out of Mermaid HTML labels since sanitized foreignObject labels disappear on some platforms.
+      // Why: render language-mermaid fenced blocks as live diagrams (htmlLabels
+      // on; MermaidBlock sanitizes with foreignObject-preserving config).
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
-          return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
-          )
+          return <MermaidBlock content={String(children).trimEnd()} isDark={isDark} />
         }
         return (
           <code className={className} {...props}>

--- a/src/renderer/src/components/editor/MermaidBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useId, useRef, useState } from 'react'
 import type mermaidNamespace from 'mermaid'
-import DOMPurify from 'dompurify'
 import { getMermaidConfig } from './mermaid-config'
+import { sanitizeMermaidSvg } from './mermaid-sanitize'
 import { translate } from '@/i18n/i18n'
 
 type MermaidApi = typeof mermaidNamespace
@@ -50,7 +50,7 @@ function enqueueRender(fn: () => Promise<void>): void {
 export default function MermaidBlock({
   content,
   isDark,
-  htmlLabels = false
+  htmlLabels = true
 }: MermaidBlockProps): React.JSX.Element {
   const id = useId().replace(/:/g, '_')
   const containerRef = useRef<HTMLDivElement>(null)
@@ -68,17 +68,15 @@ export default function MermaidBlock({
         // Why: Mermaid stores initialize() config in global module state. Apply
         // the config inside the same serialized render task so another
         // MermaidBlock cannot overwrite htmlLabels/theme between initialize()
-        // and render(), which would make markdown preview fall back to the
-        // broken foreignObject label path again.
+        // and render().
         mermaid.initialize(getMermaidConfig(isDark, htmlLabels))
         const { svg } = await mermaid.render(`mermaid-${id}`, content)
         if (!cancelled && containerRef.current) {
-          // Why: although mermaid uses DOMPurify internally, we add an explicit
-          // sanitization pass as defense-in-depth against XSS in case upstream
-          // behaviour changes or a mermaid version ships without sanitization.
-          containerRef.current.innerHTML = DOMPurify.sanitize(svg, {
-            USE_PROFILES: { svg: true }
-          })
+          // Why: mermaid already sanitizes with securityLevel "strict"; this
+          // second pass is defense-in-depth. Use mermaid's own DOMPurify options
+          // (HTML_INTEGRATION_POINTS.foreignobject) so XHTML labels survive —
+          // USE_PROFILES svg/html alone empties foreignObject on Chromium (#12414).
+          containerRef.current.innerHTML = sanitizeMermaidSvg(svg)
           setError(null)
         }
       } catch (err) {

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -94,10 +94,7 @@ export default function MermaidViewer({
   return (
     <div ref={rootRef} className="mermaid-viewer h-full min-h-0 overflow-auto scrollbar-editor">
       <div className="mermaid-viewer-canvas">
-        {/* Why: DOMPurify's SVG profile strips <foreignObject> elements that
-           mermaid uses for HTML labels. Force SVG-native <text> labels so
-           they survive sanitization — same fix as the markdown preview path. */}
-        <MermaidBlock content={content.trim()} isDark={isDark} htmlLabels={false} />
+        <MermaidBlock content={content.trim()} isDark={isDark} />
       </div>
     </div>
   )

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -270,12 +270,10 @@ export function RichMarkdownCodeBlock({
       <NodeViewContent<'pre'> as="pre" />
       {/* Why: mermaid diagrams render as a live SVG preview below the editable
           source so users can see the result while editing. The code block stays
-          editable — the diagram is read-only output. This preview also goes
-          through MermaidBlock's sanitized SVG path, so it must opt out of
-          Mermaid HTML labels just like markdown preview to keep labels visible. */}
+          editable — the diagram is read-only output. */}
       {isMermaid && node.textContent.trim() && (
         <div contentEditable={false} className="mermaid-preview">
-          <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
+          <MermaidBlock content={node.textContent.trim()} isDark={isDark} />
         </div>
       )}
     </NodeViewWrapper>

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -146,12 +146,10 @@ export function RichMarkdownCodeBlock({
       <NodeViewContent<'pre'> as="pre" />
       {/* Why: mermaid diagrams render as a live SVG preview below the editable
           source so users can see the result while editing. The code block stays
-          editable — the diagram is read-only output. This preview also goes
-          through MermaidBlock's sanitized SVG path, so it must opt out of
-          Mermaid HTML labels just like markdown preview to keep labels visible. */}
+          editable — the diagram is read-only output. */}
       {isMermaid && node.textContent.trim() && (
         <div contentEditable={false} className="mermaid-preview">
-          <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
+          <MermaidBlock content={node.textContent.trim()} isDark={isDark} />
         </div>
       )}
     </NodeViewWrapper>

--- a/src/renderer/src/components/editor/mermaid-config.test.ts
+++ b/src/renderer/src/components/editor/mermaid-config.test.ts
@@ -3,28 +3,28 @@ import { describe, expect, it } from 'vitest'
 import { getMermaidConfig } from './mermaid-config'
 
 describe('getMermaidConfig', () => {
-  it('uses strict Mermaid rendering defaults', () => {
+  it('uses strict Mermaid rendering with HTML labels by default', () => {
     expect(getMermaidConfig(false)).toMatchObject({
       startOnLoad: false,
       securityLevel: 'strict',
       suppressErrorRendering: true,
       theme: 'default',
-      htmlLabels: false
+      htmlLabels: true
     })
   })
 
-  it('can enable HTML labels for callers that explicitly need them', () => {
-    expect(getMermaidConfig(false, true)).toMatchObject({
+  it('can disable HTML labels when a caller needs SVG-native text only', () => {
+    expect(getMermaidConfig(false, false)).toMatchObject({
       startOnLoad: false,
       theme: 'default',
-      htmlLabels: true
+      htmlLabels: false
     })
   })
 
   it('switches to the dark mermaid theme when the preview is dark', () => {
     expect(getMermaidConfig(true)).toMatchObject({
       theme: 'dark',
-      htmlLabels: false
+      htmlLabels: true
     })
   })
 })

--- a/src/renderer/src/components/editor/mermaid-config.ts
+++ b/src/renderer/src/components/editor/mermaid-config.ts
@@ -2,10 +2,12 @@ import type mermaid from 'mermaid'
 
 export function getMermaidConfig(
   isDark: boolean,
-  htmlLabels = false
+  htmlLabels = true
 ): Parameters<typeof mermaid.initialize>[0] {
   return {
     startOnLoad: false,
+    // Why: mermaid runs DOMPurify on HTML labels under "strict"; required so we
+    // can enable htmlLabels without injecting unsanitized foreignObject HTML.
     securityLevel: 'strict',
     suppressErrorRendering: true,
     theme: isDark ? 'dark' : 'default',

--- a/src/renderer/src/components/editor/mermaid-sanitize.chromium.test.ts
+++ b/src/renderer/src/components/editor/mermaid-sanitize.chromium.test.ts
@@ -1,0 +1,70 @@
+// Why: happy-dom does not exercise DOMPurify's Chromium namespace rules for
+// foreignObject XHTML; this suite is the security regression gate for #12414.
+// Unit CI does not install Playwright browsers — probe once and skip honestly
+// (not a silent pass) when Chromium is unavailable.
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { chromium } from '@playwright/test'
+import { describe, expect, it } from 'vitest'
+
+import { mermaidSvgSanitizeConfig } from './mermaid-sanitize'
+
+const require = createRequire(import.meta.url)
+
+async function probeChromium(): Promise<boolean> {
+  try {
+    const browser = await chromium.launch({ headless: true })
+    await browser.close()
+    return true
+  } catch {
+    return false
+  }
+}
+
+const chromiumAvailable = await probeChromium()
+
+async function sanitizeInChromium(svg: string): Promise<string> {
+  const purifyPath = require.resolve('dompurify/dist/purify.min.js')
+  const purifySrc = readFileSync(purifyPath, 'utf8')
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const page = await browser.newPage()
+    await page.setContent('<!doctype html><html><body></body></html>')
+    await page.addScriptTag({ content: purifySrc })
+    return await page.evaluate(
+      ({ svg, cfg }) => {
+        const purify = (
+          globalThis as unknown as {
+            DOMPurify: { sanitize: (dirty: string, config: unknown) => string }
+          }
+        ).DOMPurify
+        return purify.sanitize(svg, cfg)
+      },
+      { svg, cfg: mermaidSvgSanitizeConfig }
+    )
+  } finally {
+    await browser.close()
+  }
+}
+
+describe.skipIf(!chromiumAvailable)('sanitizeMermaidSvg (Chromium)', () => {
+  it('keeps mermaid HTML label formatting tags inside foreignObject', async () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><g><foreignObject width="100" height="40"><div xmlns="http://www.w3.org/1999/xhtml"><b>Bold</b> and <i>italic</i></div></foreignObject></g></svg>`
+    const out = await sanitizeInChromium(svg)
+    expect(out).toContain('foreignObject')
+    expect(out).toMatch(/<b[\s>]/i)
+    expect(out).toMatch(/<i[\s>]/i)
+    expect(out).toContain('Bold')
+  }, 30_000)
+
+  it('strips script, event handlers, and javascript: URLs while keeping label text', async () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><g><foreignObject width="100" height="40"><div xmlns="http://www.w3.org/1999/xhtml"><b onclick="alert(1)">Bold</b><script>alert(1)</script><a href="javascript:alert(1)">x</a><img src="x" onerror="alert(1)"></div></foreignObject><script>alert(2)</script></g></svg>`
+    const out = await sanitizeInChromium(svg)
+    expect(out).toContain('Bold')
+    expect(out).toMatch(/<b[\s>]/i)
+    expect(out.toLowerCase()).not.toContain('<script')
+    expect(out.toLowerCase()).not.toContain('onclick')
+    expect(out.toLowerCase()).not.toContain('onerror')
+    expect(out.toLowerCase()).not.toContain('javascript:')
+  }, 30_000)
+})

--- a/src/renderer/src/components/editor/mermaid-sanitize.test.ts
+++ b/src/renderer/src/components/editor/mermaid-sanitize.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+
+import { mermaidSvgSanitizeConfig, sanitizeMermaidSvg } from './mermaid-sanitize'
+
+describe('mermaidSvgSanitizeConfig', () => {
+  // Why: Chromium only keeps foreignObject XHTML when these options match
+  // mermaid's own post-render sanitize (HTML_INTEGRATION_POINTS + lowercase tags).
+  it('matches mermaid post-render DOMPurify options for foreignObject labels', () => {
+    expect(mermaidSvgSanitizeConfig.ADD_TAGS).toEqual(['foreignobject'])
+    expect(mermaidSvgSanitizeConfig.ADD_ATTR).toEqual(['dominant-baseline'])
+    expect(mermaidSvgSanitizeConfig.HTML_INTEGRATION_POINTS).toEqual({ foreignobject: true })
+  })
+})
+
+describe('sanitizeMermaidSvg', () => {
+  it('keeps foreignObject XHTML formatting tags (b/i) that SVG-only profiles strip', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><g><foreignObject width="100" height="40"><div xmlns="http://www.w3.org/1999/xhtml"><b>Bold</b> and <i>italic</i></div></foreignObject></g></svg>`
+    const out = sanitizeMermaidSvg(svg)
+    expect(out).toContain('foreignObject')
+    expect(out).toMatch(/<b[\s>]/i)
+    expect(out).toMatch(/<i[\s>]/i)
+    expect(out).toContain('Bold')
+    expect(out).toContain('italic')
+  })
+})

--- a/src/renderer/src/components/editor/mermaid-sanitize.ts
+++ b/src/renderer/src/components/editor/mermaid-sanitize.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'dompurify'
+import DOMPurify from 'dompurify'
+
+// Why: match mermaid's own post-render DOMPurify options (mermaid.core.mjs).
+// HTML_INTEGRATION_POINTS.foreignobject (lowercase) is required so XHTML label
+// children survive Chromium's namespace checks; without it foreignObject is
+// emptied (#12414 / #659). ADD_TAGS lowercase matches mermaid's DOMPURIFY_TAGS.
+export const mermaidSvgSanitizeConfig: Config = {
+  ADD_TAGS: ['foreignobject'],
+  ADD_ATTR: ['dominant-baseline'],
+  HTML_INTEGRATION_POINTS: { foreignobject: true }
+}
+
+export function sanitizeMermaidSvg(svg: string): string {
+  return DOMPurify.sanitize(svg, mermaidSvgSanitizeConfig)
+}

--- a/src/renderer/src/components/editor/use-markdown-preview-components.tsx
+++ b/src/renderer/src/components/editor/use-markdown-preview-components.tsx
@@ -153,11 +153,11 @@ export function useMarkdownPreviewComponents({
 
         return <img {...props} src={resolvedSrc} alt={alt ?? ''} onClick={handleImageClick} />
       },
+      // Why: render language-mermaid fenced blocks as live diagrams (htmlLabels
+      // on; MermaidBlock sanitizes with foreignObject-preserving config).
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
-          return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
-          )
+          return <MermaidBlock content={String(children).trimEnd()} isDark={isDark} />
         }
         return (
           <code className={className} {...props}>

--- a/src/renderer/src/components/sidebar/CommentMermaidBlock.tsx
+++ b/src/renderer/src/components/sidebar/CommentMermaidBlock.tsx
@@ -5,9 +5,7 @@ import { useAppStore } from '@/store'
 
 // Why: comment markdown components are module-level constants without access to
 // the live theme, so this wrapper resolves dark mode from the app store (same
-// logic the editor uses) and reuses the editor's MermaidBlock renderer. Mermaid
-// HTML labels are disabled because MermaidBlock sanitizes the SVG, and sanitized
-// foreignObject labels disappear on some platforms.
+// logic the editor uses) and reuses the editor's MermaidBlock renderer.
 export default function CommentMermaidBlock({
   content,
   className
@@ -22,7 +20,7 @@ export default function CommentMermaidBlock({
 
   return (
     <div className={cn(className)}>
-      <MermaidBlock content={content} isDark={isDark} htmlLabels={false} />
+      <MermaidBlock content={content} isDark={isDark} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Preserve Mermaid HTML labels during Orca's final SVG cleanup. The sanitizer now retains `foreignObject` and its XHTML label contents using Mermaid's own DOMPurify integration-point options. HTML labels are enabled by default, and preview, editor and comment call sites no longer force them off. Mermaid's strict security mode remains enabled.

This restores formatted labels such as bold text, italics and line breaks while the final cleanup still removes scripts, event-handler attributes and JavaScript URLs. Related: #12414.

## Validation

At `e7ec906cd1120ae1543a8ce40abd1e33b79ec1dd`:

- All 7 tests passed across configuration, sanitizer and Chromium suites, with no skips. The independent worktree selected installed Chrome via `channel: 'chrome'` in the two launch calls; the committed assertions were unchanged.
- A separate real-Chrome render imported the actual sanitizer, Mermaid configuration and Mermaid package. Bold/italic node labels remained visible with nonzero dimensions; hostile SVG lost scripts and event handlers, and the test payload did not execute. Screenshot inspected.
- CLI, Node and Web TypeScript (`--composite false`), changed-file lint, formatting and diff whitespace checks passed. Independent Cursor review passed after inspecting the Chromium evidence.

The default Chromium test launch still skips when its Playwright browser is unavailable. Happy-dom alone is not treated as the security verifier. Full repository tests, packaged builds and rendered checks of every Orca embedding surface were not run; the browser proof covers the actual rendering/sanitizer pipeline rather than a complete Electron session.

## AI disclosure

Cursor ported and reviewed this change. Codex independently ran the existing assertions in Chrome, inspected a rendered proof and checked the source and validation results before updating the PR.
