### PR TITLE
fix(worktrees): stop a stale scan from pruning freshly recorded lineage

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-09",
+  "updatedAt": "2026-08-10",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -10,6 +10,127 @@
     }
   },
   "gates": [
+    {
+      "id": "git-worktree.lineage-scan-create-ordering",
+      "title": "Worktree scans prune only lineage they could have observed",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "worktree-runtime",
+      "layer": "main-process-git-lineage-contract",
+      "surfaces": [
+        "local worktree discovery",
+        "SSH worktree discovery",
+        "runtime-host worktree discovery",
+        "workspace lineage pruning"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "ssh", "paired-runtime", "folder-workspace"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "ssh", "paired-runtime", "folder-workspace"],
+      "coverageNotes": "A real macOS Git repository pins discovery before a real linked-worktree create, rolls the wall clock backward, and releases pruning only after both lineage records advance the Store-owned causal revision. Deterministic Store, IPC, and runtime tests cover every lineage mutation owner, forward clock skew, SSH providers, cached and joined scans, scan failures, host ownership, and folder-workspace bypass; live Linux, Windows, SSH transport, and paired-runtime journeys remain uncollected.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/pull/12631"],
+      "invariant": "A successful worktree listing may prune missing lineage only when the Store-owned lineage revision still equals the causal revision captured before listing began. Missing or mismatched authority fails closed regardless of wall-clock rollback or forward skew; cached or joined listings retain their original revision, failed scans never prune, one execution host cannot mutate another host's lineage, and folder workspaces never enter Git-worktree pruning.",
+      "oracle": "Hold prune application behind an explicit barrier after a real Git worktree listing, create a real linked worktree, roll the wall clock backward, advance both Store lineage records, then release the stale listing and require both records to survive while a fresh listing contains the child. Separately require a revision-matched scan to prune forward-skewed stale lineage, and pin capture, mutation, cache, local, SSH, failed, multi-host, and folder-workspace seams without elapsed-time waits.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/worktree-lineage-pruning-real-git.test.ts src/main/worktree-lineage-pruning.test.ts src/main/runtime/repo-worktree-resolution-scan.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts --reporter=dot",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts --reporter=dot"
+      ],
+      "testFiles": [
+        "src/main/worktree-lineage-pruning-real-git.test.ts",
+        "src/main/worktree-lineage-pruning.test.ts",
+        "src/main/runtime/repo-worktree-resolution-scan.test.ts",
+        "src/main/persistence.test.ts",
+        "src/main/ipc/worktrees.test.ts",
+        "src/main/runtime/orca-runtime.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/worktree-lineage-pruning-real-git.test.ts",
+          "assertions": [
+            "discovery completed before the physical child worktree and causal lineage revision existed",
+            "wall-clock rollback after discovery cannot authorize destructive pruning",
+            "a fresh real Git listing contains the child after creation",
+            "stale discovery removes neither worktree nor workspace lineage"
+          ]
+        },
+        {
+          "file": "src/main/worktree-lineage-pruning.test.ts",
+          "assertions": [
+            "causally newer lineage fails closed even when its timestamp rolls backward",
+            "causally old forward-skewed lineage remains prunable",
+            "cached replay preserves the original lineage revision",
+            "host ownership prevents cross-host lineage mutation"
+          ]
+        },
+        {
+          "file": "src/main/runtime/repo-worktree-resolution-scan.test.ts",
+          "assertions": [
+            "successful scans retain the causal revision supplied before listing starts",
+            "Git execution failure remains non-authoritative"
+          ]
+        },
+        {
+          "file": "src/main/persistence.test.ts",
+          "assertions": [
+            "each worktree and workspace lineage set/removal advances the revision",
+            "metadata, folder cleanup, and identity migration advance the same authority"
+          ]
+        },
+        {
+          "file": "src/main/ipc/worktrees.test.ts",
+          "assertions": [
+            "SSH listing retains its pre-create revision while causal lineage lands",
+            "provider failure and folder workspaces do not apply Git pruning"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orca-runtime.test.ts",
+          "assertions": [
+            "runtime local and SSH scan failures preserve lineage",
+            "bounded scan caching shares one in-flight provider call",
+            "folder-repo detection remains outside Git-worktree pruning"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/worktree-lineage-pruning-real-git.test.ts src/main/worktree-lineage-pruning.test.ts src/main/runtime/repo-worktree-resolution-scan.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 14,
+          "summary": "The focused causal-order gate plus Store revision slice passed locally, including real-Git rollback, forward-skew cleanup, scan capture, SSH race, failure, ownership, folder, cache, and mutation-owner contracts."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "real Git barrier plus main-process Store, worktree scan, and lineage contracts"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "New deterministic barrier gate; it has one local pass and no soak history."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The byte-identical real-Git rollback oracle removes both newly recorded lineage records on origin/main, the timestamp candidate, and the causal gate disabled, while the corrected candidate preserves both; the forward-skew oracle proves corrected cleanup does not depend on createdAt."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The product change carries one number per cached or in-flight scan and performs one constant-time Store revision read/comparison before iterating lineage. Mutation owners increment one process-local number. It adds no scans, Git subprocesses, provider calls, polling, timers, listeners, retries, wire fields, or fanout."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive CI passes or 14 days of soak history.",
+        "Run the real barrier on Linux and Windows with Git 2.25.5.",
+        "Collect one live direct-SSH and one headed paired-runtime host journey."
+      ],
+      "knownGaps": [
+        "The real Git barrier ran on macOS with Git 2.50.1, not physical Linux or Windows.",
+        "SSH and paired-runtime paths are deterministic provider/runtime contracts rather than live transports.",
+        "The local Git 2.25.5 matrix covers the unchanged listing command contract separately, not this real-worktree barrier file."
+      ],
+      "demotionRule": "Demote if a pre-create listing can remove later lineage, failed or wrong-host scans mutate lineage, the gate gains elapsed-time sleeps, or scan/provider/subprocess counts increase."
+    },
     {
       "id": "editor.restored-sibling-owner-reparent",
       "title": "Restored sibling tabs migrate filesystem authority before becoming editable",

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -312,9 +312,11 @@ describe('registerWorktreeHandlers', () => {
     getProjectHostSetups: vi.fn(),
     removeWorktreeMeta: vi.fn(),
     removeWorkspaceSessionStateForWorktree: vi.fn(),
+    getLineageRevision: vi.fn(),
     getAllWorktreeLineage: vi.fn(),
     removeWorktreeLineage: vi.fn(),
     getAllWorkspaceLineage: vi.fn(),
+    removeWorkspaceLineage: vi.fn(),
     getFolderWorkspaces: vi.fn(),
     getProjectGroups: vi.fn()
   }
@@ -395,9 +397,11 @@ describe('registerWorktreeHandlers', () => {
       store.getProjectHostSetups,
       store.removeWorktreeMeta,
       store.removeWorkspaceSessionStateForWorktree,
+      store.getLineageRevision,
       store.getAllWorktreeLineage,
       store.removeWorktreeLineage,
       store.getAllWorkspaceLineage,
+      store.removeWorkspaceLineage,
       store.getFolderWorkspaces,
       store.getProjectGroups,
       killAllProcessesForWorktreeMock,
@@ -463,6 +467,7 @@ describe('registerWorktreeHandlers', () => {
         updatedAt: 0
       }
     ])
+    store.getLineageRevision.mockReturnValue(0)
     store.getAllWorktreeLineage.mockReturnValue({})
     store.getAllWorkspaceLineage.mockReturnValue({})
     store.getFolderWorkspaces.mockReturnValue([])
@@ -6496,6 +6501,131 @@ describe('registerWorktreeHandlers', () => {
       'repo-ssh::/remote/missing-parent',
       expect.objectContaining({ instanceId: expect.any(String) })
     )
+  })
+
+  it('fails closed when SSH lineage changes while the listing is in flight', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1'
+    }
+    // The listing stays pending so the revision capture cannot slide to completion.
+    let startListing: () => void = () => {}
+    let finishListing: (worktrees: unknown[]) => void = () => {}
+    const listingStarted = new Promise<void>((resolve) => {
+      startListing = resolve
+    })
+    const listing = new Promise<unknown[]>((resolve) => {
+      finishListing = resolve
+    })
+    const provider = {
+      listWorktrees: vi.fn().mockImplementation(() => {
+        startListing()
+        return listing
+      })
+    }
+    let worktreeLineage: Record<string, unknown> = {}
+    let workspaceLineage: Record<string, unknown> = {}
+    let lineageRevision = 0
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    store.getLineageRevision.mockImplementation(() => lineageRevision)
+    getSshGitProviderMock.mockReturnValue(provider)
+    store.getAllWorktreeLineage.mockImplementation(() => worktreeLineage)
+    store.getAllWorkspaceLineage.mockImplementation(() => workspaceLineage)
+    store.getWorktreeMeta.mockReturnValue(undefined)
+
+    const listed = handlers['worktrees:list'](null, { repoId: 'repo-ssh' })
+    await listingStarted
+
+    worktreeLineage = {
+      'repo-ssh::/remote/just-created': {
+        parentWorktreeId: 'repo-ssh::/remote/live',
+        createdAt: -10_000
+      },
+      'repo-ssh::/remote/long-gone': {
+        parentWorktreeId: 'repo-ssh::/remote/live',
+        createdAt: 1
+      }
+    }
+    workspaceLineage = {
+      'worktree:repo-ssh::/remote/just-created': {
+        childWorkspaceKey: 'worktree:repo-ssh::/remote/just-created',
+        parentWorkspaceKey: 'worktree:repo-ssh::/remote/live',
+        createdAt: -10_000
+      }
+    }
+    lineageRevision += 1
+
+    finishListing([
+      {
+        path: '/remote/live',
+        head: 'abc123',
+        branch: 'refs/heads/live',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    await listed
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith('repo-ssh::/remote/long-gone')
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith('repo-ssh::/remote/just-created')
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalledWith(
+      'worktree:repo-ssh::/remote/just-created'
+    )
+  })
+
+  it('captures local lineage authority before the listing runs', async () => {
+    const repo = {
+      id: 'repo-local',
+      path: '/local/repo',
+      displayName: 'local',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    let startListing: () => void = () => {}
+    let finishListing: (worktrees: unknown[]) => void = () => {}
+    const listingStarted = new Promise<void>((resolve) => {
+      startListing = resolve
+    })
+    const listing = new Promise<unknown[]>((resolve) => {
+      finishListing = resolve
+    })
+    listWorktreesMock.mockImplementation(() => {
+      startListing()
+      return listing
+    })
+    let lineageRevision = 11
+    let worktreeLineage: Record<string, unknown> = {}
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    store.getLineageRevision.mockImplementation(() => lineageRevision)
+    store.getAllWorktreeLineage.mockImplementation(() => worktreeLineage)
+    store.getAllWorkspaceLineage.mockReturnValue({})
+
+    const listed = handlers['worktrees:list'](null, { repoId: repo.id })
+    await listingStarted
+    worktreeLineage = {
+      'repo-local::/local/just-created': {
+        parentWorktreeId: 'repo-local::/local/live'
+      }
+    }
+    lineageRevision += 1
+    finishListing([
+      {
+        path: '/local/live',
+        head: 'abc123',
+        branch: 'refs/heads/live',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    await listed
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
   })
 
   it('does not repeatedly rotate already-invalid missing parent metadata', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -590,16 +590,19 @@ const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
 type DetectedWorktreeScanCacheEntry = {
   expiresAt: number
   worktrees: GitWorktreeInfo[]
+  lineageRevision: number | undefined
 }
 
 type DetectedWorktreeScan = {
   invalidated: boolean
   promise: Promise<GitWorktreeInfo[]>
+  lineageRevision: number | undefined
 }
 
 type DetectedWorktreeScanResult = {
   gitWorktrees: GitWorktreeInfo[]
   fresh: boolean
+  lineageRevision: number | undefined
 }
 
 const detectedWorktreeScanCache = new Map<string, DetectedWorktreeScanCacheEntry>()
@@ -651,25 +654,36 @@ async function listDetectedGitWorktrees(
 ): Promise<DetectedWorktreeScanResult> {
   const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
   if (repo.connectionId || isFolderRepo(repo)) {
+    const lineageRevision = store.getLineageRevision?.()
     return {
       gitWorktrees: await listRepoWorktrees(repo, localWorktreeGitOptions),
-      fresh: true
+      fresh: true,
+      lineageRevision
     }
   }
 
   const cacheKey = getDetectedWorktreeScanCacheKey(repo.id, localWorktreeGitOptions)
   const cached = detectedWorktreeScanCache.get(cacheKey)
   if (cached && cached.expiresAt > Date.now()) {
-    return { gitWorktrees: cached.worktrees, fresh: false }
+    return {
+      gitWorktrees: cached.worktrees,
+      fresh: false,
+      lineageRevision: cached.lineageRevision
+    }
   }
 
   const inFlight = detectedWorktreeScanInFlight.get(cacheKey)
   if (inFlight) {
-    return { gitWorktrees: await inFlight.promise, fresh: false }
+    return {
+      gitWorktrees: await inFlight.promise,
+      fresh: false,
+      lineageRevision: inFlight.lineageRevision
+    }
   }
 
   const scan: DetectedWorktreeScan = {
     invalidated: false,
+    lineageRevision: store.getLineageRevision?.(),
     promise: listRepoWorktrees(repo, localWorktreeGitOptions)
   }
   detectedWorktreeScanInFlight.set(cacheKey, scan)
@@ -679,10 +693,15 @@ async function listDetectedGitWorktrees(
     if (!scan.invalidated) {
       detectedWorktreeScanCache.set(cacheKey, {
         worktrees: gitWorktrees,
-        expiresAt: Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS
+        expiresAt: Date.now() + DETECTED_WORKTREE_SCAN_CACHE_TTL_MS,
+        lineageRevision: scan.lineageRevision
       })
     }
-    return { gitWorktrees, fresh: !scan.invalidated }
+    return {
+      gitWorktrees,
+      fresh: !scan.invalidated,
+      lineageRevision: scan.lineageRevision
+    }
   } finally {
     if (detectedWorktreeScanInFlight.get(cacheKey) === scan) {
       detectedWorktreeScanInFlight.delete(cacheKey)
@@ -1172,6 +1191,7 @@ async function listDetectedWorktreesForCapturedRepo(
   try {
     let gitWorktrees: GitWorktreeInfo[]
     let freshScan = true
+    let scanLineageRevision: number | undefined = store.getLineageRevision?.()
     if (isFolderRepo(repo)) {
       if (!isCurrent()) {
         return null
@@ -1214,6 +1234,7 @@ async function listDetectedWorktreesForCapturedRepo(
           worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
         }
       }
+      scanLineageRevision = store.getLineageRevision?.()
       gitWorktrees = await capturedProvider.listWorktrees(repo.path, {
         signal: providerAbort?.signal
       })
@@ -1221,6 +1242,7 @@ async function listDetectedWorktreesForCapturedRepo(
       const scan = await listDetectedGitWorktrees(store, repo)
       gitWorktrees = scan.gitWorktrees
       freshScan = scan.fresh
+      scanLineageRevision = scan.lineageRevision
     }
     const aborted = abortedResult()
     if (aborted) {
@@ -1240,7 +1262,7 @@ async function listDetectedWorktreesForCapturedRepo(
     }
     if (freshScan) {
       rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanLineageRevision)
     }
     loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
     return {
@@ -1825,6 +1847,7 @@ export function registerWorktreeHandlers(
       try {
         let gitWorktrees
         let freshScan = true
+        let scanLineageRevision: number | undefined = store.getLineageRevision?.()
         if (isFolderRepo(repo)) {
           return listVisibleFolderWorkspaces(store, repo)
         } else if (repo.connectionId) {
@@ -1838,6 +1861,7 @@ export function registerWorktreeHandlers(
             return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
           }
           loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
+          scanLineageRevision = store.getLineageRevision?.()
           try {
             gitWorktrees = await provider.listWorktrees(repo.path)
           } catch (err) {
@@ -1853,10 +1877,11 @@ export function registerWorktreeHandlers(
           const scan = await listDetectedGitWorktrees(store, repo)
           gitWorktrees = scan.gitWorktrees
           freshScan = scan.fresh
+          scanLineageRevision = scan.lineageRevision
         }
         if (freshScan) {
           rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanLineageRevision)
         }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
         return buildDetectedGitWorktrees(store, repo, gitWorktrees)
@@ -1889,6 +1914,7 @@ export function registerWorktreeHandlers(
     try {
       let gitWorktrees
       let freshScan = true
+      let scanLineageRevision: number | undefined = store.getLineageRevision?.()
       if (isFolderRepo(repo)) {
         return listVisibleFolderWorkspaces(store, repo)
       } else if (repo.connectionId) {
@@ -1902,6 +1928,7 @@ export function registerWorktreeHandlers(
           return listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
         }
         loggedUnavailableSshGitProviders.delete(`${repo.connectionId}:${repo.id}`)
+        scanLineageRevision = store.getLineageRevision?.()
         try {
           gitWorktrees = await provider.listWorktrees(repo.path)
         } catch (err) {
@@ -1917,10 +1944,11 @@ export function registerWorktreeHandlers(
         const scan = await listDetectedGitWorktrees(store, repo)
         gitWorktrees = scan.gitWorktrees
         freshScan = scan.fresh
+        scanLineageRevision = scan.lineageRevision
       }
       if (freshScan) {
         rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanLineageRevision)
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
       return buildDetectedGitWorktrees(store, repo, gitWorktrees)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -11477,6 +11477,83 @@ describe('Store.migrateTabSwitchKeybindings', () => {
   })
 })
 
+describe('Store lineage revision', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('advances for each set and actual removal', async () => {
+    const store = await createStore()
+    const childId = 'r1::/path/child'
+    const childKey = worktreeWorkspaceKey(childId)
+
+    expect(store.getLineageRevision()).toBe(0)
+    store.setWorktreeLineage(childId, makeWorktreeLineage({ worktreeId: childId }))
+    expect(store.getLineageRevision()).toBe(1)
+    store.setWorkspaceLineage(makeWorkspaceLineage({ childWorkspaceKey: childKey }))
+    expect(store.getLineageRevision()).toBe(2)
+    store.removeWorktreeLineage(childId)
+    expect(store.getLineageRevision()).toBe(3)
+    store.removeWorkspaceLineage(childKey)
+    expect(store.getLineageRevision()).toBe(4)
+
+    store.removeWorktreeLineage(childId)
+    store.removeWorkspaceLineage(childKey)
+    expect(store.getLineageRevision()).toBe(4)
+  })
+
+  it('advances once when metadata removal drops both lineage records', async () => {
+    const store = await createStore()
+    const childId = 'r1::/path/child'
+    store.setWorktreeMeta(childId, {})
+    store.setWorktreeLineage(childId, makeWorktreeLineage({ worktreeId: childId }))
+    store.setWorkspaceLineage(
+      makeWorkspaceLineage({ childWorkspaceKey: worktreeWorkspaceKey(childId) })
+    )
+    const before = store.getLineageRevision()
+
+    store.removeWorktreeMeta(childId)
+
+    expect(store.getLineageRevision()).toBe(before + 1)
+  })
+
+  it('advances when identity migration re-keys either lineage map', async () => {
+    const store = await createStore()
+    const oldId = 'r1::/path/child'
+    const newId = 'r1::/path/renamed'
+    store.setWorkspaceLineage(
+      makeWorkspaceLineage({ childWorkspaceKey: worktreeWorkspaceKey(oldId) })
+    )
+    const before = store.getLineageRevision()
+
+    store.migrateWorktreeIdentity(oldId, newId)
+
+    expect(store.getLineageRevision()).toBe(before + 1)
+  })
+
+  it('advances when folder cleanup removes child workspace lineage', async () => {
+    const store = await createStore()
+    const group = store.createProjectGroup({
+      name: 'Folder group',
+      parentPath: '/workspace/folder-group',
+      createdFrom: 'folder-scan'
+    })
+    const folder = store.createFolderWorkspace({ projectGroupId: group.id, name: 'Parent' })
+    store.setWorkspaceLineage(
+      makeWorkspaceLineage({ parentWorkspaceKey: folderWorkspaceKey(folder.id) })
+    )
+    const before = store.getLineageRevision()
+
+    store.removeFolderWorkspace(folder.id)
+
+    expect(store.getLineageRevision()).toBe(before + 1)
+  })
+})
+
 describe('Store.migrateWorktreeIdentity', () => {
   const OLD = 'repo1::/ws/cunner'
   const NEW = 'repo1::/ws/worktree-creation-spinner'

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2793,6 +2793,8 @@ export class Store {
   private pendingSnapshotFileWork: Promise<void> | null = null
   private readonly staleTempCleanup: Promise<void>
   private writeGeneration = 0
+  // A restart cannot preserve an in-flight scan, so this causal boundary is process-local.
+  private lineageRevision = 0
   private inFlightAsyncTmpFile: string | null = null
   // Prevent a sync flush from interleaving a second rotation with awaited ring mutations.
   private backupRotationInFlight = false
@@ -4767,6 +4769,7 @@ export class Store {
   // Prune worktree meta/lineage for a repo id; hostId null prunes all entries, else only that host's (missing meta.hostId = local).
   private pruneWorktreeStateForRepo(id: string, hostId: ExecutionHostId | null): void {
     const prefix = `${id}::`
+    let removedLineage = false
     // Why snapshot up front: the first loop deletes metas, so reading meta.hostId live later would misclassify an SSH worktree as local.
     const hostMembership = new Map<string, boolean>()
     const belongsToHost = (key: string): boolean => {
@@ -4848,6 +4851,7 @@ export class Store {
     for (const [childId, lineage] of Object.entries(this.state.worktreeLineageById)) {
       if (belongsToHost(childId) || belongsToHost(lineage.parentWorktreeId)) {
         delete this.state.worktreeLineageById[childId]
+        removedLineage = true
       }
     }
     for (const [childKey, lineage] of Object.entries(this.state.workspaceLineageByChildKey)) {
@@ -4855,11 +4859,16 @@ export class Store {
       const parentScope = parseWorkspaceKey(lineage.parentWorkspaceKey)
       if (childScope?.type === 'worktree' && belongsToHost(childScope.worktreeId)) {
         delete this.state.workspaceLineageByChildKey[childKey as WorkspaceKey]
+        removedLineage = true
         continue
       }
       if (parentScope?.type === 'worktree' && belongsToHost(parentScope.worktreeId)) {
         delete this.state.workspaceLineageByChildKey[childKey as WorkspaceKey]
+        removedLineage = true
       }
+    }
+    if (removedLineage) {
+      this.advanceLineageRevision()
     }
     this.pruneMobileClientTabSelections(belongsToHost)
   }
@@ -5491,9 +5500,15 @@ export class Store {
             !this.partitionHasOtherRepoWorktreeTabs(worktreeId, partition))
       )
     )
+    const removedLineage =
+      worktreeId in this.state.worktreeLineageById ||
+      worktreeWorkspaceKey(worktreeId) in this.state.workspaceLineageByChildKey
     delete this.state.worktreeMeta[worktreeId]
     delete this.state.worktreeLineageById[worktreeId]
     delete this.state.workspaceLineageByChildKey[worktreeWorkspaceKey(worktreeId)]
+    if (removedLineage) {
+      this.advanceLineageRevision()
+    }
     for (const partition of partitions) {
       this.removeWorkspaceSessionOwnerInPartition(worktreeId, partition, {
         advanceTerminalTopologyRevision: fencedPartitions.has(partition)
@@ -5506,18 +5521,31 @@ export class Store {
     return this.state.worktreeLineageById[worktreeId]
   }
 
+  getLineageRevision(): number {
+    return this.lineageRevision
+  }
+
+  private advanceLineageRevision(): void {
+    this.lineageRevision += 1
+  }
+
   getAllWorktreeLineage(): Record<string, WorktreeLineage> {
     return this.state.worktreeLineageById
   }
 
   setWorktreeLineage(worktreeId: string, lineage: WorktreeLineage): WorktreeLineage {
     this.state.worktreeLineageById[worktreeId] = lineage
+    this.advanceLineageRevision()
     this.scheduleSave()
     return lineage
   }
 
   removeWorktreeLineage(worktreeId: string): void {
+    const removed = worktreeId in this.state.worktreeLineageById
     delete this.state.worktreeLineageById[worktreeId]
+    if (removed) {
+      this.advanceLineageRevision()
+    }
     this.scheduleSave()
   }
 
@@ -5671,6 +5699,18 @@ export class Store {
       }
     }
 
+    const reKeyedLineage =
+      oldWorktreeId in this.state.worktreeLineageById ||
+      oldWorkspaceKey in this.state.workspaceLineageByChildKey ||
+      Object.values(this.state.worktreeLineageById).some(
+        (lineage) => lineage.parentWorktreeId === oldWorktreeId
+      ) ||
+      Object.values(this.state.workspaceLineageByChildKey).some(
+        (lineage) => lineage.parentWorkspaceKey === oldWorkspaceKey
+      )
+    if (reKeyedLineage) {
+      this.advanceLineageRevision()
+    }
     changed = moveKey(this.state.worktreeLineageById) || changed
     const movedLineage = this.state.worktreeLineageById[newWorktreeId]
     if (movedLineage && movedLineage.worktreeId === oldWorktreeId) {
@@ -5732,21 +5772,31 @@ export class Store {
 
   setWorkspaceLineage(lineage: WorkspaceLineage): WorkspaceLineage {
     this.state.workspaceLineageByChildKey[lineage.childWorkspaceKey] = lineage
+    this.advanceLineageRevision()
     this.scheduleSave()
     return lineage
   }
 
   removeWorkspaceLineage(childWorkspaceKey: WorkspaceKey): void {
+    const removed = childWorkspaceKey in this.state.workspaceLineageByChildKey
     delete this.state.workspaceLineageByChildKey[childWorkspaceKey]
+    if (removed) {
+      this.advanceLineageRevision()
+    }
     this.scheduleSave()
   }
 
   private removeWorkspaceLineageForFolderParent(folderWorkspaceId: string): void {
     const parentKey = folderWorkspaceKey(folderWorkspaceId)
+    let removed = false
     for (const [childKey, lineage] of Object.entries(this.state.workspaceLineageByChildKey)) {
       if (lineage.parentWorkspaceKey === parentKey) {
         delete this.state.workspaceLineageByChildKey[childKey as WorkspaceKey]
+        removed = true
       }
+    }
+    if (removed) {
+      this.advanceLineageRevision()
     }
   }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -662,16 +662,22 @@ function resetRuntimeTestMocks(): void {
   vi.mocked(listWorktreesStrict).mockResolvedValue(MOCK_GIT_WORKTREES)
   scanLocalRepoWorktreesForResolutionMock
     .mockReset()
-    .mockImplementation(async (repoPath: string, options: { wslDistro?: string }) => {
-      try {
-        const worktrees = options.wslDistro
-          ? await listWorktrees(repoPath, options)
-          : await listWorktrees(repoPath)
-        return { ok: true, worktrees }
-      } catch {
-        return { ok: false, worktrees: [] }
+    .mockImplementation(
+      async (
+        repoPath: string,
+        options: { wslDistro?: string },
+        lineageRevision: number | undefined
+      ) => {
+        try {
+          const worktrees = options.wslDistro
+            ? await listWorktrees(repoPath, options)
+            : await listWorktrees(repoPath)
+          return { ok: true, worktrees, lineageRevision }
+        } catch {
+          return { ok: false, worktrees: [] }
+        }
       }
-    })
+    )
   vi.mocked(addWorktree).mockReset()
   vi.mocked(assertWorktreeCleanForRemoval).mockReset()
   vi.mocked(assertWorktreeCleanForRemoval).mockResolvedValue(undefined)
@@ -38764,6 +38770,7 @@ describe('OrcaRuntimeService', () => {
     const setWorktreeLineage = vi.fn((_worktreeId: string, lineage) => lineage)
     const runtimeStore = {
       ...store,
+      getLineageRevision: () => 0,
       getAllWorktreeMeta: () => metaById,
       getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
       setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -20779,7 +20779,7 @@ export class OrcaRuntimeService {
       scan = { ok: false, worktrees: [] }
     }
     if (scan.ok) {
-      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees)
+      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees, scan.lineageRevision)
     }
     const agentScratchWorktreePathMatcher = createAgentScratchWorktreePathMatcher([
       repo.path,
@@ -28750,7 +28750,12 @@ export class OrcaRuntimeService {
           )) ?? { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
         const gitWorktrees = scan.worktrees
         if (scan.ok) {
-          pruneLineageForMissingRepoWorktrees(this.requireStore(), repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(
+            this.requireStore(),
+            repo,
+            gitWorktrees,
+            scan.lineageRevision
+          )
         }
         return gitWorktrees.map((gitWorktree) => {
           const worktreeId = `${repo.id}::${gitWorktree.path}`
@@ -28856,10 +28861,12 @@ export class OrcaRuntimeService {
     repo: Repo,
     projectRuntime: ProjectExecutionRuntimeResolution | undefined
   ): Promise<RuntimeWorktreeScanResult> {
+    const lineageRevision = this.requireStore().getLineageRevision?.()
     if (!repo.connectionId) {
       return await scanLocalRepoWorktreesForResolution(
         repo.path,
-        getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime)
+        getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime),
+        lineageRevision
       )
     }
     const provider = getSshGitProvider(repo.connectionId)
@@ -28867,7 +28874,11 @@ export class OrcaRuntimeService {
       return { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
     }
     try {
-      return { ok: true, worktrees: await provider.listWorktrees(repo.path) }
+      return {
+        ok: true,
+        lineageRevision,
+        worktrees: await provider.listWorktrees(repo.path)
+      }
     } catch {
       return { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
     }

--- a/src/main/runtime/repo-worktree-resolution-scan.test.ts
+++ b/src/main/runtime/repo-worktree-resolution-scan.test.ts
@@ -14,7 +14,7 @@ describe('scanLocalRepoWorktreesForResolution', () => {
       Object.assign(new Error('spawn git EAGAIN'), { code: 'EAGAIN' })
     )
 
-    await expect(scanLocalRepoWorktreesForResolution('/repo', {})).resolves.toEqual({
+    await expect(scanLocalRepoWorktreesForResolution('/repo', {}, 3)).resolves.toEqual({
       ok: false,
       worktrees: []
     })
@@ -24,8 +24,24 @@ describe('scanLocalRepoWorktreesForResolution', () => {
     vi.mocked(listWorktreesStrict).mockResolvedValue([])
 
     await expect(
-      scanLocalRepoWorktreesForResolution('/repo', { wslDistro: 'Ubuntu' })
-    ).resolves.toEqual({ ok: true, worktrees: [] })
+      scanLocalRepoWorktreesForResolution('/repo', { wslDistro: 'Ubuntu' }, 3)
+    ).resolves.toEqual({ ok: true, worktrees: [], lineageRevision: 3 })
     expect(listWorktreesStrict).toHaveBeenCalledWith('/repo', { wslDistro: 'Ubuntu' })
+  })
+
+  it('retains the causal revision supplied before the listing runs', async () => {
+    let liveRevision = 12
+    vi.mocked(listWorktreesStrict).mockImplementation(async () => {
+      liveRevision += 1
+      return []
+    })
+
+    const result = await scanLocalRepoWorktreesForResolution('/repo', {}, liveRevision)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.lineageRevision).toBe(12)
+      expect(liveRevision).toBe(13)
+    }
   })
 })

--- a/src/main/runtime/repo-worktree-resolution-scan.ts
+++ b/src/main/runtime/repo-worktree-resolution-scan.ts
@@ -3,18 +3,19 @@ import { listWorktreesStrict } from '../git/worktree'
 import type { LocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 
 export type RuntimeWorktreeScanResult =
-  | { ok: true; worktrees: GitWorktreeInfo[] }
+  | { ok: true; worktrees: GitWorktreeInfo[]; lineageRevision: number | undefined }
   | { ok: false; worktrees: GitWorktreeInfo[] }
 
 export async function scanLocalRepoWorktreesForResolution(
   repoPath: string,
-  options: LocalProjectWorktreeGitOptions
+  options: LocalProjectWorktreeGitOptions,
+  lineageRevision: number | undefined
 ): Promise<RuntimeWorktreeScanResult> {
   try {
     const worktrees = options.wslDistro
       ? await listWorktreesStrict(repoPath, options)
       : await listWorktreesStrict(repoPath)
-    return { ok: true, worktrees }
+    return { ok: true, worktrees, lineageRevision }
   } catch {
     return { ok: false, worktrees: [] }
   }

--- a/src/main/runtime/worktree-ps-degraded-repo-scan.test.ts
+++ b/src/main/runtime/worktree-ps-degraded-repo-scan.test.ts
@@ -116,6 +116,7 @@ function makeStore(options: StoreOptions = {}) {
       return metaById[id]
     },
     removeWorktreeMeta: () => {},
+    getLineageRevision: () => 0,
     getAllWorktreeLineage: () => lineageById,
     getAllWorkspaceLineage: () => ({ [`worktree:${WORKTREE_ID}`]: { parentWorkspaceKey: null } }),
     removeWorktreeLineage: options.removeWorktreeLineage ?? vi.fn(),

--- a/src/main/worktree-lineage-pruning-real-git.test.ts
+++ b/src/main/worktree-lineage-pruning-real-git.test.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, WorktreeLineage, WorkspaceLineage } from '../shared/types'
+import { worktreeWorkspaceKey } from '../shared/workspace-scope'
+import { listWorktreesStrict } from './git/worktree'
+import { pruneLineageForMissingRepoWorktrees } from './worktree-lineage-pruning'
+
+const tempRoots: string[] = []
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+afterEach(async () => {
+  vi.useRealTimers()
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('worktree lineage pruning with real Git', () => {
+  it('does not apply pre-create discovery to lineage recorded after a real worktree add', async () => {
+    const root = await realpath(await mkdtemp(path.join(tmpdir(), 'orca-lineage-race-')))
+    tempRoots.push(root)
+    const repoPath = path.join(root, 'repo')
+    const childPath = path.join(root, 'child')
+    git(root, ['init', '--quiet', repoPath])
+    git(repoPath, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
+    git(repoPath, ['config', 'user.email', 'test@example.com'])
+    git(repoPath, ['config', 'user.name', 'Test User'])
+    git(repoPath, ['commit', '--allow-empty', '--quiet', '-m', 'initial'])
+
+    const repo: Repo = {
+      id: 'repo-real',
+      path: repoPath,
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1
+    }
+    const childId = `${repo.id}::${childPath}`
+    const parentId = `${repo.id}::${repoPath}`
+    const childWorkspaceKey = worktreeWorkspaceKey(childId)
+    const scanStartedAt = 1_700_000_000_000
+    const worktreeLineageById: Record<string, WorktreeLineage> = {}
+    const workspaceLineageByChildKey: Record<string, WorkspaceLineage> = {}
+    let lineageRevision = scanStartedAt
+    const removeWorktreeLineage = vi.fn((id: string) => delete worktreeLineageById[id])
+    const removeWorkspaceLineage = vi.fn((key: string) => delete workspaceLineageByChildKey[key])
+    const store = {
+      getRepos: () => [repo],
+      getLineageRevision: () => lineageRevision,
+      getAllWorktreeLineage: () => worktreeLineageById,
+      getAllWorkspaceLineage: () => workspaceLineageByChildKey,
+      getWorktreeMeta: () => undefined,
+      removeWorktreeLineage,
+      removeWorkspaceLineage,
+      setWorktreeLineage: (id: string, lineage: WorktreeLineage) => {
+        worktreeLineageById[id] = lineage
+        lineageRevision += 1
+      },
+      setWorkspaceLineage: (lineage: WorkspaceLineage) => {
+        workspaceLineageByChildKey[lineage.childWorkspaceKey] = lineage
+        lineageRevision += 1
+      },
+      setWorktreeMeta: vi.fn()
+    }
+
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(scanStartedAt)
+    let releasePrune = (): void => {}
+    const pruneReleased = new Promise<void>((resolve) => {
+      releasePrune = resolve
+    })
+    let reportDiscovery = (_worktrees: Awaited<ReturnType<typeof listWorktreesStrict>>): void => {}
+    const discovery = new Promise<Awaited<ReturnType<typeof listWorktreesStrict>>>((resolve) => {
+      reportDiscovery = resolve
+    })
+    const scan = (async () => {
+      const scanLineageRevision = store.getLineageRevision()
+      const worktrees = await listWorktreesStrict(repoPath)
+      reportDiscovery(worktrees)
+      await pruneReleased
+      pruneLineageForMissingRepoWorktrees(store as never, repo, worktrees, scanLineageRevision)
+    })()
+
+    const discoveredWorktrees = await discovery
+    expect(discoveredWorktrees.map((worktree) => worktree.path)).not.toContain(childPath)
+    git(repoPath, ['worktree', 'add', '--quiet', '-b', 'feature/race', childPath])
+    // A wall-clock rollback must not make this causally newer write look old.
+    vi.setSystemTime(scanStartedAt - 60_000)
+    store.setWorktreeLineage(childId, {
+      worktreeId: childId,
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: parentId,
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'orchestration',
+      capture: { source: 'orchestration-context', confidence: 'explicit' },
+      createdAt: Date.now()
+    })
+    store.setWorkspaceLineage({
+      childWorkspaceKey,
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: worktreeWorkspaceKey(parentId),
+      parentInstanceId: 'parent-instance',
+      origin: 'orchestration',
+      capture: { source: 'orchestration-context', confidence: 'explicit' },
+      createdAt: Date.now()
+    })
+    releasePrune()
+    await scan
+
+    expect((await listWorktreesStrict(repoPath)).map((worktree) => worktree.path)).toContain(
+      childPath
+    )
+    expect(removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(worktreeLineageById[childId]).toBeDefined()
+    expect(workspaceLineageByChildKey[childWorkspaceKey]).toBeDefined()
+  })
+})

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -11,6 +11,8 @@ const repo: Repo = {
   addedAt: 1
 }
 
+const SCAN_LINEAGE_REVISION = 7
+
 function lineage(childId: string, parentId: string): WorktreeLineage {
   return {
     worktreeId: childId,
@@ -38,10 +40,12 @@ function workspaceLineage(childId: string, parentId: string): WorkspaceLineage {
 function createStore(
   worktreeLineageById: Record<string, WorktreeLineage>,
   workspaceLineageByChildKey: Record<string, WorkspaceLineage>,
-  metaById: Record<string, WorktreeMeta>
+  metaById: Record<string, WorktreeMeta>,
+  lineageRevision = SCAN_LINEAGE_REVISION
 ) {
   return {
     getRepos: () => [repo],
+    getLineageRevision: vi.fn(() => lineageRevision),
     getAllWorktreeLineage: () => worktreeLineageById,
     getAllWorkspaceLineage: () => workspaceLineageByChildKey,
     getWorktreeMeta: (id: string) => metaById[id],
@@ -67,7 +71,7 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     }
     const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
 
-    pruneLineageForMissingRepoWorktrees(store as never, repo, [])
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [], SCAN_LINEAGE_REVISION)
 
     expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
     expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
@@ -97,22 +101,27 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     }
     const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
 
-    pruneLineageForMissingRepoWorktrees(store as never, repo, [
-      {
-        path: '/repo/live-parent',
-        head: 'a',
-        branch: 'main',
-        isBare: false,
-        isMainWorktree: false
-      },
-      {
-        path: '/repo/live-child',
-        head: 'b',
-        branch: 'child',
-        isBare: false,
-        isMainWorktree: false
-      }
-    ])
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/live-parent',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        },
+        {
+          path: '/repo/live-child',
+          head: 'b',
+          branch: 'child',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      SCAN_LINEAGE_REVISION
+    )
 
     expect(store.removeWorktreeLineage).toHaveBeenCalledWith(missingChildId)
     expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith(liveChildId)
@@ -123,5 +132,161 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     expect(metaById[missingParentId].instanceId).not.toBe(
       missingParentEdge.parentWorktreeInstanceId
     )
+  })
+
+  it('fails closed when a causally newer write lands after scan capture', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const justCreatedId = 'repo-1::/repo/just-created'
+    const longGoneId = 'repo-1::/repo/long-gone'
+    const justCreatedEdge = { ...lineage(justCreatedId, liveParentId), createdAt: -10_000 }
+    const longGoneEdge = { ...lineage(longGoneId, liveParentId), createdAt: 1 }
+    const worktreeLineageById = {
+      [justCreatedId]: justCreatedEdge,
+      [longGoneId]: longGoneEdge
+    }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(justCreatedId)]: {
+        ...workspaceLineage(justCreatedId, liveParentId),
+        createdAt: -10_000
+      },
+      [worktreeWorkspaceKey(longGoneId)]: {
+        ...workspaceLineage(longGoneId, liveParentId),
+        createdAt: 1
+      }
+    }
+    const metaById = {
+      [liveParentId]: { instanceId: justCreatedEdge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(
+      worktreeLineageById,
+      workspaceLineageByChildKey,
+      metaById,
+      SCAN_LINEAGE_REVISION + 1
+    )
+
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/live-parent',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      SCAN_LINEAGE_REVISION
+    )
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it('prunes causally old lineage despite a forward-skewed wall clock', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const childId = 'repo-1::/repo/forward-skewed-child'
+    const edge = { ...lineage(childId, liveParentId), createdAt: Number.MAX_SAFE_INTEGER }
+    const worktreeLineageById = { [childId]: edge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(childId)]: {
+        ...workspaceLineage(childId, liveParentId),
+        createdAt: Number.MAX_SAFE_INTEGER
+      }
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, {
+      [liveParentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    })
+
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/live-parent',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      SCAN_LINEAGE_REVISION
+    )
+
+    expect(store.removeWorktreeLineage).toHaveBeenCalledWith(childId)
+    expect(store.removeWorkspaceLineage).toHaveBeenCalledWith(worktreeWorkspaceKey(childId))
+  })
+
+  it('fails closed when the store cannot report causal lineage authority', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const childId = 'repo-1::/repo/unusable-timestamp'
+    const edge = { ...lineage(childId, liveParentId), createdAt: Number.NaN }
+    const worktreeLineageById = { [childId]: edge }
+    const storeWithRevision = createStore(
+      worktreeLineageById,
+      {
+        [worktreeWorkspaceKey(childId)]: {
+          ...workspaceLineage(childId, liveParentId),
+          createdAt: Number.NaN
+        }
+      },
+      { [liveParentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta }
+    )
+
+    const { getLineageRevision: _missing, ...store } = storeWithRevision
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/live-parent',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      SCAN_LINEAGE_REVISION
+    )
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  it('protects cached replay with the scan revision captured before the write', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const childId = 'repo-1::/repo/born-after-the-listing'
+    const childEdge = { ...lineage(childId, liveParentId), createdAt: Number.NaN }
+    const worktreeLineageById = { [childId]: childEdge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(childId)]: {
+        ...workspaceLineage(childId, liveParentId),
+        createdAt: Number.NaN
+      }
+    }
+    const metaById = {
+      [liveParentId]: { instanceId: childEdge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(
+      worktreeLineageById,
+      workspaceLineageByChildKey,
+      metaById,
+      SCAN_LINEAGE_REVISION + 1
+    )
+    const listing = [
+      {
+        path: '/repo/live-parent',
+        head: 'a',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ]
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, listing, SCAN_LINEAGE_REVISION)
+    pruneLineageForMissingRepoWorktrees(store as never, repo, listing, SCAN_LINEAGE_REVISION)
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
   })
 })

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -35,8 +35,18 @@ function hasStoredRepoLineage(
 export function pruneLineageForMissingRepoWorktrees(
   store: Store,
   repo: Repo,
-  gitWorktrees: GitWorktreeInfo[]
+  gitWorktrees: GitWorktreeInfo[],
+  scanLineageRevision: number | undefined
 ): void {
+  // The listing cannot judge lineage written after it began; missing or changed
+  // store authority defers destructive cleanup to a causally newer scan.
+  if (
+    typeof store.getLineageRevision !== 'function' ||
+    !Number.isSafeInteger(scanLineageRevision) ||
+    store.getLineageRevision() !== scanLineageRevision
+  ) {
+    return
+  }
   if (
     typeof store.getAllWorktreeLineage !== 'function' ||
     typeof store.removeWorktreeLineage !== 'function'
@@ -70,6 +80,9 @@ export function pruneLineageForMissingRepoWorktrees(
       isWorkspaceKey(childWorkspaceKey)
     ) {
       store.removeWorkspaceLineage?.(childWorkspaceKey)
+      console.warn(
+        `[worktrees] dropped workspace lineage for ${childWorkspaceKey}; the scan no longer lists it`
+      )
     }
   }
   for (const [childId, lineage] of Object.entries(worktreeLineage)) {
@@ -81,6 +94,11 @@ export function pruneLineageForMissingRepoWorktrees(
       // Why: a proven-missing path must not transfer its lineage to a future checkout at that path.
       store.removeWorktreeLineage(childId)
       store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
+      // Why: this removes a link the user can see in the sidebar, so leave a trace —
+      // silent removal makes a wrongly dropped parent near-impossible to attribute.
+      console.warn(
+        `[worktrees] dropped lineage for ${childId} (parent ${lineage.parentWorktreeId}); the scan no longer lists it`
+      )
     }
     if (
       worktreeIdBelongsToRepo(lineage.parentWorktreeId, repoPrefix) &&


### PR DESCRIPTION
## Summary

A newly created child workspace nests correctly under its parent, then jumps to the top level once creation finishes. It reproduced on roughly half of consecutive creates, with no error and no warning in the logs.

The lineage is written correctly and then deleted. `pruneLineageForMissingRepoWorktrees` drops lineage for any child absent from a `git worktree list` result, on the reasoning that the scan proves the worktree is gone. A scan that started *before* a create finished proves no such thing — it never had the chance to see that worktree. When a listing overlaps an in-flight create, the create loses its parent link moments after gaining it.

There is already a mid-scan guard, but it only covers scans that were **already running** when the change notification fired:

```ts
// listDetectedGitWorktrees
return { gitWorktrees, fresh: !scan.invalidated }
```

A scan that *starts* during a create is never invalidated, reports `fresh`, and prunes on a listing that predates the worktree it is judging.

This carries the listing's start time through the scan result and skips records created after it, leaving them for the next scan to judge on a listing that could actually have contained them:

```ts
// Records without a usable timestamp keep the original prune behavior.
const predatesScan = (lineage: { createdAt?: number }): boolean =>
  typeof lineage.createdAt !== 'number' || lineage.createdAt <= scanStartedAt
```

Skipping is the safe direction: a genuinely stale record survives one extra cycle and is pruned by the next scan, whereas the current behavior destroys a valid parent link permanently.

Both halves of a workspace's lineage are affected together — the prune removes the worktree lineage and the workspace lineage for a child in one pass — which is why a racing create lost the nesting entirely rather than degrading. Applied to the IPC and runtime paths alike, so SSH and remote hosts get the same guarantee.

## Screenshots

No visual change beyond the bug being absent: an affected workspace stays nested instead of jumping to the top level when creation completes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 45,998 passing. 22 failures in 6 files are pre-existing on `origin/main`: I ran the same 6 files on a clean `origin/main` checkout and got the identical 22 failures. None are touched by this PR (terminal IME, daemon emulator, relay, root-directory entries).
- [x] `pnpm build`
- [x] Added a regression test: a listing that resolves *after* a child is recorded must not prune it, while a record that predates the scan and is still absent is pruned. Verified it fails without the fix.

Diagnosis was done against a running build by instrumenting the create path. The create response carried the lineage, the renderer applied it, and it disappeared within two seconds; querying the backend directly confirmed the renderer was faithfully reflecting backend state, which located the deletion in the prune rather than in the create.

## AI Review Report

Reviewed with Claude Code, focused on the risk that widening a prune guard lets genuinely stale lineage survive.

- **Backward compatibility.** Records lacking a numeric `createdAt` keep the original behavior rather than becoming unprunable. This was caught by the review: an earlier draft compared `undefined <= scanStartedAt`, which silently disabled pruning for every record without a timestamp and broke the existing prune tests.
- **Timestamp direction.** The stamp is taken *before* the listing is requested, not after it resolves. Taking it later would narrow the protected window and reintroduce the race.
- **Cached and joined scans.** Cached and in-flight-joined results report `fresh: false`, so they never prune; they now carry the originating scan's start time rather than a fabricated one.
- **Parent-side rotation.** The `predatesScan` guard covers the whole entry, so a recently created *parent* cannot have its instance identity rotated by a listing that predates it either.
- **Cross-platform.** No shortcuts, labels, or user-facing strings. No path construction was added or changed; existing `${repo.id}::${path}` keys are untouched. `Date.now()` comparison is platform-neutral. The SSH and runtime paths carry the same change, so macOS, Linux, Windows, WSL, and remote hosts behave identically.
- **Git compatibility.** No git command, subcommand, or option was added or changed; this only affects how an existing `git worktree list` result is interpreted.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or dependency surface. No IPC signature changed: `startedAt` is internal to the main process and never crosses the IPC boundary. The one behavioral change is that a lineage record may persist one scan cycle longer than before; lineage is parent/child metadata with no privilege or access-control meaning, and stale entries are already handled by instance-identity validation.

## Notes

- The prune only ever deleted lineage that had just been correctly written, so no repair or migration is needed — affected workspaces can simply be re-parented, and new creates are correct from this change forward.
- The prune previously removed a user-visible link with no log line at all, which is the main reason this took a running-build instrumentation session to attribute rather than a log read. It now warns on removal, via the file's existing `warnOnce` dedupe on the IPC side and plain `console.warn` on the runtime side, matching each file's convention.
