### PR TITLE
refactor(runtime): preserve transport error codes over IPC

### DIFF
--- a/src/main/ipc/runtime-environment-connectivity-handlers.ts
+++ b/src/main/ipc/runtime-environment-connectivity-handlers.ts
@@ -9,7 +9,9 @@ import {
   redactRuntimeEnvironment,
   type PublicKnownRuntimeEnvironment
 } from '../../shared/runtime-environments'
-import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
+import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+import { RuntimeRpcCallQueueOverloadError } from '../../shared/runtime-rpc-call-queue'
+import type { RuntimeRpcFailure, RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
 import type { RuntimeStatus } from '../../shared/runtime-types'
 import type { Store } from '../persistence'
 import { verifyAndAddRuntimeEnvironmentFromPairingCode } from './runtime-environment-pairing-verification'
@@ -151,6 +153,25 @@ function registerPassiveStatusHandler(getUserDataPath: () => string): void {
   )
 }
 
+function runtimeEnvironmentCallFailure(
+  environment: ReturnType<typeof resolveEnvironment>,
+  method: string,
+  error: unknown
+): RuntimeRpcFailure | null {
+  if (
+    !(error instanceof RemoteRuntimeClientError) &&
+    !(error instanceof RuntimeRpcCallQueueOverloadError)
+  ) {
+    return null
+  }
+  return {
+    id: method,
+    ok: false,
+    error: { code: error.code, message: error.message },
+    _meta: { runtimeId: environment.runtimeId }
+  }
+}
+
 function registerPassiveCallHandler(getUserDataPath: () => string): void {
   ipcMain.handle(
     'runtimeEnvironments:call',
@@ -168,14 +189,23 @@ function registerPassiveCallHandler(getUserDataPath: () => string): void {
       if (isRuntimeEnvironmentManuallyDisconnected(environment.id)) {
         return manuallyDisconnectedResponse(environment)
       }
-      const response = await callRuntimeEnvironment(
-        getUserDataPath(),
-        environment.id,
-        args.method,
-        args.params,
-        args.timeoutMs,
-        args.expectedEnvironmentPairingRevision
-      )
+      let response: RuntimeRpcResponse<unknown>
+      try {
+        response = await callRuntimeEnvironment(
+          getUserDataPath(),
+          environment.id,
+          args.method,
+          args.params,
+          args.timeoutMs,
+          args.expectedEnvironmentPairingRevision
+        )
+      } catch (error) {
+        const failure = runtimeEnvironmentCallFailure(environment, args.method, error)
+        if (failure) {
+          return failure
+        }
+        throw error
+      }
       return isRuntimeEnvironmentManuallyDisconnected(environment.id)
         ? manuallyDisconnectedResponse(environment)
         : response

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../../shared/protocol-version'
 import * as environmentStore from '../../shared/runtime-environment-store'
 import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+import { RuntimeRpcCallQueueOverloadError } from '../../shared/runtime-rpc-call-queue'
+import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
 
 const {
   handleMock,
@@ -933,6 +935,67 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'repo.list'
     ])
     expect(sendRemoteRuntimeSharedControlRequestMock).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    [
+      new RemoteRuntimeClientError(
+        'remote_runtime_unavailable',
+        'Transport vanished without legacy classifier wording.'
+      ),
+      'remote_runtime_unavailable',
+      'Transport vanished without legacy classifier wording.'
+    ],
+    [
+      Object.assign(new RuntimeRpcCallQueueOverloadError('selector'), {
+        message: 'Capacity rejected without legacy classifier wording.'
+      }),
+      'runtime_rpc_queue_overloaded',
+      'Capacity rejected without legacy classifier wording.'
+    ]
+  ])(
+    'returns coded transport failure %s so the renderer restores its identity',
+    async (transportError, expectedCode, expectedMessage) => {
+      registerRuntimeEnvironmentHandlers(store as never)
+      sendRemoteRuntimeRequestMock.mockRejectedValue(transportError)
+
+      const add = handler<
+        { name: string; pairingCode: string },
+        { environment: { id: string; name: string } }
+      >('runtimeEnvironments:addFromPairingCode')
+      await add(null, { name: 'desk', pairingCode: pairingCode() })
+      const call = handler<{ selector: string; method: string }, RuntimeRpcResponse<unknown>>(
+        'runtimeEnvironments:call'
+      )
+
+      const response = structuredClone(await call(null, { selector: 'desk', method: 'status.get' }))
+      expect(response).toMatchObject({
+        ok: false,
+        error: { code: expectedCode, message: expectedMessage }
+      })
+      expect(response.ok).toBe(false)
+      if (response.ok === false) {
+        expect(response.error).toEqual({ code: expectedCode, message: expectedMessage })
+      }
+    }
+  )
+
+  it('keeps uncoded call failures on the rejected IPC fallback path', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    sendRemoteRuntimeRequestMock.mockRejectedValue(new Error('shared down'))
+
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const call = handler<{ selector: string; method: string }, RuntimeRpcResponse<unknown>>(
+      'runtimeEnvironments:call'
+    )
+
+    await expect(call(null, { selector: 'desk', method: 'status.get' })).rejects.toThrow(
+      'shared down'
+    )
   })
 
   it('does not fall back after a shared-control request fails on a supported runtime', async () => {

--- a/src/shared/remote-runtime-client-error-classification.test.ts
+++ b/src/shared/remote-runtime-client-error-classification.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   isRecoverableRemoteRuntimeConnectionError,
+  isRuntimeRpcQueueOverloadError,
   toRemoteRuntimeClientErrorLike
 } from './remote-runtime-client-error-classification'
 
@@ -25,6 +26,24 @@ describe('remote runtime client error classification', () => {
       isRecoverableRemoteRuntimeConnectionError({
         code: 'invalid_runtime_response',
         message: 'bad frame'
+      })
+    ).toBe(false)
+  })
+
+  it('trusts a structured recovery code before legacy message fragments', () => {
+    expect(
+      isRecoverableRemoteRuntimeConnectionError({
+        code: 'unauthorized',
+        message: 'Remote Orca runtime closed the connection.'
+      })
+    ).toBe(false)
+  })
+
+  it('trusts a structured queue code before legacy message fragments', () => {
+    expect(
+      isRuntimeRpcQueueOverloadError({
+        code: 'remote_runtime_unavailable',
+        message: 'Remote runtime call queue is full; retry after current calls finish.'
       })
     ).toBe(false)
   })

