### PR TITLE
fix(browser): add native-UA session profiles

### DIFF
--- a/src/cli/browser-format.ts
+++ b/src/cli/browser-format.ts
@@ -47,7 +47,8 @@ export function formatBrowserProfileList(result: BrowserProfileListResult): stri
     .map((profile) => {
       const marker = profile.scope === 'default' ? '* ' : '  '
       const source = profile.source?.browserFamily ?? 'none'
-      return `${marker}${profile.id}  ${profile.label}  ${profile.scope}  source:${source}`
+      const userAgent = profile.userAgentMode === 'native' ? '  ua:native' : ''
+      return `${marker}${profile.id}  ${profile.label}  ${profile.scope}  source:${source}${userAgent}`
     })
     .join('\n')
 }

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -414,6 +414,29 @@ describe('orca cli browser tab profiles', () => {
     expect(logSpy).toHaveBeenCalledWith('No browser profiles found.')
   })
 
+  it('marks native-UA profiles in text output', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profiles_native_ua', {
+        profiles: [
+          {
+            id: 'google',
+            scope: 'isolated',
+            label: 'Google',
+            partition: 'persist:orca-browser-session-google',
+            source: null,
+            userAgentMode: 'native'
+          }
+        ]
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['tab', 'profile', 'list'], '/tmp/not-an-orca-worktree')
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('ua:native'))
+  })
+
   it('creates isolated browser tab profiles by default', async () => {
     queueFixtures(
       callMock,
@@ -462,6 +485,33 @@ describe('orca cli browser tab profiles', () => {
     expect(callMock).toHaveBeenCalledWith('browser.profileCreate', {
       label: 'From Chrome',
       scope: 'imported'
+    })
+  })
+
+  it('creates a profile with the native user agent when requested', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_profile_native_ua', {
+        profile: {
+          id: 'google',
+          scope: 'isolated',
+          label: 'Google',
+          partition: 'persist:orca-browser-session-google',
+          userAgentMode: 'native'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['tab', 'profile', 'create', '--label', 'Google', '--no-ua-spoof', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledWith('browser.profileCreate', {
+      label: 'Google',
+      scope: 'isolated',
+      userAgentMode: 'native'
     })
   })
 

--- a/src/cli/handlers/browser-profile.ts
+++ b/src/cli/handlers/browser-profile.ts
@@ -38,7 +38,8 @@ export const BROWSER_PROFILE_HANDLERS: Record<string, CommandHandler> = {
     const scope = parseScopeFlag(flags)
     const result = await client.call<BrowserProfileCreateResult>('browser.profileCreate', {
       label,
-      scope
+      scope,
+      ...(flags.get('no-ua-spoof') === true ? { userAgentMode: 'native' } : {})
     })
     if (result.result.profile === null) {
       // Why: registry refuses non-isolated/imported scopes; we already validated

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -318,6 +318,7 @@ Browser Options:
   --page <id>               Stable browser page id (preferred for concurrent workflows)
   --profile <id>            Browser profile id
   --show-profile            Include the tab's browser profile in text output
+  --no-ua-spoof             Keep Electron's native user agent for a new profile
   --format <png|jpeg>       Screenshot image format
   --from <ref>              Drag source element ref
   --to <ref>                Drag target element ref
@@ -611,6 +612,7 @@ export function formatFlagHelp(flag: string): string {
     page: '--page <id>            Stable browser page id from `orca tab list --json`',
     profile: '--profile <id>        Browser profile id',
     'show-profile': '--show-profile        Include tab profile in text output',
+    'no-ua-spoof': "--no-ua-spoof         Keep Electron's native user agent",
     format: '--format <png|jpeg>    Screenshot image format'
   }
 

--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -190,8 +190,9 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['tab', 'profile', 'create'],
     summary: 'Create a browser session profile for browser tabs',
-    usage: 'orca tab profile create --label <name> [--scope <isolated|imported>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'label', 'scope']
+    usage:
+      'orca tab profile create --label <name> [--scope <isolated|imported>] [--no-ua-spoof] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'label', 'scope', 'no-ua-spoof']
   },
   {
     path: ['tab', 'profile', 'delete'],

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -2891,6 +2891,36 @@ describe('browserManager', () => {
       })
     })
 
+    it.each([false, true])(
+      'keeps the session UA for native-mode profiles when mobile=%s',
+      async (mobile) => {
+        const { guest, debuggerSendCommand } = makeGuest(mobile ? 4244 : 4243)
+        webContentsFromIdMock.mockReturnValue(guest)
+        browserManager.attachGuestPolicies(guest as never)
+        browserManager.registerGuest({
+          browserPageId: `tab-native-${mobile}`,
+          sessionProfileId: 'native-profile',
+          userAgentMode: 'native',
+          webContentsId: guest.id as number,
+          rendererWebContentsId
+        })
+
+        await expect(
+          browserManager.setViewportOverride(`tab-native-${mobile}`, {
+            width: mobile ? 375 : 1024,
+            height: mobile ? 667 : 768,
+            deviceScaleFactor: mobile ? 2 : 1,
+            mobile
+          })
+        ).resolves.toBe(true)
+
+        expect(debuggerSendCommand).not.toHaveBeenCalledWith(
+          'Emulation.setUserAgentOverride',
+          expect.anything()
+        )
+      }
+    )
+
     it('clears device metrics and disables touch for override=null', async () => {
       const { guest, debuggerSendCommand } = makeGuest(4343)
       webContentsFromIdMock.mockReturnValue(guest)

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -46,7 +46,8 @@ import { cleanElectronUserAgent } from './browser-session-ua'
 import type {
   BrowserViewportOverride,
   BrowserCertificateFailure,
-  BrowserLoadError
+  BrowserLoadError,
+  BrowserSessionUserAgentMode
 } from '../../shared/types'
 import {
   type BrowserAnnotationViewportBridgeOptions,
@@ -145,6 +146,7 @@ export type BrowserGuestRegistration = {
   workspaceId?: string
   worktreeId?: string
   sessionProfileId?: string | null
+  userAgentMode?: BrowserSessionUserAgentMode
   webContentsId: number
   rendererWebContentsId: number
 }
@@ -225,6 +227,7 @@ export class BrowserManager {
   // Why: guests are keyed by page id but renderer visibility by workspace id; bridge the mismatch to activate the right tab before capture.
   private readonly workspaceIdByPageId = new Map<string, string>()
   private readonly sessionProfileIdByPageId = new Map<string, string | null>()
+  private readonly userAgentModeByPageId = new Map<string, BrowserSessionUserAgentMode>()
   private readonly rendererWebContentsIdByTabId = new Map<string, number>()
   // Why: serialize per-tab setViewportOverride so rapid toggles don't interleave CDP commands and leave emulation in a wrong state.
   private readonly viewportOpsByTabId = new Map<string, Promise<unknown>>()
@@ -980,6 +983,7 @@ export class BrowserManager {
     workspaceId,
     worktreeId,
     sessionProfileId,
+    userAgentMode,
     webContentsId,
     rendererWebContentsId
   }: BrowserGuestRegistration): boolean {
@@ -1020,6 +1024,11 @@ export class BrowserManager {
       this.workspaceIdByPageId.set(browserTabId, workspaceId)
     }
     this.sessionProfileIdByPageId.set(browserTabId, sessionProfileId ?? null)
+    if (userAgentMode) {
+      this.userAgentModeByPageId.set(browserTabId, userAgentMode)
+    } else {
+      this.userAgentModeByPageId.delete(browserTabId)
+    }
     this.rendererWebContentsIdByTabId.set(browserTabId, rendererWebContentsId)
     if (worktreeId) {
       this.worktreeIdByTabId.set(browserTabId, worktreeId)
@@ -1081,6 +1090,7 @@ export class BrowserManager {
     this.rendererWebContentsIdByTabId.delete(browserTabId)
     this.workspaceIdByPageId.delete(browserTabId)
     this.sessionProfileIdByPageId.delete(browserTabId)
+    this.userAgentModeByPageId.delete(browserTabId)
     this.worktreeIdByTabId.delete(browserTabId)
     // Why: drop the viewport-op chain so the Map doesn't retain a promise keyed to a destroyed guest.
     this.viewportOpsByTabId.delete(browserTabId)
@@ -1092,11 +1102,13 @@ export class BrowserManager {
     browserPageId,
     worktreeId,
     sessionProfileId,
+    userAgentMode,
     webContentsId
   }: {
     browserPageId: string
     worktreeId?: string
     sessionProfileId?: string | null
+    userAgentMode?: BrowserSessionUserAgentMode
     webContentsId: number
   }): void {
     const guest = webContents.fromId(webContentsId)
@@ -1113,6 +1125,11 @@ export class BrowserManager {
     this.webContentsIdByTabId.set(browserPageId, webContentsId)
     this.tabIdByWebContentsId.set(webContentsId, browserPageId)
     this.sessionProfileIdByPageId.set(browserPageId, sessionProfileId ?? null)
+    if (userAgentMode) {
+      this.userAgentModeByPageId.set(browserPageId, userAgentMode)
+    } else {
+      this.userAgentModeByPageId.delete(browserPageId)
+    }
     if (worktreeId) {
       this.worktreeIdByTabId.set(browserPageId, worktreeId)
     }
@@ -1141,6 +1158,7 @@ export class BrowserManager {
     this.popupOwnerContextByGuestId.clear()
     this.worktreeIdByTabId.clear()
     this.sessionProfileIdByPageId.clear()
+    this.userAgentModeByPageId.clear()
     this.pendingLoadFailuresByGuestId.clear()
     this.loadErrorsByGuestId.clear()
     this.clearedLoadErrorsByGuestId.clear()
@@ -1532,35 +1550,38 @@ export class BrowserManager {
           enabled: override.mobile,
           maxTouchPoints: override.mobile ? 5 : 0
         })
-        if (override.mobile) {
-          const chromeMajor = extractChromeMajor(cleanElectronUserAgent(guest.getUserAgent()))
-          // Why: userAgentMetadata must accompany the mobile UA so client hints match, or bot-detection flags the desktop-hint leak.
-          await dbg.sendCommand('Emulation.setUserAgentOverride', {
-            userAgent: buildMobileUserAgent(chromeMajor),
-            userAgentMetadata: {
-              brands: [
-                { brand: 'Google Chrome', version: chromeMajor },
-                { brand: 'Chromium', version: chromeMajor },
-                { brand: 'Not/A)Brand', version: '24' }
-              ],
-              fullVersionList: [
-                { brand: 'Google Chrome', version: `${chromeMajor}.0.0.0` },
-                { brand: 'Chromium', version: `${chromeMajor}.0.0.0` },
-                { brand: 'Not/A)Brand', version: '24.0.0.0' }
-              ],
-              fullVersion: `${chromeMajor}.0.0.0`,
-              platform: 'iOS',
-              platformVersion: '17.0',
-              architecture: '',
-              model: 'iPhone',
-              mobile: true
-            }
-          })
-        } else {
-          // Why: desktop presets still need the clean (non-Electron) UA so Cloudflare/Turnstile don't flag the session.
-          await dbg.sendCommand('Emulation.setUserAgentOverride', {
-            userAgent: cleanElectronUserAgent(guest.getUserAgent())
-          })
+        // Why: viewport sizing must not override a profile's explicit native-UA identity.
+        if (this.userAgentModeByPageId.get(browserTabId) !== 'native') {
+          if (override.mobile) {
+            const chromeMajor = extractChromeMajor(cleanElectronUserAgent(guest.getUserAgent()))
+            // Why: userAgentMetadata must accompany the mobile UA so client hints match, or bot-detection flags the desktop-hint leak.
+            await dbg.sendCommand('Emulation.setUserAgentOverride', {
+              userAgent: buildMobileUserAgent(chromeMajor),
+              userAgentMetadata: {
+                brands: [
+                  { brand: 'Google Chrome', version: chromeMajor },
+                  { brand: 'Chromium', version: chromeMajor },
+                  { brand: 'Not/A)Brand', version: '24' }
+                ],
+                fullVersionList: [
+                  { brand: 'Google Chrome', version: `${chromeMajor}.0.0.0` },
+                  { brand: 'Chromium', version: `${chromeMajor}.0.0.0` },
+                  { brand: 'Not/A)Brand', version: '24.0.0.0' }
+                ],
+                fullVersion: `${chromeMajor}.0.0.0`,
+                platform: 'iOS',
+                platformVersion: '17.0',
+                architecture: '',
+                model: 'iPhone',
+                mobile: true
+              }
+            })
+          } else {
+            // Why: desktop presets still need the clean (non-Electron) UA so Cloudflare/Turnstile don't flag the session.
+            await dbg.sendCommand('Emulation.setUserAgentOverride', {
+              userAgent: cleanElectronUserAgent(guest.getUserAgent())
+            })
+          }
         }
       } else {
         await dbg.sendCommand('Emulation.clearDeviceMetricsOverride', {})

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -195,7 +195,9 @@ describe('BrowserSessionRegistry persistence', () => {
       orcaProfileId: 'local-work',
       profileDirectory: '/user-data/profiles/local-work'
     })
-    const profile = browserSessionRegistry.createProfile('isolated', 'Work Browser')
+    const profile = browserSessionRegistry.createProfile('isolated', 'Work Browser', {
+      userAgentMode: 'native'
+    })
 
     expect(profile).not.toBeNull()
     expect(fsState.files.has(profileMetaPath)).toBe(true)
@@ -203,8 +205,33 @@ describe('BrowserSessionRegistry persistence', () => {
     expect(JSON.parse(fsState.files.get(profileMetaPath) ?? '{}').profiles[0]).toMatchObject({
       id: profile!.id,
       partition: profile!.partition,
-      label: 'Work Browser'
+      label: 'Work Browser',
+      userAgentMode: 'native'
     })
+  })
+
+  it('keeps UA cleaning as the fallback for profiles without an override', async () => {
+    const fsState = createFsState()
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const { browserSessionRegistry } = await import('./browser-session-registry')
+
+    browserSessionRegistry.createProfile('isolated', 'Default identity')
+
+    const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
+    expect(profileSession.setUserAgent).toHaveBeenCalledWith('Mozilla/5.0 Orca')
+    expect(setupClientHintsOverrideMock).toHaveBeenCalledWith(profileSession, 'Mozilla/5.0 Orca')
+  })
+
+  it('leaves UA and client hints untouched for native-mode profiles', async () => {
+    const fsState = createFsState()
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const { browserSessionRegistry } = await import('./browser-session-registry')
+
+    browserSessionRegistry.createProfile('isolated', 'Google', { userAgentMode: 'native' })
+
+    const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
+    expect(profileSession.setUserAgent).not.toHaveBeenCalled()
+    expect(setupClientHintsOverrideMock).not.toHaveBeenCalled()
   })
 
   it('merges partition-keyed pending entries without clobbering unrelated entries', async () => {
@@ -320,7 +347,7 @@ describe('BrowserSessionRegistry persistence', () => {
     expect(fsState.present.has('/staged/default')).toBe(true)
   })
 
-  it('restores persisted UA for non-default partitions', async () => {
+  it('restores a persisted source UA even for native-mode profiles', async () => {
     const importedPartition = 'persist:orca-browser-session-11111111-1111-4111-8111-111111111111'
     const importedUa = 'Mozilla/5.0 Chrome/120.0.0.0 Safari/537.36'
     const defaultUa = 'Mozilla/5.0 Chrome/119.0.0.0 Safari/537.36'
@@ -340,7 +367,8 @@ describe('BrowserSessionRegistry persistence', () => {
           scope: 'imported',
           partition: importedPartition,
           label: 'Imported',
-          source: { browserFamily: 'comet', importedAt: 1 }
+          source: { browserFamily: 'comet', importedAt: 1 },
+          userAgentMode: 'native'
         }
       ]
     })
@@ -366,6 +394,44 @@ describe('BrowserSessionRegistry persistence', () => {
           c[1] === importedUa
       )
     ).toBe(true)
+  })
+
+  it('preserves native mode across hydration when no source UA was imported', async () => {
+    const importedPartition = 'persist:orca-browser-session-12121212-1212-4121-8121-121212121212'
+    const fsState = createFsState()
+    seedMeta(fsState, {
+      defaultSource: null,
+      userAgent: null,
+      userAgentByPartition: {},
+      pendingCookieDbPath: null,
+      pendingCookieImports: {},
+      profiles: [
+        {
+          id: '12121212-1212-4121-8121-121212121212',
+          scope: 'isolated',
+          partition: importedPartition,
+          label: 'Google',
+          source: null,
+          userAgentMode: 'native'
+        }
+      ]
+    })
+
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const { browserSessionRegistry } = await import('./browser-session-registry')
+
+    browserSessionRegistry.initializeBrowserSessionsFromPersistedState()
+
+    const importedSessions = sessionFromPartitionMock.mock.results
+      .filter((_, index) => sessionFromPartitionMock.mock.calls[index]?.[0] === importedPartition)
+      .map((result) => result.value)
+    expect(importedSessions.length).toBeGreaterThan(0)
+    expect(importedSessions.every((sess) => sess.setUserAgent.mock.calls.length === 0)).toBe(true)
+    expect(
+      setupClientHintsOverrideMock.mock.calls.some(
+        ([sess]) => (sess as { partition?: string }).partition === importedPartition
+      )
+    ).toBe(false)
   })
 
   it('sets up default-partition policies on restore', async () => {

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -206,6 +206,25 @@ describe('BrowserSessionRegistry', () => {
     expect(browserSessionRegistry.isAllowedPartition(fakeProfile.partition)).toBe(true)
   })
 
+  it('rejects a persisted profile whose partition belongs to a different profile id', () => {
+    const profileId = '00000000-0000-4000-8000-000000000021'
+    const claimedPartition = 'persist:orca-browser-session-00000000-0000-4000-8000-000000000022'
+
+    browserSessionRegistry.hydrateFromPersisted([
+      {
+        id: profileId,
+        scope: 'isolated',
+        partition: claimedPartition,
+        label: 'Conflicting identity',
+        source: null,
+        userAgentMode: 'native'
+      }
+    ])
+
+    expect(browserSessionRegistry.getProfile(profileId)).toBeNull()
+    expect(browserSessionRegistry.isAllowedPartition(claimedPartition)).toBe(false)
+  })
+
   it('sets up session policies for new partitions', () => {
     browserSessionRegistry.createProfile('isolated', 'Policy Test')
     expect(sessionFromPartitionMock).toHaveBeenCalled()

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -85,6 +85,13 @@ describe('BrowserSessionRegistry', () => {
     expect(profile).toBeNull()
   })
 
+  it('rejects invalid user-agent modes at the registry boundary', () => {
+    const profile = browserSessionRegistry.createProfile('isolated', 'Invalid UA', {
+      userAgentMode: 'rotating' as never
+    })
+    expect(profile).toBeNull()
+  })
+
   it('allows created profile partitions', () => {
     const profile = browserSessionRegistry.createProfile('isolated', 'Allowed')
     expect(profile).not.toBeNull()

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -19,7 +19,11 @@ import {
   getOrcaProfileBrowserPartitionSegment,
   getOrcaProfileBrowserSessionPartition
 } from '../../shared/orca-profiles'
-import type { BrowserSessionProfile, BrowserSessionProfileScope } from '../../shared/types'
+import type {
+  BrowserSessionProfile,
+  BrowserSessionProfileCreateOptions,
+  BrowserSessionProfileScope
+} from '../../shared/types'
 import { browserManager } from './browser-manager'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from './browser-media-access'
 import { cleanElectronUserAgent, setupClientHintsOverride } from './browser-session-ua'
@@ -181,19 +185,20 @@ class BrowserSessionRegistry {
     }
 
     // Why: nothing else installs policies on the default partition (hydrate skips it), so without this its guest permissions would be denied.
-    this.setupSessionPolicies(this.defaultPartition)
+    this.setupSessionPolicies(this.getDefaultProfile())
 
-    const partitions = new Set([
-      this.defaultPartition,
-      ...this.listProfiles().map((p) => p.partition)
-    ])
-    for (const partition of partitions) {
+    for (const profile of this.listProfiles()) {
+      const partition = profile.partition
       try {
         const sess = session.fromPartition(partition)
         const persistedUa = meta.userAgentByPartition[partition]
         if (persistedUa) {
           sess.setUserAgent(persistedUa)
           setupClientHintsOverride(sess, persistedUa)
+          continue
+        }
+
+        if (profile.userAgentMode === 'native') {
           continue
         }
 
@@ -360,9 +365,18 @@ class BrowserSessionRegistry {
     return this.profiles.get(profileId)?.partition ?? null
   }
 
-  createProfile(scope: BrowserSessionProfileScope, label: string): BrowserSessionProfile | null {
-    // Why: block scope:'default' here — only the constructor makes the default profile; a second one sharing the partition breaks delete.
-    if (scope === 'default') {
+  createProfile(
+    scope: BrowserSessionProfileScope,
+    label: string,
+    options: BrowserSessionProfileCreateOptions = {}
+  ): BrowserSessionProfile | null {
+    // Why: the registry is also an IPC boundary, so runtime types alone cannot keep invalid values out of persisted metadata.
+    if (
+      (scope !== 'isolated' && scope !== 'imported') ||
+      (options.userAgentMode !== undefined &&
+        options.userAgentMode !== 'clean' &&
+        options.userAgentMode !== 'native')
+    ) {
       return null
     }
     const id = randomUUID()
@@ -373,10 +387,11 @@ class BrowserSessionRegistry {
       scope,
       partition,
       label,
-      source: null
+      source: null,
+      ...(options.userAgentMode ? { userAgentMode: options.userAgentMode } : {})
     }
     this.profiles.set(id, profile)
-    this.setupSessionPolicies(partition)
+    this.setupSessionPolicies(profile)
     this.persistProfiles()
     return profile
   }
@@ -471,6 +486,9 @@ class BrowserSessionRegistry {
       typeof candidate.id === 'string' &&
       typeof candidate.partition === 'string' &&
       typeof candidate.label === 'string' &&
+      (candidate.userAgentMode === undefined ||
+        candidate.userAgentMode === 'clean' ||
+        candidate.userAgentMode === 'native') &&
       this.isProfileOwnedSessionPartition(candidate.partition)
     )
   }
@@ -499,7 +517,7 @@ class BrowserSessionRegistry {
       }
       this.profiles.set(profile.id, profile)
       if (profile.partition !== this.defaultPartition) {
-        this.setupSessionPolicies(profile.partition)
+        this.setupSessionPolicies(profile)
       }
     }
   }
@@ -514,14 +532,15 @@ class BrowserSessionRegistry {
     browserManager.handleGuestWillDownload({ guestWebContentsId: webContents.id, item })
   }
 
-  private setupSessionPolicies(partition: string): void {
+  private setupSessionPolicies(profile: BrowserSessionProfile): void {
+    const { partition } = profile
     if (this.configuredPartitions.has(partition)) {
       return
     }
 
     const sess = session.fromPartition(partition)
     browserManager.installCertificateRequestGuard(sess)
-    if (typeof sess.getUserAgent === 'function') {
+    if (profile.userAgentMode !== 'native' && typeof sess.getUserAgent === 'function') {
       const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
       sess.setUserAgent(cleanUA)
       setupClientHintsOverride(sess, cleanUA)

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -16,7 +16,6 @@ import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import {
   DEFAULT_LOCAL_ORCA_PROFILE_ID,
   getOrcaProfileBrowserDefaultPartition,
-  getOrcaProfileBrowserPartitionSegment,
   getOrcaProfileBrowserSessionPartition
 } from '../../shared/orca-profiles'
 import type {
@@ -50,8 +49,8 @@ export type BrowserSessionRegistryProfileOptions = {
 }
 
 const BROWSER_SESSION_META_FILE_NAME = 'browser-session-meta.json'
-const LEGACY_BROWSER_SESSION_PARTITION_RE =
-  /^persist:orca-browser-session-[\da-f-]{8}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{12}$/
+const BROWSER_SESSION_PROFILE_ID_RE =
+  /^[\da-f-]{8}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{12}$/
 
 // Why: source of truth for valid partitions; will-attach-webview consults it so a compromised renderer can't smuggle in an arbitrary partition.
 
@@ -489,25 +488,15 @@ class BrowserSessionRegistry {
       (candidate.userAgentMode === undefined ||
         candidate.userAgentMode === 'clean' ||
         candidate.userAgentMode === 'native') &&
-      this.isProfileOwnedSessionPartition(candidate.partition)
+      this.isProfileOwnedSessionPartition(candidate.id, candidate.partition)
     )
   }
 
-  private isProfileOwnedSessionPartition(partition: string): boolean {
-    if (
-      this.activeOrcaProfileId === DEFAULT_LOCAL_ORCA_PROFILE_ID &&
-      LEGACY_BROWSER_SESSION_PARTITION_RE.test(partition)
-    ) {
-      return true
-    }
-
-    const segment = getOrcaProfileBrowserPartitionSegment(this.activeOrcaProfileId)
-    const prefix = `persist:orca-profile-${segment}-browser-session-`
-    if (!partition.startsWith(prefix)) {
-      return false
-    }
-    const profileId = partition.slice(prefix.length)
-    return /^[\da-f-]{8}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{12}$/.test(profileId)
+  private isProfileOwnedSessionPartition(profileId: string, partition: string): boolean {
+    return (
+      BROWSER_SESSION_PROFILE_ID_RE.test(profileId) &&
+      partition === getOrcaProfileBrowserSessionPartition(this.activeOrcaProfileId, profileId)
+    )
   }
 
   hydrateFromPersisted(profiles: BrowserSessionProfile[]): void {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -66,6 +66,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       browserPageId,
       worktreeId: params.worktreeId,
       sessionProfileId: profile?.id ?? null,
+      userAgentMode: profile?.userAgentMode,
       webContentsId: win.webContents.id
     })
 

--- a/src/main/ipc/browser-session-profile-ipc.test.ts
+++ b/src/main/ipc/browser-session-profile-ipc.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, removeHandlerMock, createProfileMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  createProfileMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  ipcMain: { handle: handleMock, removeHandler: removeHandlerMock },
+  webContents: { fromId: vi.fn() }
+}))
+
+vi.mock('../browser/browser-manager', () => ({
+  browserCertificateTrustController: { proceed: vi.fn() },
+  browserManager: {
+    getWebContentsIdByTabId: vi.fn(() => new Map())
+  }
+}))
+
+vi.mock('../browser/browser-session-registry', () => ({
+  browserSessionRegistry: {
+    createProfile: createProfileMock
+  }
+}))
+
+vi.mock('../browser/browser-cookie-import', () => ({
+  detectInstalledBrowsers: vi.fn(() => []),
+  importCookiesFromBrowser: vi.fn(),
+  importCookiesFromFile: vi.fn(),
+  pickCookieFile: vi.fn(),
+  selectBrowserProfile: vi.fn()
+}))
+
+import { registerBrowserHandlers, setTrustedBrowserRendererWebContentsId } from './browser'
+
+describe('browser session profile IPC', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    removeHandlerMock.mockReset()
+    createProfileMock.mockReset()
+    setTrustedBrowserRendererWebContentsId(null)
+  })
+
+  it('forwards the user-agent mode from a trusted renderer', () => {
+    const profile = {
+      id: 'profile-google',
+      scope: 'isolated',
+      partition: 'persist:orca-browser-session-profile-google',
+      label: 'Google',
+      source: null,
+      userAgentMode: 'native'
+    }
+    createProfileMock.mockReturnValue(profile)
+    registerBrowserHandlers()
+    const createHandler = handleMock.mock.calls.find(
+      ([channel]) => channel === 'browser:session:createProfile'
+    )?.[1] as (
+      event: { sender: Electron.WebContents },
+      args: { scope: 'isolated'; label: string; userAgentMode: 'native' }
+    ) => unknown
+    const sender = {
+      id: 91,
+      isDestroyed: () => false,
+      getType: () => 'window',
+      getURL: () => 'file:///renderer/index.html'
+    } as Electron.WebContents
+
+    expect(
+      createHandler({ sender }, { scope: 'isolated', label: 'Google', userAgentMode: 'native' })
+    ).toEqual(profile)
+    expect(createProfileMock).toHaveBeenCalledWith('isolated', 'Google', {
+      userAgentMode: 'native'
+    })
+  })
+})

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -256,8 +256,10 @@ export function registerBrowserHandlers(): void {
     // with a new webContentsId. The bridge must destroy the old session's
     // proxy (its webContents is gone) and let the next command recreate it.
     const previousWcId = browserManager.getGuestWebContentsId(args.browserPageId)
+    const profile = browserSessionRegistry.getProfile(args.sessionProfileId ?? 'default')
     const registered = browserManager.registerGuest({
       ...args,
+      userAgentMode: profile?.userAgentMode,
       rendererWebContentsId: event.sender.id
     })
     if (!registered) {

--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -26,6 +26,7 @@ import type {
   BrowserCookieImportResult,
   BrowserCertificateProceedResult,
   BrowserSessionProfile,
+  BrowserSessionProfileCreateOptions,
   BrowserSessionProfileScope,
   BrowserViewportOverride
 } from '../../shared/types'
@@ -584,12 +585,17 @@ export function registerBrowserHandlers(): void {
     'browser:session:createProfile',
     (
       event,
-      args: { scope: BrowserSessionProfileScope; label: string }
+      args: {
+        scope: BrowserSessionProfileScope
+        label: string
+      } & BrowserSessionProfileCreateOptions
     ): BrowserSessionProfile | null => {
       if (!isTrustedBrowserRenderer(event.sender)) {
         return null
       }
-      return browserSessionRegistry.createProfile(args.scope, args.label)
+      return browserSessionRegistry.createProfile(args.scope, args.label, {
+        userAgentMode: args.userAgentMode
+      })
     }
   )
 

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -42,7 +42,8 @@ const {
     ]),
     getDefaultProfile: vi.fn(),
     getProfile: vi.fn(),
-    resolveKnownPartition: vi.fn()
+    resolveKnownPartition: vi.fn(),
+    createProfile: vi.fn()
   }
 }))
 
@@ -129,6 +130,32 @@ describe('RuntimeBrowserCommands browser screencast', () => {
         return browserSessionRegistryMock.profiles.get(profileId)?.partition ?? null
       }
     )
+    browserSessionRegistryMock.createProfile.mockReset()
+  })
+
+  it('creates profiles with the requested user-agent mode', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const profile = {
+      id: 'profile-google',
+      scope: 'isolated',
+      partition: 'persist:orca-browser-session-profile-google',
+      label: 'Google',
+      source: null,
+      userAgentMode: 'native'
+    }
+    browserSessionRegistryMock.createProfile.mockReturnValue(profile)
+    const commands = new RuntimeBrowserCommands(createHost())
+
+    await expect(
+      commands.browserProfileCreate({
+        label: 'Google',
+        scope: 'isolated',
+        userAgentMode: 'native'
+      })
+    ).resolves.toEqual({ profile })
+    expect(browserSessionRegistryMock.createProfile).toHaveBeenCalledWith('isolated', 'Google', {
+      userAgentMode: 'native'
+    })
   })
 
   it('waits for explicit worktree browser registration after requesting a hidden mount', async () => {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -49,7 +49,10 @@ import type {
   BrowserViewportResult,
   BrowserWaitResult
 } from '../../shared/runtime-types'
-import type { BrowserCertificateProceedResult } from '../../shared/types'
+import type {
+  BrowserCertificateProceedResult,
+  BrowserSessionUserAgentMode
+} from '../../shared/types'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
 import type { BrowserBackend } from '../browser/browser-backend'
 import { browserCertificateTrustController, browserManager } from '../browser/browser-manager'
@@ -1496,9 +1499,12 @@ export class RuntimeBrowserCommands {
   async browserProfileCreate(params: {
     label: string
     scope: 'isolated' | 'imported'
+    userAgentMode?: BrowserSessionUserAgentMode
   }): Promise<BrowserProfileCreateResult> {
     return {
-      profile: browserSessionRegistry.createProfile(params.scope, params.label)
+      profile: browserSessionRegistry.createProfile(params.scope, params.label, {
+        userAgentMode: params.userAgentMode
+      })
     }
   }
 

--- a/src/main/runtime/rpc/methods/browser-schemas.ts
+++ b/src/main/runtime/rpc/methods/browser-schemas.ts
@@ -152,7 +152,8 @@ export const ProfileCreate = z.object({
   label: requiredString('Missing required --label'),
   // Strict enum so unknown scope values surface validation errors instead of being
   // silently coerced to 'isolated' (pr-bug-scan finding from #1397).
-  scope: z.enum(['isolated', 'imported'])
+  scope: z.enum(['isolated', 'imported']),
+  userAgentMode: z.enum(['clean', 'native']).optional()
 })
 
 export const ProfileDelete = z.object({ profileId: requiredString('Missing required --profile') })

--- a/src/main/runtime/rpc/methods/browser.test.ts
+++ b/src/main/runtime/rpc/methods/browser.test.ts
@@ -10,13 +10,25 @@ import {
 import { BROWSER_CORE_METHODS } from './browser-core'
 import { BROWSER_EXTRA_METHODS } from './browser-extras'
 import { BROWSER_SCREENCAST_METHODS } from './browser-screencast'
-import { ClipboardWrite, Fill, KeyboardInsert, Type } from './browser-schemas'
+import { ClipboardWrite, Fill, KeyboardInsert, ProfileCreate, Type } from './browser-schemas'
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
   return { id: 'req-1', authToken: 'tok', method, params }
 }
 
 describe('browser RPC methods', () => {
+  it('validates profile user-agent modes', () => {
+    expect(
+      ProfileCreate.safeParse({ label: 'Google', scope: 'isolated', userAgentMode: 'native' })
+        .success
+    ).toBe(true)
+    expect(ProfileCreate.safeParse({ label: 'Work', scope: 'isolated' }).success).toBe(true)
+    expect(
+      ProfileCreate.safeParse({ label: 'Bad', scope: 'isolated', userAgentMode: 'rotating' })
+        .success
+    ).toBe(false)
+  })
+
   it('routes core browser automation commands to the runtime server', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -124,6 +124,7 @@ import type {
   BrowserCertificateProceedResult,
   BrowserLoadError,
   BrowserSessionProfile,
+  BrowserSessionProfileCreateOptions,
   BrowserSessionProfileScope,
   BrowserSessionProfileSource,
   BrowserViewportOverride,
@@ -617,10 +618,12 @@ export type BrowserApi = {
     callback: (args: { browserPageId: string; key: 'c' | 's' }) => void
   ) => () => void
   sessionListProfiles: () => Promise<BrowserSessionProfile[]>
-  sessionCreateProfile: (args: {
-    scope: BrowserSessionProfileScope
-    label: string
-  }) => Promise<BrowserSessionProfile | null>
+  sessionCreateProfile: (
+    args: {
+      scope: BrowserSessionProfileScope
+      label: string
+    } & BrowserSessionProfileCreateOptions
+  ) => Promise<BrowserSessionProfile | null>
   sessionDeleteProfile: (args: { profileId: string }) => Promise<boolean>
   sessionImportCookies: (args: { profileId: string }) => Promise<BrowserCookieImportResult>
   sessionResolvePartition: (args: { profileId: string | null }) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2743,6 +2743,7 @@ const api = {
     sessionCreateProfile: (args: {
       scope: 'default' | 'isolated' | 'imported'
       label: string
+      userAgentMode?: 'clean' | 'native'
     }): Promise<unknown> => ipcRenderer.invoke('browser:session:createProfile', args),
 
     sessionDeleteProfile: (args: { profileId: string }): Promise<boolean> =>

--- a/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserToolbarMenu.tsx
@@ -61,6 +61,7 @@ export function BrowserToolbarMenu({
 
   const [newProfileDialogOpen, setNewProfileDialogOpen] = useState(false)
   const [newProfileName, setNewProfileName] = useState('')
+  const [useNativeUserAgent, setUseNativeUserAgent] = useState(false)
   const [isCreatingProfile, setIsCreatingProfile] = useState(false)
   const [pendingSwitchProfileId, setPendingSwitchProfileId] = useState<string | null | undefined>(
     undefined
@@ -79,6 +80,14 @@ export function BrowserToolbarMenu({
       return
     }
     setMenuOpen(open)
+  }
+
+  const handleNewProfileDialogOpenChange = (open: boolean): void => {
+    setNewProfileDialogOpen(open)
+    if (!open) {
+      setNewProfileName('')
+      setUseNativeUserAgent(false)
+    }
   }
 
   const effectiveProfileId = currentProfileId ?? 'default'
@@ -129,7 +138,11 @@ export function BrowserToolbarMenu({
 
     setIsCreatingProfile(true)
     try {
-      const profile = await createBrowserSessionProfile('isolated', trimmed)
+      const profile = await createBrowserSessionProfile(
+        'isolated',
+        trimmed,
+        useNativeUserAgent ? { userAgentMode: 'native' } : undefined
+      )
       if (!profile) {
         if (mountedRef.current) {
           toast.error(
@@ -148,6 +161,7 @@ export function BrowserToolbarMenu({
 
       setNewProfileDialogOpen(false)
       setNewProfileName('')
+      setUseNativeUserAgent(false)
 
       onDestroyWebview()
       switchBrowserTabProfile(workspaceId, profile.id, profile.partition)
@@ -239,14 +253,17 @@ export function BrowserToolbarMenu({
         onPendingSwitchChange={() => setPendingSwitchProfileId(undefined)}
         onConfirmSwitch={confirmSwitchProfile}
         newProfileDialogOpen={newProfileDialogOpen}
-        onNewProfileDialogOpenChange={setNewProfileDialogOpen}
+        onNewProfileDialogOpenChange={handleNewProfileDialogOpenChange}
         newProfileName={newProfileName}
         onNewProfileNameChange={setNewProfileName}
+        useNativeUserAgent={useNativeUserAgent}
+        onUseNativeUserAgentChange={setUseNativeUserAgent}
         isCreatingProfile={isCreatingProfile}
         onCreateProfile={() => void handleCreateProfile()}
         onCancelNewProfile={() => {
           setNewProfileDialogOpen(false)
           setNewProfileName('')
+          setUseNativeUserAgent(false)
         }}
       />
     </>

--- a/src/renderer/src/components/browser-pane/browser-toolbar-profile-dialogs.tsx
+++ b/src/renderer/src/components/browser-pane/browser-toolbar-profile-dialogs.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { translate } from '@/i18n/i18n'
+import { BrowserProfileUserAgentOption } from '../browser-profile-user-agent-option'
 
 type BrowserToolbarProfileDialogsProps = {
   pendingSwitchProfileId: string | null | undefined
@@ -18,6 +19,8 @@ type BrowserToolbarProfileDialogsProps = {
   onNewProfileDialogOpenChange: (open: boolean) => void
   newProfileName: string
   onNewProfileNameChange: (value: string) => void
+  useNativeUserAgent: boolean
+  onUseNativeUserAgentChange: (value: boolean) => void
   isCreatingProfile: boolean
   onCreateProfile: () => void
   onCancelNewProfile: () => void
@@ -31,6 +34,8 @@ export function BrowserToolbarProfileDialogs({
   onNewProfileDialogOpenChange,
   newProfileName,
   onNewProfileNameChange,
+  useNativeUserAgent,
+  onUseNativeUserAgentChange,
   isCreatingProfile,
   onCreateProfile,
   onCancelNewProfile
@@ -96,8 +101,14 @@ export function BrowserToolbarProfileDialogs({
               )}
               autoFocus
               maxLength={50}
-              className="mb-4"
+              className="mb-3"
             />
+            <div className="mb-4">
+              <BrowserProfileUserAgentOption
+                checked={useNativeUserAgent}
+                onCheckedChange={onUseNativeUserAgentChange}
+              />
+            </div>
             <DialogFooter>
               <Button type="button" variant="outline" size="sm" onClick={onCancelNewProfile}>
                 {translate('auto.components.browser.pane.BrowserToolbarMenu.429ef481f9', 'Cancel')}

--- a/src/renderer/src/components/browser-profile-user-agent-option.test.tsx
+++ b/src/renderer/src/components/browser-profile-user-agent-option.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import { act, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { BrowserProfileUserAgentOption } from './browser-profile-user-agent-option'
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  act(() => root?.unmount())
+  container?.remove()
+  root = null
+  container = null
+})
+
+function renderOption(): HTMLDivElement {
+  function Harness(): React.JSX.Element {
+    const [checked, setChecked] = useState(false)
+    return <BrowserProfileUserAgentOption checked={checked} onCheckedChange={setChecked} />
+  }
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => root?.render(<Harness />))
+  return container
+}
+
+describe('BrowserProfileUserAgentOption', () => {
+  it('explains the compatibility tradeoff and toggles the native mode', () => {
+    const rendered = renderOption()
+    const checkbox = rendered.querySelector<HTMLButtonElement>('[role="checkbox"]')
+
+    expect(rendered.textContent).toContain('May improve Google sign-in')
+    expect(checkbox?.getAttribute('aria-checked')).toBe('false')
+
+    act(() => checkbox?.click())
+
+    expect(checkbox?.getAttribute('aria-checked')).toBe('true')
+  })
+})

--- a/src/renderer/src/components/browser-profile-user-agent-option.tsx
+++ b/src/renderer/src/components/browser-profile-user-agent-option.tsx
@@ -1,0 +1,43 @@
+import { useId } from 'react'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { translate } from '@/i18n/i18n'
+
+type BrowserProfileUserAgentOptionProps = {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}
+
+export function BrowserProfileUserAgentOption({
+  checked,
+  onCheckedChange
+}: BrowserProfileUserAgentOptionProps): React.JSX.Element {
+  const id = useId()
+  const descriptionId = `${id}-description`
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-border/70 p-3">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(nextChecked) => onCheckedChange(nextChecked === true)}
+        aria-describedby={descriptionId}
+        className="mt-0.5"
+      />
+      <div className="space-y-1">
+        <Label htmlFor={id} className="text-sm">
+          {translate(
+            'auto.components.browser.profile.user.agent.option.04af3dc12b',
+            'Use unmodified user agent'
+          )}
+        </Label>
+        <p id={descriptionId} className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.browser.profile.user.agent.option.5bf47a3c91',
+            'May improve Google sign-in, but can reduce compatibility with bot-protected sites.'
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserNewProfileDialog.tsx
+++ b/src/renderer/src/components/settings/BrowserNewProfileDialog.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '
 import { useAppStore } from '../../store'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
+import { BrowserProfileUserAgentOption } from '../browser-profile-user-agent-option'
 
 type BrowserNewProfileDialogProps = {
   open: boolean
@@ -18,11 +19,13 @@ export function BrowserNewProfileDialog({
 }: BrowserNewProfileDialogProps): React.JSX.Element {
   const mountedRef = useMountedRef()
   const [newProfileName, setNewProfileName] = useState('')
+  const [useNativeUserAgent, setUseNativeUserAgent] = useState(false)
   const [isCreatingProfile, setIsCreatingProfile] = useState(false)
 
   const handleClose = (): void => {
     onOpenChange(false)
     setNewProfileName('')
+    setUseNativeUserAgent(false)
   }
 
   return (
@@ -51,7 +54,11 @@ export function BrowserNewProfileDialog({
             try {
               const profile = await useAppStore
                 .getState()
-                .createBrowserSessionProfile('isolated', trimmed)
+                .createBrowserSessionProfile(
+                  'isolated',
+                  trimmed,
+                  useNativeUserAgent ? { userAgentMode: 'native' } : undefined
+                )
               if (!mountedRef.current) {
                 return
               }
@@ -88,8 +95,14 @@ export function BrowserNewProfileDialog({
             )}
             autoFocus
             maxLength={50}
-            className="mb-4"
+            className="mb-3"
           />
+          <div className="mb-4">
+            <BrowserProfileUserAgentOption
+              checked={useNativeUserAgent}
+              onCheckedChange={setUseNativeUserAgent}
+            />
+          </div>
           <DialogFooter>
             <Button type="button" variant="outline" size="sm" onClick={handleClose}>
               {translate('auto.components.settings.BrowserPane.81ff774667', 'Cancel')}

--- a/src/renderer/src/components/settings/BrowserProfileRow.tsx
+++ b/src/renderer/src/components/settings/BrowserProfileRow.tsx
@@ -105,7 +105,11 @@ export function BrowserProfileRow({
 
   const sourceLabel = profile.source
     ? `${BROWSER_FAMILY_LABELS[profile.source.browserFamily] ?? profile.source.browserFamily}${profile.source.profileName ? ` (${profile.source.profileName})` : ''}`
-    : null
+    : translate('auto.components.settings.BrowserProfileRow.796d846483', 'No cookies imported')
+  const userAgentLabel =
+    profile.userAgentMode === 'native'
+      ? translate('auto.components.settings.BrowserProfileRow.b5c0479e21', 'Unmodified user agent')
+      : null
 
   // Why: uses div[role=button] instead of <button> to avoid nested <button>
   // elements — the dropdown trigger and trash actions inside also render as
@@ -136,16 +140,10 @@ export function BrowserProfileRow({
             </span>
           ) : null}
         </div>
-        {sourceLabel ? (
-          <p className="truncate text-[11px] text-muted-foreground">{sourceLabel}</p>
-        ) : (
-          <p className="text-[11px] text-muted-foreground">
-            {translate(
-              'auto.components.settings.BrowserProfileRow.796d846483',
-              'No cookies imported'
-            )}
-          </p>
-        )}
+        <p className="truncate text-[11px] text-muted-foreground">
+          {sourceLabel}
+          {userAgentLabel ? ` · ${userAgentLabel}` : ''}
+        </p>
       </div>
       <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
         <DropdownMenu

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5635,7 +5635,8 @@
           "b4c167764d": "Imported {{value0}} cookies from file into {{value1}}.",
           "a3f8c2d1e0b4": "Imported {{value0}} cookies from {{value1}} ({{value2}}) into {{value3}}.",
           "b4e9d3f2a1c5": "Imported {{value0}} cookies from {{value1}} into {{value2}}.",
-          "c5a273a809": "From {{value0}}"
+          "c5a273a809": "From {{value0}}",
+          "b5c0479e21": "Unmodified user agent"
         },
         "BrowserUseComputerUseNotice": {
           "15b5e680ba": "Open Computer Use",
@@ -13768,6 +13769,16 @@
                 "suggestions": {
                   "87fcdd0da9": "{{value0}} Search"
                 }
+              }
+            }
+          }
+        },
+        "profile": {
+          "user": {
+            "agent": {
+              "option": {
+                "04af3dc12b": "Use unmodified user agent",
+                "5bf47a3c91": "May improve Google sign-in, but can reduce compatibility with bot-protected sites."
               }
             }
           }

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -585,6 +585,37 @@ describe('createBrowserSlice runtime guard', () => {
     ])
   })
 
+  it('forwards profile UA options to the active runtime environment', async () => {
+    const store = createTestStore()
+    const profile = {
+      id: 'remote-google',
+      scope: 'isolated' as const,
+      partition: 'persist:remote-google',
+      label: 'Google',
+      source: null,
+      userAgentMode: 'native' as const
+    }
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-create',
+      ok: true,
+      result: { profile },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({ settings: settingsWithRuntime('env-1') })
+
+    await expect(
+      store
+        .getState()
+        .createBrowserSessionProfile('isolated', 'Google', { userAgentMode: 'native' })
+    ).resolves.toEqual(profile)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'browser.profileCreate',
+      params: { scope: 'isolated', label: 'Google', userAgentMode: 'native' },
+      timeoutMs: 15_000
+    })
+  })
+
   it('keeps browser profile lists separate per host', async () => {
     const store = createTestStore()
     runtimeEnvironmentCall.mockResolvedValueOnce({
@@ -1059,6 +1090,30 @@ describe('createBrowserSlice runtime guard', () => {
         source: null
       }
     ])
+  })
+
+  it('forwards profile UA options to local browser IPC', async () => {
+    const store = createTestStore()
+    const profile = {
+      id: 'local-google',
+      scope: 'isolated' as const,
+      partition: 'persist:local-google',
+      label: 'Google',
+      source: null,
+      userAgentMode: 'native' as const
+    }
+    mockApi.browser.sessionCreateProfile.mockResolvedValueOnce(profile)
+
+    await expect(
+      store
+        .getState()
+        .createBrowserSessionProfile('isolated', 'Google', { userAgentMode: 'native' })
+    ).resolves.toEqual(profile)
+    expect(mockApi.browser.sessionCreateProfile).toHaveBeenCalledWith({
+      scope: 'isolated',
+      label: 'Google',
+      userAgentMode: 'native'
+    })
   })
 
   it('does not notify the local browser manager when selecting tabs under runtime', () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -9,6 +9,7 @@ import type {
   BrowserLoadError,
   BrowserPage,
   BrowserSessionProfile,
+  BrowserSessionProfileCreateOptions,
   BrowserViewportPresetId,
   BrowserWorkspace,
   WorkspaceSessionState
@@ -195,7 +196,8 @@ export type BrowserSlice = {
   fetchBrowserSessionProfiles: () => Promise<void>
   createBrowserSessionProfile: (
     scope: 'isolated' | 'imported',
-    label: string
+    label: string,
+    options?: BrowserSessionProfileCreateOptions
   ) => Promise<BrowserSessionProfile | null>
   deleteBrowserSessionProfile: (profileId: string) => Promise<boolean>
   importCookiesToProfile: (profileId: string) => Promise<BrowserCookieImportResult>
@@ -1841,7 +1843,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     }
   },
 
-  createBrowserSessionProfile: async (scope, label) => {
+  createBrowserSessionProfile: async (scope, label, options) => {
     const hostId = getBrowserSettingsHostId(get())
     const runtimeEnvironmentId = getBrowserSettingsRuntimeEnvironmentId(get())
     if (runtimeEnvironmentId) {
@@ -1849,7 +1851,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         const result = await callRuntimeRpc<BrowserProfileCreateResult>(
           { kind: 'environment', environmentId: runtimeEnvironmentId },
           'browser.profileCreate',
-          { scope, label },
+          { scope, label, ...options },
           { timeoutMs: 15_000 }
         )
         const profile = result.profile
@@ -1870,7 +1872,8 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     try {
       const profile = (await window.api.browser.sessionCreateProfile({
         scope,
-        label
+        label,
+        ...options
       })) as BrowserSessionProfile | null
       if (profile) {
         set((s) => ({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1026,6 +1026,12 @@ export type BrowserTab = BrowserWorkspace
 
 export type BrowserSessionProfileScope = 'default' | 'isolated' | 'imported'
 
+export type BrowserSessionUserAgentMode = 'clean' | 'native'
+
+export type BrowserSessionProfileCreateOptions = {
+  userAgentMode?: BrowserSessionUserAgentMode
+}
+
 export type BrowserSessionProfileSource = {
   browserFamily:
     | 'chrome'
@@ -1047,6 +1053,7 @@ export type BrowserSessionProfile = {
   partition: string
   label: string
   source: BrowserSessionProfileSource | null
+  userAgentMode?: BrowserSessionUserAgentMode
 }
 
 export type BrowserCookieImportSummary = {

--- a/tests/tools/google-signin-ua-probe.cjs
+++ b/tests/tools/google-signin-ua-probe.cjs
@@ -1,0 +1,195 @@
+// Run with `node_modules/.bin/electron tests/tools/google-signin-ua-probe.cjs --mode=cleaned`.
+const { app, BrowserWindow, session } = require('electron')
+const { mkdtempSync } = require('node:fs')
+const { tmpdir } = require('node:os')
+const { join } = require('node:path')
+
+const MODES = new Set([
+  'cleaned',
+  'electron-auth',
+  'electron-fixed',
+  'firefox-auth',
+  'firefox-fixed'
+])
+const mode = process.argv.find((arg) => arg.startsWith('--mode='))?.slice('--mode='.length)
+if (!mode || !MODES.has(mode)) {
+  throw new Error(`Expected --mode=${[...MODES].join('|')}`)
+}
+
+const profileRoot = mkdtempSync(join(tmpdir(), `orca-google-signin-${mode}-`))
+const partition = `persist:google-signin-${mode}`
+app.setPath('userData', profileRoot)
+
+function log(event, details = {}) {
+  process.stdout.write(
+    `${JSON.stringify({ event, mode, at: new Date().toISOString(), ...details })}\n`
+  )
+}
+
+function cleanElectronUserAgent(userAgent) {
+  return userAgent.replace(/\s+Electron\/\S+/, '').replace(/(\)\s+)\S+\s+(Chrome\/)/, '$1$2')
+}
+
+function firefoxUserAgent() {
+  const platform =
+    process.platform === 'darwin'
+      ? 'Macintosh; Intel Mac OS X 10.15'
+      : process.platform === 'win32'
+        ? 'Windows NT 10.0; Win64; x64'
+        : 'X11; Linux x86_64'
+  return `Mozilla/5.0 (${platform}; rv:140.0) Gecko/20100101 Firefox/140.0`
+}
+
+function isGoogleAuthUrl(rawUrl) {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase()
+    return hostname === 'accounts.google.com' || hostname === 'accounts.youtube.com'
+  } catch {
+    return false
+  }
+}
+
+function safeUrl(rawUrl) {
+  try {
+    const url = new URL(rawUrl)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return '<invalid>'
+  }
+}
+
+function setHeader(headers, name, value) {
+  const existing = Object.keys(headers).find((key) => key.toLowerCase() === name.toLowerCase())
+  headers[existing ?? name] = value
+}
+
+function removeClientHints(headers) {
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase().startsWith('sec-ch-ua')) {
+      delete headers[key]
+    }
+  }
+}
+
+function applyChromeClientHints(headers, userAgent) {
+  const fullVersion = userAgent.match(/Chrome\/([\d.]+)/)?.[1]
+  if (!fullVersion) {
+    return
+  }
+  const majorVersion = fullVersion.split('.')[0]
+  setHeader(
+    headers,
+    'sec-ch-ua',
+    `"Google Chrome";v="${majorVersion}", "Chromium";v="${majorVersion}", "Not/A)Brand";v="24"`
+  )
+  setHeader(
+    headers,
+    'sec-ch-ua-full-version-list',
+    `"Google Chrome";v="${fullVersion}", "Chromium";v="${fullVersion}", "Not/A)Brand";v="24.0.0.0"`
+  )
+}
+
+function identityForUrl(rawUrl, identities) {
+  if (mode === 'electron-fixed') {
+    return identities.native
+  }
+  if (mode === 'firefox-fixed') {
+    return identities.firefox
+  }
+  if (isGoogleAuthUrl(rawUrl) && mode === 'electron-auth') {
+    return identities.native
+  }
+  if (isGoogleAuthUrl(rawUrl) && mode === 'firefox-auth') {
+    return identities.firefox
+  }
+  return identities.cleaned
+}
+
+function relevantHeaders(headers) {
+  const result = {}
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase()
+    if (lower === 'user-agent' || lower.startsWith('sec-ch-ua')) {
+      result[lower] = value
+    }
+  }
+  return result
+}
+
+app.whenReady().then(async () => {
+  const browserSession = session.fromPartition(partition)
+  await browserSession.clearStorageData()
+  const identities = {
+    native: browserSession.getUserAgent(),
+    firefox: firefoxUserAgent()
+  }
+  identities.cleaned = cleanElectronUserAgent(identities.native)
+  browserSession.setUserAgent(identityForUrl('about:blank', identities))
+
+  browserSession.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
+    const headers = details.requestHeaders
+    const identity = identityForUrl(details.url, identities)
+    setHeader(headers, 'user-agent', identity)
+    if (identity === identities.firefox) {
+      removeClientHints(headers)
+    } else if (identity === identities.cleaned) {
+      applyChromeClientHints(headers, identity)
+    }
+    if (details.resourceType === 'mainFrame') {
+      log('main-frame-request', {
+        url: safeUrl(details.url),
+        headers: relevantHeaders(headers)
+      })
+    }
+    callback({ requestHeaders: headers })
+  })
+
+  const window = new BrowserWindow({
+    show: true,
+    title: `Google sign-in UA probe: ${mode}`,
+    width: 980,
+    height: 840,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      partition,
+      sandbox: true
+    }
+  })
+
+  window.webContents.on('did-start-navigation', (_event, url, _inPlace, isMainFrame) => {
+    if (!isMainFrame) {
+      return
+    }
+    const identity = identityForUrl(url, identities)
+    if (window.webContents.getUserAgent() !== identity) {
+      window.webContents.setUserAgent(identity)
+    }
+    log('main-frame-navigation', { url: safeUrl(url), appliedUserAgent: identity })
+  })
+  window.webContents.on('did-finish-load', async () => {
+    try {
+      const identity = await window.webContents.executeJavaScript(`({
+        userAgent: navigator.userAgent,
+        userAgentData: navigator.userAgentData ? {
+          brands: navigator.userAgentData.brands,
+          mobile: navigator.userAgentData.mobile,
+          platform: navigator.userAgentData.platform
+        } : null
+      })`)
+      log('document-identity', { url: safeUrl(window.webContents.getURL()), ...identity })
+    } catch (error) {
+      log('document-identity-error', { error: String(error) })
+    }
+  })
+
+  log('ready', {
+    electron: process.versions.electron,
+    chromium: process.versions.chrome,
+    profileRoot,
+    nativeUserAgent: identities.native,
+    cleanedUserAgent: identities.cleaned,
+    firefoxUserAgent: identities.firefox
+  })
+  await window.loadURL('https://accounts.google.com/')
+})


### PR DESCRIPTION
## Summary

- let users create an isolated browser profile that keeps Electron's unmodified user agent
- keep Orca's cleaned Chrome-shaped UA as the default for Cloudflare compatibility
- preserve a single, stable UA identity for the profile across redirects and subresources
- expose the opt-out in Settings, the browser toolbar, runtime RPC, and `orca tab profile create --no-ua-spoof`
- add a repeatable Google sign-in UA probe for future regression investigation

Google sign-in testing consistently reached `/v3/signin/rejected` with Orca's cleaned Chrome-shaped UA and reached normal account lookup with the untouched Electron UA. A fresh sign-in under the untouched UA also completed and remained usable for 92 minutes. This PR therefore adds a narrow opt-out rather than changing the default or switching identity by destination host.

Closes #11518

## Screenshots

Profile creation option:

![New browser profile dialog with Use unmodified user agent option](https://github.com/user-attachments/assets/39c53cca-d461-467c-ab46-23fe65189a69)

Persisted profile label:

![Browser settings showing an Unmodified user agent profile](https://github.com/user-attachments/assets/8882d101-25a4-49b7-936c-0a21fbcca310)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 9 focused files / 166 tests passed instead
- [ ] `pnpm build` — no dependency or packaging changes
- [x] Added or updated high-quality tests that would catch regressions

Additional validation:

- Google UA probe: cleaned UA rejected; untouched Electron UA reached account lookup
- probe syntax: `node --check tests/tools/google-signin-ua-probe.cjs`
- Electron QA: option defaults off, toggles, resets after creation, persists `userAgentMode: "native"`, and appears on the profile row

## AI Review Report

Reviewed the user-agent precedence and lifecycle end to end: persisted imported-browser UA first, then the profile's native/clean fallback choice before first navigation. Checked metadata hydration and validation, profile creation through trusted local IPC and remote runtime RPC, CLI parsing, deletion cleanup, UI state reset, and client-hint behavior. The review rejected destination-host UA switching because it would create one session under inconsistent request and JavaScript-visible identities.

Cross-platform review: production changes add no OS-specific paths, shell commands, shortcuts, or labels. The profile option flows through local IPC and runtime RPC, so it applies to local, SSH, and folder-workspace use without assuming a git worktree. Behavior is the same on macOS, Linux, and Windows; the live Google measurement and Electron screenshot QA were run on macOS.

## Security Audit

The new mode is a closed enum validated at RPC and registry boundaries, and persisted profiles still pass the owned-partition allowlist before hydration. Local profile creation remains restricted to the trusted browser renderer. No cookies, auth tokens, or secrets are logged; no dependency, command-execution, or new filesystem-path input is introduced in production code. The diagnostic probe accepts a test account identifier and records navigation/request metadata, but does not accept or store passwords.

## Notes

- Existing profiles and newly created profiles keep today's cleaned UA unless the user explicitly opts out.
- A UA persisted by native browser import still wins over the fallback mode, preserving source-browser fidelity.
- Native mode also avoids Orca's client-hint override, keeping the request headers consistent with Electron's UA.
- Google embedded-browser policy and detection behavior are external and undocumented; this is a compatibility option, not a guarantee.
