### PR TITLE
fix: prioritize filenames in cmd+p quick open

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -11,7 +11,6 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
 import { useModalReturnFocus } from '@/hooks/useModalReturnFocus'
@@ -153,28 +152,17 @@ export default function QuickOpen(): React.JSX.Element | null {
             const FileIcon = getFileTypeIcon(item.path)
 
             return (
-              <Tooltip key={item.path}>
-                <TooltipTrigger asChild>
-                  <div className="min-w-0">
-                    <CommandItem
-                      value={item.path}
-                      onSelect={() => handleSelect(item.path)}
-                      className="flex min-w-0 items-center gap-2 px-3 py-1.5"
-                    >
-                      <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 shrink-0 truncate text-foreground">{filename}</span>
-                      {dir && <span className="min-w-0 truncate text-muted-foreground">{dir}</span>}
-                    </CommandItem>
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent
-                  side="top"
-                  sideOffset={4}
-                  className="max-w-[min(90vw,600px)] break-all font-mono"
-                >
-                  {item.path}
-                </TooltipContent>
-              </Tooltip>
+              <CommandItem
+                key={item.path}
+                value={item.path}
+                title={item.path}
+                onSelect={() => handleSelect(item.path)}
+                className="flex min-w-0 items-center gap-2 px-3 py-1.5"
+              >
+                <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 shrink-0 truncate text-foreground">{filename}</span>
+                {dir && <span className="min-w-0 truncate text-muted-foreground">{dir}</span>}
+              </CommandItem>
             )
           })
         )}

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -11,6 +11,7 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
 import { useModalReturnFocus } from '@/hooks/useModalReturnFocus'
@@ -152,17 +153,29 @@ export default function QuickOpen(): React.JSX.Element | null {
             const FileIcon = getFileTypeIcon(item.path)
 
             return (
-              <CommandItem
-                key={item.path}
-                value={item.path}
-                title={item.path}
-                onSelect={() => handleSelect(item.path)}
-                className="flex min-w-0 items-center gap-2 px-3 py-1.5"
-              >
-                <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                <span className="min-w-0 shrink-0 truncate text-foreground">{filename}</span>
-                {dir && <span className="min-w-0 truncate text-muted-foreground">{dir}</span>}
-              </CommandItem>
+              <Tooltip key={item.path}>
+                <CommandItem
+                  asChild
+                  value={item.path}
+                  onSelect={() => handleSelect(item.path)}
+                  className="flex min-w-0 items-center gap-2 px-3 py-1.5"
+                >
+                  <TooltipTrigger asChild>
+                    <div>
+                      <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 shrink-0 truncate text-foreground">{filename}</span>
+                      {dir && <span className="min-w-0 truncate text-muted-foreground">{dir}</span>}
+                    </div>
+                  </TooltipTrigger>
+                </CommandItem>
+                <TooltipContent
+                  side="top"
+                  sideOffset={4}
+                  className="max-w-[min(90vw,600px)] break-all font-mono"
+                >
+                  {item.path}
+                </TooltipContent>
+              </Tooltip>
             )
           })
         )}

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -11,7 +11,7 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { FilePathCursorTooltip, splitTrailingSegment } from '@/components/file-path-cursor-tooltip'
 import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
 import { useModalReturnFocus } from '@/hooks/useModalReturnFocus'
