### PR TITLE
fix(terminal): keep Pi Shift+Enter newline through detection gaps

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -339,37 +339,8 @@ export function useTerminalKeyboardShortcuts({
       }
     }
 
-    // Why: this callback is installed once per active tab and invoked only for
-    // Windows Shift+Enter, keeping store work and allocations off ordinary keys.
-    const getActivePaneWindowsShiftEnterEncoding = () => {
-      const manager = managerRef.current
-      const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
-      if (!activePane) {
-        return 'alt-enter' as const
-      }
-      const state = useAppStore.getState()
-      const paneKey = makePaneKey(tabId, activePane.leafId)
-      return resolveWindowsShiftEnterEncodingForPane(state, paneKey)
-    }
-
-    // Why: host metadata is live and can hydrate after the terminal mounts;
-    // resolve it only when Shift+Enter needs to choose a byte protocol.
-    const isActivePaneWindowsTerminalHost = (): boolean => {
-      const manager = managerRef.current
-      const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
-      return (
-        resolveTerminalInputHostPlatform({
-          clientPlatform: shortcutPlatform,
-          state: useAppStore.getState(),
-          worktreeId,
-          transport: activePane ? (paneTransportsRef.current.get(activePane.id) ?? null) : null
-        }) === 'win32'
-      )
-    }
-
-    // Why: the active pane's live PTY session decides whether Ctrl+Arrow should
-    // pass through as native \e[1;5C/\e[1;5D or be translated to \eb/\ef.
-    // Resolved lazily so session/runtime lookups stay off other keystrokes.
+    // Why: foreground proof and Ctrl+Arrow translation are local ConPTY-only;
+    // resolve lazily so session/runtime lookups stay off ordinary keystrokes.
     const isLocalWindowsConptyPane = (): boolean => {
       const manager = managerRef.current
       const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
@@ -388,6 +359,40 @@ export function useTerminalKeyboardShortcuts({
         fallbackCwd,
         transport: paneTransportsRef.current.get(activePane.id) ?? null
       })
+    }
+
+    // Why: this callback is installed once per active tab and invoked only for
+    // Windows Shift+Enter, keeping store work and allocations off ordinary keys.
+    const getActivePaneWindowsShiftEnterEncoding = () => {
+      const manager = managerRef.current
+      const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
+      if (!activePane) {
+        return 'alt-enter' as const
+      }
+      const state = useAppStore.getState()
+      const paneKey = makePaneKey(tabId, activePane.leafId)
+      return resolveWindowsShiftEnterEncodingForPane(
+        state,
+        paneKey,
+        isLocalWindowsConptyPane()
+          ? state.runtimePaneTitlesByTabId[tabId]?.[activePane.id]
+          : undefined
+      )
+    }
+
+    // Why: host metadata is live and can hydrate after the terminal mounts;
+    // resolve it only when Shift+Enter needs to choose a byte protocol.
+    const isActivePaneWindowsTerminalHost = (): boolean => {
+      const manager = managerRef.current
+      const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
+      return (
+        resolveTerminalInputHostPlatform({
+          clientPlatform: shortcutPlatform,
+          state: useAppStore.getState(),
+          worktreeId,
+          transport: activePane ? (paneTransportsRef.current.get(activePane.id) ?? null) : null
+        }) === 'win32'
+      )
     }
 
     // Why: the pane's TUI opted into kitty keyboard reporting via CSI > u;

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7190,6 +7190,7 @@ describe('connectPanePty', () => {
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
       agent: 'droid',
+      routingRevoked: true,
       shellForeground: false
     })
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
@@ -23218,6 +23219,7 @@ describe('connectPanePty', () => {
       await vi.advanceTimersByTimeAsync(1)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'droid',
+        routingRevoked: true,
         shellForeground: false
       })
 
@@ -23260,6 +23262,7 @@ describe('connectPanePty', () => {
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'pi',
+        routingRevoked: true,
         shellForeground: false
       })
       expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2183,6 +2183,7 @@ export function connectPanePty(
     // as a hint, but revoke bytes until one current provider confirmation lands.
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
       agent: foreground.agent,
+      routingRevoked: true,
       shellForeground: false
     })
     visibleForegroundSamplePending = false

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -23,7 +23,79 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'pi' })).toBe('alt-enter')
   })
 
