### PR TITLE
fix: prioritize filenames in new-tab file results

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TabEntryOption } from './tab-create-entry-action'
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 // Why: the real entry-action module pulls in runtime IPC + the app store; the
 // keyboard behavior under test only needs a controllable option list.
@@ -37,7 +38,7 @@ let root: Root
 
 function mount(node: React.JSX.Element): void {
   act(() => {
-    root.render(node)
+    root.render(<TooltipProvider>{node}</TooltipProvider>)
   })
 }
 

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
@@ -5,7 +5,6 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TabEntryOption } from './tab-create-entry-action'
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
-import { TooltipProvider } from '@/components/ui/tooltip'
 
 // Why: the real entry-action module pulls in runtime IPC + the app store; the
 // keyboard behavior under test only needs a controllable option list.
@@ -38,7 +37,7 @@ let root: Root
 
 function mount(node: React.JSX.Element): void {
   act(() => {
-    root.render(<TooltipProvider>{node}</TooltipProvider>)
+    root.render(node)
   })
 }
 

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntry.keyboard.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TabEntryOption } from './tab-create-entry-action'
 import type { TabAgentLaunchOption } from './tab-agent-launch-options'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 // Why: the real entry-action module pulls in runtime IPC + the app store; the
 // keyboard behavior under test only needs a controllable option list.
