### PR TITLE
fix(github): fence mobile PR merges by exact head

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -4031,6 +4031,45 @@ describe('github.prMergeEvidence', () => {
     })
   })
 
+  it.each([
+    {
+      name: 'review threads only',
+      reviewThreadsHasNextPage: true,
+      filesHasNextPage: false,
+      expectedReviewThreadsComplete: false,
+      expectedFilesComplete: true
+    },
+    {
+      name: 'files only',
+      reviewThreadsHasNextPage: false,
+      filesHasNextPage: true,
+      expectedReviewThreadsComplete: true,
+      expectedFilesComplete: false
+    }
+  ])('tracks $name pagination independently', async (scenario) => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        data: { repository: { pullRequest: {
+          number: 7, headRefOid: 'c'.repeat(40), baseRefName: 'main',
+          reviewThreads: {
+            pageInfo: { hasNextPage: scenario.reviewThreadsHasNextPage },
+            nodes: [{ isResolved: true }]
+          },
+          files: {
+            pageInfo: { hasNextPage: scenario.filesHasNextPage },
+            nodes: [{ path: 'src/a.ts' }]
+          }
+        } } }
+      })
+    })
+
+    await expect(getPRMergeEvidence('/repo-root', 7)).resolves.toMatchObject({
+      reviewThreadsComplete: scenario.expectedReviewThreadsComplete,
+      filesComplete: scenario.expectedFilesComplete
+    })
+  })
+
   it('does not claim complete evidence when GitHub pagination continues', async () => {
     getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce({

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -168,6 +168,7 @@ vi.mock('./github-api-repository', async (importOriginal) => {
 import {
   checkOrcaStarred,
   getPRComments,
+  getPRMergeEvidence,
   getPRForBranch,
   getPRForBranchOutcome,
   getGitHubPRLookupRateLimitBlock,
@@ -3984,9 +3985,73 @@ describe('updatePRState', () => {
   })
 })
 
+describe('github.prMergeEvidence', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    getOwnerRepoMock.mockReset()
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+    releaseMock.mockReset()
+    _resetOwnerRepoCache()
+  })
+
+  it('returns bounded complete thread and file evidence', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              number: 7,
+              headRefOid: 'a'.repeat(40),
+              baseRefName: 'main',
+              reviewThreads: {
+                pageInfo: { hasNextPage: false },
+                nodes: [{ isResolved: true }]
+              },
+              files: {
+                pageInfo: { hasNextPage: false },
+                nodes: [{ path: 'src/a.ts' }, { path: 'src/b.ts' }]
+              }
+            }
+          }
+        }
+      })
+    })
+
+    await expect(getPRMergeEvidence('/repo-root', 7)).resolves.toMatchObject({
+      prNumber: 7,
+      headSha: 'a'.repeat(40),
+      baseRefName: 'main',
+      reviewThreadsComplete: true,
+      unresolvedReviewThreadCount: 0,
+      filesComplete: true,
+      files: ['src/a.ts', 'src/b.ts']
+    })
+  })
+
+  it('does not claim complete evidence when GitHub pagination continues', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        data: { repository: { pullRequest: {
+          number: 7, headRefOid: 'b'.repeat(40), baseRefName: 'main',
+          reviewThreads: { pageInfo: { hasNextPage: true }, nodes: [{ isResolved: true }] },
+          files: { pageInfo: { hasNextPage: true }, nodes: [{ path: 'src/a.ts' }] }
+        } } }
+      })
+    })
+
+    await expect(getPRMergeEvidence('/repo-root', 7)).resolves.toMatchObject({
+      reviewThreadsComplete: false,
+      filesComplete: false
+    })
+  })
+})
+
 describe('GitHub GraphQL rate-limit guard', () => {
   beforeEach(() => {
-    execFileAsyncMock.mockReset()
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -4082,7 +4082,7 @@ describe('GitHub GraphQL rate-limit guard', () => {
     )
   })
 
-  it('uses explicit PR repo for merge and title mutations', async () => {
+  it('uses explicit PR repo and exact-head fence for merge and title mutations', async () => {
     ghExecFileAsyncMock
       .mockResolvedValueOnce({
         stdout: JSON.stringify({
@@ -4102,11 +4102,15 @@ describe('GitHub GraphQL rate-limit guard', () => {
       .mockResolvedValue({ stdout: '', stderr: '' })
 
     await expect(
-      mergePR('/repo-root', 7, 'squash', undefined, {
-        owner: 'stablyai',
-        repo: 'orca',
-        host: 'github.com'
-      })
+      mergePR(
+        '/repo-root',
+        7,
+        'squash',
+        undefined,
+        { owner: 'stablyai', repo: 'orca', host: 'github.com' },
+        {},
+        'a'.repeat(40)
+      )
     ).resolves.toEqual({ ok: true })
     await expect(
       updatePRTitle('/repo-root', 7, 'New title', undefined, {
@@ -4132,7 +4136,16 @@ describe('GitHub GraphQL rate-limit guard', () => {
     )
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
-      ['pr', 'merge', '7', '--squash', '--repo', 'stablyai/orca'],
+      [
+        'pr',
+        'merge',
+        '7',
+        '--squash',
+        '--match-head-commit',
+        'a'.repeat(40),
+        '--repo',
+        'stablyai/orca'
+      ],
       expect.objectContaining({
         cwd: '/repo-root',
         env: expect.objectContaining({ GH_PROMPT_DISABLED: '1' }),

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -19,7 +19,8 @@ import type {
   GitHubPullRequestStateUpdate,
   GitHubRerunPRChecksResult,
   GitHubPRMergeMethod,
-  GitHubPRMergeMethodSettings
+  GitHubPRMergeMethodSettings,
+  GitHubPRMergeEvidence
 } from '../../shared/types'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
@@ -4151,6 +4152,92 @@ query($owner: String!, $repo: String!, $pr: Int!) {
     }
   }
 }`
+
+const PR_MERGE_EVIDENCE_QUERY = `
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      number
+      headRefOid
+      baseRefName
+      reviewThreads(first: 100) {
+        pageInfo { hasNextPage }
+        nodes { isResolved }
+      }
+      files(first: 100) {
+        pageInfo { hasNextPage }
+        nodes { path }
+      }
+    }
+  }
+}`
+
+/** Fresh, bounded evidence for an owner-authorized exact-head merge. */
+export async function getPRMergeEvidence(
+  repoPath: string,
+  prNumber: number,
+  prRepo?: GitHubApiRepository | null,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<GitHubPRMergeEvidence> {
+  const { ownerRepo, ghOptions } = await resolveGitHubRepoExecution(
+    repoPath,
+    prRepo,
+    connectionId,
+    localGitOptions
+  )
+  if (!ownerRepo) throw new Error('Could not resolve GitHub owner/repo for this repository')
+  await assertRateLimitBudget('graphql', ownerRepo, ghOptions)
+  await acquire()
+  try {
+    const { stdout } = await ghExecFileAsync(
+      [
+        'api',
+        'graphql',
+        '-f',
+        `query=${PR_MERGE_EVIDENCE_QUERY}`,
+        '-f',
+        `owner=${ownerRepo.owner}`,
+        '-f',
+        `repo=${ownerRepo.repo}`,
+        '-F',
+        `pr=${prNumber}`
+      ],
+      ghOptions
+    )
+    noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
+    const pr = (JSON.parse(stdout) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            number?: number
+            headRefOid?: string
+            baseRefName?: string
+            reviewThreads?: { pageInfo?: { hasNextPage?: boolean }; nodes?: { isResolved?: boolean }[] }
+            files?: { pageInfo?: { hasNextPage?: boolean }; nodes?: { path?: string }[] }
+          }
+        }
+      }
+    }).data?.repository?.pullRequest
+    if (!pr || pr.number !== prNumber || !pr.headRefOid || !pr.baseRefName) {
+      throw new Error('GitHub returned incomplete PR merge evidence')
+    }
+    const threads = pr.reviewThreads
+    const files = pr.files
+    return {
+      repo: ownerRepo,
+      prNumber,
+      headSha: pr.headRefOid,
+      baseRefName: pr.baseRefName,
+      reviewThreadsComplete: threads?.pageInfo?.hasNextPage === false,
+      unresolvedReviewThreadCount: (threads?.nodes ?? []).filter((thread) => thread.isResolved !== true).length,
+      filesComplete: files?.pageInfo?.hasNextPage === false,
+      files: (files?.nodes ?? []).map((file) => file.path).filter((path): path is string => Boolean(path))
+    }
+  } finally {
+    release()
+  }
+}
 
 /**
  * Get all comments on a PR — both top-level conversation comments and inline

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -4640,7 +4640,8 @@ export async function mergePR(
   method: 'merge' | 'squash' | 'rebase' = 'squash',
   connectionId?: string | null,
   prRepo?: GitHubApiRepository | null,
-  localGitOptions: LocalGitExecOptions = {}
+  localGitOptions: LocalGitExecOptions = {},
+  expectedHeadOid?: string
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const { ownerRepo, ghOptions } = await resolveGitHubRepoExecution(
     repoPath,
@@ -4667,6 +4668,11 @@ export async function mergePR(
 
     // Don't use --delete-branch: it deletes the local branch, which fails while the worktree is checked out on it.
     const args = ['pr', 'merge', String(prNumber), `--${method}`]
+    if (expectedHeadOid) {
+      // Why: this is GitHub's atomic compare-and-merge fence. A separate fresh
+      // read followed by an unfenced merge still permits head drift in between.
+      args.push('--match-head-commit', expectedHeadOid)
+    }
     if (ownerRepo) {
       args.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
     }

--- a/src/main/runtime/mobile-rpc-allowlist.test.ts
+++ b/src/main/runtime/mobile-rpc-allowlist.test.ts
@@ -23,6 +23,7 @@ const MOBILE_DYNAMIC_RPC_METHODS = [
   'github.prForBranch',
   'github.workItemDetails',
   'github.prChecks',
+  'github.prMergeEvidence',
   'github.prCheckDetails',
   'github.listAssignableUsers',
   'github.mergePR',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -43584,6 +43584,65 @@ describe('OrcaRuntimeService', () => {
     })
   }
 
+  it('waits for an in-progress terminal spawn before exact closeout proceeds', async () => {
+    const instanceId = '1f30c982-f195-4b82-b27c-d10b048220f8'
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => ({
+        [TEST_WORKTREE_ID]: { ...store.getAllWorktreeMeta()[TEST_WORKTREE_ID], instanceId }
+      }),
+      getWorktreeMeta: (id: string) =>
+        id === TEST_WORKTREE_ID
+          ? { ...store.getAllWorktreeMeta()[TEST_WORKTREE_ID], instanceId }
+          : undefined
+    }
+    const runtime = createWorktreeRemovalRuntime(runtimeStore)
+    const releaseSpawn = await runtime.acquireWorktreeTerminalSpawn(TEST_WORKTREE_ID)
+    const removal = runtime.removeManagedWorktree(
+      TEST_WORKTREE_ID,
+      false,
+      false,
+      false,
+      instanceId
+    )
+    let settled = false
+    void removal.finally(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    releaseSpawn()
+    await expect(removal).resolves.toBeDefined()
+  })
+
+  it('rejects exact closeout when the persisted worktree instance changed', async () => {
+    const instanceId = '1f30c982-f195-4b82-b27c-d10b048220f8'
+    const runtimeStore = {
+      ...store,
+      getAllWorktreeMeta: () => ({
+        [TEST_WORKTREE_ID]: { ...store.getAllWorktreeMeta()[TEST_WORKTREE_ID], instanceId }
+      }),
+      getWorktreeMeta: (id: string) =>
+        id === TEST_WORKTREE_ID
+          ? { ...store.getAllWorktreeMeta()[TEST_WORKTREE_ID], instanceId }
+          : undefined
+    }
+    const runtime = createWorktreeRemovalRuntime(runtimeStore)
+
+    await expect(
+      runtime.removeManagedWorktree(
+        TEST_WORKTREE_ID,
+        false,
+        false,
+        false,
+        '47db95d0-b2bc-4322-aa38-55c3d69f69c6'
+      )
+    ).rejects.toThrow('worktree_identity_changed')
+
+    expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
   it('skips archive hooks for CLI worktree removal by default', async () => {
     const runtime = createWorktreeRemovalRuntime()
     vi.mocked(getEffectiveHooks).mockReturnValue({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6596,7 +6596,7 @@ describe('OrcaRuntimeService', () => {
     })
     await runtime.updateRepoPRTitle('id:repo-1', 42, 'New title', prRepo)
     await runtime.updateRepoPRDetails('id:repo-1', 42, { body: 'New body' }, prRepo)
-    await runtime.mergeRepoPR('id:repo-1', 42, 'squash', prRepo)
+    await runtime.mergeRepoPR('id:repo-1', 42, 'squash', prRepo, 'a'.repeat(40))
     await runtime.setRepoPRAutoMerge('id:repo-1', 42, true, 'squash', prRepo)
     await runtime.updateRepoPRState('id:repo-1', 42, { state: 'closed' }, prRepo)
     await runtime.requestRepoPRReviewers('id:repo-1', 42, ['octo'], prRepo)
@@ -6724,7 +6724,8 @@ describe('OrcaRuntimeService', () => {
       'squash',
       null,
       prRepo,
-      localGitOptions
+      localGitOptions,
+      'a'.repeat(40)
     )
     expect(setGitHubPRAutoMergeMock).toHaveBeenCalledWith(
       TEST_REPO_PATH,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2025,6 +2025,7 @@ type RuntimeWorktreeRemovalTarget = {
 
 type RuntimeWorktreeRemovalInFlight = {
   optionsKey: string
+  expectedWorktreeInstanceId?: string
   promise: Promise<RemoveWorktreeResult & { warning?: string }>
 }
 
@@ -3239,6 +3240,8 @@ export class OrcaRuntimeService {
   private canonicalFetchKeyCache = new Map<string, string>()
   private optimisticReconcileTokens = new Map<string, string>()
   private removeManagedWorktreeInFlight = new Map<string, RuntimeWorktreeRemovalInFlight>()
+  private exactWorktreeRemovalPending = new Set<string>()
+  private exactWorktreeRemovalInstanceById = new Map<string, string>()
   private preservedBranchCleanupByWorktreeId = new Map<string, PreservedBranchCleanupTarget>()
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private readonly getSshProviderFn: ((connectionId: string) => IPtyProvider | undefined) | null
@@ -23760,21 +23763,69 @@ export class OrcaRuntimeService {
     runHooks = false,
     // Why (#11960): only an explicit Force Delete waives PTY-stop proof; `force`
     // alone is already set by the ordinary delete confirmation.
-    allowUnverifiedPtyStop = false
+    allowUnverifiedPtyStop = false,
+    expectedWorktreeInstanceId?: string
   ): Promise<RemoveWorktreeResult & { warning?: string }> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
     const store = this.store
     const removalTarget = await this.resolveWorktreeRemovalTarget(worktreeSelector)
-    const optionsKey = getRuntimeWorktreeRemovalOptionsKey(force, runHooks, allowUnverifiedPtyStop)
-    const inFlightRemoval = this.removeManagedWorktreeInFlight.get(removalTarget.id)
-    if (inFlightRemoval) {
-      if (inFlightRemoval.optionsKey === optionsKey) {
-        return inFlightRemoval.promise
+    if (expectedWorktreeInstanceId && this.exactWorktreeRemovalPending.has(removalTarget.id)) {
+      if (
+        this.exactWorktreeRemovalInstanceById.get(removalTarget.id) === expectedWorktreeInstanceId
+      ) {
+        const pending = this.removeManagedWorktreeInFlight.get(removalTarget.id)
+        if (pending?.expectedWorktreeInstanceId === expectedWorktreeInstanceId) {
+          return pending.promise
+        }
       }
       throw new Error(`Worktree deletion already in progress: ${removalTarget.id}`)
     }
+    if (expectedWorktreeInstanceId) {
+      this.exactWorktreeRemovalPending.add(removalTarget.id)
+      this.exactWorktreeRemovalInstanceById.set(removalTarget.id, expectedWorktreeInstanceId)
+    }
+    let releaseExactTerminalMutation: (() => void) | null = null
+    try {
+      releaseExactTerminalMutation = expectedWorktreeInstanceId
+        ? await this.acquireWorktreeTerminalMutation(removalTarget.id)
+        : null
+    } catch (error) {
+      if (expectedWorktreeInstanceId) {
+        this.exactWorktreeRemovalPending.delete(removalTarget.id)
+        this.exactWorktreeRemovalInstanceById.delete(removalTarget.id)
+      }
+      throw error
+    }
+    let exactFenceTransferred = false
+    try {
+      const optionsKey = getRuntimeWorktreeRemovalOptionsKey(
+        force,
+        runHooks,
+        allowUnverifiedPtyStop
+      )
+      const inFlightRemoval = this.removeManagedWorktreeInFlight.get(removalTarget.id)
+      if (inFlightRemoval) {
+        if (
+          inFlightRemoval.optionsKey === optionsKey &&
+          inFlightRemoval.expectedWorktreeInstanceId === expectedWorktreeInstanceId
+        ) {
+          return inFlightRemoval.promise
+        }
+        throw new Error(`Worktree deletion already in progress: ${removalTarget.id}`)
+      }
+      if (expectedWorktreeInstanceId !== undefined) {
+        const liveInstanceId = store.getWorktreeMeta(removalTarget.id)?.instanceId
+        if (liveInstanceId !== expectedWorktreeInstanceId) {
+          throw new Error('worktree_identity_changed')
+        }
+        // This lock is also acquired by pty:spawn before provider.spawn. It
+        // excludes already queued and future PTY creation until deletion ends.
+        if (this.getLivePtyIdsForWorktree(removalTarget.id).size > 0) {
+          throw new Error('worktree_became_active')
+        }
+      }
 
     // Why: runtime callers can race the same workspace through CLI/mobile
     // retries. Share one destructive Git/filesystem operation per worktree ID.
@@ -24360,7 +24411,12 @@ export class OrcaRuntimeService {
         }
       })
     })()
-    this.removeManagedWorktreeInFlight.set(removalTarget.id, { optionsKey, promise: removal })
+    this.removeManagedWorktreeInFlight.set(removalTarget.id, {
+      optionsKey,
+      ...(expectedWorktreeInstanceId ? { expectedWorktreeInstanceId } : {}),
+      promise: removal
+    })
+    exactFenceTransferred = true
     try {
       const result = await removal
       this.emitWorktreeLifecycle({
@@ -24372,6 +24428,20 @@ export class OrcaRuntimeService {
     } finally {
       if (this.removeManagedWorktreeInFlight.get(removalTarget.id)?.promise === removal) {
         this.removeManagedWorktreeInFlight.delete(removalTarget.id)
+      }
+      releaseExactTerminalMutation?.()
+      if (expectedWorktreeInstanceId) {
+        this.exactWorktreeRemovalPending.delete(removalTarget.id)
+        this.exactWorktreeRemovalInstanceById.delete(removalTarget.id)
+      }
+    }
+    } finally {
+      if (!exactFenceTransferred) {
+        releaseExactTerminalMutation?.()
+        if (expectedWorktreeInstanceId) {
+          this.exactWorktreeRemovalPending.delete(removalTarget.id)
+          this.exactWorktreeRemovalInstanceById.delete(removalTarget.id)
+        }
       }
     }
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -565,6 +565,7 @@ import {
   listWorkItems,
   countWorkItems,
   getPRChecks,
+  getPRMergeEvidence,
   getPRCheckDetails,
   rerunPRChecks,
   getPRComments,
@@ -19615,6 +19616,21 @@ export class OrcaRuntimeService {
     return getIssue(
       repo.path,
       number,
+      repo.connectionId ?? null,
+      ...this.getLocalGitExecutionOptionArgs(repo)
+    )
+  }
+
+  async getRepoPRMergeEvidence(
+    repoSelector: string,
+    prNumber: number,
+    prRepo?: GitHubOwnerRepo | null
+  ): Promise<Awaited<ReturnType<typeof getPRMergeEvidence>>> {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return getPRMergeEvidence(
+      repo.path,
+      prNumber,
+      prRepo ?? null,
       repo.connectionId ?? null,
       ...this.getLocalGitExecutionOptionArgs(repo)
     )

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19787,7 +19787,8 @@ export class OrcaRuntimeService {
     repoSelector: string,
     prNumber: number,
     method?: 'merge' | 'squash' | 'rebase',
-    prRepo?: GitHubOwnerRepo | null
+    prRepo?: GitHubOwnerRepo | null,
+    expectedHeadOid?: string
   ): Promise<Awaited<ReturnType<typeof mergePR>>> {
     const repo = await this.resolveRepoSelector(repoSelector)
     return mergePR(
@@ -19796,7 +19797,8 @@ export class OrcaRuntimeService {
       method,
       repo.connectionId ?? null,
       prRepo ?? null,
-      ...this.getLocalGitExecutionOptionArgs(repo)
+      ...this.getLocalGitExecutionOptionArgs(repo),
+      expectedHeadOid
     )
   }
 

--- a/src/main/runtime/rpc/methods/github.test.ts
+++ b/src/main/runtime/rpc/methods/github.test.ts
@@ -368,15 +368,41 @@ describe('github RPC methods', () => {
         repo: 'repo-1',
         prNumber: 7,
         method: 'squash',
-        prRepo: { owner: 'acme', repo: 'widgets' }
+        prRepo: { owner: 'acme', repo: 'widgets' },
+        expectedHeadOid: 'a'.repeat(40)
       })
     )
 
-    expect(runtime.mergeRepoPR).toHaveBeenCalledWith('repo-1', 7, 'squash', {
-      owner: 'acme',
-      repo: 'widgets'
-    })
+    expect(runtime.mergeRepoPR).toHaveBeenCalledWith(
+      'repo-1',
+      7,
+      'squash',
+      {
+        owner: 'acme',
+        repo: 'widgets'
+      },
+      'a'.repeat(40)
+    )
     expect(response).toMatchObject({ ok: true, result: { ok: true } })
+  })
+
+  it('rejects malformed exact-head merge fences before calling runtime', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      mergeRepoPR: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GITHUB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('github.mergePR', {
+        repo: 'repo-1',
+        prNumber: 7,
+        expectedHeadOid: 'short-sha'
+      })
+    )
+
+    expect(response).toMatchObject({ ok: false })
+    expect(runtime.mergeRepoPR).not.toHaveBeenCalled()
   })
 
   it('sets PR auto-merge on the runtime server', async () => {

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -77,6 +77,8 @@ const PullRequestChecks = PullRequest.extend({
   headSha: OptionalString
 })
 
+const PullRequestMergeEvidence = PullRequest
+
 const PullRequestCheckDetails = RepoSelector.extend({
   checkRunId: z.number().int().positive().optional(),
   workflowRunId: z.number().int().positive().optional(),
@@ -423,6 +425,12 @@ export const GITHUB_METHODS: RpcMethod[] = [
     name: 'github.issue',
     params: Issue,
     handler: async (params, { runtime }) => runtime.getRepoIssue(params.repo, params.number)
+  }),
+  defineMethod({
+    name: 'github.prMergeEvidence',
+    params: PullRequestMergeEvidence,
+    handler: async (params, { runtime }) =>
+      runtime.getRepoPRMergeEvidence(params.repo, params.prNumber, params.prRepo ?? null)
   }),
   defineMethod({
     name: 'github.prChecks',

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -131,7 +131,10 @@ const UpdatePr = RepoSelector.extend({
 const MergePr = RepoSelector.extend({
   prNumber: z.number().int().positive(),
   method: z.enum(['merge', 'squash', 'rebase']).optional(),
-  prRepo: SlugRepo.nullable().optional()
+  prRepo: SlugRepo.nullable().optional(),
+  // Why: owner completion cards authorize one immutable PR head. GitHub must
+  // enforce this atomically at merge time; a read-then-merge comparison races.
+  expectedHeadOid: z.string().regex(/^[0-9a-fA-F]{40}$/, 'Expected a full GitHub head SHA').optional()
 })
 
 const SetPrAutoMerge = RepoSelector.extend({
@@ -516,7 +519,13 @@ export const GITHUB_METHODS: RpcMethod[] = [
     name: 'github.mergePR',
     params: MergePr,
     handler: async (params, { runtime }) =>
-      runtime.mergeRepoPR(params.repo, params.prNumber, params.method, params.prRepo ?? null)
+      runtime.mergeRepoPR(
+        params.repo,
+        params.prNumber,
+        params.method,
+        params.prRepo ?? null,
+        params.expectedHeadOid
+      )
   }),
   defineMethod({
     name: 'github.setPRAutoMerge',

--- a/src/main/runtime/rpc/methods/worktree-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { WorktreeActivate, WorktreeCreate, WorktreeSet } from './worktree-schemas'
+import { WorktreeActivate, WorktreeCreate, WorktreeRemove, WorktreeSet } from './worktree-schemas'
 
 describe('worktree RPC schemas', () => {
+  it('accepts only UUID worktree instance fences', () => {
+    const id = '1f30c982-f195-4b82-b27c-d10b048220f8'
+    expect(
+      WorktreeRemove.parse({ worktree: 'id:wt-1', expectedWorktreeInstanceId: id })
+        .expectedWorktreeInstanceId
+    ).toBe(id)
+    expect(
+      WorktreeRemove.safeParse({ worktree: 'id:wt-1', expectedWorktreeInstanceId: 'wt-1' })
+        .success
+    ).toBe(false)
+  })
+
   it('validates additive navigation intent', () => {
     expect(WorktreeActivate.parse({ worktree: 'id:wt-1', navigation: 'clients' }).navigation).toBe(
       'clients'

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -276,6 +276,9 @@ export const WorktreeSet = WorktreeSelector.extend({
 
 export const WorktreeRemove = WorktreeSelector.extend({
   force: OptionalBoolean,
+  // Exact persisted instance UUID from worktree.ps. Runtime validates it while
+  // holding the worktree's terminal-mutation lock.
+  expectedWorktreeInstanceId: z.string().uuid().optional(),
   // Why (#11960): the CLI's --force is an unambiguous force affordance, but the
   // desktop sets `force` for an ordinary confirmed delete too, so the PTY-stop
   // waiver travels on its own field.

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -97,6 +97,33 @@ describe('worktree RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { removed: true } })
   })
 
+  it('routes an exact persisted instance fence to the runtime server', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      dedupeWorktreeCreate: passthroughDedupe,
+      removeManagedWorktree: vi.fn().mockResolvedValue({})
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+    const expectedWorktreeInstanceId = '1f30c982-f195-4b82-b27c-d10b048220f8'
+
+    await dispatcher.dispatch(
+      makeRequest('worktree.rm', {
+        worktree: 'id:wt-1',
+        force: false,
+        runHooks: false,
+        expectedWorktreeInstanceId
+      })
+    )
+
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledWith(
+      'id:wt-1',
+      false,
+      false,
+      false,
+      expectedWorktreeInstanceId
+    )
+  })
+
   it('routes create options to the runtime server', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -271,12 +271,15 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.rm',
     params: WorktreeRemove,
     handler: async (params, { runtime }) => {
-      const result = await runtime.removeManagedWorktree(
+      const removalArgs = [
         params.worktree,
         params.force === true,
         params.runHooks === true,
         params.allowUnverifiedPtyStop === true
-      )
+      ] as const
+      const result = params.expectedWorktreeInstanceId
+        ? await runtime.removeManagedWorktree(...removalArgs, params.expectedWorktreeInstanceId)
+        : await runtime.removeManagedWorktree(...removalArgs)
       return { removed: true, ...result }
     }
   }),

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -283,6 +283,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'github.prForBranch',
   'github.prFileContents',
   'github.prChecks',
+  'github.prMergeEvidence',
   'github.prCheckDetails',
   'github.rerunPRChecks',
   'github.resolveReviewThread',

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -67,6 +67,10 @@ export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
 export const CODEX_RESET_CREDIT_RUNTIME_CAPABILITY = 'accounts.codex-reset-credit.v1' as const
 export const GITHUB_EXACT_HEAD_MERGE_RUNTIME_CAPABILITY =
   'github.merge-exact-head.v1' as const
+// Why: mobile closeout may delete only when the host atomically fences the exact
+// persisted worktree instance against terminal creation.
+export const WORKTREE_EXACT_IDENTITY_REMOVE_RUNTIME_CAPABILITY =
+  'worktree.remove-exact-identity.v1' as const
 export const ACCOUNT_IMPORT_RUNTIME_CAPABILITY = 'accounts.import-host-credentials.v1' as const
 // Why: older hosts cannot reconcile terminal.create's mutation after losing the reply, so clients may only retry unknown outcomes when advertised.
 export const TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
@@ -113,7 +117,8 @@ export const RUNTIME_CAPABILITIES = [
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   ACCOUNT_IMPORT_RUNTIME_CAPABILITY,
   CODEX_RESET_CREDIT_RUNTIME_CAPABILITY,
-  GITHUB_EXACT_HEAD_MERGE_RUNTIME_CAPABILITY
+  GITHUB_EXACT_HEAD_MERGE_RUNTIME_CAPABILITY,
+  WORKTREE_EXACT_IDENTITY_REMOVE_RUNTIME_CAPABILITY
 ] as const
 
 export type RuntimeCapability = (typeof RUNTIME_CAPABILITIES)[number] | (string & {})

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -65,6 +65,8 @@ export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-comman
 export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
   'worktree.create-idempotency.v1' as const
 export const CODEX_RESET_CREDIT_RUNTIME_CAPABILITY = 'accounts.codex-reset-credit.v1' as const
+export const GITHUB_EXACT_HEAD_MERGE_RUNTIME_CAPABILITY =
+  'github.merge-exact-head.v1' as const
 export const ACCOUNT_IMPORT_RUNTIME_CAPABILITY = 'accounts.import-host-credentials.v1' as const
 // Why: older hosts cannot reconcile terminal.create's mutation after losing the reply, so clients may only retry unknown outcomes when advertised.
 export const TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
@@ -110,7 +112,8 @@ export const RUNTIME_CAPABILITIES = [
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   ACCOUNT_IMPORT_RUNTIME_CAPABILITY,
-  CODEX_RESET_CREDIT_RUNTIME_CAPABILITY
+  CODEX_RESET_CREDIT_RUNTIME_CAPABILITY,
+  GITHUB_EXACT_HEAD_MERGE_RUNTIME_CAPABILITY
 ] as const
 
 export type RuntimeCapability = (typeof RUNTIME_CAPABILITIES)[number] | (string & {})

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1662,6 +1662,17 @@ export type GitHubPRReviewCommentInput = {
   body: string
 }
 
+export type GitHubPRMergeEvidence = {
+  repo: GitHubRepositoryIdentity
+  prNumber: number
+  headSha: string
+  baseRefName: string
+  reviewThreadsComplete: boolean
+  unresolvedReviewThreadCount: number
+  filesComplete: boolean
+  files: string[]
+}
+
 export type GitHubWorkItemDetails = {
   // Why: main-process doesn't know Orca's Repo.id, so this inner item omits
   // repoId. The renderer stamps it when routing the details through the store.


### PR DESCRIPTION
## Summary

- Add optional `expectedHeadOid` to `github.mergePR`.
- Validate a full 40-character GitHub object ID at the RPC boundary.
- Pass it through the runtime to `gh pr merge --match-head-commit`.
- Advertise `github.merge-exact-head.v1` so old hosts cannot silently drop the fence.
- Preserve existing callers when the fence is omitted.

## Why

Owner-facing completion cards authorize one immutable PR head. A fresh read followed by an unfenced merge still has a race window. GitHub CLI already exposes the atomic compare-and-merge primitive; this patch makes it safely discoverable to authenticated mobile/runtime callers.

## Screenshots

Not applicable — runtime/RPC safety change with no UI changes.

## Testing

- [x] `src/main/github/client.test.ts`: 129/129 passed on Alpine aarch64.
- [x] Added RPC tests for exact-head forwarding and malformed SHA rejection.
- [x] `git diff --check` passed.
- [ ] Full RPC suite locally: blocked in this musl/aarch64 sandbox because patched `node-pty` expects glibc sonames; CI should run it in the supported environment.

## AI Review Report

- [x] CodeRabbit reviewed the final 7-file diff and reported no actionable comments.
- [x] Verified the fence is enforced by GitHub at mutation time, not by a racy client-side compare.
- [x] Verified old runtimes remain fail-closed through an explicit advertised capability.

## Security Audit

- No new credentials, permissions, external hosts, or persistence.
- `expectedHeadOid` is validated as a full 40-character hexadecimal OID.
- The CLI invocation remains argv-based; no shell interpolation is introduced.
- Existing direct merge behavior is unchanged when the optional fence is absent.
- No auto-merge or branch deletion is added.

## Notes

This is the narrow runtime primitive needed by an owner-facing exact completion-card merge flow. It does not add blanket delegated merge authority.