### PR TITLE
fix(renderer): break Activity and terminal React #185 loops

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -238,21 +238,39 @@ describe('renderer breadcrumb IPC routing', () => {
 
   // Why: park-churn notices are per-tab but the ring is process-wide, so many
   // tabs churning at once would otherwise evict the pre-crash trail.
-  it('coalesces park-verdict churn notices by name across tabs', () => {
+  it('coalesces park-verdict churn notices by trigger across tabs', () => {
     emitRendererBreadcrumb({
       name: 'terminal_park_verdict_churn',
-      data: { tabId: 'tab-1', flips: 12, elapsedMs: 8 }
+      data: { tabId: 'tab-1', trigger: 'window', flips: 12, elapsedMs: 8 }
     })
     emitRendererBreadcrumb({
       name: 'terminal_park_verdict_churn',
-      data: { tabId: 'tab-2', flips: 12, elapsedMs: 9 }
+      data: { tabId: 'tab-2', trigger: 'window', flips: 12, elapsedMs: 9 }
     })
 
     expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
     expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledTimes(2)
     for (const call of recordCoalescedCrashBreadcrumbMock.mock.calls) {
-      expect(call[0]).toMatchObject({ coalesceKey: 'terminal_park_verdict_churn' })
+      expect(call[0]).toMatchObject({ coalesceKey: 'terminal_park_verdict_churn:window' })
     }
+  })
+
+  // Why: `burst` means damping engaged a commit short of React #185 while
+  // `window` is slow benign churn. A shared key would drop the near-crash
+  // signal into the slow-churn slot.
+  it('keeps burst and window park-verdict churn triggers in separate slots', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_park_verdict_churn',
+      data: { tabId: 'tab-1', trigger: 'burst', flips: 3, elapsedMs: 4 }
+    })
+    emitRendererBreadcrumb({
+      name: 'terminal_park_verdict_churn',
+      data: { tabId: 'tab-1', trigger: 'window', flips: 12, elapsedMs: 900 }
+    })
+
+    expect(
+      recordCoalescedCrashBreadcrumbMock.mock.calls.map((call) => call[0].coalesceKey)
+    ).toEqual(['terminal_park_verdict_churn:burst', 'terminal_park_verdict_churn:window'])
   })
 
   // Why: every hidden pane is 0x0, so one post-reload reattach wave exhausts

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -327,12 +327,13 @@ function buildUncapturedCrashReportText(
 // erasing the pre-crash trail. Coalesce repeats into one entry that carries a
 // suppressed count instead.
 const DUPLICATE_TAB_OWNER_BREADCRUMB = 'terminal_tab_id_owned_by_multiple_worktrees'
+const PARK_VERDICT_CHURN_BREADCRUMB = 'terminal_park_verdict_churn'
 const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'renderer_error',
   'renderer_unhandled_rejection',
-  'terminal_park_verdict_churn',
   'terminal_safe_fit_retry_exhausted',
   DUPLICATE_TAB_OWNER_BREADCRUMB,
+  PARK_VERDICT_CHURN_BREADCRUMB,
   TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB
 ])
 const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
@@ -345,10 +346,7 @@ const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
 // mounted pane within ~60ms. Windows crash F0BKR84AHEH lost 26-90% of its
 // 30-entry ring to two such bursts. `suppressedSinceLast` keeps the pane count
 // — the only signal these carry — in one slot.
-const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set([
-  'terminal_park_verdict_churn',
-  'terminal_safe_fit_retry_exhausted'
-])
+const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set(['terminal_safe_fit_retry_exhausted'])
 
 function rendererBreadcrumbCoalesceKey(
   name: string,
@@ -356,6 +354,13 @@ function rendererBreadcrumbCoalesceKey(
 ): string | undefined {
   if (NAME_ONLY_COALESCED_BREADCRUMB_NAMES.has(name)) {
     return name
+  }
+  // Why trigger and not name alone: `burst` means damping engaged a commit
+  // short of React #185, `window` means slow benign churn. Collapsing them
+  // would drop the near-crash signal into a slow-churn slot. Still bounded —
+  // two slots per storm regardless of tab count.
+  if (name === PARK_VERDICT_CHURN_BREADCRUMB) {
+    return `${name}:${String(data?.trigger ?? '')}`
   }
   // Why kind and not name alone: a context loss (GPU/driver gave up on this
   // renderer) and an atlas reset (routine post-wake repaint) must never

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -56,7 +56,9 @@ import {
   resolveActivityPortalSwap
 } from './activity-portal-thread-reconciliation'
 import {
+  ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS,
   createActivityPortalReadinessLatch,
+  type ActivityPortalReadinessLatch,
   type ActivityPortalReadinessStatus
 } from './activity-portal-readiness-oscillation'
 import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
@@ -289,13 +291,16 @@ export function useActivityTerminalPortalStatus(
     paneKey: null,
     status: 'loading'
   })
+  // Why: portal churn replaces every subscription identity, so the burst budget must outlive it.
+  const readinessLatchRef = useRef<ActivityPortalReadinessLatch | null>(null)
 
   useLayoutEffect(() => {
     let disposed = false
     let readinessFrame: number | null = null
+    let readinessReleaseTimer: number | null = null
     let pendingStatus: ActivityTerminalPortalReadiness['status'] | null = null
 
-    // Why: subscription churn can otherwise chain layout-effect updates past React's root-wide limit.
+    // Why: coalesce observer bursts and cancel frames from stale portal subscriptions.
     const scheduleReadiness = (status: ActivityTerminalPortalReadiness['status']): void => {
       if (disposed) {
         return
@@ -325,6 +330,10 @@ export function useActivityTerminalPortalStatus(
         cancelAnimationFrame(readinessFrame)
         readinessFrame = null
       }
+      if (readinessReleaseTimer !== null) {
+        window.clearTimeout(readinessReleaseTimer)
+        readinessReleaseTimer = null
+      }
     }
 
     if (!target || !paneKey) {
@@ -336,10 +345,22 @@ export function useActivityTerminalPortalStatus(
       return disposeFrame
     }
 
-    const readinessLatch = createActivityPortalReadinessLatch()
+    const readinessLatch = (readinessLatchRef.current ??= createActivityPortalReadinessLatch())
 
     const updateReadiness = (status: ActivityTerminalPortalReadiness['status']): void => {
-      scheduleReadiness(readinessLatch.next(status))
+      const nextStatus = readinessLatch.next(status)
+      scheduleReadiness(nextStatus)
+      if (readinessReleaseTimer !== null) {
+        window.clearTimeout(readinessReleaseTimer)
+        readinessReleaseTimer = null
+      }
+      if (nextStatus !== status) {
+        // Why: a quiet loading pane has no mutation to release the burst latch on its own.
+        readinessReleaseTimer = window.setTimeout(
+          checkReadiness,
+          ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS
+        )
+      }
     }
 
     const checkReadiness = (): void => {
@@ -1578,6 +1599,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     visibleThread
   ])
 
+  // Why: swap-staged makes the displayed thread selected, so this branch cannot repeat by itself.
   useLayoutEffect(() => {
     const swap = resolveActivityPortalSwap({
       selectedThread,

--- a/src/renderer/src/components/activity/activity-portal-churn-budget.test.ts
+++ b/src/renderer/src/components/activity/activity-portal-churn-budget.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createActivityPortalChurnBudget,
+  type ActivityPortalChurnBudget
+} from './activity-portal-churn-budget'
+
+function budgetAt(clock: { ms: number }): ActivityPortalChurnBudget {
+  return createActivityPortalChurnBudget({ limit: 3, windowMs: 1_000, now: () => clock.ms })
+}
+
+describe('createActivityPortalChurnBudget', () => {
+  it('spends once the window holds a full burst', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    expect(budget.record()).toBe(false)
+    expect(budget.record()).toBe(false)
+    expect(budget.record()).toBe(true)
+    clock.ms += 900
+    expect(budget.isSpent()).toBe(true)
+  })
+
+  it('stays spent while the churn keeps firing', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 500; i += 1) {
+      clock.ms += 10
+      budget.record()
+    }
+    expect(budget.isSpent()).toBe(true)
+  })
+
+  it('releases a window after the churn stops', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 3; i += 1) {
+      budget.record()
+    }
+    clock.ms += 1_000
+    expect(budget.isSpent()).toBe(false)
+    expect(budget.record()).toBe(false)
+  })
+
+  it('never spends on events paced slower than the window allows', () => {
+    // A user hopping between threads must keep the seamless path, however long they keep hopping.
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 100; i += 1) {
+      clock.ms += 500
+      expect(budget.record()).toBe(false)
+    }
+  })
+
+  it('treats a backwards clock as an expired window', () => {
+    // Date.now() jumps backwards on NTP/sleep-wake.
+    const clock = { ms: 10_000 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 3; i += 1) {
+      budget.record()
+    }
+    clock.ms = 5_000
+    expect(budget.isSpent()).toBe(false)
+  })
+
+  it('clears on demand', () => {
+    const clock = { ms: 0 }
+    const budget = budgetAt(clock)
+    for (let i = 0; i < 3; i += 1) {
+      budget.record()
+    }
+    budget.clear()
+    expect(budget.isSpent()).toBe(false)
+  })
+})

--- a/src/renderer/src/components/activity/activity-portal-churn-budget.ts
+++ b/src/renderer/src/components/activity/activity-portal-churn-budget.ts
@@ -1,0 +1,42 @@
+/** Sliding-window burst budget for Activity portal readiness churn. */
+export type ActivityPortalChurnBudget = {
+  /** Records one churn event; returns whether the budget is spent afterwards. */
+  record: () => boolean
+  /** True while the window still holds a full burst. */
+  isSpent: () => boolean
+  clear: () => void
+}
+
+export function createActivityPortalChurnBudget(args: {
+  limit: number
+  windowMs: number
+  now?: () => number
+}): ActivityPortalChurnBudget {
+  const { limit, windowMs, now = () => Date.now() } = args
+  // Why: only the newest limit events can affect the verdict.
+  let eventsAt: number[] = []
+
+  const prune = (at: number): void => {
+    // Why: clock rollback must not preserve a stale spent budget.
+    eventsAt = eventsAt.filter((eventAt) => eventAt > at - windowMs && eventAt <= at)
+  }
+
+  return {
+    record() {
+      const at = now()
+      prune(at)
+      eventsAt.push(at)
+      if (eventsAt.length > limit) {
+        eventsAt.shift()
+      }
+      return eventsAt.length >= limit
+    },
+    isSpent() {
+      prune(now())
+      return eventsAt.length >= limit
+    },
+    clear() {
+      eventsAt = []
+    }
+  }
+}

--- a/src/renderer/src/components/activity/activity-portal-readiness-decay.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-portal-readiness-decay.react185.test.tsx
@@ -1,0 +1,111 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useActivityTerminalPortalStatus } from './ActivityPrototypePage'
+import {
+  ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS,
+  ACTIVITY_PORTAL_READINESS_MAX_FLIPS
+} from './activity-portal-readiness-oscillation'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const TAB_ID = 'tab-readiness-decay'
+const LEAF_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
+const LEAF_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
+const PANE_KEY = `${TAB_ID}:${LEAF_A}`
+
+let root: Root
+
+beforeEach(() => vi.useFakeTimers())
+
+afterEach(() => {
+  act(() => root?.unmount())
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  document.body.replaceChildren()
+})
+
+function installControllers(): { flushFrame: () => Promise<void>; notify: () => void } {
+  let frame: FrameRequestCallback | null = null
+  const observers = new Map<MutationObserver, MutationCallback>()
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    frame = callback
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', () => {
+    frame = null
+  })
+  class ControlledMutationObserver implements MutationObserver {
+    constructor(callback: MutationCallback) {
+      observers.set(this, callback)
+    }
+    observe(): void {}
+    disconnect(): void {
+      observers.delete(this)
+    }
+    takeRecords(): MutationRecord[] {
+      return []
+    }
+  }
+  vi.stubGlobal('MutationObserver', ControlledMutationObserver)
+  return {
+    async flushFrame() {
+      const callback = frame
+      frame = null
+      await act(async () => callback?.(performance.now()))
+    },
+    notify() {
+      for (const [observer, callback] of observers) {
+        callback([], observer)
+      }
+    }
+  }
+}
+
+function renderPortalDom(target: HTMLElement, loading: boolean): void {
+  const tabRoot = document.createElement('div')
+  tabRoot.dataset.terminalTabId = TAB_ID
+  for (const leafId of loading ? [LEAF_A, LEAF_B] : [LEAF_B]) {
+    const pane = document.createElement('div')
+    pane.dataset.leafId = leafId
+    pane.dataset.ptyId = `pty-${leafId}`
+    pane.appendChild(Object.assign(document.createElement('div'), { className: 'xterm-screen' }))
+    Object.defineProperty(pane, 'getClientRects', { value: () => [{}] })
+    tabRoot.appendChild(pane)
+  }
+  target.replaceChildren(tabRoot)
+}
+
+describe('Activity portal readiness latch decay', () => {
+  it('rechecks a quiet loading pane when the burst window expires', async () => {
+    const controls = installControllers()
+    const target = document.createElement('div')
+    document.body.append(target)
+    renderPortalDom(target, false)
+    let status = 'loading'
+
+    function PortalStatus(): null {
+      status = useActivityTerminalPortalStatus(target, PANE_KEY)
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => root.render(<PortalStatus />))
+    await controls.flushFrame()
+
+    for (let flip = 0; flip < ACTIVITY_PORTAL_READINESS_MAX_FLIPS * 2; flip += 1) {
+      renderPortalDom(target, flip % 2 === 0)
+      controls.notify()
+      await controls.flushFrame()
+    }
+    renderPortalDom(target, true)
+    controls.notify()
+    await controls.flushFrame()
+    expect(status).toBe('unavailable')
+
+    act(() => vi.advanceTimersByTime(ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS))
+    await controls.flushFrame()
+    expect(status).toBe('loading')
+  })
+})

