### PR TITLE
fix(terminal): speed file-link hover with positive worktree path index

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-file-path-exists.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-path-exists.ts
@@ -19,6 +19,7 @@ export async function resolveTerminalFilePathExists(args: {
   fileContext: RuntimeFileOperationArgs
   runtimeEnvironmentId?: string | null
   pathExistsCache: Map<string, boolean>
+  pathIndexOwnerKey?: string | null
 }): Promise<boolean> {
   const {
     mappedPath,
@@ -26,7 +27,8 @@ export async function resolveTerminalFilePathExists(args: {
     worktreePath,
     fileContext,
     runtimeEnvironmentId,
-    pathExistsCache
+    pathExistsCache,
+    pathIndexOwnerKey
   } = args
   const isRemoteRuntimePath = isRemoteRuntimeFileOperation(fileContext, mappedPath)
   const cacheKey = getTerminalPathExistsCacheKey({
@@ -36,14 +38,17 @@ export async function resolveTerminalFilePathExists(args: {
     runtimeEnvironmentId
   })
   const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
-  const listedExists = lookupWorktreeListedPathExists(
-    worktreeId,
-    worktreePath,
-    mappedPath,
+  const ownerKey =
+    pathIndexOwnerKey?.trim() ||
     terminalWorktreePathIndexOwnerKey({
       connectionId: fileContext.connectionId,
       runtimeEnvironmentId
     })
+  const listedExists = lookupWorktreeListedPathExists(
+    worktreeId,
+    worktreePath,
+    mappedPath,
+    ownerKey
   )
   const exists =
     cachedExists ??

--- a/src/renderer/src/components/terminal-pane/terminal-file-path-exists.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-path-exists.ts
@@ -1,0 +1,56 @@
+import { isRemoteRuntimeFileOperation, runtimePathExists } from '@/runtime/runtime-file-client'
+import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import {
+  getTerminalPathExistsCacheKey,
+  readTerminalPathExistsCache,
+  writeTerminalPathExistsCache
+} from './terminal-path-exists-cache'
+import {
+  lookupWorktreeListedPathExists,
+  terminalWorktreePathIndexOwnerKey
+} from './terminal-worktree-path-index'
+
+// Why: hover linkify used to await shell:pathExists per candidate (#11975).
+// Order: pathExistsCache → positive-only worktree listing → IPC/stat.
+export async function resolveTerminalFilePathExists(args: {
+  mappedPath: string
+  worktreeId: string
+  worktreePath: string
+  fileContext: RuntimeFileOperationArgs
+  runtimeEnvironmentId?: string | null
+  pathExistsCache: Map<string, boolean>
+}): Promise<boolean> {
+  const {
+    mappedPath,
+    worktreeId,
+    worktreePath,
+    fileContext,
+    runtimeEnvironmentId,
+    pathExistsCache
+  } = args
+  const isRemoteRuntimePath = isRemoteRuntimeFileOperation(fileContext, mappedPath)
+  const cacheKey = getTerminalPathExistsCacheKey({
+    absolutePath: mappedPath,
+    connectionId: fileContext.connectionId,
+    isRemoteRuntimePath,
+    runtimeEnvironmentId
+  })
+  const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
+  const listedExists = lookupWorktreeListedPathExists(
+    worktreeId,
+    worktreePath,
+    mappedPath,
+    terminalWorktreePathIndexOwnerKey({
+      connectionId: fileContext.connectionId,
+      runtimeEnvironmentId
+    })
+  )
+  const exists =
+    cachedExists ??
+    listedExists ??
+    (fileContext.connectionId || isRemoteRuntimePath
+      ? await runtimePathExists(fileContext, mappedPath)
+      : await window.api.shell.pathExists(mappedPath))
+  writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+  return exists
+}

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -15,6 +15,10 @@ import {
   openDetectedFilePath
 } from './terminal-link-handlers'
 import { TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES } from './terminal-path-exists-cache'
+import {
+  resetTerminalWorktreePathIndexForTests,
+  seedTerminalWorktreePathIndexForTests
+} from './terminal-worktree-path-index'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { installHttpLinkClickFallback } from './terminal-url-link-hit-testing'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
@@ -103,6 +107,7 @@ async function flushDoubleRaf(): Promise<void> {
 
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
+  resetTerminalWorktreePathIndexForTests()
   vi.clearAllMocks()
   runtimeEnvironmentTransportCallMock.mockReset()
   runtimeEnvironmentTransportCallMock.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
@@ -1514,6 +1519,42 @@ describe('createFilePathLinkProvider range bounds', () => {
     links[0]!.hover?.({} as MouseEvent, links[0]!.text)
 
     expect(linkTooltip.textContent).toBe('/repo/CLAUDE.md (⌘+click to open in Orca)')
+  })
+
+  it('uses worktree listing as positive-only evidence and skips pathExists IPC (#11975)', async () => {
+    seedTerminalWorktreePathIndexForTests('wt-1', '/repo', ['listed.ts'])
+    const pathExistsCache = new Map<string, boolean>()
+    const shellPathExists = vi.mocked(window.api.shell.pathExists)
+    shellPathExists.mockClear()
+    shellPathExists.mockResolvedValue(false)
+
+    const pane = makePane([makeBufferLine('listed.ts unknown.ts')])
+    const managerRef = {
+      current: { getPanes: () => [pane] } as unknown as PaneManager
+    }
+    const provider = createFilePathLinkProvider(
+      1,
+      {
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        startupCwd: '/repo',
+        managerRef,
+        linkProviderDisposablesRef: { current: new Map<number, IDisposable>() },
+        pathExistsCache
+      },
+      { textContent: '', style: { display: '' } } as unknown as HTMLElement,
+      getTerminalFileOpenHint()
+    )
+
+    const links = await new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(links.map((link) => link.text)).toEqual(['listed.ts'])
+    // Why: listed.ts resolved from the index without IPC; unknown.ts still probed.
+    expect(shellPathExists).toHaveBeenCalledWith('/repo/unknown.ts')
+    expect(shellPathExists).not.toHaveBeenCalledWith('/repo/listed.ts')
+    expect(pathExistsCache.get('active\0/repo/listed.ts')).toBe(true)
   })
 
   it('bounds the terminal path-exists cache while preserving recent probes', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -51,6 +51,9 @@ export type LinkHandlerDeps = {
   runtimeEnvironmentId?: string | null
   terminalHomePath?: string | null
   getRuntimeEnvironmentIdForPane?: (paneId: number) => string | null
+  // Why: must match primeTerminalWorktreePathIndex's file-explorer owner key so
+  // local shells on runtime/SSH worktrees still hit the warm listing (#11975).
+  pathIndexOwnerKey?: string | null
 }
 
 type ProvidedFileLink = {
@@ -155,7 +158,8 @@ export function createFilePathLinkProvider(
                   worktreePath,
                   fileContext,
                   runtimeEnvironmentId,
-                  pathExistsCache
+                  pathExistsCache,
+                  pathIndexOwnerKey: deps.pathIndexOwnerKey
                 })
                 if (!exists) {
                   return null

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -5,12 +5,12 @@ import {
   resolveTerminalFileLink
 } from '@/lib/terminal-links'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { isRemoteRuntimeFileOperation, runtimePathExists } from '@/runtime/runtime-file-client'
 import {
   buildCandidateLogicalLinesForBufferPosition,
   dedupeLogicalLines,
   openFilePathLinkAtBufferPosition
 } from './terminal-file-link-hit-testing'
+import { resolveTerminalFilePathExists } from './terminal-file-path-exists'
 import {
   getTerminalFileContext,
   isHtmlFilePath,
@@ -24,11 +24,6 @@ import {
   rangeForParsedFileLink,
   type WrappedLogicalLine
 } from './wrapped-terminal-link-ranges'
-import {
-  getTerminalPathExistsCacheKey,
-  readTerminalPathExistsCache,
-  writeTerminalPathExistsCache
-} from './terminal-path-exists-cache'
 import {
   getTerminalHtmlFileOpenHint,
   getTerminalOrcaFileOpenHint,
@@ -147,13 +142,6 @@ export function createFilePathLinkProvider(
                 worktreePath,
                 runtimeEnvironmentId
               )
-              const isRemoteRuntimePath = isRemoteRuntimeFileOperation(fileContext, mappedPath)
-              const cacheKey = getTerminalPathExistsCacheKey({
-                absolutePath: mappedPath,
-                connectionId: fileContext.connectionId,
-                isRemoteRuntimePath,
-                runtimeEnvironmentId
-              })
               const worktreeRootLink = resolveKnownWorktreeRootPathLink(mappedPath)
               if (/[\\/]$/.test(parsed.pathText) && !worktreeRootLink) {
                 return null
@@ -161,13 +149,14 @@ export function createFilePathLinkProvider(
               // Why: exact known workspace roots must stay clickable for SSH or
               // stale local paths even when filesystem probing says "missing".
               if (!worktreeRootLink) {
-                const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
-                const exists =
-                  cachedExists ??
-                  (fileContext.connectionId || isRemoteRuntimePath
-                    ? await runtimePathExists(fileContext, mappedPath)
-                    : await window.api.shell.pathExists(mappedPath))
-                writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+                const exists = await resolveTerminalFilePathExists({
+                  mappedPath,
+                  worktreeId,
+                  worktreePath,
+                  fileContext,
+                  runtimeEnvironmentId,
+                  pathExistsCache
+                })
                 if (!exists) {
                   return null
                 }

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  lookupWorktreeListedPathExists,
+  normalizeWorktreeRelativePathKey,
+  primeTerminalWorktreePathIndex,
+  releaseTerminalWorktreePathIndexLease,
+  resetTerminalWorktreePathIndexForTests,
+  seedTerminalWorktreePathIndexForTests,
+  terminalWorktreePathIndexOwnerKey
+} from './terminal-worktree-path-index'
+
+afterEach(() => {
+  resetTerminalWorktreePathIndexForTests()
+  vi.useRealTimers()
+})
+
+describe('normalizeWorktreeRelativePathKey', () => {
+  it('normalizes backslashes and leading slashes', () => {
+    expect(normalizeWorktreeRelativePathKey('src\\foo.ts')).toBe('src/foo.ts')
+    expect(normalizeWorktreeRelativePathKey('/src/foo.ts')).toBe('src/foo.ts')
+  })
+})
+
+describe('terminalWorktreePathIndexOwnerKey', () => {
+  it('prefers runtime over ssh over local', () => {
+    expect(
+      terminalWorktreePathIndexOwnerKey({
+        runtimeEnvironmentId: 'env-1',
+        connectionId: 'ssh-1'
+      })
+    ).toBe('runtime:env-1')
+    expect(terminalWorktreePathIndexOwnerKey({ connectionId: 'ssh-1' })).toBe('ssh:ssh-1')
+    expect(terminalWorktreePathIndexOwnerKey({})).toBe('local')
+  })
+})
+
+describe('lookupWorktreeListedPathExists', () => {
+  it('returns true only for positive index hits under the matching owner', () => {
+    seedTerminalWorktreePathIndexForTests('wt-1', '/repo', ['src/foo.ts', 'README.md'], 'local')
+
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/src/foo.ts', 'local')).toBe(true)
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/README.md', 'local')).toBe(true)
+    expect(
+      lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/missing.ts', 'local')
+    ).toBeUndefined()
+    expect(
+      lookupWorktreeListedPathExists('wt-1', '/repo', '/outside/foo.ts', 'local')
+    ).toBeUndefined()
+    expect(
+      lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/src/foo.ts', 'ssh:other')
+    ).toBeUndefined()
+  })
+
+  it('ignores stale positive hits after STALE_MS', () => {
+    vi.useFakeTimers()
+    seedTerminalWorktreePathIndexForTests('wt-1', '/repo', ['a.ts'], 'local')
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBe(true)
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1)
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBeUndefined()
+  })
+
+  it('treats a successful empty listing as fresh positive-evidence set', async () => {
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths: async () => []
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBeUndefined()
+    const listRelativePaths = vi.fn(async () => ['a.ts'])
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths
+    })
+    expect(listRelativePaths).not.toHaveBeenCalled()
+  })
+})
+
+describe('primeTerminalWorktreePathIndex', () => {
+  it('loads relative paths without blocking and serves later lookups', async () => {
+    let resolveList!: (paths: string[]) => void
+    const listPromise = new Promise<string[]>((resolve) => {
+      resolveList = resolve
+    })
+    const listRelativePaths = vi.fn((_token: string) => listPromise)
+
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths
+    })
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBeUndefined()
+
+    resolveList(['a.ts', 'nested\\b.ts'])
+    await listPromise
+    await Promise.resolve()
+
+    expect(listRelativePaths).toHaveBeenCalledOnce()
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBe(true)
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/nested/b.ts', 'local')).toBe(true)
+  })
+
+  it('does not start a second load while one is in flight', () => {
+    const listRelativePaths = vi.fn((_token: string) => new Promise<string[]>(() => {}))
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths
+    })
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths
+    })
+    expect(listRelativePaths).toHaveBeenCalledOnce()
+  })
+
+  it('only cancels when the last lease is released', async () => {
+    let resolveList!: (paths: string[]) => void
+    const listPromise = new Promise<string[]>((resolve) => {
+      resolveList = resolve
+    })
+    const cancelLoad = vi.fn()
+    const listRelativePaths = vi.fn(() => listPromise)
+
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths,
+      cancelLoad
+    })
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths,
+      cancelLoad
+    })
+    expect(listRelativePaths).toHaveBeenCalledOnce()
+
+    releaseTerminalWorktreePathIndexLease('wt-1', '/repo', 'local')
+    expect(cancelLoad).not.toHaveBeenCalled()
+
+    releaseTerminalWorktreePathIndexLease('wt-1', '/repo', 'local')
+    expect(cancelLoad).toHaveBeenCalledOnce()
+
+    resolveList(['ghost.ts'])
+    await listPromise
+    await Promise.resolve()
+    expect(
+      lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/ghost.ts', 'local')
+    ).toBeUndefined()
+  })
+
+  it('cancel then re-prime keeps the newer load; old finally does not clear it', async () => {
+    let resolveOld!: (paths: string[]) => void
+    let resolveNew!: (paths: string[]) => void
+    const oldPromise = new Promise<string[]>((resolve) => {
+      resolveOld = resolve
+    })
+    const newPromise = new Promise<string[]>((resolve) => {
+      resolveNew = resolve
+    })
+    const cancelLoad = vi.fn()
+    const listRelativePaths = vi
+      .fn()
+      .mockImplementationOnce(() => oldPromise)
+      .mockImplementationOnce(() => newPromise)
+
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths,
+      cancelLoad
+    })
+    releaseTerminalWorktreePathIndexLease('wt-1', '/repo', 'local')
+    expect(cancelLoad).toHaveBeenCalledOnce()
+
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths,
+      cancelLoad
+    })
+    expect(listRelativePaths).toHaveBeenCalledTimes(2)
+
+    resolveOld(['stale.ts'])
+    await oldPromise
+    await Promise.resolve()
+    expect(
+      lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/stale.ts', 'local')
+    ).toBeUndefined()
+
+    resolveNew(['fresh.ts'])
+    await newPromise
+    await Promise.resolve()
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/fresh.ts', 'local')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.test.ts
@@ -60,6 +60,30 @@ describe('lookupWorktreeListedPathExists', () => {
     expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBeUndefined()
   })
 
