### PR TITLE
fix(runtime): make sibling-workspace terminal-path resolution an explicit client opt-in

### DIFF
--- a/mobile/src/session/mobile-file-tap-open.test.ts
+++ b/mobile/src/session/mobile-file-tap-open.test.ts
@@ -64,7 +64,12 @@ describe('openMobileFileTap', () => {
 
     expect(client.sendRequest).toHaveBeenCalledWith(
       'files.resolveTerminalPath',
-      { worktree: 'id:wt-1', pathText: '/tmp/result.json', terminal: 'terminal-1' },
+      {
+        worktree: 'id:wt-1',
+        pathText: '/tmp/result.json',
+        terminal: 'terminal-1',
+        crossWorkspace: true
+      },
       { timeoutMs: 10_000 }
     )
     expect(pushPreviewRoute).toHaveBeenCalledWith({
@@ -322,7 +327,13 @@ describe('openMobileFileTap', () => {
 
     expect(client.sendRequest).toHaveBeenCalledWith(
       'files.resolveTerminalPath',
-      { worktree: 'id:wt-1', pathText: 'index.ts', terminal: 'term-1', cwd: '/repo/src' },
+      {
+        worktree: 'id:wt-1',
+        pathText: 'index.ts',
+        terminal: 'term-1',
+        cwd: '/repo/src',
+        crossWorkspace: true
+      },
       { timeoutMs: 10_000 }
     )
   })

--- a/mobile/src/session/mobile-file-tap-open.ts
+++ b/mobile/src/session/mobile-file-tap-open.ts
@@ -75,6 +75,8 @@ async function openMobileFileTapAsync<T extends FileTapSessionTab>(
     {
       worktree,
       pathText: options.pathText,
+      // Why: opts into sibling-workspace resolutions; this caller honors resolved.worktree.
+      crossWorkspace: true,
       ...(options.terminalHandle && options.terminalHandle.trim().length > 0
         ? { terminal: options.terminalHandle }
         : {}),

--- a/mobile/src/session/mobile-native-chat-open-file.test.ts
+++ b/mobile/src/session/mobile-native-chat-open-file.test.ts
@@ -60,7 +60,7 @@ describe('openMobileNativeChatFileTap', () => {
 
     expect(sendRequest).toHaveBeenCalledWith(
       'files.resolveTerminalPath',
-      { worktree: 'id:wt-1', pathText: 'src/app.ts' },
+      { worktree: 'id:wt-1', pathText: 'src/app.ts', crossWorkspace: true },
       { timeoutMs: 10_000 }
     )
   })
@@ -74,7 +74,7 @@ describe('openMobileNativeChatFileTap', () => {
 
     expect(sendRequest).toHaveBeenCalledWith(
       'files.resolveTerminalPath',
-      { worktree: 'id:wt-1', pathText: 'src/app.ts' },
+      { worktree: 'id:wt-1', pathText: 'src/app.ts', crossWorkspace: true },
       { timeoutMs: 10_000 }
     )
     expect(options.triggerOpenFeedback).toHaveBeenCalledTimes(1)

--- a/mobile/src/session/use-mobile-file-tap-handlers.test.ts
+++ b/mobile/src/session/use-mobile-file-tap-handlers.test.ts
@@ -98,7 +98,13 @@ describe('useMobileFileTapHandlers', () => {
 
     expect(sendRequest).toHaveBeenCalledWith(
       'files.resolveTerminalPath',
-      { worktree: 'id:wt-1', pathText: 'index.ts', terminal: 'terminal-1', cwd: '/repo/sub' },
+      {
+        worktree: 'id:wt-1',
+        pathText: 'index.ts',
+        terminal: 'terminal-1',
+        cwd: '/repo/sub',
+        crossWorkspace: true
+      },
       { timeoutMs: 10_000 }
     )
   })
@@ -126,7 +132,7 @@ describe('useMobileFileTapHandlers', () => {
 
     expect(sendRequest).toHaveBeenCalledWith(
       'files.resolveTerminalPath',
-      { worktree: 'id:wt-1', pathText: 'mobile/src/x.ts' },
+      { worktree: 'id:wt-1', pathText: 'mobile/src/x.ts', crossWorkspace: true },
       { timeoutMs: 10_000 }
     )
     expect(options.reportChatTapFailure).toHaveBeenCalledWith("Couldn't open mobile/src/x.ts:12")

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -836,9 +836,17 @@ describe('RuntimeFileCommands', () => {
       commands: RuntimeFileCommands,
       pathText: string,
       cwd: string | null = null,
-      clientId = 'client-a'
+      clientId = 'client-a',
+      crossWorkspace = false
     ) {
-      return commands.resolveTerminalPath('id:wt-1', pathText, cwd, clientId, 'term-1')
+      return commands.resolveTerminalPath(
+        'id:wt-1',
+        pathText,
+        cwd,
+        clientId,
+        'term-1',
+        crossWorkspace
+      )
     }
 
     function createRemoteTerminalArtifactGrantFixture(artifactPath = '/tmp/result.json') {
@@ -911,7 +919,14 @@ describe('RuntimeFileCommands', () => {
       })
       statAsFile()
 
-      const result = await commands.resolveTerminalPath('id:wt-1', '/sibling/docs/readme.md')
+      const result = await commands.resolveTerminalPath(
+        'id:wt-1',
+        '/sibling/docs/readme.md',
+        null,
+        undefined,
+        null,
+        true
+      )
 
       expect(resolveKnownWorkspaceFileTarget).toHaveBeenCalledWith(
         '/sibling/docs/readme.md',
@@ -958,7 +973,7 @@ describe('RuntimeFileCommands', () => {
       resolveAuthorizedPathMock.mockImplementation(async (p: string) => p)
       statMock.mockResolvedValue({ isDirectory: () => true })
 
-      const result = await resolveTerminalArtifactPath(commands, '/sibling')
+      const result = await resolveTerminalArtifactPath(commands, '/sibling', null, 'client-a', true)
 
       expect(resolveKnownWorkspaceFileTarget).toHaveBeenCalledWith('/sibling', 'local')
       expect(result).toEqual({
@@ -999,7 +1014,14 @@ describe('RuntimeFileCommands', () => {
       const remoteStat = vi.fn().mockResolvedValue({ type: 'file', size: 12, mtime: 3 })
       vi.mocked(getSshFilesystemProvider).mockReturnValue({ stat: remoteStat } as never)
 
-      const result = await commands.resolveTerminalPath('id:wt-1', '/sibling/docs/readme.md')
+      const result = await commands.resolveTerminalPath(
+        'id:wt-1',
+        '/sibling/docs/readme.md',
+        null,
+        undefined,
+        null,
+        true
+      )
 
       expect(resolveKnownWorkspaceFileTarget).toHaveBeenCalledWith(
         '/sibling/docs/readme.md',
@@ -1044,7 +1066,7 @@ describe('RuntimeFileCommands', () => {
       const remoteStat = vi.fn().mockResolvedValue({ type: 'directory', size: 0, mtime: 3 })
       vi.mocked(getSshFilesystemProvider).mockReturnValue({ stat: remoteStat } as never)
 
-      const result = await resolveTerminalArtifactPath(commands, '/sibling')
+      const result = await resolveTerminalArtifactPath(commands, '/sibling', null, 'client-a', true)
 
       expect(resolveKnownWorkspaceFileTarget).toHaveBeenCalledWith('/sibling', 'ssh:ssh-1')
       expect(remoteStat).toHaveBeenCalledWith('/sibling')
@@ -1068,12 +1090,49 @@ describe('RuntimeFileCommands', () => {
         resolveKnownWorkspaceFileTarget
       })
 
-      await commands.resolveTerminalPath('id:wt-1', '/repo-b/docs/readme.md')
+      await commands.resolveTerminalPath(
+        'id:wt-1',
+        '/repo-b/docs/readme.md',
+        null,
+        undefined,
+        null,
+        true
+      )
 
       expect(resolveKnownWorkspaceFileTarget).toHaveBeenCalledWith(
         '/repo-b/docs/readme.md',
         'runtime:env-a'
       )
+    })
+
+    // Why: clients predating crossWorkspace (mobile <=0.0.36) reuse their own worktree
+    // id for files.open, so they must keep the pre-sibling-resolution contract.
+    it('keeps the caller worktree and a null relativePath when crossWorkspace is not requested', async () => {
+      const resolveKnownWorkspaceFileTarget = vi.fn(async () => ({
+        worktree: {
+          id: 'wt-2',
+          repoId: 'repo-2',
+          path: '/sibling',
+          git: { path: '/sibling', head: '', branch: '', isBare: false, isMainWorktree: true }
+        },
+        relativePath: 'docs/readme.md'
+      }))
+      const { commands } = createRuntimeFileCommands({
+        path: '/repo',
+        resolveKnownWorkspaceFileTarget
+      })
+      statAsFile()
+
+      const result = await commands.resolveTerminalPath('id:wt-1', '/sibling/docs/readme.md')
+
+      expect(resolveKnownWorkspaceFileTarget).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        worktree: 'wt-1',
+        relativePath: null,
+        absolutePath: '/sibling/docs/readme.md',
+        exists: false,
+        isDirectory: false
+      })
     })
 
     it('resolves a relative path against the provided cwd', async () => {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -719,7 +719,8 @@ export class RuntimeFileCommands {
     pathText: string,
     cwd?: string | null,
     clientId?: string,
-    terminalHandle?: string | null
+    terminalHandle?: string | null,
+    crossWorkspace?: boolean
   ): Promise<RuntimeTerminalPathResolution> {
     const store = this.host.requireStore()
     const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
@@ -757,8 +758,10 @@ export class RuntimeFileCommands {
       terminalFileUriHostname
     })
     const relativePath = relativePathInsideRoot(worktree.path, absolutePath)
+    // Why: clients that predate crossWorkspace reuse their own worktree id for the
+    // follow-up files.open, so retargeting to a sibling workspace must be opt-in.
     const knownWorkspaceTarget =
-      relativePath === null
+      crossWorkspace && relativePath === null
         ? await this.host.resolveKnownWorkspaceFileTarget?.(
             absolutePath,
             getRuntimeFileTargetExecutionHostId(target)

--- a/src/main/runtime/rpc/methods/files-terminal-path-resolution.test.ts
+++ b/src/main/runtime/rpc/methods/files-terminal-path-resolution.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { FILE_METHODS } from './files'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+describe('files.resolveTerminalPath RPC', () => {
+  function createDispatcher() {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveTerminalPath: vi.fn().mockResolvedValue({
+        worktree: 'wt-1',
+        relativePath: 'src/index.ts',
+        exists: true,
+        isDirectory: false
+      })
+    } as unknown as OrcaRuntimeService
+    return { runtime, dispatcher: new RpcDispatcher({ runtime, methods: FILE_METHODS }) }
+  }
+
+  it('resolves a tapped terminal path for a selected worktree', async () => {
+    const { runtime, dispatcher } = createDispatcher()
+
+    const response = await dispatcher.dispatch(
+      makeRequest('files.resolveTerminalPath', {
+        worktree: 'id:wt-1',
+        pathText: '/repo/src/index.ts',
+        cwd: '/repo',
+        terminal: 'term-1'
+      })
+    )
+
+    expect(runtime.resolveTerminalPath).toHaveBeenCalledWith(
+      'id:wt-1',
+      '/repo/src/index.ts',
+      '/repo',
+      undefined,
+      'term-1',
+      false
+    )
+    expect(response).toMatchObject({
+      ok: true,
+      result: { relativePath: 'src/index.ts', exists: true, isDirectory: false }
+    })
+  })
+
+  // Why: clients predating crossWorkspace reuse their own worktree id for the
+  // follow-up files.open, so sibling-workspace retargeting must be an explicit opt-in.
+  it('forwards crossWorkspace only when the client opts in', async () => {
+    const { runtime, dispatcher } = createDispatcher()
+
+    await dispatcher.dispatch(
+      makeRequest('files.resolveTerminalPath', {
+        worktree: 'id:wt-1',
+        pathText: '/sibling/docs/readme.md',
+        crossWorkspace: true
+      })
+    )
+
+    expect(runtime.resolveTerminalPath).toHaveBeenLastCalledWith(
+      'id:wt-1',
+      '/sibling/docs/readme.md',
+      null,
+      undefined,
+      null,
+      true
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -325,40 +325,6 @@ describe('file RPC methods', () => {
     })
   })
 
-  it('resolves a tapped terminal path for a selected worktree', async () => {
-    const runtime = {
-      getRuntimeId: () => 'test-runtime',
-      resolveTerminalPath: vi.fn().mockResolvedValue({
-        worktree: 'wt-1',
-        relativePath: 'src/index.ts',
-        exists: true,
-        isDirectory: false
-      })
-    } as unknown as OrcaRuntimeService
-    const dispatcher = new RpcDispatcher({ runtime, methods: FILE_METHODS })
-
-    const response = await dispatcher.dispatch(
-      makeRequest('files.resolveTerminalPath', {
-        worktree: 'id:wt-1',
-        pathText: '/repo/src/index.ts',
-        cwd: '/repo',
-        terminal: 'term-1'
-      })
-    )
-
-    expect(runtime.resolveTerminalPath).toHaveBeenCalledWith(
-      'id:wt-1',
-      '/repo/src/index.ts',
-      '/repo',
-      undefined,
-      'term-1'
-    )
-    expect(response).toMatchObject({
-      ok: true,
-      result: { relativePath: 'src/index.ts', exists: true, isDirectory: false }
-    })
-  })
-
   it('reads a terminal artifact through a grant-scoped method', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -74,6 +74,10 @@ const ResolveTerminalPath = WorktreeSelector.extend({
     .unknown()
     .transform((v) => (typeof v === 'string' && v.length > 0 ? v : null))
     .nullable()
+    .optional(),
+  crossWorkspace: z
+    .unknown()
+    .transform((v) => v === true)
     .optional()
 })
 
@@ -252,7 +256,8 @@ export const FILE_METHODS: RpcAnyMethod[] = [
         params.pathText,
         params.cwd ?? null,
         clientId,
-        params.terminal ?? null
+        params.terminal ?? null,
+        params.crossWorkspace === true
       )
   }),
   defineMethod({


### PR DESCRIPTION
## Problem

`files.resolveTerminalPath` (new in the 1.4.169 cycle) returns a **foreign worktree id + relativePath** when a tapped absolute path belongs to a sibling workspace — with no protocol bump or capability gate. `src/shared/protocol-version.ts`'s own rules say a response-nullability/meaning change like this requires one.

Fielded mobile **0.0.36** ignores `resolved.worktree` and reuses its own worktree id for the follow-up `files.open`, so with two worktrees of the same repo sharing a relative path, tapping the sibling's absolute path opens the **wrong worktree's copy** in the desktop editor. On 1.4.168 the same tap was a safe no-op. Found by the v1.4.169-rc.0 release scan; proven end-to-end with a runtime test (foreign id returned ungated for any clientId; 0.0.36 flow then opens its own worktree).

## Fix

New optional `crossWorkspace` request field on `files.resolveTerminalPath`; the sibling-workspace lookup only runs when the client opts in. The mobile tap flow (the one production caller that honors `resolved.worktree`) now sends it; the artifact-grant refresh intentionally does not (it only consumes grant resolutions).

Compat matrix — every pairing is safe:
- new desktop + old mobile (0.0.36): flag absent → legacy contract (`relativePath: null`, caller worktree) → safe no-op
- old desktop + new mobile: zod strips the unknown field → legacy behavior
- new + new: sibling-workspace resolution works as designed

Optional-field addition ⇒ no `RUNTIME_PROTOCOL_VERSION` bump (per the rules in `protocol-version.ts`).

## Tests

- New legacy-contract test: without the flag, `resolveKnownWorkspaceFileTarget` is never called and the response keeps the caller worktree + null relativePath. **Mutation-checked**: removing the gate fails this test.
- Existing sibling-workspace tests updated to opt in; RPC forwarding pinned both ways (absent → `false`, `true` → `true`).
- Terminal-path RPC tests moved to `files-terminal-path-resolution.test.ts` — `files.test.ts` is at the max-lines cap and per AGENTS.md that cap must not be bumped.
- 128 server + 23 mobile tests green; tsc (node project), oxlint, oxfmt clean.

## Release note

Cherry-pick candidate for the 1.4.169 release line (protects users during desktop↔mobile version skew); tracked in the v1.4.169-rc.0 release-scan tracker.