### PR TITLE
perf(terminal): prepaint parked SSH sessions

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -20689,6 +20689,198 @@ describe('connectPanePty', () => {
     })
   })
 
+  it('drops an in-flight parked SSH prepaint after its retry lease is replaced', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('conn-1', 'relay-pty-1')
+    const snapshot = createDeferred<{
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+    }>()
+    const sshConnect = createDeferred<SshConnectionState | null>()
+    const pendingRetry = {
+      attemptId: 'attempt-prepaint',
+      authority: {
+        targetId: 'conn-1',
+        providerEpoch: 'epoch-1',
+        connectionGeneration: 3
+      },
+      tabGeneration: 7,
+      startedAt: 1
+    }
+    transportFactoryQueue.push(createMockTransport())
+    vi.mocked(window.api.pty.getMainBufferSnapshot).mockReturnValue(snapshot.promise)
+    vi.mocked(window.api.ssh.connect).mockReturnValue(sshConnect.promise)
+    await parkTabForReveal('tab-1', sshPtyId)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: sshPtyId, generation: 7 }] },
+      ptyIdsByTabId: { 'tab-1': [sshPtyId] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([
+        [
+          'conn-1',
+          {
+            status: 'disconnected',
+            providerEpoch: 'epoch-1',
+            connectionGeneration: 3
+          }
+        ]
+      ]),
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': sshPtyId },
+      directSshPaneRetryByTabId: { 'tab-1': pendingRetry }
+    }
+
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const binding = connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
+      }) as never
+    )
+    await flushAsyncTicks(8)
+    expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalledOnce()
+
+    mockStoreState.sshConnectionStates = new Map([
+      [
+        'conn-1',
+        {
+          status: 'disconnected',
+          providerEpoch: 'epoch-1',
+          connectionGeneration: 4
+        }
+      ]
+    ])
+    mockStoreState.directSshPaneRetryByTabId = {
+      'tab-1': {
+        ...pendingRetry,
+        attemptId: 'attempt-prepaint-new',
+        authority: { ...pendingRetry.authority, connectionGeneration: 4 }
+      }
+    }
+    snapshot.resolve({
+      data: 'OBSOLETE-LEASE-SNAPSHOT\r\n',
+      cols: 101,
+      rows: 31,
+      seq: 124,
+      source: 'headless'
+    })
+    await flushAsyncTicks(12)
+
+    expect(writes.join('')).not.toContain('OBSOLETE-LEASE-SNAPSHOT')
+    binding.dispose()
+    sshConnect.resolve(null)
+    await flushAsyncTicks(4)
+  })
+
+  it('does not prepaint a parked SSH snapshot owned by another connection', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const foreignPtyId = toAppSshPtyId('conn-2', 'relay-pty-1')
+    const sshConnect = createDeferred<SshConnectionState | null>()
+    transportFactoryQueue.push(createMockTransport())
+    vi.mocked(window.api.ssh.connect).mockReturnValue(sshConnect.promise)
+    vi.mocked(window.api.pty.getMainBufferSnapshot).mockResolvedValue({
+      data: 'FOREIGN-CONNECTION-SNAPSHOT\r\n',
+      cols: 101,
+      rows: 31,
+      seq: 125,
+      source: 'headless'
+    })
+    await parkTabForReveal('tab-1', foreignPtyId)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: foreignPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [foreignPtyId] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([['conn-1', { status: 'disconnected' }]]),
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': foreignPtyId }
+    }
+
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const binding = connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: foreignPtyId }
+      }) as never
+    )
+    await flushAsyncTicks(12)
+
+    expect(window.api.pty.getMainBufferSnapshot).not.toHaveBeenCalled()
+    expect(writes.join('')).not.toContain('FOREIGN-CONNECTION-SNAPSHOT')
+    binding.dispose()
+    sshConnect.resolve(null)
+    await flushAsyncTicks(4)
+  })
+
+  it('does not paint a delayed parked snapshot over an expired-session replacement', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('conn-1', 'relay-pty-expired')
+    const freshPtyId = toAppSshPtyId('conn-1', 'relay-pty-fresh')
+    const snapshot = createDeferred<{
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+    }>()
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(async (opts) => {
+      if (opts.sessionId) {
+        opts.callbacks?.onError?.(`SSH_SESSION_EXPIRED: ${opts.sessionId}`)
+        return undefined
+      }
+      transport.getPtyId.mockReturnValue(freshPtyId)
+      return freshPtyId
+    })
+    transportFactoryQueue.push(transport)
+    vi.mocked(window.api.pty.getMainBufferSnapshot).mockReturnValue(snapshot.promise)
+    await parkTabForReveal('tab-1', sshPtyId)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: sshPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [sshPtyId] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([['conn-1', { status: 'connected' }]]),
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': sshPtyId }
+    }
+
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const binding = connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
+      }) as never
+    )
+    await flushAsyncTicks(30)
+    expect(transport.connect).toHaveBeenCalledTimes(2)
+
+    snapshot.resolve({
+      data: 'EXPIRED-SESSION-SNAPSHOT\r\n',
+      cols: 101,
+      rows: 31,
+      seq: 126,
+      source: 'headless'
+    })
+    await flushAsyncTicks(20)
+
+    expect(writes.join('')).not.toContain('EXPIRED-SESSION-SNAPSHOT')
+    binding.dispose()
+  })
+
   it('restores configured paired scrollback after an ordinary park reveal', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const remotePtyId = 'remote:env-1@@terminal-1'

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -20638,6 +20638,57 @@ describe('connectPanePty', () => {
     expect(api.pty.signal).toHaveBeenCalledWith('leaf-session', 'SIGWINCH')
   })
 
+  it('paints a parked SSH model before the remote connection settles', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('conn-1', 'relay-pty-1')
+    const sshConnect = createDeferred<SshConnectionState | null>()
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.mocked(window.api.ssh.connect).mockReturnValue(sshConnect.promise)
+    vi.mocked(window.api.pty.getMainBufferSnapshot).mockResolvedValue({
+      data: 'PARKED-SSH-PAINTED-WITHOUT-NETWORK\r\n',
+      cols: 101,
+      rows: 31,
+      seq: 123,
+      source: 'headless'
+    })
+    await parkTabForReveal('tab-1', sshPtyId)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: sshPtyId }] },
+      ptyIdsByTabId: { 'tab-1': [sshPtyId] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      sshConnectionStates: new Map([['conn-1', { status: 'disconnected' }]]),
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': sshPtyId }
+    }
+
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+    const binding = connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
+      }) as never
+    )
+    await flushAsyncTicks(20)
+
+    expect(window.api.ssh.connect).toHaveBeenCalledWith({ targetId: 'conn-1' })
+    expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalledOnce()
+    expect(writes.join('')).toContain('PARKED-SSH-PAINTED-WITHOUT-NETWORK')
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    binding.dispose()
+    sshConnect.resolve({
+      targetId: 'conn-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+  })
+
   it('restores configured paired scrollback after an ordinary park reveal', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const remotePtyId = 'remote:env-1@@terminal-1'

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1054,6 +1054,7 @@ export function connectPanePty(
   // that follows this mount, so connect time is the only moment a pane can tell
   // a reveal remount from an in-place reattach.
   let mountFollowsTerminalPark = isTerminalTabParked(deps.tabId)
+  let authoritativeReattachGeneration = 0
   exposeE2eTerminalPtyOutputDebug()
   let disposed = false
   const structuralReplayCoordinator = createTerminalStructuralReplayCoordinator(pane.terminal)
@@ -4701,7 +4702,6 @@ export function connectPanePty(
             void window.api.pty.reportRendererSerializerReady?.(ptyId)
           }
         })
-        // The remote attach remains authoritative if this cosmetic prepaint fails.
         .catch(() => {})
     }
 
@@ -5147,6 +5147,7 @@ export function connectPanePty(
         // about to unmount — so skip the doomed respawn instead of racing it.
         return Promise.resolve(null)
       }
+      authoritativeReattachGeneration += 1
       clearPaneMode2031State()
       clearHiddenOutputRestoreState()
       // Why: a canceled old replay clear can preserve xterm's native
@@ -7753,7 +7754,6 @@ export function connectPanePty(
       return true
     }
 
-    let authoritativeReattachGeneration = 0
     let parkedSshSnapshotPrefetch: {
       ptyId: string
       fetch: () => Promise<PtyBufferSnapshot | null>
@@ -8264,6 +8264,7 @@ export function connectPanePty(
 
     const attachRetainedLegacyPty = (ptyId: string): boolean => {
       try {
+        authoritativeReattachGeneration += 1
         clearPaneMode2031State()
         clearHiddenOutputRestoreState()
         const outputCallbacks = captureTransportOutputCallbacks(reportError)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4701,6 +4701,7 @@ export function connectPanePty(
             void window.api.pty.reportRendererSerializerReady?.(ptyId)
           }
         })
+        // The remote attach remains authoritative if this cosmetic prepaint fails.
         .catch(() => {})
     }
 
@@ -7752,12 +7753,108 @@ export function connectPanePty(
       return true
     }
 
+    let authoritativeReattachGeneration = 0
+    let parkedSshSnapshotPrefetch: {
+      ptyId: string
+      fetch: () => Promise<PtyBufferSnapshot | null>
+    } | null = null
+
+    const createSshMainModelSnapshotProbe = (
+      ptyId: string
+    ): (() => Promise<PtyBufferSnapshot | null>) =>
+      memoizeSshReattachModelSnapshotProbe(async (): Promise<PtyBufferSnapshot | null> => {
+        const sshParkingEnabled = useAppStore.getState().settings?.terminalSshViewParking !== false
+        if (!shouldFetchSshReattachModelSnapshot({ ptyId, sshParkingEnabled })) {
+          return null
+        }
+        const snapshot = await resolveSshReattachModelSnapshotWithTimeout(
+          window.api.pty.getMainBufferSnapshot(ptyId, {
+            scrollbackRows: resolveHiddenRestoreScrollbackRows(pane.terminal.options.scrollback)
+          })
+        )
+        return snapshot &&
+          decideSshReattachPaintSource({ ptyId, sshParkingEnabled, snapshot }) ===
+            'main-model-snapshot'
+          ? snapshot
+          : null
+      })
+
+    const getSshMainModelSnapshotProbe = (
+      ptyId: string
+    ): (() => Promise<PtyBufferSnapshot | null>) => {
+      if (parkedSshSnapshotPrefetch?.ptyId !== ptyId) {
+        parkedSshSnapshotPrefetch = { ptyId, fetch: createSshMainModelSnapshotProbe(ptyId) }
+      }
+      return parkedSshSnapshotPrefetch.fetch
+    }
+
+    const prepaintParkedSshSnapshot = (ptyId: string | null): void => {
+      const parsedPtyId = ptyId ? parseAppSshPtyId(ptyId) : null
+      if (
+        !ptyId ||
+        !mountFollowsTerminalPark ||
+        parsedPtyId?.connectionId !== connectionId ||
+        !capturedDirectSshRetryLeaseMatches()
+      ) {
+        return
+      }
+      const capturedGeneration = authoritativeReattachGeneration
+      const isCurrent = (): boolean =>
+        !disposed &&
+        mountFollowsTerminalPark &&
+        authoritativeReattachGeneration === capturedGeneration &&
+        capturedDirectSshRetryLeaseMatches()
+      const fetchSnapshot = getSshMainModelSnapshotProbe(ptyId)
+      void fetchSnapshot()
+        .then(async (snapshot) => {
+          if (!snapshot || !isCurrent()) {
+            return
+          }
+          await structuralReplayCoordinator.run(
+            async () => {
+              if (!isCurrent()) {
+                return
+              }
+              const modelData = `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}`
+              rememberReattachPayloadAgentSignal(modelData, { fullScreenReplay: true })
+              if (
+                hasPositiveTerminalDimensions(snapshot.cols, snapshot.rows) &&
+                (pane.terminal.cols !== snapshot.cols || pane.terminal.rows !== snapshot.rows)
+              ) {
+                suppressStructuralReplayPtyResize = true
+                try {
+                  pane.terminal.resize(snapshot.cols, snapshot.rows)
+                } finally {
+                  suppressStructuralReplayPtyResize = false
+                }
+              }
+              kittyKeyboardModes.scanReplay(modelData)
+              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot)) {
+                writeReplayData(replayChunk)
+              }
+              writeReplayData(reattachReplayResetSequence(modelData))
+              if (snapshot.pendingEscapeTailAnsi) {
+                writeReplayData(snapshot.pendingEscapeTailAnsi)
+              }
+              recordTerminalOutput(pane.terminal)
+              await waitForTerminalReplayWritesParsed(pane.terminal)
+              if (isCurrent()) {
+                manager.rebuildPaneWebgl(pane.id)
+              }
+            },
+            { shouldRestore: isCurrent }
+          )
+        })
+        .catch(() => {})
+    }
+
     const handleReattachResult = async (
       result: PtyConnectResult | string | void,
       staleSessionId?: string | null,
       coldRestoreStartup?: ColdRestoreAgentResumeStartup | null,
       attemptGeneration = transportStreamGeneration
     ): Promise<boolean> => {
+      authoritativeReattachGeneration += 1
       if (disposed) {
         return false
       }
@@ -7885,28 +7982,7 @@ export function connectPanePty(
       // deadlock on the coordinator's tail chain.
       // Memoized: the prefetch and the payload task share one probe result, so a
       // null prefetch can never buy a second timeout before the relay paint.
-      const fetchSshMainModelReattachSnapshot = memoizeSshReattachModelSnapshotProbe(
-        async (): Promise<PtyBufferSnapshot | null> => {
-          const sshParkingEnabled =
-            useAppStore.getState().settings?.terminalSshViewParking !== false
-          if (!shouldFetchSshReattachModelSnapshot({ ptyId, sshParkingEnabled })) {
-            return null
-          }
-          const snapshot = await resolveSshReattachModelSnapshotWithTimeout(
-            window.api.pty.getMainBufferSnapshot(ptyId, {
-              scrollbackRows: resolveHiddenRestoreScrollbackRows(pane.terminal.options.scrollback)
-            })
-          )
-          if (
-            !snapshot ||
-            decideSshReattachPaintSource({ ptyId, sshParkingEnabled, snapshot }) !==
-              'main-model-snapshot'
-          ) {
-            return null
-          }
-          return snapshot
-        }
-      )
+      const fetchSshMainModelReattachSnapshot = getSshMainModelSnapshotProbe(ptyId)
       // Why consume-once: only the first reattach of a reveal remount may pay
       // the probe; a later in-place reconnect on this same mount must not buy a
       // second timeout before the relay paint.
@@ -8245,6 +8321,8 @@ export function connectPanePty(
       )
       const legacyWorkerOwnsPane = isLegacyWorkerAutomaticResumeBlocked()
       if (gate.enterDeferredFlow && (!legacyWorkerOwnsPane || !gate.sshConnected)) {
+        // Paint main's parked model while SSH recovery continues off the render path.
+        prepaintParkedSshSnapshot(pendingSessionId)
         void (async () => {
           // Why: for a passphrase target with no cached credential, don't auto-fire ssh.connect — a prompt popping just from focusing a tab / Cmd+J would surprise the user.
           // Wait for a user-initiated connect first; no-passphrase targets return false here and auto-connect as before.
@@ -8607,6 +8685,7 @@ export function connectPanePty(
     if (deferredReattachSessionId) {
       allowInitialIdleCacheSeed = true
       recordPtyConnectDiagnostic(`pane=${pane.id} -> REATTACH ${deferredReattachSessionId}`)
+      prepaintParkedSshSnapshot(deferredReattachSessionId)
 
       // Why: pre-signal (declare) before the reattach connect so the cooperation gate suppresses the daemon seed for this paneKey; Electron preserves IPC order.
       // See docs/mobile-prefer-renderer-scrollback.md (Renderer-side prerequisite requirement #4).


### PR DESCRIPTION
## Summary

- paint the trusted main-process headless snapshot as soon as a parked SSH terminal is revealed
- keep SSH connection and PTY reattach in the background, with the completed remote attach remaining authoritative
- reject mismatched SSH identities and obsolete recovery generations, and share the bounded snapshot probe so fallback never pays a second timeout
- fence late parked snapshots when an expired reattach hands authority to a fresh PTY or retained legacy PTY

## Root cause

SSH establishment can spend roughly one minute in retry and durable-PTY recovery paths. The renderer already had a usable headless terminal model locally, but it waited for the network attach to settle before requesting and painting that snapshot.

A delayed snapshot also remained eligible to paint when an expired reattach started a fresh replacement shell, which could clear and overwrite output from the new authoritative PTY.

## Reliability

- Invariant: terminal-provider.ssh-remote-reattach-contract — a parked SSH reveal may paint only a trusted snapshot for its exact SSH authority and retry generation; any remote reattach, fresh spawn, or retained-PTY attach supersedes that cosmetic paint.
- Failure source: parked SSH reveal latency plus delayed snapshot settlement during expired-session recovery.
- Oracle: deterministic tests prove prepaint before the SSH connection promise settles, foreign-connection and replaced-lease rejection, fresh-shell fencing, and exactly one bounded snapshot probe; Docker E2E proves deep scrollback survives park and reveal.
- Gate: existing experimental terminal-provider.ssh-remote-reattach-contract.
- Provider and platform coverage: direct SSH and local renderer behavior are covered on macOS; local, daemon, remote-runtime, WSL, and mobile ownership paths are unchanged. Linux and Windows renderer execution remain the existing live-platform gap, with platform-neutral unit coverage and Windows packaging CI.
- Performance budget: one memoized bounded main-model query per parked reveal, no polling, provider inventory, subprocess, retry loop, or retained buffer added.
- Diagnostics: existing PTY connection and reattach lifecycle diagnostics retain the pane, tab, PTY, and generation evidence.
- Residual gap: the live Docker provider runs on Linux behind a macOS Electron renderer; physical Linux and Windows direct-SSH reveal runs were not collected.

## Validation

- pnpm run lint
- pnpm run typecheck
- 559 terminal connection and SSH model tests
- red/green delayed-snapshot authority regression test
- Docker-backed SSH parking and reveal E2E
- Electron renderer, terminal input/output, and PR checks through CDP in an isolated profile
- 42 GitHub checks passing