### PR TITLE
fix(browser): stop an over-limit screencast frame from killing the paired runtime socket (STA-2970)

### DIFF
--- a/src/main/browser/browser-screencast-snapshot-scaling.test.ts
+++ b/src/main/browser/browser-screencast-snapshot-scaling.test.ts
@@ -1,0 +1,94 @@
+import { Buffer } from 'node:buffer'
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+
+import { startBrowserScreencast } from './browser-screencast-stream'
+
+function createMockWebContents(capturePage: () => Promise<unknown>) {
+  let attached = false
+  const dbg = new EventEmitter() as EventEmitter & {
+    isAttached: ReturnType<typeof vi.fn>
+    attach: ReturnType<typeof vi.fn>
+    detach: ReturnType<typeof vi.fn>
+    sendCommand: ReturnType<typeof vi.fn>
+  }
+  dbg.isAttached = vi.fn(() => attached)
+  dbg.attach = vi.fn(() => {
+    attached = true
+  })
+  dbg.detach = vi.fn(() => {
+    attached = false
+  })
+  dbg.sendCommand = vi.fn(async () => ({}))
+  return { isDestroyed: vi.fn(() => false), debugger: dbg, capturePage: vi.fn(capturePage) }
+}
+
+function createCapturedImage(width: number, height: number) {
+  const resized = {
+    getSize: vi.fn(() => ({ width, height })),
+    resize: vi.fn(),
+    toJPEG: vi.fn(() => Buffer.from('scaled-frame')),
+    toPNG: vi.fn(() => Buffer.from('scaled-frame'))
+  }
+  const image = {
+    getSize: vi.fn(() => ({ width, height })),
+    resize: vi.fn(() => resized),
+    toJPEG: vi.fn(() => Buffer.from('captured-frame')),
+    toPNG: vi.fn(() => Buffer.from('captured-frame'))
+  }
+  return { image, resized }
+}
+
+describe('browser screencast snapshot scaling', () => {
+  it('scales a hi-DPI capture down to the requested frame bounds', async () => {
+    const { image, resized } = createCapturedImage(4000, 3000)
+    const webContents = createMockWebContents(async () => image)
+    const onFrame = vi.fn()
+
+    const session = await startBrowserScreencast(webContents as never, {
+      format: 'jpeg',
+      quality: 70,
+      maxWidth: 1440,
+      maxHeight: 1200,
+      viewportWidth: 2000,
+      viewportHeight: 1500,
+      deviceScaleFactor: 2,
+      everyNthFrame: 2,
+      minFrameIntervalMs: 0,
+      onFrame
+    })
+
+    await vi.waitFor(() => expect(onFrame).toHaveBeenCalledTimes(1))
+    expect(image.resize).toHaveBeenCalledWith({ width: 1440, height: 1080 })
+    expect(resized.toJPEG).toHaveBeenCalledWith(70)
+    expect(image.toJPEG).not.toHaveBeenCalled()
+
+    session.stop()
+    await session.done
+  })
+
+  it('leaves a capture already within the frame bounds unscaled', async () => {
+    const { image } = createCapturedImage(1200, 800)
+    const webContents = createMockWebContents(async () => image)
+    const onFrame = vi.fn()
+
+    const session = await startBrowserScreencast(webContents as never, {
+      format: 'jpeg',
+      quality: 70,
+      maxWidth: 1440,
+      maxHeight: 1200,
+      viewportWidth: 1200,
+      viewportHeight: 800,
+      everyNthFrame: 2,
+      minFrameIntervalMs: 0,
+      onFrame
+    })
+
+    await vi.waitFor(() => expect(onFrame).toHaveBeenCalledTimes(1))
+    expect(image.resize).not.toHaveBeenCalled()
+    expect(image.toJPEG).toHaveBeenCalledWith(70)
+
+    session.stop()
+    await session.done
+  })
+})

--- a/src/main/browser/browser-screencast-stream.ts
+++ b/src/main/browser/browser-screencast-stream.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: screencast setup, CDP lifecycle, metadata normalization, and stream teardown stay together so frame behavior cannot drift across files. */
 import { Buffer } from 'node:buffer'