--- a/src/renderer/src/components/activity/activity-portal-readiness-loop.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-portal-readiness-loop.react185.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment happy-dom */
 import { act, useLayoutEffect, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -46,10 +46,17 @@ const PANE_C = thread(OTHER_TAB_ID, LEAF_C)
 
 let root: Root
 
+// Freeze Date (not timers/rAF) so the latch's flip window cannot expire between two drains on a
+// loaded CI machine; the readiness frames are still driven by the controllers below.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+})
+
 afterEach(() => {
   act(() => {
     root?.unmount()
   })
+  vi.useRealTimers()
   document.body.replaceChildren()
   vi.unstubAllGlobals()
 })

--- a/src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts
+++ b/src/renderer/src/components/activity/activity-portal-readiness-oscillation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS,
   ACTIVITY_PORTAL_READINESS_MAX_FLIPS,
   createActivityPortalReadinessLatch
 } from './activity-portal-readiness-oscillation'
@@ -49,5 +50,44 @@ describe('createActivityPortalReadinessLatch', () => {
     expect(latch.next('ready')).toBe('ready')
     expect(latch.next('loading')).toBe('loading')
     expect(latch.next('ready')).toBe('ready')
+  })
+
+  it('holds the latch for as long as the DOM keeps flipping', () => {
+    // The field loop ran 239 renders in 847ms, so the window never empties while it spins.
+    const clock = { ms: 0 }
+    const latch = createActivityPortalReadinessLatch(() => clock.ms)
+    const seen: string[] = []
+    for (let i = 0; i < 240; i += 1) {
+      clock.ms += 4
+      seen.push(latch.next(i % 2 === 0 ? 'loading' : 'unavailable'))
+    }
+    expect(
+      seen.slice(ACTIVITY_PORTAL_READINESS_MAX_FLIPS + 2).every((s) => s === 'unavailable')
+    ).toBe(true)
+  })
+
+  it('releases a latched pane once the churn stops, so a slow attach still reports loading', () => {
+    // A latched pane must not answer for the next pane the Activity slot shows (SSH panes take seconds).
+    const clock = { ms: 0 }
+    const latch = createActivityPortalReadinessLatch(() => clock.ms)
+    for (let i = 0; i < ACTIVITY_PORTAL_READINESS_MAX_FLIPS * 2; i += 1) {
+      clock.ms += 5
+      latch.next(i % 2 === 0 ? 'loading' : 'unavailable')
+    }
+    expect(latch.next('loading')).toBe('unavailable')
+    clock.ms += ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS
+    expect(latch.next('loading')).toBe('loading')
+  })
+
+  it('ignores flips paced by a human clicking between threads', () => {
+    // The latch outlives the subscription, so thread-hopping must never spend the burst budget.
+    const clock = { ms: 0 }
+    const latch = createActivityPortalReadinessLatch(() => clock.ms)
+    for (let i = 0; i < ACTIVITY_PORTAL_READINESS_MAX_FLIPS * 4; i += 1) {
+      clock.ms += 500
+      expect(latch.next(i % 2 === 0 ? 'loading' : 'unavailable')).toBe(
+        i % 2 === 0 ? 'loading' : 'unavailable'
+      )
+    }
   })
 })

--- a/src/renderer/src/components/activity/activity-portal-readiness-oscillation.ts
+++ b/src/renderer/src/components/activity/activity-portal-readiness-oscillation.ts
@@ -1,39 +1,40 @@
+import { createActivityPortalChurnBudget } from './activity-portal-churn-budget'
+
 export type ActivityPortalReadinessStatus = 'loading' | 'ready' | 'unavailable'
 
-// Why: stop a fixed subscription from repainting forever after frame coalescing breaks its sync cascade.
+// Why: stop a subscription from repainting forever after frame coalescing breaks its sync cascade.
 export const ACTIVITY_PORTAL_READINESS_MAX_FLIPS = 8
+/** Separates render-cadence churn from deliberate thread selection. */
+export const ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS = 500
 
 export type ActivityPortalReadinessLatch = {
   next: (status: ActivityPortalReadinessStatus) => ActivityPortalReadinessStatus
 }
 
-/** Bounds non-ready status flips for one readiness subscription. */
-export function createActivityPortalReadinessLatch(): ActivityPortalReadinessLatch {
+/** Bounds non-ready flips across every identity hosted by one portal slot. */
+export function createActivityPortalReadinessLatch(
+  now: () => number = () => Date.now()
+): ActivityPortalReadinessLatch {
   let lastStatus: ActivityPortalReadinessStatus | null = null
-  let flips = 0
-  let latched = false
+  const flipBudget = createActivityPortalChurnBudget({
+    limit: ACTIVITY_PORTAL_READINESS_MAX_FLIPS,
+    windowMs: ACTIVITY_PORTAL_READINESS_BURST_WINDOW_MS,
+    now
+  })
 
   return {
     next(status) {
       // Why: a slow terminal may become ready after exhausting the flip budget.
       if (status === 'ready') {
         lastStatus = status
-        flips = 0
-        latched = false
+        flipBudget.clear()
         return status
       }
-      if (latched) {
-        return 'unavailable'
-      }
-      if (lastStatus !== null && lastStatus !== status) {
-        flips += 1
-      }
+      // Why: underlying flips must keep the latch engaged even while its output is stable.
+      const flipped = lastStatus !== null && lastStatus !== status
       lastStatus = status
-      if (flips >= ACTIVITY_PORTAL_READINESS_MAX_FLIPS) {
-        latched = true
-        return 'unavailable'
-      }
-      return status
+      const spent = flipped ? flipBudget.record() : flipBudget.isSpent()
+      return spent ? 'unavailable' : status
     }
   }
 }

--- a/src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-portal-readiness-subscription-churn.react185.test.tsx
@@ -2,30 +2,40 @@
 import { act, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useActivityTerminalPortalStatus } from './ActivityPrototypePage'
+import { ACTIVITY_PORTAL_READINESS_MAX_FLIPS } from './activity-portal-readiness-oscillation'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
 const TAB_ID = 'tab-readiness-churn'
+const OTHER_TAB_ID = 'tab-readiness-churn-other'
 const LEAF_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1'
 const LEAF_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
 const LEAF_C = 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
 const PANE_A = `${TAB_ID}:${LEAF_A}`
 const PANE_B = `${TAB_ID}:${LEAF_B}`
+const OTHER_PANE_B = `${OTHER_TAB_ID}:${LEAF_B}`
 
 let root: Root
+
+// Freeze Date (not timers/rAF, which still drive the readiness frames) so the latch's flip window is
+// decided by the churn under test rather than by how slowly the machine runs it.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ['Date'] })
+})
 
 afterEach(() => {
   act(() => {
     root?.unmount()
   })
+  vi.useRealTimers()
   document.body.replaceChildren()
 })
 