@@ -147,35 +147,33 @@ export default function QuickOpen(): React.JSX.Element | null {
           </CommandEmpty>
         ) : (
           filtered.map((item) => {
-            const lastSlash = item.path.lastIndexOf('/')
-            const dir = lastSlash >= 0 ? item.path.slice(0, lastSlash) : ''
-            const filename = item.path.slice(lastSlash + 1)
+            const { directory, filename } = splitTrailingSegment(item.path)
             const FileIcon = getFileTypeIcon(item.path)
 
             return (
-              <Tooltip key={item.path}>
-                <CommandItem
-                  asChild
-                  value={item.path}
-                  onSelect={() => handleSelect(item.path)}
-                  className="flex min-w-0 items-center gap-2 px-3 py-1.5"
-                >
-                  <TooltipTrigger asChild>
-                    <div>
-                      <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                      <span className="min-w-0 shrink-0 truncate text-foreground">{filename}</span>
-                      {dir && <span className="min-w-0 truncate text-muted-foreground">{dir}</span>}
-                    </div>
-                  </TooltipTrigger>
-                </CommandItem>
-                <TooltipContent
-                  side="top"
-                  sideOffset={4}
-                  className="max-w-[min(90vw,600px)] break-all font-mono"
-                >
-                  {item.path}
-                </TooltipContent>
-              </Tooltip>
+              <CommandItem
+                key={item.path}
+                value={item.path}
+                onSelect={() => handleSelect(item.path)}
+                className="min-w-0 p-0"
+              >
+                {/* Why: the trigger is this inner element, not the CommandItem.
+                    cmdk sets its own onPointerMove after spreading props, which
+                    drops the one Radix needs to open the tooltip. */}
+                <FilePathCursorTooltip path={item.path}>
+                  <div className="flex w-full min-w-0 items-center gap-2 px-3 py-1.5">
+                    <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    {/* shrink-0 + max-w-full: the directory gives up all of its
+                        width before the filename loses a character. */}
+                    <span className="min-w-0 max-w-full shrink-0 truncate text-foreground">
+                      {filename}
+                    </span>
+                    {directory ? (
+                      <span className="min-w-0 truncate text-muted-foreground">{directory}</span>
+                    ) : null}
+                  </div>
+                </FilePathCursorTooltip>
+              </CommandItem>
             )
           })
         )}

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -11,6 +11,7 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
 import { useModalReturnFocus } from '@/hooks/useModalReturnFocus'
@@ -152,16 +153,28 @@ export default function QuickOpen(): React.JSX.Element | null {
             const FileIcon = getFileTypeIcon(item.path)
 
             return (
-              <CommandItem
-                key={item.path}
-                value={item.path}
-                onSelect={() => handleSelect(item.path)}
-                className="flex items-center gap-2 px-3 py-1.5"
-              >
-                <FileIcon className="size-3.5 text-muted-foreground flex-shrink-0" />
-                <span className="truncate text-foreground">{filename}</span>
-                {dir && <span className="truncate text-muted-foreground ml-1">{dir}</span>}
-              </CommandItem>
+              <Tooltip key={item.path}>
+                <TooltipTrigger asChild>
+                  <div className="min-w-0">
+                    <CommandItem
+                      value={item.path}
+                      onSelect={() => handleSelect(item.path)}
+                      className="flex min-w-0 items-center gap-2 px-3 py-1.5"
+                    >
+                      <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                      <span className="min-w-0 shrink-0 truncate text-foreground">{filename}</span>
+                      {dir && <span className="min-w-0 truncate text-muted-foreground">{dir}</span>}
+                    </CommandItem>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent
+                  side="top"
+                  sideOffset={4}
+                  className="max-w-[min(90vw,600px)] break-all font-mono"
+                >
+                  {item.path}
+                </TooltipContent>
+              </Tooltip>
             )
           })
         )}

--- a/src/renderer/src/components/file-path-cursor-tooltip.test.ts
+++ b/src/renderer/src/components/file-path-cursor-tooltip.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { cursorTooltipOffsets, splitTrailingSegment } from './file-path-cursor-tooltip'
+
+describe('cursorTooltipOffsets', () => {
+  const row = { bottom: 120, left: 400 }
+
+  it('places the tooltip under the cursor rather than the row', () => {
+    // Row-anchored placement would be align 0; the cursor is 64px into the row.
+    expect(cursorTooltipOffsets({ x: 464, y: 108 }, row)).toEqual({ align: 64, side: 6 })
+  })
+
+  it('tracks the cursor across the row', () => {
+    const left = cursorTooltipOffsets({ x: 410, y: 108 }, row)
+    const right = cursorTooltipOffsets({ x: 610, y: 108 }, row)
+
+    expect(right.align - left.align).toBe(200)
+    expect(right.side).toBe(left.side)
+  })
+
+  it('stays anchored to the cursor when the row moves under it', () => {
+    // The dropdown reflows while results stream in; re-measuring the row must
+    // keep the tooltip on the cursor, not drag it along with the row.
+    const before = cursorTooltipOffsets({ x: 464, y: 108 }, row)
+    const after = cursorTooltipOffsets({ x: 464, y: 108 }, { bottom: 148, left: 576 })
+
+    expect(row.left + before.align).toBe(576 + after.align)
+    expect(row.bottom + before.side).toBe(148 + after.side)
+  })
+})
+
+describe('splitTrailingSegment', () => {
+  it('keeps the separator on the directory', () => {
+    expect(splitTrailingSegment('app/src/SecondaryNav.tsx')).toEqual({
+      directory: 'app/src/',
+      filename: 'SecondaryNav.tsx'
+    })
+  })
+
+  it('does not duplicate the root separator', () => {
+    expect(splitTrailingSegment('/foo')).toEqual({ directory: '/', filename: 'foo' })
+  })
+
+  it('preserves Windows separators', () => {
+    expect(splitTrailingSegment('C:\\repo\\src\\a.ts')).toEqual({
+      directory: 'C:\\repo\\src\\',
+      filename: 'a.ts'
+    })
+  })
+
+  it('returns no directory for a bare filename', () => {
+    expect(splitTrailingSegment('README.md')).toEqual({ directory: '', filename: 'README.md' })
+  })
+})