-  it('does not let hook or OSC-derived status forge Droid input routing', () => {
+  it('recovers Pi CSI-u from its explicit title when process trust is unavailable', () => {
+    const state = {
+      paneForegroundAgentByPaneKey: {
+        'tab:pane': { agent: null, shellForeground: false }
+      },
+      agentLaunchConfigByPaneKey: {}
+    }
+
+    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', '⠸ Pi')).toBe('csi-u')
+    expect(
+      resolveWindowsShiftEnterEncodingForPane(
+        { paneForegroundAgentByPaneKey: {}, agentLaunchConfigByPaneKey: {} },
+        'tab:pane',
+        'Pi ready'
+      )
+    ).toBe('csi-u')
+  })
+
+  it('keeps trusted process and shell evidence authoritative over titles', () => {
+    const state = {
+      paneForegroundAgentByPaneKey: {
+        'tab:pane': {
+          agent: 'codex' as const,
+          routingTrusted: true,
+          shellForeground: false
+        }
+      },
+      agentLaunchConfigByPaneKey: {}
+    }
+
+    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', 'Pi ready')).toBe('alt-enter')
+    expect(
+      resolveWindowsShiftEnterEncodingForPane(
+        {
+          paneForegroundAgentByPaneKey: {
+            'tab:pane': { agent: null, shellForeground: true }
+          },
+          agentLaunchConfigByPaneKey: {}
+        },
+        'tab:pane',
+        'Pi ready'
+      )
+    ).toBe('alt-enter')
+  })
+
+  it('does not let a stale title undo explicit routing revocation', () => {
+    const state = {
+      paneForegroundAgentByPaneKey: {
+        'tab:pane': {
+          agent: 'pi' as const,
+          routingRevoked: true,
+          shellForeground: false
+        }
+      },
+      agentLaunchConfigByPaneKey: {}
+    }
+
+    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', 'Pi ready')).toBe('alt-enter')
+  })
+
+  it('keeps legacy bytes for plain shell and unsupported-agent titles', () => {
+    const state = {
+      paneForegroundAgentByPaneKey: {},
+      agentLaunchConfigByPaneKey: {}
+    }
+
+    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', 'C:\\work\\pi-project')).toBe(
+      'alt-enter'
+    )
+    expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', 'Codex')).toBe('alt-enter')
+  })
+
+  it('does not let hook status route bytes without a pane title or process proof', () => {
     const state = {
       paneForegroundAgentByPaneKey: {},
       agentStatusByPaneKey: {

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
@@ -1,5 +1,6 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
+import { resolveCommittedTitleAgentType } from '../../lib/pane-agent-evidence'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export type WindowsShiftEnterEncoding = 'alt-enter' | 'csi-u'
@@ -34,10 +35,26 @@ export function resolveWindowsShiftEnterEncoding(
 /** Resolves only pane-keyed evidence so a split sibling cannot inherit tab ownership. */
 export function resolveWindowsShiftEnterEncodingForPane(
   state: WindowsShiftEnterPaneState,
-  paneKey: string
+  paneKey: string,
+  terminalTitle?: string
 ): WindowsShiftEnterEncoding {
-  return resolveWindowsShiftEnterEncoding({
+  const foreground = state.paneForegroundAgentByPaneKey[paneKey]
+  const encoding = resolveWindowsShiftEnterEncoding({
     foreground: state.paneForegroundAgentByPaneKey[paneKey],
     launchAgentType: state.agentLaunchConfigByPaneKey[paneKey]?.identity.agentType
   })
+  if (
+    encoding === 'csi-u' ||
+    !terminalTitle ||
+    foreground?.routingTrusted === true ||
+    foreground?.routingRevoked === true ||
+    foreground?.shellForeground === true
+  ) {
+    return encoding
+  }
+  // Why: strict pane-local titles recover Pi/Droid through process-scan gaps without overriding process or shell proof.
+  const titleAgent = resolveCommittedTitleAgentType(terminalTitle)
+  return titleAgent
+    ? (TUI_AGENT_CONFIG[titleAgent].windowsShiftEnterEncoding ?? 'alt-enter')
+    : 'alt-enter'
 }

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -28,6 +28,14 @@ describe('pane foreground agent slice', () => {
       .setPaneForegroundAgent('tab-1:leaf-1', { agent: 'aider', shellForeground: false })
     expect(store.getState().paneForegroundAgentByPaneKey).toBe(first)
 
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'aider',
+      routingRevoked: true,
+      shellForeground: false
+    })
+    expect(store.getState().paneForegroundAgentByPaneKey).not.toBe(first)
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.routingRevoked).toBe(true)
+
     store.getState().clearPaneForegroundAgent('tab-1:leaf-1')
     expect(store.getState().paneForegroundAgentByPaneKey).toEqual({})
   })

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -7,6 +7,8 @@ export type PaneForegroundAgentEntry = {
   agent: TuiAgent | null
   /** True only when fresh provider evidence is safe for input-byte routing. */
   routingTrusted?: boolean
+  /** True after exit/input evidence revokes routing until provider confirmation. */
+  routingRevoked?: boolean
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
@@ -41,6 +43,7 @@ export const createPaneForegroundAgentSlice: StateCreator<
         current &&
         current.agent === entry.agent &&
         current.routingTrusted === entry.routingTrusted &&
+        current.routingRevoked === entry.routingRevoked &&
         current.shellForeground === entry.shellForeground
       ) {
         return s


### PR DESCRIPTION
## Summary

- Keep Windows Shift+Enter as a newline in Pi when foreground-process trust temporarily disappears during tool churn, typed launches, or pane restore.
- Use only the active local Windows ConPTY pane's strict explicit agent title as the fallback; trusted process identity and confirmed shell state remain authoritative.
- Record explicit routing revocation so a stale Pi/Droid title cannot re-enable CSI-u after exit, Ctrl+C, or focus reconfirmation.

## ELI5

Orca already knew the right "newline" code for Pi, but it only used it while a short-lived process check said "this is definitely Pi." Tool runs and restarts can briefly hide Pi from that check, so Orca sent Pi the old Enter-like code and Pi submitted the message.

Now, during only that blind spot, Orca can also read the active pane's explicit "Pi" nameplate and keep sending the newline code. A real process check, a confirmed shell, or an explicit "stop trusting this pane" signal still wins, so ordinary shells and other agents keep their previous behavior.

## Why this preserves both behaviors

- Trusted foreground process evidence wins over the title.
- Confirmed shell evidence wins over the title.
- Exit/input/focus revocation blocks the title until a provider confirms the agent again.
- The title is pane-local, so split siblings cannot inherit it.
- Strict title parsing rejects cwd fragments such as `C:\work\pi-project`.
- Only agents already configured for CSI-u (Pi/Droid) can opt into it; Codex and other agents retain Esc+Enter.
- Title fallback is limited to local Windows ConPTY, where Orca has the process/shell confirmation lifecycle needed to retire stale titles. SSH, WSL, remote runtimes, macOS, and Linux retain the existing path.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — required static analysis CI passed every lint, freshness, localization, reliability, and max-lines stage.
- [x] `pnpm typecheck`
- [x] `pnpm test` — all 32 Node 24/26 test shards passed in required PR CI; the focused local suite passed 627/627.
- [x] `pnpm build` — Linux and Windows package jobs passed, including packaged CLI smoke tests.
- [x] Added high-quality regression tests for title fallback, authoritative process/shell precedence, explicit revocation, cwd false positives, unsupported agents, and Zustand persistence.

## Proof

Red/green regression:

- Before the implementation, the new tool-churn/restore title case failed: expected `csi-u`, received `alt-enter`.
- After the implementation: 627/627 affected terminal, foreground lifecycle, shortcut, title-evidence, and store tests pass.

Commands:

- `pnpm exec vitest run --config config/vitest.config.ts ...terminal-windows-shift-enter.test.ts ...keyboard-handlers.test.ts ...terminal-shortcut-policy.test.ts ...pane-agent-evidence.test.ts ...pane-foreground-agent.test.ts ...pty-connection.test.ts` — 627 passed after the final SSH/local boundary change.
- `pnpm run typecheck` — node, CLI, and web typechecks pass.
- Changed-file Oxlint, type-aware Oxlint, React Doctor lint, Oxfmt check, and `git diff --check` — pass.
- `pnpm run check:max-lines-ratchet` — pass; no new bypasses.
- `pnpm run check:reliability-gates` — 66 gates pass.
- Required PR CI — 40 successful jobs, 1 expected E2E skip, and the final verify aggregator passed on `fdfea2182d`.

## AI Review Report

Reviewed the regression against merged PR #11769 and closed PR #12299, then traced process trust, OSC titles, restored panes, no-OSC Git Bash/cmd lifecycle, split ownership, IME shortcut dispatch, and local/remote transports.

Main findings and actions:

- Raw title fallback could undo the safety revocation added by #11769; added `routingRevoked` and precedence tests.
- Remote/SSH panes do not have local process confirmation to retire a stale title; limited fallback to local Windows ConPTY.
- CodeRabbit requested proof that `routingRevoked` is stored, not just that Zustand replaces the map; added the direct value assertion.
- Cross-platform review confirmed no shortcut labels, paths, shell commands, or Electron menu accelerators changed. macOS/Linux/WSL/SSH/remote runtime routing is unchanged.

## Security Audit

Terminal OSC titles are untrusted process output. The fallback therefore:

- uses the existing strict committed-title parser rather than substring matching;
- is scoped to the active pane and local Windows ConPTY;
- cannot override trusted process evidence, confirmed shell evidence, or explicit routing revocation;
- only selects an existing allowlisted per-agent byte encoding and performs no command execution, path access, auth, secret, dependency, or IPC expansion.

No follow-up security work is required for this change.

## Notes

- User-visible effect is local Windows Pi/Droid terminal input only.
- The issue comment's proposed `sendInputImmediate` change is intentionally out of scope: local IPC already drains in the same turn, while changing remote batching would broaden ordering/performance risk without fixing the incorrect-byte root cause.
- Required PR CI must be green before merge.

Closes #12541