-function buildNeverReadyRoot(target: HTMLElement): void {
+function buildNeverReadyRoot(target: HTMLElement, tabId: string = TAB_ID): void {
   const tabRoot = document.createElement('div')
-  tabRoot.dataset.terminalTabId = TAB_ID
+  tabRoot.dataset.terminalTabId = tabId
   for (const leafId of [LEAF_A, LEAF_C]) {
     const pane = document.createElement('div')
     pane.dataset.leafId = leafId
@@ -37,7 +47,57 @@ function buildNeverReadyRoot(target: HTMLElement): void {
   target.replaceChildren(tabRoot)
 }
 
+/** Lets the readiness rAF this churn step scheduled land in React state. */
+async function drainReadinessFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+  })
+}
+
 describe('Activity portal readiness subscription churn', () => {
+  // Why this bound matters: React raises #185 only after >50 *consecutive* commits that each leave a
+  // pending sync/default lane; any commit that leaves none resets nestedUpdateCount. This pins the
+  // reason the readiness subscription can never be that source -- its only writer is an rAF callback,
+  // and the effect cleanup cancels that frame on every churn step, so a synchronous cascade of
+  // subscription churn commits nothing at all. A #185 on this page must come from another setState.
+  it('contributes no state updates to a synchronous churn cascade past React nested-update limit', () => {
+    const target = document.createElement('div')
+    buildNeverReadyRoot(target)
+    document.body.append(target)
+
+    let selectPane: (paneKey: string) => void = () => {}
+    let readinessCommits = 0
+    let lastStatus = 'loading'
+
+    function ActivityTerminalSlot(): null {
+      const [paneKey, setPaneKey] = useState(PANE_A)
+      selectPane = setPaneKey
+      const status = useActivityTerminalPortalStatus(target, paneKey)
+      if (status !== lastStatus) {
+        readinessCommits += 1
+        lastStatus = status
+      }
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+    readinessCommits = 0
+
+    act(() => {
+      expect(() => {
+        for (let index = 0; index < 60; index += 1) {
+          flushSync(() => {
+            selectPane(index % 2 === 0 ? PANE_B : PANE_A)
+          })
+        }
+      }).not.toThrow()
+    })
+    expect(readinessCommits).toBe(0)
+  })
+
   it('coalesces pane-key churn and commits the latest readiness', async () => {
     const target = document.createElement('div')
     buildNeverReadyRoot(target)
@@ -76,5 +136,136 @@ describe('Activity portal readiness subscription churn', () => {
     })
     expect(status).toBe('unavailable')
     expect(renders).toBeLessThanOrEqual(32)
+  })
+
+  // Asserts the loop-terminating property, not just a final value: the status that drives the page's
+  // swap effect (stagedPortalUnavailable) must stop alternating part-way through the churn and stay
+  // put. While it alternates, every step re-targets both readiness subscriptions and re-stages.
+  function expectReadinessStopsAlternating(statuses: string[]): void {
+    // Sanity: the fixture really does alternate early, so the run below is the latch, not a rig.
+    const head = statuses.slice(0, ACTIVITY_PORTAL_READINESS_MAX_FLIPS)
+    expect(new Set(head)).toEqual(new Set(['loading', 'unavailable']))
+    // Termination: the churn keeps flipping the DOM but the status the swap effect reads stops moving.
+    const tail = statuses.slice(ACTIVITY_PORTAL_READINESS_MAX_FLIPS)
+    expect(tail.length).toBeGreaterThan(20)
+    expect(new Set(tail)).toEqual(new Set(['unavailable']))
+  }
+
+  // Why: staging only happens across tabs (reconcileActivityPortalThreads returns no stagedThread for
+  // same-tab panes), so the production swap moves slot element, pane key AND tab id in lockstep --
+  // every identity a subscription-scoped latch could key on.
+  it('stops alternating readiness when the slot, pane key and tab id all churn together', async () => {
+    const targets = [document.createElement('div'), document.createElement('div')]
+    buildNeverReadyRoot(targets[0], TAB_ID)
+    buildNeverReadyRoot(targets[1], OTHER_TAB_ID)
+    for (const target of targets) {
+      document.body.append(target)
+    }
+
+    let selectFlip: (flip: number) => void = () => {}
+    let status = 'loading'
+    const settledStatuses: string[] = []
+
+    function ActivityTerminalSlot(): null {
+      const [flip, setFlip] = useState(0)
+      selectFlip = setFlip
+      // Alternating panes report 'loading' (unisolated sibling) then 'unavailable' (missing leaf).
+      status = useActivityTerminalPortalStatus(
+        targets[flip % 2],
+        flip % 2 === 0 ? PANE_A : OTHER_PANE_B
+      )
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+
+    for (let flip = 1; flip <= 40; flip += 1) {
+      await act(async () => {
+        selectFlip(flip)
+      })
+      await drainReadinessFrame()
+      settledStatuses.push(status)
+    }
+
+    expectReadinessStopsAlternating(settledStatuses)
+  })
+
+  it('stops alternating readiness when only the pane key churns within one tab', async () => {
+    const target = document.createElement('div')
+    buildNeverReadyRoot(target, TAB_ID)
+    document.body.append(target)
+
+    let selectPane: (paneKey: string) => void = () => {}
+    let status = 'loading'
+    const settledStatuses: string[] = []
+
+    function ActivityTerminalSlot(): null {
+      const [paneKey, setPaneKey] = useState(PANE_A)
+      selectPane = setPaneKey
+      status = useActivityTerminalPortalStatus(target, paneKey)
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+
+    for (let flip = 0; flip < 40; flip += 1) {
+      await act(async () => {
+        selectPane(flip % 2 === 0 ? PANE_B : PANE_A)
+      })
+      await drainReadinessFrame()
+      settledStatuses.push(status)
+    }
+
+    expectReadinessStopsAlternating(settledStatuses)
+  })
+
+  // Why: the flip budget outlives the subscription, so a burst window wide enough to cover ordinary
+  // clicking would let one user's thread-hopping answer 'unavailable' for the next healthy pane.
+  it('does not answer for a later attaching pane after human-paced selections', async () => {
+    const churnTarget = document.createElement('div')
+    buildNeverReadyRoot(churnTarget, TAB_ID)
+    const attachingTarget = document.createElement('div')
+    buildNeverReadyRoot(attachingTarget, OTHER_TAB_ID)
+    for (const target of [churnTarget, attachingTarget]) {
+      document.body.append(target)
+    }
+
+    type SelectedPane = { target: HTMLElement; paneKey: string }
+    let selectPane: (pane: SelectedPane) => void = () => {}
+    let status = 'loading'
+
+    function ActivityTerminalSlot(): null {
+      const [pane, setPane] = useState<SelectedPane>({ target: churnTarget, paneKey: PANE_A })
+      selectPane = setPane
+      status = useActivityTerminalPortalStatus(pane.target, pane.paneKey)
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => {
+      root.render(<ActivityTerminalSlot />)
+    })
+
+    // Two clicks a second between a live thread ('loading') and a retained one ('unavailable').
+    for (let click = 1; click <= 10; click += 1) {
+      vi.setSystemTime(click * 500)
+      await act(async () => {
+        selectPane({ target: churnTarget, paneKey: click % 2 === 0 ? PANE_A : PANE_B })
+      })
+      await drainReadinessFrame()
+    }
+
+    vi.setSystemTime(5_500)
+    await act(async () => {
+      selectPane({ target: attachingTarget, paneKey: `${OTHER_TAB_ID}:${LEAF_A}` })
+    })
+    await drainReadinessFrame()
+    expect(status).toBe('loading')
   })
 })

--- a/src/renderer/src/components/activity/activity-portal-thread-reconciliation.test.ts
+++ b/src/renderer/src/components/activity/activity-portal-thread-reconciliation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  reconcileActivityPortalThreads,
+  resolveActivityPortalSwap,
+  type ActivityPortalThreadRef
+} from './activity-portal-thread-reconciliation'
+
+const thread = (tabId: string, leafId: string): ActivityPortalThreadRef => ({
+  paneKey: `${tabId}:${leafId}`,
+  worktree: { id: `wt-${tabId}` },
+  tab: { id: tabId }
+})
+
+// Two tabs in one worktree (staging applies) plus one in another worktree.
+const ALL_THREADS = [
+  thread('tab-a', 'leaf-1'),
+  thread('tab-b', 'leaf-2'),
+  thread('tab-c', 'leaf-3')
+]
+
+/** Replays ActivityPrototypePage's swap layout effect over a fixed selection. */
+function replaySwapCascade(args: {
+  selectedThread: ActivityPortalThreadRef
+  initialDisplayedPaneKey: string | null
+  steps: number
+}): string[] {
+  let displayedPaneKey = args.initialDisplayedPaneKey
+  const kinds: string[] = []
+  for (let step = 0; step < args.steps; step += 1) {
+    const displayedThread = displayedPaneKey
+      ? (ALL_THREADS.find((entry) => entry.paneKey === displayedPaneKey) ?? null)
+      : null
+    const { visibleThread, stagedThread } = reconcileActivityPortalThreads({
+      selectedThread: args.selectedThread,
+      displayedThread,
+      selectedHasLiveTab: true,
+      displayedHasLiveTab: true
+    })
+    // Most permissive readiness the page can hand in, so no swap is withheld.
+    const swap = resolveActivityPortalSwap({
+      selectedThread: args.selectedThread,
+      selectedHasLiveTab: true,
+      visibleThread,
+      stagedThread,
+      visiblePortalReady: true,
+      stagedPortalReady: true,
+      stagedPortalUnavailable: true
+    })
+    kinds.push(swap?.kind ?? 'none')
+    if (swap?.kind === 'clear') {
+      displayedPaneKey = null
+    } else if (swap) {
+      displayedPaneKey = swap.paneKey
+    }
+  }
+  return kinds
+}
+
+describe('resolveActivityPortalSwap cascade', () => {
+  // Why this matters: the swap effect writes setActivePortalSlotId/setDisplayedPaneKey straight from a
+  // layout effect. If 'swap-staged' could resolve on two consecutive commits it would toggle the slot
+  // forever on React's sync lane. It cannot, so the effect needs no churn budget.
+  it('never resolves swap-staged twice in a row for a fixed selection', () => {
+    for (const selectedThread of ALL_THREADS) {
+      for (const displayed of [null, ...ALL_THREADS]) {
+        const kinds = replaySwapCascade({
+          selectedThread,
+          initialDisplayedPaneKey: displayed?.paneKey ?? null,
+          steps: 6
+        })
+        const label = `selected=${selectedThread.paneKey} displayed=${displayed?.paneKey ?? 'null'}`
+        expect(
+          kinds.filter((kind) => kind === 'swap-staged').length,
+          `${label}: ${kinds.join(',')}`
+        ).toBeLessThanOrEqual(1)
+        // And the cascade settles: no write at all once displayedPaneKey caught up.
+        expect(kinds.at(-1), `${label}: ${kinds.join(',')}`).toBe('settle-visible')
+      }
+    }
+  })
+
+  it('stages across tabs and refuses to stage inside one tab', () => {
+    const sameTabDisplayed = reconcileActivityPortalThreads({
+      selectedThread: thread('tab-a', 'leaf-9'),
+      displayedThread: ALL_THREADS[0],
+      selectedHasLiveTab: true,
+      displayedHasLiveTab: true
+    })
+    expect(sameTabDisplayed.stagedThread).toBeNull()
+
+    const crossTabDisplayed = reconcileActivityPortalThreads({
+      selectedThread: ALL_THREADS[1],
+      displayedThread: ALL_THREADS[0],
+      selectedHasLiveTab: true,
+      displayedHasLiveTab: true
+    })
+    expect(crossTabDisplayed.stagedThread).toBe(ALL_THREADS[1])
+  })
+})

--- a/src/renderer/src/components/activity/activity-terminal-portal-publication-loop.react185.test.tsx
+++ b/src/renderer/src/components/activity/activity-terminal-portal-publication-loop.react185.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment happy-dom */
+import { act, useCallback, useLayoutEffect, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  setActivityTerminalPortals,
+  useActivityTerminalPortals,
+  type ActivityTerminalPortalTarget
+} from './activity-terminal-portal'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const target = document.createElement('div')
+const descriptor: ActivityTerminalPortalTarget = {
+  slotId: 'primary',
+  requestToken: 'primary:tab-a:leaf-a',
+  target,
+  worktreeId: 'worktree-a',
+  tabId: 'tab-a',
+  paneKey: 'tab-a:leaf-a',
+  active: true
+}
+
+afterEach(() => setActivityTerminalPortals([]))
+
+describe('Activity terminal portal publication loop', () => {
+  it('settles when Terminal feeds an identical descriptor back into Activity', () => {
+    let renders = 0
+
+    function ActivityPublisher(): null {
+      useLayoutEffect(() => setActivityTerminalPortals([{ ...descriptor }]))
+      return null
+    }
+
+    function TerminalSubscriber({ invalidate }: { invalidate: () => void }): null {
+      const portals = useActivityTerminalPortals(true)
+      useLayoutEffect(invalidate, [invalidate, portals])
+      return null
+    }
+
+    function CrossSurfaceHost(): React.JSX.Element {
+      renders += 1
+      const [, setRevision] = useState(0)
+      const invalidate = useCallback(() => setRevision((revision) => revision + 1), [])
+      return (
+        <>
+          <ActivityPublisher />
+          <TerminalSubscriber invalidate={invalidate} />
+        </>
+      )
+    }
+
+    const root = createRoot(document.createElement('div'))
+    expect(() => act(() => root.render(<CrossSurfaceHost />))).not.toThrow()
+    expect(renders).toBeLessThan(10)
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/activity/activity-terminal-portal.test.tsx
+++ b/src/renderer/src/components/activity/activity-terminal-portal.test.tsx
@@ -1,0 +1,71 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  setActivityTerminalPortals,
+  useActivityTerminalPortals,
+  type ActivityTerminalPortalTarget
+} from './activity-terminal-portal'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+
+beforeEach(() => setActivityTerminalPortals([]))
+
+afterEach(() => {
+  act(() => root?.unmount())
+  setActivityTerminalPortals([])
+})
+
+function portal(target: HTMLElement): ActivityTerminalPortalTarget {
+  return {
+    slotId: 'primary',
+    requestToken: 'primary:tab-a:leaf-a',
+    target,
+    worktreeId: 'worktree-a',
+    tabId: 'tab-a',
+    paneKey: 'tab-a:leaf-a',
+    forceUnavailable: false,
+    active: true
+  }
+}
+
+describe('Activity terminal portal publication', () => {
+  it('does not notify Terminal for a value-identical descriptor array', () => {
+    const descriptor = portal(document.createElement('div'))
+    setActivityTerminalPortals([descriptor])
+    let renders = 0
+
+    function Subscriber(): null {
+      useActivityTerminalPortals(true)
+      renders += 1
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => root.render(<Subscriber />))
+    const initialRenders = renders
+    act(() => setActivityTerminalPortals([{ ...descriptor }]))
+    expect(renders).toBe(initialRenders)
+  })
+
+  it('notifies Terminal when a routing value changes', () => {
+    const descriptor = portal(document.createElement('div'))
+    setActivityTerminalPortals([descriptor])
+    let renders = 0
+
+    function Subscriber(): null {
+      useActivityTerminalPortals(true)
+      renders += 1
+      return null
+    }
+
+    root = createRoot(document.createElement('div'))
+    act(() => root.render(<Subscriber />))
+    const initialRenders = renders
+    act(() => setActivityTerminalPortals([{ ...descriptor, paneKey: 'tab-a:leaf-b' }]))
+    expect(renders).toBe(initialRenders + 1)
+  })
+})

--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -18,6 +18,29 @@ let currentTargets: ActivityTerminalPortalTarget[] = []
 const emptyTargets: ActivityTerminalPortalTarget[] = []
 const subscribers = new Set<() => void>()
 
+function haveSameActivityTerminalPortals(
+  left: readonly ActivityTerminalPortalTarget[],
+  right: readonly ActivityTerminalPortalTarget[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((target, index) => {
+      const candidate = right[index]
+      return (
+        candidate !== undefined &&
+        target.slotId === candidate.slotId &&
+        target.requestToken === candidate.requestToken &&
+        target.target === candidate.target &&
+        target.worktreeId === candidate.worktreeId &&
+        target.tabId === candidate.tabId &&
+        target.paneKey === candidate.paneKey &&
+        target.forceUnavailable === candidate.forceUnavailable &&
+        target.active === candidate.active
+      )
+    })
+  )
+}
+
 // Why: the portal target is published with its {worktreeId, tabId} already
 // attached so consumers don't have to derive routing from the global
 // activeTabId/activeWorktreeId. The activity page knows which agent pane it
@@ -26,7 +49,8 @@ const subscribers = new Set<() => void>()
 // portaling a different terminal into the activity slot ("flash" of the wrong
 // terminal for a few ms).
 export function setActivityTerminalPortals(targets: ActivityTerminalPortalTarget[]): void {
-  if (currentTargets === targets) {
+  // Why: semantic no-ops must not synchronously bounce through Terminal and back into Activity.
+  if (currentTargets === targets || haveSameActivityTerminalPortals(currentTargets, targets)) {
     return
   }
   currentTargets = targets

--- a/src/renderer/src/components/activity/activity-terminal-portal.ts
+++ b/src/renderer/src/components/activity/activity-terminal-portal.ts
@@ -18,6 +18,26 @@ let currentTargets: ActivityTerminalPortalTarget[] = []
 const emptyTargets: ActivityTerminalPortalTarget[] = []
 const subscribers = new Set<() => void>()
 
+type ActivityTerminalPortalFieldEquals = (
+  left: ActivityTerminalPortalTarget,
+  right: ActivityTerminalPortalTarget
+) => boolean
+
+// Why the keyed record: a dropped field here silently suppresses a publish and
+// strands Terminal on stale routing — the wrong-terminal flash this file exists
+// to prevent. `satisfies` turns a new descriptor field into a build error.
+const ACTIVITY_TERMINAL_PORTAL_FIELD_EQUALS: readonly ActivityTerminalPortalFieldEquals[] =
+  Object.values({
+    slotId: (left, right) => left.slotId === right.slotId,
+    requestToken: (left, right) => left.requestToken === right.requestToken,
+    target: (left, right) => left.target === right.target,
+    worktreeId: (left, right) => left.worktreeId === right.worktreeId,
+    tabId: (left, right) => left.tabId === right.tabId,
+    paneKey: (left, right) => left.paneKey === right.paneKey,
+    forceUnavailable: (left, right) => left.forceUnavailable === right.forceUnavailable,
+    active: (left, right) => left.active === right.active
+  } satisfies Record<keyof ActivityTerminalPortalTarget, ActivityTerminalPortalFieldEquals>)
+
 function haveSameActivityTerminalPortals(
   left: readonly ActivityTerminalPortalTarget[],
   right: readonly ActivityTerminalPortalTarget[]
@@ -28,14 +48,7 @@ function haveSameActivityTerminalPortals(
       const candidate = right[index]
       return (
         candidate !== undefined &&
-        target.slotId === candidate.slotId &&
-        target.requestToken === candidate.requestToken &&
-        target.target === candidate.target &&
-        target.worktreeId === candidate.worktreeId &&
-        target.tabId === candidate.tabId &&
-        target.paneKey === candidate.paneKey &&
-        target.forceUnavailable === candidate.forceUnavailable &&
-        target.active === candidate.active
+        ACTIVITY_TERMINAL_PORTAL_FIELD_EQUALS.every((isEqual) => isEqual(target, candidate))
       )
     })
   )

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.test.ts
@@ -169,4 +169,45 @@ describe('getTerminalTabColdParkRecheckDelayMs', () => {
       })
     ).toBe(250)
   })
+
+  // Why: a flip-damped tab is long past every hysteresis deadline, so the pin
+  // expiry is the only wakeup left — drop it and the tab never re-parks.
+  it('wakes at the flip-damping pin deadline when all ordinary deadlines have passed', () => {
+    expect(
+      getTerminalTabColdParkRecheckDelayMs({
+        parkingEnabled: true,
+        hiddenSinceMs: 1_000,
+        nowMs: 1_000_000,
+        coldParkDelayMs: 100,
+        hotRetainMs: 1_000,
+        parkVerdictPinUntilMs: 1_060_000
+      })
+    ).toBe(60_000)
+  })
+
+  // Why: the earliest pending deadline wins — a pin must not delay a nearer
+  // cool-down wakeup, and vice versa.
+  it('takes the nearest of the pin and cool-down deadlines', () => {
+    const base = {
+      parkingEnabled: true,
+      hiddenSinceMs: 1_000,
+      nowMs: 2_500,
+      coldParkDelayMs: 100,
+      hotRetainMs: 1_000
+    }
+    expect(
+      getTerminalTabColdParkRecheckDelayMs({
+        ...base,
+        parkCooldownUntilMs: 2_750,
+        parkVerdictPinUntilMs: 62_500
+      })
+    ).toBe(250)
+    expect(
+      getTerminalTabColdParkRecheckDelayMs({
+        ...base,
+        parkCooldownUntilMs: 62_500,
+        parkVerdictPinUntilMs: 2_750
+      })
+    ).toBe(250)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-recheck-deadlines.ts
@@ -18,6 +18,7 @@ function nextColdParkDeadlineDelayMs(args: {
   hotRetainMs: number
   retentionTtlMs?: number
   parkCooldownUntilMs?: number | null
+  parkVerdictPinUntilMs?: number | null
 }): number | null {
   if (!args.parkingEnabled || args.hiddenSinceMs === null) {
     return null
@@ -27,7 +28,9 @@ function nextColdParkDeadlineDelayMs(args: {
     args.hiddenSinceMs + args.hotRetainMs,
     ...(args.retentionTtlMs !== undefined ? [args.hiddenSinceMs + args.retentionTtlMs] : []),
     // Why: the cool-down holds past-deadline candidates out of the parked set; without this wakeup nothing re-parks them.
-    ...(args.parkCooldownUntilMs != null ? [args.parkCooldownUntilMs] : [])
+    ...(args.parkCooldownUntilMs != null ? [args.parkCooldownUntilMs] : []),
+    // Why: damping stops the churn that would otherwise wake this deadline.
+    ...(args.parkVerdictPinUntilMs != null ? [args.parkVerdictPinUntilMs] : [])
   ].filter((deadlineMs) => deadlineMs > args.nowMs)
   return pendingDeadlines.length === 0 ? null : Math.min(...pendingDeadlines) - args.nowMs
 }
@@ -60,6 +63,8 @@ export function getTerminalTabColdParkRecheckDelayMs(args: {
   coldParkDelayMs?: number
   hotRetainMs?: number
   parkCooldownUntilMs?: number | null
+  /** Provided only for tabs damped out of the parked set by flip churn. */
+  parkVerdictPinUntilMs?: number | null
 }): number | null {
   return nextColdParkDeadlineDelayMs({
     parkingEnabled: args.parkingEnabled,
@@ -67,6 +72,7 @@ export function getTerminalTabColdParkRecheckDelayMs(args: {
     nowMs: args.nowMs,
     coldParkDelayMs: args.coldParkDelayMs ?? TERMINAL_TAB_COLD_PARK_DELAY_MS,
     hotRetainMs: args.hotRetainMs ?? TERMINAL_TAB_HOT_RETAIN_MS,
-    parkCooldownUntilMs: args.parkCooldownUntilMs
+    parkCooldownUntilMs: args.parkCooldownUntilMs,
+    parkVerdictPinUntilMs: args.parkVerdictPinUntilMs
   })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
@@ -1,0 +1,245 @@
+/** @vitest-environment happy-dom */
+/**
+ * Cold-park verdict oscillation (crash cluster: React #185 in the terminal overlay).
+ *
+ * Why this shape: canWatcherCoverParkedTerminalTab is re-derived from store and
+ * registry state that mounting/unmounting the very pane the verdict controls
+ * rewrites, and the parked watchers write the tab model back. The pane stand-in
+ * models that edge — mounted pane grants coverage, parked pane withdraws it,
+ * and either transition re-mints the tab array the cold-park effect depends on.
+ *
+ * Why the store-write chain is parameterised: React bails on *commits*, not on
+ * flips, so a damping threshold expressed in flips is only safe if it holds at
+ * the real cycle's commits-per-flip cost (pane-connect updateTabPtyId, the
+ * watcher-sync writes, the overlay's own subscriber renders). The chain models
+ * that cost so the derived burst limit stays regression-tested.
+ */
+import { act, useEffect, useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalTab } from '../../../../shared/types'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const park = vi.hoisted(() => ({
+  worktreeId: 'repo::/wt-park-loop',
+  /** Whether the byte watchers could cover the tab if it parked right now. */
+  coverage: true
+}))
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useAppStore = create(() => ({
+    pendingStartupByTabId: {} as Record<string, unknown>,
+    runtimeStatusByEnvironmentId: new Map<string, unknown>(),
+    settings: {} as Record<string, unknown>,
+    terminalLayoutsByTabId: {} as Record<string, unknown>,
+    runtimePaneTitlesByTabId: {} as Record<string, unknown>,
+    tabsByWorktree: {} as Record<string, TerminalTab[]>
+  }))
+  return { useAppStore }
+})
+
+vi.mock('./terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: () => park.coverage,
+  disposeParkedTerminalWatchersForWorktree: () => {},
+  resolveParkedTerminalPaneCandidates: () => [],
+  syncParkedTerminalTabWatchers: () => {}
+}))
+
+vi.mock('./terminal-parking-e2e-overrides', () => ({
+  getTerminalParkingPolicyOverrides: () => ({ coldParkDelayMs: 0, hotRetainMs: 0 })
+}))
+
+import { useAppStore } from '../../store'
+import {
+  TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_COMMIT_COST
+} from './terminal-park-verdict-flip-telemetry'
+import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
+
+/** The most recently hidden tab holds the last-active retain exemption. */
+const EXEMPT_TAB_ID = 'tab-a'
+const PARKABLE_TAB_ID = 'tab-b'
+/** Stops an unfixed loop from hanging the run if React ever raises its bail. */
+const RENDER_HARD_STOP = 500
+/** +1: the pin lands in the passive effect observing the burst flip, so the
+ *  verdict settles one flip after damping engages. */
+const SETTLED_FLIP_BUDGET = TERMINAL_TAB_PARK_FLIP_BURST_LIMIT + 1
+const EMPTY_ASSIGNMENTS = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
+const EMPTY_PORTALS: never[] = []
+
+type ParkingStoreState = { tabsByWorktree: Record<string, TerminalTab[]> }
+
+const parkingStore = useAppStore as unknown as {
+  setState: (partial: (state: ParkingStoreState) => Partial<ParkingStoreState>) => void
+}
+
+function terminalTab(id: string): TerminalTab {
+  return { id, ptyId: `${park.worktreeId}@@session-${id}`, title: id } as TerminalTab
+}
+
+let tabModelRevision = 0
+
+// Models the store writes a pane mount/unmount produces — updateTabPtyId on
+// connect, parked-watcher title writes — both of which re-mint the tab array.
+function rewriteTabModel(tabId: string): void {
+  tabModelRevision += 1
+  const revision = tabModelRevision
+  parkingStore.setState((state) => ({
+    tabsByWorktree: {
+      ...state.tabsByWorktree,
+      [park.worktreeId]: (state.tabsByWorktree[park.worktreeId] ?? []).map((tab) =>
+        tab.id === tabId ? { ...tab, title: `${tab.id}-${revision}` } : tab
+      )
+    }
+  }))
+}
+
+/** Store writes a single park transition costs; each lands in its own commit. */
+let storeCommitsPerParkTransition = 1
+let paneMountCount = 0
+
+/** The pane whose mount/unmount the park verdict authorizes. */
+function TerminalPaneStandIn(): null {
+  useEffect(() => {
+    paneMountCount += 1
+  }, [])
+  return null
+}
+
+/**
+ * The store writes a park transition drags behind it — pane-connect
+ * updateTabPtyId, then the watcher-sync writes that each only see the tab model
+ * the previous write produced. Coverage is re-derived from the last of them, so
+ * the verdict cannot flip until the whole chain has committed. Why staged
+ * rather than batched: nested commits are what React counts against
+ * NESTED_UPDATE_LIMIT, so this is the per-flip cost the damping must beat.
+ */
+function ParkTransitionStoreWrites({ parked }: { parked: boolean }): null {
+  const pendingWritesRef = useRef(storeCommitsPerParkTransition)
+  const lastParkedRef = useRef(parked)
+  const [writeTick, setWriteTick] = useState(0)
+  useEffect(() => {
+    if (lastParkedRef.current !== parked) {
+      lastParkedRef.current = parked
+      pendingWritesRef.current = storeCommitsPerParkTransition
+    }
+    if (pendingWritesRef.current <= 0) {
+      return
+    }
+    pendingWritesRef.current -= 1
+    if (pendingWritesRef.current === 0) {
+      // A mounted pane grants byte-watcher coverage; a parked one withdraws it.
+      park.coverage = !parked
+    }
+    rewriteTabModel(PARKABLE_TAB_ID)
+    setWriteTick((tick) => tick + 1)
+  }, [parked, writeTick])
+  return null
+}
+
+let hostRenderCount = 0
+let parkVerdictFlipCount = 0
+let lastParkVerdict = false
+
+function OverlayHost(): React.JSX.Element | null {
+  hostRenderCount += 1
+  const terminalTabs = useAppStore(
+    (state) => (state as ParkingStoreState).tabsByWorktree[park.worktreeId]
+  ) as TerminalTab[]
+  const parkedTerminalTabIds = useTerminalTabColdParking({
+    worktreeId: park.worktreeId,
+    terminalTabs,
+    assignments: EMPTY_ASSIGNMENTS,
+    isWorktreeActive: false,
+    coldParkTerminalPanes: false,
+    shouldMeasureHiddenWorktree: false,
+    activityTerminalPortals: EMPTY_PORTALS,
+    activationDeferredMountTabIds: null
+  })
+  const parked = parkedTerminalTabIds.has(PARKABLE_TAB_ID)
+  if (parked !== lastParkVerdict) {
+    parkVerdictFlipCount += 1
+  }
+  lastParkVerdict = parked
+  if (hostRenderCount > RENDER_HARD_STOP) {
+    return null
+  }
+  return (
+    <>
+      {parked ? null : <TerminalPaneStandIn />}
+      <ParkTransitionStoreWrites parked={parked} />
+    </>
+  )
+}
+
+function renderOverlayHost(root: Root): unknown {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  let thrown: unknown = null
+  try {
+    act(() => {
+      root.render(<OverlayHost />)
+    })
+  } catch (error) {
+    thrown = error
+  }
+  consoleError.mockRestore()
+  return thrown
+}
+
+describe('cold-park verdict oscillation', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    park.coverage = true
+    hostRenderCount = 0
+    parkVerdictFlipCount = 0
+    lastParkVerdict = false
+    tabModelRevision = 0
+    paneMountCount = 0
+    storeCommitsPerParkTransition = 1
+    parkingStore.setState(() => ({
+      tabsByWorktree: {
+        [park.worktreeId]: [terminalTab(EXEMPT_TAB_ID), terminalTab(PARKABLE_TAB_ID)]
+      }
+    }))
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  it('settles the park verdict when watcher coverage tracks the pane it unmounts', () => {
+    root = createRoot(container)
+    const thrown = renderOverlayHost(root)
+
+    // Damping must land inside the burst window and settle on the safe side:
+    // the pane stays mounted, so bells/titles/completions never go silent.
+    expect(thrown).toBeNull()
+    expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDGET)
+    expect(lastParkVerdict).toBe(false)
+    expect(paneMountCount).toBeGreaterThan(0)
+  })
+
+  // Why: the burst limit is derived from React's 50-commit bail divided by an
+  // assumed worst-case commits-per-flip. Running the loop at exactly that cost
+  // is what keeps the derivation honest — a limit tuned on a one-write-per-flip
+  // model pins only after React has already thrown #185.
+  it('settles at the assumed worst-case commit cost per park transition', () => {
+    storeCommitsPerParkTransition = TERMINAL_TAB_PARK_FLIP_COMMIT_COST
+    root = createRoot(container)
+    const thrown = renderOverlayHost(root)
+
+    expect(thrown).toBeNull()
+    expect(parkVerdictFlipCount).toBeLessThanOrEqual(SETTLED_FLIP_BUDGET)
+    expect(lastParkVerdict).toBe(false)
+    expect(paneMountCount).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-verdict-loop.test.tsx
@@ -190,7 +190,8 @@ function renderOverlayHost(root: Root): unknown {
 
 describe('cold-park verdict oscillation', () => {
   let container: HTMLDivElement
-  let root: Root
+  // Why optional: a throwing createRoot must not be masked by an afterEach TypeError.
+  let root: Root | undefined
 
   beforeEach(() => {
     park.coverage = true
@@ -211,8 +212,9 @@ describe('cold-park verdict oscillation', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root?.unmount()
     })
+    root = undefined
     container.remove()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalTab } from '../../../../shared/types'
+import type { ParkVerdictFlipRecord } from './terminal-park-verdict-flip-telemetry'
+import { withholdUnparkableTerminalTabs } from './terminal-cold-park-withheld-tabs'
+
+const coverage = vi.hoisted(() => ({ byTabId: new Map<string, boolean>() }))
+
+vi.mock('./terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: (_worktreeId: string, tab: TerminalTab) =>
+    coverage.byTabId.get(tab.id) ?? true
+}))
+
+const WORKTREE = 'repo::/wt'
+
+function terminalTab(id: string): TerminalTab {
+  return { id, ptyId: `${WORKTREE}@@${id}`, title: id } as TerminalTab
+}
+
+function pinnedRecord(pinnedUntilMs: number | null): ParkVerdictFlipRecord {
+  return {
+    parked: false,
+    windowStartMs: 0,
+    flips: 0,
+    notified: false,
+    burstStartMs: 0,
+    burstFlips: 0,
+    pinnedUntilMs
+  }
+}
+
+beforeEach(() => {
+  coverage.byTabId.clear()
+})
+
+describe('withholdUnparkableTerminalTabs', () => {
+  it('parks a covered tab with no pin', () => {
+    const { parkedTabIds, parkVerdictPinUntilMsByTabId } = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab('tab-a')],
+      coldParkedTabIds: new Set(['tab-a']),
+      parkVerdictRecords: new Map(),
+      nowMs: 1_000
+    })
+
+    expect(parkedTabIds).toEqual(new Set(['tab-a']))
+    expect(parkVerdictPinUntilMsByTabId.size).toBe(0)
+  })
+
+  // Why both returned values matter: the caller needs the deadline to schedule
+  // the recheck that lets the tab park again once damping lapses.
+  it('withholds a pinned tab and reports its deadline', () => {
+    const records = new Map([['tab-a', pinnedRecord(9_000)]])
+
+    const { parkedTabIds, parkVerdictPinUntilMsByTabId } = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab('tab-a')],
+      coldParkedTabIds: new Set(['tab-a']),
+      parkVerdictRecords: records,
+      nowMs: 1_000
+    })
+
+    expect(parkedTabIds.has('tab-a')).toBe(false)
+    expect(parkVerdictPinUntilMsByTabId.get('tab-a')).toBe(9_000)
+  })
+
+  it('withholds a tab the watchers cannot cover', () => {
+    coverage.byTabId.set('tab-a', false)
+
+    const { parkedTabIds, parkVerdictPinUntilMsByTabId } = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab('tab-a')],
+      coldParkedTabIds: new Set(['tab-a']),
+      parkVerdictRecords: new Map(),
+      nowMs: 1_000
+    })
+
+    expect(parkedTabIds.has('tab-a')).toBe(false)
+    // No pin: an uncovered tab has no damping deadline to recheck at.
+    expect(parkVerdictPinUntilMsByTabId.size).toBe(0)
+  })
+
+  // Why: an expired pin must hand the tab back to the parking policy, not
+  // strand it mounted for the rest of the session.
+  it('parks a tab whose pin has lapsed', () => {
+    const records = new Map([['tab-a', pinnedRecord(500)]])
+
+    const { parkedTabIds, parkVerdictPinUntilMsByTabId } = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab('tab-a')],
+      coldParkedTabIds: new Set(['tab-a']),
+      parkVerdictRecords: records,
+      nowMs: 1_000
+    })
+
+    expect(parkedTabIds.has('tab-a')).toBe(true)
+    expect(parkVerdictPinUntilMsByTabId.size).toBe(0)
+  })
+
+  it('does not consult non-candidates and leaves the input set untouched', () => {
+    const coldParkedTabIds = new Set(['tab-a'])
+    coverage.byTabId.set('tab-b', false)
+
+    const { parkedTabIds } = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab('tab-a'), terminalTab('tab-b')],
+      coldParkedTabIds,
+      parkVerdictRecords: new Map(),
+      nowMs: 1_000
+    })
+
+    expect(parkedTabIds).toEqual(new Set(['tab-a']))
+    expect(coldParkedTabIds).toEqual(new Set(['tab-a']))
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.ts
@@ -1,0 +1,54 @@
+/**
+ * Last gate between a cold-park candidate and an unmounted pane.
+ *
+ * Two reasons withhold a tab, both settling on the safe mounted side: the byte
+ * watchers cannot cover it, or a verdict-flip burst pinned it. The pin deadline
+ * is returned because it is also the only remaining recheck wakeup once damping
+ * has stopped the churn that was waking the parking effect.
+ */
+import type { TerminalTab } from '../../../../shared/types'
+import {
+  getParkVerdictUnparkPinUntilMs,
+  type ParkVerdictFlipRecord
+} from './terminal-park-verdict-flip-telemetry'
+import { canWatcherCoverParkedTerminalTab } from './terminal-parked-tab-watchers'
+
+export type WithheldTerminalTabParking = {
+  parkedTabIds: Set<string>
+  parkVerdictPinUntilMsByTabId: Map<string, number>
+}
+
+export function withholdUnparkableTerminalTabs(args: {
+  worktreeId: string
+  terminalTabs: readonly TerminalTab[]
+  coldParkedTabIds: ReadonlySet<string>
+  parkVerdictRecords: Map<string, ParkVerdictFlipRecord>
+  nowMs: number
+}): WithheldTerminalTabParking {
+  const parkedTabIds = new Set(args.coldParkedTabIds)
+  const parkVerdictPinUntilMsByTabId = new Map<string, number>()
+
+  for (const terminalTab of args.terminalTabs) {
+    if (!parkedTabIds.has(terminalTab.id)) {
+      continue
+    }
+    const parkVerdictPinUntilMs = getParkVerdictUnparkPinUntilMs({
+      records: args.parkVerdictRecords,
+      tabId: terminalTab.id,
+      nowMs: args.nowMs
+    })
+    if (parkVerdictPinUntilMs !== null) {
+      parkVerdictPinUntilMsByTabId.set(terminalTab.id, parkVerdictPinUntilMs)
+    }
+    // Why coverage matters: a parked tab the watchers cannot reach goes silent
+    // for bells/titles/completions — the failure that sank the first attempt.
+    if (
+      parkVerdictPinUntilMs !== null ||
+      !canWatcherCoverParkedTerminalTab(args.worktreeId, terminalTab)
+    ) {
+      parkedTabIds.delete(terminalTab.id)
+    }
+  }
+
+  return { parkedTabIds, parkVerdictPinUntilMsByTabId }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS,
+  TERMINAL_TAB_PARK_FLIP_COMMIT_COST,
   TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
   TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+  getParkVerdictUnparkPinUntilMs,
   recordParkVerdictFlips,
   type ParkVerdictFlipRecord
 } from './terminal-park-verdict-flip-telemetry'