--- a/src/renderer/src/components/file-path-cursor-tooltip.tsx
+++ b/src/renderer/src/components/file-path-cursor-tooltip.tsx
@@ -91,7 +91,7 @@ export function FilePathCursorTooltip({
         sideOffset={offset.side}
         alignOffset={offset.align}
         showArrow={false}
-        className="max-w-[420px] rounded-md border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-words text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+        className="max-w-[min(90vw,800px)] rounded-md border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-words text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
       >
         {path}
       </TooltipContent>

--- a/src/renderer/src/components/file-path-cursor-tooltip.tsx
+++ b/src/renderer/src/components/file-path-cursor-tooltip.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { Slot } from 'radix-ui'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+// Clears the pointer without putting the label under the cursor's own hotspot.
+const CURSOR_TOOLTIP_GAP = 18
+
+/**
+ * Radix positions the tooltip against the trigger, so a cursor position has to
+ * be restated as offsets from the trigger's bottom-left corner to land under
+ * the pointer.
+ */
+export function cursorTooltipOffsets(
+  pointer: { x: number; y: number },
+  trigger: { bottom: number; left: number }
+): { align: number; side: number } {
+  return {
+    align: pointer.x - trigger.left,
+    side: pointer.y + CURSOR_TOOLTIP_GAP - trigger.bottom
+  }
+}
+
+/**
+ * Splits a path for filename-first display, keeping the separator attached to
+ * the directory so `/foo` renders `foo` + `/` and Windows paths keep `\`.
+ */
+export function splitTrailingSegment(path: string): { directory: string; filename: string } {
+  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+
+  return separatorIndex === -1
+    ? { directory: '', filename: path }
+    : { directory: path.slice(0, separatorIndex + 1), filename: path.slice(separatorIndex + 1) }
+}
+
+/**
+ * Wraps a single result row so its full path appears in a system-styled tooltip
+ * anchored under the cursor. The child is the trigger; it receives a ref and a
+ * pointer-move handler.
+ */
+export function FilePathCursorTooltip({
+  children,
+  path
+}: {
+  children: React.ReactNode
+  path: string
+}): React.JSX.Element {
+  const triggerRef = React.useRef<HTMLElement>(null)
+  const pointerRef = React.useRef<{ x: number; y: number } | null>(null)
+  const [open, setOpen] = React.useState(false)
+  const [offset, setOffset] = React.useState({ align: 0, side: 0 })
+
+  // Why: the offsets are only valid for the trigger's position at the moment
+  // Radix positions it. Results stream in and move rows while the open delay
+  // runs, so re-measure on open rather than trusting the pointer-move rect.
+  React.useLayoutEffect(() => {
+    const rect = triggerRef.current?.getBoundingClientRect()
+    const pointer = pointerRef.current
+    if (!open || !rect || !pointer) {
+      return
+    }
+    const next = cursorTooltipOffsets(pointer, rect)
+    setOffset((current) =>
+      current.align === next.align && current.side === next.side ? current : next
+    )
+  }, [open])
+
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger asChild>
+        <Slot.Root
+          ref={triggerRef}
+          // Why: a ref, not state — read once when the tooltip opens, so
+          // re-rendering per pointer move would be churn for nothing.
+          // pointermove (not mousemove) because Radix opens off pointermove and
+          // Slot runs the child handler first, keeping this fresh on instant open.
+          onPointerMove={(event: React.PointerEvent) => {
+            if (open) {
+              return
+            }
+            pointerRef.current = { x: event.clientX, y: event.clientY }
+          }}
+        >
+          {children}
+        </Slot.Root>
+      </TooltipTrigger>
+      {/* Anchored under the cursor the way a system tooltip is, rather than to
+          the row. Collision shifting still applies near the viewport edge. */}
+      <TooltipContent
+        side="bottom"
+        align="start"
+        sideOffset={offset.side}
+        alignOffset={offset.align}
+        showArrow={false}
+        className="max-w-[420px] rounded-md border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-words text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
+      >
+        {path}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.test.tsx
@@ -5,7 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import type { ActiveOption } from './tab-create-entry-active-option'
-import { cursorTooltipOffsets, EntryActionRow } from './TabBarCreateEntryRow'
+import { EntryActionRow } from './TabBarCreateEntryRow'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -87,32 +87,5 @@ describe('EntryActionRow', () => {
   it('renders a bare filename without a directory fragment', () => {
     expect(renderRow(makeFileOption('README.md')).textContent).toContain('README.md')
     expect(container.textContent).not.toContain('/')
-  })
-})
-
-describe('cursorTooltipOffsets', () => {
-  const row = { bottom: 120, left: 400 }
-
-  it('places the tooltip under the cursor rather than the row', () => {
-    // Row-anchored placement would be align 0; the cursor is 64px into the row.
-    expect(cursorTooltipOffsets({ x: 464, y: 108 }, row)).toEqual({ align: 64, side: 6 })
-  })
-
-  it('tracks the cursor across the row', () => {
-    const left = cursorTooltipOffsets({ x: 410, y: 108 }, row)
-    const right = cursorTooltipOffsets({ x: 610, y: 108 }, row)
-
-    expect(right.align - left.align).toBe(200)
-    expect(right.side).toBe(left.side)
-  })
-
-  it('stays anchored to the cursor when the row moves under it', () => {
-    // The dropdown reflows while results stream in; re-measuring the row must
-    // keep the tooltip on the cursor, not drag it along with the row.
-    const before = cursorTooltipOffsets({ x: 464, y: 108 }, row)
-    const after = cursorTooltipOffsets({ x: 464, y: 108 }, { bottom: 148, left: 576 })
-
-    expect(row.left + before.align).toBe(576 + after.align)
-    expect(row.bottom + before.side).toBe(148 + after.side)
   })
 })

--- a/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarCreateEntryRow.tsx
@@ -2,28 +2,11 @@ import React from 'react'
 import { FilePlus, FileText, Globe, Loader2, Smartphone, TerminalSquare } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { FilePathCursorTooltip, splitTrailingSegment } from '@/components/file-path-cursor-tooltip'
 import { translate } from '@/i18n/i18n'
 import type { ActiveOption } from './tab-create-entry-active-option'
 
 export const RESULT_LISTBOX_ID = 'tab-create-entry-results'
-
-// Clears the macOS pointer without putting the label under the cursor's own hotspot.
-const CURSOR_TOOLTIP_GAP = 18
-
-/**
- * Radix positions the tooltip against the row, so a cursor position has to be
- * restated as offsets from the row's bottom-left corner to land under the pointer.
- */
-export function cursorTooltipOffsets(
-  pointer: { x: number; y: number },
-  row: { bottom: number; left: number }
-): { align: number; side: number } {
-  return {
-    align: pointer.x - row.left,
-    side: pointer.y + CURSOR_TOOLTIP_GAP - row.bottom
-  }
-}
 
 // Index-based (not the option id, which may contain spaces/slashes from file
 // paths) so it is always a valid aria-activedescendant IDREF.
@@ -58,43 +41,13 @@ export function EntryActionRow({
   selected: boolean
 }): React.JSX.Element {
   const presentation = getActionPresentation(option)
-  const rowRef = React.useRef<HTMLButtonElement>(null)
-  const pointerRef = React.useRef<{ x: number; y: number } | null>(null)
-  const [tooltipOpen, setTooltipOpen] = React.useState(false)
-  const [pointerOffset, setPointerOffset] = React.useState({ align: 0, side: 0 })
-
-  // Why: Radix positions against the row, so the offsets are only valid for the
-  // row's position at the moment it positions. Results stream in while the open
-  // delay runs, so re-measure on open rather than trusting the pointer-move rect.
-  React.useLayoutEffect(() => {
-    const rect = rowRef.current?.getBoundingClientRect()
-    const pointer = pointerRef.current
-    if (!tooltipOpen || !rect || !pointer) {
-      return
-    }
-    const next = cursorTooltipOffsets(pointer, rect)
-    setPointerOffset((current) =>
-      current.align === next.align && current.side === next.side ? current : next
-    )
-  }, [tooltipOpen])
 
   const row = (
     <button
-      ref={rowRef}
       type="button"
       id={id}
       role="option"
       aria-selected={selected}
-      // Why: a ref, not state — this is read once when the tooltip opens, so
-      // re-rendering the row on every pointer move would be churn for nothing.
-      // pointermove (not mousemove) because Radix opens off pointermove and Slot
-      // runs the child handler first, keeping this fresh even on instant open.
-      onPointerMove={(event) => {
-        if (tooltipOpen) {
-          return
-        }
-        pointerRef.current = { x: event.clientX, y: event.clientY }
-      }}
       className={cn(
         'flex h-6 w-full items-center gap-1.5 rounded-[7px] px-1 text-left text-[11px] leading-5 outline-none',
         selected
@@ -128,35 +81,7 @@ export function EntryActionRow({
     return row
   }
 
-  return (
-    <Tooltip open={tooltipOpen} onOpenChange={setTooltipOpen}>
-      <TooltipTrigger asChild>{row}</TooltipTrigger>
-      {/* Anchored under the cursor the way a system tooltip is, rather than to
-          the row. Radix anchors to the trigger, so the cursor is expressed as
-          offsets off the row's bottom-left corner; collision flipping still
-          applies near the viewport edge. */}
-      <TooltipContent
-        side="bottom"
-        align="start"
-        sideOffset={pointerOffset.side}
-        alignOffset={pointerOffset.align}
-        showArrow={false}
-        className="max-w-[420px] rounded-md border border-border/80 bg-popover px-2 py-1 text-[11px] leading-[15px] break-words text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]"
-      >
-        {presentation.detail}
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
-// Why: keeps the separator attached to the directory, so `/foo` renders as
-// `foo` + `/` rather than re-deriving a separator that may not match the path.
-function splitTrailingSegment(path: string): { directory: string; filename: string } {
-  const separatorIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
-
-  return separatorIndex === -1
-    ? { directory: '', filename: path }
-    : { directory: path.slice(0, separatorIndex + 1), filename: path.slice(separatorIndex + 1) }
+  return <FilePathCursorTooltip path={presentation.detail}>{row}</FilePathCursorTooltip>
 }
 
 function FilenameFirstPath({ path }: { path: string }): React.JSX.Element {

--- a/src/renderer/src/components/ui/command.tsx
+++ b/src/renderer/src/components/ui/command.tsx
@@ -205,9 +205,14 @@ function CommandGroup({
   )
 }
 
-function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+function CommandItem({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
   return (
     <CommandPrimitive.Item
+      ref={ref}
       data-slot="command-item"
       className={cn(
         'relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4',

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -6,7 +6,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const relativeFilePath =
   'packages/orca/src/renderer/src/components/navigation/worktree/quick-open/long-path-fixtures/very-deeply-nested-folder/QuickOpenTarget.tsx'
 
-test('cmd+p quick open prioritizes the filename and reveals the full path on hover', async ({
+test('cmd+p quick open prioritizes the filename and exposes the full path natively', async ({
   electronApp,
   orcaPage,
   testRepoPath
@@ -37,9 +37,7 @@ test('cmd+p quick open prioritizes the filename and reveals the full path on hov
   )
 
   await row.hover({ force: true })
-  await expect(
-    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
-  ).toBeVisible()
+  await expect(row).toHaveAttribute('title', relativeFilePath)
 
   const proofPath = process.env.ORCA_QUICK_OPEN_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -6,7 +6,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 const relativeFilePath =
   'packages/orca/src/renderer/src/components/navigation/worktree/quick-open/long-path-fixtures/very-deeply-nested-folder/QuickOpenTarget.tsx'
 
-test('cmd+p quick open prioritizes the filename and exposes the full path natively', async ({
+test('cmd+p quick open prioritizes the filename and reveals the full path on hover', async ({
   electronApp,
   orcaPage,
   testRepoPath
@@ -37,7 +37,9 @@ test('cmd+p quick open prioritizes the filename and exposes the full path native
   )
 
   await row.hover({ force: true })
-  await expect(row).toHaveAttribute('title', relativeFilePath)
+  await expect(
+    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
+  ).toBeVisible()
 
   const proofPath = process.env.ORCA_QUICK_OPEN_PROOF_PATH
   if (proofPath) {

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -1,0 +1,48 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const relativeFilePath =
+  'packages/orca/src/renderer/src/components/navigation/worktree/quick-open/long-path-fixtures/very-deeply-nested-folder/QuickOpenTarget.tsx'
+
+test('cmd+p quick open prioritizes the filename and reveals the full path on hover', async ({
+  electronApp,
+  orcaPage,
+  testRepoPath
+}) => {
+  const filePath = path.join(testRepoPath, ...relativeFilePath.split('/'))
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, 'export const QuickOpenTarget = true\n')
+
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+
+  // Headless Playwright keyboard events bypass Electron’s before-input-event shortcut path.
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.webContents.send('ui:openQuickOpen')
+  })
+  const dialog = orcaPage.getByRole('dialog', { name: 'Go to file' })
+  await expect(dialog).toBeVisible()
+  const input = dialog.locator('input[placeholder="Go to file..."]')
+  await input.fill('QuickOpenTarget')
+
+  const row = dialog.getByRole('option').filter({ hasText: 'QuickOpenTarget.tsx' }).first()
+  await expect(row).toBeVisible()
+  await expect(row).toContainText('packages/orca/src/renderer/src/components/navigation/')
+  const rowText = await row.textContent()
+  expect(rowText?.indexOf('QuickOpenTarget.tsx')).toBeLessThan(
+    rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1
+  )
+
+  await row.hover({ force: true })
+  await expect(
+    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
+  ).toBeVisible()
+
+  const proofPath = process.env.ORCA_QUICK_OPEN_PROOF_PATH
+  if (proofPath) {
+    await orcaPage.screenshot({ path: proofPath })
+  }
+})

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -36,9 +36,18 @@ test('cmd+p quick open prioritizes the filename and reveals the full path on hov
     rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1
   )
 
-  await row.hover({ force: true })
+  // Two hovers on purpose: results stream in and remount the row, and Radix only
+  // opens on a pointermove it actually receives. A single hover can land before
+  // the remount and leave the cursor sitting still over a row that never saw it.
+  await row.hover({ position: { x: 20, y: 12 } })
+  await orcaPage.waitForTimeout(250)
+  await row.hover({ position: { x: 40, y: 12 } })
+
+  // Exact cursor placement is arithmetic, unit-tested via cursorTooltipOffsets.
+  // Asserting it here measures the app mid-reflow and is flaky; what E2E is
+  // uniquely good for is that the tooltip really opens with the whole path.
   await expect(
-    orcaPage.locator('[role="tooltip"]').filter({ hasText: relativeFilePath })
+    orcaPage.locator('[data-slot="tooltip-content"]').filter({ hasText: relativeFilePath })
   ).toBeVisible()
 
   const proofPath = process.env.ORCA_QUICK_OPEN_PROOF_PATH


### PR DESCRIPTION
## Summary

- Prioritize the actual filename in cmd+p Quick Open results, truncating the parent directory instead.
- Show the complete path in the same system-style, cursor-anchored tooltip that #12670 introduced for the new-tab dropdown.
- Extract that tooltip into a shared `FilePathCursorTooltip` so both surfaces stay identical.

Follows #12670 (merged), which shipped the same treatment for the new-tab `+` dropdown. Rebased on top of it.

## Visual proof

**Before** — the three top hits are all called `ExpoTwoWayAudio…`; the filename is truncated away and the shared directory prefix is what survives, so you cannot tell them apart.

![before](https://github.com/user-attachments/assets/af9f9c19-11fb-464f-8c41-c71da285005a)

**After** — the filename leads and the directory truncates, with the full path in a tooltip anchored under the cursor.

![after](https://github.com/user-attachments/assets/d411ed52-7602-4af5-b42e-62712e99a7ab)

## Shared component

`src/renderer/src/components/file-path-cursor-tooltip.tsx` now owns what #12670 had inlined in the tab bar:

- `splitTrailingSegment` — splits on the last separator and keeps the separator attached to the directory, so `/foo` renders `foo` + `/` and Windows paths keep their backslashes. Quick Open previously split on `lastIndexOf('/')` only, so it mishandled backslash paths and dropped the trailing separator.
- `cursorTooltipOffsets` — restates a cursor position as Radix `alignOffset`/`sideOffset` from the trigger's bottom-left corner, 18px below the pointer.
- `FilePathCursorTooltip` — the trigger wiring, re-measuring on open because results stream in and move rows during the open delay.

The tooltip caps at `min(90vw, 800px)` so a full path usually lands on one line instead of wrapping. Verified it cannot run off screen: at a 1680px viewport with the cursor at 95% across the row it clamps to the right edge, and at a 600px viewport it caps to 540px and wraps — on screen in every case, because Radix shifts it back inside the viewport.

`TabBarCreateEntryRow.tsx` drops ~80 lines and now calls the shared component, so the two surfaces cannot drift.

## One non-obvious thing

In Quick Open the tooltip trigger is an inner `div`, **not** the `CommandItem`. cmdk sets its own `onPointerMove` *after* spreading incoming props (`cmdk/dist/index.mjs`, `Item`), so any handler passed to `CommandItem` is silently dropped — including the one Radix needs to open the tooltip. Putting the trigger one level in keeps cmdk's pointer-selection working (events still bubble) while letting Radix see the move.

This also let me revert the `ref` passthrough this PR previously added to `ui/command.tsx`: with the trigger inside the item, `CommandItem` no longer needs to forward a ref, so the shared `command.tsx` primitive is untouched.

## Testing

- `pnpm exec playwright test tests/e2e/quick-open-file-paths.spec.ts tests/e2e/tab-create-entry-file-paths.spec.ts … --repeat-each=3` — 6/6 passed. Both specs, so the extraction is verified against the surface #12670 already shipped.
- `pnpm exec vitest run … src/renderer/src/components/tab-bar/ file-path-cursor-tooltip.test.ts` — 271 passed.
- `pnpm run typecheck:web`, `oxlint` — clean.
- Verified interactively in a dev build over CDP: tooltip lands at `dx=0.0, dy=18.0` from the cursor.

Placement is asserted in unit tests against `cursorTooltipOffsets`; the E2E asserts the tooltip really opens with the whole path. Asserting pixels through the running app measures it mid-reflow and is flaky — that lesson came from #12670.

## Security

No new IPC payloads, filesystem permissions, subprocesses, network sinks, secrets, or dependencies. The tooltip renders a path the row already received.

## Readiness

- **SSH/remote:** presentation-only renderer change; no transport, reconnect, relay, or provider behavior touched.
- **Crash/retry/growth:** no new async loop, retry, cache, listener, timer, or retained collection. Pointer position is a ref, so hovering does not re-render per move.
- **Cross-platform:** separators are preserved from the input path rather than inferred; Windows backslash paths covered by unit test.
- **Backward compatibility:** no persisted state, route, RPC contract, or serialized data changed. `ui/command.tsx` is back to its original form. No mobile surface touched.

### Known limits (same as #12670)

- Once open, the tooltip stays anchored to the row, so scrolling the list drags it with the row while the cursor stays put.
- Pointer-only: cmdk drives selection via `aria-activedescendant`, so keyboard users get no tooltip. The full path remains in the option's accessible name.
