### PR TITLE
fix(browser): align cookie import Google session safeguards

### DIFF
--- a/src/main/browser/browser-cookie-import-google-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-google-policy.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const sessionFromPartitionMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  app: { getPath: () => tmpdir() },
+  session: { fromPartition: sessionFromPartitionMock }
+}))
+
+import {
+  cookieHostBelongsToImportedDomain,
+  importCookiesFromFile,
+  isGoogleIntegrityCookie
+} from './browser-cookie-import'
+
+describe('Google integrity cookie policy', () => {
+  it('matches Google hosts and integrity names only', () => {
+    expect(isGoogleIntegrityCookie('SIDCC', '.google.com')).toBe(true)
+    expect(isGoogleIntegrityCookie('AEC', 'accounts.google.com')).toBe(true)
+    expect(isGoogleIntegrityCookie('SIDCC', 'notgoogle.com')).toBe(false)
+    expect(isGoogleIntegrityCookie('SID', '.google.com')).toBe(false)
+    expect(isGoogleIntegrityCookie('AEC', 'example.com')).toBe(false)
+  })
+
+  it('scopes domain membership without suffix confusion', () => {
+    const imported = new Set(['google.com', 'github.com'])
+    expect(cookieHostBelongsToImportedDomain('.google.com', imported)).toBe(true)
+    expect(cookieHostBelongsToImportedDomain('mail.google.com', imported)).toBe(true)
+    expect(cookieHostBelongsToImportedDomain('notgoogle.com', imported)).toBe(false)
+    expect(cookieHostBelongsToImportedDomain('evilgithub.com', imported)).toBe(false)
+  })
+})
+
+describe('shared cookie import Google safeguards', () => {
+  let tmpDir: string
+  let cookiesSetMock: ReturnType<typeof vi.fn>
+  let cookiesGetMock: ReturnType<typeof vi.fn>
+  let cookiesRemoveMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'orca-cookie-policy-'))
+    cookiesSetMock = vi.fn().mockResolvedValue(undefined)
+    cookiesGetMock = vi.fn().mockResolvedValue([])
+    cookiesRemoveMock = vi.fn().mockResolvedValue(undefined)
+    sessionFromPartitionMock.mockReset()
+    sessionFromPartitionMock.mockReturnValue({
+      cookies: { set: cookiesSetMock, get: cookiesGetMock, remove: cookiesRemoveMock }
+    })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeCookieFile(cookies: unknown[]): string {
+    const filePath = join(tmpDir, 'cookies.json')
+    writeFileSync(filePath, JSON.stringify(cookies))
+    return filePath
+  }
+
+  it('skips Google integrity cookies on the shared import path and counts them as skipped', async () => {
+    const filePath = writeCookieFile([
+      { domain: '.google.com', name: 'SIDCC', value: 'bound', secure: true },
+      { domain: '.google.com', name: 'SID', value: 'session', secure: true },
+      { domain: '.example.com', name: 'SIDCC', value: 'not-google', secure: true }
+    ])
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.summary.totalCookies).toBe(3)
+    expect(result.summary.importedCookies).toBe(2)
+    expect(result.summary.skippedCookies).toBe(1)
+    const names = cookiesSetMock.mock.calls.map((call) => call[0].name)
+    expect(names).toEqual(expect.arrayContaining(['SID', 'SIDCC']))
+    expect(names.filter((name) => name === 'SIDCC')).toHaveLength(1)
+    expect(
+      cookiesSetMock.mock.calls.find((call) => call[0].domain === '.example.com')?.[0].name
+    ).toBe('SIDCC')
+  })
+
+  it('removes only conflicting cookies in imported domains before write', async () => {
+    cookiesGetMock.mockResolvedValue([
+      { domain: '.google.com', name: 'SID', secure: true },
+      { domain: '.other.com', name: 'keep', secure: false }
+    ])
+    const filePath = writeCookieFile([
+      { domain: '.google.com', name: 'SID', value: 'new', secure: true }
+    ])
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+    expect(result.ok).toBe(true)
+    expect(cookiesRemoveMock).toHaveBeenCalledTimes(1)
+    expect(cookiesRemoveMock.mock.calls[0][1]).toBe('SID')
+    expect(cookiesSetMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear existing cookies when the import is fully integrity-filtered', async () => {
+    cookiesGetMock.mockResolvedValue([{ domain: '.google.com', name: 'SID', secure: true }])
+    const filePath = writeCookieFile([
+      { domain: '.google.com', name: 'SIDCC', value: 'bound', secure: true },
+      { domain: 'accounts.google.com', name: 'AEC', value: 'bound', secure: true }
+    ])
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.summary.importedCookies).toBe(0)
+    expect(result.summary.skippedCookies).toBe(2)
+    expect(cookiesGetMock).not.toHaveBeenCalled()
+    expect(cookiesRemoveMock).not.toHaveBeenCalled()
+    expect(cookiesSetMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/browser/browser-cookie-import-google-policy.test.ts
+++ b/src/main/browser/browser-cookie-import-google-policy.test.ts
@@ -13,6 +13,7 @@ vi.mock('electron', () => ({
 import {
   cookieHostBelongsToImportedDomain,
   importCookiesFromFile,
+  isCookieImportDomainSafeForScopedClear,
   isGoogleIntegrityCookie
 } from './browser-cookie-import'
 
@@ -98,6 +99,29 @@ describe('shared cookie import Google safeguards', () => {
     expect(cookiesRemoveMock).toHaveBeenCalledTimes(1)
     expect(cookiesRemoveMock.mock.calls[0][1]).toBe('SID')
     expect(cookiesSetMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses scoped clear for bare TLD / single-label import domains', () => {
+    expect(isCookieImportDomainSafeForScopedClear('com')).toBe(false)
+    expect(isCookieImportDomainSafeForScopedClear('.com')).toBe(false)
+    expect(isCookieImportDomainSafeForScopedClear('localhost')).toBe(false)
+    expect(isCookieImportDomainSafeForScopedClear('google.com')).toBe(true)
+    expect(isCookieImportDomainSafeForScopedClear('.google.com')).toBe(true)
+  })
+
+  it('does not wipe *.com cookies when the import only carries a bare TLD domain', async () => {
+    cookiesGetMock.mockResolvedValue([
+      { domain: '.google.com', name: 'SID', secure: true },
+      { domain: '.example.com', name: 'keep', secure: false }
+    ])
+    const filePath = writeCookieFile([
+      { domain: 'com', name: 'evil', value: 'x', secure: false }
+    ])
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+    expect(result.ok).toBe(true)
+    expect(cookiesRemoveMock).not.toHaveBeenCalled()
+    expect(cookiesSetMock).toHaveBeenCalled()
   })
 
   it('does not clear existing cookies when the import is fully integrity-filtered', async () => {

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -553,6 +553,21 @@ export function cookieHostBelongsToImportedDomain(
   return false
 }
 
+// Why: domain-scoped clear uses endsWith(`.${imported}`). A host like "com"
+// would match nearly every *.com cookie and wipe unrelated sessions (#12601 review).
+// Require at least one label separator (eTLD+1 or longer); bare TLDs/public
+// suffixes are never safe clear keys for this heuristic.
+export function isCookieImportDomainSafeForScopedClear(domain: string): boolean {
+  const host = normalizeCookieHost(domain)
+  if (!host || host.includes('/') || host.includes(':') || host.includes(' ')) {
+    return false
+  }
+  // Need two+ labels: example.com, co.uk is still two labels — good enough to
+  // block bare "com"/"uk" without a full PSL dependency.
+  const labels = host.split('.').filter((part) => part.length > 0)
+  return labels.length >= 2 && labels.every((part) => part.length > 0)
+}
+
 function validateCookieEntry(raw: RawCookieEntry): ValidatedCookie | null {
   if (typeof raw.domain !== 'string' || raw.domain.trim().length === 0) {
     return null
@@ -633,11 +648,15 @@ async function importValidatedCookies(
 
   // Why: replace only domains present in this import so other site sessions survive.
   // Native Chromium full-snapshot import still clears the whole jar on its own path.
+  // Drop bare TLD / single-label keys from the clear set so "com" cannot wipe *.com.
+  const clearDomainSet = new Set(
+    [...domainSet].filter((host) => isCookieImportDomainSafeForScopedClear(host))
+  )
   try {
     const existing = await targetSession.cookies.get({})
     for (const existingCookie of existing) {
       const host = existingCookie.domain ?? ''
-      if (!cookieHostBelongsToImportedDomain(host, domainSet)) {
+      if (!cookieHostBelongsToImportedDomain(host, clearDomainSet)) {
         continue
       }
       const url = deriveUrl(host, existingCookie.secure)

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -513,6 +513,46 @@ function deriveUrl(domain: string, secure: boolean): string | null {
   }
 }
 
+// Why: Google integrity cookies are bound to the source browser TLS/env; planting
+// them into Orca's embedded jar triggers CookieMismatch. Same policy for native
+// Chromium import and file/Firefox/Safari shared import (#12601).
+const GOOGLE_INTEGRITY_COOKIE_NAMES = new Set([
+  'SIDCC',
+  '__Secure-1PSIDCC',
+  '__Secure-3PSIDCC',
+  '__Secure-STRP',
+  'AEC'
+])
+
+export function normalizeCookieHost(domain: string): string {
+  return (domain.startsWith('.') ? domain.slice(1) : domain).toLowerCase()
+}
+
+export function isGoogleIntegrityCookie(name: string, domain: string): boolean {
+  if (!GOOGLE_INTEGRITY_COOKIE_NAMES.has(name)) {
+    return false
+  }
+  const host = normalizeCookieHost(domain)
+  // Why: require exact google.com or a real subdomain — not suffix-confusion like notgoogle.com.
+  return host === 'google.com' || host.endsWith('.google.com')
+}
+
+export function cookieHostBelongsToImportedDomain(
+  cookieDomain: string,
+  importedHosts: ReadonlySet<string>
+): boolean {
+  const host = normalizeCookieHost(cookieDomain)
+  if (importedHosts.has(host)) {
+    return true
+  }
+  for (const imported of importedHosts) {
+    if (host.endsWith(`.${imported}`)) {
+      return true
+    }
+  }
+  return false
+}
+
 function validateCookieEntry(raw: RawCookieEntry): ValidatedCookie | null {
   if (typeof raw.domain !== 'string' || raw.domain.trim().length === 0) {
     return null
@@ -558,14 +598,67 @@ async function importValidatedCookies(
     `importValidatedCookies: ${cookies.length} validated of ${totalInput} total, partition="${targetPartition}"`
   )
   const targetSession = session.fromPartition(targetPartition)
-  let importedCount = 0
+  // Why: validation failures already count as skipped; integrity skips share the same bucket
+  // so totalCookies = importedCookies + skippedCookies (#12601).
   let skipped = totalInput - cookies.length
-  const domainSet = new Set<string>()
+  const importable: ValidatedCookie[] = []
+  for (const cookie of cookies) {
+    if (isGoogleIntegrityCookie(cookie.name, cookie.domain)) {
+      skipped++
+      continue
+    }
+    importable.push(cookie)
+  }
 
+  const domainSet = new Set<string>()
+  for (const cookie of importable) {
+    domainSet.add(normalizeCookieHost(cookie.domain))
+  }
+
+  // Why: do not clear the jar when nothing is importable — preserves unrelated sessions
+  // and avoids wiping on fully-filtered Google integrity payloads.
+  if (importable.length === 0) {
+    diag(`importValidatedCookies: nothing importable after integrity filter (skipped=${skipped})`)
+    return {
+      ok: true,
+      profileId: '',
+      summary: {
+        totalCookies: totalInput,
+        importedCookies: 0,
+        skippedCookies: skipped,
+        domains: []
+      }
+    }
+  }
+
+  // Why: replace only domains present in this import so other site sessions survive.
+  // Native Chromium full-snapshot import still clears the whole jar on its own path.
+  try {
+    const existing = await targetSession.cookies.get({})
+    for (const existingCookie of existing) {
+      const host = existingCookie.domain ?? ''
+      if (!cookieHostBelongsToImportedDomain(host, domainSet)) {
+        continue
+      }
+      const url = deriveUrl(host, existingCookie.secure)
+      if (!url) {
+        continue
+      }
+      try {
+        await targetSession.cookies.remove(url, existingCookie.name)
+      } catch (err) {
+        diag(`  cookie.remove failed domain=${host} name=${existingCookie.name}: ${String(err)}`)
+      }
+    }
+  } catch (err) {
+    diag(`  cookies.get for domain-scoped clear failed: ${String(err)}`)
+  }
+
+  let importedCount = 0
   // Why: Electron's cookies.set() rejects any non-printable-ASCII byte; strip as a safety net.
   const stripNonPrintable = (s: string): string => s.replace(/[^\x20-\x7E]/g, '')
 
-  for (const cookie of cookies) {
+  for (const cookie of importable) {
     try {
       // Why: Chromium rejects __Host- cookies unless they omit domain and use path=/.
       const isHostPrefixed = cookie.name.startsWith('__Host-')
@@ -581,13 +674,9 @@ async function importValidatedCookies(
         expirationDate: cookie.expirationDate
       })
       importedCount++
-      // Why: surface only the domain (never name/value/path) so the summary doesn't leak secret cookie data.
-      const cleanDomain = cookie.domain.startsWith('.') ? cookie.domain.slice(1) : cookie.domain
-      domainSet.add(cleanDomain)
     } catch (err) {
       skipped++
       if (skipped <= 5) {
-        // Find the exact offending character position and code
         const val = cookie.value
         let badInfo = 'none found'
         for (let i = 0; i < val.length; i++) {
@@ -1572,22 +1661,6 @@ export async function importCookiesFromBrowser(
       }
     }
 
-    // Why: Google integrity cookies are bound to the source browser's TLS/env; importing them triggers CookieMismatch, so skip and let Google reissue.
-    const INTEGRITY_COOKIE_NAMES = new Set([
-      'SIDCC',
-      '__Secure-1PSIDCC',
-      '__Secure-3PSIDCC',
-      '__Secure-STRP',
-      'AEC'
-    ])
-    function isIntegrityCookie(name: string, domain: string): boolean {
-      if (!INTEGRITY_COOKIE_NAMES.has(name)) {
-        return false
-      }
-      const d = domain.startsWith('.') ? domain.slice(1) : domain
-      return d === 'google.com' || d.endsWith('.google.com')
-    }
-
     let imported = 0
     let skipped = 0
     let integritySkipped = 0
@@ -1658,7 +1731,7 @@ export async function importCookiesFromBrowser(
       const domain = sourceRow.host_key as string
       const name = sourceRow.name as string
 
-      if (isIntegrityCookie(name, domain)) {
+      if (isGoogleIntegrityCookie(name, domain)) {
         integritySkipped++
         continue
       }
@@ -1783,10 +1856,12 @@ export async function importCookiesFromBrowser(
       diag(`  set UA for partition: ${ua.substring(0, 80)}...`)
     }
 
+    // Why: integrity skips are deliberate filters, not silent drops — count them so
+    // totalCookies = importedCookies + skippedCookies for the Chromium path too (#12601).
     const summary: BrowserCookieImportSummary = {
       totalCookies: sourceRows.length,
       importedCookies: imported,
-      skippedCookies: skipped,
+      skippedCookies: skipped + integritySkipped,
       domains: [...domainSet].sort(),
       ...(warning ? { warning } : {})
     }


### PR DESCRIPTION
## Summary
- File/Firefox/Safari cookie import now skips the same source-bound Google integrity cookies as native Chromium import.
- Shared import replaces only cookies for domains in the validated set.
- Fully filtered imports do not clear the destination jar.
- Chromium path counts integrity skips in `skippedCookies`.

Fixes #12601

## Test plan
- [x] `vitest` browser-cookie-import + google-policy tests (31)