@@ -12,6 +16,8 @@ vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
 }))
 
 const TAB = 'tab-1'
+/** Slower than the burst window, so only the notice limit can fire. */
+const SLOW_CHURN_STEP_MS = TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS * 4
 
 function observe(args: {
   records: Map<string, ParkVerdictFlipRecord>
@@ -31,6 +37,16 @@ beforeEach(() => {
   recordBreadcrumb.mockClear()
 })
 
+// Why asserted: the whole point of the burst trigger is that it is derived from
+// React's 50-commit bail, not copied from the breadcrumb notice limit. If the
+// two ever converge again the damping stops firing before React throws #185.
+describe('burst damping threshold', () => {
+  it('stays under React NESTED_UPDATE_LIMIT at the assumed commits-per-flip cost', () => {
+    expect(TERMINAL_TAB_PARK_FLIP_BURST_LIMIT * TERMINAL_TAB_PARK_FLIP_COMMIT_COST).toBeLessThan(50)
+    expect(TERMINAL_TAB_PARK_FLIP_BURST_LIMIT).toBeLessThan(TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT)
+  })
+})
+
 describe('recordParkVerdictFlips', () => {
   it('stays silent for a stable verdict', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
@@ -42,7 +58,7 @@ describe('recordParkVerdictFlips', () => {
     expect(records.get(TAB)?.flips).toBe(0)
   })
 
-  it('emits one breadcrumb per window once the verdict churns', () => {
+  it('emits one burst breadcrumb once the verdict churns at render cadence', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 40; i += 1) {
       observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
@@ -51,32 +67,59 @@ describe('recordParkVerdictFlips', () => {
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ tabId: TAB, flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT })
+      expect.objectContaining({
+        tabId: TAB,
+        trigger: 'burst',
+        flips: TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+        pinnedForMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+      })
     )
   })
 
-  // Why: flips saturates at the notice limit, so elapsedMs is the only field
-  // that tells a runaway loop apart from slow churn — assert both ends.
-  it('reports elapsedMs so a tight loop is distinguishable from slow churn', () => {
+  // Why: the two triggers answer different questions — 'burst' means damping
+  // engaged before React could bail, 'window' means churn too slow to loop.
+  it('separates a damped burst from slow churn', () => {
     const tightRecords = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 40; i += 1) {
       observe({ records: tightRecords, parked: i % 2 === 0, nowMs: 1_000 + i })
     }
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT, elapsedMs: 12 })
+      expect.objectContaining({
+        trigger: 'burst',
+        flips: TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+        elapsedMs: TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+        windowMs: TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS
+      })
     )
 
     recordBreadcrumb.mockClear()
 
     const slowRecords = new Map<string, ParkVerdictFlipRecord>()
-    for (let i = 0; i < 13; i += 1) {
-      observe({ records: slowRecords, parked: i % 2 === 0, nowMs: 1_000 + i * 4_000 })
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      observe({ records: slowRecords, parked: i % 2 === 0, nowMs: 1_000 + i * SLOW_CHURN_STEP_MS })
     }
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT, elapsedMs: 48_000 })
+      expect.objectContaining({
+        trigger: 'window',
+        flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
+        elapsedMs: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT * SLOW_CHURN_STEP_MS,
+        windowMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+      })
     )
+  })
+
+  // Why: slow churn must not be damped — parking it out for a minute would cost
+  // a mounted pane's memory for a verdict that was never near React's bail.
+  it('does not pin churn spread past the burst window', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * SLOW_CHURN_STEP_MS })
+    }
+
+    expect(records.get(TAB)?.pinnedUntilMs ?? null).toBeNull()
   })
 
   it('re-arms after the window elapses', () => {
@@ -116,23 +159,27 @@ describe('recordParkVerdictFlips', () => {
     expect(records.get(TAB)?.flips).toBe(1)
   })
 
-  it('honours flipWindowMs and noticeLimit overrides', () => {
+  it('honours the window, notice, burst-window and burst-limit overrides', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 10; i += 1) {
       recordParkVerdictFlips({
         records,
         liveTabIds: new Set([TAB]),
         nextParkedTabIds: i % 2 === 0 ? new Set([TAB]) : new Set(),
-        nowMs: 1_000 + i,
-        flipWindowMs: 500,
-        noticeLimit: 3
+        nowMs: 1_000 + i * 100,
+        flipWindowMs: 5_000,
+        noticeLimit: 3,
+        burstWindowMs: 10,
+        burstLimit: 2
       })
     }
 
+    // Why 'window': the 100ms step outruns the 10ms burst window, so the burst
+    // counter resets on every flip and only the notice limit can fire.
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ flips: 3, windowMs: 500 })
+      expect.objectContaining({ trigger: 'window', flips: 3, windowMs: 5_000 })
     )
   })
 