-import type { WebContents } from 'electron'
+import type { NativeImage, WebContents } from 'electron'
 import {
   BrowserScreencastOpcode,
   encodeBrowserScreencastFrame,
@@ -84,6 +84,20 @@ function scaleToFit(
     width: Math.round(width * scale),
     height: Math.round(height * scale)
   }
+}
+
+// Why: capturePage returns device pixels, so a hi-DPI viewport yields a bitmap several times
+// larger than the live path is allowed to send. Apply the caller's cap here too.
+function scaleSnapshotToFit(image: NativeImage, options: BrowserScreencastOptions): NativeImage {
+  const size = image.getSize()
+  if (!size.width || !size.height) {
+    return image
+  }
+  const fitted = scaleToFit(size.width, size.height, options.maxWidth, options.maxHeight)
+  if (fitted.width === size.width && fitted.height === size.height) {
+    return image
+  }
+  return image.resize(fitted)
 }
 
 function isNearSize(
@@ -518,8 +532,9 @@ export async function startBrowserScreencast(
             width: viewportWidth,
             height: viewportHeight
           })
+          const capture = scaleSnapshotToFit(nativeImage, options)
           const buffer =
-            options.format === 'png' ? nativeImage.toPNG() : nativeImage.toJPEG(options.quality)
+            options.format === 'png' ? capture.toPNG() : capture.toJPEG(options.quality)
           if (buffer.byteLength > 0) {
             image = new Uint8Array(buffer)
           }

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES } from '../../shared/remote-runtime-memory-limits'
 import type { RuntimeBrowserCommandHost } from './orca-runtime-browser'
 
 const {
@@ -579,6 +580,32 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     await second.session.done
     expect(secondStop).toHaveBeenCalledTimes(1)
   }, 10_000)