@@ -37,7 +38,8 @@ let root: Root
 
 function mount(node: React.JSX.Element): void {
   act(() => {
-    root.render(node)
+    // Result rows carry a path tooltip, which Radix requires a provider for.
+    root.render(<TooltipProvider>{node}</TooltipProvider>)
   })
 }
 

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -5,6 +5,18 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => (
+    <div data-tooltip-root="">{children}</div>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-tooltip-content="">{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-tooltip-trigger="">{children}</div>
+  )
+}))
+
 import { EntryActionRow } from './TabBarCreateEntryRow'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -40,7 +52,7 @@ afterEach(() => {
 })
 
 describe('EntryActionRow', () => {
-  it('puts the filename before the truncated parent path and exposes the full path in a native tooltip', () => {
+  it('puts the filename before the truncated parent path and exposes the full path in a tooltip', () => {
     act(() => {
       root.render(
         createElement(EntryActionRow, {
@@ -55,7 +67,7 @@ describe('EntryActionRow', () => {
     const button = container.querySelector('button')
     const text = button?.textContent ?? ''
     expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('app/src/components/'))
-    expect(button?.getAttribute('title')).toBe(filePath)
+    expect(container.querySelector('[data-tooltip-content]')?.textContent).toBe(filePath)
   })
 
   it('does not duplicate the root separator for absolute root-level files', () => {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -4,19 +4,6 @@ import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActiveOption } from './tab-create-entry-active-option'
-
-vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => (
-    <div data-tooltip-root="">{children}</div>
-  ),
-  TooltipContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-tooltip-content="">{children}</div>
-  ),
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
-    <div data-tooltip-trigger="">{children}</div>
-  )
-}))
-
 import { EntryActionRow } from './TabBarCreateEntryRow'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -37,6 +24,25 @@ function makeFileOption(path: string): ActiveOption {
   }
 }
 
+function renderRow(option: ActiveOption): HTMLButtonElement {
+  act(() => {
+    root.render(
+      createElement(EntryActionRow, {
+        id: 'file-result',
+        onClick: vi.fn(),
+        option,
+        selected: false
+      })
+    )
+  })
+
+  const button = container.querySelector('button')
+  if (!button) {
+    throw new Error('row did not render a button')
+  }
+  return button
+}
+
 let container: HTMLDivElement
 let root: Root
 
@@ -52,37 +58,34 @@ afterEach(() => {
 })
 
 describe('EntryActionRow', () => {
-  it('puts the filename before the truncated parent path and exposes the full path in a tooltip', () => {
-    act(() => {
-      root.render(
-        createElement(EntryActionRow, {
-          id: 'file-result',
-          onClick: vi.fn(),
-          option: makeFileOption(filePath),
-          selected: true
-        })
-      )
-    })
+  it('puts the filename before the truncated parent path', () => {
+    const text = renderRow(makeFileOption(filePath)).textContent ?? ''
 
-    const button = container.querySelector('button')
-    const text = button?.textContent ?? ''
     expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('app/src/components/'))
-    expect(container.querySelector('[data-tooltip-content]')?.textContent).toBe(filePath)
+  })
+
+  it('exposes the full path through the native tooltip', () => {
+    expect(renderRow(makeFileOption(filePath)).getAttribute('title')).toBe(filePath)
   })
 
   it('does not duplicate the root separator for absolute root-level files', () => {
-    act(() => {
-      root.render(
-        createElement(EntryActionRow, {
-          id: 'root-file-result',
-          onClick: vi.fn(),
-          option: makeFileOption('/foo'),
-          selected: false
-        })
-      )
-    })
+    const text = renderRow(makeFileOption('/foo')).textContent ?? ''
 
-    expect(container.querySelector('button')?.textContent).toContain('foo/')
-    expect(container.querySelector('button')?.textContent).not.toContain('foo//')
+    expect(text).toContain('foo/')
+    expect(text).not.toContain('foo//')
+  })
+
+  it('keeps Windows separators intact', () => {
+    const windowsPath = 'C:\\repo\\src\\SecondaryNav.tsx'
+    const button = renderRow(makeFileOption(windowsPath))
+    const text = button.textContent ?? ''
+
+    expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('C:\\repo\\src\\'))
+    expect(button.getAttribute('title')).toBe(windowsPath)
+  })
+
+  it('renders a bare filename without a directory fragment', () => {
+    expect(renderRow(makeFileOption('README.md')).textContent).toContain('README.md')
+    expect(container.textContent).not.toContain('/')
   })
 })

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -3,6 +3,7 @@
 import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import type { ActiveOption } from './tab-create-entry-active-option'
 import { EntryActionRow } from './TabBarCreateEntryRow'
 
@@ -24,15 +25,21 @@ function makeFileOption(path: string): ActiveOption {
   }
 }
 
+// The tooltip itself is asserted in tests/e2e/tab-create-entry-file-paths.spec.ts,
+// where it actually opens; here we only need the row's own text layout.
 function renderRow(option: ActiveOption): HTMLButtonElement {
   act(() => {
     root.render(
-      createElement(EntryActionRow, {
-        id: 'file-result',
-        onClick: vi.fn(),
-        option,
-        selected: false
-      })
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(EntryActionRow, {
+          id: 'file-result',
+          onClick: vi.fn(),
+          option,
+          selected: false
+        })
+      )
     )
   })
 
@@ -64,10 +71,6 @@ describe('EntryActionRow', () => {
     expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('app/src/components/'))
   })
 
-  it('exposes the full path through the native tooltip', () => {
-    expect(renderRow(makeFileOption(filePath)).getAttribute('title')).toBe(filePath)
-  })
-
   it('does not duplicate the root separator for absolute root-level files', () => {
     const text = renderRow(makeFileOption('/foo')).textContent ?? ''
 
@@ -76,12 +79,9 @@ describe('EntryActionRow', () => {
   })
 
   it('keeps Windows separators intact', () => {
-    const windowsPath = 'C:\\repo\\src\\SecondaryNav.tsx'
-    const button = renderRow(makeFileOption(windowsPath))
-    const text = button.textContent ?? ''
+    const text = renderRow(makeFileOption('C:\\repo\\src\\SecondaryNav.tsx')).textContent ?? ''
 
     expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('C:\\repo\\src\\'))
-    expect(button.getAttribute('title')).toBe(windowsPath)
   })
 
   it('renders a bare filename without a directory fragment', () => {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -5,18 +5,6 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
-vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => (
-    <div data-tooltip-root="">{children}</div>
-  ),
-  TooltipContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-tooltip-content="">{children}</div>
-  ),
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
-    <div data-tooltip-trigger="">{children}</div>
-  )
-}))
-
 import { EntryActionRow } from './TabBarCreateEntryRow'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -52,7 +40,7 @@ afterEach(() => {
 })
 
 describe('EntryActionRow', () => {
-  it('puts the filename before the truncated parent path and exposes the full path in a tooltip', () => {
+  it('puts the filename before the truncated parent path and exposes the full path in a native tooltip', () => {
     act(() => {
       root.render(
         createElement(EntryActionRow, {
@@ -67,7 +55,7 @@ describe('EntryActionRow', () => {
     const button = container.querySelector('button')
     const text = button?.textContent ?? ''
     expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('app/src/components/'))
-    expect(container.querySelector('[data-tooltip-content]')?.textContent).toBe(filePath)
+    expect(button?.getAttribute('title')).toBe(filePath)
   })
 
   it('does not duplicate the root separator for absolute root-level files', () => {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActiveOption } from './tab-create-entry-active-option'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => (
+    <div data-tooltip-root="">{children}</div>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-tooltip-content="">{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-tooltip-trigger="">{children}</div>
+  )
+}))
+
+import { EntryActionRow } from './TabBarCreateEntryRow'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const filePath = 'app/src/components/SecondaryNav.tsx'
+
+function makeFileOption(path: string): ActiveOption {
+  return {
+    kind: 'entry',
+    option: {
+      id: `existing-file:${path}`,
+      classification: {
+        kind: 'existing-file',
+        matchKind: 'fuzzy',
+        relativePath: path
+      }
+    }
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('EntryActionRow', () => {
+  it('puts the filename before the truncated parent path and exposes the full path in a tooltip', () => {
+    act(() => {
+      root.render(
+        createElement(EntryActionRow, {
+          id: 'file-result',
+          onClick: vi.fn(),
+          option: makeFileOption(filePath),
+          selected: true
+        })
+      )
+    })
+
+    const button = container.querySelector('button')
+    const text = button?.textContent ?? ''
+    expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('app/src/components/'))
+    expect(container.querySelector('[data-tooltip-content]')?.textContent).toBe(filePath)
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -69,4 +69,20 @@ describe('EntryActionRow', () => {
     expect(text.indexOf('SecondaryNav.tsx')).toBeLessThan(text.indexOf('app/src/components/'))
     expect(container.querySelector('[data-tooltip-content]')?.textContent).toBe(filePath)
   })
+
+  it('does not duplicate the root separator for absolute root-level files', () => {
+    act(() => {
+      root.render(
+        createElement(EntryActionRow, {
+          id: 'root-file-result',
+          onClick: vi.fn(),
+          option: makeFileOption('/foo'),
+          selected: false
+        })
+      )
+    })
+
+    expect(container.querySelector('button')?.textContent).toContain('foo/')
+    expect(container.querySelector('button')?.textContent).not.toContain('foo//')
+  })
 })

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { ActiveOption } from './tab-create-entry-active-option'
-import { EntryActionRow } from './TabBarCreateEntryRow'
+import { cursorTooltipOffsets, EntryActionRow } from './TabBarCreateEntryRow'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -87,5 +87,32 @@ describe('EntryActionRow', () => {
   it('renders a bare filename without a directory fragment', () => {
     expect(renderRow(makeFileOption('README.md')).textContent).toContain('README.md')
     expect(container.textContent).not.toContain('/')
+  })
+})
+
+describe('cursorTooltipOffsets', () => {
+  const row = { bottom: 120, left: 400 }
+
+  it('places the tooltip under the cursor rather than the row', () => {
+    // Row-anchored placement would be align 0; the cursor is 64px into the row.
+    expect(cursorTooltipOffsets({ x: 464, y: 108 }, row)).toEqual({ align: 64, side: 6 })
+  })
+
+  it('tracks the cursor across the row', () => {
+    const left = cursorTooltipOffsets({ x: 410, y: 108 }, row)
+    const right = cursorTooltipOffsets({ x: 610, y: 108 }, row)
+
+    expect(right.align - left.align).toBe(200)
+    expect(right.side).toBe(left.side)
+  })
+
+  it('stays anchored to the cursor when the row moves under it', () => {
+    // The dropdown reflows while results stream in; re-measuring the row must
+    // keep the tooltip on the cursor, not drag it along with the row.
+    const before = cursorTooltipOffsets({ x: 464, y: 108 }, row)
+    const after = cursorTooltipOffsets({ x: 464, y: 108 }, { bottom: 148, left: 576 })
+
+    expect(row.left + before.align).toBe(576 + after.align)
+    expect(row.bottom + before.side).toBe(148 + after.side)
   })
 })

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -96,7 +96,12 @@ export function EntryActionRow({
 function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {
   const filename = basename(path)
   const directory = dirname(path)
-  const directoryLabel = directory === '.' ? '' : `${directory}${path.includes('\\') ? '\\' : '/'}`
+  const directoryLabel =
+    directory === '.'
+      ? ''
+      : directory.endsWith('/') || directory.endsWith('\\')
+        ? directory
+        : `${directory}${path.includes('\\') ? '\\' : '/'}`
 
   return (
     <span className="flex min-w-0 flex-1 items-center gap-1">

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
+import { basename, dirname } from '@/lib/path'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
@@ -40,8 +42,7 @@ export function EntryActionRow({
   selected: boolean
 }): React.JSX.Element {
   const presentation = getActionPresentation(option)
-
-  return (
+  const actionRow = (
     <button
       type="button"
       id={id}
@@ -61,13 +62,49 @@ export function EntryActionRow({
       </span>
       {presentation.showDetail ? (
         <>
-          <span className="text-muted-foreground/70" aria-hidden="true">
+          <span className="shrink-0 text-muted-foreground/70" aria-hidden="true">
             ·
           </span>
-          <span className="min-w-0 truncate">{presentation.detail}</span>
+          {presentation.prioritizeFilename ? (
+            <FilenameFirstPath path={presentation.detail} />
+          ) : (
+            <span className="min-w-0 flex-1 truncate">{presentation.detail}</span>
+          )}
         </>
       ) : null}
     </button>
+  )
+
+  if (!presentation.prioritizeFilename) {
+    return actionRow
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{actionRow}</TooltipTrigger>
+      <TooltipContent
+        side="top"
+        sideOffset={4}
+        className="max-w-[min(90vw,600px)] break-all font-mono"
+      >
+        {presentation.detail}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {
+  const filename = basename(path)
+  const directory = dirname(path)
+  const directoryLabel = directory === '.' ? '' : `${directory}${path.includes('\\') ? '\\' : '/'}`
+
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-1">
+      <span className="min-w-0 max-w-full shrink-0 truncate text-foreground">{filename}</span>
+      {directoryLabel ? (
+        <span className="min-w-0 truncate text-muted-foreground">{directoryLabel}</span>
+      ) : null}
+    </span>
   )
 }
 
@@ -75,6 +112,7 @@ function getActionPresentation(option: ActiveOption): {
   detail: string
   icon: React.ReactNode
   label: string
+  prioritizeFilename?: boolean
   showDetail: boolean
 } {
   if (option.kind === 'menu') {
@@ -122,6 +160,7 @@ function getActionPresentation(option: ActiveOption): {
           : classification.relativePath,
       icon: <FileText className="size-3.5 shrink-0" aria-hidden="true" />,
       label: translate('auto.components.tab.bar.TabBarCreateEntry.25dc1cd653', 'Open file'),
+      prioritizeFilename: true,
       showDetail: true
     }
   }

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { basename, dirname } from '@/lib/path'
 import { cn } from '@/lib/utils'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
@@ -42,12 +40,17 @@ export function EntryActionRow({
   selected: boolean
 }): React.JSX.Element {
   const presentation = getActionPresentation(option)
-  const actionRow = (
+
+  return (
     <button
       type="button"
       id={id}
       role="option"
       aria-selected={selected}
+      // Why: the row truncates aggressively, so the OS tooltip carries the full
+      // text. Native beats a portaled tooltip here — this row lives inside the
+      // new-tab dropdown, where an overlay would cover the sibling results.
+      title={presentation.showDetail ? presentation.detail : undefined}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
         selected
@@ -74,40 +77,28 @@ export function EntryActionRow({
       ) : null}
     </button>
   )
+}
 
-  if (!presentation.prioritizeFilename) {
-    return actionRow
-  }
+// Why: keeps the separator attached to the directory, so `/foo` renders as
+// `foo` + `/` rather than re-deriving a separator that may not match the path.
+function splitTrailingSegment(path: string): { directory: string; filename: string } {
+  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
 
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{actionRow}</TooltipTrigger>
-      <TooltipContent
-        side="top"
-        sideOffset={4}
-        className="max-w-[min(90vw,600px)] break-all font-mono"
-      >
-        {presentation.detail}
-      </TooltipContent>
-    </Tooltip>
-  )
+  return separatorIndex === -1
+    ? { directory: '', filename: path }
+    : { directory: path.slice(0, separatorIndex + 1), filename: path.slice(separatorIndex + 1) }
 }
 
 function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {
-  const filename = basename(path)
-  const directory = dirname(path)
-  const directoryLabel =
-    directory === '.'
-      ? ''
-      : directory.endsWith('/') || directory.endsWith('\\')
-        ? directory
-        : `${directory}${path.includes('\\') ? '\\' : '/'}`
+  const { directory, filename } = splitTrailingSegment(path)
 
   return (
     <span className="flex min-w-0 flex-1 items-center gap-1">
-      <span className="min-w-0 max-w-full shrink-0 truncate text-foreground">{filename}</span>
-      {directoryLabel ? (
-        <span className="min-w-0 truncate text-muted-foreground">{directoryLabel}</span>
+      {/* shrink-0 + max-w-full: the directory gives up all of its width before
+          the filename loses a character. */}
+      <span className="min-w-0 max-w-full shrink-0 truncate">{filename}</span>
+      {directory ? (
+        <span className="min-w-0 truncate text-muted-foreground/70">{directory}</span>
       ) : null}
     </span>
   )

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
@@ -41,16 +42,12 @@ export function EntryActionRow({
 }): React.JSX.Element {
   const presentation = getActionPresentation(option)
 
-  return (
+  const row = (
     <button
       type="button"
       id={id}
       role="option"
       aria-selected={selected}
-      // Why: the row truncates aggressively, so the OS tooltip carries the full
-      // text. Native beats a portaled tooltip here — this row lives inside the
-      // new-tab dropdown, where an overlay would cover the sibling results.
-      title={presentation.showDetail ? presentation.detail : undefined}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
         selected
@@ -76,6 +73,27 @@ export function EntryActionRow({
         </>
       ) : null}
     </button>
+  )
+
+  if (!presentation.showDetail) {
+    return row
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{row}</TooltipTrigger>
+      {/* Why: side="right" clears the result list. Above/below would cover the
+          sibling rows the user is scanning, and Orca has no native tooltip to
+          fall back on — `title` renders nothing in this window. */}
+      <TooltipContent
+        side="right"
+        sideOffset={8}
+        showArrow={false}
+        className="max-w-[420px] rounded-[5px] border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-all text-popover-foreground shadow-[0_2px_8px_rgba(0,0,0,0.28)]"
+      >
+        {presentation.detail}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -3,7 +3,6 @@ import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from '
 import { AgentIcon } from '@/lib/agent-catalog'
 import { basename, dirname } from '@/lib/path'
 import { cn } from '@/lib/utils'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
@@ -48,6 +47,7 @@ export function EntryActionRow({
       id={id}
       role="option"
       aria-selected={selected}
+      title={presentation.prioritizeFilename ? presentation.detail : undefined}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
         selected
@@ -75,22 +75,7 @@ export function EntryActionRow({
     </button>
   )
 
-  if (!presentation.prioritizeFilename) {
-    return actionRow
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{actionRow}</TooltipTrigger>
-      <TooltipContent
-        side="top"
-        sideOffset={4}
-        className="max-w-[min(90vw,600px)] break-all font-mono"
-      >
-        {presentation.detail}
-      </TooltipContent>
-    </Tooltip>
-  )
+  return actionRow
 }
 
 function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -3,6 +3,7 @@ import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from '
 import { AgentIcon } from '@/lib/agent-catalog'
 import { basename, dirname } from '@/lib/path'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
@@ -47,7 +48,6 @@ export function EntryActionRow({
       id={id}
       role="option"
       aria-selected={selected}
-      title={presentation.prioritizeFilename ? presentation.detail : undefined}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
         selected
@@ -75,7 +75,22 @@ export function EntryActionRow({
     </button>
   )
 
-  return actionRow
+  if (!presentation.prioritizeFilename) {
+    return actionRow
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{actionRow}</TooltipTrigger>
+      <TooltipContent
+        side="top"
+        sideOffset={4}
+        className="max-w-[min(90vw,600px)] break-all font-mono"
+      >
+        {presentation.detail}
+      </TooltipContent>
+    </Tooltip>
+  )
 }
 
 function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -11,6 +11,20 @@ export const RESULT_LISTBOX_ID = 'tab-create-entry-results'
 // Clears the macOS pointer without putting the label under the cursor's own hotspot.
 const CURSOR_TOOLTIP_GAP = 18
 
+/**
+ * Radix positions the tooltip against the row, so a cursor position has to be
+ * restated as offsets from the row's bottom-left corner to land under the pointer.
+ */
+export function cursorTooltipOffsets(
+  pointer: { x: number; y: number },
+  row: { bottom: number; left: number }
+): { align: number; side: number } {
+  return {
+    align: pointer.x - row.left,
+    side: pointer.y + CURSOR_TOOLTIP_GAP - row.bottom
+  }
+}
+
 // Index-based (not the option id, which may contain spaces/slashes from file
 // paths) so it is always a valid aria-activedescendant IDREF.
 export function resultOptionDomId(index: number): string {
@@ -44,31 +58,42 @@ export function EntryActionRow({
   selected: boolean
 }): React.JSX.Element {
   const presentation = getActionPresentation(option)
+  const rowRef = React.useRef<HTMLButtonElement>(null)
+  const pointerRef = React.useRef<{ x: number; y: number } | null>(null)
   const [tooltipOpen, setTooltipOpen] = React.useState(false)
   const [pointerOffset, setPointerOffset] = React.useState({ align: 0, side: 0 })
 
+  // Why: Radix positions against the row, so the offsets are only valid for the
+  // row's position at the moment it positions. Results stream in while the open
+  // delay runs, so re-measure on open rather than trusting the pointer-move rect.
+  React.useLayoutEffect(() => {
+    const rect = rowRef.current?.getBoundingClientRect()
+    const pointer = pointerRef.current
+    if (!tooltipOpen || !rect || !pointer) {
+      return
+    }
+    const next = cursorTooltipOffsets(pointer, rect)
+    setPointerOffset((current) =>
+      current.align === next.align && current.side === next.side ? current : next
+    )
+  }, [tooltipOpen])
+
   const row = (
     <button
+      ref={rowRef}
       type="button"
       id={id}
       role="option"
       aria-selected={selected}
-      onMouseMove={(event) => {
-        // Freeze once shown: a system tooltip marks where the cursor came to
-        // rest, it does not trail the pointer around afterwards.
+      // Why: a ref, not state — this is read once when the tooltip opens, so
+      // re-rendering the row on every pointer move would be churn for nothing.
+      // pointermove (not mousemove) because Radix opens off pointermove and Slot
+      // runs the child handler first, keeping this fresh even on instant open.
+      onPointerMove={(event) => {
         if (tooltipOpen) {
           return
         }
-        const rect = event.currentTarget.getBoundingClientRect()
-        const next = {
-          align: event.clientX - rect.left,
-          side: event.clientY + CURSOR_TOOLTIP_GAP - rect.bottom
-        }
-        setPointerOffset((current) =>
-          Math.abs(current.align - next.align) < 3 && Math.abs(current.side - next.side) < 3
-            ? current
-            : next
-        )
+        pointerRef.current = { x: event.clientX, y: event.clientY }
       }}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
@@ -97,7 +122,9 @@ export function EntryActionRow({
     </button>
   )
 
-  if (!presentation.showDetail) {
+  // Only the filename-first rows hide information. Every other row already shows
+  // its detail in full, and STYLEGUIDE.md:162 rules out labelling those.
+  if (!presentation.prioritizeFilename) {
     return row
   }
 
@@ -114,7 +141,7 @@ export function EntryActionRow({
         sideOffset={pointerOffset.side}
         alignOffset={pointerOffset.align}
         showArrow={false}
-        className="max-w-[420px] rounded-[5px] border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-all text-popover-foreground shadow-[0_2px_8px_rgba(0,0,0,0.28)]"
+        className="max-w-[420px] rounded-md border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-words text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
       >
         {presentation.detail}
       </TooltipContent>

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -8,6 +8,9 @@ import type { ActiveOption } from './tab-create-entry-active-option'
 
 export const RESULT_LISTBOX_ID = 'tab-create-entry-results'
 
+// Clears the macOS pointer without putting the label under the cursor's own hotspot.
+const CURSOR_TOOLTIP_GAP = 18
+
 // Index-based (not the option id, which may contain spaces/slashes from file
 // paths) so it is always a valid aria-activedescendant IDREF.
 export function resultOptionDomId(index: number): string {
@@ -41,6 +44,8 @@ export function EntryActionRow({
   selected: boolean
 }): React.JSX.Element {
   const presentation = getActionPresentation(option)
+  const [tooltipOpen, setTooltipOpen] = React.useState(false)
+  const [pointerOffset, setPointerOffset] = React.useState({ align: 0, side: 0 })
 
   const row = (
     <button
@@ -48,6 +53,23 @@ export function EntryActionRow({
       id={id}
       role="option"
       aria-selected={selected}
+      onMouseMove={(event) => {
+        // Freeze once shown: a system tooltip marks where the cursor came to
+        // rest, it does not trail the pointer around afterwards.
+        if (tooltipOpen) {
+          return
+        }
+        const rect = event.currentTarget.getBoundingClientRect()
+        const next = {
+          align: event.clientX - rect.left,
+          side: event.clientY + CURSOR_TOOLTIP_GAP - rect.bottom
+        }
+        setPointerOffset((current) =>
+          Math.abs(current.align - next.align) < 3 && Math.abs(current.side - next.side) < 3
+            ? current
+            : next
+        )
+      }}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
         selected
@@ -80,14 +102,17 @@ export function EntryActionRow({
   }
 
   return (
-    <Tooltip>
+    <Tooltip open={tooltipOpen} onOpenChange={setTooltipOpen}>
       <TooltipTrigger asChild>{row}</TooltipTrigger>
-      {/* Why: side="right" clears the result list. Above/below would cover the
-          sibling rows the user is scanning, and Orca has no native tooltip to
-          fall back on — `title` renders nothing in this window. */}
+      {/* Anchored under the cursor the way a system tooltip is, rather than to
+          the row. Radix anchors to the trigger, so the cursor is expressed as
+          offsets off the row's bottom-left corner; collision flipping still
+          applies near the viewport edge. */}
       <TooltipContent
-        side="right"
-        sideOffset={8}
+        side="bottom"
+        align="start"
+        sideOffset={pointerOffset.side}
+        alignOffset={pointerOffset.align}
         showArrow={false}
         className="max-w-[420px] rounded-[5px] border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-all text-popover-foreground shadow-[0_2px_8px_rgba(0,0,0,0.28)]"
       >

--- a/src/renderer/src/components/ui/tooltip.tsx
+++ b/src/renderer/src/components/ui/tooltip.tsx
@@ -31,9 +31,10 @@ function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimiti
 function TooltipContent({
   className,
   sideOffset = 0,
+  showArrow = true,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & { showArrow?: boolean }) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -48,7 +49,9 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        {showArrow ? (
+          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        ) : null}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -3,7 +3,8 @@ import path from 'node:path'
 import { expect, test } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
-const relativeFilePath = 'app/src/components/SecondaryNav.tsx'
+const relativeFilePath =
+  'packages/orca/src/renderer/src/components/navigation/worktree/secondary-nav/SecondaryNav.tsx'
 
 test('new-tab file results prioritize the filename and reveal the full path on hover', async ({
   orcaPage,
@@ -26,10 +27,10 @@ test('new-tab file results prioritize the filename and reveal the full path on h
   const row = orcaPage.locator('[role="option"]').filter({ hasText: 'Open file' }).first()
   await expect(row).toBeVisible()
   await expect(row).toContainText('SecondaryNav.tsx')
-  await expect(row).toContainText('app/src/components/')
+  await expect(row).toContainText('packages/orca/src/renderer/src/components/navigation/')
   const rowText = await row.textContent()
   expect(rowText?.indexOf('SecondaryNav.tsx')).toBeLessThan(
-    rowText?.indexOf('app/src/components/') ?? -1
+    rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1
   )
 
   await row.hover({ force: true })

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -6,7 +6,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const relativeFilePath =
   'packages/orca/src/renderer/src/components/navigation/worktree/secondary-nav/SecondaryNav.tsx'
 
-test('new-tab file results prioritize the filename and reveal the full path on hover', async ({
+test('new-tab file results prioritize the filename and expose the full path natively', async ({
   orcaPage,
   testRepoPath
 }) => {
@@ -34,9 +34,7 @@ test('new-tab file results prioritize the filename and reveal the full path on h
   )
 
   await row.hover({ force: true })
-  await expect(
-    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
-  ).toBeVisible()
+  await expect(row).toHaveAttribute('title', relativeFilePath)
 
   const proofPath = process.env.ORCA_STA3424_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -6,7 +6,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const relativeFilePath =
   'packages/orca/src/renderer/src/components/navigation/worktree/secondary-nav/SecondaryNav.tsx'
 
-test('new-tab file results prioritize the filename and reveal the full path on hover', async ({
+test('new-tab file results prioritize the filename and carry the full path in a native tooltip', async ({
   orcaPage,
   testRepoPath
 }) => {
@@ -33,10 +33,20 @@ test('new-tab file results prioritize the filename and reveal the full path on h
     rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1
   )
 
+  await expect(row).toHaveAttribute('title', relativeFilePath)
+
+  // The filename must survive intact; only the directory may be clipped, and the
+  // row itself must never spill past the dropdown.
+  const overflow = await row.evaluate((element) => {
+    const filename = element.querySelector(':scope > span:last-of-type > span:first-child')
+    return {
+      filenameClipped: filename ? filename.scrollWidth > filename.clientWidth : true,
+      rowClipped: element.scrollWidth > element.clientWidth
+    }
+  })
+  expect(overflow).toEqual({ filenameClipped: false, rowClipped: false })
+
   await row.hover({ force: true })
-  await expect(
-    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
-  ).toBeVisible()
 
   const proofPath = process.env.ORCA_STA3424_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -6,7 +6,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const relativeFilePath =
   'packages/orca/src/renderer/src/components/navigation/worktree/secondary-nav/SecondaryNav.tsx'
 
-test('new-tab file results prioritize the filename and expose the full path natively', async ({
+test('new-tab file results prioritize the filename and reveal the full path on hover', async ({
   orcaPage,
   testRepoPath
 }) => {
@@ -34,7 +34,9 @@ test('new-tab file results prioritize the filename and expose the full path nati
   )
 
   await row.hover({ force: true })
-  await expect(row).toHaveAttribute('title', relativeFilePath)
+  await expect(
+    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
+  ).toBeVisible()
 
   const proofPath = process.env.ORCA_STA3424_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -1,0 +1,44 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const relativeFilePath = 'app/src/components/SecondaryNav.tsx'
+
+test('new-tab file results prioritize the filename and reveal the full path on hover', async ({
+  orcaPage,
+  testRepoPath
+}) => {
+  const filePath = path.join(testRepoPath, ...relativeFilePath.split('/'))
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, 'export const SecondaryNav = true\n')
+
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+
+  await orcaPage.getByRole('button', { name: 'New tab' }).click({ force: true })
+  const input = orcaPage.getByRole('combobox', {
+    name: 'Open any file, URL, agent, ...'
+  })
+  await input.fill('secondaryNav')
+
+  const row = orcaPage.locator('[role="option"]').filter({ hasText: 'Open file' }).first()
+  await expect(row).toBeVisible()
+  await expect(row).toContainText('SecondaryNav.tsx')
+  await expect(row).toContainText('app/src/components/')
+  const rowText = await row.textContent()
+  expect(rowText?.indexOf('SecondaryNav.tsx')).toBeLessThan(
+    rowText?.indexOf('app/src/components/') ?? -1
+  )
+
+  await row.hover({ force: true })
+  await expect(
+    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
+  ).toBeVisible()
+
+  const proofPath = process.env.ORCA_STA3424_PROOF_PATH
+  if (proofPath) {
+    await orcaPage.screenshot({ path: proofPath })
+  }
+})

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -6,7 +6,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const relativeFilePath =
   'packages/orca/src/renderer/src/components/navigation/worktree/secondary-nav/SecondaryNav.tsx'
 
-test('new-tab file results prioritize the filename and carry the full path in a native tooltip', async ({
+test('new-tab file results prioritize the filename and reveal the full path on hover', async ({
   orcaPage,
   testRepoPath
 }) => {
@@ -33,8 +33,6 @@ test('new-tab file results prioritize the filename and carry the full path in a 
     rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1
   )
 
-  await expect(row).toHaveAttribute('title', relativeFilePath)
-
   // The filename must survive intact; only the directory may be clipped, and the
   // row itself must never spill past the dropdown.
   const overflow = await row.evaluate((element) => {
@@ -46,7 +44,20 @@ test('new-tab file results prioritize the filename and carry the full path in a 
   })
   expect(overflow).toEqual({ filenameClipped: false, rowClipped: false })
 
-  await row.hover({ force: true })
+  await row.hover()
+  const tooltip = orcaPage.locator('[data-slot="tooltip-content"]').filter({
+    hasText: relativeFilePath
+  })
+  await expect(tooltip).toBeVisible()
+
+  // Beside the list, not over it — the sibling results stay readable while the
+  // full path is up.
+  const [rowBox, tooltipBox] = await Promise.all([row.boundingBox(), tooltip.boundingBox()])
+  expect(rowBox).not.toBeNull()
+  expect(tooltipBox).not.toBeNull()
+  const overlapsRow =
+    tooltipBox!.x < rowBox!.x + rowBox!.width && tooltipBox!.x + tooltipBox!.width > rowBox!.x
+  expect(overlapsRow).toBe(false)
 
   const proofPath = process.env.ORCA_STA3424_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -44,20 +44,51 @@ test('new-tab file results prioritize the filename and reveal the full path on h
   })
   expect(overflow).toEqual({ filenameClipped: false, rowClipped: false })
 
-  await row.hover()
+  // Record the cursor in page coordinates: Playwright's boundingBox() is a
+  // different space than the page's client rects under Electron, so mixing the
+  // two silently compares unrelated numbers.
+  await orcaPage.evaluate(() => {
+    const store = window as unknown as { __pointer?: { x: number; y: number } }
+    document.addEventListener(
+      'mousemove',
+      (event) => {
+        store.__pointer = { x: event.clientX, y: event.clientY }
+      },
+      true
+    )
+  })
+
+  // Deliberately off-centre: anchoring to the row instead of the cursor misses.
+  await row.hover({ position: { x: 24, y: 12 } })
+
   const tooltip = orcaPage.locator('[data-slot="tooltip-content"]').filter({
     hasText: relativeFilePath
   })
   await expect(tooltip).toBeVisible()
 
-  // Beside the list, not over it — the sibling results stay readable while the
-  // full path is up.
-  const [rowBox, tooltipBox] = await Promise.all([row.boundingBox(), tooltip.boundingBox()])
-  expect(rowBox).not.toBeNull()
-  expect(tooltipBox).not.toBeNull()
-  const overlapsRow =
-    tooltipBox!.x < rowBox!.x + rowBox!.width && tooltipBox!.x + tooltipBox!.width > rowBox!.x
-  expect(overlapsRow).toBe(false)
+  const placement = await tooltip.evaluate((element) => {
+    const rect = element.getBoundingClientRect()
+    const store = window as unknown as { __pointer?: { x: number; y: number } }
+    return {
+      pointer: store.__pointer,
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      viewportWidth: window.innerWidth
+    }
+  })
+  expect(placement.pointer).toBeTruthy()
+
+  // Anchored under the cursor like a system tooltip, except where Radix shifts
+  // it back inside the viewport — so the clamp is part of the expectation.
+  const expectedLeft = Math.min(
+    placement.pointer?.x ?? 0,
+    placement.viewportWidth - placement.width
+  )
+  expect(Math.abs(placement.left - expectedLeft)).toBeLessThanOrEqual(2)
+
+  // CURSOR_TOOLTIP_GAP in TabBarCreateEntryRow.tsx.
+  expect(Math.abs(placement.top - ((placement.pointer?.y ?? 0) + 18))).toBeLessThanOrEqual(2)
 
   const proofPath = process.env.ORCA_STA3424_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/tab-create-entry-file-paths.spec.ts
+++ b/tests/e2e/tab-create-entry-file-paths.spec.ts
@@ -44,51 +44,19 @@ test('new-tab file results prioritize the filename and reveal the full path on h
   })
   expect(overflow).toEqual({ filenameClipped: false, rowClipped: false })
 
-  // Record the cursor in page coordinates: Playwright's boundingBox() is a
-  // different space than the page's client rects under Electron, so mixing the
-  // two silently compares unrelated numbers.
-  await orcaPage.evaluate(() => {
-    const store = window as unknown as { __pointer?: { x: number; y: number } }
-    document.addEventListener(
-      'mousemove',
-      (event) => {
-        store.__pointer = { x: event.clientX, y: event.clientY }
-      },
-      true
-    )
-  })
+  // Two hovers on purpose: results stream in and remount the row, and Radix only
+  // opens on a pointermove it actually receives. A single hover can land before
+  // the remount and leave the cursor sitting still over a row that never saw it.
+  await row.hover({ position: { x: 20, y: 12 } })
+  await orcaPage.waitForTimeout(250)
+  await row.hover({ position: { x: 40, y: 12 } })
 
-  // Deliberately off-centre: anchoring to the row instead of the cursor misses.
-  await row.hover({ position: { x: 24, y: 12 } })
-
-  const tooltip = orcaPage.locator('[data-slot="tooltip-content"]').filter({
-    hasText: relativeFilePath
-  })
-  await expect(tooltip).toBeVisible()
-
-  const placement = await tooltip.evaluate((element) => {
-    const rect = element.getBoundingClientRect()
-    const store = window as unknown as { __pointer?: { x: number; y: number } }
-    return {
-      pointer: store.__pointer,
-      left: rect.left,
-      top: rect.top,
-      width: rect.width,
-      viewportWidth: window.innerWidth
-    }
-  })
-  expect(placement.pointer).toBeTruthy()
-
-  // Anchored under the cursor like a system tooltip, except where Radix shifts
-  // it back inside the viewport — so the clamp is part of the expectation.
-  const expectedLeft = Math.min(
-    placement.pointer?.x ?? 0,
-    placement.viewportWidth - placement.width
-  )
-  expect(Math.abs(placement.left - expectedLeft)).toBeLessThanOrEqual(2)
-
-  // CURSOR_TOOLTIP_GAP in TabBarCreateEntryRow.tsx.
-  expect(Math.abs(placement.top - ((placement.pointer?.y ?? 0) + 18))).toBeLessThanOrEqual(2)
+  // Exact cursor placement is arithmetic, unit-tested via cursorTooltipOffsets.
+  // Asserting it here measured the app mid-reflow and was flaky; what E2E is
+  // uniquely good for is that the tooltip really opens with the whole path.
+  await expect(
+    orcaPage.locator('[data-slot="tooltip-content"]').filter({ hasText: relativeFilePath })
+  ).toBeVisible()
 
   const proofPath = process.env.ORCA_STA3424_PROOF_PATH
   if (proofPath) {


### PR DESCRIPTION
## Summary

- Prioritize the actual filename in new-tab file results, truncating the parent directory instead.
- Show the complete path in a compact, system-style tooltip anchored at the cursor.
- Add renderer and Electron coverage for filename ordering, separators, overflow, and tooltip placement.

Fixes STA-3424

@swieder227 this addresses the reported file-name visibility issue.

## Visual proof

**Before** — searching `twowayaudio` returns four results that are visually identical, because every row truncates in the shared `mobile/packages/expo-two-way…` prefix. You cannot tell which file is which.

![before](https://github.com/user-attachments/assets/c1c0baa5-335b-4c3e-9589-67922377385f)

**After** — the filename leads, so all four rows are distinguishable at a glance.

![after](https://github.com/user-attachments/assets/870c3df6-cb78-41ed-a392-57b7ffa2c031)

**Hover** — the full path opens at the cursor, the way a system tooltip does.

![tooltip](https://github.com/user-attachments/assets/674dcfb8-9ecb-4505-bbb1-7de94d424975)

## Layout behavior

`FilenameFirstPath` splits on the last separator and keeps the separator attached to the directory, so `/foo` renders `foo` + `/` and `C:\repo\src\x.ts` keeps its backslashes — no separator is re-derived from the path shape.

The filename is `shrink-0 max-w-full`, so the directory yields all of its width before the filename loses a character. When the filename alone overflows the row, the directory is dropped entirely and the tooltip carries the full path. Verified live: `scrollWidth === clientWidth` at 270px, so the row never spills out of the dropdown.

## Why not a native `title` tooltip

The first pass used `title`, which would have been the smaller change. **Native tooltips do not render anywhere in Orca** — verified by hand in a dev build; `title` on these rows produces nothing on hover. Root-causing that is out of scope here (nothing in `createMainWindow.ts` explains it: no `transparent`, no macOS vibrancy since #8482, no Blink feature switches on the main window).

So this uses the Radix `Tooltip` primitive, restyled to read as a system tooltip: not inverted, no arrow, 11px text, tight padding. Radius and shadow use the documented `rounded-md` and floating tier from `docs/STYLEGUIDE.md:97,101` rather than new values.

**Two deliberate deviations from `docs/STYLEGUIDE.md` worth a reviewer's eye:**

1. The styleguide's default placement is `side="top" sideOffset={4}`. This anchors to the cursor instead: Radix positions relative to the trigger, so the pointer is expressed as `alignOffset`/`sideOffset` from the row's bottom-left corner, leaving it 18px below the cursor. The offsets are re-measured in a layout effect when the tooltip opens, because results stream in and move the row during the open delay.
2. `TooltipContent` gains an opt-in `showArrow` prop (defaults to `true`, so every existing call site is unchanged). The arrow reads as an app tooltip rather than a system one.

If the design system would rather absorb this as a named variant than as per-call-site classes, say so and I will move it.

Only the filename-first rows get a tooltip. Agent/URL/create-file rows already show their detail in full, and `STYLEGUIDE.md:162` rules out labelling a control that has a visible label.

### Known limits

- Once open, the tooltip stays anchored to the row, so scrolling the result list drags it with the row while the cursor stays put. A true system tooltip is screen-fixed. Not fixed here.
- It is pointer-only: rows are driven by `aria-activedescendant`, never focused, so Radix's focus-open path never runs and keyboard users get no tooltip. The full path is still in the option's accessible name, though it now reads filename-first.
- `CURSOR_TOOLTIP_GAP = 18` is reasoned from the macOS cursor hotspot; Windows cursor scaling could sit over the label.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts` across all 98 tooltip-touching suites — 814 passed.
- `pnpm exec playwright test tests/e2e/tab-create-entry-file-paths.spec.ts … --repeat-each=6` — 6/6 passed. Asserts filename ordering, that the row does not overflow, and that the tooltip really opens carrying the whole path.

  Cursor placement is asserted in unit tests against `cursorTooltipOffsets`, not in E2E. Asserting pixels through the running app measured it mid-reflow and was genuinely flaky (2/5, then 5/5 failures) — the arithmetic belongs at the unit layer, and `--repeat-each` is what proved the difference.
- `pnpm run typecheck:web`, `oxlint` — clean.
- Verified interactively in a dev build over CDP: tooltip opens on hover with the full path, and wraps to two lines for a 117-character path.

The unit tests cover the text layout only; the tooltip is asserted in E2E where it actually opens, rather than by mocking the primitive under test.

## Security

No new IPC payloads, filesystem permissions, subprocesses, network sinks, secrets, or dependencies. The tooltip renders a path the row already received.

## Readiness

- **SSH/remote:** presentation-only renderer change; no transport, reconnect, relay, or provider behavior touched.
- **Crash/retry/growth:** no new async loop, retry, cache, listener, timer, or retained collection. The tooltip is `pointer-events-none` under the app's existing `disableHoverableContent` provider.
- **Cross-platform:** separators are preserved from the input path rather than inferred; Windows backslash paths covered by unit test.
- **Backward compatibility:** no persisted state, route, RPC contract, or serialized data changed. `showArrow` defaults to the previous behavior. No mobile surface touched.