@@ -169,5 +216,54 @@ describe('recordParkVerdictFlips', () => {
     })
 
     expect(records.size).toBe(0)
+  })
+})
+
+describe('getParkVerdictUnparkPinUntilMs', () => {
+  function churnToBurst(records: Map<string, ParkVerdictFlipRecord>, startMs = 1_000): number {
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: startMs + i * 10 })
+    }
+    // The first observation only seeds the record, so flip N lands one step later.
+    return startMs + TERMINAL_TAB_PARK_FLIP_BURST_LIMIT * 10
+  }
+
+  it('does not pin a stable verdict', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    observe({ records, parked: true, nowMs: 1_000 })
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: 2_000 })).toBeNull()
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: 'missing', nowMs: 2_000 })).toBeNull()
+  })
+
+  // Why the deadline and not a boolean: the caller has to schedule a recheck at
+  // it, or the pin never lifts once it has stopped the churn that woke the
+  // verdict effect.
+  it('reports the pin deadline one window out, then re-arms', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    const pinnedAtMs = churnToBurst(records)
+    const pinUntilMs = pinnedAtMs + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinnedAtMs + 1 })).toBe(
+      pinUntilMs
+    )
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinUntilMs })).toBeNull()
+    expect(records.get(TAB)?.flips).toBe(0)
+    expect(records.get(TAB)?.burstFlips).toBe(0)
+
+    recordBreadcrumb.mockClear()
+    churnToBurst(records, pinUntilMs)
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinUntilMs + 1 })).not.toBe(
+      null
+    )
+  })
+
+  // Why: a backwards clock jump must release the pin, not strand it for a window.
+  it('releases the pin when the clock jumps backwards', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    churnToBurst(records)
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: 5 })).toBeNull()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -266,4 +266,74 @@ describe('getParkVerdictUnparkPinUntilMs', () => {
 
     expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: 5 })).toBeNull()
   })
