### PR TITLE
fix(terminal): clear selection before disposing remounted panes

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -527,6 +527,12 @@ describe('openTerminal — addon and provider wiring', () => {
       deregisterCharacterJoiner: vi.fn((joinerId: number) => {
         events.push(`deregisterCharacterJoiner:${joinerId}`)
       }),
+      clearSelection: vi.fn(() => {
+        events.push('clearSelection')
+      }),
+      dispose: vi.fn(() => {
+        events.push('dispose')
+      }),
       unicode: unicodeProxy,
       buffer: { active: { cursorX: 0, cursorY: 0 } }
     } as unknown as ManagedPaneInternal['terminal']
@@ -605,6 +611,17 @@ describe('openTerminal — addon and provider wiring', () => {
 
     expect(events).toContain('deregisterCharacterJoiner:3')
     expect(pane.arabicShapingJoinerCleanup).toBeNull()
+  })
+
+  it('clears selection before disposing the terminal on pane teardown (#12517)', () => {
+    const { pane, events } = createOpenTerminalHarness()
+    openTerminal(pane)
+
+    disposePane(pane, new Map([[pane.id, pane]]))
+
+    expect(events).toContain('clearSelection')
+    expect(events).toContain('dispose')
+    expect(events.indexOf('clearSelection')).toBeLessThan(events.indexOf('dispose'))
   })
 
   // Why: a link streamed under a stationary pointer must re-linkify on the next

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -243,6 +243,14 @@ export function disposePane(
     /* ignore */
   }
   try {
+    // Why: recovery remount replaces the xterm instance while the old canvas
+    // can still paint a selection highlight; clear before dispose so Cmd/Ctrl+C
+    // is not a silent no-op against an empty new instance (#12517).
+    pane.terminal.clearSelection()
+  } catch {
+    /* ignore */
+  }
+  try {
     pane.terminal.dispose()
   } catch {
     /* ignore */


### PR DESCRIPTION
## Summary
- Recovery remount replaces the xterm instance while a pre-remount selection can still look highlighted; Cmd/Ctrl+C then no-ops against the empty new instance.
- Call `terminal.clearSelection()` immediately before `terminal.dispose()` so teardown drops the highlight with the old pane.

Fixes #12517

## Test plan
- [x] pane-lifecycle unit coverage
- [x] Codex review APPROVED