### PR TITLE
fix(plugins): surface reserved-identity install errors for local forks

### DIFF
--- a/src/main/plugins/plugin-install-trust.test.ts
+++ b/src/main/plugins/plugin-install-trust.test.ts
@@ -46,7 +46,7 @@ describe('plugin install trust', () => {
         url: 'https://github.com/attacker/orca-secrets.git',
         ref: 'main'
       },
-      'reserved plugin identity community.orca-secrets must resolve to the stablyai organization'
+      'reserved plugin identity community.orca-secrets must resolve to the stablyai organization. Forks must either publish from github.com/stablyai/... or rename publisher/id away from the reserved namespace.'
     ],
     [
       {

--- a/src/main/plugins/plugin-install-trust.test.ts
+++ b/src/main/plugins/plugin-install-trust.test.ts
@@ -67,9 +67,11 @@ describe('plugin install trust', () => {
 
     await expect(
       installPluginFromLocalPath({ pluginsDir, sourcePath, hostVersion: '1.4.0' })
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       ok: false,
-      error: 'reserved plugin identity stablyai.orca-skills cannot be installed from a local path'
+      error: expect.stringMatching(
+        /reserved plugin identity stablyai\.orca-skills cannot be installed from a local path.*orca-plugin\.json/s
+      )
     })
     await expect(readPluginLockfile(pluginsDir)).resolves.toEqual({ version: 1, plugins: {} })
   })

--- a/src/main/plugins/plugin-install-trust.ts
+++ b/src/main/plugins/plugin-install-trust.ts
@@ -18,10 +18,17 @@ export function pluginInstallTrustError(
     return null
   }
   if (source.kind === 'local-path') {
-    return `reserved plugin identity ${pluginKey} cannot be installed from a local path`
+    // Why: keep "reserved plugin identity" as the stable error prefix for UI matching,
+    // and spell out the fork-and-test fix so the dialog is actionable (#12598).
+    return (
+      `reserved plugin identity ${pluginKey} cannot be installed from a local path. ` +
+      `Forked official templates still use publisher "stablyai" and/or an id starting with "orca-". ` +
+      `Change publisher and id in orca-plugin.json to your own identity before local testing.`
+    )
   }
   const url = source.kind === 'git' ? source.url : source.plugin.url
   return isOfficialOrganizationGitSource(url)
     ? null
-    : `reserved plugin identity ${pluginKey} must resolve to the stablyai organization`
+    : `reserved plugin identity ${pluginKey} must resolve to the stablyai organization. ` +
+        `Forks must either publish from github.com/stablyai/... or rename publisher/id away from the reserved namespace.`
 }

--- a/src/renderer/src/components/settings/plugin-error-presentation.test.ts
+++ b/src/renderer/src/components/settings/plugin-error-presentation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { pluginInstallErrorMessage } from './plugin-error-presentation'
+
+describe('pluginInstallErrorMessage', () => {
+  it('explains reserved local-path identity blocks for official template forks', () => {
+    const message = pluginInstallErrorMessage(
+      new Error(
+        'reserved plugin identity stablyai.orca-portuguese cannot be installed from a local path. Change publisher and id in orca-plugin.json'
+      )
+    )
+    expect(message.toLowerCase()).toContain('reserved official identity')
+    expect(message.toLowerCase()).toContain('orca-plugin.json')
+  })
+
+  it('explains reserved git identity blocks', () => {
+    const message = pluginInstallErrorMessage(
+      new Error(
+        'reserved plugin identity community.orca-secrets must resolve to the stablyai organization'
+      )
+    )
+    expect(message.toLowerCase()).toContain('reserved official identity')
+    expect(message.toLowerCase()).toContain('stablyai')
+  })
+})

