### PR TITLE
fix(fonts): decode Windows font names as UTF-8

### DIFF
--- a/src/main/system-fonts.test.ts
+++ b/src/main/system-fonts.test.ts
@@ -95,4 +95,21 @@ describe('listSystemFontFamilies', () => {
   ])('keeps the %s font command timeout short', async (platform, timeoutMs) => {
     await expectFontCommandTimeout(platform, timeoutMs)
   })
+
+  it('requests UTF-8 output for Windows font family names', async () => {
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      expect(args.at(-1)).toContain(
+        '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)'
+      )
+      callback(null, '굴림\r\nG마켓 산스 Medium\r\n')
+      return { kill: killMock }
+    })
+
+    const fonts = await withPlatform('win32', async () => {
+      const { listSystemFontFamilies } = await import('./system-fonts')
+      return listSystemFontFamilies()
+    })
+
+    expect(fonts).toEqual(['굴림', 'G마켓 산스 Medium'])
+  })
 })

--- a/src/main/system-fonts.ts
+++ b/src/main/system-fonts.ts
@@ -78,6 +78,7 @@ function listLinuxFonts(): Promise<string[]> {
 
 function listWindowsFonts(): Promise<string[]> {
   const script = `
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 Add-Type -AssemblyName System.Drawing
 $fonts = New-Object System.Drawing.Text.InstalledFontCollection
 $fonts.Families | ForEach-Object { $_.Name }


### PR DESCRIPTION
## Summary

Fixes #12590.

Windows font discovery now pins the PowerShell script's stdout to UTF-8 before it emits installed font family names. This prevents localized names such as `굴림`, `휴먼명조`, and `G마켓 산스 Medium` from becoming mojibake in the Settings font picker.

`execFileText()` already decodes stdout as UTF-8, but Windows PowerShell 5.1 can emit redirected text in the active console/OEM code page. The previous producer/consumer encoding mismatch corrupted non-ASCII family names. The fix makes the producer explicitly match the existing UTF-8 decoder.

The new regression test verifies both sides of the contract: the Windows script requests UTF-8 output and Korean family names survive parsing unchanged.

This is separate from #7573 (renderer-side list truncation) and #11771 / #11785 (PowerShell launch failure). It composes with #11785 because the output-encoding line is part of the shared script and works in both Windows PowerShell and PowerShell 7.

## Screenshots

No visual change to the UI itself. The user-visible change is that localized entries in the existing font picker are readable.

## Testing

- [ ] `pnpm lint` — implementation lint, type-aware lint, reliability gates, and max-lines checks passed; the full command then stopped because upstream generated skill artifacts are stale (`resources/skills/current-manifest.json`, `snapshot-registry.json`, and `release-mapping.json`). This PR does not touch those files.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full repository run did not finish within 10 minutes and was terminated; no final suite result was produced.
- [x] `pnpm build`
- [x] Added a regression test that would fail if Windows font enumeration stops pinning UTF-8 or mangles Korean names.

Additional focused verification:

- `pnpm exec vitest run src/main/system-fonts.test.ts --config config/vitest.config.ts` — 5/5 passed.
- `pnpm exec oxlint src/main/system-fonts.ts src/main/system-fonts.test.ts --deny-warnings` — passed.
- `pnpm exec oxfmt --check src/main/system-fonts.ts src/main/system-fonts.test.ts` — passed.
- Real Windows PowerShell enumeration using the patched script returned 279 family names, zero Unicode replacement characters, and the Korean family `휴먼명조` intact.
- The production build output contains the UTF-8 output-encoding assignment.

## AI Review Report

The final two-file diff was reviewed for platform, runtime, performance, UI, and integration risk:

- **Cross-platform:** the changed script runs only inside the existing `win32` branch. macOS `system_profiler` and Linux `fc-list` behavior is unchanged.
- **Local/remote/SSH:** no IPC contract, remote host behavior, SSH path, or repository operation changes. The existing font-list result and cache semantics are unchanged.
- **Agents/integrations:** no agent-specific or integration-specific path is touched.
- **Performance:** one constant-time encoding assignment is added before enumeration; no new process, retry, or hot-path work.
- **UI quality:** no layout or component changes; only the text values supplied to the existing picker are corrected.
- **Compatibility:** `[System.Text.UTF8Encoding]::new($false)` is supported by Windows PowerShell 5.1 and PowerShell 7.

No further code changes were needed after review.

## Security Audit

- No user-controlled input is added to the PowerShell script.
- No command interpolation, path handling, auth, secret, dependency, or IPC surface changes.
- The static encoding assignment does not weaken execution policy or alter process privileges.
- No new security follow-up is required.

## Notes

- Windows-only behavior fix, reproduced and directly verified on Windows 11 with Orca 1.4.168.
- X: not provided.