+  it('reloads on lookup when a leased index is stale', async () => {
+    vi.useFakeTimers()
+    const listRelativePaths = vi
+      .fn()
+      .mockResolvedValueOnce(['a.ts'])
+      .mockResolvedValueOnce(['a.ts', 'b.ts'])
+
+    primeTerminalWorktreePathIndex({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      ownerKey: 'local',
+      listRelativePaths
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBe(true)
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1)
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/a.ts', 'local')).toBeUndefined()
+    expect(listRelativePaths).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(lookupWorktreeListedPathExists('wt-1', '/repo', '/repo/b.ts', 'local')).toBe(true)
+  })
+
   it('treats a successful empty listing as fresh positive-evidence set', async () => {
     primeTerminalWorktreePathIndex({
       worktreeId: 'wt-1',

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.ts
@@ -1,0 +1,219 @@
+import { createBrowserUuid } from '@/lib/browser-uuid'
+import { toWorktreeRelativePath } from '@/lib/terminal-links'
+
+// Why: terminal hover linkify fans out shell:pathExists IPC per candidate
+// (#11975). A worktree file listing (same source Quick Open uses) is positive
+// evidence only — hit → exists with zero IPC; miss → fall through to stat.
+
+export type TerminalWorktreePathIndexOwnerKey = string
+
+type WorktreePathIndexEntry = {
+  relativePaths: Set<string>
+  loadedAt: number
+  loadPromise: Promise<void> | null
+  activeRequestToken: string | null
+  cancelLoad: ((requestToken: string) => void) | null
+  // Why: multiple terminal tabs share one listing; only cancel when last consumer leaves.
+  leaseCount: number
+}
+
+const indexesByKey = new Map<string, WorktreePathIndexEntry>()
+
+const STALE_MS = 5 * 60 * 1000
+const MAX_INDEX_ENTRIES = 32
+
+function indexKey(
+  worktreeId: string,
+  worktreePath: string,
+  ownerKey: TerminalWorktreePathIndexOwnerKey
+): string {
+  return `${worktreeId}\0${worktreePath}\0${ownerKey}`
+}
+
+// Why: listFiles returns mixed separators on Windows; comparison keys use '/'.
+export function normalizeWorktreeRelativePathKey(relativePath: string): string {
+  return relativePath.replace(/\\/g, '/').replace(/^\/+/, '')
+}
+
+export function terminalWorktreePathIndexOwnerKey(args: {
+  connectionId?: string | null
+  runtimeEnvironmentId?: string | null
+}): TerminalWorktreePathIndexOwnerKey {
+  const runtimeId = args.runtimeEnvironmentId?.trim()
+  if (runtimeId) {
+    return `runtime:${runtimeId}`
+  }
+  const connectionId = args.connectionId?.trim()
+  if (connectionId) {
+    return `ssh:${connectionId}`
+  }
+  return 'local'
+}
+
+function isFresh(entry: WorktreePathIndexEntry): boolean {
+  return entry.loadedAt > 0 && Date.now() - entry.loadedAt < STALE_MS
+}
+
+export function lookupWorktreeListedPathExists(
+  worktreeId: string,
+  worktreePath: string,
+  absolutePath: string,
+  ownerKey: TerminalWorktreePathIndexOwnerKey = 'local'
+): true | undefined {
+  const entry = indexesByKey.get(indexKey(worktreeId, worktreePath, ownerKey))
+  // Why: stale positive hits must not bypass pathExists forever (#11975 review).
+  if (!entry || !isFresh(entry)) {
+    return undefined
+  }
+  const relative = toWorktreeRelativePath(absolutePath, worktreePath)
+  if (relative === null || relative === '') {
+    return undefined
+  }
+  if (entry.relativePaths.has(normalizeWorktreeRelativePathKey(relative))) {
+    return true
+  }
+  return undefined
+}
+
+function evictOldestIdleIndexesIfNeeded(): void {
+  while (indexesByKey.size > MAX_INDEX_ENTRIES) {
+    let victimKey: string | undefined
+    for (const [key, entry] of indexesByKey) {
+      if (entry.leaseCount === 0 && !entry.loadPromise) {
+        victimKey = key
+        break
+      }
+    }
+    if (victimKey === undefined) {
+      break
+    }
+    indexesByKey.delete(victimKey)
+  }
+}
+
+export function primeTerminalWorktreePathIndex({
+  worktreeId,
+  worktreePath,
+  ownerKey,
+  listRelativePaths,
+  cancelLoad
+}: {
+  worktreeId: string
+  worktreePath: string
+  ownerKey: TerminalWorktreePathIndexOwnerKey
+  listRelativePaths: (requestToken: string) => Promise<readonly string[]>
+  cancelLoad?: (requestToken: string) => void
+}): void {
+  if (!worktreeId || !worktreePath) {
+    return
+  }
+  const key = indexKey(worktreeId, worktreePath, ownerKey)
+  let entry = indexesByKey.get(key)
+  if (!entry) {
+    entry = {
+      relativePaths: new Set(),
+      loadedAt: 0,
+      loadPromise: null,
+      activeRequestToken: null,
+      cancelLoad: null,
+      leaseCount: 0
+    }
+    indexesByKey.set(key, entry)
+  }
+  // Why: lease before eviction so a brand-new entry is never chosen as idle victim.
+  entry.leaseCount += 1
+  evictOldestIdleIndexesIfNeeded()
+
+  if (entry.loadPromise) {
+    return
+  }
+  if (isFresh(entry)) {
+    return
+  }
+
+  const requestToken = createBrowserUuid()
+  entry.activeRequestToken = requestToken
+  entry.cancelLoad = cancelLoad ?? null
+
+  const loadPromise = listRelativePaths(requestToken)
+    .then((paths) => {
+      if (entry.activeRequestToken !== requestToken) {
+        return
+      }
+      const next = new Set<string>()
+      for (const path of paths) {
+        if (typeof path === 'string' && path.length > 0) {
+          next.add(normalizeWorktreeRelativePathKey(path))
+        }
+      }
+      entry.relativePaths = next
+      entry.loadedAt = Date.now()
+    })
+    .catch(() => {
+      // Why: listing is best-effort acceleration; hover still uses pathExists.
+    })
+    .finally(() => {
+      // Why: only the active request may clear in-flight state; a cancelled
+      // request finishing later must not wipe a newer loadPromise (#11975).
+      if (entry.activeRequestToken === requestToken) {
+        entry.activeRequestToken = null
+        entry.cancelLoad = null
+        entry.loadPromise = null
+      }
+    })
+  entry.loadPromise = loadPromise
+}
+
+export function releaseTerminalWorktreePathIndexLease(
+  worktreeId: string,
+  worktreePath: string,
+  ownerKey: TerminalWorktreePathIndexOwnerKey
+): void {
+  const entry = indexesByKey.get(indexKey(worktreeId, worktreePath, ownerKey))
+  if (!entry) {
+    return
+  }
+  entry.leaseCount = Math.max(0, entry.leaseCount - 1)
+  if (entry.leaseCount > 0) {
+    return
+  }
+  // Why: only the last consumer cancels an in-flight full-tree scan (#7721).
+  if (entry.activeRequestToken && entry.cancelLoad) {
+    const token = entry.activeRequestToken
+    entry.activeRequestToken = null
+    entry.loadPromise = null
+    const cancel = entry.cancelLoad
+    entry.cancelLoad = null
+    cancel(token)
+  }
+}
+
+/** @deprecated use releaseTerminalWorktreePathIndexLease */
+export function cancelTerminalWorktreePathIndexLoad(
+  worktreeId: string,
+  worktreePath: string,
+  ownerKey: TerminalWorktreePathIndexOwnerKey
+): void {
+  releaseTerminalWorktreePathIndexLease(worktreeId, worktreePath, ownerKey)
+}
+
+export function resetTerminalWorktreePathIndexForTests(): void {
+  indexesByKey.clear()
+}
+
+// Test helper: inject a ready index without going through listFiles.
+export function seedTerminalWorktreePathIndexForTests(
+  worktreeId: string,
+  worktreePath: string,
+  relativePaths: readonly string[],
+  ownerKey: TerminalWorktreePathIndexOwnerKey = 'local'
+): void {
+  indexesByKey.set(indexKey(worktreeId, worktreePath, ownerKey), {
+    relativePaths: new Set(relativePaths.map(normalizeWorktreeRelativePathKey)),
+    loadedAt: Date.now(),
+    loadPromise: null,
+    activeRequestToken: null,
+    cancelLoad: null,
+    leaseCount: 1
+  })
+}

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-path-index.ts
@@ -13,6 +13,7 @@ type WorktreePathIndexEntry = {
   loadPromise: Promise<void> | null
   activeRequestToken: string | null
   cancelLoad: ((requestToken: string) => void) | null
+  listRelativePaths: ((requestToken: string) => Promise<readonly string[]>) | null
   // Why: multiple terminal tabs share one listing; only cancel when last consumer leaves.
   leaseCount: number
 }
@@ -54,6 +55,41 @@ function isFresh(entry: WorktreePathIndexEntry): boolean {
   return entry.loadedAt > 0 && Date.now() - entry.loadedAt < STALE_MS
 }
 
+function startIndexLoad(entry: WorktreePathIndexEntry): void {
+  if (entry.loadPromise || !entry.listRelativePaths) {
+    return
+  }
+  const requestToken = createBrowserUuid()
+  entry.activeRequestToken = requestToken
+  const listRelativePaths = entry.listRelativePaths
+  const loadPromise = listRelativePaths(requestToken)
+    .then((paths) => {
+      if (entry.activeRequestToken !== requestToken) {
+        return
+      }
+      const next = new Set<string>()
+      for (const path of paths) {
+        if (typeof path === 'string' && path.length > 0) {
+          next.add(normalizeWorktreeRelativePathKey(path))
+        }
+      }
+      entry.relativePaths = next
+      entry.loadedAt = Date.now()
+    })
+    .catch(() => {
+      // Why: listing is best-effort acceleration; hover still uses pathExists.
+    })
+    .finally(() => {
+      // Why: only the active request may clear in-flight state; a cancelled
+      // request finishing later must not wipe a newer loadPromise (#11975).
+      if (entry.activeRequestToken === requestToken) {
+        entry.activeRequestToken = null
+        entry.loadPromise = null
+      }
+    })
+  entry.loadPromise = loadPromise
+}
+
 export function lookupWorktreeListedPathExists(
   worktreeId: string,
   worktreePath: string,
@@ -62,7 +98,15 @@ export function lookupWorktreeListedPathExists(
 ): true | undefined {
   const entry = indexesByKey.get(indexKey(worktreeId, worktreePath, ownerKey))
   // Why: stale positive hits must not bypass pathExists forever (#11975 review).
-  if (!entry || !isFresh(entry)) {
+  // With an active lease, kick a background reload so multi-minute sessions
+  // regain the hot path without waiting for remount.
+  if (!entry) {
+    return undefined
+  }
+  if (!isFresh(entry)) {
+    if (entry.leaseCount > 0) {
+      startIndexLoad(entry)
+    }
     return undefined
   }
   const relative = toWorktreeRelativePath(absolutePath, worktreePath)
@@ -116,12 +160,15 @@ export function primeTerminalWorktreePathIndex({
       loadPromise: null,
       activeRequestToken: null,
       cancelLoad: null,
+      listRelativePaths: null,
       leaseCount: 0
     }
     indexesByKey.set(key, entry)
   }
   // Why: lease before eviction so a brand-new entry is never chosen as idle victim.
   entry.leaseCount += 1
+  entry.listRelativePaths = listRelativePaths
+  entry.cancelLoad = cancelLoad ?? null
   evictOldestIdleIndexesIfNeeded()
 
   if (entry.loadPromise) {
@@ -131,37 +178,7 @@ export function primeTerminalWorktreePathIndex({
     return
   }
 
-  const requestToken = createBrowserUuid()
-  entry.activeRequestToken = requestToken
-  entry.cancelLoad = cancelLoad ?? null
-
-  const loadPromise = listRelativePaths(requestToken)
-    .then((paths) => {
-      if (entry.activeRequestToken !== requestToken) {
-        return
-      }
-      const next = new Set<string>()
-      for (const path of paths) {
-        if (typeof path === 'string' && path.length > 0) {
-          next.add(normalizeWorktreeRelativePathKey(path))
-        }
-      }
-      entry.relativePaths = next
-      entry.loadedAt = Date.now()
-    })
-    .catch(() => {
-      // Why: listing is best-effort acceleration; hover still uses pathExists.
-    })
-    .finally(() => {
-      // Why: only the active request may clear in-flight state; a cancelled
-      // request finishing later must not wipe a newer loadPromise (#11975).
-      if (entry.activeRequestToken === requestToken) {
-        entry.activeRequestToken = null
-        entry.cancelLoad = null
-        entry.loadPromise = null
-      }
-    })
-  entry.loadPromise = loadPromise
+  startIndexLoad(entry)
 }
 
 export function releaseTerminalWorktreePathIndexLease(
@@ -214,6 +231,7 @@ export function seedTerminalWorktreePathIndexForTests(
     loadPromise: null,
     activeRequestToken: null,
     cancelLoad: null,
+    listRelativePaths: null,
     leaseCount: 1
   })
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -32,6 +32,16 @@ import {
   getTerminalUrlOpenHint,
   installFilePathLinkClickFallback
 } from './terminal-link-handlers'
+import {
+  primeTerminalWorktreePathIndex,
+  releaseTerminalWorktreePathIndexLease,
+  terminalWorktreePathIndexOwnerKey
+} from './terminal-worktree-path-index'
+import { cancelRuntimeFileList, listRuntimeFiles } from '@/runtime/runtime-file-client'
+import {
+  getFileExplorerOperationOwner,
+  getFileExplorerOperationRoute
+} from '@/components/right-sidebar/file-explorer-operation-owner'
 import { terminalUrlOpenHintOptionsFor } from './terminal-link-open-hints'
 import { createTerminalHandleLinkProvider } from './terminal-handle-links'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
@@ -742,6 +752,39 @@ export function useTerminalPaneLifecycle({
       getRuntimeEnvironmentIdForPane: (paneId) => {
         const sourceOwner = getHttpLinkSourceOwnerForPane(paneId)
         return sourceOwner.kind === 'runtime' ? sourceOwner.runtimeEnvironmentId : null
+      }
+    }
+    // Why: warm positive-only worktree path index so hover linkify can skip
+    // per-candidate shell:pathExists IPC for in-repo files (#11975). Never
+    // awaited — miss degrades to the existing stat path. Use the worktree's
+    // file-explorer owner (not global runtime focus) and cancel on teardown
+    // so abandoned full-tree scans cannot stack on SSH/relay (#7721).
+    let pathIndexOwnerKey: string | null = null
+    if (worktreeId && worktreePath) {
+      const operationOwner = getFileExplorerOperationOwner(worktreeId)
+      const operationRoute = getFileExplorerOperationRoute(operationOwner)
+      if (operationRoute) {
+        pathIndexOwnerKey = terminalWorktreePathIndexOwnerKey({
+          connectionId: operationRoute.connectionId,
+          runtimeEnvironmentId: operationRoute.settings.activeRuntimeEnvironmentId
+        })
+        const fileContext = {
+          settings: operationRoute.settings,
+          worktreeId,
+          worktreePath,
+          connectionId: operationRoute.connectionId
+        }
+        primeTerminalWorktreePathIndex({
+          worktreeId,
+          worktreePath,
+          ownerKey: pathIndexOwnerKey,
+          listRelativePaths: (requestToken) =>
+            listRuntimeFiles(fileContext, {
+              rootPath: worktreePath,
+              requestToken
+            }),
+          cancelLoad: (requestToken) => cancelRuntimeFileList(fileContext, requestToken)
+        })
       }
     }
     let resizeRaf: number | null = null
@@ -1692,6 +1735,9 @@ export function useTerminalPaneLifecycle({
     return () => {
       window.removeEventListener(SPLIT_TERMINAL_PANE_EVENT, onCliSplitPane)
       window.removeEventListener(CLOSE_TERMINAL_PANE_EVENT, onCliClosePane)
+      if (pathIndexOwnerKey && worktreeId && worktreePath) {
+        releaseTerminalWorktreePathIndexLease(worktreeId, worktreePath, pathIndexOwnerKey)
+      }
       const currentWorktreeTabs = useAppStore.getState().tabsByWorktree[worktreeId]
       const tabStillExists = Boolean(
         currentWorktreeTabs?.some((candidate) => candidate.id === tabId)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -740,25 +740,14 @@ export function useTerminalPaneLifecycle({
       resolveTerminalHttpLinkSourceOwner(paneTransportsRef.current.get(paneId))
     // Why: lifecycle-scoped cache for cross-SSH/runtime existence probes; may hold temporarily stale entries.
     const pathExistsCache = new Map<string, boolean>()
-    const linkDeps: LinkHandlerDeps = {
-      worktreeId,
-      worktreePath,
-      startupCwd,
-      getPaneLinkCwd,
-      terminalHomePath,
-      managerRef,
-      linkProviderDisposablesRef,
-      pathExistsCache,
-      getRuntimeEnvironmentIdForPane: (paneId) => {
-        const sourceOwner = getHttpLinkSourceOwnerForPane(paneId)
-        return sourceOwner.kind === 'runtime' ? sourceOwner.runtimeEnvironmentId : null
-      }
-    }
     // Why: warm positive-only worktree path index so hover linkify can skip
     // per-candidate shell:pathExists IPC for in-repo files (#11975). Never
     // awaited — miss degrades to the existing stat path. Use the worktree's
     // file-explorer owner (not global runtime focus) and cancel on teardown
     // so abandoned full-tree scans cannot stack on SSH/relay (#7721).
+    // Lookup must use this same owner key (via linkDeps.pathIndexOwnerKey), not
+    // the pane transport key — a local shell on a runtime-owned worktree still
+    // lists files through the explorer route.
     let pathIndexOwnerKey: string | null = null
     if (worktreeId && worktreePath) {
       const operationOwner = getFileExplorerOperationOwner(worktreeId)
@@ -785,6 +774,21 @@ export function useTerminalPaneLifecycle({
             }),
           cancelLoad: (requestToken) => cancelRuntimeFileList(fileContext, requestToken)
         })
+      }
+    }
+    const linkDeps: LinkHandlerDeps = {
+      worktreeId,
+      worktreePath,
+      startupCwd,
+      getPaneLinkCwd,
+      terminalHomePath,
+      managerRef,
+      linkProviderDisposablesRef,
+      pathExistsCache,
+      pathIndexOwnerKey,
+      getRuntimeEnvironmentIdForPane: (paneId) => {
+        const sourceOwner = getHttpLinkSourceOwnerForPane(paneId)
+        return sourceOwner.kind === 'runtime' ? sourceOwner.runtimeEnvironmentId : null
       }
     }
     let resizeRaf: number | null = null


### PR DESCRIPTION
## Summary
- Hover linkify waited on a `shell:pathExists` IPC per path-shaped token before xterm could draw underlines.
- Prime a worktree file listing (same source Quick Open uses) as **positive-only** evidence: listing hits resolve with zero IPC; misses still fall through to `pathExists`.
- Owner-scoped keys (local/SSH/runtime), lease-count cancel, STALE_MS, requestToken cancel for listing teardown.

Fixes #11975

## Test plan
- [x] Targeted vitest for index + link handlers (hot path / cancel / re-prime)
- [x] Codex review APPROVED