--- a/src/renderer/src/components/settings/plugin-error-presentation.test.ts
+++ b/src/renderer/src/components/settings/plugin-error-presentation.test.ts
@@ -6,24 +6,39 @@ vi.mock('@/i18n/i18n', () => ({
 
 import { pluginInstallErrorMessage } from './plugin-error-presentation'
 
+// Why: keep presentation tests locked to pluginInstallTrustError production strings
+// so a "github" substring cannot silently re-route reserved errors to installGit.
+
+const PRODUCTION_RESERVED_LOCAL =
+  'reserved plugin identity stablyai.orca-skills cannot be installed from a local path. ' +
+  'Forked official templates still use publisher "stablyai" and/or an id starting with "orca-". ' +
+  'Change publisher and id in orca-plugin.json to your own identity before local testing.'
+
+const PRODUCTION_RESERVED_GIT =
+  'reserved plugin identity community.orca-secrets must resolve to the stablyai organization. ' +
+  'Forks must either publish from github.com/stablyai/... or rename publisher/id away from the reserved namespace.'
+
 describe('pluginInstallErrorMessage', () => {
   it('explains reserved local-path identity blocks for official template forks', () => {
-    const message = pluginInstallErrorMessage(
-      new Error(
-        'reserved plugin identity stablyai.orca-portuguese cannot be installed from a local path. Change publisher and id in orca-plugin.json'
-      )
-    )
+    const message = pluginInstallErrorMessage(new Error(PRODUCTION_RESERVED_LOCAL))
     expect(message.toLowerCase()).toContain('reserved official identity')
     expect(message.toLowerCase()).toContain('orca-plugin.json')
+    expect(message.toLowerCase()).toContain('change publisher and id')
+    expect(message.toLowerCase()).not.toContain('could not fetch')
   })
 
-  it('explains reserved git identity blocks', () => {
-    const message = pluginInstallErrorMessage(
-      new Error(
-        'reserved plugin identity community.orca-secrets must resolve to the stablyai organization'
-      )
-    )
+  it('explains reserved git identity blocks even when the message mentions github.com', () => {
+    const message = pluginInstallErrorMessage(new Error(PRODUCTION_RESERVED_GIT))
     expect(message.toLowerCase()).toContain('reserved official identity')
     expect(message.toLowerCase()).toContain('stablyai')
+    expect(message.toLowerCase()).toContain('github.com/stablyai')
+    expect(message.toLowerCase()).not.toContain('could not fetch')
+  })
+
+  it('still maps genuine git fetch failures to the installGit message', () => {
+    const message = pluginInstallErrorMessage(
+      new Error('git fetch failed: could not clone repository from remote')
+    )
+    expect(message.toLowerCase()).toContain('could not fetch the pinned git revision')
   })
 })

--- a/src/renderer/src/components/settings/plugin-error-presentation.test.ts
+++ b/src/renderer/src/components/settings/plugin-error-presentation.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
 
 import { pluginInstallErrorMessage } from './plugin-error-presentation'
 

--- a/src/renderer/src/components/settings/plugin-error-presentation.ts
+++ b/src/renderer/src/components/settings/plugin-error-presentation.ts
@@ -36,14 +36,9 @@ export function pluginInstallErrorMessage(cause: unknown): string {
       "The plugin exceeds Orca's install size or file-count limits."
     )
   }
-  if (/(git|repository|fetch|clone|checkout|remote)/.test(detail)) {
-    return translate(
-      'auto.components.settings.pluginError.installGit',
-      'Orca could not fetch the pinned Git revision. Check the URL, #ref, access, and system Git setup.'
-    )
-  }
-  // Why: reserved-namespace blocks used to fall through to a generic failure, so fork
-  // template installs looked like a silent no-op (#12598). Surface the rename guidance.
+  // Why before the git heuristic: production trust strings mention github.com, and
+  // /(git|...)/ matches the "git" substring inside "github", so reserved-identity
+  // blocks would mis-surface as a fetch failure (#12598 review).
   if (detail.includes('reserved plugin identity')) {
     if (detail.includes('local path')) {
       return translate(
@@ -54,6 +49,12 @@ export function pluginInstallErrorMessage(cause: unknown): string {
     return translate(
       'auto.components.settings.pluginError.installReservedGit',
       'This plugin uses a reserved official identity. Install it only from github.com/stablyai/..., or rename publisher/id for a third-party fork.'
+    )
+  }
+  if (/(git|repository|fetch|clone|checkout|remote)/.test(detail)) {
+    return translate(
+      'auto.components.settings.pluginError.installGit',
+      'Orca could not fetch the pinned Git revision. Check the URL, #ref, access, and system Git setup.'
     )
   }
   return translate(

--- a/src/renderer/src/components/settings/plugin-error-presentation.ts
+++ b/src/renderer/src/components/settings/plugin-error-presentation.ts
@@ -42,6 +42,20 @@ export function pluginInstallErrorMessage(cause: unknown): string {
       'Orca could not fetch the pinned Git revision. Check the URL, #ref, access, and system Git setup.'
     )
   }
+  // Why: reserved-namespace blocks used to fall through to a generic failure, so fork
+  // template installs looked like a silent no-op (#12598). Surface the rename guidance.
+  if (detail.includes('reserved plugin identity')) {
+    if (detail.includes('local path')) {
+      return translate(
+        'auto.components.settings.pluginError.installReservedLocal',
+        'This plugin still uses a reserved official identity (publisher "stablyai" or an id starting with "orca-"). For local testing of a fork, change publisher and id in orca-plugin.json to your own values first.'
+      )
+    }
+    return translate(
+      'auto.components.settings.pluginError.installReservedGit',
+      'This plugin uses a reserved official identity. Install it only from github.com/stablyai/..., or rename publisher/id for a third-party fork.'
+    )
+  }
   return translate(
     'auto.components.settings.PluginInstallDialog.installFailed',
     'Plugin installation failed. Check the source and try again.'


### PR DESCRIPTION
## Summary

Forking an official plugin template (for example `orca-portuguese`) and installing it from a local path failed with an error that never said what to change. The dialog now names the two fields to edit: `publisher` and `id` in `orca-plugin.json`.

- Surface reserved-identity install errors with actionable rename guidance for local forks, and point non-official git sources at either the `stablyai` organisation or a renamed identity.
- Match reserved-identity presentation **before** the broad git heuristic so production trust strings containing `github.com` are not misclassified as fetch failures (`/git/` matching inside `github`).
- Lock presentation tests to full `pluginInstallTrustError` production strings.

Fixes #12598

## Test plan
- [x] Unit tests with full production reserved local/git strings
- [x] Negative: genuine git fetch failures still map to installGit
- [x] Campaign review follow-up for high finding