### PR TITLE
fix(terminal): follow output when a pinned scroll anchor is trimmed away

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -522,6 +522,7 @@ describe('terminal scroll intent', () => {
 
     restoreTerminalStructuralScrollIntent(terminal, intent, { restoreBy: 'bottomOffset' })
 
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1)
     expect(terminal.scrollToLine).not.toHaveBeenCalled()
     expect(terminal.buffer.active.viewportY).toBe(800)
     expect(getTerminalScrollIntentKind(terminal)).toBe('followOutput')

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.test.ts
@@ -508,6 +508,25 @@ describe('terminal scroll intent', () => {
     disposable.dispose()
   })
 
+  it('follows output when a bottom-offset restore outruns the rebuilt scrollback', () => {
+    // Long agent session: pinned 4000 rows above the bottom of a 5000-row
+    // scrollback, then a byte-capped snapshot replay rebuilds a far shorter
+    // buffer. The pinned content no longer exists to scroll back to.
+    const terminal = createTerminal({ viewportY: 1000, baseY: 5000 })
+    syncTerminalScrollIntentFromViewport(terminal)
+    const intent = captureTerminalStructuralScrollIntent(terminal)
+    expect(intent?.kind).toBe('pinnedViewport')
+
+    terminal.buffer.active.baseY = 800
+    terminal.buffer.active.viewportY = 800
+
+    restoreTerminalStructuralScrollIntent(terminal, intent, { restoreBy: 'bottomOffset' })
+
+    expect(terminal.scrollToLine).not.toHaveBeenCalled()
+    expect(terminal.buffer.active.viewportY).toBe(800)
+    expect(getTerminalScrollIntentKind(terminal)).toBe('followOutput')
+  })
+
   it('does not treat terminal body pointer activity as scrollbar intent', () => {
     vi.stubGlobal('Element', TestElement)
     const terminal = createTerminal({ viewportY: 100, baseY: 100 })

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -272,6 +272,15 @@ export function restoreTerminalStructuralScrollIntent(
     options.restoreBy === 'bottomOffset'
       ? current.baseY - Math.max(0, snapshot.baseY - snapshot.viewportY)
       : snapshot.viewportY
+  // Why: an offset deeper than the rebuilt scrollback means the pinned content
+  // was trimmed away. Clamping to line 0 would strand the reader at the top and
+  // re-latch that as a durable pin, which mouse reports then re-enforce.
+  if (options.restoreBy === 'bottomOffset' && requestedY < 0) {
+    if (safeTerminalScrollCall(() => terminal.scrollToBottom?.())) {
+      writeIntent(terminal, 'followOutput')
+    }
+    return
+  }
   const targetY = clampTerminalViewportY(requestedY, current.baseY)
   if (current.viewportY !== targetY) {
     if (!safeTerminalScrollCall(() => terminal.scrollToLine?.(targetY))) {


### PR DESCRIPTION
## Summary

  A terminal pane that the user had scrolled up in could suddenly jump to the very
  top of its scrollback during a long agent session, then keep snapping back there
  whenever the mouse moved over the pane.

  The pane's scroll position is restored after a structural replay (returning to a
  hidden tab, a relay reconnect, an SSH park reveal, or a reattach) by re-applying
  the viewport's distance from the bottom. Snapshot replay is byte-capped at 512 KB,
  so a long session rebuilds a much shorter buffer than the one the offset was
  measured against. The subtraction then went negative and was silently clamped to
  line 0 — the top of the scrollback — and that position was latched as a durable
  "pinned viewport" intent. Because an agent TUI with mouse tracking enabled emits a
  mouse report on every pointer move, and a stored pin is re-enforced on each
  report, the viewport kept being pulled back to the top until the user manually
  scrolled to the bottom.

  A pin whose anchored content no longer exists in the buffer is no longer a
  meaningful pin, so it now resolves to following live output instead of stranding
  the reader at line 0.

  ## Screenshots

  No visual change — this changes scroll position behavior, not rendering. A
  recording is impractical because the trigger requires a byte-capped snapshot
  replay after a long streaming session; the added regression test pins the
  behavior instead.

  ## Testing

  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [x] `pnpm test`
  - [x] `pnpm build`
  - [x] Added or updated high-quality tests that would catch regressions, or explained why
  tests were not needed

  Added `follows output when a bottom-offset restore outruns the rebuilt scrollback`
  to `terminal-scroll-intent.test.ts`. It reproduces the real geometry — pinned
  4000 rows above the bottom of a 5000-row scrollback, then a rebuild to an 800-row
  buffer — and fails on `main` with `scrollToLine(0)`, which is exactly the reported
  symptom. It passes with the fix.

  Also ran the two suites that own this state machine: `pane-manager/` (632 passed)
  and `terminal-pane/` (3076 passed).

  ## AI Review Report

  Reviewed with Claude Code. Risks checked and findings:

  - **Cross-platform (macOS / Linux / Windows) — explicitly checked:** no
    platform-specific surface is touched. The change is viewport arithmetic in
    renderer code. There are no keyboard shortcuts, no shortcut labels, no
    `metaKey`/`ctrlKey` branch, no filesystem paths, no shell invocation, and no
    Electron main-process or platform API involved, so no runtime platform check is
    warranted. Reviewed the neighbouring Windows-specific path
    (`shouldKeepPhysicalResizeAnchor` in `terminal-reflow-scroll-anchor.ts`, which
    disables reflow anchoring on legacy conpty builds) and confirmed this change is
    independent of it.
  - **SSH / remote / local:** the modified `restoreTerminalStructuralScrollIntent`
    is reached from all four structural-replay call sites in `pty-connection.ts`
    (hidden-snapshot replay, relay replay drain, SSH park prepaint, reattach
    payload) via the shared `terminal-structural-replay-coordinator`, so local,
    SSH, and remote-relay panes all get the same corrected behavior. No transport
    assumptions were added.
  - **Agent / integration neutrality:** no agent-specific or git-provider-specific
    logic. The bug is most visible with agents that enable mouse tracking, because
    mouse reports re-enforce a stored pin, but the fix itself is agent-neutral.
  - **Performance:** one integer comparison and an early return on an existing code
    path. No new allocation, no new subscription, nothing added to an output hot
    path.
  - **Behavior tradeoff — flagged, and deliberately accepted:** when the pinned
    anchor has been trimmed away, the viewport now follows live output rather than
    landing on line 0. Line 0 was never content the user chose, and latching it as
    a durable pin is what made the symptom recur on every mouse move. Reviewed the
  ## Security Audit

  No security-relevant surface. The change adds a numeric comparison and an early
  return inside existing renderer scroll logic:

  - **Input handling:** none. The values compared are integers already read from
    xterm's own buffer state (`viewportY`, `baseY`).
  - **Command execution / shell:** none.
  - **Path handling:** none.
  - **Auth / secrets:** none touched.
  - **Dependencies:** none added, removed, or upgraded. 
  - **IPC:** none. No main-process or preload boundary is crossed.

  No follow-up needed.

  ## Notes

  - Platform-neutral; no platform-specific behavior added or changed.
  - Applies equally to local, SSH, and remote-relay panes, since all structural
    replay paths share the coordinator that performs this restore.
  - Related: #9079 describes the same "jump to scrollback top" family from a
    different trigger (hidden-terminal reveal replay) and stays open — this PR does
    not claim to close it, though both share the "absolute viewport line copied
    across a rebuilt buffer" root pattern its discussion identifies. #11753 was a
    different cause (transient `viewportY = 0` sampled mid-write) and was fixed in
    v1.4.164.
  - Follow-up work: the two backstops listed in the AI Review Report.