### PR TITLE
fix(settings): emit Windows font family names as UTF-8

### DIFF
--- a/src/main/system-fonts.test.ts
+++ b/src/main/system-fonts.test.ts
@@ -59,12 +59,36 @@ async function expectFontCommandTimeout(
   })
 }
 
+describe('buildWindowsFontListScript', () => {
+  it('forces UTF-8 console output before enumerating font families', async () => {
+    const { buildWindowsFontListScript } = await import('./system-fonts')
+    const script = buildWindowsFontListScript()
+    expect(script).toContain('[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)')
+    expect(script).toContain('InstalledFontCollection')
+  })
+})
+
 describe('listSystemFontFamilies', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.resetModules()
     execFileMock.mockReset()
     killMock.mockReset()
+  })
+
+  it('keeps Korean font family names when PowerShell already emits UTF-8', async () => {
+    await withPlatform('win32', async () => {
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+        cb(null, '굴림\nG마켓 산스 Medium\nConsolas\n')
+        return { kill: killMock }
+      })
+      const { listSystemFontFamilies } = await import('./system-fonts')
+      await expect(listSystemFontFamilies()).resolves.toEqual(
+        expect.arrayContaining(['굴림', 'G마켓 산스 Medium', 'Consolas'])
+      )
+      const script = String(execFileMock.mock.calls[0]?.[1]?.at(-1) ?? '')
+      expect(script).toContain('UTF8Encoding')
+    })
   })
 
   it('falls back when the platform font command never exits', async () => {

--- a/src/main/system-fonts.test.ts
+++ b/src/main/system-fonts.test.ts
@@ -59,23 +59,6 @@ async function expectFontCommandTimeout(
   })
 }
 
