### PR TITLE
fix(workspaces): add space after emoji picker selection

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -289,6 +289,6 @@ describe('SmartWorkspaceNameField emoji shortcodes', () => {
     })
     pressEnter(input)
 
-    expect(onValueChange).toHaveBeenCalledWith('Launch 😉')
+    expect(onValueChange).toHaveBeenCalledWith('Launch 😉 ')
   })
 })

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
@@ -86,7 +86,20 @@ describe('workspace emoji shortcodes', () => {
       )
     ).toEqual({
       value: 'Ship 😉 today',
-      cursor: 7
+      cursor: 8
+    })
+  })
+
+  it('adds a trailing space when a selected suggestion is at the end of the name', () => {
+    expect(
+      applyWorkspaceEmojiSuggestion(
+        'Launch :win',
+        { start: 7, end: 11, query: 'win' },
+        { emoji: '😉', shortcode: 'wink' }
+      )
+    ).toEqual({
+      value: 'Launch 😉 ',
+      cursor: 10
     })
   })
 })

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -109,17 +109,20 @@ export function applyWorkspaceEmojiSuggestion(
   active: ActiveWorkspaceEmojiShortcode,
   suggestion: WorkspaceEmojiSuggestion
 ): WorkspaceEmojiReplacement {
-  return replaceWorkspaceEmojiRange(value, active.start, active.end, suggestion.emoji)
+  return replaceWorkspaceEmojiRange(value, active.start, active.end, suggestion.emoji, true)
 }
 
 function replaceWorkspaceEmojiRange(
   value: string,
   start: number,
   end: number,
-  emoji: string
+  emoji: string,
+  addTrailingSpace = false
 ): WorkspaceEmojiReplacement {
+  const hasFollowingWhitespace = /\s/.test(value[end] ?? '')
+  const trailingSpace = addTrailingSpace && !hasFollowingWhitespace ? ' ' : ''
   return {
-    value: `${value.slice(0, start)}${emoji}${value.slice(end)}`,
-    cursor: start + emoji.length
+    value: `${value.slice(0, start)}${emoji}${trailingSpace}${value.slice(end)}`,
+    cursor: start + emoji.length + (addTrailingSpace ? 1 : 0)
   }
 }


### PR DESCRIPTION
## Summary

- Add a trailing space after selecting an emoji from the create-worktree colon picker.
- Preserve an existing separator to avoid double spaces and advance the caret past it.
- Add regression coverage for picker selection and end-of-name insertion.

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts`
- `pnpm lint`
- `pnpm typecheck`