### PR TITLE
fix(cursor): accept BOM-prefixed hook JSON

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -171,6 +171,26 @@ describe('shared agent-hook-listener', () => {
     expect(event?.hookEventName).toBe('beforeSubmitPrompt')
   })
 
+  // Why: pins the allowance to exactly one leading U+FEFF, so nobody widens it into a trim.
+  it('still rejects a hook payload that is malformed once the BOM is removed', () => {
+    const bom = '\uFEFF'
+    const body = '{"hook_event_name":"beforeSubmitPrompt"}'
+    for (const payload of [
+      `${bom}${bom}${body}`,
+      `${bom}not json`,
+      ` ${bom}${body}`,
+      `{"hook_event_name"${bom}:"beforeSubmitPrompt"}`
+    ]) {
+      const event = normalizeHookPayload(
+        state,
+        'cursor',
+        { paneKey: PANE_KEY, payload },
+        'production'
+      )
+      expect(event).toBeNull()
+    }
+  })
+
   it('normalizes Gemini BeforeTool to working with tool fields', () => {
     const event = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -152,6 +152,25 @@ describe('shared agent-hook-listener', () => {
     expect(event!.payload.agentType).toBe('claude')
   })
 
+  it('normalizes a BOM-prefixed Cursor hook payload to a working state', () => {
+    const event = normalizeHookPayload(
+      state,
+      'cursor',
+      {
+        paneKey: PANE_KEY,
+        payload: '\uFEFF{"hook_event_name":"beforeSubmitPrompt","prompt":"Synthetic Cursor prompt"}'
+      },
+      'production'
+    )
+
+    expect(event?.payload).toMatchObject({
+      agentType: 'cursor',
+      state: 'working',
+      prompt: 'Synthetic Cursor prompt'
+    })
+    expect(event?.hookEventName).toBe('beforeSubmitPrompt')
+  })
+
   it('normalizes Gemini BeforeTool to working with tool fields', () => {
     const event = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -85,8 +85,9 @@ const AGENT_HOOK_JSON_STRUCTURE_LIMITS = {
 } as const
 
 function parseAgentHookJson(content: string): unknown {
-  assertJsonTextStructureWithinLimits(content, AGENT_HOOK_JSON_STRUCTURE_LIMITS)
-  return JSON.parse(content) as unknown
+  const normalizedContent = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content
+  assertJsonTextStructureWithinLimits(normalizedContent, AGENT_HOOK_JSON_STRUCTURE_LIMITS)
+  return JSON.parse(normalizedContent) as unknown
 }
 
 /** Bound the warn-once Sets so a client varying `version`/`env` per request can't grow them unbounded. */

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -85,6 +85,9 @@ const AGENT_HOOK_JSON_STRUCTURE_LIMITS = {
 } as const
 
 function parseAgentHookJson(content: string): unknown {
+  // Why: Cursor on Windows writes UTF-8-with-BOM to the hook's stdin and `JSON.parse` rejects U+FEFF,
+  // so the whole event was dropped. Strip exactly one leading BOM — not a trim — to keep every other
+  // malformed payload rejected as before.
   const normalizedContent = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content
   assertJsonTextStructureWithinLimits(normalizedContent, AGENT_HOOK_JSON_STRUCTURE_LIMITS)
   return JSON.parse(normalizedContent) as unknown


### PR DESCRIPTION
## Summary

Accept a single leading UTF-8 BOM character in string-valued agent-hook JSON before structure validation and parsing.

This restores Cursor hook event normalization without broad trimming or changes to malformed-JSON handling.

This addresses a separate failure mode from #12466: #12466 restores Cursor identity through the hookless/title-derived sidebar path, while this PR prevents valid Cursor hook events from being silently dropped when their JSON payload begins with a UTF-8 BOM.

Related to #10258
Complements #12466

## Screenshots

No visual change.

## Testing

* [x] Focused listener regression: 125 tests passed
* [x] `pnpm typecheck`
* [x] `pnpm lint`
* [ ] `pnpm test` — blocked locally by the Node 24 native `node-pty` rebuild environment
* [ ] `pnpm build` — desktop build completed; macOS native Swift package linking is blocked locally
* [x] Added a synthetic BOM-prefixed Cursor payload regression test
* [x] External runtime validation by @brennanb2025: a byte-exact `EF BB BF` payload sent to the running hook listener produces the Cursor session row; the same request against a build without this change returns `204` and is silently dropped

## AI Review Report

Reviewed the JSON parse boundary and affected Cursor normalization path. The change removes exactly one leading BOM before the existing structural-limit validation and `JSON.parse`; non-BOM payloads and malformed JSON behavior are unchanged.

No platform-specific code, shell behavior, paths, UI, SSH/remote behavior, or other agent providers are changed.

## Security Audit

The change remains within the existing local hook JSON boundary. It preserves the size and structural limits and does not broaden accepted malformed input. The test fixture is synthetic and contains no environment-specific data.

## Notes

For SSH workspaces, this fix must be present on the remote host because hook payload normalization occurs there. An updated client connected to an older host can therefore still drop BOM-prefixed Cursor hook payloads.

The separate BOM handling issue in `readHooksJsonWithRaw` / `~/.cursor/hooks.json` is intentionally out of scope for this PR and should be handled independently.