-describe('buildWindowsFontListScript', () => {
-  it('forces UTF-8 console output before enumerating font families', async () => {
-    const { buildWindowsFontListScript } = await import('./system-fonts')
-    const script = buildWindowsFontListScript()
-    expect(script).toContain('InstalledFontCollection')
-    // Why: pin order so enumeration cannot drift above the UTF-8 setup (#12590 review).
-    const encodingIndex = script.indexOf(
-      '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)'
-    )
-    const outputEncodingIndex = script.indexOf('$OutputEncoding = [Console]::OutputEncoding')
-    const enumerationIndex = script.indexOf('$fonts.Families | ForEach-Object')
-    expect(encodingIndex).toBeGreaterThanOrEqual(0)
-    expect(outputEncodingIndex).toBeGreaterThan(encodingIndex)
-    expect(enumerationIndex).toBeGreaterThan(outputEncodingIndex)
-  })
-})
-
 describe('listSystemFontFamilies', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -84,18 +67,22 @@ describe('listSystemFontFamilies', () => {
     killMock.mockReset()
   })
 
-  it('keeps Korean font family names when PowerShell already emits UTF-8', async () => {
+  it('sets UTF-8 stdout encoding as the first statement of the Windows font script', async () => {
     await withPlatform('win32', async () => {
       execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
-        cb(null, '굴림\nG마켓 산스 Medium\nConsolas\n')
+        cb(null, 'Consolas\n')
         return { kill: killMock }
       })
       const { listSystemFontFamilies } = await import('./system-fonts')
-      await expect(listSystemFontFamilies()).resolves.toEqual(
-        expect.arrayContaining(['굴림', 'G마켓 산스 Medium', 'Consolas'])
+      await listSystemFontFamilies()
+
+      const args = (execFileMock.mock.calls[0]?.[1] ?? []) as string[]
+      const script = args[args.indexOf('-Command') + 1] ?? ''
+      // Why: match the whole statement, not a substring — anything emitted above it
+      // still leaves in the OEM code page, and a swapped encoding must not slip by.
+      expect(script.trim().split(/\r?\n/)[0]).toBe(
+        '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)'
       )
-      const script = String(execFileMock.mock.calls[0]?.[1]?.at(-1) ?? '')
-      expect(script).toContain('UTF8Encoding')
     })
   })
 

--- a/src/main/system-fonts.test.ts
+++ b/src/main/system-fonts.test.ts
@@ -63,8 +63,16 @@ describe('buildWindowsFontListScript', () => {
   it('forces UTF-8 console output before enumerating font families', async () => {
     const { buildWindowsFontListScript } = await import('./system-fonts')
     const script = buildWindowsFontListScript()
-    expect(script).toContain('[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)')
     expect(script).toContain('InstalledFontCollection')
+    // Why: pin order so enumeration cannot drift above the UTF-8 setup (#12590 review).
+    const encodingIndex = script.indexOf(
+      '[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)'
+    )
+    const outputEncodingIndex = script.indexOf('$OutputEncoding = [Console]::OutputEncoding')
+    const enumerationIndex = script.indexOf('$fonts.Families | ForEach-Object')
+    expect(encodingIndex).toBeGreaterThanOrEqual(0)
+    expect(outputEncodingIndex).toBeGreaterThan(encodingIndex)
+    expect(enumerationIndex).toBeGreaterThan(outputEncodingIndex)
   })
 })
 

--- a/src/main/system-fonts.ts
+++ b/src/main/system-fonts.ts
@@ -76,30 +76,19 @@ function listLinuxFonts(): Promise<string[]> {
   )
 }
 
-// Why: Windows PowerShell 5.1 redirected stdout uses the console/OEM code page
-// unless OutputEncoding is forced. Node always decodes with encoding:'utf8', so
-// Korean/CJK font family names become mojibake without this pin (#12590).
-export function buildWindowsFontListScript(): string {
-  return `
+function listWindowsFonts(): Promise<string[]> {
+  // Why: PowerShell 5.1 emits redirected stdout in the OEM code page; pin UTF-8
+  // before the first name is written or localized families arrive as mojibake (#12590).
+  const script = `
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-$OutputEncoding = [Console]::OutputEncoding
 Add-Type -AssemblyName System.Drawing
 $fonts = New-Object System.Drawing.Text.InstalledFontCollection
 $fonts.Families | ForEach-Object { $_.Name }
 `
-}
 
-function listWindowsFonts(): Promise<string[]> {
   return execFileText(
     'powershell.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-ExecutionPolicy',
-      'Bypass',
-      '-Command',
-      buildWindowsFontListScript()
-    ],
+    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
     8 * 1024 * 1024
   ).then((output) =>
     uniqueSorted(

--- a/src/main/system-fonts.ts
+++ b/src/main/system-fonts.ts
@@ -76,16 +76,30 @@ function listLinuxFonts(): Promise<string[]> {
   )
 }
 
-function listWindowsFonts(): Promise<string[]> {
-  const script = `
+// Why: Windows PowerShell 5.1 redirected stdout uses the console/OEM code page
+// unless OutputEncoding is forced. Node always decodes with encoding:'utf8', so
+// Korean/CJK font family names become mojibake without this pin (#12590).
+export function buildWindowsFontListScript(): string {
+  return `
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
 Add-Type -AssemblyName System.Drawing
 $fonts = New-Object System.Drawing.Text.InstalledFontCollection
 $fonts.Families | ForEach-Object { $_.Name }
 `
+}
 
+function listWindowsFonts(): Promise<string[]> {
   return execFileText(
     'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      buildWindowsFontListScript()
+    ],
     8 * 1024 * 1024
   ).then((output) =>
     uniqueSorted(


### PR DESCRIPTION
## Summary
- Windows PowerShell 5.1 can emit font family names with the console code page while Node always decodes stdout as UTF-8.
- Force `[Console]::OutputEncoding` to UTF-8 before enumerating `InstalledFontCollection`.
- Regression tests cover script UTF-8 pin and Korean name round-trip on the parse path.

Fixes #12590

## Test plan
- [x] `vitest` `src/main/system-fonts.test.ts` (6/6)
- [x] Windows host PowerShell UTF-8 enumeration smoke