+
+  // Why: the notice window starts at the first flip and the pin starts one
+  // burst later, so the notice window always lapses first. Resetting it must
+  // not hand the pane back to the parking policy mid-damping.
+  it('survives a notice-window expiry that lands mid-pin', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    const pinnedAtMs = churnToBurst(records)
+    const pinUntilMs = pinnedAtMs + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+    const windowLapseMs = 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+
+    // An exogenous flip (visibility change, tab removal) after the notice
+    // window lapsed but before the pin deadline.
+    expect(windowLapseMs).toBeLessThan(pinUntilMs)
+    observe({ records, parked: true, nowMs: windowLapseMs })
+
+    expect(records.get(TAB)?.flips).toBe(1)
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: windowLapseMs })).toBe(
+      pinUntilMs
+    )
+  })
+})
+
+// Why liveness and not presence: a pinned tab can stop being cold-park eligible
+// before its deadline, and nothing consults getParkVerdictUnparkPinUntilMs for
+// it again. A stale deadline must not silence churn telemetry forever.
+describe('expired pins stop gating breadcrumbs', () => {
+  it('re-arms damping and notices without a getParkVerdictUnparkPinUntilMs call', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
+    }
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(recordBreadcrumb).toHaveBeenLastCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ trigger: 'burst' })
+    )
+
+    // Churn resumes past the pin deadline; the pin was never read back.
+    const afterPinMs = 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS * 2
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: afterPinMs + i * 10 })
+    }
+
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(2)
+    expect(recordBreadcrumb).toHaveBeenLastCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ trigger: 'burst' })
+    )
+    expect(records.get(TAB)?.pinnedUntilMs).toBeGreaterThan(afterPinMs)
+  })
+
+  it('still reports slow churn after a pin lapses', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
+    }
+    recordBreadcrumb.mockClear()
+
+    // Slow churn only: each step outruns the burst window, so the notice limit
+    // is the only trigger left. It must not stay gated by the lapsed pin.
+    const afterPinMs = 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS * 2
+    for (let i = 0; i <= TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: afterPinMs + i * SLOW_CHURN_STEP_MS })
+    }
+
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ trigger: 'window' })
+    )
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -1,36 +1,68 @@
 /**
- * Cold-park verdict flip telemetry (observation only — changes no verdict).
- *
- * Why: crash cluster C5 (React #185 in TerminalPaneOverlayLayer) points at a
- * setState loop in the cold-parking passive effect, but no park-flip loop has
- * been reproduced, and the capture-coverage oscillator that looked like the
- * cause provably self-terminates (the unmount capture is never cleared on
- * remount, so coverage pins rather than alternates). This records whether the
- * rendered park verdict actually churns in the field. Deliberately no damping:
- * guarding a loop nobody has shown can run would add a park delay and a
- * retention path for no demonstrated benefit.
- *
- * Reading the signal: breadcrumbs also emit a durable `renderer.breadcrumb`
- * trace span, so this is queryable without waiting for a crash bundle. `flips`
- * always equals the notice limit — `elapsedMs` is what separates a render loop
- * from slow churn. Silence only rules out churn at effect cadence; a same-tick
- * cascade can crash before the limit accumulates. If it fires, start with the
- * candidate selection in terminal-hidden-view-parking.ts.
+ * Cold-park verdict telemetry and a safe-side circuit breaker.
+ * Field breadcrumbs prove render-cadence flips, but not which eligibility input
+ * oscillates; burst damping keeps the pane mounted before React reaches #185.
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 
 export const TERMINAL_TAB_PARK_FLIP_WINDOW_MS = 60_000
-/** Flips per window that no sane park policy should reach. */
+/** Flips per window that no sane park policy should reach. Breadcrumb only. */
 export const TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT = 12