+
+  it('admits screencast frames through the paired-runtime size guard', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    webContentsFromIdMock.mockReturnValue({ isDestroyed: () => false })
+    const done = deferred<void>()
+    startBrowserScreencastMock.mockResolvedValue({
+      stop: vi.fn(() => done.resolve()),
+      done: done.promise
+    })
+    const sendBinary = vi.fn(() => true)
+
+    const commands = new RuntimeBrowserCommands(createHost())
+    const started = await commands.browserScreencast(
+      { worktree: 'id:wt-1', page: 'page-1', format: 'jpeg' },
+      { sendBinary }
+    )
+    const { onFrame } = startBrowserScreencastMock.mock.calls[0][1]
+
+    expect(onFrame(new Uint8Array(REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES + 1))).toBe(true)
+    expect(sendBinary).not.toHaveBeenCalled()
+    expect(onFrame(new Uint8Array(64))).toBe(true)
+    expect(sendBinary).toHaveBeenCalledTimes(1)
+
+    started.session.stop()
+    await started.session.done
+  })
 })
 
 describe('RuntimeBrowserCommands headless offscreen routing', () => {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -68,6 +68,7 @@ import {
   selectBrowserProfile
 } from '../browser/browser-cookie-import'
 import { waitForTabRegistration, waitForWorktreeTabRegistration } from '../ipc/browser'
+import { sendRemoteBrowserScreencastFrame } from './remote-browser-screencast-frame-admission'
 
 export type BrowserCommandTargetParams = {
   worktree?: string
@@ -507,7 +508,7 @@ export class RuntimeBrowserCommands {
         mobile: params.mobile === true,
         everyNthFrame: clampInteger(params.everyNthFrame, 1, 10, 2),
         minFrameIntervalMs: clampInteger(params.minFrameIntervalMs, 0, 1000, 0),
-        onFrame: stream.sendBinary,
+        onFrame: (bytes) => sendRemoteBrowserScreencastFrame(stream.sendBinary, bytes),
         onEvent: stream.emit,
         onError: (message) => stream.emit?.({ type: 'error', message })
       })

--- a/src/main/runtime/remote-browser-screencast-frame-admission.test.ts
+++ b/src/main/runtime/remote-browser-screencast-frame-admission.test.ts
@@ -1,0 +1,149 @@
+import { Buffer } from 'node:buffer'
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+
+import { deriveSharedKey, encrypt, generateKeyPair } from '../../shared/e2ee-crypto'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES } from '../../shared/remote-runtime-memory-limits'
+import { startBrowserScreencast } from '../browser/browser-screencast-stream'
+import { E2EEChannel } from './rpc/e2ee-channel'
+import { sendRemoteBrowserScreencastFrame } from './remote-browser-screencast-frame-admission'
+
+function createMockWebContents() {
+  let attached = false
+  const dbg = new EventEmitter() as EventEmitter & {
+    isAttached: ReturnType<typeof vi.fn>
+    attach: ReturnType<typeof vi.fn>
+    detach: ReturnType<typeof vi.fn>
+    sendCommand: ReturnType<typeof vi.fn>
+  }
+  dbg.isAttached = vi.fn(() => attached)
+  dbg.attach = vi.fn(() => {
+    attached = true
+  })
+  dbg.detach = vi.fn(() => {
+    attached = false
+  })
+  dbg.sendCommand = vi.fn(async () => ({}))
+  return { isDestroyed: vi.fn(() => false), debugger: dbg }
+}
+
+// Why: exercises the real E2EE channel so the oracle fails if an over-limit frame ever reaches
+// the transport that answers it with close code 1013.
+function createRuntimeBinarySender() {
+  const serverKeys = generateKeyPair()
+  const clientKeys = generateKeyPair()
+  const ws = {
+    OPEN: 1 as const,
+    readyState: 1,
+    send: vi.fn(),
+    close: vi.fn()
+  }
+  const onTransportError = vi.fn((code: number, reason: string) => ws.close(code, reason))
+  const channel = new E2EEChannel(ws as never, {
+    serverSecretKey: serverKeys.secretKey,
+    resolveAuthenticatedDevice: (token) =>
+      token === 'valid-token'
+        ? { deviceId: 'device-1', deviceToken: token, scope: 'runtime' }
+        : null,
+    onReady: vi.fn(),
+    onError: onTransportError
+  })
+  const sharedKey = deriveSharedKey(clientKeys.secretKey, serverKeys.publicKey)
+  channel.handleRawMessage(
+    JSON.stringify({
+      type: 'e2ee_hello',
+      publicKeyB64: Buffer.from(clientKeys.publicKey).toString('base64')
+    })
+  )
+  channel.handleRawMessage(
+    encrypt(JSON.stringify({ type: 'e2ee_auth', deviceToken: 'valid-token' }), sharedKey)
+  )
+  let sendBinary: ((bytes: Uint8Array<ArrayBufferLike>) => boolean | void) | undefined
+  channel.onMessage((_plaintext, _sendText, sendBinaryReply) => {
+    sendBinary = sendBinaryReply
+  })
+  channel.handleRawMessage(encrypt('start-screencast', sharedKey))
+  if (!sendBinary) {
+    throw new Error('Runtime binary sender was not established')
+  }
+  return { channel, ws, onTransportError, sendBinary }
+}
+
+describe('sendRemoteBrowserScreencastFrame', () => {
+  it('reports an over-limit frame as handled so the producer does not retry it', () => {
+    const sendBinary = vi.fn(() => true)
+    const oversized = new Uint8Array(REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES + 1)
+
+    expect(sendRemoteBrowserScreencastFrame(sendBinary, oversized)).toBe(true)
+    expect(sendBinary).not.toHaveBeenCalled()
+  })
+
+  it('still forwards backpressure for a frame the transport can accept', () => {
+    const withinLimit = new Uint8Array(1024)
+
+    expect(
+      sendRemoteBrowserScreencastFrame(
+        vi.fn(() => false),
+        withinLimit
+      )
+    ).toBe(false)
+    expect(
+      sendRemoteBrowserScreencastFrame(
+        vi.fn(() => true),
+        withinLimit
+      )
+    ).toBe(true)
+    expect(sendRemoteBrowserScreencastFrame(vi.fn(), withinLimit)).toBe(true)
+  })
+
+  it('drops an oversized encoded frame without closing or stalling the paired stream', async () => {
+    vi.useFakeTimers()
+    const webContents = createMockWebContents()
+    const transport = createRuntimeBinarySender()
+    const session = await startBrowserScreencast(webContents as never, {
+      format: 'jpeg',
+      quality: 70,
+      maxWidth: 3840,
+      maxHeight: 2160,
+      everyNthFrame: 1,
+      minFrameIntervalMs: 0,
+      onFrame: (bytes) => sendRemoteBrowserScreencastFrame(transport.sendBinary, bytes)
+    })
+
+    try {
+      webContents.debugger.emit('message', {}, 'Page.screencastFrame', {
+        data: Buffer.alloc(REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES + 1).toString('base64'),
+        sessionId: 42,
+        metadata: {}
+      })
+      await Promise.resolve()
+
+      expect(transport.onTransportError).not.toHaveBeenCalled()
+      expect(transport.ws.close).not.toHaveBeenCalled()
+      expect(webContents.debugger.sendCommand).toHaveBeenCalledWith('Page.screencastFrameAck', {
+        sessionId: 42
+      })
+      const sendsAfterDrop = transport.ws.send.mock.calls.length
+      await vi.advanceTimersByTimeAsync(500)
+      expect(transport.ws.send).toHaveBeenCalledTimes(sendsAfterDrop)
+
+      webContents.debugger.emit('message', {}, 'Page.screencastFrame', {
+        data: Buffer.from('next-frame').toString('base64'),
+        sessionId: 43,
+        metadata: {}
+      })
+      await Promise.resolve()
+
+      expect(transport.onTransportError).not.toHaveBeenCalled()
+      expect(webContents.debugger.sendCommand).toHaveBeenCalledWith('Page.screencastFrameAck', {
+        sessionId: 43
+      })
+      expect(transport.ws.send.mock.calls.length).toBeGreaterThan(sendsAfterDrop)
+    } finally {
+      session.stop()
+      await session.done
+      transport.channel.destroy()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/runtime/remote-browser-screencast-frame-admission.ts
+++ b/src/main/runtime/remote-browser-screencast-frame-admission.ts
@@ -1,0 +1,14 @@
+import { isRemoteRuntimeBinaryFrameWithinLimit } from '../../shared/remote-runtime-memory-limits'
+
+// Why: the E2EE channel closes the socket (1013) on an over-limit binary frame, and the
+// screencast producer reads `false` as backpressure and retries the identical frame. Reporting
+// an over-limit frame as handled drops it so the stream advances instead of retrying forever.
+export function sendRemoteBrowserScreencastFrame(
+  sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => boolean | void,
+  bytes: Uint8Array<ArrayBufferLike>
+): boolean {
+  if (!isRemoteRuntimeBinaryFrameWithinLimit(bytes)) {
+    return true
+  }
+  return sendBinary(bytes) !== false
+}


### PR DESCRIPTION
Fixes STA-2970.

## Symptom

A Mac client paired to another Mac over LAN. Opening any webpage in the remote browser drops the runtime connection, and the client then retries forever and never recovers until the whole client app is restarted.

## Why it happens

Host -> client screencast frames are admitted up to **8 MiB** (`REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES`, `src/shared/remote-runtime-memory-limits.ts:19`). The host's E2EE channel refuses anything larger and answers by closing the **entire runtime socket** with close code **1013 "Outbound reply buffer overflow"** (`src/main/runtime/rpc/e2ee-channel.ts:300-306`) — taking terminals and agent streams down with the browser view, not just the screencast.

The screencast producer reads a `false` return from its `onFrame` sink as **backpressure** and re-queues the *identical* frame every 50 ms (`schedulePendingFrameRetry`, `src/main/browser/browser-screencast-stream.ts:285-303`). An over-limit frame can never become smaller, so the retry can never succeed: every attempt trips 1013 again. That single confusion explains both halves of the report — the connection dying on page load, and never coming back.

This is a **permanent condition being treated as transient** — the mirror image of the hidden-output bug fixed in #12655, where a transient condition was treated as permanent.

## What makes an 8 MiB frame reachable at all

Live frames are hard-bounded: `maxWidth`/`maxHeight` go straight to `Page.startScreencast` and Chromium scales to fit.

The **navigation snapshot** path does not. `emitSnapshotFrame` fires on `Page.frameNavigated` / `Page.loadEventFired` — i.e. exactly "opening a webpage" — and passed `webContents.capturePage(...)` straight into `toJPEG()`/`toPNG()`. `capturePage`'s rect is CSS pixels but the returned bitmap is *device* pixels, so with `deviceScaleFactor` up to 2 (desktop) the snapshot could be **4x the pixel area the live path is allowed to send**, and `maxWidth`/`maxHeight` were never applied there. That is the path that produces the over-limit frame on an ordinary page load.

## The fix

Two parts, both small:

1. **`src/main/runtime/remote-browser-screencast-frame-admission.ts` (new)** — an over-limit frame is reported as *handled*, so the producer advances to the next frame instead of retrying a doomed one, and it never reaches the transport that would close the socket. Genuine backpressure still round-trips: a `false` from the transport is still returned as `false`.

2. **`scaleSnapshotToFit`** in `browser-screencast-stream.ts` — apply the caller's own `maxWidth`/`maxHeight` to the snapshot capture, using the `scaleToFit` helper already in that file. This removes the asymmetry above, so the drop guard becomes a backstop rather than the primary mitigation. It can only ever make a frame smaller, and only when the capture already exceeds bounds the live path enforces anyway.

### Why the guard sits at the paired-runtime boundary, not in the generic producer

The 8 MiB ceiling is a property of the *paired-runtime transport*, not of screencasting. Putting the check in `startBrowserScreencast` would bake a remote-transport constant into the generic Chromium producer. Wrapping at `orca-runtime-browser.ts` keeps it where the limit actually applies.

Ordering matters here and is deliberate: `stream.sendBinary` is already wrapped by `sendBinaryAfterReady` (`orca-runtime.ts:34257`), which legitimately returns `false` for frames arriving before the JSON `ready` event. The size check runs **before** delegating, so an over-limit first snapshot is dropped immediately rather than spinning in the 50 ms retry loop until `ready`, while the pre-`ready` transient backpressure is preserved untouched.

## Behavior questions a reviewer should ask

**Does dropping a frame leave the view stuck?** Frames are complete standalone JPEG/PNG images, not deltas — each one replaces the `<img>` wholesale on the client. A dropped frame is self-healing by construction: the next frame fully repaints. In the transient case (one heavy frame mid-load) the user sees nothing at all.

The honest caveat: if *every* frame for a given page and viewport were over the limit, the pane would sit on its last good image with no error shown, because Chromium stops producing frames once a static page settles. Part 2 is what closes that gap for the realistic trigger. It is not fully closed for one residual path — the mobile web-view mode sends no viewport, so its snapshot takes the `Page.captureScreenshot` branch with no clip and no clamp; there the drop guard is still the only protection. Even then the outcome is strictly better than today: a quiet skipped frame instead of a 1013 that kills every subscription on the connection.

**Is "never reconnects without an app restart" fixed?** Partly, and I want to be precise. The doomed-retry loop is gone, so the specific failure in the report no longer strands anyone. But there is an **independent client-side recovery defect** that this PR does not touch: `scheduleRemoteStreamRestart`'s terminal `.catch` in `BrowserPane.tsx:1621-1633` arms exactly one 500 ms retry and never reschedules. If that single attempt fails — host still unreachable, RPC queue overloaded — the pane holds a null subscription with no live callbacks, so nothing can re-arm it short of tab reactivation or an app restart. Any cause of connection loss triggers it, not just this one. It is a renderer-side concern with a different trigger surface and needs its own renderer test setup, so it belongs in a separate ticket rather than mixed into a main-process transport fix. Not yet filed — flagging it here so it gets an owner.

## Validation

- Red re-proven before green, by reverting each production change in place:
  - admission guard reverted -> **3 failed / 20 passed**; the integration oracle failed with the real `[1013, "Outbound reply buffer overflow"]` from the actual `E2EEChannel`, and the call-site wiring test failed independently.
  - snapshot clamp reverted -> **1 failed / 1 passed** in the snapshot suite.
- `src/main/browser` + `src/main/runtime` + `src/preload`: **278 files, 4239 passed, 6 skipped**.
- `pnpm run typecheck` clean; `oxlint` (default + code-quality-native) clean; `oxfmt --check` clean; `check:max-lines-ratchet` OK (new snapshot tests went in their own file rather than pushing an existing one past the 800-line cap).