--- a/src/shared/remote-runtime-client-error-classification.ts
+++ b/src/shared/remote-runtime-client-error-classification.ts
@@ -25,17 +25,17 @@ const RECOVERABLE_MESSAGE_FRAGMENTS = [
 ]
 
 export function isRuntimeRpcQueueOverloadError(error: RemoteRuntimeClientErrorLike): boolean {
-  return (
-    error.code === RUNTIME_RPC_QUEUE_OVERLOAD_CODE ||
-    error.message.toLowerCase().includes(RUNTIME_RPC_QUEUE_OVERLOAD_MESSAGE_FRAGMENT)
-  )
+  if (error.code) {
+    return error.code === RUNTIME_RPC_QUEUE_OVERLOAD_CODE
+  }
+  return error.message.toLowerCase().includes(RUNTIME_RPC_QUEUE_OVERLOAD_MESSAGE_FRAGMENT)
 }
 
 export function isRecoverableRemoteRuntimeConnectionError(
   error: RemoteRuntimeClientErrorLike
 ): boolean {
-  if (error.code && RECOVERABLE_CODES.has(error.code)) {
-    return true
+  if (error.code) {
+    return RECOVERABLE_CODES.has(error.code)
   }
   const message = error.message.toLowerCase()
   return RECOVERABLE_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment))


### PR DESCRIPTION
## Summary

- return typed `RemoteRuntimeClientError` and `RuntimeRpcCallQueueOverloadError` rejections from `runtimeEnvironments:call` as the existing structured `RuntimeRpcFailure` response
- let the existing renderer `unwrapRuntimeRpcResult` path reconstruct `RuntimeRpcCallError` with the original machine code
- classify a present structured code authoritatively, while retaining English message fragments only as a fallback for code-less errors

Fixes STA-3456.

## Why

Electron strips custom error properties when an `ipcMain.handle` callback rejects. The renderer therefore lost transport error codes and had to infer recoverability from English message fragments. That made classification fragile: a new or reworded upstream message could silently become an unrecoverable raw error surface.

The main-process handler now catches the two established typed transport rejection classes and returns an `ok: false` response carrying `{ code, message }`. The preload already preserves this response unchanged, and the renderer's existing `unwrapRuntimeRpcResult` turns it into `RuntimeRpcCallError`, restoring the code end to end.

Untyped handler rejections still reject as before. Their renderer consumers, subscription-start rejections, direct Electron-style rejections from older paths, and code-less test/mixed-path errors continue to rely on the message-fragment fallback. The fallback is now consulted only when no structured code exists.

## Compatibility

This change is entirely within one desktop app install: main process -> Electron IPC -> preload -> renderer. It does **not** add fields or opcodes to the paired client/server runtime protocol and does not cross the paired-runtime wire. Runtime RPC success/failure envelopes received from the paired host are unchanged.

The connection-level offline state and single reconnect affordance are intentionally out of scope for this PR and remain follow-up work for STA-3456.

## Verification

### Boundary proof

The new handler test uses deliberately non-matching messages for both:

- `remote_runtime_unavailable`
- `runtime_rpc_queue_overloaded`

Applied as test-only changes to unmodified `origin/main`, the focused suites were red: **4 failed, 66 passed**. Both boundary cases rejected instead of returning a coded response; the two code-precedence tests also exposed the previous message-first behavior.

Mutation checks on this branch:

- disabling typed IPC serialization: **2 failed, 68 passed**
- restoring old message-first classification: **2 failed, 68 passed**
- restored implementation: **70 passed**

### Regression matrix

**221 passed** across:

- `src/main/ipc/runtime-environments.test.ts`
- `src/main/ipc/runtime-environment-transport-routing-tailscale-hint.test.ts`
- `src/shared/remote-runtime-client-error-classification.test.ts`
- `src/renderer/src/runtime/runtime-rpc-client.test.ts`
- `src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts`
- `src/renderer/src/components/terminal-pane/remote-runtime-outage-toast-flood-and-stuck-reconnect.test.ts`
- `src/renderer/src/components/terminal-pane/remote-runtime-resubscribe-failure-recovery-routing.test.ts`
- `src/renderer/src/components/terminal-pane/remote-runtime-error-surface-dismissal.test.ts`

This covers queue-overload backoff plus terminal-gone retirement, stale-handle re-resolution, SSH-session-expired recovery, oversized-snapshot suppression, outage toast deduplication, reconnect recovery, and dismissed-error resurfacing.

Additional checks:

- `pnpm run typecheck` — passed
- repository-wide `oxlint --deny-warnings` — passed
- `oxlint --deny-warnings` on changed files after rebase — passed
- `oxfmt --check` on changed files — passed
- repository-wide `oxfmt --check .` — reports 19 pre-existing unchanged files; none are touched by this PR
