### PR TITLE
fix(menu): restore paste in macOS native dialogs

### DIFF
--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -226,24 +226,30 @@ describe('registerAppMenu', () => {
     expect(paletteItem?.accelerator).toBeUndefined()
   })
 
-  it('routes Edit > Paste through Orca coordinated paste ownership', () => {
-    const send = vi.fn()
-    getFocusedWindowMock.mockReturnValue({ webContents: { send } })
-    registerAppMenu(buildMenuOptions())
+  // Why: pin the platform on every case — CI runs this suite on Linux only, so an
+  // unpinned test leaves the other platforms' branches entirely uncovered.
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'routes Edit > Paste through Orca coordinated paste ownership on %s',
+    (platform) => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+      const send = vi.fn()
+      getFocusedWindowMock.mockReturnValue({ webContents: { send } })
+      registerAppMenu(buildMenuOptions())
 
-    const editSubmenu = getSubmenu(getTemplate(), 'Edit')
-    const pasteItem = editSubmenu.find((item) => item.label === 'Paste')
+      const editSubmenu = getSubmenu(getTemplate(), 'Edit')
+      const pasteItem = editSubmenu.find((item) => item.label === 'Paste')
 
-    expect(pasteItem).toBeDefined()
-    expect(pasteItem?.role).toBeUndefined()
-    expect(pasteItem?.accelerator).toBe('CmdOrCtrl+V')
+      expect(pasteItem).toBeDefined()
+      expect(pasteItem?.role).toBeUndefined()
+      expect(pasteItem?.accelerator).toBe('CmdOrCtrl+V')
 
-    pasteItem?.click?.({} as never, {} as never, {} as never)
+      pasteItem?.click?.({} as never, {} as never, {} as never)
 
-    expect(send).toHaveBeenCalledOnce()
-    expect(send).toHaveBeenCalledWith('ui:appMenuPaste')
-    expect(sendActionToFirstResponderMock).not.toHaveBeenCalled()
-  })
+      expect(send).toHaveBeenCalledOnce()
+      expect(send).toHaveBeenCalledWith('ui:appMenuPaste')
+      expect(sendActionToFirstResponderMock).not.toHaveBeenCalled()
+    }
+  )
 
   it('routes Edit > Paste to the native first responder once on macOS without a focused window', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
@@ -265,6 +271,8 @@ describe('registerAppMenu', () => {
       registerAppMenu(buildMenuOptions())
 
       const pasteItem = getSubmenu(getTemplate(), 'Edit').find((item) => item.label === 'Paste')
+      // Why: this case asserts only a negative, so it would pass green if the item vanished.
+      expect(pasteItem).toBeDefined()
       pasteItem?.click?.({} as never, {} as never, {} as never)
 
       expect(sendActionToFirstResponderMock).not.toHaveBeenCalled()

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -1,9 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { buildFromTemplateMock, setApplicationMenuMock, getFocusedWindowMock } = vi.hoisted(() => ({
+const {
+  buildFromTemplateMock,
+  setApplicationMenuMock,
+  getFocusedWindowMock,
+  sendActionToFirstResponderMock
+} = vi.hoisted(() => ({
   buildFromTemplateMock: vi.fn(),
   setApplicationMenuMock: vi.fn(),
-  getFocusedWindowMock: vi.fn()
+  getFocusedWindowMock: vi.fn(),
+  sendActionToFirstResponderMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -12,7 +18,8 @@ vi.mock('electron', () => ({
   },
   Menu: {
     buildFromTemplate: buildFromTemplateMock,
-    setApplicationMenu: setApplicationMenuMock
+    setApplicationMenu: setApplicationMenuMock,
+    sendActionToFirstResponder: sendActionToFirstResponderMock
   },
   app: {
     name: 'Orca'
@@ -70,7 +77,12 @@ describe('registerAppMenu', () => {
     buildFromTemplateMock.mockReset()
     setApplicationMenuMock.mockReset()
     getFocusedWindowMock.mockReset()
+    sendActionToFirstResponderMock.mockReset()
     buildFromTemplateMock.mockImplementation((template) => ({ template }))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('shows reload shortcuts as policy-routed menu hints', () => {
@@ -228,8 +240,36 @@ describe('registerAppMenu', () => {
 
     pasteItem?.click?.({} as never, {} as never, {} as never)
 
+    expect(send).toHaveBeenCalledOnce()
     expect(send).toHaveBeenCalledWith('ui:appMenuPaste')
+    expect(sendActionToFirstResponderMock).not.toHaveBeenCalled()
   })
+
+  it('routes Edit > Paste to the native first responder once on macOS without a focused window', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    getFocusedWindowMock.mockReturnValue(null)
+    registerAppMenu(buildMenuOptions())
+
+    const pasteItem = getSubmenu(getTemplate(), 'Edit').find((item) => item.label === 'Paste')
+    pasteItem?.click?.({} as never, {} as never, {} as never)
+
+    expect(sendActionToFirstResponderMock).toHaveBeenCalledOnce()
+    expect(sendActionToFirstResponderMock).toHaveBeenCalledWith('paste:')
+  })
+
+  it.each(['linux', 'win32'] as const)(
+    'does not invoke the native paste responder on %s without a focused window',
+    (platform) => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+      getFocusedWindowMock.mockReturnValue(null)
+      registerAppMenu(buildMenuOptions())
+
+      const pasteItem = getSubmenu(getTemplate(), 'Edit').find((item) => item.label === 'Paste')
+      pasteItem?.click?.({} as never, {} as never, {} as never)
+
+      expect(sendActionToFirstResponderMock).not.toHaveBeenCalled()
+    }
+  )
 
   it.runIf(!isMac)('puts Settings and Exit under File on Windows/Linux', () => {
     registerAppMenu(buildMenuOptions())

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -180,7 +180,15 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
         click: () => {
           // Why: a focused terminal/native-chat pane is not a native editable
           // control, so raw Electron paste cannot know which Orca surface owns it.
-          BrowserWindow.getFocusedWindow()?.webContents.send('ui:appMenuPaste')
+          const focusedWindow = BrowserWindow.getFocusedWindow()
+          if (focusedWindow) {
+            focusedWindow.webContents.send('ui:appMenuPaste')
+            return
+          }
+
+          if (isMac) {
+            Menu.sendActionToFirstResponder('paste:')
+          }
         }
       },
       { role: 'selectAll' }

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -186,6 +186,8 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
             return
           }
 
+          // Why: a macOS native panel (open/save, Go to Folder) leaves no focused
+          // BrowserWindow, so overriding the paste role would strand Cmd+V as a no-op.
           if (isMac) {
             Menu.sendActionToFirstResponder('paste:')
           }


### PR DESCRIPTION
## Summary

- preserve Orca coordinated paste when a `BrowserWindow` is focused
- forward Edit > Paste to the native macOS first responder when no `BrowserWindow` is focused
- keep Windows and Linux behavior unchanged

The custom Edit > Paste handler replaced the Electron paste role so terminal and native-chat surfaces could coordinate clipboard ownership. When a native macOS open/save panel owned focus, `BrowserWindow.getFocusedWindow()` returned `null` and the handler became a no-op.

## Screenshots

Before the fix, Cmd+V does not insert the clipboard path into the macOS Go to Folder field, while context-menu Paste remains available:

<img width="1760" height="896" alt="macOS Go to Folder field where keyboard paste fails" src="https://github.com/user-attachments/assets/1323df6f-95fa-4eee-8d31-f7ea0e8eca9d" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] focused menu tests: 17 passed with one platform-specific skip
- [x] `pnpm build` under Node 24
- [x] added regression tests covering exact-once renderer routing, the macOS native responder fallback, and unchanged Linux/Windows behavior

The new macOS regression test fails against upstream `main` and passes on this branch.

## AI Review Report

The AI coding-agent review and CodeRabbit checked exact-once routing, Electron focus behavior, and platform boundaries. No actionable code issues were found.

- macOS: a focused Orca `BrowserWindow` still receives exactly one `ui:appMenuPaste`; only the no-focused-window path calls `Menu.sendActionToFirstResponder("paste:")`
- Linux and Windows: the native responder fallback is not invoked, and the existing `CmdOrCtrl+V` accelerator remains unchanged
- shortcuts, labels, file paths, shell behavior, SSH sessions, and folder workspaces are otherwise untouched

## Security Audit

- no new dependencies, authentication, secret handling, filesystem access, path parsing, or command execution
- no new IPC channel; the focused-window path retains the existing `ui:appMenuPaste` message
- the native fallback does not read clipboard contents and delegates only the standard `paste:` selector to the macOS first responder
- the fallback is runtime-gated to macOS and only runs when no Orca `BrowserWindow` is focused, preventing double routing

## Notes

- Fixes #12640
- the change is macOS-specific by design; Linux and Windows retain the previous no-focused-window behavior
- upstream PR Checks currently require maintainer approval before fork CI jobs can run