+
+/** react-dom 19.2.x nested commit limit. */
+const REACT_NESTED_UPDATE_LIMIT = 50
+/** Measured upper bound after the passive-effect pin engages. */
+const PARK_PIN_SETTLE_COMMITS = 6
+/** Worst-case commits from pane, watcher, and store work per verdict flip. */
+export const TERMINAL_TAB_PARK_FLIP_COMMIT_COST = 12
+/** Pin threshold derived from React's remaining commit budget. */
+export const TERMINAL_TAB_PARK_FLIP_BURST_LIMIT = Math.max(
+  2,
+  Math.floor(
+    (REACT_NESTED_UPDATE_LIMIT - PARK_PIN_SETTLE_COMMITS) / TERMINAL_TAB_PARK_FLIP_COMMIT_COST
+  )
+)
+/** Honest cold parking cannot round-trip inside this horizon. */
+export const TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS = 1_000
 
 export type ParkVerdictFlipRecord = {
   parked: boolean
   windowStartMs: number
   flips: number
   notified: boolean
+  burstStartMs: number
+  burstFlips: number
+  /** Set when a flip burst engaged damping; the verdict stays unparked until then. */
+  pinnedUntilMs?: number | null
 }
 
-/** Records park-verdict churn per tab; emits one breadcrumb per window. */
+function resetFlipWindows(record: ParkVerdictFlipRecord, nowMs: number): void {
+  record.windowStartMs = nowMs
+  record.flips = 0
+  record.notified = false
+  record.burstStartMs = nowMs
+  record.burstFlips = 0
+  record.pinnedUntilMs = null
+}
+
+/** Returns the safe-side pin deadline and re-arms an expired window. */
+export function getParkVerdictUnparkPinUntilMs(args: {
+  records: Map<string, ParkVerdictFlipRecord>
+  tabId: string
+  nowMs: number
+}): number | null {
+  const record = args.records.get(args.tabId)
+  if (record?.pinnedUntilMs == null) {
+    return null
+  }
+  if (args.nowMs >= record.pinnedUntilMs || args.nowMs < record.windowStartMs) {
+    resetFlipWindows(record, args.nowMs)
+    return null
+  }
+  return record.pinnedUntilMs
+}
+
+/** Records park-verdict churn per tab; damps bursts and breadcrumbs the rest. */
 export function recordParkVerdictFlips(args: {
   records: Map<string, ParkVerdictFlipRecord>
   liveTabIds: ReadonlySet<string>
@@ -38,6 +70,8 @@ export function recordParkVerdictFlips(args: {
   nowMs: number
   flipWindowMs?: number
   noticeLimit?: number
+  burstWindowMs?: number
+  burstLimit?: number
 }): void {
   const {
     records,
@@ -45,7 +79,9 @@ export function recordParkVerdictFlips(args: {
     nextParkedTabIds,
     nowMs,
     flipWindowMs = TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
-    noticeLimit = TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT
+    noticeLimit = TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
+    burstWindowMs = TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS,
+    burstLimit = TERMINAL_TAB_PARK_FLIP_BURST_LIMIT
   } = args
 
   for (const tabId of Array.from(records.keys())) {
@@ -59,7 +95,15 @@ export function recordParkVerdictFlips(args: {
     const record = records.get(tabId)
 
     if (!record) {
-      records.set(tabId, { parked, windowStartMs: nowMs, flips: 0, notified: false })
+      records.set(tabId, {
+        parked,
+        windowStartMs: nowMs,
+        flips: 0,
+        notified: false,
+        burstStartMs: nowMs,
+        burstFlips: 0,
+        pinnedUntilMs: null
+      })
       continue
     }
     if (parked === record.parked) {
@@ -70,20 +114,40 @@ export function recordParkVerdictFlips(args: {
     // elapsed value as a fresh window rather than trusting the delta.
     const elapsedMs = nowMs - record.windowStartMs
     if (elapsedMs >= flipWindowMs || elapsedMs < 0) {
-      record.windowStartMs = nowMs
-      record.flips = 0
-      record.notified = false
+      resetFlipWindows(record, nowMs)
+    }
+    const burstElapsedMs = nowMs - record.burstStartMs
+    if (burstElapsedMs >= burstWindowMs || burstElapsedMs < 0) {
+      record.burstStartMs = nowMs
+      record.burstFlips = 0
     }
 
     record.parked = parked
     record.flips += 1
+    record.burstFlips += 1
 
-    if (!record.notified && record.flips >= noticeLimit) {
-      record.notified = true
-      // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
-      // field that separates a render loop from slow benign churn.
+    if (record.pinnedUntilMs == null && record.burstFlips >= burstLimit) {
+      record.pinnedUntilMs = nowMs + flipWindowMs
       recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
         tabId,
+        trigger: 'burst',
+        flips: record.burstFlips,
+        elapsedMs: nowMs - record.burstStartMs,
+        windowMs: burstWindowMs,
+        pinnedForMs: flipWindowMs
+      })
+      continue
+    }
+    // Why pinnedUntilMs gates this: the burst crumb already reported the same
+    // window, so a second crumb would only double the volume the notice limit
+    // exists to keep down.
+    if (record.pinnedUntilMs == null && !record.notified && record.flips >= noticeLimit) {
+      record.notified = true
+      // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
+      // field that separates slow churn from a burst the damping already caught.
+      recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
+        tabId,
+        trigger: 'window',
         flips: record.flips,
         elapsedMs: nowMs - record.windowStartMs,
         windowMs: flipWindowMs

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -2,6 +2,12 @@
  * Cold-park verdict telemetry and a safe-side circuit breaker.
  * Field breadcrumbs prove render-cadence flips, but not which eligibility input
  * oscillates; burst damping keeps the pane mounted before React reaches #185.
+ *
+ * Scope: flips are counted on the rendered verdict, but the pin can only
+ * subtract from the cold-park candidate set. Churn driven by the other parked
+ * inputs (forced parking, portal ownership, deferred activation mounts) is
+ * observed and breadcrumbed, not damped — read a repeating `burst` crumb for
+ * one tab as "damping did not reach the oscillating input".
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 
@@ -36,13 +42,21 @@ export type ParkVerdictFlipRecord = {
   pinnedUntilMs?: number | null
 }
 
+// Why it leaves pinnedUntilMs alone: the notice window is 60s from the first
+// flip, so it lapses mid-pin; clearing here would release damping early.
 function resetFlipWindows(record: ParkVerdictFlipRecord, nowMs: number): void {
   record.windowStartMs = nowMs
   record.flips = 0
   record.notified = false
   record.burstStartMs = nowMs
   record.burstFlips = 0
-  record.pinnedUntilMs = null
+}
+
+// Why liveness and not presence: a tab pinned while cold-park-eligible can stop
+// being a candidate before its deadline, and nothing would consult it again. An
+// expired pin must stop damping and stop gating breadcrumbs on its own.
+function isParkVerdictPinLive(record: ParkVerdictFlipRecord, nowMs: number): boolean {
+  return record.pinnedUntilMs != null && nowMs < record.pinnedUntilMs
 }
 
 /** Returns the safe-side pin deadline and re-arms an expired window. */
@@ -55,8 +69,9 @@ export function getParkVerdictUnparkPinUntilMs(args: {
   if (record?.pinnedUntilMs == null) {
     return null
   }
-  if (args.nowMs >= record.pinnedUntilMs || args.nowMs < record.windowStartMs) {
+  if (!isParkVerdictPinLive(record, args.nowMs) || args.nowMs < record.windowStartMs) {
     resetFlipWindows(record, args.nowMs)
+    record.pinnedUntilMs = null
     return null
   }
   return record.pinnedUntilMs
@@ -126,7 +141,7 @@ export function recordParkVerdictFlips(args: {
     record.flips += 1
     record.burstFlips += 1
 
-    if (record.pinnedUntilMs == null && record.burstFlips >= burstLimit) {
+    if (!isParkVerdictPinLive(record, nowMs) && record.burstFlips >= burstLimit) {
       record.pinnedUntilMs = nowMs + flipWindowMs
       recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
         tabId,
@@ -138,10 +153,10 @@ export function recordParkVerdictFlips(args: {
       })
       continue
     }
-    // Why pinnedUntilMs gates this: the burst crumb already reported the same
+    // Why a live pin gates this: the burst crumb already reported the same
     // window, so a second crumb would only double the volume the notice limit
     // exists to keep down.
-    if (record.pinnedUntilMs == null && !record.notified && record.flips >= noticeLimit) {
+    if (!isParkVerdictPinLive(record, nowMs) && !record.notified && record.flips >= noticeLimit) {
       record.notified = true
       // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
       // field that separates slow churn from a burst the damping already caught.

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -15,7 +15,9 @@ const mocks = vi.hoisted(() => ({
     >
   },
   exemptTabIds: new Set<string>(),
-  exemptSelectCalls: 0
+  exemptSelectCalls: 0,
+  /** Toggled to churn the park verdict the way the crash cluster does. */
+  watcherCoverage: true
 }))
 
 vi.mock('../../store', () => ({
@@ -39,15 +41,23 @@ vi.mock('./terminal-eviction-exempt-tabs', () => ({
 }))
 
 vi.mock('./terminal-parked-tab-watchers', () => ({
-  canWatcherCoverParkedTerminalTab: () => true,
+  canWatcherCoverParkedTerminalTab: () => mocks.watcherCoverage,
   disposeParkedTerminalWatchersForWorktree: vi.fn(),
   syncParkedTerminalTabWatchers: vi.fn()
+}))
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: vi.fn()
 }))
 
 import {
   TERMINAL_TAB_COLD_PARK_DELAY_MS,
   TERMINAL_TAB_HOT_RETAIN_MS
 } from './terminal-hidden-view-parking'
+import {
+  TERMINAL_TAB_PARK_FLIP_BURST_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+} from './terminal-park-verdict-flip-telemetry'
 import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
 
 const WORKTREE_ID = 'wt-1'
@@ -79,6 +89,7 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
     vi.useRealTimers()
     mocks.exemptTabIds = new Set()
     mocks.exemptSelectCalls = 0
+    mocks.watcherCoverage = true
     mocks.storeState.terminalLayoutsByTabId = {}
     mocks.storeState.sleepingAgentSessionsByPaneKey = {}
     mocks.storeState.runtimeStatusByEnvironmentId = new Map()
@@ -109,6 +120,41 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
       expect(result.current).toEqual(expected)
       unmount()
     }
+  })
+
+  // Why: the flip-damping pin removes the tab from the parked set, and every
+  // hysteresis deadline of a long-hidden tab is already past — so the pin
+  // deadline is the only wakeup that can ever re-park it. Without scheduling
+  // it, damping silently becomes a permanent unpark: the pane (~4-5MB) stays
+  // mounted for the life of the window, which is the renderer-OOM cluster.
+  it('re-parks a damped tab once the pin expires with no other store change', () => {
+    const { result, rerender } = renderHook(
+      (args: ReturnType<typeof hookArgs>) => useTerminalTabColdParking(args),
+      { initialProps: hookArgs(false) }
+    )
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_HOT_RETAIN_MS + 1)
+    })
+    expect(result.current).toEqual(new Set(['tab-2']))
+
+    // Churn the coverage veto at render cadence — no clock advance, so every
+    // flip lands inside the burst window and damping engages.
+    for (let flip = 0; flip <= TERMINAL_TAB_PARK_FLIP_BURST_LIMIT + 1; flip += 1) {
+      mocks.watcherCoverage = flip % 2 === 1
+      act(() => {
+        rerender(hookArgs(false))
+      })
+    }
+    mocks.watcherCoverage = true
+    act(() => {
+      rerender(hookArgs(false))
+    })
+    expect(result.current.size).toBe(0)
+
+    act(() => {
+      vi.advanceTimersByTime(TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
+    })
+    expect(result.current).toEqual(new Set(['tab-2']))
   })
 
   // Why: the worktree layer preserves hiddenSince through a background-measure

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -21,10 +21,10 @@ import {
   type TerminalTabColdParkCandidate
 } from './terminal-hidden-view-parking'
 import {
-  getParkVerdictUnparkPinUntilMs,
   recordParkVerdictFlips,
   type ParkVerdictFlipRecord
 } from './terminal-park-verdict-flip-telemetry'
+import { withholdUnparkableTerminalTabs } from './terminal-cold-park-withheld-tabs'
 import { getTerminalParkingPolicyOverrides } from './terminal-parking-e2e-overrides'
 import {
   selectEvictionExemptTerminalTabIds,
@@ -210,41 +210,22 @@ export function useTerminalTabColdParking(args: {
       },
       ...overrides
     })
-    // Why: a tab the byte watchers cannot cover (no capture, no layout
-    // snapshot, legacy leaf ids) must never park — it would go silent for
-    // bells/titles/completions, the failure that sank the first attempt.
-    // Why: any endogenous eligibility churn settles on the safe mounted side.
-    const parkVerdictPinUntilMsByTabId = new Map<string, number>()
-    for (const terminalTab of terminalTabs) {
-      if (!nextColdParkedTerminalTabIds.has(terminalTab.id)) {
-        continue
-      }
-      const parkVerdictPinUntilMs = getParkVerdictUnparkPinUntilMs({
-        records: parkVerdictRecordsRef.current,
-        tabId: terminalTab.id,
-        nowMs
-      })
-      if (parkVerdictPinUntilMs !== null) {
-        parkVerdictPinUntilMsByTabId.set(terminalTab.id, parkVerdictPinUntilMs)
-      }
-      if (
-        parkVerdictPinUntilMs !== null ||
-        !canWatcherCoverParkedTerminalTab(worktreeId, terminalTab)
-      ) {
-        nextColdParkedTerminalTabIds.delete(terminalTab.id)
-      }
-    }
+    const { parkedTabIds, parkVerdictPinUntilMsByTabId } = withholdUnparkableTerminalTabs({
+      worktreeId,
+      terminalTabs,
+      coldParkedTabIds: nextColdParkedTerminalTabIds,
+      parkVerdictRecords: parkVerdictRecordsRef.current,
+      nowMs
+    })
     setColdParkedTerminalTabIds((current) =>
-      haveSameTerminalTabIds(current, nextColdParkedTerminalTabIds)
-        ? current
-        : nextColdParkedTerminalTabIds
+      haveSameTerminalTabIds(current, parkedTabIds) ? current : parkedTabIds
     )
 
     for (const candidate of candidates) {
       if (
         candidate.isVisible ||
         candidate.hasActivityTerminalPortal ||
-        nextColdParkedTerminalTabIds.has(candidate.id)
+        parkedTabIds.has(candidate.id)
       ) {
         continue
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -21,6 +21,7 @@ import {
   type TerminalTabColdParkCandidate
 } from './terminal-hidden-view-parking'
 import {
+  getParkVerdictUnparkPinUntilMs,
   recordParkVerdictFlips,
   type ParkVerdictFlipRecord
 } from './terminal-park-verdict-flip-telemetry'
@@ -212,9 +213,22 @@ export function useTerminalTabColdParking(args: {
     // Why: a tab the byte watchers cannot cover (no capture, no layout
     // snapshot, legacy leaf ids) must never park — it would go silent for
     // bells/titles/completions, the failure that sank the first attempt.
+    // Why: any endogenous eligibility churn settles on the safe mounted side.
+    const parkVerdictPinUntilMsByTabId = new Map<string, number>()
     for (const terminalTab of terminalTabs) {
+      if (!nextColdParkedTerminalTabIds.has(terminalTab.id)) {
+        continue
+      }
+      const parkVerdictPinUntilMs = getParkVerdictUnparkPinUntilMs({
+        records: parkVerdictRecordsRef.current,
+        tabId: terminalTab.id,
+        nowMs
+      })
+      if (parkVerdictPinUntilMs !== null) {
+        parkVerdictPinUntilMsByTabId.set(terminalTab.id, parkVerdictPinUntilMs)
+      }
       if (
-        nextColdParkedTerminalTabIds.has(terminalTab.id) &&
+        parkVerdictPinUntilMs !== null ||
         !canWatcherCoverParkedTerminalTab(worktreeId, terminalTab)
       ) {
         nextColdParkedTerminalTabIds.delete(terminalTab.id)
@@ -238,6 +252,8 @@ export function useTerminalTabColdParking(args: {
         parkingEnabled: terminalParkingEnabled,
         hiddenSinceMs: candidate.hiddenSinceMs,
         parkCooldownUntilMs: measureParkCooldownUntilRef.current,
+        // Why: pin expiry may be the only remaining wakeup after damping stops churn.
+        parkVerdictPinUntilMs: parkVerdictPinUntilMsByTabId.get(candidate.id) ?? null,
         nowMs,
         ...overrides
       })


### PR DESCRIPTION
## Summary

Breaks two independent React #185 (`Maximum update depth exceeded`) crash loops in the renderer.

- **Activity portal publication** is now idempotent by descriptor *value*, so a semantic no-op no longer bounces synchronously through Terminal and back into Activity.
- **Activity readiness burst budget** is kept across slot, target, pane, and tab retargeting instead of being re-minted per subscription identity, and a quiet loading pane is explicitly rechecked when the burst window expires.
- **Terminal cold-parking** pins verdict bursts to the safe *mounted* side before React reaches its nested-update limit, with an expiry deadline so tabs can park again.

This supersedes #12492 and #12485.

- #12492 contains the useful terminal circuit breaker, but its exact watcher-coverage root-cause attribution is stronger than the evidence. This PR keeps the protection and states the evidence conservatively.
- #12485 catches a real latch-lifetime bug, but it does not reproduce the reported Activity React cascade, lacked an automatic quiet-loading recovery wakeup, and failed type-aware static analysis. This PR adds the structural external-store guard, recovery path, and fixes those warnings.

**Commits**

1. `fix(renderer): break activity and terminal React 185 loops` — the two fixes above.
2. `fix(renderer): harden portal equality, park pin lifetime, churn crumbs` — review follow-ups (see AI Review Report).
3. `refactor(terminal): extract the cold-park withholding gate` — rebase fallout, see Notes.

## Screenshots

No visual change. The user-visible effect is the absence of a crash; both fixes settle existing surfaces on their current rendering (pane stays mounted, portal stays on its last good routing).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — full renderer green; 3,132 tests across the affected `activity/`, `terminal-pane/`, and crash-reporting directories re-run after every change below
- [x] `pnpm build` (package + package (windows) green in CI)
- [x] Added or updated high-quality tests that would catch regressions

**Reproduction evidence — verified by re-running the new tests against `main` with production source unchanged.** All four fail on `main` and pass here:

| Test | Failure on `main` |
|---|---|
| `terminal-cold-park-verdict-loop.test.tsx` | `Error: Maximum update depth exceeded` (53 verdict flips, budget 5) |
| `activity-terminal-portal-publication-loop.react185.test.tsx` | `Error: Maximum update depth exceeded` |
| `activity-portal-readiness-subscription-churn.react185.test.tsx` | `Set{'unavailable','loading'}` vs `Set{'unavailable'}` |
| `activity-portal-readiness-decay.react185.test.tsx` | `expected 'unavailable' to be 'loading'` |

Recovery is covered too: terminal re-parking after damping, and Activity returning from latched-unavailable to quiet loading without an unrelated DOM mutation.

## AI Review Report

Ran the `/readiness-checklist` review across all seven areas with independent agents per area. **No P0 or P1 findings.** Verified clean: no unsafe casts; no unbounded growth (`eventsAt` capped at `limit`, the flip-record `Map` is pruned against `liveTabIds` each pass, timers rebuilt per effect run); no TDZ on the new `checkReadiness` closure; the release timer provably terminates in one hop; and no wedge path — a pinned tab always retains a scheduled wakeup, and `next('ready')` unconditionally clears the readiness budget.

Four review findings were fixed in commit 2:

1. **Portal equality was hand-enumerated.** Correct for all 8 fields today, but adding a field to `ActivityTerminalPortalTarget` would have silently *suppressed* a publish — the stale-routing bug this file exists to prevent. Now keyed off `keyof ActivityTerminalPortalTarget` via `satisfies`; confirmed empirically that adding a field is a compile error.
2. **Park-pin lifetime was coupled to the notice window.** The 60s notice window starts at the first flip and the pin one burst later, so the window always lapses first and `resetFlipWindows` released the pin early. Damping and breadcrumbs now gate on pin *liveness*.
3. **Pin could silence telemetry indefinitely.** A tab pinned while cold-park-eligible that stops being a candidate was never re-consulted, so a stale `pinnedUntilMs` gated both breadcrumb triggers forever. Liveness fixes this too.
4. **The new `trigger` field was erased by coalescing.** `terminal_park_verdict_churn` was name-only coalesced in `src/main/ipc/crash-reporting.ts`, collapsing a `burst` (damping engaged one commit short of #185) into a slow-churn `window` slot. Now keyed by trigger — still bounded to two slots per storm.

Also addressed the CodeRabbit review: the `root?.unmount()` guard and the pin-lifetime nitpick are fixed above. The one comment flagged "actionable" — that React 19 routes render errors to `onUncaughtError` instead of rethrowing from `act` — was declined with evidence: these tests do not import `@testing-library/react` at all (raw `createRoot` + React's own `act`), and on `main` the `expect(thrown).toBeNull()` assertion is precisely the one that fails. Full reply in the thread.

Cross-platform explicitly checked: `window.setTimeout`/`clearTimeout` use the DOM overload matching the existing pattern in this directory; all `window` access sits inside effect bodies, so node-env specs still import cleanly. `Date.now()` sleep/resume and NTP jumps were checked in **both** directions — a forward jump empties the churn window and a backward jump releases the pin; neither can wedge a pane. No keyboard shortcuts, paths, or shell behavior touched. Nothing here reaches `mobile/` or the paired web client (grep-confirmed).

## Security Audit

No input handling, command execution, path handling, auth, secrets, or dependency risk. Renderer-only behavior change; **no `package.json`, lockfile, `.npmrc`, or `patches/` change**, and all three branch commits are accounted for. No shell, `eval`, dynamic require, network sink, or URL is introduced. The only cross-process surface is the existing `terminal_park_verdict_churn` breadcrumb, whose payload gains one literal string (`trigger`) and numbers — no user data, and the change is purely additive. `ActivityTerminalPortalTarget` holds a live `HTMLElement` and cannot cross IPC; `ParkVerdictFlipRecord` is `useRef`-local with no persistence, schema, or migration.

## Notes

**Rebase fallout (commit 3).** `main` advanced 11 commits under this branch, and #12574 grew `use-terminal-tab-cold-parking.ts` — the same file this PR grows. Neither is over budget alone, but CI lints the merge, and together they hit 303 effective lines against the 300 limit for `.ts`. Fixed by extracting `terminal-cold-park-withheld-tabs.ts` (the last gate between a cold-park candidate and an unmounted pane: watcher coverage and the verdict-flip pin), **not** by a `max-lines` disable or a ratchet bump. Ships with 5 tests including the pin-lapse path. Note that a local `pnpm lint` on a branch behind `main` cannot catch this class of merge-only violation.

Accepted trade-offs and follow-ups, none release-blocking:

- **Damping scope is narrower than the signal it watches.** Flips are counted on the rendered verdict, which unions six inputs, but the pin can only subtract from the cold-park candidate set. Churn from the other inputs is breadcrumbed, not damped. Documented in the module header; a repeating `burst` crumb for one tab reads as "damping did not reach the oscillating input".
- **Readiness latch now outlives subscription identity.** During a genuine 8-flip/500ms burst, a merely-slow pane can be reported `unavailable` for up to 500ms and swap early. Bounded, self-healing, and deliberately tested — the alternative is the crash.
- **`TERMINAL_TAB_PARK_FLIP_COMMIT_COST = 12` is an asserted worst case, not a measurement.** The test pins the arithmetic against React's 50-commit bail at exactly that cost, but not the premise.
- **Possible e2e follow-up:** `ORCA_E2E_TERMINAL_PARKING_DELAY_MS` shrinks the park delay to 500ms but the 1s burst window and 60s pin are not overridable. A spec producing 3 park transitions inside 1s would hold a pane mounted for 60s. Not reproduced (needs the Electron e2e run, skipped on this PR); if the parking suite goes flaky, route the burst/pin windows through `getTerminalParkingPolicyOverrides`.
