### PR TITLE
feat(shortcuts): jump to the agent that needs input

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -82,6 +82,10 @@ import {
 import { createFloatingWorkspaceTourInteractionSnapshot } from '@/lib/floating-workspace-tour-interaction-snapshot'
 import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-current-workspace-status'
 import { OPEN_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
+import {
+  focusAttentionTarget,
+  resolveNextAttentionTarget
+} from './components/sidebar/next-attention-target'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
 import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
@@ -1627,6 +1631,20 @@ function App(): React.JSX.Element {
             return claim('worktree.history.forward', () =>
               useAppStore.getState().goForwardWorktree()
             )
+          }
+        ],
+        [
+          'worktree.jumpToNextAttention',
+          () => {
+            if (creationLayoutActive) {
+              return false
+            }
+            // Why resolve before claiming: with no agent waiting the chord must reach the terminal unclaimed.
+            const target = resolveNextAttentionTarget()
+            if (target === null) {
+              return false
+            }
+            return claim('worktree.jumpToNextAttention', () => focusAttentionTarget(target))
           }
         ],
         ['sidebar.left.toggle', () => claim('sidebar.left.toggle', () => actions.toggleSidebar())],

--- a/src/renderer/src/components/sidebar/next-attention-target.test.ts
+++ b/src/renderer/src/components/sidebar/next-attention-target.test.ts
@@ -137,6 +137,31 @@ describe('findNextAttentionTarget', () => {
     expect(target).toEqual({ worktreeId: 'wt-a', tabId: 'tab-9', leafId: LEAF_A })
   })
 
+  it('refuses a pane whose tab belongs to another worktree, even when the row is stamped here', () => {
+    const target = findNextAttentionTarget({
+      attentionByWorktree: new Map([['wt-a', CLASS_1(NOW)]]),
+      agentStatusByPaneKey: {
+        [`tab-a:${LEAF_A}`]: makeWaitingEntry({
+          paneKey: `tab-a:${LEAF_A}`,
+          worktreeId: 'wt-a',
+          stateStartedAt: NOW - 5_000
+        }),
+        [`tab-b:${LEAF_B}`]: makeWaitingEntry({
+          paneKey: `tab-b:${LEAF_B}`,
+          worktreeId: 'wt-a',
+          stateStartedAt: NOW
+        })
+      },
+      tabsByWorktree: { 'wt-a': [makeTab('tab-a', 'wt-a')], 'wt-b': [makeTab('tab-b', 'wt-b')] },
+      eligibleWorktreeIds: new Set(['wt-a']),
+      activeWorktreeId: null,
+      now: NOW
+    })
+
+    // The fresher row names wt-b's tab; focusing it would reveal another worktree's pane.
+    expect(target).toEqual({ worktreeId: 'wt-a', tabId: 'tab-a', leafId: LEAF_A })
+  })
+
   it('still targets the worktree when its only waiting row is stale or unroutable', () => {
     const target = findNextAttentionTarget({
       attentionByWorktree: new Map([['wt-a', CLASS_1(NOW)]]),

--- a/src/renderer/src/components/sidebar/next-attention-target.test.ts
+++ b/src/renderer/src/components/sidebar/next-attention-target.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import { findNextAttentionTarget } from './next-attention-target'
+import type { WorktreeAttention } from './smart-attention'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+const NOW = 1_000_000
+
+function makeWaitingEntry(overrides: Partial<AgentStatusEntry> & { paneKey: string }) {
+  return {
+    state: 'waiting',
+    prompt: '',
+    updatedAt: NOW,
+    stateStartedAt: NOW,
+    ...overrides
+  } as AgentStatusEntry
+}
+
+function makeTab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+const CLASS_1 = (attentionTimestamp: number): WorktreeAttention => ({
+  cls: 1,
+  attentionTimestamp,
+  cause: 'waiting'
+})
+
+describe('findNextAttentionTarget', () => {
+  it('targets the most recent waiting worktree and its freshest waiting pane', () => {
+    const target = findNextAttentionTarget({
+      attentionByWorktree: new Map<string, WorktreeAttention>([
+        ['wt-old', CLASS_1(NOW - 5_000)],
+        ['wt-new', CLASS_1(NOW - 1_000)],
+        ['wt-working', { cls: 3, attentionTimestamp: NOW }]
+      ]),
+      agentStatusByPaneKey: {
+        [`tab-1:${LEAF_A}`]: makeWaitingEntry({
+          paneKey: `tab-1:${LEAF_A}`,
+          worktreeId: 'wt-new',
+          stateStartedAt: NOW - 4_000
+        }),
+        [`tab-1:${LEAF_B}`]: makeWaitingEntry({
+          paneKey: `tab-1:${LEAF_B}`,
+          worktreeId: 'wt-new',
+          stateStartedAt: NOW - 1_000
+        })
+      },
+      tabsByWorktree: { 'wt-new': [makeTab('tab-1', 'wt-new')] },
+      eligibleWorktreeIds: new Set(['wt-old', 'wt-new', 'wt-working']),
+      activeWorktreeId: null,
+      now: NOW
+    })
+
+    expect(target).toEqual({ worktreeId: 'wt-new', tabId: 'tab-1', leafId: LEAF_B })
+  })
+
+  it('skips the worktree already on screen so repeated presses walk the queue', () => {
+    const args = {
+      attentionByWorktree: new Map([
+        ['wt-a', CLASS_1(NOW - 1_000)],
+        ['wt-b', CLASS_1(NOW - 2_000)]
+      ]),
+      agentStatusByPaneKey: {},
+      tabsByWorktree: {},
+      eligibleWorktreeIds: new Set(['wt-a', 'wt-b']),
+      now: NOW
+    }
+
+    expect(findNextAttentionTarget({ ...args, activeWorktreeId: null })?.worktreeId).toBe('wt-a')
+    expect(findNextAttentionTarget({ ...args, activeWorktreeId: 'wt-a' })?.worktreeId).toBe('wt-b')
+    // Why: the last waiting agent stays reachable rather than falling through to nothing.
+    expect(
+      findNextAttentionTarget({
+        ...args,
+        attentionByWorktree: new Map([['wt-a', CLASS_1(NOW)]]),
+        eligibleWorktreeIds: new Set(['wt-a']),
+        activeWorktreeId: 'wt-a'
+      })?.worktreeId
+    ).toBe('wt-a')
+  })
+
+  it('returns null when nothing waits, and ignores worktrees outside the eligible set', () => {
+    const attentionByWorktree = new Map([['wt-archived', CLASS_1(NOW)]])
+
+    expect(
+      findNextAttentionTarget({
+        attentionByWorktree: new Map<string, WorktreeAttention>([
+          ['wt-a', { cls: 3, attentionTimestamp: NOW }]
+        ]),
+        agentStatusByPaneKey: {},
+        tabsByWorktree: {},
+        eligibleWorktreeIds: new Set(['wt-a']),
+        activeWorktreeId: null,
+        now: NOW
+      })
+    ).toBeNull()
+
+    expect(
+      findNextAttentionTarget({
+        attentionByWorktree,
+        agentStatusByPaneKey: {},
+        tabsByWorktree: {},
+        eligibleWorktreeIds: new Set<string>(),
+        activeWorktreeId: null,
+        now: NOW
+      })
+    ).toBeNull()
+  })
+
+  it('attributes a pane by tab ownership when the hook row carries no worktree stamp', () => {
+    const target = findNextAttentionTarget({
+      attentionByWorktree: new Map([['wt-a', CLASS_1(NOW)]]),
+      agentStatusByPaneKey: {
+        [`tab-9:${LEAF_A}`]: makeWaitingEntry({ paneKey: `tab-9:${LEAF_A}` })
+      },
+      tabsByWorktree: { 'wt-a': [makeTab('tab-9', 'wt-a')] },
+      eligibleWorktreeIds: new Set(['wt-a']),
+      activeWorktreeId: null,
+      now: NOW
+    })
+
+    expect(target).toEqual({ worktreeId: 'wt-a', tabId: 'tab-9', leafId: LEAF_A })
+  })
+
+  it('still targets the worktree when its only waiting row is stale or unroutable', () => {
+    const target = findNextAttentionTarget({
+      attentionByWorktree: new Map([['wt-a', CLASS_1(NOW)]]),
+      agentStatusByPaneKey: {
+        [`tab-1:${LEAF_A}`]: makeWaitingEntry({
+          paneKey: `tab-1:${LEAF_A}`,
+          worktreeId: 'wt-a',
+          updatedAt: NOW - AGENT_STATUS_STALE_AFTER_MS - 1
+        }),
+        'tab-2:7': makeWaitingEntry({ paneKey: 'tab-2:7', worktreeId: 'wt-a' })
+      },
+      tabsByWorktree: { 'wt-a': [makeTab('tab-1', 'wt-a')] },
+      eligibleWorktreeIds: new Set(['wt-a']),
+      activeWorktreeId: null,
+      now: NOW
+    })
+
+    // Focus falls back to activating the worktree alone; no pane is claimed on stale evidence.
+    expect(target).toEqual({ worktreeId: 'wt-a', tabId: null, leafId: null })
+  })
+})

--- a/src/renderer/src/components/sidebar/next-attention-target.ts
+++ b/src/renderer/src/components/sidebar/next-attention-target.ts
@@ -1,0 +1,131 @@
+import { isExplicitAgentStatusFresh } from '@/lib/pane-agent-evidence'
+import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { activateTerminalInitiatedWorktree } from '@/lib/terminal-initiated-worktree-activation'
+import { useAppStore } from '@/store'
+import { getAllWorktreesFromState } from '@/store/selectors'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+import { buildAttentionByWorktree, type WorktreeAttention } from './smart-attention'
+
+export type AttentionTarget = {
+  worktreeId: string
+  /** Null for worktrees promoted by the title heuristic, which carry no paneKey to focus. */
+  tabId: string | null
+  leafId: string | null
+}
+
+/**
+ * Pick the pane to focus inside an attention worktree: the freshest `blocked`/`waiting`
+ * hook entry it owns. Mirrors the paneKey the notification click handler focuses.
+ */
+function resolveAttentionPane(
+  worktreeId: string,
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>,
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  now: number
+): Pick<AttentionTarget, 'tabId' | 'leafId'> {
+  const worktreeTabIds = new Set((tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id))
+  let best: { tabId: string; leafId: string; startedAt: number } | null = null
+
+  for (const entry of Object.values(agentStatusByPaneKey)) {
+    if (entry.state !== 'blocked' && entry.state !== 'waiting') {
+      continue
+    }
+    if (!isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)) {
+      continue
+    }
+    // Why: a non-finite stateStartedAt would win every comparison and pin focus to a corrupted row.
+    if (!Number.isFinite(entry.stateStartedAt)) {
+      continue
+    }
+    const parsed = parsePaneKey(entry.paneKey)
+    if (parsed === null) {
+      continue
+    }
+    // Why both: hook rows can omit the worktree stamp and still map through a mirrored tab.
+    if (entry.worktreeId !== worktreeId && !worktreeTabIds.has(parsed.tabId)) {
+      continue
+    }
+    if (best === null || entry.stateStartedAt > best.startedAt) {
+      best = { tabId: parsed.tabId, leafId: parsed.leafId, startedAt: entry.stateStartedAt }
+    }
+  }
+
+  return best ? { tabId: best.tabId, leafId: best.leafId } : { tabId: null, leafId: null }
+}
+
+/**
+ * Resolve the agent that should receive focus next: Class 1 (`blocked`/`waiting`) worktrees
+ * ordered by most recent attention event, skipping the one already on screen so repeated
+ * presses walk the queue. Returns null when nothing is waiting.
+ */
+export function findNextAttentionTarget(args: {
+  attentionByWorktree: Map<string, WorktreeAttention>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  tabsByWorktree: Record<string, TerminalTab[]>
+  eligibleWorktreeIds: Set<string>
+  activeWorktreeId: string | null
+  now: number
+}): AttentionTarget | null {
+  const waiting = [...args.attentionByWorktree.entries()]
+    .filter(([id, attention]) => attention.cls === 1 && args.eligibleWorktreeIds.has(id))
+    .sort(([, a], [, b]) => b.attentionTimestamp - a.attentionTimestamp)
+
+  if (waiting.length === 0) {
+    return null
+  }
+
+  const [worktreeId] = waiting.find(([id]) => id !== args.activeWorktreeId) ?? waiting[0]
+  return {
+    worktreeId,
+    ...resolveAttentionPane(worktreeId, args.agentStatusByPaneKey, args.tabsByWorktree, args.now)
+  }
+}
+
+/**
+ * Read the live store and resolve the next agent waiting on input. Side-effect free so a
+ * shortcut handler can decline the chord (returning null) before claiming the key event.
+ */
+export function resolveNextAttentionTarget(): AttentionTarget | null {
+  const state = useAppStore.getState()
+  const worktrees = getAllWorktreesFromState(state).filter((worktree) => !worktree.isArchived)
+  const now = Date.now()
+
+  return findNextAttentionTarget({
+    attentionByWorktree: buildAttentionByWorktree(
+      worktrees,
+      state.tabsByWorktree,
+      state.agentStatusByPaneKey,
+      state.runtimePaneTitlesByTabId,
+      state.ptyIdsByTabId,
+      now,
+      state.migrationUnsupportedByPtyId,
+      state.terminalLayoutsByTabId
+    ),
+    agentStatusByPaneKey: state.agentStatusByPaneKey,
+    tabsByWorktree: state.tabsByWorktree,
+    eligibleWorktreeIds: new Set(worktrees.map((worktree) => worktree.id)),
+    activeWorktreeId: state.activeWorktreeId,
+    now
+  })
+}
+
+/**
+ * Focus a resolved attention target through the same path the notification click uses:
+ * activate the worktree, reveal it in the sidebar, then flash and scroll its exact pane.
+ */
+export function focusAttentionTarget(target: AttentionTarget): void {
+  const state = useAppStore.getState()
+  activateTerminalInitiatedWorktree(state, target.worktreeId)
+  state.revealWorktreeInSidebar(target.worktreeId)
+  if (target.tabId !== null) {
+    activateTabAndFocusPane(target.tabId, target.leafId, {
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+  }
+}

--- a/src/renderer/src/components/sidebar/next-attention-target.ts
+++ b/src/renderer/src/components/sidebar/next-attention-target.ts
@@ -46,8 +46,10 @@ function resolveAttentionPane(
     if (parsed === null) {
       continue
     }
-    // Why both: hook rows can omit the worktree stamp and still map through a mirrored tab.
-    if (entry.worktreeId !== worktreeId && !worktreeTabIds.has(parsed.tabId)) {
+    // Why tab ownership alone: a row stamped for this worktree can still name another worktree's
+    // tab, and focusing that would activate one worktree while revealing another's pane. The stamp
+    // already decided which worktree is Class 1; here it must not override live tab ownership.
+    if (!worktreeTabIds.has(parsed.tabId)) {
       continue
     }
     if (best === null || entry.stateStartedAt > best.startedAt) {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -122,6 +122,7 @@ import {
   rollbackLegacyWorkerTerminalSurfaceInStore
 } from './legacy-worker-terminal-recovery-event'
 import type { AppState } from '../store/types'
+import { activateTerminalInitiatedWorktree } from '@/lib/terminal-initiated-worktree-activation'
 import { guardPinnedTabClose, resolvePinnedTabLabel } from '../store/pinned-tab-close-guard'
 import {
   closeWebRuntimeSessionTab,
@@ -330,16 +331,6 @@ function getVisibleWorktreeIdsForRepo(state: AppState, repoId: string): Set<stri
 function focusTerminalInitiatedTab(tabId: string, leafId?: string | null): void {
   if (!focusRuntimeTerminalSurface(tabId, leafId)) {
     focusTerminalTabSurface(tabId, leafId)
-  }
-}
-
-function activateTerminalInitiatedWorktree(store: AppState, worktreeId: string): void {
-  store.setActiveView('terminal')
-  store.setActiveWorktree(worktreeId)
-  // Why: CLI/runtime terminal focus is user-visible navigation, so feed both Cmd+J recency and the back/forward stack.
-  store.markWorktreeVisited(worktreeId)
-  if (!store.isNavigatingHistory) {
-    store.recordWorktreeVisit(worktreeId)
   }
 }
 

--- a/src/renderer/src/lib/terminal-initiated-worktree-activation.ts
+++ b/src/renderer/src/lib/terminal-initiated-worktree-activation.ts
@@ -3,7 +3,7 @@ import type { AppState } from '@/store/types'
 export function activateTerminalInitiatedWorktree(store: AppState, worktreeId: string): void {
   store.setActiveView('terminal')
   store.setActiveWorktree(worktreeId)
-  // Why: CLI/runtime terminal focus is user-visible navigation, so feed both Cmd+J recency and the back/forward stack.
+  // Why: CLI/runtime terminal focus is user-visible navigation, so feed both worktree-palette recency and the back/forward stack.
   store.markWorktreeVisited(worktreeId)
   if (!store.isNavigatingHistory) {
     store.recordWorktreeVisit(worktreeId)

--- a/src/renderer/src/lib/terminal-initiated-worktree-activation.ts
+++ b/src/renderer/src/lib/terminal-initiated-worktree-activation.ts
@@ -1,0 +1,11 @@
+import type { AppState } from '@/store/types'
+
+export function activateTerminalInitiatedWorktree(store: AppState, worktreeId: string): void {
+  store.setActiveView('terminal')
+  store.setActiveWorktree(worktreeId)
+  // Why: CLI/runtime terminal focus is user-visible navigation, so feed both Cmd+J recency and the back/forward stack.
+  store.markWorktreeVisited(worktreeId)
+  if (!store.isNavigatingHistory) {
+    store.recordWorktreeVisit(worktreeId)
+  }
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -31,6 +31,7 @@ export type KeybindingActionId =
   | 'worktree.palette'
   | 'worktree.navigateUp'
   | 'worktree.navigateDown'
+  | 'worktree.jumpToNextAttention'
   | 'app.settings'
   | 'app.forceReload'
   | 'workspace.create'
@@ -253,6 +254,24 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'global',
     searchKeywords: ['shortcut', 'global', 'worktree', 'next', 'down'],
     defaultBindings: platformBindings(['Mod+Shift+ArrowDown'])
+  },
+  {
+    id: 'worktree.jumpToNextAttention',
+    title: 'Jump to agent needing input',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'worktree',
+      'agent',
+      'attention',
+      'waiting',
+      'blocked',
+      'needs input',
+      'jump'
+    ],
+    defaultBindings: platformBindings(['Mod+Shift+K'])
   },
   {
     id: 'workspace.create',

--- a/src/shared/plugins/plugin-command-actions.ts
+++ b/src/shared/plugins/plugin-command-actions.ts
@@ -5,6 +5,7 @@ import type { KeybindingActionId, PluginKeybindingActionId } from '../keybinding
 export const PLUGIN_COMMAND_ALIAS_ACTION_IDS = [
   'worktree.history.back',
   'worktree.history.forward',
+  'worktree.jumpToNextAttention',
   'sidebar.left.toggle',
   'sidebar.sleepingWorkspaces.toggle',
   'floatingWorkspace.maximize',


### PR DESCRIPTION
## Summary

Adds `worktree.jumpToNextAttention` (default `Mod+Shift+K`): focus the agent that needs input, without reaching for the mouse. Closes #12577.

Clicking a native notification was the only direct route to a waiting agent. The selector reuses `buildAttentionByWorktree` from `smart-attention.ts`, which already computes the Class 1 (`blocked`/`waiting`) set for Smart sort, picks the most recent one, and focuses its exact pane through the same path the notification click uses. Pressing again skips the worktree already on screen, so a queue of waiting agents can be walked from the keyboard.

With nothing waiting, the handler declines before claiming the key event, so the chord still reaches the terminal.

Only the first of the two proposed actions. The drain variant needs a per-agent handled/unread concept that does not exist today, so it belongs in its own PR.

`activateTerminalInitiatedWorktree` moved out of `useIpcEvents.ts` into its own module so the shortcut and the notification click share one implementation instead of two copies.

## Screenshots

No visual change. No new UI surface; the action appears in Settings > Shortcuts from the existing registry.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`next-attention-target.test.ts` covers ordering by most recent attention, the skip-active-worktree walk, the last-waiting-agent case that must stay reachable, pane attribution when a hook row carries no worktree stamp, and stale or unroutable rows falling back to activating the worktree without claiming a pane.

Three failures in the full local run, all traced and none in touched code. `macos-computer-helper-owner-loss-processes.test.mjs` and `terminal-output-frame-chunks-equivalence.test.ts` (a 30s fuzz timeout) both pass on rerun once the machine is idle; they failed while a package install and a Swift build were competing for the box. `terminal-attribution.test.ts` reproduces with the branch stashed, so it predates this change: my global `core.hooksPath` shadows the repo-local `commit-msg` hook the test installs, and it passes 22/22 under `GIT_CONFIG_GLOBAL=/dev/null`. Local Node is 22, so CI on Node 24/26 is the real verdict.

## AI Review Report

Risks checked: cross-platform behavior, chord conflicts, hot-path cost, and whether the shortcut can swallow input.

Flagged and fixed during review:

- The handler map in `App.tsx` is only consulted on keydown for ids in `PLUGIN_COMMAND_ALIAS_ACTION_IDS`. Without registering the action there the shortcut is dead and no unit test would catch it, since the selector stays green. Registered.
- The first draft called `claim()` before knowing whether an agent was waiting, so an unmatched press would still `preventDefault()` and fire the terminal-capture toast. Split into `resolveNextAttentionTarget()` and `focusAttentionTarget()` so the chord is declined before it is claimed.
- Fixture maps in the test widened `cls` to `number` against the `SmartClass` union.

Cross-platform: the binding is declared through `platformBindings`, so `Mod` resolves to Command on macOS and Control on Linux and Windows through the existing matcher; labels come from the shared formatter. No `metaKey` check, no path handling, no shell invocation, no Electron accelerator added. `Mod+Shift+K` is unused as a default on every platform (`Mod+K` belongs to `terminal.clear`, and the `Mod+Shift+K` occurrences in editor tests are per-test overrides, not defaults). Nothing here assumes local execution: the selector reads the same renderer state that SSH and remote worktrees populate, and focusing goes through the existing renderer path rather than a local process.

Cost: `buildAttentionByWorktree` runs only after the chord matches, not per keystroke, and it is the same call the sidebar already makes per sort.

## Security Audit

No new IPC channel, no command execution, no path or credential handling, no network access, no dependency change. Input is the existing agent-status store, and every row is validated before use: stale entries are skipped through `isExplicitAgentStatusFresh`, non-finite `stateStartedAt` is rejected so a corrupted row cannot pin focus, malformed pane keys are dropped by `parsePaneKey`, and archived worktrees are excluded from the candidate set.

One capability change worth naming: adding the action to `PLUGIN_COMMAND_ALIAS_ACTION_IDS` lets a declarative plugin command alias invoke it. That list is deliberately closed, and the new entry sits in the same class as the sidebar toggles and history navigation already on it. The action only moves focus; it sends no input to an agent and exposes no data to the plugin.

## Notes

The chord does not fire while a browser guest holds focus, since `resolveWindowShortcutAction` in the main process is untouched. Worktrees promoted by the title heuristic carry no pane key, so those activate the worktree without focusing a pane.
