### PR TITLE
fix(computer-use): deliver macOS coordinate clicks via HID event tap

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -2298,10 +2298,36 @@ private enum Input {
         let flags = modifiers.reduce(into: CGEventFlags()) { result, modifier in
             result.insert(modifier.flag)
         }
-        for _ in 0..<max(count, 1) {
-            try mouse(.mouseMoved, source: source, point: point, button: button.cgButton, flags: flags, pid: pid)
-            try mouse(button.downEvent, source: source, point: point, button: button.cgButton, flags: flags, pid: pid)
-            try mouse(button.upEvent, source: source, point: point, button: button.cgButton, flags: flags, pid: pid)
+        for clickIndex in 1...max(count, 1) {
+            try mouse(
+                .mouseMoved,
+                source: source,
+                point: point,
+                button: button.cgButton,
+                flags: flags,
+                pid: pid
+            )
+            // Why: a move+down in the same tick is ignored by some AppKit/Electron
+            // controls even when the cursor visibly arrives (#12592).
+            usleep(10_000)
+            try mouse(
+                button.downEvent,
+                source: source,
+                point: point,
+                button: button.cgButton,
+                flags: flags,
+                pid: pid,
+                clickState: clickIndex
+            )
+            try mouse(
+                button.upEvent,
+                source: source,
+                point: point,
+                button: button.cgButton,
+                flags: flags,
+                pid: pid,
+                clickState: clickIndex
+            )
         }
     }
 
@@ -2399,13 +2425,34 @@ private enum Input {
         point: CGPoint,
         button: CGMouseButton,
         flags: CGEventFlags = [],
-        pid: pid_t
+        pid: pid_t,
+        clickState: Int = 1
     ) throws {
         guard let event = CGEvent(mouseEventSource: source, mouseType: type, mouseCursorPosition: point, mouseButton: button) else {
             throw ProviderError.coded("accessibility_error", "failed to create mouse event")
         }
         event.flags = flags
-        event.postToPid(pid)
+        if type == .leftMouseDown || type == .leftMouseUp
+            || type == .rightMouseDown || type == .rightMouseUp
+            || type == .otherMouseDown || type == .otherMouseUp
+        {
+            event.setIntegerValueField(.mouseEventClickState, value: Int64(max(clickState, 1)))
+        }
+        // Why: postToPid alone moves the cursor (hover/tooltips work) but many
+        // AppKit and Electron controls never activate on a pid-targeted press.
+        // Keyboard already posts via cghidEventTap; use that for button
+        // down/up so --x/--y clicks activate (#12592). Keep postToPid for
+        // motion/drag so targeted apps still track the pointer.
+        let isButtonPress =
+            type == .leftMouseDown || type == .leftMouseUp
+            || type == .rightMouseDown || type == .rightMouseUp
+            || type == .otherMouseDown || type == .otherMouseUp
+        if isButtonPress {
+            event.post(tap: .cghidEventTap)
+        } else {
+            event.postToPid(pid)
+            event.post(tap: .cghidEventTap)
+        }
     }
 
     private static func keyEvent(_ keyCode: CGKeyCode, down: Bool, flags: CGEventFlags, pid: pid_t) throws {

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -729,6 +729,15 @@ final class Provider {
         let snapshot = try currentSnapshot(params: params)
         let button = params["mouseButton"]?.string ?? "left"
         let count = try positiveInteger(params["clickCount"]?.number, defaultValue: 1, name: "clickCount")
+        // Why: Input.click sleeps 10ms per iteration; reject huge counts so a
+        // bad agent payload cannot stall the helper for minutes (#12592 review).
+        let maxClickCount = 20
+        guard count <= maxClickCount else {
+            throw ProviderError.coded(
+                "invalid_argument",
+                "clickCount must be <= \(maxClickCount)"
+            )
+        }
         let modifiers = try KeyMap.parseModifiers(params["modifiers"]?.string)
         // Why: agents expect a click into a target app to make the next
         // keyboard action safe, even when the click uses an AX action path.

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -909,6 +909,9 @@ final class Provider {
             start = try coordinatePoint(params: params, xKey: "fromX", yKey: "fromY", snapshot: snapshot)
             end = try coordinatePoint(params: params, xKey: "toX", yKey: "toY", snapshot: snapshot)
         }
+        // Why: HID button presses no longer postToPid (#12592); focus the target
+        // first so global presses land on the intended app, matching Provider.click.
+        recoverWindow(snapshot.app)
         try Input.drag(pid: snapshot.app.pid, from: start, to: end)
         return actionMetadata(path: "synthetic")
     }
@@ -2441,8 +2444,9 @@ private enum Input {
         // Why: postToPid alone moves the cursor (hover/tooltips work) but many
         // AppKit and Electron controls never activate on a pid-targeted press.
         // Keyboard already posts via cghidEventTap; use that for button
-        // down/up so --x/--y clicks activate (#12592). Keep postToPid for
-        // motion/drag so targeted apps still track the pointer.
+        // down/up so --x/--y clicks activate (#12592). Motion/drag stay
+        // postToPid-only — dual-posting leftMouseDragged doubles delivery
+        // when the target is frontmost.
         let isButtonPress =
             type == .leftMouseDown || type == .leftMouseUp
             || type == .rightMouseDown || type == .rightMouseUp
@@ -2451,7 +2455,6 @@ private enum Input {
             event.post(tap: .cghidEventTap)
         } else {
             event.postToPid(pid)
-            event.post(tap: .cghidEventTap)
         }
     }
 

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
@@ -37,6 +37,20 @@ final class AgentEntrypointSourceSafetyTests: XCTestCase {
         XCTAssertTrue(source.contains("event.post(tap: .cghidEventTap)"))
         XCTAssertTrue(source.contains("event.postToPid(pid)"))
         XCTAssertTrue(source.contains("mouseEventClickState"))
+        // Why: whole-file contains(cghidEventTap) is satisfied by keyEvent alone;
+        // pin the mouse button-press branch so the #12592 path cannot regress.
+        XCTAssertTrue(
+            source.contains(
+                """
+                        if isButtonPress {
+                            event.post(tap: .cghidEventTap)
+                        } else {
+                            event.postToPid(pid)
+                        }
+                """
+            ),
+            "Input.mouse must HID-post button presses and postToPid motion without dual-post"
+        )
     }
 
     private func agentEntrypointSource() throws -> String {

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentEntrypointSourceSafetyTests.swift
@@ -31,7 +31,12 @@ final class AgentEntrypointSourceSafetyTests: XCTestCase {
                             try? keyEvent(modifier.keyCode, down: false, flags: flags, pid: pid)
             """
         ))
-        XCTAssertTrue(source.contains("event.flags = flags\n        event.postToPid(pid)"))
+        // Why: synthetic mouse delivery must set modifier flags and use the HID
+        // tap path so coordinate clicks actually press (#12592), not only move.
+        XCTAssertTrue(source.contains("event.flags = flags"))
+        XCTAssertTrue(source.contains("event.post(tap: .cghidEventTap)"))
+        XCTAssertTrue(source.contains("event.postToPid(pid)"))
+        XCTAssertTrue(source.contains("mouseEventClickState"))
     }
 
     private func agentEntrypointSource() throws -> String {


### PR DESCRIPTION
## Summary

`orca computer click --x/--y` is a no-op on macOS — the pointer moves and hover fires, but the control is never activated; `--element-index` works.

- `postToPid` moved the cursor (hover worked) but button down/up often never activated AppKit/Electron controls.
- Post mouse button presses via `cghidEventTap` (same path as keyboard), set `mouseEventClickState`, and add a short move→down delay.
- Source-safety test updated for the new delivery path.

Fixes #12592

## Test plan
- [x] `swift test --filter AgentEntrypointSourceSafetyTests`
- The change is CI-gated once workflows run: `config/scripts/verify-computer-native.mjs` runs `swift test --package-path native/computer-use-macos`, and `.github/workflows/computer-e2e.yml` lists `native/computer-use-macos/**` as a trigger path, so this diff re-runs the native suite.