### PR TITLE
feat(daemon): retain pane key as optional session metadata

### DIFF
--- a/src/main/daemon/daemon-session-info.ts
+++ b/src/main/daemon/daemon-session-info.ts
@@ -1,0 +1,39 @@
+// Session-inventory shapes, split out of types.ts so the listing payload can
+// grow without pushing that entry point over its line budget. Re-exported from
+// `./types` so existing importers keep one entry point.
+import type { AgentSessionOwnerBinding } from '../../shared/agent-session-host-authority'
+
+// ─── Session State Machine ──────────────────────────────────────────
+export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'
+
+export type ShellReadyState = 'pending' | 'ready' | 'timed_out' | 'unsupported'
+
+export type SessionInfo = {
+  sessionId: string
+  incarnationId?: string
+  state: SessionState
+  shellState: ShellReadyState
+  isAlive: boolean
+  terminalHandle?: string
+  /** Routing metadata for status bindings only, never an identity key — pane keys are reusable. */
+  paneKey?: string
+  wslDistro?: string | null
+  pid: number | null
+  cwd: string | null
+  cols: number
+  rows: number
+  createdAt: number
+  agentSessionOwners?: AgentSessionOwnerBinding[]
+}
+
+export type ListSessionsResult = {
+  sessions: SessionInfo[]
+}
+
+// Why: SessionInfo + source protocol version, so the Manage Sessions UI can
+// label legacy-backed sessions. Populated by the router/adapter at RPC time;
+// never transmitted over the daemon wire (daemon only speaks its own
+// protocol version and doesn't know about other versions).
+export type DaemonSessionInfo = SessionInfo & {
+  protocolVersion: number
+}

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -80,6 +80,7 @@ export type SessionOptions = {
   cols: number
   rows: number
   terminalHandle?: string
+  paneKey?: string
   launchAgent?: TuiAgent
   subprocess: SubprocessHandle
   shellReadySupported: boolean
@@ -104,6 +105,8 @@ export class Session {
   readonly sessionId: string
   readonly incarnationId = randomUUID()
   readonly terminalHandle: string | null
+  /** Routing metadata for status bindings only — never an identity key, since pane keys are reusable across sessions. */
+  readonly paneKey: string | null
   readonly launchAgent: TuiAgent | null
   readonly wslDistro: string | null
   private _state: SessionState = 'running'
@@ -136,6 +139,7 @@ export class Session {
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
     this.terminalHandle = opts.terminalHandle ?? null
+    this.paneKey = opts.paneKey ?? null
     this.launchAgent = opts.launchAgent ?? null
     this.wslDistro = opts.wslDistro ?? null
     this.subprocess = opts.subprocess

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -1,5 +1,6 @@
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
+import { MAX_PANE_KEY_LEN, parsePaneKey } from '../../shared/stable-pane-id'
 import { getDaemonSessionResultMetadata } from './daemon-create-or-attach-result'
 import { normalizePtySize } from './daemon-pty-size'
 import { Session } from './session'
@@ -21,6 +22,16 @@ type TerminalHostSessionCreateDependencies = {
   onDeadSessionRemoved: (sessionId: string) => void
   onSessionCreated: (sessionId: string, generation: string | undefined, isAlive: boolean) => void
   onSessionExit: (sessionId: string, generation: string | undefined) => void
+}
+
+// Why: the spawn env is caller-supplied, so retain the pane key only when it
+// parses as one — an arbitrary string under `paneKey` would look authoritative
+// to every downstream reader.
+function resolvePaneKeyMetadata(value: string | undefined): string | undefined {
+  if (!value || value.length > MAX_PANE_KEY_LEN || parsePaneKey(value) === null) {
+    return undefined
+  }
+  return value
 }
 
 export async function createOrAttachTerminalSession(
@@ -99,6 +110,7 @@ export async function createOrAttachTerminalSession(
     cols: size.cols,
     rows: size.rows,
     terminalHandle: opts.env?.ORCA_TERMINAL_HANDLE,
+    paneKey: resolvePaneKeyMetadata(opts.env?.ORCA_PANE_KEY),
     launchAgent: opts.launchAgent,
     subprocess,
     ownerBackend: resolvePtyOwnerBackend({

--- a/src/main/daemon/terminal-host-session-listing.ts
+++ b/src/main/daemon/terminal-host-session-listing.ts
@@ -19,6 +19,7 @@ export function listLiveTerminalHostSessions(
       shellState: session.shellState,
       isAlive: true,
       ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
+      ...(session.paneKey ? { paneKey: session.paneKey } : {}),
       wslDistro: session.wslDistro,
       pid: session.pid,
       cwd: session.getCwd(),

--- a/src/main/daemon/terminal-host-session-pane-key.test.ts
+++ b/src/main/daemon/terminal-host-session-pane-key.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SubprocessHandle } from './session'
+import { TerminalHost } from './terminal-host'
+
+vi.mock('../pty-descendant-termination', () => ({ killWithDescendantSweep: vi.fn() }))
+
+const PANE_KEY = 'tab-1:1b8c2f10-4a3e-4b1c-9d2e-7f6a5b4c3d2e'
+
+function createSubprocess(): SubprocessHandle {
+  let onExit: ((code: number) => void) | null = null
+  return {
+    pid: 99_999,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => onExit?.(0)),
+    forceKill: vi.fn(() => onExit?.(137)),
+    signal: vi.fn(),
+    onData: () => {},
+    onExit: (callback) => {
+      onExit = callback
+    },
+    dispose: vi.fn()
+  }
+}
+
+describe('TerminalHost session pane identity', () => {
+  let host: TerminalHost
+
+  afterEach(async () => {
+    await host?.dispose()
+  })
+
+  async function listWithPaneEnv(paneKey?: string) {
+    host = new TerminalHost({ spawnSubprocess: () => createSubprocess() })
+    await host.createOrAttach({
+      sessionId: 'pane-test',
+      cols: 80,
+      rows: 24,
+      env: {
+        ORCA_TERMINAL_HANDLE: 'term_abc',
+        ...(paneKey === undefined ? {} : { ORCA_PANE_KEY: paneKey })
+      },
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+    return host.listSessions()[0]
+  }
+
+  it('retains and lists a valid ORCA_PANE_KEY', async () => {
+    expect(await listWithPaneEnv(PANE_KEY)).toMatchObject({
+      terminalHandle: 'term_abc',
+      paneKey: PANE_KEY
+    })
+  })
+
+  // Why: an absent key must omit the field, not emit null — older adapters read
+  // the listing structurally and a null would read as "known to have no pane".
+  it('omits paneKey entirely when ORCA_PANE_KEY is absent', async () => {
+    const listed = await listWithPaneEnv(undefined)
+    expect(listed).not.toHaveProperty('paneKey')
+    expect(listed.terminalHandle).toBe('term_abc')
+  })
+
+  it.each([
+    ['no delimiter', 'tab-1'],
+    ['non-UUID leaf', 'tab-1:pane-3'],
+    ['extra delimiter', 'tab-1:2:1b8c2f10-4a3e-4b1c-9d2e-7f6a5b4c3d2e'],
+    ['empty tabId', ':1b8c2f10-4a3e-4b1c-9d2e-7f6a5b4c3d2e'],
+    ['empty value', ''],
+    ['overlong', `${'t'.repeat(300)}:1b8c2f10-4a3e-4b1c-9d2e-7f6a5b4c3d2e`]
+  ])('drops a malformed ORCA_PANE_KEY (%s)', async (_label, value) => {
+    expect(await listWithPaneEnv(value)).not.toHaveProperty('paneKey')
+  })
+})

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -16,7 +16,6 @@ import type { TuiAgent } from '../../shared/types'
 import type { PtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
 import type {
   AgentSessionExecutionClaim,
-  AgentSessionOwnerBinding,
   AgentSessionSurfaceBinding
 } from '../../shared/agent-session-host-authority'
 import type * as HistorySeedProtocol from './terminal-history-seed-transfer-protocol'
@@ -38,10 +37,9 @@ export {
   supportsPtyStartupIngress
 } from './daemon-protocol-version'
 
-// ─── Session State Machine ──────────────────────────────────────────
-export type SessionState = 'created' | 'spawning' | 'running' | 'exiting' | 'exited'
-
-export type ShellReadyState = 'pending' | 'ready' | 'timed_out' | 'unsupported'
+// Session state machine + session-inventory shapes live in daemon-session-info.ts;
+// re-exported so existing importers keep one types entry point.
+export * from './daemon-session-info'
 
 // The on-disk checkpoint.json shape lives in daemon-checkpoint-file.ts (it
 // depends only on TerminalModes here) — re-exported so existing importers of
@@ -341,10 +339,6 @@ export type GetSnapshotResult = {
   snapshot: TerminalSnapshot | null
 }
 
-export type ListSessionsResult = {
-  sessions: SessionInfo[]
-}
-
 export type ShutdownIfIdleResult = {
   retiring: boolean
 }
@@ -353,30 +347,6 @@ export type SystemResolverHealth = 'healthy' | 'unhealthy' | 'unknown'
 
 export type SystemResolverHealthResult = {
   health: SystemResolverHealth
-}
-
-export type SessionInfo = {
-  sessionId: string
-  incarnationId?: string
-  state: SessionState
-  shellState: ShellReadyState
-  isAlive: boolean
-  terminalHandle?: string
-  wslDistro?: string | null
-  pid: number | null
-  cwd: string | null
-  cols: number
-  rows: number
-  createdAt: number
-  agentSessionOwners?: AgentSessionOwnerBinding[]
-}
-
-// Why: SessionInfo + source protocol version, so the Manage Sessions UI can
-// label legacy-backed sessions. Populated by the router/adapter at RPC time;
-// never transmitted over the daemon wire (daemon only speaks its own
-// protocol version and doesn't know about other versions).
-export type DaemonSessionInfo = SessionInfo & {
-  protocolVersion: number
 }
 
 // Stream-socket event shapes live in daemon-stream-events.ts; re-exported so

--- a/src/main/ipc/pty-management.test.ts
+++ b/src/main/ipc/pty-management.test.ts
@@ -184,6 +184,25 @@ describe('pty:management IPC handlers', () => {
       expect(result.sessions.map((s) => s.sessionId)).toEqual(['preserved-1'])
     })
 
+    // Why: paneKey ships as an additive optional field with no protocol bump, so
+    // the client parsing path must pass it through rather than shape-validate.
+    it('passes an unknown-to-older-clients paneKey through the client parsing path', async () => {
+      const paneKey = 'tab-1:1b8c2f10-4a3e-4b1c-9d2e-7f6a5b4c3d2e'
+      const current = makeAdapter(5, [makeSession('with-pane', { paneKey })])
+      const { registerDaemonManagementHandlers } = await importFresh()
+      getDaemonProviderMock.mockReturnValue(await makeRouter(current))
+      registerDaemonManagementHandlers()
+
+      const handlers = buildHandlerMap()
+      const result = (await handlers['pty:management:listSessions']({})) as {
+        sessions: DaemonSessionInfo[]
+      }
+
+      expect(result.sessions).toHaveLength(1)
+      expect(result.sessions[0]).toMatchObject({ sessionId: 'with-pane', paneKey })
+      expect(result.sessions[0]?.protocolVersion).toBe(5)
+    })
+
     it('clears degraded mode after durable fresh-spawn routing recovers', async () => {
       const current = makeAdapter(5, [makeSession('preserved-1')])
       const provider = await makeDegradedProvider(current)

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -59,7 +59,7 @@ import {
   extractAgentProviderSession,
   type AgentProviderSessionMetadata
 } from './agent-session-resume'
-import { parsePaneKey } from './stable-pane-id'
+import { MAX_PANE_KEY_LEN, parsePaneKey } from './stable-pane-id'
 import {
   isCompactContinuationUserTurnText,
   isKnownHarnessInjectedUserTurnText
@@ -104,8 +104,8 @@ function capOpenCodeHookText(text: string): string {
     : text
 }
 
-/** Bound paneKey size (real keys are well under 200); caps per-pane caches against pathological input. Exported so non-HTTP ingest (`ingestRemote`) applies the same cap as defense-in-depth. */
-export const MAX_PANE_KEY_LEN = 200
+// Re-exported so existing importers (`ingestRemote` and the hook server) keep one entry point.
+export { MAX_PANE_KEY_LEN }
 const CLAUDE_PROMPT_ID_RE = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i
 
 export function normalizeClaudePromptId(value: unknown): string | undefined {

--- a/src/shared/stable-pane-id.ts
+++ b/src/shared/stable-pane-id.ts
@@ -11,6 +11,9 @@ export type StablePaneId = string & { readonly [stablePaneIdBrand]: true }
 export type TerminalLeafId = StablePaneId & { readonly [terminalLeafIdBrand]: true }
 export type PaneKey = string & { readonly [paneKeyBrand]: true }
 
+/** Bound paneKey size (real keys are well under 200); caps per-pane caches and untrusted ingest against pathological input. Lives here so validators can cap before `parsePaneKey` without pulling in the hook-listener graph. */
+export const MAX_PANE_KEY_LEN = 200
+
 export function isStablePaneId(value: string): value is StablePaneId {
   return UUID_RE.test(value)
 }


### PR DESCRIPTION
## Summary

The terminal daemon already receives `ORCA_PANE_KEY` in the PTY spawn env (it is in the `PANE_IDENTITY_ENV_KEYS` pass-through allowlist) but drops it on the floor. This PR retains it as **optional session metadata** and exposes it additively in the daemon session listing.

- `createOrAttachTerminalSession` reads `ORCA_PANE_KEY` from `opts.env` alongside the existing `ORCA_TERMINAL_HANDLE` read, validates it, and passes it to `Session`.
- `Session` retains it as `readonly paneKey: string | null`, mirroring `terminalHandle`.
- `listLiveTerminalHostSessions` spreads it into `SessionInfo` only when present, mirroring how `terminalHandle` is emitted.

Validation is **fail-closed**: the value is length-capped with the shared `MAX_PANE_KEY_LEN`, then must parse via the shared `parsePaneKey` from `src/shared/stable-pane-id.ts`. Anything absent, malformed, or overlong stores `undefined` — an arbitrary env string is never stored under a `paneKey` field.

No user-visible behavior change. No `PROTOCOL_VERSION` bump: the field is optional and additive, and every consumer of the listing spreads/reads structurally rather than shape-validating, so older Electron adapters ignore it.

Two supporting moves, both mechanical:

- `MAX_PANE_KEY_LEN` moves from `src/shared/agent-hook-listener.ts` to `src/shared/stable-pane-id.ts` (its natural home, next to `parsePaneKey`) and is re-exported from the old location so existing importers are untouched. This keeps the ~4k-line hook-listener module and its transitive graph **out of the forked `daemon-entry` bundle** — verified: the built `out/main/daemon-entry.js` contains `ORCA_PANE_KEY` but none of the hook-listener symbols.
- The session-inventory types (`SessionState`, `ShellReadyState`, `SessionInfo`, `ListSessionsResult`, `DaemonSessionInfo`) move from `src/main/daemon/types.ts` into a new `src/main/daemon/daemon-session-info.ts`, re-exported via `export *`. `types.ts` sat at exactly its 300-line `max-lines` budget, so the new field did not fit; this follows the precedent already in that file for `daemon-stream-events.ts` / `daemon-checkpoint-file.ts` rather than adding a lint disable or a ratchet-baseline entry. Type-only move — no runtime change, and every existing `from './types'` import keeps working.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New `src/main/daemon/terminal-host-session-pane-key.test.ts` (sibling to the existing `terminal-host-pty-owner-backend.test.ts` / `terminal-host-wsl-context.test.ts` focused suites) drives the real `TerminalHost.createOrAttach` → `listSessions` path:

- a valid `ORCA_PANE_KEY` is retained and listed alongside `terminalHandle`;
- an absent key **omits the field** rather than emitting `null` (a `null` would read as "known to have no pane" to a structural consumer);
- six malformed shapes are dropped: no delimiter, non-UUID leaf, extra delimiter, empty tabId, empty value, and a 300-char overlong key.

Adapter-side tolerance is covered in `src/main/ipc/pty-management.test.ts`: a listing payload carrying `paneKey` flows through `DaemonPtyAdapter.listSessions` → `collectSessions` → the `pty:management:listSessions` IPC result with the field intact and `protocolVersion` still annotated.

Both new suites were **mutation-checked** rather than assumed green:

- deleting the `paneKey` spread in `terminal-host-session-listing.ts` → the positive test fails (1 failed / 44 passed);
- weakening the validator to `if (!value)` → all five malformed cases fail (5 failed / 40 passed).

Existing daemon and `pty-management` listing tests pass unchanged, which is the additive-only proof.

Full-suite note (honest reporting): `pnpm test` was run in full and finished with 26 local timeout failures across 4 files — `orchestration-creator-authority-performance`, `terminal-output-frame-chunks-equivalence`, `run-electron-vite-dev`, and `project-view-wrapper-source-context-boundary`. All 4 **pass in isolation** (32/32 in 9.5s); they are load-induced timeouts from 22 parallel vitest workers on this machine, and none of them touch the daemon session path. Separately, `src/main/daemon/pty-subprocess.test.ts` timed out twice in an earlier targeted run — reproduced identically on a clean `git stash`ed tree at the same base commit, so also not introduced here. No failure was attributable to this change.

Also ran `config/scripts/check-changed-code-quality.mjs`: 0 new findings across 9 changed files for native, type-aware, and React Doctor.

## AI Review Report

Reviewed for correctness, cross-platform behavior, and additive-compatibility risk.

**Cross-platform (macOS + Linux + Windows) — explicitly checked.** The change is platform-neutral: no path handling, no shell invocation, no keyboard shortcuts, no UI labels, no Electron platform branching. `ORCA_PANE_KEY` is read out of the same caller-supplied `opts.env` object that `ORCA_TERMINAL_HANDLE` is already read from, with the same exact-case lookup, so no new platform divergence is introduced. Concretely:

- **Windows named-pipe daemon** and the POSIX unix-socket daemon share `createOrAttachTerminalSession` and `listLiveTerminalHostSessions` verbatim — this path is transport-agnostic and both get the field.
- **WSL sessions** flow through the same create path (`resolveWslSessionContext` runs alongside, and does not gate the env read), so a WSL-backed session retains its pane key identically.
- **Folder workspaces vs. git worktrees**: the pane key derives from tab id + terminal-layout leaf UUID, not from git state, so there is no worktree assumption — folder workspaces behave the same.
- **SSH / remote hosts**: the daemon-side create path is the same one remote providers drive; nothing here assumes local execution.

**Additive-compatibility risk (the main thing checked).** Traced the full listing serialization path for any exact-shape validation that a new key could break: `TerminalHost.listSessions` → `daemon-server.ts` `case 'listSessions'` → JSON line framing → `client.ts` (`JSON.parse` + cast, no schema) → `DaemonPtyAdapter.listSessions` (returns `result.sessions` as-is) → `pty-management.ts` `collectSessions` (object spread + `protocolVersion`). No zod, no `.strict()`, no allowlist, no `Object.keys` walk, no `toEqual` exact-shape assertion on `SessionInfo` in any existing test. An older adapter reading a newer daemon's listing ignores the field. This is why no protocol bump is warranted, and it is now pinned by a test.

**Flagged and addressed during review:**

- *Naive import of `MAX_PANE_KEY_LEN` from `agent-hook-listener.ts`* would have pulled that module's whole graph (`node:http`, `node:fs`, the Claude subagent roster, background-task inventory) into the separately-bundled, asar-unpacked `daemon-entry` fork. Moved the constant down to `stable-pane-id.ts` instead and verified the built daemon bundle stayed clean.
- *`null` vs. omitted* — an early draft emitted the key unconditionally. Changed to a conditional spread matching `terminalHandle`, and added an explicit `not.toHaveProperty('paneKey')` assertion so a future refactor can't silently start emitting `null`.
- *Empty string* — `''` is rejected by the `!value` guard before the parse, so it can never be retained as a falsy-but-present key.

**Explicitly out of scope / not changed:** `daemon-protocol-version.ts`, the PTY spawn env composition in `pty-subprocess.ts` / `local-pty-provider.ts`, checkpoint persistence, and any status-binding consumer. This PR only retains and exposes the value.

## Security Audit

**Input handling — the one risk surface here, and it is fail-closed.** `ORCA_PANE_KEY` arrives in a caller-supplied spawn-env map over the daemon RPC, so it is treated as untrusted input:

1. **Length cap first**, using the shared `MAX_PANE_KEY_LEN` (200) — bounds work before any parsing and before the value can be retained per-session.
2. **Shape parse second**, via the shared `parsePaneKey` (single `:` delimiter, non-empty tab id, RFC-4122 UUID leaf). The UUID regex is fully anchored and fixed-length, so it is not ReDoS-prone; the cap is defense-in-depth regardless.
3. **Reject to `undefined`**, never to a raw passthrough. The invariant enforced by the tests is that `paneKey` either holds a well-formed pane key or is absent — a downstream reader can never receive an arbitrary attacker-chosen string under a field that looks authoritative.

**Trust semantics.** The field is documented in code as *routing metadata only, never an identity key* — pane keys are reusable across sessions, so the forthcoming daemon-hosted status bindings key on `terminalHandle` + per-session `incarnationId` (both already stored) and may use `paneKey` only for routing. This is the security-relevant reason the comment exists.

**Other categories reviewed:** no command execution, no path handling, no filesystem writes, no auth or credential surface, no new dependency, and no new IPC channel — the value rides an existing authenticated daemon RPC (`listSessions`) that already carries `cwd`, `pid`, and `terminalHandle`, so it adds no new exposure class. The value is never logged, and it is in-memory only (not persisted to checkpoint files).

**Follow-up needed:** none for this PR. When bindings actually consume `paneKey`, the consumer must re-assert the "routing, not identity" rule at the binding site — a reused pane key must not be able to adopt another session's status.

## Notes

- Groundwork for moving agent hook status ownership to the PTY-owning daemon. **No protocol change** and **no behavior change** for any current consumer; the field is metadata only and nothing reads it yet.
- Bindings will be keyed by `terminalHandle` + per-session `incarnationId` (both already stored on `Session`), with `paneKey` as optional routing metadata. Pane keys are **reusable**, so this field must never become an identity key — the code comments say so at both the `Session` field and the `SessionInfo` field.
- The Windows named-pipe daemon and WSL sessions share this create/listing path, so they are covered by the same code and the same tests — no platform-specific follow-up.
- Session-inventory types now live in `src/main/daemon/daemon-session-info.ts` and are re-exported from `types.ts`; imports elsewhere are unchanged.
- `MAX_PANE_KEY_LEN` now lives in `src/shared/stable-pane-id.ts` and is re-exported from `src/shared/agent-hook-listener.ts`; existing importers (`ingestRemote`, the hook server) are unchanged.
